### PR TITLE
Show Game Title on Titlebar

### DIFF
--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -141,7 +141,7 @@ namespace Ryujinx.HLE.HOS
                 throw new NotImplementedException("32-bit titles are unsupported!");
             }
 
-            CurrentTitle = MainProcess.MetaData.ACI0.TitleId.ToString("x32");
+            CurrentTitle = MainProcess.MetaData.ACI0.TitleId.ToString("x16");
 
             LoadNso("rtld");
 
@@ -372,7 +372,7 @@ namespace Ryujinx.HLE.HOS
             }
             else
             {
-                CurrentTitle = MainProcess.MetaData.ACI0.TitleId.ToString("x32");
+                CurrentTitle = MainProcess.MetaData.ACI0.TitleId.ToString("x16");
             }
 
             if (!MainProcess.MetaData.Is64Bits)

--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -356,7 +356,7 @@ namespace Ryujinx.HLE.HOS
 
                 Nacp ControlData = new Nacp(Reader);
 
-                CurrentTitle = ControlData.Languages[(int)State.DesiredLanguage].Title;
+                CurrentTitle = ControlData.Languages[(int)State.DesiredTitleLanguage].Title;
 
                 if (string.IsNullOrWhiteSpace(CurrentTitle))
                 {

--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -160,7 +160,7 @@ namespace Ryujinx.HLE.HOS
 
             Xci Xci = new Xci(KeySet, File);
 
-            (Nca MainNca, Nca ControlNca) = GetXciMainNca(Xci);
+            (Nca MainNca, Nca ControlNca) = GetXciGameData(Xci);
 
             if (MainNca == null)
             {
@@ -172,7 +172,7 @@ namespace Ryujinx.HLE.HOS
             LoadNca(MainNca, ControlNca);
         }
 
-        private (Nca Main,Nca Control) GetXciMainNca(Xci Xci)
+        private (Nca Main, Nca Control) GetXciGameData(Xci Xci)
         {
             if (Xci.SecurePartition == null)
             {
@@ -200,7 +200,7 @@ namespace Ryujinx.HLE.HOS
                         PatchNca = Nca;
                     }
                 }
-                else if(Nca.Header.ContentType == ContentType.Control)
+                else if (Nca.Header.ContentType == ContentType.Control)
                 {
                     ControlNca = Nca;
                 }
@@ -269,7 +269,7 @@ namespace Ryujinx.HLE.HOS
                 {
                     MainNca = Nca;
                 }
-                else if(Nca.Header.ContentType == ContentType.Control)
+                else if (Nca.Header.ContentType == ContentType.Control)
                 {
                     ControlNca = Nca;
                 }
@@ -305,9 +305,11 @@ namespace Ryujinx.HLE.HOS
             }
 
             Stream RomfsStream = MainNca.OpenSection(RomfsSection.SectionNum, false);
+
             Device.FileSystem.SetRomFs(RomfsStream);
 
             Stream ExefsStream = MainNca.OpenSection(ExefsSection.SectionNum, false);
+
             Pfs Exefs = new Pfs(ExefsStream);
 
             Npdm MetaData = null;
@@ -358,7 +360,7 @@ namespace Ryujinx.HLE.HOS
 
                 if (string.IsNullOrWhiteSpace(CurrentTitle))
                 {
-                    CurrentTitle = ControlData.Languages[0].Title;
+                    CurrentTitle = ControlData.Languages.ToList().Find(x => !string.IsNullOrWhiteSpace(x.Title)).Title;
                 }
 
                 return ControlData;

--- a/Ryujinx.HLE/HOS/Process.cs
+++ b/Ryujinx.HLE/HOS/Process.cs
@@ -2,6 +2,7 @@ using ChocolArm64;
 using ChocolArm64.Events;
 using ChocolArm64.Memory;
 using ChocolArm64.State;
+using LibHac;
 using Ryujinx.HLE.Exceptions;
 using Ryujinx.HLE.HOS.Diagnostics.Demangler;
 using Ryujinx.HLE.HOS.Kernel;
@@ -41,6 +42,8 @@ namespace Ryujinx.HLE.HOS
         private List<KTlsPageManager> TlsPages;
 
         public Npdm MetaData { get; private set; }
+
+        public Nacp ControlData { get; set; }
 
         public KProcessHandleTable HandleTable { get; private set; }
 

--- a/Ryujinx.HLE/HOS/SystemState/SystemStateMgr.cs
+++ b/Ryujinx.HLE/HOS/SystemState/SystemStateMgr.cs
@@ -37,6 +37,8 @@ namespace Ryujinx.HLE.HOS.SystemState
 
         internal long DesiredLanguageCode { get; private set; }
 
+        public SystemLanguage DesiredLanguage { get; private set; }
+
         internal string ActiveAudioOutput { get; private set; }
 
         public bool DockedMode { get; set; }
@@ -64,6 +66,8 @@ namespace Ryujinx.HLE.HOS.SystemState
         public void SetLanguage(SystemLanguage Language)
         {
             DesiredLanguageCode = GetLanguageCode((int)Language);
+
+            DesiredLanguage = Language;
         }
 
         public void SetAudioOutputAsTv()

--- a/Ryujinx.HLE/HOS/SystemState/SystemStateMgr.cs
+++ b/Ryujinx.HLE/HOS/SystemState/SystemStateMgr.cs
@@ -37,7 +37,7 @@ namespace Ryujinx.HLE.HOS.SystemState
 
         internal long DesiredLanguageCode { get; private set; }
 
-        public SystemLanguage DesiredLanguage { get; private set; }
+        public TitleLanguage DesiredTitleLanguage { get; private set; }
 
         internal string ActiveAudioOutput { get; private set; }
 
@@ -67,7 +67,7 @@ namespace Ryujinx.HLE.HOS.SystemState
         {
             DesiredLanguageCode = GetLanguageCode((int)Language);
 
-            DesiredLanguage = Language;
+            DesiredTitleLanguage = Enum.Parse<TitleLanguage>(Enum.GetName(typeof(SystemLanguage), Language));
         }
 
         public void SetAudioOutputAsTv()

--- a/Ryujinx.HLE/HOS/SystemState/TitleLanguage.cs
+++ b/Ryujinx.HLE/HOS/SystemState/TitleLanguage.cs
@@ -1,0 +1,21 @@
+﻿namespace Ryujinx.HLE.HOS.SystemState
+{
+    public enum TitleLanguage
+    {
+        AmericanEnglish,
+        BritishEnglish,
+        Japanese,
+        French,
+        German,
+        LatinAmericanSpanish,
+        Spanish,
+        Italian,
+        Dutch,
+        CanadianFrench,
+        Portuguese,
+        Russian,
+        Korean,
+        Taiwanese,
+        Chinese        
+    }
+}

--- a/Ryujinx/Ui/GLScreen.cs
+++ b/Ryujinx/Ui/GLScreen.cs
@@ -258,8 +258,11 @@ namespace Ryujinx
             double HostFps = Device.Statistics.GetSystemFrameRate();
             double GameFps = Device.Statistics.GetGameFrameRate();
 
-            NewTitle = $"Ryujinx | {Device.System.CurrentTitle ?? ""} | Host FPS: {HostFps:0.0} " +
-                $"| Game FPS: {GameFps:0.0} | Game Vsync: {(Device.EnableDeviceVsync ? "On" : "Off")}";
+            string TitleSection = string.IsNullOrWhiteSpace(Device.System.CurrentTitle) ? string.Empty
+                : " | " + Device.System.CurrentTitle;
+
+            NewTitle = $"Ryujinx{TitleSection} | Host FPS: {HostFps:0.0} | Game FPS: {GameFps:0.0} | " +
+                $"Game Vsync: {(Device.EnableDeviceVsync ? "On" : "Off")}";
 
             TitleEvent = true;
 

--- a/Ryujinx/Ui/GLScreen.cs
+++ b/Ryujinx/Ui/GLScreen.cs
@@ -258,8 +258,8 @@ namespace Ryujinx
             double HostFps = Device.Statistics.GetSystemFrameRate();
             double GameFps = Device.Statistics.GetGameFrameRate();
 
-            NewTitle = $"Ryujinx | Host FPS: {HostFps:0.0} | Game FPS: {GameFps:0.0} | Game Vsync: " +
-               (Device.EnableDeviceVsync ? "On" : "Off");
+            NewTitle = $"Ryujinx | {Device.System.CurrentTitle ?? ""} | Host FPS: {HostFps:0.0} " +
+                $"| Game FPS: {GameFps:0.0} | Game Vsync: {(Device.EnableDeviceVsync ? "On" : "Off")}";
 
             TitleEvent = true;
 


### PR DESCRIPTION
This adds the current game title on the titlebar. if control data is found in the nsp/xci, it uses the real game title that corresponds to the current language of the emulated system, which if not available, uses the title for American English( default is American English by the way). If control data is not found, it shows the title id.
 Changing language is not available now.