### PR TITLE
Quads, QuadStrip, const attributes and half-float attributes support

### DIFF
--- a/Ryujinx.Graphics/Gal/GalPipelineState.cs
+++ b/Ryujinx.Graphics/Gal/GalPipelineState.cs
@@ -1,17 +1,5 @@
 ﻿namespace Ryujinx.Graphics.Gal
 {
-    public struct GalVertexBinding
-    {
-        //VboKey shouldn't be here, but ARB_vertex_attrib_binding is core since 4.3
-
-        public bool Enabled;
-        public int Stride;
-        public long VboKey;
-        public bool Instanced;
-        public int Divisor;
-        public GalVertexAttrib[] Attribs;
-    }
-
     public class GalPipelineState
     {
         public const int Stages = 5;

--- a/Ryujinx.Graphics/Gal/GalVertexAttrib.cs
+++ b/Ryujinx.Graphics/Gal/GalVertexAttrib.cs
@@ -1,10 +1,13 @@
+using System;
+
 namespace Ryujinx.Graphics.Gal
 {
     public struct GalVertexAttrib
     {
-        public int  Index   { get; private set; }
-        public bool IsConst { get; private set; }
-        public int  Offset  { get; private set; }
+        public int    Index   { get; private set; }
+        public bool   IsConst { get; private set; }
+        public int    Offset  { get; private set; }
+        public IntPtr Pointer { get; private set; }
 
         public GalVertexAttribSize Size { get; private set; }
         public GalVertexAttribType Type { get; private set; }
@@ -15,12 +18,14 @@ namespace Ryujinx.Graphics.Gal
             int                 Index,
             bool                IsConst,
             int                 Offset,
+            IntPtr              Pointer,
             GalVertexAttribSize Size,
             GalVertexAttribType Type,
             bool                IsBgra)
         {
             this.Index   = Index;
             this.IsConst = IsConst;
+            this.Pointer = Pointer;
             this.Offset  = Offset;
             this.Size    = Size;
             this.Type    = Type;

--- a/Ryujinx.Graphics/Gal/GalVertexBinding.cs
+++ b/Ryujinx.Graphics/Gal/GalVertexBinding.cs
@@ -1,0 +1,14 @@
+namespace Ryujinx.Graphics.Gal
+{
+    public struct GalVertexBinding
+    {
+        //VboKey shouldn't be here, but ARB_vertex_attrib_binding is core since 4.3
+
+        public bool Enabled;
+        public int Stride;
+        public long VboKey;
+        public bool Instanced;
+        public int Divisor;
+        public GalVertexAttrib[] Attribs;
+    }
+}

--- a/Ryujinx.Graphics/Gal/IGalRasterizer.cs
+++ b/Ryujinx.Graphics/Gal/IGalRasterizer.cs
@@ -21,6 +21,7 @@ namespace Ryujinx.Graphics.Gal
         void CreateVbo(long Key, int DataSize, IntPtr HostAddress);
 
         void CreateIbo(long Key, int DataSize, IntPtr HostAddress);
+        void CreateIbo(long Key, int DataSize, byte[] Buffer);
 
         void SetIndexArray(int Size, GalIndexFormat Format);
 

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLEnumConverter.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLEnumConverter.cs
@@ -13,7 +13,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 case GalFrontFace.CCW: return FrontFaceDirection.Ccw;
             }
 
-            throw new ArgumentException(nameof(FrontFace));
+            throw new ArgumentException(nameof(FrontFace) + " \"" + FrontFace + "\" is not valid!");
         }
 
         public static CullFaceMode GetCullFace(GalCullFace CullFace)
@@ -25,7 +25,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 case GalCullFace.FrontAndBack: return CullFaceMode.FrontAndBack;
             }
 
-            throw new ArgumentException(nameof(CullFace));
+            throw new ArgumentException(nameof(CullFace) + " \"" + CullFace + "\" is not valid!");
         }
 
         public static StencilOp GetStencilOp(GalStencilOp Op)
@@ -42,7 +42,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 case GalStencilOp.DecrWrap: return StencilOp.DecrWrap;
             }
 
-            throw new ArgumentException(nameof(Op));
+            throw new ArgumentException(nameof(Op) + " \"" + Op + "\" is not valid!");
         }
 
         public static DepthFunction GetDepthFunc(GalComparisonOp Func)
@@ -66,7 +66,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 case GalComparisonOp.Always:   return DepthFunction.Always;
             }
 
-            throw new ArgumentException(nameof(Func));
+            throw new ArgumentException(nameof(Func) + " \"" + Func + "\" is not valid!");
         }
 
         public static StencilFunction GetStencilFunc(GalComparisonOp Func)
@@ -84,7 +84,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 case GalIndexFormat.Int32: return DrawElementsType.UnsignedInt;
             }
 
-            throw new ArgumentException(nameof(Format));
+            throw new ArgumentException(nameof(Format) + " \"" + Format + "\" is not valid!");
         }
 
         public static PrimitiveType GetPrimitiveType(GalPrimitiveType Type)
@@ -98,8 +98,6 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 case GalPrimitiveType.Triangles:              return PrimitiveType.Triangles;
                 case GalPrimitiveType.TriangleStrip:          return PrimitiveType.TriangleStrip;
                 case GalPrimitiveType.TriangleFan:            return PrimitiveType.TriangleFan;
-                case GalPrimitiveType.Quads:                  return PrimitiveType.Quads;
-                case GalPrimitiveType.QuadStrip:              return PrimitiveType.QuadStrip;
                 case GalPrimitiveType.Polygon:                return PrimitiveType.Polygon;
                 case GalPrimitiveType.LinesAdjacency:         return PrimitiveType.LinesAdjacency;
                 case GalPrimitiveType.LineStripAdjacency:     return PrimitiveType.LineStripAdjacency;
@@ -108,7 +106,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 case GalPrimitiveType.Patches:                return PrimitiveType.Patches;
             }
 
-            throw new ArgumentException(nameof(Type));
+            throw new ArgumentException(nameof(Type) + " \"" + Type + "\" is not valid!");
         }
 
         public static ShaderType GetShaderType(GalShaderType Type)
@@ -122,7 +120,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 case GalShaderType.Fragment:       return ShaderType.FragmentShader;
             }
 
-            throw new ArgumentException(nameof(Type));
+            throw new ArgumentException(nameof(Type) + " \"" + Type + "\" is not valid!");
         }
 
         public static (PixelInternalFormat, PixelFormat, PixelType) GetImageFormat(GalImageFormat Format)
@@ -211,7 +209,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 case GalTextureSource.OneFloat: return All.One;
             }
 
-            throw new ArgumentException(nameof(Source));
+            throw new ArgumentException(nameof(Source) + " \"" + Source + "\" is not valid!");
         }
 
         public static TextureWrapMode GetTextureWrapMode(GalTextureWrap Wrap)
@@ -245,7 +243,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 }
             }
 
-            throw new ArgumentException(nameof(Wrap));
+            throw new ArgumentException(nameof(Wrap) + " \"" + Wrap + "\" is not valid!");
         }
 
         public static TextureMinFilter GetTextureMinFilter(
@@ -259,7 +257,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 case GalTextureFilter.Linear:  return TextureMinFilter.Linear;
             }
 
-            throw new ArgumentException(nameof(MinFilter));
+            throw new ArgumentException(nameof(MinFilter) + " \"" + MinFilter + "\" is not valid!");
         }
 
         public static TextureMagFilter GetTextureMagFilter(GalTextureFilter Filter)
@@ -270,7 +268,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 case GalTextureFilter.Linear:  return TextureMagFilter.Linear;
             }
 
-            throw new ArgumentException(nameof(Filter));
+            throw new ArgumentException(nameof(Filter) + " \"" + Filter + "\" is not valid!");
         }
 
         public static BlendEquationMode GetBlendEquation(GalBlendEquation BlendEquation)
@@ -284,7 +282,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 case GalBlendEquation.Max:                 return BlendEquationMode.Max;
             }
 
-            throw new ArgumentException(nameof(BlendEquation));
+            throw new ArgumentException(nameof(BlendEquation) + " \"" + BlendEquation + "\" is not valid!");
         }
 
         public static BlendingFactor GetBlendFactor(GalBlendFactor BlendFactor)
@@ -315,7 +313,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                     return BlendingFactor.ConstantColor;
             }
 
-            throw new ArgumentException(nameof(BlendFactor));
+            throw new ArgumentException(nameof(BlendFactor) + " \"" + BlendFactor + "\" is not valid!");
         }
     }
 }

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLPipeline.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLPipeline.cs
@@ -454,10 +454,15 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
         private unsafe static void SetConstAttrib(GalVertexAttrib Attrib)
         {
+            void Unsupported()
+            {
+                throw new NotImplementedException("Constant attribute " + Attrib.Size + " not implemented!");
+            }
+
             if (Attrib.Size == GalVertexAttribSize._10_10_10_2 ||
                 Attrib.Size == GalVertexAttribSize._11_11_10)
             {
-                throw new NotImplementedException("Constant attribute " + Attrib.Size + " not implemented!");
+                Unsupported();
             }
 
             if (Attrib.Type == GalVertexAttribType.Unorm)
@@ -566,7 +571,17 @@ namespace Ryujinx.Graphics.Gal.OpenGL
             }
             else if (Attrib.Type == GalVertexAttribType.Float)
             {
-                GL.VertexAttrib4(Attrib.Index, (float*)Attrib.Pointer);
+                switch (Attrib.Size)
+                {
+                    case GalVertexAttribSize._32:
+                    case GalVertexAttribSize._32_32:
+                    case GalVertexAttribSize._32_32_32:
+                    case GalVertexAttribSize._32_32_32_32:
+                        GL.VertexAttrib4(Attrib.Index, (float*)Attrib.Pointer);
+                        break;
+
+                    default: Unsupported(); break;
+                }
             }
         }
 

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLPipeline.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLPipeline.cs
@@ -25,6 +25,19 @@ namespace Ryujinx.Graphics.Gal.OpenGL
             { GalVertexAttribSize._11_11_10,    3 }
         };
 
+        private static Dictionary<GalVertexAttribSize, VertexAttribPointerType> FloatAttribTypes =
+                   new Dictionary<GalVertexAttribSize, VertexAttribPointerType>()
+        {
+            { GalVertexAttribSize._32_32_32_32, VertexAttribPointerType.Float     },
+            { GalVertexAttribSize._32_32_32,    VertexAttribPointerType.Float     },
+            { GalVertexAttribSize._16_16_16_16, VertexAttribPointerType.HalfFloat },
+            { GalVertexAttribSize._32_32,       VertexAttribPointerType.Float     },
+            { GalVertexAttribSize._16_16_16,    VertexAttribPointerType.HalfFloat },
+            { GalVertexAttribSize._16_16,       VertexAttribPointerType.HalfFloat },
+            { GalVertexAttribSize._32,          VertexAttribPointerType.Float     },
+            { GalVertexAttribSize._16,          VertexAttribPointerType.HalfFloat }
+        };
+
         private static Dictionary<GalVertexAttribSize, VertexAttribPointerType> SignedAttribTypes =
                    new Dictionary<GalVertexAttribSize, VertexAttribPointerType>()
         {
@@ -371,21 +384,25 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
                     if (Attrib.Type == GalVertexAttribType.Float)
                     {
-                        Type = VertexAttribPointerType.Float;
+                        Type = GetType(FloatAttribTypes, Attrib);
                     }
                     else
                     {
                         if (Unsigned)
                         {
-                            Type = UnsignedAttribTypes[Attrib.Size];
+                            Type = GetType(UnsignedAttribTypes, Attrib);
                         }
                         else
                         {
-                            Type = SignedAttribTypes[Attrib.Size];
+                            Type = GetType(SignedAttribTypes, Attrib);
                         }
                     }
 
-                    int Size = AttribElements[Attrib.Size];
+                    if (!AttribElements.TryGetValue(Attrib.Size, out int Size))
+                    {
+                        throw new InvalidOperationException("Invalid attribute size \"" + Attrib.Size + "\"!");
+                    }
+
                     int Offset = Attrib.Offset;
 
                     if (Binding.Stride != 0)
@@ -423,6 +440,16 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                     }
                 }
             }
+        }
+
+        private static VertexAttribPointerType GetType(Dictionary<GalVertexAttribSize, VertexAttribPointerType> Dict, GalVertexAttrib Attrib)
+        {
+            if (!Dict.TryGetValue(Attrib.Size, out VertexAttribPointerType Type))
+            {
+                throw new NotImplementedException("Unsupported size \"" + Attrib.Size + "\" on type \"" + Attrib.Type + "\"!");
+            }
+
+            return Type;
         }
 
         private unsafe static void SetConstAttrib(GalVertexAttrib Attrib)

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLPipeline.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLPipeline.cs
@@ -356,8 +356,6 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                         continue;
                     }
 
-                    GL.EnableVertexAttribArray(Attrib.Index);
-
                     GL.BindBuffer(BufferTarget.ArrayBuffer, VboHandle);
 
                     bool Unsigned =
@@ -390,18 +388,29 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                     int Size = AttribElements[Attrib.Size];
                     int Offset = Attrib.Offset;
 
-                    if (Attrib.Type == GalVertexAttribType.Sint ||
-                        Attrib.Type == GalVertexAttribType.Uint)
+                    if (Binding.Stride != 0)
                     {
-                        IntPtr Pointer = new IntPtr(Offset);
+                        GL.EnableVertexAttribArray(Attrib.Index);
 
-                        VertexAttribIntegerType IType = (VertexAttribIntegerType)Type;
+                        if (Attrib.Type == GalVertexAttribType.Sint ||
+                            Attrib.Type == GalVertexAttribType.Uint)
+                        {
+                            IntPtr Pointer = new IntPtr(Offset);
 
-                        GL.VertexAttribIPointer(Attrib.Index, Size, IType, Binding.Stride, Pointer);
+                            VertexAttribIntegerType IType = (VertexAttribIntegerType)Type;
+
+                            GL.VertexAttribIPointer(Attrib.Index, Size, IType, Binding.Stride, Pointer);
+                        }
+                        else
+                        {
+                            GL.VertexAttribPointer(Attrib.Index, Size, Type, Normalize, Binding.Stride, Offset);
+                        }
                     }
                     else
                     {
-                        GL.VertexAttribPointer(Attrib.Index, Size, Type, Normalize, Binding.Stride, Offset);
+                        GL.DisableVertexAttribArray(Attrib.Index);
+
+                        SetConstAttrib(Attrib);
                     }
 
                     if (Binding.Instanced && Binding.Divisor != 0)
@@ -413,6 +422,124 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                         GL.VertexAttribDivisor(Attrib.Index, 0);
                     }
                 }
+            }
+        }
+
+        private unsafe static void SetConstAttrib(GalVertexAttrib Attrib)
+        {
+            if (Attrib.Size == GalVertexAttribSize._10_10_10_2 ||
+                Attrib.Size == GalVertexAttribSize._11_11_10)
+            {
+                throw new NotImplementedException("Constant attribute " + Attrib.Size + " not implemented!");
+            }
+
+            if (Attrib.Type == GalVertexAttribType.Unorm)
+            {
+                switch (Attrib.Size)
+                {
+                    case GalVertexAttribSize._8:
+                    case GalVertexAttribSize._8_8:
+                    case GalVertexAttribSize._8_8_8:
+                    case GalVertexAttribSize._8_8_8_8:
+                        GL.VertexAttrib4N((uint)Attrib.Index, (byte*)Attrib.Pointer);
+                        break;
+
+                    case GalVertexAttribSize._16:
+                    case GalVertexAttribSize._16_16:
+                    case GalVertexAttribSize._16_16_16:
+                    case GalVertexAttribSize._16_16_16_16:
+                        GL.VertexAttrib4N((uint)Attrib.Index, (ushort*)Attrib.Pointer);
+                        break;
+
+                    case GalVertexAttribSize._32:
+                    case GalVertexAttribSize._32_32:
+                    case GalVertexAttribSize._32_32_32:
+                    case GalVertexAttribSize._32_32_32_32:
+                        GL.VertexAttrib4N((uint)Attrib.Index, (uint*)Attrib.Pointer);
+                        break;
+                }
+            }
+            else if (Attrib.Type == GalVertexAttribType.Snorm)
+            {
+                switch (Attrib.Size)
+                {
+                    case GalVertexAttribSize._8:
+                    case GalVertexAttribSize._8_8:
+                    case GalVertexAttribSize._8_8_8:
+                    case GalVertexAttribSize._8_8_8_8:
+                        GL.VertexAttrib4N((uint)Attrib.Index, (sbyte*)Attrib.Pointer);
+                        break;
+
+                    case GalVertexAttribSize._16:
+                    case GalVertexAttribSize._16_16:
+                    case GalVertexAttribSize._16_16_16:
+                    case GalVertexAttribSize._16_16_16_16:
+                        GL.VertexAttrib4N((uint)Attrib.Index, (short*)Attrib.Pointer);
+                        break;
+
+                    case GalVertexAttribSize._32:
+                    case GalVertexAttribSize._32_32:
+                    case GalVertexAttribSize._32_32_32:
+                    case GalVertexAttribSize._32_32_32_32:
+                        GL.VertexAttrib4N((uint)Attrib.Index, (int*)Attrib.Pointer);
+                        break;
+                }
+            }
+            else if (Attrib.Type == GalVertexAttribType.Uint)
+            {
+                switch (Attrib.Size)
+                {
+                    case GalVertexAttribSize._8:
+                    case GalVertexAttribSize._8_8:
+                    case GalVertexAttribSize._8_8_8:
+                    case GalVertexAttribSize._8_8_8_8:
+                        GL.VertexAttribI4((uint)Attrib.Index, (byte*)Attrib.Pointer);
+                        break;
+
+                    case GalVertexAttribSize._16:
+                    case GalVertexAttribSize._16_16:
+                    case GalVertexAttribSize._16_16_16:
+                    case GalVertexAttribSize._16_16_16_16:
+                        GL.VertexAttribI4((uint)Attrib.Index, (ushort*)Attrib.Pointer);
+                        break;
+
+                    case GalVertexAttribSize._32:
+                    case GalVertexAttribSize._32_32:
+                    case GalVertexAttribSize._32_32_32:
+                    case GalVertexAttribSize._32_32_32_32:
+                        GL.VertexAttribI4((uint)Attrib.Index, (uint*)Attrib.Pointer);
+                        break;
+                }
+            }
+            else if (Attrib.Type == GalVertexAttribType.Sint)
+            {
+                switch (Attrib.Size)
+                {
+                    case GalVertexAttribSize._8:
+                    case GalVertexAttribSize._8_8:
+                    case GalVertexAttribSize._8_8_8:
+                    case GalVertexAttribSize._8_8_8_8:
+                        GL.VertexAttribI4((uint)Attrib.Index, (sbyte*)Attrib.Pointer);
+                        break;
+
+                    case GalVertexAttribSize._16:
+                    case GalVertexAttribSize._16_16:
+                    case GalVertexAttribSize._16_16_16:
+                    case GalVertexAttribSize._16_16_16_16:
+                        GL.VertexAttribI4((uint)Attrib.Index, (short*)Attrib.Pointer);
+                        break;
+
+                    case GalVertexAttribSize._32:
+                    case GalVertexAttribSize._32_32:
+                    case GalVertexAttribSize._32_32_32:
+                    case GalVertexAttribSize._32_32_32_32:
+                        GL.VertexAttribI4((uint)Attrib.Index, (int*)Attrib.Pointer);
+                        break;
+                }
+            }
+            else if (Attrib.Type == GalVertexAttribType.Float)
+            {
+                GL.VertexAttrib4(Attrib.Index, (float*)Attrib.Pointer);
             }
         }
 

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLRasterizer.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLRasterizer.cs
@@ -119,6 +119,18 @@ namespace Ryujinx.Graphics.Gal.OpenGL
             GL.BufferData(BufferTarget.ElementArrayBuffer, Length, HostAddress, BufferUsageHint.StreamDraw);
         }
 
+        public void CreateIbo(long Key, int DataSize, byte[] Buffer)
+        {
+            int Handle = GL.GenBuffer();
+
+            IboCache.AddOrUpdate(Key, Handle, (uint)DataSize);
+
+            IntPtr Length = new IntPtr(Buffer.Length);
+
+            GL.BindBuffer(BufferTarget.ElementArrayBuffer, Handle);
+            GL.BufferData(BufferTarget.ElementArrayBuffer, Length, Buffer, BufferUsageHint.StreamDraw);
+        }
+
         public void SetIndexArray(int Size, GalIndexFormat Format)
         {
             IndexBuffer.Type = OGLEnumConverter.GetDrawElementsType(Format);
@@ -135,7 +147,26 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 return;
             }
 
-            GL.DrawArrays(OGLEnumConverter.GetPrimitiveType(PrimType), First, Count);
+            if (PrimType == GalPrimitiveType.Quads)
+            {
+                for (int Offset = 0; Offset < Count; Offset += 4)
+                {
+                    GL.DrawArrays(PrimitiveType.TriangleFan, First + Offset, 4);
+                }
+            }
+            else if (PrimType == GalPrimitiveType.QuadStrip)
+            {
+                GL.DrawArrays(PrimitiveType.TriangleFan, First, 4);
+
+                for (int Offset = 2; Offset < Count; Offset += 2)
+                {
+                    GL.DrawArrays(PrimitiveType.TriangleFan, First + Offset, 4);
+                }
+            }
+            else
+            {
+                GL.DrawArrays(OGLEnumConverter.GetPrimitiveType(PrimType), First, Count);
+            }
         }
 
         public void DrawElements(long IboKey, int First, int VertexBase, GalPrimitiveType PrimType)

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLRenderTarget.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLRenderTarget.cs
@@ -219,7 +219,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
         {
             Attachments.Zeta = Key;
         }
-        
+
         public void UnbindZeta()
         {
             Attachments.Zeta = 0;

--- a/Ryujinx.Graphics/QuadHelper.cs
+++ b/Ryujinx.Graphics/QuadHelper.cs
@@ -1,0 +1,81 @@
+using System;
+
+namespace Ryujinx.Graphics
+{
+    static class QuadHelper
+    {
+        public static int ConvertIbSizeQuadsToTris(int Size)
+        {
+            return Size <= 0 ? 0 : (Size / 4) * 6;
+        }
+
+        public static int ConvertIbSizeQuadStripToTris(int Size)
+        {
+            return Size <= 1 ? 0 : ((Size - 2) / 2) * 6;
+        }
+
+        public static byte[] ConvertIbQuadsToTris(byte[] Data, int EntrySize, int Count)
+        {
+            int PrimitivesCount = Count / 4;
+
+            int QuadPrimSize = 4 * EntrySize;
+            int TrisPrimSize = 6 * EntrySize;
+
+            byte[] Output = new byte[PrimitivesCount * 6 * EntrySize];
+
+            for (int Prim = 0; Prim < PrimitivesCount; Prim++)
+            {
+                void AssignIndex(int Src, int Dst, int CopyCount = 1)
+                {
+                    Src = Prim * QuadPrimSize + Src * EntrySize;
+                    Dst = Prim * TrisPrimSize + Dst * EntrySize;
+
+                    Buffer.BlockCopy(Data, Src, Output, Dst, CopyCount * EntrySize);
+                }
+
+                //0 1 2 -> 0 1 2.
+                AssignIndex(0, 0, 3);
+
+                //2 3 -> 3 4.
+                AssignIndex(2, 3, 2);
+
+                //0 -> 5.
+                AssignIndex(0, 5);
+            }
+
+            return Output;
+        }
+
+        public static byte[] ConvertIbQuadStripToTris(byte[] Data, int EntrySize, int Count)
+        {
+            int PrimitivesCount = (Count - 2) / 2;
+
+            int QuadPrimSize = 2 * EntrySize;
+            int TrisPrimSize = 6 * EntrySize;
+
+            byte[] Output = new byte[PrimitivesCount * 6 * EntrySize];
+
+            for (int Prim = 0; Prim < PrimitivesCount; Prim++)
+            {
+                void AssignIndex(int Src, int Dst, int CopyCount = 1)
+                {
+                    Src = Prim * QuadPrimSize + Src * EntrySize + 2 * EntrySize;
+                    Dst = Prim * TrisPrimSize + Dst * EntrySize;
+
+                    Buffer.BlockCopy(Data, Src, Output, Dst, CopyCount * EntrySize);
+                }
+
+                //-2 -1 0 -> 0 1 2.
+                AssignIndex(-2, 0, 3);
+
+                //0 1 -> 3 4.
+                AssignIndex(0, 3, 2);
+
+                //-2 -> 5.
+                AssignIndex(-2, 5);
+            }
+
+            return Output;
+        }
+    }
+}

--- a/Ryujinx.Graphics/Texture/ImageUtils.cs
+++ b/Ryujinx.Graphics/Texture/ImageUtils.cs
@@ -289,7 +289,11 @@ namespace Ryujinx.Graphics.Texture
         {
             ImageDescriptor Desc = GetImageDescriptor(Format);
 
-            return Desc.BytesPerPixel * DivRoundUp(Width, Desc.BlockWidth);
+            int Pitch = Desc.BytesPerPixel * DivRoundUp(Width, Desc.BlockWidth);
+
+            Pitch = (Pitch + 0x1f) & ~0x1f;
+
+            return Pitch;
         }
 
         public static int GetBlockWidth(GalImageFormat Format)

--- a/Ryujinx.Graphics/Texture/TextureFactory.cs
+++ b/Ryujinx.Graphics/Texture/TextureFactory.cs
@@ -40,7 +40,7 @@ namespace Ryujinx.Graphics.Texture
             int Width  = (Tic[4] & 0xffff) + 1;
             int Height = (Tic[5] & 0xffff) + 1;
 
-            return new GalImage(
+            GalImage Image = new GalImage(
                 Width,
                 Height,
                 TileWidth,
@@ -51,6 +51,13 @@ namespace Ryujinx.Graphics.Texture
                 YSource,
                 ZSource,
                 WSource);
+
+            if (Layout == GalMemoryLayout.Pitch)
+            {
+                Image.Pitch = (Tic[3] & 0xffff) << 5;
+            }
+
+            return Image;
         }
 
         public static GalTextureSampler MakeSampler(NvGpu Gpu, NvGpuVmm Vmm, long TscPosition)


### PR DESCRIPTION
This PR:
- Fixes Quads and QuadStrip primitive modes on DrawArrays. It was using the respective OpenGL primitive modes, however they were deprecated on OpenGL 3.x, so it doesn't work anymore. I replaced it with multiple calls to DrawArrays with an offset, and a count of 4. It's not optimal, however the only other option I can think of is creating another vertex buffer, or using a index buffer. Draw Elements now doesn't support Quads or QuadStrip, it should throw an exception if those two are used.
- Allow constant attributes to work properly. When the stride is 0, it should read the attribute from the same location every time, effectively being a constant value, however on OpenGL the value 0 being used as stride is special, it assumes that the data is tightly packed.