### PR TITLE
[WIP] Support loading DLC data from XCIs

### DIFF
--- a/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
+++ b/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
@@ -12,16 +12,21 @@ namespace Ryujinx.HLE.FileSystem.Content
     {
         private Dictionary<StorageId, LinkedList<LocationEntry>> _locationEntries;
 
-        private Dictionary<string, long> _sharedFontTitleDictionary;
-
         private SortedDictionary<(ulong, ContentType), string> _contentDictionary;
+
+        private Dictionary<ulong, (int, Nca)> _currentApplicationAocData;
+
+        private Dictionary<string, long> _sharedFontTitleDictionary;
 
         private Switch _device;
 
         public ContentManager(Switch device)
         {
+            _locationEntries = new Dictionary<StorageId, LinkedList<LocationEntry>>();
+
             _contentDictionary = new SortedDictionary<(ulong, ContentType), string>();
-            _locationEntries   = new Dictionary<StorageId, LinkedList<LocationEntry>>();
+
+            _currentApplicationAocData = new Dictionary<ulong, (int, Nca)>();
 
             _sharedFontTitleDictionary = new Dictionary<string, long>
             {
@@ -292,6 +297,35 @@ namespace Ryujinx.HLE.FileSystem.Content
             LinkedList<LocationEntry> locationList = _locationEntries[storageId];
 
             return locationList.ToList().Find(x => x.TitleId == titleId && x.ContentType == contentType);
+        }
+
+        public void SetCurrentApplicationAocData(int index, Nca aocData)
+        {
+            _currentApplicationAocData.Add(aocData.Header.TitleId, (index, aocData));
+        }
+
+        public Nca GetCurrentApplicationAocData(long titleId)
+        {
+            return _currentApplicationAocData[(ulong)titleId].Item2;
+        }
+
+        public int GetCurrentApplicationAocDataCount()
+        {
+            return _currentApplicationAocData.Count;
+        }
+
+        public int[] GetCurrentApplicationAocDataIndices()
+        {
+            List<int> indices = new List<int>();
+
+            foreach ((int index, Nca aocData) tuple in _currentApplicationAocData.Values)
+            {
+                indices.Add(tuple.index);
+            }
+
+            indices.Sort();
+
+            return indices.ToArray();
         }
     }
 }

--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -292,6 +292,8 @@ namespace Ryujinx.HLE.HOS
 
                 Nca nca = new Nca(KeySet, ncaStorage, true);
 
+                nca.Filename = fileEntry.Name;
+
                 if (nca.Header.ContentType == ContentType.Program)
                 {
                     if (nca.Sections.Any(x => x?.Type == SectionType.Romfs))
@@ -302,6 +304,10 @@ namespace Ryujinx.HLE.HOS
                     {
                         patchNca = nca;
                     }
+                }
+                else if (nca.Header.ContentType == ContentType.AocData)
+                {
+                    ContentManager.SetCurrentApplicationAocData(fileEntry.Index, nca);
                 }
                 else if (nca.Header.ContentType == ContentType.Control)
                 {

--- a/Ryujinx.HLE/HOS/Services/Ns/IAddOnContentManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Ns/IAddOnContentManager.cs
@@ -14,27 +14,46 @@ namespace Ryujinx.HLE.HOS.Services.Ns
         {
             _commands = new Dictionary<int, ServiceProcessRequest>
             {
-                { 2, CountAddOnContent },
-                { 3, ListAddOnContent  }
+                { 2, CountAddOnContent     },
+                { 3, ListAddOnContent      },
+                { 5, GetAddOnContentBaseId },
+                { 7, PrepareAddOnContent   }
             };
         }
 
         public static long CountAddOnContent(ServiceCtx context)
         {
-            context.ResponseData.Write(0);
-
-            Logger.PrintStub(LogClass.ServiceNs);
+            context.ResponseData.Write(context.Device.System.ContentManager.GetCurrentApplicationAocDataCount());
 
             return 0;
         }
 
         public static long ListAddOnContent(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceNs);
+            int[] aocIndices = context.Device.System.ContentManager.GetCurrentApplicationAocDataIndices();
 
-            //TODO: This is supposed to write a u32 array aswell.
-            //It's unknown what it contains.
-            context.ResponseData.Write(0);
+            for (int index = 0; index < aocIndices.Length; index++)
+            {
+                long address = context.Request.ReceiveBuff[0].Position + index * 4;
+
+                context.Memory.WriteInt32(address, aocIndices[index]);
+            }
+
+            context.ResponseData.Write(aocIndices.Length);
+
+            return 0;
+        }
+
+        public static long GetAddOnContentBaseId(ServiceCtx context)
+        {
+            context.ResponseData.Write(context.Process.TitleId + 0x1000);
+
+            return 0;
+        }
+
+        public static long PrepareAddOnContent(ServiceCtx context)
+        {
+            Logger.PrintStub(LogClass.ServiceNs);
 
             return 0;
         }


### PR DESCRIPTION
The plan was implementing it properly using the current content manager, but it turns out that it is a bit limited and can only handle NCAs installed to the "nand" (inside ryufs nand path), and can't load AOC (Add-on content) data embedded on the cart itself. So, rather than rewriting some parts of it to handle both cases properly (which would require some mounting support), I just added a quick check that gets the cart data instead depending on the storage id.

I don't plan to work in improving the content manager, but I'm open to suggestions to improve this implementation.

Should help with the following games (needs retesting):

https://github.com/Ryujinx/Ryujinx-Games-List/issues/147 