### PR TITLE
Sleep OpenAL thread

### DIFF
--- a/Ryujinx.Audio/OpenAL/OpenALAudioOut.cs
+++ b/Ryujinx.Audio/OpenAL/OpenALAudioOut.cs
@@ -222,7 +222,8 @@ namespace Ryujinx.Audio.OpenAL
                     Td.CallReleaseCallbackIfNeeded();
                 }
 
-                Thread.Yield();
+                //If it's not slept it will waste cycles
+                Thread.Sleep(10);
             }
             while (KeepPolling);
         }


### PR DESCRIPTION
OpenAL's thread is wasting cycles waiting for data to dispatch.
Sleeping for 10ms didn't generate audio issues and avoided OpenAL's thread short circuit.