### PR TITLE
Fix race condition on OpenALAudioOut

### DIFF
--- a/Ryujinx.Audio/OpenAL/OpenALAudioOut.cs
+++ b/Ryujinx.Audio/OpenAL/OpenALAudioOut.cs
@@ -182,7 +182,10 @@ namespace Ryujinx.Audio.OpenAL
             {
                 foreach (Track Td in Tracks.Values)
                 {
-                    Td.CallReleaseCallbackIfNeeded();
+                    lock (Td)
+                    {
+                        Td.CallReleaseCallbackIfNeeded();
+                    }
                 }
 
                 //If it's not slept it will waste cycles.


### PR DESCRIPTION
Without the lock, `TryDequeue` and `Enqueue` could be called at the same time (on `CallReleaseCallbackIfNeeded` and `AppendBuffer`). This causes problems since `Queue` is not thread safe.