### PR TITLE
Fix Frecpe_S/V and Frsqrte_S/V (full FP emu.). Add Sse Opt. & SoftFloat Impl. for Fcmeq/ge/gt/le/lt_S/V (Reg & Zero), Faddp_S/V, Fmaxp_V, Fminp_V Inst.; add Sse Opt. for Shll_V, S/Ushll_V Inst.; improve Sse Opt. for Xtn_V Inst.. Add Tests.

### DIFF
--- a/ChocolArm64/Instructions/InstEmitSimdArithmetic.cs
+++ b/ChocolArm64/Instructions/InstEmitSimdArithmetic.cs
@@ -1146,7 +1146,7 @@ namespace ChocolArm64.Instructions
         {
             EmitScalarUnaryOpF(context, () =>
             {
-                EmitUnarySoftFloatCall(context, nameof(SoftFloat.RecipEstimate));
+                EmitSoftFloatCall(context, nameof(SoftFloat32.FPRecipEstimate));
             });
         }
 
@@ -1154,7 +1154,7 @@ namespace ChocolArm64.Instructions
         {
             EmitVectorUnaryOpF(context, () =>
             {
-                EmitUnarySoftFloatCall(context, nameof(SoftFloat.RecipEstimate));
+                EmitSoftFloatCall(context, nameof(SoftFloat32.FPRecipEstimate));
             });
         }
 
@@ -1443,7 +1443,7 @@ namespace ChocolArm64.Instructions
         {
             EmitScalarUnaryOpF(context, () =>
             {
-                EmitUnarySoftFloatCall(context, nameof(SoftFloat.InvSqrtEstimate));
+                EmitSoftFloatCall(context, nameof(SoftFloat32.FPRSqrtEstimate));
             });
         }
 
@@ -1451,7 +1451,7 @@ namespace ChocolArm64.Instructions
         {
             EmitVectorUnaryOpF(context, () =>
             {
-                EmitUnarySoftFloatCall(context, nameof(SoftFloat.InvSqrtEstimate));
+                EmitSoftFloatCall(context, nameof(SoftFloat32.FPRSqrtEstimate));
             });
         }
 

--- a/ChocolArm64/Instructions/InstEmitSimdArithmetic.cs
+++ b/ChocolArm64/Instructions/InstEmitSimdArithmetic.cs
@@ -1251,18 +1251,42 @@ namespace ChocolArm64.Instructions
 
         public static void Frecpe_S(ILEmitterCtx context)
         {
-            EmitScalarUnaryOpF(context, () =>
+            OpCodeSimd64 op = (OpCodeSimd64)context.CurrOp;
+
+            int sizeF = op.Size & 1;
+
+            if (Optimizations.FastFP && Optimizations.UseSse
+                                     && sizeF == 0)
             {
-                EmitSoftFloatCall(context, nameof(SoftFloat32.FPRecipEstimate));
-            });
+                EmitScalarSseOrSse2OpF(context, nameof(Sse.ReciprocalScalar));
+            }
+            else
+            {
+                EmitScalarUnaryOpF(context, () =>
+                {
+                    EmitSoftFloatCall(context, nameof(SoftFloat32.FPRecipEstimate));
+                });
+            }
         }
 
         public static void Frecpe_V(ILEmitterCtx context)
         {
-            EmitVectorUnaryOpF(context, () =>
+            OpCodeSimd64 op = (OpCodeSimd64)context.CurrOp;
+
+            int sizeF = op.Size & 1;
+
+            if (Optimizations.FastFP && Optimizations.UseSse
+                                     && sizeF == 0)
             {
-                EmitSoftFloatCall(context, nameof(SoftFloat32.FPRecipEstimate));
-            });
+                EmitVectorSseOrSse2OpF(context, nameof(Sse.Reciprocal));
+            }
+            else
+            {
+                EmitVectorUnaryOpF(context, () =>
+                {
+                    EmitSoftFloatCall(context, nameof(SoftFloat32.FPRecipEstimate));
+                });
+            }
         }
 
         public static void Frecps_S(ILEmitterCtx context) // Fused.
@@ -1548,18 +1572,42 @@ namespace ChocolArm64.Instructions
 
         public static void Frsqrte_S(ILEmitterCtx context)
         {
-            EmitScalarUnaryOpF(context, () =>
+            OpCodeSimd64 op = (OpCodeSimd64)context.CurrOp;
+
+            int sizeF = op.Size & 1;
+
+            if (Optimizations.FastFP && Optimizations.UseSse
+                                     && sizeF == 0)
             {
-                EmitSoftFloatCall(context, nameof(SoftFloat32.FPRSqrtEstimate));
-            });
+                EmitScalarSseOrSse2OpF(context, nameof(Sse.ReciprocalSqrtScalar));
+            }
+            else
+            {
+                EmitScalarUnaryOpF(context, () =>
+                {
+                    EmitSoftFloatCall(context, nameof(SoftFloat32.FPRSqrtEstimate));
+                });
+            }
         }
 
         public static void Frsqrte_V(ILEmitterCtx context)
         {
-            EmitVectorUnaryOpF(context, () =>
+            OpCodeSimd64 op = (OpCodeSimd64)context.CurrOp;
+
+            int sizeF = op.Size & 1;
+
+            if (Optimizations.FastFP && Optimizations.UseSse
+                                     && sizeF == 0)
             {
-                EmitSoftFloatCall(context, nameof(SoftFloat32.FPRSqrtEstimate));
-            });
+                EmitVectorSseOrSse2OpF(context, nameof(Sse.ReciprocalSqrt));
+            }
+            else
+            {
+                EmitVectorUnaryOpF(context, () =>
+                {
+                    EmitSoftFloatCall(context, nameof(SoftFloat32.FPRSqrtEstimate));
+                });
+            }
         }
 
         public static void Frsqrts_S(ILEmitterCtx context) // Fused.

--- a/ChocolArm64/Instructions/InstEmitSimdCmp.cs
+++ b/ChocolArm64/Instructions/InstEmitSimdCmp.cs
@@ -15,7 +15,7 @@ namespace ChocolArm64.Instructions
     {
         public static void Cmeq_S(ILEmitterCtx context)
         {
-            EmitCmp(context, OpCodes.Beq_S, scalar: true);
+            EmitCmpOp(context, OpCodes.Beq_S, scalar: true);
         }
 
         public static void Cmeq_V(ILEmitterCtx context)
@@ -32,28 +32,28 @@ namespace ChocolArm64.Instructions
                 }
                 else
                 {
-                    EmitCmp(context, OpCodes.Beq_S, scalar: false);
+                    EmitCmpOp(context, OpCodes.Beq_S, scalar: false);
                 }
             }
             else
             {
-                EmitCmp(context, OpCodes.Beq_S, scalar: false);
+                EmitCmpOp(context, OpCodes.Beq_S, scalar: false);
             }
         }
 
         public static void Cmge_S(ILEmitterCtx context)
         {
-            EmitCmp(context, OpCodes.Bge_S, scalar: true);
+            EmitCmpOp(context, OpCodes.Bge_S, scalar: true);
         }
 
         public static void Cmge_V(ILEmitterCtx context)
         {
-            EmitCmp(context, OpCodes.Bge_S, scalar: false);
+            EmitCmpOp(context, OpCodes.Bge_S, scalar: false);
         }
 
         public static void Cmgt_S(ILEmitterCtx context)
         {
-            EmitCmp(context, OpCodes.Bgt_S, scalar: true);
+            EmitCmpOp(context, OpCodes.Bgt_S, scalar: true);
         }
 
         public static void Cmgt_V(ILEmitterCtx context)
@@ -70,63 +70,63 @@ namespace ChocolArm64.Instructions
                 }
                 else
                 {
-                    EmitCmp(context, OpCodes.Bgt_S, scalar: false);
+                    EmitCmpOp(context, OpCodes.Bgt_S, scalar: false);
                 }
             }
             else
             {
-                EmitCmp(context, OpCodes.Bgt_S, scalar: false);
+                EmitCmpOp(context, OpCodes.Bgt_S, scalar: false);
             }
         }
 
         public static void Cmhi_S(ILEmitterCtx context)
         {
-            EmitCmp(context, OpCodes.Bgt_Un_S, scalar: true);
+            EmitCmpOp(context, OpCodes.Bgt_Un_S, scalar: true);
         }
 
         public static void Cmhi_V(ILEmitterCtx context)
         {
-            EmitCmp(context, OpCodes.Bgt_Un_S, scalar: false);
+            EmitCmpOp(context, OpCodes.Bgt_Un_S, scalar: false);
         }
 
         public static void Cmhs_S(ILEmitterCtx context)
         {
-            EmitCmp(context, OpCodes.Bge_Un_S, scalar: true);
+            EmitCmpOp(context, OpCodes.Bge_Un_S, scalar: true);
         }
 
         public static void Cmhs_V(ILEmitterCtx context)
         {
-            EmitCmp(context, OpCodes.Bge_Un_S, scalar: false);
+            EmitCmpOp(context, OpCodes.Bge_Un_S, scalar: false);
         }
 
         public static void Cmle_S(ILEmitterCtx context)
         {
-            EmitCmp(context, OpCodes.Ble_S, scalar: true);
+            EmitCmpOp(context, OpCodes.Ble_S, scalar: true);
         }
 
         public static void Cmle_V(ILEmitterCtx context)
         {
-            EmitCmp(context, OpCodes.Ble_S, scalar: false);
+            EmitCmpOp(context, OpCodes.Ble_S, scalar: false);
         }
 
         public static void Cmlt_S(ILEmitterCtx context)
         {
-            EmitCmp(context, OpCodes.Blt_S, scalar: true);
+            EmitCmpOp(context, OpCodes.Blt_S, scalar: true);
         }
 
         public static void Cmlt_V(ILEmitterCtx context)
         {
-            EmitCmp(context, OpCodes.Blt_S, scalar: false);
+            EmitCmpOp(context, OpCodes.Blt_S, scalar: false);
         }
 
         public static void Cmtst_S(ILEmitterCtx context)
         {
-            EmitCmtst(context, scalar: true);
+            EmitCmtstOp(context, scalar: true);
         }
 
         public static void Cmtst_V(ILEmitterCtx context)
         {
-            EmitCmtst(context, scalar: false);
+            EmitCmtstOp(context, scalar: false);
         }
 
         public static void Fccmp_S(ILEmitterCtx context)
@@ -145,7 +145,7 @@ namespace ChocolArm64.Instructions
 
             context.MarkLabel(lblTrue);
 
-            EmitFcmpE(context, signalNaNs: false);
+            EmitFcmpOrFcmpe(context, signalNaNs: false);
 
             context.MarkLabel(lblEnd);
         }
@@ -166,120 +166,152 @@ namespace ChocolArm64.Instructions
 
             context.MarkLabel(lblTrue);
 
-            EmitFcmpE(context, signalNaNs: true);
+            EmitFcmpOrFcmpe(context, signalNaNs: true);
 
             context.MarkLabel(lblEnd);
         }
 
         public static void Fcmeq_S(ILEmitterCtx context)
         {
-            if (context.CurrOp is OpCodeSimdReg64 && Optimizations.UseSse
-                                                  && Optimizations.UseSse2)
+            if (Optimizations.FastFP && Optimizations.UseSse
+                                     && Optimizations.UseSse2)
             {
-                EmitScalarSseOrSse2OpF(context, nameof(Sse.CompareEqualScalar));
+                EmitCmpSseOrSse2OpF(context, nameof(Sse.CompareEqualScalar), scalar: true);
             }
             else
             {
-                EmitScalarFcmp(context, OpCodes.Beq_S);
+                EmitCmpOpF(context, nameof(SoftFloat32.FPCompareEQ), scalar: true);
             }
         }
 
         public static void Fcmeq_V(ILEmitterCtx context)
         {
-            if (context.CurrOp is OpCodeSimdReg64 && Optimizations.UseSse
-                                                  && Optimizations.UseSse2)
+            if (Optimizations.FastFP && Optimizations.UseSse
+                                     && Optimizations.UseSse2)
             {
-                EmitVectorSseOrSse2OpF(context, nameof(Sse.CompareEqual));
+                EmitCmpSseOrSse2OpF(context, nameof(Sse.CompareEqual), scalar: false);
             }
             else
             {
-                EmitVectorFcmp(context, OpCodes.Beq_S);
+                EmitCmpOpF(context, nameof(SoftFloat32.FPCompareEQ), scalar: false);
             }
         }
 
         public static void Fcmge_S(ILEmitterCtx context)
         {
-            if (context.CurrOp is OpCodeSimdReg64 && Optimizations.UseSse
-                                                  && Optimizations.UseSse2)
+            if (Optimizations.FastFP && Optimizations.UseSse
+                                     && Optimizations.UseSse2)
             {
-                EmitScalarSseOrSse2OpF(context, nameof(Sse.CompareGreaterThanOrEqualScalar));
+                EmitCmpSseOrSse2OpF(context, nameof(Sse.CompareGreaterThanOrEqualScalar), scalar: true);
             }
             else
             {
-                EmitScalarFcmp(context, OpCodes.Bge_S);
+                EmitCmpOpF(context, nameof(SoftFloat32.FPCompareGE), scalar: true);
             }
         }
 
         public static void Fcmge_V(ILEmitterCtx context)
         {
-            if (context.CurrOp is OpCodeSimdReg64 && Optimizations.UseSse
-                                                  && Optimizations.UseSse2)
+            if (Optimizations.FastFP && Optimizations.UseSse
+                                     && Optimizations.UseSse2)
             {
-                EmitVectorSseOrSse2OpF(context, nameof(Sse.CompareGreaterThanOrEqual));
+                EmitCmpSseOrSse2OpF(context, nameof(Sse.CompareGreaterThanOrEqual), scalar: false);
             }
             else
             {
-                EmitVectorFcmp(context, OpCodes.Bge_S);
+                EmitCmpOpF(context, nameof(SoftFloat32.FPCompareGE), scalar: false);
             }
         }
 
         public static void Fcmgt_S(ILEmitterCtx context)
         {
-            if (context.CurrOp is OpCodeSimdReg64 && Optimizations.UseSse
-                                                  && Optimizations.UseSse2)
+            if (Optimizations.FastFP && Optimizations.UseSse
+                                     && Optimizations.UseSse2)
             {
-                EmitScalarSseOrSse2OpF(context, nameof(Sse.CompareGreaterThanScalar));
+                EmitCmpSseOrSse2OpF(context, nameof(Sse.CompareGreaterThanScalar), scalar: true);
             }
             else
             {
-                EmitScalarFcmp(context, OpCodes.Bgt_S);
+                EmitCmpOpF(context, nameof(SoftFloat32.FPCompareGT), scalar: true);
             }
         }
 
         public static void Fcmgt_V(ILEmitterCtx context)
         {
-            if (context.CurrOp is OpCodeSimdReg64 && Optimizations.UseSse
-                                                  && Optimizations.UseSse2)
+            if (Optimizations.FastFP && Optimizations.UseSse
+                                     && Optimizations.UseSse2)
             {
-                EmitVectorSseOrSse2OpF(context, nameof(Sse.CompareGreaterThan));
+                EmitCmpSseOrSse2OpF(context, nameof(Sse.CompareGreaterThan), scalar: false);
             }
             else
             {
-                EmitVectorFcmp(context, OpCodes.Bgt_S);
+                EmitCmpOpF(context, nameof(SoftFloat32.FPCompareGT), scalar: false);
             }
         }
 
         public static void Fcmle_S(ILEmitterCtx context)
         {
-            EmitScalarFcmp(context, OpCodes.Ble_S);
+            if (Optimizations.FastFP && Optimizations.UseSse
+                                     && Optimizations.UseSse2)
+            {
+                EmitCmpSseOrSse2OpF(context, nameof(Sse.CompareGreaterThanOrEqualScalar), scalar: true, isLeOrLt: true);
+            }
+            else
+            {
+                EmitCmpOpF(context, nameof(SoftFloat32.FPCompareLE), scalar: true);
+            }
         }
 
         public static void Fcmle_V(ILEmitterCtx context)
         {
-            EmitVectorFcmp(context, OpCodes.Ble_S);
+            if (Optimizations.FastFP && Optimizations.UseSse
+                                     && Optimizations.UseSse2)
+            {
+                EmitCmpSseOrSse2OpF(context, nameof(Sse.CompareGreaterThanOrEqual), scalar: false, isLeOrLt: true);
+            }
+            else
+            {
+                EmitCmpOpF(context, nameof(SoftFloat32.FPCompareLE), scalar: false);
+            }
         }
 
         public static void Fcmlt_S(ILEmitterCtx context)
         {
-            EmitScalarFcmp(context, OpCodes.Blt_S);
+            if (Optimizations.FastFP && Optimizations.UseSse
+                                     && Optimizations.UseSse2)
+            {
+                EmitCmpSseOrSse2OpF(context, nameof(Sse.CompareGreaterThanScalar), scalar: true, isLeOrLt: true);
+            }
+            else
+            {
+                EmitCmpOpF(context, nameof(SoftFloat32.FPCompareLT), scalar: true);
+            }
         }
 
         public static void Fcmlt_V(ILEmitterCtx context)
         {
-            EmitVectorFcmp(context, OpCodes.Blt_S);
+            if (Optimizations.FastFP && Optimizations.UseSse
+                                     && Optimizations.UseSse2)
+            {
+                EmitCmpSseOrSse2OpF(context, nameof(Sse.CompareGreaterThan), scalar: false, isLeOrLt: true);
+            }
+            else
+            {
+                EmitCmpOpF(context, nameof(SoftFloat32.FPCompareLT), scalar: false);
+            }
         }
 
         public static void Fcmp_S(ILEmitterCtx context)
         {
-            EmitFcmpE(context, signalNaNs: false);
+            EmitFcmpOrFcmpe(context, signalNaNs: false);
         }
 
         public static void Fcmpe_S(ILEmitterCtx context)
         {
-            EmitFcmpE(context, signalNaNs: true);
+            EmitFcmpOrFcmpe(context, signalNaNs: true);
         }
 
-        private static void EmitFcmpE(ILEmitterCtx context, bool signalNaNs)
+        private static void EmitFcmpOrFcmpe(ILEmitterCtx context, bool signalNaNs)
         {
             OpCodeSimdReg64 op = (OpCodeSimdReg64)context.CurrOp;
 
@@ -430,7 +462,7 @@ namespace ChocolArm64.Instructions
                     {
                         context.EmitLdc_R4(0f);
                     }
-                    else // if (op.Size == 1)
+                    else /* if (op.Size == 1) */
                     {
                         context.EmitLdc_R8(0d);
                     }
@@ -448,7 +480,7 @@ namespace ChocolArm64.Instructions
             }
         }
 
-        private static void EmitCmp(ILEmitterCtx context, OpCode ilOp, bool scalar)
+        private static void EmitCmpOp(ILEmitterCtx context, OpCode ilOp, bool scalar)
         {
             OpCodeSimd64 op = (OpCodeSimd64)context.CurrOp;
 
@@ -492,7 +524,7 @@ namespace ChocolArm64.Instructions
             }
         }
 
-        private static void EmitCmtst(ILEmitterCtx context, bool scalar)
+        private static void EmitCmtstOp(ILEmitterCtx context, bool scalar)
         {
             OpCodeSimdReg64 op = (OpCodeSimdReg64)context.CurrOp;
 
@@ -532,84 +564,134 @@ namespace ChocolArm64.Instructions
             }
         }
 
-        private static void EmitScalarFcmp(ILEmitterCtx context, OpCode ilOp)
-        {
-            EmitFcmp(context, ilOp, 0, scalar: true);
-        }
-
-        private static void EmitVectorFcmp(ILEmitterCtx context, OpCode ilOp)
+        private static void EmitCmpOpF(ILEmitterCtx context, string name, bool scalar)
         {
             OpCodeSimd64 op = (OpCodeSimd64)context.CurrOp;
 
             int sizeF = op.Size & 1;
 
             int bytes = op.GetBitsCount() >> 3;
-            int elems = bytes >> sizeF + 2;
+            int elems = !scalar ? bytes >> sizeF + 2 : 1;
 
             for (int index = 0; index < elems; index++)
             {
-                EmitFcmp(context, ilOp, index, scalar: false);
+                EmitVectorExtractF(context, op.Rn, index, sizeF);
+
+                if (op is OpCodeSimdReg64 binOp)
+                {
+                    EmitVectorExtractF(context, binOp.Rm, index, sizeF);
+                }
+                else
+                {
+                    if (sizeF == 0)
+                    {
+                        context.EmitLdc_R4(0f);
+                    }
+                    else /* if (sizeF == 1) */
+                    {
+                        context.EmitLdc_R8(0d);
+                    }
+                }
+
+                EmitSoftFloatCall(context, name);
+
+                EmitVectorInsertF(context, op.Rd, index, sizeF);
             }
 
-            if (op.RegisterSize == RegisterSize.Simd64)
+            if (!scalar)
             {
-                EmitVectorZeroUpper(context, op.Rd);
+                if (op.RegisterSize == RegisterSize.Simd64)
+                {
+                    EmitVectorZeroUpper(context, op.Rd);
+                }
+            }
+            else
+            {
+                if (sizeF == 0)
+                {
+                    EmitVectorZero32_128(context, op.Rd);
+                }
+                else /* if (sizeF == 1) */
+                {
+                    EmitVectorZeroUpper(context, op.Rd);
+                }
             }
         }
 
-        private static void EmitFcmp(ILEmitterCtx context, OpCode ilOp, int index, bool scalar)
+        private static void EmitCmpSseOrSse2OpF(ILEmitterCtx context, string name, bool scalar, bool isLeOrLt = false)
         {
             OpCodeSimd64 op = (OpCodeSimd64)context.CurrOp;
 
             int sizeF = op.Size & 1;
 
-            ulong szMask = ulong.MaxValue >> (64 - (32 << sizeF));
-
-            EmitVectorExtractF(context, op.Rn, index, sizeF);
-
-            if (op is OpCodeSimdReg64 binOp)
+            if (sizeF == 0)
             {
-                EmitVectorExtractF(context, binOp.Rm, index, sizeF);
-            }
-            else if (sizeF == 0)
-            {
-                context.EmitLdc_R4(0f);
+                Type[] types = new Type[] { typeof(Vector128<float>), typeof(Vector128<float>) };
+
+                if (!isLeOrLt)
+                {
+                    context.EmitLdvec(op.Rn);
+                }
+
+                if (op is OpCodeSimdReg64 binOp)
+                {
+                    context.EmitLdvec(binOp.Rm);
+                }
+                else
+                {
+                    VectorHelper.EmitCall(context, nameof(VectorHelper.VectorSingleZero));
+                }
+
+                if (isLeOrLt)
+                {
+                    context.EmitLdvec(op.Rn);
+                }
+
+                context.EmitCall(typeof(Sse).GetMethod(name, types));
+
+                context.EmitStvec(op.Rd);
+
+                if (scalar)
+                {
+                    EmitVectorZero32_128(context, op.Rd);
+                }
+                else if (op.RegisterSize == RegisterSize.Simd64)
+                {
+                    EmitVectorZeroUpper(context, op.Rd);
+                }
             }
             else /* if (sizeF == 1) */
             {
-                context.EmitLdc_R8(0d);
+                Type[] types = new Type[] { typeof(Vector128<double>), typeof(Vector128<double>) };
+
+                if (!isLeOrLt)
+                {
+                    EmitLdvecWithCastToDouble(context, op.Rn);
+                }
+
+                if (op is OpCodeSimdReg64 binOp)
+                {
+                    EmitLdvecWithCastToDouble(context, binOp.Rm);
+                }
+                else
+                {
+                    VectorHelper.EmitCall(context, nameof(VectorHelper.VectorDoubleZero));
+                }
+
+                if (isLeOrLt)
+                {
+                    EmitLdvecWithCastToDouble(context, op.Rn);
+                }
+
+                context.EmitCall(typeof(Sse2).GetMethod(name, types));
+
+                EmitStvecWithCastFromDouble(context, op.Rd);
+
+                if (scalar)
+                {
+                    EmitVectorZeroUpper(context, op.Rd);
+                }
             }
-
-            ILLabel lblTrue = new ILLabel();
-            ILLabel lblEnd  = new ILLabel();
-
-            context.Emit(ilOp, lblTrue);
-
-            if (scalar)
-            {
-                EmitVectorZeroAll(context, op.Rd);
-            }
-            else
-            {
-                EmitVectorInsert(context, op.Rd, index, sizeF + 2, 0);
-            }
-
-            context.Emit(OpCodes.Br_S, lblEnd);
-
-            context.MarkLabel(lblTrue);
-
-            if (scalar)
-            {
-                EmitVectorInsert(context, op.Rd, index, 3, (long)szMask);
-
-                EmitVectorZeroUpper(context, op.Rd);
-            }
-            else
-            {
-                EmitVectorInsert(context, op.Rd, index, sizeF + 2, (long)szMask);
-            }
-
-            context.MarkLabel(lblEnd);
         }
     }
 }

--- a/ChocolArm64/Instructions/InstEmitSimdHelper.cs
+++ b/ChocolArm64/Instructions/InstEmitSimdHelper.cs
@@ -322,26 +322,6 @@ namespace ChocolArm64.Instructions
             context.EmitCall(mthdInfo);
         }
 
-        public static void EmitUnarySoftFloatCall(ILEmitterCtx context, string name)
-        {
-            IOpCodeSimd64 op = (IOpCodeSimd64)context.CurrOp;
-
-            int sizeF = op.Size & 1;
-
-            MethodInfo mthdInfo;
-
-            if (sizeF == 0)
-            {
-                mthdInfo = typeof(SoftFloat).GetMethod(name, new Type[] { typeof(float) });
-            }
-            else /* if (sizeF == 1) */
-            {
-                mthdInfo = typeof(SoftFloat).GetMethod(name, new Type[] { typeof(double) });
-            }
-
-            context.EmitCall(mthdInfo);
-        }
-
         public static void EmitSoftFloatCall(ILEmitterCtx context, string name)
         {
             IOpCodeSimd64 op = (IOpCodeSimd64)context.CurrOp;

--- a/ChocolArm64/Instructions/InstEmitSimdHelper.cs
+++ b/ChocolArm64/Instructions/InstEmitSimdHelper.cs
@@ -909,6 +909,96 @@ namespace ChocolArm64.Instructions
             }
         }
 
+        public static void EmitVectorPairwiseSseOrSse2OpF(ILEmitterCtx context, string name)
+        {
+            OpCodeSimdReg64 op = (OpCodeSimdReg64)context.CurrOp;
+
+            int sizeF = op.Size & 1;
+
+            if (sizeF == 0)
+            {
+                if (op.RegisterSize == RegisterSize.Simd64)
+                {
+                    Type[] types = new Type[] { typeof(Vector128<float>), typeof(Vector128<float>) };
+
+                    context.EmitLdvec(op.Rn);
+                    context.EmitLdvec(op.Rm);
+
+                    context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.UnpackLow), types));
+
+                    context.Emit(OpCodes.Dup);
+                    context.EmitStvectmp();
+
+                    VectorHelper.EmitCall(context, nameof(VectorHelper.VectorSingleZero));
+
+                    context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.MoveLowToHigh), types));
+
+                    VectorHelper.EmitCall(context, nameof(VectorHelper.VectorSingleZero));
+
+                    context.EmitLdvectmp();
+
+                    context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.MoveHighToLow), types));
+
+                    context.EmitCall(typeof(Sse).GetMethod(name, types));
+
+                    context.EmitStvec(op.Rd);
+                }
+                else /* if (op.RegisterSize == RegisterSize.Simd128) */
+                {
+                    Type[] typesSfl = new Type[] { typeof(Vector128<float>), typeof(Vector128<float>), typeof(byte) };
+                    Type[] types    = new Type[] { typeof(Vector128<float>), typeof(Vector128<float>) };
+
+                    context.EmitLdvec(op.Rn);
+
+                    context.Emit(OpCodes.Dup);
+                    context.EmitStvectmp();
+
+                    context.EmitLdvec(op.Rm);
+
+                    context.Emit(OpCodes.Dup);
+                    context.EmitStvectmp2();
+
+                    context.EmitLdc_I4(2 << 6 | 0 << 4 | 2 << 2 | 0 << 0);
+                    context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.Shuffle), typesSfl));
+
+                    context.EmitLdvectmp();
+                    context.EmitLdvectmp2();
+
+                    context.EmitLdc_I4(3 << 6 | 1 << 4 | 3 << 2 | 1 << 0);
+                    context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.Shuffle), typesSfl));
+
+                    context.EmitCall(typeof(Sse).GetMethod(name, types));
+
+                    context.EmitStvec(op.Rd);
+                }
+            }
+            else /* if (sizeF == 1) */
+            {
+                Type[] types = new Type[] { typeof(Vector128<double>), typeof(Vector128<double>) };
+
+                EmitLdvecWithCastToDouble(context, op.Rn);
+
+                context.Emit(OpCodes.Dup);
+                context.EmitStvectmp();
+
+                EmitLdvecWithCastToDouble(context, op.Rm);
+
+                context.Emit(OpCodes.Dup);
+                context.EmitStvectmp2();
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.UnpackLow), types));
+
+                context.EmitLdvectmp();
+                context.EmitLdvectmp2();
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.UnpackHigh), types));
+
+                context.EmitCall(typeof(Sse2).GetMethod(name, types));
+
+                EmitStvecWithCastFromDouble(context, op.Rd);
+            }
+        }
+
         [Flags]
         public enum SaturatingFlags
         {

--- a/ChocolArm64/Instructions/SoftFloat.cs
+++ b/ChocolArm64/Instructions/SoftFloat.cs
@@ -20,9 +20,9 @@ namespace ChocolArm64.Instructions
         {
             byte[] tbl = new byte[256];
 
-            for (uint idx = 0u; idx < 256u; idx++)
+            for (int idx = 0; idx < 256; idx++)
             {
-                uint src = idx + 256u;
+                uint src = (uint)idx + 256u;
 
                 Debug.Assert(256u <= src && src < 512u);
 
@@ -44,9 +44,9 @@ namespace ChocolArm64.Instructions
         {
             byte[] tbl = new byte[384];
 
-            for (uint idx = 0u; idx < 384u; idx++)
+            for (int idx = 0; idx < 384; idx++)
             {
-                uint src = idx + 128u;
+                uint src = (uint)idx + 128u;
 
                 Debug.Assert(128u <= src && src < 512u);
 
@@ -1225,7 +1225,7 @@ namespace ChocolArm64.Instructions
 
                 uint resultExp = 253u - exp;
 
-                uint estimate = SoftFloat.RecipEstimateTable[scaled - 256u] + 256u;
+                uint estimate = (uint)SoftFloat.RecipEstimateTable[(int)(scaled - 256u)] + 256u;
 
                 fraction = (ulong)(estimate & 0xFFu) << 44;
 
@@ -1370,7 +1370,7 @@ namespace ChocolArm64.Instructions
 
                 uint resultExp = (380u - exp) >> 1;
 
-                uint estimate = SoftFloat.InvSqrtEstimateTable[scaled - 128u] + 256u;
+                uint estimate = (uint)SoftFloat.InvSqrtEstimateTable[(int)(scaled - 128u)] + 256u;
 
                 result = BitConverter.Int32BitsToSingle((int)((resultExp & 0xFFu) << 23 | (estimate & 0xFFu) << 15));
             }
@@ -2309,7 +2309,7 @@ namespace ChocolArm64.Instructions
 
                 uint resultExp = 2045u - exp;
 
-                uint estimate = SoftFloat.RecipEstimateTable[scaled - 256u] + 256u;
+                uint estimate = (uint)SoftFloat.RecipEstimateTable[(int)(scaled - 256u)] + 256u;
 
                 fraction = (ulong)(estimate & 0xFFu) << 44;
 
@@ -2454,7 +2454,7 @@ namespace ChocolArm64.Instructions
 
                 uint resultExp = (3068u - exp) >> 1;
 
-                uint estimate = SoftFloat.InvSqrtEstimateTable[scaled - 128u] + 256u;
+                uint estimate = (uint)SoftFloat.InvSqrtEstimateTable[(int)(scaled - 128u)] + 256u;
 
                 result = BitConverter.Int64BitsToDouble((long)((resultExp & 0x7FFul) << 52 | (estimate & 0xFFul) << 44));
             }

--- a/ChocolArm64/Instructions/SoftFloat.cs
+++ b/ChocolArm64/Instructions/SoftFloat.cs
@@ -826,6 +826,94 @@ namespace ChocolArm64.Instructions
             return result;
         }
 
+        public static float FPCompareEQ(float value1, float value2, CpuThreadState state)
+        {
+            Debug.WriteLineIf(state.Fpcr != 0, $"SoftFloat32.FPCompareEQ: state.Fpcr = 0x{state.Fpcr:X8}");
+
+            value1 = value1.FPUnpack(out FpType type1, out _, out _, state);
+            value2 = value2.FPUnpack(out FpType type2, out _, out _, state);
+
+            float result;
+
+            if (type1 == FpType.SNaN || type1 == FpType.QNaN || type2 == FpType.SNaN || type2 == FpType.QNaN)
+            {
+                result = ZerosOrOnes(false);
+
+                if (type1 == FpType.SNaN || type2 == FpType.SNaN)
+                {
+                    FPProcessException(FpExc.InvalidOp, state);
+                }
+            }
+            else
+            {
+                result = ZerosOrOnes(value1 == value2);
+            }
+
+            return result;
+        }
+
+        public static float FPCompareGE(float value1, float value2, CpuThreadState state)
+        {
+            Debug.WriteLineIf(state.Fpcr != 0, $"SoftFloat32.FPCompareGE: state.Fpcr = 0x{state.Fpcr:X8}");
+
+            value1 = value1.FPUnpack(out FpType type1, out _, out _, state);
+            value2 = value2.FPUnpack(out FpType type2, out _, out _, state);
+
+            float result;
+
+            if (type1 == FpType.SNaN || type1 == FpType.QNaN || type2 == FpType.SNaN || type2 == FpType.QNaN)
+            {
+                result = ZerosOrOnes(false);
+
+                FPProcessException(FpExc.InvalidOp, state);
+            }
+            else
+            {
+                result = ZerosOrOnes(value1 >= value2);
+            }
+
+            return result;
+        }
+
+        public static float FPCompareGT(float value1, float value2, CpuThreadState state)
+        {
+            Debug.WriteLineIf(state.Fpcr != 0, $"SoftFloat32.FPCompareGT: state.Fpcr = 0x{state.Fpcr:X8}");
+
+            value1 = value1.FPUnpack(out FpType type1, out _, out _, state);
+            value2 = value2.FPUnpack(out FpType type2, out _, out _, state);
+
+            float result;
+
+            if (type1 == FpType.SNaN || type1 == FpType.QNaN || type2 == FpType.SNaN || type2 == FpType.QNaN)
+            {
+                result = ZerosOrOnes(false);
+
+                FPProcessException(FpExc.InvalidOp, state);
+            }
+            else
+            {
+                result = ZerosOrOnes(value1 > value2);
+            }
+
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float FPCompareLE(float value1, float value2, CpuThreadState state)
+        {
+            Debug.WriteLineIf(state.Fpcr != 0, $"SoftFloat32.FPCompareLE: state.Fpcr = 0x{state.Fpcr:X8}");
+
+            return FPCompareGE(value2, value1, state);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float FPCompareLT(float value1, float value2, CpuThreadState state)
+        {
+            Debug.WriteLineIf(state.Fpcr != 0, $"SoftFloat32.FPCompareLT: state.Fpcr = 0x{state.Fpcr:X8}");
+
+            return FPCompareGT(value2, value1, state);
+        }
+
         public static float FPDiv(float value1, float value2, CpuThreadState state)
         {
             Debug.WriteLineIf(state.Fpcr != 0, $"SoftFloat32.FPDiv: state.Fpcr = 0x{state.Fpcr:X8}");
@@ -1417,6 +1505,11 @@ namespace ChocolArm64.Instructions
             return -value;
         }
 
+        private static float ZerosOrOnes(bool zeros)
+        {
+            return BitConverter.Int32BitsToSingle(!zeros ? 0 : -1);
+        }
+
         private static float FPUnpack(
             this float value,
             out FpType type,
@@ -1656,6 +1749,94 @@ namespace ChocolArm64.Instructions
             }
 
             return result;
+        }
+
+        public static double FPCompareEQ(double value1, double value2, CpuThreadState state)
+        {
+            Debug.WriteLineIf(state.Fpcr != 0, $"SoftFloat64.FPCompareEQ: state.Fpcr = 0x{state.Fpcr:X8}");
+
+            value1 = value1.FPUnpack(out FpType type1, out _, out _, state);
+            value2 = value2.FPUnpack(out FpType type2, out _, out _, state);
+
+            double result;
+
+            if (type1 == FpType.SNaN || type1 == FpType.QNaN || type2 == FpType.SNaN || type2 == FpType.QNaN)
+            {
+                result = ZerosOrOnes(false);
+
+                if (type1 == FpType.SNaN || type2 == FpType.SNaN)
+                {
+                    FPProcessException(FpExc.InvalidOp, state);
+                }
+            }
+            else
+            {
+                result = ZerosOrOnes(value1 == value2);
+            }
+
+            return result;
+        }
+
+        public static double FPCompareGE(double value1, double value2, CpuThreadState state)
+        {
+            Debug.WriteLineIf(state.Fpcr != 0, $"SoftFloat64.FPCompareGE: state.Fpcr = 0x{state.Fpcr:X8}");
+
+            value1 = value1.FPUnpack(out FpType type1, out _, out _, state);
+            value2 = value2.FPUnpack(out FpType type2, out _, out _, state);
+
+            double result;
+
+            if (type1 == FpType.SNaN || type1 == FpType.QNaN || type2 == FpType.SNaN || type2 == FpType.QNaN)
+            {
+                result = ZerosOrOnes(false);
+
+                FPProcessException(FpExc.InvalidOp, state);
+            }
+            else
+            {
+                result = ZerosOrOnes(value1 >= value2);
+            }
+
+            return result;
+        }
+
+        public static double FPCompareGT(double value1, double value2, CpuThreadState state)
+        {
+            Debug.WriteLineIf(state.Fpcr != 0, $"SoftFloat64.FPCompareGT: state.Fpcr = 0x{state.Fpcr:X8}");
+
+            value1 = value1.FPUnpack(out FpType type1, out _, out _, state);
+            value2 = value2.FPUnpack(out FpType type2, out _, out _, state);
+
+            double result;
+
+            if (type1 == FpType.SNaN || type1 == FpType.QNaN || type2 == FpType.SNaN || type2 == FpType.QNaN)
+            {
+                result = ZerosOrOnes(false);
+
+                FPProcessException(FpExc.InvalidOp, state);
+            }
+            else
+            {
+                result = ZerosOrOnes(value1 > value2);
+            }
+
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double FPCompareLE(double value1, double value2, CpuThreadState state)
+        {
+            Debug.WriteLineIf(state.Fpcr != 0, $"SoftFloat64.FPCompareLE: state.Fpcr = 0x{state.Fpcr:X8}");
+
+            return FPCompareGE(value2, value1, state);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double FPCompareLT(double value1, double value2, CpuThreadState state)
+        {
+            Debug.WriteLineIf(state.Fpcr != 0, $"SoftFloat64.FPCompareLT: state.Fpcr = 0x{state.Fpcr:X8}");
+
+            return FPCompareGT(value2, value1, state);
         }
 
         public static double FPDiv(double value1, double value2, CpuThreadState state)
@@ -2247,6 +2428,11 @@ namespace ChocolArm64.Instructions
         private static double FPNeg(this double value)
         {
             return -value;
+        }
+
+        private static double ZerosOrOnes(bool zeros)
+        {
+            return BitConverter.Int64BitsToDouble(!zeros ? 0L : -1L);
         }
 
         private static double FPUnpack(

--- a/ChocolArm64/Instructions/SoftFloat.cs
+++ b/ChocolArm64/Instructions/SoftFloat.cs
@@ -13,187 +13,68 @@ namespace ChocolArm64.Instructions
             InvSqrtEstimateTable = BuildInvSqrtEstimateTable();
         }
 
-        private static readonly byte[] RecipEstimateTable;
-        private static readonly byte[] InvSqrtEstimateTable;
+        internal static readonly byte[] RecipEstimateTable;
+        internal static readonly byte[] InvSqrtEstimateTable;
 
         private static byte[] BuildRecipEstimateTable()
         {
-            byte[] table = new byte[256];
-            for (ulong index = 0; index < 256; index++)
+            byte[] tbl = new byte[256];
+
+            for (uint idx = 0u; idx < 256u; idx++)
             {
-                ulong a = index | 0x100;
+                uint src = idx + 256u;
 
-                a = (a << 1) + 1;
-                ulong b = 0x80000 / a;
-                b = (b + 1) >> 1;
+                Debug.Assert(256u <= src && src < 512u);
 
-                table[index] = (byte)(b & 0xFF);
+                src = (src << 1) + 1u;
+
+                uint aux = 0x00080000u / src;
+
+                uint dst = (aux + 1u) >> 1;
+
+                Debug.Assert(256u <= dst && dst < 512u);
+
+                tbl[idx] = (byte)(dst - 256u);
             }
-            return table;
+
+            return tbl;
         }
 
         private static byte[] BuildInvSqrtEstimateTable()
         {
-            byte[] table = new byte[512];
-            for (ulong index = 128; index < 512; index++)
+            byte[] tbl = new byte[384];
+
+            for (uint idx = 0u; idx < 384u; idx++)
             {
-                ulong a = index;
-                if (a < 256)
+                uint src = idx + 128u;
+
+                Debug.Assert(128u <= src && src < 512u);
+
+                if (src < 256u)
                 {
-                    a = (a << 1) + 1;
+                    src = (src << 1) + 1u;
                 }
                 else
                 {
-                    a = (a | 1) << 1;
+                    src = (src >> 1) << 1;
+                    src = (src + 1u) << 1;
                 }
 
-                ulong b = 256;
-                while (a * (b + 1) * (b + 1) < (1ul << 28))
+                uint aux = 512u;
+
+                while (src * (aux + 1u) * (aux + 1u) < 0x10000000u)
                 {
-                    b++;
-                }
-                b = (b + 1) >> 1;
-
-                table[index] = (byte)(b & 0xFF);
-            }
-            return table;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float RecipEstimate(float x)
-        {
-            return (float)RecipEstimate((double)x);
-        }
-
-        public static double RecipEstimate(double x)
-        {
-            ulong xBits  = (ulong)BitConverter.DoubleToInt64Bits(x);
-            ulong xSign  = xBits & 0x8000000000000000;
-            ulong xExp   = (xBits >> 52) & 0x7FF;
-            ulong scaled = xBits & ((1ul << 52) - 1);
-
-            if (xExp >= 2045)
-            {
-                if (xExp == 0x7ff && scaled != 0)
-                {
-                    // NaN
-                    return BitConverter.Int64BitsToDouble((long)(xBits | 0x0008000000000000));
+                    aux = aux + 1u;
                 }
 
-                // Infinity, or Out of range -> Zero
-                return BitConverter.Int64BitsToDouble((long)xSign);
+                uint dst = (aux + 1u) >> 1;
+
+                Debug.Assert(256u <= dst && dst < 512u);
+
+                tbl[idx] = (byte)(dst - 256u);
             }
 
-            if (xExp == 0)
-            {
-                if (scaled == 0)
-                {
-                    // Zero -> Infinity
-                    return BitConverter.Int64BitsToDouble((long)(xSign | 0x7FF0000000000000));
-                }
-
-                // Denormal
-                if ((scaled & (1ul << 51)) == 0)
-                {
-                    xExp = ~0ul;
-                    scaled <<= 2;
-                }
-                else
-                {
-                    scaled <<= 1;
-                }
-            }
-
-            scaled >>= 44;
-            scaled &= 0xFF;
-
-            ulong resultExp = (2045 - xExp) & 0x7FF;
-            ulong estimate  = (ulong)RecipEstimateTable[scaled];
-            ulong fraction  = estimate << 44;
-
-            if (resultExp == 0)
-            {
-                fraction >>= 1;
-                fraction |= 1ul << 51;
-            }
-            else if (resultExp == 0x7FF)
-            {
-                resultExp = 0;
-                fraction >>= 2;
-                fraction |= 1ul << 50;
-            }
-
-            ulong result = xSign | (resultExp << 52) | fraction;
-            return BitConverter.Int64BitsToDouble((long)result);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float InvSqrtEstimate(float x)
-        {
-            return (float)InvSqrtEstimate((double)x);
-        }
-
-        public static double InvSqrtEstimate(double x)
-        {
-            ulong xBits  = (ulong)BitConverter.DoubleToInt64Bits(x);
-            ulong xSign  = xBits & 0x8000000000000000;
-            long  xExp   = (long)((xBits >> 52) & 0x7FF);
-            ulong scaled = xBits & ((1ul << 52) - 1);
-
-            if (xExp == 0x7FF && scaled != 0)
-            {
-                // NaN
-                return BitConverter.Int64BitsToDouble((long)(xBits | 0x0008000000000000));
-            }
-
-            if (xExp == 0)
-            {
-                if (scaled == 0)
-                {
-                    // Zero -> Infinity
-                    return BitConverter.Int64BitsToDouble((long)(xSign | 0x7FF0000000000000));
-                }
-
-                // Denormal
-                while ((scaled & (1 << 51)) == 0)
-                {
-                    scaled <<= 1;
-                    xExp--;
-                }
-                scaled <<= 1;
-            }
-
-            if (xSign != 0)
-            {
-                // Negative -> NaN
-                return BitConverter.Int64BitsToDouble((long)0x7FF8000000000000);
-            }
-
-            if (xExp == 0x7ff && scaled == 0)
-            {
-                // Infinity -> Zero
-                return BitConverter.Int64BitsToDouble((long)xSign);
-            }
-
-            if (((ulong)xExp & 1) == 1)
-            {
-                scaled >>= 45;
-                scaled &= 0xFF;
-                scaled |= 0x80;
-            }
-            else
-            {
-                scaled >>= 44;
-                scaled &= 0xFF;
-                scaled |= 0x100;
-            }
-
-            ulong resultExp = ((ulong)(3068 - xExp) / 2) & 0x7FF;
-            ulong estimate  = (ulong)InvSqrtEstimateTable[scaled];
-            ulong fraction  = estimate << 44;
-
-            ulong result = xSign | (resultExp << 52) | fraction;
-            return BitConverter.Int64BitsToDouble((long)result);
+            return tbl;
         }
     }
 
@@ -1276,6 +1157,95 @@ namespace ChocolArm64.Instructions
             return result;
         }
 
+        public static float FPRecipEstimate(float value, CpuThreadState state)
+        {
+            Debug.WriteLineIf(state.Fpcr != 0, $"SoftFloat32.FPRecipEstimate: state.Fpcr = 0x{state.Fpcr:X8}");
+
+            value.FPUnpack(out FpType type, out bool sign, out uint op, state);
+
+            float result;
+
+            if (type == FpType.SNaN || type == FpType.QNaN)
+            {
+                result = FPProcessNaN(type, op, state);
+            }
+            else if (type == FpType.Infinity)
+            {
+                result = FPZero(sign);
+            }
+            else if (type == FpType.Zero)
+            {
+                result = FPInfinity(sign);
+
+                FPProcessException(FpExc.DivideByZero, state);
+            }
+            else if (MathF.Abs(value) < MathF.Pow(2f, -128))
+            {
+                bool overflowToInf;
+
+                switch (state.FPRoundingMode())
+                {
+                    default:
+                    case RoundMode.ToNearest:            overflowToInf = true;  break;
+                    case RoundMode.TowardsPlusInfinity:  overflowToInf = !sign; break;
+                    case RoundMode.TowardsMinusInfinity: overflowToInf = sign;  break;
+                    case RoundMode.TowardsZero:          overflowToInf = false; break;
+                }
+
+                result = overflowToInf ? FPInfinity(sign) : FPMaxNormal(sign);
+
+                FPProcessException(FpExc.Overflow, state);
+                FPProcessException(FpExc.Inexact,  state);
+            }
+            else if (state.GetFpcrFlag(Fpcr.Fz) && (MathF.Abs(value) >= MathF.Pow(2f, 126)))
+            {
+                result = FPZero(sign);
+
+                state.SetFpsrFlag(Fpsr.Ufc);
+            }
+            else
+            {
+                ulong fraction = (ulong)(op & 0x007FFFFFu) << 29;
+                uint exp = (op & 0x7F800000u) >> 23;
+
+                if (exp == 0u)
+                {
+                    if ((fraction & 0x0008000000000000ul) == 0ul)
+                    {
+                        fraction = (fraction & 0x0003FFFFFFFFFFFFul) << 2;
+                        exp -= 1u;
+                    }
+                    else
+                    {
+                        fraction = (fraction & 0x0007FFFFFFFFFFFFul) << 1;
+                    }
+                }
+
+                uint scaled = (uint)(((fraction & 0x000FF00000000000ul) | 0x0010000000000000ul) >> 44);
+
+                uint resultExp = 253u - exp;
+
+                uint estimate = SoftFloat.RecipEstimateTable[scaled - 256u] + 256u;
+
+                fraction = (ulong)(estimate & 0xFFu) << 44;
+
+                if (resultExp == 0u)
+                {
+                    fraction = ((fraction & 0x000FFFFFFFFFFFFEul) | 0x0010000000000000ul) >> 1;
+                }
+                else if (resultExp + 1u == 0u)
+                {
+                    fraction = ((fraction & 0x000FFFFFFFFFFFFCul) | 0x0010000000000000ul) >> 2;
+                    resultExp = 0u;
+                }
+
+                result = BitConverter.Int32BitsToSingle(
+                    (int)((sign ? 1u : 0u) << 31 | (resultExp & 0xFFu) << 23 | (uint)(fraction >> 29) & 0x007FFFFFu));
+            }
+
+            return result;
+        }
+
         public static float FPRecipStepFused(float value1, float value2, CpuThreadState state)
         {
             Debug.WriteLineIf(state.Fpcr != 0, $"SoftFloat32.FPRecipStepFused: state.Fpcr = 0x{state.Fpcr:X8}");
@@ -1338,6 +1308,71 @@ namespace ChocolArm64.Instructions
 
                 result = BitConverter.Int32BitsToSingle(
                     (int)((sign ? 1u : 0u) << 31 | (notExp == 0xFFu ? maxExp : notExp) << 23));
+            }
+
+            return result;
+        }
+
+        public static float FPRSqrtEstimate(float value, CpuThreadState state)
+        {
+            Debug.WriteLineIf(state.Fpcr != 0, $"SoftFloat32.FPRSqrtEstimate: state.Fpcr = 0x{state.Fpcr:X8}");
+
+            value.FPUnpack(out FpType type, out bool sign, out uint op, state);
+
+            float result;
+
+            if (type == FpType.SNaN || type == FpType.QNaN)
+            {
+                result = FPProcessNaN(type, op, state);
+            }
+            else if (type == FpType.Zero)
+            {
+                result = FPInfinity(sign);
+
+                FPProcessException(FpExc.DivideByZero, state);
+            }
+            else if (sign)
+            {
+                result = FPDefaultNaN();
+
+                FPProcessException(FpExc.InvalidOp, state);
+            }
+            else if (type == FpType.Infinity)
+            {
+                result = FPZero(false);
+            }
+            else
+            {
+                ulong fraction = (ulong)(op & 0x007FFFFFu) << 29;
+                uint exp = (op & 0x7F800000u) >> 23;
+
+                if (exp == 0u)
+                {
+                    while ((fraction & 0x0008000000000000ul) == 0ul)
+                    {
+                        fraction = (fraction & 0x0007FFFFFFFFFFFFul) << 1;
+                        exp -= 1u;
+                    }
+
+                    fraction = (fraction & 0x0007FFFFFFFFFFFFul) << 1;
+                }
+
+                uint scaled;
+
+                if ((exp & 1u) == 0u)
+                {
+                    scaled = (uint)(((fraction & 0x000FF00000000000ul) | 0x0010000000000000ul) >> 44);
+                }
+                else
+                {
+                    scaled = (uint)(((fraction & 0x000FE00000000000ul) | 0x0010000000000000ul) >> 45);
+                }
+
+                uint resultExp = (380u - exp) >> 1;
+
+                uint estimate = SoftFloat.InvSqrtEstimateTable[scaled - 128u] + 256u;
+
+                result = BitConverter.Int32BitsToSingle((int)((resultExp & 0xFFu) << 23 | (estimate & 0xFFu) << 15));
             }
 
             return result;
@@ -1488,6 +1523,11 @@ namespace ChocolArm64.Instructions
         private static float FPZero(bool sign)
         {
             return sign ? -0f : +0f;
+        }
+
+        private static float FPMaxNormal(bool sign)
+        {
+            return sign ? float.MinValue : float.MaxValue;
         }
 
         private static float FPTwo(bool sign)
@@ -2201,6 +2241,95 @@ namespace ChocolArm64.Instructions
             return result;
         }
 
+        public static double FPRecipEstimate(double value, CpuThreadState state)
+        {
+            Debug.WriteLineIf(state.Fpcr != 0, $"SoftFloat64.FPRecipEstimate: state.Fpcr = 0x{state.Fpcr:X8}");
+
+            value.FPUnpack(out FpType type, out bool sign, out ulong op, state);
+
+            double result;
+
+            if (type == FpType.SNaN || type == FpType.QNaN)
+            {
+                result = FPProcessNaN(type, op, state);
+            }
+            else if (type == FpType.Infinity)
+            {
+                result = FPZero(sign);
+            }
+            else if (type == FpType.Zero)
+            {
+                result = FPInfinity(sign);
+
+                FPProcessException(FpExc.DivideByZero, state);
+            }
+            else if (Math.Abs(value) < Math.Pow(2d, -1024))
+            {
+                bool overflowToInf;
+
+                switch (state.FPRoundingMode())
+                {
+                    default:
+                    case RoundMode.ToNearest:            overflowToInf = true;  break;
+                    case RoundMode.TowardsPlusInfinity:  overflowToInf = !sign; break;
+                    case RoundMode.TowardsMinusInfinity: overflowToInf = sign;  break;
+                    case RoundMode.TowardsZero:          overflowToInf = false; break;
+                }
+
+                result = overflowToInf ? FPInfinity(sign) : FPMaxNormal(sign);
+
+                FPProcessException(FpExc.Overflow, state);
+                FPProcessException(FpExc.Inexact,  state);
+            }
+            else if (state.GetFpcrFlag(Fpcr.Fz) && (Math.Abs(value) >= Math.Pow(2d, 1022)))
+            {
+                result = FPZero(sign);
+
+                state.SetFpsrFlag(Fpsr.Ufc);
+            }
+            else
+            {
+                ulong fraction = op & 0x000FFFFFFFFFFFFFul;
+                uint exp = (uint)((op & 0x7FF0000000000000ul) >> 52);
+
+                if (exp == 0u)
+                {
+                    if ((fraction & 0x0008000000000000ul) == 0ul)
+                    {
+                        fraction = (fraction & 0x0003FFFFFFFFFFFFul) << 2;
+                        exp -= 1u;
+                    }
+                    else
+                    {
+                        fraction = (fraction & 0x0007FFFFFFFFFFFFul) << 1;
+                    }
+                }
+
+                uint scaled = (uint)(((fraction & 0x000FF00000000000ul) | 0x0010000000000000ul) >> 44);
+
+                uint resultExp = 2045u - exp;
+
+                uint estimate = SoftFloat.RecipEstimateTable[scaled - 256u] + 256u;
+
+                fraction = (ulong)(estimate & 0xFFu) << 44;
+
+                if (resultExp == 0u)
+                {
+                    fraction = ((fraction & 0x000FFFFFFFFFFFFEul) | 0x0010000000000000ul) >> 1;
+                }
+                else if (resultExp + 1u == 0u)
+                {
+                    fraction = ((fraction & 0x000FFFFFFFFFFFFCul) | 0x0010000000000000ul) >> 2;
+                    resultExp = 0u;
+                }
+
+                result = BitConverter.Int64BitsToDouble(
+                    (long)((sign ? 1ul : 0ul) << 63 | (resultExp & 0x7FFul) << 52 | (fraction & 0x000FFFFFFFFFFFFFul)));
+            }
+
+            return result;
+        }
+
         public static double FPRecipStepFused(double value1, double value2, CpuThreadState state)
         {
             Debug.WriteLineIf(state.Fpcr != 0, $"SoftFloat64.FPRecipStepFused: state.Fpcr = 0x{state.Fpcr:X8}");
@@ -2263,6 +2392,71 @@ namespace ChocolArm64.Instructions
 
                 result = BitConverter.Int64BitsToDouble(
                     (long)((sign ? 1ul : 0ul) << 63 | (notExp == 0x7FFul ? maxExp : notExp) << 52));
+            }
+
+            return result;
+        }
+
+        public static double FPRSqrtEstimate(double value, CpuThreadState state)
+        {
+            Debug.WriteLineIf(state.Fpcr != 0, $"SoftFloat64.FPRSqrtEstimate: state.Fpcr = 0x{state.Fpcr:X8}");
+
+            value.FPUnpack(out FpType type, out bool sign, out ulong op, state);
+
+            double result;
+
+            if (type == FpType.SNaN || type == FpType.QNaN)
+            {
+                result = FPProcessNaN(type, op, state);
+            }
+            else if (type == FpType.Zero)
+            {
+                result = FPInfinity(sign);
+
+                FPProcessException(FpExc.DivideByZero, state);
+            }
+            else if (sign)
+            {
+                result = FPDefaultNaN();
+
+                FPProcessException(FpExc.InvalidOp, state);
+            }
+            else if (type == FpType.Infinity)
+            {
+                result = FPZero(false);
+            }
+            else
+            {
+                ulong fraction = op & 0x000FFFFFFFFFFFFFul;
+                uint exp = (uint)((op & 0x7FF0000000000000ul) >> 52);
+
+                if (exp == 0u)
+                {
+                    while ((fraction & 0x0008000000000000ul) == 0ul)
+                    {
+                        fraction = (fraction & 0x0007FFFFFFFFFFFFul) << 1;
+                        exp -= 1u;
+                    }
+
+                    fraction = (fraction & 0x0007FFFFFFFFFFFFul) << 1;
+                }
+
+                uint scaled;
+
+                if ((exp & 1u) == 0u)
+                {
+                    scaled = (uint)(((fraction & 0x000FF00000000000ul) | 0x0010000000000000ul) >> 44);
+                }
+                else
+                {
+                    scaled = (uint)(((fraction & 0x000FE00000000000ul) | 0x0010000000000000ul) >> 45);
+                }
+
+                uint resultExp = (3068u - exp) >> 1;
+
+                uint estimate = SoftFloat.InvSqrtEstimateTable[scaled - 128u] + 256u;
+
+                result = BitConverter.Int64BitsToDouble((long)((resultExp & 0x7FFul) << 52 | (estimate & 0xFFul) << 44));
             }
 
             return result;
@@ -2413,6 +2607,11 @@ namespace ChocolArm64.Instructions
         private static double FPZero(bool sign)
         {
             return sign ? -0d : +0d;
+        }
+
+        private static double FPMaxNormal(bool sign)
+        {
+            return sign ? double.MinValue : double.MaxValue;
         }
 
         private static double FPTwo(bool sign)

--- a/ChocolArm64/OpCodeTable.cs
+++ b/ChocolArm64/OpCodeTable.cs
@@ -222,6 +222,7 @@ namespace ChocolArm64
             SetA64("0x101110001xxxxx000111xxxxxxxxxx", InstEmit.Eor_V,           typeof(OpCodeSimdReg64));
             SetA64("0>101110000xxxxx0<xxx0xxxxxxxxxx", InstEmit.Ext_V,           typeof(OpCodeSimdExt64));
             SetA64("011111101x1xxxxx110101xxxxxxxxxx", InstEmit.Fabd_S,          typeof(OpCodeSimdReg64));
+            SetA64("0>1011101<1xxxxx110101xxxxxxxxxx", InstEmit.Fabd_V,          typeof(OpCodeSimdReg64));
             SetA64("000111100x100000110000xxxxxxxxxx", InstEmit.Fabs_S,          typeof(OpCodeSimd64));
             SetA64("0>0011101<100000111110xxxxxxxxxx", InstEmit.Fabs_V,          typeof(OpCodeSimd64));
             SetA64("000111100x1xxxxx001010xxxxxxxxxx", InstEmit.Fadd_S,          typeof(OpCodeSimdReg64));

--- a/ChocolArm64/Optimizations.cs
+++ b/ChocolArm64/Optimizations.cs
@@ -8,12 +8,14 @@ public static class Optimizations
 
     private static bool _useSseIfAvailable   = true;
     private static bool _useSse2IfAvailable  = true;
+    private static bool _useSse3IfAvailable  = true;
     private static bool _useSsse3IfAvailable = true;
     private static bool _useSse41IfAvailable = true;
     private static bool _useSse42IfAvailable = true;
 
     internal static bool UseSse   = (_useAllSseIfAvailable && _useSseIfAvailable)   && Sse.IsSupported;
     internal static bool UseSse2  = (_useAllSseIfAvailable && _useSse2IfAvailable)  && Sse2.IsSupported;
+    internal static bool UseSse3  = (_useAllSseIfAvailable && _useSse3IfAvailable)  && Sse3.IsSupported;
     internal static bool UseSsse3 = (_useAllSseIfAvailable && _useSsse3IfAvailable) && Ssse3.IsSupported;
     internal static bool UseSse41 = (_useAllSseIfAvailable && _useSse41IfAvailable) && Sse41.IsSupported;
     internal static bool UseSse42 = (_useAllSseIfAvailable && _useSse42IfAvailable) && Sse42.IsSupported;

--- a/Ryujinx.Tests/Cpu/CpuTestSimd.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestSimd.cs
@@ -256,6 +256,112 @@ namespace Ryujinx.Tests.Cpu
 #endregion
 
 #region "ValueSource (Opcodes)"
+        private static uint[] _F_Abs_Neg_Recpx_Sqrt_S_S_()
+        {
+            return new uint[]
+            {
+                0x1E20C020u, // FABS   S0, S1
+                0x1E214020u, // FNEG   S0, S1
+                0x5EA1F820u, // FRECPX S0, S1
+                0x1E21C020u  // FSQRT  S0, S1
+            };
+        }
+
+        private static uint[] _F_Abs_Neg_Recpx_Sqrt_S_D_()
+        {
+            return new uint[]
+            {
+                0x1E60C020u, // FABS   D0, D1
+                0x1E614020u, // FNEG   D0, D1
+                0x5EE1F820u, // FRECPX D0, D1
+                0x1E61C020u  // FSQRT  D0, D1
+            };
+        }
+
+        private static uint[] _F_Abs_Neg_Sqrt_V_2S_4S_()
+        {
+            return new uint[]
+            {
+                0x0EA0F800u, // FABS  V0.2S, V0.2S
+                0x2EA0F800u, // FNEG  V0.2S, V0.2S
+                0x2EA1F800u  // FSQRT V0.2S, V0.2S
+            };
+        }
+
+        private static uint[] _F_Abs_Neg_Sqrt_V_2D_()
+        {
+            return new uint[]
+            {
+                0x4EE0F800u, // FABS  V0.2D, V0.2D
+                0x6EE0F800u, // FNEG  V0.2D, V0.2D
+                0x6EE1F800u  // FSQRT V0.2D, V0.2D
+            };
+        }
+
+        private static uint[] _F_Add_P_S_2SS_()
+        {
+            return new uint[]
+            {
+                0x7E30D820u // FADDP S0, V1.2S
+            };
+        }
+
+        private static uint[] _F_Add_P_S_2DD_()
+        {
+            return new uint[]
+            {
+                0x7E70D820u // FADDP D0, V1.2D
+            };
+        }
+
+        private static uint[] _F_Cm_EqGeGtLeLt_S_S_()
+        {
+            return new uint[]
+            {
+                0x5EA0D820u, // FCMEQ S0, S1, #0.0
+                0x7EA0C820u, // FCMGE S0, S1, #0.0
+                0x5EA0C820u, // FCMGT S0, S1, #0.0
+                0x7EA0D820u, // FCMLE S0, S1, #0.0
+                0x5EA0E820u  // FCMLT S0, S1, #0.0
+            };
+        }
+
+        private static uint[] _F_Cm_EqGeGtLeLt_S_D_()
+        {
+            return new uint[]
+            {
+                0x5EE0D820u, // FCMEQ D0, D1, #0.0
+                0x7EE0C820u, // FCMGE D0, D1, #0.0
+                0x5EE0C820u, // FCMGT D0, D1, #0.0
+                0x7EE0D820u, // FCMLE D0, D1, #0.0
+                0x5EE0E820u  // FCMLT D0, D1, #0.0
+            };
+        }
+
+        private static uint[] _F_Cm_EqGeGtLeLt_V_2S_4S_()
+        {
+            return new uint[]
+            {
+                0x0EA0D800u, // FCMEQ V0.2S, V0.2S, #0.0
+                0x2EA0C800u, // FCMGE V0.2S, V0.2S, #0.0
+                0x0EA0C800u, // FCMGT V0.2S, V0.2S, #0.0
+                0x2EA0D800u, // FCMLE V0.2S, V0.2S, #0.0
+                0x0EA0E800u  // FCMLT V0.2S, V0.2S, #0.0
+            };
+        }
+
+        private static uint[] _F_Cm_EqGeGtLeLt_V_2D_()
+        {
+            return new uint[]
+            {
+                0x4EE0D800u, // FCMEQ V0.2D, V0.2D, #0.0
+                0x6EE0C800u, // FCMGE V0.2D, V0.2D, #0.0
+                0x4EE0C800u, // FCMGT V0.2D, V0.2D, #0.0
+                0x6EE0D800u, // FCMLE V0.2D, V0.2D, #0.0
+                0x4EE0E800u  // FCMLT V0.2D, V0.2D, #0.0
+            };
+        }
+
         private static uint[] _F_Cmp_Cmpe_S_S_()
         {
             return new uint[]
@@ -363,48 +469,6 @@ namespace Ryujinx.Tests.Cpu
             return new uint[]
             {
                 0x0E616800u // FCVTN V0.2S, V0.2D
-            };
-        }
-
-        private static uint[] _F_Abs_Neg_Recpx_Sqrt_S_S_()
-        {
-            return new uint[]
-            {
-                0x1E20C020u, // FABS   S0, S1
-                0x1E214020u, // FNEG   S0, S1
-                0x5EA1F820u, // FRECPX S0, S1
-                0x1E21C020u  // FSQRT  S0, S1
-            };
-        }
-
-        private static uint[] _F_Abs_Neg_Recpx_Sqrt_S_D_()
-        {
-            return new uint[]
-            {
-                0x1E60C020u, // FABS   D0, D1
-                0x1E614020u, // FNEG   D0, D1
-                0x5EE1F820u, // FRECPX D0, D1
-                0x1E61C020u  // FSQRT  D0, D1
-            };
-        }
-
-        private static uint[] _F_Abs_Neg_Sqrt_V_2S_4S_()
-        {
-            return new uint[]
-            {
-                0x0EA0F800u, // FABS  V0.2S, V0.2S
-                0x2EA0F800u, // FNEG  V0.2S, V0.2S
-                0x2EA1F800u  // FSQRT V0.2S, V0.2S
-            };
-        }
-
-        private static uint[] _F_Abs_Neg_Sqrt_V_2D_()
-        {
-            return new uint[]
-            {
-                0x4EE0F800u, // FABS  V0.2D, V0.2D
-                0x6EE0F800u, // FNEG  V0.2D, V0.2D
-                0x6EE1F800u  // FSQRT V0.2D, V0.2D
             };
         }
 
@@ -964,6 +1028,202 @@ namespace Ryujinx.Tests.Cpu
         }
 
         [Test, Pairwise] [Explicit]
+        public void F_Abs_Neg_Recpx_Sqrt_S_S([ValueSource("_F_Abs_Neg_Recpx_Sqrt_S_S_")] uint opcodes,
+                                             [ValueSource("_1S_F_")] ulong a)
+        {
+            ulong z = TestContext.CurrentContext.Random.NextULong();
+            Vector128<float> v0 = MakeVectorE0E1(z, z);
+            Vector128<float> v1 = MakeVectorE0E1(a, z);
+
+            int rnd = (int)TestContext.CurrentContext.Random.NextUInt();
+
+            int fpcr = rnd & (1 << (int)Fpcr.Fz);
+            fpcr |= rnd & (1 << (int)Fpcr.Dn);
+
+            SingleOpcode(opcodes, v0: v0, v1: v1, fpcr: fpcr);
+
+            CompareAgainstUnicorn(fpsrMask: Fpsr.Ioc | Fpsr.Idc);
+        }
+
+        [Test, Pairwise] [Explicit]
+        public void F_Abs_Neg_Recpx_Sqrt_S_D([ValueSource("_F_Abs_Neg_Recpx_Sqrt_S_D_")] uint opcodes,
+                                             [ValueSource("_1D_F_")] ulong a)
+        {
+            ulong z = TestContext.CurrentContext.Random.NextULong();
+            Vector128<float> v0 = MakeVectorE1(z);
+            Vector128<float> v1 = MakeVectorE0E1(a, z);
+
+            int rnd = (int)TestContext.CurrentContext.Random.NextUInt();
+
+            int fpcr = rnd & (1 << (int)Fpcr.Fz);
+            fpcr |= rnd & (1 << (int)Fpcr.Dn);
+
+            SingleOpcode(opcodes, v0: v0, v1: v1, fpcr: fpcr);
+
+            CompareAgainstUnicorn(fpsrMask: Fpsr.Ioc | Fpsr.Idc);
+        }
+
+        [Test, Pairwise] [Explicit]
+        public void F_Abs_Neg_Sqrt_V_2S_4S([ValueSource("_F_Abs_Neg_Sqrt_V_2S_4S_")] uint opcodes,
+                                           [Values(0u)]     uint rd,
+                                           [Values(1u, 0u)] uint rn,
+                                           [ValueSource("_2S_F_")] ulong z,
+                                           [ValueSource("_2S_F_")] ulong a,
+                                           [Values(0b0u, 0b1u)] uint q) // <2S, 4S>
+        {
+            opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
+            opcodes |= ((q & 1) << 30);
+
+            Vector128<float> v0 = MakeVectorE0E1(z, z);
+            Vector128<float> v1 = MakeVectorE0E1(a, a * q);
+
+            int rnd = (int)TestContext.CurrentContext.Random.NextUInt();
+
+            int fpcr = rnd & (1 << (int)Fpcr.Fz);
+            fpcr |= rnd & (1 << (int)Fpcr.Dn);
+
+            SingleOpcode(opcodes, v0: v0, v1: v1, fpcr: fpcr);
+
+            CompareAgainstUnicorn(fpsrMask: Fpsr.Ioc | Fpsr.Idc);
+        }
+
+        [Test, Pairwise] [Explicit]
+        public void F_Abs_Neg_Sqrt_V_2D([ValueSource("_F_Abs_Neg_Sqrt_V_2D_")] uint opcodes,
+                                        [Values(0u)]     uint rd,
+                                        [Values(1u, 0u)] uint rn,
+                                        [ValueSource("_1D_F_")] ulong z,
+                                        [ValueSource("_1D_F_")] ulong a)
+        {
+            opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
+
+            Vector128<float> v0 = MakeVectorE0E1(z, z);
+            Vector128<float> v1 = MakeVectorE0E1(a, a);
+
+            int rnd = (int)TestContext.CurrentContext.Random.NextUInt();
+
+            int fpcr = rnd & (1 << (int)Fpcr.Fz);
+            fpcr |= rnd & (1 << (int)Fpcr.Dn);
+
+            SingleOpcode(opcodes, v0: v0, v1: v1, fpcr: fpcr);
+
+            CompareAgainstUnicorn(fpsrMask: Fpsr.Ioc | Fpsr.Idc);
+        }
+
+        [Test, Pairwise] [Explicit]
+        public void F_Add_P_S_2SS([ValueSource("_F_Add_P_S_2SS_")] uint opcodes,
+                                  [ValueSource("_2S_F_")] ulong a)
+        {
+            ulong z = TestContext.CurrentContext.Random.NextULong();
+            Vector128<float> v0 = MakeVectorE0E1(z, z);
+            Vector128<float> v1 = MakeVectorE0(a);
+
+            int rnd = (int)TestContext.CurrentContext.Random.NextUInt();
+
+            int fpcr = rnd & (1 << (int)Fpcr.Fz);
+            fpcr |= rnd & (1 << (int)Fpcr.Dn);
+
+            SingleOpcode(opcodes, v0: v0, v1: v1, fpcr: fpcr);
+
+            CompareAgainstUnicorn(fpsrMask: Fpsr.Ioc | Fpsr.Idc);
+        }
+
+        [Test, Pairwise] [Explicit]
+        public void F_Add_P_S_2DD([ValueSource("_F_Add_P_S_2DD_")] uint opcodes,
+                                  [ValueSource("_1D_F_")] ulong a)
+        {
+            ulong z = TestContext.CurrentContext.Random.NextULong();
+            Vector128<float> v0 = MakeVectorE1(z);
+            Vector128<float> v1 = MakeVectorE0E1(a, a);
+
+            int rnd = (int)TestContext.CurrentContext.Random.NextUInt();
+
+            int fpcr = rnd & (1 << (int)Fpcr.Fz);
+            fpcr |= rnd & (1 << (int)Fpcr.Dn);
+
+            SingleOpcode(opcodes, v0: v0, v1: v1, fpcr: fpcr);
+
+            CompareAgainstUnicorn(fpsrMask: Fpsr.Ioc | Fpsr.Idc);
+        }
+
+        [Test, Pairwise] [Explicit]
+        public void F_Cm_EqGeGtLeLt_S_S([ValueSource("_F_Cm_EqGeGtLeLt_S_S_")] uint opcodes,
+                                        [ValueSource("_1S_F_")] ulong a)
+        {
+            ulong z = TestContext.CurrentContext.Random.NextULong();
+            Vector128<float> v0 = MakeVectorE0E1(z, z);
+            Vector128<float> v1 = MakeVectorE0(a);
+
+            int rnd = (int)TestContext.CurrentContext.Random.NextUInt();
+
+            int fpcr = rnd & (1 << (int)Fpcr.Fz);
+
+            SingleOpcode(opcodes, v0: v0, v1: v1, fpcr: fpcr);
+
+            CompareAgainstUnicorn(fpsrMask: Fpsr.Ioc | Fpsr.Idc);
+        }
+
+        [Test, Pairwise] [Explicit]
+        public void F_Cm_EqGeGtLeLt_S_D([ValueSource("_F_Cm_EqGeGtLeLt_S_D_")] uint opcodes,
+                                        [ValueSource("_1D_F_")] ulong a)
+        {
+            ulong z = TestContext.CurrentContext.Random.NextULong();
+            Vector128<float> v0 = MakeVectorE1(z);
+            Vector128<float> v1 = MakeVectorE0(a);
+
+            int rnd = (int)TestContext.CurrentContext.Random.NextUInt();
+
+            int fpcr = rnd & (1 << (int)Fpcr.Fz);
+
+            SingleOpcode(opcodes, v0: v0, v1: v1, fpcr: fpcr);
+
+            CompareAgainstUnicorn(fpsrMask: Fpsr.Ioc | Fpsr.Idc);
+        }
+
+        [Test, Pairwise] [Explicit]
+        public void F_Cm_EqGeGtLeLt_V_2S_4S([ValueSource("_F_Cm_EqGeGtLeLt_V_2S_4S_")] uint opcodes,
+                                            [Values(0u)]     uint rd,
+                                            [Values(1u, 0u)] uint rn,
+                                            [ValueSource("_2S_F_")] ulong z,
+                                            [ValueSource("_2S_F_")] ulong a,
+                                            [Values(0b0u, 0b1u)] uint q) // <2S, 4S>
+        {
+            opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
+            opcodes |= ((q & 1) << 30);
+
+            Vector128<float> v0 = MakeVectorE0E1(z, z);
+            Vector128<float> v1 = MakeVectorE0E1(a, a * q);
+
+            int rnd = (int)TestContext.CurrentContext.Random.NextUInt();
+
+            int fpcr = rnd & (1 << (int)Fpcr.Fz);
+
+            SingleOpcode(opcodes, v0: v0, v1: v1, fpcr: fpcr);
+
+            CompareAgainstUnicorn(fpsrMask: Fpsr.Ioc | Fpsr.Idc);
+        }
+
+        [Test, Pairwise] [Explicit]
+        public void F_Cm_EqGeGtLeLt_V_2D([ValueSource("_F_Cm_EqGeGtLeLt_V_2D_")] uint opcodes,
+                                         [Values(0u)]     uint rd,
+                                         [Values(1u, 0u)] uint rn,
+                                         [ValueSource("_1D_F_")] ulong z,
+                                         [ValueSource("_1D_F_")] ulong a)
+        {
+            opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
+
+            Vector128<float> v0 = MakeVectorE0E1(z, z);
+            Vector128<float> v1 = MakeVectorE0E1(a, a);
+
+            int rnd = (int)TestContext.CurrentContext.Random.NextUInt();
+
+            int fpcr = rnd & (1 << (int)Fpcr.Fz);
+
+            SingleOpcode(opcodes, v0: v0, v1: v1, fpcr: fpcr);
+
+            CompareAgainstUnicorn(fpsrMask: Fpsr.Ioc | Fpsr.Idc);
+        }
+
+        [Test, Pairwise] [Explicit]
         public void F_Cmp_Cmpe_S_S([ValueSource("_F_Cmp_Cmpe_S_S_")] uint opcodes,
                                    [ValueSource("_1S_F_")] ulong a)
         {
@@ -1089,13 +1349,13 @@ namespace Ryujinx.Tests.Cpu
                                        [Values(1u, 0u)] uint rn,
                                        [ValueSource("_4H_F_")] ulong z,
                                        [ValueSource("_4H_F_")] ulong a,
-                                       [Values(0b0u, 0b1u)] uint q, // <4H, 8H>
+                                       [Values(0b0u, 0b1u)] uint q, // <4H4S, 8H4S>
                                        [Values(RMode.Rn)] RMode rMode)
         {
             opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
             opcodes |= ((q & 1) << 30);
 
-            Vector128<float> v0 = MakeVectorE0E1(q == 0u ? z : 0ul, q == 1u ? z : 0ul);
+            Vector128<float> v0 = MakeVectorE0E1(z, z);
             Vector128<float> v1 = MakeVectorE0E1(q == 0u ? a : 0ul, q == 1u ? a : 0ul);
 
             int rnd = (int)TestContext.CurrentContext.Random.NextUInt();
@@ -1116,12 +1376,12 @@ namespace Ryujinx.Tests.Cpu
                                        [Values(1u, 0u)] uint rn,
                                        [ValueSource("_2S_F_")] ulong z,
                                        [ValueSource("_2S_F_")] ulong a,
-                                       [Values(0b0u, 0b1u)] uint q) // <2S, 4S>
+                                       [Values(0b0u, 0b1u)] uint q) // <2S2D, 4S2D>
         {
             opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
             opcodes |= ((q & 1) << 30);
 
-            Vector128<float> v0 = MakeVectorE0E1(q == 0u ? z : 0ul, q == 1u ? z : 0ul);
+            Vector128<float> v0 = MakeVectorE0E1(z, z);
             Vector128<float> v1 = MakeVectorE0E1(q == 0u ? a : 0ul, q == 1u ? a : 0ul);
 
             SingleOpcode(opcodes, v0: v0, v1: v1);
@@ -1135,7 +1395,7 @@ namespace Ryujinx.Tests.Cpu
                                        [Values(1u, 0u)] uint rn,
                                        [ValueSource("_2S_F_")] ulong z,
                                        [ValueSource("_2S_F_")] ulong a,
-                                       [Values(0b0u, 0b1u)] uint q, // <4H, 8H>
+                                       [Values(0b0u, 0b1u)] uint q, // <4S4H, 4S8H>
                                        [Values(RMode.Rn)] RMode rMode)
         {
             opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
@@ -1162,7 +1422,7 @@ namespace Ryujinx.Tests.Cpu
                                        [Values(1u, 0u)] uint rn,
                                        [ValueSource("_1D_F_")] ulong z,
                                        [ValueSource("_1D_F_")] ulong a,
-                                       [Values(0b0u, 0b1u)] uint q) // <2S, 4S>
+                                       [Values(0b0u, 0b1u)] uint q) // <2D2S, 2D4S>
         {
             opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
             opcodes |= ((q & 1) << 30);
@@ -1173,88 +1433,6 @@ namespace Ryujinx.Tests.Cpu
             SingleOpcode(opcodes, v0: v0, v1: v1);
 
             CompareAgainstUnicorn();
-        }
-
-        [Test, Pairwise] [Explicit]
-        public void F_Abs_Neg_Recpx_Sqrt_S_S([ValueSource("_F_Abs_Neg_Recpx_Sqrt_S_S_")] uint opcodes,
-                                             [ValueSource("_1S_F_")] ulong a)
-        {
-            ulong z = TestContext.CurrentContext.Random.NextULong();
-            Vector128<float> v0 = MakeVectorE0E1(z, z);
-            Vector128<float> v1 = MakeVectorE0E1(a, z);
-
-            int rnd = (int)TestContext.CurrentContext.Random.NextUInt();
-
-            int fpcr = rnd & (1 << (int)Fpcr.Fz);
-            fpcr |= rnd & (1 << (int)Fpcr.Dn);
-
-            SingleOpcode(opcodes, v0: v0, v1: v1, fpcr: fpcr);
-
-            CompareAgainstUnicorn(fpsrMask: Fpsr.Ioc | Fpsr.Idc);
-        }
-
-        [Test, Pairwise] [Explicit]
-        public void F_Abs_Neg_Recpx_Sqrt_S_D([ValueSource("_F_Abs_Neg_Recpx_Sqrt_S_D_")] uint opcodes,
-                                             [ValueSource("_1D_F_")] ulong a)
-        {
-            ulong z = TestContext.CurrentContext.Random.NextULong();
-            Vector128<float> v0 = MakeVectorE1(z);
-            Vector128<float> v1 = MakeVectorE0E1(a, z);
-
-            int rnd = (int)TestContext.CurrentContext.Random.NextUInt();
-
-            int fpcr = rnd & (1 << (int)Fpcr.Fz);
-            fpcr |= rnd & (1 << (int)Fpcr.Dn);
-
-            SingleOpcode(opcodes, v0: v0, v1: v1, fpcr: fpcr);
-
-            CompareAgainstUnicorn(fpsrMask: Fpsr.Ioc | Fpsr.Idc);
-        }
-
-        [Test, Pairwise] [Explicit]
-        public void F_Abs_Neg_Sqrt_V_2S_4S([ValueSource("_F_Abs_Neg_Sqrt_V_2S_4S_")] uint opcodes,
-                                           [Values(0u)]     uint rd,
-                                           [Values(1u, 0u)] uint rn,
-                                           [ValueSource("_2S_F_")] ulong z,
-                                           [ValueSource("_2S_F_")] ulong a,
-                                           [Values(0b0u, 0b1u)] uint q) // <2S, 4S>
-        {
-            opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
-            opcodes |= ((q & 1) << 30);
-
-            Vector128<float> v0 = MakeVectorE0E1(z, z);
-            Vector128<float> v1 = MakeVectorE0E1(a, a * q);
-
-            int rnd = (int)TestContext.CurrentContext.Random.NextUInt();
-
-            int fpcr = rnd & (1 << (int)Fpcr.Fz);
-            fpcr |= rnd & (1 << (int)Fpcr.Dn);
-
-            SingleOpcode(opcodes, v0: v0, v1: v1, fpcr: fpcr);
-
-            CompareAgainstUnicorn(fpsrMask: Fpsr.Ioc | Fpsr.Idc);
-        }
-
-        [Test, Pairwise] [Explicit]
-        public void F_Abs_Neg_Sqrt_V_2D([ValueSource("_F_Abs_Neg_Sqrt_V_2D_")] uint opcodes,
-                                        [Values(0u)]     uint rd,
-                                        [Values(1u, 0u)] uint rn,
-                                        [ValueSource("_1D_F_")] ulong z,
-                                        [ValueSource("_1D_F_")] ulong a)
-        {
-            opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
-
-            Vector128<float> v0 = MakeVectorE0E1(z, z);
-            Vector128<float> v1 = MakeVectorE0E1(a, a);
-
-            int rnd = (int)TestContext.CurrentContext.Random.NextUInt();
-
-            int fpcr = rnd & (1 << (int)Fpcr.Fz);
-            fpcr |= rnd & (1 << (int)Fpcr.Dn);
-
-            SingleOpcode(opcodes, v0: v0, v1: v1, fpcr: fpcr);
-
-            CompareAgainstUnicorn(fpsrMask: Fpsr.Ioc | Fpsr.Idc);
         }
 
         [Test, Pairwise, Description("NEG <V><d>, <V><n>")]
@@ -1658,6 +1836,27 @@ namespace Ryujinx.Tests.Cpu
             Vector128<float> v1 = MakeVectorE0E1(a0, a1);
 
             SingleOpcode(opcodes, v0: v0, v1: v1);
+
+            CompareAgainstUnicorn();
+        }
+
+        [Test, Pairwise, Description("SHLL{2} <Vd>.<Ta>, <Vn>.<Tb>, #<shift>")]
+        public void Shll_V([Values(0u)]     uint rd,
+                           [Values(1u, 0u)] uint rn,
+                           [ValueSource("_8B4H2S_")] [Random(RndCnt)] ulong z,
+                           [ValueSource("_8B4H2S_")] [Random(RndCnt)] ulong a,
+                           [Values(0b00u, 0b01u, 0b10u)] uint size, // <shift: 8, 16, 32>
+                           [Values(0b0u, 0b1u)] uint q)
+        {
+            uint opcode = 0x2E213800; // SHLL V0.8H, V0.8B, #8
+            opcode |= ((rn & 31) << 5) | ((rd & 31) << 0);
+            opcode |= ((size & 3) << 22);
+            opcode |= ((q & 1) << 30);
+
+            Vector128<float> v0 = MakeVectorE0E1(z, z);
+            Vector128<float> v1 = MakeVectorE0E1(q == 0u ? a : 0ul, q == 1u ? a : 0ul);
+
+            SingleOpcode(opcode, v0: v0, v1: v1);
 
             CompareAgainstUnicorn();
         }

--- a/Ryujinx.Tests/Cpu/CpuTestSimd.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestSimd.cs
@@ -1033,7 +1033,7 @@ namespace Ryujinx.Tests.Cpu
         {
             ulong z = TestContext.CurrentContext.Random.NextULong();
             Vector128<float> v0 = MakeVectorE0E1(z, z);
-            Vector128<float> v1 = MakeVectorE0E1(a, z);
+            Vector128<float> v1 = MakeVectorE0(a);
 
             int rnd = (int)TestContext.CurrentContext.Random.NextUInt();
 
@@ -1051,7 +1051,7 @@ namespace Ryujinx.Tests.Cpu
         {
             ulong z = TestContext.CurrentContext.Random.NextULong();
             Vector128<float> v0 = MakeVectorE1(z);
-            Vector128<float> v1 = MakeVectorE0E1(a, z);
+            Vector128<float> v1 = MakeVectorE0(a);
 
             int rnd = (int)TestContext.CurrentContext.Random.NextUInt();
 

--- a/Ryujinx.Tests/Cpu/CpuTestSimdReg.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestSimdReg.cs
@@ -206,6 +206,7 @@ namespace Ryujinx.Tests.Cpu
         {
             return new uint[]
             {
+                0x7EA2D420u, // FABD  S0, S1, S2
                 0x1E222820u, // FADD  S0, S1, S2
                 0x1E221820u, // FDIV  S0, S1, S2
                 0x1E220820u, // FMUL  S0, S1, S2
@@ -218,6 +219,7 @@ namespace Ryujinx.Tests.Cpu
         {
             return new uint[]
             {
+                0x7EE2D420u, // FABD  D0, D1, D2
                 0x1E622820u, // FADD  D0, D1, D2
                 0x1E621820u, // FDIV  D0, D1, D2
                 0x1E620820u, // FMUL  D0, D1, D2
@@ -230,6 +232,7 @@ namespace Ryujinx.Tests.Cpu
         {
             return new uint[]
             {
+                0x2EA0D400u, // FABD  V0.2S, V0.2S, V0.2S
                 0x0E20D400u, // FADD  V0.2S, V0.2S, V0.2S
                 0x2E20D400u, // FADDP V0.2S, V0.2S, V0.2S
                 0x2E20FC00u, // FDIV  V0.2S, V0.2S, V0.2S
@@ -243,6 +246,7 @@ namespace Ryujinx.Tests.Cpu
         {
             return new uint[]
             {
+                0x6EE0D400u, // FABD  V0.2D, V0.2D, V0.2D
                 0x4E60D400u, // FADD  V0.2D, V0.2D, V0.2D
                 0x6E60D400u, // FADDP V0.2D, V0.2D, V0.2D
                 0x6E60FC00u, // FDIV  V0.2D, V0.2D, V0.2D

--- a/Ryujinx.Tests/Cpu/CpuTestSimdReg.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestSimdReg.cs
@@ -226,11 +226,12 @@ namespace Ryujinx.Tests.Cpu
             };
         }
 
-        private static uint[] _F_Add_Div_Mul_Mulx_Sub_V_2S_4S_()
+        private static uint[] _F_Add_Div_Mul_Mulx_Sub_P_V_2S_4S_()
         {
             return new uint[]
             {
                 0x0E20D400u, // FADD  V0.2S, V0.2S, V0.2S
+                0x2E20D400u, // FADDP V0.2S, V0.2S, V0.2S
                 0x2E20FC00u, // FDIV  V0.2S, V0.2S, V0.2S
                 0x2E20DC00u, // FMUL  V0.2S, V0.2S, V0.2S
                 0x0E20DC00u, // FMULX V0.2S, V0.2S, V0.2S
@@ -238,15 +239,56 @@ namespace Ryujinx.Tests.Cpu
             };
         }
 
-        private static uint[] _F_Add_Div_Mul_Mulx_Sub_V_2D_()
+        private static uint[] _F_Add_Div_Mul_Mulx_Sub_P_V_2D_()
         {
             return new uint[]
             {
                 0x4E60D400u, // FADD  V0.2D, V0.2D, V0.2D
+                0x6E60D400u, // FADDP V0.2D, V0.2D, V0.2D
                 0x6E60FC00u, // FDIV  V0.2D, V0.2D, V0.2D
                 0x6E60DC00u, // FMUL  V0.2D, V0.2D, V0.2D
                 0x4E60DC00u, // FMULX V0.2D, V0.2D, V0.2D
                 0x4EE0D400u  // FSUB  V0.2D, V0.2D, V0.2D
+            };
+        }
+
+        private static uint[] _F_Cm_EqGeGt_S_S_()
+        {
+            return new uint[]
+            {
+                0x5E22E420u, // FCMEQ S0, S1, S2
+                0x7E22E420u, // FCMGE S0, S1, S2
+                0x7EA2E420u  // FCMGT S0, S1, S2
+            };
+        }
+
+        private static uint[] _F_Cm_EqGeGt_S_D_()
+        {
+            return new uint[]
+            {
+                0x5E62E420u, // FCMEQ D0, D1, D2
+                0x7E62E420u, // FCMGE D0, D1, D2
+                0x7EE2E420u  // FCMGT D0, D1, D2
+            };
+        }
+
+        private static uint[] _F_Cm_EqGeGt_V_2S_4S_()
+        {
+            return new uint[]
+            {
+                0x0E20E400u, // FCMEQ V0.2S, V0.2S, V0.2S
+                0x2E20E400u, // FCMGE V0.2S, V0.2S, V0.2S
+                0x2EA0E400u  // FCMGT V0.2S, V0.2S, V0.2S
+            };
+        }
+
+        private static uint[] _F_Cm_EqGeGt_V_2D_()
+        {
+            return new uint[]
+            {
+                0x4E60E400u, // FCMEQ V0.2D, V0.2D, V0.2D
+                0x6E60E400u, // FCMGE V0.2D, V0.2D, V0.2D
+                0x6EE0E400u  // FCMGT V0.2D, V0.2D, V0.2D
             };
         }
 
@@ -1285,14 +1327,14 @@ namespace Ryujinx.Tests.Cpu
         }
 
         [Test, Pairwise] [Explicit]
-        public void F_Add_Div_Mul_Mulx_Sub_V_2S_4S([ValueSource("_F_Add_Div_Mul_Mulx_Sub_V_2S_4S_")] uint opcodes,
-                                                   [Values(0u)]     uint rd,
-                                                   [Values(1u, 0u)] uint rn,
-                                                   [Values(2u, 0u)] uint rm,
-                                                   [ValueSource("_2S_F_")] ulong z,
-                                                   [ValueSource("_2S_F_")] ulong a,
-                                                   [ValueSource("_2S_F_")] ulong b,
-                                                   [Values(0b0u, 0b1u)] uint q) // <2S, 4S>
+        public void F_Add_Div_Mul_Mulx_Sub_P_V_2S_4S([ValueSource("_F_Add_Div_Mul_Mulx_Sub_P_V_2S_4S_")] uint opcodes,
+                                                     [Values(0u)]     uint rd,
+                                                     [Values(1u, 0u)] uint rn,
+                                                     [Values(2u, 0u)] uint rm,
+                                                     [ValueSource("_2S_F_")] ulong z,
+                                                     [ValueSource("_2S_F_")] ulong a,
+                                                     [ValueSource("_2S_F_")] ulong b,
+                                                     [Values(0b0u, 0b1u)] uint q) // <2S, 4S>
         {
             opcodes |= ((rm & 31) << 16) | ((rn & 31) << 5) | ((rd & 31) << 0);
             opcodes |= ((q & 1) << 30);
@@ -1312,13 +1354,13 @@ namespace Ryujinx.Tests.Cpu
         }
 
         [Test, Pairwise] [Explicit]
-        public void F_Add_Div_Mul_Mulx_Sub_V_2D([ValueSource("_F_Add_Div_Mul_Mulx_Sub_V_2D_")] uint opcodes,
-                                                [Values(0u)]     uint rd,
-                                                [Values(1u, 0u)] uint rn,
-                                                [Values(2u, 0u)] uint rm,
-                                                [ValueSource("_1D_F_")] ulong z,
-                                                [ValueSource("_1D_F_")] ulong a,
-                                                [ValueSource("_1D_F_")] ulong b)
+        public void F_Add_Div_Mul_Mulx_Sub_P_V_2D([ValueSource("_F_Add_Div_Mul_Mulx_Sub_P_V_2D_")] uint opcodes,
+                                                  [Values(0u)]     uint rd,
+                                                  [Values(1u, 0u)] uint rn,
+                                                  [Values(2u, 0u)] uint rm,
+                                                  [ValueSource("_1D_F_")] ulong z,
+                                                  [ValueSource("_1D_F_")] ulong a,
+                                                  [ValueSource("_1D_F_")] ulong b)
         {
             opcodes |= ((rm & 31) << 16) | ((rn & 31) << 5) | ((rd & 31) << 0);
 
@@ -1334,6 +1376,94 @@ namespace Ryujinx.Tests.Cpu
             SingleOpcode(opcodes, v0: v0, v1: v1, v2: v2, fpcr: fpcr);
 
             CompareAgainstUnicorn(fpsrMask: Fpsr.Ioc | Fpsr.Dzc | Fpsr.Idc);
+        }
+
+        [Test, Pairwise] [Explicit]
+        public void F_Cm_EqGeGt_S_S([ValueSource("_F_Cm_EqGeGt_S_S_")] uint opcodes,
+                                    [ValueSource("_1S_F_")] ulong a,
+                                    [ValueSource("_1S_F_")] ulong b)
+        {
+            ulong z = TestContext.CurrentContext.Random.NextULong();
+            Vector128<float> v0 = MakeVectorE0E1(z, z);
+            Vector128<float> v1 = MakeVectorE0(a);
+            Vector128<float> v2 = MakeVectorE0(b);
+
+            int rnd = (int)TestContext.CurrentContext.Random.NextUInt();
+
+            int fpcr = rnd & (1 << (int)Fpcr.Fz);
+
+            SingleOpcode(opcodes, v0: v0, v1: v1, v2: v2, fpcr: fpcr);
+
+            CompareAgainstUnicorn(fpsrMask: Fpsr.Ioc | Fpsr.Idc);
+        }
+
+        [Test, Pairwise] [Explicit]
+        public void F_Cm_EqGeGt_S_D([ValueSource("_F_Cm_EqGeGt_S_D_")] uint opcodes,
+                                    [ValueSource("_1D_F_")] ulong a,
+                                    [ValueSource("_1D_F_")] ulong b)
+        {
+            ulong z = TestContext.CurrentContext.Random.NextULong();
+            Vector128<float> v0 = MakeVectorE1(z);
+            Vector128<float> v1 = MakeVectorE0(a);
+            Vector128<float> v2 = MakeVectorE0(b);
+
+            int rnd = (int)TestContext.CurrentContext.Random.NextUInt();
+
+            int fpcr = rnd & (1 << (int)Fpcr.Fz);
+
+            SingleOpcode(opcodes, v0: v0, v1: v1, v2: v2, fpcr: fpcr);
+
+            CompareAgainstUnicorn(fpsrMask: Fpsr.Ioc | Fpsr.Idc);
+        }
+
+        [Test, Pairwise] [Explicit]
+        public void F_Cm_EqGeGt_V_2S_4S([ValueSource("_F_Cm_EqGeGt_V_2S_4S_")] uint opcodes,
+                                        [Values(0u)]     uint rd,
+                                        [Values(1u, 0u)] uint rn,
+                                        [Values(2u, 0u)] uint rm,
+                                        [ValueSource("_2S_F_")] ulong z,
+                                        [ValueSource("_2S_F_")] ulong a,
+                                        [ValueSource("_2S_F_")] ulong b,
+                                        [Values(0b0u, 0b1u)] uint q) // <2S, 4S>
+        {
+            opcodes |= ((rm & 31) << 16) | ((rn & 31) << 5) | ((rd & 31) << 0);
+            opcodes |= ((q & 1) << 30);
+
+            Vector128<float> v0 = MakeVectorE0E1(z, z);
+            Vector128<float> v1 = MakeVectorE0E1(a, a * q);
+            Vector128<float> v2 = MakeVectorE0E1(b, b * q);
+
+            int rnd = (int)TestContext.CurrentContext.Random.NextUInt();
+
+            int fpcr = rnd & (1 << (int)Fpcr.Fz);
+
+            SingleOpcode(opcodes, v0: v0, v1: v1, v2: v2, fpcr: fpcr);
+
+            CompareAgainstUnicorn(fpsrMask: Fpsr.Ioc | Fpsr.Idc);
+        }
+
+        [Test, Pairwise] [Explicit]
+        public void F_Cm_EqGeGt_V_2D([ValueSource("_F_Cm_EqGeGt_V_2D_")] uint opcodes,
+                                     [Values(0u)]     uint rd,
+                                     [Values(1u, 0u)] uint rn,
+                                     [Values(2u, 0u)] uint rm,
+                                     [ValueSource("_1D_F_")] ulong z,
+                                     [ValueSource("_1D_F_")] ulong a,
+                                     [ValueSource("_1D_F_")] ulong b)
+        {
+            opcodes |= ((rm & 31) << 16) | ((rn & 31) << 5) | ((rd & 31) << 0);
+
+            Vector128<float> v0 = MakeVectorE0E1(z, z);
+            Vector128<float> v1 = MakeVectorE0E1(a, a);
+            Vector128<float> v2 = MakeVectorE0E1(b, b);
+
+            int rnd = (int)TestContext.CurrentContext.Random.NextUInt();
+
+            int fpcr = rnd & (1 << (int)Fpcr.Fz);
+
+            SingleOpcode(opcodes, v0: v0, v1: v1, v2: v2, fpcr: fpcr);
+
+            CompareAgainstUnicorn(fpsrMask: Fpsr.Ioc | Fpsr.Idc);
         }
 
         [Test, Pairwise] [Explicit]

--- a/Ryujinx.Tests/Cpu/CpuTestSimdShImm.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestSimdShImm.cs
@@ -50,6 +50,33 @@ namespace Ryujinx.Tests.Cpu
 #endregion
 
 #region "ValueSource (Opcodes)"
+        private static uint[] _SU_Shll_V_8B8H_16B8H_()
+        {
+            return new uint[]
+            {
+                0x0F08A400u, // SSHLL V0.8H, V0.8B, #0
+                0x2F08A400u  // USHLL V0.8H, V0.8B, #0
+            };
+        }
+
+        private static uint[] _SU_Shll_V_4H4S_8H4S_()
+        {
+            return new uint[]
+            {
+                0x0F10A400u, // SSHLL V0.4S, V0.4H, #0
+                0x2F10A400u  // USHLL V0.4S, V0.4H, #0
+            };
+        }
+
+        private static uint[] _SU_Shll_V_2S2D_4S2D_()
+        {
+            return new uint[]
+            {
+                0x0F20A400u, // SSHLL V0.2D, V0.2S, #0
+                0x2F20A400u  // USHLL V0.2D, V0.2S, #0
+            };
+        }
+
         private static uint[] _ShrImm_S_D_()
         {
             return new uint[]
@@ -340,6 +367,75 @@ namespace Ryujinx.Tests.Cpu
             Vector128<float> v1 = MakeVectorE0E1(a, a);
 
             SingleOpcode(opcode, v0: v0, v1: v1);
+
+            CompareAgainstUnicorn();
+        }
+
+        [Test, Pairwise]
+        public void SU_Shll_V_8B8H_16B8H([ValueSource("_SU_Shll_V_8B8H_16B8H_")] uint opcodes,
+                                         [Values(0u)]     uint rd,
+                                         [Values(1u, 0u)] uint rn,
+                                         [ValueSource("_8B_")] [Random(RndCnt)] ulong z,
+                                         [ValueSource("_8B_")] [Random(RndCnt)] ulong a,
+                                         [Range(0u, 7u)] uint shift,
+                                         [Values(0b0u, 0b1u)] uint q) // <8B8H, 16B8H>
+        {
+            uint immHb = (8 + shift) & 0x7F;
+
+            opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
+            opcodes |= (immHb << 16);
+            opcodes |= ((q & 1) << 30);
+
+            Vector128<float> v0 = MakeVectorE0E1(z, z);
+            Vector128<float> v1 = MakeVectorE0E1(q == 0u ? a : 0ul, q == 1u ? a : 0ul);
+
+            SingleOpcode(opcodes, v0: v0, v1: v1);
+
+            CompareAgainstUnicorn();
+        }
+
+        [Test, Pairwise]
+        public void SU_Shll_V_4H4S_8H4S([ValueSource("_SU_Shll_V_4H4S_8H4S_")] uint opcodes,
+                                        [Values(0u)]     uint rd,
+                                        [Values(1u, 0u)] uint rn,
+                                        [ValueSource("_4H_")] [Random(RndCnt)] ulong z,
+                                        [ValueSource("_4H_")] [Random(RndCnt)] ulong a,
+                                        [Range(0u, 15u)] uint shift,
+                                        [Values(0b0u, 0b1u)] uint q) // <4H4S, 8H4S>
+        {
+            uint immHb = (16 + shift) & 0x7F;
+
+            opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
+            opcodes |= (immHb << 16);
+            opcodes |= ((q & 1) << 30);
+
+            Vector128<float> v0 = MakeVectorE0E1(z, z);
+            Vector128<float> v1 = MakeVectorE0E1(q == 0u ? a : 0ul, q == 1u ? a : 0ul);
+
+            SingleOpcode(opcodes, v0: v0, v1: v1);
+
+            CompareAgainstUnicorn();
+        }
+
+        [Test, Pairwise]
+        public void SU_Shll_V_2S2D_4S2D([ValueSource("_SU_Shll_V_2S2D_4S2D_")] uint opcodes,
+                                        [Values(0u)]     uint rd,
+                                        [Values(1u, 0u)] uint rn,
+                                        [ValueSource("_2S_")] [Random(RndCnt)] ulong z,
+                                        [ValueSource("_2S_")] [Random(RndCnt)] ulong a,
+                                        [Range(0u, 31u)] uint shift,
+                                        [Values(0b0u, 0b1u)] uint q) // <2S2D, 4S2D>
+        {
+            uint immHb = (32 + shift) & 0x7F;
+
+            opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
+            opcodes |= (immHb << 16);
+            opcodes |= ((q & 1) << 30);
+
+            Vector128<float> v0 = MakeVectorE0E1(z, z);
+            Vector128<float> v1 = MakeVectorE0E1(q == 0u ? a : 0ul, q == 1u ? a : 0ul);
+
+            SingleOpcode(opcodes, v0: v0, v1: v1);
 
             CompareAgainstUnicorn();
         }


### PR DESCRIPTION
### **Added Fast (Intrinsics) & Slow (SoftFloat) paths:**

_InstEmitSimdCmp:_

**Fcmeq, Fcmge, Fcmgt, Fcmle, Fcmlt (Scalar & Vector, Reg & Zero):**
- Max Sse Req.: Sse2
- Types Covered: All

_InstEmitSimdArithmetic:_

**Faddp_S:**
- Max Sse Req.: Sse3
- Types Covered: All

**Faddp_V;**
**Fmaxp_V, Fminp_V:**
- Max Sse Req.: Sse2
- Types Covered: All

### **Added Fast (Intrinsics) paths:**

_InstEmitSimdShift:_

**Shll_V;**
**Sshll_V, Ushll_V:**
- Max Sse Req.: Sse41
- Types Covered: All

_InstEmitSimdMove:_

**Xtn_V (improved):**
- Max Sse Req.: Ssse3
- Types Covered: All

**Tests provided for all instructions involved.**

Nits.