### PR TITLE
Sse optimized all the fp to integer conversion instructions (signed) with Tests (signed & unsigned).

### DIFF
--- a/ChocolArm64/Instructions/InstEmitSimdCmp.cs
+++ b/ChocolArm64/Instructions/InstEmitSimdCmp.cs
@@ -563,7 +563,7 @@ namespace ChocolArm64.Instructions
 
                     if (cmpWithZero)
                     {
-                        VectorHelper.EmitCall(context, nameof(VectorHelper.VectorDoubleZero));
+                        VectorHelper.EmitCall(context, nameof(VectorHelper.VectorSingleZero));
                     }
                     else
                     {
@@ -574,7 +574,7 @@ namespace ChocolArm64.Instructions
                     context.EmitLdvectmp();
 
                     context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.CompareOrderedScalar), typesCmp));
-                    VectorHelper.EmitCall(context, nameof(VectorHelper.VectorDoubleZero));
+                    VectorHelper.EmitCall(context, nameof(VectorHelper.VectorSingleZero));
 
                     context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.CompareEqualOrderedScalar), typesCmp));
 
@@ -839,7 +839,7 @@ namespace ChocolArm64.Instructions
                 }
                 else
                 {
-                    VectorHelper.EmitCall(context, nameof(VectorHelper.VectorDoubleZero));
+                    VectorHelper.EmitCall(context, nameof(VectorHelper.VectorSingleZero));
                 }
 
                 if (isLeOrLt)

--- a/ChocolArm64/Instructions/InstEmitSimdCvt.cs
+++ b/ChocolArm64/Instructions/InstEmitSimdCvt.cs
@@ -35,7 +35,7 @@ namespace ChocolArm64.Instructions
                     //Single -> Double.
                     Type[] typesCvt = new Type[] { typeof(Vector128<double>), typeof(Vector128<float>) };
 
-                    VectorHelper.EmitCall(context, nameof(VectorHelper.VectorDoubleZero));
+                    VectorHelper.EmitCall(context, nameof(VectorHelper.VectorSingleZero));
                     context.EmitLdvec(op.Rn);
 
                     context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.ConvertScalarToVector128Double), typesCvt));
@@ -125,7 +125,14 @@ namespace ChocolArm64.Instructions
 
         public static void Fcvtms_Gp(ILEmitterCtx context)
         {
-            EmitFcvt_s_Gp(context, () => EmitUnaryMathCall(context, nameof(Math.Floor)));
+            if (Optimizations.UseSse41)
+            {
+                EmitSse41Fcvt_Signed_Gp(context, RoundMode.TowardsMinusInfinity, isFixed: false);
+            }
+            else
+            {
+                EmitFcvt_s_Gp(context, () => EmitUnaryMathCall(context, nameof(Math.Floor)));
+            }
         }
 
         public static void Fcvtmu_Gp(ILEmitterCtx context)
@@ -207,12 +214,26 @@ namespace ChocolArm64.Instructions
 
         public static void Fcvtns_S(ILEmitterCtx context)
         {
-            EmitFcvtn(context, signed: true, scalar: true);
+            if (Optimizations.UseSse41)
+            {
+                EmitSse41Fcvt_Signed(context, RoundMode.ToNearest, isFixed: false, scalar: true);
+            }
+            else
+            {
+                EmitFcvtn(context, signed: true, scalar: true);
+            }
         }
 
         public static void Fcvtns_V(ILEmitterCtx context)
         {
-            EmitFcvtn(context, signed: true, scalar: false);
+            if (Optimizations.UseSse41)
+            {
+                EmitSse41Fcvt_Signed(context, RoundMode.ToNearest, isFixed: false, scalar: false);
+            }
+            else
+            {
+                EmitFcvtn(context, signed: true, scalar: false);
+            }
         }
 
         public static void Fcvtnu_S(ILEmitterCtx context)
@@ -227,7 +248,14 @@ namespace ChocolArm64.Instructions
 
         public static void Fcvtps_Gp(ILEmitterCtx context)
         {
-            EmitFcvt_s_Gp(context, () => EmitUnaryMathCall(context, nameof(Math.Ceiling)));
+            if (Optimizations.UseSse41)
+            {
+                EmitSse41Fcvt_Signed_Gp(context, RoundMode.TowardsPlusInfinity, isFixed: false);
+            }
+            else
+            {
+                EmitFcvt_s_Gp(context, () => EmitUnaryMathCall(context, nameof(Math.Ceiling)));
+            }
         }
 
         public static void Fcvtpu_Gp(ILEmitterCtx context)
@@ -237,22 +265,62 @@ namespace ChocolArm64.Instructions
 
         public static void Fcvtzs_Gp(ILEmitterCtx context)
         {
-            EmitFcvt_s_Gp(context, () => { });
+            if (Optimizations.UseSse41)
+            {
+                EmitSse41Fcvt_Signed_Gp(context, RoundMode.TowardsZero, isFixed: false);
+            }
+            else
+            {
+                EmitFcvt_s_Gp(context, () => { });
+            }
         }
 
         public static void Fcvtzs_Gp_Fixed(ILEmitterCtx context)
         {
-            EmitFcvtzs_Gp_Fixed(context);
+            if (Optimizations.UseSse41)
+            {
+                EmitSse41Fcvt_Signed_Gp(context, RoundMode.TowardsZero, isFixed: true);
+            }
+            else
+            {
+                EmitFcvtzs_Gp_Fixed(context);
+            }
         }
 
         public static void Fcvtzs_S(ILEmitterCtx context)
         {
-            EmitFcvtz(context, signed: true, scalar: true);
+            if (Optimizations.UseSse41)
+            {
+                EmitSse41Fcvt_Signed(context, RoundMode.TowardsZero, isFixed: false, scalar: true);
+            }
+            else
+            {
+                EmitFcvtz(context, signed: true, scalar: true);
+            }
         }
 
         public static void Fcvtzs_V(ILEmitterCtx context)
         {
-            EmitFcvtz(context, signed: true, scalar: false);
+            if (Optimizations.UseSse41)
+            {
+                EmitSse41Fcvt_Signed(context, RoundMode.TowardsZero, isFixed: false, scalar: false);
+            }
+            else
+            {
+                EmitFcvtz(context, signed: true, scalar: false);
+            }
+        }
+
+        public static void Fcvtzs_V_Fixed(ILEmitterCtx context)
+        {
+            if (Optimizations.UseSse41)
+            {
+                EmitSse41Fcvt_Signed(context, RoundMode.TowardsZero, isFixed: true, scalar: false);
+            }
+            else
+            {
+                EmitFcvtz(context, signed: true, scalar: false);
+            }
         }
 
         public static void Fcvtzu_Gp(ILEmitterCtx context)
@@ -271,6 +339,11 @@ namespace ChocolArm64.Instructions
         }
 
         public static void Fcvtzu_V(ILEmitterCtx context)
+        {
+            EmitFcvtz(context, signed: false, scalar: false);
+        }
+
+        public static void Fcvtzu_V_Fixed(ILEmitterCtx context)
         {
             EmitFcvtz(context, signed: false, scalar: false);
         }
@@ -728,6 +801,315 @@ namespace ChocolArm64.Instructions
                 }
 
                 context.Emit(OpCodes.Mul);
+            }
+        }
+
+        private static void EmitSse41Fcvt_Signed_Gp(ILEmitterCtx context, RoundMode roundMode, bool isFixed)
+        {
+            OpCodeSimdCvt64 op = (OpCodeSimdCvt64)context.CurrOp;
+
+            if (op.Size == 0)
+            {
+                Type[] typesCmpMul = new Type[] { typeof(Vector128<float>), typeof(Vector128<float>) };
+                Type[] typesAnd    = new Type[] { typeof(Vector128<long> ), typeof(Vector128<long> ) };
+                Type[] typesRndCvt = new Type[] { typeof(Vector128<float>) };
+                Type[] typesCvt    = new Type[] { typeof(Vector128<int>  ) };
+                Type[] typesSav    = new Type[] { typeof(int) };
+
+                //string nameCvt;
+                int    fpMaxVal;
+
+                if (op.RegisterSize == RegisterSize.Int32)
+                {
+                    //nameCvt  = nameof(Sse.ConvertToInt32);
+                    fpMaxVal = 0x4F000000; // 2.14748365E9f (2147483648)
+                }
+                else
+                {
+                    //nameCvt  = nameof(Sse.ConvertToInt64);
+                    fpMaxVal = 0x5F000000; // 9.223372E18f (9223372036854775808)
+                }
+
+                context.EmitLdvec(op.Rn);
+                context.EmitLdvec(op.Rn);
+
+                context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.CompareOrdered), typesCmpMul));
+
+                context.EmitLdvec(op.Rn);
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.And), typesAnd));
+
+                if (isFixed)
+                {
+                    // BitConverter.Int32BitsToSingle(fpScaled) == MathF.Pow(2f, op.FBits)
+                    int fpScaled = 0x40000000 + (op.FBits - 1) * 0x800000;
+
+                    context.EmitLdc_I4(fpScaled);
+                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.SetAllVector128), typesSav));
+
+                    context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.Multiply), typesCmpMul));
+                }
+
+                context.EmitCall(typeof(Sse41).GetMethod(GetSse41NameRnd(roundMode), typesRndCvt));
+
+                context.EmitStvectmp();
+                context.EmitLdvectmp();
+
+                // TODO: Use Sse.ConvertToInt64 once it is fixed,
+                // remove the following if/else and comment out the code.
+
+                //context.EmitCall(typeof(Sse).GetMethod(nameCvt, typesRndCvt));
+
+                if (op.RegisterSize == RegisterSize.Int32)
+                {
+                    context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.ConvertToInt32), typesRndCvt));
+                }
+                else
+                {
+                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.ConvertToVector128Double), typesRndCvt));
+                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.ConvertToInt64), new Type[] { typeof(Vector128<double>) }));
+                }
+
+                context.EmitLdvectmp();
+
+                context.EmitLdc_I4(fpMaxVal);
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.SetAllVector128), typesSav));
+
+                context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.CompareGreaterThanOrEqual), typesCmpMul));
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.ConvertToInt32), typesCvt));
+
+                if (op.RegisterSize == RegisterSize.Int32)
+                {
+                    context.Emit(OpCodes.Xor);
+                    context.Emit(OpCodes.Conv_U8);
+                }
+                else
+                {
+                    context.Emit(OpCodes.Conv_I8);
+                    context.Emit(OpCodes.Xor);
+                }
+
+                context.EmitStintzr(op.Rd);
+            }
+            else /* if (op.Size == 1) */
+            {
+                Type[] typesCmpMul = new Type[] { typeof(Vector128<double>), typeof(Vector128<double>) };
+                Type[] typesAnd    = new Type[] { typeof(Vector128<long>  ), typeof(Vector128<long>  ) };
+                Type[] typesRndCvt = new Type[] { typeof(Vector128<double>) };
+                Type[] typesCvt    = new Type[] { typeof(Vector128<int>   ) };
+                Type[] typesSav    = new Type[] { typeof(long) };
+
+                string nameCvt;
+                long   fpMaxVal;
+
+                if (op.RegisterSize == RegisterSize.Int32)
+                {
+                    nameCvt  = nameof(Sse2.ConvertToInt32);
+                    fpMaxVal = 0x41E0000000000000L; // 2147483648.0000000d (2147483648)
+                }
+                else
+                {
+                    nameCvt  = nameof(Sse2.ConvertToInt64);
+                    fpMaxVal = 0x43E0000000000000L; // 9.2233720368547760E18d (9223372036854775808)
+                }
+
+                context.EmitLdvec(op.Rn);
+                context.EmitLdvec(op.Rn);
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.CompareOrdered), typesCmpMul));
+
+                context.EmitLdvec(op.Rn);
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.And), typesAnd));
+
+                if (isFixed)
+                {
+                    // BitConverter.Int64BitsToDouble(fpScaled) == Math.Pow(2d, op.FBits)
+                    long fpScaled = 0x4000000000000000L + (op.FBits - 1) * 0x10000000000000L;
+
+                    context.EmitLdc_I8(fpScaled);
+                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.SetAllVector128), typesSav));
+
+                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.Multiply), typesCmpMul));
+                }
+
+                context.EmitCall(typeof(Sse41).GetMethod(GetSse41NameRnd(roundMode), typesRndCvt));
+
+                context.EmitStvectmp();
+                context.EmitLdvectmp();
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameCvt, typesRndCvt));
+
+                context.EmitLdvectmp();
+
+                context.EmitLdc_I8(fpMaxVal);
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.SetAllVector128), typesSav));
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.CompareGreaterThanOrEqual), typesCmpMul));
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.ConvertToInt32), typesCvt));
+
+                if (op.RegisterSize == RegisterSize.Int32)
+                {
+                    context.Emit(OpCodes.Xor);
+                    context.Emit(OpCodes.Conv_U8);
+                }
+                else
+                {
+                    context.Emit(OpCodes.Conv_I8);
+                    context.Emit(OpCodes.Xor);
+                }
+
+                context.EmitStintzr(op.Rd);
+            }
+        }
+
+        private static void EmitSse41Fcvt_Signed(ILEmitterCtx context, RoundMode roundMode, bool isFixed, bool scalar)
+        {
+            OpCodeSimd64 op = (OpCodeSimd64)context.CurrOp;
+
+            // sizeF == ((OpCodeSimdShImm64)op).Size - 2
+            int sizeF = op.Size & 1;
+
+            if (sizeF == 0)
+            {
+                Type[] typesCmpMul = new Type[] { typeof(Vector128<float>), typeof(Vector128<float>) };
+                Type[] typesAndXor = new Type[] { typeof(Vector128<long> ), typeof(Vector128<long> ) };
+                Type[] typesRndCvt = new Type[] { typeof(Vector128<float>) };
+                Type[] typesSav    = new Type[] { typeof(int) };
+
+                context.EmitLdvec(op.Rn);
+                context.EmitLdvec(op.Rn);
+
+                context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.CompareOrdered), typesCmpMul));
+
+                context.EmitLdvec(op.Rn);
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.And), typesAndXor));
+
+                if (isFixed)
+                {
+                    int fBits = GetImmShr((OpCodeSimdShImm64)op);
+
+                    // BitConverter.Int32BitsToSingle(fpScaled) == MathF.Pow(2f, fBits)
+                    int fpScaled = 0x40000000 + (fBits - 1) * 0x800000;
+
+                    context.EmitLdc_I4(fpScaled);
+                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.SetAllVector128), typesSav));
+
+                    context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.Multiply), typesCmpMul));
+                }
+
+                context.EmitCall(typeof(Sse41).GetMethod(GetSse41NameRnd(roundMode), typesRndCvt));
+
+                context.EmitStvectmp();
+                context.EmitLdvectmp();
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.ConvertToVector128Int32), typesRndCvt));
+
+                context.EmitLdvectmp();
+
+                context.EmitLdc_I4(0x4F000000); // 2.14748365E9f (2147483648)
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.SetAllVector128), typesSav));
+
+                context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.CompareGreaterThanOrEqual), typesCmpMul));
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.Xor), typesAndXor));
+
+                context.EmitStvec(op.Rd);
+
+                if (scalar)
+                {
+                    EmitVectorZero32_128(context, op.Rd);
+                }
+                else if (op.RegisterSize == RegisterSize.Simd64)
+                {
+                    EmitVectorZeroUpper(context, op.Rd);
+                }
+            }
+            else /* if (sizeF == 1) */
+            {
+                Type[] typesCmpMulUpk = new Type[] { typeof(Vector128<double> ), typeof(Vector128<double>) };
+                Type[] typesAndXor    = new Type[] { typeof(Vector128<long>   ), typeof(Vector128<long>  ) };
+                Type[] typesRndCvt    = new Type[] { typeof(Vector128<double> ) };
+                Type[] typesSv        = new Type[] { typeof(long), typeof(long) };
+                Type[] typesSav       = new Type[] { typeof(long) };
+
+                context.EmitLdvec(op.Rn);
+                context.EmitLdvec(op.Rn);
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.CompareOrdered), typesCmpMulUpk));
+
+                context.EmitLdvec(op.Rn);
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.And), typesAndXor));
+
+                if (isFixed)
+                {
+                    int fBits = GetImmShr((OpCodeSimdShImm64)op);
+
+                    // BitConverter.Int64BitsToDouble(fpScaled) == Math.Pow(2d, fBits)
+                    long fpScaled = 0x4000000000000000L + (fBits - 1) * 0x10000000000000L;
+
+                    context.EmitLdc_I8(fpScaled);
+                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.SetAllVector128), typesSav));
+
+                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.Multiply), typesCmpMulUpk));
+                }
+
+                context.EmitCall(typeof(Sse41).GetMethod(GetSse41NameRnd(roundMode), typesRndCvt));
+
+                context.EmitStvectmp();
+                context.EmitLdvectmp();
+
+                context.EmitLdvectmp();
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.UnpackHigh), typesCmpMulUpk));
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.ConvertToInt64), typesRndCvt));
+
+                context.EmitLdvectmp();
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.ConvertToInt64), typesRndCvt));
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.SetVector128), typesSv));
+
+                context.EmitLdvectmp();
+
+                context.EmitLdc_I8(0x43E0000000000000L); // 9.2233720368547760E18d (9223372036854775808)
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.SetAllVector128), typesSav));
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.CompareGreaterThanOrEqual), typesCmpMulUpk));
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.Xor), typesAndXor));
+
+                context.EmitStvec(op.Rd);
+
+                if (scalar)
+                {
+                    EmitVectorZeroUpper(context, op.Rd);
+                }
+            }
+        }
+
+        private static string GetSse41NameRnd(RoundMode roundMode)
+        {
+            switch (roundMode)
+            {
+                case RoundMode.ToNearest:
+                    return nameof(Sse41.RoundToNearestInteger); // even
+
+                case RoundMode.TowardsMinusInfinity:
+                    return nameof(Sse41.RoundToNegativeInfinity);
+
+                case RoundMode.TowardsPlusInfinity:
+                    return nameof(Sse41.RoundToPositiveInfinity);
+
+                case RoundMode.TowardsZero:
+                    return nameof(Sse41.RoundToZero);
+
+                default: throw new ArgumentException(nameof(roundMode));
             }
         }
     }

--- a/ChocolArm64/Instructions/InstEmitSimdCvt.cs
+++ b/ChocolArm64/Instructions/InstEmitSimdCvt.cs
@@ -811,9 +811,9 @@ namespace ChocolArm64.Instructions
             if (op.Size == 0)
             {
                 Type[] typesCmpMul = new Type[] { typeof(Vector128<float>), typeof(Vector128<float>) };
-                Type[] typesAnd    = new Type[] { typeof(Vector128<long> ), typeof(Vector128<long> ) };
+                Type[] typesAnd    = new Type[] { typeof(Vector128<long>),  typeof(Vector128<long>) };
                 Type[] typesRndCvt = new Type[] { typeof(Vector128<float>) };
-                Type[] typesCvt    = new Type[] { typeof(Vector128<int>  ) };
+                Type[] typesCvt    = new Type[] { typeof(Vector128<int>) };
                 Type[] typesSav    = new Type[] { typeof(int) };
 
                 //string nameCvt;
@@ -855,8 +855,8 @@ namespace ChocolArm64.Instructions
                 context.EmitStvectmp();
                 context.EmitLdvectmp();
 
-                // TODO: Use Sse.ConvertToInt64 once it is fixed,
-                // remove the following if/else and comment out the code.
+                // TODO: Use Sse.ConvertToInt64 once it is fixed (in .NET Core 3.0),
+                // remove the following if/else and uncomment the code.
 
                 //context.EmitCall(typeof(Sse).GetMethod(nameCvt, typesRndCvt));
 
@@ -895,9 +895,9 @@ namespace ChocolArm64.Instructions
             else /* if (op.Size == 1) */
             {
                 Type[] typesCmpMul = new Type[] { typeof(Vector128<double>), typeof(Vector128<double>) };
-                Type[] typesAnd    = new Type[] { typeof(Vector128<long>  ), typeof(Vector128<long>  ) };
+                Type[] typesAnd    = new Type[] { typeof(Vector128<long>),   typeof(Vector128<long>) };
                 Type[] typesRndCvt = new Type[] { typeof(Vector128<double>) };
-                Type[] typesCvt    = new Type[] { typeof(Vector128<int>   ) };
+                Type[] typesCvt    = new Type[] { typeof(Vector128<int>) };
                 Type[] typesSav    = new Type[] { typeof(long) };
 
                 string nameCvt;
@@ -975,7 +975,7 @@ namespace ChocolArm64.Instructions
             if (sizeF == 0)
             {
                 Type[] typesCmpMul = new Type[] { typeof(Vector128<float>), typeof(Vector128<float>) };
-                Type[] typesAndXor = new Type[] { typeof(Vector128<long> ), typeof(Vector128<long> ) };
+                Type[] typesAndXor = new Type[] { typeof(Vector128<long>),  typeof(Vector128<long>) };
                 Type[] typesRndCvt = new Type[] { typeof(Vector128<float>) };
                 Type[] typesSav    = new Type[] { typeof(int) };
 
@@ -1030,9 +1030,9 @@ namespace ChocolArm64.Instructions
             }
             else /* if (sizeF == 1) */
             {
-                Type[] typesCmpMulUpk = new Type[] { typeof(Vector128<double> ), typeof(Vector128<double>) };
-                Type[] typesAndXor    = new Type[] { typeof(Vector128<long>   ), typeof(Vector128<long>  ) };
-                Type[] typesRndCvt    = new Type[] { typeof(Vector128<double> ) };
+                Type[] typesCmpMulUpk = new Type[] { typeof(Vector128<double>), typeof(Vector128<double>) };
+                Type[] typesAndXor    = new Type[] { typeof(Vector128<long>),   typeof(Vector128<long>) };
+                Type[] typesRndCvt    = new Type[] { typeof(Vector128<double>) };
                 Type[] typesSv        = new Type[] { typeof(long), typeof(long) };
                 Type[] typesSav       = new Type[] { typeof(long) };
 

--- a/ChocolArm64/Instructions/InstEmitSimdHelper.cs
+++ b/ChocolArm64/Instructions/InstEmitSimdHelper.cs
@@ -1367,8 +1367,8 @@ namespace ChocolArm64.Instructions
         {
             if (Optimizations.UseSse)
             {
-                //TODO: Use Sse2.MoveScalar once it is fixed,
-                //as of the time of writing it just crashes the JIT (SDK 2.1.504).
+                // TODO: Use Sse2.MoveScalar once it is fixed,
+                // as of the time of writing it just crashes the JIT (SDK 2.1.505).
 
                 /*Type[] typesMov = new Type[] { typeof(Vector128<ulong>) };
 

--- a/ChocolArm64/Instructions/InstEmitSimdHelper.cs
+++ b/ChocolArm64/Instructions/InstEmitSimdHelper.cs
@@ -1367,8 +1367,8 @@ namespace ChocolArm64.Instructions
         {
             if (Optimizations.UseSse)
             {
-                // TODO: Use Sse2.MoveScalar once it is fixed,
-                // as of the time of writing it just crashes the JIT (SDK 2.1.505).
+                // TODO: Use Sse2.MoveScalar once it is fixed (in .NET Core 3.0),
+                // as of the time of writing it just crashes the JIT.
 
                 /*Type[] typesMov = new Type[] { typeof(Vector128<ulong>) };
 

--- a/ChocolArm64/Instructions/InstEmitSimdMove.cs
+++ b/ChocolArm64/Instructions/InstEmitSimdMove.cs
@@ -358,7 +358,7 @@ namespace ChocolArm64.Instructions
             if (Optimizations.UseSsse3)
             {
                 Type[] typesCmpSflSub = new Type[] { typeof(Vector128<sbyte>), typeof(Vector128<sbyte>) };
-                Type[] typesOr        = new Type[] { typeof(Vector128<long> ), typeof(Vector128<long> ) };
+                Type[] typesOr        = new Type[] { typeof(Vector128<long>),  typeof(Vector128<long>) };
                 Type[] typesSav       = new Type[] { typeof(long) };
 
                 context.EmitLdvec(op.Rn);

--- a/ChocolArm64/Instructions/InstEmitSimdMove.cs
+++ b/ChocolArm64/Instructions/InstEmitSimdMove.cs
@@ -710,7 +710,7 @@ namespace ChocolArm64.Instructions
                         context.EmitCall(typeof(Ssse3).GetMethod(nameof(Ssse3.Shuffle), GetTypesSflUpk(0)));
                     }
 
-                    VectorHelper.EmitCall(context, nameof(VectorHelper.VectorInt64Zero));
+                    VectorHelper.EmitCall(context, nameof(VectorHelper.VectorSingleZero));
 
                     context.EmitCall(typeof(Sse2).GetMethod(nameUpk, GetTypesSflUpk(3)));
 
@@ -763,7 +763,7 @@ namespace ChocolArm64.Instructions
                 else
                 {
                     context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.UnpackLow), GetTypesSflUpk(op.Size)));
-                    VectorHelper.EmitCall(context, nameof(VectorHelper.VectorInt64Zero));
+                    VectorHelper.EmitCall(context, nameof(VectorHelper.VectorSingleZero));
 
                     context.EmitCall(typeof(Sse2).GetMethod(nameUpk, GetTypesSflUpk(3)));
                 }

--- a/ChocolArm64/Instructions/VectorHelper.cs
+++ b/ChocolArm64/Instructions/VectorHelper.cs
@@ -26,8 +26,8 @@ namespace ChocolArm64.Instructions
         {
             if (float.IsNaN(value)) return 0;
 
-            return value > int.MaxValue ? int.MaxValue :
-                   value < int.MinValue ? int.MinValue : (int)value;
+            return value >= int.MaxValue ? int.MaxValue :
+                   value <= int.MinValue ? int.MinValue : (int)value;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -35,8 +35,8 @@ namespace ChocolArm64.Instructions
         {
             if (float.IsNaN(value)) return 0;
 
-            return value > long.MaxValue ? long.MaxValue :
-                   value < long.MinValue ? long.MinValue : (long)value;
+            return value >= long.MaxValue ? long.MaxValue :
+                   value <= long.MinValue ? long.MinValue : (long)value;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -44,8 +44,8 @@ namespace ChocolArm64.Instructions
         {
             if (float.IsNaN(value)) return 0;
 
-            return value > uint.MaxValue ? uint.MaxValue :
-                   value < uint.MinValue ? uint.MinValue : (uint)value;
+            return value >= uint.MaxValue ? uint.MaxValue :
+                   value <= uint.MinValue ? uint.MinValue : (uint)value;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -53,8 +53,8 @@ namespace ChocolArm64.Instructions
         {
             if (float.IsNaN(value)) return 0;
 
-            return value > ulong.MaxValue ? ulong.MaxValue :
-                   value < ulong.MinValue ? ulong.MinValue : (ulong)value;
+            return value >= ulong.MaxValue ? ulong.MaxValue :
+                   value <= ulong.MinValue ? ulong.MinValue : (ulong)value;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -62,8 +62,8 @@ namespace ChocolArm64.Instructions
         {
             if (double.IsNaN(value)) return 0;
 
-            return value > int.MaxValue ? int.MaxValue :
-                   value < int.MinValue ? int.MinValue : (int)value;
+            return value >= int.MaxValue ? int.MaxValue :
+                   value <= int.MinValue ? int.MinValue : (int)value;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -71,8 +71,8 @@ namespace ChocolArm64.Instructions
         {
             if (double.IsNaN(value)) return 0;
 
-            return value > long.MaxValue ? long.MaxValue :
-                   value < long.MinValue ? long.MinValue : (long)value;
+            return value >= long.MaxValue ? long.MaxValue :
+                   value <= long.MinValue ? long.MinValue : (long)value;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -80,8 +80,8 @@ namespace ChocolArm64.Instructions
         {
             if (double.IsNaN(value)) return 0;
 
-            return value > uint.MaxValue ? uint.MaxValue :
-                   value < uint.MinValue ? uint.MinValue : (uint)value;
+            return value >= uint.MaxValue ? uint.MaxValue :
+                   value <= uint.MinValue ? uint.MinValue : (uint)value;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -89,8 +89,8 @@ namespace ChocolArm64.Instructions
         {
             if (double.IsNaN(value)) return 0;
 
-            return value > ulong.MaxValue ? ulong.MaxValue :
-                   value < ulong.MinValue ? ulong.MinValue : (ulong)value;
+            return value >= ulong.MaxValue ? ulong.MaxValue :
+                   value <= ulong.MinValue ? ulong.MinValue : (ulong)value;
         }
 
         public static double Round(double value, CpuThreadState state)
@@ -501,66 +501,11 @@ namespace ChocolArm64.Instructions
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Vector128<sbyte> VectorSByteZero()
-        {
-            if (Sse2.IsSupported)
-            {
-                return Sse2.SetZeroVector128<sbyte>();
-            }
-
-            throw new PlatformNotSupportedException();
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Vector128<short> VectorInt16Zero()
-        {
-            if (Sse2.IsSupported)
-            {
-                return Sse2.SetZeroVector128<short>();
-            }
-
-            throw new PlatformNotSupportedException();
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Vector128<int> VectorInt32Zero()
-        {
-            if (Sse2.IsSupported)
-            {
-                return Sse2.SetZeroVector128<int>();
-            }
-
-            throw new PlatformNotSupportedException();
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Vector128<long> VectorInt64Zero()
-        {
-            if (Sse2.IsSupported)
-            {
-                return Sse2.SetZeroVector128<long>();
-            }
-
-            throw new PlatformNotSupportedException();
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector128<float> VectorSingleZero()
         {
             if (Sse.IsSupported)
             {
                 return Sse.SetZeroVector128();
-            }
-
-            throw new PlatformNotSupportedException();
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static Vector128<double> VectorDoubleZero()
-        {
-            if (Sse2.IsSupported)
-            {
-                return Sse2.SetZeroVector128<double>();
             }
 
             throw new PlatformNotSupportedException();

--- a/ChocolArm64/OpCodeTable.cs
+++ b/ChocolArm64/OpCodeTable.cs
@@ -313,12 +313,14 @@ namespace ChocolArm64
             SetA64(">00111100x011000>xxxxxxxxxxxxxxx", InstEmit.Fcvtzs_Gp_Fixed, typeof(OpCodeSimdCvt64));
             SetA64("010111101x100001101110xxxxxxxxxx", InstEmit.Fcvtzs_S,        typeof(OpCodeSimd64));
             SetA64("0>0011101<100001101110xxxxxxxxxx", InstEmit.Fcvtzs_V,        typeof(OpCodeSimd64));
-            SetA64("0x0011110>>xxxxx111111xxxxxxxxxx", InstEmit.Fcvtzs_V,        typeof(OpCodeSimdShImm64));
+            SetA64("0x001111001xxxxx111111xxxxxxxxxx", InstEmit.Fcvtzs_V_Fixed,  typeof(OpCodeSimdShImm64));
+            SetA64("0100111101xxxxxx111111xxxxxxxxxx", InstEmit.Fcvtzs_V_Fixed,  typeof(OpCodeSimdShImm64));
             SetA64("x00111100x111001000000xxxxxxxxxx", InstEmit.Fcvtzu_Gp,       typeof(OpCodeSimdCvt64));
             SetA64(">00111100x011001>xxxxxxxxxxxxxxx", InstEmit.Fcvtzu_Gp_Fixed, typeof(OpCodeSimdCvt64));
             SetA64("011111101x100001101110xxxxxxxxxx", InstEmit.Fcvtzu_S,        typeof(OpCodeSimd64));
             SetA64("0>1011101<100001101110xxxxxxxxxx", InstEmit.Fcvtzu_V,        typeof(OpCodeSimd64));
-            SetA64("0x1011110>>xxxxx111111xxxxxxxxxx", InstEmit.Fcvtzu_V,        typeof(OpCodeSimdShImm64));
+            SetA64("0x101111001xxxxx111111xxxxxxxxxx", InstEmit.Fcvtzu_V_Fixed,  typeof(OpCodeSimdShImm64));
+            SetA64("0110111101xxxxxx111111xxxxxxxxxx", InstEmit.Fcvtzu_V_Fixed,  typeof(OpCodeSimdShImm64));
             SetA64("000111100x1xxxxx000110xxxxxxxxxx", InstEmit.Fdiv_S,          typeof(OpCodeSimdReg64));
             SetA64("0>1011100<1xxxxx111111xxxxxxxxxx", InstEmit.Fdiv_V,          typeof(OpCodeSimdReg64));
             SetA64("000111110x0xxxxx0xxxxxxxxxxxxxxx", InstEmit.Fmadd_S,         typeof(OpCodeSimdReg64));

--- a/Ryujinx.Tests/Cpu/CpuTestSimd.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestSimd.cs
@@ -172,6 +172,56 @@ namespace Ryujinx.Tests.Cpu
             }
         }
 
+        private static IEnumerable<ulong> _1S_F_Cvt_()
+        {
+            // int
+            yield return 0x00000000CF000001; // -2.1474839E9f  (-2147483904)
+            yield return 0x00000000CF000000; // -2.14748365E9f (-2147483648)
+            yield return 0x00000000CEFFFFFF; // -2.14748352E9f (-2147483520)
+            yield return 0x000000004F000001; //  2.1474839E9f  (2147483904)
+            yield return 0x000000004F000000; //  2.14748365E9f (2147483648)
+            yield return 0x000000004EFFFFFF; //  2.14748352E9f (2147483520)
+
+            yield return 0x00000000FF7FFFFFul; // -Max Normal    (float.MinValue)
+            yield return 0x0000000080800000ul; // -Min Normal
+            yield return 0x00000000807FFFFFul; // -Max Subnormal
+            yield return 0x0000000080000001ul; // -Min Subnormal (-float.Epsilon)
+            yield return 0x000000007F7FFFFFul; // +Max Normal    (float.MaxValue)
+            yield return 0x0000000000800000ul; // +Min Normal
+            yield return 0x00000000007FFFFFul; // +Max Subnormal
+            yield return 0x0000000000000001ul; // +Min Subnormal (float.Epsilon)
+
+            if (!NoZeros)
+            {
+                yield return 0x0000000080000000ul; // -Zero
+                yield return 0x0000000000000000ul; // +Zero
+            }
+
+            if (!NoInfs)
+            {
+                yield return 0x00000000FF800000ul; // -Infinity
+                yield return 0x000000007F800000ul; // +Infinity
+            }
+
+            if (!NoNaNs)
+            {
+                yield return 0x00000000FFC00000ul; // -QNaN (all zeros payload) (float.NaN)
+                yield return 0x00000000FFBFFFFFul; // -SNaN (all ones  payload)
+                yield return 0x000000007FC00000ul; // +QNaN (all zeros payload) (-float.NaN) (DefaultNaN)
+                yield return 0x000000007FBFFFFFul; // +SNaN (all ones  payload)
+            }
+
+            for (int cnt = 1; cnt <= RndCnt; cnt++)
+            {
+                ulong grbg = TestContext.CurrentContext.Random.NextUInt();
+                ulong rnd1 = GenNormalS();
+                ulong rnd2 = GenSubnormalS();
+
+                yield return (grbg << 32) | rnd1;
+                yield return (grbg << 32) | rnd2;
+            }
+        }
+
         private static IEnumerable<ulong> _2S_F_()
         {
             yield return 0xFF7FFFFFFF7FFFFFul; // -Max Normal    (float.MinValue)
@@ -213,8 +263,106 @@ namespace Ryujinx.Tests.Cpu
             }
         }
 
+        private static IEnumerable<ulong> _2S_F_Cvt_()
+        {
+            // int
+            yield return 0xCF000001CF000001; // -2.1474839E9f  (-2147483904)
+            yield return 0xCF000000CF000000; // -2.14748365E9f (-2147483648)
+            yield return 0xCEFFFFFFCEFFFFFF; // -2.14748352E9f (-2147483520)
+            yield return 0x4F0000014F000001; //  2.1474839E9f  (2147483904)
+            yield return 0x4F0000004F000000; //  2.14748365E9f (2147483648)
+            yield return 0x4EFFFFFF4EFFFFFF; //  2.14748352E9f (2147483520)
+
+            yield return 0xFF7FFFFFFF7FFFFFul; // -Max Normal    (float.MinValue)
+            yield return 0x8080000080800000ul; // -Min Normal
+            yield return 0x807FFFFF807FFFFFul; // -Max Subnormal
+            yield return 0x8000000180000001ul; // -Min Subnormal (-float.Epsilon)
+            yield return 0x7F7FFFFF7F7FFFFFul; // +Max Normal    (float.MaxValue)
+            yield return 0x0080000000800000ul; // +Min Normal
+            yield return 0x007FFFFF007FFFFFul; // +Max Subnormal
+            yield return 0x0000000100000001ul; // +Min Subnormal (float.Epsilon)
+
+            if (!NoZeros)
+            {
+                yield return 0x8000000080000000ul; // -Zero
+                yield return 0x0000000000000000ul; // +Zero
+            }
+
+            if (!NoInfs)
+            {
+                yield return 0xFF800000FF800000ul; // -Infinity
+                yield return 0x7F8000007F800000ul; // +Infinity
+            }
+
+            if (!NoNaNs)
+            {
+                yield return 0xFFC00000FFC00000ul; // -QNaN (all zeros payload) (float.NaN)
+                yield return 0xFFBFFFFFFFBFFFFFul; // -SNaN (all ones  payload)
+                yield return 0x7FC000007FC00000ul; // +QNaN (all zeros payload) (-float.NaN) (DefaultNaN)
+                yield return 0x7FBFFFFF7FBFFFFFul; // +SNaN (all ones  payload)
+            }
+
+            for (int cnt = 1; cnt <= RndCnt; cnt++)
+            {
+                ulong rnd1 = GenNormalS();
+                ulong rnd2 = GenSubnormalS();
+
+                yield return (rnd1 << 32) | rnd1;
+                yield return (rnd2 << 32) | rnd2;
+            }
+        }
+
         private static IEnumerable<ulong> _1D_F_()
         {
+            yield return 0xFFEFFFFFFFFFFFFFul; // -Max Normal    (double.MinValue)
+            yield return 0x8010000000000000ul; // -Min Normal
+            yield return 0x800FFFFFFFFFFFFFul; // -Max Subnormal
+            yield return 0x8000000000000001ul; // -Min Subnormal (-double.Epsilon)
+            yield return 0x7FEFFFFFFFFFFFFFul; // +Max Normal    (double.MaxValue)
+            yield return 0x0010000000000000ul; // +Min Normal
+            yield return 0x000FFFFFFFFFFFFFul; // +Max Subnormal
+            yield return 0x0000000000000001ul; // +Min Subnormal (double.Epsilon)
+
+            if (!NoZeros)
+            {
+                yield return 0x8000000000000000ul; // -Zero
+                yield return 0x0000000000000000ul; // +Zero
+            }
+
+            if (!NoInfs)
+            {
+                yield return 0xFFF0000000000000ul; // -Infinity
+                yield return 0x7FF0000000000000ul; // +Infinity
+            }
+
+            if (!NoNaNs)
+            {
+                yield return 0xFFF8000000000000ul; // -QNaN (all zeros payload) (double.NaN)
+                yield return 0xFFF7FFFFFFFFFFFFul; // -SNaN (all ones  payload)
+                yield return 0x7FF8000000000000ul; // +QNaN (all zeros payload) (-double.NaN) (DefaultNaN)
+                yield return 0x7FF7FFFFFFFFFFFFul; // +SNaN (all ones  payload)
+            }
+
+            for (int cnt = 1; cnt <= RndCnt; cnt++)
+            {
+                ulong rnd1 = GenNormalD();
+                ulong rnd2 = GenSubnormalD();
+
+                yield return rnd1;
+                yield return rnd2;
+            }
+        }
+
+        private static IEnumerable<ulong> _1D_F_Cvt_()
+        {
+            // long
+            yield return 0xC3E0000000000001ul; // -9.2233720368547780E18d (-9223372036854778000)
+            yield return 0xC3E0000000000000ul; // -9.2233720368547760E18d (-9223372036854776000)
+            yield return 0xC3DFFFFFFFFFFFFFul; // -9.2233720368547750E18d (-9223372036854775000)
+            yield return 0x43E0000000000001ul; //  9.2233720368547780E18d (9223372036854778000)
+            yield return 0x43E0000000000000ul; //  9.2233720368547760E18d (9223372036854776000)
+            yield return 0x43DFFFFFFFFFFFFFul; //  9.2233720368547750E18d (9223372036854775000)
+
             yield return 0xFFEFFFFFFFFFFFFFul; // -Max Normal    (double.MinValue)
             yield return 0x8010000000000000ul; // -Min Normal
             yield return 0x800FFFFFFFFFFFFFul; // -Max Subnormal
@@ -1319,7 +1467,7 @@ namespace Ryujinx.Tests.Cpu
 
         [Test, Pairwise] [Explicit]
         public void F_Cvt_NZ_SU_S_S([ValueSource("_F_Cvt_NZ_SU_S_S_")] uint opcodes,
-                                    [ValueSource("_1S_F_")] ulong a)
+                                    [ValueSource("_1S_F_Cvt_")] ulong a)
         {
             ulong z = TestContext.CurrentContext.Random.NextULong();
             Vector128<float> v0 = MakeVectorE0E1(z, z);
@@ -1332,7 +1480,7 @@ namespace Ryujinx.Tests.Cpu
 
         [Test, Pairwise] [Explicit]
         public void F_Cvt_NZ_SU_S_D([ValueSource("_F_Cvt_NZ_SU_S_D_")] uint opcodes,
-                                    [ValueSource("_1D_F_")] ulong a)
+                                    [ValueSource("_1D_F_Cvt_")] ulong a)
         {
             ulong z = TestContext.CurrentContext.Random.NextULong();
             Vector128<float> v0 = MakeVectorE1(z);
@@ -1347,8 +1495,8 @@ namespace Ryujinx.Tests.Cpu
         public void F_Cvt_NZ_SU_V_2S_4S([ValueSource("_F_Cvt_NZ_SU_V_2S_4S_")] uint opcodes,
                                         [Values(0u)]     uint rd,
                                         [Values(1u, 0u)] uint rn,
-                                        [ValueSource("_2S_F_")] ulong z,
-                                        [ValueSource("_2S_F_")] ulong a,
+                                        [ValueSource("_2S_F_Cvt_")] ulong z,
+                                        [ValueSource("_2S_F_Cvt_")] ulong a,
                                         [Values(0b0u, 0b1u)] uint q) // <2S, 4S>
         {
             opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
@@ -1366,8 +1514,8 @@ namespace Ryujinx.Tests.Cpu
         public void F_Cvt_NZ_SU_V_2D([ValueSource("_F_Cvt_NZ_SU_V_2D_")] uint opcodes,
                                      [Values(0u)]     uint rd,
                                      [Values(1u, 0u)] uint rn,
-                                     [ValueSource("_1D_F_")] ulong z,
-                                     [ValueSource("_1D_F_")] ulong a)
+                                     [ValueSource("_1D_F_Cvt_")] ulong z,
+                                     [ValueSource("_1D_F_Cvt_")] ulong a)
         {
             opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
 

--- a/Ryujinx.Tests/Cpu/CpuTestSimdCvt.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestSimdCvt.cs
@@ -13,8 +13,24 @@ namespace Ryujinx.Tests.Cpu
 #if SimdCvt
 
 #region "ValueSource (Types)"
-        private static IEnumerable<ulong> _1S_F_()
+        private static IEnumerable<ulong> _1S_F_Cvt_()
         {
+            // int
+            yield return 0x00000000CF000001; // -2.1474839E9f  (-2147483904)
+            yield return 0x00000000CF000000; // -2.14748365E9f (-2147483648)
+            yield return 0x00000000CEFFFFFF; // -2.14748352E9f (-2147483520)
+            yield return 0x000000004F000001; //  2.1474839E9f  (2147483904)
+            yield return 0x000000004F000000; //  2.14748365E9f (2147483648)
+            yield return 0x000000004EFFFFFF; //  2.14748352E9f (2147483520)
+
+            // long
+            yield return 0x00000000DF000001ul; // -9.223373E18f  (-9223373136366403584)
+            yield return 0x00000000DF000000ul; // -9.223372E18f  (-9223372036854775808)
+            yield return 0x00000000DEFFFFFFul; // -9.2233715E18f (-9223371487098961920)
+            yield return 0x000000005F000001ul; //  9.223373E18f  (9223373136366403584)
+            yield return 0x000000005F000000ul; //  9.223372E18f  (9223372036854775808)
+            yield return 0x000000005EFFFFFFul; //  9.2233715E18f (9223371487098961920)
+
             yield return 0x00000000FF7FFFFFul; // -Max Normal    (float.MinValue)
             yield return 0x0000000080800000ul; // -Min Normal
             yield return 0x00000000807FFFFFul; // -Max Subnormal
@@ -55,8 +71,24 @@ namespace Ryujinx.Tests.Cpu
             }
         }
 
-        private static IEnumerable<ulong> _1D_F_()
+        private static IEnumerable<ulong> _1D_F_Cvt_()
         {
+            // int
+            yield return 0xC1E0000000200000ul; // -2147483649.0000000d (-2147483649)
+            yield return 0xC1E0000000000000ul; // -2147483648.0000000d (-2147483648)
+            yield return 0xC1DFFFFFFFC00000ul; // -2147483647.0000000d (-2147483647)
+            yield return 0x41E0000000200000ul; //  2147483649.0000000d (2147483649)
+            yield return 0x41E0000000000000ul; //  2147483648.0000000d (2147483648)
+            yield return 0x41DFFFFFFFC00000ul; //  2147483647.0000000d (2147483647)
+
+            // long
+            yield return 0xC3E0000000000001ul; // -9.2233720368547780E18d (-9223372036854778000)
+            yield return 0xC3E0000000000000ul; // -9.2233720368547760E18d (-9223372036854776000)
+            yield return 0xC3DFFFFFFFFFFFFFul; // -9.2233720368547750E18d (-9223372036854775000)
+            yield return 0x43E0000000000001ul; //  9.2233720368547780E18d (9223372036854778000)
+            yield return 0x43E0000000000000ul; //  9.2233720368547760E18d (9223372036854776000)
+            yield return 0x43DFFFFFFFFFFFFFul; //  9.2233720368547750E18d (9223372036854775000)
+
             yield return 0xFFEFFFFFFFFFFFFFul; // -Max Normal    (double.MinValue)
             yield return 0x8010000000000000ul; // -Min Normal
             yield return 0x800FFFFFFFFFFFFFul; // -Max Subnormal
@@ -110,7 +142,67 @@ namespace Ryujinx.Tests.Cpu
 #endregion
 
 #region "ValueSource (Opcodes)"
-        private static uint[] _F_Cvt_Z_SU_S_SW_()
+        private static uint[] _F_Cvt_AMPZ_SU_Gp_SW_()
+        {
+            return new uint[]
+            {
+                0x1E240000u, // FCVTAS W0, S0
+                0x1E250000u, // FCVTAU W0, S0
+                0x1E300000u, // FCVTMS W0, S0
+                0x1E310000u, // FCVTMU W0, S0
+                0x1E280000u, // FCVTPS W0, S0
+                0x1E290000u, // FCVTPU W0, S0
+                0x1E380000u, // FCVTZS W0, S0
+                0x1E390000u  // FCVTZU W0, S0
+            };
+        }
+
+        private static uint[] _F_Cvt_AMPZ_SU_Gp_SX_()
+        {
+            return new uint[]
+            {
+                0x9E240000u, // FCVTAS X0, S0
+                0x9E250000u, // FCVTAU X0, S0
+                0x9E300000u, // FCVTMS X0, S0
+                0x9E310000u, // FCVTMU X0, S0
+                0x9E280000u, // FCVTPS X0, S0
+                0x9E290000u, // FCVTPU X0, S0
+                0x9E380000u, // FCVTZS X0, S0
+                0x9E390000u  // FCVTZU X0, S0
+            };
+        }
+
+        private static uint[] _F_Cvt_AMPZ_SU_Gp_DW_()
+        {
+            return new uint[]
+            {
+                0x1E640000u, // FCVTAS W0, D0
+                0x1E650000u, // FCVTAU W0, D0
+                0x1E700000u, // FCVTMS W0, D0
+                0x1E710000u, // FCVTMU W0, D0
+                0x1E680000u, // FCVTPS W0, D0
+                0x1E690000u, // FCVTPU W0, D0
+                0x1E780000u, // FCVTZS W0, D0
+                0x1E790000u  // FCVTZU W0, D0
+            };
+        }
+
+        private static uint[] _F_Cvt_AMPZ_SU_Gp_DX_()
+        {
+            return new uint[]
+            {
+                0x9E640000u, // FCVTAS X0, D0
+                0x9E650000u, // FCVTAU X0, D0
+                0x9E700000u, // FCVTMS X0, D0
+                0x9E710000u, // FCVTMU X0, D0
+                0x9E680000u, // FCVTPS X0, D0
+                0x9E690000u, // FCVTPU X0, D0
+                0x9E780000u, // FCVTZS X0, D0
+                0x9E790000u  // FCVTZU X0, D0
+            };
+        }
+
+        private static uint[] _F_Cvt_Z_SU_Gp_Fixed_SW_()
         {
             return new uint[]
             {
@@ -119,7 +211,7 @@ namespace Ryujinx.Tests.Cpu
             };
         }
 
-        private static uint[] _F_Cvt_Z_SU_S_SX_()
+        private static uint[] _F_Cvt_Z_SU_Gp_Fixed_SX_()
         {
             return new uint[]
             {
@@ -128,7 +220,7 @@ namespace Ryujinx.Tests.Cpu
             };
         }
 
-        private static uint[] _F_Cvt_Z_SU_S_DW_()
+        private static uint[] _F_Cvt_Z_SU_Gp_Fixed_DW_()
         {
             return new uint[]
             {
@@ -137,7 +229,7 @@ namespace Ryujinx.Tests.Cpu
             };
         }
 
-        private static uint[] _F_Cvt_Z_SU_S_DX_()
+        private static uint[] _F_Cvt_Z_SU_Gp_Fixed_DX_()
         {
             return new uint[]
             {
@@ -146,7 +238,7 @@ namespace Ryujinx.Tests.Cpu
             };
         }
 
-        private static uint[] _SU_Cvt_F_S_WS_()
+        private static uint[] _SU_Cvt_F_Gp_Fixed_WS_()
         {
             return new uint[]
             {
@@ -155,7 +247,7 @@ namespace Ryujinx.Tests.Cpu
             };
         }
 
-        private static uint[] _SU_Cvt_F_S_WD_()
+        private static uint[] _SU_Cvt_F_Gp_Fixed_WD_()
         {
             return new uint[]
             {
@@ -164,7 +256,7 @@ namespace Ryujinx.Tests.Cpu
             };
         }
 
-        private static uint[] _SU_Cvt_F_S_XS_()
+        private static uint[] _SU_Cvt_F_Gp_Fixed_XS_()
         {
             return new uint[]
             {
@@ -173,7 +265,7 @@ namespace Ryujinx.Tests.Cpu
             };
         }
 
-        private static uint[] _SU_Cvt_F_S_XD_()
+        private static uint[] _SU_Cvt_F_Gp_Fixed_XD_()
         {
             return new uint[]
             {
@@ -184,20 +276,86 @@ namespace Ryujinx.Tests.Cpu
 #endregion
 
         private const int RndCnt      = 2;
-        private const int RndCntFbits = 2;
+        private const int RndCntFBits = 2;
 
         private static readonly bool NoZeros = false;
         private static readonly bool NoInfs  = false;
         private static readonly bool NoNaNs  = false;
 
         [Test, Pairwise] [Explicit]
-        public void F_Cvt_Z_SU_S_SW([ValueSource("_F_Cvt_Z_SU_S_SW_")] uint opcodes,
-                                    [Values(0u, 31u)] uint rd,
-                                    [Values(1u)]      uint rn,
-                                    [ValueSource("_1S_F_")] ulong a,
-                                    [Values(1u, 32u)] [Random(2u, 31u, RndCntFbits)] uint fbits)
+        public void F_Cvt_AMPZ_SU_Gp_SW([ValueSource("_F_Cvt_AMPZ_SU_Gp_SW_")] uint opcodes,
+                                        [Values(0u, 31u)] uint rd,
+                                        [Values(1u)]      uint rn,
+                                        [ValueSource("_1S_F_Cvt_")] ulong a)
         {
-            uint scale = (64u - fbits) & 0x3Fu;
+            opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
+
+            ulong x0 = (ulong)TestContext.CurrentContext.Random.NextUInt() << 32;
+            uint w31 = TestContext.CurrentContext.Random.NextUInt();
+            Vector128<float> v1 = MakeVectorE0(a);
+
+            SingleOpcode(opcodes, x0: x0, x31: w31, v1: v1);
+
+            CompareAgainstUnicorn();
+        }
+
+        [Test, Pairwise] [Explicit]
+        public void F_Cvt_AMPZ_SU_Gp_SX([ValueSource("_F_Cvt_AMPZ_SU_Gp_SX_")] uint opcodes,
+                                        [Values(0u, 31u)] uint rd,
+                                        [Values(1u)]      uint rn,
+                                        [ValueSource("_1S_F_Cvt_")] ulong a)
+        {
+            opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
+
+            ulong x31 = TestContext.CurrentContext.Random.NextULong();
+            Vector128<float> v1 = MakeVectorE0(a);
+
+            SingleOpcode(opcodes, x31: x31, v1: v1);
+
+            CompareAgainstUnicorn();
+        }
+
+        [Test, Pairwise] [Explicit]
+        public void F_Cvt_AMPZ_SU_Gp_DW([ValueSource("_F_Cvt_AMPZ_SU_Gp_DW_")] uint opcodes,
+                                        [Values(0u, 31u)] uint rd,
+                                        [Values(1u)]      uint rn,
+                                        [ValueSource("_1D_F_Cvt_")] ulong a)
+        {
+            opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
+
+            ulong x0 = (ulong)TestContext.CurrentContext.Random.NextUInt() << 32;
+            uint w31 = TestContext.CurrentContext.Random.NextUInt();
+            Vector128<float> v1 = MakeVectorE0(a);
+
+            SingleOpcode(opcodes, x0: x0, x31: w31, v1: v1);
+
+            CompareAgainstUnicorn();
+        }
+
+        [Test, Pairwise] [Explicit]
+        public void F_Cvt_AMPZ_SU_Gp_DX([ValueSource("_F_Cvt_AMPZ_SU_Gp_DX_")] uint opcodes,
+                                        [Values(0u, 31u)] uint rd,
+                                        [Values(1u)]      uint rn,
+                                        [ValueSource("_1D_F_Cvt_")] ulong a)
+        {
+            opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
+
+            ulong x31 = TestContext.CurrentContext.Random.NextULong();
+            Vector128<float> v1 = MakeVectorE0(a);
+
+            SingleOpcode(opcodes, x31: x31, v1: v1);
+
+            CompareAgainstUnicorn();
+        }
+
+        [Test, Pairwise] [Explicit]
+        public void F_Cvt_Z_SU_Gp_Fixed_SW([ValueSource("_F_Cvt_Z_SU_Gp_Fixed_SW_")] uint opcodes,
+                                           [Values(0u, 31u)] uint rd,
+                                           [Values(1u)]      uint rn,
+                                           [ValueSource("_1S_F_Cvt_")] ulong a,
+                                           [Values(1u, 32u)] [Random(2u, 31u, RndCntFBits)] uint fBits)
+        {
+            uint scale = (64u - fBits) & 0x3Fu;
 
             opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
             opcodes |= (scale << 10);
@@ -212,13 +370,13 @@ namespace Ryujinx.Tests.Cpu
         }
 
         [Test, Pairwise] [Explicit]
-        public void F_Cvt_Z_SU_S_SX([ValueSource("_F_Cvt_Z_SU_S_SX_")] uint opcodes,
-                                    [Values(0u, 31u)] uint rd,
-                                    [Values(1u)]      uint rn,
-                                    [ValueSource("_1S_F_")] ulong a,
-                                    [Values(1u, 64u)] [Random(2u, 63u, RndCntFbits)] uint fbits)
+        public void F_Cvt_Z_SU_Gp_Fixed_SX([ValueSource("_F_Cvt_Z_SU_Gp_Fixed_SX_")] uint opcodes,
+                                           [Values(0u, 31u)] uint rd,
+                                           [Values(1u)]      uint rn,
+                                           [ValueSource("_1S_F_Cvt_")] ulong a,
+                                           [Values(1u, 64u)] [Random(2u, 63u, RndCntFBits)] uint fBits)
         {
-            uint scale = (64u - fbits) & 0x3Fu;
+            uint scale = (64u - fBits) & 0x3Fu;
 
             opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
             opcodes |= (scale << 10);
@@ -232,13 +390,13 @@ namespace Ryujinx.Tests.Cpu
         }
 
         [Test, Pairwise] [Explicit]
-        public void F_Cvt_Z_SU_S_DW([ValueSource("_F_Cvt_Z_SU_S_DW_")] uint opcodes,
-                                    [Values(0u, 31u)] uint rd,
-                                    [Values(1u)]      uint rn,
-                                    [ValueSource("_1D_F_")] ulong a,
-                                    [Values(1u, 32u)] [Random(2u, 31u, RndCntFbits)] uint fbits)
+        public void F_Cvt_Z_SU_Gp_Fixed_DW([ValueSource("_F_Cvt_Z_SU_Gp_Fixed_DW_")] uint opcodes,
+                                           [Values(0u, 31u)] uint rd,
+                                           [Values(1u)]      uint rn,
+                                           [ValueSource("_1D_F_Cvt_")] ulong a,
+                                           [Values(1u, 32u)] [Random(2u, 31u, RndCntFBits)] uint fBits)
         {
-            uint scale = (64u - fbits) & 0x3Fu;
+            uint scale = (64u - fBits) & 0x3Fu;
 
             opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
             opcodes |= (scale << 10);
@@ -253,13 +411,13 @@ namespace Ryujinx.Tests.Cpu
         }
 
         [Test, Pairwise] [Explicit]
-        public void F_Cvt_Z_SU_S_DX([ValueSource("_F_Cvt_Z_SU_S_DX_")] uint opcodes,
-                                    [Values(0u, 31u)] uint rd,
-                                    [Values(1u)]      uint rn,
-                                    [ValueSource("_1D_F_")] ulong a,
-                                    [Values(1u, 64u)] [Random(2u, 63u, RndCntFbits)] uint fbits)
+        public void F_Cvt_Z_SU_Gp_Fixed_DX([ValueSource("_F_Cvt_Z_SU_Gp_Fixed_DX_")] uint opcodes,
+                                           [Values(0u, 31u)] uint rd,
+                                           [Values(1u)]      uint rn,
+                                           [ValueSource("_1D_F_Cvt_")] ulong a,
+                                           [Values(1u, 64u)] [Random(2u, 63u, RndCntFBits)] uint fBits)
         {
-            uint scale = (64u - fbits) & 0x3Fu;
+            uint scale = (64u - fBits) & 0x3Fu;
 
             opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
             opcodes |= (scale << 10);
@@ -273,13 +431,13 @@ namespace Ryujinx.Tests.Cpu
         }
 
         [Test, Pairwise] [Explicit]
-        public void SU_Cvt_F_S_WS([ValueSource("_SU_Cvt_F_S_WS_")] uint opcodes,
-                                  [Values(0u)]      uint rd,
-                                  [Values(1u, 31u)] uint rn,
-                                  [ValueSource("_W_")] [Random(RndCnt)] uint wn,
-                                  [Values(1u, 32u)] [Random(2u, 31u, RndCntFbits)] uint fbits)
+        public void SU_Cvt_F_Gp_Fixed_WS([ValueSource("_SU_Cvt_F_Gp_Fixed_WS_")] uint opcodes,
+                                         [Values(0u)]      uint rd,
+                                         [Values(1u, 31u)] uint rn,
+                                         [ValueSource("_W_")] [Random(RndCnt)] uint wn,
+                                         [Values(1u, 32u)] [Random(2u, 31u, RndCntFBits)] uint fBits)
         {
-            uint scale = (64u - fbits) & 0x3Fu;
+            uint scale = (64u - fBits) & 0x3Fu;
 
             opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
             opcodes |= (scale << 10);
@@ -294,13 +452,13 @@ namespace Ryujinx.Tests.Cpu
         }
 
         [Test, Pairwise] [Explicit]
-        public void SU_Cvt_F_S_WD([ValueSource("_SU_Cvt_F_S_WD_")] uint opcodes,
-                                  [Values(0u)]      uint rd,
-                                  [Values(1u, 31u)] uint rn,
-                                  [ValueSource("_W_")] [Random(RndCnt)] uint wn,
-                                  [Values(1u, 32u)] [Random(2u, 31u, RndCntFbits)] uint fbits)
+        public void SU_Cvt_F_Gp_Fixed_WD([ValueSource("_SU_Cvt_F_Gp_Fixed_WD_")] uint opcodes,
+                                         [Values(0u)]      uint rd,
+                                         [Values(1u, 31u)] uint rn,
+                                         [ValueSource("_W_")] [Random(RndCnt)] uint wn,
+                                         [Values(1u, 32u)] [Random(2u, 31u, RndCntFBits)] uint fBits)
         {
-            uint scale = (64u - fbits) & 0x3Fu;
+            uint scale = (64u - fBits) & 0x3Fu;
 
             opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
             opcodes |= (scale << 10);
@@ -315,13 +473,13 @@ namespace Ryujinx.Tests.Cpu
         }
 
         [Test, Pairwise] [Explicit]
-        public void SU_Cvt_F_S_XS([ValueSource("_SU_Cvt_F_S_XS_")] uint opcodes,
-                                  [Values(0u)]      uint rd,
-                                  [Values(1u, 31u)] uint rn,
-                                  [ValueSource("_X_")] [Random(RndCnt)] ulong xn,
-                                  [Values(1u, 64u)] [Random(2u, 63u, RndCntFbits)] uint fbits)
+        public void SU_Cvt_F_Gp_Fixed_XS([ValueSource("_SU_Cvt_F_Gp_Fixed_XS_")] uint opcodes,
+                                         [Values(0u)]      uint rd,
+                                         [Values(1u, 31u)] uint rn,
+                                         [ValueSource("_X_")] [Random(RndCnt)] ulong xn,
+                                         [Values(1u, 64u)] [Random(2u, 63u, RndCntFBits)] uint fBits)
         {
-            uint scale = (64u - fbits) & 0x3Fu;
+            uint scale = (64u - fBits) & 0x3Fu;
 
             opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
             opcodes |= (scale << 10);
@@ -336,13 +494,13 @@ namespace Ryujinx.Tests.Cpu
         }
 
         [Test, Pairwise] [Explicit]
-        public void SU_Cvt_F_S_XD([ValueSource("_SU_Cvt_F_S_XD_")] uint opcodes,
-                                  [Values(0u)]      uint rd,
-                                  [Values(1u, 31u)] uint rn,
-                                  [ValueSource("_X_")] [Random(RndCnt)] ulong xn,
-                                  [Values(1u, 64u)] [Random(2u, 63u, RndCntFbits)] uint fbits)
+        public void SU_Cvt_F_Gp_Fixed_XD([ValueSource("_SU_Cvt_F_Gp_Fixed_XD_")] uint opcodes,
+                                         [Values(0u)]      uint rd,
+                                         [Values(1u, 31u)] uint rn,
+                                         [ValueSource("_X_")] [Random(RndCnt)] ulong xn,
+                                         [Values(1u, 64u)] [Random(2u, 63u, RndCntFBits)] uint fBits)
         {
-            uint scale = (64u - fbits) & 0x3Fu;
+            uint scale = (64u - fBits) & 0x3Fu;
 
             opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
             opcodes |= (scale << 10);


### PR DESCRIPTION
Fixed a bug about all the fp to integer conversion instructions (signed & unsigned); where all those fp values close to T.MaxValue were mistakenly converted to ~T.MaxValue.

Fixed the instruction table (Fcvtzs_V_Fixed & Fcvtzu_V_Fixed).

Uniformed the use of the zero vector to the float type only.

Nits.