### PR TITLE
Move prio/core locals inside the lock on yield

### DIFF
--- a/Ryujinx.HLE/HOS/Kernel/KThread.cs
+++ b/Ryujinx.HLE/HOS/Kernel/KThread.cs
@@ -226,10 +226,10 @@ namespace Ryujinx.HLE.HOS.Kernel
 
         public void YieldWithLoadBalancing()
         {
+            System.CriticalSectionLock.Lock();
+
             int Prio = DynamicPriority;
             int Core = CurrentCore;
-
-            System.CriticalSectionLock.Lock();
 
             if (SchedFlags != ThreadSchedState.Running)
             {


### PR DESCRIPTION
This should be inside the lock, otherwise another thread may modify those values and it may use the old value.