### PR TITLE
Asynchronously log messages to the Console window

### DIFF
--- a/Ryujinx/Ui/ConsoleLog.cs
+++ b/Ryujinx/Ui/ConsoleLog.cs
@@ -1,5 +1,6 @@
 using Ryujinx.HLE.Logging;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 
@@ -7,6 +8,8 @@ namespace Ryujinx
 {
     static class ConsoleLog
     {
+        private static Thread MessageThread;
+        private static BlockingCollection<LogEventArgs> MessageQueue;
         private static Dictionary<LogLevel, ConsoleColor> LogColors;
 
         private static object ConsoleLock;
@@ -21,15 +24,37 @@ namespace Ryujinx
                 { LogLevel.Error,   ConsoleColor.Red      }
             };
 
+            MessageQueue = new BlockingCollection<LogEventArgs>();
+
             ConsoleLock = new object();
+
+            MessageThread = new Thread(() =>
+            {
+                while (!MessageQueue.IsCompleted)
+                {
+                    try
+                    {
+                        PrintLog(MessageQueue.Take());
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        // IOE means that Take() was called on a completed collection.
+                        // Some other thread can call CompleteAdding after we pass the
+                        // IsCompleted check but before we call Take.
+                        // We can simply catch the exception since the loop will break
+                        // on the next iteration.
+                    }
+                }
+            });
+
+            MessageThread.IsBackground = true;
+            MessageThread.Start();
         }
 
-        public static void PrintLog(object sender, LogEventArgs e)
+        private static void PrintLog(LogEventArgs e)
         {
             string FormattedTime = e.Time.ToString(@"hh\:mm\:ss\.fff");
-
             string CurrentThread = Thread.CurrentThread.ManagedThreadId.ToString("d4");
-
             string Message = FormattedTime + " | " + CurrentThread + " " + e.Message;
 
             if (LogColors.TryGetValue(e.Level, out ConsoleColor Color))
@@ -45,6 +70,14 @@ namespace Ryujinx
             else
             {
                 Console.WriteLine(Message);
+            }
+        }
+
+        public static void Log(object sender, LogEventArgs e)
+        {
+            if (!MessageQueue.IsAddingCompleted)
+            {
+                MessageQueue.Add(e);
             }
         }
     }

--- a/Ryujinx/Ui/ConsoleLog.cs
+++ b/Ryujinx/Ui/ConsoleLog.cs
@@ -9,7 +9,9 @@ namespace Ryujinx
     static class ConsoleLog
     {
         private static Thread MessageThread;
+
         private static BlockingCollection<LogEventArgs> MessageQueue;
+
         private static Dictionary<LogLevel, ConsoleColor> LogColors;
 
         private static object ConsoleLock;
@@ -54,7 +56,9 @@ namespace Ryujinx
         private static void PrintLog(LogEventArgs e)
         {
             string FormattedTime = e.Time.ToString(@"hh\:mm\:ss\.fff");
+
             string CurrentThread = Thread.CurrentThread.ManagedThreadId.ToString("d4");
+            
             string Message = FormattedTime + " | " + CurrentThread + " " + e.Message;
 
             if (LogColors.TryGetValue(e.Level, out ConsoleColor Color))

--- a/Ryujinx/Ui/Program.cs
+++ b/Ryujinx/Ui/Program.cs
@@ -22,7 +22,7 @@ namespace Ryujinx
 
             Config.Read(Device);
 
-            Device.Log.Updated += ConsoleLog.PrintLog;
+            Device.Log.Updated += ConsoleLog.Log;
 
             if (args.Length == 1)
             {


### PR DESCRIPTION
Writing to the Console blocks until the write completes. This has the potential to block any code path that logs to the application logger.

By queuing up log messages in an asynchronous queue and returning without blocking, we can speed up code paths that heavily log to the console (for example stubbed services like ServiceHid).

From testing, this results in a roughly 8% time decrease between Ryujinx startup and the splash screen in Super Mario Odyssey on my system (in Debug) - 00:03:19.591 down to
00:03:04.354. Depending on your system, YMMV.