### PR TITLE
Clean Up Build

### DIFF
--- a/Ryujinx.Profiler/Profile.cs
+++ b/Ryujinx.Profiler/Profile.cs
@@ -17,9 +17,9 @@ namespace Ryujinx.Profiler
         private static ProfilerSettings _settings;
 
         [Conditional("USE_PROFILING")]
-        public static void Initalize()
+        public static void Initalize(bool wrappedBuild)
         {
-            var config = ProfilerConfiguration.Load(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ProfilerConfig.jsonc"));
+            var config = ProfilerConfiguration.Load(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, (wrappedBuild) ? "..\\ProfilerConfig.jsonc" : "ProfilerConfig.jsonc"));
 
             _settings = new ProfilerSettings()
             {

--- a/Ryujinx/Configuration.cs
+++ b/Ryujinx/Configuration.cs
@@ -160,7 +160,7 @@ namespace Ryujinx
         /// Configures a <see cref="Switch"/> instance
         /// </summary>
         /// <param name="device">The instance to configure</param>
-        public static void Configure(Switch device)
+        public static void Configure(Switch device, bool wrapped_build)
         {
             if (Instance == null)
             {
@@ -178,7 +178,7 @@ namespace Ryujinx
             if (Instance.EnableFileLog)
             {
                 Logger.AddTarget(new AsyncLogTargetWrapper(
-                    new FileLogTarget(Path.Combine(Program.ApplicationDirectory, "Ryujinx.log")),
+                    new FileLogTarget(Path.Combine(Program.ApplicationDirectory, (wrapped_build) ? "..\\Ryujinx.log" : "Ryujinx.log")),
                     1000,
                     AsyncLogTargetOverflowAction.Block
                 ));

--- a/Ryujinx/Program.cs
+++ b/Ryujinx/Program.cs
@@ -35,7 +35,7 @@ namespace Ryujinx
 
             Configuration.Configure(device, wrappedBuild);
 
-            Profile.Initalize();
+            Profile.Initalize(wrappedBuild);
 
             AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
             AppDomain.CurrentDomain.ProcessExit        += CurrentDomain_ProcessExit;

--- a/Ryujinx/Program.cs
+++ b/Ryujinx/Program.cs
@@ -29,8 +29,11 @@ namespace Ryujinx
 
             Switch device = new Switch(renderer, audioOut);
 
-            Configuration.Load(Path.Combine(ApplicationDirectory, "Config.jsonc"));
-            Configuration.Configure(device);
+            bool wrappedBuild = ((args.Length > 0) && (args.Last() == "-WRAPPED_BUILD"));
+
+            Configuration.Load(Path.Combine(ApplicationDirectory, (wrappedBuild) ? "..\\Config.jsonc" : "Config.jsonc"));
+
+            Configuration.Configure(device, wrappedBuild);
 
             Profile.Initalize();
 
@@ -53,7 +56,7 @@ namespace Ryujinx
                 DiscordClient.SetPresence(DiscordPresence);
             }
 
-            if (args.Length == 1)
+            if (args.Length >= 1)
             {
                 if (Directory.Exists(args[0]))
                 {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,15 @@ build_script:
     
     dotnet publish -c $env:config -r osx-x64
 
-    7z a ryujinx$env:config_name$env:APPVEYOR_BUILD_VERSION-win_x64.zip $env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\publish\
+
+    New-Item -Path "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\" -Name "Ryujinx" -ItemType "directory"
+
+    Move-Item -Path "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\publish\" -Destination "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\bin\"
+
+    Move-Item -Path "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\bin\Config.jsonc" -Destination "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\Config.jsonc"
+    
+
+    7z a ryujinx$env:config_name$env:APPVEYOR_BUILD_VERSION-win_x64.zip $env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\
 
     7z a ryujinx$env:config_name$env:APPVEYOR_BUILD_VERSION-linux_x64.tar $env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\linux-x64\publish\
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ build_script:
 
     Move-Item -Path "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\bin\Config.jsonc" -Destination "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\Config.jsonc"
     
-    curl -fsS -o "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\Ryujinx.exe" "https://github.com/BaronKiko/RyujinxWrapper/releases/download/0/RyujinxWrapper.exe"
+    curl -f -o "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\Ryujinx.exe" "https://github.com/BaronKiko/RyujinxWrapper/releases/download/0/RyujinxWrapper.exe"
 
     7z a ryujinx$env:config_name$env:APPVEYOR_BUILD_VERSION-win_x64.zip $env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,7 @@ build_script:
     Move-Item -Path "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\publish\" -Destination "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\bin\"
 
     Move-Item -Path "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\bin\Config.jsonc" -Destination "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\Config.jsonc"
+    Move-Item -Path "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\bin\ProfilerConfig.jsonc" -Destination "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\ProfilerConfig.jsonc" -Force -ErrorAction SilentlyContinue
     
     curl -o "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\Ryujinx.exe" "https://github.com/BaronKiko/RyujinxWrapper/releases/download/0/RyujinxWrapper.exe"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,9 +26,10 @@ build_script:
     Move-Item -Path "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\publish\" -Destination "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\bin\"
 
     Move-Item -Path "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\bin\Config.jsonc" -Destination "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\Config.jsonc"
-
-    (New-Object Net.WebClient).DownloadFile('https://github.com/BaronKiko/RyujinxWrapper/releases/download/0/RyujinxWrapper.exe', '$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\Ryujinx.exe')
     
+    $source = "https://github.com/BaronKiko/RyujinxWrapper/releases/download/0/RyujinxWrapper.exe"
+    $destination = "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\Ryujinx.exe"
+    Invoke-WebRequest $source -OutFile $destination
 
     7z a ryujinx$env:config_name$env:APPVEYOR_BUILD_VERSION-win_x64.zip $env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ build_script:
 
     Move-Item -Path "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\bin\Config.jsonc" -Destination "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\Config.jsonc"
     
-    curl -f -o "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\Ryujinx.exe" "https://github.com/BaronKiko/RyujinxWrapper/releases/download/0/RyujinxWrapper.exe"
+    curl -o "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\Ryujinx.exe" "https://github.com/BaronKiko/RyujinxWrapper/releases/download/0/RyujinxWrapper.exe"
 
     7z a ryujinx$env:config_name$env:APPVEYOR_BUILD_VERSION-win_x64.zip $env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,8 @@ build_script:
     Move-Item -Path "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\publish\" -Destination "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\bin\"
 
     Move-Item -Path "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\bin\Config.jsonc" -Destination "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\Config.jsonc"
+
+    (New-Object Net.WebClient).DownloadFile('https://github.com/BaronKiko/RyujinxWrapper/releases/download/0/RyujinxWrapper.exe', '$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\Ryujinx.exe')
     
 
     7z a ryujinx$env:config_name$env:APPVEYOR_BUILD_VERSION-win_x64.zip $env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,9 +27,7 @@ build_script:
 
     Move-Item -Path "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\bin\Config.jsonc" -Destination "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\Config.jsonc"
     
-    $source = "https://github.com/BaronKiko/RyujinxWrapper/releases/download/0/RyujinxWrapper.exe"
-    $destination = "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\Ryujinx.exe"
-    Invoke-WebRequest $source -OutFile $destination
+    curl -fsS -o "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\Ryujinx.exe" "https://github.com/BaronKiko/RyujinxWrapper/releases/download/0/RyujinxWrapper.exe"
 
     7z a ryujinx$env:config_name$env:APPVEYOR_BUILD_VERSION-win_x64.zip $env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,11 @@ build_script:
     Move-Item -Path "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\publish\" -Destination "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\bin\"
 
     Move-Item -Path "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\bin\Config.jsonc" -Destination "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\Config.jsonc"
-    Move-Item -Path "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\bin\ProfilerConfig.jsonc" -Destination "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\ProfilerConfig.jsonc" -Force -ErrorAction SilentlyContinue
+
+    if (Test-Path -Path "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\bin\ProfilerConfig.jsonc")
+    {
+      Move-Item -Path "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\bin\ProfilerConfig.jsonc" -Destination "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\ProfilerConfig.jsonc"
+    }
     
     curl -o "$env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\netcoreapp2.1\win-x64\Ryujinx\Ryujinx.exe" "https://github.com/BaronKiko/RyujinxWrapper/releases/download/0/RyujinxWrapper.exe"
 


### PR DESCRIPTION
This pr intends to clean up the build directory from AppVeyor builds.
A finished build now looks like this: 
![explorer_2019-06-05_05-29-15](https://user-images.githubusercontent.com/16206533/58930377-f6407c00-8752-11e9-98b0-51229fd8e37a.png)
The log will appear there after the first run along with the profiler config on a profiled build.
Currently this only works on windows builds because it depends on this wrapper I wrote: https://github.com/BaronKiko/RyujinxWrapper
It needs to be ported to linux, I am hoping somebody else can help me with that as I don't fancy setting up a linux install.
That wrapper also needs an icon set just for prettiness and to be moved to a more sensible place. A fork under the ryujinx account is probably wise.

That is all.

Summarized todo:
- [ ] Linux version of wrapper
- [ ] Wrapper icon
- [ ] Fork wrapper under Ryujinx account
- [ ] Review and cleanup for merge
- [ ] Celebrate