### PR TITLE
Do not increment played wave buffers count for empty wave buffers

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Aud/AudioRenderer/IAudioRenderer.cs
+++ b/Ryujinx.HLE/HOS/Services/Aud/AudioRenderer/IAudioRenderer.cs
@@ -312,7 +312,7 @@ namespace Ryujinx.HLE.HOS.Services.Aud.AudioRenderer
 
             foreach (VoiceContext voice in _voices)
             {
-                if (!voice.Playing)
+                if (!voice.Playing || voice.CurrentWaveBuffer.Size == 0)
                 {
                     continue;
                 }

--- a/Ryujinx.HLE/HOS/Services/Aud/AudioRenderer/VoiceContext.cs
+++ b/Ryujinx.HLE/HOS/Services/Aud/AudioRenderer/VoiceContext.cs
@@ -25,7 +25,7 @@ namespace Ryujinx.HLE.HOS.Services.Aud.AudioRenderer
 
         public AdpcmDecoderContext AdpcmCtx { get; set; }
 
-        public WaveBuffer[] WaveBuffers { get; set; }
+        public WaveBuffer[] WaveBuffers { get; }
 
         public WaveBuffer CurrentWaveBuffer => WaveBuffers[_bufferIndex];
 

--- a/Ryujinx.HLE/HOS/Services/Aud/AudioRenderer/VoiceContext.cs
+++ b/Ryujinx.HLE/HOS/Services/Aud/AudioRenderer/VoiceContext.cs
@@ -14,20 +14,24 @@ namespace Ryujinx.HLE.HOS.Services.Aud.AudioRenderer
         private int _bufferIndex;
         private int _offset;
 
-        public int SampleRate;
-        public int ChannelsCount;
+        public int SampleRate    { get; set; }
+        public int ChannelsCount { get; set; }
 
-        public float Volume;
+        public float Volume { get; set; }
 
-        public PlayState PlayState;
+        public PlayState PlayState { get; set; }
 
-        public SampleFormat SampleFormat;
+        public SampleFormat SampleFormat { get; set; }
 
-        public AdpcmDecoderContext AdpcmCtx;
+        public AdpcmDecoderContext AdpcmCtx { get; set; }
 
-        public WaveBuffer[] WaveBuffers;
+        public WaveBuffer[] WaveBuffers { get; set; }
 
-        public VoiceOut OutStatus;
+        public WaveBuffer CurrentWaveBuffer => WaveBuffers[_bufferIndex];
+
+        private VoiceOut _outStatus;
+
+        public VoiceOut OutStatus => _outStatus;
 
         private int[] _samples;
 
@@ -56,9 +60,9 @@ namespace Ryujinx.HLE.HOS.Services.Aud.AudioRenderer
             _bufferIndex = 0;
             _offset      = 0;
 
-            OutStatus.PlayedSamplesCount     = 0;
-            OutStatus.PlayedWaveBuffersCount = 0;
-            OutStatus.VoiceDropsCount        = 0;
+            _outStatus.PlayedSamplesCount     = 0;
+            _outStatus.PlayedWaveBuffersCount = 0;
+            _outStatus.VoiceDropsCount        = 0;
         }
 
         public int[] GetBufferData(MemoryManager memory, int maxSamples, out int samplesCount)
@@ -94,7 +98,7 @@ namespace Ryujinx.HLE.HOS.Services.Aud.AudioRenderer
 
             samplesCount = size / AudioConsts.HostChannelsCount;
 
-            OutStatus.PlayedSamplesCount += samplesCount;
+            _outStatus.PlayedSamplesCount += samplesCount;
 
             _offset += size;
 
@@ -107,7 +111,7 @@ namespace Ryujinx.HLE.HOS.Services.Aud.AudioRenderer
                     SetBufferIndex((_bufferIndex + 1) & 3);
                 }
 
-                OutStatus.PlayedWaveBuffersCount++;
+                _outStatus.PlayedWaveBuffersCount++;
 
                 if (wb.LastBuffer != 0)
                 {


### PR DESCRIPTION
On some games, it seems to add an empty buffer (before the game even calls AppendWaveBuffer), and this was causing the played wave buffers count to be incremented. However it caused bugs on the game, because it doesn't expect that and it caused the released buffers count to be decremented to -1 on `nn::audio::GetReleasedWaveBuffer`, which later leads to memory corruption.

I'm not sure if this is the right fix.

May affect the following games, they need to be retested:

https://github.com/Ryujinx/Ryujinx-Games-List/issues/76
https://github.com/Ryujinx/Ryujinx-Games-List/issues/77
https://github.com/Ryujinx/Ryujinx-Games-List/issues/79
https://github.com/Ryujinx/Ryujinx-Games-List/issues/80
https://github.com/Ryujinx/Ryujinx-Games-List/issues/88
https://github.com/Ryujinx/Ryujinx-Games-List/issues/111
https://github.com/Ryujinx/Ryujinx-Games-List/issues/120
https://github.com/Ryujinx/Ryujinx-Games-List/issues/139