### PR TITLE
Config option to ignore missing services

### DIFF
--- a/Ryujinx.HLE/HOS/Services/DummyService.cs
+++ b/Ryujinx.HLE/HOS/Services/DummyService.cs
@@ -1,0 +1,20 @@
+﻿using Ryujinx.HLE.HOS.Ipc;
+using System.Collections.Generic;
+
+namespace Ryujinx.HLE.HOS.Services
+{
+    class DummyService : IpcService
+    {
+        private Dictionary<int, ServiceProcessRequest> _commands;
+
+        public override IReadOnlyDictionary<int, ServiceProcessRequest> Commands => _commands;
+
+        public string ServiceName { get; set; }
+
+        public DummyService(string serviceName)
+        {
+            _commands = new Dictionary<int, ServiceProcessRequest>();
+            ServiceName = serviceName;
+        }
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/IpcService.cs
+++ b/Ryujinx.HLE/HOS/Services/IpcService.cs
@@ -6,7 +6,6 @@ using Ryujinx.HLE.HOS.Kernel.Ipc;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Net.Security;
 
 namespace Ryujinx.HLE.HOS.Services
 {

--- a/Ryujinx.HLE/HOS/Services/IpcService.cs
+++ b/Ryujinx.HLE/HOS/Services/IpcService.cs
@@ -6,6 +6,7 @@ using Ryujinx.HLE.HOS.Kernel.Ipc;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net.Security;
 
 namespace Ryujinx.HLE.HOS.Services
 {
@@ -89,13 +90,29 @@ namespace Ryujinx.HLE.HOS.Services
             long sfciMagic =      context.RequestData.ReadInt64();
             int  commandId = (int)context.RequestData.ReadInt64();
 
-            if (service.Commands.TryGetValue(commandId, out ServiceProcessRequest processRequest))
+            bool serviceExists = service.Commands.TryGetValue(commandId, out ServiceProcessRequest processRequest);
+
+            if (ServiceConfiguration.IgnoreMissingServices || serviceExists)
             {
+                long result = 0;
+
                 context.ResponseData.BaseStream.Seek(_isDomain ? 0x20 : 0x10, SeekOrigin.Begin);
 
-                Logger.PrintDebug(LogClass.KernelIpc, $"{service.GetType().Name}: {processRequest.Method.Name}");
+                if (serviceExists)
+                {
+                    Logger.PrintDebug(LogClass.KernelIpc, $"{service.GetType().Name}: {processRequest.Method.Name}");
 
-                long result = processRequest(context);
+                    result = processRequest(context);
+                }
+                else
+                {
+                    string serviceName;
+                    DummyService dummyService = service as DummyService;
+
+                    serviceName = (dummyService == null) ? serviceName = service.GetType().FullName : dummyService.ServiceName;
+
+                    Logger.PrintWarning(LogClass.KernelIpc, $"Missing service {serviceName}: {commandId} ignored");
+                }
 
                 if (_isDomain)
                 {

--- a/Ryujinx.HLE/HOS/Services/IpcService.cs
+++ b/Ryujinx.HLE/HOS/Services/IpcService.cs
@@ -108,7 +108,7 @@ namespace Ryujinx.HLE.HOS.Services
                     string serviceName;
                     DummyService dummyService = service as DummyService;
 
-                    serviceName = (dummyService == null) ? serviceName = service.GetType().FullName : dummyService.ServiceName;
+                    serviceName = (dummyService == null) ? service.GetType().FullName : dummyService.ServiceName;
 
                     Logger.PrintWarning(LogClass.KernelIpc, $"Missing service {serviceName}: {commandId} ignored");
                 }

--- a/Ryujinx.HLE/HOS/Services/ServiceFactory.cs
+++ b/Ryujinx.HLE/HOS/Services/ServiceFactory.cs
@@ -1,3 +1,4 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Services.Acc;
 using Ryujinx.HLE.HOS.Services.Am;
 using Ryujinx.HLE.HOS.Services.Apm;
@@ -30,6 +31,11 @@ using System;
 
 namespace Ryujinx.HLE.HOS.Services
 {
+    public static class ServiceConfiguration
+    {
+        public static bool IgnoreMissingServices { get; set; }
+    }
+
     static class ServiceFactory
     {
         public static IpcService MakeService(Horizon system, string name)
@@ -207,6 +213,12 @@ namespace Ryujinx.HLE.HOS.Services
 
                 case "vi:u":
                     return new IApplicationRootService();
+            }
+
+            if (ServiceConfiguration.IgnoreMissingServices)
+            {
+                Logger.PrintWarning(LogClass.Service, $"Missing service {name} ignored");
+                return new DummyService(name);
             }
 
             throw new NotImplementedException(name);

--- a/Ryujinx/Config.jsonc
+++ b/Ryujinx/Config.jsonc
@@ -44,7 +44,7 @@
     // Enable or disable aggressive CPU optimizations
     "enable_aggressive_cpu_opts": true,
 
-    // Enable or disable ignoring missing services, this may cause instability however lets some games progress further
+    // Enable or disable ignoring missing services, this may cause instability
     "ignore_missing_services": false, 
 
     // The primary controller's type

--- a/Ryujinx/Config.jsonc
+++ b/Ryujinx/Config.jsonc
@@ -44,6 +44,9 @@
     // Enable or disable aggressive CPU optimizations
     "enable_aggressive_cpu_opts": true,
 
+    // Enable or disable ignoring missing services, this may cause instability however lets some games progress further
+    "ignore_missing_services": false, 
+
     // The primary controller's type
     // Supported Values: Handheld, ProController, NpadPair, NpadLeft, NpadRight
     "controller_type": "Handheld",

--- a/Ryujinx/Configuration.cs
+++ b/Ryujinx/Configuration.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Threading.Tasks;
 using Utf8Json;
 using Utf8Json.Resolvers;
+using Ryujinx.HLE.HOS.Services;
 
 namespace Ryujinx
 {
@@ -90,6 +91,11 @@ namespace Ryujinx
         /// Enable or Disable aggressive CPU optimizations
         /// </summary>
         public bool EnableAggressiveCpuOpts { get; private set; }
+
+        /// <summary>
+        /// Enable or disable ignoring missing services
+        /// </summary>
+        public bool IgnoreMissingServices { get; private set; }
 
         /// <summary>
         ///  The primary controller's type
@@ -206,6 +212,8 @@ namespace Ryujinx
             {
                 Optimizations.AssumeStrictAbiCompliance = true;
             }
+
+            ServiceConfiguration.IgnoreMissingServices = Instance.IgnoreMissingServices;
 
             if(Instance.GamepadControls.Enabled)
             {

--- a/Ryujinx/Configuration.cs
+++ b/Ryujinx/Configuration.cs
@@ -4,6 +4,7 @@ using Ryujinx.Common;
 using Ryujinx.Common.Logging;
 using Ryujinx.HLE;
 using Ryujinx.HLE.HOS.SystemState;
+using Ryujinx.HLE.HOS.Services;
 using Ryujinx.HLE.Input;
 using Ryujinx.UI.Input;
 using System;
@@ -11,7 +12,6 @@ using System.IO;
 using System.Threading.Tasks;
 using Utf8Json;
 using Utf8Json.Resolvers;
-using Ryujinx.HLE.HOS.Services;
 
 namespace Ryujinx
 {

--- a/Ryujinx/_schema.json
+++ b/Ryujinx/_schema.json
@@ -415,7 +415,7 @@
       "$id": "#/properties/ignore_missing_services",
       "type": "boolean",
       "title": "Ignore Missing Services",
-      "description": "Enable or disable ignoring missing services, this may cause instability however lets some games progress further",
+      "description": "Enable or disable ignoring missing services, this may cause instability",
       "default": false,
       "examples": [
         true,

--- a/Ryujinx/_schema.json
+++ b/Ryujinx/_schema.json
@@ -411,6 +411,17 @@
         false
       ]
     },
+    "ignore_missing_services": {
+      "$id": "#/properties/ignore_missing_services",
+      "type": "boolean",
+      "title": "Ignore Missing Services",
+      "description": "Enable or disable ignoring missing services, this may cause instability however lets some games progress further",
+      "default": false,
+      "examples": [
+        true,
+        false
+      ]
+    },
     "controller_type": {
       "$id": "#/properties/controller_type",
       "type": "string",


### PR DESCRIPTION
Adds a config option to ignore missing services. This allows some games to boot with warnings for missing services.
This also provides a quick way to see how many, and what, services are needed to boot a specific game without this option.

Test case, bloons td 5 doesn't boot because of network service requirements however with this it manages to get in game. While slow and containing some graphical errors in the main menu it seems playable.