### PR TITLE
Initialize FrontFace register with a default value

### DIFF
--- a/Ryujinx.Graphics/Graphics3d/NvGpuEngine3d.cs
+++ b/Ryujinx.Graphics/Graphics3d/NvGpuEngine3d.cs
@@ -66,6 +66,8 @@ namespace Ryujinx.Graphics.Graphics3d
 
             WriteRegister(NvGpuEngine3dReg.FrameBufferSrgb, 1);
 
+            WriteRegister(NvGpuEngine3dReg.FrontFace, (int)GalFrontFace.CW);
+
             for (int Index = 0; Index < GalPipelineState.RenderTargetsCount; Index++)
             {
                 WriteRegister(NvGpuEngine3dReg.IBlendNEquationRgb   + Index * 8, (int)GalBlendEquation.FuncAdd);


### PR DESCRIPTION
This fixes the "invalid front face 0" kind of error (introduced with #583) for games that does not initialize this register.