### PR TITLE
Add missing TextureCubeMapArray texture type entry

### DIFF
--- a/Ryujinx.Graphics/Gal/OpenGL/OglTexture.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OglTexture.cs
@@ -95,6 +95,7 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                         type,
                         IntPtr.Zero);
                     break;
+                case TextureTarget.TextureCubeMapArray:
                 case TextureTarget.Texture2DArray:
                     GL.TexImage3D(
                         target,

--- a/Ryujinx.Graphics/Gal/OpenGL/OglTexture.cs
+++ b/Ryujinx.Graphics/Gal/OpenGL/OglTexture.cs
@@ -95,6 +95,8 @@ namespace Ryujinx.Graphics.Gal.OpenGL
                         type,
                         IntPtr.Zero);
                     break;
+                // Cube map arrays are just 2D texture arrays with 6 entries
+                // per cube map so we can handle them in the same way
                 case TextureTarget.TextureCubeMapArray:
                 case TextureTarget.Texture2DArray:
                     GL.TexImage3D(


### PR DESCRIPTION
Add missing `TextureCubeMapArray` texture type alias to other texture creation path.