### PR TITLE
Disable virtual memory

### DIFF
--- a/Ryujinx.HLE/OsHle/Kernel/SvcSystem.cs
+++ b/Ryujinx.HLE/OsHle/Kernel/SvcSystem.cs
@@ -18,7 +18,7 @@ namespace Ryujinx.HLE.OsHle.Kernel
 
         private const bool EnableProcessDebugging = false;
 
-        private const bool IsVirtualMemoryEnabled = true; //This is always true(?)
+        private const bool IsVirtualMemoryEnabled = false; //TODO: Fix virtual memory and re-enable it
 
         private void SvcExitProcess(AThreadState ThreadState)
         {


### PR DESCRIPTION
Octopath Traveler seems to have issues with virtual memory, so I am disabling virtual memory until further notice (aka until its fixed).