### PR TITLE
Vi: Implement ConvertScalingMode

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Vi/IApplicationDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/IApplicationDisplayService.cs
@@ -179,11 +179,11 @@ namespace Ryujinx.HLE.HOS.Services.Vi
 
         private long ConvertScalingMode(ServiceCtx context)
         {
-            int ScalingMode = context.RequestData.ReadInt32();
+            int scalingMode = context.RequestData.ReadInt32();
 
             // Currently, the "source" scaling mode is mapped 1:1
             // to the "target" scaling mode.
-            context.ResponseData.Write((ulong)ScalingMode);
+            context.ResponseData.Write((ulong)scalingMode);
 
             return 0;
         }

--- a/Ryujinx.HLE/HOS/Services/Vi/IApplicationDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/IApplicationDisplayService.cs
@@ -35,6 +35,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi
                 { 2030, CreateStrayLayer                     },
                 { 2031, DestroyStrayLayer                    },
                 { 2101, SetLayerScalingMode                  },
+                { 2102, ConvertScalingMode                   },
                 { 5202, GetDisplayVSyncEvent                 }
             };
 
@@ -172,6 +173,17 @@ namespace Ryujinx.HLE.HOS.Services.Vi
         {
             int  scalingMode = context.RequestData.ReadInt32();
             long unknown     = context.RequestData.ReadInt64();
+
+            return 0;
+        }
+
+        private long ConvertScalingMode(ServiceCtx context)
+        {
+            int ScalingMode = context.RequestData.ReadInt32();
+
+            // Currently, the "source" scaling mode is mapped 1:1
+            // to the "target" scaling mode.
+            context.ResponseData.Write((ulong)ScalingMode);
 
             return 0;
         }

--- a/Ryujinx.HLE/HOS/Services/Vi/ScalingMode.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/ScalingMode.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ryujinx.HLE.HOS.Services.Vi
+{
+    enum SrcScalingMode
+    {
+        Freeze = 0,
+        ScaleToWindow = 1,
+        ScaleAndCrop = 2,
+        None = 3,
+        PreserveAspectRatio = 4
+    }
+
+    enum DstScalingMode
+    {
+        None = 0,
+        Freeze = 1,
+        ScaleToWindow = 2,
+        ScaleAndCrop = 3,
+        PreserveAspectRatio = 4
+    }
+}


### PR DESCRIPTION
For now, it seems Nintendo just map 1:1 between the two enums.