### PR TITLE
Misc. CPU optimizations

### DIFF
--- a/ChocolArm64/Instructions/InstEmitFlow.cs
+++ b/ChocolArm64/Instructions/InstEmitFlow.cs
@@ -39,7 +39,6 @@ namespace ChocolArm64.Instructions
 
             context.EmitLdc_I(op.Position + 4);
             context.EmitStint(RegisterAlias.Lr);
-            context.EmitStoreState();
 
             EmitCall(context, op.Imm);
         }

--- a/ChocolArm64/Instructions/InstEmitFlow.cs
+++ b/ChocolArm64/Instructions/InstEmitFlow.cs
@@ -60,6 +60,8 @@ namespace ChocolArm64.Instructions
         {
             OpCodeBReg64 op = (OpCodeBReg64)context.CurrOp;
 
+            context.HasIndirectJump = true;
+
             context.EmitStoreState();
             context.EmitLdintzr(op.Rn);
 

--- a/ChocolArm64/Instructions/InstEmitFlow32.cs
+++ b/ChocolArm64/Instructions/InstEmitFlow32.cs
@@ -65,7 +65,6 @@ namespace ChocolArm64.Instructions
             }
 
             context.EmitStint(GetBankedRegisterAlias(context.Mode, RegisterAlias.Aarch32Lr));
-            context.EmitStoreState();
 
             //If x is true, then this is a branch with link and exchange.
             //In this case we need to swap the mode between Arm <-> Thumb.

--- a/ChocolArm64/Instructions/InstEmitFlowHelper.cs
+++ b/ChocolArm64/Instructions/InstEmitFlowHelper.cs
@@ -22,6 +22,8 @@ namespace ChocolArm64.Instructions
 
             if (!context.TryOptEmitSubroutineCall())
             {
+                context.EmitStoreState();
+
                 context.TranslateAhead(imm);
 
                 context.EmitLdarg(TranslatedSub.StateArgIdx);

--- a/ChocolArm64/Instructions/InstEmitFlowHelper.cs
+++ b/ChocolArm64/Instructions/InstEmitFlowHelper.cs
@@ -86,7 +86,11 @@ namespace ChocolArm64.Instructions
                 context.EmitLdarg(TranslatedSub.StateArgIdx);
                 context.EmitLdtmp();
 
-                context.EmitPrivateCall(typeof(Translator), nameof(Translator.GetOrTranslateVirtualSubroutine));
+                string name = isJump
+                    ? nameof(Translator.GetOrTranslateVirtualSubroutineForJump)
+                    : nameof(Translator.GetOrTranslateVirtualSubroutine);
+
+                context.EmitPrivateCall(typeof(Translator), name);
 
                 context.EmitLdarg(TranslatedSub.StateArgIdx);
                 context.EmitLdarg(TranslatedSub.MemoryArgIdx);

--- a/ChocolArm64/Optimizations.cs
+++ b/ChocolArm64/Optimizations.cs
@@ -2,21 +2,23 @@ using System.Runtime.Intrinsics.X86;
 
 public static class Optimizations
 {
-    internal static bool FastFP = true;
+    public static bool AssumeStrictAbiCompliance { get; set; } = true;
 
-    private static bool _useAllSseIfAvailable = true;
+    public static bool FastFP { get; set; } = true;
 
-    private static bool _useSseIfAvailable   = true;
-    private static bool _useSse2IfAvailable  = true;
-    private static bool _useSse3IfAvailable  = true;
-    private static bool _useSsse3IfAvailable = true;
-    private static bool _useSse41IfAvailable = true;
-    private static bool _useSse42IfAvailable = true;
+    private const bool UseAllSseIfAvailable = true;
 
-    internal static bool UseSse   = (_useAllSseIfAvailable && _useSseIfAvailable)   && Sse.IsSupported;
-    internal static bool UseSse2  = (_useAllSseIfAvailable && _useSse2IfAvailable)  && Sse2.IsSupported;
-    internal static bool UseSse3  = (_useAllSseIfAvailable && _useSse3IfAvailable)  && Sse3.IsSupported;
-    internal static bool UseSsse3 = (_useAllSseIfAvailable && _useSsse3IfAvailable) && Ssse3.IsSupported;
-    internal static bool UseSse41 = (_useAllSseIfAvailable && _useSse41IfAvailable) && Sse41.IsSupported;
-    internal static bool UseSse42 = (_useAllSseIfAvailable && _useSse42IfAvailable) && Sse42.IsSupported;
+    public static bool UseSseIfAvailable   { get; set; } = UseAllSseIfAvailable;
+    public static bool UseSse2IfAvailable  { get; set; } = UseAllSseIfAvailable;
+    public static bool UseSse3IfAvailable  { get; set; } = UseAllSseIfAvailable;
+    public static bool UseSsse3IfAvailable { get; set; } = UseAllSseIfAvailable;
+    public static bool UseSse41IfAvailable { get; set; } = UseAllSseIfAvailable;
+    public static bool UseSse42IfAvailable { get; set; } = UseAllSseIfAvailable;
+
+    internal static bool UseSse   => UseSseIfAvailable   && Sse.IsSupported;
+    internal static bool UseSse2  => UseSse2IfAvailable  && Sse2.IsSupported;
+    internal static bool UseSse3  => UseSse3IfAvailable  && Sse3.IsSupported;
+    internal static bool UseSsse3 => UseSsse3IfAvailable && Ssse3.IsSupported;
+    internal static bool UseSse41 => UseSse41IfAvailable && Sse41.IsSupported;
+    internal static bool UseSse42 => UseSse42IfAvailable && Sse42.IsSupported;
 }

--- a/ChocolArm64/Optimizations.cs
+++ b/ChocolArm64/Optimizations.cs
@@ -2,7 +2,7 @@ using System.Runtime.Intrinsics.X86;
 
 public static class Optimizations
 {
-    public static bool AssumeStrictAbiCompliance { get; set; } = true;
+    public static bool AssumeStrictAbiCompliance { get; set; }
 
     public static bool FastFP { get; set; } = true;
 

--- a/ChocolArm64/Translation/CallType.cs
+++ b/ChocolArm64/Translation/CallType.cs
@@ -1,0 +1,9 @@
+namespace ChocolArm64.Translation
+{
+    enum CallType
+    {
+        Call,
+        VirtualCall,
+        VirtualJump
+    }
+}

--- a/ChocolArm64/Translation/ILBlock.cs
+++ b/ChocolArm64/Translation/ILBlock.cs
@@ -4,13 +4,13 @@ namespace ChocolArm64.Translation
 {
     class ILBlock : IILEmit
     {
-        public long IntInputs    { get; private set; }
-        public long IntOutputs   { get; private set; }
-        public long IntAwOutputs { get; private set; }
+        public  long IntInputs  { get; private set; }
+        public  long IntOutputs { get; private set; }
+        private long _intAwOutputs;
 
-        public long VecInputs    { get; private set; }
-        public long VecOutputs   { get; private set; }
-        public long VecAwOutputs { get; private set; }
+        public  long VecInputs  { get; private set; }
+        public  long VecOutputs { get; private set; }
+        private long _vecAwOutputs;
 
         public bool HasStateStore { get; private set; }
 
@@ -34,16 +34,16 @@ namespace ChocolArm64.Translation
                 //opcodes emitted by each ARM instruction.
                 //We can only consider the new outputs for doing input elimination
                 //after all the CIL opcodes used by the instruction being emitted.
-                IntAwOutputs = IntOutputs;
-                VecAwOutputs = VecOutputs;
+                _intAwOutputs = IntOutputs;
+                _vecAwOutputs = VecOutputs;
             }
             else if (emitter is ILOpCodeLoad ld && ILMethodBuilder.IsRegIndex(ld.Index))
             {
                 switch (ld.IoType)
                 {
-                    case IoType.Flag:   IntInputs |= ((1L << ld.Index) << 32) & ~IntAwOutputs; break;
-                    case IoType.Int:    IntInputs |=  (1L << ld.Index)        & ~IntAwOutputs; break;
-                    case IoType.Vector: VecInputs |=  (1L << ld.Index)        & ~VecAwOutputs; break;
+                    case IoType.Flag:   IntInputs |= ((1L << ld.Index) << 32) & ~_intAwOutputs; break;
+                    case IoType.Int:    IntInputs |=  (1L << ld.Index)        & ~_intAwOutputs; break;
+                    case IoType.Vector: VecInputs |=  (1L << ld.Index)        & ~_vecAwOutputs; break;
                 }
             }
             else if (emitter is ILOpCodeStore st && ILMethodBuilder.IsRegIndex(st.Index))

--- a/ChocolArm64/Translation/ILBlock.cs
+++ b/ChocolArm64/Translation/ILBlock.cs
@@ -39,7 +39,7 @@ namespace ChocolArm64.Translation
             }
             else if (emitter is ILOpCodeLoad ld && ILMethodBuilder.IsRegIndex(ld.Index))
             {
-                switch (ld.IoType)
+                switch (ld.VarType)
                 {
                     case VarType.Flag:   IntInputs |= ((1L << ld.Index) << 32) & ~_intAwOutputs; break;
                     case VarType.Int:    IntInputs |=  (1L << ld.Index)        & ~_intAwOutputs; break;
@@ -48,7 +48,7 @@ namespace ChocolArm64.Translation
             }
             else if (emitter is ILOpCodeStore st && ILMethodBuilder.IsRegIndex(st.Index))
             {
-                switch (st.IoType)
+                switch (st.VarType)
                 {
                     case VarType.Flag:   IntOutputs |= (1L << st.Index) << 32; break;
                     case VarType.Int:    IntOutputs |=  1L << st.Index;        break;

--- a/ChocolArm64/Translation/ILBlock.cs
+++ b/ChocolArm64/Translation/ILBlock.cs
@@ -41,18 +41,18 @@ namespace ChocolArm64.Translation
             {
                 switch (ld.IoType)
                 {
-                    case IoType.Flag:   IntInputs |= ((1L << ld.Index) << 32) & ~_intAwOutputs; break;
-                    case IoType.Int:    IntInputs |=  (1L << ld.Index)        & ~_intAwOutputs; break;
-                    case IoType.Vector: VecInputs |=  (1L << ld.Index)        & ~_vecAwOutputs; break;
+                    case VarType.Flag:   IntInputs |= ((1L << ld.Index) << 32) & ~_intAwOutputs; break;
+                    case VarType.Int:    IntInputs |=  (1L << ld.Index)        & ~_intAwOutputs; break;
+                    case VarType.Vector: VecInputs |=  (1L << ld.Index)        & ~_vecAwOutputs; break;
                 }
             }
             else if (emitter is ILOpCodeStore st && ILMethodBuilder.IsRegIndex(st.Index))
             {
                 switch (st.IoType)
                 {
-                    case IoType.Flag:   IntOutputs |= (1L << st.Index) << 32; break;
-                    case IoType.Int:    IntOutputs |=  1L << st.Index;        break;
-                    case IoType.Vector: VecOutputs |=  1L << st.Index;        break;
+                    case VarType.Flag:   IntOutputs |= (1L << st.Index) << 32; break;
+                    case VarType.Int:    IntOutputs |=  1L << st.Index;        break;
+                    case VarType.Vector: VecOutputs |=  1L << st.Index;        break;
                 }
             }
             else if (emitter is ILOpCodeStoreState)

--- a/ChocolArm64/Translation/ILEmitterCtx.cs
+++ b/ChocolArm64/Translation/ILEmitterCtx.cs
@@ -644,19 +644,19 @@ namespace ChocolArm64.Translation
             Stloc(index, VarType.Flag);
         }
 
-        private void Ldloc(int index, VarType ioType)
+        private void Ldloc(int index, VarType varType)
         {
-            _ilBlock.Add(new ILOpCodeLoad(index, ioType, CurrOp.RegisterSize));
+            _ilBlock.Add(new ILOpCodeLoad(index, varType, CurrOp.RegisterSize));
         }
 
-        private void Ldloc(int index, VarType ioType, RegisterSize registerSize)
+        private void Ldloc(int index, VarType varType, RegisterSize registerSize)
         {
-            _ilBlock.Add(new ILOpCodeLoad(index, ioType, registerSize));
+            _ilBlock.Add(new ILOpCodeLoad(index, varType, registerSize));
         }
 
-        private void Stloc(int index, VarType ioType)
+        private void Stloc(int index, VarType varType)
         {
-            _ilBlock.Add(new ILOpCodeStore(index, ioType, CurrOp.RegisterSize));
+            _ilBlock.Add(new ILOpCodeStore(index, varType, CurrOp.RegisterSize));
         }
 
         public void EmitCallPropGet(Type objType, string propName)

--- a/ChocolArm64/Translation/ILEmitterCtx.cs
+++ b/ChocolArm64/Translation/ILEmitterCtx.cs
@@ -31,6 +31,8 @@ namespace ChocolArm64.Translation
 
         public Aarch32Mode Mode { get; } = Aarch32Mode.User; //TODO
 
+        public bool HasIndirectJump { get; set; }
+
         private Dictionary<Block, ILBlock> _visitedBlocks;
 
         private Queue<Block> _branchTargets;
@@ -91,7 +93,12 @@ namespace ChocolArm64.Translation
 
             ResetBlockState();
 
-            AdvanceOpCode();
+            if (AdvanceOpCode())
+            {
+                EmitSynchronization();
+
+                _ilBlock.Add(new ILOpCodeLoadState(_ilBlock, isSubEntry: true));
+            }
         }
 
         public static int GetIntTempIndex()
@@ -127,10 +134,18 @@ namespace ChocolArm64.Translation
                 return;
             }
 
-            if (_opcIndex == 0)
+            int opcIndex = _opcIndex;
+
+            if (opcIndex == 0)
             {
                 MarkLabel(GetLabel(_currBlock.Position));
+            }
 
+            bool isLastOp = opcIndex == CurrBlock.OpCodes.Count - 1;
+
+            if (isLastOp && CurrBlock.Branch != null &&
+                     (ulong)CurrBlock.Branch.Position <= (ulong)CurrBlock.Position)
+            {
                 EmitSynchronization();
             }
 
@@ -161,7 +176,7 @@ namespace ChocolArm64.Translation
                 //of the next instruction to be executed (in the case that the condition
                 //is false, and the branch was not taken, as all basic blocks should end with
                 //some kind of branch).
-                if (CurrOp == CurrBlock.GetLastOp() && CurrBlock.Next == null)
+                if (isLastOp && CurrBlock.Next == null)
                 {
                     EmitStoreState();
                     EmitLdc_I8(CurrOp.Position + CurrOp.OpCodeSizeInBytes);
@@ -285,7 +300,7 @@ namespace ChocolArm64.Translation
                 return;
             }
 
-            _queue.Enqueue(new TranslatorQueueItem(position, mode, TranslationTier.Tier1));
+            _queue.Enqueue(new TranslatorQueueItem(position, mode, TranslationTier.Tier1, isComplete: true));
         }
 
         public bool TryOptEmitSubroutineCall()

--- a/ChocolArm64/Translation/ILEmitterCtx.cs
+++ b/ChocolArm64/Translation/ILEmitterCtx.cs
@@ -336,8 +336,8 @@ namespace ChocolArm64.Translation
 
             InstEmitAluHelper.EmitAluLoadOpers(this);
 
-            Stloc(CmpOptTmp2Index, IoType.Int);
-            Stloc(CmpOptTmp1Index, IoType.Int);
+            Stloc(CmpOptTmp2Index, VarType.Int);
+            Stloc(CmpOptTmp1Index, VarType.Int);
         }
 
         private Dictionary<Condition, OpCode> _branchOps = new Dictionary<Condition, OpCode>()
@@ -361,8 +361,8 @@ namespace ChocolArm64.Translation
             {
                 if (_optOpLastCompare.Emitter == InstEmit.Subs)
                 {
-                    Ldloc(CmpOptTmp1Index, IoType.Int, _optOpLastCompare.RegisterSize);
-                    Ldloc(CmpOptTmp2Index, IoType.Int, _optOpLastCompare.RegisterSize);
+                    Ldloc(CmpOptTmp1Index, VarType.Int, _optOpLastCompare.RegisterSize);
+                    Ldloc(CmpOptTmp2Index, VarType.Int, _optOpLastCompare.RegisterSize);
 
                     Emit(_branchOps[cond], target);
 
@@ -384,7 +384,7 @@ namespace ChocolArm64.Translation
                     //Such invalid values can't be encoded on the immediate encodings.
                     if (_optOpLastCompare is IOpCodeAluImm64 op)
                     {
-                        Ldloc(CmpOptTmp1Index, IoType.Int, _optOpLastCompare.RegisterSize);
+                        Ldloc(CmpOptTmp1Index, VarType.Int, _optOpLastCompare.RegisterSize);
 
                         if (_optOpLastCompare.RegisterSize == RegisterSize.Int32)
                         {
@@ -506,14 +506,14 @@ namespace ChocolArm64.Translation
         {
             if (amount > 0)
             {
-                Stloc(RorTmpIndex, IoType.Int);
-                Ldloc(RorTmpIndex, IoType.Int);
+                Stloc(RorTmpIndex, VarType.Int);
+                Ldloc(RorTmpIndex, VarType.Int);
 
                 EmitLdc_I4(amount);
 
                 Emit(OpCodes.Shr_Un);
 
-                Ldloc(RorTmpIndex, IoType.Int);
+                Ldloc(RorTmpIndex, VarType.Int);
 
                 EmitLdc_I4(CurrOp.GetBitsCount() - amount);
 
@@ -561,7 +561,7 @@ namespace ChocolArm64.Translation
 
         public void EmitLdarg(int index)
         {
-            _ilBlock.Add(new ILOpCodeLoad(index, IoType.Arg));
+            _ilBlock.Add(new ILOpCodeLoad(index, VarType.Arg));
         }
 
         public void EmitLdintzr(int index)
@@ -615,13 +615,13 @@ namespace ChocolArm64.Translation
         public void EmitLdvectmp2() => EmitLdvec(VecGpTmp2Index);
         public void EmitStvectmp2() => EmitStvec(VecGpTmp2Index);
 
-        public void EmitLdint(int index) => Ldloc(index, IoType.Int);
-        public void EmitStint(int index) => Stloc(index, IoType.Int);
+        public void EmitLdint(int index) => Ldloc(index, VarType.Int);
+        public void EmitStint(int index) => Stloc(index, VarType.Int);
 
-        public void EmitLdvec(int index) => Ldloc(index, IoType.Vector);
-        public void EmitStvec(int index) => Stloc(index, IoType.Vector);
+        public void EmitLdvec(int index) => Ldloc(index, VarType.Vector);
+        public void EmitStvec(int index) => Stloc(index, VarType.Vector);
 
-        public void EmitLdflg(int index) => Ldloc(index, IoType.Flag);
+        public void EmitLdflg(int index) => Ldloc(index, VarType.Flag);
         public void EmitStflg(int index)
         {
             //Set this only if any of the NZCV flag bits were modified.
@@ -634,20 +634,20 @@ namespace ChocolArm64.Translation
                 _optOpLastFlagSet = CurrOp;
             }
 
-            Stloc(index, IoType.Flag);
+            Stloc(index, VarType.Flag);
         }
 
-        private void Ldloc(int index, IoType ioType)
+        private void Ldloc(int index, VarType ioType)
         {
             _ilBlock.Add(new ILOpCodeLoad(index, ioType, CurrOp.RegisterSize));
         }
 
-        private void Ldloc(int index, IoType ioType, RegisterSize registerSize)
+        private void Ldloc(int index, VarType ioType, RegisterSize registerSize)
         {
             _ilBlock.Add(new ILOpCodeLoad(index, ioType, registerSize));
         }
 
-        private void Stloc(int index, IoType ioType)
+        private void Stloc(int index, VarType ioType)
         {
             _ilBlock.Add(new ILOpCodeStore(index, ioType, CurrOp.RegisterSize));
         }

--- a/ChocolArm64/Translation/ILEmitterCtx.cs
+++ b/ChocolArm64/Translation/ILEmitterCtx.cs
@@ -315,17 +315,19 @@ namespace ChocolArm64.Translation
                 return false;
             }
 
-            if (!_cache.TryGetSubroutine(((OpCodeBImmAl64)CurrOp).Imm, out TranslatedSub subroutine))
+            if (!_cache.TryGetSubroutine(((OpCodeBImmAl64)CurrOp).Imm, out TranslatedSub sub))
             {
                 return false;
             }
+
+            EmitStoreState(sub);
 
             for (int index = 0; index < TranslatedSub.FixedArgTypes.Length; index++)
             {
                 EmitLdarg(index);
             }
 
-            EmitCall(subroutine.Method);
+            EmitCall(sub.Method);
 
             return true;
         }
@@ -601,6 +603,11 @@ namespace ChocolArm64.Translation
         public void EmitStoreState()
         {
             _ilBlock.Add(new ILOpCodeStoreState(_ilBlock));
+        }
+
+        private void EmitStoreState(TranslatedSub callSub)
+        {
+            _ilBlock.Add(new ILOpCodeStoreState(_ilBlock, callSub));
         }
 
         public void EmitLdtmp() => EmitLdint(IntGpTmp1Index);

--- a/ChocolArm64/Translation/ILLabel.cs
+++ b/ChocolArm64/Translation/ILLabel.cs
@@ -6,7 +6,7 @@ namespace ChocolArm64.Translation
     {
         private bool _hasLabel;
 
-        private Label _lbl;
+        private Label _label;
 
         public void Emit(ILMethodBuilder context)
         {
@@ -17,12 +17,12 @@ namespace ChocolArm64.Translation
         {
             if (!_hasLabel)
             {
-                _lbl = context.Generator.DefineLabel();
+                _label = context.Generator.DefineLabel();
 
                 _hasLabel = true;
             }
 
-            return _lbl;
+            return _label;
         }
     }
 }

--- a/ChocolArm64/Translation/ILMethodBuilder.cs
+++ b/ChocolArm64/Translation/ILMethodBuilder.cs
@@ -47,7 +47,10 @@ namespace ChocolArm64.Translation
 
             DynamicMethod method = new DynamicMethod(_subName, typeof(long), TranslatedSub.FixedArgTypes);
 
-            TranslatedSub subroutine = new TranslatedSub(method, tier);
+            long intNiRegsMask = RegUsage.GetIntNotInputs(_ilBlocks[0]);
+            long vecNiRegsMask = RegUsage.GetVecNotInputs(_ilBlocks[0]);
+
+            TranslatedSub subroutine = new TranslatedSub(method, tier, intNiRegsMask, vecNiRegsMask);
 
             _locals = new Dictionary<Register, int>();
 

--- a/ChocolArm64/Translation/ILMethodBuilder.cs
+++ b/ChocolArm64/Translation/ILMethodBuilder.cs
@@ -18,17 +18,29 @@ namespace ChocolArm64.Translation
 
         private string _subName;
 
+        public bool IsAarch64 { get; }
+
+        public bool IsSubComplete { get; }
+
         private int _localsCount;
 
-        public ILMethodBuilder(ILBlock[] ilBlocks, string subName)
+        public ILMethodBuilder(
+            ILBlock[] ilBlocks,
+            string    subName,
+            bool      isAarch64,
+            bool      isSubComplete = false)
         {
-            _ilBlocks = ilBlocks;
-            _subName  = subName;
+            _ilBlocks     = ilBlocks;
+            _subName      = subName;
+            IsAarch64     = isAarch64;
+            IsSubComplete = isSubComplete;
         }
 
         public TranslatedSub GetSubroutine(TranslationTier tier)
         {
-            LocalAlloc = new LocalAlloc(_ilBlocks, _ilBlocks[0]);
+            LocalAlloc = new LocalAlloc();
+
+            LocalAlloc.BuildUses(_ilBlocks[0]);
 
             DynamicMethod method = new DynamicMethod(_subName, typeof(long), TranslatedSub.FixedArgTypes);
 
@@ -39,8 +51,6 @@ namespace ChocolArm64.Translation
             _locals = new Dictionary<Register, int>();
 
             _localsCount = 0;
-
-            new ILOpCodeLoadState(_ilBlocks[0]).Emit(this);
 
             foreach (ILBlock ilBlock in _ilBlocks)
             {

--- a/ChocolArm64/Translation/ILMethodBuilder.cs
+++ b/ChocolArm64/Translation/ILMethodBuilder.cs
@@ -39,7 +39,7 @@ namespace ChocolArm64.Translation
             IsSubComplete = isSubComplete;
         }
 
-        public TranslatedSub GetSubroutine(TranslationTier tier)
+        public TranslatedSub GetSubroutine(TranslationTier tier, bool isWorthOptimizing)
         {
             RegUsage = new RegisterUsage();
 
@@ -50,7 +50,12 @@ namespace ChocolArm64.Translation
             long intNiRegsMask = RegUsage.GetIntNotInputs(_ilBlocks[0]);
             long vecNiRegsMask = RegUsage.GetVecNotInputs(_ilBlocks[0]);
 
-            TranslatedSub subroutine = new TranslatedSub(method, tier, intNiRegsMask, vecNiRegsMask);
+            TranslatedSub subroutine = new TranslatedSub(
+                method,
+                intNiRegsMask,
+                vecNiRegsMask,
+                tier,
+                isWorthOptimizing);
 
             _locals = new Dictionary<Register, int>();
 

--- a/ChocolArm64/Translation/ILMethodBuilder.cs
+++ b/ChocolArm64/Translation/ILMethodBuilder.cs
@@ -8,7 +8,10 @@ namespace ChocolArm64.Translation
 {
     class ILMethodBuilder
     {
-        public LocalAlloc LocalAlloc { get; private set; }
+        private const int RegsCount = 32;
+        private const int RegsMask  = RegsCount - 1;
+
+        public RegisterUsage RegUsage { get; private set; }
 
         public ILGenerator Generator { get; private set; }
 
@@ -38,19 +41,19 @@ namespace ChocolArm64.Translation
 
         public TranslatedSub GetSubroutine(TranslationTier tier)
         {
-            LocalAlloc = new LocalAlloc();
+            RegUsage = new RegisterUsage();
 
-            LocalAlloc.BuildUses(_ilBlocks[0]);
+            RegUsage.BuildUses(_ilBlocks[0]);
 
             DynamicMethod method = new DynamicMethod(_subName, typeof(long), TranslatedSub.FixedArgTypes);
-
-            Generator = method.GetILGenerator();
 
             TranslatedSub subroutine = new TranslatedSub(method, tier);
 
             _locals = new Dictionary<Register, int>();
 
             _localsCount = 0;
+
+            Generator = method.GetILGenerator();
 
             foreach (ILBlock ilBlock in _ilBlocks)
             {
@@ -90,13 +93,13 @@ namespace ChocolArm64.Translation
 
         public static Register GetRegFromBit(int bit, RegisterType baseType)
         {
-            if (bit < 32)
+            if (bit < RegsCount)
             {
                 return new Register(bit, baseType);
             }
             else if (baseType == RegisterType.Int)
             {
-                return new Register(bit & 0x1f, RegisterType.Flag);
+                return new Register(bit & RegsMask, RegisterType.Flag);
             }
             else
             {
@@ -106,7 +109,7 @@ namespace ChocolArm64.Translation
 
         public static bool IsRegIndex(int index)
         {
-            return (uint)index < 32;
+            return (uint)index < RegsCount;
         }
     }
 }

--- a/ChocolArm64/Translation/ILOpCode.cs
+++ b/ChocolArm64/Translation/ILOpCode.cs
@@ -4,16 +4,16 @@ namespace ChocolArm64.Translation
 {
     struct ILOpCode : IILEmit
     {
-        private OpCode _ilOp;
+        public OpCode ILOp { get; }
 
         public ILOpCode(OpCode ilOp)
         {
-            _ilOp = ilOp;
+            ILOp = ilOp;
         }
 
         public void Emit(ILMethodBuilder context)
         {
-            context.Generator.Emit(_ilOp);
+            context.Generator.Emit(ILOp);
         }
     }
 }

--- a/ChocolArm64/Translation/ILOpCodeBranch.cs
+++ b/ChocolArm64/Translation/ILOpCodeBranch.cs
@@ -4,18 +4,18 @@ namespace ChocolArm64.Translation
 {
     struct ILOpCodeBranch : IILEmit
     {
-        private OpCode  _ilOp;
-        private ILLabel _label;
+        public OpCode  ILOp  { get; }
+        public ILLabel Label { get; }
 
         public ILOpCodeBranch(OpCode ilOp, ILLabel label)
         {
-            _ilOp  = ilOp;
-            _label = label;
+            ILOp  = ilOp;
+            Label = label;
         }
 
         public void Emit(ILMethodBuilder context)
         {
-            context.Generator.Emit(_ilOp, _label.GetLabel(context));
+            context.Generator.Emit(ILOp, Label.GetLabel(context));
         }
     }
 }

--- a/ChocolArm64/Translation/ILOpCodeBranch.cs
+++ b/ChocolArm64/Translation/ILOpCodeBranch.cs
@@ -4,7 +4,7 @@ namespace ChocolArm64.Translation
 {
     struct ILOpCodeBranch : IILEmit
     {
-        private OpCode   _ilOp;
+        private OpCode  _ilOp;
         private ILLabel _label;
 
         public ILOpCodeBranch(OpCode ilOp, ILLabel label)

--- a/ChocolArm64/Translation/ILOpCodeCall.cs
+++ b/ChocolArm64/Translation/ILOpCodeCall.cs
@@ -5,9 +5,9 @@ namespace ChocolArm64.Translation
 {
     struct ILOpCodeCall : IILEmit
     {
-        public MethodInfo Info { get; private set; }
+        public MethodInfo Info { get; }
 
-        public bool IsVirtual { get; private set; }
+        public bool IsVirtual { get; }
 
         public ILOpCodeCall(MethodInfo info, bool isVirtual)
         {

--- a/ChocolArm64/Translation/ILOpCodeConst.cs
+++ b/ChocolArm64/Translation/ILOpCodeConst.cs
@@ -16,6 +16,8 @@ namespace ChocolArm64.Translation
 
         private ImmVal _value;
 
+        public long Value => _value.I8;
+
         private enum ConstType
         {
             Int32,

--- a/ChocolArm64/Translation/ILOpCodeLoad.cs
+++ b/ChocolArm64/Translation/ILOpCodeLoad.cs
@@ -7,20 +7,20 @@ namespace ChocolArm64.Translation
     {
         public int Index { get; }
 
-        public VarType IoType { get; }
+        public VarType VarType { get; }
 
         public RegisterSize RegisterSize { get; }
 
-        public ILOpCodeLoad(int index, VarType ioType, RegisterSize registerSize = 0)
+        public ILOpCodeLoad(int index, VarType varType, RegisterSize registerSize = 0)
         {
             Index        = index;
-            IoType       = ioType;
+            VarType      = varType;
             RegisterSize = registerSize;
         }
 
         public void Emit(ILMethodBuilder context)
         {
-            switch (IoType)
+            switch (VarType)
             {
                 case VarType.Arg: context.Generator.EmitLdarg(Index); break;
 

--- a/ChocolArm64/Translation/ILOpCodeLoad.cs
+++ b/ChocolArm64/Translation/ILOpCodeLoad.cs
@@ -5,13 +5,13 @@ namespace ChocolArm64.Translation
 {
     struct ILOpCodeLoad : IILEmit
     {
-        public int Index { get; private set; }
+        public int Index { get; }
 
-        public IoType IoType { get; private set; }
+        public VarType IoType { get; }
 
-        public RegisterSize RegisterSize { get; private set; }
+        public RegisterSize RegisterSize { get; }
 
-        public ILOpCodeLoad(int index, IoType ioType, RegisterSize registerSize = 0)
+        public ILOpCodeLoad(int index, VarType ioType, RegisterSize registerSize = 0)
         {
             Index        = index;
             IoType       = ioType;
@@ -22,11 +22,11 @@ namespace ChocolArm64.Translation
         {
             switch (IoType)
             {
-                case IoType.Arg: context.Generator.EmitLdarg(Index); break;
+                case VarType.Arg: context.Generator.EmitLdarg(Index); break;
 
-                case IoType.Flag:   EmitLdloc(context, Index, RegisterType.Flag);   break;
-                case IoType.Int:    EmitLdloc(context, Index, RegisterType.Int);    break;
-                case IoType.Vector: EmitLdloc(context, Index, RegisterType.Vector); break;
+                case VarType.Flag:   EmitLdloc(context, Index, RegisterType.Flag);   break;
+                case VarType.Int:    EmitLdloc(context, Index, RegisterType.Int);    break;
+                case VarType.Vector: EmitLdloc(context, Index, RegisterType.Vector); break;
             }
         }
 

--- a/ChocolArm64/Translation/ILOpCodeLoadField.cs
+++ b/ChocolArm64/Translation/ILOpCodeLoadField.cs
@@ -5,7 +5,7 @@ namespace ChocolArm64.Translation
 {
     struct ILOpCodeLoadField : IILEmit
     {
-        public FieldInfo Info { get; private set; }
+        public FieldInfo Info { get; }
 
         public ILOpCodeLoadField(FieldInfo info)
         {

--- a/ChocolArm64/Translation/ILOpCodeLoadState.cs
+++ b/ChocolArm64/Translation/ILOpCodeLoadState.cs
@@ -17,13 +17,13 @@ namespace ChocolArm64.Translation
 
         public void Emit(ILMethodBuilder context)
         {
-            long intInputs = context.LocalAlloc.GetIntInputs(_block);
-            long vecInputs = context.LocalAlloc.GetVecInputs(_block);
+            long intInputs = context.RegUsage.GetIntInputs(_block);
+            long vecInputs = context.RegUsage.GetVecInputs(_block);
 
             if (Optimizations.AssumeStrictAbiCompliance && context.IsSubComplete)
             {
-                intInputs = LocalAlloc.ClearCallerSavedIntRegs(intInputs, context.IsAarch64);
-                vecInputs = LocalAlloc.ClearCallerSavedVecRegs(vecInputs, context.IsAarch64);
+                intInputs = RegisterUsage.ClearCallerSavedIntRegs(intInputs, context.IsAarch64);
+                vecInputs = RegisterUsage.ClearCallerSavedVecRegs(vecInputs, context.IsAarch64);
             }
 
             LoadLocals(context, intInputs, RegisterType.Int);

--- a/ChocolArm64/Translation/ILOpCodeLog.cs
+++ b/ChocolArm64/Translation/ILOpCodeLog.cs
@@ -2,16 +2,16 @@ namespace ChocolArm64.Translation
 {
     struct ILOpCodeLog : IILEmit
     {
-        private string _text;
+        public string Text { get; }
 
         public ILOpCodeLog(string text)
         {
-            _text = text;
+            Text = text;
         }
 
         public void Emit(ILMethodBuilder context)
         {
-            context.Generator.EmitWriteLine(_text);
+            context.Generator.EmitWriteLine(Text);
         }
     }
 }

--- a/ChocolArm64/Translation/ILOpCodeStore.cs
+++ b/ChocolArm64/Translation/ILOpCodeStore.cs
@@ -7,20 +7,20 @@ namespace ChocolArm64.Translation
     {
         public int Index { get; }
 
-        public VarType IoType { get; }
+        public VarType VarType { get; }
 
         public RegisterSize RegisterSize { get; }
 
-        public ILOpCodeStore(int index, VarType ioType, RegisterSize registerSize = 0)
+        public ILOpCodeStore(int index, VarType varType, RegisterSize registerSize = 0)
         {
             Index        = index;
-            IoType       = ioType;
+            VarType      = varType;
             RegisterSize = registerSize;
         }
 
         public void Emit(ILMethodBuilder context)
         {
-            switch (IoType)
+            switch (VarType)
             {
                 case VarType.Arg: context.Generator.EmitStarg(Index); break;
 

--- a/ChocolArm64/Translation/ILOpCodeStore.cs
+++ b/ChocolArm64/Translation/ILOpCodeStore.cs
@@ -5,13 +5,13 @@ namespace ChocolArm64.Translation
 {
     struct ILOpCodeStore : IILEmit
     {
-        public int Index { get; private set; }
+        public int Index { get; }
 
-        public IoType IoType { get; private set; }
+        public VarType IoType { get; }
 
-        public RegisterSize RegisterSize { get; private set; }
+        public RegisterSize RegisterSize { get; }
 
-        public ILOpCodeStore(int index, IoType ioType, RegisterSize registerSize = 0)
+        public ILOpCodeStore(int index, VarType ioType, RegisterSize registerSize = 0)
         {
             Index        = index;
             IoType       = ioType;
@@ -22,11 +22,11 @@ namespace ChocolArm64.Translation
         {
             switch (IoType)
             {
-                case IoType.Arg: context.Generator.EmitStarg(Index); break;
+                case VarType.Arg: context.Generator.EmitStarg(Index); break;
 
-                case IoType.Flag:   EmitStloc(context, Index, RegisterType.Flag);   break;
-                case IoType.Int:    EmitStloc(context, Index, RegisterType.Int);    break;
-                case IoType.Vector: EmitStloc(context, Index, RegisterType.Vector); break;
+                case VarType.Flag:   EmitStloc(context, Index, RegisterType.Flag);   break;
+                case VarType.Int:    EmitStloc(context, Index, RegisterType.Int);    break;
+                case VarType.Vector: EmitStloc(context, Index, RegisterType.Vector); break;
             }
         }
 

--- a/ChocolArm64/Translation/ILOpCodeStoreState.cs
+++ b/ChocolArm64/Translation/ILOpCodeStoreState.cs
@@ -17,6 +17,12 @@ namespace ChocolArm64.Translation
             long intOutputs = context.LocalAlloc.GetIntOutputs(_block);
             long vecOutputs = context.LocalAlloc.GetVecOutputs(_block);
 
+            if (Optimizations.AssumeStrictAbiCompliance && context.IsSubComplete)
+            {
+                intOutputs = LocalAlloc.ClearCallerSavedIntRegs(intOutputs, context.IsAarch64);
+                vecOutputs = LocalAlloc.ClearCallerSavedVecRegs(vecOutputs, context.IsAarch64);
+            }
+
             StoreLocals(context, intOutputs, RegisterType.Int);
             StoreLocals(context, vecOutputs, RegisterType.Vector);
         }

--- a/ChocolArm64/Translation/ILOpCodeStoreState.cs
+++ b/ChocolArm64/Translation/ILOpCodeStoreState.cs
@@ -14,13 +14,13 @@ namespace ChocolArm64.Translation
 
         public void Emit(ILMethodBuilder context)
         {
-            long intOutputs = context.LocalAlloc.GetIntOutputs(_block);
-            long vecOutputs = context.LocalAlloc.GetVecOutputs(_block);
+            long intOutputs = context.RegUsage.GetIntOutputs(_block);
+            long vecOutputs = context.RegUsage.GetVecOutputs(_block);
 
             if (Optimizations.AssumeStrictAbiCompliance && context.IsSubComplete)
             {
-                intOutputs = LocalAlloc.ClearCallerSavedIntRegs(intOutputs, context.IsAarch64);
-                vecOutputs = LocalAlloc.ClearCallerSavedVecRegs(vecOutputs, context.IsAarch64);
+                intOutputs = RegisterUsage.ClearCallerSavedIntRegs(intOutputs, context.IsAarch64);
+                vecOutputs = RegisterUsage.ClearCallerSavedVecRegs(vecOutputs, context.IsAarch64);
             }
 
             StoreLocals(context, intOutputs, RegisterType.Int);

--- a/ChocolArm64/Translation/LocalAlloc.cs
+++ b/ChocolArm64/Translation/LocalAlloc.cs
@@ -5,6 +5,11 @@ namespace ChocolArm64.Translation
 {
     class LocalAlloc
     {
+        public const long CallerSavedIntRegistersMask = 0x7fL  << 9;
+        public const long PStateNzcvFlagsMask         = 0xfL   << 60;
+
+        public const long CallerSavedVecRegistersMask = 0xffffL << 16;
+
         private class PathIo
         {
             private Dictionary<ILBlock, long> _allInputs;
@@ -57,15 +62,40 @@ namespace ChocolArm64.Translation
         private Dictionary<ILBlock, PathIo> _intPaths;
         private Dictionary<ILBlock, PathIo> _vecPaths;
 
+        private HashSet<ILBlock> _entryBlocks;
+
         private struct BlockIo
         {
-            public ILBlock Block;
-            public ILBlock Entry;
+            public ILBlock Block { get; }
+            public ILBlock Entry { get; }
 
-            public long IntInputs;
-            public long VecInputs;
-            public long IntOutputs;
-            public long VecOutputs;
+            public long IntInputs  { get; set; }
+            public long VecInputs  { get; set; }
+            public long IntOutputs { get; set; }
+            public long VecOutputs { get; set; }
+
+            public BlockIo(ILBlock block, ILBlock entry)
+            {
+                Block = block;
+                Entry = entry;
+
+                IntInputs = IntOutputs = 0;
+                VecInputs = VecOutputs = 0;
+            }
+
+            public BlockIo(
+                ILBlock block,
+                ILBlock entry,
+                long    intInputs,
+                long    vecInputs,
+                long    intOutputs,
+                long    vecOutputs) : this(block, entry)
+            {
+                IntInputs  = intInputs;
+                VecInputs  = vecInputs;
+                IntOutputs = intOutputs;
+                VecOutputs = vecOutputs;
+            }
 
             public override bool Equals(object obj)
             {
@@ -98,25 +128,15 @@ namespace ChocolArm64.Translation
             }
         }
 
-        private const int MaxOptGraphLength = 40;
-
-        public LocalAlloc(ILBlock[] graph, ILBlock entry)
+        public LocalAlloc()
         {
             _intPaths = new Dictionary<ILBlock, PathIo>();
             _vecPaths = new Dictionary<ILBlock, PathIo>();
 
-            if (graph.Length > 1 &&
-                graph.Length < MaxOptGraphLength)
-            {
-                InitializeOptimal(graph, entry);
-            }
-            else
-            {
-                InitializeFast(graph);
-            }
+            _entryBlocks = new HashSet<ILBlock>();
         }
 
-        private void InitializeOptimal(ILBlock[] graph, ILBlock entry)
+        public void BuildUses(ILBlock entry)
         {
             //This will go through all possible paths on the graph,
             //and store all inputs/outputs for each block. A register
@@ -133,19 +153,15 @@ namespace ChocolArm64.Translation
 
             void Enqueue(BlockIo block)
             {
-                if (!visited.Contains(block))
+                if (visited.Add(block))
                 {
                     unvisited.Enqueue(block);
-
-                    visited.Add(block);
                 }
             }
 
-            Enqueue(new BlockIo()
-            {
-                Block = entry,
-                Entry = entry
-            });
+            _entryBlocks.Add(entry);
+
+            Enqueue(new BlockIo(entry, entry));
 
             while (unvisited.Count > 0)
             {
@@ -177,19 +193,23 @@ namespace ChocolArm64.Translation
 
                 void EnqueueFromCurrent(ILBlock block, bool retTarget)
                 {
-                    BlockIo blockIo = new BlockIo() { Block = block };
+                    BlockIo blockIo;
 
                     if (retTarget)
                     {
-                        blockIo.Entry = block;
+                        blockIo = new BlockIo(block, block);
+
+                        _entryBlocks.Add(block);
                     }
                     else
                     {
-                        blockIo.Entry      = current.Entry;
-                        blockIo.IntInputs  = current.IntInputs;
-                        blockIo.VecInputs  = current.VecInputs;
-                        blockIo.IntOutputs = current.IntOutputs;
-                        blockIo.VecOutputs = current.VecOutputs;
+                        blockIo = new BlockIo(
+                            block,
+                            current.Entry,
+                            current.IntInputs,
+                            current.VecInputs,
+                            current.IntOutputs,
+                            current.VecOutputs);
                     }
 
                     Enqueue(blockIo);
@@ -204,38 +224,6 @@ namespace ChocolArm64.Translation
                 {
                     EnqueueFromCurrent(current.Block.Branch, false);
                 }
-            }
-        }
-
-        private void InitializeFast(ILBlock[] graph)
-        {
-            //This is WAY faster than InitializeOptimal, but results in
-            //unneeded loads and stores, so the resulting code will be slower.
-            long intInputs = 0, intOutputs = 0;
-            long vecInputs = 0, vecOutputs = 0;
-
-            foreach (ILBlock block in graph)
-            {
-                intInputs  |= block.IntInputs;
-                intOutputs |= block.IntOutputs;
-                vecInputs  |= block.VecInputs;
-                vecOutputs |= block.VecOutputs;
-            }
-
-            //It's possible that not all code paths writes to those output registers,
-            //in those cases if we attempt to write an output registers that was
-            //not written, we will be just writing zero and messing up the old register value.
-            //So we just need to ensure that all outputs are loaded.
-            if (graph.Length > 1)
-            {
-                intInputs |= intOutputs;
-                vecInputs |= vecOutputs;
-            }
-
-            foreach (ILBlock block in graph)
-            {
-                _intPaths.Add(block, new PathIo(block, intInputs, intOutputs));
-                _vecPaths.Add(block, new PathIo(block, vecInputs, vecOutputs));
             }
         }
 
@@ -256,5 +244,29 @@ namespace ChocolArm64.Translation
 
         public long GetIntOutputs(ILBlock block) => _intPaths[block].GetOutputs();
         public long GetVecOutputs(ILBlock block) => _vecPaths[block].GetOutputs();
+
+        public static long ClearCallerSavedIntRegs(long mask, bool isAarch64)
+        {
+            //TODO: ARM32 support.
+            if (isAarch64)
+            {
+                mask &= ~CallerSavedIntRegistersMask;
+                mask &= ~PStateNzcvFlagsMask;
+            }
+
+
+            return mask;
+        }
+
+        public static long ClearCallerSavedVecRegs(long mask, bool isAarch64)
+        {
+            //TODO: ARM32 support.
+            if (isAarch64)
+            {
+                mask &= ~CallerSavedVecRegistersMask;
+            }
+
+            return mask;
+        }
     }
 }

--- a/ChocolArm64/Translation/RegisterUsage.cs
+++ b/ChocolArm64/Translation/RegisterUsage.cs
@@ -238,6 +238,25 @@ namespace ChocolArm64.Translation
             return inputs;
         }
 
+        public long GetIntNotInputs(ILBlock entry) => GetNotInputsImpl(entry, _intPaths.Values);
+        public long GetVecNotInputs(ILBlock entry) => GetNotInputsImpl(entry, _vecPaths.Values);
+
+        private long GetNotInputsImpl(ILBlock entry, IEnumerable<PathIo> values)
+        {
+            //Returns a mask with registers that are written to
+            //before being read. Only those registers that are
+            //written in all paths, and is not read before being
+            //written to on those paths, should be set on the mask.
+            long mask = -1L;
+
+            foreach (PathIo path in values)
+            {
+                mask &= path.GetOutputs() & ~path.GetInputs(entry);
+            }
+
+            return mask;
+        }
+
         public long GetIntOutputs(ILBlock block) => _intPaths[block].GetOutputs();
         public long GetVecOutputs(ILBlock block) => _vecPaths[block].GetOutputs();
 

--- a/ChocolArm64/Translation/TranslatedSub.cs
+++ b/ChocolArm64/Translation/TranslatedSub.cs
@@ -12,19 +12,28 @@ namespace ChocolArm64.Translation
     {
         public ArmSubroutine Delegate { get; private set; }
 
-        public static int StateArgIdx  { get; private set; }
-        public static int MemoryArgIdx { get; private set; }
+        public static int StateArgIdx  { get; }
+        public static int MemoryArgIdx { get; }
 
-        public static Type[] FixedArgTypes { get; private set; }
+        public static Type[] FixedArgTypes { get; }
 
-        public DynamicMethod Method { get; private set; }
+        public DynamicMethod Method { get; }
 
-        public TranslationTier Tier { get; private set; }
+        public TranslationTier Tier { get; }
 
-        public TranslatedSub(DynamicMethod method, TranslationTier tier)
+        public long IntNiRegsMask { get; }
+        public long VecNiRegsMask { get; }
+
+        public TranslatedSub(
+            DynamicMethod   method,
+            TranslationTier tier,
+            long            intNiRegsMask,
+            long            vecNiRegsMask)
         {
-            Method = method ?? throw new ArgumentNullException(nameof(method));;
-            Tier   = tier;
+            Method        = method ?? throw new ArgumentNullException(nameof(method));;
+            Tier          = tier;
+            IntNiRegsMask = intNiRegsMask;
+            VecNiRegsMask = vecNiRegsMask;
         }
 
         static TranslatedSub()

--- a/ChocolArm64/Translation/Translator.cs
+++ b/ChocolArm64/Translation/Translator.cs
@@ -164,9 +164,9 @@ namespace ChocolArm64.Translation
                 ilOpCount += ilBlock.Count;
             }
 
-            _cache.AddOrUpdate(position, subroutine, ilOpCount);
-
             ForceAheadOfTimeCompilation(subroutine);
+
+            _cache.AddOrUpdate(position, subroutine, ilOpCount);
 
             return subroutine;
         }

--- a/ChocolArm64/Translation/TranslatorQueue.cs
+++ b/ChocolArm64/Translation/TranslatorQueue.cs
@@ -1,3 +1,4 @@
+using ChocolArm64.State;
 using System.Collections.Concurrent;
 using System.Threading;
 
@@ -5,10 +6,6 @@ namespace ChocolArm64.Translation
 {
     class TranslatorQueue
     {
-        //This is the maximum number of functions to be translated that the queue can hold.
-        //The value may need some tuning to find the sweet spot.
-        private const int MaxQueueSize = 1024;
-
         private ConcurrentStack<TranslatorQueueItem>[] _translationQueue;
 
         private ManualResetEvent _queueDataReceivedEvent;
@@ -27,14 +24,11 @@ namespace ChocolArm64.Translation
             _queueDataReceivedEvent = new ManualResetEvent(false);
         }
 
-        public void Enqueue(TranslatorQueueItem item)
+        public void Enqueue(long position, ExecutionMode mode, TranslationTier tier, bool isComplete)
         {
-            ConcurrentStack<TranslatorQueueItem> queue = _translationQueue[(int)item.Tier];
+            TranslatorQueueItem item = new TranslatorQueueItem(position, mode, tier, isComplete);
 
-            if (queue.Count >= MaxQueueSize)
-            {
-                queue.TryPop(out _);
-            }
+            ConcurrentStack<TranslatorQueueItem> queue = _translationQueue[(int)tier];
 
             queue.Push(item);
 

--- a/ChocolArm64/Translation/TranslatorQueueItem.cs
+++ b/ChocolArm64/Translation/TranslatorQueueItem.cs
@@ -10,11 +10,18 @@ namespace ChocolArm64.Translation
 
         public TranslationTier Tier { get; }
 
-        public TranslatorQueueItem(long position, ExecutionMode mode, TranslationTier tier)
+        public bool IsComplete { get; }
+
+        public TranslatorQueueItem(
+            long            position,
+            ExecutionMode   mode,
+            TranslationTier tier,
+            bool            isComplete = false)
         {
-            Position = position;
-            Mode     = mode;
-            Tier     = tier;
+            Position   = position;
+            Mode       = mode;
+            Tier       = tier;
+            IsComplete = isComplete;
         }
     }
 }

--- a/ChocolArm64/Translation/VarType.cs
+++ b/ChocolArm64/Translation/VarType.cs
@@ -1,6 +1,6 @@
 namespace ChocolArm64.Translation
 {
-    enum IoType
+    enum VarType
     {
         Arg,
         Flag,

--- a/Ryujinx/Config.jsonc
+++ b/Ryujinx/Config.jsonc
@@ -29,18 +29,21 @@
     // System Language list: https://gist.github.com/HorrorTroll/b6e4a88d774c3c9b3bdf54d79a7ca43b
     "system_language": "AmericanEnglish",
 
-    // Enable or Disable Docked Mode
+    // Enable or disable Docked Mode
     "docked_mode": false,
-    
-    // Enable or Disable Game Vsync
+
+    // Enable or disable Game Vsync
     "enable_vsync": true,
-    
-    // Enable or Disable Multi-core scheduling of threads
+
+    // Enable or disable Multi-core scheduling of threads
     "enable_multicore_scheduling": true,
-    
+
     // Enable integrity checks on Switch content files
     "enable_fs_integrity_checks": true,
-    
+
+    // Enable or disable aggressive CPU optimizations
+    "enable_aggressive_cpu_opts": true,
+
     // The primary controller's type
     // Supported Values: Handheld, ProController, NpadPair, NpadLeft, NpadRight
     "controller_type": "Handheld",

--- a/Ryujinx/Configuration.cs
+++ b/Ryujinx/Configuration.cs
@@ -87,6 +87,11 @@ namespace Ryujinx
         public bool EnableFsIntegrityChecks { get; private set; }
 
         /// <summary>
+        /// Enable or Disable aggressive CPU optimizations
+        /// </summary>
+        public bool EnableAggressiveCpuOpts { get; private set; }
+
+        /// <summary>
         ///  The primary controller's type
         /// </summary>
         public HidControllerType ControllerType { get; private set; }
@@ -196,6 +201,11 @@ namespace Ryujinx
             device.System.FsIntegrityCheckLevel = Instance.EnableFsIntegrityChecks
                 ? IntegrityCheckLevel.ErrorOnInvalid
                 : IntegrityCheckLevel.None;
+
+            if (Instance.EnableAggressiveCpuOpts)
+            {
+                Optimizations.AssumeStrictAbiCompliance = true;
+            }
 
             if(Instance.GamepadControls.Enabled)
             {

--- a/Ryujinx/_schema.json
+++ b/Ryujinx/_schema.json
@@ -399,6 +399,17 @@
         false
       ]
     },
+    "enable_aggressive_cpu_opts": {
+      "$id": "#/properties/enable_aggressive_cpu_opts",
+      "type": "boolean",
+      "title": "Enable Aggressive CPU Optimizations",
+      "description": "Enable or disable aggressive CPU optimizations",
+      "default": true,
+      "examples": [
+        true,
+        false
+      ]
+    },
     "controller_type": {
       "$id": "#/properties/controller_type",
       "type": "string",

--- a/Ryujinx/_schema.json
+++ b/Ryujinx/_schema.json
@@ -17,6 +17,7 @@
     "enable_vsync",
     "enable_multicore_scheduling",
     "enable_fs_integrity_checks",
+    "enable_aggressive_cpu_opts",
     "controller_type",
     "keyboard_controls",
     "gamepad_controls"


### PR DESCRIPTION
This implements two optimizations:

- Do not save caller saved registers on the thread state, when the function is "complete".  Caller saved register, as the name implies, should be saved by the caller, after calling any function, and the callee is free to modify those registers. If the function needs to preserve the values on those registers after a call, it is supposed to push it to the stack, and pop after the function call. So, we don't need to save those registers on the thread state, since they should only be used locally (within a function).

Of couse, this optimization is only valid if the code is following the arm64 abi (which all the applications should be following), but anyway, I consider this a rather "dangerous" optimization, so I added a new config entry to disable it, called `enable_aggressive_cpu_opts`.

- Do not save registers that are not read by the callee function before calls, when the callee is know, and we are sure that those registers are going to be written by the callee (or a function called by the callee). This also avoids some unnecessary register writes to the thread state, for the cases where a direct call is made.

- Only "synchronize" the thread when needed. We need to emit some code to ensure that the thread will stop running, so other thread can run on the core when a new thread is selected by the scheduler. This is done by checking some fields on the `ThreadState`, but the previous code was quite inefficient as it was doing those checks at the start of *every* basic block. Now, we just check it at the start of a function, and before a backwards jump (to prevent a long running or infinite loop from keeping the thread going forever).