### PR TITLE
PrntStub: Add a way to print arrays

### DIFF
--- a/Ryujinx.Common/Extensions/BinaryReaderExtensions.cs
+++ b/Ryujinx.Common/Extensions/BinaryReaderExtensions.cs
@@ -19,6 +19,26 @@ namespace Ryujinx.Common
             }
         }
 
+        public unsafe static T[] ReadStructArray<T>(this BinaryReader reader, int count)
+            where T : struct
+        {
+            int size = Marshal.SizeOf<T>();
+
+            T[] result = new T[count];
+
+            for (int i = 0; i < count; i++)
+            {
+                byte[] data = reader.ReadBytes(size);
+
+                fixed (byte* ptr = data)
+                {
+                    result[i] = Marshal.PtrToStructure<T>((IntPtr)ptr);
+                }
+            }
+
+            return result;
+        }
+
         public unsafe static void WriteStruct<T>(this BinaryWriter writer, T value)
             where T : struct
         {

--- a/Ryujinx.Common/Logging/Formatters/DefaultLogFormatter.cs
+++ b/Ryujinx.Common/Logging/Formatters/DefaultLogFormatter.cs
@@ -33,7 +33,7 @@ namespace Ryujinx.Common.Logging
                         sb.Append(prop.Name);
                         sb.Append(": ");
 
-                        if(typeof(Array).IsAssignableFrom(prop.PropertyType))
+                        if (typeof(Array).IsAssignableFrom(prop.PropertyType))
                         {
                             Array enumerable = (Array)prop.GetValue(args.Data);
                             foreach (var item in enumerable)

--- a/Ryujinx.Common/Logging/Formatters/DefaultLogFormatter.cs
+++ b/Ryujinx.Common/Logging/Formatters/DefaultLogFormatter.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Text;
 
 namespace Ryujinx.Common.Logging
@@ -31,7 +32,23 @@ namespace Ryujinx.Common.Logging
                     {
                         sb.Append(prop.Name);
                         sb.Append(": ");
-                        sb.Append(prop.GetValue(args.Data));
+
+                        if(typeof(Array).IsAssignableFrom(prop.PropertyType))
+                        {
+                            Array enumerable = (Array)prop.GetValue(args.Data);
+                            foreach (var item in enumerable)
+                            {
+                                sb.Append(item.ToString());
+                                sb.Append(", ");
+                            }
+
+                            sb.Remove(sb.Length - 2, 2);
+                        }
+                        else
+                        {
+                            sb.Append(prop.GetValue(args.Data));
+                        }
+
                         sb.Append(" - ");
                     }
 


### PR DESCRIPTION
This PR adds support for printing arrays in stubs (useful for IPC InBuffer/InPointer).
This also add an util to parse an array of structure from a BinaryReader.

Thanks to @jduncanator for the DefaultLogFormatter.cs changes.