### PR TITLE
Shader invalidation and cache

### DIFF
--- a/Ryujinx.Graphics/Gal/IGalShader.cs
+++ b/Ryujinx.Graphics/Gal/IGalShader.cs
@@ -4,9 +4,7 @@ namespace Ryujinx.Graphics.Gal
 {
     public interface IGalShader
     {
-        void Create(IGalMemory Memory, long Key, GalShaderType Type);
-
-        void Create(IGalMemory Memory, long VpAPos, long Key, GalShaderType Type);
+        void Create(long Key, byte[] BinaryA, byte[] BinaryB, GalShaderType Type);
 
         IEnumerable<ShaderDeclInfo> GetConstBufferUsage(long Key);
         IEnumerable<ShaderDeclInfo> GetTextureUsage(long Key);

--- a/Ryujinx.Graphics/Gal/IGalShader.cs
+++ b/Ryujinx.Graphics/Gal/IGalShader.cs
@@ -4,7 +4,9 @@ namespace Ryujinx.Graphics.Gal
 {
     public interface IGalShader
     {
-        void Create(long Key, byte[] BinaryA, byte[] BinaryB, GalShaderType Type);
+        void Create(long KeyA, long KeyB, byte[] BinaryA, byte[] BinaryB, GalShaderType Type);
+
+        bool TryGetSize(long Key, out long Size);
 
         IEnumerable<ShaderDeclInfo> GetConstBufferUsage(long Key);
         IEnumerable<ShaderDeclInfo> GetTextureUsage(long Key);

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLShader.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLShader.cs
@@ -15,7 +15,9 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
         public OGLShaderProgram Current;
 
-        private ConcurrentDictionary<long, OGLShaderStage> Stages;
+        private Dictionary<long, List<OGLShaderStage>> Stages;
+
+        private Dictionary<long, OGLShaderStage> TopStages;
 
         private Dictionary<OGLShaderProgram, int> Programs;
 
@@ -29,60 +31,71 @@ namespace Ryujinx.Graphics.Gal.OpenGL
         {
             this.Buffer = Buffer;
 
-            Stages = new ConcurrentDictionary<long, OGLShaderStage>();
+            Stages = new Dictionary<long, List<OGLShaderStage>>();
+
+            TopStages = new Dictionary<long, OGLShaderStage>();
 
             Programs = new Dictionary<OGLShaderProgram, int>();
         }
 
-        public void Create(IGalMemory Memory, long Key, GalShaderType Type)
-        {
-            Stages.GetOrAdd(Key, (Stage) => ShaderStageFactory(Memory, Key, 0, false, Type));
-        }
-
-        public void Create(IGalMemory Memory, long VpAPos, long Key, GalShaderType Type)
-        {
-            Stages.GetOrAdd(Key, (Stage) => ShaderStageFactory(Memory, VpAPos, Key, true, Type));
-        }
-
-        private OGLShaderStage ShaderStageFactory(
-            IGalMemory    Memory,
-            long          Position,
-            long          PositionB,
-            bool          IsDualVp,
+        public void Create(
+            long          Key,
+            byte[]        BinaryA,
+            byte[]        BinaryB,
             GalShaderType Type)
         {
+            if (Stages.TryGetValue(Key, out List<OGLShaderStage> Cache))
+            {
+                OGLShaderStage CachedStage = Cache.Find((OGLShaderStage Stage) => Stage.EqualsBinary(BinaryA, BinaryB));
+
+                if (CachedStage != null)
+                {
+                    TopStages[Key] = CachedStage;
+
+                    return;
+                }
+            }
+            else
+            {
+                Cache = new List<OGLShaderStage>();
+
+                Stages.Add(Key, Cache);
+            }
+
             GlslProgram Program;
 
             GlslDecompiler Decompiler = new GlslDecompiler();
 
-            if (IsDualVp)
+            if (BinaryA != null)
             {
-                ShaderDumper.Dump(Memory, Position,  Type, "a");
-                ShaderDumper.Dump(Memory, PositionB, Type, "b");
+                ShaderHelper.Dump(BinaryA, Type, "a");
+                ShaderHelper.Dump(BinaryB, Type, "b");
 
-                Program = Decompiler.Decompile(
-                    Memory,
-                    Position,
-                    PositionB,
-                    Type);
+                Program = Decompiler.Decompile(BinaryA, BinaryB, Type);
             }
             else
             {
-                ShaderDumper.Dump(Memory, Position, Type);
+                ShaderHelper.Dump(BinaryB, Type);
 
-                Program = Decompiler.Decompile(Memory, Position, Type);
+                Program = Decompiler.Decompile(BinaryB, Type);
             }
 
-            return new OGLShaderStage(
+            OGLShaderStage NewStage = new OGLShaderStage(
                 Type,
+                BinaryA,
+                BinaryB,
                 Program.Code,
                 Program.Uniforms,
                 Program.Textures);
+
+            Cache.Add(NewStage);
+
+            TopStages[Key] = NewStage;
         }
 
         public IEnumerable<ShaderDeclInfo> GetConstBufferUsage(long Key)
         {
-            if (Stages.TryGetValue(Key, out OGLShaderStage Stage))
+            if (TopStages.TryGetValue(Key, out OGLShaderStage Stage))
             {
                 return Stage.ConstBufferUsage;
             }
@@ -92,7 +105,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
         public IEnumerable<ShaderDeclInfo> GetTextureUsage(long Key)
         {
-            if (Stages.TryGetValue(Key, out OGLShaderStage Stage))
+            if (TopStages.TryGetValue(Key, out OGLShaderStage Stage))
             {
                 return Stage.TextureUsage;
             }
@@ -121,7 +134,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
         public void Bind(long Key)
         {
-            if (Stages.TryGetValue(Key, out OGLShaderStage Stage))
+            if (TopStages.TryGetValue(Key, out OGLShaderStage Stage))
             {
                 Bind(Stage);
             }

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLShader.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLShader.cs
@@ -19,6 +19,8 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
         private Dictionary<long, OGLShaderStage> TopStages;
 
+        private Dictionary<long, long> TopStageSizes;
+
         private Dictionary<OGLShaderProgram, int> Programs;
 
         public int CurrentProgramHandle { get; private set; }
@@ -35,15 +37,20 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
             TopStages = new Dictionary<long, OGLShaderStage>();
 
+            TopStageSizes = new Dictionary<long, long>();
+
             Programs = new Dictionary<OGLShaderProgram, int>();
         }
 
         public void Create(
-            long          Key,
+            long          KeyA,
+            long          KeyB,
             byte[]        BinaryA,
             byte[]        BinaryB,
             GalShaderType Type)
         {
+            long Key = KeyB;
+
             if (Stages.TryGetValue(Key, out List<OGLShaderStage> Cache))
             {
                 OGLShaderStage CachedStage = Cache.Find((OGLShaderStage Stage) => Stage.EqualsBinary(BinaryA, BinaryB));
@@ -91,6 +98,25 @@ namespace Ryujinx.Graphics.Gal.OpenGL
             Cache.Add(NewStage);
 
             TopStages[Key] = NewStage;
+
+            if (BinaryA != null)
+            {
+                TopStageSizes[KeyA] = BinaryA.Length;
+            }
+
+            TopStageSizes[KeyB] = BinaryB.Length;
+        }
+
+        public bool TryGetSize(long Key, out long Size)
+        {
+            if (TopStageSizes.TryGetValue(Key, out Size))
+            {
+                return true;
+            }
+
+            Size = 0;
+
+            return false;
         }
 
         public IEnumerable<ShaderDeclInfo> GetConstBufferUsage(long Key)

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLShaderProgram.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLShaderProgram.cs
@@ -1,6 +1,7 @@
 ﻿using OpenTK.Graphics.OpenGL;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Ryujinx.Graphics.Gal.OpenGL
 {
@@ -17,8 +18,6 @@ namespace Ryujinx.Graphics.Gal.OpenGL
     {
         public int Handle { get; private set; }
 
-        public bool IsCompiled { get; private set; }
-
         public GalShaderType Type { get; private set; }
 
         public string Code { get; private set; }
@@ -26,13 +25,20 @@ namespace Ryujinx.Graphics.Gal.OpenGL
         public IEnumerable<ShaderDeclInfo> ConstBufferUsage { get; private set; }
         public IEnumerable<ShaderDeclInfo> TextureUsage     { get; private set; }
 
+        private byte[] BinaryA;
+        private byte[] BinaryB;
+
         public OGLShaderStage(
             GalShaderType               Type,
+            byte[]                      BinaryA,
+            byte[]                      BinaryB,
             string                      Code,
             IEnumerable<ShaderDeclInfo> ConstBufferUsage,
             IEnumerable<ShaderDeclInfo> TextureUsage)
         {
             this.Type             = Type;
+            this.BinaryA          = BinaryA;
+            this.BinaryB          = BinaryB;
             this.Code             = Code;
             this.ConstBufferUsage = ConstBufferUsage;
             this.TextureUsage     = TextureUsage;
@@ -61,6 +67,21 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
                 Handle = 0;
             }
+        }
+
+        public bool EqualsBinary(byte[] BinaryA, byte[] BinaryB)
+        {
+            if (!BinaryB.SequenceEqual(this.BinaryB))
+            {
+                return false;
+            }
+
+            if (BinaryA != null)
+            {
+                return BinaryA.SequenceEqual(this.BinaryA);
+            }
+
+            return true;
         }
 
         public static void CompileAndCheck(int Handle, string Code)

--- a/Ryujinx.Graphics/Gal/Shader/GlslDecompiler.cs
+++ b/Ryujinx.Graphics/Gal/Shader/GlslDecompiler.cs
@@ -109,16 +109,15 @@ namespace Ryujinx.Graphics.Gal.Shader
         }
 
         public GlslProgram Decompile(
-            IGalMemory    Memory,
-            long          VpAPosition,
-            long          VpBPosition,
+            byte[]        BinaryA,
+            byte[]        BinaryB,
             GalShaderType ShaderType)
         {
-            Header  = new ShaderHeader(Memory, VpAPosition);
-            HeaderB = new ShaderHeader(Memory, VpBPosition);
+            Header  = new ShaderHeader(BinaryA);
+            HeaderB = new ShaderHeader(BinaryB);
 
-            Blocks  = ShaderDecoder.Decode(Memory, VpAPosition);
-            BlocksB = ShaderDecoder.Decode(Memory, VpBPosition);
+            Blocks  = ShaderDecoder.Decode(BinaryA);
+            BlocksB = ShaderDecoder.Decode(BinaryB);
 
             GlslDecl DeclVpA = new GlslDecl(Blocks,  ShaderType, Header);
             GlslDecl DeclVpB = new GlslDecl(BlocksB, ShaderType, HeaderB);
@@ -128,12 +127,12 @@ namespace Ryujinx.Graphics.Gal.Shader
             return Decompile();
         }
 
-        public GlslProgram Decompile(IGalMemory Memory, long Position, GalShaderType ShaderType)
+        public GlslProgram Decompile(byte[] Binary, GalShaderType ShaderType)
         {
-            Header  = new ShaderHeader(Memory, Position);
+            Header  = new ShaderHeader(Binary);
             HeaderB = null;
 
-            Blocks  = ShaderDecoder.Decode(Memory, Position);
+            Blocks  = ShaderDecoder.Decode(Binary);
             BlocksB = null;
 
             Decl = new GlslDecl(Blocks, ShaderType, Header);

--- a/Ryujinx.Graphics/Gal/Shader/ShaderDecoder.cs
+++ b/Ryujinx.Graphics/Gal/Shader/ShaderDecoder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Ryujinx.Graphics.Gal.Shader
@@ -138,7 +139,7 @@ namespace Ryujinx.Graphics.Gal.Shader
                     continue;
                 }
 
-                long OpCode = ReadQWord(Binary, Position);
+                long OpCode = BitConverter.ToInt64(Binary, (int)Position);
 
                 Position += 8;
 
@@ -198,19 +199,6 @@ namespace Ryujinx.Graphics.Gal.Shader
 
             return Op.Inst != ShaderIrInst.Exit &&
                    Op.Inst != ShaderIrInst.Bra;
-        }
-
-        private static unsafe long ReadQWord(byte[] Bytes, long Position)
-        {
-            if (Position >= Bytes.Length)
-            {
-                throw new System.InvalidOperationException();
-            }
-
-            fixed (byte* Pointer = Bytes)
-            {
-                return *((long*)(Pointer + Position));
-            }
         }
     }
 }

--- a/Ryujinx.Graphics/Gal/Shader/ShaderHeader.cs
+++ b/Ryujinx.Graphics/Gal/Shader/ShaderHeader.cs
@@ -59,13 +59,13 @@ namespace Ryujinx.Graphics.Gal.Shader
         public bool         OmapSampleMask { get; private set; }
         public bool         OmapDepth      { get; private set; }
 
-        public ShaderHeader(IGalMemory Memory, long Position)
+        public unsafe ShaderHeader(byte[] Binary)
         {
-            uint CommonWord0 = (uint)Memory.ReadInt32(Position + 0);
-            uint CommonWord1 = (uint)Memory.ReadInt32(Position + 4);
-            uint CommonWord2 = (uint)Memory.ReadInt32(Position + 8);
-            uint CommonWord3 = (uint)Memory.ReadInt32(Position + 12);
-            uint CommonWord4 = (uint)Memory.ReadInt32(Position + 16);
+            uint CommonWord0 = ReadWord(Binary, 0);
+            uint CommonWord1 = ReadWord(Binary, 4);
+            uint CommonWord2 = ReadWord(Binary, 8);
+            uint CommonWord3 = ReadWord(Binary, 12);
+            uint CommonWord4 = ReadWord(Binary, 16);
 
             SphType         = ReadBits(CommonWord0,  0, 5);
             Version         = ReadBits(CommonWord0,  5, 5);
@@ -92,8 +92,8 @@ namespace Ryujinx.Graphics.Gal.Shader
             StoreReqEnd          = ReadBits(CommonWord4, 24,  8);
 
             //Type 2 (fragment?) reading
-            uint Type2OmapTarget = (uint)Memory.ReadInt32(Position + 72);
-            uint Type2Omap       = (uint)Memory.ReadInt32(Position + 76);
+            uint Type2OmapTarget = ReadWord(Binary, 72);
+            uint Type2Omap       = ReadWord(Binary, 76);
 
             OmapTargets = new OmapTarget[8];
 
@@ -133,6 +133,14 @@ namespace Ryujinx.Graphics.Gal.Shader
 
                 // Depth register is always two registers after the last color output
                 return Count + 1;
+            }
+        }
+
+        private static unsafe uint ReadWord(byte[] Bytes, long Position)
+        {
+            fixed (byte* Pointer = Bytes)
+            {
+                return *((uint*)(Pointer + Position));
             }
         }
 

--- a/Ryujinx.Graphics/Gal/Shader/ShaderHeader.cs
+++ b/Ryujinx.Graphics/Gal/Shader/ShaderHeader.cs
@@ -61,11 +61,11 @@ namespace Ryujinx.Graphics.Gal.Shader
 
         public unsafe ShaderHeader(byte[] Binary)
         {
-            uint CommonWord0 = ReadWord(Binary, 0);
-            uint CommonWord1 = ReadWord(Binary, 4);
-            uint CommonWord2 = ReadWord(Binary, 8);
-            uint CommonWord3 = ReadWord(Binary, 12);
-            uint CommonWord4 = ReadWord(Binary, 16);
+            uint CommonWord0 = BitConverter.ToUInt32(Binary, 0);
+            uint CommonWord1 = BitConverter.ToUInt32(Binary, 4);
+            uint CommonWord2 = BitConverter.ToUInt32(Binary, 8);
+            uint CommonWord3 = BitConverter.ToUInt32(Binary, 12);
+            uint CommonWord4 = BitConverter.ToUInt32(Binary, 16);
 
             SphType         = ReadBits(CommonWord0,  0, 5);
             Version         = ReadBits(CommonWord0,  5, 5);
@@ -92,8 +92,8 @@ namespace Ryujinx.Graphics.Gal.Shader
             StoreReqEnd          = ReadBits(CommonWord4, 24,  8);
 
             //Type 2 (fragment?) reading
-            uint Type2OmapTarget = ReadWord(Binary, 72);
-            uint Type2Omap       = ReadWord(Binary, 76);
+            uint Type2OmapTarget = BitConverter.ToUInt32(Binary, 72);
+            uint Type2Omap       = BitConverter.ToUInt32(Binary, 76);
 
             OmapTargets = new OmapTarget[8];
 
@@ -133,14 +133,6 @@ namespace Ryujinx.Graphics.Gal.Shader
 
                 // Depth register is always two registers after the last color output
                 return Count + 1;
-            }
-        }
-
-        private static unsafe uint ReadWord(byte[] Bytes, long Position)
-        {
-            fixed (byte* Pointer = Bytes)
-            {
-                return *((uint*)(Pointer + Position));
             }
         }
 

--- a/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3d.cs
+++ b/Ryujinx.HLE/Gpu/Engines/NvGpuEngine3d.cs
@@ -29,8 +29,6 @@ namespace Ryujinx.HLE.Gpu.Engines
 
         private int CurrentInstance = 0;
 
-        private Dictionary<long, long> ShadersSize;
-
         public NvGpuEngine3d(NvGpu Gpu)
         {
             this.Gpu = Gpu;
@@ -70,8 +68,6 @@ namespace Ryujinx.HLE.Gpu.Engines
             {
                 UploadedKeys[i] = new List<long>();
             }
-
-            ShadersSize = new Dictionary<long, long>();
         }
 
         public void CallMethod(NvGpuVmm Vmm, NvGpuPBEntry PBEntry)
@@ -279,7 +275,7 @@ namespace Ryujinx.HLE.Gpu.Engines
                     byte[] BinaryA = ReadShaderBinary(Vmm, VpAPos); 
                     byte[] BinaryB = ReadShaderBinary(Vmm, VpBPos);
 
-                    Gpu.Renderer.Shader.Create(VpBPos, BinaryA, BinaryB, GalShaderType.Vertex);
+                    Gpu.Renderer.Shader.Create(VpAPos, VpBPos, BinaryA, BinaryB, GalShaderType.Vertex);
                 }
 
                 Gpu.Renderer.Shader.Bind(VpBPos);
@@ -312,7 +308,7 @@ namespace Ryujinx.HLE.Gpu.Engines
                 {
                     byte[] Binary = ReadShaderBinary(Vmm, Key);
 
-                    Gpu.Renderer.Shader.Create(Key, null, Binary, Type);
+                    Gpu.Renderer.Shader.Create(0, Key, null, Binary, Type);
                 }
 
                 Gpu.Renderer.Shader.Bind(Key);
@@ -892,7 +888,7 @@ namespace Ryujinx.HLE.Gpu.Engines
         {
             long Address = Vmm.GetPhysicalAddress(Key);
 
-            if (ShadersSize.TryGetValue(Address, out long Size))
+            if (Gpu.Renderer.Shader.TryGetSize(Address, out long Size))
             {
                 if (!QueryKeyUpload(Vmm, Address, Size, NvGpuBufferType.Shader))
                 {
@@ -908,8 +904,6 @@ namespace Ryujinx.HLE.Gpu.Engines
             long Size = GetShaderSize(Vmm, Key);
 
             long Address = Vmm.GetPhysicalAddress(Key);
-
-            ShadersSize[Address] = Size;
 
             return Vmm.ReadBytes(Key, Size);
         }

--- a/Ryujinx.HLE/Gpu/Memory/NvGpuBufferType.cs
+++ b/Ryujinx.HLE/Gpu/Memory/NvGpuBufferType.cs
@@ -2,6 +2,7 @@ namespace Ryujinx.HLE.Gpu.Memory
 {
     enum NvGpuBufferType
     {
+        Shader,
         Index,
         Vertex,
         Texture,

--- a/Ryujinx.ShaderTools/Program.cs
+++ b/Ryujinx.ShaderTools/Program.cs
@@ -24,14 +24,11 @@ namespace Ryujinx.ShaderTools
                     case "f":  ShaderType = GalShaderType.Fragment;       break;
                 }
 
-                using (FileStream FS = new FileStream(args[1], FileMode.Open, FileAccess.Read))
-                {
-                    Memory Mem = new Memory(FS);
+                byte[] Binary = File.ReadAllBytes(args[1]);
 
-                    GlslProgram Program = Decompiler.Decompile(Mem, 0, ShaderType);
+                GlslProgram Program = Decompiler.Decompile(Binary, ShaderType);
 
-                    Console.WriteLine(Program.Code);
-                }
+                Console.WriteLine(Program.Code);
             }
             else
             {


### PR DESCRIPTION
Currently we're ignoring shader changes that can end up in undefined behaviour. This adds shaders to the cache invalidation and keeps tracks of them in OGLShader to avoid rebuilding shaders.

I'm not happy with how the code ended up being, I'll happily listen suggestion.
I think it could end up being better if all LLE GPU emulation is moved from Ryujinx.HLE to Ryujinx.Graphics.