### PR TITLE
Avoid calling buffer binding when shader didn't change

### DIFF
--- a/Ryujinx.Graphics/Gal/OpenGL/OGLShader.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLShader.cs
@@ -257,7 +257,10 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
             GL.UseProgram(Handle);
 
-            BindUniformBuffers(Handle);
+            if (CurrentProgramHandle != Handle)
+            {
+                BindUniformBuffers(Handle);
+            }
 
             CurrentProgramHandle = Handle;
         }


### PR DESCRIPTION
It should give a small performance boost on some games without breaking Tiny Nightmare.