### PR TITLE
Allow copy between frame buffers

### DIFF
--- a/Ryujinx.Graphics/Gal/IGalFrameBuffer.cs
+++ b/Ryujinx.Graphics/Gal/IGalFrameBuffer.cs
@@ -22,6 +22,18 @@ namespace Ryujinx.Graphics.Gal
 
         void Render();
 
+        void Copy(
+            long SrcKey,
+            long DstKey,
+            int  SrcX0,
+            int  SrcY0,
+            int  SrcX1,
+            int  SrcY1,
+            int  DstX0,
+            int  DstY0,
+            int  DstX1,
+            int  DstY1);
+
         void GetBufferData(long Key, Action<byte[]> Callback);
     }
 }

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLFrameBuffer.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLFrameBuffer.cs
@@ -304,6 +304,34 @@ namespace Ryujinx.Graphics.Gal.OpenGL
             }
         }
 
+        public void Copy(
+            long SrcKey,
+            long DstKey,
+            int  SrcX0,
+            int  SrcY0,
+            int  SrcX1,
+            int  SrcY1,
+            int  DstX0,
+            int  DstY0,
+            int  DstX1,
+            int  DstY1)
+        {
+            if (Fbs.TryGetValue(SrcKey, out FrameBuffer SrcFb) &&
+                Fbs.TryGetValue(DstKey, out FrameBuffer DstFb))
+            {
+                GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, SrcFb.Handle);
+                GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, DstFb.Handle);
+
+                GL.Clear(ClearBufferMask.ColorBufferBit);
+
+                GL.BlitFramebuffer(
+                    SrcX0, SrcY0, SrcX1, SrcY1,
+                    DstX0, DstY0, DstX1, DstY1,
+                    ClearBufferMask.ColorBufferBit,
+                    BlitFramebufferFilter.Linear);
+            }
+        }
+
         public void GetBufferData(long Key, Action<byte[]> Callback)
         {
             if (Fbs.TryGetValue(Key, out FrameBuffer Fb))


### PR DESCRIPTION
This still needs improvements (de-hardcoding frame buffer sizes, and in general the texture copy engine is really lacking, it needs the ability to convert between formats, change resolution, and so on...). However I don't plan to do this work now.