### PR TITLE
Loop GLScreen with custom method

### DIFF
--- a/Ryujinx.HLE/Gpu/Engines/NvGpuFifo.cs
+++ b/Ryujinx.HLE/Gpu/Engines/NvGpuFifo.cs
@@ -1,5 +1,6 @@
 using Ryujinx.HLE.Gpu.Memory;
 using System.Collections.Concurrent;
+using System.Threading;
 
 namespace Ryujinx.HLE.Gpu.Engines
 {
@@ -17,6 +18,8 @@ namespace Ryujinx.HLE.Gpu.Engines
         private ConcurrentQueue<(NvGpuVmm, NvGpuPBEntry)> BufferQueue;
 
         private NvGpuEngine[] SubChannels;
+
+        public ManualResetEvent Event { get; private set; }
 
         private struct CachedMacro
         {
@@ -60,6 +63,8 @@ namespace Ryujinx.HLE.Gpu.Engines
             Macros = new CachedMacro[MacrosCount];
 
             Mme = new int[MmeWords];
+
+            Event = new ManualResetEvent(false);
         }
 
         public void PushBuffer(NvGpuVmm Vmm, NvGpuPBEntry[] Buffer)
@@ -68,6 +73,8 @@ namespace Ryujinx.HLE.Gpu.Engines
             {
                 BufferQueue.Enqueue((Vmm, PBEntry));
             }
+
+            Event.Set();
         }
 
         public void DispatchCalls()

--- a/Ryujinx.HLE/Gpu/Engines/NvGpuFifo.cs
+++ b/Ryujinx.HLE/Gpu/Engines/NvGpuFifo.cs
@@ -19,7 +19,7 @@ namespace Ryujinx.HLE.Gpu.Engines
 
         private NvGpuEngine[] SubChannels;
 
-        public ManualResetEvent Event { get; private set; }
+        public AutoResetEvent Event { get; private set; }
 
         private struct CachedMacro
         {
@@ -64,7 +64,7 @@ namespace Ryujinx.HLE.Gpu.Engines
 
             Mme = new int[MmeWords];
 
-            Event = new ManualResetEvent(false);
+            Event = new AutoResetEvent(false);
         }
 
         public void PushBuffer(NvGpuVmm Vmm, NvGpuPBEntry[] Buffer)

--- a/Ryujinx.HLE/Switch.cs
+++ b/Ryujinx.HLE/Switch.cs
@@ -71,9 +71,16 @@ namespace Ryujinx.HLE
             Os.LoadProgram(FileName);
         }
 
+        public bool WaitFifo()
+        {
+            return Gpu.Fifo.Event.WaitOne(1);
+        }
+
         public void ProcessFrame()
         {
             Gpu.Fifo.DispatchCalls();
+
+            Gpu.Fifo.Event.Reset();
         }
 
         internal virtual void OnFinish(EventArgs e)

--- a/Ryujinx.HLE/Switch.cs
+++ b/Ryujinx.HLE/Switch.cs
@@ -73,14 +73,12 @@ namespace Ryujinx.HLE
 
         public bool WaitFifo()
         {
-            return Gpu.Fifo.Event.WaitOne(1);
+            return Gpu.Fifo.Event.WaitOne(8);
         }
 
         public void ProcessFrame()
         {
             Gpu.Fifo.DispatchCalls();
-
-            Gpu.Fifo.Event.Reset();
         }
 
         internal virtual void OnFinish(EventArgs e)

--- a/Ryujinx/Ui/GLScreen.cs
+++ b/Ryujinx/Ui/GLScreen.cs
@@ -31,7 +31,7 @@ namespace Ryujinx
 
         private Thread RenderThread;
 
-        private AutoResetEvent ResizeEvent;
+        private bool ResizeEvent;
 
         public GLScreen(Switch Ns, IGalRenderer Renderer)
             : base(1280, 720,
@@ -46,7 +46,7 @@ namespace Ryujinx
                 (DisplayDevice.Default.Width  / 2) - (Width  / 2),
                 (DisplayDevice.Default.Height / 2) - (Height / 2));
 
-            ResizeEvent = new AutoResetEvent(false);
+            ResizeEvent = false;
         }
 
         private void RenderLoop()
@@ -70,8 +70,10 @@ namespace Ryujinx
 
                 Renderer.RunActions();
 
-                if (ResizeEvent.WaitOne(0))
+                if (ResizeEvent)
                 {
+                    ResizeEvent = false;
+
                     Renderer.FrameBuffer.SetWindowSize(Width, Height);
                 }
 
@@ -374,7 +376,7 @@ namespace Ryujinx
 
         protected override void OnResize(EventArgs e)
         {
-            ResizeEvent.Set();
+            ResizeEvent = true;
         }
 
         protected override void OnKeyDown(KeyboardKeyEventArgs e)

--- a/Ryujinx/Ui/GLScreen.cs
+++ b/Ryujinx/Ui/GLScreen.cs
@@ -91,7 +91,8 @@ namespace Ryujinx
                 {
                     RenderFrame();
 
-                    Ticks -= TicksPerFrame;
+                    //Queue max. 1 vsync
+                    Ticks = Math.Min(Ticks - TicksPerFrame, TicksPerFrame);
                 }
             }
         }

--- a/Ryujinx/Ui/GLScreen.cs
+++ b/Ryujinx/Ui/GLScreen.cs
@@ -59,14 +59,12 @@ namespace Ryujinx
 
             while (!IsExiting)
             {
-                //Sleeping until Fifo event improves performance, but it deadlocks most games
-                //should not be uncommented until it's found why it happens
-                //if (Ns.WaitFifo())
+                if (Ns.WaitFifo())
                 {
                     Ns.ProcessFrame();
-
-                    Renderer.RunActions();
                 }
+
+                Renderer.RunActions();
 
                 Ticks += Chrono.ElapsedTicks;
 

--- a/Ryujinx/Ui/GLScreen.cs
+++ b/Ryujinx/Ui/GLScreen.cs
@@ -33,6 +33,8 @@ namespace Ryujinx
 
         private bool ResizeEvent;
 
+        private bool Quit;
+
         public GLScreen(Switch Ns, IGalRenderer Renderer)
             : base(1280, 720,
             new GraphicsMode(), "Ryujinx", 0,
@@ -47,6 +49,8 @@ namespace Ryujinx
                 (DisplayDevice.Default.Height / 2) - (Height / 2));
 
             ResizeEvent = false;
+
+            Quit = false;
         }
 
         private void RenderLoop()
@@ -61,7 +65,7 @@ namespace Ryujinx
 
             long Ticks = 0;
 
-            while (!IsExiting)
+            while (!Quit && Exists && !IsExiting)
             {
                 if (Ns.WaitFifo())
                 {
@@ -369,6 +373,8 @@ namespace Ryujinx
 
         protected override void OnUnload(EventArgs e)
         {
+            Quit = true;
+
             RenderThread.Join();
 
             base.OnUnload(e);

--- a/Ryujinx/Ui/GLScreen.cs
+++ b/Ryujinx/Ui/GLScreen.cs
@@ -31,6 +31,8 @@ namespace Ryujinx
 
         private Thread RenderThread;
 
+        private AutoResetEvent ResizeEvent;
+
         public GLScreen(Switch Ns, IGalRenderer Renderer)
             : base(1280, 720,
             new GraphicsMode(), "Ryujinx", 0,
@@ -43,6 +45,8 @@ namespace Ryujinx
             Location = new Point(
                 (DisplayDevice.Default.Width  / 2) - (Width  / 2),
                 (DisplayDevice.Default.Height / 2) - (Height / 2));
+
+            ResizeEvent = new AutoResetEvent(false);
         }
 
         private void RenderLoop()
@@ -65,6 +69,11 @@ namespace Ryujinx
                 }
 
                 Renderer.RunActions();
+
+                if (ResizeEvent.WaitOne(0))
+                {
+                    Renderer.FrameBuffer.SetWindowSize(Width, Height);
+                }
 
                 Ticks += Chrono.ElapsedTicks;
 
@@ -365,7 +374,7 @@ namespace Ryujinx
 
         protected override void OnResize(EventArgs e)
         {
-            Renderer.FrameBuffer.SetWindowSize(Width, Height);
+            ResizeEvent.Set();
         }
 
         protected override void OnKeyDown(KeyboardKeyEventArgs e)

--- a/Ryujinx/Ui/Program.cs
+++ b/Ryujinx/Ui/Program.cs
@@ -67,7 +67,7 @@ namespace Ryujinx
                     Screen.Exit();
                 };
 
-                Screen.Run(0.0, 60.0);
+                Screen.MainLoop();
             }
 
             Environment.Exit(0);


### PR DESCRIPTION
Bypasses OpenTK's "jail".

Using OpenTK's event system we're able to dispatch GPU calls just once per frame, this PR calls it "as much as possible". This is not ideal because CPU cycles are wasted, but it's better than current approach.

It has included an event system to avoid this (locking host FPS to 60 most of the time) but it deadlocks almost every game so it's disabled.

It also forks OpenTK's event handling and GPU rendering in two different threads, this is mainly because OpenTK malfunctions when sleeps are called in its thread.