### PR TITLE
NvGetConfig with production/non production swapping

### DIFF
--- a/Ryujinx.HLE/OsHle/Services/Nv/NvHostCtrl/NvHostCtrlIoctl.cs
+++ b/Ryujinx.HLE/OsHle/Services/Nv/NvHostCtrl/NvHostCtrlIoctl.cs
@@ -16,7 +16,7 @@ namespace Ryujinx.HLE.OsHle.Services.Nv.NvHostCtrl
         {
             UserCtxs = new ConcurrentDictionary<Process, NvHostCtrlUserCtx>();
 
-            if (Set.NxSettings.Settings.TryGetValue("", out object ProductionModeSetting))
+            if (Set.NxSettings.Settings.TryGetValue("nv!rmos_set_production_mode", out object ProductionModeSetting))
             {
                 IsProductionMode = ((string)ProductionModeSetting) != "0"; // Default value is ""
             }

--- a/Ryujinx.HLE/OsHle/Services/Nv/NvHostCtrl/NvHostCtrlIoctl.cs
+++ b/Ryujinx.HLE/OsHle/Services/Nv/NvHostCtrl/NvHostCtrlIoctl.cs
@@ -71,17 +71,7 @@ namespace Ryujinx.HLE.OsHle.Services.Nv.NvHostCtrl
 
         private static int GetConfig(ServiceCtx Context)
         {
-            long InputPosition  = Context.Request.GetBufferType0x21().Position;
-            long OutputPosition = Context.Request.GetBufferType0x22().Position;
-
-            string Nv   = AMemoryHelper.ReadAsciiString(Context.Memory, InputPosition + 0,    0x41);
-            string Name = AMemoryHelper.ReadAsciiString(Context.Memory, InputPosition + 0x41, 0x41);
-
-            Context.Memory.WriteByte(OutputPosition + 0x82, 0);
-
-            Context.Ns.Log.PrintStub(LogClass.ServiceNv, "Stubbed.");
-
-            return NvResult.Success;
+            return NvResult.NotAvailableInProduction;
         }
 
         private static int EventWait(ServiceCtx Context)

--- a/Ryujinx.HLE/OsHle/Services/Nv/NvHostCtrl/NvHostCtrlIoctl.cs
+++ b/Ryujinx.HLE/OsHle/Services/Nv/NvHostCtrl/NvHostCtrlIoctl.cs
@@ -16,10 +16,9 @@ namespace Ryujinx.HLE.OsHle.Services.Nv.NvHostCtrl
         {
             UserCtxs = new ConcurrentDictionary<Process, NvHostCtrlUserCtx>();
 
-            Set.NxSettings.Settings.TryGetValue("", out object ProductionModeSetting);
-            if (ProductionModeSetting != null)
+            if (Set.NxSettings.Settings.TryGetValue("", out object ProductionModeSetting))
             {
-                IsProductionMode = ProductionModeSetting.ToString() != "0"; // Default value is ""
+                IsProductionMode = ((string)ProductionModeSetting) != "0"; // Default value is ""
             }
         }
 

--- a/Ryujinx.HLE/OsHle/Services/Nv/NvHostCtrl/NvHostCtrlIoctl.cs
+++ b/Ryujinx.HLE/OsHle/Services/Nv/NvHostCtrl/NvHostCtrlIoctl.cs
@@ -81,11 +81,11 @@ namespace Ryujinx.HLE.OsHle.Services.Nv.NvHostCtrl
         {
             if (!IsProductionMode)
             {
-                long InputPosition = Context.Request.GetBufferType0x21().Position;
+                long InputPosition  = Context.Request.GetBufferType0x21().Position;
                 long OutputPosition = Context.Request.GetBufferType0x22().Position;
 
                 string Domain = AMemoryHelper.ReadAsciiString(Context.Memory, InputPosition + 0, 0x41);
-                string Name = AMemoryHelper.ReadAsciiString(Context.Memory, InputPosition + 0x41, 0x41);
+                string Name   = AMemoryHelper.ReadAsciiString(Context.Memory, InputPosition + 0x41, 0x41);
 
                 if (Set.NxSettings.Settings.TryGetValue($"{Domain}!{Name}", out object NvSetting))
                 {
@@ -102,6 +102,7 @@ namespace Ryujinx.HLE.OsHle.Services.Nv.NvHostCtrl
                             SettingBuffer = Encoding.ASCII.GetBytes(StringValue + "\0");
                         }
                     }
+
                     if (NvSetting is int IntValue)
                     {
                         SettingBuffer = BitConverter.GetBytes(IntValue);

--- a/Ryujinx.HLE/OsHle/Services/Nv/NvHostCtrl/NvHostCtrlIoctl.cs
+++ b/Ryujinx.HLE/OsHle/Services/Nv/NvHostCtrl/NvHostCtrlIoctl.cs
@@ -9,14 +9,17 @@ namespace Ryujinx.HLE.OsHle.Services.Nv.NvHostCtrl
     class NvHostCtrlIoctl
     {
         private static ConcurrentDictionary<Process, NvHostCtrlUserCtx> UserCtxs;
+
         private static bool IsProductionMode = true;
 
         static NvHostCtrlIoctl()
         {
             UserCtxs = new ConcurrentDictionary<Process, NvHostCtrlUserCtx>();
-            if(Set.NxSettings.Settings.ContainsKey("nv!rmos_set_production_mode"))
+
+            Set.NxSettings.Settings.TryGetValue("", out object ProductionModeSetting);
+            if (ProductionModeSetting != null)
             {
-                IsProductionMode = Set.NxSettings.Settings["nv!rmos_set_production_mode"].ToString() != "0"; // Default value is ""
+                IsProductionMode = ProductionModeSetting.ToString() != "0"; // Default value is ""
             }
         }
 
@@ -87,8 +90,10 @@ namespace Ryujinx.HLE.OsHle.Services.Nv.NvHostCtrl
                 Context.Memory.WriteByte(OutputPosition + 0x82, (byte)'0');
 
                 Context.Ns.Log.PrintStub(LogClass.ServiceNv, "Stubbed.");
+                
                 return NvResult.Success;
             }
+
             return NvResult.NotAvailableInProduction;
         }
 

--- a/Ryujinx.HLE/OsHle/Services/Nv/NvHostCtrl/NvHostCtrlIoctl.cs
+++ b/Ryujinx.HLE/OsHle/Services/Nv/NvHostCtrl/NvHostCtrlIoctl.cs
@@ -93,7 +93,7 @@ namespace Ryujinx.HLE.OsHle.Services.Nv.NvHostCtrl
 
                     if (NvSetting is string StringValue)
                     {
-                        if(StringValue.Length > 0x100)
+                        if (StringValue.Length > 0x100)
                         {
                             Context.Ns.Log.PrintError(Logging.LogClass.ServiceNv, $"{Domain}!{Name} String value size is too big!");
                         }

--- a/Ryujinx.HLE/OsHle/Services/Nv/NvResult.cs
+++ b/Ryujinx.HLE/OsHle/Services/Nv/NvResult.cs
@@ -2,12 +2,13 @@ namespace Ryujinx.HLE.OsHle.Services.Nv
 {
     static class NvResult
     {
-        public const int Success      = 0;
-        public const int TryAgain     = -11;
-        public const int OutOfMemory  = -12;
-        public const int InvalidInput = -22;
-        public const int NotSupported = -25;
-        public const int Restart      = -85;
-        public const int TimedOut     = -110;
+        public const int NotAvailableInProduction = 196614,
+        public const int Success                  = 0;
+        public const int TryAgain                 = -11;
+        public const int OutOfMemory              = -12;
+        public const int InvalidInput             = -22;
+        public const int NotSupported             = -25;
+        public const int Restart                  = -85;
+        public const int TimedOut                 = -110;
     }
 }

--- a/Ryujinx.HLE/OsHle/Services/Nv/NvResult.cs
+++ b/Ryujinx.HLE/OsHle/Services/Nv/NvResult.cs
@@ -2,7 +2,7 @@ namespace Ryujinx.HLE.OsHle.Services.Nv
 {
     static class NvResult
     {
-        public const int NotAvailableInProduction = 196614,
+        public const int NotAvailableInProduction = 196614;
         public const int Success                  = 0;
         public const int TryAgain                 = -11;
         public const int OutOfMemory              = -12;


### PR DESCRIPTION
If `nv!rmos_set_production_mode` is set to 0, the default impl with the fixed return is called. However, if we're running in production mode(default mode) then we should return the error code 0x30006