### PR TITLE
Lock GbpQueueBuffer till Vsync is signalled

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Vi/NvFlinger.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/NvFlinger.cs
@@ -166,6 +166,13 @@ namespace Ryujinx.HLE.HOS.Services.Android
         {
             Context.Device.Statistics.RecordGameFrameTime();
 
+            if (Context.Ns.EnableVsync)
+            {
+                Context.Ns.Os.VsyncEvent.WaitEvent.WaitOne();
+
+                Context.Ns.Os.VsyncEvent.WaitEvent.Reset();
+            }
+
             //TODO: Errors.
             int Slot            = ParcelReader.ReadInt32();
             int Unknown4        = ParcelReader.ReadInt32();

--- a/Ryujinx.HLE/HOS/Services/Vi/NvFlinger.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/NvFlinger.cs
@@ -166,11 +166,6 @@ namespace Ryujinx.HLE.HOS.Services.Android
         {
             Context.Device.Statistics.RecordGameFrameTime();
 
-            if (Context.Device.EnableVsync)
-            {
-                Context.Device.VsyncEvent.WaitOne();
-            }
-
             //TODO: Errors.
             int Slot            = ParcelReader.ReadInt32();
             int Unknown4        = ParcelReader.ReadInt32();
@@ -203,6 +198,11 @@ namespace Ryujinx.HLE.HOS.Services.Android
             BufferQueue[Slot].State = BufferState.Queued;
 
             SendFrameBuffer(Context, Slot);
+
+            if (Context.Device.EnableDeviceVsync)
+            {
+                Context.Device.VsyncEvent.WaitOne();
+            }
 
             return MakeReplyParcel(Context, 1280, 720, 0, 0, 0);
         }

--- a/Ryujinx.HLE/HOS/Services/Vi/NvFlinger.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/NvFlinger.cs
@@ -166,11 +166,9 @@ namespace Ryujinx.HLE.HOS.Services.Android
         {
             Context.Device.Statistics.RecordGameFrameTime();
 
-            if (Context.Ns.EnableVsync)
+            if (Context.Device.EnableVsync)
             {
-                Context.Ns.Os.VsyncEvent.WaitEvent.WaitOne();
-
-                Context.Ns.Os.VsyncEvent.WaitEvent.Reset();
+                Context.Device.VsyncEvent.WaitOne();
             }
 
             //TODO: Errors.

--- a/Ryujinx.HLE/Switch.cs
+++ b/Ryujinx.HLE/Switch.cs
@@ -62,7 +62,7 @@ namespace Ryujinx.HLE
 
             Hid = new Hid(this, System.HidSharedMem.PA);
 
-            VsyncEvent =  new AutoResetEvent(true);
+            VsyncEvent = new AutoResetEvent(true);
         }
 
         public void LoadCart(string ExeFsDir, string RomFsFile = null)

--- a/Ryujinx.HLE/Switch.cs
+++ b/Ryujinx.HLE/Switch.cs
@@ -27,6 +27,12 @@ namespace Ryujinx.HLE
 
         public Hid Hid { get; private set; }
 
+        public bool LimitSpeed { get; set; }
+
+        public bool EnableVsync { get; set; }
+
+        public event EventHandler Finish;
+
         public Switch(IGalRenderer Renderer, IAalOutput AudioOut)
         {
             if (Renderer == null)

--- a/Ryujinx.HLE/Switch.cs
+++ b/Ryujinx.HLE/Switch.cs
@@ -28,7 +28,7 @@ namespace Ryujinx.HLE
 
         public Hid Hid { get; private set; }
 
-        public bool EnableVsync { get; set; } = true;
+        public bool EnableDeviceVsync { get; set; } = true;
 
         public AutoResetEvent VsyncEvent { get; private set; }
 

--- a/Ryujinx.HLE/Switch.cs
+++ b/Ryujinx.HLE/Switch.cs
@@ -6,6 +6,7 @@ using Ryujinx.HLE.Input;
 using Ryujinx.HLE.Logging;
 using Ryujinx.HLE.Memory;
 using System;
+using System.Threading;
 
 namespace Ryujinx.HLE
 {
@@ -27,9 +28,9 @@ namespace Ryujinx.HLE
 
         public Hid Hid { get; private set; }
 
-        public bool LimitSpeed { get; set; }
+        public bool EnableVsync { get; set; } = true;
 
-        public bool EnableVsync { get; set; }
+        public AutoResetEvent VsyncEvent { get; private set; }
 
         public event EventHandler Finish;
 
@@ -60,6 +61,8 @@ namespace Ryujinx.HLE
             Statistics = new PerformanceStatistics();
 
             Hid = new Hid(this, System.HidSharedMem.PA);
+
+            VsyncEvent =  new AutoResetEvent(true);
         }
 
         public void LoadCart(string ExeFsDir, string RomFsFile = null)
@@ -114,6 +117,8 @@ namespace Ryujinx.HLE
             if (Disposing)
             {
                 System.Dispose();
+
+                VsyncEvent.Dispose();
             }
         }
     }

--- a/Ryujinx/Config.cs
+++ b/Ryujinx/Config.cs
@@ -31,7 +31,9 @@ namespace Ryujinx
             Device.Log.SetEnable(LogLevel.Warning, Convert.ToBoolean(Parser.Value("Logging_Enable_Warn")));
             Device.Log.SetEnable(LogLevel.Error,   Convert.ToBoolean(Parser.Value("Logging_Enable_Error")));
 
-            Device.System.State.DockedMode = Convert.ToBoolean(Parser.Value("Docked_Mode"));
+            Device.System.State.DockedMode   = Convert.ToBoolean(Parser.Value("Docked_Mode"));
+
+            Device.EnableDeviceVsync = Convert.ToBoolean(Parser.Value("Enable_Vsync"));
 
             string[] FilteredLogClasses = Parser.Value("Logging_Filtered_Classes").Split(',', StringSplitOptions.RemoveEmptyEntries);
 

--- a/Ryujinx/Config.cs
+++ b/Ryujinx/Config.cs
@@ -31,7 +31,7 @@ namespace Ryujinx
             Device.Log.SetEnable(LogLevel.Warning, Convert.ToBoolean(Parser.Value("Logging_Enable_Warn")));
             Device.Log.SetEnable(LogLevel.Error,   Convert.ToBoolean(Parser.Value("Logging_Enable_Error")));
 
-            Device.System.State.DockedMode   = Convert.ToBoolean(Parser.Value("Docked_Mode"));
+            Device.System.State.DockedMode = Convert.ToBoolean(Parser.Value("Docked_Mode"));
 
             Device.EnableDeviceVsync = Convert.ToBoolean(Parser.Value("Enable_Vsync"));
 

--- a/Ryujinx/Ryujinx.conf
+++ b/Ryujinx/Ryujinx.conf
@@ -25,6 +25,9 @@ Logging_Filtered_Classes =
 #Enable or Disable Docked Mode
 Docked_Mode = false
 
+#Enable Game Vsync
+Enable_Vsync = true
+
 #Controller Device Index
 GamePad_Index = 0
 

--- a/Ryujinx/Ui/GLScreen.cs
+++ b/Ryujinx/Ui/GLScreen.cs
@@ -82,6 +82,8 @@ namespace Ryujinx
 
                 if (Ticks >= TicksPerFrame)
                 {
+                    Ns.Os.SignalVsync();
+
                     RenderFrame();
 
                     //Queue max. 1 vsync
@@ -258,7 +260,8 @@ namespace Ryujinx
             double HostFps = Device.Statistics.GetSystemFrameRate();
             double GameFps = Device.Statistics.GetGameFrameRate();
 
-            NewTitle = $"Ryujinx | Host FPS: {HostFps:0.0} | Game FPS: {GameFps:0.0}";
+            NewTitle = $"Ryujinx | Host FPS: {HostFps:0.0} | Game FPS: {GameFps:0.0} | Game Vsync: " +
+               (Ns.EnableVsync ? "On" : "Off");
 
             TitleEvent = true;
 
@@ -310,6 +313,9 @@ namespace Ryujinx
         protected override void OnKeyUp(KeyboardKeyEventArgs e)
         {
             Keyboard = e.Keyboard;
+
+            if (e.Key == Key.Tab)
+                Ns.EnableVsync = !Ns.EnableVsync;
         }
 
         protected override void OnMouseDown(MouseButtonEventArgs e)

--- a/Ryujinx/Ui/GLScreen.cs
+++ b/Ryujinx/Ui/GLScreen.cs
@@ -82,8 +82,6 @@ namespace Ryujinx
 
                 if (Ticks >= TicksPerFrame)
                 {
-                    Device.VsyncEvent.Set();
-
                     RenderFrame();
 
                     //Queue max. 1 vsync
@@ -261,13 +259,15 @@ namespace Ryujinx
             double GameFps = Device.Statistics.GetGameFrameRate();
 
             NewTitle = $"Ryujinx | Host FPS: {HostFps:0.0} | Game FPS: {GameFps:0.0} | Game Vsync: " +
-               (Device.EnableVsync ? "On" : "Off");
+               (Device.EnableDeviceVsync ? "On" : "Off");
 
             TitleEvent = true;
 
             SwapBuffers();
 
             Device.System.SignalVsync();
+
+            Device.VsyncEvent.Set();
         }
 
         protected override void OnUnload(EventArgs e)
@@ -315,7 +315,7 @@ namespace Ryujinx
             Keyboard = e.Keyboard;
 
             if (e.Key == Key.Tab)
-                Device.EnableVsync = !Device.EnableVsync;
+                Device.EnableDeviceVsync = !Device.EnableDeviceVsync;
         }
 
         protected override void OnMouseDown(MouseButtonEventArgs e)

--- a/Ryujinx/Ui/GLScreen.cs
+++ b/Ryujinx/Ui/GLScreen.cs
@@ -82,7 +82,7 @@ namespace Ryujinx
 
                 if (Ticks >= TicksPerFrame)
                 {
-                    Ns.Os.SignalVsync();
+                    Device.VsyncEvent.Set();
 
                     RenderFrame();
 
@@ -261,7 +261,7 @@ namespace Ryujinx
             double GameFps = Device.Statistics.GetGameFrameRate();
 
             NewTitle = $"Ryujinx | Host FPS: {HostFps:0.0} | Game FPS: {GameFps:0.0} | Game Vsync: " +
-               (Ns.EnableVsync ? "On" : "Off");
+               (Device.EnableVsync ? "On" : "Off");
 
             TitleEvent = true;
 
@@ -315,7 +315,7 @@ namespace Ryujinx
             Keyboard = e.Keyboard;
 
             if (e.Key == Key.Tab)
-                Ns.EnableVsync = !Ns.EnableVsync;
+                Device.EnableVsync = !Device.EnableVsync;
         }
 
         protected override void OnMouseDown(MouseButtonEventArgs e)

--- a/Ryujinx/Ui/GLScreen.cs
+++ b/Ryujinx/Ui/GLScreen.cs
@@ -313,9 +313,6 @@ namespace Ryujinx
         protected override void OnKeyUp(KeyboardKeyEventArgs e)
         {
             Keyboard = e.Keyboard;
-
-            if (e.Key == Key.Tab)
-                Device.EnableDeviceVsync = !Device.EnableDeviceVsync;
         }
 
         protected override void OnMouseDown(MouseButtonEventArgs e)


### PR DESCRIPTION
This change locks nvflinger's queuebuffer till a vsync event is signalled, effectively limiting the game speed to 60 fps. I have not noticed any performance hit if speed is less than 100%, whether the toggle is on or off. `Tab` toggles the emulated vsync.