### PR TITLE
Move MaxUboSize definition

### DIFF
--- a/Ryujinx.Graphics/Gal/OpenGL/OGLShader.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OGLShader.cs
@@ -53,7 +53,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
         {
             GlslProgram Program;
 
-            GlslDecompiler Decompiler = new GlslDecompiler();
+            GlslDecompiler Decompiler = new GlslDecompiler(OGLLimit.MaxUboSize);
 
             int ShaderDumpIndex = ShaderDumper.DumpIndex;
 

--- a/Ryujinx.Graphics/Gal/Shader/GlslDecl.cs
+++ b/Ryujinx.Graphics/Gal/Shader/GlslDecl.cs
@@ -1,4 +1,3 @@
-using Ryujinx.Graphics.Gal.OpenGL;
 using System;
 using System.Collections.Generic;
 
@@ -49,8 +48,6 @@ namespace Ryujinx.Graphics.Gal.Shader
         public const int SsyStackSize = 16;
         public const string SsyStackName = "ssy_stack";
         public const string SsyCursorName = "ssy_cursor";
-
-        public static int MaxUboSize => OGLLimit.MaxUboSize / 16;
 
         private string[] StagePrefixes = new string[] { "vp", "tcp", "tep", "gp", "fp" };
 

--- a/Ryujinx.Graphics/Gal/Shader/GlslDecompiler.cs
+++ b/Ryujinx.Graphics/Gal/Shader/GlslDecompiler.cs
@@ -31,7 +31,7 @@ namespace Ryujinx.Graphics.Gal.Shader
 
         private StringBuilder SB;
 
-        public static int MaxUboSize { get; private set; }
+        public int MaxUboSize { get; }
 
         public GlslDecompiler(int MaxUboSize)
         {
@@ -109,7 +109,7 @@ namespace Ryujinx.Graphics.Gal.Shader
                 { ShaderIrInst.Xor,    GetXorExpr    }
             };
 
-            GlslDecompiler.MaxUboSize = MaxUboSize / 16;
+            this.MaxUboSize = MaxUboSize / 16;
         }
 
         public GlslProgram Decompile(

--- a/Ryujinx.Graphics/Gal/Shader/GlslDecompiler.cs
+++ b/Ryujinx.Graphics/Gal/Shader/GlslDecompiler.cs
@@ -31,7 +31,9 @@ namespace Ryujinx.Graphics.Gal.Shader
 
         private StringBuilder SB;
 
-        public GlslDecompiler()
+        public static int MaxUboSize { get; private set; }
+
+        public GlslDecompiler(int MaxUboSize)
         {
             InstsExpr = new Dictionary<ShaderIrInst, GetInstExpr>()
             {
@@ -106,6 +108,8 @@ namespace Ryujinx.Graphics.Gal.Shader
                 { ShaderIrInst.Utof,   GetUtofExpr   },
                 { ShaderIrInst.Xor,    GetXorExpr    }
             };
+
+            GlslDecompiler.MaxUboSize = MaxUboSize / 16;
         }
 
         public GlslProgram Decompile(
@@ -259,7 +263,7 @@ namespace Ryujinx.Graphics.Gal.Shader
             {
                 SB.AppendLine($"layout (std140) uniform {DeclInfo.Name} {{");
 
-                SB.AppendLine($"{IdentationStr}vec4 {DeclInfo.Name}_data[{GlslDecl.MaxUboSize}];");
+                SB.AppendLine($"{IdentationStr}vec4 {DeclInfo.Name}_data[{MaxUboSize}];");
 
                 SB.AppendLine("};");
             }

--- a/Ryujinx.ShaderTools/Program.cs
+++ b/Ryujinx.ShaderTools/Program.cs
@@ -7,11 +7,13 @@ namespace Ryujinx.ShaderTools
 {
     class Program
     {
+        private static readonly int MaxUboSize = 65536;
+
         static void Main(string[] args)
         {
             if (args.Length == 2)
             {
-                GlslDecompiler Decompiler = new GlslDecompiler(65536);
+                GlslDecompiler Decompiler = new GlslDecompiler(MaxUboSize);
 
                 GalShaderType ShaderType = GalShaderType.Vertex;
 

--- a/Ryujinx.ShaderTools/Program.cs
+++ b/Ryujinx.ShaderTools/Program.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.ShaderTools
         {
             if (args.Length == 2)
             {
-                GlslDecompiler Decompiler = new GlslDecompiler();
+                GlslDecompiler Decompiler = new GlslDecompiler(65536);
 
                 GalShaderType ShaderType = GalShaderType.Vertex;
 


### PR DESCRIPTION
This fix a crash on Ryujinx.ShaderTools caused by the absence of an
OpenGL context.