### PR TITLE
Profiler fix to handle drag and drop opening

### DIFF
--- a/Ryujinx.Profiler/Profile.cs
+++ b/Ryujinx.Profiler/Profile.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 
 namespace Ryujinx.Profiler
 {
@@ -18,7 +19,7 @@ namespace Ryujinx.Profiler
         [Conditional("USE_PROFILING")]
         public static void Initalize()
         {
-            var config = ProfilerConfiguration.Load("ProfilerConfig.jsonc");
+            var config = ProfilerConfiguration.Load(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ProfilerConfig.jsonc"));
 
             _settings = new ProfilerSettings()
             {


### PR DESCRIPTION
I found a bug where it couldn't find the profiler config file when opening via drag and drop as relative paths are based on the path of the opened file.
This fixes that.