### PR TITLE
Fix for integer vertex attributes and iset bf flag

### DIFF
--- a/Ryujinx.Graphics/Gal/OpenGL/OGLRasterizer.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLRasterizer.cs
@@ -278,7 +278,19 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 int Size   = AttribElements[Attrib.Size];
                 int Offset = Attrib.Offset;
 
-                GL.VertexAttribPointer(Attrib.Index, Size, Type, Normalize, Stride, Offset);
+                if (Attrib.Type == GalVertexAttribType.Sint ||
+                    Attrib.Type == GalVertexAttribType.Uint)
+                {
+                    IntPtr Pointer = new IntPtr(Offset);
+
+                    VertexAttribIntegerType IType = (VertexAttribIntegerType)Type;
+
+                    GL.VertexAttribIPointer(Attrib.Index, Size, IType, Stride, Pointer);
+                }
+                else
+                {
+                    GL.VertexAttribPointer(Attrib.Index, Size, Type, Normalize, Stride, Offset);
+                }
             }
         }
 

--- a/Ryujinx.Graphics/Gal/Shader/ShaderDecodeAlu.cs
+++ b/Ryujinx.Graphics/Gal/Shader/ShaderDecodeAlu.cs
@@ -871,11 +871,12 @@ namespace Ryujinx.Graphics.Gal.Shader
 
         private static void EmitSet(ShaderIrBlock Block, long OpCode, bool IsFloat, ShaderOper Oper)
         {
-            bool NegA      = ((OpCode >> 43) & 1) != 0;
-            bool AbsB      = ((OpCode >> 44) & 1) != 0;
-            bool BoolFloat = ((OpCode >> 52) & 1) != 0;
-            bool NegB      = ((OpCode >> 53) & 1) != 0;
-            bool AbsA      = ((OpCode >> 54) & 1) != 0;
+            bool NegA = ((OpCode >> 43) & 1) != 0;
+            bool AbsB = ((OpCode >> 44) & 1) != 0;
+            bool NegB = ((OpCode >> 53) & 1) != 0;
+            bool AbsA = ((OpCode >> 54) & 1) != 0;
+
+            bool BoolFloat = ((OpCode >> (IsFloat ? 52 : 44)) & 1) != 0;
 
             ShaderIrNode OperA = GetOperGpr8(OpCode), OperB;
 


### PR DESCRIPTION
Fixes two issues:
- glVertexAttribPointer will aways convert the values to float no matter what. Vertex attributes with integer types were being converted to float, but being read on the shader as if they were integers. The fix is to use glVertexAttribIPointer that passes integers without conversion.
- The bit for the bf flag on the Iset instruction was wrong.

FYI @ReinUsesLisp.