### PR TITLE
Allow loops inside basic blocks

### DIFF
--- a/ChocolArm64/ATranslator.cs
+++ b/ChocolArm64/ATranslator.cs
@@ -117,13 +117,11 @@ namespace ChocolArm64
 
         private ATranslatedSub TranslateTier0(AThreadState State, AMemory Memory, long Position)
         {
-            ABlock Block = ADecoder.DecodeBasicBlock(State, this, Memory, Position);
-
-            ABlock[] Graph = new ABlock[] { Block };
+            (ABlock[] Graph, ABlock Root) = ADecoder.DecodeBasicBlock(State, this, Memory, Position);
 
             string SubName = GetSubName(Position);
 
-            AILEmitterCtx Context = new AILEmitterCtx(this, Graph, Block, SubName);
+            AILEmitterCtx Context = new AILEmitterCtx(this, Graph, Root, SubName);
 
             do
             {
@@ -136,8 +134,6 @@ namespace ChocolArm64
             Subroutine.SetType(ATranslatedSubType.SubTier0);
 
             CachedSubs.AddOrUpdate(Position, Subroutine, (Key, OldVal) => Subroutine);
-
-            AOpCode LastOp = Block.GetLastOp();
 
             return Subroutine;
         }

--- a/ChocolArm64/Instruction/AInstEmitFlow.cs
+++ b/ChocolArm64/Instruction/AInstEmitFlow.cs
@@ -163,10 +163,18 @@ namespace ChocolArm64.Instruction
         {
             AOpCodeBImm Op = (AOpCodeBImm)Context.CurrOp;
 
-            if (Context.CurrBlock.Next   != null &&
-                Context.CurrBlock.Branch != null)
+            if (Context.CurrBlock.Branch != null)
             {
                 Context.EmitCondBranch(Context.GetLabel(Op.Imm), Cond);
+
+                if (Context.CurrBlock.Next == null)
+                {
+                    Context.EmitStoreState();
+
+                    Context.EmitLdc_I8(Op.Position + 4);
+
+                    Context.Emit(OpCodes.Ret);
+                }
             }
             else
             {
@@ -192,10 +200,18 @@ namespace ChocolArm64.Instruction
         {
             AOpCodeBImm Op = (AOpCodeBImm)Context.CurrOp;
 
-            if (Context.CurrBlock.Next   != null &&
-                Context.CurrBlock.Branch != null)
+            if (Context.CurrBlock.Branch != null)
             {
                 Context.Emit(ILOp, Context.GetLabel(Op.Imm));
+
+                if (Context.CurrBlock.Next == null)
+                {
+                    Context.EmitStoreState();
+
+                    Context.EmitLdc_I8(Op.Position + 4);
+
+                    Context.Emit(OpCodes.Ret);
+                }
             }
             else
             {


### PR DESCRIPTION
When theres a loop with a target inside the basic block, we don't need to return to the dispatcher, we can just jump to the offset inside the basic block directly.