### PR TITLE
Add config entry to enable OpenGL debug context and callbacks

### DIFF
--- a/Ryujinx.Graphics/Gal/IGalRenderer.cs
+++ b/Ryujinx.Graphics/Gal/IGalRenderer.cs
@@ -4,6 +4,8 @@ namespace Ryujinx.Graphics.Gal
 {
     public interface IGalRenderer
     {
+        void Initialize();
+
         void QueueAction(Action ActionMthd);
 
         void RunActions();

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLExtension.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLExtension.cs
@@ -6,7 +6,15 @@ namespace Ryujinx.Graphics.Gal.OpenGL
     {
         private static bool Initialized = false;
 
+        private static bool Debug;
         private static bool EnhancedLayouts;
+
+        public static bool HasDebug()
+        {
+            EnsureInitialized();
+
+            return Debug;
+        }
 
         public static bool HasEnhancedLayouts()
         {
@@ -22,6 +30,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 return;
             }
 
+            Debug           = HasExtension("GL_KHR_debug");
             EnhancedLayouts = HasExtension("GL_ARB_enhanced_layouts");
         }
 

--- a/Ryujinx.Graphics/Gal/OpenGL/OpenGLException.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OpenGLException.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Ryujinx.Graphics.Gal.OpenGL
+{
+    class OpenGLException : Exception
+    {
+        public OpenGLException() : base() { }
+
+        public OpenGLException(string Message) : base(Message) { }
+    }
+}

--- a/Ryujinx.Graphics/GraphicsConfig.cs
+++ b/Ryujinx.Graphics/GraphicsConfig.cs
@@ -1,4 +1,10 @@
 ﻿public static class GraphicsConfig
 {
+    public static bool DebugMode;
+
+    public static bool DebugFatalErrors;
+
+    public static bool DebugEnableInfo;
+
     public static string ShadersDumpPath;
 }

--- a/Ryujinx/Config.cs
+++ b/Ryujinx/Config.cs
@@ -23,7 +23,10 @@ namespace Ryujinx
 
             IniParser Parser = new IniParser(IniPath);
 
-            GraphicsConfig.ShadersDumpPath = Parser.Value("Graphics_Shaders_Dump_Path");
+            GraphicsConfig.DebugMode        = Convert.ToBoolean(Parser.Value("Graphics_Enable_Debug"));
+            GraphicsConfig.DebugFatalErrors = Convert.ToBoolean(Parser.Value("Graphics_Debug_Fatal_Errors"));
+            GraphicsConfig.DebugEnableInfo  = Convert.ToBoolean(Parser.Value("Graphics_Debug_Enable_Info"));
+            GraphicsConfig.ShadersDumpPath  =                   Parser.Value("Graphics_Shaders_Dump_Path");
 
             Device.Log.SetEnable(LogLevel.Debug,   Convert.ToBoolean(Parser.Value("Logging_Enable_Debug")));
             Device.Log.SetEnable(LogLevel.Stub,    Convert.ToBoolean(Parser.Value("Logging_Enable_Stub")));

--- a/Ryujinx/Ryujinx.conf
+++ b/Ryujinx/Ryujinx.conf
@@ -1,6 +1,15 @@
 #Enable cpu memory checks (slow)
 Enable_Memory_Checks = false
 
+#Enable graphics API debug functionality
+Graphics_Enable_Debug = false
+
+#Graphics errors are fatal
+Graphics_Debug_Fatal_Errors = true
+
+#Show graphics info messages
+Graphics_Debug_Enable_Info = false
+
 #Dump shaders in local directory (e.g. `C:\ShaderDumps`)
 Graphics_Shaders_Dump_Path =
 

--- a/Ryujinx/Ui/GLScreen.cs
+++ b/Ryujinx/Ui/GLScreen.cs
@@ -38,7 +38,8 @@ namespace Ryujinx
             : base(1280, 720,
             new GraphicsMode(), "Ryujinx", 0,
             DisplayDevice.Default, 3, 3,
-            GraphicsContextFlags.ForwardCompatible)
+            GraphicsContextFlags.ForwardCompatible |
+                  (GraphicsConfig.DebugMode ? GraphicsContextFlags.Debug : 0))
         {
             this.Device   = Device;
             this.Renderer = Renderer;
@@ -95,6 +96,8 @@ namespace Ryujinx
             VSync = VSyncMode.Off;
 
             Visible = true;
+
+            Renderer.Initialize();
 
             Renderer.FrameBuffer.SetWindowSize(Width, Height);
 


### PR DESCRIPTION
It's to ease detecting OpenGL errors (it requires GL_KHR_debug). Disabled by default.