### PR TITLE
Added missing ++ in BindMacro GPU method

### DIFF
--- a/Ryujinx.Graphics/Graphics3d/NvGpuFifo.cs
+++ b/Ryujinx.Graphics/Graphics3d/NvGpuFifo.cs
@@ -131,7 +131,7 @@ namespace Ryujinx.Graphics.Graphics3d
                     {
                         int position = methCall.Argument;
 
-                        _macros[_currMacroBindIndex] = new CachedMacro(this, _gpu.Engine3d, position);
+                        _macros[_currMacroBindIndex++] = new CachedMacro(this, _gpu.Engine3d, position);
 
                         break;
                     }


### PR DESCRIPTION
As was shown by fincs there should be a ++ in the bind macro method.
There is still another issue but it's 1 bug fixed