### PR TITLE
Do not set front face if face culling is not enabled

### DIFF
--- a/Ryujinx.Graphics/Gal/GalFrontFace.cs
+++ b/Ryujinx.Graphics/Gal/GalFrontFace.cs
@@ -2,7 +2,7 @@
 {
     public enum GalFrontFace
     {
-        CW  = 0x900,
-        CCW = 0x901
+        Cw  = 0x900,
+        Ccw = 0x901
     }
 }

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLEnumConverter.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLEnumConverter.cs
@@ -9,8 +9,8 @@ namespace Ryujinx.Graphics.Gal.OpenGL
         {
             switch (FrontFace)
             {
-                case GalFrontFace.CW:  return FrontFaceDirection.Cw;
-                case GalFrontFace.CCW: return FrontFaceDirection.Ccw;
+                case GalFrontFace.Cw:  return FrontFaceDirection.Cw;
+                case GalFrontFace.Ccw: return FrontFaceDirection.Ccw;
             }
 
             throw new ArgumentException(nameof(FrontFace));

--- a/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3d.cs
+++ b/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3d.cs
@@ -79,8 +79,7 @@ namespace Ryujinx.HLE.Gpu.Engines
 
             Gpu.Renderer.Shader.BindProgram();
 
-            SetFrontFace();
-            SetCullFace();
+            SetFaceCulling();
             SetDepth();
             SetStencil();
             SetAlphaBlending();
@@ -198,32 +197,7 @@ namespace Ryujinx.HLE.Gpu.Engines
             throw new ArgumentOutOfRangeException(nameof(Program));
         }
 
-        private void SetFrontFace()
-        {
-            float SignX = GetFlipSign(NvGpuEngine3dReg.ViewportScaleX);
-            float SignY = GetFlipSign(NvGpuEngine3dReg.ViewportScaleY);
-
-            GalFrontFace FrontFace = (GalFrontFace)ReadRegister(NvGpuEngine3dReg.FrontFace);
-
-            //Flipping breaks facing. Flipping front facing too fixes it
-            if (SignX != SignY)
-            {
-                switch (FrontFace)
-                {
-                    case GalFrontFace.CW:
-                        FrontFace = GalFrontFace.CCW;
-                        break;
-
-                    case GalFrontFace.CCW:
-                        FrontFace = GalFrontFace.CW;
-                        break;
-                }
-            }
-
-            Gpu.Renderer.Rasterizer.SetFrontFace(FrontFace);
-        }
-
-        private void SetCullFace()
+        private void SetFaceCulling()
         {
             bool Enable = (ReadRegister(NvGpuEngine3dReg.CullFaceEnable) & 1) != 0;
 
@@ -240,6 +214,23 @@ namespace Ryujinx.HLE.Gpu.Engines
             {
                 return;
             }
+
+            float SignX = GetFlipSign(NvGpuEngine3dReg.ViewportScaleX);
+            float SignY = GetFlipSign(NvGpuEngine3dReg.ViewportScaleY);
+
+            GalFrontFace FrontFace = (GalFrontFace)ReadRegister(NvGpuEngine3dReg.FrontFace);
+
+            //Flipping breaks facing. Flipping front facing too fixes it
+            if (SignX != SignY)
+            {
+                switch (FrontFace)
+                {
+                    case GalFrontFace.Cw:  FrontFace = GalFrontFace.Ccw; break;
+                    case GalFrontFace.Ccw: FrontFace = GalFrontFace.Cw;  break;
+                }
+            }
+
+            Gpu.Renderer.Rasterizer.SetFrontFace(FrontFace);
 
             GalCullFace CullFace = (GalCullFace)ReadRegister(NvGpuEngine3dReg.CullFace);
 


### PR DESCRIPTION
This fixes a regression in Sonic Mania due to a invalid FrontFace value.
AFAIK, when face culling is not enabled, whatever is set for FrontFace doesn't matter, so the driver doesn't need to set the register in this case.