### PR TITLE
Initial support for shader half float instructions

### DIFF
--- a/Ryujinx.Graphics/Gal/Shader/GlslDecl.cs
+++ b/Ryujinx.Graphics/Gal/Shader/GlslDecl.cs
@@ -65,6 +65,7 @@ namespace Ryujinx.Graphics.Gal.Shader
         private Dictionary<int, ShaderDeclInfo> m_OutAttributes;
 
         private Dictionary<int, ShaderDeclInfo> m_Gprs;
+        private Dictionary<int, ShaderDeclInfo> m_GprsHalf;
         private Dictionary<int, ShaderDeclInfo> m_Preds;
 
         public IReadOnlyDictionary<ShaderIrOp, ShaderDeclInfo> CbTextures => m_CbTextures;
@@ -76,8 +77,9 @@ namespace Ryujinx.Graphics.Gal.Shader
         public IReadOnlyDictionary<int, ShaderDeclInfo> InAttributes  => m_InAttributes;
         public IReadOnlyDictionary<int, ShaderDeclInfo> OutAttributes => m_OutAttributes;
 
-        public IReadOnlyDictionary<int, ShaderDeclInfo> Gprs  => m_Gprs;
-        public IReadOnlyDictionary<int, ShaderDeclInfo> Preds => m_Preds;
+        public IReadOnlyDictionary<int, ShaderDeclInfo> Gprs     => m_Gprs;
+        public IReadOnlyDictionary<int, ShaderDeclInfo> GprsHalf => m_GprsHalf;
+        public IReadOnlyDictionary<int, ShaderDeclInfo> Preds    => m_Preds;
 
         public GalShaderType ShaderType { get; private set; }
 
@@ -94,8 +96,9 @@ namespace Ryujinx.Graphics.Gal.Shader
             m_InAttributes  = new Dictionary<int, ShaderDeclInfo>();
             m_OutAttributes = new Dictionary<int, ShaderDeclInfo>();
 
-            m_Gprs  = new Dictionary<int, ShaderDeclInfo>();
-            m_Preds = new Dictionary<int, ShaderDeclInfo>();
+            m_Gprs     = new Dictionary<int, ShaderDeclInfo>();
+            m_GprsHalf = new Dictionary<int, ShaderDeclInfo>();
+            m_Preds    = new Dictionary<int, ShaderDeclInfo>();
         }
 
         public GlslDecl(ShaderIrBlock[] Blocks, GalShaderType ShaderType, ShaderHeader Header)
@@ -149,8 +152,9 @@ namespace Ryujinx.Graphics.Gal.Shader
             Merge(Combined.m_Attributes,    VpA.m_Attributes,    VpB.m_Attributes);
             Merge(Combined.m_OutAttributes, VpA.m_OutAttributes, VpB.m_OutAttributes);
 
-            Merge(Combined.m_Gprs,  VpA.m_Gprs,  VpB.m_Gprs);
-            Merge(Combined.m_Preds, VpA.m_Preds, VpB.m_Preds);
+            Merge(Combined.m_Gprs,     VpA.m_Gprs,     VpB.m_Gprs);
+            Merge(Combined.m_GprsHalf, VpA.m_GprsHalf, VpB.m_GprsHalf);
+            Merge(Combined.m_Preds,    VpA.m_Preds,    VpB.m_Preds);
 
             //Merge input attributes.
             foreach (KeyValuePair<int, ShaderDeclInfo> KV in VpA.m_InAttributes)
@@ -346,7 +350,20 @@ namespace Ryujinx.Graphics.Gal.Shader
                     {
                         string Name = GetGprName(Gpr.Index);
 
-                        m_Gprs.TryAdd(Gpr.Index, new ShaderDeclInfo(Name, Gpr.Index));
+                        if (Gpr.RegisterSize == ShaderRegisterSize.Single)
+                        {
+                            m_Gprs.TryAdd(Gpr.Index, new ShaderDeclInfo(Name, Gpr.Index));
+                        }
+                        else if (Gpr.RegisterSize == ShaderRegisterSize.Half)
+                        {
+                            Name += "_h" + Gpr.HalfPart;
+
+                            m_GprsHalf.TryAdd((Gpr.Index << 1) | Gpr.HalfPart, new ShaderDeclInfo(Name, Gpr.Index));
+                        }
+                        else /* if (Gpr.RegisterSize == ShaderRegisterSize.Double) */
+                        {
+                            throw new NotImplementedException("Double types are not supported.");
+                        }
                     }
                     break;
                 }

--- a/Ryujinx.Graphics/Gal/Shader/GlslDecompiler.cs
+++ b/Ryujinx.Graphics/Gal/Shader/GlslDecompiler.cs
@@ -360,6 +360,7 @@ namespace Ryujinx.Graphics.Gal.Shader
         private void PrintDeclGprs()
         {
             PrintDecls(Decl.Gprs);
+            PrintDecls(Decl.GprsHalf);
         }
 
         private void PrintDeclPreds()
@@ -893,7 +894,23 @@ namespace Ryujinx.Graphics.Gal.Shader
 
         private string GetName(ShaderIrOperGpr Gpr)
         {
-            return Gpr.IsConst ? "0" : GetNameWithSwizzle(Decl.Gprs, Gpr.Index);
+            if (Gpr.IsConst)
+            {
+                return "0";
+            }
+
+            if (Gpr.RegisterSize == ShaderRegisterSize.Single)
+            {
+                return GetNameWithSwizzle(Decl.Gprs, Gpr.Index);
+            }
+            else if (Gpr.RegisterSize == ShaderRegisterSize.Half)
+            {
+                return GetNameWithSwizzle(Decl.GprsHalf, (Gpr.Index << 1) | Gpr.HalfPart);
+            }
+            else /* if (Gpr.RegisterSize == ShaderRegisterSize.Double) */
+            {
+                throw new NotImplementedException("Double types are not supported.");
+            }
         }
 
         private string GetValue(ShaderIrOperImm Imm)

--- a/Ryujinx.Graphics/Gal/Shader/ShaderDecodeOpCode.cs
+++ b/Ryujinx.Graphics/Gal/Shader/ShaderDecodeOpCode.cs
@@ -75,6 +75,49 @@ namespace Ryujinx.Graphics.Gal.Shader
             return new ShaderIrOperGpr(OpCode.Read(28, 0xff));
         }
 
+        private static ShaderIrOperGpr[] GprHalfVec8(this long OpCode)
+        {
+            return GetGprHalfVec2(OpCode.Read(8, 0xff), OpCode.Read(47, 3));
+        }
+
+        private static ShaderIrOperGpr[] GprHalfVec20(this long OpCode)
+        {
+            return GetGprHalfVec2(OpCode.Read(20, 0xff), OpCode.Read(28, 3));
+        }
+
+        private static ShaderIrOperGpr[] GetGprHalfVec2(int Gpr, int Mask)
+        {
+            if (Mask == 1)
+            {
+                //This value is used for FP32, the whole 32-bits register
+                //is used as each element on the vector.
+                return new ShaderIrOperGpr[]
+                {
+                    new ShaderIrOperGpr(Gpr),
+                    new ShaderIrOperGpr(Gpr)
+                };
+            }
+
+            ShaderIrOperGpr Low  = new ShaderIrOperGpr(Gpr, 0);
+            ShaderIrOperGpr High = new ShaderIrOperGpr(Gpr, 1);
+
+            return new ShaderIrOperGpr[]
+            {
+                (Mask & 1) != 0 ? High : Low,
+                (Mask & 2) != 0 ? High : Low
+            };
+        }
+
+        private static ShaderIrOperGpr GprHalf0(this long OpCode, int HalfPart)
+        {
+            return new ShaderIrOperGpr(OpCode.Read(0, 0xff), HalfPart);
+        }
+
+        private static ShaderIrOperGpr GprHalf28(this long OpCode, int HalfPart)
+        {
+            return new ShaderIrOperGpr(OpCode.Read(28, 0xff), HalfPart);
+        }
+
         private static ShaderIrOperImm Imm5_39(this long OpCode)
         {
             return new ShaderIrOperImm(OpCode.Read(39, 0x1f));

--- a/Ryujinx.Graphics/Gal/Shader/ShaderIrOperGpr.cs
+++ b/Ryujinx.Graphics/Gal/Shader/ShaderIrOperGpr.cs
@@ -6,13 +6,26 @@ namespace Ryujinx.Graphics.Gal.Shader
 
         public bool IsConst => Index == ZRIndex;
 
-        public bool IsValidRegister => (Index <= ZRIndex);
+        public bool IsValidRegister => (uint)Index <= ZRIndex;
 
-        public int Index { get; set; }
+        public int Index    { get; set; }
+        public int HalfPart { get; set; }
+
+        public ShaderRegisterSize RegisterSize { get; private set; }
 
         public ShaderIrOperGpr(int Index)
         {
             this.Index = Index;
+
+            RegisterSize = ShaderRegisterSize.Single;
+        }
+
+        public ShaderIrOperGpr(int Index, int HalfPart)
+        {
+            this.Index    = Index;
+            this.HalfPart = HalfPart;
+
+            RegisterSize = ShaderRegisterSize.Half;
         }
 
         public static ShaderIrOperGpr MakeTemporary(int Index = 0)

--- a/Ryujinx.Graphics/Gal/Shader/ShaderOpCodeTable.cs
+++ b/Ryujinx.Graphics/Gal/Shader/ShaderOpCodeTable.cs
@@ -58,6 +58,8 @@ namespace Ryujinx.Graphics.Gal.Shader
             Set("010010111011xx", ShaderDecode.Fsetp_C);
             Set("0011011x1011xx", ShaderDecode.Fsetp_I);
             Set("010110111011xx", ShaderDecode.Fsetp_R);
+            Set("0101110100010x", ShaderDecode.Hadd2_R);
+            Set("0101110100001x", ShaderDecode.Hmul2_R);
             Set("0100110010111x", ShaderDecode.I2f_C);
             Set("0011100x10111x", ShaderDecode.I2f_I);
             Set("0101110010111x", ShaderDecode.I2f_R);
@@ -118,7 +120,7 @@ namespace Ryujinx.Graphics.Gal.Shader
             Set("110000xxxx111x", ShaderDecode.Tex);
             Set("1101111010111x", ShaderDecode.Tex_B);
             Set("1101111101001x", ShaderDecode.Texq);
-            Set("1101100xxxxxxx", ShaderDecode.Texs);
+            Set("1101x00xxxxxxx", ShaderDecode.Texs);
             Set("1101101xxxxxxx", ShaderDecode.Tlds);
             Set("01011111xxxxxx", ShaderDecode.Vmad);
             Set("0100111xxxxxxx", ShaderDecode.Xmad_CR);

--- a/Ryujinx.Graphics/Gal/Shader/ShaderRegisterSize.cs
+++ b/Ryujinx.Graphics/Gal/Shader/ShaderRegisterSize.cs
@@ -1,0 +1,9 @@
+namespace Ryujinx.Graphics.Gal.Shader
+{
+    enum ShaderRegisterSize
+    {
+        Half,
+        Single,
+        Double
+    }
+}

--- a/Ryujinx.Graphics/Gal/ShaderDumper.cs
+++ b/Ryujinx.Graphics/Gal/ShaderDumper.cs
@@ -39,7 +39,7 @@ namespace Ryujinx.Graphics.Gal
                 ulong Instruction = 0;
 
                 //Dump until a NOP instruction is found
-                while ((Instruction >> 52 & 0xfff8) != 0x50b0)
+                while ((Instruction >> 48 & 0xfff8) != 0x50b0)
                 {
                     uint Word0 = (uint)Memory.ReadInt32(Position + 0x50 + Offset + 0);
                     uint Word1 = (uint)Memory.ReadInt32(Position + 0x50 + Offset + 4);


### PR DESCRIPTION
Only HADD, HMUL (register only variants) and TEXS.FP16 are supported so far. Currently it just uses 32-bits floats to store the values, since older gpus doesn't have any support for packed half float values. In the future we may use halfs for the gpus that supports it.

Currently it uses a different set of variables for half and single precision float values. However, on the real GPU they share the same register (with 2 half-precision floating point values on each register), so this approach will not work correctly  on all cases (for example, a MOV from one register to another is not going to work since it moves the 32-bits register). One thing that would work properly is packing and unpacking the 16-bits values into 32-bits registers, but doing this without support from the gpu (`packhalf2x16` and friends) is going to be very expensive. On the future, when we can do more advanced analysis on the code, we should be able to do the right thing and only pack if absolutely needed.

This affects the following game:
https://github.com/Ryujinx/Ryujinx-Games-List/issues/104

May also affect this one (since the issue looks similar):
https://github.com/Ryujinx/Ryujinx-Games-List/issues/114