### PR TITLE
Fix load/store exclusive/atomic pairwise instructions

### DIFF
--- a/ChocolArm64/Instruction/AInstEmitMemoryEx.cs
+++ b/ChocolArm64/Instruction/AInstEmitMemoryEx.cs
@@ -75,7 +75,7 @@ namespace ChocolArm64.Instruction
             {
                 Context.EmitLdarg(ATranslatedSub.MemoryArgIdx);
                 Context.EmitLdtmp();
-                Context.EmitLdc_I(8 << Op.Size);
+                Context.EmitLdc_I8(1 << Op.Size);
 
                 Context.Emit(OpCodes.Add);
 
@@ -145,7 +145,7 @@ namespace ChocolArm64.Instruction
             {
                 Context.EmitLdarg(ATranslatedSub.MemoryArgIdx);
                 Context.EmitLdint(Op.Rn);
-                Context.EmitLdc_I(8 << Op.Size);
+                Context.EmitLdc_I8(1 << Op.Size);
 
                 Context.Emit(OpCodes.Add);
 


### PR DESCRIPTION
The offset was wrong and it was reading/writing data to the wrong location, potentially corrupting memory.