### PR TITLE
Crop instead of resizing on 2d engine texture copies

### DIFF
--- a/Ryujinx.Graphics/NvGpuEngine2d.cs
+++ b/Ryujinx.Graphics/NvGpuEngine2d.cs
@@ -1,7 +1,7 @@
 using Ryujinx.Graphics.Gal;
 using Ryujinx.Graphics.Memory;
 using Ryujinx.Graphics.Texture;
-using System.Collections.Generic;
+using System;
 
 namespace Ryujinx.Graphics
 {
@@ -22,42 +22,24 @@ namespace Ryujinx.Graphics
 
         private NvGpu Gpu;
 
-        private Dictionary<int, NvGpuMethod> Methods;
-
         public NvGpuEngine2d(NvGpu Gpu)
         {
             this.Gpu = Gpu;
 
-            Registers = new int[0xe00];
-
-            Methods = new Dictionary<int, NvGpuMethod>();
-
-            void AddMethod(int Meth, int Count, int Stride, NvGpuMethod Method)
-            {
-                while (Count-- > 0)
-                {
-                    Methods.Add(Meth, Method);
-
-                    Meth += Stride;
-                }
-            }
-
-            AddMethod(0xb5, 1, 1, TextureCopy);
+            Registers = new int[0x238];
         }
 
         public void CallMethod(NvGpuVmm Vmm, NvGpuPBEntry PBEntry)
         {
-            if (Methods.TryGetValue(PBEntry.Method, out NvGpuMethod Method))
+            WriteRegister(PBEntry);
+
+            if ((NvGpuEngine2dReg)PBEntry.Method == NvGpuEngine2dReg.BlitSrcYInt)
             {
-                Method(Vmm, PBEntry);
-            }
-            else
-            {
-                WriteRegister(PBEntry);
+                TextureCopy(Vmm);
             }
         }
 
-        private void TextureCopy(NvGpuVmm Vmm, NvGpuPBEntry PBEntry)
+        private void TextureCopy(NvGpuVmm Vmm)
         {
             CopyOperation Operation = (CopyOperation)ReadRegister(NvGpuEngine2dReg.CopyOperation);
 
@@ -80,6 +62,8 @@ namespace Ryujinx.Graphics
 
             GalMemoryLayout SrcLayout = GetLayout(SrcLinear);
             GalMemoryLayout DstLayout = GetLayout(DstLinear);
+
+            bool ClipEnable = ReadRegister(NvGpuEngine2dReg.ClipEnable) != 0;
 
             int SrcBlockHeight = 1 << ((SrcBlkDim >> 4) & 0xf);
             int DstBlockHeight = 1 << ((DstBlkDim >> 4) & 0xf);
@@ -107,17 +91,20 @@ namespace Ryujinx.Graphics
             Gpu.ResourceManager.SendTexture(Vmm, SrcKey, SrcTexture);
             Gpu.ResourceManager.SendTexture(Vmm, DstKey, DstTexture);
 
+            int Width  = Math.Min(SrcWidth,  DstWidth);
+            int Height = Math.Min(SrcHeight, DstHeight);
+
             Gpu.Renderer.RenderTarget.Copy(
                 SrcKey,
                 DstKey,
                 0,
                 0,
-                SrcWidth,
-                SrcHeight,
+                Width,
+                Height,
                 0,
                 0,
-                DstWidth,
-                DstHeight);
+                Width,
+                Height);
         }
 
         private static GalMemoryLayout GetLayout(bool Linear)
@@ -147,11 +134,6 @@ namespace Ryujinx.Graphics
         private int ReadRegister(NvGpuEngine2dReg Reg)
         {
             return Registers[(int)Reg];
-        }
-
-        private void WriteRegister(NvGpuEngine2dReg Reg, int Value)
-        {
-            Registers[(int)Reg] = Value;
         }
     }
 }

--- a/Ryujinx.Graphics/NvGpuEngine2d.cs
+++ b/Ryujinx.Graphics/NvGpuEngine2d.cs
@@ -63,8 +63,6 @@ namespace Ryujinx.Graphics
             GalMemoryLayout SrcLayout = GetLayout(SrcLinear);
             GalMemoryLayout DstLayout = GetLayout(DstLinear);
 
-            bool ClipEnable = ReadRegister(NvGpuEngine2dReg.ClipEnable) != 0;
-
             int SrcBlockHeight = 1 << ((SrcBlkDim >> 4) & 0xf);
             int DstBlockHeight = 1 << ((DstBlkDim >> 4) & 0xf);
 

--- a/Ryujinx.Graphics/NvGpuEngine2dReg.cs
+++ b/Ryujinx.Graphics/NvGpuEngine2dReg.cs
@@ -20,6 +20,20 @@ namespace Ryujinx.Graphics
         SrcWidth           = 0x92,
         SrcHeight          = 0x93,
         SrcAddress         = 0x94,
-        CopyOperation      = 0xab
+        ClipEnable         = 0xa4,
+        CopyOperation      = 0xab,
+        BlitControl        = 0x223,
+        BlitDstX           = 0x22c,
+        BlitDstY           = 0x22d,
+        BlitDstW           = 0x22e,
+        BlitDstH           = 0x22f,
+        BlitDuDxFract      = 0x230,
+        BlitDuDxInt        = 0x231,
+        BlitDvDyFract      = 0x232,
+        BlitDvDyInt        = 0x233,
+        BlitSrcXFract      = 0x234,
+        BlitSrcXInt        = 0x235,
+        BlitSrcYFract      = 0x236,
+        BlitSrcYInt        = 0x237
     }
 }


### PR DESCRIPTION
So far all games I've seen that does copies of textures with different sizes seems to expect it to be cropped. Maybe there's a bit to control that somewhere, I guess we'll figure out if we find a game that expects the texture to be resized.

Additionally, removed the old trigger method since it was wrong.