### PR TITLE
Fix ListOpenUsers

### DIFF
--- a/Ryujinx.HLE/OsHle/Services/Acc/IAccountServiceForApplication.cs
+++ b/Ryujinx.HLE/OsHle/Services/Acc/IAccountServiceForApplication.cs
@@ -52,6 +52,11 @@ namespace Ryujinx.HLE.OsHle.Services.Acc
 
         public long ListOpenUsers(ServiceCtx Context)
         {
+            long Position = Context.Request.RecvListBuff[0].Position;
+
+            Context.Memory.WriteInt64(Position,     1L);
+            Context.Memory.WriteInt64(Position + 8, 0L);
+			
             Context.Ns.Log.PrintStub(LogClass.ServiceAcc, "Stubbed.");
 
             return 0;


### PR DESCRIPTION
This fix the crash on Retro City Rampage Dx when the game try to execute this function and fix the spam of this function in Rayman Legends Definitive Edition