### PR TITLE
Quad to triangle optimization

### DIFF
--- a/Ryujinx.Graphics/Graphics3d/NvGpuEngine3d.cs
+++ b/Ryujinx.Graphics/Graphics3d/NvGpuEngine3d.cs
@@ -691,11 +691,11 @@ namespace Ryujinx.Graphics.Graphics3d
 
                         if (PrimType == GalPrimitiveType.Quads)
                         {
-                            Buffer = QuadHelper.ConvertIbQuadsToTris(Buffer, IndexEntrySize, IndexCount);
+                            Buffer = QuadHelper.ConvertQuadsToTris(Buffer, IndexEntrySize, IndexCount);
                         }
                         else /* if (PrimType == GalPrimitiveType.QuadStrip) */
                         {
-                            Buffer = QuadHelper.ConvertIbQuadStripToTris(Buffer, IndexEntrySize, IndexCount);
+                            Buffer = QuadHelper.ConvertQuadStripToTris(Buffer, IndexEntrySize, IndexCount);
                         }
 
                         Gpu.Renderer.Rasterizer.CreateIbo(IboKey, IbSize, Buffer);
@@ -710,11 +710,11 @@ namespace Ryujinx.Graphics.Graphics3d
                 {
                     if (PrimType == GalPrimitiveType.Quads)
                     {
-                        Gpu.Renderer.Rasterizer.SetIndexArray(QuadHelper.ConvertIbSizeQuadsToTris(IbSize), IndexFormat);
+                        Gpu.Renderer.Rasterizer.SetIndexArray(QuadHelper.ConvertSizeQuadsToTris(IbSize), IndexFormat);
                     }
                     else /* if (PrimType == GalPrimitiveType.QuadStrip) */
                     {
-                        Gpu.Renderer.Rasterizer.SetIndexArray(QuadHelper.ConvertIbSizeQuadStripToTris(IbSize), IndexFormat);
+                        Gpu.Renderer.Rasterizer.SetIndexArray(QuadHelper.ConvertSizeQuadStripToTris(IbSize), IndexFormat);
                     }
                 }
             }
@@ -803,9 +803,9 @@ namespace Ryujinx.Graphics.Graphics3d
                 if (Stride == 0)
                 {
                     if (PrimType == GalPrimitiveType.Quads)
-                        ModifiedVbSize = QuadHelper.ConvertIbSizeQuadsToTris(ModifiedVbSize);
+                        ModifiedVbSize = QuadHelper.ConvertSizeQuadsToTris(ModifiedVbSize);
                     else if (PrimType == GalPrimitiveType.QuadStrip)
-                        ModifiedVbSize = QuadHelper.ConvertIbSizeQuadStripToTris(ModifiedVbSize);
+                        ModifiedVbSize = QuadHelper.ConvertSizeQuadStripToTris(ModifiedVbSize);
                 }
 
                 bool VboCached = Gpu.Renderer.Rasterizer.IsVboCached(VboKey, ModifiedVbSize);
@@ -818,9 +818,9 @@ namespace Ryujinx.Graphics.Graphics3d
                         byte[] data = Vmm.ReadBytes(VbPosition, VbSize);
 
                         if (PrimType == GalPrimitiveType.Quads)
-                            data = QuadHelper.ConvertIbQuadsToTris(data, Stride, (int)(VbSize / Stride));
+                            data = QuadHelper.ConvertQuadsToTris(data, Stride, (int)(VbSize / Stride));
                         else
-                            data = QuadHelper.ConvertIbQuadStripToTris(data, Stride, (int)(VbSize / Stride));
+                            data = QuadHelper.ConvertQuadStripToTris(data, Stride, (int)(VbSize / Stride));
                         Gpu.Renderer.Rasterizer.CreateVbo(VboKey, data);
                     }
                     else if (Vmm.TryGetHostAddress(VbPosition, VbSize, out IntPtr VbPtr))
@@ -887,9 +887,9 @@ namespace Ryujinx.Graphics.Graphics3d
                     //vertex of a quad, if it points to the middle of a
                     //quad (First % 4 != 0 for Quads) then it will not work properly.
                     if (PrimType == GalPrimitiveType.Quads)
-                        IndexFirst = QuadHelper.ConvertIbSizeQuadsToTris(IndexFirst);
+                        IndexFirst = QuadHelper.ConvertSizeQuadsToTris(IndexFirst);
                     else // QuadStrip
-                        IndexFirst = QuadHelper.ConvertIbSizeQuadStripToTris(IndexFirst);
+                        IndexFirst = QuadHelper.ConvertSizeQuadStripToTris(IndexFirst);
 
                     PrimType = GalPrimitiveType.Triangles;
                 }
@@ -910,12 +910,12 @@ namespace Ryujinx.Graphics.Graphics3d
                     //vertex of a quad, if it points to the middle of a
                     //quad (First % 4 != 0 for Quads) then it will not work properly.
                     if (PrimType == GalPrimitiveType.Quads)
-                        VertexFirst = QuadHelper.ConvertIbSizeQuadsToTris(VertexFirst);
+                        VertexFirst = QuadHelper.ConvertSizeQuadsToTris(VertexFirst);
                     else // QuadStrip
-                        VertexFirst = QuadHelper.ConvertIbSizeQuadStripToTris(VertexFirst);
+                        VertexFirst = QuadHelper.ConvertSizeQuadStripToTris(VertexFirst);
 
                     PrimType = GalPrimitiveType.Triangles;
-                    VertexCount = QuadHelper.ConvertIbSizeQuadsToTris(VertexCount);
+                    VertexCount = QuadHelper.ConvertSizeQuadsToTris(VertexCount);
                 }
 
                 Gpu.Renderer.Rasterizer.DrawArrays(VertexFirst, VertexCount, PrimType);

--- a/Ryujinx.Graphics/Graphics3d/NvGpuEngine3d.cs
+++ b/Ryujinx.Graphics/Graphics3d/NvGpuEngine3d.cs
@@ -803,9 +803,13 @@ namespace Ryujinx.Graphics.Graphics3d
                 if (Stride == 0)
                 {
                     if (PrimType == GalPrimitiveType.Quads)
+                    {
                         ModifiedVbSize = QuadHelper.ConvertSizeQuadsToTris(ModifiedVbSize);
+                    }
                     else if (PrimType == GalPrimitiveType.QuadStrip)
+                    {
                         ModifiedVbSize = QuadHelper.ConvertSizeQuadStripToTris(ModifiedVbSize);
+                    }
                 }
 
                 bool VboCached = Gpu.Renderer.Rasterizer.IsVboCached(VboKey, ModifiedVbSize);
@@ -818,15 +822,23 @@ namespace Ryujinx.Graphics.Graphics3d
                         byte[] data = Vmm.ReadBytes(VbPosition, VbSize);
 
                         if (PrimType == GalPrimitiveType.Quads)
+                        {
                             data = QuadHelper.ConvertQuadsToTris(data, Stride, (int)(VbSize / Stride));
+                        }
                         else
+                        {
                             data = QuadHelper.ConvertQuadStripToTris(data, Stride, (int)(VbSize / Stride));
+                        }
                         Gpu.Renderer.Rasterizer.CreateVbo(VboKey, data);
                     }
                     else if (Vmm.TryGetHostAddress(VbPosition, VbSize, out IntPtr VbPtr))
+                    {
                         Gpu.Renderer.Rasterizer.CreateVbo(VboKey, (int)VbSize, VbPtr);
+                    }
                     else
+                    {
                         Gpu.Renderer.Rasterizer.CreateVbo(VboKey, Vmm.ReadBytes(VbPosition, VbSize));
+                    }
                 }
 
                 State.VertexBindings[Index].Enabled   = true;
@@ -887,9 +899,13 @@ namespace Ryujinx.Graphics.Graphics3d
                     //vertex of a quad, if it points to the middle of a
                     //quad (First % 4 != 0 for Quads) then it will not work properly.
                     if (PrimType == GalPrimitiveType.Quads)
+                    {
                         IndexFirst = QuadHelper.ConvertSizeQuadsToTris(IndexFirst);
+                    }
                     else // QuadStrip
+                    {
                         IndexFirst = QuadHelper.ConvertSizeQuadStripToTris(IndexFirst);
+                    }
 
                     PrimType = GalPrimitiveType.Triangles;
                 }
@@ -910,9 +926,13 @@ namespace Ryujinx.Graphics.Graphics3d
                     //vertex of a quad, if it points to the middle of a
                     //quad (First % 4 != 0 for Quads) then it will not work properly.
                     if (PrimType == GalPrimitiveType.Quads)
+                    {
                         VertexFirst = QuadHelper.ConvertSizeQuadsToTris(VertexFirst);
+                    }
                     else // QuadStrip
+                    {
                         VertexFirst = QuadHelper.ConvertSizeQuadStripToTris(VertexFirst);
+                    }
 
                     PrimType = GalPrimitiveType.Triangles;
                     VertexCount = QuadHelper.ConvertSizeQuadsToTris(VertexCount);

--- a/Ryujinx.Graphics/Graphics3d/NvGpuEngine3d.cs
+++ b/Ryujinx.Graphics/Graphics3d/NvGpuEngine3d.cs
@@ -863,22 +863,17 @@ namespace Ryujinx.Graphics.Graphics3d
                 //Quad primitive types were deprecated on OpenGL 3.x,
                 //they are converted to a triangles index buffer on IB creation,
                 //so we should use the triangles type here too.
-                if (PrimType == GalPrimitiveType.Quads ||
-                    PrimType == GalPrimitiveType.QuadStrip)
+                if (PrimType == GalPrimitiveType.Quads || PrimType == GalPrimitiveType.QuadStrip)
                 {
-                    PrimType = GalPrimitiveType.Triangles;
-
                     //Note: We assume that index first points to the first
                     //vertex of a quad, if it points to the middle of a
                     //quad (First % 4 != 0 for Quads) then it will not work properly.
                     if (PrimType == GalPrimitiveType.Quads)
-                    {
                         IndexFirst = QuadHelper.ConvertIbSizeQuadsToTris(IndexFirst);
-                    }
-                    else /* if (PrimType == GalPrimitiveType.QuadStrip) */
-                    {
+                    else // QuadStrip
                         IndexFirst = QuadHelper.ConvertIbSizeQuadStripToTris(IndexFirst);
-                    }
+
+                    PrimType = GalPrimitiveType.Triangles;
                 }
 
                 Gpu.Renderer.Rasterizer.DrawElements(IboKey, IndexFirst, VertexBase, PrimType);

--- a/Ryujinx.Graphics/Graphics3d/NvGpuEngine3d.cs
+++ b/Ryujinx.Graphics/Graphics3d/NvGpuEngine3d.cs
@@ -816,6 +816,7 @@ namespace Ryujinx.Graphics.Graphics3d
                     {
                         // Convert quad buffer to triangles
                         byte[] data = Vmm.ReadBytes(VbPosition, VbSize);
+
                         if (PrimType == GalPrimitiveType.Quads)
                             data = QuadHelper.ConvertIbQuadsToTris(data, Stride, (int)(VbSize / Stride));
                         else

--- a/Ryujinx.Graphics/QuadHelper.cs
+++ b/Ryujinx.Graphics/QuadHelper.cs
@@ -4,17 +4,17 @@ namespace Ryujinx.Graphics
 {
     static class QuadHelper
     {
-        public static int ConvertIbSizeQuadsToTris(int Size)
+        public static int ConvertSizeQuadsToTris(int Size)
         {
             return Size <= 0 ? 0 : (Size / 4) * 6;
         }
 
-        public static int ConvertIbSizeQuadStripToTris(int Size)
+        public static int ConvertSizeQuadStripToTris(int Size)
         {
             return Size <= 1 ? 0 : ((Size - 2) / 2) * 6;
         }
 
-        public static byte[] ConvertIbQuadsToTris(byte[] Data, int EntrySize, int Count)
+        public static byte[] ConvertQuadsToTris(byte[] Data, int EntrySize, int Count)
         {
             int PrimitivesCount = Count / 4;
 
@@ -46,7 +46,7 @@ namespace Ryujinx.Graphics
             return Output;
         }
 
-        public static byte[] ConvertIbQuadStripToTris(byte[] Data, int EntrySize, int Count)
+        public static byte[] ConvertQuadStripToTris(byte[] Data, int EntrySize, int Count)
         {
             int PrimitivesCount = (Count - 2) / 2;
 


### PR DESCRIPTION
Optimizes quad rendering by converting to triangles when uploading (reduces gpu load by 2/3rds in Shantae)
Also fixes minor bug regarding IndexFirst not being converted correctly with quad and quad strips