### PR TITLE
Sse optimized the Vector & Scalar fp-to-integer conversion instructions (unsigned); improved the related Tests.

### DIFF
--- a/ChocolArm64/Instructions/InstEmitSimdCvt.cs
+++ b/ChocolArm64/Instructions/InstEmitSimdCvt.cs
@@ -209,7 +209,7 @@ namespace ChocolArm64.Instructions
         {
             if (Optimizations.UseSse41)
             {
-                EmitSse41Fcvt_Signed(context, RoundMode.ToNearest, isFixed: false, scalar: true);
+                EmitSse41Fcvt_Signed(context, RoundMode.ToNearest, scalar: true);
             }
             else
             {
@@ -221,7 +221,7 @@ namespace ChocolArm64.Instructions
         {
             if (Optimizations.UseSse41)
             {
-                EmitSse41Fcvt_Signed(context, RoundMode.ToNearest, isFixed: false, scalar: false);
+                EmitSse41Fcvt_Signed(context, RoundMode.ToNearest, scalar: false);
             }
             else
             {
@@ -233,7 +233,7 @@ namespace ChocolArm64.Instructions
         {
             if (Optimizations.UseSse41)
             {
-                EmitSse41Fcvt_Unsigned(context, RoundMode.ToNearest, isFixed: false, scalar: true);
+                EmitSse41Fcvt_Unsigned(context, RoundMode.ToNearest, scalar: true);
             }
             else
             {
@@ -245,7 +245,7 @@ namespace ChocolArm64.Instructions
         {
             if (Optimizations.UseSse41)
             {
-                EmitSse41Fcvt_Unsigned(context, RoundMode.ToNearest, isFixed: false, scalar: false);
+                EmitSse41Fcvt_Unsigned(context, RoundMode.ToNearest, scalar: false);
             }
             else
             {
@@ -277,7 +277,7 @@ namespace ChocolArm64.Instructions
         {
             if (Optimizations.UseSse41)
             {
-                EmitSse41Fcvt_Signed(context, RoundMode.TowardsZero, isFixed: false, scalar: true);
+                EmitSse41Fcvt_Signed(context, RoundMode.TowardsZero, scalar: true);
             }
             else
             {
@@ -289,7 +289,7 @@ namespace ChocolArm64.Instructions
         {
             if (Optimizations.UseSse41)
             {
-                EmitSse41Fcvt_Signed(context, RoundMode.TowardsZero, isFixed: false, scalar: false);
+                EmitSse41Fcvt_Signed(context, RoundMode.TowardsZero, scalar: false);
             }
             else
             {
@@ -301,7 +301,7 @@ namespace ChocolArm64.Instructions
         {
             if (Optimizations.UseSse41)
             {
-                EmitSse41Fcvt_Signed(context, RoundMode.TowardsZero, isFixed: true, scalar: false);
+                EmitSse41Fcvt_Signed(context, RoundMode.TowardsZero, scalar: false);
             }
             else
             {
@@ -323,7 +323,7 @@ namespace ChocolArm64.Instructions
         {
             if (Optimizations.UseSse41)
             {
-                EmitSse41Fcvt_Unsigned(context, RoundMode.TowardsZero, isFixed: false, scalar: true);
+                EmitSse41Fcvt_Unsigned(context, RoundMode.TowardsZero, scalar: true);
             }
             else
             {
@@ -335,7 +335,7 @@ namespace ChocolArm64.Instructions
         {
             if (Optimizations.UseSse41)
             {
-                EmitSse41Fcvt_Unsigned(context, RoundMode.TowardsZero, isFixed: false, scalar: false);
+                EmitSse41Fcvt_Unsigned(context, RoundMode.TowardsZero, scalar: false);
             }
             else
             {
@@ -347,7 +347,7 @@ namespace ChocolArm64.Instructions
         {
             if (Optimizations.UseSse41)
             {
-                EmitSse41Fcvt_Unsigned(context, RoundMode.TowardsZero, isFixed: true, scalar: false);
+                EmitSse41Fcvt_Unsigned(context, RoundMode.TowardsZero, scalar: false);
             }
             else
             {
@@ -811,7 +811,7 @@ namespace ChocolArm64.Instructions
             }
         }
 
-        private static void EmitSse41Fcvt_Signed(ILEmitterCtx context, RoundMode roundMode, bool isFixed, bool scalar)
+        private static void EmitSse41Fcvt_Signed(ILEmitterCtx context, RoundMode roundMode, bool scalar)
         {
             OpCodeSimd64 op = (OpCodeSimd64)context.CurrOp;
 
@@ -833,9 +833,9 @@ namespace ChocolArm64.Instructions
 
                 context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.And), types));
 
-                if (isFixed)
+                if (op is OpCodeSimdShImm64 fixedOp)
                 {
-                    int fBits = GetImmShr((OpCodeSimdShImm64)op);
+                    int fBits = GetImmShr(fixedOp);
 
                     // BitConverter.Int32BitsToSingle(fpScaled) == MathF.Pow(2f, fBits)
                     int fpScaled = 0x40000000 + (fBits - 1) * 0x800000;
@@ -889,9 +889,9 @@ namespace ChocolArm64.Instructions
 
                 context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.And), types));
 
-                if (isFixed)
+                if (op is OpCodeSimdShImm64 fixedOp)
                 {
-                    int fBits = GetImmShr((OpCodeSimdShImm64)op);
+                    int fBits = GetImmShr(fixedOp);
 
                     // BitConverter.Int64BitsToDouble(fpScaled) == Math.Pow(2d, fBits)
                     long fpScaled = 0x4000000000000000L + (fBits - 1) * 0x10000000000000L;
@@ -944,7 +944,7 @@ namespace ChocolArm64.Instructions
             }
         }
 
-        private static void EmitSse41Fcvt_Unsigned(ILEmitterCtx context, RoundMode roundMode, bool isFixed, bool scalar)
+        private static void EmitSse41Fcvt_Unsigned(ILEmitterCtx context, RoundMode roundMode, bool scalar)
         {
             OpCodeSimd64 op = (OpCodeSimd64)context.CurrOp;
 
@@ -967,9 +967,9 @@ namespace ChocolArm64.Instructions
 
                 context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.And), types));
 
-                if (isFixed)
+                if (op is OpCodeSimdShImm64 fixedOp)
                 {
-                    int fBits = GetImmShr((OpCodeSimdShImm64)op);
+                    int fBits = GetImmShr(fixedOp);
 
                     // BitConverter.Int32BitsToSingle(fpScaled) == MathF.Pow(2f, fBits)
                     int fpScaled = 0x40000000 + (fBits - 1) * 0x800000;
@@ -1055,9 +1055,9 @@ namespace ChocolArm64.Instructions
 
                 context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.And), types));
 
-                if (isFixed)
+                if (op is OpCodeSimdShImm64 fixedOp)
                 {
-                    int fBits = GetImmShr((OpCodeSimdShImm64)op);
+                    int fBits = GetImmShr(fixedOp);
 
                     // BitConverter.Int64BitsToDouble(fpScaled) == Math.Pow(2d, fBits)
                     long fpScaled = 0x4000000000000000L + (fBits - 1) * 0x10000000000000L;

--- a/ChocolArm64/Instructions/InstEmitSimdCvt.cs
+++ b/ChocolArm64/Instructions/InstEmitSimdCvt.cs
@@ -125,14 +125,7 @@ namespace ChocolArm64.Instructions
 
         public static void Fcvtms_Gp(ILEmitterCtx context)
         {
-            if (Optimizations.UseSse41)
-            {
-                EmitSse41Fcvt_Signed_Gp(context, RoundMode.TowardsMinusInfinity, isFixed: false);
-            }
-            else
-            {
-                EmitFcvt_s_Gp(context, () => EmitUnaryMathCall(context, nameof(Math.Floor)));
-            }
+            EmitFcvt_s_Gp(context, () => EmitUnaryMathCall(context, nameof(Math.Floor)));
         }
 
         public static void Fcvtmu_Gp(ILEmitterCtx context)
@@ -238,24 +231,31 @@ namespace ChocolArm64.Instructions
 
         public static void Fcvtnu_S(ILEmitterCtx context)
         {
-            EmitFcvtn(context, signed: false, scalar: true);
+            if (Optimizations.UseSse41)
+            {
+                EmitSse41Fcvt_Unsigned(context, RoundMode.ToNearest, isFixed: false, scalar: true);
+            }
+            else
+            {
+                EmitFcvtn(context, signed: false, scalar: true);
+            }
         }
 
         public static void Fcvtnu_V(ILEmitterCtx context)
         {
-            EmitFcvtn(context, signed: false, scalar: false);
+            if (Optimizations.UseSse41)
+            {
+                EmitSse41Fcvt_Unsigned(context, RoundMode.ToNearest, isFixed: false, scalar: false);
+            }
+            else
+            {
+                EmitFcvtn(context, signed: false, scalar: false);
+            }
         }
 
         public static void Fcvtps_Gp(ILEmitterCtx context)
         {
-            if (Optimizations.UseSse41)
-            {
-                EmitSse41Fcvt_Signed_Gp(context, RoundMode.TowardsPlusInfinity, isFixed: false);
-            }
-            else
-            {
-                EmitFcvt_s_Gp(context, () => EmitUnaryMathCall(context, nameof(Math.Ceiling)));
-            }
+            EmitFcvt_s_Gp(context, () => EmitUnaryMathCall(context, nameof(Math.Ceiling)));
         }
 
         public static void Fcvtpu_Gp(ILEmitterCtx context)
@@ -265,26 +265,12 @@ namespace ChocolArm64.Instructions
 
         public static void Fcvtzs_Gp(ILEmitterCtx context)
         {
-            if (Optimizations.UseSse41)
-            {
-                EmitSse41Fcvt_Signed_Gp(context, RoundMode.TowardsZero, isFixed: false);
-            }
-            else
-            {
-                EmitFcvt_s_Gp(context, () => { });
-            }
+            EmitFcvt_s_Gp(context, () => { });
         }
 
         public static void Fcvtzs_Gp_Fixed(ILEmitterCtx context)
         {
-            if (Optimizations.UseSse41)
-            {
-                EmitSse41Fcvt_Signed_Gp(context, RoundMode.TowardsZero, isFixed: true);
-            }
-            else
-            {
-                EmitFcvtzs_Gp_Fixed(context);
-            }
+            EmitFcvtzs_Gp_Fixed(context);
         }
 
         public static void Fcvtzs_S(ILEmitterCtx context)
@@ -335,17 +321,38 @@ namespace ChocolArm64.Instructions
 
         public static void Fcvtzu_S(ILEmitterCtx context)
         {
-            EmitFcvtz(context, signed: false, scalar: true);
+            if (Optimizations.UseSse41)
+            {
+                EmitSse41Fcvt_Unsigned(context, RoundMode.TowardsZero, isFixed: false, scalar: true);
+            }
+            else
+            {
+                EmitFcvtz(context, signed: false, scalar: true);
+            }
         }
 
         public static void Fcvtzu_V(ILEmitterCtx context)
         {
-            EmitFcvtz(context, signed: false, scalar: false);
+            if (Optimizations.UseSse41)
+            {
+                EmitSse41Fcvt_Unsigned(context, RoundMode.TowardsZero, isFixed: false, scalar: false);
+            }
+            else
+            {
+                EmitFcvtz(context, signed: false, scalar: false);
+            }
         }
 
         public static void Fcvtzu_V_Fixed(ILEmitterCtx context)
         {
-            EmitFcvtz(context, signed: false, scalar: false);
+            if (Optimizations.UseSse41)
+            {
+                EmitSse41Fcvt_Unsigned(context, RoundMode.TowardsZero, isFixed: true, scalar: false);
+            }
+            else
+            {
+                EmitFcvtz(context, signed: false, scalar: false);
+            }
         }
 
         public static void Scvtf_Gp(ILEmitterCtx context)
@@ -804,167 +811,6 @@ namespace ChocolArm64.Instructions
             }
         }
 
-        private static void EmitSse41Fcvt_Signed_Gp(ILEmitterCtx context, RoundMode roundMode, bool isFixed)
-        {
-            OpCodeSimdCvt64 op = (OpCodeSimdCvt64)context.CurrOp;
-
-            if (op.Size == 0)
-            {
-                Type[] typesCmpMul = new Type[] { typeof(Vector128<float>), typeof(Vector128<float>) };
-                Type[] typesAnd    = new Type[] { typeof(Vector128<long>),  typeof(Vector128<long>) };
-                Type[] typesRndCvt = new Type[] { typeof(Vector128<float>) };
-                Type[] typesCvt    = new Type[] { typeof(Vector128<int>) };
-                Type[] typesSav    = new Type[] { typeof(int) };
-
-                //string nameCvt;
-                int    fpMaxVal;
-
-                if (op.RegisterSize == RegisterSize.Int32)
-                {
-                    //nameCvt  = nameof(Sse.ConvertToInt32);
-                    fpMaxVal = 0x4F000000; // 2.14748365E9f (2147483648)
-                }
-                else
-                {
-                    //nameCvt  = nameof(Sse.ConvertToInt64);
-                    fpMaxVal = 0x5F000000; // 9.223372E18f (9223372036854775808)
-                }
-
-                context.EmitLdvec(op.Rn);
-                context.EmitLdvec(op.Rn);
-
-                context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.CompareOrdered), typesCmpMul));
-
-                context.EmitLdvec(op.Rn);
-
-                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.And), typesAnd));
-
-                if (isFixed)
-                {
-                    // BitConverter.Int32BitsToSingle(fpScaled) == MathF.Pow(2f, op.FBits)
-                    int fpScaled = 0x40000000 + (op.FBits - 1) * 0x800000;
-
-                    context.EmitLdc_I4(fpScaled);
-                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.SetAllVector128), typesSav));
-
-                    context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.Multiply), typesCmpMul));
-                }
-
-                context.EmitCall(typeof(Sse41).GetMethod(GetSse41NameRnd(roundMode), typesRndCvt));
-
-                context.EmitStvectmp();
-                context.EmitLdvectmp();
-
-                // TODO: Use Sse.ConvertToInt64 once it is fixed (in .NET Core 3.0),
-                // remove the following if/else and uncomment the code.
-
-                //context.EmitCall(typeof(Sse).GetMethod(nameCvt, typesRndCvt));
-
-                if (op.RegisterSize == RegisterSize.Int32)
-                {
-                    context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.ConvertToInt32), typesRndCvt));
-                }
-                else
-                {
-                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.ConvertToVector128Double), typesRndCvt));
-                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.ConvertToInt64), new Type[] { typeof(Vector128<double>) }));
-                }
-
-                context.EmitLdvectmp();
-
-                context.EmitLdc_I4(fpMaxVal);
-                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.SetAllVector128), typesSav));
-
-                context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.CompareGreaterThanOrEqual), typesCmpMul));
-
-                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.ConvertToInt32), typesCvt));
-
-                if (op.RegisterSize == RegisterSize.Int32)
-                {
-                    context.Emit(OpCodes.Xor);
-                    context.Emit(OpCodes.Conv_U8);
-                }
-                else
-                {
-                    context.Emit(OpCodes.Conv_I8);
-                    context.Emit(OpCodes.Xor);
-                }
-
-                context.EmitStintzr(op.Rd);
-            }
-            else /* if (op.Size == 1) */
-            {
-                Type[] typesCmpMul = new Type[] { typeof(Vector128<double>), typeof(Vector128<double>) };
-                Type[] typesAnd    = new Type[] { typeof(Vector128<long>),   typeof(Vector128<long>) };
-                Type[] typesRndCvt = new Type[] { typeof(Vector128<double>) };
-                Type[] typesCvt    = new Type[] { typeof(Vector128<int>) };
-                Type[] typesSav    = new Type[] { typeof(long) };
-
-                string nameCvt;
-                long   fpMaxVal;
-
-                if (op.RegisterSize == RegisterSize.Int32)
-                {
-                    nameCvt  = nameof(Sse2.ConvertToInt32);
-                    fpMaxVal = 0x41E0000000000000L; // 2147483648.0000000d (2147483648)
-                }
-                else
-                {
-                    nameCvt  = nameof(Sse2.ConvertToInt64);
-                    fpMaxVal = 0x43E0000000000000L; // 9.2233720368547760E18d (9223372036854775808)
-                }
-
-                context.EmitLdvec(op.Rn);
-                context.EmitLdvec(op.Rn);
-
-                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.CompareOrdered), typesCmpMul));
-
-                context.EmitLdvec(op.Rn);
-
-                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.And), typesAnd));
-
-                if (isFixed)
-                {
-                    // BitConverter.Int64BitsToDouble(fpScaled) == Math.Pow(2d, op.FBits)
-                    long fpScaled = 0x4000000000000000L + (op.FBits - 1) * 0x10000000000000L;
-
-                    context.EmitLdc_I8(fpScaled);
-                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.SetAllVector128), typesSav));
-
-                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.Multiply), typesCmpMul));
-                }
-
-                context.EmitCall(typeof(Sse41).GetMethod(GetSse41NameRnd(roundMode), typesRndCvt));
-
-                context.EmitStvectmp();
-                context.EmitLdvectmp();
-
-                context.EmitCall(typeof(Sse2).GetMethod(nameCvt, typesRndCvt));
-
-                context.EmitLdvectmp();
-
-                context.EmitLdc_I8(fpMaxVal);
-                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.SetAllVector128), typesSav));
-
-                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.CompareGreaterThanOrEqual), typesCmpMul));
-
-                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.ConvertToInt32), typesCvt));
-
-                if (op.RegisterSize == RegisterSize.Int32)
-                {
-                    context.Emit(OpCodes.Xor);
-                    context.Emit(OpCodes.Conv_U8);
-                }
-                else
-                {
-                    context.Emit(OpCodes.Conv_I8);
-                    context.Emit(OpCodes.Xor);
-                }
-
-                context.EmitStintzr(op.Rd);
-            }
-        }
-
         private static void EmitSse41Fcvt_Signed(ILEmitterCtx context, RoundMode roundMode, bool isFixed, bool scalar)
         {
             OpCodeSimd64 op = (OpCodeSimd64)context.CurrOp;
@@ -974,19 +820,18 @@ namespace ChocolArm64.Instructions
 
             if (sizeF == 0)
             {
-                Type[] typesCmpMul = new Type[] { typeof(Vector128<float>), typeof(Vector128<float>) };
-                Type[] typesAndXor = new Type[] { typeof(Vector128<long>),  typeof(Vector128<long>) };
+                Type[] types       = new Type[] { typeof(Vector128<float>), typeof(Vector128<float>) };
                 Type[] typesRndCvt = new Type[] { typeof(Vector128<float>) };
                 Type[] typesSav    = new Type[] { typeof(int) };
 
                 context.EmitLdvec(op.Rn);
                 context.EmitLdvec(op.Rn);
 
-                context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.CompareOrdered), typesCmpMul));
+                context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.CompareOrdered), types));
 
                 context.EmitLdvec(op.Rn);
 
-                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.And), typesAndXor));
+                context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.And), types));
 
                 if (isFixed)
                 {
@@ -998,7 +843,7 @@ namespace ChocolArm64.Instructions
                     context.EmitLdc_I4(fpScaled);
                     context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.SetAllVector128), typesSav));
 
-                    context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.Multiply), typesCmpMul));
+                    context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.Multiply), types));
                 }
 
                 context.EmitCall(typeof(Sse41).GetMethod(GetSse41NameRnd(roundMode), typesRndCvt));
@@ -1013,9 +858,9 @@ namespace ChocolArm64.Instructions
                 context.EmitLdc_I4(0x4F000000); // 2.14748365E9f (2147483648)
                 context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.SetAllVector128), typesSav));
 
-                context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.CompareGreaterThanOrEqual), typesCmpMul));
+                context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.CompareGreaterThanOrEqual), types));
 
-                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.Xor), typesAndXor));
+                context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.Xor), types));
 
                 context.EmitStvec(op.Rd);
 
@@ -1030,20 +875,19 @@ namespace ChocolArm64.Instructions
             }
             else /* if (sizeF == 1) */
             {
-                Type[] typesCmpMulUpk = new Type[] { typeof(Vector128<double>), typeof(Vector128<double>) };
-                Type[] typesAndXor    = new Type[] { typeof(Vector128<long>),   typeof(Vector128<long>) };
-                Type[] typesRndCvt    = new Type[] { typeof(Vector128<double>) };
-                Type[] typesSv        = new Type[] { typeof(long), typeof(long) };
-                Type[] typesSav       = new Type[] { typeof(long) };
+                Type[] types       = new Type[] { typeof(Vector128<double>), typeof(Vector128<double>) };
+                Type[] typesRndCvt = new Type[] { typeof(Vector128<double>) };
+                Type[] typesSv     = new Type[] { typeof(long), typeof(long) };
+                Type[] typesSav    = new Type[] { typeof(long) };
 
                 context.EmitLdvec(op.Rn);
                 context.EmitLdvec(op.Rn);
 
-                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.CompareOrdered), typesCmpMulUpk));
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.CompareOrdered), types));
 
                 context.EmitLdvec(op.Rn);
 
-                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.And), typesAndXor));
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.And), types));
 
                 if (isFixed)
                 {
@@ -1055,19 +899,26 @@ namespace ChocolArm64.Instructions
                     context.EmitLdc_I8(fpScaled);
                     context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.SetAllVector128), typesSav));
 
-                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.Multiply), typesCmpMulUpk));
+                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.Multiply), types));
                 }
 
                 context.EmitCall(typeof(Sse41).GetMethod(GetSse41NameRnd(roundMode), typesRndCvt));
 
                 context.EmitStvectmp();
-                context.EmitLdvectmp();
 
-                context.EmitLdvectmp();
+                if (!scalar)
+                {
+                    context.EmitLdvectmp();
+                    context.EmitLdvectmp();
 
-                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.UnpackHigh), typesCmpMulUpk));
+                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.UnpackHigh), types));
 
-                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.ConvertToInt64), typesRndCvt));
+                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.ConvertToInt64), typesRndCvt));
+                }
+                else
+                {
+                    context.EmitLdc_I8(0L);
+                }
 
                 context.EmitLdvectmp();
 
@@ -1080,9 +931,223 @@ namespace ChocolArm64.Instructions
                 context.EmitLdc_I8(0x43E0000000000000L); // 9.2233720368547760E18d (9223372036854775808)
                 context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.SetAllVector128), typesSav));
 
-                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.CompareGreaterThanOrEqual), typesCmpMulUpk));
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.CompareGreaterThanOrEqual), types));
 
-                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.Xor), typesAndXor));
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.Xor), types));
+
+                context.EmitStvec(op.Rd);
+
+                if (scalar)
+                {
+                    EmitVectorZeroUpper(context, op.Rd);
+                }
+            }
+        }
+
+        private static void EmitSse41Fcvt_Unsigned(ILEmitterCtx context, RoundMode roundMode, bool isFixed, bool scalar)
+        {
+            OpCodeSimd64 op = (OpCodeSimd64)context.CurrOp;
+
+            // sizeF == ((OpCodeSimdShImm64)op).Size - 2
+            int sizeF = op.Size & 1;
+
+            if (sizeF == 0)
+            {
+                Type[] types       = new Type[] { typeof(Vector128<float>), typeof(Vector128<float>) };
+                Type[] typesAdd    = new Type[] { typeof(Vector128<int>),   typeof(Vector128<int>) };
+                Type[] typesRndCvt = new Type[] { typeof(Vector128<float>) };
+                Type[] typesSav    = new Type[] { typeof(int) };
+
+                context.EmitLdvec(op.Rn);
+                context.EmitLdvec(op.Rn);
+
+                context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.CompareOrdered), types));
+
+                context.EmitLdvec(op.Rn);
+
+                context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.And), types));
+
+                if (isFixed)
+                {
+                    int fBits = GetImmShr((OpCodeSimdShImm64)op);
+
+                    // BitConverter.Int32BitsToSingle(fpScaled) == MathF.Pow(2f, fBits)
+                    int fpScaled = 0x40000000 + (fBits - 1) * 0x800000;
+
+                    context.EmitLdc_I4(fpScaled);
+                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.SetAllVector128), typesSav));
+
+                    context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.Multiply), types));
+                }
+
+                context.EmitCall(typeof(Sse41).GetMethod(GetSse41NameRnd(roundMode), typesRndCvt));
+
+                context.Emit(OpCodes.Dup);
+
+                VectorHelper.EmitCall(context, nameof(VectorHelper.VectorSingleZero));
+
+                context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.CompareGreaterThan), types));
+
+                context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.And), types));
+
+                context.EmitStvectmp();
+                context.EmitLdvectmp();
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.ConvertToVector128Int32), typesRndCvt));
+
+                context.EmitLdvectmp();
+
+                context.EmitLdc_I4(0x4F000000); // 2.14748365E9f (2147483648)
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.SetAllVector128), typesSav));
+
+                context.EmitStvectmp2();
+                context.EmitLdvectmp2();
+
+                context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.Subtract), types));
+
+                context.Emit(OpCodes.Dup);
+
+                VectorHelper.EmitCall(context, nameof(VectorHelper.VectorSingleZero));
+
+                context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.CompareGreaterThan), types));
+
+                context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.And), types));
+
+                context.EmitStvectmp();
+                context.EmitLdvectmp();
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.ConvertToVector128Int32), typesRndCvt));
+
+                context.EmitLdvectmp();
+                context.EmitLdvectmp2();
+
+                context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.CompareGreaterThanOrEqual), types));
+
+                context.EmitCall(typeof(Sse).GetMethod(nameof(Sse.Xor), types));
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.Add), typesAdd));
+
+                context.EmitStvec(op.Rd);
+
+                if (scalar)
+                {
+                    EmitVectorZero32_128(context, op.Rd);
+                }
+                else if (op.RegisterSize == RegisterSize.Simd64)
+                {
+                    EmitVectorZeroUpper(context, op.Rd);
+                }
+            }
+            else /* if (sizeF == 1) */
+            {
+                Type[] types       = new Type[] { typeof(Vector128<double>), typeof(Vector128<double>) };
+                Type[] typesAdd    = new Type[] { typeof(Vector128<long>),   typeof(Vector128<long>) };
+                Type[] typesRndCvt = new Type[] { typeof(Vector128<double>) };
+                Type[] typesSv     = new Type[] { typeof(long), typeof(long) };
+                Type[] typesSav    = new Type[] { typeof(long) };
+
+                context.EmitLdvec(op.Rn);
+                context.EmitLdvec(op.Rn);
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.CompareOrdered), types));
+
+                context.EmitLdvec(op.Rn);
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.And), types));
+
+                if (isFixed)
+                {
+                    int fBits = GetImmShr((OpCodeSimdShImm64)op);
+
+                    // BitConverter.Int64BitsToDouble(fpScaled) == Math.Pow(2d, fBits)
+                    long fpScaled = 0x4000000000000000L + (fBits - 1) * 0x10000000000000L;
+
+                    context.EmitLdc_I8(fpScaled);
+                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.SetAllVector128), typesSav));
+
+                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.Multiply), types));
+                }
+
+                context.EmitCall(typeof(Sse41).GetMethod(GetSse41NameRnd(roundMode), typesRndCvt));
+
+                context.Emit(OpCodes.Dup);
+
+                VectorHelper.EmitCall(context, nameof(VectorHelper.VectorSingleZero));
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.CompareGreaterThan), types));
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.And), types));
+
+                context.EmitStvectmp();
+
+                if (!scalar)
+                {
+                    context.EmitLdvectmp();
+                    context.EmitLdvectmp();
+
+                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.UnpackHigh), types));
+
+                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.ConvertToInt64), typesRndCvt));
+                }
+                else
+                {
+                    context.EmitLdc_I8(0L);
+                }
+
+                context.EmitLdvectmp();
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.ConvertToInt64), typesRndCvt));
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.SetVector128), typesSv));
+
+                context.EmitLdvectmp();
+
+                context.EmitLdc_I8(0x43E0000000000000L); // 9.2233720368547760E18d (9223372036854775808)
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.SetAllVector128), typesSav));
+
+                context.EmitStvectmp2();
+                context.EmitLdvectmp2();
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.Subtract), types));
+
+                context.Emit(OpCodes.Dup);
+
+                VectorHelper.EmitCall(context, nameof(VectorHelper.VectorSingleZero));
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.CompareGreaterThan), types));
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.And), types));
+
+                context.EmitStvectmp();
+
+                if (!scalar)
+                {
+                    context.EmitLdvectmp();
+                    context.EmitLdvectmp();
+
+                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.UnpackHigh), types));
+
+                    context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.ConvertToInt64), typesRndCvt));
+                }
+                else
+                {
+                    context.EmitLdc_I8(0L);
+                }
+
+                context.EmitLdvectmp();
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.ConvertToInt64), typesRndCvt));
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.SetVector128), typesSv));
+
+                context.EmitLdvectmp();
+                context.EmitLdvectmp2();
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.CompareGreaterThanOrEqual), types));
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.Xor), types));
+
+                context.EmitCall(typeof(Sse2).GetMethod(nameof(Sse2.Add), typesAdd));
 
                 context.EmitStvec(op.Rd);
 

--- a/Ryujinx.Tests/Cpu/CpuTestSimd.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestSimd.cs
@@ -2,6 +2,7 @@
 
 using NUnit.Framework;
 
+using System;
 using System.Collections.Generic;
 using System.Runtime.Intrinsics;
 
@@ -172,15 +173,20 @@ namespace Ryujinx.Tests.Cpu
             }
         }
 
-        private static IEnumerable<ulong> _1S_F_Cvt_()
+        private static IEnumerable<ulong> _1S_F_W_()
         {
             // int
-            yield return 0x00000000CF000001; // -2.1474839E9f  (-2147483904)
-            yield return 0x00000000CF000000; // -2.14748365E9f (-2147483648)
-            yield return 0x00000000CEFFFFFF; // -2.14748352E9f (-2147483520)
-            yield return 0x000000004F000001; //  2.1474839E9f  (2147483904)
-            yield return 0x000000004F000000; //  2.14748365E9f (2147483648)
-            yield return 0x000000004EFFFFFF; //  2.14748352E9f (2147483520)
+            yield return 0x00000000CF000001ul; // -2.1474839E9f  (-2147483904)
+            yield return 0x00000000CF000000ul; // -2.14748365E9f (-2147483648)
+            yield return 0x00000000CEFFFFFFul; // -2.14748352E9f (-2147483520)
+            yield return 0x000000004F000001ul; //  2.1474839E9f  (2147483904)
+            yield return 0x000000004F000000ul; //  2.14748365E9f (2147483648)
+            yield return 0x000000004EFFFFFFul; //  2.14748352E9f (2147483520)
+
+            // uint
+            yield return 0x000000004F800001ul; // 4.2949678E9f  (4294967808)
+            yield return 0x000000004F800000ul; // 4.2949673E9f  (4294967296)
+            yield return 0x000000004F7FFFFFul; // 4.29496704E9f (4294967040)
 
             yield return 0x00000000FF7FFFFFul; // -Max Normal    (float.MinValue)
             yield return 0x0000000080800000ul; // -Min Normal
@@ -214,11 +220,20 @@ namespace Ryujinx.Tests.Cpu
             for (int cnt = 1; cnt <= RndCnt; cnt++)
             {
                 ulong grbg = TestContext.CurrentContext.Random.NextUInt();
-                ulong rnd1 = GenNormalS();
-                ulong rnd2 = GenSubnormalS();
+
+                ulong rnd1 = (uint)BitConverter.SingleToInt32Bits(
+                    (float)((int)TestContext.CurrentContext.Random.NextUInt()));
+                ulong rnd2 = (uint)BitConverter.SingleToInt32Bits(
+                    (float)((uint)TestContext.CurrentContext.Random.NextUInt()));
+
+                ulong rnd3 = GenNormalS();
+                ulong rnd4 = GenSubnormalS();
 
                 yield return (grbg << 32) | rnd1;
                 yield return (grbg << 32) | rnd2;
+
+                yield return (grbg << 32) | rnd3;
+                yield return (grbg << 32) | rnd4;
             }
         }
 
@@ -263,15 +278,20 @@ namespace Ryujinx.Tests.Cpu
             }
         }
 
-        private static IEnumerable<ulong> _2S_F_Cvt_()
+        private static IEnumerable<ulong> _2S_F_W_()
         {
             // int
-            yield return 0xCF000001CF000001; // -2.1474839E9f  (-2147483904)
-            yield return 0xCF000000CF000000; // -2.14748365E9f (-2147483648)
-            yield return 0xCEFFFFFFCEFFFFFF; // -2.14748352E9f (-2147483520)
-            yield return 0x4F0000014F000001; //  2.1474839E9f  (2147483904)
-            yield return 0x4F0000004F000000; //  2.14748365E9f (2147483648)
-            yield return 0x4EFFFFFF4EFFFFFF; //  2.14748352E9f (2147483520)
+            yield return 0xCF000001CF000001ul; // -2.1474839E9f  (-2147483904)
+            yield return 0xCF000000CF000000ul; // -2.14748365E9f (-2147483648)
+            yield return 0xCEFFFFFFCEFFFFFFul; // -2.14748352E9f (-2147483520)
+            yield return 0x4F0000014F000001ul; //  2.1474839E9f  (2147483904)
+            yield return 0x4F0000004F000000ul; //  2.14748365E9f (2147483648)
+            yield return 0x4EFFFFFF4EFFFFFFul; //  2.14748352E9f (2147483520)
+
+            // uint
+            yield return 0x4F8000014F800001ul; // 4.2949678E9f  (4294967808)
+            yield return 0x4F8000004F800000ul; // 4.2949673E9f  (4294967296)
+            yield return 0x4F7FFFFF4F7FFFFFul; // 4.29496704E9f (4294967040)
 
             yield return 0xFF7FFFFFFF7FFFFFul; // -Max Normal    (float.MinValue)
             yield return 0x8080000080800000ul; // -Min Normal
@@ -304,11 +324,19 @@ namespace Ryujinx.Tests.Cpu
 
             for (int cnt = 1; cnt <= RndCnt; cnt++)
             {
-                ulong rnd1 = GenNormalS();
-                ulong rnd2 = GenSubnormalS();
+                ulong rnd1 = (uint)BitConverter.SingleToInt32Bits(
+                    (float)((int)TestContext.CurrentContext.Random.NextUInt()));
+                ulong rnd2 = (uint)BitConverter.SingleToInt32Bits(
+                    (float)((uint)TestContext.CurrentContext.Random.NextUInt()));
+
+                ulong rnd3 = GenNormalS();
+                ulong rnd4 = GenSubnormalS();
 
                 yield return (rnd1 << 32) | rnd1;
                 yield return (rnd2 << 32) | rnd2;
+
+                yield return (rnd3 << 32) | rnd3;
+                yield return (rnd4 << 32) | rnd4;
             }
         }
 
@@ -353,7 +381,7 @@ namespace Ryujinx.Tests.Cpu
             }
         }
 
-        private static IEnumerable<ulong> _1D_F_Cvt_()
+        private static IEnumerable<ulong> _1D_F_X_()
         {
             // long
             yield return 0xC3E0000000000001ul; // -9.2233720368547780E18d (-9223372036854778000)
@@ -362,6 +390,11 @@ namespace Ryujinx.Tests.Cpu
             yield return 0x43E0000000000001ul; //  9.2233720368547780E18d (9223372036854778000)
             yield return 0x43E0000000000000ul; //  9.2233720368547760E18d (9223372036854776000)
             yield return 0x43DFFFFFFFFFFFFFul; //  9.2233720368547750E18d (9223372036854775000)
+
+            // ulong
+            yield return 0x43F0000000000001ul; // 1.8446744073709556e19d (18446744073709556000)
+            yield return 0x43F0000000000000ul; // 1.8446744073709552E19d (18446744073709552000)
+            yield return 0x43EFFFFFFFFFFFFFul; // 1.8446744073709550e19d (18446744073709550000)
 
             yield return 0xFFEFFFFFFFFFFFFFul; // -Max Normal    (double.MinValue)
             yield return 0x8010000000000000ul; // -Min Normal
@@ -394,11 +427,19 @@ namespace Ryujinx.Tests.Cpu
 
             for (int cnt = 1; cnt <= RndCnt; cnt++)
             {
-                ulong rnd1 = GenNormalD();
-                ulong rnd2 = GenSubnormalD();
+                ulong rnd1 = (ulong)BitConverter.DoubleToInt64Bits(
+                    (double)((long)TestContext.CurrentContext.Random.NextULong()));
+                ulong rnd2 = (ulong)BitConverter.DoubleToInt64Bits(
+                    (double)((ulong)TestContext.CurrentContext.Random.NextULong()));
+
+                ulong rnd3 = GenNormalD();
+                ulong rnd4 = GenSubnormalD();
 
                 yield return rnd1;
                 yield return rnd2;
+
+                yield return rnd3;
+                yield return rnd4;
             }
         }
 #endregion
@@ -1467,7 +1508,7 @@ namespace Ryujinx.Tests.Cpu
 
         [Test, Pairwise] [Explicit]
         public void F_Cvt_NZ_SU_S_S([ValueSource("_F_Cvt_NZ_SU_S_S_")] uint opcodes,
-                                    [ValueSource("_1S_F_Cvt_")] ulong a)
+                                    [ValueSource("_1S_F_W_")] ulong a)
         {
             ulong z = TestContext.CurrentContext.Random.NextULong();
             Vector128<float> v0 = MakeVectorE0E1(z, z);
@@ -1480,7 +1521,7 @@ namespace Ryujinx.Tests.Cpu
 
         [Test, Pairwise] [Explicit]
         public void F_Cvt_NZ_SU_S_D([ValueSource("_F_Cvt_NZ_SU_S_D_")] uint opcodes,
-                                    [ValueSource("_1D_F_Cvt_")] ulong a)
+                                    [ValueSource("_1D_F_X_")] ulong a)
         {
             ulong z = TestContext.CurrentContext.Random.NextULong();
             Vector128<float> v0 = MakeVectorE1(z);
@@ -1495,8 +1536,8 @@ namespace Ryujinx.Tests.Cpu
         public void F_Cvt_NZ_SU_V_2S_4S([ValueSource("_F_Cvt_NZ_SU_V_2S_4S_")] uint opcodes,
                                         [Values(0u)]     uint rd,
                                         [Values(1u, 0u)] uint rn,
-                                        [ValueSource("_2S_F_Cvt_")] ulong z,
-                                        [ValueSource("_2S_F_Cvt_")] ulong a,
+                                        [ValueSource("_2S_F_W_")] ulong z,
+                                        [ValueSource("_2S_F_W_")] ulong a,
                                         [Values(0b0u, 0b1u)] uint q) // <2S, 4S>
         {
             opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
@@ -1514,8 +1555,8 @@ namespace Ryujinx.Tests.Cpu
         public void F_Cvt_NZ_SU_V_2D([ValueSource("_F_Cvt_NZ_SU_V_2D_")] uint opcodes,
                                      [Values(0u)]     uint rd,
                                      [Values(1u, 0u)] uint rn,
-                                     [ValueSource("_1D_F_Cvt_")] ulong z,
-                                     [ValueSource("_1D_F_Cvt_")] ulong a)
+                                     [ValueSource("_1D_F_X_")] ulong z,
+                                     [ValueSource("_1D_F_X_")] ulong a)
         {
             opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
 


### PR DESCRIPTION
This PR is intended as a complement to #655.

The Sse optimizations related to the General Purpose fp-to-integer conversion instructions have been removed due to the poor performance improvement in relation to the size and complexity of the signed and unsigned (above all) implementations.