### PR TITLE
Reducing log sizes

### DIFF
--- a/Ryujinx.Common/Configuration/LoggerModule.cs
+++ b/Ryujinx.Common/Configuration/LoggerModule.cs
@@ -78,7 +78,7 @@ namespace Ryujinx.Configuration
             if (e.NewValue)
             {
                 Logger.AddTarget(new AsyncLogTargetWrapper(
-                    new FileLogTarget(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Ryujinx.log"), "file"),
+                    new FileLogTarget(AppDomain.CurrentDomain.BaseDirectory, "file"),
                     1000,
                     AsyncLogTargetOverflowAction.Block
                 ));

--- a/Ryujinx.Common/Logging/Targets/FileLogTarget.cs
+++ b/Ryujinx.Common/Logging/Targets/FileLogTarget.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace Ryujinx.Common.Logging
@@ -20,6 +21,20 @@ namespace Ryujinx.Common.Logging
 
         public FileLogTarget(string path, string name, FileShare fileShare, FileMode fileMode)
         {
+            // Ensure directory is present
+            DirectoryInfo logDir = new DirectoryInfo(Path.Combine(path, "Logs"));
+            logDir.Create();
+
+            // Clean up old logs, should only keep 3
+            FileInfo[] files = logDir.GetFiles("*.log").OrderBy((info => info.CreationTime)).ToArray();
+            for (int i = 0; i < files.Length - 2; i++)
+            {
+                files[i].Delete();
+            }
+
+            // Get path for the current time
+            path = Path.Combine(logDir.FullName, $"Ryujinx_{DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss")}.log");
+
             _name      = name;
             _logWriter = new StreamWriter(File.Open(path, fileMode, FileAccess.Write, fileShare));
             _formatter = new DefaultLogFormatter();


### PR DESCRIPTION
I have separated logs into a single file per run. It should keep up to 3 runs before deleting them.
I have also disable stubs by default as they are the majority of the logs and they aren't very helpful.
I chose not to create a setting for max number for simplicity. I also chose not to limit the size of individual files as it would require checks during runtime and rewriting the whole file when it overflows. This shouldn't really be a concern with the other changes.