### PR TITLE
.gitignore: ignore autogenerated launchSettings.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ $RECYCLE.BIN/
 
 # Mac desktop service store files
 .DS_Store
+
+# VS Launch Settings
+launchSettings.json


### PR DESCRIPTION
VS 2017 creates file Ryujinx\Properties\launchSettings.json while changing debug properties in IDE. This PR ignores this file

thanks to @Cyuubi