### PR TITLE
Update to LibHac 0.5.0

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Acc/IAccountService.cs
+++ b/Ryujinx.HLE/HOS/Services/Acc/IAccountService.cs
@@ -319,8 +319,7 @@ namespace Ryujinx.HLE.HOS.Services.Acc
             // Account actually calls nn::arp::detail::IReader::GetApplicationControlProperty() with the current PID and store the result (NACP File) internally.
             // But since we use LibHac and we load one Application at a time, it's not necessary.
 
-            // TODO : Use "context.Device.System.ControlData.UserAccountSwitchLock" when LibHac is updated.
-            context.ResponseData.Write(false);
+            context.ResponseData.Write(context.Device.System.ControlData.UserAccountSwitchLock);
 
             Logger.PrintStub(LogClass.ServiceAcc);
 

--- a/Ryujinx.HLE/HOS/Services/FspSrv/IFile.cs
+++ b/Ryujinx.HLE/HOS/Services/FspSrv/IFile.cs
@@ -2,6 +2,7 @@ using LibHac.Fs;
 using Ryujinx.HLE.HOS.Ipc;
 using System;
 using System.Collections.Generic;
+using LibHac;
 
 namespace Ryujinx.HLE.HOS.Services.FspSrv
 {
@@ -13,11 +14,7 @@ namespace Ryujinx.HLE.HOS.Services.FspSrv
 
         private LibHac.Fs.IFile _baseFile;
 
-        public event EventHandler<EventArgs> Disposed;
-
-        public string Path { get; private set; }
-
-        public IFile(LibHac.Fs.IFile baseFile, string path)
+        public IFile(LibHac.Fs.IFile baseFile)
         {
             _commands = new Dictionary<int, ServiceProcessRequest>
             {
@@ -29,7 +26,6 @@ namespace Ryujinx.HLE.HOS.Services.FspSrv
             };
 
             _baseFile = baseFile;
-            Path      = PathTools.Normalize(path);
         }
 
         // Read(u32 readOption, u64 offset, u64 size) -> (u64 out_size, buffer<u8, 0x46, 0> out_buf)
@@ -44,8 +40,16 @@ namespace Ryujinx.HLE.HOS.Services.FspSrv
             long size   = context.RequestData.ReadInt64();
 
             byte[] data = new byte[size];
+            int readSize;
 
-            int readSize = _baseFile.Read(data, offset, readOption);
+            try
+            {
+                readSize = _baseFile.Read(data, offset, readOption);
+            }
+            catch (HorizonResultException ex)
+            {
+                return ex.ResultValue.Value;
+            }
 
             context.Memory.WriteBytes(position, data);
 
@@ -67,7 +71,14 @@ namespace Ryujinx.HLE.HOS.Services.FspSrv
 
             byte[] data = context.Memory.ReadBytes(position, size);
 
-            _baseFile.Write(data, offset, writeOption);
+            try
+            {
+                _baseFile.Write(data, offset, writeOption);
+            }
+            catch (HorizonResultException ex)
+            {
+                return ex.ResultValue.Value;
+            }
 
             return 0;
         }
@@ -75,7 +86,14 @@ namespace Ryujinx.HLE.HOS.Services.FspSrv
         // Flush()
         public long Flush(ServiceCtx context)
         {
-            _baseFile.Flush();
+            try
+            {
+                _baseFile.Flush();
+            }
+            catch (HorizonResultException ex)
+            {
+                return ex.ResultValue.Value;
+            }
 
             return 0;
         }
@@ -83,9 +101,16 @@ namespace Ryujinx.HLE.HOS.Services.FspSrv
         // SetSize(u64 size)
         public long SetSize(ServiceCtx context)
         {
-            long size = context.RequestData.ReadInt64();
+            try
+            {
+                long size = context.RequestData.ReadInt64();
 
-            _baseFile.SetSize(size);
+                _baseFile.SetSize(size);
+            }
+            catch (HorizonResultException ex)
+            {
+                return ex.ResultValue.Value;
+            }
 
             return 0;
         }
@@ -93,7 +118,14 @@ namespace Ryujinx.HLE.HOS.Services.FspSrv
         // GetSize() -> u64 fileSize
         public long GetSize(ServiceCtx context)
         {
-            context.ResponseData.Write(_baseFile.GetSize());
+            try
+            {
+                context.ResponseData.Write(_baseFile.GetSize());
+            }
+            catch (HorizonResultException ex)
+            {
+                return ex.ResultValue.Value;
+            }
 
             return 0;
         }
@@ -105,11 +137,9 @@ namespace Ryujinx.HLE.HOS.Services.FspSrv
 
         protected virtual void Dispose(bool disposing)
         {
-            if (disposing && _baseFile != null)
+            if (disposing)
             {
-                _baseFile.Dispose();
-
-                Disposed?.Invoke(this, EventArgs.Empty);
+                _baseFile?.Dispose();
             }
         }
     }

--- a/Ryujinx.HLE/HOS/Services/FspSrv/IFile.cs
+++ b/Ryujinx.HLE/HOS/Services/FspSrv/IFile.cs
@@ -1,8 +1,8 @@
+using LibHac;
 using LibHac.Fs;
 using Ryujinx.HLE.HOS.Ipc;
 using System;
 using System.Collections.Generic;
-using LibHac;
 
 namespace Ryujinx.HLE.HOS.Services.FspSrv
 {

--- a/Ryujinx.HLE/HOS/Services/FspSrv/IFileSystem.cs
+++ b/Ryujinx.HLE/HOS/Services/FspSrv/IFileSystem.cs
@@ -3,6 +3,7 @@ using LibHac.Fs;
 using Ryujinx.HLE.HOS.Ipc;
 using System.Collections.Generic;
 
+using static Ryujinx.HLE.HOS.ErrorCode;
 using static Ryujinx.HLE.Utilities.StringUtils;
 
 namespace Ryujinx.HLE.HOS.Services.FspSrv
@@ -174,7 +175,14 @@ namespace Ryujinx.HLE.HOS.Services.FspSrv
             {
                 DirectoryEntryType entryType = _fileSystem.GetEntryType(name);
 
-                context.ResponseData.Write((int)entryType);
+                if (entryType == DirectoryEntryType.Directory || entryType == DirectoryEntryType.File)
+                {
+                    context.ResponseData.Write((int)entryType);
+                }
+                else
+                {
+                    return MakeError(ErrorModule.Fs, FsErr.PathDoesNotExist);
+                }
             }
             catch (HorizonResultException ex)
             {

--- a/Ryujinx.HLE/HOS/Services/FspSrv/IFileSystem.cs
+++ b/Ryujinx.HLE/HOS/Services/FspSrv/IFileSystem.cs
@@ -109,7 +109,7 @@ namespace Ryujinx.HLE.HOS.Services.FspSrv
             {
                 return ex.ResultValue.Value;
             }
-            
+
             return 0;
         }
 

--- a/Ryujinx.HLE/HOS/Services/FspSrv/IFileSystemProxy.cs
+++ b/Ryujinx.HLE/HOS/Services/FspSrv/IFileSystemProxy.cs
@@ -126,17 +126,13 @@ namespace Ryujinx.HLE.HOS.Services.FspSrv
         // OpenSaveDataFileSystem(u8 save_data_space_id, nn::fssrv::sf::SaveStruct saveStruct) -> object<nn::fssrv::sf::IFileSystem> saveDataFs
         public long OpenSaveDataFileSystem(ServiceCtx context)
         {
-            LoadSaveDataFileSystem(context);
-
-            return 0;
+            return LoadSaveDataFileSystem(context);
         }
 
         // OpenSaveDataFileSystemBySystemSaveDataId(u8 save_data_space_id, nn::fssrv::sf::SaveStruct saveStruct) -> object<nn::fssrv::sf::IFileSystem> systemSaveDataFs
         public long OpenSaveDataFileSystemBySystemSaveDataId(ServiceCtx context)
         {
-            LoadSaveDataFileSystem(context);
-
-            return 0;
+            return LoadSaveDataFileSystem(context);
         }
 
         // OpenDataStorageByCurrentProcess() -> object<nn::fssrv::sf::IStorage> dataStorage
@@ -178,11 +174,18 @@ namespace Ryujinx.HLE.HOS.Services.FspSrv
 
                     if (File.Exists(ncaPath))
                     {
-                        LibHac.Fs.IStorage ncaStorage   = new LocalStorage(ncaPath, FileAccess.Read, FileMode.Open);
-                        Nca                nca          = new Nca(context.Device.System.KeySet, ncaStorage);
-                        LibHac.Fs.IStorage romfsStorage = nca.OpenStorage(NcaSectionType.Data, context.Device.System.FsIntegrityCheckLevel);
+                        try
+                        {
+                            LibHac.Fs.IStorage ncaStorage   = new LocalStorage(ncaPath, FileAccess.Read, FileMode.Open);
+                            Nca                nca          = new Nca(context.Device.System.KeySet, ncaStorage);
+                            LibHac.Fs.IStorage romfsStorage = nca.OpenStorage(NcaSectionType.Data, context.Device.System.FsIntegrityCheckLevel);
 
-                        MakeObject(context, new IStorage(romfsStorage));
+                            MakeObject(context, new IStorage(romfsStorage));
+                        }
+                        catch (HorizonResultException ex)
+                        {
+                            return ex.ResultValue.Value;
+                        }
 
                         return 0;
                     }
@@ -229,7 +232,7 @@ namespace Ryujinx.HLE.HOS.Services.FspSrv
             return 0;
         }
 
-        public void LoadSaveDataFileSystem(ServiceCtx context)
+        public long LoadSaveDataFileSystem(ServiceCtx context)
         {
             SaveSpaceId saveSpaceId = (SaveSpaceId)context.RequestData.ReadInt64();
 
@@ -241,39 +244,63 @@ namespace Ryujinx.HLE.HOS.Services.FspSrv
             SaveDataType    saveDataType = (SaveDataType)context.RequestData.ReadByte();
             SaveInfo        saveInfo     = new SaveInfo(titleId, saveId, saveDataType, userId, saveSpaceId);
             string          savePath     = context.Device.FileSystem.GetGameSavePath(saveInfo, context);
-            LocalFileSystem fileSystem   = new LocalFileSystem(savePath);
 
-            DirectorySaveDataFileSystem saveFileSystem = new DirectorySaveDataFileSystem(fileSystem);
+            try
+            {
+                LocalFileSystem fileSystem = new LocalFileSystem(savePath);
 
-            MakeObject(context, new IFileSystem(saveFileSystem));
+                DirectorySaveDataFileSystem saveFileSystem = new DirectorySaveDataFileSystem(fileSystem);
+
+                MakeObject(context, new IFileSystem(saveFileSystem));
+            }
+            catch (HorizonResultException ex)
+            {
+                return ex.ResultValue.Value;
+            }
+
+            return 0;
         }
 
         private long OpenNsp(ServiceCtx context, string pfsPath)
         {
-            LocalStorage        storage = new LocalStorage(pfsPath, FileAccess.Read, FileMode.Open);
-            PartitionFileSystem nsp     = new PartitionFileSystem(storage);
+            try
+            {
+                LocalStorage        storage = new LocalStorage(pfsPath, FileAccess.Read, FileMode.Open);
+                PartitionFileSystem nsp     = new PartitionFileSystem(storage);
 
-            ImportTitleKeysFromNsp(nsp, context.Device.System.KeySet);
-            
-            IFileSystem nspFileSystem = new IFileSystem(nsp);
+                ImportTitleKeysFromNsp(nsp, context.Device.System.KeySet);
+                
+                IFileSystem nspFileSystem = new IFileSystem(nsp);
 
-            MakeObject(context, nspFileSystem);
+                MakeObject(context, nspFileSystem);
+            }
+            catch (HorizonResultException ex)
+            {
+                return ex.ResultValue.Value;
+            }
 
             return 0;
         }
 
         private long OpenNcaFs(ServiceCtx context, string ncaPath, LibHac.Fs.IStorage ncaStorage)
         {
-            Nca nca = new Nca(context.Device.System.KeySet, ncaStorage);
-
-            if (!nca.SectionExists(NcaSectionType.Data))
+            try
             {
-                return MakeError(ErrorModule.Fs, FsErr.PartitionNotFound);
+                Nca nca = new Nca(context.Device.System.KeySet, ncaStorage);
+
+                if (!nca.SectionExists(NcaSectionType.Data))
+                {
+                    return MakeError(ErrorModule.Fs, FsErr.PartitionNotFound);
+                }
+
+                LibHac.Fs.IFileSystem fileSystem = nca.OpenFileSystem(NcaSectionType.Data, context.Device.System.FsIntegrityCheckLevel);
+
+                MakeObject(context, new IFileSystem(fileSystem));
             }
-
-            LibHac.Fs.IFileSystem fileSystem = nca.OpenFileSystem(NcaSectionType.Data, context.Device.System.FsIntegrityCheckLevel);
-
-            MakeObject(context, new IFileSystem(fileSystem));
+            catch (HorizonResultException ex)
+            {
+                return ex.ResultValue.Value;
+            }
 
             return 0;
         }
@@ -294,15 +321,22 @@ namespace Ryujinx.HLE.HOS.Services.FspSrv
                     FileMode.Open,
                     FileAccess.Read);
 
-                PartitionFileSystem nsp = new PartitionFileSystem(pfsFile.AsStorage());
-
-                ImportTitleKeysFromNsp(nsp, context.Device.System.KeySet);
-                
-                string filename = fullPath.Replace(archivePath.FullName, string.Empty).TrimStart('\\');
-
-                if (nsp.FileExists(filename))
+                try
                 {
-                    return OpenNcaFs(context, fullPath, nsp.OpenFile(filename, OpenMode.Read).AsStorage());
+                    PartitionFileSystem nsp = new PartitionFileSystem(pfsFile.AsStorage());
+
+                    ImportTitleKeysFromNsp(nsp, context.Device.System.KeySet);
+                    
+                    string filename = fullPath.Replace(archivePath.FullName, string.Empty).TrimStart('\\');
+
+                    if (nsp.FileExists(filename))
+                    {
+                        return OpenNcaFs(context, fullPath, nsp.OpenFile(filename, OpenMode.Read).AsStorage());
+                    }
+                }
+                catch (HorizonResultException ex)
+                {
+                    return ex.ResultValue.Value;
                 }
             }
 

--- a/Ryujinx.HLE/HOS/Services/FspSrv/IFileSystemProxy.cs
+++ b/Ryujinx.HLE/HOS/Services/FspSrv/IFileSystemProxy.cs
@@ -247,8 +247,7 @@ namespace Ryujinx.HLE.HOS.Services.FspSrv
 
             try
             {
-                LocalFileSystem fileSystem = new LocalFileSystem(savePath);
-
+                LocalFileSystem             fileSystem     = new LocalFileSystem(savePath);
                 DirectorySaveDataFileSystem saveFileSystem = new DirectorySaveDataFileSystem(fileSystem);
 
                 MakeObject(context, new IFileSystem(saveFileSystem));

--- a/Ryujinx.HLE/HOS/Services/FspSrv/IStorage.cs
+++ b/Ryujinx.HLE/HOS/Services/FspSrv/IStorage.cs
@@ -1,5 +1,6 @@
 using Ryujinx.HLE.HOS.Ipc;
 using System.Collections.Generic;
+using LibHac;
 
 namespace Ryujinx.HLE.HOS.Services.FspSrv
 {
@@ -40,7 +41,14 @@ namespace Ryujinx.HLE.HOS.Services.FspSrv
 
                 byte[] data = new byte[size];
 
-                _baseStorage.Read(data, offset);
+                try
+                {
+                    _baseStorage.Read(data, offset);
+                }
+                catch (HorizonResultException ex)
+                {
+                    return ex.ResultValue.Value;
+                }
 
                 context.Memory.WriteBytes(buffDesc.Position, data);
             }
@@ -51,7 +59,14 @@ namespace Ryujinx.HLE.HOS.Services.FspSrv
         // GetSize() -> u64 size
         public long GetSize(ServiceCtx context)
         {
-            context.ResponseData.Write(_baseStorage.GetSize());
+            try
+            {
+                context.ResponseData.Write(_baseStorage.GetSize());
+            }
+            catch (HorizonResultException ex)
+            {
+                return ex.ResultValue.Value;
+            }
 
             return 0;
         }

--- a/Ryujinx.HLE/HOS/Services/FspSrv/IStorage.cs
+++ b/Ryujinx.HLE/HOS/Services/FspSrv/IStorage.cs
@@ -1,6 +1,6 @@
+using LibHac;
 using Ryujinx.HLE.HOS.Ipc;
 using System.Collections.Generic;
-using LibHac;
 
 namespace Ryujinx.HLE.HOS.Services.FspSrv
 {

--- a/Ryujinx.HLE/HOS/Services/Ns/IApplicationManagerInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Ns/IApplicationManagerInterface.cs
@@ -64,7 +64,7 @@ namespace Ryujinx.HLE.HOS.Services.Ns
             position += isbn.Length;
 
             context.Memory.WriteByte(position++, nacp.StartupUserAccount);
-            context.Memory.WriteByte(position++, nacp.TouchScreenUsageMode);
+            context.Memory.WriteByte(position++, nacp.UserAccountSwitchLock);
             context.Memory.WriteByte(position++, nacp.AocRegistrationType);
 
             context.Memory.WriteInt32(position, nacp.AttributeFlag);

--- a/Ryujinx.HLE/Ryujinx.HLE.csproj
+++ b/Ryujinx.HLE/Ryujinx.HLE.csproj
@@ -46,7 +46,7 @@
 
   <ItemGroup>
     <PackageReference Include="Concentus" Version="1.1.7" />
-    <PackageReference Include="LibHac" Version="0.4.2--more-results.21" />
+    <PackageReference Include="LibHac" Version="0.5.0" />
     <PackageReference Include="TimeZoneConverter.Posix" Version="2.1.0" />
   </ItemGroup>
 

--- a/Ryujinx.HLE/Ryujinx.HLE.csproj
+++ b/Ryujinx.HLE/Ryujinx.HLE.csproj
@@ -46,7 +46,7 @@
 
   <ItemGroup>
     <PackageReference Include="Concentus" Version="1.1.7" />
-    <PackageReference Include="LibHac" Version="0.4.1" />
+    <PackageReference Include="LibHac" Version="0.4.2--more-results.21" />
     <PackageReference Include="TimeZoneConverter.Posix" Version="2.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Many LibHac types will now return or throw result codes the same as Horizon code would.
Small IFileSystem behavior details now match their behavior in Horizon.
Removed open-file tracking in IFileSystem. 