### PR TITLE
Implement GetAccumulatedSuspendedTickChangedEvent to ISelfController

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Am/ISelfController.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/ISelfController.cs
@@ -13,7 +13,8 @@ namespace Ryujinx.HLE.HOS.Services.Am
 
         public override IReadOnlyDictionary<int, ServiceProcessRequest> Commands => _commands;
 
-        private KEvent _launchableEvent;
+        private KEvent _libraryAppletLaunchableEvent;
+        private KEvent _accumulatedSuspendedTickChangedEvent;
 
         private int _idleTimeDetectionExtension;
 
@@ -21,23 +22,50 @@ namespace Ryujinx.HLE.HOS.Services.Am
         {
             _commands = new Dictionary<int, ServiceProcessRequest>
             {
-                { 0,  Exit                                  },
-                { 1,  LockExit                              },
-                { 2,  UnlockExit                            },
-                { 9,  GetLibraryAppletLaunchableEvent       },
-                { 10, SetScreenShotPermission               },
-                { 11, SetOperationModeChangedNotification   },
-                { 12, SetPerformanceModeChangedNotification },
-                { 13, SetFocusHandlingMode                  },
-                { 14, SetRestartMessageEnabled              },
-                { 16, SetOutOfFocusSuspendingEnabled        },
-                { 19, SetScreenShotImageOrientation         },
-                { 50, SetHandlesRequestToDisplay            },
-                { 62, SetIdleTimeDetectionExtension         },
-                { 63, GetIdleTimeDetectionExtension         }
+                { 0,    Exit                                        },
+                { 1,    LockExit                                    },
+                { 2,    UnlockExit                                  },
+              //{ 3,    EnterFatalSection                           }, // 2.0.0+
+              //{ 4,    LeaveFatalSection                           }, // 2.0.0+
+                { 9,    GetLibraryAppletLaunchableEvent             },
+                { 10,   SetScreenShotPermission                     },
+                { 11,   SetOperationModeChangedNotification         },
+                { 12,   SetPerformanceModeChangedNotification       },
+                { 13,   SetFocusHandlingMode                        },
+                { 14,   SetRestartMessageEnabled                    },
+              //{ 15,   SetScreenShotAppletIdentityInfo             }, // 2.0.0+
+                { 16,   SetOutOfFocusSuspendingEnabled              }, // 2.0.0+
+              //{ 17,   SetControllerFirmwareUpdateSection          }, // 3.0.0+
+              //{ 18,   SetRequiresCaptureButtonShortPressedMessage }, // 3.0.0+
+                { 19,   SetScreenShotImageOrientation               }, // 3.0.0+
+              //{ 20,   SetDesirableKeyboardLayout                  }, // 4.0.0+
+              //{ 40,   CreateManagedDisplayLayer                   },
+              //{ 41,   IsSystemBufferSharingEnabled                }, // 4.0.0+
+              //{ 42,   GetSystemSharedLayerHandle                  }, // 4.0.0+
+              //{ 43,   GetSystemSharedBufferHandle                 }, // 5.0.0+
+                { 50,   SetHandlesRequestToDisplay                  },
+              //{ 51,   ApproveToDisplay                            },
+              //{ 60,   OverrideAutoSleepTimeAndDimmingTime         },
+              //{ 61,   SetMediaPlaybackState                       },
+                { 62,   SetIdleTimeDetectionExtension               },
+                { 63,   GetIdleTimeDetectionExtension               },
+              //{ 64,   SetInputDetectionSourceSet                  },
+              //{ 65,   ReportUserIsActive                          }, // 2.0.0+
+              //{ 66,   GetCurrentIlluminance                       }, // 3.0.0+
+              //{ 67,   IsIlluminanceAvailable                      }, // 3.0.0+
+              //{ 68,   SetAutoSleepDisabled                        }, // 5.0.0+
+              //{ 69,   IsAutoSleepDisabled                         }, // 5.0.0+
+              //{ 70,   ReportMultimediaError                       }, // 4.0.0+
+              //{ 71,   GetCurrentIlluminanceEx                     }, // 5.0.0+
+              //{ 80,   SetWirelessPriorityMode                     }, // 4.0.0+
+              //{ 90,   GetAccumulatedSuspendedTickValue            }, // 6.0.0+
+                { 91,   GetAccumulatedSuspendedTickChangedEvent     }, // 6.0.0+
+              //{ 100,  SetAlbumImageTakenNotificationEnabled       }, // 7.0.0+
+              //{ 110,  SetApplicationAlbumUserData                 }, // 8.0.0+
+              //{ 1000, GetDebugStorageChannel                      }, // 7.0.0+
             };
 
-            _launchableEvent = new KEvent(system);
+            _libraryAppletLaunchableEvent = new KEvent(system);
         }
 
         public long Exit(ServiceCtx context)
@@ -63,9 +91,9 @@ namespace Ryujinx.HLE.HOS.Services.Am
 
         public long GetLibraryAppletLaunchableEvent(ServiceCtx context)
         {
-            _launchableEvent.ReadableEvent.Signal();
+            _libraryAppletLaunchableEvent.ReadableEvent.Signal();
 
-            if (context.Process.HandleTable.GenerateHandle(_launchableEvent.ReadableEvent, out int handle) != KernelResult.Success)
+            if (context.Process.HandleTable.GenerateHandle(_libraryAppletLaunchableEvent.ReadableEvent, out int handle) != KernelResult.Success)
             {
                 throw new InvalidOperationException("Out of handles!");
             }
@@ -167,6 +195,26 @@ namespace Ryujinx.HLE.HOS.Services.Am
             context.ResponseData.Write(_idleTimeDetectionExtension);
 
             Logger.PrintStub(LogClass.ServiceAm, new { _idleTimeDetectionExtension });
+
+            return 0;
+        }
+
+        // GetAccumulatedSuspendedTickChangedEvent() -> handle<copy>
+        public long GetAccumulatedSuspendedTickChangedEvent(ServiceCtx context)
+        {
+            if (_accumulatedSuspendedTickChangedEvent == null)
+            {
+                _accumulatedSuspendedTickChangedEvent = new KEvent(context.Device.System);
+
+                _accumulatedSuspendedTickChangedEvent.ReadableEvent.Signal();
+            }
+
+            if (context.Process.HandleTable.GenerateHandle(_accumulatedSuspendedTickChangedEvent.ReadableEvent, out int handle) != KernelResult.Success)
+            {
+                throw new InvalidOperationException("Out of handles!");
+            }
+
+            context.Response.HandleDesc = IpcHandleDesc.MakeCopy(handle);
 
             return 0;
         }


### PR DESCRIPTION
- Add all IPC call to the Dictionary.
- Rename _libraryAppletLaunchableEvent.
- Implement GetAccumulatedSuspendedTickChangedEvent according to the RE:
```C
undefined8 GetAccumulatedSuspendedTickChangedEvent (struct this, uint *ouput_event_handle)
{
    svcArbitrateLock(&this->tag_location);

    if (this->event_created == 0)
    {
        if (CreateEvent(&this->event_object, 0, 1) != 0)
        {
            Assert(&DAT_710018f73b, &DAT_710018f73b, &DAT_710018f73b, 0, result, &DAT_710018f73b);
        }

        this->event_created = 1;

        svcSignalEvent(&this->event_object);
    }

    svcArbitrateUnlock(&this->tag_location);

    uint event_handle = GetEventHandle(&this->event_object);

    uint uVar1 = *ouput_event_handle;
    *ouput_event_handle = event_handle;

    char cVar2 = *(char *)(ouput_event_handle + 1);
    *(undefined *)(ouput_event_handle + 1) = 0;

    if (cVar2 != 0)
    {
        svcCloseHandle((ulonglong)uVar1);
    }

    return 0;
}
```

Should close #615 !