### PR TITLE
Tweak cpu cache deletion policy values

### DIFF
--- a/ChocolArm64/ATranslatorCache.cs
+++ b/ChocolArm64/ATranslatorCache.cs
@@ -8,9 +8,9 @@ namespace ChocolArm64
 {
     class ATranslatorCache
     {
-        private const int MaxTotalSize          = 2 * 1024 * 256;
-        private const int MaxTimeDelta          = 30000;
-        private const int MinCallCountForUpdate = 1000;
+        private const int MaxTotalSize          = 4 * 1024 * 256;
+        private const int MaxTimeDelta          = 2 * 60000;
+        private const int MinCallCountForUpdate = 250;
 
         private class CacheBucket
         {

--- a/ChocolArm64/ATranslatorCache.cs
+++ b/ChocolArm64/ATranslatorCache.cs
@@ -8,8 +8,13 @@ namespace ChocolArm64
 {
     class ATranslatorCache
     {
-        private const int MaxTotalSize          = 4 * 1024 * 256;
-        private const int MaxTimeDelta          = 2 * 60000;
+        //Maximum size of the cache, in bytes, measured in ARM code size.
+        private const int MaxTotalSize = 4 * 1024 * 256;
+
+        //Minimum time required in milliseconds for a method to be eligible for deletion.
+        private const int MinTimeDelta = 2 * 60000;
+
+        //Minimum number of calls required to update the timestamp.
         private const int MinCallCountForUpdate = 250;
 
         private class CacheBucket
@@ -134,7 +139,7 @@ namespace ChocolArm64
 
                     int TimeDelta = RingDelta(Bucket.Timestamp, Timestamp);
 
-                    if ((uint)TimeDelta <= (uint)MaxTimeDelta)
+                    if ((uint)TimeDelta <= (uint)MinTimeDelta)
                     {
                         break;
                     }


### PR DESCRIPTION
Previous values were too strict and resulted in functions being deleted too often and in stuttering on some games, this improves that.

- Minimum time since last use for deletion was increased from 30 seconds to 2 minutes.
- Max cache size (in ARM code size, not IL or x86 code size unfortunately) was increased from 2 MB to 4 MB.
- Minimum call count for updating cache entries timestamp was decreased from 1000 calls to 250 calls.