### PR TITLE
[WIP] Implement speculative translation on the CPU

### DIFF
--- a/ChocolArm64/Instructions/InstEmitFlow.cs
+++ b/ChocolArm64/Instructions/InstEmitFlow.cs
@@ -17,6 +17,8 @@ namespace ChocolArm64.Instructions
             }
             else
             {
+                context.TranslateAhead(op.Imm);
+
                 context.EmitStoreState();
                 context.EmitLdc_I8(op.Imm);
 
@@ -34,6 +36,8 @@ namespace ChocolArm64.Instructions
         public static void Bl(ILEmitterCtx context)
         {
             OpCodeBImmAl64 op = (OpCodeBImmAl64)context.CurrOp;
+
+            context.TranslateAhead(op.Position + 4);
 
             context.EmitLdc_I(op.Position + 4);
             context.EmitStint(CpuThreadState.LrIndex);
@@ -62,6 +66,8 @@ namespace ChocolArm64.Instructions
             }
             else
             {
+                context.TranslateAhead(op.Imm);
+
                 context.EmitLdc_I8(op.Imm);
 
                 context.Emit(OpCodes.Ret);
@@ -71,6 +77,8 @@ namespace ChocolArm64.Instructions
         public static void Blr(ILEmitterCtx context)
         {
             OpCodeBReg64 op = (OpCodeBReg64)context.CurrOp;
+
+            context.TranslateAhead(op.Position + 4);
 
             context.EmitLdintzr(op.Rn);
             context.EmitSttmp();
@@ -142,6 +150,8 @@ namespace ChocolArm64.Instructions
             }
             else
             {
+                BranchTranslateAhead(context, op);
+
                 context.EmitStoreState();
 
                 ILLabel lblTaken = new ILLabel();
@@ -171,6 +181,8 @@ namespace ChocolArm64.Instructions
             }
             else
             {
+                BranchTranslateAhead(context, op);
+
                 context.EmitStoreState();
 
                 ILLabel lblTaken = new ILLabel();
@@ -187,6 +199,12 @@ namespace ChocolArm64.Instructions
 
                 context.Emit(OpCodes.Ret);
             }
+        }
+
+        private static void BranchTranslateAhead(ILEmitterCtx context, OpCodeBImm64 op)
+        {
+            context.TranslateAhead(op.Position + 4);
+            context.TranslateAhead(op.Imm);
         }
     }
 }

--- a/ChocolArm64/TranslatedSub.cs
+++ b/ChocolArm64/TranslatedSub.cs
@@ -11,11 +11,11 @@ namespace ChocolArm64
 {
     class TranslatedSub
     {
-        private delegate long Aa64Subroutine(CpuThreadState register, MemoryManager memory);
+        private const int CallCountForReJit = 250;
 
-        private const int MinCallCountForReJit = 250;
+        private delegate long ArmSubroutine(CpuThreadState register, MemoryManager memory);
 
-        private Aa64Subroutine _execDelegate;
+        private ArmSubroutine _execDelegate;
 
         public static int StateArgIdx  { get; private set; }
         public static int MemoryArgIdx { get; private set; }
@@ -24,30 +24,21 @@ namespace ChocolArm64
 
         public DynamicMethod Method { get; private set; }
 
-        public ReadOnlyCollection<Register> Params { get; private set; }
+        public ReadOnlyCollection<Register> SubArgs { get; private set; }
 
         private HashSet<long> _callers;
 
-        private TranslatedSubType _type;
+        public TranslationCodeQuality TranslationCq { get; private set; }
 
         private int _callCount;
 
-        private bool _needsReJit;
-
-        public TranslatedSub(DynamicMethod method, List<Register> Params)
+        public TranslatedSub(DynamicMethod method, List<Register> subArgs, TranslationCodeQuality translationCq)
         {
-            if (method == null)
-            {
-                throw new ArgumentNullException(nameof(method));
-            }
+            Method = method ?? throw new ArgumentNullException(nameof(method));
 
-            if (Params == null)
-            {
-                throw new ArgumentNullException(nameof(Params));
-            }
+            SubArgs = subArgs?.AsReadOnly() ?? throw new ArgumentNullException(nameof(subArgs));
 
-            Method = method;
-            this.Params = Params.AsReadOnly();
+            TranslationCq = translationCq;
 
             _callers = new HashSet<long>();
 
@@ -56,7 +47,7 @@ namespace ChocolArm64
 
         static TranslatedSub()
         {
-            MethodInfo mthdInfo = typeof(Aa64Subroutine).GetMethod("Invoke");
+            MethodInfo mthdInfo = typeof(ArmSubroutine).GetMethod("Invoke");
 
             ParameterInfo[] Params = mthdInfo.GetParameters();
 
@@ -89,7 +80,7 @@ namespace ChocolArm64
 
             generator.EmitLdargSeq(FixedArgTypes.Length);
 
-            foreach (Register reg in Params)
+            foreach (Register reg in SubArgs)
             {
                 generator.EmitLdarg(StateArgIdx);
 
@@ -99,24 +90,22 @@ namespace ChocolArm64
             generator.Emit(OpCodes.Call, Method);
             generator.Emit(OpCodes.Ret);
 
-            _execDelegate = (Aa64Subroutine)mthd.CreateDelegate(typeof(Aa64Subroutine));
-        }
-
-        public bool ShouldReJit()
-        {
-            if (_needsReJit && _callCount < MinCallCountForReJit)
-            {
-                _callCount++;
-
-                return false;
-            }
-
-            return _needsReJit;
+            _execDelegate = (ArmSubroutine)mthd.CreateDelegate(typeof(ArmSubroutine));
         }
 
         public long Execute(CpuThreadState threadState, MemoryManager memory)
         {
             return _execDelegate(threadState, memory);
+        }
+
+        public bool ShouldReJit()
+        {
+            if (TranslationCq == TranslationCodeQuality.High || _callCount++ != CallCountForReJit)
+            {
+                return false;
+            }
+
+            return true;
         }
 
         public void AddCaller(long position)
@@ -134,17 +123,5 @@ namespace ChocolArm64
                 return _callers.ToArray();
             }
         }
-
-        public void SetType(TranslatedSubType type)
-        {
-            _type = type;
-
-            if (type == TranslatedSubType.SubTier0)
-            {
-                _needsReJit = true;
-            }
-        }
-
-        public void MarkForReJit() => _needsReJit = true;
     }
 }

--- a/ChocolArm64/TranslatedSubType.cs
+++ b/ChocolArm64/TranslatedSubType.cs
@@ -1,8 +1,0 @@
-namespace ChocolArm64
-{
-    enum TranslatedSubType
-    {
-        SubTier0,
-        SubTier1
-    }
-}

--- a/ChocolArm64/TranslationCodeQuality.cs
+++ b/ChocolArm64/TranslationCodeQuality.cs
@@ -1,0 +1,8 @@
+namespace ChocolArm64
+{
+    enum TranslationCodeQuality
+    {
+        Low,
+        High
+    }
+}

--- a/ChocolArm64/TranslationPriority.cs
+++ b/ChocolArm64/TranslationPriority.cs
@@ -1,0 +1,11 @@
+namespace ChocolArm64
+{
+    enum TranslationPriority
+    {
+        High,
+        Medium,
+        Low,
+
+        Count
+    }
+}

--- a/ChocolArm64/TranslatorCache.cs
+++ b/ChocolArm64/TranslatorCache.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/ChocolArm64/TranslatorQueue.cs
+++ b/ChocolArm64/TranslatorQueue.cs
@@ -1,0 +1,56 @@
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace ChocolArm64
+{
+    class TranslatorQueue
+    {
+        private ConcurrentStack<TranslatorQueueItem>[] _translationQueue;
+
+        private AutoResetEvent _queueDataReceivedEvent;
+
+        public TranslatorQueue()
+        {
+            _translationQueue = new ConcurrentStack<TranslatorQueueItem>[(int)TranslationPriority.Count];
+
+            for (int prio = 0; prio < _translationQueue.Length; prio++)
+            {
+                _translationQueue[prio] = new ConcurrentStack<TranslatorQueueItem>();
+            }
+
+            _queueDataReceivedEvent = new AutoResetEvent(false);
+        }
+
+        public void Enqueue(TranslatorQueueItem item)
+        {
+            _translationQueue[(int)item.Priority].Push(item);
+
+            _queueDataReceivedEvent.Set();
+        }
+
+        public bool TryDequeue(out TranslatorQueueItem item)
+        {
+            for (int prio = 0; prio < (int)TranslationPriority.Count; prio++)
+            {
+                if (_translationQueue[prio].TryPop(out item))
+                {
+                    return true;
+                }
+            }
+
+            item = default(TranslatorQueueItem);
+
+            return false;
+        }
+
+        public void WaitForItems()
+        {
+            _queueDataReceivedEvent.WaitOne();
+        }
+
+        public void ForceSignal()
+        {
+            _queueDataReceivedEvent.Set();
+        }
+    }
+}

--- a/ChocolArm64/TranslatorQueueItem.cs
+++ b/ChocolArm64/TranslatorQueueItem.cs
@@ -1,0 +1,23 @@
+namespace ChocolArm64
+{
+    struct TranslatorQueueItem
+    {
+        public long Position { get; private set; }
+        public int  Depth    { get; private set; }
+
+        public TranslationPriority    Priority      { get; private set; }
+        public TranslationCodeQuality TranslationCq { get; private set; }
+
+        public TranslatorQueueItem(
+            long                   position,
+            int                    depth,
+            TranslationPriority    priority,
+            TranslationCodeQuality translationCq)
+        {
+            Position      = position;
+            Depth         = depth;
+            Priority      = priority;
+            TranslationCq = translationCq;
+        }
+    }
+}

--- a/Ryujinx.HLE/HOS/Process.cs
+++ b/Ryujinx.HLE/HOS/Process.cs
@@ -332,7 +332,7 @@ namespace Ryujinx.HLE.HOS
         {
             if (Translator == null)
             {
-                Translator = new Translator();
+                Translator = new Translator(Memory);
 
                 Translator.CpuTrace += CpuTraceHandler;
             }

--- a/Ryujinx.Tests/Cpu/CpuTest.cs
+++ b/Ryujinx.Tests/Cpu/CpuTest.cs
@@ -48,10 +48,12 @@ namespace Ryujinx.Tests.Cpu
 
             _entryPoint = Position;
 
-            Translator translator = new Translator();
             _ramPointer = Marshal.AllocHGlobal(new IntPtr(_size));
             _memory = new MemoryManager(_ramPointer);
             _memory.Map(Position, 0, _size);
+
+            Translator translator = new Translator(_memory);
+
             _thread = new CpuThread(translator, _memory, _entryPoint);
 
             if (_unicornAvailable)


### PR DESCRIPTION
Should decrease startup time a bit on some games. Basically it translates the code on a separate thread, it uses a queue and adds all branch targets of the function being translated to that queue. They are then translated on another thread while the function is running. If the function happens to jump to any of those branch targets, it will be already translated and ready to run. Of course, since it has no way to know where it will or will not jump, it also does some useless work (translating functions that are never called etc).