### PR TITLE
Timing: Optimize Timestamp Aquisition

### DIFF
--- a/ChocolArm64/ATranslatorCache.cs
+++ b/ChocolArm64/ATranslatorCache.cs
@@ -138,7 +138,7 @@ namespace ChocolArm64
 
                     CacheBucket Bucket = Cache[Node.Value];
 
-                    long TimeDelta = RingDelta(Bucket.Timestamp, Timestamp);
+                    long TimeDelta = Bucket.Timestamp - Timestamp;
 
                     if (TimeDelta <= MinTimeDelta)
                     {
@@ -159,12 +159,7 @@ namespace ChocolArm64
         {
             long timestamp = Stopwatch.GetTimestamp();
 
-            return (long)(timestamp * (1000.0f / Stopwatch.Frequency));
-        }
-
-        private static long RingDelta(long Old, long New)
-        {
-            return New - Old;
+            return timestamp / (Stopwatch.Frequency / 1000);
         }
     }
 }

--- a/ChocolArm64/ATranslatorCache.cs
+++ b/ChocolArm64/ATranslatorCache.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -27,7 +28,7 @@ namespace ChocolArm64
 
             public int Size { get; private set; }
 
-            public int Timestamp { get; private set; }
+            public long Timestamp { get; private set; }
 
             public CacheBucket(ATranslatedSub Subroutine, LinkedListNode<long> Node, int Size)
             {
@@ -41,7 +42,7 @@ namespace ChocolArm64
             {
                 this.Node = Node;
 
-                Timestamp = Environment.TickCount;
+                Timestamp = GetTimestamp();
             }
         }
 
@@ -122,7 +123,7 @@ namespace ChocolArm64
 
         private void ClearCacheIfNeeded()
         {
-            int Timestamp = Environment.TickCount;
+            long Timestamp = GetTimestamp();
 
             while (TotalSize > MaxTotalSize)
             {
@@ -137,9 +138,9 @@ namespace ChocolArm64
 
                     CacheBucket Bucket = Cache[Node.Value];
 
-                    int TimeDelta = RingDelta(Bucket.Timestamp, Timestamp);
+                    long TimeDelta = RingDelta(Bucket.Timestamp, Timestamp);
 
-                    if ((uint)TimeDelta <= (uint)MinTimeDelta)
+                    if (TimeDelta <= MinTimeDelta)
                     {
                         break;
                     }
@@ -154,16 +155,16 @@ namespace ChocolArm64
             }
         }
 
-        private static int RingDelta(int Old, int New)
+        private static long GetTimestamp()
         {
-            if ((uint)New < (uint)Old)
-            {
-                return New + (~Old + 1);
-            }
-            else
-            {
-                return New - Old;
-            }
+            long timestamp = Stopwatch.GetTimestamp();
+
+            return (long)(timestamp * (1000.0f / Stopwatch.Frequency));
+        }
+
+        private static long RingDelta(long Old, long New)
+        {
+            return New - Old;
         }
     }
 }

--- a/Ryujinx.Common/PerformanceCounter.cs
+++ b/Ryujinx.Common/PerformanceCounter.cs
@@ -56,10 +56,10 @@ namespace Ryujinx.Common
         static PerformanceCounter()
         {
             TicksPerMillisecond = Stopwatch.Frequency / 1000;
-            TicksPerSecond = Stopwatch.Frequency;
-            TicksPerMinute = TicksPerSecond * 60;
-            TicksPerHour = TicksPerMinute * 60;
-            TicksPerDay = TicksPerHour * 24;
+            TicksPerSecond      = Stopwatch.Frequency;
+            TicksPerMinute      = TicksPerSecond * 60;
+            TicksPerHour        = TicksPerMinute * 60;
+            TicksPerDay         = TicksPerHour * 24;
         }
     }
 }

--- a/Ryujinx.Common/PerformanceCounter.cs
+++ b/Ryujinx.Common/PerformanceCounter.cs
@@ -4,6 +4,40 @@ namespace Ryujinx.Common
 {
     public static class PerformanceCounter
     {
+        static PerformanceCounter()
+        {
+            TicksPerMillisecond = Stopwatch.Frequency / 1000;
+            TicksPerSecond = Stopwatch.Frequency;
+            TicksPerMinute = TicksPerSecond * 60;
+            TicksPerHour = TicksPerMinute * 60;
+            TicksPerDay = TicksPerHour * 24;
+        }
+
+        /// <summary>
+        /// Represents the number of ticks in 1 day.
+        /// </summary>
+        public static long TicksPerDay { get; }
+
+        /// <summary>
+        /// Represents the number of ticks in 1 hour.
+        /// </summary>
+        public static long TicksPerHour { get; }
+
+        /// <summary>
+        /// Represents the number of ticks in 1 minute.
+        /// </summary>
+        public static long TicksPerMinute { get; }
+
+        /// <summary>
+        /// Represents the number of ticks in 1 second.
+        /// </summary>
+        public static long TicksPerSecond { get; }
+
+        /// <summary>
+        /// Represents the number of ticks in 1 millisecond.
+        /// </summary>
+        public static long TicksPerMillisecond { get; }
+
         /// <summary>
         /// Gets the number of milliseconds elapsed since the system started.
         /// </summary>
@@ -13,7 +47,20 @@ namespace Ryujinx.Common
             {
                 long timestamp = Stopwatch.GetTimestamp();
 
-                return (long)(timestamp * (1000.0f / Stopwatch.Frequency));
+                return timestamp;
+            }
+        }
+
+        /// <summary>
+        /// Gets the number of milliseconds elapsed since the system started.
+        /// </summary>
+        public static long ElapsedMilliseconds
+        {
+            get
+            {
+                long timestamp = Stopwatch.GetTimestamp();
+
+                return timestamp / TicksPerMillisecond;
             }
         }
     }

--- a/Ryujinx.Common/PerformanceCounter.cs
+++ b/Ryujinx.Common/PerformanceCounter.cs
@@ -1,0 +1,20 @@
+﻿using System.Diagnostics;
+
+namespace Ryujinx.Common
+{
+    public static class PerformanceCounter
+    {
+        /// <summary>
+        /// Gets the number of milliseconds elapsed since the system started.
+        /// </summary>
+        public static long ElapsedTicks
+        {
+            get
+            {
+                long timestamp = Stopwatch.GetTimestamp();
+
+                return (long)(timestamp * (1000.0f / Stopwatch.Frequency));
+            }
+        }
+    }
+}

--- a/Ryujinx.Common/PerformanceCounter.cs
+++ b/Ryujinx.Common/PerformanceCounter.cs
@@ -4,15 +4,6 @@ namespace Ryujinx.Common
 {
     public static class PerformanceCounter
     {
-        static PerformanceCounter()
-        {
-            TicksPerMillisecond = Stopwatch.Frequency / 1000;
-            TicksPerSecond = Stopwatch.Frequency;
-            TicksPerMinute = TicksPerSecond * 60;
-            TicksPerHour = TicksPerMinute * 60;
-            TicksPerDay = TicksPerHour * 24;
-        }
-
         /// <summary>
         /// Represents the number of ticks in 1 day.
         /// </summary>
@@ -45,9 +36,7 @@ namespace Ryujinx.Common
         {
             get
             {
-                long timestamp = Stopwatch.GetTimestamp();
-
-                return timestamp;
+                return Stopwatch.GetTimestamp();
             }
         }
 
@@ -62,6 +51,15 @@ namespace Ryujinx.Common
 
                 return timestamp / TicksPerMillisecond;
             }
+        }
+
+        static PerformanceCounter()
+        {
+            TicksPerMillisecond = Stopwatch.Frequency / 1000;
+            TicksPerSecond = Stopwatch.Frequency;
+            TicksPerMinute = TicksPerSecond * 60;
+            TicksPerHour = TicksPerMinute * 60;
+            TicksPerDay = TicksPerHour * 24;
         }
     }
 }

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLCachedResource.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLCachedResource.cs
@@ -27,7 +27,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 this.DataSize = DataSize;
                 this.Node     = Node;
 
-                Timestamp = PerformanceCounter.ElapsedTicks;
+                Timestamp = PerformanceCounter.ElapsedMilliseconds;
             }
         }
 
@@ -142,7 +142,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
         private void ClearCacheIfNeeded()
         {
-            long Timestamp = PerformanceCounter.ElapsedTicks;
+            long Timestamp = PerformanceCounter.ElapsedMilliseconds;
 
             int Count = 0;
 
@@ -157,7 +157,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
                 CacheBucket Bucket = Cache[Node.Value];
 
-                long TimeDelta = RingDelta(Bucket.Timestamp, Timestamp);
+                long TimeDelta = Bucket.Timestamp - Timestamp;
 
                 if ((uint)TimeDelta <= (uint)MaxTimeDelta)
                 {
@@ -170,11 +170,6 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
                 DeleteValueCallback(Bucket.Value);
             }
-        }
-
-        private long RingDelta(long Old, long New)
-        {
-            return New - Old;
         }
     }
 }

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLCachedResource.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLCachedResource.cs
@@ -1,3 +1,4 @@
+using Ryujinx.Common;
 using System;
 using System.Collections.Generic;
 
@@ -18,7 +19,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
             public long DataSize { get; private set; }
 
-            public int Timestamp { get; private set; }
+            public long Timestamp { get; private set; }
 
             public CacheBucket(T Value, long DataSize, LinkedListNode<long> Node)
             {
@@ -26,7 +27,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                 this.DataSize = DataSize;
                 this.Node     = Node;
 
-                Timestamp = Environment.TickCount;
+                Timestamp = PerformanceCounter.ElapsedTicks;
             }
         }
 
@@ -141,7 +142,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
         private void ClearCacheIfNeeded()
         {
-            int Timestamp = Environment.TickCount;
+            long Timestamp = PerformanceCounter.ElapsedTicks;
 
             int Count = 0;
 
@@ -156,7 +157,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 
                 CacheBucket Bucket = Cache[Node.Value];
 
-                int TimeDelta = RingDelta(Bucket.Timestamp, Timestamp);
+                long TimeDelta = RingDelta(Bucket.Timestamp, Timestamp);
 
                 if ((uint)TimeDelta <= (uint)MaxTimeDelta)
                 {
@@ -171,16 +172,9 @@ namespace Ryujinx.Graphics.Gal.OpenGL
             }
         }
 
-        private int RingDelta(int Old, int New)
+        private long RingDelta(long Old, long New)
         {
-            if ((uint)New < (uint)Old)
-            {
-                return New + (~Old + 1);
-            }
-            else
-            {
-                return New - Old;
-            }
+            return New - Old;
         }
     }
 }

--- a/Ryujinx.Graphics/NvGpuEngine3d.cs
+++ b/Ryujinx.Graphics/NvGpuEngine3d.cs
@@ -851,7 +851,7 @@ namespace Ryujinx.Graphics
                     //TODO: Implement counters.
                     long Counter = 1;
 
-                    long Timestamp = PerformanceCounter.ElapsedTicks;
+                    long Timestamp = PerformanceCounter.ElapsedMilliseconds;
 
                     Timestamp = (long)(Timestamp * 615384.615385);
 

--- a/Ryujinx.Graphics/NvGpuEngine3d.cs
+++ b/Ryujinx.Graphics/NvGpuEngine3d.cs
@@ -1,3 +1,4 @@
+using Ryujinx.Common;
 using Ryujinx.Graphics.Gal;
 using Ryujinx.Graphics.Memory;
 using Ryujinx.Graphics.Texture;
@@ -850,7 +851,7 @@ namespace Ryujinx.Graphics
                     //TODO: Implement counters.
                     long Counter = 1;
 
-                    long Timestamp = (uint)Environment.TickCount;
+                    long Timestamp = PerformanceCounter.ElapsedTicks;
 
                     Timestamp = (long)(Timestamp * 615384.615385);
 

--- a/Ryujinx.HLE/HOS/Kernel/KCoreContext.cs
+++ b/Ryujinx.HLE/HOS/Kernel/KCoreContext.cs
@@ -26,7 +26,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (Thread != null)
             {
-                Thread.LastScheduledTicks = PerformanceCounter.ElapsedTicks;
+                Thread.LastScheduledTicks = PerformanceCounter.ElapsedMilliseconds;
             }
 
             if (SelectedThread != CurrentThread)

--- a/Ryujinx.HLE/HOS/Kernel/KCoreContext.cs
+++ b/Ryujinx.HLE/HOS/Kernel/KCoreContext.cs
@@ -1,3 +1,4 @@
+using Ryujinx.Common;
 using System;
 
 namespace Ryujinx.HLE.HOS.Kernel
@@ -25,7 +26,7 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             if (Thread != null)
             {
-                Thread.LastScheduledTicks = (uint)Environment.TickCount;
+                Thread.LastScheduledTicks = PerformanceCounter.ElapsedTicks;
             }
 
             if (SelectedThread != CurrentThread)

--- a/Ryujinx.HLE/Hid/Hid.cs
+++ b/Ryujinx.HLE/Hid/Hid.cs
@@ -216,7 +216,7 @@ namespace Ryujinx.HLE.Input
 
         private static long GetTimestamp()
         {
-            return PerformanceCounter.ElapsedTicks * 19200;
+            return PerformanceCounter.ElapsedMilliseconds * 19200;
         }
     }
 }

--- a/Ryujinx.HLE/Hid/Hid.cs
+++ b/Ryujinx.HLE/Hid/Hid.cs
@@ -1,4 +1,5 @@
-﻿using Ryujinx.HLE.HOS;
+﻿using Ryujinx.Common;
+using Ryujinx.HLE.HOS;
 using System;
 
 namespace Ryujinx.HLE.Input
@@ -98,12 +99,12 @@ namespace Ryujinx.HLE.Input
 
             HidControllerColorDesc SplitColorDesc = 0;
 
-            Device.Memory.WriteInt32(BaseControllerOffset + 0x0,  (int)Type);
+            Device.Memory.WriteInt32(BaseControllerOffset + 0x00, (int)Type);
 
-            Device.Memory.WriteInt32(BaseControllerOffset + 0x4,  IsHalf ? 1 : 0);
+            Device.Memory.WriteInt32(BaseControllerOffset + 0x04, IsHalf ? 1 : 0);
 
-            Device.Memory.WriteInt32(BaseControllerOffset + 0x8,  (int)SingleColorDesc);
-            Device.Memory.WriteInt32(BaseControllerOffset + 0xc,  (int)SingleColorBody);
+            Device.Memory.WriteInt32(BaseControllerOffset + 0x08, (int)SingleColorDesc);
+            Device.Memory.WriteInt32(BaseControllerOffset + 0x0c, (int)SingleColorBody);
             Device.Memory.WriteInt32(BaseControllerOffset + 0x10, (int)SingleColorButtons);
             Device.Memory.WriteInt32(BaseControllerOffset + 0x14, (int)SplitColorDesc);
 
@@ -135,8 +136,8 @@ namespace Ryujinx.HLE.Input
 
             long Timestamp = GetTimestamp();
 
-            Device.Memory.WriteInt64(ControllerOffset + 0x0,  Timestamp);
-            Device.Memory.WriteInt64(ControllerOffset + 0x8,  HidEntryCount);
+            Device.Memory.WriteInt64(ControllerOffset + 0x00, Timestamp);
+            Device.Memory.WriteInt64(ControllerOffset + 0x08, HidEntryCount);
             Device.Memory.WriteInt64(ControllerOffset + 0x10, CurrEntry);
             Device.Memory.WriteInt64(ControllerOffset + 0x18, HidEntryCount - 1);
 
@@ -148,8 +149,8 @@ namespace Ryujinx.HLE.Input
 
             long SampleCounter = Device.Memory.ReadInt64(LastEntryOffset) + 1;
 
-            Device.Memory.WriteInt64(ControllerOffset + 0x0, SampleCounter);
-            Device.Memory.WriteInt64(ControllerOffset + 0x8, SampleCounter);
+            Device.Memory.WriteInt64(ControllerOffset + 0x00, SampleCounter);
+            Device.Memory.WriteInt64(ControllerOffset + 0x08, SampleCounter);
 
             Device.Memory.WriteInt64(ControllerOffset + 0x10, (uint)Buttons);
 
@@ -174,8 +175,8 @@ namespace Ryujinx.HLE.Input
 
             long Timestamp = GetTimestamp();
 
-            Device.Memory.WriteInt64(TouchScreenOffset + 0x0,  Timestamp);
-            Device.Memory.WriteInt64(TouchScreenOffset + 0x8,  HidEntryCount);
+            Device.Memory.WriteInt64(TouchScreenOffset + 0x00, Timestamp);
+            Device.Memory.WriteInt64(TouchScreenOffset + 0x08, HidEntryCount);
             Device.Memory.WriteInt64(TouchScreenOffset + 0x10, CurrEntry);
             Device.Memory.WriteInt64(TouchScreenOffset + 0x18, HidEntryCount - 1);
             Device.Memory.WriteInt64(TouchScreenOffset + 0x20, Timestamp);
@@ -188,8 +189,8 @@ namespace Ryujinx.HLE.Input
 
             TouchEntryOffset += CurrEntry * HidTouchEntrySize;
 
-            Device.Memory.WriteInt64(TouchEntryOffset + 0x0, SampleCounter);
-            Device.Memory.WriteInt64(TouchEntryOffset + 0x8, Points.Length);
+            Device.Memory.WriteInt64(TouchEntryOffset + 0x00, SampleCounter);
+            Device.Memory.WriteInt64(TouchEntryOffset + 0x08, Points.Length);
 
             TouchEntryOffset += HidTouchEntryHeaderSize;
 
@@ -199,9 +200,9 @@ namespace Ryujinx.HLE.Input
 
             foreach (HidTouchPoint Point in Points)
             {
-                Device.Memory.WriteInt64(TouchEntryOffset + 0x0,  Timestamp);
-                Device.Memory.WriteInt32(TouchEntryOffset + 0x8,  Padding);
-                Device.Memory.WriteInt32(TouchEntryOffset + 0xc,  Index++);
+                Device.Memory.WriteInt64(TouchEntryOffset + 0x00, Timestamp);
+                Device.Memory.WriteInt32(TouchEntryOffset + 0x08, Padding);
+                Device.Memory.WriteInt32(TouchEntryOffset + 0x0c, Index++);
                 Device.Memory.WriteInt32(TouchEntryOffset + 0x10, Point.X);
                 Device.Memory.WriteInt32(TouchEntryOffset + 0x14, Point.Y);
                 Device.Memory.WriteInt32(TouchEntryOffset + 0x18, Point.DiameterX);
@@ -215,7 +216,7 @@ namespace Ryujinx.HLE.Input
 
         private static long GetTimestamp()
         {
-            return (long)((ulong)Environment.TickCount * 19_200);
+            return PerformanceCounter.ElapsedTicks * 19200;
         }
     }
 }


### PR DESCRIPTION
Currently, we make use of `Environment.TickCount` in a number of places. This has some downsides, mainly being that the `TickCount` is a signed 32-bit integer, and has an effective limit of ~25 days before overflowing and wrapping around. Due to the signed-ness of the value, this also caused issues with negative numbers. This resolves these issues by using a 64-bit tick count obtained from Performance Counters (via the `Stopwatch` class). This has the favorable side effect of being significantly more accurate than the `TickCount`.

The biggest benefit of this change is that it ensures the monotonicity of the value returned (unless you leave your computer on for over 90,000 years).

I've left the member name as `ElapsedTicks`, because we originally used `TickCount`, however a more accurate representation would probably be `ElapsedMilliseconds` given we are returning a value in milliseconds and a "tick" from the underlying performance counter is actually a much smaller and more precise value; this could get confusing. If we renamed it, it would also allow us to expose the precise, accurate underlying tick count via `ElapsedTicks` instead of milliseconds. I'm happy to make these changes if you think this is a worthwhile.