### PR TITLE
.gitignore: ignore Ryujinx/Properties folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,7 @@ ClientBin/
 *.publishsettings
 packages/*
 *.config
+Ryujinx/Properties/
 
 # RIA/Silverlight projects
 Generated_Code/


### PR DESCRIPTION
VS 2017 creates file `Ryujinx\Properties\launchSettings.json` if I change debug properties in IDE. This PR ignore this folder as autogenerated