### PR TITLE
Compressed cubemap support

### DIFF
--- a/Ryujinx.Graphics/Gal/OpenGL/OglTexture.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OglTexture.cs
@@ -177,6 +177,24 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                             data.Length,
                             data);
                         break;
+                    case TextureTarget.TextureCubeMap:
+                        Span<byte> array = new Span<byte>(data);
+
+                        int faceSize = ImageUtils.GetSize(image) / 6;
+
+                        for (int Face = 0; Face < 6; Face++)
+                        {
+                            GL.CompressedTexImage2D(
+                                TextureTarget.TextureCubeMapPositiveX + Face,
+                                level,
+                                internalFmt,
+                                image.Width,
+                                image.Height,
+                                border,
+                                faceSize,
+                                array.Slice(Face * faceSize, faceSize).ToArray());
+                        }
+                        break;
                     default:
                         throw new NotImplementedException($"Unsupported texture target type: {target}");
                 }


### PR DESCRIPTION
Implements support for compressed cubemaps.

M2MF doesn't currently support copying compressed textures correctly, however this also affects 2D textures and not just cubemaps so I feel this can be resolved in another PR.

This should allow games that previously booted, but now throw a texture type not implemented exception since the merge of #525, to boot again, excluding games that required Texture Buffer support.

This is basically an implementation of @Thog's code.