### PR TITLE
ContentServices: Handle null LocationEntry Path in VerifyContentType

### DIFF
--- a/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
+++ b/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
@@ -223,6 +223,11 @@ namespace Ryujinx.HLE.FileSystem.Content
 
         private bool VerifyContentType(LocationEntry LocationEntry, ContentType ContentType)
         {
+            if (LocationEntry.ContentPath == null)
+            {
+                return false;
+            }
+
             StorageId StorageId     = LocationHelper.GetStorageId(LocationEntry.ContentPath);
             string    InstalledPath = Device.FileSystem.SwitchPathToSystemPath(LocationEntry.ContentPath);
 

--- a/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
+++ b/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
@@ -78,6 +78,7 @@ namespace Ryujinx.HLE.FileSystem
             {
                 return null;
             }
+
             return GetFullPath(MakeDirAndGetFullPath(Parts[0]), Parts[1]);
         }
 


### PR DESCRIPTION
Avoids a `NullReferenceException` when the `ContentPath` is `null`.

When `LocationEntry.ContentPath` is `null`, we can always return `false` as it can't possibly be a valid `ContentType`