### PR TITLE
Update to LibHac 0.2.0

### DIFF
--- a/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
+++ b/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using LibHac.IO;
 
 namespace Ryujinx.HLE.FileSystem.Content
 {
@@ -73,7 +74,7 @@ namespace Ryujinx.HLE.FileSystem.Content
 
                         using (FileStream ncaFile = new FileStream(Directory.GetFiles(directoryPath)[0], FileMode.Open, FileAccess.Read))
                         {
-                            Nca nca = new Nca(_device.System.KeySet, ncaFile, false);
+                            Nca nca = new Nca(_device.System.KeySet, ncaFile.AsStorage(), false);
 
                             string switchPath = Path.Combine(contentPathString + ":",
                                                               ncaFile.Name.Replace(contentDirectory, string.Empty).TrimStart('\\'));
@@ -89,10 +90,6 @@ namespace Ryujinx.HLE.FileSystem.Content
                             AddEntry(entry);
 
                             _contentDictionary.Add((nca.Header.TitleId, nca.Header.ContentType), ncaName);
-
-                            ncaFile.Close();
-                            nca.Dispose();
-                            ncaFile.Dispose();
                         }
                     }
                 }
@@ -105,7 +102,7 @@ namespace Ryujinx.HLE.FileSystem.Content
 
                         using (FileStream ncaFile = new FileStream(filePath, FileMode.Open, FileAccess.Read))
                         {
-                            Nca nca = new Nca(_device.System.KeySet, ncaFile, false);
+                            Nca nca = new Nca(_device.System.KeySet, ncaFile.AsStorage(), false);
 
                             string switchPath = Path.Combine(contentPathString + ":",
                                                               filePath.Replace(contentDirectory, string.Empty).TrimStart('\\'));
@@ -121,10 +118,6 @@ namespace Ryujinx.HLE.FileSystem.Content
                             AddEntry(entry);
 
                             _contentDictionary.Add((nca.Header.TitleId, nca.Header.ContentType), ncaName);
-
-                            ncaFile.Close();
-                            nca.Dispose();
-                            ncaFile.Dispose();
                         }
                     }
                 }
@@ -235,14 +228,13 @@ namespace Ryujinx.HLE.FileSystem.Content
             {
                 if (File.Exists(installedPath))
                 {
-                    FileStream file         = new FileStream(installedPath, FileMode.Open, FileAccess.Read);
-                    Nca        nca          = new Nca(_device.System.KeySet, file, false);
-                    bool       contentCheck = nca.Header.ContentType == contentType;
+                    using (FileStream file = new FileStream(installedPath, FileMode.Open, FileAccess.Read))
+                    {
+                        Nca  nca          = new Nca(_device.System.KeySet, file.AsStorage(), false);
+                        bool contentCheck = nca.Header.ContentType == contentType;
 
-                    nca.Dispose();
-                    file.Dispose();
-
-                    return contentCheck;
+                        return contentCheck;
+                    }
                 }
             }
 

--- a/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
+++ b/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
@@ -1,10 +1,10 @@
 ﻿using LibHac;
+using LibHac.IO;
 using Ryujinx.HLE.Utilities;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using LibHac.IO;
 
 namespace Ryujinx.HLE.FileSystem.Content
 {

--- a/Ryujinx.HLE/FileSystem/PFsProvider.cs
+++ b/Ryujinx.HLE/FileSystem/PFsProvider.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-
+using LibHac.IO;
 using static Ryujinx.HLE.HOS.ErrorCode;
 
 namespace Ryujinx.HLE.FileSystem
@@ -117,7 +117,7 @@ namespace Ryujinx.HLE.FileSystem
 
             if (_pfs.FileExists(name))
             {
-                Stream stream = _pfs.OpenFile(name);
+                Stream stream = _pfs.OpenFile(name).AsStream();
                 fileInterface = new IFile(stream, name);
 
                 return 0;

--- a/Ryujinx.HLE/FileSystem/PFsProvider.cs
+++ b/Ryujinx.HLE/FileSystem/PFsProvider.cs
@@ -1,11 +1,12 @@
 ﻿using LibHac;
+using LibHac.IO;
 using Ryujinx.HLE.HOS;
 using Ryujinx.HLE.HOS.Services.FspSrv;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using LibHac.IO;
+
 using static Ryujinx.HLE.HOS.ErrorCode;
 
 namespace Ryujinx.HLE.FileSystem

--- a/Ryujinx.HLE/FileSystem/RomFsProvider.cs
+++ b/Ryujinx.HLE/FileSystem/RomFsProvider.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-
+using LibHac.IO;
 using static Ryujinx.HLE.HOS.ErrorCode;
 
 namespace Ryujinx.HLE.FileSystem
@@ -14,9 +14,9 @@ namespace Ryujinx.HLE.FileSystem
     {
         private Romfs _romFs;
 
-        public RomFsProvider(Stream storageStream)
+        public RomFsProvider(LibHac.IO.IStorage storage)
         {
-            _romFs = new Romfs(storageStream);
+            _romFs = new Romfs(storage);
         }
 
         public long CreateDirectory(string name)
@@ -133,7 +133,7 @@ namespace Ryujinx.HLE.FileSystem
         {
             if (_romFs.FileExists(name))
             {
-                Stream stream = _romFs.OpenFile(name);
+                Stream stream = _romFs.OpenFile(name).AsStream();
 
                 fileInterface = new IFile(stream, name);
 

--- a/Ryujinx.HLE/FileSystem/RomFsProvider.cs
+++ b/Ryujinx.HLE/FileSystem/RomFsProvider.cs
@@ -1,11 +1,12 @@
 ﻿using LibHac;
+using LibHac.IO;
 using Ryujinx.HLE.HOS;
 using Ryujinx.HLE.HOS.Services.FspSrv;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using LibHac.IO;
+
 using static Ryujinx.HLE.HOS.ErrorCode;
 
 namespace Ryujinx.HLE.FileSystem

--- a/Ryujinx.HLE/HOS/Font/SharedFontManager.cs
+++ b/Ryujinx.HLE/HOS/Font/SharedFontManager.cs
@@ -1,4 +1,5 @@
 using LibHac;
+using LibHac.IO;
 using Ryujinx.HLE.FileSystem;
 using Ryujinx.HLE.FileSystem.Content;
 using Ryujinx.HLE.Resource;
@@ -6,7 +7,7 @@ using Ryujinx.HLE.Utilities;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using LibHac.IO;
+
 using static Ryujinx.HLE.Utilities.FontUtils;
 
 namespace Ryujinx.HLE.HOS.Font

--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -1,4 +1,5 @@
 using LibHac;
+using LibHac.IO;
 using Ryujinx.Common.Logging;
 using Ryujinx.HLE.FileSystem.Content;
 using Ryujinx.HLE.HOS.Font;
@@ -16,7 +17,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
-using LibHac.IO;
+
 using NxStaticObject = Ryujinx.HLE.Loaders.Executables.NxStaticObject;
 
 namespace Ryujinx.HLE.HOS
@@ -281,7 +282,7 @@ namespace Ryujinx.HLE.HOS
 
             foreach (PfsFileEntry fileEntry in xci.SecurePartition.Files.Where(x => x.Name.EndsWith(".nca")))
             {
-                LibHac.IO.IStorage ncaStorage = xci.SecurePartition.OpenFile(fileEntry);
+                IStorage ncaStorage = xci.SecurePartition.OpenFile(fileEntry);
 
                 Nca nca = new Nca(KeySet, ncaStorage, true);
 
@@ -328,7 +329,7 @@ namespace Ryujinx.HLE.HOS
         {
             Romfs controlRomfs = new Romfs(controlNca.OpenSection(0, false, FsIntegrityCheckLevel, true));
 
-            LibHac.IO.IStorage controlFile = controlRomfs.OpenFile("/control.nacp");
+            IStorage controlFile = controlRomfs.OpenFile("/control.nacp");
 
             ControlData = new Nacp(controlFile.AsStream());
         }
@@ -394,8 +395,8 @@ namespace Ryujinx.HLE.HOS
                 return;
             }
 
-            LibHac.IO.IStorage romfsStorage = mainNca.OpenSection(ProgramPartitionType.Data, false, FsIntegrityCheckLevel, false);
-            LibHac.IO.IStorage exefsStorage = mainNca.OpenSection(ProgramPartitionType.Code, false, FsIntegrityCheckLevel, true);
+            IStorage romfsStorage = mainNca.OpenSection(ProgramPartitionType.Data, false, FsIntegrityCheckLevel, false);
+            IStorage exefsStorage = mainNca.OpenSection(ProgramPartitionType.Code, false, FsIntegrityCheckLevel, true);
 
             if (exefsStorage == null)
             {
@@ -453,7 +454,7 @@ namespace Ryujinx.HLE.HOS
             {
                 Romfs controlRomfs = new Romfs(controlNca.OpenSection(0, false, FsIntegrityCheckLevel, true));
 
-                LibHac.IO.IStorage controlFile = controlRomfs.OpenFile("/control.nacp");
+                IStorage controlFile = controlRomfs.OpenFile("/control.nacp");
 
                 Nacp controlData = new Nacp(controlFile.AsStream());
 

--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -16,7 +16,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
-
+using LibHac.IO;
 using NxStaticObject = Ryujinx.HLE.Loaders.Executables.NxStaticObject;
 
 namespace Ryujinx.HLE.HOS
@@ -242,7 +242,7 @@ namespace Ryujinx.HLE.HOS
         {
             FileStream file = new FileStream(xciFile, FileMode.Open, FileAccess.Read);
 
-            Xci xci = new Xci(KeySet, file);
+            Xci xci = new Xci(KeySet, file.AsStorage());
 
             (Nca mainNca, Nca controlNca) = GetXciGameData(xci);
 
@@ -271,7 +271,7 @@ namespace Ryujinx.HLE.HOS
 
             foreach (PfsFileEntry ticketEntry in xci.SecurePartition.Files.Where(x => x.Name.EndsWith(".tik")))
             {
-                Ticket ticket = new Ticket(xci.SecurePartition.OpenFile(ticketEntry));
+                Ticket ticket = new Ticket(xci.SecurePartition.OpenFile(ticketEntry).AsStream());
 
                 if (!KeySet.TitleKeys.ContainsKey(ticket.RightsId))
                 {
@@ -281,9 +281,9 @@ namespace Ryujinx.HLE.HOS
 
             foreach (PfsFileEntry fileEntry in xci.SecurePartition.Files.Where(x => x.Name.EndsWith(".nca")))
             {
-                Stream ncaStream = xci.SecurePartition.OpenFile(fileEntry);
+                LibHac.IO.IStorage ncaStorage = xci.SecurePartition.OpenFile(fileEntry);
 
-                Nca nca = new Nca(KeySet, ncaStream, true);
+                Nca nca = new Nca(KeySet, ncaStorage, true);
 
                 if (nca.Header.ContentType == ContentType.Program)
                 {
@@ -326,20 +326,18 @@ namespace Ryujinx.HLE.HOS
 
         public void ReadControlData(Nca controlNca)
         {
-            Romfs controlRomfs = new Romfs(controlNca.OpenSection(0, false, FsIntegrityCheckLevel));
+            Romfs controlRomfs = new Romfs(controlNca.OpenSection(0, false, FsIntegrityCheckLevel, true));
 
-            byte[] controlFile = controlRomfs.GetFile("/control.nacp");
+            LibHac.IO.IStorage controlFile = controlRomfs.OpenFile("/control.nacp");
 
-            BinaryReader reader = new BinaryReader(new MemoryStream(controlFile));
-
-            ControlData = new Nacp(reader);
+            ControlData = new Nacp(controlFile.AsStream());
         }
 
         public void LoadNca(string ncaFile)
         {
             FileStream file = new FileStream(ncaFile, FileMode.Open, FileAccess.Read);
 
-            Nca nca = new Nca(KeySet, file, true);
+            Nca nca = new Nca(KeySet, file.AsStorage(false), false);
 
             LoadNca(nca, null);
         }
@@ -348,16 +346,16 @@ namespace Ryujinx.HLE.HOS
         {
             FileStream file = new FileStream(nspFile, FileMode.Open, FileAccess.Read);
 
-            Pfs nsp = new Pfs(file);
+            Pfs nsp = new Pfs(file.AsStorage(false));
 
-            PfsFileEntry ticketFile = nsp.Files.FirstOrDefault(x => x.Name.EndsWith(".tik"));
-
-            // Load title key from the NSP's ticket in case the user doesn't have a title key file
-            if (ticketFile != null)
+            foreach (PfsFileEntry ticketEntry in nsp.Files.Where(x => x.Name.EndsWith(".tik")))
             {
-                Ticket ticket = new Ticket(nsp.OpenFile(ticketFile));
+                Ticket ticket = new Ticket(nsp.OpenFile(ticketEntry).AsStream());
 
-                KeySet.TitleKeys[ticket.RightsId] = ticket.GetTitleKey(KeySet);
+                if (!KeySet.TitleKeys.ContainsKey(ticket.RightsId))
+                {
+                    KeySet.TitleKeys.Add(ticket.RightsId, ticket.GetTitleKey(KeySet));
+                }
             }
 
             Nca mainNca    = null;
@@ -396,26 +394,26 @@ namespace Ryujinx.HLE.HOS
                 return;
             }
 
-            Stream romfsStream = mainNca.OpenSection(ProgramPartitionType.Data, false, FsIntegrityCheckLevel);
-            Stream exefsStream = mainNca.OpenSection(ProgramPartitionType.Code, false, FsIntegrityCheckLevel);
+            LibHac.IO.IStorage romfsStorage = mainNca.OpenSection(ProgramPartitionType.Data, false, FsIntegrityCheckLevel, false);
+            LibHac.IO.IStorage exefsStorage = mainNca.OpenSection(ProgramPartitionType.Code, false, FsIntegrityCheckLevel, true);
 
-            if (exefsStream == null)
+            if (exefsStorage == null)
             {
                 Logger.PrintError(LogClass.Loader, "No ExeFS found in NCA");
 
                 return;
             }
 
-            if (romfsStream == null)
+            if (romfsStorage == null)
             {
                 Logger.PrintWarning(LogClass.Loader, "No RomFS found in NCA");
             }
             else
             {
-                Device.FileSystem.SetRomFs(romfsStream);
+                Device.FileSystem.SetRomFs(romfsStorage.AsStream(false));
             }
 
-            Pfs exefs = new Pfs(exefsStream);
+            Pfs exefs = new Pfs(exefsStorage);
 
             Npdm metaData = null;
 
@@ -423,7 +421,7 @@ namespace Ryujinx.HLE.HOS
             {
                 Logger.PrintInfo(LogClass.Loader, "Loading main.npdm...");
 
-                metaData = new Npdm(exefs.OpenFile("main.npdm"));
+                metaData = new Npdm(exefs.OpenFile("main.npdm").AsStream());
             }
             else
             {
@@ -445,7 +443,7 @@ namespace Ryujinx.HLE.HOS
 
                     Logger.PrintInfo(LogClass.Loader, $"Loading {filename}...");
 
-                    NxStaticObject staticObject = new NxStaticObject(exefs.OpenFile(file));
+                    NxStaticObject staticObject = new NxStaticObject(exefs.OpenFile(file).AsStream());
 
                     staticObjects.Add(staticObject);
                 }
@@ -453,19 +451,17 @@ namespace Ryujinx.HLE.HOS
 
             Nacp ReadControlData()
             {
-                Romfs controlRomfs = new Romfs(controlNca.OpenSection(0, false, FsIntegrityCheckLevel));
+                Romfs controlRomfs = new Romfs(controlNca.OpenSection(0, false, FsIntegrityCheckLevel, true));
 
-                byte[] controlFile = controlRomfs.GetFile("/control.nacp");
+                LibHac.IO.IStorage controlFile = controlRomfs.OpenFile("/control.nacp");
 
-                BinaryReader reader = new BinaryReader(new MemoryStream(controlFile));
+                Nacp controlData = new Nacp(controlFile.AsStream());
 
-                Nacp controlData = new Nacp(reader);
-
-                CurrentTitle = controlData.Languages[(int)State.DesiredTitleLanguage].Title;
+                CurrentTitle = controlData.Descriptions[(int)State.DesiredTitleLanguage].Title;
 
                 if (string.IsNullOrWhiteSpace(CurrentTitle))
                 {
-                    CurrentTitle = controlData.Languages.ToList().Find(x => !string.IsNullOrWhiteSpace(x.Title)).Title;
+                    CurrentTitle = controlData.Descriptions.ToList().Find(x => !string.IsNullOrWhiteSpace(x.Title)).Title;
                 }
 
                 return controlData;

--- a/Ryujinx.HLE/HOS/Services/FspSrv/IFileSystemProxy.cs
+++ b/Ryujinx.HLE/HOS/Services/FspSrv/IFileSystemProxy.cs
@@ -5,7 +5,7 @@ using Ryujinx.HLE.Utilities;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-
+using LibHac.IO;
 using static Ryujinx.HLE.FileSystem.VirtualFileSystem;
 using static Ryujinx.HLE.HOS.ErrorCode;
 using static Ryujinx.HLE.Utilities.StringUtils;
@@ -65,7 +65,7 @@ namespace Ryujinx.HLE.HOS.Services.FspSrv
 
             if (extension == ".nca")
             {
-                return OpenNcaFs(context, fullPath, fileStream);
+                return OpenNcaFs(context, fullPath, fileStream.AsStorage());
             }
             else if (extension == ".nsp")
             {
@@ -176,10 +176,10 @@ namespace Ryujinx.HLE.HOS.Services.FspSrv
 
                     if (File.Exists(ncaPath))
                     {
-                        FileStream ncaStream    = new FileStream(ncaPath, FileMode.Open, FileAccess.Read);
-                        Nca        nca          = new Nca(context.Device.System.KeySet, ncaStream, false);
-                        NcaSection romfsSection = nca.Sections.FirstOrDefault(x => x?.Type == SectionType.Romfs);
-                        Stream     romfsStream  = nca.OpenSection(romfsSection.SectionNum, false, context.Device.System.FsIntegrityCheckLevel);
+                        LibHac.IO.IStorage ncaStorage   = new FileStream(ncaPath, FileMode.Open, FileAccess.Read).AsStorage();
+                        Nca                nca          = new Nca(context.Device.System.KeySet, ncaStorage, false);
+                        NcaSection         romfsSection = nca.Sections.FirstOrDefault(x => x?.Type == SectionType.Romfs);
+                        Stream             romfsStream  = nca.OpenSection(romfsSection.SectionNum, false, context.Device.System.FsIntegrityCheckLevel, false).AsStream();
 
                         MakeObject(context, new IStorage(romfsStream));
 
@@ -236,17 +236,11 @@ namespace Ryujinx.HLE.HOS.Services.FspSrv
 
         private long OpenNsp(ServiceCtx context, string pfsPath)
         {
-            FileStream   pfsFile    = new FileStream(pfsPath, FileMode.Open, FileAccess.Read);
-            Pfs          nsp        = new Pfs(pfsFile);
-            PfsFileEntry ticketFile = nsp.Files.FirstOrDefault(x => x.Name.EndsWith(".tik"));
+            FileStream pfsFile = new FileStream(pfsPath, FileMode.Open, FileAccess.Read);
+            Pfs        nsp     = new Pfs(pfsFile.AsStorage());
 
-            if (ticketFile != null)
-            {
-                Ticket ticket = new Ticket(nsp.OpenFile(ticketFile));
+            ImportTitleKeysFromNsp(nsp, context.Device.System.KeySet);
 
-                context.Device.System.KeySet.TitleKeys[ticket.RightsId] =
-                    ticket.GetTitleKey(context.Device.System.KeySet);
-            }
 
             IFileSystem nspFileSystem = new IFileSystem(pfsPath, new PFsProvider(nsp));
 
@@ -255,25 +249,25 @@ namespace Ryujinx.HLE.HOS.Services.FspSrv
             return 0;
         }
 
-        private long OpenNcaFs(ServiceCtx context,string ncaPath, Stream ncaStream)
+        private long OpenNcaFs(ServiceCtx context, string ncaPath, LibHac.IO.IStorage ncaStorage)
         {
-            Nca nca = new Nca(context.Device.System.KeySet, ncaStream, false);
+            Nca nca = new Nca(context.Device.System.KeySet, ncaStorage, false);
 
             NcaSection romfsSection = nca.Sections.FirstOrDefault(x => x?.Type == SectionType.Romfs);
             NcaSection pfsSection   = nca.Sections.FirstOrDefault(x => x?.Type == SectionType.Pfs0);
 
             if (romfsSection != null)
             {
-                Stream      romfsStream   = nca.OpenSection(romfsSection.SectionNum, false, context.Device.System.FsIntegrityCheckLevel);
-                IFileSystem ncaFileSystem = new IFileSystem(ncaPath, new RomFsProvider(romfsStream));
+                LibHac.IO.IStorage romfsStorage = nca.OpenSection(romfsSection.SectionNum, false, context.Device.System.FsIntegrityCheckLevel, false);
+                IFileSystem ncaFileSystem       = new IFileSystem(ncaPath, new RomFsProvider(romfsStorage));
 
                 MakeObject(context, ncaFileSystem);
             }
-            else if(pfsSection !=null)
+            else if(pfsSection != null)
             {
-                Stream      pfsStream     = nca.OpenSection(pfsSection.SectionNum, false, context.Device.System.FsIntegrityCheckLevel);
-                Pfs         pfs           = new Pfs(pfsStream);
-                IFileSystem ncaFileSystem = new IFileSystem(ncaPath, new PFsProvider(pfs));
+                LibHac.IO.IStorage pfsStorage    = nca.OpenSection(pfsSection.SectionNum, false, context.Device.System.FsIntegrityCheckLevel, false);
+                Pfs                pfs           = new Pfs(pfsStorage);
+                IFileSystem        ncaFileSystem = new IFileSystem(ncaPath, new PFsProvider(pfs));
 
                 MakeObject(context, ncaFileSystem);
             }
@@ -301,17 +295,10 @@ namespace Ryujinx.HLE.HOS.Services.FspSrv
                     FileMode.Open,
                     FileAccess.Read);
 
-                Pfs          nsp        = new Pfs(pfsFile);
-                PfsFileEntry ticketFile = nsp.Files.FirstOrDefault(x => x.Name.EndsWith(".tik"));
+                Pfs nsp = new Pfs(pfsFile.AsStorage());
 
-                if (ticketFile != null)
-                {
-                    Ticket ticket = new Ticket(nsp.OpenFile(ticketFile));
-
-                    context.Device.System.KeySet.TitleKeys[ticket.RightsId] =
-                        ticket.GetTitleKey(context.Device.System.KeySet);
-                }
-
+                ImportTitleKeysFromNsp(nsp, context.Device.System.KeySet);
+                
                 string filename = fullPath.Replace(archivePath.FullName, string.Empty).TrimStart('\\');
 
                 if (nsp.FileExists(filename))
@@ -321,6 +308,19 @@ namespace Ryujinx.HLE.HOS.Services.FspSrv
             }
 
             return MakeError(ErrorModule.Fs, FsErr.PathDoesNotExist);
+        }
+
+        private void ImportTitleKeysFromNsp(Pfs nsp, Keyset keySet)
+        {
+            foreach (PfsFileEntry ticketEntry in nsp.Files.Where(x => x.Name.EndsWith(".tik")))
+            {
+                Ticket ticket = new Ticket(nsp.OpenFile(ticketEntry).AsStream());
+
+                if (!keySet.TitleKeys.ContainsKey(ticket.RightsId))
+                {
+                    keySet.TitleKeys.Add(ticket.RightsId, ticket.GetTitleKey(keySet));
+                }
+            }
         }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/FspSrv/IFileSystemProxy.cs
+++ b/Ryujinx.HLE/HOS/Services/FspSrv/IFileSystemProxy.cs
@@ -1,11 +1,12 @@
 using LibHac;
+using LibHac.IO;
 using Ryujinx.HLE.FileSystem;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.Utilities;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using LibHac.IO;
+
 using static Ryujinx.HLE.FileSystem.VirtualFileSystem;
 using static Ryujinx.HLE.HOS.ErrorCode;
 using static Ryujinx.HLE.Utilities.StringUtils;

--- a/Ryujinx.HLE/HOS/Services/Set/ISystemSettingsServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Set/ISystemSettingsServer.cs
@@ -1,13 +1,13 @@
+using LibHac;
+using LibHac.IO;
 using Ryujinx.Common.Logging;
+using Ryujinx.HLE.FileSystem;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.SystemState;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using LibHac;
-using LibHac.IO;
-using Ryujinx.HLE.FileSystem;
 
 namespace Ryujinx.HLE.HOS.Services.Set
 {
@@ -186,8 +186,8 @@ namespace Ryujinx.HLE.HOS.Services.Set
 
             using(FileStream firmwareStream = File.Open(firmwareTitlePath, FileMode.Open, FileAccess.Read))
             { 
-                Nca                firmwareContent = new Nca(device.System.KeySet, firmwareStream.AsStorage(), false);
-                LibHac.IO.IStorage romFsStorage    = firmwareContent.OpenSection(0, false, device.System.FsIntegrityCheckLevel, false);
+                Nca      firmwareContent = new Nca(device.System.KeySet, firmwareStream.AsStorage(), false);
+                IStorage romFsStorage    = firmwareContent.OpenSection(0, false, device.System.FsIntegrityCheckLevel, false);
 
                 if(romFsStorage == null)
                 {
@@ -196,7 +196,7 @@ namespace Ryujinx.HLE.HOS.Services.Set
 
                 Romfs firmwareRomFs = new Romfs(romFsStorage);
 
-                LibHac.IO.IStorage firmwareFile = firmwareRomFs.OpenFile("/file");
+                IStorage firmwareFile = firmwareRomFs.OpenFile("/file");
 
                 byte[] data = new byte[firmwareFile.Length];
 

--- a/Ryujinx.HLE/Ryujinx.HLE.csproj
+++ b/Ryujinx.HLE/Ryujinx.HLE.csproj
@@ -28,11 +28,11 @@
     <ProjectReference Include="..\Ryujinx.Audio\Ryujinx.Audio.csproj" />
     <ProjectReference Include="..\Ryujinx.Common\Ryujinx.Common.csproj" />
     <ProjectReference Include="..\Ryujinx.Graphics\Ryujinx.Graphics.csproj" />
-    <PackageReference Include="LibHac" Version="0.1.3" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Concentus" Version="1.1.7" />
+    <PackageReference Include="LibHac" Version="0.2.0" />
   </ItemGroup>
 
 </Project>

--- a/Ryujinx/Config.cs
+++ b/Ryujinx/Config.cs
@@ -1,4 +1,4 @@
-using LibHac;
+using LibHac.IO;
 using Ryujinx.Common.Logging;
 using Ryujinx.HLE;
 using Ryujinx.HLE.Input;
@@ -9,7 +9,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using LibHac.IO;
 
 namespace Ryujinx
 {

--- a/Ryujinx/Config.cs
+++ b/Ryujinx/Config.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using LibHac.IO;
 
 namespace Ryujinx
 {


### PR DESCRIPTION
Copy/pasted applicable changes from changelog

- Use a new `IStorage` interface throughout the library instead of `Stream`
    - This interface is more similar to the `IStorage` interface used by Horizon.
    - Instead of having a Stream that keeps track of the current position, IStorage accepts an offset, buffer, and length when reading or writing.
    - Unlike a Stream, an IStorage instance can be shared between multiple consumers without issue
    - `Stream.AsStorage()` and `IStorage.AsStream()` methods are provided for switching between `Stream` and `IStorage`
- Improve AES-XTS performance by ~16x
- Improve AES-CTR performance by 2x
- Allow more disposal methods to cascade down to the base storage