### PR TITLE
Zero out bits 63:32 of scalar float operations with SSE intrinsics

### DIFF
--- a/ChocolArm64/Instruction/AInstEmitSimdArithmetic.cs
+++ b/ChocolArm64/Instruction/AInstEmitSimdArithmetic.cs
@@ -234,7 +234,7 @@ namespace ChocolArm64.Instruction
         {
             if (AOptimizations.UseSse && AOptimizations.UseSse2)
             {
-                EmitSseOrSse2CallF(Context, nameof(Sse.AddScalar));
+                EmitScalarSseOrSse2CallF(Context, nameof(Sse.AddScalar));
             }
             else
             {
@@ -246,7 +246,7 @@ namespace ChocolArm64.Instruction
         {
             if (AOptimizations.UseSse && AOptimizations.UseSse2)
             {
-                EmitSseOrSse2CallF(Context, nameof(Sse.Add));
+                EmitVectorSseOrSse2CallF(Context, nameof(Sse.Add));
             }
             else
             {
@@ -304,7 +304,7 @@ namespace ChocolArm64.Instruction
         {
             if (AOptimizations.UseSse && AOptimizations.UseSse2)
             {
-                EmitSseOrSse2CallF(Context, nameof(Sse.DivideScalar));
+                EmitScalarSseOrSse2CallF(Context, nameof(Sse.DivideScalar));
             }
             else
             {
@@ -316,7 +316,7 @@ namespace ChocolArm64.Instruction
         {
             if (AOptimizations.UseSse && AOptimizations.UseSse2)
             {
-                EmitSseOrSse2CallF(Context, nameof(Sse.Divide));
+                EmitVectorSseOrSse2CallF(Context, nameof(Sse.Divide));
             }
             else
             {
@@ -487,7 +487,7 @@ namespace ChocolArm64.Instruction
         {
             if (AOptimizations.UseSse && AOptimizations.UseSse2)
             {
-                EmitSseOrSse2CallF(Context, nameof(Sse.MultiplyScalar));
+                EmitScalarSseOrSse2CallF(Context, nameof(Sse.MultiplyScalar));
             }
             else
             {
@@ -504,7 +504,7 @@ namespace ChocolArm64.Instruction
         {
             if (AOptimizations.UseSse && AOptimizations.UseSse2)
             {
-                EmitSseOrSse2CallF(Context, nameof(Sse.Multiply));
+                EmitVectorSseOrSse2CallF(Context, nameof(Sse.Multiply));
             }
             else
             {
@@ -871,7 +871,7 @@ namespace ChocolArm64.Instruction
         {
             if (AOptimizations.UseSse && AOptimizations.UseSse2)
             {
-                EmitSseOrSse2CallF(Context, nameof(Sse.SubtractScalar));
+                EmitScalarSseOrSse2CallF(Context, nameof(Sse.SubtractScalar));
             }
             else
             {
@@ -883,7 +883,7 @@ namespace ChocolArm64.Instruction
         {
             if (AOptimizations.UseSse && AOptimizations.UseSse2)
             {
-                EmitSseOrSse2CallF(Context, nameof(Sse.Subtract));
+                EmitVectorSseOrSse2CallF(Context, nameof(Sse.Subtract));
             }
             else
             {

--- a/ChocolArm64/Instruction/AInstEmitSimdCmp.cs
+++ b/ChocolArm64/Instruction/AInstEmitSimdCmp.cs
@@ -158,7 +158,7 @@ namespace ChocolArm64.Instruction
             if (Context.CurrOp is AOpCodeSimdReg && AOptimizations.UseSse
                                                  && AOptimizations.UseSse2)
             {
-                EmitSseOrSse2CallF(Context, nameof(Sse.CompareEqualScalar));
+                EmitScalarSseOrSse2CallF(Context, nameof(Sse.CompareEqualScalar));
             }
             else
             {
@@ -171,7 +171,7 @@ namespace ChocolArm64.Instruction
             if (Context.CurrOp is AOpCodeSimdReg && AOptimizations.UseSse
                                                  && AOptimizations.UseSse2)
             {
-                EmitSseOrSse2CallF(Context, nameof(Sse.CompareEqual));
+                EmitVectorSseOrSse2CallF(Context, nameof(Sse.CompareEqual));
             }
             else
             {
@@ -184,7 +184,7 @@ namespace ChocolArm64.Instruction
             if (Context.CurrOp is AOpCodeSimdReg && AOptimizations.UseSse
                                                  && AOptimizations.UseSse2)
             {
-                EmitSseOrSse2CallF(Context, nameof(Sse.CompareGreaterThanOrEqualScalar));
+                EmitScalarSseOrSse2CallF(Context, nameof(Sse.CompareGreaterThanOrEqualScalar));
             }
             else
             {
@@ -197,7 +197,7 @@ namespace ChocolArm64.Instruction
             if (Context.CurrOp is AOpCodeSimdReg && AOptimizations.UseSse
                                                  && AOptimizations.UseSse2)
             {
-                EmitSseOrSse2CallF(Context, nameof(Sse.CompareGreaterThanOrEqual));
+                EmitVectorSseOrSse2CallF(Context, nameof(Sse.CompareGreaterThanOrEqual));
             }
             else
             {
@@ -210,7 +210,7 @@ namespace ChocolArm64.Instruction
             if (Context.CurrOp is AOpCodeSimdReg && AOptimizations.UseSse
                                                  && AOptimizations.UseSse2)
             {
-                EmitSseOrSse2CallF(Context, nameof(Sse.CompareGreaterThanScalar));
+                EmitScalarSseOrSse2CallF(Context, nameof(Sse.CompareGreaterThanScalar));
             }
             else
             {
@@ -223,7 +223,7 @@ namespace ChocolArm64.Instruction
             if (Context.CurrOp is AOpCodeSimdReg && AOptimizations.UseSse
                                                  && AOptimizations.UseSse2)
             {
-                EmitSseOrSse2CallF(Context, nameof(Sse.CompareGreaterThan));
+                EmitVectorSseOrSse2CallF(Context, nameof(Sse.CompareGreaterThan));
             }
             else
             {

--- a/ChocolArm64/Instruction/AInstEmitSimdHelper.cs
+++ b/ChocolArm64/Instruction/AInstEmitSimdHelper.cs
@@ -110,7 +110,17 @@ namespace ChocolArm64.Instruction
             }
         }
 
-        public static void EmitSseOrSse2CallF(AILEmitterCtx Context, string Name)
+        public static void EmitScalarSseOrSse2CallF(AILEmitterCtx Context, string Name)
+        {
+            EmitSseOrSse2CallF(Context, Name, true);
+        }
+
+        public static void EmitVectorSseOrSse2CallF(AILEmitterCtx Context, string Name)
+        {
+            EmitSseOrSse2CallF(Context, Name, false);
+        }
+
+        public static void EmitSseOrSse2CallF(AILEmitterCtx Context, string Name, bool Scalar)
         {
             AOpCodeSimd Op = (AOpCodeSimd)Context.CurrOp;
 
@@ -160,7 +170,18 @@ namespace ChocolArm64.Instruction
 
             Context.EmitStvec(Op.Rd);
 
-            if (Op.RegisterSize == ARegisterSize.SIMD64)
+            if (Scalar)
+            {
+                if (SizeF == 0)
+                {
+                    EmitVectorZero32_128(Context, Op.Rd);
+                }
+                else /* if (SizeF == 1) */
+                {
+                    EmitVectorZeroUpper(Context, Op.Rd);
+                }
+            }
+            else if (Op.RegisterSize == ARegisterSize.SIMD64)
             {
                 EmitVectorZeroUpper(Context, Op.Rd);
             }
@@ -966,6 +987,15 @@ namespace ChocolArm64.Instruction
         public static void EmitVectorZeroUpper(AILEmitterCtx Context, int Rd)
         {
             EmitVectorInsert(Context, Rd, 1, 3, 0);
+        }
+
+        public static void EmitVectorZero32_128(AILEmitterCtx Context, int Reg)
+        {
+            Context.EmitLdvec(Reg);
+
+            AVectorHelper.EmitCall(Context, nameof(AVectorHelper.VectorZero32_128));
+
+            Context.EmitStvec(Reg);
         }
 
         public static void EmitVectorInsert(AILEmitterCtx Context, int Reg, int Index, int Size)

--- a/ChocolArm64/Instruction/AVectorHelper.cs
+++ b/ChocolArm64/Instruction/AVectorHelper.cs
@@ -9,6 +9,18 @@ namespace ChocolArm64.Instruction
 {
     static class AVectorHelper
     {
+        private static readonly Vector128<float> Zero32_128Mask;
+
+        static AVectorHelper()
+        {
+            if (!Sse2.IsSupported)
+            {
+                throw new PlatformNotSupportedException();
+            }
+
+            Zero32_128Mask = Sse.StaticCast<uint, float>(Sse2.SetVector128(0, 0, 0, 0xffffffff));
+        }
+
         public static void EmitCall(AILEmitterCtx Context, string Name64, string Name128)
         {
             bool IsSimd64 = Context.CurrOp.RegisterSize == ARegisterSize.SIMD64;
@@ -523,6 +535,17 @@ namespace ChocolArm64.Instruction
                 ShortVector = Sse2.Insert(ShortVector, High, (byte)(Index * 2 + 1));
 
                 return Sse.StaticCast<ushort, float>(ShortVector);
+            }
+
+            throw new PlatformNotSupportedException();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<float> VectorZero32_128(Vector128<float> Vector)
+        {
+            if (Sse.IsSupported)
+            {
+                return Sse.And(Vector, Zero32_128Mask);
             }
 
             throw new PlatformNotSupportedException();


### PR DESCRIPTION
On ARM, all scalar operations will set the unused bits to zero. So on a float scalar operation, bits 31:0 are set to the scalar result, and bits 127:32 are set to 0. On x86 however this doesn't happen, instead it uses the value at the first operand. This was not taken into account when using the SSE intrinsics, and only the zero upper method was being called, which means that only bits 127:64 were zeroed, and bits 63:32 could still contain "garbage". This introduces a new method `VectorZero32_128` that is used to zero out all needed bits for float operations, and for double operations `VectorZeroUpper` is used.

It's unlikely that applications were affected by this unless it accesses the upper bits for some reason. This still needs testing (althrough I ran some games with it and didn't see any regressions).