### PR TITLE
Misc content loading improvements

### DIFF
--- a/Ryujinx.HLE/Ryujinx.HLE.csproj
+++ b/Ryujinx.HLE/Ryujinx.HLE.csproj
@@ -26,7 +26,7 @@
     <ProjectReference Include="..\Ryujinx.Audio\Ryujinx.Audio.csproj" />
     <ProjectReference Include="..\Ryujinx.Common\Ryujinx.Common.csproj" />
     <ProjectReference Include="..\Ryujinx.Graphics\Ryujinx.Graphics.csproj" />
-    <PackageReference Include="LibHac" Version="0.1.2" />
+    <PackageReference Include="LibHac" Version="0.1.3" />
   </ItemGroup>
 
 </Project>

--- a/Ryujinx/Config.cs
+++ b/Ryujinx/Config.cs
@@ -1,3 +1,4 @@
+using LibHac;
 using Ryujinx.Common.Logging;
 using Ryujinx.HLE;
 using Ryujinx.UI.Input;
@@ -68,7 +69,9 @@ namespace Ryujinx
                 device.System.EnableMultiCoreScheduling();
             }
 
-            device.System.EnableFsIntegrityChecks = Convert.ToBoolean(parser.Value("Enable_FS_Integrity_Checks"));
+            device.System.FsIntegrityCheckLevel = Convert.ToBoolean(parser.Value("Enable_FS_Integrity_Checks"))
+                ? IntegrityCheckLevel.ErrorOnInvalid
+                : IntegrityCheckLevel.None;
 
             JoyConKeyboard = new JoyConKeyboard(
 


### PR DESCRIPTION
- Load tickets from XCI files when needed

LibHac updates:
- When a required key is missing, the error gives info about which key is missing and why it's needed
- Hash-verified storage is only hashed the first time a block is read, resulting in performance gains
- Partition FS verification is enabled

Fixes #470 