### PR TITLE
Config: Resolve config and file log to application directory

### DIFF
--- a/Ryujinx/Configuration.cs
+++ b/Ryujinx/Configuration.cs
@@ -157,7 +157,7 @@ namespace Ryujinx
             if (Instance.EnableFileLog)
             {
                 Logger.AddTarget(new AsyncLogTargetWrapper(
-                    new FileLogTarget("Ryujinx.log"),
+                    new FileLogTarget(Path.Combine(Program.ApplicationDirectory, "Ryujinx.log")),
                     1000,
                     AsyncLogTargetOverflowAction.Block
                 ));

--- a/Ryujinx/Program.cs
+++ b/Ryujinx/Program.cs
@@ -10,6 +10,8 @@ namespace Ryujinx
 {
     class Program
     {
+        public static string ApplicationDirectory => AppDomain.CurrentDomain.BaseDirectory;
+
         static void Main(string[] args)
         {
             Console.Title = "Ryujinx Console";
@@ -20,7 +22,7 @@ namespace Ryujinx
 
             Switch device = new Switch(renderer, audioOut);
 
-            Configuration.Load("Config.jsonc");
+            Configuration.Load(Path.Combine(ApplicationDirectory, "Config.jsonc"));
             Configuration.Configure(device);
 
             AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;


### PR DESCRIPTION
Fixes configuration file resolution by looking in the currently running applications directory, rather than the working directory (which might be a ROM directory if the user used drag/drop to load a ROM).

This also fixes the directory the file logger logs into.

Resolves #579 