### PR TITLE
Avoid gpr overwritting on Ld_C instruction

### DIFF
--- a/Ryujinx.Graphics/Gal/Shader/ShaderDecodeHelper.cs
+++ b/Ryujinx.Graphics/Gal/Shader/ShaderDecodeHelper.cs
@@ -35,13 +35,6 @@ namespace Ryujinx.Graphics.Gal.Shader
                 (int)(OpCode >> 20) & 0x3fff);
         }
 
-        public static ShaderIrOperCbuf GetOperCbuf36(long OpCode)
-        {
-            return new ShaderIrOperCbuf(
-                (int)(OpCode >> 36) & 0x1f,
-                (int)(OpCode >> 22) & 0x3fff, GetOperGpr8(OpCode));
-        }
-
         public static ShaderIrOperGpr GetOperGpr8(long OpCode)
         {
             return new ShaderIrOperGpr((int)(OpCode >> 8) & 0xff);

--- a/Ryujinx.Graphics/Gal/Shader/ShaderDecodeMem.cs
+++ b/Ryujinx.Graphics/Gal/Shader/ShaderDecodeMem.cs
@@ -76,6 +76,11 @@ namespace Ryujinx.Graphics.Gal.Shader
                 OperA.Pos   += Index;
                 OperD.Index += Index;
 
+                if (!OperD.IsValidRegister)
+                {
+                    break;
+                }
+
                 ShaderIrNode Node = OperA;
 
                 if (Type < 4)

--- a/Ryujinx.Graphics/Gal/Shader/ShaderDecodeMem.cs
+++ b/Ryujinx.Graphics/Gal/Shader/ShaderDecodeMem.cs
@@ -52,9 +52,9 @@ namespace Ryujinx.Graphics.Gal.Shader
 
         public static void Ld_C(ShaderIrBlock Block, long OpCode)
         {
-            int Type      = (int)(OpCode >> 48) & 7;
-            int CbufIndex = (int)(OpCode >> 36) & 0x1f;
             int CbufPos   = (int)(OpCode >> 22) & 0x3fff;
+            int CbufIndex = (int)(OpCode >> 36) & 0x1f;
+            int Type      = (int)(OpCode >> 48) & 7;
 
             if (Type > 5)
             {

--- a/Ryujinx.Graphics/Gal/Shader/ShaderDecodeMem.cs
+++ b/Ryujinx.Graphics/Gal/Shader/ShaderDecodeMem.cs
@@ -52,19 +52,26 @@ namespace Ryujinx.Graphics.Gal.Shader
 
         public static void Ld_C(ShaderIrBlock Block, long OpCode)
         {
-            int Type = (int)(OpCode >> 48) & 7;
+            int Type      = (int)(OpCode >> 48) & 7;
+            int CbufIndex = (int)(OpCode >> 36) & 0x1f;
+            int CbufPos   = (int)(OpCode >> 22) & 0x3fff;
 
             if (Type > 5)
             {
                 throw new InvalidOperationException();
             }
 
+            ShaderIrOperGpr Temp = ShaderIrOperGpr.MakeTemporary();
+
+            Block.AddNode(new ShaderIrAsg(Temp, GetOperGpr8(OpCode)));
+
             int Count = Type == 5 ? 2 : 1;
 
             for (int Index = 0; Index < Count; Index++)
             {
-                ShaderIrOperCbuf OperA = GetOperCbuf36(OpCode);
-                ShaderIrOperGpr  OperD = GetOperGpr0  (OpCode);
+                ShaderIrOperCbuf OperA = new ShaderIrOperCbuf(CbufIndex, CbufPos, Temp);
+
+                ShaderIrOperGpr OperD = GetOperGpr0(OpCode);
 
                 OperA.Pos   += Index;
                 OperD.Index += Index;

--- a/Ryujinx.Graphics/Gal/Shader/ShaderIrOperGpr.cs
+++ b/Ryujinx.Graphics/Gal/Shader/ShaderIrOperGpr.cs
@@ -4,6 +4,8 @@ namespace Ryujinx.Graphics.Gal.Shader
     {
         public const int ZRIndex = 0xff;
 
+        public static ShaderIrOperGpr MakeTemporary() => new ShaderIrOperGpr(0x100);
+
         public bool IsConst => Index == ZRIndex;
 
         public int Index { get; set; }

--- a/Ryujinx.Graphics/Gal/Shader/ShaderIrOperGpr.cs
+++ b/Ryujinx.Graphics/Gal/Shader/ShaderIrOperGpr.cs
@@ -4,8 +4,6 @@ namespace Ryujinx.Graphics.Gal.Shader
     {
         public const int ZRIndex = 0xff;
 
-        public static ShaderIrOperGpr MakeTemporary() => new ShaderIrOperGpr(0x100);
-
         public bool IsConst => Index == ZRIndex;
 
         public int Index { get; set; }
@@ -13,6 +11,11 @@ namespace Ryujinx.Graphics.Gal.Shader
         public ShaderIrOperGpr(int Index)
         {
             this.Index = Index;
+        }
+
+        public static ShaderIrOperGpr MakeTemporary(int Index = 0)
+        {
+            return new ShaderIrOperGpr(0x100 + Index);
         }
     }
 }

--- a/Ryujinx.Graphics/Gal/Shader/ShaderIrOperGpr.cs
+++ b/Ryujinx.Graphics/Gal/Shader/ShaderIrOperGpr.cs
@@ -6,6 +6,8 @@ namespace Ryujinx.Graphics.Gal.Shader
 
         public bool IsConst => Index == ZRIndex;
 
+        public bool IsValidRegister => (Index <= ZRIndex);
+
         public int Index { get; set; }
 
         public ShaderIrOperGpr(int Index)


### PR DESCRIPTION
It should fix some vertex explosions.
Thanks to bunnei (from yuzu) for pointing out this issue.