### PR TITLE
Add depth range support on the GPU

### DIFF
--- a/Ryujinx.Graphics/Gal/GalPipelineState.cs
+++ b/Ryujinx.Graphics/Gal/GalPipelineState.cs
@@ -43,6 +43,8 @@
         public bool DepthTestEnabled;
         public bool DepthWriteEnabled;
         public GalComparisonOp DepthFunc;
+        public float DepthRangeNear;
+        public float DepthRangeFar;
 
         public bool StencilTestEnabled;
         public bool StencilTwoSideEnabled;

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLPipeline.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLPipeline.cs
@@ -95,46 +95,46 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 FrontFace = GalFrontFace.CCW,
 
                 CullFaceEnabled = false,
-                CullFace = GalCullFace.Back,
+                CullFace        = GalCullFace.Back,
 
-                DepthTestEnabled = false,
+                DepthTestEnabled  = false,
                 DepthWriteEnabled = true,
-                DepthFunc = GalComparisonOp.Less,
-                DepthRangeNear = 0,
-                DepthRangeFar = 1,
+                DepthFunc         = GalComparisonOp.Less,
+                DepthRangeNear    = 0,
+                DepthRangeFar     = 1,
 
                 StencilTestEnabled = false,
 
                 StencilBackFuncFunc = GalComparisonOp.Always,
-                StencilBackFuncRef = 0,
+                StencilBackFuncRef  = 0,
                 StencilBackFuncMask = UInt32.MaxValue,
-                StencilBackOpFail = GalStencilOp.Keep,
-                StencilBackOpZFail = GalStencilOp.Keep,
-                StencilBackOpZPass = GalStencilOp.Keep,
-                StencilBackMask = UInt32.MaxValue,
+                StencilBackOpFail   = GalStencilOp.Keep,
+                StencilBackOpZFail  = GalStencilOp.Keep,
+                StencilBackOpZPass  = GalStencilOp.Keep,
+                StencilBackMask     = UInt32.MaxValue,
 
                 StencilFrontFuncFunc = GalComparisonOp.Always,
-                StencilFrontFuncRef = 0,
+                StencilFrontFuncRef  = 0,
                 StencilFrontFuncMask = UInt32.MaxValue,
-                StencilFrontOpFail = GalStencilOp.Keep,
-                StencilFrontOpZFail = GalStencilOp.Keep,
-                StencilFrontOpZPass = GalStencilOp.Keep,
-                StencilFrontMask = UInt32.MaxValue,
+                StencilFrontOpFail   = GalStencilOp.Keep,
+                StencilFrontOpZFail  = GalStencilOp.Keep,
+                StencilFrontOpZPass  = GalStencilOp.Keep,
+                StencilFrontMask     = UInt32.MaxValue,
 
-                BlendEnabled = false,
+                BlendEnabled       = false,
                 BlendSeparateAlpha = false,
 
-                BlendEquationRgb = 0,
-                BlendFuncSrcRgb = GalBlendFactor.One,
-                BlendFuncDstRgb = GalBlendFactor.Zero,
+                BlendEquationRgb   = 0,
+                BlendFuncSrcRgb    = GalBlendFactor.One,
+                BlendFuncDstRgb    = GalBlendFactor.Zero,
                 BlendEquationAlpha = 0,
-                BlendFuncSrcAlpha = GalBlendFactor.One,
-                BlendFuncDstAlpha = GalBlendFactor.Zero,
+                BlendFuncSrcAlpha  = GalBlendFactor.One,
+                BlendFuncDstAlpha  = GalBlendFactor.Zero,
 
                 ColorMask = ColorMaskRgba.Default,
 
                 PrimitiveRestartEnabled = false,
-                PrimitiveRestartIndex = 0
+                PrimitiveRestartIndex   = 0
             };
 
             for (int Index = 0; Index < GalPipelineState.RenderTargetsCount; Index++)

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLPipeline.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLPipeline.cs
@@ -100,6 +100,8 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 DepthTestEnabled = false,
                 DepthWriteEnabled = true,
                 DepthFunc = GalComparisonOp.Less,
+                DepthRangeNear = 0,
+                DepthRangeFar = 1,
 
                 StencilTestEnabled = false,
 
@@ -193,6 +195,12 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 {
                     GL.DepthFunc(OGLEnumConverter.GetDepthFunc(New.DepthFunc));
                 }
+            }
+
+            if (New.DepthRangeNear != Old.DepthRangeNear ||
+                New.DepthRangeFar  != Old.DepthRangeFar)
+            {
+                GL.DepthRange(New.DepthRangeNear, New.DepthRangeFar);
             }
 
             if (New.StencilTestEnabled != Old.StencilTestEnabled)

--- a/Ryujinx.Graphics/NvGpuEngine3d.cs
+++ b/Ryujinx.Graphics/NvGpuEngine3d.cs
@@ -371,6 +371,9 @@ namespace Ryujinx.Graphics
             {
                 State.DepthFunc = (GalComparisonOp)ReadRegister(NvGpuEngine3dReg.DepthTestFunction);
             }
+
+            State.DepthRangeNear = ReadRegisterFloat(NvGpuEngine3dReg.DepthRangeNNear);
+            State.DepthRangeFar  = ReadRegisterFloat(NvGpuEngine3dReg.DepthRangeNFar);
         }
 
         private void SetStencil(GalPipelineState State)

--- a/Ryujinx.Graphics/NvGpuEngine3dReg.cs
+++ b/Ryujinx.Graphics/NvGpuEngine3dReg.cs
@@ -15,6 +15,8 @@ namespace Ryujinx.Graphics
         ViewportNTranslateZ  = 0x285,
         ViewportNHoriz       = 0x300,
         ViewportNVert        = 0x301,
+        DepthRangeNNear      = 0x302,
+        DepthRangeNFar       = 0x303,
         VertexArrayFirst     = 0x35d,
         VertexArrayCount     = 0x35e,
         ClearNColor          = 0x360,


### PR DESCRIPTION
There are multiple (16) depth range values, it assumes that only the first one is used for now.