### PR TITLE
Implement gl_ClipDistance on the shader generator

### DIFF
--- a/Ryujinx.Graphics/Shader/CodeGen/Glsl/OperandManager.cs
+++ b/Ryujinx.Graphics/Shader/CodeGen/Glsl/OperandManager.cs
@@ -182,7 +182,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
             //TODO: Warn about unknown built-in attribute.
 
-            return "// bad_attr0x" + value.ToString("X");
+            return isOutAttr ? "// bad_attr0x" + value.ToString("X") : "0.0";
         }
 
         public static string GetUbName(GalShaderType shaderType, int slot)

--- a/Ryujinx.Graphics/Shader/CodeGen/Glsl/OperandManager.cs
+++ b/Ryujinx.Graphics/Shader/CodeGen/Glsl/OperandManager.cs
@@ -28,20 +28,28 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
         private static Dictionary<int, BuiltInAttribute> _builtInAttributes =
                    new Dictionary<int, BuiltInAttribute>()
         {
-            { AttributeConsts.Layer,               new BuiltInAttribute("gl_Layer",        VariableType.S32)  },
-            { AttributeConsts.PointSize,           new BuiltInAttribute("gl_PointSize",    VariableType.F32)  },
-            { AttributeConsts.PositionX,           new BuiltInAttribute("gl_Position.x",   VariableType.F32)  },
-            { AttributeConsts.PositionY,           new BuiltInAttribute("gl_Position.y",   VariableType.F32)  },
-            { AttributeConsts.PositionZ,           new BuiltInAttribute("gl_Position.z",   VariableType.F32)  },
-            { AttributeConsts.PositionW,           new BuiltInAttribute("gl_Position.w",   VariableType.F32)  },
-            { AttributeConsts.PointCoordX,         new BuiltInAttribute("gl_PointCoord.x", VariableType.F32)  },
-            { AttributeConsts.PointCoordY,         new BuiltInAttribute("gl_PointCoord.y", VariableType.F32)  },
-            { AttributeConsts.TessCoordX,          new BuiltInAttribute("gl_TessCoord.x",  VariableType.F32)  },
-            { AttributeConsts.TessCoordY,          new BuiltInAttribute("gl_TessCoord.y",  VariableType.F32)  },
-            { AttributeConsts.InstanceId,          new BuiltInAttribute("instance",        VariableType.S32)  },
-            { AttributeConsts.VertexId,            new BuiltInAttribute("gl_VertexID",     VariableType.S32)  },
-            { AttributeConsts.FrontFacing,         new BuiltInAttribute("gl_FrontFacing",  VariableType.Bool) },
-            { AttributeConsts.FragmentOutputDepth, new BuiltInAttribute("gl_FragDepth",    VariableType.F32)  }
+            { AttributeConsts.Layer,               new BuiltInAttribute("gl_Layer",           VariableType.S32)  },
+            { AttributeConsts.PointSize,           new BuiltInAttribute("gl_PointSize",       VariableType.F32)  },
+            { AttributeConsts.PositionX,           new BuiltInAttribute("gl_Position.x",      VariableType.F32)  },
+            { AttributeConsts.PositionY,           new BuiltInAttribute("gl_Position.y",      VariableType.F32)  },
+            { AttributeConsts.PositionZ,           new BuiltInAttribute("gl_Position.z",      VariableType.F32)  },
+            { AttributeConsts.PositionW,           new BuiltInAttribute("gl_Position.w",      VariableType.F32)  },
+            { AttributeConsts.ClipDistance0,       new BuiltInAttribute("gl_ClipDistance[0]", VariableType.F32)  },
+            { AttributeConsts.ClipDistance1,       new BuiltInAttribute("gl_ClipDistance[1]", VariableType.F32)  },
+            { AttributeConsts.ClipDistance2,       new BuiltInAttribute("gl_ClipDistance[2]", VariableType.F32)  },
+            { AttributeConsts.ClipDistance3,       new BuiltInAttribute("gl_ClipDistance[3]", VariableType.F32)  },
+            { AttributeConsts.ClipDistance4,       new BuiltInAttribute("gl_ClipDistance[4]", VariableType.F32)  },
+            { AttributeConsts.ClipDistance5,       new BuiltInAttribute("gl_ClipDistance[5]", VariableType.F32)  },
+            { AttributeConsts.ClipDistance6,       new BuiltInAttribute("gl_ClipDistance[6]", VariableType.F32)  },
+            { AttributeConsts.ClipDistance7,       new BuiltInAttribute("gl_ClipDistance[7]", VariableType.F32)  },
+            { AttributeConsts.PointCoordX,         new BuiltInAttribute("gl_PointCoord.x",    VariableType.F32)  },
+            { AttributeConsts.PointCoordY,         new BuiltInAttribute("gl_PointCoord.y",    VariableType.F32)  },
+            { AttributeConsts.TessCoordX,          new BuiltInAttribute("gl_TessCoord.x",     VariableType.F32)  },
+            { AttributeConsts.TessCoordY,          new BuiltInAttribute("gl_TessCoord.y",     VariableType.F32)  },
+            { AttributeConsts.InstanceId,          new BuiltInAttribute("instance",           VariableType.S32)  },
+            { AttributeConsts.VertexId,            new BuiltInAttribute("gl_VertexID",        VariableType.S32)  },
+            { AttributeConsts.FrontFacing,         new BuiltInAttribute("gl_FrontFacing",     VariableType.Bool) },
+            { AttributeConsts.FragmentOutputDepth, new BuiltInAttribute("gl_FragDepth",       VariableType.F32)  }
         };
 
         private Dictionary<AstOperand, string> _locals;
@@ -172,7 +180,9 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
                 }
             }
 
-            return DefaultNames.UndefinedName;
+            //TODO: Warn about unknown built-in attribute.
+
+            return "// bad_attr0x" + value.ToString("X");
         }
 
         public static string GetUbName(GalShaderType shaderType, int slot)

--- a/Ryujinx.Graphics/Shader/Translation/AttributeConsts.cs
+++ b/Ryujinx.Graphics/Shader/Translation/AttributeConsts.cs
@@ -2,19 +2,27 @@ namespace Ryujinx.Graphics.Shader.IntermediateRepresentation
 {
     static class AttributeConsts
     {
-        public const int Layer       = 0x064;
-        public const int PointSize   = 0x06c;
-        public const int PositionX   = 0x070;
-        public const int PositionY   = 0x074;
-        public const int PositionZ   = 0x078;
-        public const int PositionW   = 0x07c;
-        public const int PointCoordX = 0x2e0;
-        public const int PointCoordY = 0x2e4;
-        public const int TessCoordX  = 0x2f0;
-        public const int TessCoordY  = 0x2f4;
-        public const int InstanceId  = 0x2f8;
-        public const int VertexId    = 0x2fc;
-        public const int FrontFacing = 0x3fc;
+        public const int Layer         = 0x064;
+        public const int PointSize     = 0x06c;
+        public const int PositionX     = 0x070;
+        public const int PositionY     = 0x074;
+        public const int PositionZ     = 0x078;
+        public const int PositionW     = 0x07c;
+        public const int ClipDistance0 = 0x2c0;
+        public const int ClipDistance1 = 0x2c4;
+        public const int ClipDistance2 = 0x2c8;
+        public const int ClipDistance3 = 0x2cc;
+        public const int ClipDistance4 = 0x2d0;
+        public const int ClipDistance5 = 0x2d4;
+        public const int ClipDistance6 = 0x2d8;
+        public const int ClipDistance7 = 0x2dc;
+        public const int PointCoordX   = 0x2e0;
+        public const int PointCoordY   = 0x2e4;
+        public const int TessCoordX    = 0x2f0;
+        public const int TessCoordY    = 0x2f4;
+        public const int InstanceId    = 0x2f8;
+        public const int VertexId      = 0x2fc;
+        public const int FrontFacing   = 0x3fc;
 
         public const int UserAttributesCount = 32;
         public const int UserAttributeBase   = 0x80;


### PR DESCRIPTION
This implements gl_ClipDistance.
Additionally, for unimplemented attributes, do not produce an invalid assignment for the constant "undef" that is used for unintialized variables. Instead, it now produces a commented out line with the attribute offset, like this:
```glsl
// bad_attr0x2C0 = temp_82;
```