### PR TITLE
Implement ConvertScalingMode properly

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Vi/IApplicationDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/IApplicationDisplayService.cs
@@ -182,7 +182,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi
         {
             SrcScalingMode scalingMode = (SrcScalingMode)context.RequestData.ReadInt32();
 
-            DstScalingMode? convertedScalingMode = ConvetScalingMode(scalingMode);
+            DstScalingMode? convertedScalingMode = ConvertScalingMode(scalingMode);
 
             if (!convertedScalingMode.HasValue)
             {
@@ -197,12 +197,12 @@ namespace Ryujinx.HLE.HOS.Services.Vi
                 return MakeError(ErrorModule.Vi, 6);
             }
 
-            context.ResponseData.Write((ulong)ConvetScalingMode(scalingMode));
+            context.ResponseData.Write((ulong)ConvertScalingMode(scalingMode));
 
             return 0;
         }
 
-        private DstScalingMode? ConvetScalingMode(SrcScalingMode source)
+        private DstScalingMode? ConvertScalingMode(SrcScalingMode source)
         {
             switch (source)
             {

--- a/Ryujinx.HLE/HOS/Services/Vi/IApplicationDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/IApplicationDisplayService.cs
@@ -197,7 +197,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi
                 return MakeError(ErrorModule.Vi, 6);
             }
 
-            context.ResponseData.Write((ulong)ConvertScalingMode(scalingMode));
+            context.ResponseData.Write((ulong)convertedScalingMode);
 
             return 0;
         }

--- a/Ryujinx.HLE/HOS/Services/Vi/IApplicationDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/IApplicationDisplayService.cs
@@ -182,7 +182,9 @@ namespace Ryujinx.HLE.HOS.Services.Vi
         {
             SrcScalingMode scalingMode = (SrcScalingMode)context.RequestData.ReadInt32();
 
-            if (scalingMode > SrcScalingMode.PreserveAspectRatio)
+            DstScalingMode? convertedScalingMode = ConvetScalingMode(scalingMode);
+
+            if (!convertedScalingMode.HasValue)
             {
                 //Scaling mode out of the range of valid values.
                 return MakeError(ErrorModule.Vi, 1);
@@ -200,7 +202,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi
             return 0;
         }
 
-        private DstScalingMode ConvetScalingMode(SrcScalingMode source)
+        private DstScalingMode? ConvetScalingMode(SrcScalingMode source)
         {
             switch (source)
             {
@@ -211,7 +213,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi
                 case SrcScalingMode.PreserveAspectRatio: return DstScalingMode.PreserveAspectRatio;
             }
 
-            throw new ArgumentException($"Invalid scaling mode \"{source}\" specified.");
+            return null;
         }
 
         public long GetDisplayVSyncEvent(ServiceCtx context)

--- a/Ryujinx.HLE/HOS/Services/Vi/IApplicationDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/IApplicationDisplayService.cs
@@ -188,7 +188,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi
                 return MakeError(ErrorModule.Vi, 1);
             }
 
-            if (scalingMode != SrcScalingMode.ScaleAndCrop &&
+            if (scalingMode != SrcScalingMode.ScaleToWindow &&
                 scalingMode != SrcScalingMode.PreserveAspectRatio)
             {
                 //Invalid scaling mode specified.

--- a/Ryujinx.HLE/HOS/Services/Vi/ScalingMode.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/ScalingMode.cs
@@ -2,19 +2,19 @@
 {
     enum SrcScalingMode
     {
-        Freeze              = 0,
-        ScaleToWindow       = 1,
-        ScaleAndCrop        = 2,
-        None                = 3,
+        None                = 0,
+        Freeze              = 1,
+        ScaleToWindow       = 2,
+        ScaleAndCrop        = 3,
         PreserveAspectRatio = 4
     }
 
     enum DstScalingMode
     {
-        ScaleToWindow       = 0,
-        ScaleAndCrop        = 1,
-        None                = 2,
-        Freeze              = 3,
+        Freeze              = 0,
+        ScaleToWindow       = 1,
+        ScaleAndCrop        = 2,
+        None                = 3,
         PreserveAspectRatio = 4
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Vi/ScalingMode.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/ScalingMode.cs
@@ -1,24 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Ryujinx.HLE.HOS.Services.Vi
+﻿namespace Ryujinx.HLE.HOS.Services.Vi
 {
     enum SrcScalingMode
     {
-        Freeze = 0,
-        ScaleToWindow = 1,
-        ScaleAndCrop = 2,
-        None = 3,
+        Freeze              = 0,
+        ScaleToWindow       = 1,
+        ScaleAndCrop        = 2,
+        None                = 3,
         PreserveAspectRatio = 4
     }
 
     enum DstScalingMode
     {
-        None = 0,
-        Freeze = 1,
-        ScaleToWindow = 2,
-        ScaleAndCrop = 3,
+        ScaleToWindow       = 0,
+        ScaleAndCrop        = 1,
+        None                = 2,
+        Freeze              = 3,
         PreserveAspectRatio = 4
     }
 }


### PR DESCRIPTION
This improves the `ConvertScalingMode` implementation, by correcting some issues, and implementing a missing error check:
- The Src/DstScalingMode enums were swapped.
- One error condition check was missing.

Would be nice to re-test with games that depends on it.