### PR TITLE
Force cache to remove entries when memory usage exceeds a given threshold

### DIFF
--- a/Ryujinx.Graphics/Gal/OpenGL/OGLConstBuffer.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLConstBuffer.cs
@@ -5,11 +5,13 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 {
     class OGLConstBuffer : IGalConstBuffer
     {
+        private const long MaxConstBufferCacheSize = 64 * 1024 * 1024;
+
         private OGLCachedResource<OGLStreamBuffer> Cache;
 
         public OGLConstBuffer()
         {
-            Cache = new OGLCachedResource<OGLStreamBuffer>(DeleteBuffer);
+            Cache = new OGLCachedResource<OGLStreamBuffer>(DeleteBuffer, MaxConstBufferCacheSize);
         }
 
         public void LockCache()

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLRasterizer.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLRasterizer.cs
@@ -5,6 +5,9 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 {
     class OGLRasterizer : IGalRasterizer
     {
+        private const long MaxVertexBufferCacheSize = 128 * 1024 * 1024;
+        private const long MaxIndexBufferCacheSize  = 64  * 1024 * 1024;
+
         private int[] VertexBuffers;
 
         private OGLCachedResource<int> VboCache;
@@ -24,8 +27,8 @@ namespace Ryujinx.Graphics.Gal.OpenGL
         {
             VertexBuffers = new int[32];
 
-            VboCache = new OGLCachedResource<int>(GL.DeleteBuffer);
-            IboCache = new OGLCachedResource<int>(GL.DeleteBuffer);
+            VboCache = new OGLCachedResource<int>(GL.DeleteBuffer, MaxVertexBufferCacheSize);
+            IboCache = new OGLCachedResource<int>(GL.DeleteBuffer, MaxIndexBufferCacheSize);
 
             IndexBuffer = new IbInfo();
         }

--- a/Ryujinx.Graphics/Gal/OpenGL/OGLTexture.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLTexture.cs
@@ -6,13 +6,15 @@ namespace Ryujinx.Graphics.Gal.OpenGL
 {
     class OGLTexture : IGalTexture
     {
+        private const long MaxTextureCacheSize = 768 * 1024 * 1024;
+
         private OGLCachedResource<ImageHandler> TextureCache;
 
         public EventHandler<int> TextureDeleted { get; set; }
 
         public OGLTexture()
         {
-            TextureCache = new OGLCachedResource<ImageHandler>(DeleteTexture);
+            TextureCache = new OGLCachedResource<ImageHandler>(DeleteTexture, MaxTextureCacheSize);
         }
 
         public void LockCache()


### PR DESCRIPTION
Some games may use different addresses for the same data (probably happens when it deletes and re-creates a buffer all the time, which is inefficient but still...). Since resources are cached by resource, this will cause the creation of a growing number of resources on the host, which may eventually cause the system to get out of memory. This PR attempts to solve this by forcing the cached resources to be removed if memory usage exceeds a given threshold.

Now total amount of gpu memory that the emulator can use is 1GB, being currently divided as 768MB for textures, 64MB for const buffers, 128MB for vertex buffers and 64MB for index buffers. The values may need tweaking, it was just what I came up with but I will need to check the impact on perf. Tried to give more mem to textures since thats what uses the largets amount of memory.