### PR TITLE
Implement a conservative cache

### DIFF
--- a/Ryujinx.Graphics/Gal/GalImage.cs
+++ b/Ryujinx.Graphics/Gal/GalImage.cs
@@ -2,7 +2,7 @@ using Ryujinx.Graphics.Texture;
 
 namespace Ryujinx.Graphics.Gal
 {
-    public struct GalImage
+    public struct GalImage : ICompatible<GalImage>
     {
         public int Width;
         public int Height;
@@ -58,6 +58,11 @@ namespace Ryujinx.Graphics.Gal
             }
 
             return Height == Image.Height;
+        }
+
+        public bool IsCompatible(GalImage Other)
+        {
+            return Format == Other.Format && SizeMatches(Other);
         }
     }
 }

--- a/Ryujinx.Graphics/Gal/IGalTexture.cs
+++ b/Ryujinx.Graphics/Gal/IGalTexture.cs
@@ -5,9 +5,9 @@ namespace Ryujinx.Graphics.Gal
         void LockCache();
         void UnlockCache();
 
-        void Create(long Key, int Size, GalImage Image);
+        void CreateEmpty(long Key, int Size, GalImage Image);
 
-        void Create(long Key, byte[] Data, GalImage Image);
+        void CreateData(long Key, byte[] Data, GalImage Image);
 
         bool TryGetImage(long Key, out GalImage Image);
 

--- a/Ryujinx.Graphics/Gal/OpenGL/BufferParams.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/BufferParams.cs
@@ -1,0 +1,24 @@
+﻿using OpenTK.Graphics.OpenGL;
+
+namespace Ryujinx.Graphics.Gal.OpenGL
+{
+    class BufferParams : ICompatible<BufferParams>
+    {
+        public BufferTarget Target { get; private set; }
+
+        public long Size { get; private set; }
+
+        public BufferParams(BufferTarget Target, long Size)
+        {
+            this.Target = Target;
+            this.Size = Size;
+        }
+
+        public bool IsCompatible(BufferParams Other)
+        {
+            //Target is not needed for compatibility
+
+            return Size == Other.Size;
+        }
+    }
+}

--- a/Ryujinx.Graphics/Gal/OpenGL/ImageHandler.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/ImageHandler.cs
@@ -2,7 +2,7 @@
 
 namespace Ryujinx.Graphics.Gal.OpenGL
 {
-    class ImageHandler
+    class ImageHandler : Resource
     {
         public GalImage Image { get; private set; }
 

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLCachedResource.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLCachedResource.cs
@@ -30,19 +30,11 @@ namespace Ryujinx.Graphics.Gal.OpenGL
             ResourcePool<TKey, TValue>.CreateValue CreateValueCallback,
             ResourcePool<TKey, TValue>.DeleteValue DeleteValueCallback)
         {
-            if (CreateValueCallback == null)
-            {
-                throw new ArgumentNullException(nameof(CreateValueCallback));
-            }
-
-            if (DeleteValueCallback == null)
-            {
-                throw new ArgumentNullException(nameof(DeleteValueCallback));
-            }
-
             Cache = new Dictionary<long, CacheBucket>();
 
-            Pool = new ResourcePool<TKey, TValue>(CreateValueCallback, DeleteValueCallback);
+            Pool = new ResourcePool<TKey, TValue>(
+                CreateValueCallback ?? throw new ArgumentNullException(nameof(CreateValueCallback)),
+                DeleteValueCallback ?? throw new ArgumentNullException(nameof(DeleteValueCallback)));
         }
 
         public void Lock()
@@ -82,7 +74,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
             {
                 Value = Bucket.Value;
 
-                Value.UpdateStamp();
+                Value.UpdateTimestamp();
 
                 return true;
             }

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLCachedResource.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLCachedResource.cs
@@ -27,8 +27,8 @@ namespace Ryujinx.Graphics.Gal.OpenGL
         private bool Locked;
 
         public OGLCachedResource(
-            ResourcePool<TKey, TValue>.CreateValue CreateValueCallback,
-            ResourcePool<TKey, TValue>.DeleteValue DeleteValueCallback)
+            Func<TKey, TValue> CreateValueCallback,
+            Action<TValue>     DeleteValueCallback)
         {
             Cache = new Dictionary<long, CacheBucket>();
 

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLCachedResource.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLCachedResource.cs
@@ -3,57 +3,46 @@ using System.Collections.Generic;
 
 namespace Ryujinx.Graphics.Gal.OpenGL
 {
-    class OGLCachedResource<T>
+    class OGLCachedResource<TKey, TValue>
+        where TKey   : ICompatible<TKey>
+        where TValue : Resource
     {
-        public delegate void DeleteValue(T Value);
-
-        private const int MaxTimeDelta      = 5 * 60000;
-        private const int MaxRemovalsPerRun = 10;
-
         private struct CacheBucket
         {
-            public T Value { get; private set; }
-
-            public LinkedListNode<long> Node { get; private set; }
+            public TValue Value { get; private set; }
 
             public long DataSize { get; private set; }
 
-            public int Timestamp { get; private set; }
-
-            public CacheBucket(T Value, long DataSize, LinkedListNode<long> Node)
+            public CacheBucket(TValue Value, long DataSize)
             {
                 this.Value    = Value;
                 this.DataSize = DataSize;
-                this.Node     = Node;
-
-                Timestamp = Environment.TickCount;
             }
         }
 
         private Dictionary<long, CacheBucket> Cache;
 
-        private LinkedList<long> SortedCache;
-
-        private DeleteValue DeleteValueCallback;
-
-        private Queue<T> DeletePending;
+        private ResourcePool<TKey, TValue> Pool;
 
         private bool Locked;
 
-        public OGLCachedResource(DeleteValue DeleteValueCallback)
+        public OGLCachedResource(
+            ResourcePool<TKey, TValue>.CreateValue CreateValueCallback,
+            ResourcePool<TKey, TValue>.DeleteValue DeleteValueCallback)
         {
+            if (CreateValueCallback == null)
+            {
+                throw new ArgumentNullException(nameof(CreateValueCallback));
+            }
+
             if (DeleteValueCallback == null)
             {
                 throw new ArgumentNullException(nameof(DeleteValueCallback));
             }
 
-            this.DeleteValueCallback = DeleteValueCallback;
-
             Cache = new Dictionary<long, CacheBucket>();
 
-            SortedCache = new LinkedList<long>();
-
-            DeletePending = new Queue<T>();
+            Pool = new ResourcePool<TKey, TValue>(CreateValueCallback, DeleteValueCallback);
         }
 
         public void Lock()
@@ -65,62 +54,40 @@ namespace Ryujinx.Graphics.Gal.OpenGL
         {
             Locked = false;
 
-            while (DeletePending.TryDequeue(out T Value))
-            {
-                DeleteValueCallback(Value);
-            }
-
-            ClearCacheIfNeeded();
+            Pool.ReleaseMemory();
         }
 
-        public void AddOrUpdate(long Key, T Value, long Size)
+        public TValue CreateOrRecycle(long Key, TKey Parameters, long Size)
         {
             if (!Locked)
             {
-                ClearCacheIfNeeded();
+                Pool.ReleaseMemory();
             }
-
-            LinkedListNode<long> Node = SortedCache.AddLast(Key);
-
-            CacheBucket NewBucket = new CacheBucket(Value, Size, Node);
 
             if (Cache.TryGetValue(Key, out CacheBucket Bucket))
             {
-                if (Locked)
-                {
-                    DeletePending.Enqueue(Bucket.Value);
-                }
-                else
-                {
-                    DeleteValueCallback(Bucket.Value);
-                }
-
-                SortedCache.Remove(Bucket.Node);
-
-                Cache[Key] = NewBucket;
+                Bucket.Value.MarkAsUnused();
             }
-            else
-            {
-                Cache.Add(Key, NewBucket);
-            }
+
+            TValue Value = Pool.CreateOrRecycle(Parameters);
+
+            Cache[Key] = new CacheBucket(Value, Size);
+
+            return Value;
         }
 
-        public bool TryGetValue(long Key, out T Value)
+        public bool TryGetValue(long Key, out TValue Value)
         {
             if (Cache.TryGetValue(Key, out CacheBucket Bucket))
             {
                 Value = Bucket.Value;
 
-                SortedCache.Remove(Bucket.Node);
-
-                LinkedListNode<long> Node = SortedCache.AddLast(Key);
-
-                Cache[Key] = new CacheBucket(Value, Bucket.DataSize, Node);
+                Value.UpdateStamp();
 
                 return true;
             }
 
-            Value = default(T);
+            Value = default(TValue);
 
             return false;
         }
@@ -137,50 +104,6 @@ namespace Ryujinx.Graphics.Gal.OpenGL
             Size = 0;
 
             return false;
-        }
-
-        private void ClearCacheIfNeeded()
-        {
-            int Timestamp = Environment.TickCount;
-
-            int Count = 0;
-
-            while (Count++ < MaxRemovalsPerRun)
-            {
-                LinkedListNode<long> Node = SortedCache.First;
-
-                if (Node == null)
-                {
-                    break;
-                }
-
-                CacheBucket Bucket = Cache[Node.Value];
-
-                int TimeDelta = RingDelta(Bucket.Timestamp, Timestamp);
-
-                if ((uint)TimeDelta <= (uint)MaxTimeDelta)
-                {
-                    break;
-                }
-
-                SortedCache.Remove(Node);
-
-                Cache.Remove(Node.Value);
-
-                DeleteValueCallback(Bucket.Value);
-            }
-        }
-
-        private int RingDelta(int Old, int New)
-        {
-            if ((uint)New < (uint)Old)
-            {
-                return New + (~Old + 1);
-            }
-            else
-            {
-                return New - Old;
-            }
         }
     }
 }

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLConstBuffer.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLConstBuffer.cs
@@ -5,11 +5,11 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 {
     class OGLConstBuffer : IGalConstBuffer
     {
-        private OGLCachedResource<OGLStreamBuffer> Cache;
+        private OGLCachedResource<BufferParams, OGLStreamBuffer> Cache;
 
         public OGLConstBuffer()
         {
-            Cache = new OGLCachedResource<OGLStreamBuffer>(DeleteBuffer);
+            Cache = new OGLCachedResource<BufferParams, OGLStreamBuffer>(CreateBuffer, DeleteBuffer);
         }
 
         public void LockCache()
@@ -24,9 +24,9 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
         public void Create(long Key, long Size)
         {
-            OGLStreamBuffer Buffer = new OGLStreamBuffer(BufferTarget.UniformBuffer, Size);
+            BufferParams Params = new BufferParams(BufferTarget.UniformBuffer, Size);
 
-            Cache.AddOrUpdate(Key, Buffer, Size);
+            Cache.CreateOrRecycle(Key, Params, Size);
         }
 
         public bool IsCached(long Key, long Size)
@@ -54,6 +54,11 @@ namespace Ryujinx.Graphics.Gal.OpenGL
             UboHandle = 0;
 
             return false;
+        }
+
+        private static OGLStreamBuffer CreateBuffer(BufferParams Params)
+        {
+            return new OGLStreamBuffer(Params.Target, Params.Size);
         }
 
         private static void DeleteBuffer(OGLStreamBuffer Buffer)

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLRasterizer.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLRasterizer.cs
@@ -101,11 +101,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
             OGLStreamBuffer CachedBuffer = VboCache.CreateOrRecycle(Key, Params, (uint)DataSize);
 
-            IntPtr Length = new IntPtr(DataSize);
-
-            GL.BindBuffer(BufferTarget.ArrayBuffer, CachedBuffer.Handle);
-
-            GL.BufferSubData(BufferTarget.ArrayBuffer, IntPtr.Zero, Length, HostAddress);
+            CachedBuffer.SetData(DataSize, HostAddress);
         }
 
         public void CreateIbo(long Key, int DataSize, IntPtr HostAddress)
@@ -114,11 +110,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
             OGLStreamBuffer CachedBuffer = IboCache.CreateOrRecycle(Key, Params, (uint)DataSize);
 
-            IntPtr Length = new IntPtr(DataSize);
-
-            GL.BindBuffer(BufferTarget.ElementArrayBuffer, CachedBuffer.Handle);
-
-            GL.BufferSubData(BufferTarget.ElementArrayBuffer, IntPtr.Zero, Length, HostAddress);
+            CachedBuffer.SetData(DataSize, HostAddress);
         }
 
         public void SetIndexArray(int Size, GalIndexFormat Format)

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLRenderTarget.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLRenderTarget.cs
@@ -382,11 +382,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
             GL.BindBuffer(BufferTarget.PixelPackBuffer, 0);
 
-            GL.BindBuffer(BufferTarget.PixelUnpackBuffer, CopyPBO);
-
-            Texture.Create(Key, ImageUtils.GetSize(NewImage), NewImage);
-
-            GL.BindBuffer(BufferTarget.PixelUnpackBuffer, 0);
+            Texture.CreatePBO(Key, ImageUtils.GetSize(NewImage), NewImage, CopyPBO);
         }
 
         private static FramebufferAttachment GetAttachment(ImageHandler CachedImage)

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLStreamBuffer.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLStreamBuffer.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Ryujinx.Graphics.Gal.OpenGL
 {
-    class OGLStreamBuffer : IDisposable
+    class OGLStreamBuffer : Resource, IDisposable
     {
         public int Handle { get; protected set; }
 

--- a/Ryujinx.Graphics/GpuResourceManager.cs
+++ b/Ryujinx.Graphics/GpuResourceManager.cs
@@ -37,13 +37,13 @@ namespace Ryujinx.Graphics
 
         public void SendColorBuffer(NvGpuVmm Vmm, long Position, int Attachment, GalImage NewImage)
         {
-            long Size = (uint)ImageUtils.GetSize(NewImage);
-
             ImageTypes[Position] = ImageType.ColorBuffer;
 
             if (!TryReuse(Vmm, Position, NewImage))
             {
-                Gpu.Renderer.Texture.Create(Position, (int)Size, NewImage);
+                int Size = ImageUtils.GetSize(NewImage);
+
+                Gpu.Renderer.Texture.CreateEmpty(Position, Size, NewImage);
             }
 
             Gpu.Renderer.RenderTarget.BindColor(Position, Attachment, NewImage);
@@ -51,13 +51,13 @@ namespace Ryujinx.Graphics
 
         public void SendZetaBuffer(NvGpuVmm Vmm, long Position, GalImage NewImage)
         {
-            long Size = (uint)ImageUtils.GetSize(NewImage);
-
             ImageTypes[Position] = ImageType.ZetaBuffer;
 
             if (!TryReuse(Vmm, Position, NewImage))
             {
-                Gpu.Renderer.Texture.Create(Position, (int)Size, NewImage);
+                int Size = ImageUtils.GetSize(NewImage);
+
+                Gpu.Renderer.Texture.CreateEmpty(Position, Size, NewImage);
             }
 
             Gpu.Renderer.RenderTarget.BindZeta(Position, NewImage);
@@ -102,7 +102,7 @@ namespace Ryujinx.Graphics
 
             byte[] Data = ImageUtils.ReadTexture(Vmm, NewImage, Position);
 
-            Gpu.Renderer.Texture.Create(Position, Data, NewImage);
+            Gpu.Renderer.Texture.CreateData(Position, Data, NewImage);
         }
 
         private bool TryReuse(NvGpuVmm Vmm, long Position, GalImage NewImage)

--- a/Ryujinx.Graphics/ResourcePool.cs
+++ b/Ryujinx.Graphics/ResourcePool.cs
@@ -121,11 +121,16 @@ namespace Ryujinx.Graphics
 
         private LinkedList<TValue> GetOrAddEntry(TKey Params)
         {
-            foreach ((TKey MyParams, LinkedList<TValue> Resources) in Entries)
+            foreach ((TKey MyParams, LinkedList<TValue> Resources) Tuple in Entries)
             {
-                if (MyParams.IsCompatible(Params))
+                if (Tuple.MyParams.IsCompatible(Params))
                 {
-                    return Resources;
+                    //Move accessed siblings to the top of the list, for faster access in the future
+                    Entries.Remove(Tuple);
+
+                    Entries.AddFirst(Tuple);
+
+                    return Tuple.Resources;
                 }
             }
 

--- a/Ryujinx.Graphics/ResourcePool.cs
+++ b/Ryujinx.Graphics/ResourcePool.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Ryujinx.Graphics
+{
+    public interface ICompatible<T>
+    {
+        bool IsCompatible(T Other);
+    }
+
+    public class Resource
+    {
+        public int Timestamp { get; private set; }
+
+        public bool IsUsed { get; private set; }
+
+        public void UpdateStamp()
+        {
+            Timestamp = Environment.TickCount;
+        }
+
+        public void MarkAsUsed()
+        {
+            UpdateStamp();
+
+            IsUsed = true;
+        }
+
+        public void MarkAsUnused()
+        {
+            IsUsed = false;
+        }
+    }
+
+    class ResourcePool<TKey, TValue>
+        where TKey   : ICompatible<TKey>
+        where TValue : Resource
+    {
+        private const int MaxTimeDelta      = 5 * 60000;
+        private const int MaxRemovalsPerRun = 10;
+
+        public delegate TValue CreateValue(TKey Params);
+
+        public delegate void DeleteValue(TValue Resource);
+
+        private List<(TKey, List<TValue>)> Entries;
+
+        private Queue<(TValue, List<TValue>)> SortedCache;
+
+        private CreateValue CreateValueCallback;
+        private DeleteValue DeleteValueCallback;
+
+        public ResourcePool(CreateValue CreateValueCallback, DeleteValue DeleteValueCallback)
+        {
+            this.CreateValueCallback = CreateValueCallback;
+            this.DeleteValueCallback = DeleteValueCallback;
+
+            Entries = new List<(TKey, List<TValue>)>();
+
+            SortedCache = new Queue<(TValue, List<TValue>)>();
+        }
+
+        public TValue CreateOrRecycle(TKey Params)
+        {
+            List<TValue> Family = GetOrAddEntry(Params);
+
+            foreach (TValue RecycledValue in Family)
+            {
+                if (!RecycledValue.IsUsed)
+                {
+                    RecycledValue.MarkAsUsed();
+
+                    return RecycledValue;
+                }
+            }
+
+            TValue Resource = CreateValueCallback(Params);
+
+            Resource.MarkAsUsed();
+
+            Family.Add(Resource);
+
+            SortedCache.Enqueue((Resource, Family));
+
+            return Resource;
+        }
+
+        public void ReleaseMemory()
+        {
+            int Timestamp = Environment.TickCount;
+
+            for (int Count = 0; Count < MaxRemovalsPerRun; Count++)
+            {
+                if (!SortedCache.TryDequeue(out (TValue Resource, List<TValue> Family) Tuple))
+                {
+                    break;
+                }
+
+                TValue Resource = Tuple.Resource;
+
+                List<TValue> Family = Tuple.Family;
+
+                if (!Resource.IsUsed)
+                {
+                    int TimeDelta = RingDelta(Resource.Timestamp, Timestamp);
+
+                    if ((uint)TimeDelta > MaxTimeDelta)
+                    {
+                        if (!Family.Remove(Resource))
+                        {
+                            throw new InvalidOperationException();
+                        }
+
+                        DeleteValueCallback(Resource);
+
+                        continue;
+                    }
+                }
+
+                SortedCache.Enqueue((Resource, Family));
+            }
+        }
+
+        private List<TValue> GetOrAddEntry(TKey Params)
+        {
+            foreach ((TKey MyParams, List<TValue> Resources) in Entries)
+            {
+                if (MyParams.IsCompatible(Params))
+                {
+                    return Resources;
+                }
+            }
+
+            List<TValue> Family = new List<TValue>();
+
+            Entries.Add((Params, Family));
+
+            return Family;
+        }
+
+        private static int RingDelta(int Old, int New)
+        {
+            if ((uint)New < (uint)Old)
+            {
+                return New + (~Old + 1);
+            }
+            else
+            {
+                return New - Old;
+            }
+        }
+    }
+}

--- a/Ryujinx.Graphics/ResourcePool.cs
+++ b/Ryujinx.Graphics/ResourcePool.cs
@@ -62,7 +62,7 @@ namespace Ryujinx.Graphics
 
         public TValue CreateOrRecycle(TKey Params)
         {
-            LinkedList<TValue> Siblings = GetOrAddEntry(Params);
+            LinkedList<TValue> Siblings = GetOrAddSiblings(Params);
 
             foreach (TValue RecycledValue in Siblings)
             {
@@ -119,19 +119,24 @@ namespace Ryujinx.Graphics
             }
         }
 
-        private LinkedList<TValue> GetOrAddEntry(TKey Params)
+        private LinkedList<TValue> GetOrAddSiblings(TKey Params)
         {
-            foreach ((TKey MyParams, LinkedList<TValue> Resources) Tuple in Entries)
+            LinkedListNode<(TKey, LinkedList<TValue>)> Node = Entries.First;
+
+            while (Node != null)
             {
-                if (Tuple.MyParams.IsCompatible(Params))
+                (TKey Params, LinkedList<TValue> Resources) Tuple = Node.Value;
+
+                if (Tuple.Params.IsCompatible(Params))
                 {
-                    //Move accessed siblings to the top of the list, for faster access in the future
-                    Entries.Remove(Tuple);
+                    Entries.Remove(Node);
 
                     Entries.AddFirst(Tuple);
 
                     return Tuple.Resources;
                 }
+
+                Node = Node.Next;
             }
 
             LinkedList<TValue> Siblings = new LinkedList<TValue>();


### PR DESCRIPTION
Instead of destroying unused resources, this PR saves them for future recycle when they are compatible. Core functionality (`ResourcePool.cs` and `OGLCachedResource`) should be working but I still have to clean up its users (e.g.: `OGLTexture`), there are lots of repeated code there.
It should give a performance boost in almost every game that uses GPU resources.
Originally it was planned to recycle compatible textures, but it also constant buffers, vertex and index cache (these last two could be unified).