### PR TITLE
Reset cache on command buffer execution instead of sync calls

### DIFF
--- a/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3d.cs
+++ b/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3d.cs
@@ -80,6 +80,14 @@ namespace Ryujinx.HLE.Gpu.Engines
             }
         }
 
+        public void ResetCache()
+        {
+            foreach (List<long> Uploaded in UploadedKeys)
+            {
+                Uploaded.Clear();
+            }
+        }
+
         private void VertexEndGl(NvGpuVmm Vmm, NvGpuPBEntry PBEntry)
         {
             LockCaches();
@@ -614,11 +622,6 @@ namespace Ryujinx.HLE.Gpu.Engines
 
             if (Mode == 0)
             {
-                foreach (List<long> Uploaded in UploadedKeys)
-                {
-                    Uploaded.Clear();
-                }
-
                 //Write mode.
                 Vmm.WriteInt32(Position, Seq);
             }
@@ -640,6 +643,8 @@ namespace Ryujinx.HLE.Gpu.Engines
             }
 
             WriteRegister(NvGpuEngine3dReg.ConstBufferOffset, Offset);
+
+            UploadedKeys[(int)NvGpuBufferType.ConstBuffer].Clear();
         }
 
         private void CbBind(NvGpuVmm Vmm, NvGpuPBEntry PBEntry)


### PR DESCRIPTION
Also resets const buffer cache on CbData calls.
Non-const buffer data might also change while a command buffer is executing but that's very unlikely.

It fixes es2gears regression.