### PR TITLE
Fix multiple rendertargets

### DIFF
--- a/Ryujinx.Graphics/Gal/IGalRenderTarget.cs
+++ b/Ryujinx.Graphics/Gal/IGalRenderTarget.cs
@@ -2,15 +2,17 @@ namespace Ryujinx.Graphics.Gal
 {
     public interface IGalRenderTarget
     {
-        void BindColor(long Key, int Attachment, GalImage Image);
+        void Bind();
+
+        void BindColor(long Key, int Attachment);
 
         void UnbindColor(int Attachment);
 
-        void BindZeta(long Key, GalImage Image);
+        void BindZeta(long Key);
 
         void UnbindZeta();
 
-        void Set(long Key);
+        void Present(long Key);
 
         void SetMap(int[] Map);
 

--- a/Ryujinx.Graphics/Gal/IGalRenderTarget.cs
+++ b/Ryujinx.Graphics/Gal/IGalRenderTarget.cs
@@ -20,7 +20,7 @@ namespace Ryujinx.Graphics.Gal
 
         void SetWindowSize(int Width, int Height);
 
-        void SetViewport(int X, int Y, int Width, int Height);
+        void SetViewport(int Attachment, int X, int Y, int Width, int Height);
 
         void Render();
 

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLEnumConverter.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLEnumConverter.cs
@@ -225,7 +225,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 case GalTextureWrap.Clamp:          return TextureWrapMode.Clamp;
             }
 
-            if (OGLExtension.HasTextureMirrorClamp())
+            if (OGLExtension.TextureMirrorClamp)
             {
                 switch (Wrap)
                 {

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLExtension.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLExtension.cs
@@ -7,33 +7,23 @@ namespace Ryujinx.Graphics.Gal.OpenGL
         private static bool Initialized = false;
 
         private static bool EnhancedLayouts;
-
+        private static bool ViewportArray;
         private static bool TextureMirrorClamp;
 
-        public static bool HasEnhancedLayouts()
+        public static bool HasEnhancedLayouts()    => Query(ref EnhancedLayouts);
+        public static bool HasViewportArray()      => Query(ref ViewportArray);
+        public static bool HasTextureMirrorClamp() => Query(ref TextureMirrorClamp);
+        
+        private static bool Query(ref bool Extension)
         {
-            EnsureInitialized();
-
-            return EnhancedLayouts;
-        }
-
-        public static bool HasTextureMirrorClamp()
-        {
-            EnsureInitialized();
-
-            return TextureMirrorClamp;
-        }
-
-        private static void EnsureInitialized()
-        {
-            if (Initialized)
+            if (!Initialized)
             {
-                return;
+                EnhancedLayouts    = HasExtension("GL_ARB_enhanced_layouts");
+                ViewportArray      = HasExtension("GL_ARB_viewport_array");
+                TextureMirrorClamp = HasExtension("GL_EXT_texture_mirror_clamp");
             }
 
-            EnhancedLayouts = HasExtension("GL_ARB_enhanced_layouts");
-
-            TextureMirrorClamp = HasExtension("GL_EXT_texture_mirror_clamp");
+            return Extension;
         }
 
         private static bool HasExtension(string Name)

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLExtension.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLExtension.cs
@@ -6,21 +6,21 @@ namespace Ryujinx.Graphics.Gal.OpenGL
     {
         private static bool Initialized = false;
 
-        private static bool EnhancedLayouts;
-        private static bool ViewportArray;
-        private static bool TextureMirrorClamp;
+        private static bool s_EnhancedLayouts;
+        private static bool s_ViewportArray;
+        private static bool s_TextureMirrorClamp;
 
-        public static bool HasEnhancedLayouts()    => Query(ref EnhancedLayouts);
-        public static bool HasViewportArray()      => Query(ref ViewportArray);
-        public static bool HasTextureMirrorClamp() => Query(ref TextureMirrorClamp);
+        public static bool EnhancedLayouts    => Query(ref s_EnhancedLayouts);
+        public static bool ViewportArray      => Query(ref s_ViewportArray);
+        public static bool TextureMirrorClamp => Query(ref s_TextureMirrorClamp);
         
         private static bool Query(ref bool Extension)
         {
             if (!Initialized)
             {
-                EnhancedLayouts    = HasExtension("GL_ARB_enhanced_layouts");
-                ViewportArray      = HasExtension("GL_ARB_viewport_array");
-                TextureMirrorClamp = HasExtension("GL_EXT_texture_mirror_clamp");
+                s_EnhancedLayouts = HasExtension("GL_ARB_enhanced_layouts");
+                s_ViewportArray = HasExtension("GL_ARB_viewport_array");
+                s_TextureMirrorClamp = HasExtension("GL_EXT_texture_mirror_clamp");
 
                 Initialized = true;
             }

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLExtension.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLExtension.cs
@@ -21,6 +21,8 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 EnhancedLayouts    = HasExtension("GL_ARB_enhanced_layouts");
                 ViewportArray      = HasExtension("GL_ARB_viewport_array");
                 TextureMirrorClamp = HasExtension("GL_EXT_texture_mirror_clamp");
+
+                Initialized = true;
             }
 
             return Extension;

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLExtension.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLExtension.cs
@@ -1,32 +1,17 @@
 ﻿using OpenTK.Graphics.OpenGL;
+using System;
 
 namespace Ryujinx.Graphics.Gal.OpenGL
 {
     static class OGLExtension
     {
-        private static bool Initialized = false;
+        private static Lazy<bool> s_EnhancedLayouts    = new Lazy<bool>(() => HasExtension("GL_ARB_enhanced_layouts"));
+        private static Lazy<bool> s_TextureMirrorClamp = new Lazy<bool>(() => HasExtension("GL_EXT_texture_mirror_clamp"));
+        private static Lazy<bool> s_ViewportArray      = new Lazy<bool>(() => HasExtension("GL_ARB_viewport_array"));
 
-        private static bool s_EnhancedLayouts;
-        private static bool s_ViewportArray;
-        private static bool s_TextureMirrorClamp;
-
-        public static bool EnhancedLayouts    => Query(ref s_EnhancedLayouts);
-        public static bool ViewportArray      => Query(ref s_ViewportArray);
-        public static bool TextureMirrorClamp => Query(ref s_TextureMirrorClamp);
-        
-        private static bool Query(ref bool Extension)
-        {
-            if (!Initialized)
-            {
-                s_EnhancedLayouts = HasExtension("GL_ARB_enhanced_layouts");
-                s_ViewportArray = HasExtension("GL_ARB_viewport_array");
-                s_TextureMirrorClamp = HasExtension("GL_EXT_texture_mirror_clamp");
-
-                Initialized = true;
-            }
-
-            return Extension;
-        }
+        public static bool EnhancedLayouts    => s_EnhancedLayouts.Value;
+        public static bool TextureMirrorClamp => s_TextureMirrorClamp.Value;
+        public static bool ViewportArray      => s_ViewportArray.Value;
 
         private static bool HasExtension(string Name)
         {

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLRenderTarget.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLRenderTarget.cs
@@ -31,7 +31,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
         private ImageHandler ReadTex;
 
-        private Rect Viewport;
+        private Rect[] Viewports;
         private Rect Window;
 
         private bool FlipX;
@@ -64,6 +64,8 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
             AttachmentMap = new DrawBuffersEnum[8];
 
+            Viewports = new Rect[8];
+
             this.Texture = Texture;
         }
 
@@ -93,6 +95,15 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                     FramebufferAttachment.ColorAttachment0 + Attachment,
                     Handle,
                     0);
+
+                Rect Viewport = Viewports[Attachment];
+
+                GL.ViewportIndexed(
+                    Attachment,
+                    Viewport.X,
+                    Viewport.Y,
+                    Viewport.Width,
+                    Viewport.Height);
             }
             
             if (ZetaAttachment != 0 && Texture.TryGetImageHandler(ZetaAttachment, out CachedImage))
@@ -205,20 +216,9 @@ namespace Ryujinx.Graphics.Gal.OpenGL
             Window = new Rect(0, 0, Width, Height);
         }
 
-        public void SetViewport(int X, int Y, int Width, int Height)
+        public void SetViewport(int Attachment, int X, int Y, int Width, int Height)
         {
-            Viewport = new Rect(X, Y, Width, Height);
-
-            SetViewport(Viewport);
-        }
-
-        private void SetViewport(Rect Viewport)
-        {
-            GL.Viewport(
-                Viewport.X,
-                Viewport.Y,
-                Viewport.Width,
-                Viewport.Height);
+            Viewports[Attachment] = new Rect(X, Y, Width, Height);
         }
 
         public void Render()

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLRenderTarget.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLRenderTarget.cs
@@ -176,7 +176,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 }
             }
 
-            if (OGLExtension.HasViewportArray())
+            if (OGLExtension.ViewportArray)
             {
                 GL.ViewportArray(0, 8, Viewports);
             }

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLRenderTarget.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLRenderTarget.cs
@@ -97,7 +97,18 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                     0);
             }
 
-            GL.ViewportArray(0, 8, Viewports);
+            if (OGLExtension.HasViewportArray())
+            {
+                GL.ViewportArray(0, 8, Viewports);
+            }
+            else
+            {
+                GL.Viewport(
+                    (int)Viewports[0],
+                    (int)Viewports[1],
+                    (int)Viewports[2],
+                    (int)Viewports[3]);
+            }
             
             if (ZetaAttachment != 0 && Texture.TryGetImageHandler(ZetaAttachment, out CachedImage))
             {

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLRenderTarget.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLRenderTarget.cs
@@ -31,7 +31,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
         private ImageHandler ReadTex;
 
-        private Rect[] Viewports;
+        private float[] Viewports;
         private Rect Window;
 
         private bool FlipX;
@@ -64,7 +64,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
             AttachmentMap = new DrawBuffersEnum[8];
 
-            Viewports = new Rect[8];
+            Viewports = new float[8 * 4];
 
             this.Texture = Texture;
         }
@@ -95,16 +95,9 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                     FramebufferAttachment.ColorAttachment0 + Attachment,
                     Handle,
                     0);
-
-                Rect Viewport = Viewports[Attachment];
-
-                GL.ViewportIndexed(
-                    Attachment,
-                    Viewport.X,
-                    Viewport.Y,
-                    Viewport.Width,
-                    Viewport.Height);
             }
+
+            GL.ViewportArray(0, 8, Viewports);
             
             if (ZetaAttachment != 0 && Texture.TryGetImageHandler(ZetaAttachment, out CachedImage))
             {
@@ -218,7 +211,12 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
         public void SetViewport(int Attachment, int X, int Y, int Width, int Height)
         {
-            Viewports[Attachment] = new Rect(X, Y, Width, Height);
+            int Offset = Attachment * 4;
+
+            Viewports[Offset + 0] = X;
+            Viewports[Offset + 1] = Y;
+            Viewports[Offset + 2] = Width;
+            Viewports[Offset + 3] = Height;
         }
 
         public void Render()

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLShader.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLShader.cs
@@ -133,7 +133,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
             {
                 //Enhanced layouts are required for Geometry shaders
                 //skip this stage if current driver has no ARB_enhanced_layouts
-                if (!OGLExtension.HasEnhancedLayouts())
+                if (!OGLExtension.EnhancedLayouts)
                 {
                     return;
                 }

--- a/Ryujinx.Graphics/GpuResourceManager.cs
+++ b/Ryujinx.Graphics/GpuResourceManager.cs
@@ -46,7 +46,7 @@ namespace Ryujinx.Graphics
                 Gpu.Renderer.Texture.Create(Position, (int)Size, NewImage);
             }
 
-            Gpu.Renderer.RenderTarget.BindColor(Position, Attachment, NewImage);
+            Gpu.Renderer.RenderTarget.BindColor(Position, Attachment);
         }
 
         public void SendZetaBuffer(NvGpuVmm Vmm, long Position, GalImage NewImage)
@@ -60,7 +60,7 @@ namespace Ryujinx.Graphics
                 Gpu.Renderer.Texture.Create(Position, (int)Size, NewImage);
             }
 
-            Gpu.Renderer.RenderTarget.BindZeta(Position, NewImage);
+            Gpu.Renderer.RenderTarget.BindZeta(Position);
         }
 
         public void SendTexture(NvGpuVmm Vmm, long Position, GalImage NewImage, int TexIndex = -1)

--- a/Ryujinx.Graphics/NvGpuEngine3d.cs
+++ b/Ryujinx.Graphics/NvGpuEngine3d.cs
@@ -154,6 +154,8 @@ namespace Ryujinx.Graphics
 
             SetZeta(Vmm);
 
+            Gpu.Renderer.RenderTarget.Bind();
+
             Gpu.Renderer.Rasterizer.ClearBuffers(
                 Flags,
                 FbIndex,
@@ -426,14 +428,15 @@ namespace Ryujinx.Graphics
 
         private void SetRenderTargets()
         {
-            bool SeparateFragData = ReadRegisterBool(NvGpuEngine3dReg.RTSeparateFragData);
+            //Commercial games do not seem to 
+            //bool SeparateFragData = ReadRegisterBool(NvGpuEngine3dReg.RTSeparateFragData);
 
-            if (SeparateFragData)
+            uint Control = (uint)(ReadRegister(NvGpuEngine3dReg.RTControl));
+
+            uint Count = Control & 0xf;
+
+            if (Count > 0)
             {
-                uint Control = (uint)(ReadRegister(NvGpuEngine3dReg.RTControl));
-
-                uint Count = Control & 0xf;
-
                 int[] Map = new int[Count];
 
                 for (int i = 0; i < Count; i++)
@@ -701,6 +704,8 @@ namespace Ryujinx.Graphics
             State.Instance = CurrentInstance;
 
             Gpu.Renderer.Pipeline.Bind(State);
+
+            Gpu.Renderer.RenderTarget.Bind();
 
             if (IndexCount != 0)
             {

--- a/Ryujinx.Graphics/NvGpuEngine3d.cs
+++ b/Ryujinx.Graphics/NvGpuEngine3d.cs
@@ -100,7 +100,10 @@ namespace Ryujinx.Graphics
             SetAlphaBlending(State);
             SetPrimitiveRestart(State);
 
-            SetFrameBuffer(Vmm, 0);
+            for (int FbIndex = 0; FbIndex < 8; FbIndex++)
+            {
+                SetFrameBuffer(Vmm, FbIndex);
+            }
 
             SetZeta(Vmm);
 
@@ -206,7 +209,7 @@ namespace Ryujinx.Graphics
 
             Gpu.ResourceManager.SendColorBuffer(Vmm, Key, FbIndex, Image);
 
-            Gpu.Renderer.RenderTarget.SetViewport(VpX, VpY, VpW, VpH);
+            Gpu.Renderer.RenderTarget.SetViewport(FbIndex, VpX, VpY, VpW, VpH);
         }
 
         private void SetFrameBuffer(GalPipelineState State)

--- a/Ryujinx.Graphics/NvGpuEngine3d.cs
+++ b/Ryujinx.Graphics/NvGpuEngine3d.cs
@@ -157,6 +157,8 @@ namespace Ryujinx.Graphics
 
             SetZeta(Vmm);
 
+            SetRenderTargets();
+
             Gpu.Renderer.RenderTarget.Bind();
 
             Gpu.Renderer.Rasterizer.ClearBuffers(

--- a/Ryujinx.HLE/HOS/Services/Vi/NvFlinger.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/NvFlinger.cs
@@ -328,7 +328,7 @@ namespace Ryujinx.HLE.HOS.Services.Android
                 Context.Device.Gpu.ResourceManager.SendTexture(Vmm, FbAddr, Image);
 
                 Renderer.RenderTarget.SetTransform(FlipX, FlipY, Top, Left, Right, Bottom);
-                Renderer.RenderTarget.Set(FbAddr);
+                Renderer.RenderTarget.Present(FbAddr);
 
                 ReleaseBuffer(Slot);
             });

--- a/Ryujinx/Ryujinx.conf
+++ b/Ryujinx/Ryujinx.conf
@@ -29,7 +29,7 @@ Docked_Mode = false
 Enable_Vsync = true
 
 #Enable or Disable Multi-core scheduling of threads
-Enable_MultiCore_Scheduling = false
+Enable_MultiCore_Scheduling = true
 
 #Controller Device Index
 GamePad_Index = 0

--- a/Ryujinx/Ryujinx.conf
+++ b/Ryujinx/Ryujinx.conf
@@ -29,7 +29,7 @@ Docked_Mode = false
 Enable_Vsync = true
 
 #Enable or Disable Multi-core scheduling of threads
-Enable_MultiCore_Scheduling = true
+Enable_MultiCore_Scheduling = false
 
 #Controller Device Index
 GamePad_Index = 0


### PR DESCRIPTION
`RT_SEPARATE_FRAG_DATA` doesn't seem to be set to commercial games. Until we found out why (probably its set by the OS?), this considers it always being on. I also simplified how OpenGL framebuffers are being bound, but it ends up with more superfluous OpenGL calls.
This requires [ARB_viewport_array](https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_viewport_array.txt) (or OpenGL 4.1) to set individual viewports per attachment.