### PR TITLE
 Move logging to Ryujinx.Common and make it a static class 

### DIFF
--- a/Ryujinx.Audio/Ryujinx.Audio.csproj
+++ b/Ryujinx.Audio/Ryujinx.Audio.csproj
@@ -9,4 +9,8 @@
     <PackageReference Include="OpenTK.NetStandard" Version="1.0.4" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Ryujinx.Common\Ryujinx.Common.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/Ryujinx.Common/Logging/LogClass.cs
+++ b/Ryujinx.Common/Logging/LogClass.cs
@@ -1,4 +1,4 @@
-namespace Ryujinx.HLE.Logging
+namespace Ryujinx.Common.Logging
 {
     public enum LogClass
     {

--- a/Ryujinx.Common/Logging/LogEventArgs.cs
+++ b/Ryujinx.Common/Logging/LogEventArgs.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Ryujinx.HLE.Logging
+namespace Ryujinx.Common.Logging
 {
     public class LogEventArgs : EventArgs
     {

--- a/Ryujinx.Common/Logging/LogLevel.cs
+++ b/Ryujinx.Common/Logging/LogLevel.cs
@@ -1,4 +1,4 @@
-namespace Ryujinx.HLE.Logging
+namespace Ryujinx.Common.Logging
 {
     public enum LogLevel
     {

--- a/Ryujinx.Common/Logging/Logger.cs
+++ b/Ryujinx.Common/Logging/Logger.cs
@@ -2,18 +2,18 @@ using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
-namespace Ryujinx.HLE.Logging
+namespace Ryujinx.Common.Logging
 {
-    public class Logger
+    public static class Logger
     {
-        private bool[] EnabledLevels;
-        private bool[] EnabledClasses;
+        private static bool[] EnabledLevels;
+        private static bool[] EnabledClasses;
 
-        public event EventHandler<LogEventArgs> Updated;
+        public static event EventHandler<LogEventArgs> Updated;
 
-        private Stopwatch Time;
+        private static Stopwatch Time;
 
-        public Logger()
+        static Logger()
         {
             EnabledLevels  = new bool[Enum.GetNames(typeof(LogLevel)).Length];
             EnabledClasses = new bool[Enum.GetNames(typeof(LogClass)).Length];
@@ -33,50 +33,50 @@ namespace Ryujinx.HLE.Logging
             Time.Start();
         }
 
-        public void SetEnable(LogLevel Level, bool Enabled)
+        public static void SetEnable(LogLevel Level, bool Enabled)
         {
             EnabledLevels[(int)Level] = Enabled;
         }
 
-        public void SetEnable(LogClass Class, bool Enabled)
+        public static void SetEnable(LogClass Class, bool Enabled)
         {
             EnabledClasses[(int)Class] = Enabled;
         }
 
-        internal void PrintDebug(LogClass Class, string Message, [CallerMemberName] string Caller = "")
+        public static void PrintDebug(LogClass Class, string Message, [CallerMemberName] string Caller = "")
         {
             Print(LogLevel.Debug, Class, GetFormattedMessage(Class, Message, Caller));
         }
 
-        internal void PrintStub(LogClass Class, string Message, [CallerMemberName] string Caller = "")
+        public static void PrintStub(LogClass Class, string Message, [CallerMemberName] string Caller = "")
         {
             Print(LogLevel.Stub, Class, GetFormattedMessage(Class, Message, Caller));
         }
 
-        internal void PrintInfo(LogClass Class, string Message, [CallerMemberName] string Caller = "")
+        public static void PrintInfo(LogClass Class, string Message, [CallerMemberName] string Caller = "")
         {
             Print(LogLevel.Info, Class, GetFormattedMessage(Class, Message, Caller));
         }
 
-        internal void PrintWarning(LogClass Class, string Message, [CallerMemberName] string Caller = "")
+        public static void PrintWarning(LogClass Class, string Message, [CallerMemberName] string Caller = "")
         {
             Print(LogLevel.Warning, Class, GetFormattedMessage(Class, Message, Caller));
         }
 
-        internal void PrintError(LogClass Class, string Message, [CallerMemberName] string Caller = "")
+        public static void PrintError(LogClass Class, string Message, [CallerMemberName] string Caller = "")
         {
             Print(LogLevel.Error, Class, GetFormattedMessage(Class, Message, Caller));
         }
 
-        private void Print(LogLevel Level, LogClass Class, string Message)
+        private static void Print(LogLevel Level, LogClass Class, string Message)
         {
             if (EnabledLevels[(int)Level] && EnabledClasses[(int)Class])
             {
-                Updated?.Invoke(this, new LogEventArgs(Level, Time.Elapsed, Message));
+                Updated?.Invoke(null, new LogEventArgs(Level, Time.Elapsed, Message));
             }
         }
 
-        private string GetFormattedMessage(LogClass Class, string Message, string Caller)
+        private static string GetFormattedMessage(LogClass Class, string Message, string Caller)
         {
             return $"{Class} {Caller}: {Message}";
         }

--- a/Ryujinx.Common/Ryujinx.Common.csproj
+++ b/Ryujinx.Common/Ryujinx.Common.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -12,14 +12,5 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="OpenTK.NetStandard" Version="1.0.4" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\ChocolArm64\ChocolArm64.csproj" />
-    <ProjectReference Include="..\Ryujinx.Common\Ryujinx.Common.csproj" />
-  </ItemGroup>
 
 </Project>

--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -1,10 +1,10 @@
 using LibHac;
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Font;
 using Ryujinx.HLE.HOS.Kernel;
 using Ryujinx.HLE.HOS.SystemState;
 using Ryujinx.HLE.Loaders.Executables;
 using Ryujinx.HLE.Loaders.Npdm;
-using Ryujinx.HLE.Logging;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -104,7 +104,7 @@ namespace Ryujinx.HLE.HOS
 
             if (File.Exists(NpdmFileName))
             {
-                Device.Log.PrintInfo(LogClass.Loader, $"Loading main.npdm...");
+                Logger.PrintInfo(LogClass.Loader, $"Loading main.npdm...");
 
                 using (FileStream Input = new FileStream(NpdmFileName, FileMode.Open))
                 {
@@ -113,7 +113,7 @@ namespace Ryujinx.HLE.HOS
             }
             else
             {
-                Device.Log.PrintWarning(LogClass.Loader, $"NPDM file not found, using default values!");
+                Logger.PrintWarning(LogClass.Loader, $"NPDM file not found, using default values!");
             }
 
             Process MainProcess = MakeProcess(MetaData);
@@ -127,7 +127,7 @@ namespace Ryujinx.HLE.HOS
                         continue;
                     }
 
-                    Device.Log.PrintInfo(LogClass.Loader, $"Loading {Path.GetFileNameWithoutExtension(File)}...");
+                    Logger.PrintInfo(LogClass.Loader, $"Loading {Path.GetFileNameWithoutExtension(File)}...");
 
                     using (FileStream Input = new FileStream(File, FileMode.Open))
                     {
@@ -168,7 +168,7 @@ namespace Ryujinx.HLE.HOS
 
             if (MainNca == null)
             {
-                Device.Log.PrintError(LogClass.Loader, "Unable to load XCI");
+                Logger.PrintError(LogClass.Loader, "Unable to load XCI");
 
                 return;
             }
@@ -212,7 +212,7 @@ namespace Ryujinx.HLE.HOS
 
             if (MainNca == null)
             {
-                Device.Log.PrintError(LogClass.Loader, "Could not find an Application NCA in the provided XCI file");
+                Logger.PrintError(LogClass.Loader, "Could not find an Application NCA in the provided XCI file");
             }
 
             MainNca.SetBaseNca(PatchNca);
@@ -292,7 +292,7 @@ namespace Ryujinx.HLE.HOS
                 return;
             }
 
-            Device.Log.PrintError(LogClass.Loader, "Could not find an Application NCA in the provided NSP file");
+            Logger.PrintError(LogClass.Loader, "Could not find an Application NCA in the provided NSP file");
         }
 
         public void LoadNca(Nca MainNca, Nca ControlNca)
@@ -302,14 +302,14 @@ namespace Ryujinx.HLE.HOS
 
             if (ExefsSection == null)
             {
-                Device.Log.PrintError(LogClass.Loader, "No ExeFS found in NCA");
+                Logger.PrintError(LogClass.Loader, "No ExeFS found in NCA");
 
                 return;
             }
 
             if (RomfsSection == null)
             {
-                Device.Log.PrintWarning(LogClass.Loader, "No RomFS found in NCA");
+                Logger.PrintWarning(LogClass.Loader, "No RomFS found in NCA");
             }
             else
             {
@@ -326,13 +326,13 @@ namespace Ryujinx.HLE.HOS
 
             if (Exefs.FileExists("main.npdm"))
             {
-                Device.Log.PrintInfo(LogClass.Loader, "Loading main.npdm...");
+                Logger.PrintInfo(LogClass.Loader, "Loading main.npdm...");
 
                 MetaData = new Npdm(Exefs.OpenFile("main.npdm"));
             }
             else
             {
-                Device.Log.PrintWarning(LogClass.Loader, $"NPDM file not found, using default values!");
+                Logger.PrintWarning(LogClass.Loader, $"NPDM file not found, using default values!");
             }
 
             Process MainProcess = MakeProcess(MetaData);
@@ -346,7 +346,7 @@ namespace Ryujinx.HLE.HOS
                         continue;
                     }
 
-                    Device.Log.PrintInfo(LogClass.Loader, $"Loading {Filename}...");
+                    Logger.PrintInfo(LogClass.Loader, $"Loading {Filename}...");
 
                     string Name = Path.GetFileNameWithoutExtension(File.Name);
 

--- a/Ryujinx.HLE/HOS/Kernel/SvcHandler.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SvcHandler.cs
@@ -1,8 +1,8 @@
 using ChocolArm64.Events;
 using ChocolArm64.Memory;
 using ChocolArm64.State;
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
-using Ryujinx.HLE.Logging;
 using System;
 using System.Collections.Generic;
 
@@ -109,11 +109,11 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (SvcFuncs.TryGetValue(e.Id, out SvcFunc Func))
             {
-                Device.Log.PrintDebug(LogClass.KernelSvc, $"{Func.Method.Name} called.");
+                Logger.PrintDebug(LogClass.KernelSvc, $"{Func.Method.Name} called.");
 
                 Func(ThreadState);
 
-                Device.Log.PrintDebug(LogClass.KernelSvc, $"{Func.Method.Name} ended.");
+                Logger.PrintDebug(LogClass.KernelSvc, $"{Func.Method.Name} ended.");
             }
             else
             {

--- a/Ryujinx.HLE/HOS/Kernel/SvcMemory.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SvcMemory.cs
@@ -1,5 +1,5 @@
 using ChocolArm64.State;
-using Ryujinx.HLE.Logging;
+using Ryujinx.Common.Logging;
 
 using static Ryujinx.HLE.HOS.ErrorCode;
 
@@ -13,7 +13,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if ((Size & 0xFFFFFFFE001FFFFF) != 0)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Heap size 0x{Size:x16} is not aligned!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Heap size 0x{Size:x16} is not aligned!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidSize);
 
@@ -30,7 +30,7 @@ namespace Ryujinx.HLE.HOS.Kernel
             }
             else
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
             }
         }
 
@@ -41,7 +41,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (!PageAligned(Position))
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Address 0x{Position:x16} is not page aligned!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Address 0x{Position:x16} is not page aligned!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidAddress);
 
@@ -50,7 +50,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (!PageAligned(Size) || Size == 0)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Size 0x{Size:x16} is not page aligned or is zero!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Size 0x{Size:x16} is not page aligned or is zero!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidSize);
 
@@ -65,7 +65,7 @@ namespace Ryujinx.HLE.HOS.Kernel
             if (Attributes != AttributeMask ||
                (Attributes | MemoryAttribute.Uncached) != MemoryAttribute.Uncached)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, "Invalid memory attributes!");
+                Logger.PrintWarning(LogClass.KernelSvc, "Invalid memory attributes!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidMaskValue);
 
@@ -80,7 +80,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (Result != 0)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
             }
             else
             {
@@ -98,7 +98,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (!PageAligned(Src | Dst))
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, "Addresses are not page aligned!");
+                Logger.PrintWarning(LogClass.KernelSvc, "Addresses are not page aligned!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidAddress);
 
@@ -107,7 +107,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (!PageAligned(Size) || Size == 0)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Size 0x{Size:x16} is not page aligned or is zero!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Size 0x{Size:x16} is not page aligned or is zero!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidSize);
 
@@ -116,7 +116,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if ((ulong)(Src + Size) <= (ulong)Src || (ulong)(Dst + Size) <= (ulong)Dst)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, "Addresses outside of range!");
+                Logger.PrintWarning(LogClass.KernelSvc, "Addresses outside of range!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.NoAccessPerm);
 
@@ -125,7 +125,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (!InsideAddrSpace(Src, Size))
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Src address 0x{Src:x16} out of range!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Src address 0x{Src:x16} out of range!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.NoAccessPerm);
 
@@ -134,7 +134,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (!InsideNewMapRegion(Dst, Size))
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Dst address 0x{Dst:x16} out of range!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Dst address 0x{Dst:x16} out of range!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidMemRange);
 
@@ -145,7 +145,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (Result != 0)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
             }
 
             ThreadState.X0 = (ulong)Result;
@@ -159,7 +159,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (!PageAligned(Src | Dst))
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, "Addresses are not page aligned!");
+                Logger.PrintWarning(LogClass.KernelSvc, "Addresses are not page aligned!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidAddress);
 
@@ -168,7 +168,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (!PageAligned(Size) || Size == 0)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Size 0x{Size:x16} is not page aligned or is zero!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Size 0x{Size:x16} is not page aligned or is zero!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidSize);
 
@@ -177,7 +177,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if ((ulong)(Src + Size) <= (ulong)Src || (ulong)(Dst + Size) <= (ulong)Dst)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, "Addresses outside of range!");
+                Logger.PrintWarning(LogClass.KernelSvc, "Addresses outside of range!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.NoAccessPerm);
 
@@ -186,7 +186,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (!InsideAddrSpace(Src, Size))
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Src address 0x{Src:x16} out of range!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Src address 0x{Src:x16} out of range!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.NoAccessPerm);
 
@@ -195,7 +195,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (!InsideNewMapRegion(Dst, Size))
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Dst address 0x{Dst:x16} out of range!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Dst address 0x{Dst:x16} out of range!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidMemRange);
 
@@ -206,7 +206,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (Result != 0)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
             }
 
             ThreadState.X0 = (ulong)Result;
@@ -240,7 +240,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (!PageAligned(Position))
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Address 0x{Position:x16} is not page aligned!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Address 0x{Position:x16} is not page aligned!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidAddress);
 
@@ -249,7 +249,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (!PageAligned(Size) || Size == 0)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Size 0x{Size:x16} is not page aligned or is zero!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Size 0x{Size:x16} is not page aligned or is zero!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidSize);
 
@@ -258,7 +258,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if ((ulong)(Position + Size) <= (ulong)Position)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid region address 0x{Position:x16} / size 0x{Size:x16}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid region address 0x{Position:x16} / size 0x{Size:x16}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.NoAccessPerm);
 
@@ -269,7 +269,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if ((Permission | MemoryPermission.Write) != MemoryPermission.ReadAndWrite)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid permission {Permission}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid permission {Permission}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidPermission);
 
@@ -280,7 +280,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (SharedMemory == null)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid shared memory handle 0x{Handle:x8}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid shared memory handle 0x{Handle:x8}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidHandle);
 
@@ -289,7 +289,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (!InsideAddrSpace(Position, Size) || InsideMapRegion(Position, Size) || InsideHeapRegion(Position, Size))
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Address 0x{Position:x16} out of range!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Address 0x{Position:x16} out of range!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.NoAccessPerm);
 
@@ -298,7 +298,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (SharedMemory.Size != Size)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Size 0x{Size:x16} does not match shared memory size 0x{SharedMemory.Size:16}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Size 0x{Size:x16} does not match shared memory size 0x{SharedMemory.Size:16}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidSize);
 
@@ -309,7 +309,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (Result != 0)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
             }
 
             ThreadState.X0 = (ulong)Result;
@@ -323,7 +323,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (!PageAligned(Position))
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Address 0x{Position:x16} is not page aligned!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Address 0x{Position:x16} is not page aligned!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidAddress);
 
@@ -332,7 +332,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (!PageAligned(Size) || Size == 0)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Size 0x{Size:x16} is not page aligned or is zero!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Size 0x{Size:x16} is not page aligned or is zero!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidSize);
 
@@ -341,7 +341,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if ((ulong)(Position + Size) <= (ulong)Position)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid region address 0x{Position:x16} / size 0x{Size:x16}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid region address 0x{Position:x16} / size 0x{Size:x16}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.NoAccessPerm);
 
@@ -352,7 +352,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (SharedMemory == null)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid shared memory handle 0x{Handle:x8}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid shared memory handle 0x{Handle:x8}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidHandle);
 
@@ -361,7 +361,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (!InsideAddrSpace(Position, Size) || InsideMapRegion(Position, Size) || InsideHeapRegion(Position, Size))
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Address 0x{Position:x16} out of range!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Address 0x{Position:x16} out of range!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.NoAccessPerm);
 
@@ -372,7 +372,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (Result != 0)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
             }
 
             ThreadState.X0 = (ulong)Result;
@@ -385,7 +385,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (!PageAligned(Position))
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Address 0x{Position:x16} is not page aligned!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Address 0x{Position:x16} is not page aligned!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidAddress);
 
@@ -394,7 +394,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (!PageAligned(Size) || Size == 0)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Size 0x{Size:x16} is not page aligned or is zero!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Size 0x{Size:x16} is not page aligned or is zero!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidAddress);
 
@@ -403,7 +403,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if ((ulong)(Position + Size) <= (ulong)Position)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid region address 0x{Position:x16} / size 0x{Size:x16}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid region address 0x{Position:x16} / size 0x{Size:x16}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.NoAccessPerm);
 
@@ -414,7 +414,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (Permission > MemoryPermission.ReadAndWrite || Permission == MemoryPermission.Write)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid permission {Permission}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid permission {Permission}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidPermission);
 
@@ -438,7 +438,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (!PageAligned(Position))
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Address 0x{Position:x16} is not page aligned!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Address 0x{Position:x16} is not page aligned!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidAddress);
 
@@ -447,7 +447,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (!PageAligned(Size) || Size == 0)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Size 0x{Size:x16} is not page aligned or is zero!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Size 0x{Size:x16} is not page aligned or is zero!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidSize);
 
@@ -456,7 +456,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if ((ulong)(Position + Size) <= (ulong)Position)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid region address 0x{Position:x16} / size 0x{Size:x16}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid region address 0x{Position:x16} / size 0x{Size:x16}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.NoAccessPerm);
 
@@ -465,7 +465,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (!InsideAddrSpace(Position, Size))
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid address {Position:x16}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid address {Position:x16}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.NoAccessPerm);
 
@@ -476,7 +476,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (Result != 0)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
             }
 
             ThreadState.X0 = (ulong)Result;
@@ -489,7 +489,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (!PageAligned(Position))
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Address 0x{Position:x16} is not page aligned!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Address 0x{Position:x16} is not page aligned!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidAddress);
 
@@ -498,7 +498,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (!PageAligned(Size) || Size == 0)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Size 0x{Size:x16} is not page aligned or is zero!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Size 0x{Size:x16} is not page aligned or is zero!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidSize);
 
@@ -507,7 +507,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if ((ulong)(Position + Size) <= (ulong)Position)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid region address 0x{Position:x16} / size 0x{Size:x16}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid region address 0x{Position:x16} / size 0x{Size:x16}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.NoAccessPerm);
 
@@ -516,7 +516,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (!InsideAddrSpace(Position, Size))
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid address {Position:x16}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid address {Position:x16}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.NoAccessPerm);
 
@@ -527,7 +527,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (Result != 0)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
             }
 
             ThreadState.X0 = (ulong)Result;

--- a/Ryujinx.HLE/HOS/Kernel/SvcSystem.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SvcSystem.cs
@@ -1,9 +1,9 @@
 using ChocolArm64.Memory;
 using ChocolArm64.State;
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.Exceptions;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Services;
-using Ryujinx.HLE.Logging;
 using System;
 using System.Threading;
 
@@ -46,7 +46,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (Result != KernelResult.Success)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, "Operation failed with error: " + Result + "!");
+                Logger.PrintWarning(LogClass.KernelSvc, "Operation failed with error: " + Result + "!");
             }
 
             return Result;
@@ -76,7 +76,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (Result != KernelResult.Success)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, "Operation failed with error: " + Result + "!");
+                Logger.PrintWarning(LogClass.KernelSvc, "Operation failed with error: " + Result + "!");
             }
 
             return Result;
@@ -92,7 +92,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (Obj == null)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid handle 0x{Handle:x8}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid handle 0x{Handle:x8}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidHandle);
 
@@ -136,11 +136,11 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (Result == KernelResult.InvalidState)
             {
-                Device.Log.PrintDebug(LogClass.KernelSvc, "Operation failed with error: " + Result + "!");
+                Logger.PrintDebug(LogClass.KernelSvc, "Operation failed with error: " + Result + "!");
             }
             else if (Result != KernelResult.Success)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, "Operation failed with error: " + Result + "!");
+                Logger.PrintWarning(LogClass.KernelSvc, "Operation failed with error: " + Result + "!");
             }
 
             return Result;
@@ -220,7 +220,7 @@ namespace Ryujinx.HLE.HOS.Kernel
             }
             else
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid session handle 0x{Handle:x8}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid session handle 0x{Handle:x8}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidHandle);
             }
@@ -255,7 +255,7 @@ namespace Ryujinx.HLE.HOS.Kernel
             }
             else
             {
-                Device.Log.PrintInfo(LogClass.KernelSvc, "Debugger triggered");
+                Logger.PrintInfo(LogClass.KernelSvc, "Debugger triggered");
                 Process.PrintStackTrace(ThreadState);
             }
         }
@@ -267,7 +267,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             string Str = AMemoryHelper.ReadAsciiString(Memory, Position, Size);
 
-            Device.Log.PrintWarning(LogClass.KernelSvc, Str);
+            Logger.PrintWarning(LogClass.KernelSvc, Str);
 
             ThreadState.X0 = 0;
         }

--- a/Ryujinx.HLE/HOS/Kernel/SvcThread.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SvcThread.cs
@@ -1,5 +1,5 @@
 using ChocolArm64.State;
-using Ryujinx.HLE.Logging;
+using Ryujinx.Common.Logging;
 
 using static Ryujinx.HLE.HOS.ErrorCode;
 
@@ -17,7 +17,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if ((uint)Priority > 0x3f)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid priority 0x{Priority:x8}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid priority 0x{Priority:x8}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidPriority);
 
@@ -31,7 +31,7 @@ namespace Ryujinx.HLE.HOS.Kernel
             }
             else if ((uint)ProcessorId > 3)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid core id 0x{ProcessorId:x8}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid core id 0x{ProcessorId:x8}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidCoreId);
 
@@ -61,14 +61,14 @@ namespace Ryujinx.HLE.HOS.Kernel
 
                 if (Result != 0)
                 {
-                    Device.Log.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
+                    Logger.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
                 }
 
                 ThreadState.X0 = (ulong)Result;
             }
             else
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid thread handle 0x{Handle:x8}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid thread handle 0x{Handle:x8}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidHandle);
             }
@@ -87,7 +87,7 @@ namespace Ryujinx.HLE.HOS.Kernel
         {
             long Timeout = (long)ThreadState.X0;
 
-            Device.Log.PrintDebug(LogClass.KernelSvc, "Timeout = 0x" + Timeout.ToString("x16"));
+            Logger.PrintDebug(LogClass.KernelSvc, "Timeout = 0x" + Timeout.ToString("x16"));
 
             KThread CurrentThread = System.Scheduler.GetCurrentThread();
 
@@ -121,7 +121,7 @@ namespace Ryujinx.HLE.HOS.Kernel
             }
             else
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid thread handle 0x{Handle:x8}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid thread handle 0x{Handle:x8}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidHandle);
             }
@@ -132,7 +132,7 @@ namespace Ryujinx.HLE.HOS.Kernel
             int Handle   = (int)ThreadState.X0;
             int Priority = (int)ThreadState.X1;
 
-            Device.Log.PrintDebug(LogClass.KernelSvc,
+            Logger.PrintDebug(LogClass.KernelSvc,
                 "Handle = 0x"   + Handle  .ToString("x8") + ", " +
                 "Priority = 0x" + Priority.ToString("x8"));
 
@@ -142,7 +142,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (Thread == null)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid thread handle 0x{Handle:x8}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid thread handle 0x{Handle:x8}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidHandle);
 
@@ -158,7 +158,7 @@ namespace Ryujinx.HLE.HOS.Kernel
         {
             int Handle = (int)ThreadState.X2;
 
-            Device.Log.PrintDebug(LogClass.KernelSvc, "Handle = 0x" + Handle.ToString("x8"));
+            Logger.PrintDebug(LogClass.KernelSvc, "Handle = 0x" + Handle.ToString("x8"));
 
             KThread Thread = Process.HandleTable.GetKThread(Handle);
 
@@ -170,7 +170,7 @@ namespace Ryujinx.HLE.HOS.Kernel
             }
             else
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid thread handle 0x{Handle:x8}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid thread handle 0x{Handle:x8}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidHandle);
             }
@@ -182,7 +182,7 @@ namespace Ryujinx.HLE.HOS.Kernel
             int  PrefferedCore =  (int)ThreadState.X1;
             long AffinityMask  = (long)ThreadState.X2;
 
-            Device.Log.PrintDebug(LogClass.KernelSvc,
+            Logger.PrintDebug(LogClass.KernelSvc,
                 "Handle = 0x"        + Handle       .ToString("x8") + ", " +
                 "PrefferedCore = 0x" + PrefferedCore.ToString("x8") + ", " +
                 "AffinityMask = 0x"  + AffinityMask .ToString("x16"));
@@ -202,7 +202,7 @@ namespace Ryujinx.HLE.HOS.Kernel
                 {
                     if ((PrefferedCore | 2) != -1)
                     {
-                        Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid core id 0x{PrefferedCore:x8}!");
+                        Logger.PrintWarning(LogClass.KernelSvc, $"Invalid core id 0x{PrefferedCore:x8}!");
 
                         ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidCoreId);
 
@@ -211,7 +211,7 @@ namespace Ryujinx.HLE.HOS.Kernel
                 }
                 else if ((AffinityMask & (1 << PrefferedCore)) == 0)
                 {
-                    Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid core mask 0x{AffinityMask:x8}!");
+                    Logger.PrintWarning(LogClass.KernelSvc, $"Invalid core mask 0x{AffinityMask:x8}!");
 
                     ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidMaskValue);
 
@@ -223,7 +223,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (Thread == null)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid thread handle 0x{Handle:x8}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid thread handle 0x{Handle:x8}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidHandle);
 
@@ -234,7 +234,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (Result != 0)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
             }
 
             ThreadState.X0 = (ulong)Result;
@@ -258,7 +258,7 @@ namespace Ryujinx.HLE.HOS.Kernel
             }
             else
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid thread handle 0x{Handle:x8}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid thread handle 0x{Handle:x8}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidHandle);
             }
@@ -273,7 +273,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (Thread == null)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid thread handle 0x{Handle:x8}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid thread handle 0x{Handle:x8}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidHandle);
 
@@ -282,7 +282,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (Thread.Owner != Process)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid thread owner process!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid thread owner process!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidHandle);
 
@@ -293,7 +293,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (Result != 0)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
             }
 
             ThreadState.X0 = (ulong)Result;
@@ -308,7 +308,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (Thread == null)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid thread handle 0x{Handle:x8}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid thread handle 0x{Handle:x8}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidHandle);
 
@@ -317,7 +317,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (Process.GetThread(ThreadState.Tpidr) == Thread)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Thread handle 0x{Handle:x8} is current thread!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Thread handle 0x{Handle:x8} is current thread!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidThread);
 

--- a/Ryujinx.HLE/HOS/Kernel/SvcThreadSync.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SvcThreadSync.cs
@@ -1,5 +1,5 @@
 using ChocolArm64.State;
-using Ryujinx.HLE.Logging;
+using Ryujinx.Common.Logging;
 using System.Collections.Generic;
 
 using static Ryujinx.HLE.HOS.ErrorCode;
@@ -14,7 +14,7 @@ namespace Ryujinx.HLE.HOS.Kernel
             int  HandlesCount =  (int)ThreadState.X2;
             long Timeout      = (long)ThreadState.X3;
 
-            Device.Log.PrintDebug(LogClass.KernelSvc,
+            Logger.PrintDebug(LogClass.KernelSvc,
                 "HandlesPtr = 0x"   + HandlesPtr  .ToString("x16") + ", " +
                 "HandlesCount = 0x" + HandlesCount.ToString("x8")  + ", " +
                 "Timeout = 0x"      + Timeout     .ToString("x16"));
@@ -53,11 +53,11 @@ namespace Ryujinx.HLE.HOS.Kernel
                 if (Result == MakeError(ErrorModule.Kernel, KernelErr.Timeout) ||
                     Result == MakeError(ErrorModule.Kernel, KernelErr.Cancelled))
                 {
-                    Device.Log.PrintDebug(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
+                    Logger.PrintDebug(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
                 }
                 else
                 {
-                    Device.Log.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
+                    Logger.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
                 }
             }
 
@@ -69,13 +69,13 @@ namespace Ryujinx.HLE.HOS.Kernel
         {
             int ThreadHandle = (int)ThreadState.X0;
 
-            Device.Log.PrintDebug(LogClass.KernelSvc, "ThreadHandle = 0x" + ThreadHandle.ToString("x8"));
+            Logger.PrintDebug(LogClass.KernelSvc, "ThreadHandle = 0x" + ThreadHandle.ToString("x8"));
 
             KThread Thread = Process.HandleTable.GetKThread(ThreadHandle);
 
             if (Thread == null)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid thread handle 0x{ThreadHandle:x8}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid thread handle 0x{ThreadHandle:x8}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidHandle);
 
@@ -93,14 +93,14 @@ namespace Ryujinx.HLE.HOS.Kernel
             long MutexAddress    = (long)ThreadState.X1;
             int  RequesterHandle =  (int)ThreadState.X2;
 
-            Device.Log.PrintDebug(LogClass.KernelSvc,
+            Logger.PrintDebug(LogClass.KernelSvc,
                 "OwnerHandle = 0x"     + OwnerHandle    .ToString("x8")  + ", " +
                 "MutexAddress = 0x"    + MutexAddress   .ToString("x16") + ", " +
                 "RequesterHandle = 0x" + RequesterHandle.ToString("x8"));
 
             if (IsPointingInsideKernel(MutexAddress))
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid mutex address 0x{MutexAddress:x16}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid mutex address 0x{MutexAddress:x16}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.NoAccessPerm);
 
@@ -109,7 +109,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (IsAddressNotWordAligned(MutexAddress))
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Unaligned mutex address 0x{MutexAddress:x16}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Unaligned mutex address 0x{MutexAddress:x16}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidAddress);
 
@@ -125,7 +125,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (Result != 0)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
             }
 
             ThreadState.X0 = (ulong)Result;
@@ -135,11 +135,11 @@ namespace Ryujinx.HLE.HOS.Kernel
         {
             long MutexAddress = (long)ThreadState.X0;
 
-            Device.Log.PrintDebug(LogClass.KernelSvc, "MutexAddress = 0x" + MutexAddress.ToString("x16"));
+            Logger.PrintDebug(LogClass.KernelSvc, "MutexAddress = 0x" + MutexAddress.ToString("x16"));
 
             if (IsPointingInsideKernel(MutexAddress))
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid mutex address 0x{MutexAddress:x16}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid mutex address 0x{MutexAddress:x16}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.NoAccessPerm);
 
@@ -148,7 +148,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (IsAddressNotWordAligned(MutexAddress))
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Unaligned mutex address 0x{MutexAddress:x16}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Unaligned mutex address 0x{MutexAddress:x16}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidAddress);
 
@@ -159,7 +159,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (Result != 0)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
             }
 
             ThreadState.X0 = (ulong)Result;
@@ -172,7 +172,7 @@ namespace Ryujinx.HLE.HOS.Kernel
             int   ThreadHandle   =  (int)ThreadState.X2;
             long  Timeout        = (long)ThreadState.X3;
 
-            Device.Log.PrintDebug(LogClass.KernelSvc,
+            Logger.PrintDebug(LogClass.KernelSvc,
                 "MutexAddress = 0x"   + MutexAddress  .ToString("x16") + ", " +
                 "CondVarAddress = 0x" + CondVarAddress.ToString("x16") + ", " +
                 "ThreadHandle = 0x"   + ThreadHandle  .ToString("x8")  + ", " +
@@ -180,7 +180,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (IsPointingInsideKernel(MutexAddress))
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid mutex address 0x{MutexAddress:x16}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid mutex address 0x{MutexAddress:x16}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.NoAccessPerm);
 
@@ -189,7 +189,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (IsAddressNotWordAligned(MutexAddress))
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Unaligned mutex address 0x{MutexAddress:x16}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Unaligned mutex address 0x{MutexAddress:x16}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidAddress);
 
@@ -207,11 +207,11 @@ namespace Ryujinx.HLE.HOS.Kernel
             {
                 if (Result == MakeError(ErrorModule.Kernel, KernelErr.Timeout))
                 {
-                    Device.Log.PrintDebug(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
+                    Logger.PrintDebug(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
                 }
                 else
                 {
-                    Device.Log.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
+                    Logger.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
                 }
             }
 
@@ -223,7 +223,7 @@ namespace Ryujinx.HLE.HOS.Kernel
             long Address = (long)ThreadState.X0;
             int  Count   =  (int)ThreadState.X1;
 
-            Device.Log.PrintDebug(LogClass.KernelSvc,
+            Logger.PrintDebug(LogClass.KernelSvc,
                 "Address = 0x" + Address.ToString("x16") + ", " +
                 "Count = 0x"   + Count  .ToString("x8"));
 
@@ -239,7 +239,7 @@ namespace Ryujinx.HLE.HOS.Kernel
             int             Value   =             (int)ThreadState.X2;
             long            Timeout =            (long)ThreadState.X3;
 
-            Device.Log.PrintDebug(LogClass.KernelSvc,
+            Logger.PrintDebug(LogClass.KernelSvc,
                 "Address = 0x" + Address.ToString("x16") + ", " +
                 "Type = "      + Type   .ToString()      + ", " +
                 "Value = 0x"   + Value  .ToString("x8")  + ", " +
@@ -247,7 +247,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (IsPointingInsideKernel(Address))
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid address 0x{Address:x16}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid address 0x{Address:x16}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.NoAccessPerm);
 
@@ -256,7 +256,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (IsAddressNotWordAligned(Address))
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Unaligned address 0x{Address:x16}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Unaligned address 0x{Address:x16}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidAddress);
 
@@ -286,7 +286,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (Result != 0)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
             }
 
             ThreadState.X0 = (ulong)Result;
@@ -299,7 +299,7 @@ namespace Ryujinx.HLE.HOS.Kernel
             int        Value   =        (int)ThreadState.X2;
             int        Count   =        (int)ThreadState.X3;
 
-            Device.Log.PrintDebug(LogClass.KernelSvc,
+            Logger.PrintDebug(LogClass.KernelSvc,
                 "Address = 0x" + Address.ToString("x16") + ", " +
                 "Type = "      + Type   .ToString()      + ", " +
                 "Value = 0x"   + Value  .ToString("x8")  + ", " +
@@ -307,7 +307,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (IsPointingInsideKernel(Address))
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Invalid address 0x{Address:x16}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid address 0x{Address:x16}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.NoAccessPerm);
 
@@ -316,7 +316,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (IsAddressNotWordAligned(Address))
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Unaligned address 0x{Address:x16}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Unaligned address 0x{Address:x16}!");
 
                 ThreadState.X0 = MakeError(ErrorModule.Kernel, KernelErr.InvalidAddress);
 
@@ -346,7 +346,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (Result != 0)
             {
-                Device.Log.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
+                Logger.PrintWarning(LogClass.KernelSvc, $"Operation failed with error 0x{Result:x}!");
             }
 
             ThreadState.X0 = (ulong)Result;

--- a/Ryujinx.HLE/HOS/Process.cs
+++ b/Ryujinx.HLE/HOS/Process.cs
@@ -3,6 +3,7 @@ using ChocolArm64.Events;
 using ChocolArm64.Memory;
 using ChocolArm64.State;
 using LibHac;
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.Exceptions;
 using Ryujinx.HLE.HOS.Diagnostics.Demangler;
 using Ryujinx.HLE.HOS.Kernel;
@@ -11,7 +12,6 @@ using Ryujinx.HLE.HOS.SystemState;
 using Ryujinx.HLE.Loaders;
 using Ryujinx.HLE.Loaders.Executables;
 using Ryujinx.HLE.Loaders.Npdm;
-using Ryujinx.HLE.Logging;
 using Ryujinx.HLE.Utilities;
 using System;
 using System.Collections.Concurrent;
@@ -118,7 +118,7 @@ namespace Ryujinx.HLE.HOS
                 throw new ObjectDisposedException(nameof(Process));
             }
 
-            Device.Log.PrintInfo(LogClass.Loader, $"Image base at 0x{ExecutableBase:x16}.");
+            Logger.PrintInfo(LogClass.Loader, $"Image base at 0x{ExecutableBase:x16}.");
 
             Executable Executable = new Executable(Program, MemoryManager, Memory, ExecutableBase);
 
@@ -319,7 +319,7 @@ namespace Ryujinx.HLE.HOS
 
             string ExeNameWithAddr = $"{Exe.Name}:0x{Offset:x8}";
 
-            Device.Log.PrintDebug(LogClass.Cpu, ExeNameWithAddr + " " + SubName);
+            Logger.PrintDebug(LogClass.Cpu, ExeNameWithAddr + " " + SubName);
         }
 
         private ATranslator GetTranslator()
@@ -374,7 +374,7 @@ namespace Ryujinx.HLE.HOS
                 FramePointer = Memory.ReadInt64(FramePointer);
             }
 
-            Device.Log.PrintInfo(LogClass.Cpu, Trace.ToString());
+            Logger.PrintInfo(LogClass.Cpu, Trace.ToString());
         }
 
         private bool TryGetSubName(Executable Exe, long Position, out string Name)
@@ -475,7 +475,7 @@ namespace Ryujinx.HLE.HOS
                 File.Delete(Executables[0].FilePath);
             }
 
-            Device.Log.PrintInfo(LogClass.Loader, $"Process {ProcessId} exiting...");
+            Logger.PrintInfo(LogClass.Loader, $"Process {ProcessId} exiting...");
         }
 
         public void Dispose()

--- a/Ryujinx.HLE/HOS/Services/Acc/IAccountService.cs
+++ b/Ryujinx.HLE/HOS/Services/Acc/IAccountService.cs
@@ -1,6 +1,6 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.SystemState;
-using Ryujinx.HLE.Logging;
 using Ryujinx.HLE.Utilities;
 using System.Collections.Generic;
 
@@ -103,7 +103,7 @@ namespace Ryujinx.HLE.HOS.Services.Acc
 
             if (!Context.Device.System.State.TryGetUser(Uuid, out UserProfile Profile))
             {
-                Context.Device.Log.PrintWarning(LogClass.ServiceAcc, $"User 0x{Uuid} not found!");
+                Logger.PrintWarning(LogClass.ServiceAcc, $"User 0x{Uuid} not found!");
 
                 return MakeError(ErrorModule.Account, AccErr.UserNotFound);
             }
@@ -118,7 +118,7 @@ namespace Ryujinx.HLE.HOS.Services.Acc
         {
             long Unknown = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAcc, $"Stubbed. Unknown: {Unknown}");
+            Logger.PrintStub(LogClass.ServiceAcc, $"Stubbed. Unknown: {Unknown}");
 
             Context.ResponseData.Write(false);
 
@@ -130,7 +130,7 @@ namespace Ryujinx.HLE.HOS.Services.Acc
         {
             bool Unknown = Context.RequestData.ReadBoolean();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAcc, $"Stubbed. Unknown: {Unknown}");
+            Logger.PrintStub(LogClass.ServiceAcc, $"Stubbed. Unknown: {Unknown}");
 
             UserProfile Profile = Context.Device.System.State.LastOpenUser;
 
@@ -144,7 +144,7 @@ namespace Ryujinx.HLE.HOS.Services.Acc
         {
             long Unknown = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAcc, $"Stubbed. Unknown: {Unknown}");
+            Logger.PrintStub(LogClass.ServiceAcc, $"Stubbed. Unknown: {Unknown}");
 
             return 0;
         }

--- a/Ryujinx.HLE/HOS/Services/Acc/IManagerForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Acc/IManagerForApplication.cs
@@ -1,5 +1,5 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
-using Ryujinx.HLE.Logging;
 using Ryujinx.HLE.Utilities;
 using System.Collections.Generic;
 
@@ -27,7 +27,7 @@ namespace Ryujinx.HLE.HOS.Services.Acc
         // CheckAvailability()
         public long CheckAvailability(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceAcc, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAcc, "Stubbed.");
 
             return 0;
         }
@@ -37,7 +37,7 @@ namespace Ryujinx.HLE.HOS.Services.Acc
         {
             long NetworkServiceAccountId = 0xcafe;
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAcc, $"Stubbed. NetworkServiceAccountId: {NetworkServiceAccountId}");
+            Logger.PrintStub(LogClass.ServiceAcc, $"Stubbed. NetworkServiceAccountId: {NetworkServiceAccountId}");
 
             Context.ResponseData.Write(NetworkServiceAccountId);
 

--- a/Ryujinx.HLE/HOS/Services/Acc/IProfile.cs
+++ b/Ryujinx.HLE/HOS/Services/Acc/IProfile.cs
@@ -1,7 +1,7 @@
 using ChocolArm64.Memory;
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.SystemState;
-using Ryujinx.HLE.Logging;
 using Ryujinx.HLE.Utilities;
 using System.Collections.Generic;
 using System.IO;
@@ -37,7 +37,7 @@ namespace Ryujinx.HLE.HOS.Services.Acc
 
         public long Get(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceAcc, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAcc, "Stubbed.");
 
             long Position = Context.Request.ReceiveBuff[0].Position;
 

--- a/Ryujinx.HLE/HOS/Services/Am/IApplicationFunctions.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/IApplicationFunctions.cs
@@ -1,5 +1,5 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
-using Ryujinx.HLE.Logging;
 using System.Collections.Generic;
 
 namespace Ryujinx.HLE.HOS.Services.Am
@@ -39,7 +39,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
             long UIdLow  = Context.RequestData.ReadInt64();
             long UIdHigh = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             Context.ResponseData.Write(0L);
 
@@ -59,7 +59,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
 
             string Result = GetFormattedErrorCode(ErrorCode);
 
-            Context.Device.Log.PrintInfo(LogClass.ServiceAm, $"Result = 0x{ErrorCode:x8} ({Result}).");
+            Logger.PrintInfo(LogClass.ServiceAm, $"Result = 0x{ErrorCode:x8} ({Result}).");
 
             return 0;
         }
@@ -90,7 +90,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
 
         public long GetPseudoDeviceId(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             Context.ResponseData.Write(0L);
             Context.ResponseData.Write(0L);
@@ -100,7 +100,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
 
         public long InitializeGamePlayRecording(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }
@@ -109,7 +109,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
         {
             int State = Context.RequestData.ReadInt32();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }

--- a/Ryujinx.HLE/HOS/Services/Am/IAudioController.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/IAudioController.cs
@@ -1,5 +1,5 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
-using Ryujinx.HLE.Logging;
 using System.Collections.Generic;
 
 namespace Ryujinx.HLE.HOS.Services.Am
@@ -27,7 +27,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
             float AppletVolume        = Context.RequestData.ReadSingle();
             float LibraryAppletVolume = Context.RequestData.ReadSingle();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }
@@ -36,7 +36,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
         {
             Context.ResponseData.Write(1f);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }
@@ -45,7 +45,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
         {
             Context.ResponseData.Write(1f);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }
@@ -55,7 +55,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
             float Unknown0 = Context.RequestData.ReadSingle();
             long  Unknown1 = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }
@@ -64,7 +64,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
         {
             float Unknown0 = Context.RequestData.ReadSingle();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }

--- a/Ryujinx.HLE/HOS/Services/Am/ICommonStateGetter.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/ICommonStateGetter.cs
@@ -1,6 +1,6 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Kernel;
-using Ryujinx.HLE.Logging;
 using System;
 using System.Collections.Generic;
 
@@ -85,7 +85,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
         {
             Context.ResponseData.Write((byte)0); //Unknown value.
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }
@@ -114,7 +114,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
 
             Context.Response.HandleDesc = IpcHandleDesc.MakeCopy(Handle);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }

--- a/Ryujinx.HLE/HOS/Services/Am/IHomeMenuFunctions.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/IHomeMenuFunctions.cs
@@ -1,6 +1,6 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Kernel;
-using Ryujinx.HLE.Logging;
 using System;
 using System.Collections.Generic;
 
@@ -28,7 +28,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
 
         public long RequestToGetForeground(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }
@@ -42,7 +42,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
 
             Context.Response.HandleDesc = IpcHandleDesc.MakeCopy(Handle);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }

--- a/Ryujinx.HLE/HOS/Services/Am/ILibraryAppletAccessor.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/ILibraryAppletAccessor.cs
@@ -1,6 +1,6 @@
-﻿using Ryujinx.HLE.HOS.Ipc;
+﻿using Ryujinx.Common.Logging;
+using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Kernel;
-using Ryujinx.HLE.Logging;
 using System;
 using System.Collections.Generic;
 
@@ -39,28 +39,28 @@ namespace Ryujinx.HLE.HOS.Services.Am
 
             Context.Response.HandleDesc = IpcHandleDesc.MakeCopy(Handle);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }
 
         public long Start(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }
 
         public long GetResult(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }
 
         public long PushInData(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }

--- a/Ryujinx.HLE/HOS/Services/Am/ISelfController.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/ISelfController.cs
@@ -1,6 +1,6 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Kernel;
-using Ryujinx.HLE.Logging;
 using System;
 using System.Collections.Generic;
 
@@ -41,21 +41,21 @@ namespace Ryujinx.HLE.HOS.Services.Am
 
         public long Exit(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }
 
         public long LockExit(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }
 
         public long UnlockExit(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }
@@ -71,7 +71,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
 
             Context.Response.HandleDesc = IpcHandleDesc.MakeCopy(Handle);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }
@@ -80,7 +80,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
         {
             bool Enable = Context.RequestData.ReadByte() != 0 ? true : false;
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }
@@ -89,7 +89,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
         {
             bool Enable = Context.RequestData.ReadByte() != 0 ? true : false;
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }
@@ -98,7 +98,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
         {
             bool Enable = Context.RequestData.ReadByte() != 0 ? true : false;
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }
@@ -109,7 +109,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
             bool Flag2 = Context.RequestData.ReadByte() != 0 ? true : false;
             bool Flag3 = Context.RequestData.ReadByte() != 0 ? true : false;
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }
@@ -118,7 +118,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
         {
             bool Enable = Context.RequestData.ReadByte() != 0 ? true : false;
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }
@@ -127,7 +127,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
         {
             bool Enable = Context.RequestData.ReadByte() != 0 ? true : false;
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }
@@ -136,7 +136,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
         {
             int Orientation = Context.RequestData.ReadInt32();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }
@@ -145,7 +145,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
         {
             bool Enable = Context.RequestData.ReadByte() != 0 ? true : false;
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }
@@ -155,7 +155,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
         {
             IdleTimeDetectionExtension = Context.RequestData.ReadInt32();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, $"Stubbed. IdleTimeDetectionExtension: {IdleTimeDetectionExtension}");
+            Logger.PrintStub(LogClass.ServiceAm, $"Stubbed. IdleTimeDetectionExtension: {IdleTimeDetectionExtension}");
 
             return 0;
         }
@@ -165,7 +165,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
         {
             Context.ResponseData.Write(IdleTimeDetectionExtension);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, $"Stubbed. IdleTimeDetectionExtension: {IdleTimeDetectionExtension}");
+            Logger.PrintStub(LogClass.ServiceAm, $"Stubbed. IdleTimeDetectionExtension: {IdleTimeDetectionExtension}");
 
             return 0;
         }

--- a/Ryujinx.HLE/HOS/Services/Am/IWindowController.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/IWindowController.cs
@@ -1,5 +1,5 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
-using Ryujinx.HLE.Logging;
 using System.Collections.Generic;
 
 namespace Ryujinx.HLE.HOS.Services.Am
@@ -21,7 +21,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
 
         public long GetAppletResourceUserId(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             Context.ResponseData.Write(0L);
 
@@ -30,7 +30,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
 
         public long AcquireForegroundRights(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceAm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAm, "Stubbed.");
 
             return 0;
         }

--- a/Ryujinx.HLE/HOS/Services/Apm/ISession.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/ISession.cs
@@ -1,5 +1,5 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
-using Ryujinx.HLE.Logging;
 using System.Collections.Generic;
 
 namespace Ryujinx.HLE.HOS.Services.Apm
@@ -33,7 +33,7 @@ namespace Ryujinx.HLE.HOS.Services.Apm
 
             Context.ResponseData.Write((uint)PerformanceConfiguration.PerformanceConfiguration1);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceApm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceApm, "Stubbed.");
 
             return 0;
         }

--- a/Ryujinx.HLE/HOS/Services/Aud/AudioRenderer/IAudioRenderer.cs
+++ b/Ryujinx.HLE/HOS/Services/Aud/AudioRenderer/IAudioRenderer.cs
@@ -1,9 +1,9 @@
 using ChocolArm64.Memory;
 using Ryujinx.Audio;
 using Ryujinx.Audio.Adpcm;
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Kernel;
-using Ryujinx.HLE.Logging;
 using Ryujinx.HLE.Utilities;
 using System;
 using System.Collections.Generic;
@@ -107,7 +107,7 @@ namespace Ryujinx.HLE.HOS.Services.Aud.AudioRenderer
         {
             Context.ResponseData.Write((int)PlayState);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAudio, $"Stubbed. Renderer State: {Enum.GetName(typeof(PlayState), PlayState)}");
+            Logger.PrintStub(LogClass.ServiceAudio, $"Stubbed. Renderer State: {Enum.GetName(typeof(PlayState), PlayState)}");
 
             return 0;
         }
@@ -246,7 +246,7 @@ namespace Ryujinx.HLE.HOS.Services.Aud.AudioRenderer
 
         public long StartAudioRenderer(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceAudio, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAudio, "Stubbed.");
 
             PlayState = PlayState.Playing;
 
@@ -255,7 +255,7 @@ namespace Ryujinx.HLE.HOS.Services.Aud.AudioRenderer
 
         public long StopAudioRenderer(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceAudio, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAudio, "Stubbed.");
 
             PlayState = PlayState.Stopped;
 

--- a/Ryujinx.HLE/HOS/Services/Aud/IAudioDevice.cs
+++ b/Ryujinx.HLE/HOS/Services/Aud/IAudioDevice.cs
@@ -1,7 +1,7 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Kernel;
 using Ryujinx.HLE.HOS.SystemState;
-using Ryujinx.HLE.Logging;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -56,7 +56,7 @@ namespace Ryujinx.HLE.HOS.Services.Aud
 
                 if ((Position - BasePosition) + Buffer.Length > Size)
                 {
-                    Context.Device.Log.PrintError(LogClass.ServiceAudio, $"Output buffer size {Size} too small!");
+                    Logger.PrintError(LogClass.ServiceAudio, $"Output buffer size {Size} too small!");
 
                     break;
                 }
@@ -80,7 +80,7 @@ namespace Ryujinx.HLE.HOS.Services.Aud
 
             string DeviceName = Encoding.ASCII.GetString(DeviceNameBuffer);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAudio, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAudio, "Stubbed.");
 
             return 0;
         }
@@ -100,7 +100,7 @@ namespace Ryujinx.HLE.HOS.Services.Aud
             }
             else
             {
-                Context.Device.Log.PrintError(LogClass.ServiceAudio, $"Output buffer size {Size} too small!");
+                Logger.PrintError(LogClass.ServiceAudio, $"Output buffer size {Size} too small!");
             }
 
             return 0;
@@ -115,7 +115,7 @@ namespace Ryujinx.HLE.HOS.Services.Aud
 
             Context.Response.HandleDesc = IpcHandleDesc.MakeCopy(Handle);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAudio, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAudio, "Stubbed.");
 
             return 0;
         }
@@ -124,7 +124,7 @@ namespace Ryujinx.HLE.HOS.Services.Aud
         {
             Context.ResponseData.Write(2);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAudio, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAudio, "Stubbed.");
 
             return 0;
         }
@@ -145,7 +145,7 @@ namespace Ryujinx.HLE.HOS.Services.Aud
 
                 if ((Position - BasePosition) + Buffer.Length > Size)
                 {
-                    Context.Device.Log.PrintError(LogClass.ServiceAudio, $"Output buffer size {Size} too small!");
+                    Logger.PrintError(LogClass.ServiceAudio, $"Output buffer size {Size} too small!");
 
                     break;
                 }
@@ -168,7 +168,7 @@ namespace Ryujinx.HLE.HOS.Services.Aud
 
             string DeviceName = Encoding.UTF8.GetString(DeviceNameBuffer);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAudio, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAudio, "Stubbed.");
 
             return 0;
         }
@@ -177,7 +177,7 @@ namespace Ryujinx.HLE.HOS.Services.Aud
         {
             Context.ResponseData.Write(1f);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAudio, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAudio, "Stubbed.");
 
             return 0;
         }
@@ -196,7 +196,7 @@ namespace Ryujinx.HLE.HOS.Services.Aud
             }
             else
             {
-                Context.Device.Log.PrintError(LogClass.ServiceAudio, $"Output buffer size {Size} too small!");
+                Logger.PrintError(LogClass.ServiceAudio, $"Output buffer size {Size} too small!");
             }
 
             return 0;
@@ -211,7 +211,7 @@ namespace Ryujinx.HLE.HOS.Services.Aud
 
             Context.Response.HandleDesc = IpcHandleDesc.MakeCopy(Handle);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAudio, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAudio, "Stubbed.");
 
             return 0;
         }
@@ -225,7 +225,7 @@ namespace Ryujinx.HLE.HOS.Services.Aud
 
             Context.Response.HandleDesc = IpcHandleDesc.MakeCopy(Handle);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAudio, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceAudio, "Stubbed.");
 
             return 0;
         }

--- a/Ryujinx.HLE/HOS/Services/Aud/IAudioOutManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Aud/IAudioOutManager.cs
@@ -1,9 +1,9 @@
 using ChocolArm64.Memory;
 using Ryujinx.Audio;
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Kernel;
 using Ryujinx.HLE.HOS.Services.Aud.AudioOut;
-using Ryujinx.HLE.Logging;
 using System.Collections.Generic;
 using System.Text;
 
@@ -86,7 +86,7 @@ namespace Ryujinx.HLE.HOS.Services.Aud
             }
             else
             {
-                Context.Device.Log.PrintError(LogClass.ServiceAudio, $"Output buffer size {Size} too small!");
+                Logger.PrintError(LogClass.ServiceAudio, $"Output buffer size {Size} too small!");
             }
 
             Context.ResponseData.Write(NameCount);
@@ -108,7 +108,7 @@ namespace Ryujinx.HLE.HOS.Services.Aud
 
             if (DeviceName != DefaultAudioOutput)
             {
-                Context.Device.Log.PrintWarning(LogClass.Audio, "Invalid device name!");
+                Logger.PrintWarning(LogClass.Audio, "Invalid device name!");
 
                 return MakeError(ErrorModule.Audio, AudErr.DeviceNotFound);
             }
@@ -121,7 +121,7 @@ namespace Ryujinx.HLE.HOS.Services.Aud
             }
             else
             {
-                Context.Device.Log.PrintError(LogClass.ServiceAudio, $"Output buffer size {ReceiveSize} too small!");
+                Logger.PrintError(LogClass.ServiceAudio, $"Output buffer size {ReceiveSize} too small!");
             }
 
             int SampleRate = Context.RequestData.ReadInt32();
@@ -134,7 +134,7 @@ namespace Ryujinx.HLE.HOS.Services.Aud
 
             if (SampleRate != DefaultSampleRate)
             {
-                Context.Device.Log.PrintWarning(LogClass.Audio, "Invalid sample rate!");
+                Logger.PrintWarning(LogClass.Audio, "Invalid sample rate!");
 
                 return MakeError(ErrorModule.Audio, AudErr.UnsupportedSampleRate);
             }

--- a/Ryujinx.HLE/HOS/Services/Aud/IAudioRendererManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Aud/IAudioRendererManager.cs
@@ -1,7 +1,7 @@
 using Ryujinx.Audio;
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Services.Aud.AudioRenderer;
-using Ryujinx.HLE.Logging;
 using Ryujinx.HLE.Utilities;
 using System;
 using System.Collections.Generic;
@@ -104,7 +104,7 @@ namespace Ryujinx.HLE.HOS.Services.Aud
 
                 Context.ResponseData.Write(Size);
 
-                Context.Device.Log.PrintDebug(LogClass.ServiceAudio, $"WorkBufferSize is 0x{Size:x16}.");
+                Logger.PrintDebug(LogClass.ServiceAudio, $"WorkBufferSize is 0x{Size:x16}.");
 
                 return 0;
             }
@@ -112,7 +112,7 @@ namespace Ryujinx.HLE.HOS.Services.Aud
             {
                 Context.ResponseData.Write(0L);
 
-                Context.Device.Log.PrintWarning(LogClass.ServiceAudio, $"Library Revision 0x{Params.Revision:x8} is not supported!");
+                Logger.PrintWarning(LogClass.ServiceAudio, $"Library Revision 0x{Params.Revision:x8} is not supported!");
 
                 return MakeError(ErrorModule.Audio, AudErr.UnsupportedRevision);
             }
@@ -179,7 +179,7 @@ namespace Ryujinx.HLE.HOS.Services.Aud
             long AppletResourceUserId = Context.RequestData.ReadInt64();
             int  RevisionInfo         = Context.RequestData.ReadInt32();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceAudio, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+            Logger.PrintStub(LogClass.ServiceAudio, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
                                                                 $"RevisionInfo: {RevisionInfo}");
 
             return GetAudioDeviceService(Context);

--- a/Ryujinx.HLE/HOS/Services/Friend/IFriendService.cs
+++ b/Ryujinx.HLE/HOS/Services/Friend/IFriendService.cs
@@ -1,6 +1,6 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.SystemState;
-using Ryujinx.HLE.Logging;
 using Ryujinx.HLE.Utilities;
 using System.Collections.Generic;
 
@@ -46,15 +46,15 @@ namespace Ryujinx.HLE.HOS.Services.Friend
             // There are no friends online, so we return 0 because the nn::account::NetworkServiceAccountId array is empty.
             Context.ResponseData.Write(0);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceFriend, $"Stubbed. UserId: {Uuid.ToString()} - " +
-                                                                 $"Unknown0: {Unknown0} - " +
-                                                                 $"PresenceStatus: {Filter.PresenceStatus} - " +
-                                                                 $"IsFavoriteOnly: {Filter.IsFavoriteOnly} - " +
-                                                                 $"IsSameAppPresenceOnly: {Filter.IsSameAppPresenceOnly} - " +
-                                                                 $"IsSameAppPlayedOnly: {Filter.IsSameAppPlayedOnly} - " +
-                                                                 $"IsArbitraryAppPlayedOnly: {Filter.IsArbitraryAppPlayedOnly} - " +
-                                                                 $"PresenceGroupId: {Filter.PresenceGroupId} - " +
-                                                                 $"Unknown1: {Unknown1}");
+            Logger.PrintStub(LogClass.ServiceFriend, $"Stubbed. UserId: {Uuid.ToString()} - " +
+                                                     $"Unknown0: {Unknown0} - " +
+                                                     $"PresenceStatus: {Filter.PresenceStatus} - " +
+                                                     $"IsFavoriteOnly: {Filter.IsFavoriteOnly} - " +
+                                                     $"IsSameAppPresenceOnly: {Filter.IsSameAppPresenceOnly} - " +
+                                                     $"IsSameAppPlayedOnly: {Filter.IsSameAppPlayedOnly} - " +
+                                                     $"IsArbitraryAppPlayedOnly: {Filter.IsArbitraryAppPlayedOnly} - " +
+                                                     $"PresenceGroupId: {Filter.PresenceGroupId} - " +
+                                                     $"Unknown1: {Unknown1}");
 
             return 0;
         }
@@ -71,8 +71,8 @@ namespace Ryujinx.HLE.HOS.Services.Friend
                 Profile.OnlinePlayState = OpenCloseState.Closed;
             }
 
-            Context.Device.Log.PrintStub(LogClass.ServiceFriend, $"Stubbed. Uuid: {Uuid.ToString()} - " +
-                                                                 $"OnlinePlayState: {Profile.OnlinePlayState}");
+            Logger.PrintStub(LogClass.ServiceFriend, $"Stubbed. Uuid: {Uuid.ToString()} - " +
+                                                     $"OnlinePlayState: {Profile.OnlinePlayState}");
 
             return 0;
         }
@@ -91,8 +91,8 @@ namespace Ryujinx.HLE.HOS.Services.Friend
 
             //Todo: Write the buffer content.
 
-            Context.Device.Log.PrintStub(LogClass.ServiceFriend, $"Stubbed. Uuid: {Uuid.ToString()} - " +
-                                                                 $"Unknown0: {Unknown0}");
+            Logger.PrintStub(LogClass.ServiceFriend, $"Stubbed. Uuid: {Uuid.ToString()} - " +
+                                                     $"Unknown0: {Unknown0}");
 
             return 0;
         }

--- a/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
@@ -1,7 +1,7 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Kernel;
 using Ryujinx.HLE.Input;
-using Ryujinx.HLE.Logging;
 using System;
 using System.Collections.Generic;
 
@@ -178,7 +178,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             long AppletResourceUserId = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
 
             return 0;
         }
@@ -188,7 +188,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             long AppletResourceUserId = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
 
             return 0;
         }
@@ -198,7 +198,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             long AppletResourceUserId = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
 
             return 0;
         }
@@ -208,7 +208,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             long AppletResourceUserId = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
 
             return 0;
         }
@@ -225,7 +225,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             Context.Response.HandleDesc = IpcHandleDesc.MakeCopy(XpadIdEventHandle);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. XpadId: {XpadId}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. XpadId: {XpadId}");
 
             return 0;
         }
@@ -237,7 +237,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             Context.Process.HandleTable.CloseHandle(XpadIdEventHandle);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. XpadId: {XpadId}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. XpadId: {XpadId}");
 
             return 0;
         }
@@ -248,8 +248,8 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             int  BasicXpadId          = Context.RequestData.ReadInt32();
             long AppletResourceUserId = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"BasicXpadId: {BasicXpadId}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"BasicXpadId: {BasicXpadId}");
 
             return 0;
         }
@@ -260,7 +260,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             // There is any Xpad, so we return 0 and write nothing inside the type-0xa buffer.
             Context.ResponseData.Write(0L);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed.");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed.");
 
             return 0;
         }
@@ -270,7 +270,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             int JoyXpadId = Context.RequestData.ReadInt32();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. JoyXpadId: {JoyXpadId}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. JoyXpadId: {JoyXpadId}");
 
             return 0;
         }
@@ -284,7 +284,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             Context.Response.HandleDesc = IpcHandleDesc.MakeCopy(Handle);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. JoyXpadId: {JoyXpadId}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. JoyXpadId: {JoyXpadId}");
 
             return 0;
         }
@@ -295,7 +295,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             // There is any JoyXpad, so we return 0 and write nothing inside the type-0xa buffer.
             Context.ResponseData.Write(0L);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed.");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed.");
 
             return 0;
         }
@@ -305,7 +305,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             int BasicXpadId = Context.RequestData.ReadInt32();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. BasicXpadId: {BasicXpadId}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. BasicXpadId: {BasicXpadId}");
 
             return 0;
         }
@@ -315,7 +315,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             int BasicXpadId = Context.RequestData.ReadInt32();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. BasicXpadId: {BasicXpadId}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. BasicXpadId: {BasicXpadId}");
 
             return 0;
         }
@@ -329,7 +329,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             Context.Response.HandleDesc = IpcHandleDesc.MakeCopy(Handle);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. BasicXpadId: {BasicXpadId}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. BasicXpadId: {BasicXpadId}");
 
             return 0;
         }
@@ -339,7 +339,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             int JoyXpadId = Context.RequestData.ReadInt32();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. JoyXpadId: {JoyXpadId}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. JoyXpadId: {JoyXpadId}");
 
             return 0;
         }
@@ -349,7 +349,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             int JoyXpadId = Context.RequestData.ReadInt32();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. JoyXpadId: {JoyXpadId}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. JoyXpadId: {JoyXpadId}");
 
             return 0;
         }
@@ -363,7 +363,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             Context.Response.HandleDesc = IpcHandleDesc.MakeCopy(Handle);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. JoyXpadId: {JoyXpadId}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. JoyXpadId: {JoyXpadId}");
 
             return 0;
         }
@@ -374,8 +374,8 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             int  SixAxisSensorHandle  = Context.RequestData.ReadInt32();
             long AppletResourceUserId = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"SixAxisSensorHandle: {SixAxisSensorHandle}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"SixAxisSensorHandle: {SixAxisSensorHandle}");
 
             return 0;
         }
@@ -386,8 +386,8 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             int  SixAxisSensorHandle  = Context.RequestData.ReadInt32();
             long AppletResourceUserId = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"SixAxisSensorHandle: {SixAxisSensorHandle}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"SixAxisSensorHandle: {SixAxisSensorHandle}");
 
             return 0;
         }
@@ -400,9 +400,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             Context.ResponseData.Write(SixAxisSensorFusionEnabled);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
-                                                              $"SixAxisSensorFusionEnabled: {SixAxisSensorFusionEnabled}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
+                                                  $"SixAxisSensorFusionEnabled: {SixAxisSensorFusionEnabled}");
 
             return 0;
         }
@@ -414,9 +414,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             int  SixAxisSensorHandle   = Context.RequestData.ReadInt32();
             long AppletResourceUserId  = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
-                                                              $"SixAxisSensorFusionEnabled: {SixAxisSensorFusionEnabled}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
+                                                  $"SixAxisSensorFusionEnabled: {SixAxisSensorFusionEnabled}");
 
             return 0;
         }
@@ -434,10 +434,10 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             long AppletResourceUserId = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
-                                                              $"RevisePower: {SensorFusionParams.RevisePower} - " +
-                                                              $"ReviseRange: {SensorFusionParams.ReviseRange}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
+                                                  $"RevisePower: {SensorFusionParams.RevisePower} - " +
+                                                  $"ReviseRange: {SensorFusionParams.ReviseRange}");
 
             return 0;
         }
@@ -451,10 +451,10 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             Context.ResponseData.Write(SensorFusionParams.RevisePower);
             Context.ResponseData.Write(SensorFusionParams.ReviseRange);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
-                                                              $"RevisePower: {SensorFusionParams.RevisePower} - " +
-                                                              $"ReviseRange: {SensorFusionParams.ReviseRange}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
+                                                  $"RevisePower: {SensorFusionParams.RevisePower} - " +
+                                                  $"ReviseRange: {SensorFusionParams.ReviseRange}");
 
             return 0;
         }
@@ -468,10 +468,10 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             SensorFusionParams.RevisePower = 0;
             SensorFusionParams.ReviseRange = 0;
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
-                                                              $"RevisePower: {SensorFusionParams.RevisePower} - " +
-                                                              $"ReviseRange: {SensorFusionParams.ReviseRange}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
+                                                  $"RevisePower: {SensorFusionParams.RevisePower} - " +
+                                                  $"ReviseRange: {SensorFusionParams.ReviseRange}");
 
             return 0;
         }
@@ -489,10 +489,10 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             long AppletResourceUserId = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
-                                                              $"X: {AccelerometerParams.X} - " +
-                                                              $"Y: {AccelerometerParams.Y}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
+                                                  $"X: {AccelerometerParams.X} - " +
+                                                  $"Y: {AccelerometerParams.Y}");
 
             return 0;
         }
@@ -506,10 +506,10 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             Context.ResponseData.Write(AccelerometerParams.X);
             Context.ResponseData.Write(AccelerometerParams.Y);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
-                                                              $"X: {AccelerometerParams.X} - " +
-                                                              $"Y: {AccelerometerParams.Y}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
+                                                  $"X: {AccelerometerParams.X} - " +
+                                                  $"Y: {AccelerometerParams.Y}");
 
             return 0;
         }
@@ -523,10 +523,10 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             AccelerometerParams.X = 0;
             AccelerometerParams.Y = 0;
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
-                                                              $"X: {AccelerometerParams.X} - " +
-                                                              $"Y: {AccelerometerParams.Y}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
+                                                  $"X: {AccelerometerParams.X} - " +
+                                                  $"Y: {AccelerometerParams.Y}");
 
             return 0;
         }
@@ -538,9 +538,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
                  AccelerometerPlayMode = Context.RequestData.ReadUInt32();
             long AppletResourceUserId  = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
-                                                              $"PlayMode: {AccelerometerPlayMode}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
+                                                  $"PlayMode: {AccelerometerPlayMode}");
 
             return 0;
         }
@@ -553,9 +553,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             Context.ResponseData.Write(AccelerometerPlayMode);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
-                                                              $"PlayMode: {AccelerometerPlayMode}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
+                                                  $"PlayMode: {AccelerometerPlayMode}");
 
             return 0;
         }
@@ -568,9 +568,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             AccelerometerPlayMode = 0;
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
-                                                              $"PlayMode: {AccelerometerPlayMode}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
+                                                  $"PlayMode: {AccelerometerPlayMode}");
 
             return 0;
         }
@@ -582,9 +582,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
                  GyroscopeZeroDriftMode = (HidGyroscopeZeroDriftMode)Context.RequestData.ReadInt32();
             long AppletResourceUserId   = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
-                                                              $"GyroscopeZeroDriftMode: {GyroscopeZeroDriftMode}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
+                                                  $"GyroscopeZeroDriftMode: {GyroscopeZeroDriftMode}");
 
             return 0;
         }
@@ -597,9 +597,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             Context.ResponseData.Write((int)GyroscopeZeroDriftMode);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
-                                                              $"GyroscopeZeroDriftMode: {GyroscopeZeroDriftMode}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
+                                                  $"GyroscopeZeroDriftMode: {GyroscopeZeroDriftMode}");
 
             return 0;
         }
@@ -612,9 +612,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             GyroscopeZeroDriftMode = HidGyroscopeZeroDriftMode.Standard;
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
-                                                              $"GyroscopeZeroDriftMode: {GyroscopeZeroDriftMode}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
+                                                  $"GyroscopeZeroDriftMode: {GyroscopeZeroDriftMode}");
 
             return 0;
         }
@@ -629,9 +629,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             Context.ResponseData.Write(IsAtRest);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
-                                                              $"IsAtRest: {IsAtRest}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"SixAxisSensorHandle: {SixAxisSensorHandle} - " +
+                                                  $"IsAtRest: {IsAtRest}");
 
             return 0;
         }
@@ -642,8 +642,8 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             long AppletResourceUserId = Context.RequestData.ReadInt64();
             int  Unknown0             = Context.RequestData.ReadInt32();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"Unknown0: {Unknown0}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"Unknown0: {Unknown0}");
 
             return 0;
         }
@@ -656,8 +656,8 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             long AppletResourceUserId = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"NpadStyleTag: {NpadStyleTag}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"NpadStyleTag: {NpadStyleTag}");
 
             return 0;
         }
@@ -669,8 +669,8 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             Context.ResponseData.Write((int)NpadStyleTag);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"NpadStyleTag: {NpadStyleTag}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"NpadStyleTag: {NpadStyleTag}");
 
             return 0;
         }
@@ -681,8 +681,8 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             long AppletResourceUserId  = Context.RequestData.ReadInt64();
             HidControllerId NpadIdType = (HidControllerId)Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"NpadIdType: {NpadIdType}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"NpadIdType: {NpadIdType}");
 
             return 0;
         }
@@ -692,7 +692,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             long AppletResourceUserId = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
 
             return 0;
         }
@@ -702,7 +702,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             long AppletResourceUserId = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
 
             return 0;
         }
@@ -721,9 +721,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             Context.Response.HandleDesc = IpcHandleDesc.MakeCopy(Handle);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"NpadId: {NpadId} - " +
-                                                              $"NpadStyleSet: {NpadStyleSet}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"NpadId: {NpadId} - " +
+                                                  $"NpadStyleSet: {NpadStyleSet}");
 
             return 0;
         }
@@ -734,8 +734,8 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             long AppletResourceUserId = Context.RequestData.ReadInt64();
             int  NpadIdType           = Context.RequestData.ReadInt32();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"NpadIdType: {NpadIdType}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"NpadIdType: {NpadIdType}");
 
             return 0;
         }
@@ -749,7 +749,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             Context.ResponseData.Write(LedPattern);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. NpadId: {NpadId} - Pattern: {LedPattern}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. NpadId: {NpadId} - Pattern: {LedPattern}");
 
             return 0;
         }
@@ -760,7 +760,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             long AppletResourceUserId = Context.RequestData.ReadInt64();
             int  Unknown              = Context.RequestData.ReadInt32();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - Unknown: {Unknown}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - Unknown: {Unknown}");
 
             return 0;
         }
@@ -771,8 +771,8 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             long AppletResourceUserId = Context.RequestData.ReadInt64();
             NpadJoyHoldType           = (HidNpadJoyHoldType)Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"NpadJoyHoldType: {NpadJoyHoldType}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"NpadJoyHoldType: {NpadJoyHoldType}");
 
             return 0;
         }
@@ -784,8 +784,8 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             Context.ResponseData.Write((long)NpadJoyHoldType);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"NpadJoyHoldTypeValue: {NpadJoyHoldType}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"NpadJoyHoldTypeValue: {NpadJoyHoldType}");
 
             return 0;
         }
@@ -798,9 +798,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             NpadJoyAssignmentMode = HidNpadJoyAssignmentMode.Single;
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"HidControllerId: {HidControllerId} - " +
-                                                              $"NpadJoyAssignmentModeValue: {NpadJoyAssignmentMode}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"HidControllerId: {HidControllerId} - " +
+                                                  $"NpadJoyAssignmentModeValue: {NpadJoyAssignmentMode}");
 
             return 0;
         }
@@ -814,10 +814,10 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             NpadJoyAssignmentMode = HidNpadJoyAssignmentMode.Single;
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"HidControllerId: {HidControllerId} - " +
-                                                              $"HidNpadJoyDeviceType: {HidNpadJoyDeviceType} - " +
-                                                              $"NpadJoyAssignmentModeValue: {NpadJoyAssignmentMode}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"HidControllerId: {HidControllerId} - " +
+                                                  $"HidNpadJoyDeviceType: {HidNpadJoyDeviceType} - " +
+                                                  $"NpadJoyAssignmentModeValue: {NpadJoyAssignmentMode}");
 
             return 0;
         }
@@ -830,9 +830,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             NpadJoyAssignmentMode = HidNpadJoyAssignmentMode.Dual;
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"HidControllerId: {HidControllerId} - " +
-                                                              $"NpadJoyAssignmentModeValue: {NpadJoyAssignmentMode}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"HidControllerId: {HidControllerId} - " +
+                                                  $"NpadJoyAssignmentModeValue: {NpadJoyAssignmentMode}");
 
             return 0;
         }
@@ -844,9 +844,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             long SingleJoyId1         = Context.RequestData.ReadInt32();
             long AppletResourceUserId = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"SingleJoyId0: {SingleJoyId0} - " +
-                                                              $"SingleJoyId1: {SingleJoyId1}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"SingleJoyId0: {SingleJoyId0} - " +
+                                                  $"SingleJoyId1: {SingleJoyId1}");
 
             return 0;
         }
@@ -856,7 +856,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             long AppletResourceUserId = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
 
             return 0;
         }
@@ -866,7 +866,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             long AppletResourceUserId = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
 
             return 0;
         }
@@ -877,8 +877,8 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             long AppletResourceUserId  = Context.RequestData.ReadInt64();
             NpadHandheldActivationMode = (HidNpadHandheldActivationMode)Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"NpadHandheldActivationMode: {NpadHandheldActivationMode}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"NpadHandheldActivationMode: {NpadHandheldActivationMode}");
 
             return 0;
         }
@@ -890,8 +890,8 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             Context.ResponseData.Write((long)NpadHandheldActivationMode);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"NpadHandheldActivationMode: {NpadHandheldActivationMode}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"NpadHandheldActivationMode: {NpadHandheldActivationMode}");
 
             return 0;
         }
@@ -903,9 +903,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             int  NewNpadAssignment    = Context.RequestData.ReadInt32();
             long AppletResourceUserId = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"OldNpadAssignment: {OldNpadAssignment} - " +
-                                                              $"NewNpadAssignment: {NewNpadAssignment}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"OldNpadAssignment: {OldNpadAssignment} - " +
+                                                  $"NewNpadAssignment: {NewNpadAssignment}");
 
             return 0;
         }
@@ -918,9 +918,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             Context.ResponseData.Write(UnintendedHomeButtonInputProtectionEnabled);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"Unknown0: {Unknown0} - " +
-                                                              $"UnintendedHomeButtonInputProtectionEnabled: {UnintendedHomeButtonInputProtectionEnabled}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"Unknown0: {Unknown0} - " +
+                                                  $"UnintendedHomeButtonInputProtectionEnabled: {UnintendedHomeButtonInputProtectionEnabled}");
 
             return 0;
         }
@@ -932,9 +932,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             uint  Unknown0                             = Context.RequestData.ReadUInt32();
             long AppletResourceUserId                  = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"Unknown0: {Unknown0} - " +
-                                                              $"UnintendedHomeButtonInputProtectionEnable: {UnintendedHomeButtonInputProtectionEnabled}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"Unknown0: {Unknown0} - " +
+                                                  $"UnintendedHomeButtonInputProtectionEnable: {UnintendedHomeButtonInputProtectionEnabled}");
 
             return 0;
         }
@@ -951,12 +951,12 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             Context.ResponseData.Write(0); //Unknown0
             Context.ResponseData.Write(0); //Unknown1
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"HidControllerId: {HidControllerId} - " +
-                                                              $"HidNpadJoyDeviceType: {HidNpadJoyDeviceType} - " +
-                                                              $"NpadJoyAssignmentModeValue: {NpadJoyAssignmentMode} - " +
-                                                              $"Unknown0: 0 - " +
-                                                              $"Unknown1: 0");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"HidControllerId: {HidControllerId} - " +
+                                                  $"HidNpadJoyDeviceType: {HidNpadJoyDeviceType} - " +
+                                                  $"NpadJoyAssignmentModeValue: {NpadJoyAssignmentMode} - " +
+                                                  $"Unknown0: 0 - " +
+                                                  $"Unknown1: 0");
 
             return 0;
         }
@@ -975,9 +975,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             Context.ResponseData.Write((int)DeviceInfo.DeviceType);
             Context.ResponseData.Write((int)DeviceInfo.Position);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. VibrationDeviceHandle: {VibrationDeviceHandle} - " +
-                                                              $"DeviceType: {DeviceInfo.DeviceType} - " +
-                                                              $"Position: {DeviceInfo.Position}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. VibrationDeviceHandle: {VibrationDeviceHandle} - " +
+                                                  $"DeviceType: {DeviceInfo.DeviceType} - " +
+                                                  $"Position: {DeviceInfo.Position}");
 
             return 0;
         }
@@ -997,12 +997,12 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             long AppletResourceUserId = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"VibrationDeviceHandle: {VibrationDeviceHandle} - " +
-                                                              $"AmplitudeLow: {VibrationValue.AmplitudeLow} - " +
-                                                              $"FrequencyLow: {VibrationValue.FrequencyLow} - " +
-                                                              $"AmplitudeHigh: {VibrationValue.AmplitudeHigh} - " +
-                                                              $"FrequencyHigh: {VibrationValue.FrequencyHigh}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"VibrationDeviceHandle: {VibrationDeviceHandle} - " +
+                                                  $"AmplitudeLow: {VibrationValue.AmplitudeLow} - " +
+                                                  $"FrequencyLow: {VibrationValue.FrequencyLow} - " +
+                                                  $"AmplitudeHigh: {VibrationValue.AmplitudeHigh} - " +
+                                                  $"FrequencyHigh: {VibrationValue.FrequencyHigh}");
 
             return 0;
         }
@@ -1018,12 +1018,12 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             Context.ResponseData.Write(VibrationValue.AmplitudeHigh);
             Context.ResponseData.Write(VibrationValue.FrequencyHigh);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"VibrationDeviceHandle: {VibrationDeviceHandle} - " +
-                                                              $"AmplitudeLow: {VibrationValue.AmplitudeLow} - " +
-                                                              $"FrequencyLow: {VibrationValue.FrequencyLow} - " +
-                                                              $"AmplitudeHigh: {VibrationValue.AmplitudeHigh} - " +
-                                                              $"FrequencyHigh: {VibrationValue.FrequencyHigh}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"VibrationDeviceHandle: {VibrationDeviceHandle} - " +
+                                                  $"AmplitudeLow: {VibrationValue.AmplitudeLow} - " +
+                                                  $"FrequencyLow: {VibrationValue.FrequencyLow} - " +
+                                                  $"AmplitudeHigh: {VibrationValue.AmplitudeHigh} - " +
+                                                  $"FrequencyHigh: {VibrationValue.FrequencyHigh}");
 
             return 0;
         }
@@ -1041,7 +1041,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             VibrationPermitted = Context.RequestData.ReadBoolean();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. VibrationPermitted: {VibrationPermitted}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. VibrationPermitted: {VibrationPermitted}");
 
             return 0;
         }
@@ -1051,7 +1051,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             Context.ResponseData.Write(VibrationPermitted);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. VibrationPermitted: {VibrationPermitted}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. VibrationPermitted: {VibrationPermitted}");
 
             return 0;
         }
@@ -1071,9 +1071,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             //Todo: Read all handles and values from buffer.
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"VibrationDeviceHandleBufferLength: {VibrationDeviceHandleBuffer.Length} - " +
-                                                              $"VibrationValueBufferLength: {VibrationValueBuffer.Length}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"VibrationDeviceHandleBufferLength: {VibrationDeviceHandleBuffer.Length} - " +
+                                                  $"VibrationValueBufferLength: {VibrationValueBuffer.Length}");
 
             return 0;
         }
@@ -1085,9 +1085,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             long VibrationGcErmCommand = Context.RequestData.ReadInt64();
             long AppletResourceUserId  = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"VibrationDeviceHandle: {VibrationDeviceHandle} - " +
-                                                              $"VibrationGcErmCommand: {VibrationGcErmCommand}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"VibrationDeviceHandle: {VibrationDeviceHandle} - " +
+                                                  $"VibrationGcErmCommand: {VibrationGcErmCommand}");
 
             return 0;
         }
@@ -1100,9 +1100,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             Context.ResponseData.Write(VibrationGcErmCommand);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"VibrationDeviceHandle: {VibrationDeviceHandle} - " +
-                                                              $"VibrationGcErmCommand: {VibrationGcErmCommand}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"VibrationDeviceHandle: {VibrationDeviceHandle} - " +
+                                                  $"VibrationGcErmCommand: {VibrationGcErmCommand}");
 
             return 0;
         }
@@ -1112,7 +1112,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             long AppletResourceUserId = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
 
             return 0;
         }
@@ -1120,7 +1120,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         // EndPermitVibrationSession()
         public long EndPermitVibrationSession(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed.");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed.");
 
             return 0;
         }
@@ -1130,7 +1130,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             long AppletResourceUserId = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
 
             return 0;
         }
@@ -1141,8 +1141,8 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             int  ConsoleSixAxisSensorHandle = Context.RequestData.ReadInt32();
             long AppletResourceUserId       = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"ConsoleSixAxisSensorHandle: {ConsoleSixAxisSensorHandle}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"ConsoleSixAxisSensorHandle: {ConsoleSixAxisSensorHandle}");
 
             return 0;
         }
@@ -1153,8 +1153,8 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             int  ConsoleSixAxisSensorHandle = Context.RequestData.ReadInt32();
             long AppletResourceUserId       = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"ConsoleSixAxisSensorHandle: {ConsoleSixAxisSensorHandle}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"ConsoleSixAxisSensorHandle: {ConsoleSixAxisSensorHandle}");
 
             return 0;
         }
@@ -1164,7 +1164,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             long AppletResourceUserId = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
 
             return 0;
         }
@@ -1174,7 +1174,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             long AppletResourceUserId = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
 
             return 0;
         }
@@ -1184,7 +1184,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             long AppletResourceUserId = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
 
             return 0;
         }
@@ -1198,9 +1198,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             // Todo: Determine if array<nn::sf::NativeHandle> is a buffer or not...
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"Counter0: {Counter0} - " +
-                                                              $"Counter1: {Counter1}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"Counter0: {Counter0} - " +
+                                                  $"Counter1: {Counter1}");
 
             return 0;
         }
@@ -1210,7 +1210,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             long AppletResourceUserId = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
 
             return 0;
         }
@@ -1221,8 +1221,8 @@ namespace Ryujinx.HLE.HOS.Services.Hid
                  SevenSixAxisSensorFusionStrength = Context.RequestData.ReadSingle();
             long AppletResourceUserId             = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"SevenSixAxisSensorFusionStrength: {SevenSixAxisSensorFusionStrength}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"SevenSixAxisSensorFusionStrength: {SevenSixAxisSensorFusionStrength}");
 
             return 0;
         }
@@ -1234,8 +1234,8 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             Context.ResponseData.Write(SevenSixAxisSensorFusionStrength);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"SevenSixAxisSensorFusionStrength: {SevenSixAxisSensorFusionStrength}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"SevenSixAxisSensorFusionStrength: {SevenSixAxisSensorFusionStrength}");
 
             return 0;
         }
@@ -1245,7 +1245,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             Context.ResponseData.Write(UsbFullKeyControllerEnabled);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. UsbFullKeyControllerEnabled: {UsbFullKeyControllerEnabled}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. UsbFullKeyControllerEnabled: {UsbFullKeyControllerEnabled}");
 
             return 0;
         }
@@ -1255,7 +1255,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             UsbFullKeyControllerEnabled = Context.RequestData.ReadBoolean();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. UsbFullKeyControllerEnabled: {UsbFullKeyControllerEnabled}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. UsbFullKeyControllerEnabled: {UsbFullKeyControllerEnabled}");
 
             return 0;
         }
@@ -1267,7 +1267,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             Context.ResponseData.Write(true); //FullKeyController is always connected ?
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. Unknown0: {Unknown0} - Connected: true");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. Unknown0: {Unknown0} - Connected: true");
 
             return 0;
         }
@@ -1279,7 +1279,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             Context.ResponseData.Write(true); //Npad always got a battery ?
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. NpadId: {NpadId} - HasBattery: true");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. NpadId: {NpadId} - HasBattery: true");
 
             return 0;
         }
@@ -1292,7 +1292,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             Context.ResponseData.Write(true); //Npad always got a left battery ?
             Context.ResponseData.Write(true); //Npad always got a right battery ?
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. NpadId: {NpadId} - HasLeftBattery: true - HasRightBattery: true");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. NpadId: {NpadId} - HasLeftBattery: true - HasRightBattery: true");
 
             return 0;
         }
@@ -1304,7 +1304,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             Context.ResponseData.Write((byte)0);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. NpadId: {NpadId} - NpadInterfaceType: 0");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. NpadId: {NpadId} - NpadInterfaceType: 0");
 
             return 0;
         }
@@ -1317,9 +1317,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             Context.ResponseData.Write((byte)0);
             Context.ResponseData.Write((byte)0);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. NpadId: {NpadId} - " +
-                                                              $"LeftInterfaceType: 0 - " +
-                                                              $"RightInterfaceType: 0");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. NpadId: {NpadId} - " +
+                                                  $"LeftInterfaceType: 0 - " +
+                                                  $"RightInterfaceType: 0");
 
             return 0;
         }
@@ -1334,9 +1334,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             Context.ResponseData.Write(PalmaConnectionHandle);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"Unknown0: {Unknown0} - " +
-                                                              $"PalmaConnectionHandle: {PalmaConnectionHandle}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"Unknown0: {Unknown0} - " +
+                                                  $"PalmaConnectionHandle: {PalmaConnectionHandle}");
 
             return 0;
         }
@@ -1346,7 +1346,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             int PalmaConnectionHandle = Context.RequestData.ReadInt32();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. PalmaConnectionHandle: {PalmaConnectionHandle}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. PalmaConnectionHandle: {PalmaConnectionHandle}");
 
             return 0;
         }
@@ -1363,7 +1363,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             Context.Response.HandleDesc = IpcHandleDesc.MakeCopy(Handle);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. PalmaConnectionHandle: {PalmaConnectionHandle}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. PalmaConnectionHandle: {PalmaConnectionHandle}");
 
             return 0;
         }
@@ -1377,8 +1377,8 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             Context.ResponseData.Write(Unknown0);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. PalmaConnectionHandle: {PalmaConnectionHandle} - " +
-                                                              $"Unknown0: {Unknown0}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. PalmaConnectionHandle: {PalmaConnectionHandle} - " +
+                                                  $"Unknown0: {Unknown0}");
 
             return 0;
         }
@@ -1389,8 +1389,8 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             int  PalmaConnectionHandle = Context.RequestData.ReadInt32();
             long Unknown0              = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. PalmaConnectionHandle: {PalmaConnectionHandle} - " +
-                                                              $"Unknown0: {Unknown0}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. PalmaConnectionHandle: {PalmaConnectionHandle} - " +
+                                                  $"Unknown0: {Unknown0}");
 
             return 0;
         }
@@ -1401,8 +1401,8 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             int  PalmaConnectionHandle = Context.RequestData.ReadInt32();
             long FrModeType            = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. PalmaConnectionHandle: {PalmaConnectionHandle} - " +
-                                                              $"FrModeType: {FrModeType}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. PalmaConnectionHandle: {PalmaConnectionHandle} - " +
+                                                  $"FrModeType: {FrModeType}");
 
             return 0;
         }
@@ -1412,7 +1412,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             int PalmaConnectionHandle = Context.RequestData.ReadInt32();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. PalmaConnectionHandle: {PalmaConnectionHandle}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. PalmaConnectionHandle: {PalmaConnectionHandle}");
 
             return 0;
         }
@@ -1423,8 +1423,8 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             int  PalmaConnectionHandle = Context.RequestData.ReadInt32();
             bool EnabledPalmaStep      = Context.RequestData.ReadBoolean();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. PalmaConnectionHandle: {PalmaConnectionHandle} - " +
-                                                              $"EnabledPalmaStep: {EnabledPalmaStep}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. PalmaConnectionHandle: {PalmaConnectionHandle} - " +
+                                                  $"EnabledPalmaStep: {EnabledPalmaStep}");
 
             return 0;
         }
@@ -1434,7 +1434,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             int PalmaConnectionHandle = Context.RequestData.ReadInt32();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. PalmaConnectionHandle: {PalmaConnectionHandle}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. PalmaConnectionHandle: {PalmaConnectionHandle}");
 
             return 0;
         }
@@ -1444,7 +1444,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             int PalmaConnectionHandle = Context.RequestData.ReadInt32();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. PalmaConnectionHandle: {PalmaConnectionHandle}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. PalmaConnectionHandle: {PalmaConnectionHandle}");
 
             return 0;
         }
@@ -1456,9 +1456,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             long Unknown0              = Context.RequestData.ReadInt64();
             long Unknown1              = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. PalmaConnectionHandle: {PalmaConnectionHandle} - " +
-                                                              $"Unknown0: {Unknown0} - " +
-                                                              $"Unknown1: {Unknown1}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. PalmaConnectionHandle: {PalmaConnectionHandle} - " +
+                                                  $"Unknown0: {Unknown0} - " +
+                                                  $"Unknown1: {Unknown1}");
 
             return 0;
         }
@@ -1471,9 +1471,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             long Unknown1              = Context.RequestData.ReadInt64();
             // nn::hid::PalmaApplicationSectionAccessBuffer cast is unknown
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. PalmaConnectionHandle: {PalmaConnectionHandle} - " +
-                                                              $"Unknown0: {Unknown0} - " +
-                                                              $"Unknown1: {Unknown1}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. PalmaConnectionHandle: {PalmaConnectionHandle} - " +
+                                                  $"Unknown0: {Unknown0} - " +
+                                                  $"Unknown1: {Unknown1}");
 
             return 0;
         }
@@ -1483,7 +1483,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             int PalmaConnectionHandle = Context.RequestData.ReadInt32();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. PalmaConnectionHandle: {PalmaConnectionHandle}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. PalmaConnectionHandle: {PalmaConnectionHandle}");
 
             return 0;
         }
@@ -1493,7 +1493,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             int PalmaConnectionHandle = Context.RequestData.ReadInt32();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. PalmaConnectionHandle: {PalmaConnectionHandle}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. PalmaConnectionHandle: {PalmaConnectionHandle}");
 
             return 0;
         }
@@ -1504,8 +1504,8 @@ namespace Ryujinx.HLE.HOS.Services.Hid
                  NpadCommunicationMode = Context.RequestData.ReadInt64();
             long AppletResourceUserId  = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
-                                                              $"NpadCommunicationMode: {NpadCommunicationMode}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. AppletResourceUserId: {AppletResourceUserId} - " +
+                                                  $"NpadCommunicationMode: {NpadCommunicationMode}");
 
             return 0;
         }
@@ -1515,7 +1515,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             Context.ResponseData.Write(NpadCommunicationMode);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceHid, $"Stubbed. CommunicationMode: {NpadCommunicationMode}");
+            Logger.PrintStub(LogClass.ServiceHid, $"Stubbed. CommunicationMode: {NpadCommunicationMode}");
 
             return 0;
         }

--- a/Ryujinx.HLE/HOS/Services/IpcService.cs
+++ b/Ryujinx.HLE/HOS/Services/IpcService.cs
@@ -1,6 +1,6 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Kernel;
-using Ryujinx.HLE.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -91,7 +91,7 @@ namespace Ryujinx.HLE.HOS.Services
             {
                 Context.ResponseData.BaseStream.Seek(IsDomain ? 0x20 : 0x10, SeekOrigin.Begin);
 
-                Context.Device.Log.PrintDebug(LogClass.KernelIpc, $"{Service.GetType().Name}: {ProcessRequest.Method.Name}");
+                Logger.PrintDebug(LogClass.KernelIpc, $"{Service.GetType().Name}: {ProcessRequest.Method.Name}");
 
                 long Result = ProcessRequest(Context);
 

--- a/Ryujinx.HLE/HOS/Services/Irs/IIrSensorServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Irs/IIrSensorServer.cs
@@ -1,6 +1,6 @@
-﻿using Ryujinx.HLE.HOS.Ipc;
+﻿using Ryujinx.Common.Logging;
+using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Kernel;
-using Ryujinx.HLE.Logging;
 using System;
 using System.Collections.Generic;
 
@@ -28,7 +28,7 @@ namespace Ryujinx.HLE.HOS.Services.Irs
         {
             long AppletResourceUserId = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceIrs, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
+            Logger.PrintStub(LogClass.ServiceIrs, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
 
             return 0;
         }
@@ -38,7 +38,7 @@ namespace Ryujinx.HLE.HOS.Services.Irs
         {
             long AppletResourceUserId = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceIrs, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
+            Logger.PrintStub(LogClass.ServiceIrs, $"Stubbed. AppletResourceUserId: {AppletResourceUserId}");
 
             return 0;
         }

--- a/Ryujinx.HLE/HOS/Services/Lm/ILogger.cs
+++ b/Ryujinx.HLE/HOS/Services/Lm/ILogger.cs
@@ -1,5 +1,5 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
-using Ryujinx.HLE.Logging;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -88,11 +88,11 @@ namespace Ryujinx.HLE.HOS.Services.Lm
 
                 switch((LmLogLevel)Level)
                 {
-                    case LmLogLevel.Trace:    Context.Device.Log.PrintDebug  (LogClass.ServiceLm, Text); break;
-                    case LmLogLevel.Info:     Context.Device.Log.PrintInfo   (LogClass.ServiceLm, Text); break;
-                    case LmLogLevel.Warning:  Context.Device.Log.PrintWarning(LogClass.ServiceLm, Text); break;
-                    case LmLogLevel.Error:    Context.Device.Log.PrintError  (LogClass.ServiceLm, Text); break;
-                    case LmLogLevel.Critical: Context.Device.Log.PrintError  (LogClass.ServiceLm, Text); break;
+                    case LmLogLevel.Trace:    Logger.PrintDebug  (LogClass.ServiceLm, Text); break;
+                    case LmLogLevel.Info:     Logger.PrintInfo   (LogClass.ServiceLm, Text); break;
+                    case LmLogLevel.Warning:  Logger.PrintWarning(LogClass.ServiceLm, Text); break;
+                    case LmLogLevel.Error:    Logger.PrintError  (LogClass.ServiceLm, Text); break;
+                    case LmLogLevel.Critical: Logger.PrintError  (LogClass.ServiceLm, Text); break;
                 }
             }
 

--- a/Ryujinx.HLE/HOS/Services/Mm/IRequest.cs
+++ b/Ryujinx.HLE/HOS/Services/Mm/IRequest.cs
@@ -1,5 +1,5 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
-using Ryujinx.HLE.Logging;
 using System;
 using System.Collections.Generic;
 
@@ -29,21 +29,21 @@ namespace Ryujinx.HLE.HOS.Services.Mm
             int Unknown1 = Context.RequestData.ReadInt32();
             int Unknown2 = Context.RequestData.ReadInt32();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceMm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceMm, "Stubbed.");
 
             return 0;
         }
 
         public long Initialize(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceMm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceMm, "Stubbed.");
 
             return 0;
         }
 
         public long SetAndWait(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceMm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceMm, "Stubbed.");
 
             return 0;
         }
@@ -52,7 +52,7 @@ namespace Ryujinx.HLE.HOS.Services.Mm
         {
             Context.ResponseData.Write(0);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceMm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceMm, "Stubbed.");
 
             return 0;
         }

--- a/Ryujinx.HLE/HOS/Services/Nfp/IUser.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfp/IUser.cs
@@ -1,7 +1,7 @@
-﻿using Ryujinx.HLE.HOS.Ipc;
+﻿using Ryujinx.Common.Logging;
+using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Kernel;
 using Ryujinx.HLE.Input;
-using Ryujinx.HLE.Logging;
 using System;
 using System.Collections.Generic;
 
@@ -45,7 +45,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfp
 
         public long Initialize(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceNfp, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNfp, "Stubbed.");
 
             State = State.Initialized;
 
@@ -54,7 +54,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfp
 
         public long AttachActivateEvent(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceNfp, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNfp, "Stubbed.");
 
             if (Context.Process.HandleTable.GenerateHandle(ActivateEvent.ReadableEvent, out int Handle) != KernelResult.Success)
             {
@@ -68,7 +68,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfp
 
         public long AttachDeactivateEvent(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceNfp, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNfp, "Stubbed.");
 
             if (Context.Process.HandleTable.GenerateHandle(DeactivateEvent.ReadableEvent, out int Handle) != KernelResult.Success)
             {
@@ -84,7 +84,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfp
         {
             Context.ResponseData.Write((int)State);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceNfp, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNfp, "Stubbed.");
 
             return 0;
         }
@@ -93,7 +93,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfp
         {
             Context.ResponseData.Write((int)DeviceState);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceNfp, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNfp, "Stubbed.");
 
             return 0;
         }
@@ -102,14 +102,14 @@ namespace Ryujinx.HLE.HOS.Services.Nfp
         {
             Context.ResponseData.Write((int)NpadId);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceNfp, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNfp, "Stubbed.");
 
             return 0;
         }
 
         public long AttachAvailabilityChangeEvent(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceNfp, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNfp, "Stubbed.");
 
             if (Context.Process.HandleTable.GenerateHandle(AvailabilityChangeEvent.ReadableEvent, out int Handle) != KernelResult.Success)
             {

--- a/Ryujinx.HLE/HOS/Services/Nifm/IGeneralService.cs
+++ b/Ryujinx.HLE/HOS/Services/Nifm/IGeneralService.cs
@@ -1,5 +1,5 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
-using Ryujinx.HLE.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -32,7 +32,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm
 
             MakeObject(Context, new IRequest(Context.Device.System));
 
-            Context.Device.Log.PrintStub(LogClass.ServiceNifm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNifm, "Stubbed.");
 
             return 0;
         }
@@ -50,7 +50,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm
 
             Context.ResponseData.Write(BitConverter.ToUInt32(Address.GetAddressBytes()));
 
-            Context.Device.Log.PrintInfo(LogClass.ServiceNifm, $"Console's local IP is \"{Address}\".");
+            Logger.PrintInfo(LogClass.ServiceNifm, $"Console's local IP is \"{Address}\".");
 
             return 0;
         }

--- a/Ryujinx.HLE/HOS/Services/Nifm/IRequest.cs
+++ b/Ryujinx.HLE/HOS/Services/Nifm/IRequest.cs
@@ -1,6 +1,6 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Kernel;
-using Ryujinx.HLE.Logging;
 using System;
 using System.Collections.Generic;
 
@@ -35,14 +35,14 @@ namespace Ryujinx.HLE.HOS.Services.Nifm
         {
             Context.ResponseData.Write(1);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceNifm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNifm, "Stubbed.");
 
             return 0;
         }
 
         public long GetResult(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceNifm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNifm, "Stubbed.");
 
             return 0;
         }
@@ -66,21 +66,21 @@ namespace Ryujinx.HLE.HOS.Services.Nifm
 
         public long Cancel(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceNifm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNifm, "Stubbed.");
 
             return 0;
         }
 
         public long Submit(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceNifm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNifm, "Stubbed.");
 
             return 0;
         }
 
         public long SetConnectionConfirmationOption(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceNifm, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNifm, "Stubbed.");
 
             return 0;
         }

--- a/Ryujinx.HLE/HOS/Services/Ns/IAddOnContentManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Ns/IAddOnContentManager.cs
@@ -1,5 +1,5 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
-using Ryujinx.HLE.Logging;
 using System.Collections.Generic;
 
 namespace Ryujinx.HLE.HOS.Services.Ns
@@ -23,14 +23,14 @@ namespace Ryujinx.HLE.HOS.Services.Ns
         {
             Context.ResponseData.Write(0);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceNs, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNs, "Stubbed.");
 
             return 0;
         }
 
         public static long ListAddOnContent(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceNs, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNs, "Stubbed.");
 
             //TODO: This is supposed to write a u32 array aswell.
             //It's unknown what it contains.

--- a/Ryujinx.HLE/HOS/Services/Nv/INvDrvServices.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/INvDrvServices.cs
@@ -1,4 +1,5 @@
 using ChocolArm64.Memory;
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Kernel;
 using Ryujinx.HLE.HOS.Services.Nv.NvGpuAS;
@@ -6,7 +7,6 @@ using Ryujinx.HLE.HOS.Services.Nv.NvGpuGpu;
 using Ryujinx.HLE.HOS.Services.Nv.NvHostChannel;
 using Ryujinx.HLE.HOS.Services.Nv.NvHostCtrl;
 using Ryujinx.HLE.HOS.Services.Nv.NvMap;
-using Ryujinx.HLE.Logging;
 using System;
 using System.Collections.Generic;
 
@@ -146,7 +146,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
 
         public long FinishInitialize(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceNv, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNv, "Stubbed.");
 
             return 0;
         }
@@ -180,14 +180,14 @@ namespace Ryujinx.HLE.HOS.Services.Nv
         {
             if (CmdIn(Cmd) && Context.Request.GetBufferType0x21().Position == 0)
             {
-                Context.Device.Log.PrintError(LogClass.ServiceNv, "Input buffer is null!");
+                Logger.PrintError(LogClass.ServiceNv, "Input buffer is null!");
 
                 return NvResult.InvalidInput;
             }
 
             if (CmdOut(Cmd) && Context.Request.GetBufferType0x22().Position == 0)
             {
-                Context.Device.Log.PrintError(LogClass.ServiceNv, "Output buffer is null!");
+                Logger.PrintError(LogClass.ServiceNv, "Output buffer is null!");
 
                 return NvResult.InvalidInput;
             }

--- a/Ryujinx.HLE/HOS/Services/Nv/NvGpuAS/NvGpuASIoctl.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvGpuAS/NvGpuASIoctl.cs
@@ -1,7 +1,7 @@
 using ChocolArm64.Memory;
+using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.Memory;
 using Ryujinx.HLE.HOS.Services.Nv.NvMap;
-using Ryujinx.HLE.Logging;
 using System;
 using System.Collections.Concurrent;
 
@@ -42,7 +42,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvGpuAS
             long InputPosition  = Context.Request.GetBufferType0x21().Position;
             long OutputPosition = Context.Request.GetBufferType0x22().Position;
 
-            Context.Device.Log.PrintStub(LogClass.ServiceNv, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNv, "Stubbed.");
 
             return NvResult.Success;
         }
@@ -78,7 +78,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvGpuAS
                 {
                     Args.Offset = 0;
 
-                    Context.Device.Log.PrintWarning(LogClass.ServiceNv, $"Failed to allocate size {Size:x16}!");
+                    Logger.PrintWarning(LogClass.ServiceNv, $"Failed to allocate size {Size:x16}!");
 
                     Result = NvResult.OutOfMemory;
                 }
@@ -115,7 +115,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvGpuAS
                 }
                 else
                 {
-                    Context.Device.Log.PrintWarning(LogClass.ServiceNv,
+                    Logger.PrintWarning(LogClass.ServiceNv,
                         $"Failed to free offset 0x{Args.Offset:x16} size 0x{Size:x16}!");
 
                     Result = NvResult.InvalidInput;
@@ -145,7 +145,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvGpuAS
                 }
                 else
                 {
-                    Context.Device.Log.PrintWarning(LogClass.ServiceNv, $"Invalid buffer offset {Args.Offset:x16}!");
+                    Logger.PrintWarning(LogClass.ServiceNv, $"Invalid buffer offset {Args.Offset:x16}!");
                 }
             }
 
@@ -167,7 +167,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvGpuAS
 
             if (Map == null)
             {
-                Context.Device.Log.PrintWarning(LogClass.ServiceNv, $"Invalid NvMap handle 0x{Args.NvMapHandle:x8}!");
+                Logger.PrintWarning(LogClass.ServiceNv, $"Invalid NvMap handle 0x{Args.NvMapHandle:x8}!");
 
                 return NvResult.InvalidInput;
             }
@@ -188,7 +188,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvGpuAS
                         {
                             string Msg = string.Format(MapErrorMsg, VA, Args.MappingSize);
 
-                            Context.Device.Log.PrintWarning(LogClass.ServiceNv, Msg);
+                            Logger.PrintWarning(LogClass.ServiceNv, Msg);
 
                             return NvResult.InvalidInput;
                         }
@@ -197,7 +197,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvGpuAS
                     }
                     else
                     {
-                        Context.Device.Log.PrintWarning(LogClass.ServiceNv, $"Address 0x{Args.Offset:x16} not mapped!");
+                        Logger.PrintWarning(LogClass.ServiceNv, $"Address 0x{Args.Offset:x16} not mapped!");
 
                         return NvResult.InvalidInput;
                     }
@@ -231,7 +231,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvGpuAS
                     {
                         string Msg = string.Format(MapErrorMsg, Args.Offset, Size);
 
-                        Context.Device.Log.PrintWarning(LogClass.ServiceNv, Msg);
+                        Logger.PrintWarning(LogClass.ServiceNv, Msg);
 
                         Result = NvResult.InvalidInput;
                     }
@@ -245,7 +245,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvGpuAS
                 {
                     Args.Offset = 0;
 
-                    Context.Device.Log.PrintWarning(LogClass.ServiceNv, $"Failed to map size 0x{Size:x16}!");
+                    Logger.PrintWarning(LogClass.ServiceNv, $"Failed to map size 0x{Size:x16}!");
 
                     Result = NvResult.InvalidInput;
                 }
@@ -265,7 +265,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvGpuAS
             long InputPosition  = Context.Request.GetBufferType0x21().Position;
             long OutputPosition = Context.Request.GetBufferType0x22().Position;
 
-            Context.Device.Log.PrintStub(LogClass.ServiceNv, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNv, "Stubbed.");
 
             return NvResult.Success;
         }
@@ -275,7 +275,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvGpuAS
             long InputPosition  = Context.Request.GetBufferType0x21().Position;
             long OutputPosition = Context.Request.GetBufferType0x22().Position;
 
-            Context.Device.Log.PrintStub(LogClass.ServiceNv, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNv, "Stubbed.");
 
             return NvResult.Success;
         }
@@ -296,7 +296,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvGpuAS
 
                 if (Map == null)
                 {
-                    Context.Device.Log.PrintWarning(LogClass.ServiceNv, $"Invalid NvMap handle 0x{Args.NvMapHandle:x8}!");
+                    Logger.PrintWarning(LogClass.ServiceNv, $"Invalid NvMap handle 0x{Args.NvMapHandle:x8}!");
 
                     return NvResult.InvalidInput;
                 }
@@ -306,7 +306,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvGpuAS
 
                 if (Result < 0)
                 {
-                    Context.Device.Log.PrintWarning(LogClass.ServiceNv,
+                    Logger.PrintWarning(LogClass.ServiceNv,
                         $"Page 0x{Args.Offset:x16} size 0x{Args.Pages:x16} not allocated!");
 
                     return NvResult.InvalidInput;

--- a/Ryujinx.HLE/HOS/Services/Nv/NvGpuGpu/NvGpuGpuIoctl.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvGpuGpu/NvGpuGpuIoctl.cs
@@ -1,5 +1,5 @@
 using ChocolArm64.Memory;
-using Ryujinx.HLE.Logging;
+using Ryujinx.Common.Logging;
 using System;
 using System.Diagnostics;
 
@@ -46,7 +46,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvGpuGpu
 
             AMemoryHelper.Write(Context.Memory, OutputPosition, Args);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceNv, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNv, "Stubbed.");
 
             return NvResult.Success;
         }
@@ -70,7 +70,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvGpuGpu
 
             AMemoryHelper.Write(Context.Memory, OutputPosition, Args);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceNv, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNv, "Stubbed.");
 
             return NvResult.Success;
         }
@@ -80,7 +80,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvGpuGpu
             long InputPosition  = Context.Request.GetBufferType0x21().Position;
             long OutputPosition = Context.Request.GetBufferType0x22().Position;
 
-            Context.Device.Log.PrintStub(LogClass.ServiceNv, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNv, "Stubbed.");
 
             return NvResult.Success;
         }
@@ -163,7 +163,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvGpuGpu
 
             AMemoryHelper.Write(Context.Memory, OutputPosition, Args);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceNv, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNv, "Stubbed.");
 
             return NvResult.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Nv/NvHostChannel/NvHostChannelIoctl.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvHostChannel/NvHostChannelIoctl.cs
@@ -1,7 +1,7 @@
 using ChocolArm64.Memory;
+using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.Memory;
 using Ryujinx.HLE.HOS.Services.Nv.NvGpuAS;
-using Ryujinx.HLE.Logging;
 using System;
 using System.Collections.Concurrent;
 
@@ -57,7 +57,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvHostChannel
             long InputPosition  = Context.Request.GetBufferType0x21().Position;
             long OutputPosition = Context.Request.GetBufferType0x22().Position;
 
-            Context.Device.Log.PrintStub(LogClass.ServiceNv, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNv, "Stubbed.");
 
             return NvResult.Success;
         }
@@ -67,7 +67,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvHostChannel
             long InputPosition  = Context.Request.GetBufferType0x21().Position;
             long OutputPosition = Context.Request.GetBufferType0x22().Position;
 
-            Context.Device.Log.PrintStub(LogClass.ServiceNv, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNv, "Stubbed.");
 
             return NvResult.Success;
         }
@@ -110,7 +110,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvHostChannel
             long InputPosition  = Context.Request.GetBufferType0x21().Position;
             long OutputPosition = Context.Request.GetBufferType0x22().Position;
 
-            Context.Device.Log.PrintStub(LogClass.ServiceNv, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNv, "Stubbed.");
 
             return NvResult.Success;
         }
@@ -120,7 +120,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvHostChannel
             long InputPosition  = Context.Request.GetBufferType0x21().Position;
             long OutputPosition = Context.Request.GetBufferType0x22().Position;
 
-            Context.Device.Log.PrintStub(LogClass.ServiceNv, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNv, "Stubbed.");
 
             return NvResult.Success;
         }
@@ -130,7 +130,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvHostChannel
             long InputPosition  = Context.Request.GetBufferType0x21().Position;
             long OutputPosition = Context.Request.GetBufferType0x22().Position;
 
-            Context.Device.Log.PrintStub(LogClass.ServiceNv, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNv, "Stubbed.");
 
             return NvResult.Success;
         }
@@ -140,7 +140,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvHostChannel
             long InputPosition  = Context.Request.GetBufferType0x21().Position;
             long OutputPosition = Context.Request.GetBufferType0x22().Position;
 
-            Context.Device.Log.PrintStub(LogClass.ServiceNv, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNv, "Stubbed.");
 
             return NvResult.Success;
         }
@@ -150,7 +150,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvHostChannel
             long InputPosition  = Context.Request.GetBufferType0x21().Position;
             long OutputPosition = Context.Request.GetBufferType0x22().Position;
 
-            Context.Device.Log.PrintStub(LogClass.ServiceNv, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNv, "Stubbed.");
 
             return NvResult.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Nv/NvHostCtrl/NvHostCtrlIoctl.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvHostCtrl/NvHostCtrlIoctl.cs
@@ -1,5 +1,5 @@
 using ChocolArm64.Memory;
-using Ryujinx.HLE.Logging;
+using Ryujinx.Common.Logging;
 using System;
 using System.Collections.Concurrent;
 using System.Text;
@@ -95,7 +95,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvHostCtrl
                     {
                         if (StringValue.Length > 0x100)
                         {
-                            Context.Device.Log.PrintError(Logging.LogClass.ServiceNv, $"{Domain}!{Name} String value size is too big!");
+                            Logger.PrintError(LogClass.ServiceNv, $"{Domain}!{Name} String value size is too big!");
                         }
                         else
                         {
@@ -118,7 +118,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvHostCtrl
 
                     Context.Memory.WriteBytes(OutputPosition + 0x82, SettingBuffer);
 
-                    Context.Device.Log.PrintDebug(Logging.LogClass.ServiceNv, $"Got setting {Domain}!{Name}");
+                    Logger.PrintDebug(LogClass.ServiceNv, $"Got setting {Domain}!{Name}");
                 }
 
                 return NvResult.Success;
@@ -144,7 +144,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvHostCtrl
 
             int EventId = Context.Memory.ReadInt32(InputPosition);
 
-            Context.Device.Log.PrintStub(LogClass.ServiceNv, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceNv, "Stubbed.");
 
             return NvResult.Success;
         }
@@ -201,7 +201,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvHostCtrl
             }
             else
             {
-                Context.Device.Log.PrintDebug(LogClass.ServiceNv, "Waiting syncpt with timeout of " + Args.Timeout + "ms...");
+                Logger.PrintDebug(LogClass.ServiceNv, "Waiting syncpt with timeout of " + Args.Timeout + "ms...");
 
                 using (ManualResetEvent WaitEvent = new ManualResetEvent(false))
                 {
@@ -232,7 +232,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvHostCtrl
                     }
                 }
 
-                Context.Device.Log.PrintDebug(LogClass.ServiceNv, "Resuming...");
+                Logger.PrintDebug(LogClass.ServiceNv, "Resuming...");
             }
 
             if (Extended)

--- a/Ryujinx.HLE/HOS/Services/Nv/NvMap/NvMapIoctl.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvMap/NvMapIoctl.cs
@@ -1,6 +1,6 @@
 using ChocolArm64.Memory;
+using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.Memory;
-using Ryujinx.HLE.Logging;
 using Ryujinx.HLE.Utilities;
 using System.Collections.Concurrent;
 
@@ -29,7 +29,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvMap
                 case 0x010e: return GetId (Context);
             }
 
-            Context.Device.Log.PrintWarning(LogClass.ServiceNv, $"Unsupported Ioctl command 0x{Cmd:x8}!");
+            Logger.PrintWarning(LogClass.ServiceNv, $"Unsupported Ioctl command 0x{Cmd:x8}!");
 
             return NvResult.NotSupported;
         }
@@ -43,7 +43,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvMap
 
             if (Args.Size == 0)
             {
-                Context.Device.Log.PrintWarning(LogClass.ServiceNv, $"Invalid size 0x{Args.Size:x8}!");
+                Logger.PrintWarning(LogClass.ServiceNv, $"Invalid size 0x{Args.Size:x8}!");
 
                 return NvResult.InvalidInput;
             }
@@ -52,7 +52,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvMap
 
             Args.Handle = AddNvMap(Context, new NvMapHandle(Size));
 
-            Context.Device.Log.PrintInfo(LogClass.ServiceNv, $"Created map {Args.Handle} with size 0x{Size:x8}!");
+            Logger.PrintInfo(LogClass.ServiceNv, $"Created map {Args.Handle} with size 0x{Size:x8}!");
 
             AMemoryHelper.Write(Context.Memory, OutputPosition, Args);
 
@@ -70,7 +70,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvMap
 
             if (Map == null)
             {
-                Context.Device.Log.PrintWarning(LogClass.ServiceNv, $"Invalid handle 0x{Args.Handle:x8}!");
+                Logger.PrintWarning(LogClass.ServiceNv, $"Invalid handle 0x{Args.Handle:x8}!");
 
                 return NvResult.InvalidInput;
             }
@@ -95,14 +95,14 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvMap
 
             if (Map == null)
             {
-                Context.Device.Log.PrintWarning(LogClass.ServiceNv, $"Invalid handle 0x{Args.Handle:x8}!");
+                Logger.PrintWarning(LogClass.ServiceNv, $"Invalid handle 0x{Args.Handle:x8}!");
 
                 return NvResult.InvalidInput;
             }
 
             if ((Args.Align & (Args.Align - 1)) != 0)
             {
-                Context.Device.Log.PrintWarning(LogClass.ServiceNv, $"Invalid alignment 0x{Args.Align:x8}!");
+                Logger.PrintWarning(LogClass.ServiceNv, $"Invalid alignment 0x{Args.Align:x8}!");
 
                 return NvResult.InvalidInput;
             }
@@ -159,7 +159,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvMap
 
             if (Map == null)
             {
-                Context.Device.Log.PrintWarning(LogClass.ServiceNv, $"Invalid handle 0x{Args.Handle:x8}!");
+                Logger.PrintWarning(LogClass.ServiceNv, $"Invalid handle 0x{Args.Handle:x8}!");
 
                 return NvResult.InvalidInput;
             }
@@ -168,7 +168,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvMap
             {
                 DeleteNvMap(Context, Args.Handle);
 
-                Context.Device.Log.PrintInfo(LogClass.ServiceNv, $"Deleted map {Args.Handle}!");
+                Logger.PrintInfo(LogClass.ServiceNv, $"Deleted map {Args.Handle}!");
 
                 Args.Address = Map.Address;
                 Args.Flags   = 0;
@@ -197,7 +197,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvMap
 
             if (Map == null)
             {
-                Context.Device.Log.PrintWarning(LogClass.ServiceNv, $"Invalid handle 0x{Args.Handle:x8}!");
+                Logger.PrintWarning(LogClass.ServiceNv, $"Invalid handle 0x{Args.Handle:x8}!");
 
                 return NvResult.InvalidInput;
             }
@@ -231,7 +231,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvMap
 
             if (Map == null)
             {
-                Context.Device.Log.PrintWarning(LogClass.ServiceNv, $"Invalid handle 0x{Args.Handle:x8}!");
+                Logger.PrintWarning(LogClass.ServiceNv, $"Invalid handle 0x{Args.Handle:x8}!");
 
                 return NvResult.InvalidInput;
             }

--- a/Ryujinx.HLE/HOS/Services/Pctl/IParentalControlService.cs
+++ b/Ryujinx.HLE/HOS/Services/Pctl/IParentalControlService.cs
@@ -1,5 +1,5 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
-using Ryujinx.HLE.Logging;
 using System.Collections.Generic;
 
 namespace Ryujinx.HLE.HOS.Services.Pctl
@@ -32,7 +32,7 @@ namespace Ryujinx.HLE.HOS.Services.Pctl
             }
             else
             {
-                Context.Device.Log.PrintWarning(LogClass.ServicePctl, "Service is already initialized!");
+                Logger.PrintWarning(LogClass.ServicePctl, "Service is already initialized!");
             }
 
             return 0;

--- a/Ryujinx.HLE/HOS/Services/Prepo/IPrepoService.cs
+++ b/Ryujinx.HLE/HOS/Services/Prepo/IPrepoService.cs
@@ -1,5 +1,5 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
-using Ryujinx.HLE.Logging;
 using System.Collections.Generic;
 
 namespace Ryujinx.HLE.HOS.Services.Prepo
@@ -20,7 +20,7 @@ namespace Ryujinx.HLE.HOS.Services.Prepo
 
         public static long SaveReportWithUser(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServicePrepo, "Stubbed.");
+            Logger.PrintStub(LogClass.ServicePrepo, "Stubbed.");
 
             return 0;
         }

--- a/Ryujinx.HLE/HOS/Services/Set/ISystemSettingsServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Set/ISystemSettingsServer.cs
@@ -1,3 +1,4 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.SystemState;
 using System;
@@ -115,7 +116,7 @@ namespace Ryujinx.HLE.HOS.Services.Set
                 {
                     if (StringValue.Length + 1 > ReplySize)
                     {
-                        Context.Device.Log.PrintError(Logging.LogClass.ServiceSet, $"{AskedSetting} String value size is too big!");
+                        Logger.PrintError(LogClass.ServiceSet, $"{AskedSetting} String value size is too big!");
                     }
                     else
                     {
@@ -138,11 +139,11 @@ namespace Ryujinx.HLE.HOS.Services.Set
 
                 Context.Memory.WriteBytes(ReplyPos, SettingBuffer);
 
-                Context.Device.Log.PrintDebug(Logging.LogClass.ServiceSet, $"{AskedSetting} set value: {NxSetting} as {NxSetting.GetType()}");
+                Logger.PrintDebug(LogClass.ServiceSet, $"{AskedSetting} set value: {NxSetting} as {NxSetting.GetType()}");
             }
             else
             {
-                Context.Device.Log.PrintError(Logging.LogClass.ServiceSet, $"{AskedSetting} not found!");
+                Logger.PrintError(LogClass.ServiceSet, $"{AskedSetting} not found!");
             }
 
             return 0;

--- a/Ryujinx.HLE/HOS/Services/Sfdnsres/IResolver.cs
+++ b/Ryujinx.HLE/HOS/Services/Sfdnsres/IResolver.cs
@@ -1,3 +1,4 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
 using System;
 using System.Collections.Generic;
@@ -165,7 +166,7 @@ namespace Ryujinx.HLE.HOS.Services.Sfdnsres
             long BufferSize     = Context.Request.SendBuff[0].Size;
 
             // TODO: This is stubbed in 2.0.0+, reverse 1.0.0 version for the sake completeness.
-            Context.Device.Log.PrintStub(Logging.LogClass.ServiceSfdnsres, $"Stubbed. Unknown0: {Unknown0}");
+            Logger.PrintStub(LogClass.ServiceSfdnsres, $"Stubbed. Unknown0: {Unknown0}");
 
             return MakeError(ErrorModule.Os, 1023);
         }
@@ -176,7 +177,7 @@ namespace Ryujinx.HLE.HOS.Services.Sfdnsres
             uint Unknown0 = Context.RequestData.ReadUInt32();
 
             // TODO: This is stubbed in 2.0.0+, reverse 1.0.0 version for the sake completeness.
-            Context.Device.Log.PrintStub(Logging.LogClass.ServiceSfdnsres, $"Stubbed. Unknown0: {Unknown0}");
+            Logger.PrintStub(LogClass.ServiceSfdnsres, $"Stubbed. Unknown0: {Unknown0}");
 
             return MakeError(ErrorModule.Os, 1023);
         }
@@ -368,7 +369,7 @@ namespace Ryujinx.HLE.HOS.Services.Sfdnsres
 
             Context.ResponseData.Write(0);
 
-            Context.Device.Log.PrintStub(Logging.LogClass.ServiceSfdnsres, $"Stubbed. Unknown0: {Unknown0}");
+            Logger.PrintStub(LogClass.ServiceSfdnsres, $"Stubbed. Unknown0: {Unknown0}");
 
             return 0;
         }
@@ -379,8 +380,8 @@ namespace Ryujinx.HLE.HOS.Services.Sfdnsres
             uint  Unknown0 = Context.RequestData.ReadUInt32();
             ulong Unknown1 = Context.RequestData.ReadUInt64();
 
-            Context.Device.Log.PrintStub(Logging.LogClass.ServiceSfdnsres, $"Stubbed. Unknown0: {Unknown0} - " +
-                                                                           $"Unknown1: {Unknown1}");
+            Logger.PrintStub(LogClass.ServiceSfdnsres, $"Stubbed. Unknown0: {Unknown0} - " +
+                                                       $"Unknown1: {Unknown1}");
 
             return 0;
         }
@@ -390,7 +391,7 @@ namespace Ryujinx.HLE.HOS.Services.Sfdnsres
         {
             uint Unknown0 = Context.RequestData.ReadUInt32();
 
-            Context.Device.Log.PrintStub(Logging.LogClass.ServiceSfdnsres, $"Stubbed. Unknown0: {Unknown0}");
+            Logger.PrintStub(LogClass.ServiceSfdnsres, $"Stubbed. Unknown0: {Unknown0}");
 
             return 0;
         }

--- a/Ryujinx.HLE/HOS/Services/Ssl/ISslService.cs
+++ b/Ryujinx.HLE/HOS/Services/Ssl/ISslService.cs
@@ -1,5 +1,5 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
-using Ryujinx.HLE.Logging;
 using System.Collections.Generic;
 
 namespace Ryujinx.HLE.HOS.Services.Ssl
@@ -25,7 +25,7 @@ namespace Ryujinx.HLE.HOS.Services.Ssl
             int  SslVersion = Context.RequestData.ReadInt32();
             long Unknown    = Context.RequestData.ReadInt64();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceSsl, $"Stubbed. SslVersion: {SslVersion} - Unknown: {Unknown}");
+            Logger.PrintStub(LogClass.ServiceSsl, $"Stubbed. SslVersion: {SslVersion} - Unknown: {Unknown}");
 
             MakeObject(Context, new ISslContext());
 
@@ -37,7 +37,7 @@ namespace Ryujinx.HLE.HOS.Services.Ssl
         {
             int Version = Context.RequestData.ReadInt32();
 
-            Context.Device.Log.PrintStub(LogClass.ServiceSsl, $"Stubbed. Version: {Version}");
+            Logger.PrintStub(LogClass.ServiceSsl, $"Stubbed. Version: {Version}");
 
             return 0;
         }

--- a/Ryujinx.HLE/HOS/Services/Time/ITimeZoneService.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/ITimeZoneService.cs
@@ -1,5 +1,5 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
-using Ryujinx.HLE.Logging;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -110,7 +110,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
 
             if (BufferSize != 0x4000)
             {
-                Context.Device.Log.PrintWarning(LogClass.ServiceTime, $"TimeZoneRule buffer size is 0x{BufferSize:x} (expected 0x4000)");
+                Logger.PrintWarning(LogClass.ServiceTime, $"TimeZoneRule buffer size is 0x{BufferSize:x} (expected 0x4000)");
             }
 
             long ResultCode = 0;
@@ -132,7 +132,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             }
             catch (TimeZoneNotFoundException)
             {
-                Context.Device.Log.PrintWarning(LogClass.ServiceTime, $"Timezone not found for string: {TzID} (len: {TzID.Length})");
+                Logger.PrintWarning(LogClass.ServiceTime, $"Timezone not found for string: {TzID} (len: {TzID.Length})");
 
                 ResultCode = MakeError(ErrorModule.Time, 0x3dd);
             }
@@ -170,7 +170,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
 
             if (BufferSize != 0x4000)
             {
-                Context.Device.Log.PrintWarning(LogClass.ServiceTime, $"TimeZoneRule buffer size is 0x{BufferSize:x} (expected 0x4000)");
+                Logger.PrintWarning(LogClass.ServiceTime, $"TimeZoneRule buffer size is 0x{BufferSize:x} (expected 0x4000)");
             }
 
             // TODO: Reverse the TZif2 conversion in PCV to make this match with real hardware.
@@ -189,7 +189,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             }
             catch (TimeZoneNotFoundException)
             {
-                Context.Device.Log.PrintWarning(LogClass.ServiceTime, $"Timezone not found for string: {TzID} (len: {TzID.Length})");
+                Logger.PrintWarning(LogClass.ServiceTime, $"Timezone not found for string: {TzID} (len: {TzID.Length})");
 
                 ResultCode = MakeError(ErrorModule.Time, 0x3dd);
             }
@@ -220,7 +220,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
 
             if (BufferSize != 0x4000)
             {
-                Context.Device.Log.PrintWarning(LogClass.ServiceTime, $"TimeZoneRule buffer size is 0x{BufferSize:x} (expected 0x4000)");
+                Logger.PrintWarning(LogClass.ServiceTime, $"TimeZoneRule buffer size is 0x{BufferSize:x} (expected 0x4000)");
             }
 
             // TODO: Reverse the TZif2 conversion in PCV to make this match with real hardware.
@@ -239,7 +239,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             }
             catch (TimeZoneNotFoundException)
             {
-                Context.Device.Log.PrintWarning(LogClass.ServiceTime, $"Timezone not found for string: {TzID} (len: {TzID.Length})");
+                Logger.PrintWarning(LogClass.ServiceTime, $"Timezone not found for string: {TzID} (len: {TzID.Length})");
 
                 ResultCode = MakeError(ErrorModule.Time, 0x3dd);
             }

--- a/Ryujinx.HLE/HOS/Services/Vi/IManagerDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/IManagerDisplayService.cs
@@ -1,5 +1,5 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
-using Ryujinx.HLE.Logging;
 using System.Collections.Generic;
 
 namespace Ryujinx.HLE.HOS.Services.Vi
@@ -23,7 +23,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi
 
         public static long CreateManagedLayer(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceVi, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceVi, "Stubbed.");
 
             Context.ResponseData.Write(0L); //LayerId
 
@@ -32,21 +32,21 @@ namespace Ryujinx.HLE.HOS.Services.Vi
 
         public long DestroyManagedLayer(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceVi, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceVi, "Stubbed.");
 
             return 0;
         }
 
         public static long AddToLayerStack(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceVi, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceVi, "Stubbed.");
 
             return 0;
         }
 
         public static long SetLayerVisibility(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceVi, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceVi, "Stubbed.");
 
             return 0;
         }

--- a/Ryujinx.HLE/HOS/Services/Vi/ISystemDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/ISystemDisplayService.cs
@@ -1,5 +1,5 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
-using Ryujinx.HLE.Logging;
 using System.Collections.Generic;
 
 namespace Ryujinx.HLE.HOS.Services.Vi
@@ -22,14 +22,14 @@ namespace Ryujinx.HLE.HOS.Services.Vi
 
         public static long SetLayerZ(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceVi, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceVi, "Stubbed.");
 
             return 0;
         }
 
         public static long SetLayerVisibility(ServiceCtx Context)
         {
-            Context.Device.Log.PrintStub(LogClass.ServiceVi, "Stubbed.");
+            Logger.PrintStub(LogClass.ServiceVi, "Stubbed.");
 
             return 0;
         }

--- a/Ryujinx.HLE/HOS/Services/Vi/NvFlinger.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/NvFlinger.cs
@@ -1,9 +1,9 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.Gal;
 using Ryujinx.Graphics.Memory;
 using Ryujinx.HLE.HOS.Kernel;
 using Ryujinx.HLE.HOS.Services.Nv.NvGpuAS;
 using Ryujinx.HLE.HOS.Services.Nv.NvMap;
-using Ryujinx.HLE.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -114,7 +114,7 @@ namespace Ryujinx.HLE.HOS.Services.Android
 
                 if (Commands.TryGetValue((InterfaceName, Code), out ServiceProcessParcel ProcReq))
                 {
-                    Context.Device.Log.PrintDebug(LogClass.ServiceVi, $"{InterfaceName} {ProcReq.Method.Name}");
+                    Logger.PrintDebug(LogClass.ServiceVi, $"{InterfaceName} {ProcReq.Method.Name}");
 
                     return ProcReq(Context, Reader);
                 }

--- a/Ryujinx.HLE/Ryujinx.HLE.csproj
+++ b/Ryujinx.HLE/Ryujinx.HLE.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ChocolArm64\ChocolArm64.csproj" />
     <ProjectReference Include="..\Ryujinx.Audio\Ryujinx.Audio.csproj" />
+    <ProjectReference Include="..\Ryujinx.Common\Ryujinx.Common.csproj" />
     <ProjectReference Include="..\Ryujinx.Graphics\Ryujinx.Graphics.csproj" />
     <PackageReference Include="LibHac" Version="0.1.2" />
   </ItemGroup>

--- a/Ryujinx.HLE/Switch.cs
+++ b/Ryujinx.HLE/Switch.cs
@@ -4,7 +4,6 @@ using Ryujinx.Graphics.Gal;
 using Ryujinx.HLE.FileSystem;
 using Ryujinx.HLE.HOS;
 using Ryujinx.HLE.Input;
-using Ryujinx.HLE.Logging;
 using Ryujinx.HLE.Memory;
 using System;
 using System.Threading;
@@ -14,8 +13,6 @@ namespace Ryujinx.HLE
     public class Switch : IDisposable
     {
         internal IAalOutput AudioOut { get; private set; }
-
-        public Logger Log { get; private set; }
 
         internal DeviceMemory Memory { get; private set; }
 
@@ -48,8 +45,6 @@ namespace Ryujinx.HLE
             }
 
             this.AudioOut = AudioOut;
-
-            Log = new Logger();
 
             Memory = new DeviceMemory();
 

--- a/Ryujinx.sln
+++ b/Ryujinx.sln
@@ -17,9 +17,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ryujinx.Graphics", "Ryujinx
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ryujinx.Audio", "Ryujinx.Audio\Ryujinx.Audio.csproj", "{5C1D818E-682A-46A5-9D54-30006E26C270}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ryujinx.ShaderTools", "Ryujinx.ShaderTools\Ryujinx.ShaderTools.csproj", "{3AB294D0-2230-468F-9EB3-BDFCAEAE99A5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ryujinx.ShaderTools", "Ryujinx.ShaderTools\Ryujinx.ShaderTools.csproj", "{3AB294D0-2230-468F-9EB3-BDFCAEAE99A5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Luea", "Ryujinx.LLE\Luea.csproj", "{8E7D36DD-9626-47E2-8EF5-8F2F66751C9C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Luea", "Ryujinx.LLE\Luea.csproj", "{8E7D36DD-9626-47E2-8EF5-8F2F66751C9C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Ryujinx.Common", "Ryujinx.Common\Ryujinx.Common.csproj", "{5FD4E4F6-8928-4B3C-BE07-28A675C17226}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -63,6 +65,10 @@ Global
 		{8E7D36DD-9626-47E2-8EF5-8F2F66751C9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8E7D36DD-9626-47E2-8EF5-8F2F66751C9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8E7D36DD-9626-47E2-8EF5-8F2F66751C9C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5FD4E4F6-8928-4B3C-BE07-28A675C17226}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5FD4E4F6-8928-4B3C-BE07-28A675C17226}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5FD4E4F6-8928-4B3C-BE07-28A675C17226}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5FD4E4F6-8928-4B3C-BE07-28A675C17226}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Ryujinx/Config.cs
+++ b/Ryujinx/Config.cs
@@ -1,5 +1,5 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE;
-using Ryujinx.HLE.Logging;
 using Ryujinx.UI.Input;
 using System;
 using System.Globalization;
@@ -25,11 +25,11 @@ namespace Ryujinx
 
             GraphicsConfig.ShadersDumpPath = Parser.Value("Graphics_Shaders_Dump_Path");
 
-            Device.Log.SetEnable(LogLevel.Debug,   Convert.ToBoolean(Parser.Value("Logging_Enable_Debug")));
-            Device.Log.SetEnable(LogLevel.Stub,    Convert.ToBoolean(Parser.Value("Logging_Enable_Stub")));
-            Device.Log.SetEnable(LogLevel.Info,    Convert.ToBoolean(Parser.Value("Logging_Enable_Info")));
-            Device.Log.SetEnable(LogLevel.Warning, Convert.ToBoolean(Parser.Value("Logging_Enable_Warn")));
-            Device.Log.SetEnable(LogLevel.Error,   Convert.ToBoolean(Parser.Value("Logging_Enable_Error")));
+            Logger.SetEnable(LogLevel.Debug,   Convert.ToBoolean(Parser.Value("Logging_Enable_Debug")));
+            Logger.SetEnable(LogLevel.Stub,    Convert.ToBoolean(Parser.Value("Logging_Enable_Stub")));
+            Logger.SetEnable(LogLevel.Info,    Convert.ToBoolean(Parser.Value("Logging_Enable_Info")));
+            Logger.SetEnable(LogLevel.Warning, Convert.ToBoolean(Parser.Value("Logging_Enable_Warn")));
+            Logger.SetEnable(LogLevel.Error,   Convert.ToBoolean(Parser.Value("Logging_Enable_Error")));
 
             string[] FilteredLogClasses = Parser.Value("Logging_Filtered_Classes").Split(',', StringSplitOptions.RemoveEmptyEntries);
 
@@ -41,7 +41,7 @@ namespace Ryujinx
             {
                 foreach (LogClass Class in Enum.GetValues(typeof(LogClass)))
                 {
-                    Device.Log.SetEnable(Class, false);
+                    Logger.SetEnable(Class, false);
                 }
             }
 
@@ -53,7 +53,7 @@ namespace Ryujinx
                     {
                         if (Class.ToString().ToLower().Contains(LogClass.Trim().ToLower()))
                         {
-                            Device.Log.SetEnable(Class, true);
+                            Logger.SetEnable(Class, true);
                         }
                     }
                 }

--- a/Ryujinx/Ryujinx.csproj
+++ b/Ryujinx/Ryujinx.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -15,6 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ChocolArm64\ChocolArm64.csproj" />
     <ProjectReference Include="..\Ryujinx.Audio\Ryujinx.Audio.csproj" />
+    <ProjectReference Include="..\Ryujinx.Common\Ryujinx.Common.csproj" />
     <ProjectReference Include="..\Ryujinx.Graphics\Ryujinx.Graphics.csproj" />
     <ProjectReference Include="..\Ryujinx.HLE\Ryujinx.HLE.csproj" />
   </ItemGroup>

--- a/Ryujinx/Ui/ConsoleLog.cs
+++ b/Ryujinx/Ui/ConsoleLog.cs
@@ -1,4 +1,4 @@
-using Ryujinx.HLE.Logging;
+using Ryujinx.Common.Logging;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/Ryujinx/Ui/Program.cs
+++ b/Ryujinx/Ui/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Ryujinx.Audio;
 using Ryujinx.Audio.OpenAL;
+using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.Gal;
 using Ryujinx.Graphics.Gal.OpenGL;
 using Ryujinx.HLE;
@@ -22,7 +23,7 @@ namespace Ryujinx
 
             Config.Read(Device);
 
-            Device.Log.Updated += ConsoleLog.Log;
+            Logger.Updated += ConsoleLog.Log;
 
             if (args.Length == 1)
             {


### PR DESCRIPTION
Moves logger class to a new project, `Ryujinx.Common`.
It adds a message for `per component types` and ignores them using red's type (instead of throwing an exception). Unimplemented surface formats print a message and use RGBA8 as a fallback.

@jduncanator I know you were working on this but I wanted it to be in a separate PR.