### PR TITLE
Optimize CMN/ADDS to do a single comparison like CMP/SUBS

### DIFF
--- a/ChocolArm64/Instructions/InstEmitAlu.cs
+++ b/ChocolArm64/Instructions/InstEmitAlu.cs
@@ -51,6 +51,8 @@ namespace ChocolArm64.Instructions
 
         public static void Adds(ILEmitterCtx context)
         {
+            context.TryOptMarkCondWithoutCmp();
+
             EmitAluLoadOpers(context);
 
             context.Emit(OpCodes.Add);


### PR DESCRIPTION
Apply the same optimzation that is applied to CMP/SUBS. Rather than doing the condition check based on the NZCV flags, just emit a single IL branch + comparision OpCode. This allow the jit to produce a single cmp + jump sequence, rather than all the code to calculate flag values and the check afterwards.

A few restrictions for the CMN/ADDS case:
- Unsigned comparisons are not allowed, as carry has different values on addition vs. subtractions.
- The value should be immediate (because it's not possible to negate the lowest negative value on a signed integer). The immediate value itself should be positive all the time, so that's fine. When the value comes from a register, it is unknown, so the optimization is not valid in this case.

Perf improvement is probably pretty small, as those instructions are not very common. It's most often used to compare with negative values, as it's not possible to encode negative immediates on the immediate operands of the ALU instructions.