### PR TITLE
Send data to OpenGL host without client-side copies

### DIFF
--- a/ChocolArm64/Memory/AMemory.cs
+++ b/ChocolArm64/Memory/AMemory.cs
@@ -204,6 +204,11 @@ namespace ChocolArm64.Memory
             return Modified;
         }
 
+        public IntPtr GetHostAddress(long Position)
+        {
+            return (IntPtr)(RamPtr + (ulong)Position);
+        }
+
         public sbyte ReadSByte(long Position)
         {
             return (sbyte)ReadByte(Position);

--- a/ChocolArm64/Memory/AMemory.cs
+++ b/ChocolArm64/Memory/AMemory.cs
@@ -204,8 +204,10 @@ namespace ChocolArm64.Memory
             return Modified;
         }
 
-        public IntPtr GetHostAddress(long Position)
+        public IntPtr GetHostAddress(long Position, long Size)
         {
+            EnsureRangeIsValid(Position, Size, AMemoryPerm.Read);
+
             return (IntPtr)(RamPtr + (ulong)Position);
         }
 

--- a/Ryujinx.Graphics/Gal/IGalRasterizer.cs
+++ b/Ryujinx.Graphics/Gal/IGalRasterizer.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Ryujinx.Graphics.Gal
 {
     public interface IGalRasterizer
@@ -45,9 +47,9 @@ namespace Ryujinx.Graphics.Gal
 
         void SetPrimitiveRestartIndex(uint Index);
 
-        void CreateVbo(long Key, byte[] Buffer);
+        void CreateVbo(long Key, int DataSize, IntPtr HostAddress);
 
-        void CreateIbo(long Key, byte[] Buffer);
+        void CreateIbo(long Key, int DataSize, IntPtr HostAddress);
 
         void SetVertexArray(int Stride, long VboKey, GalVertexAttrib[] Attribs);
 

--- a/Ryujinx.Graphics/Gal/IGalShader.cs
+++ b/Ryujinx.Graphics/Gal/IGalShader.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Ryujinx.Graphics.Gal
@@ -10,7 +11,7 @@ namespace Ryujinx.Graphics.Gal
 
         IEnumerable<ShaderDeclInfo> GetTextureUsage(long Key);
 
-        void SetConstBuffer(long Key, int Cbuf, byte[] Data);
+        void SetConstBuffer(long Key, int Cbuf, int DataSize, IntPtr HostAddress);
 
         void EnsureTextureBinding(string UniformName, int Value);
 

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLRasterizer.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLRasterizer.cs
@@ -211,28 +211,28 @@ namespace Ryujinx.Graphics.Gal.OpenGL
             GL.PrimitiveRestartIndex(Index);
         }
 
-        public void CreateVbo(long Key, byte[] Buffer)
+        public void CreateVbo(long Key, int DataSize, IntPtr HostAddress)
         {
             int Handle = GL.GenBuffer();
 
-            VboCache.AddOrUpdate(Key, Handle, (uint)Buffer.Length);
+            VboCache.AddOrUpdate(Key, Handle, (uint)DataSize);
 
-            IntPtr Length = new IntPtr(Buffer.Length);
+            IntPtr Length = new IntPtr(DataSize);
 
             GL.BindBuffer(BufferTarget.ArrayBuffer, Handle);
-            GL.BufferData(BufferTarget.ArrayBuffer, Length, Buffer, BufferUsageHint.StreamDraw);
+            GL.BufferData(BufferTarget.ArrayBuffer, Length, HostAddress, BufferUsageHint.StreamDraw);
         }
 
-        public void CreateIbo(long Key, byte[] Buffer)
+        public void CreateIbo(long Key, int DataSize, IntPtr HostAddress)
         {
             int Handle = GL.GenBuffer();
 
-            IboCache.AddOrUpdate(Key, Handle, (uint)Buffer.Length);
+            IboCache.AddOrUpdate(Key, Handle, (uint)DataSize);
 
-            IntPtr Length = new IntPtr(Buffer.Length);
+            IntPtr Length = new IntPtr(DataSize);
 
             GL.BindBuffer(BufferTarget.ElementArrayBuffer, Handle);
-            GL.BufferData(BufferTarget.ElementArrayBuffer, Length, Buffer, BufferUsageHint.StreamDraw);
+            GL.BufferData(BufferTarget.ElementArrayBuffer, Length, HostAddress, BufferUsageHint.StreamDraw);
         }
 
         public void SetVertexArray(int Stride, long VboKey, GalVertexAttrib[] Attribs)

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLShader.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLShader.cs
@@ -245,14 +245,11 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 Programs.Add(Current, Handle);
             }
 
-            if (Handle != CurrentProgramHandle)
-            {
-                GL.UseProgram(Handle);
+            GL.UseProgram(Handle);
 
-                BindUniformBuffers(Handle);
+            BindUniformBuffers(Handle);
 
-                CurrentProgramHandle = Handle;
-            }
+            CurrentProgramHandle = Handle;
         }
 
         private void AttachIfNotNull(int ProgramHandle, ShaderStage Stage)

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLShader.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLShader.cs
@@ -245,11 +245,14 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 Programs.Add(Current, Handle);
             }
 
-            GL.UseProgram(Handle);
+            if (Handle != CurrentProgramHandle)
+            {
+                GL.UseProgram(Handle);
 
-            BindUniformBuffers(Handle);
+                BindUniformBuffers(Handle);
 
-            CurrentProgramHandle = Handle;
+                CurrentProgramHandle = Handle;
+            }
         }
 
         private void AttachIfNotNull(int ProgramHandle, ShaderStage Stage)
@@ -266,7 +269,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
         {
             int FreeBinding = 0;
 
-            int BindUniformBlocksIfNotNull(ShaderStage Stage)
+            void BindUniformBlocksIfNotNull(ShaderStage Stage)
             {
                 if (Stage != null)
                 {
@@ -285,8 +288,6 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                         FreeBinding++;
                     }
                 }
-
-                return FreeBinding;
             }
 
             BindUniformBlocksIfNotNull(Current.Vertex);
@@ -300,7 +301,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
         {
             int FreeBinding = 0;
 
-            int BindUniformBuffersIfNotNull(ShaderStage Stage)
+            void BindUniformBuffersIfNotNull(ShaderStage Stage)
             {
                 if (Stage != null)
                 {
@@ -313,8 +314,6 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                         FreeBinding++;
                     }
                 }
-
-                return FreeBinding;
             }
 
             BindUniformBuffersIfNotNull(Current.Vertex);

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLStreamBuffer.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLStreamBuffer.cs
@@ -1,9 +1,9 @@
-using System;
 using OpenTK.Graphics.OpenGL;
+using System;
 
 namespace Ryujinx.Graphics.Gal.OpenGL
 {
-    abstract class OGLStreamBuffer : IDisposable
+    class OGLStreamBuffer : IDisposable
     {
         public int Handle { get; protected set; }
 
@@ -11,52 +11,24 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
         protected BufferTarget Target { get; private set; }
 
-        private bool Mapped = false;
-
-        public OGLStreamBuffer(BufferTarget Target, int MaxSize)
+        public OGLStreamBuffer(BufferTarget Target, int Size)
         {
-            Handle = 0;
-            Mapped = false;
-
             this.Target = Target;
-            this.Size = MaxSize;
+            this.Size   = Size;
+
+            Handle = GL.GenBuffer();
+
+            GL.BindBuffer(Target, Handle);
+
+            GL.BufferData(Target, Size, IntPtr.Zero, BufferUsageHint.StreamDraw);
         }
 
-        public static OGLStreamBuffer Create(BufferTarget Target, int MaxSize)
+        public void SetData(int Size, IntPtr HostAddress)
         {
-            //TODO: Query here for ARB_buffer_storage and use when available
-            return new SubDataBuffer(Target, MaxSize);
+            GL.BindBuffer(Target, Handle);
+
+            GL.BufferSubData(Target, IntPtr.Zero, Size, HostAddress);
         }
-
-        public byte[] Map(int Size)
-        {
-            if (Handle == 0 || Mapped || Size > this.Size)
-            {
-                throw new InvalidOperationException();
-            }
-
-            byte[] Memory = InternMap(Size);
-
-            Mapped = true;
-
-            return Memory;
-        }
-
-        public void Unmap(int UsedSize)
-        {
-            if (Handle == 0 || !Mapped)
-            {
-                throw new InvalidOperationException();
-            }
-
-            InternUnmap(UsedSize);
-
-            Mapped = false;
-        }
-
-        protected abstract byte[] InternMap(int Size);
-
-        protected abstract void InternUnmap(int UsedSize);
 
         public void Dispose()
         {
@@ -70,43 +42,6 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 GL.DeleteBuffer(Handle);
 
                 Handle = 0;
-            }
-        }
-    }
-
-    class SubDataBuffer : OGLStreamBuffer
-    {
-        private byte[] Memory;
-
-        public SubDataBuffer(BufferTarget Target, int MaxSize)
-            : base(Target, MaxSize)
-        {
-            Memory = new byte[MaxSize];
-
-            GL.GenBuffers(1, out int Handle);
-
-            GL.BindBuffer(Target, Handle);
-
-            GL.BufferData(Target, Size, IntPtr.Zero, BufferUsageHint.StreamDraw);
-
-            this.Handle = Handle;
-        }
-
-        protected override byte[] InternMap(int Size)
-        {
-            return Memory;
-        }
-
-        protected override void InternUnmap(int UsedSize)
-        {
-            GL.BindBuffer(Target, Handle);
-            
-            unsafe
-            {
-                fixed (byte* MemoryPtr = Memory)
-                {
-                    GL.BufferSubData(Target, IntPtr.Zero, UsedSize, (IntPtr)MemoryPtr);
-                }
             }
         }
     }

--- a/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3d.cs
+++ b/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3d.cs
@@ -548,7 +548,7 @@ namespace Ryujinx.HLE.Gpu.Engines
 
                     if (Cb.Enabled)
                     {
-                        IntPtr DataAddress = Vmm.GetHostAddress(Cb.Position);
+                        IntPtr DataAddress = Vmm.GetHostAddress(Cb.Position, Cb.Size);
 
                         Gpu.Renderer.Shader.SetConstBuffer(BasePosition + (uint)Offset, Cbuf, Cb.Size, DataAddress);
                     }
@@ -583,7 +583,7 @@ namespace Ryujinx.HLE.Gpu.Engines
 
                 if (!IboCached || Vmm.IsRegionModified(IboKey, (uint)IbSize, NvGpuBufferType.Index))
                 {
-                    IntPtr DataAddress = Vmm.GetHostAddress(IndexPosition);
+                    IntPtr DataAddress = Vmm.GetHostAddress(IndexPosition, IbSize);
 
                     Gpu.Renderer.Rasterizer.CreateIbo(IboKey, IbSize, DataAddress);
                 }
@@ -647,7 +647,7 @@ namespace Ryujinx.HLE.Gpu.Engines
 
                 if (!VboCached || Vmm.IsRegionModified(VboKey, VbSize, NvGpuBufferType.Vertex))
                 {
-                    IntPtr DataAddress = Vmm.GetHostAddress(VertexPosition);
+                    IntPtr DataAddress = Vmm.GetHostAddress(VertexPosition, VbSize);
 
                     Gpu.Renderer.Rasterizer.CreateVbo(VboKey, (int)VbSize, DataAddress);
                 }

--- a/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3d.cs
+++ b/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3d.cs
@@ -583,9 +583,9 @@ namespace Ryujinx.HLE.Gpu.Engines
 
                 if (!IboCached || Vmm.IsRegionModified(IboKey, (uint)IbSize, NvGpuBufferType.Index))
                 {
-                    byte[] Data = Vmm.ReadBytes(IndexPosition, (uint)IbSize);
+                    IntPtr DataAddress = Vmm.GetHostAddress(IndexPosition);
 
-                    Gpu.Renderer.Rasterizer.CreateIbo(IboKey, Data);
+                    Gpu.Renderer.Rasterizer.CreateIbo(IboKey, IbSize, DataAddress);
                 }
 
                 Gpu.Renderer.Rasterizer.SetIndexArray(IbSize, IndexFormat);
@@ -647,9 +647,9 @@ namespace Ryujinx.HLE.Gpu.Engines
 
                 if (!VboCached || Vmm.IsRegionModified(VboKey, VbSize, NvGpuBufferType.Vertex))
                 {
-                    byte[] Data = Vmm.ReadBytes(VertexPosition, VbSize);
+                    IntPtr DataAddress = Vmm.GetHostAddress(VertexPosition);
 
-                    Gpu.Renderer.Rasterizer.CreateVbo(VboKey, Data);
+                    Gpu.Renderer.Rasterizer.CreateVbo(VboKey, (int)VbSize, DataAddress);
                 }
 
                 Gpu.Renderer.Rasterizer.SetVertexArray(Stride, VboKey, Attribs[Index].ToArray());

--- a/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3d.cs
+++ b/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3d.cs
@@ -548,9 +548,9 @@ namespace Ryujinx.HLE.Gpu.Engines
 
                     if (Cb.Enabled)
                     {
-                        byte[] Data = Vmm.ReadBytes(Cb.Position, (uint)Cb.Size);
+                        IntPtr DataAddress = Vmm.GetHostAddress(Cb.Position);
 
-                        Gpu.Renderer.Shader.SetConstBuffer(BasePosition + (uint)Offset, Cbuf, Data);
+                        Gpu.Renderer.Shader.SetConstBuffer(BasePosition + (uint)Offset, Cbuf, Cb.Size, DataAddress);
                     }
                 }
             }

--- a/Ryujinx.HLE/Gpu/Memory/NvGpuVmm.cs
+++ b/Ryujinx.HLE/Gpu/Memory/NvGpuVmm.cs
@@ -1,5 +1,6 @@
 using ChocolArm64.Memory;
 using Ryujinx.Graphics.Gal;
+using System;
 using System.Collections.Concurrent;
 
 namespace Ryujinx.HLE.Gpu.Memory
@@ -277,6 +278,11 @@ namespace Ryujinx.HLE.Gpu.Memory
         public bool IsRegionModified(long PA, long Size, NvGpuBufferType BufferType)
         {
             return Cache.IsRegionModified(Memory, BufferType, PA, Size);
+        }
+
+        public IntPtr GetHostAddress(long Position)
+        {
+            return Memory.GetHostAddress(GetPhysicalAddress(Position));
         }
 
         public byte ReadByte(long Position)

--- a/Ryujinx.HLE/Gpu/Memory/NvGpuVmm.cs
+++ b/Ryujinx.HLE/Gpu/Memory/NvGpuVmm.cs
@@ -280,9 +280,9 @@ namespace Ryujinx.HLE.Gpu.Memory
             return Cache.IsRegionModified(Memory, BufferType, PA, Size);
         }
 
-        public IntPtr GetHostAddress(long Position)
+        public IntPtr GetHostAddress(long Position, long Size)
         {
-            return Memory.GetHostAddress(GetPhysicalAddress(Position));
+            return Memory.GetHostAddress(GetPhysicalAddress(Position), Size);
         }
 
         public byte ReadByte(long Position)


### PR DESCRIPTION
Currently there are three copies being made before data is sent to the GPU:
1. Vmm.ReadBytes copies to a temporary byte[]
2. Gal copies from that byte[] into a buffer in OGLStreamBuffer (cbuf-only step)
3. Buffer is then sent to the OpenGL server
4. The OpenGL driver probably copies it to a temporary address and then sends it to the GPU

Instead of that, this PR gets host memory address and sends that to the OpenGL server (skipping 1 and 2).