### PR TITLE
Audio: Properly implements audio fallback for SoundIO

### DIFF
--- a/Ryujinx.Audio/Renderers/SoundIo/SoundIoAudioOut.cs
+++ b/Ryujinx.Audio/Renderers/SoundIo/SoundIoAudioOut.cs
@@ -39,24 +39,34 @@ namespace Ryujinx.Audio
                 SoundIO context = null;
                 SoundIODevice device = null;
                 SoundIOOutStream stream = null;
+                bool backendDisconnected = false;
 
                 try
                 {
                     context = new SoundIO();
 
+                    context.OnBackendDisconnect = (i) => {
+                        backendDisconnected = true;
+                    };
+
                     context.Connect();
                     context.FlushEvents();
 
+                    if(backendDisconnected)
+                    {
+                        return false;
+                    }
+
                     device = context.GetOutputDevice(context.DefaultOutputDeviceIndex);
 
-                    if(device == null)
+                    if(device == null || backendDisconnected)
                     {
                         return false;
                     }
 
                     stream = device.CreateOutStream();
 
-                    if(stream == null)
+                    if(stream == null || backendDisconnected)
                     {
                         return false;
                     }

--- a/Ryujinx.Audio/Renderers/SoundIo/SoundIoAudioOut.cs
+++ b/Ryujinx.Audio/Renderers/SoundIo/SoundIoAudioOut.cs
@@ -36,9 +36,10 @@ namespace Ryujinx.Audio
         {
             get
             {
-                SoundIO context          = null;
-                SoundIODevice device     = null;
+                SoundIO          context = null;
+                SoundIODevice    device  = null;
                 SoundIOOutStream stream  = null;
+
                 bool backendDisconnected = false;
 
                 try

--- a/Ryujinx.Audio/Renderers/SoundIo/SoundIoAudioOut.cs
+++ b/Ryujinx.Audio/Renderers/SoundIo/SoundIoAudioOut.cs
@@ -32,7 +32,55 @@ namespace Ryujinx.Audio
         /// <summary>
         /// True if SoundIO is supported on the device.
         /// </summary>
-        public static bool IsSupported => true;
+        public static bool IsSupported
+        {
+            get
+            {
+                SoundIO context = null;
+                SoundIODevice device = null;
+                SoundIOOutStream stream = null;
+
+                try
+                {
+                    context = new SoundIO();
+
+                    context.Connect();
+                    context.FlushEvents();
+
+                    device = context.GetOutputDevice(context.DefaultOutputDeviceIndex);
+
+                    if(device == null)
+                    {
+                        return false;
+                    }
+
+                    stream = device.CreateOutStream();
+
+                    if(stream == null)
+                    {
+                        return false;
+                    }
+
+                    return true;
+                }
+                catch
+                {
+                    return false;
+                }
+                finally
+                {
+                    if(stream != null)
+                    {
+                        stream.Dispose();
+                    }
+
+                    if(context != null)
+                    {
+                        context.Dispose();
+                    }
+                }
+            }
+        }
 
         /// <summary>
         /// Constructs a new instance of a <see cref="SoundIoAudioOut"/>

--- a/Ryujinx.Audio/Renderers/SoundIo/SoundIoAudioOut.cs
+++ b/Ryujinx.Audio/Renderers/SoundIo/SoundIoAudioOut.cs
@@ -36,9 +36,9 @@ namespace Ryujinx.Audio
         {
             get
             {
-                SoundIO context = null;
-                SoundIODevice device = null;
-                SoundIOOutStream stream = null;
+                SoundIO context          = null;
+                SoundIODevice device     = null;
+                SoundIOOutStream stream  = null;
                 bool backendDisconnected = false;
 
                 try


### PR DESCRIPTION
Given some drivers have issues with SoundIO (for the time being), this attempts to detect if SoundIO can open the default audio device, and then return false in IsSupported if it can't.