### PR TITLE
Print Guest Stack Trace in ServiceNotImplemented Exception

### DIFF
--- a/Ryujinx.HLE/Exceptions/ServiceNotImplementedException.cs
+++ b/Ryujinx.HLE/Exceptions/ServiceNotImplementedException.cs
@@ -76,60 +76,70 @@ namespace Ryujinx.HLE.Exceptions
                 }
             }
 
+            sb.AppendLine("Guest Stack Trace:");
+            sb.AppendLine(Context.Thread.GetGuestStackTrace());
+
             // Print buffer information
-            sb.AppendLine("Buffer Information");
-
-            if (Request.PtrBuff.Count > 0)
+            if (Request.PtrBuff.Count > 0 ||
+                Request.SendBuff.Count > 0 ||
+                Request.ReceiveBuff.Count > 0 ||
+                Request.ExchangeBuff.Count > 0 ||
+                Request.RecvListBuff.Count > 0)
             {
-                sb.AppendLine("\tPtrBuff:");
+                sb.AppendLine("Buffer Information:");
 
-                foreach (var buff in Request.PtrBuff)
+                if (Request.PtrBuff.Count > 0)
                 {
-                    sb.AppendLine($"\t[{buff.Index}] Position: 0x{buff.Position:x16} Size: 0x{buff.Size:x16}");
+                    sb.AppendLine("\tPtrBuff:");
+
+                    foreach (var buff in Request.PtrBuff)
+                    {
+                        sb.AppendLine($"\t[{buff.Index}] Position: 0x{buff.Position:x16} Size: 0x{buff.Size:x16}");
+                    }
                 }
-            }
 
-            if (Request.SendBuff.Count > 0)
-            {
-                sb.AppendLine("\tSendBuff:");
-
-                foreach (var buff in Request.SendBuff)
+                if (Request.SendBuff.Count > 0)
                 {
-                    sb.AppendLine($"\tPosition: 0x{buff.Position:x16} Size: 0x{buff.Size:x16} Flags: {buff.Flags}");
+                    sb.AppendLine("\tSendBuff:");
+
+                    foreach (var buff in Request.SendBuff)
+                    {
+                        sb.AppendLine($"\tPosition: 0x{buff.Position:x16} Size: 0x{buff.Size:x16} Flags: {buff.Flags}");
+                    }
                 }
-            }
 
-            if (Request.ReceiveBuff.Count > 0)
-            {
-                sb.AppendLine("\tReceiveBuff:");
-
-                foreach (var buff in Request.ReceiveBuff)
+                if (Request.ReceiveBuff.Count > 0)
                 {
-                    sb.AppendLine($"\tPosition: 0x{buff.Position:x16} Size: 0x{buff.Size:x16} Flags: {buff.Flags}");
+                    sb.AppendLine("\tReceiveBuff:");
+
+                    foreach (var buff in Request.ReceiveBuff)
+                    {
+                        sb.AppendLine($"\tPosition: 0x{buff.Position:x16} Size: 0x{buff.Size:x16} Flags: {buff.Flags}");
+                    }
                 }
-            }
 
-            if (Request.ExchangeBuff.Count > 0)
-            {
-                sb.AppendLine("\tExchangeBuff:");
-
-                foreach (var buff in Request.ExchangeBuff)
+                if (Request.ExchangeBuff.Count > 0)
                 {
-                    sb.AppendLine($"\tPosition: 0x{buff.Position:x16} Size: 0x{buff.Size:x16} Flags: {buff.Flags}");
+                    sb.AppendLine("\tExchangeBuff:");
+
+                    foreach (var buff in Request.ExchangeBuff)
+                    {
+                        sb.AppendLine($"\tPosition: 0x{buff.Position:x16} Size: 0x{buff.Size:x16} Flags: {buff.Flags}");
+                    }
                 }
-            }
 
-            if (Request.RecvListBuff.Count > 0)
-            {
-                sb.AppendLine("\tRecvListBuff:");
-
-                foreach (var buff in Request.RecvListBuff)
+                if (Request.RecvListBuff.Count > 0)
                 {
-                    sb.AppendLine($"\tPosition: 0x{buff.Position:x16} Size: 0x{buff.Size:x16}");
-                }
-            }
+                    sb.AppendLine("\tRecvListBuff:");
 
-            sb.AppendLine();
+                    foreach (var buff in Request.RecvListBuff)
+                    {
+                        sb.AppendLine($"\tPosition: 0x{buff.Position:x16} Size: 0x{buff.Size:x16}");
+                    }
+                }
+
+                sb.AppendLine();
+            }
 
             sb.AppendLine("Raw Request Data:");
             sb.Append(HexUtils.HexTable(Request.RawData));

--- a/Ryujinx.HLE/HOS/Ipc/IpcHandler.cs
+++ b/Ryujinx.HLE/HOS/Ipc/IpcHandler.cs
@@ -2,6 +2,7 @@ using ChocolArm64.Memory;
 using Ryujinx.HLE.HOS.Kernel.Common;
 using Ryujinx.HLE.HOS.Kernel.Ipc;
 using Ryujinx.HLE.HOS.Kernel.Process;
+using Ryujinx.HLE.HOS.Kernel.Threading;
 using System;
 using System.IO;
 
@@ -13,6 +14,7 @@ namespace Ryujinx.HLE.HOS.Ipc
             Switch         device,
             KProcess       process,
             MemoryManager  memory,
+            KThread        thread,
             KClientSession session,
             IpcMessage     request,
             long           cmdPtr)
@@ -36,6 +38,7 @@ namespace Ryujinx.HLE.HOS.Ipc
                             device,
                             process,
                             memory,
+                            thread,
                             session,
                             request,
                             response,

--- a/Ryujinx.HLE/HOS/Kernel/Process/HleProcessDebugger.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/HleProcessDebugger.cs
@@ -67,18 +67,18 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
                     string imageName = GetGuessedNsoNameFromIndex(imageIndex);
 
-                    string imageNameAndOffset = $"{imageName}:0x{offset:x8}";
-
-                    trace.AppendLine($" {imageNameAndOffset} {subName}");
+                    trace.AppendLine($"   {imageName}:0x{offset:x8} {subName}");
                 }
                 else
                 {
-                    trace.AppendLine($" ??? {subName}");
+                    trace.AppendLine($"   ??? {subName}");
                 }
             }
 
             //TODO: ARM32.
             long framePointer = (long)threadState.X29;
+
+            trace.AppendLine($"Process: {_owner.Name}, PID: {_owner.Pid}");
 
             while (framePointer != 0)
             {

--- a/Ryujinx.HLE/HOS/Kernel/Process/HleProcessDebugger.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/HleProcessDebugger.cs
@@ -99,20 +99,6 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
             return trace.ToString();
         }
 
-        [Obsolete("Use GetGuestStackTrace")]
-        public void PrintGuestStackTrace(CpuThreadState threadState)
-        {
-            EnsureLoaded();
-
-            StringBuilder trace = new StringBuilder();
-
-            trace.AppendLine("Guest stack trace:");
-
-            trace.AppendLine(GetGuestStackTrace(threadState));
-
-            Logger.PrintInfo(LogClass.Cpu, trace.ToString());
-        }
-
         private bool TryGetSubName(Image image, long address, out string name)
         {
             address -= image.BaseAddress;

--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcIpc.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcIpc.cs
@@ -143,6 +143,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
                 _device,
                 _process,
                 _process.CpuMemory,
+                ipcMessage.Thread,
                 ipcMessage.Session,
                 ipcMessage.Message,
                 ipcMessage.MessagePtr);

--- a/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
@@ -1,10 +1,12 @@
 using ChocolArm64;
 using ChocolArm64.Memory;
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Kernel.Common;
 using Ryujinx.HLE.HOS.Kernel.Process;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 namespace Ryujinx.HLE.HOS.Kernel.Threading
 {
@@ -1009,9 +1011,19 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
             ReleaseAndResume();
         }
 
+        public string GetGuestStackTrace()
+        {
+            return Owner.Debugger.GetGuestStackTrace(Context.ThreadState);
+        }
+
         public void PrintGuestStackTrace()
         {
-            Owner.Debugger.PrintGuestStackTrace(Context.ThreadState);
+            StringBuilder trace = new StringBuilder();
+
+            trace.AppendLine("Guest stack trace:");
+            trace.AppendLine(GetGuestStackTrace());
+
+            Logger.PrintInfo(LogClass.Cpu, trace.ToString());
         }
 
         private void ThreadFinishedHandler(object sender, EventArgs e)

--- a/Ryujinx.HLE/HOS/ServiceCtx.cs
+++ b/Ryujinx.HLE/HOS/ServiceCtx.cs
@@ -2,6 +2,7 @@ using ChocolArm64.Memory;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Kernel.Ipc;
 using Ryujinx.HLE.HOS.Kernel.Process;
+using Ryujinx.HLE.HOS.Kernel.Threading;
 using System.IO;
 
 namespace Ryujinx.HLE.HOS
@@ -11,6 +12,7 @@ namespace Ryujinx.HLE.HOS
         public Switch         Device       { get; }
         public KProcess       Process      { get; }
         public MemoryManager  Memory       { get; }
+        public KThread        Thread       { get; }
         public KClientSession Session      { get; }
         public IpcMessage     Request      { get; }
         public IpcMessage     Response     { get; }
@@ -21,6 +23,7 @@ namespace Ryujinx.HLE.HOS
             Switch         device,
             KProcess       process,
             MemoryManager  memory,
+            KThread        thread,
             KClientSession session,
             IpcMessage     request,
             IpcMessage     response,
@@ -30,6 +33,7 @@ namespace Ryujinx.HLE.HOS
             Device       = device;
             Process      = process;
             Memory       = memory;
+            Thread       = thread;
             Session      = session;
             Request      = request;
             Response     = response;


### PR DESCRIPTION
When a ServiceNotImplemented exception is thrown, it's useful to obtain a guest stack trace as this usually includes critically important information in understanding what exactly was called and how. The stack trace also includes the SDK function and call stack that was used to call the IPC function, which is useful for deciphering unknown or undocumented service functions.

This PR prints a stack trace in the IPC info dump that is logged when a service function is not implemented. It also adds a few extra functions, and refactors some of the existing code to better accommodate more use-cases (eg. no printing the stack trace directly to the log, rather returning it).

I've also obsoleted the `PrintGuestStackTrace` in `HleProcessDebugger` function, as in nearly every situation, getting the stack trace and then printing it locally allows better control over formatting and logging vs having a function that prints the stack trace directly to the log immediately when called. This function could eventually be removed (the `PrintGuestStackTrace` in `KThread` is now re-implemented using `GetGuestStackTrace`).