### PR TITLE
Fix private on some call

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Acc/IProfile.cs
+++ b/Ryujinx.HLE/HOS/Services/Acc/IProfile.cs
@@ -53,7 +53,7 @@ namespace Ryujinx.HLE.HOS.Services.Acc
 
         [Command(10)]
         // GetImageSize() -> u32
-        private ResultCode GetImageSize(ServiceCtx context)
+        public ResultCode GetImageSize(ServiceCtx context)
         {
             context.ResponseData.Write(_profilePictureStream.Length);
 
@@ -62,7 +62,7 @@ namespace Ryujinx.HLE.HOS.Services.Acc
 
         [Command(11)]
         // LoadImage() -> (u32, buffer<bytes, 6>)
-        private ResultCode LoadImage(ServiceCtx context)
+        public ResultCode LoadImage(ServiceCtx context)
         {
             long bufferPosition = context.Request.ReceiveBuff[0].Position;
             long bufferLen      = context.Request.ReceiveBuff[0].Size;

--- a/Ryujinx.HLE/HOS/Services/Aud/AudioRenderer/IAudioRenderer.cs
+++ b/Ryujinx.HLE/HOS/Services/Aud/AudioRenderer/IAudioRenderer.cs
@@ -93,7 +93,7 @@ namespace Ryujinx.HLE.HOS.Services.Aud.AudioRenderer
 
         [Command(3)]
         // GetState() -> u32
-        private ResultCode GetState(ServiceCtx context)
+        public ResultCode GetState(ServiceCtx context)
         {
             context.ResponseData.Write((int)_playState);
 

--- a/Ryujinx.HLE/HOS/Services/Aud/IAudioRendererManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Aud/IAudioRendererManager.cs
@@ -179,7 +179,7 @@ namespace Ryujinx.HLE.HOS.Services.Aud
 
         [Command(4)] // 4.0.0+
         // GetAudioDeviceServiceWithRevisionInfo(nn::applet::AppletResourceUserId, u32) -> object<nn::audio::detail::IAudioDevice>
-        private ResultCode GetAudioDeviceServiceWithRevisionInfo(ServiceCtx context)
+        public ResultCode GetAudioDeviceServiceWithRevisionInfo(ServiceCtx context)
         {
             long appletResourceUserId = context.RequestData.ReadInt64();
             int  revisionInfo         = context.RequestData.ReadInt32();

--- a/Ryujinx.HLE/HOS/Services/IpcService.cs
+++ b/Ryujinx.HLE/HOS/Services/IpcService.cs
@@ -26,7 +26,7 @@ namespace Ryujinx.HLE.HOS.Services
         {
             Commands = Assembly.GetExecutingAssembly().GetTypes()
                 .Where(type => type == GetType())
-                .SelectMany(type => type.GetMethods(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public))
+                .SelectMany(type => type.GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public))
                 .SelectMany(methodInfo => methodInfo.GetCustomAttributes(typeof(CommandAttribute))
                 .Select(command => (((CommandAttribute)command).Id, methodInfo)))
                 .ToDictionary(command => command.Id, command => command.methodInfo);

--- a/Ryujinx.HLE/HOS/Services/Lr/ILocationResolverManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Lr/ILocationResolverManager.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.HLE.HOS.Services.Lr
 
         [Command(0)]
         // OpenLocationResolver()
-        private ResultCode OpenLocationResolver(ServiceCtx context)
+        public ResultCode OpenLocationResolver(ServiceCtx context)
         {
             StorageId storageId = (StorageId)context.RequestData.ReadByte();
 


### PR DESCRIPTION
Since the reflection code didn't take care about `private`, this cause regression, so I have added the flag just in case and fix calls who are declared with `private` to `public`.