### PR TITLE
Enable SRGB framebuffers by default

### DIFF
--- a/Ryujinx.Graphics/Gal/OpenGL/OGLTexture.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLTexture.cs
@@ -106,7 +106,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                         Image.Width,
                         Image.Height, 1);
 
-                    Image.Format = GalImageFormat.RGBA8 | GalImageFormat.Unorm;
+                    Image.Format = GalImageFormat.RGBA8 | (Image.Format & GalImageFormat.TypeMask);
                 }
 
                 (PixelInternalFormat InternalFmt,

--- a/Ryujinx.Graphics/NvGpuEngine3d.cs
+++ b/Ryujinx.Graphics/NvGpuEngine3d.cs
@@ -61,6 +61,8 @@ namespace Ryujinx.Graphics
             //FIXME: Is this correct?
             WriteRegister(NvGpuEngine3dReg.ColorMaskN, 0x1111);
 
+            WriteRegister(NvGpuEngine3dReg.FrameBufferSrgb, 1);
+
             for (int Index = 0; Index < GalPipelineState.RenderTargetsCount; Index++)
             {
                 WriteRegister(NvGpuEngine3dReg.IBlendNEquationRgb   + Index * 8, (int)GalBlendEquation.FuncAdd);


### PR DESCRIPTION
Games that uses SRGB textures with framebuffers needs that to display correctly.
I don't know if there's any performance impact in keeping it always enabled.