### PR TITLE
System Language can be configurable

### DIFF
--- a/Ryujinx.HLE/HOS/SystemState/SystemStateMgr.cs
+++ b/Ryujinx.HLE/HOS/SystemState/SystemStateMgr.cs
@@ -54,8 +54,6 @@ namespace Ryujinx.HLE.HOS.SystemState
 
         public SystemStateMgr()
         {
-            SetLanguage(SystemLanguage.AmericanEnglish);
-
             SetAudioOutputAsBuiltInSpeaker();
 
             _profiles = new ConcurrentDictionary<string, UserProfile>();
@@ -71,7 +69,20 @@ namespace Ryujinx.HLE.HOS.SystemState
         {
             DesiredLanguageCode = GetLanguageCode((int)language);
 
-            DesiredTitleLanguage = Enum.Parse<TitleLanguage>(Enum.GetName(typeof(SystemLanguage), language));
+            switch (language)
+            {
+                case SystemLanguage.Taiwanese:
+                case SystemLanguage.TraditionalChinese:
+                    DesiredTitleLanguage = TitleLanguage.Taiwanese;
+                    break;
+                case SystemLanguage.Chinese:
+                case SystemLanguage.SimplifiedChinese:
+                    DesiredTitleLanguage = TitleLanguage.Chinese;
+                    break;
+                default:
+                    DesiredTitleLanguage = Enum.Parse<TitleLanguage>(Enum.GetName(typeof(SystemLanguage), language));
+                    break;
+            }
         }
 
         public void SetAudioOutputAsTv()

--- a/Ryujinx/Config.cs
+++ b/Ryujinx/Config.cs
@@ -1,6 +1,7 @@
 using LibHac;
 using Ryujinx.Common.Logging;
 using Ryujinx.HLE;
+using Ryujinx.HLE.HOS.SystemState;
 using Ryujinx.HLE.Input;
 using Ryujinx.UI.Input;
 using System;
@@ -60,6 +61,10 @@ namespace Ryujinx
                     }
                 }
             }
+
+            SystemLanguage SetLanguage = Enum.Parse<SystemLanguage>(parser.Value("System_Language"));
+
+            device.System.State.SetLanguage(SetLanguage);
 
             device.System.State.DockedMode = Convert.ToBoolean(parser.Value("Docked_Mode"));
 

--- a/Ryujinx/Ryujinx.conf
+++ b/Ryujinx/Ryujinx.conf
@@ -22,6 +22,10 @@ Logging_Enable_Error = true
 #Filtered log classes, seperated by ", ", eg. `Logging_Filtered_Classes = Loader, ServiceFS`
 Logging_Filtered_Classes =
 
+#System Language list: https://gist.github.com/HorrorTroll/b6e4a88d774c3c9b3bdf54d79a7ca43b
+#Change System Language
+System_Language = AmericanEnglish
+
 #Enable or Disable Docked Mode
 Docked_Mode = false
 


### PR DESCRIPTION
This PR supersedes #532, by improving configured Chinese language so that using TraditionalChinese and SimplifiedChinese won't cause exceptions due to parsing [SystemLanguage](https://switchbrew.org/wiki/Settings_services#LanguageCode) enum as [TitleLanguage](https://switchbrew.org/wiki/Control.nacp#Title_Entry).