### PR TITLE
Update IStorage.cs

### DIFF
--- a/Ryujinx.HLE/HOS/Services/FspSrv/IStorage.cs
+++ b/Ryujinx.HLE/HOS/Services/FspSrv/IStorage.cs
@@ -39,8 +39,11 @@ namespace Ryujinx.HLE.HOS.Services.FspSrv
 
                 byte[] Data = new byte[Size];
 
-                BaseStream.Seek(Offset, SeekOrigin.Begin);
-                BaseStream.Read(Data, 0, Data.Length);
+                lock (BaseStream)
+                {
+                    BaseStream.Seek(Offset, SeekOrigin.Begin);
+                    BaseStream.Read(Data, 0, Data.Length);
+                }
 
                 Context.Memory.WriteBytes(BuffDesc.Position, Data);
             }


### PR DESCRIPTION
Lock the stream fix a multithreading error when a XCI game try to access to the RomFs.