### PR TITLE
Fix exception throw message for unimpl texture formats

### DIFF
--- a/Ryujinx.Graphics/Gal/ImageFormatConverter.cs
+++ b/Ryujinx.Graphics/Gal/ImageFormatConverter.cs
@@ -124,7 +124,7 @@ namespace Ryujinx.Graphics.Gal
                     break;
             }
 
-            throw new NotImplementedException("0x" + Format.ToString("x2") + " " + Type.ToString());
+            throw new NotImplementedException("0x" + ((int)Format).ToString("x2") + " " + Type.ToString());
         }
 
         public static GalImageFormat ConvertFrameBuffer(GalFrameBufferFormat Format)

--- a/Ryujinx.HLE/Gpu/Texture/TextureHelper.cs
+++ b/Ryujinx.HLE/Gpu/Texture/TextureHelper.cs
@@ -177,7 +177,7 @@ namespace Ryujinx.HLE.Gpu.Texture
                 }
             }
 
-            throw new NotImplementedException("0x" + Image.Format.ToString("x2"));
+            throw new NotImplementedException(Image.Format.ToString());
         }
 
         public static int CompressedTextureSize(int TextureWidth, int TextureHeight, int BlockWidth, int BlockHeight, int Bpb)

--- a/Ryujinx.HLE/Gpu/Texture/TextureReader.cs
+++ b/Ryujinx.HLE/Gpu/Texture/TextureReader.cs
@@ -49,7 +49,7 @@ namespace Ryujinx.HLE.Gpu.Texture
                 case GalTextureFormat.Astc2D10x6:   return Read16BptCompressedTexture(Memory, Texture, 10, 6);
              }
 
-            throw new NotImplementedException("0x" + Texture.Format.ToString("x2"));
+            throw new NotImplementedException("0x" + ((int)Texture.Format).ToString("x2"));
         }
 
         private unsafe static byte[] Read1Bpp(IAMemory Memory, TextureInfo Texture)


### PR DESCRIPTION
Calling to string with the `x2` format is not valid for enums, it will throw `System.FormatException: Format string can be only "G", "g",  "X", "x", "F", "f", "D" or "d".`. The fix is casting it to int first.