### PR TITLE
Allow using ulong max value as yield

### DIFF
--- a/Ryujinx.HLE/OsHle/Kernel/SvcThread.cs
+++ b/Ryujinx.HLE/OsHle/Kernel/SvcThread.cs
@@ -87,7 +87,7 @@ namespace Ryujinx.HLE.OsHle.Kernel
 
             KThread CurrThread = Process.GetThread(ThreadState.Tpidr);
 
-            if (TimeoutNs == 0)
+            if (TimeoutNs == 0 || TimeoutNs == ulong.MaxValue)
             {
                 Process.Scheduler.Yield(CurrThread);
             }


### PR DESCRIPTION
Newer games uses 0xFFFFFFFFFFFFFFFF instead of 0 as yield. I believe that the new kernel allows that (maybe to be more inline with the other svcs were ulong max usually has a different behavior).