### PR TITLE
Fix Color Mask values

### DIFF
--- a/Ryujinx.Graphics/Gal/GalPipelineState.cs
+++ b/Ryujinx.Graphics/Gal/GalPipelineState.cs
@@ -37,42 +37,42 @@
 
         public GalFrontFace FrontFace;
 
-        public bool CullFaceEnabled;
+        public bool        CullFaceEnabled;
         public GalCullFace CullFace;
 
-        public bool DepthTestEnabled;
-        public bool DepthWriteEnabled;
+        public bool            DepthTestEnabled;
+        public bool            DepthWriteEnabled;
         public GalComparisonOp DepthFunc;
 
         public bool StencilTestEnabled;
         public bool StencilTwoSideEnabled;
 
         public GalComparisonOp StencilBackFuncFunc;
-        public int StencilBackFuncRef;
-        public uint StencilBackFuncMask;
-        public GalStencilOp StencilBackOpFail;
-        public GalStencilOp StencilBackOpZFail;
-        public GalStencilOp StencilBackOpZPass;
-        public uint StencilBackMask;
+        public int             StencilBackFuncRef;
+        public uint            StencilBackFuncMask;
+        public GalStencilOp    StencilBackOpFail;
+        public GalStencilOp    StencilBackOpZFail;
+        public GalStencilOp    StencilBackOpZPass;
+        public uint            StencilBackMask;
 
         public GalComparisonOp StencilFrontFuncFunc;
-        public int StencilFrontFuncRef;
-        public uint StencilFrontFuncMask;
-        public GalStencilOp StencilFrontOpFail;
-        public GalStencilOp StencilFrontOpZFail;
-        public GalStencilOp StencilFrontOpZPass;
-        public uint StencilFrontMask;
+        public int             StencilFrontFuncRef;
+        public uint            StencilFrontFuncMask;
+        public GalStencilOp    StencilFrontOpFail;
+        public GalStencilOp    StencilFrontOpZFail;
+        public GalStencilOp    StencilFrontOpZPass;
+        public uint            StencilFrontMask;
 
-        public bool BlendEnabled;
-        public bool BlendSeparateAlpha;
+        public bool             BlendEnabled;
+        public bool             BlendSeparateAlpha;
         public GalBlendEquation BlendEquationRgb;
-        public GalBlendFactor BlendFuncSrcRgb;
-        public GalBlendFactor BlendFuncDstRgb;
+        public GalBlendFactor   BlendFuncSrcRgb;
+        public GalBlendFactor   BlendFuncDstRgb;
         public GalBlendEquation BlendEquationAlpha;
-        public GalBlendFactor BlendFuncSrcAlpha;
-        public GalBlendFactor BlendFuncDstAlpha;
+        public GalBlendFactor   BlendFuncSrcAlpha;
+        public GalBlendFactor   BlendFuncDstAlpha;
 
-        public bool ColorMaskCommon;
+        public bool            ColorMaskCommon;
         public ColorMaskRgba[] ColorMasks;
 
         public bool PrimitiveRestartEnabled;

--- a/Ryujinx.Graphics/Gal/GalPipelineState.cs
+++ b/Ryujinx.Graphics/Gal/GalPipelineState.cs
@@ -72,7 +72,7 @@
         public GalBlendFactor BlendFuncSrcAlpha;
         public GalBlendFactor BlendFuncDstAlpha;
 
-        public ColorMaskRgba ColorMask;
+        public bool ColorMaskCommon;
         public ColorMaskRgba[] ColorMasks;
 
         public bool PrimitiveRestartEnabled;

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLPipeline.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLPipeline.cs
@@ -129,8 +129,6 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 BlendFuncSrcAlpha = GalBlendFactor.One,
                 BlendFuncDstAlpha = GalBlendFactor.Zero,
 
-                ColorMask = ColorMaskRgba.Default,
-
                 PrimitiveRestartEnabled = false,
                 PrimitiveRestartIndex = 0
             };
@@ -308,16 +306,30 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 }
             }
 
-            for (int Index = 0; Index < GalPipelineState.RenderTargetsCount; Index++)
+            if (New.ColorMaskCommon)
             {
-                if (!New.ColorMasks[Index].Equals(Old.ColorMasks[Index]))
+                if (!New.ColorMasks[0].Equals(Old.ColorMasks[0]))
                 {
                     GL.ColorMask(
-                        Index,
-                        New.ColorMasks[Index].Red,
-                        New.ColorMasks[Index].Green,
-                        New.ColorMasks[Index].Blue,
-                        New.ColorMasks[Index].Alpha);
+                        New.ColorMasks[0].Red,
+                        New.ColorMasks[0].Green,
+                        New.ColorMasks[0].Blue,
+                        New.ColorMasks[0].Alpha);
+                }
+            }
+            else
+            {
+                for (int Index = 0; Index < GalPipelineState.RenderTargetsCount; Index++)
+                {
+                    if (!New.ColorMasks[Index].Equals(Old.ColorMasks[Index]))
+                    {
+                        GL.ColorMask(
+                            Index,
+                            New.ColorMasks[Index].Red,
+                            New.ColorMasks[Index].Green,
+                            New.ColorMasks[Index].Blue,
+                            New.ColorMasks[Index].Alpha);
+                    }
                 }
             }
 

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLPipeline.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLPipeline.cs
@@ -481,7 +481,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
         {
             if (!Dict.TryGetValue(Attrib.Size, out VertexAttribPointerType Type))
             {
-                throw new NotImplementedException("Unsupported size \"" + Attrib.Size + "\" on type \"" + Attrib.Type + "\"!");
+                ThrowUnsupportedAttrib(Attrib);
             }
 
             return Type;
@@ -489,15 +489,10 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
         private unsafe static void SetConstAttrib(GalVertexAttrib Attrib)
         {
-            void Unsupported()
-            {
-                throw new NotImplementedException("Constant attribute " + Attrib.Size + " not implemented!");
-            }
-
             if (Attrib.Size == GalVertexAttribSize._10_10_10_2 ||
                 Attrib.Size == GalVertexAttribSize._11_11_10)
             {
-                Unsupported();
+                ThrowUnsupportedAttrib(Attrib);
             }
 
             if (Attrib.Type == GalVertexAttribType.Unorm)
@@ -615,9 +610,14 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                         GL.VertexAttrib4(Attrib.Index, (float*)Attrib.Pointer);
                         break;
 
-                    default: Unsupported(); break;
+                    default: ThrowUnsupportedAttrib(Attrib); break;
                 }
             }
+        }
+
+        private static void ThrowUnsupportedAttrib(GalVertexAttrib Attrib)
+        {
+            throw new NotImplementedException("Unsupported size \"" + Attrib.Size + "\" on type \"" + Attrib.Type + "\"!");
         }
 
         private void Enable(EnableCap Cap, bool Enabled)

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLPipeline.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLPipeline.cs
@@ -308,7 +308,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
             if (New.ColorMaskCommon)
             {
-                if (!New.ColorMasks[0].Equals(Old.ColorMasks[0]))
+                if (New.ColorMaskCommon != Old.ColorMaskCommon || !New.ColorMasks[0].Equals(Old.ColorMasks[0]))
                 {
                     GL.ColorMask(
                         New.ColorMasks[0].Red,

--- a/Ryujinx.Graphics/NvGpuEngine3d.cs
+++ b/Ryujinx.Graphics/NvGpuEngine3d.cs
@@ -66,7 +66,7 @@ namespace Ryujinx.Graphics
             }
 
             //Ensure that all components are enabled by default.
-            //Is this correct?
+            //FIXME: Is this correct?
             WriteRegister(NvGpuEngine3dReg.ColorMaskN, 0x1111);
         }
 

--- a/Ryujinx.Graphics/NvGpuEngine3d.cs
+++ b/Ryujinx.Graphics/NvGpuEngine3d.cs
@@ -64,6 +64,10 @@ namespace Ryujinx.Graphics
             {
                 UploadedKeys[i] = new List<long>();
             }
+
+            //Ensure that all components are enabled by default.
+            //Is this correct?
+            WriteRegister(NvGpuEngine3dReg.ColorMaskN, 0x1111);
         }
 
         public void CallMethod(NvGpuVmm Vmm, NvGpuPBEntry PBEntry)
@@ -417,16 +421,13 @@ namespace Ryujinx.Graphics
 
         private void SetColorMask(GalPipelineState State)
         {
-            int ColorMask = ReadRegister(NvGpuEngine3dReg.ColorMask);
+            bool ColorMaskCommon = ReadRegisterBool(NvGpuEngine3dReg.ColorMaskCommon);
 
-            State.ColorMask.Red   = ((ColorMask >> 0)  & 0xf) != 0;
-            State.ColorMask.Green = ((ColorMask >> 4)  & 0xf) != 0;
-            State.ColorMask.Blue  = ((ColorMask >> 8)  & 0xf) != 0;
-            State.ColorMask.Alpha = ((ColorMask >> 12) & 0xf) != 0;
+            State.ColorMaskCommon = ColorMaskCommon;
 
             for (int Index = 0; Index < GalPipelineState.RenderTargetsCount; Index++)
             {
-                ColorMask = ReadRegister(NvGpuEngine3dReg.ColorMaskN + Index);
+                int ColorMask = ReadRegister(NvGpuEngine3dReg.ColorMaskN + (ColorMaskCommon ? 0 : Index));
 
                 State.ColorMasks[Index].Red   = ((ColorMask >> 0)  & 0xf) != 0;
                 State.ColorMasks[Index].Green = ((ColorMask >> 4)  & 0xf) != 0;

--- a/Ryujinx.Graphics/NvGpuEngine3dReg.cs
+++ b/Ryujinx.Graphics/NvGpuEngine3dReg.cs
@@ -23,7 +23,7 @@ namespace Ryujinx.Graphics
         StencilBackFuncRef   = 0x3d5,
         StencilBackMask      = 0x3d6,
         StencilBackFuncMask  = 0x3d7,
-        ColorMask            = 0x3e4,
+        ColorMaskCommon      = 0x3e4,
         RTSeparateFragData   = 0x3eb,
         ZetaAddress          = 0x3f8,
         ZetaFormat           = 0x3fa,


### PR DESCRIPTION
This fixes the color mask common flag (it's not another depth mask value, its just used to switch between using just the first value or the entire array, at least according to nouveau). Additionally it initializes the first color mask to 1, 1, 1, 1 by default since some games never writes to this register.