### PR TITLE
Use mirrored texture wraps when available

### DIFF
--- a/Ryujinx.Graphics/Gal/OpenGL/OGLEnumConverter.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLEnumConverter.cs
@@ -184,16 +184,31 @@ namespace Ryujinx.Graphics.Gal.OpenGL
         {
             switch (Wrap)
             {
-                case GalTextureWrap.Repeat:              return TextureWrapMode.Repeat;
-                case GalTextureWrap.MirroredRepeat:      return TextureWrapMode.MirroredRepeat;
-                case GalTextureWrap.ClampToEdge:         return TextureWrapMode.ClampToEdge;
-                case GalTextureWrap.ClampToBorder:       return TextureWrapMode.ClampToBorder;
-                case GalTextureWrap.Clamp:               return TextureWrapMode.Clamp;
+                case GalTextureWrap.Repeat:         return TextureWrapMode.Repeat;
+                case GalTextureWrap.MirroredRepeat: return TextureWrapMode.MirroredRepeat;
+                case GalTextureWrap.ClampToEdge:    return TextureWrapMode.ClampToEdge;
+                case GalTextureWrap.ClampToBorder:  return TextureWrapMode.ClampToBorder;
+                case GalTextureWrap.Clamp:          return TextureWrapMode.Clamp;
+            }
 
-                //TODO: Those needs extensions (and are currently wrong).
-                case GalTextureWrap.MirrorClampToEdge:   return TextureWrapMode.ClampToEdge;
-                case GalTextureWrap.MirrorClampToBorder: return TextureWrapMode.ClampToBorder;
-                case GalTextureWrap.MirrorClamp:         return TextureWrapMode.Clamp;
+            if (OGLExtension.HasTextureMirrorClamp())
+            {
+                switch (Wrap)
+                {
+                    case GalTextureWrap.MirrorClampToEdge:   return (TextureWrapMode)ExtTextureMirrorClamp.MirrorClampToEdgeExt;
+                    case GalTextureWrap.MirrorClampToBorder: return (TextureWrapMode)ExtTextureMirrorClamp.MirrorClampToBorderExt;
+                    case GalTextureWrap.MirrorClamp:         return (TextureWrapMode)ExtTextureMirrorClamp.MirrorClampExt;
+                }
+            }
+            else
+            {
+                //Fallback to non-mirrored clamps
+                switch (Wrap)
+                {
+                    case GalTextureWrap.MirrorClampToEdge:   return TextureWrapMode.ClampToEdge;
+                    case GalTextureWrap.MirrorClampToBorder: return TextureWrapMode.ClampToBorder;
+                    case GalTextureWrap.MirrorClamp:         return TextureWrapMode.Clamp;
+                }
             }
 
             throw new ArgumentException(nameof(Wrap));

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLExtension.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLExtension.cs
@@ -8,11 +8,20 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
         private static bool EnhancedLayouts;
 
+        private static bool TextureMirrorClamp;
+
         public static bool HasEnhancedLayouts()
         {
             EnsureInitialized();
 
             return EnhancedLayouts;
+        }
+
+        public static bool HasTextureMirrorClamp()
+        {
+            EnsureInitialized();
+
+            return TextureMirrorClamp;
         }
 
         private static void EnsureInitialized()
@@ -23,6 +32,8 @@ namespace Ryujinx.Graphics.Gal.OpenGL
             }
 
             EnhancedLayouts = HasExtension("GL_ARB_enhanced_layouts");
+
+            TextureMirrorClamp = HasExtension("GL_EXT_texture_mirror_clamp");
         }
 
         private static bool HasExtension(string Name)


### PR DESCRIPTION
I don't know if a game uses mirrored wraps, but IMO it's better to use them when available.