### PR TITLE
[WIP] Improve dma copies on the gpu

### DIFF
--- a/ChocolArm64/Memory/AMemory.cs
+++ b/ChocolArm64/Memory/AMemory.cs
@@ -691,6 +691,19 @@ namespace ChocolArm64.Memory
             Marshal.Copy(Data, 0, (IntPtr)(RamPtr + (uint)Position), Data.Length);
         }
 
+        public void CopyBytes(long Src, long Dst, long Size)
+        {
+            EnsureRangeIsValid(Src, Size, AMemoryPerm.Read);
+            EnsureRangeIsValid(Dst, Size, AMemoryPerm.Write);
+
+            Buffer.MemoryCopy(
+                RamPtr + (uint)Src,
+                RamPtr + (uint)Dst,
+                Size,
+                Size);
+        }
+
+
         private void EnsureRangeIsValid(long Position, long Size, AMemoryPerm Perm)
         {
             long EndPos = Position + Size;

--- a/Ryujinx.HLE/Gpu/Engines/NvGpuEngineDmaReg.cs
+++ b/Ryujinx.HLE/Gpu/Engines/NvGpuEngineDmaReg.cs
@@ -6,6 +6,8 @@ namespace Ryujinx.HLE.Gpu.Engines
         DstAddress = 0x102,
         SrcPitch   = 0x104,
         DstPitch   = 0x105,
+        XCount     = 0x106,
+        YCount     = 0x107,
         DstBlkDim  = 0x1c3,
         DstSizeX   = 0x1c4,
         DstSizeY   = 0x1c5,


### PR DESCRIPTION
Some games are not writing anything to the *SizeX/Y registers, however the X/YCount registers seems to be always written, so use that instead. Also, optimized copies when (de)swizzling is not necessary by just copying the data directly.

This improves some games but there are some still some issues that needs to be investigated so this is WIP.