### PR TITLE
Some fixes to IRequest on NIFM, support sending objects to services

### DIFF
--- a/Ryujinx.HLE/OsHle/Ipc/IpcHandleDesc.cs
+++ b/Ryujinx.HLE/OsHle/Ipc/IpcHandleDesc.cs
@@ -47,13 +47,15 @@ namespace Ryujinx.HLE.OsHle.Ipc
             HasPId = true;
         }
 
-        public static IpcHandleDesc MakeCopy(int Handle) => new IpcHandleDesc(
-                new int[] { Handle },
-                new int[0]);
+        public static IpcHandleDesc MakeCopy(params int[] Handles)
+        {
+            return new IpcHandleDesc(Handles, new int[0]);
+        }
 
-        public static IpcHandleDesc MakeMove(int Handle) => new IpcHandleDesc(
-                new int[0],
-                new int[] { Handle });
+        public static IpcHandleDesc MakeMove(params int[] Handles)
+        {
+            return new IpcHandleDesc(new int[0], Handles);
+        }
 
         public byte[] GetBytes()
         {

--- a/Ryujinx.HLE/OsHle/Ipc/IpcMessage.cs
+++ b/Ryujinx.HLE/OsHle/Ipc/IpcMessage.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.HLE.OsHle.Ipc
         public List<IpcBuffDesc>         ExchangeBuff { get; private set; }
         public List<IpcRecvListBuffDesc> RecvListBuff { get; private set; }
 
-        public List<int> ResponseObjIds { get; private set; }
+        public List<int> ObjectIds { get; private set; }
 
         public byte[] RawData { get; set; }
 
@@ -27,7 +27,7 @@ namespace Ryujinx.HLE.OsHle.Ipc
             ExchangeBuff = new List<IpcBuffDesc>();
             RecvListBuff = new List<IpcRecvListBuffDesc>();
 
-            ResponseObjIds = new List<int>();
+            ObjectIds = new List<int>();
         }
 
         public IpcMessage(byte[] Data, long CmdPtr) : this()

--- a/Ryujinx.HLE/OsHle/Services/Nifm/IRequest.cs
+++ b/Ryujinx.HLE/OsHle/Services/Nifm/IRequest.cs
@@ -12,7 +12,8 @@ namespace Ryujinx.HLE.OsHle.Services.Nifm
 
         public override IReadOnlyDictionary<int, ServiceProcessRequest> Commands => m_Commands;
 
-        private KEvent Event;
+        private KEvent Event0;
+        private KEvent Event1;
 
         public IRequest()
         {
@@ -26,12 +27,13 @@ namespace Ryujinx.HLE.OsHle.Services.Nifm
                 { 11, SetConnectionConfirmationOption }
             };
 
-            Event = new KEvent();
+            Event0 = new KEvent();
+            Event1 = new KEvent();
         }
 
         public long GetRequestState(ServiceCtx Context)
         {
-            Context.ResponseData.Write(0);
+            Context.ResponseData.Write(1);
 
             Context.Ns.Log.PrintStub(LogClass.ServiceNifm, "Stubbed.");
 
@@ -45,13 +47,12 @@ namespace Ryujinx.HLE.OsHle.Services.Nifm
             return 0;
         }
 
-        //GetSystemEventReadableHandles() -> (KObject, KObject)
         public long GetSystemEventReadableHandles(ServiceCtx Context)
         {
-            //FIXME: Is this supposed to return 2 events?
-            int Handle = Context.Process.HandleTable.OpenHandle(Event);
+            int Handle0 = Context.Process.HandleTable.OpenHandle(Event0);
+            int Handle1 = Context.Process.HandleTable.OpenHandle(Event1);
 
-            Context.Response.HandleDesc = IpcHandleDesc.MakeMove(Handle);
+            Context.Response.HandleDesc = IpcHandleDesc.MakeCopy(Handle0, Handle1);
 
             return 0;
         }
@@ -86,7 +87,8 @@ namespace Ryujinx.HLE.OsHle.Services.Nifm
         {
             if (Disposing)
             {
-                Event.Dispose();
+                Event0.Dispose();
+                Event1.Dispose();
             }
         }
     }


### PR DESCRIPTION
This fixes the invalid handle 0x00000000 spam on cave story and maybe other games, also adds the `GetObject` method that can be used to read objects send from user to services, needed by functions PushInData and others.

Had to change the `GetRequestState` from 0 to 1, otherwise cave story would just freeze calling it forever. Not sure about what the value means through, but I do believe it was working before because the event was wrong aswell.