### PR TITLE
General improvements for GpuResourceManager

### DIFF
--- a/Ryujinx.Graphics/Gal/IGalRenderTarget.cs
+++ b/Ryujinx.Graphics/Gal/IGalRenderTarget.cs
@@ -35,7 +35,5 @@ namespace Ryujinx.Graphics.Gal
             int  DstY1);
 
         void Reinterpret(long Key, GalImage NewImage);
-
-        byte[] GetData(long Key);
     }
 }

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLRenderTarget.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLRenderTarget.cs
@@ -389,38 +389,6 @@ namespace Ryujinx.Graphics.Gal.OpenGL
             GL.BindBuffer(BufferTarget.PixelUnpackBuffer, 0);
         }
 
-        public byte[] GetData(long Key)
-        {
-            if (!Texture.TryGetImageHandler(Key, out ImageHandler CachedImage))
-            {
-                return null;
-            }
-
-            if (SrcFb == 0)
-            {
-                SrcFb = GL.GenFramebuffer();
-            }
-
-            GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, SrcFb);
-
-            FramebufferAttachment Attachment = GetAttachment(CachedImage);
-
-            GL.FramebufferTexture(FramebufferTarget.ReadFramebuffer, Attachment, CachedImage.Handle, 0);
-
-            int Size = ImageUtils.GetSize(CachedImage.Image);
-
-            byte[] Data = new byte[Size];
-
-            int Width  = CachedImage.Width;
-            int Height = CachedImage.Height;
-
-            (_, PixelFormat Format, PixelType Type) = OGLEnumConverter.GetImageFormat(CachedImage.Format);
-
-            GL.ReadPixels(0, 0, Width, Height, Format, Type, Data);
-
-            return Data;
-        }
-
         private static FramebufferAttachment GetAttachment(ImageHandler CachedImage)
         {
             if (CachedImage.HasColor)


### PR DESCRIPTION
Simplifies GpuResourceManager code a bit.
Avoids calling Vmm.IsRegionModified on rendertarget resource bind and uses a PBO instead of CPU memory (which also avoids stalling execution) for reinterpretation.

It gives a nice boost on my end (at least on SMO's menu):
![imagen](https://user-images.githubusercontent.com/26564870/45723120-1eb52580-bb86-11e8-9ef3-68fd0ab6d0e6.png)
