### PR TITLE
Add support for ioctl2, SetTimeout and KickoffPbWithAttr

### DIFF
--- a/Ryujinx.HLE/OsHle/Services/Nv/INvDrvServices.cs
+++ b/Ryujinx.HLE/OsHle/Services/Nv/INvDrvServices.cs
@@ -23,11 +23,11 @@ namespace Ryujinx.HLE.OsHle.Services.Nv
         private static Dictionary<string, IoctlProcessor> IoctlProcessors =
                    new Dictionary<string, IoctlProcessor>()
         {
-            { "/dev/nvhost-as-gpu",   ProcessIoctlNvGpuAS       },
-            { "/dev/nvhost-ctrl",     ProcessIoctlNvHostCtrl    },
-            { "/dev/nvhost-ctrl-gpu", ProcessIoctlNvGpuGpu      },
-            { "/dev/nvhost-gpu",      ProcessIoctlNvHostChannel },
-            { "/dev/nvmap",           ProcessIoctlNvMap         }
+            { "/dev/nvhost-as-gpu",   ProcessIoctlNvGpuAS    },
+            { "/dev/nvhost-ctrl",     ProcessIoctlNvHostCtrl },
+            { "/dev/nvhost-ctrl-gpu", ProcessIoctlNvGpuGpu   },
+            { "/dev/nvhost-gpu",      ProcessIoctlNvHostGpu  },
+            { "/dev/nvmap",           ProcessIoctlNvMap      }
         };
 
         public static GlobalStateTable Fds { get; private set; }
@@ -44,6 +44,7 @@ namespace Ryujinx.HLE.OsHle.Services.Nv
                 { 3,  Initialize       },
                 { 4,  QueryEvent       },
                 { 8,  SetClientPid     },
+                { 11, Ioctl            },
                 { 13, FinishInitialize }
             };
 
@@ -162,9 +163,9 @@ namespace Ryujinx.HLE.OsHle.Services.Nv
             return ProcessIoctl(Context, Cmd, NvGpuGpuIoctl.ProcessIoctl);
         }
 
-        private static int ProcessIoctlNvHostChannel(ServiceCtx Context, int Cmd)
+        private static int ProcessIoctlNvHostGpu(ServiceCtx Context, int Cmd)
         {
-            return ProcessIoctl(Context, Cmd, NvHostChannelIoctl.ProcessIoctl);
+            return ProcessIoctl(Context, Cmd, NvHostChannelIoctl.ProcessIoctlGpu);
         }
 
         private static int ProcessIoctlNvMap(ServiceCtx Context, int Cmd)

--- a/Ryujinx.HLE/OsHle/Services/Nv/INvDrvServices.cs
+++ b/Ryujinx.HLE/OsHle/Services/Nv/INvDrvServices.cs
@@ -208,6 +208,8 @@ namespace Ryujinx.HLE.OsHle.Services.Nv
 
             NvGpuASIoctl.UnloadProcess(Process);
 
+            NvHostChannelIoctl.UnloadProcess(Process);
+
             NvHostCtrlIoctl.UnloadProcess(Process);
 
             NvMapIoctl.UnloadProcess(Process);

--- a/Ryujinx.HLE/OsHle/Services/Nv/NvHostChannel/NvChannel.cs
+++ b/Ryujinx.HLE/OsHle/Services/Nv/NvHostChannel/NvChannel.cs
@@ -1,0 +1,7 @@
+namespace Ryujinx.HLE.OsHle.Services.Nv.NvHostChannel
+{
+    class NvChannel
+    {
+        public int Timeout;
+    }
+}

--- a/Ryujinx.HLE/OsHle/Services/Nv/NvHostChannel/NvChannelName.cs
+++ b/Ryujinx.HLE/OsHle/Services/Nv/NvHostChannel/NvChannelName.cs
@@ -1,0 +1,7 @@
+namespace Ryujinx.HLE.OsHle.Services.Nv.NvHostChannel
+{
+    enum NvChannelName
+    {
+        Gpu
+    }
+}

--- a/Ryujinx.HLE/OsHle/Services/Nv/NvHostChannel/NvHostChannelIoctl.cs
+++ b/Ryujinx.HLE/OsHle/Services/Nv/NvHostChannel/NvHostChannelIoctl.cs
@@ -3,23 +3,50 @@ using Ryujinx.HLE.Gpu.Memory;
 using Ryujinx.HLE.Logging;
 using Ryujinx.HLE.OsHle.Services.Nv.NvGpuAS;
 using System;
+using System.Collections.Concurrent;
 
 namespace Ryujinx.HLE.OsHle.Services.Nv.NvHostChannel
 {
     class NvHostChannelIoctl
     {
-        public static int ProcessIoctl(ServiceCtx Context, int Cmd)
+        private class ChannelsPerProcess
+        {
+            public ConcurrentDictionary<NvChannelName, NvChannel> Channels { get; private set; }
+
+            public ChannelsPerProcess()
+            {
+                Channels = new ConcurrentDictionary<NvChannelName, NvChannel>();
+
+                Channels.TryAdd(NvChannelName.Gpu, new NvChannel());
+            }
+        }
+
+        private static ConcurrentDictionary<Process, ChannelsPerProcess> Channels;
+
+        static NvHostChannelIoctl()
+        {
+            Channels = new ConcurrentDictionary<Process, ChannelsPerProcess>();
+        }
+
+        public static int ProcessIoctlGpu(ServiceCtx Context, int Cmd)
+        {
+            return ProcessIoctl(Context, NvChannelName.Gpu, Cmd);
+        }
+
+        public static int ProcessIoctl(ServiceCtx Context, NvChannelName Channel, int Cmd)
         {
             switch (Cmd & 0xffff)
             {
-                case 0x4714: return SetUserData     (Context);
-                case 0x4801: return SetNvMap        (Context);
-                case 0x4808: return SubmitGpfifo    (Context);
-                case 0x4809: return AllocObjCtx     (Context);
-                case 0x480b: return ZcullBind       (Context);
-                case 0x480c: return SetErrorNotifier(Context);
-                case 0x480d: return SetPriority     (Context);
-                case 0x481a: return AllocGpfifoEx2  (Context);
+                case 0x4714: return SetUserData      (Context);
+                case 0x4801: return SetNvMap         (Context);
+                case 0x4803: return SetTimeout       (Context, Channel);
+                case 0x4808: return SubmitGpfifo     (Context);
+                case 0x4809: return AllocObjCtx      (Context);
+                case 0x480b: return ZcullBind        (Context);
+                case 0x480c: return SetErrorNotifier (Context);
+                case 0x480d: return SetPriority      (Context);
+                case 0x481a: return AllocGpfifoEx2   (Context);
+                case 0x481b: return KickoffPbWithAttr(Context);
             }
 
             throw new NotImplementedException(Cmd.ToString("x8"));
@@ -45,6 +72,15 @@ namespace Ryujinx.HLE.OsHle.Services.Nv.NvHostChannel
             return NvResult.Success;
         }
 
+        private static int SetTimeout(ServiceCtx Context, NvChannelName Channel)
+        {
+            long InputPosition = Context.Request.GetBufferType0x21().Position;
+
+            GetChannel(Context, Channel).Timeout = Context.Memory.ReadInt32(InputPosition);
+
+            return NvResult.Success;
+        }
+
         private static int SubmitGpfifo(ServiceCtx Context)
         {
             long InputPosition  = Context.Request.GetBufferType0x21().Position;
@@ -58,15 +94,7 @@ namespace Ryujinx.HLE.OsHle.Services.Nv.NvHostChannel
             {
                 long Gpfifo = Context.Memory.ReadInt64(InputPosition + 0x18 + Index * 8);
 
-                long VA = Gpfifo & 0xff_ffff_ffff;
-
-                int Size = (int)(Gpfifo >> 40) & 0x7ffffc;
-
-                byte[] Data = Vmm.ReadBytes(VA, Size);
-
-                NvGpuPBEntry[] PushBuffer = NvGpuPushBuffer.Decode(Data);
-
-                Context.Ns.Gpu.Fifo.PushBuffer(Vmm, PushBuffer);
+                PushGpfifo(Context, Vmm, Gpfifo);
             }
 
             Args.SyncptId    = 0;
@@ -125,6 +153,58 @@ namespace Ryujinx.HLE.OsHle.Services.Nv.NvHostChannel
             Context.Ns.Log.PrintStub(LogClass.ServiceNv, "Stubbed.");
 
             return NvResult.Success;
+        }
+
+        private static int KickoffPbWithAttr(ServiceCtx Context)
+        {
+            long InputPosition  = Context.Request.GetBufferType0x21().Position;
+            long OutputPosition = Context.Request.GetBufferType0x22().Position;
+
+            NvHostChannelSubmitGpfifo Args = AMemoryHelper.Read<NvHostChannelSubmitGpfifo>(Context.Memory, InputPosition);
+
+            NvGpuVmm Vmm = NvGpuASIoctl.GetVmm(Context);
+
+            for (int Index = 0; Index < Args.NumEntries; Index++)
+            {
+                long Gpfifo = Context.Memory.ReadInt64(Args.Address + Index * 8);
+
+                PushGpfifo(Context, Vmm, Gpfifo);
+            }
+
+            Args.SyncptId    = 0;
+            Args.SyncptValue = 0;
+
+            AMemoryHelper.Write(Context.Memory, OutputPosition, Args);
+
+            return NvResult.Success;
+        }
+
+        private static void PushGpfifo(ServiceCtx Context, NvGpuVmm Vmm, long Gpfifo)
+        {
+            long VA = Gpfifo & 0xff_ffff_ffff;
+
+            int Size = (int)(Gpfifo >> 40) & 0x7ffffc;
+
+            byte[] Data = Vmm.ReadBytes(VA, Size);
+
+            NvGpuPBEntry[] PushBuffer = NvGpuPushBuffer.Decode(Data);
+
+            Context.Ns.Gpu.Fifo.PushBuffer(Vmm, PushBuffer);
+        }
+
+        public static NvChannel GetChannel(ServiceCtx Context, NvChannelName Channel)
+        {
+            ChannelsPerProcess Cpp = Channels.GetOrAdd(Context.Process, (Key) =>
+            {
+                return new ChannelsPerProcess();
+            });
+
+            return Cpp.Channels[Channel];
+        }
+
+        public static void UnloadProcess(Process Process)
+        {
+            Channels.TryRemove(Process, out _);
         }
     }
 }

--- a/Ryujinx.HLE/OsHle/Services/Nv/NvHostChannel/NvHostChannelSubmitGpfifo.cs
+++ b/Ryujinx.HLE/OsHle/Services/Nv/NvHostChannel/NvHostChannelSubmitGpfifo.cs
@@ -2,7 +2,7 @@ namespace Ryujinx.HLE.OsHle.Services.Nv.NvHostChannel
 {
     struct NvHostChannelSubmitGpfifo
     {
-        public long Gpfifo;
+        public long Address;
         public int  NumEntries;
         public int  Flags;
         public int  SyncptId;


### PR DESCRIPTION
This adds support for Ioctl2 and a few ioctls that are used by newer games.

- Ioctl2 seems to be used with a few ioctls. It seems to be used when the buffer being sent contains cpu addresses (not mapped on the gpu). We can just use Ioctl directly in this case.
- KickoffPbWithAttr does basically the same thing that SubmitGpfifo does, but instead of sending inline data on the struct, it reads the data pointed to by the address located at 0x0.

I also went ahead and did the initial work to enable multiple channels to share the same methods on NvHostChannelIoctl (mostly for SetTimeout).