### PR TITLE
Remove IFileSystem::OpenDirectory extraneous check

### DIFF
--- a/Ryujinx.HLE/HOS/Services/FspSrv/IFileSystem.cs
+++ b/Ryujinx.HLE/HOS/Services/FspSrv/IFileSystem.cs
@@ -281,11 +281,6 @@ namespace Ryujinx.HLE.HOS.Services.FspSrv
                 return MakeError(ErrorModule.Fs, FsErr.PathDoesNotExist);
             }
 
-            if (IsPathAlreadyInUse(DirName))
-            {
-                return MakeError(ErrorModule.Fs, FsErr.PathAlreadyInUse);
-            }
-
             IDirectory DirInterface = new IDirectory(DirName, FilterFlags);
 
             DirInterface.Disposed += RemoveDirectoryInUse;


### PR DESCRIPTION
A directory can be open more than one time. This fix issues with
homebrews opening the same directory multiple time. (like ftpd)