### PR TITLE
Fix for render target and a shader compilation issue

### DIFF
--- a/Ryujinx.Graphics/Gal/OpenGL/OGLTexture.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLTexture.cs
@@ -8,6 +8,8 @@ namespace Ryujinx.Graphics.Gal.OpenGL
     {
         private OGLCachedResource<ImageHandler> TextureCache;
 
+        public EventHandler<int> TextureDeleted { get; set; }
+
         public OGLTexture()
         {
             TextureCache = new OGLCachedResource<ImageHandler>(DeleteTexture);
@@ -23,8 +25,10 @@ namespace Ryujinx.Graphics.Gal.OpenGL
             TextureCache.Unlock();
         }
 
-        private static void DeleteTexture(ImageHandler CachedImage)
+        private void DeleteTexture(ImageHandler CachedImage)
         {
+            TextureDeleted?.Invoke(this, CachedImage.Handle);
+
             GL.DeleteTexture(CachedImage.Handle);
         }
 

--- a/Ryujinx.Graphics/Gal/Shader/ShaderDecodeAlu.cs
+++ b/Ryujinx.Graphics/Gal/Shader/ShaderDecodeAlu.cs
@@ -730,7 +730,7 @@ namespace Ryujinx.Graphics.Gal.Shader
             }
 
             ShaderIrNode Src1 = GetAluIneg(ApplyHeight(OpCode.Gpr8(),  Height1), Neg1);
-            ShaderIrNode Src2 = GetAluIneg(ApplyHeight(OperB,                Height2), Neg2);
+            ShaderIrNode Src2 = GetAluIneg(ApplyHeight(OperB,          Height2), Neg2);
             ShaderIrNode Src3 = GetAluIneg(ApplyHeight(OpCode.Gpr39(), Height3), Neg3);
 
             ShaderIrOp Sum = new ShaderIrOp(ShaderIrInst.Add, Src1, Src2);


### PR DESCRIPTION
Fixes two issues:

- It was possible for render targets to use deleted handles due to an "optimization" that would compare the Key (render target address) with the old one, and if it was the same it would skip setting the new texture. This doesn't work if the texture is "reinterpreted" by creating a new texture for example. The address is still the same, but the handle changes. I still kept the "optimization", but comparing handles rather than addresses. Additionally, when the texture is removed the cached handle values are invalidated.
- Fix a compilation issue where the shader translator wouldn't emit a `return` on functions with just a KIL instruction inside (discard). Also some nits to pretify shader code output.