### PR TITLE
Set the default culture to InvariantCulture

### DIFF
--- a/Ryujinx/Ui/Program.cs
+++ b/Ryujinx/Ui/Program.cs
@@ -4,6 +4,7 @@ using Ryujinx.Graphics.Gal;
 using Ryujinx.Graphics.Gal.OpenGL;
 using Ryujinx.HLE;
 using System;
+using System.Globalization;
 using System.IO;
 
 namespace Ryujinx
@@ -13,6 +14,9 @@ namespace Ryujinx
         static void Main(string[] args)
         {
             Console.Title = "Ryujinx Console";
+
+            CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+            CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
 
             IGalRenderer Renderer = new OGLRenderer();
 


### PR DESCRIPTION
This mainly affects some C# string conversions (`ToString` and `Parse`), and I've experienced a few weird issues in other C# projects due to region differences. Setting this as early as possible doesn't have any negative impact and only makes everything behave the same in every region.

In parts of Europe, `,` is used as the decimal separator, not `.`

The most noticeable change:

![image](https://user-images.githubusercontent.com/1200380/44993079-90438000-af99-11e8-9ae7-e36378688815.png)

becomes

![image](https://user-images.githubusercontent.com/1200380/44993041-70ac5780-af99-11e8-92ee-4e903f06fe74.png)
