### PR TITLE
Some small shader related fixes

### DIFF
--- a/Ryujinx.Graphics/Gal/IGalShader.cs
+++ b/Ryujinx.Graphics/Gal/IGalShader.cs
@@ -18,6 +18,8 @@ namespace Ryujinx.Graphics.Gal
 
         void Bind(long Key);
 
+        void Unbind(GalShaderType Type);
+
         void BindProgram();
     }
 }

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLShader.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLShader.cs
@@ -203,6 +203,18 @@ namespace Ryujinx.Graphics.Gal.OpenGL
             }
         }
 
+        public void Unbind(GalShaderType Type)
+        {
+            switch (Type)
+            {
+                case GalShaderType.Vertex:         Current.Vertex         = null; break;
+                case GalShaderType.TessControl:    Current.TessControl    = null; break;
+                case GalShaderType.TessEvaluation: Current.TessEvaluation = null; break;
+                case GalShaderType.Geometry:       Current.Geometry       = null; break;
+                case GalShaderType.Fragment:       Current.Fragment       = null; break;
+            }
+        }
+
         public void BindProgram()
         {
             if (Current.Vertex   == null ||

--- a/Ryujinx.Graphics/Gal/Shader/GlslDecompiler.cs
+++ b/Ryujinx.Graphics/Gal/Shader/GlslDecompiler.cs
@@ -216,7 +216,7 @@ namespace Ryujinx.Graphics.Gal.Shader
 
         private void PrintDeclOutAttributes()
         {
-            if (Decl.ShaderType < GalShaderType.Fragment)
+            if (Decl.ShaderType != GalShaderType.Fragment)
             {
                 SB.AppendLine("layout (location = " + GlslDecl.PositionOutAttrLocation + ") out vec4 " + GlslDecl.PositionOutAttrName + ";");
             }
@@ -339,7 +339,7 @@ namespace Ryujinx.Graphics.Gal.Shader
                 SB.AppendLine(IdentationStr + "gl_Position.xy *= " + GlslDecl.FlipUniformName + ";");
             }
 
-            if (Decl.ShaderType < GalShaderType.Fragment)
+            if (Decl.ShaderType != GalShaderType.Fragment)
             {
                 SB.AppendLine(IdentationStr + GlslDecl.PositionOutAttrName + " = gl_Position;");
                 SB.AppendLine(IdentationStr + GlslDecl.PositionOutAttrName + ".w = 1;");

--- a/Ryujinx.Graphics/Gal/Shader/GlslDecompiler.cs
+++ b/Ryujinx.Graphics/Gal/Shader/GlslDecompiler.cs
@@ -216,7 +216,7 @@ namespace Ryujinx.Graphics.Gal.Shader
 
         private void PrintDeclOutAttributes()
         {
-            if (Decl.ShaderType == GalShaderType.Vertex)
+            if (Decl.ShaderType < GalShaderType.Fragment)
             {
                 SB.AppendLine("layout (location = " + GlslDecl.PositionOutAttrLocation + ") out vec4 " + GlslDecl.PositionOutAttrName + ";");
             }
@@ -337,7 +337,10 @@ namespace Ryujinx.Graphics.Gal.Shader
             if (Decl.ShaderType == GalShaderType.Vertex)
             {
                 SB.AppendLine(IdentationStr + "gl_Position.xy *= " + GlslDecl.FlipUniformName + ";");
+            }
 
+            if (Decl.ShaderType < GalShaderType.Fragment)
+            {
                 SB.AppendLine(IdentationStr + GlslDecl.PositionOutAttrName + " = gl_Position;");
                 SB.AppendLine(IdentationStr + GlslDecl.PositionOutAttrName + ".w = 1;");
             }
@@ -598,9 +601,6 @@ namespace Ryujinx.Graphics.Gal.Shader
         {
             switch (Op.Inst)
             {
-                case ShaderIrInst.Frcp:
-                    return true;
-
                 case ShaderIrInst.Ipa:
                 case ShaderIrInst.Texq:
                 case ShaderIrInst.Texs:
@@ -608,8 +608,7 @@ namespace Ryujinx.Graphics.Gal.Shader
                     return false;
             }
 
-            return Op.OperandB != null ||
-                   Op.OperandC != null;
+            return true;
         }
 
         private string GetName(ShaderIrOperCbuf Cbuf)
@@ -711,13 +710,13 @@ namespace Ryujinx.Graphics.Gal.Shader
             }
             else
             {
-                return Imm.Value.ToString(CultureInfo.InvariantCulture);
+                return GetIntConst(Imm.Value);
             }
         }
 
         private string GetValue(ShaderIrOperImmf Immf)
         {
-            return Immf.Value.ToString(CultureInfo.InvariantCulture);
+            return GetFloatConst(Immf.Value);
         }
 
         private string GetName(ShaderIrOperPred Pred)
@@ -1047,7 +1046,7 @@ namespace Ryujinx.Graphics.Gal.Shader
 
                             if (!float.IsNaN(Value) && !float.IsInfinity(Value))
                             {
-                                return Value.ToString(CultureInfo.InvariantCulture);
+                                return GetFloatConst(Value);
                             }
                         }
                         break;
@@ -1062,6 +1061,20 @@ namespace Ryujinx.Graphics.Gal.Shader
             }
 
             return Expr;
+        }
+
+        private static string GetIntConst(int Value)
+        {
+            string Expr = Value.ToString(CultureInfo.InvariantCulture);
+
+            return Value < 0 ? "(" + Expr + ")" : Expr;
+        }
+
+        private static string GetFloatConst(float Value)
+        {
+            string Expr = Value.ToString(CultureInfo.InvariantCulture);
+
+            return Value < 0 ? "(" + Expr + ")" : Expr;
         }
 
         private static OperType GetDstNodeType(ShaderIrNode Node)

--- a/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3d.cs
+++ b/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3d.cs
@@ -172,6 +172,8 @@ namespace Ryujinx.HLE.Gpu.Engines
 
             for (; Index < 6; Index++)
             {
+                GalShaderType Type = GetTypeFromProgram(Index);
+
                 int Control = ReadRegister(NvGpuEngine3dReg.ShaderNControl + Index * 0x10);
                 int Offset  = ReadRegister(NvGpuEngine3dReg.ShaderNOffset  + Index * 0x10);
 
@@ -180,16 +182,16 @@ namespace Ryujinx.HLE.Gpu.Engines
 
                 if (!Enable)
                 {
+                    Gpu.Renderer.Shader.Unbind(Type);
+
                     continue;
                 }
 
                 long Key = BasePosition + (uint)Offset;
 
-                GalShaderType ShaderType = GetTypeFromProgram(Index);
+                Keys[(int)Type] = Key;
 
-                Keys[(int)ShaderType] = Key;
-
-                Gpu.Renderer.Shader.Create(Vmm, Key, ShaderType);
+                Gpu.Renderer.Shader.Create(Vmm, Key, Type);
                 Gpu.Renderer.Shader.Bind(Key);
             }
 

--- a/Ryujinx.HLE/Gpu/Texture/TextureHelper.cs
+++ b/Ryujinx.HLE/Gpu/Texture/TextureHelper.cs
@@ -62,67 +62,67 @@ namespace Ryujinx.HLE.Gpu.Texture
                 {
                     return CompressedTextureSize(Texture.Width, Texture.Height, 4, 4, 16);
                 }
-                    
+
                 case GalTextureFormat.Astc2D5x5:
                 {
                     return CompressedTextureSize(Texture.Width, Texture.Height, 5, 5, 16);
                 }
-                
+
                 case GalTextureFormat.Astc2D6x6:
                 {
                     return CompressedTextureSize(Texture.Width, Texture.Height, 6, 6, 16);
                 }
-                    
+
                 case GalTextureFormat.Astc2D8x8:
                 {
                     return CompressedTextureSize(Texture.Width, Texture.Height, 8, 8, 16);
                 }
-                    
+
                 case GalTextureFormat.Astc2D10x10:
                 {
                     return CompressedTextureSize(Texture.Width, Texture.Height, 10, 10, 16);
                 }
-                    
+
                 case GalTextureFormat.Astc2D12x12:
                 {
                     return CompressedTextureSize(Texture.Width, Texture.Height, 12, 12, 16);
                 }
-                
+
                 case GalTextureFormat.Astc2D5x4:
                 {
                     return CompressedTextureSize(Texture.Width, Texture.Height, 5, 4, 16);
                 }
-				
+
                 case GalTextureFormat.Astc2D6x5:
                 {
                     return CompressedTextureSize(Texture.Width, Texture.Height, 6, 5, 16);
                 }
-				
+
                 case GalTextureFormat.Astc2D8x6:
                 {
                     return CompressedTextureSize(Texture.Width, Texture.Height, 8, 6, 16);
                 }
-				
+
                 case GalTextureFormat.Astc2D10x8:
                 {
                     return CompressedTextureSize(Texture.Width, Texture.Height, 10, 8, 16);
                 }
-				
+
                 case GalTextureFormat.Astc2D12x10:
                 {
                     return CompressedTextureSize(Texture.Width, Texture.Height, 12, 10, 16);
                 }
-				
+
                 case GalTextureFormat.Astc2D8x5:
                 {
                     return CompressedTextureSize(Texture.Width, Texture.Height, 8, 5, 16);
                 }
-				
+
                 case GalTextureFormat.Astc2D10x5:
                 {
                     return CompressedTextureSize(Texture.Width, Texture.Height, 10, 5, 16);
                 }
-				
+
                 case GalTextureFormat.Astc2D10x6:
                 {
                     return CompressedTextureSize(Texture.Width, Texture.Height, 10, 6, 16);
@@ -139,7 +139,7 @@ namespace Ryujinx.HLE.Gpu.Texture
 
             return W * H * Bpb;
         }
-        
+
         public static (AMemory Memory, long Position) GetMemoryAndPosition(
             IAMemory Memory,
             long     Position)

--- a/Ryujinx.HLE/Gpu/Texture/TextureReader.cs
+++ b/Ryujinx.HLE/Gpu/Texture/TextureReader.cs
@@ -30,7 +30,7 @@ namespace Ryujinx.HLE.Gpu.Texture
                 case GalTextureFormat.Astc2D5x5:    return Read16BptCompressedTexture(Memory, Texture, 5, 5);
                 case GalTextureFormat.Astc2D6x6:    return Read16BptCompressedTexture(Memory, Texture, 6, 6);
                 case GalTextureFormat.Astc2D8x8:    return Read16BptCompressedTexture(Memory, Texture, 8, 8);
-                case GalTextureFormat.Astc2D10x10:  return Read16BptCompressedTexture(Memory, Texture, 10, 10); 
+                case GalTextureFormat.Astc2D10x10:  return Read16BptCompressedTexture(Memory, Texture, 10, 10);
                 case GalTextureFormat.Astc2D12x12:  return Read16BptCompressedTexture(Memory, Texture, 12, 12);
                 case GalTextureFormat.Astc2D5x4:    return Read16BptCompressedTexture(Memory, Texture, 5, 4);
                 case GalTextureFormat.Astc2D6x5:    return Read16BptCompressedTexture(Memory, Texture, 6, 5);


### PR DESCRIPTION
This fixes the following issues:

- There was no method to unbind shaders. So if a game used for example, a geometry shader once and never anymore, it would be still bound. An unbind method was added to allow unbinding the shader when the enable flag is set to 0 on the register.
- Code like `--2` (double negation) is not valid in glsl it seems. GlslDecompiler is now more strict about adding parenthesis, and will add it to all negative constants. So now instead of `--2` it writes `-(-2)`. This also impacts some unary operations that doesn't need it through.
- Reading/writing the built-in gl_Position is valid on geometry shader, so now this is allowed instead of using the `position` varying. It also now writes it aswell. This caused problems before because the fragment shader would try to use that varying without the geometry shader writing it.