### PR TITLE
Add Npdm parsing into Ryujinx.HLE

### DIFF
--- a/Ryujinx.HLE/OsHle/Horizon.cs
+++ b/Ryujinx.HLE/OsHle/Horizon.cs
@@ -1,4 +1,5 @@
 using Ryujinx.HLE.Loaders.Executables;
+using Ryujinx.HLE.Loaders.Npdm;
 using Ryujinx.HLE.Logging;
 using Ryujinx.HLE.OsHle.Handles;
 using System;
@@ -74,6 +75,25 @@ namespace Ryujinx.HLE.OsHle
                         MainProcess.LoadProgram(Program);
                     }
                 }
+            }
+
+            void LoadNpdm(string FileName)
+            {
+                string File = Directory.GetFiles(ExeFsDir, FileName)[0];
+
+                Ns.Log.PrintInfo(LogClass.Loader, "Loading Title Metadata...");
+
+                using (FileStream Input = new FileStream(File, FileMode.Open))
+                {
+                    SystemStateMgr.TitleMetadata = new Npdm(Input);
+                }
+            }
+
+            LoadNpdm("*.npdm");
+
+            if (!SystemStateMgr.TitleMetadata.Is64Bits)
+            {
+                throw new Exception("32-bit titles are unsupported!");
             }
 
             LoadNso("rtld");

--- a/Ryujinx.HLE/OsHle/SystemStateMgr.cs
+++ b/Ryujinx.HLE/OsHle/SystemStateMgr.cs
@@ -1,9 +1,12 @@
+using Ryujinx.HLE.Loaders.Npdm;
 using System;
 
 namespace Ryujinx.HLE.OsHle
 {
     public class SystemStateMgr
     {
+        internal static Npdm TitleMetadata { get; set; }
+
         internal static string[] LanguageCodes = new string[]
         {
             "ja",


### PR DESCRIPTION
This PR adds `.npdm` file parsing into Ryujinx.HLE, though I don't know if this is the best solution.