### PR TITLE
Use the Joystick interface for game controller input.

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -85,7 +85,7 @@
     - `button_r` *(string)*
     - `button_zr` *(string)*
 
-- `gamepad_controls` *(object)* :
+- `joystick_controls` *(object)* :
   - `enabled` *(bool)*
     Whether or not to enable Controller Support.
   - `index` *(int)*
@@ -117,27 +117,27 @@
     - `button_r` *(string)*
     - `button_zr` *(string)*
   
-### Default Mapping
+### Default Mapping.
    #### Controller
      - Left Joycon:
-       - Analog Stick = Left Analog Stick
-	   - DPad Up = DPad Up
-	   - DPad Down = DPad Down
-	   - DPad Left = DPad Left
-	   - DPad Right = DPad Right
-	   - Minus = Select / Back / Share
-	   - L = Left Shoulder Button
-	   - ZL = Left Trigger
+       - Analog Stick = Axis 0
+	   - DPad Up = DPad Up #Hat0 Up
+	   - DPad Down = DPad Down #Hat0 Down
+	   - DPad Left = DPad Left #Hat0 Left
+	   - DPad Right = DPad Right #Hat0 Right
+	   - Minus = Button 10
+	   - L = Button 6
+	   - ZL = Button 8
 	 
      - Right Joycon:
-	   - Analog Stick = Right Analog Stick
-	   - A = B / Circle
-	   - B = A / Cross
-	   - X = Y / Triangle
-	   - Y = X / Square
-	   - Plus = Start / Options
-	   - R = Right Shoulder Button
-	   - ZR = Right Trigger
+	   - Analog Stick = Axis 2
+	   - A = Button 0
+	   - B = Button 1
+	   - X = Button 3
+	   - Y = Button 4
+	   - Plus = Button 11
+	   - R = Button 7
+	   - ZR = Button 9
 
    #### Keyboard
      - Left Joycon:
@@ -168,25 +168,10 @@
 	   - R = U
 	   - ZR = O
   
-### Valid Button Mappings
-  - A = The A / Cross Button
-  - B = The B / Circle Button
-  - X = The X / Square Button
-  - Y = The Y / Triangle Button
-  - LStick = The Left Analog Stick when Pressed Down
-  - RStick = The Right Analog Stick when Pressed Down
-  - Start = The Start / Options Button
-  - Back = The Select / Back / Share Button
-  - RShoulder = The Right Shoulder Button
-  - LShoulder = The Left Shoulder Button
-  - RTrigger = The Right Trigger
-  - LTrigger = The Left Trigger
-  - DPadUp = Up on the DPad
-  - DPadDown = Down on the DPad
-  - DPadLeft = Left on the DPad
-  - DpadRight = Right on the DPad
-- Valid Joystick Mappings
-  - LJoystick = The Left Analog Stick
-  - RJoystick = The Right Analog Stick
+### Valid Button Mappings.
+  - Button# = A button on the controller. # should not exceed the max # of buttons detected on your controller.
+  - Axis# = An analog axis on the controller. It can be a stick control, or a motion control axis.
+  - Hat# = A Point of View (POV), Hat or Directional Pad control on the controller.
 
-  On more obscure / weird controllers this can vary, so if this list doesn't work, trial and error will.
+  Button configuration and controller capabilities differ from one controller to another. Please use a
+  configuration tool to find out the actual button configuration of your controller.

--- a/Ryujinx/Config.jsonc
+++ b/Ryujinx/Config.jsonc
@@ -107,7 +107,7 @@
     },
 
     // Controller Controls
-    "gamepad_controls": {
+    "joystick_controls": {
         // Whether or not to enable Controller support
         "enabled": true,
 
@@ -122,28 +122,28 @@
 
         // Left JoyCon Controller Bindings
         "left_joycon": {
-            "stick": "LJoystick",
-            "stick_button": "LStick",
-            "dpad_up": "DPadUp",
-            "dpad_down": "DPadDown",
-            "dpad_left": "DPadLeft",
-            "dpad_right": "DPadRight",
-            "button_minus": "Back",
-            "button_l": "LShoulder",
-            "button_zl": "LTrigger"
+            "stick": "Axis0",
+            "stick_button": "Button13",
+            "dpad_up": "Hat0Up",
+            "dpad_down": "Hat0Down",
+            "dpad_left": "Hat0Left",
+            "dpad_right": "Hat0Right",
+            "button_minus": "Button10",
+            "button_l": "Button6",
+            "button_zl": "Button8"
         },
 
         // Right JoyCon Controller Bindings
         "right_joycon": {
-            "stick": "RJoystick",
-            "stick_button": "RStick",
-            "button_a": "B",
-            "button_b": "A",
-            "button_x": "Y",
-            "button_y": "X",
-            "button_plus": "Start",
-            "button_r": "RShoulder",
-            "button_zr": "RTrigger"
+            "stick": "Axis2",
+            "stick_button": "Button14",
+            "button_a": "Button0",
+            "button_b": "Button1",
+            "button_x": "Button3",
+            "button_y": "Button4",
+            "button_plus": "Button11",
+            "button_r": "Button7",
+            "button_zr": "Button9"
         }
     }
 }

--- a/Ryujinx/Configuration.cs
+++ b/Ryujinx/Configuration.cs
@@ -135,7 +135,7 @@ namespace Ryujinx
         /// <summary>
         /// Controller control bindings
         /// </summary>
-        public UI.Input.NpadController GamepadControls { get; private set; }
+        public UI.Input.NpadController JoystickControls { get; private set; }
 
         /// <summary>
         /// Loads a configuration file from disk
@@ -246,11 +246,11 @@ namespace Ryujinx
 
             ServiceConfiguration.IgnoreMissingServices = Instance.IgnoreMissingServices;
 
-            if (Instance.GamepadControls.Enabled)
+            if (Instance.JoystickControls.Enabled)
             {
-                if (GamePad.GetName(Instance.GamepadControls.Index) == "Unmapped Controller")
+                if (!Joystick.GetState(Instance.JoystickControls.Index).IsConnected)
                 {
-                    Instance.GamepadControls.SetEnabled(false);
+                    Instance.JoystickControls.SetEnabled(false);
                 }
             }
 

--- a/Ryujinx/Ui/GLScreen.cs
+++ b/Ryujinx/Ui/GLScreen.cs
@@ -183,17 +183,17 @@ namespace Ryujinx
                 };
             }
             
-            currentButton |= Configuration.Instance.GamepadControls.GetButtons();
+            currentButton |= Configuration.Instance.JoystickControls.GetButtons();
 
             // Keyboard has priority stick-wise
             if (leftJoystickDx == 0 && leftJoystickDy == 0)
             {
-                (leftJoystickDx, leftJoystickDy) = Configuration.Instance.GamepadControls.GetLeftStick();
+                (leftJoystickDx, leftJoystickDy) = Configuration.Instance.JoystickControls.GetLeftStick();
             }
 
             if (rightJoystickDx == 0 && rightJoystickDy == 0)
             {
-                (rightJoystickDx, rightJoystickDy) = Configuration.Instance.GamepadControls.GetRightStick();
+                (rightJoystickDx, rightJoystickDy) = Configuration.Instance.JoystickControls.GetRightStick();
             }
 
             leftJoystick = new JoystickPosition

--- a/Ryujinx/Ui/NpadController.cs
+++ b/Ryujinx/Ui/NpadController.cs
@@ -7,43 +7,64 @@ namespace Ryujinx.UI.Input
 {
     public enum ControllerInputId
     {
-        Invalid,
-        LStick,
-        RStick,
-        LShoulder,
-        RShoulder,
-        LTrigger,
-        RTrigger,
-        LJoystick,
-        RJoystick,
-        DPadUp,
-        DPadDown,
-        DPadLeft,
-        DPadRight,
-        Start,
-        Back,
-        A,
-        B,
-        X,
-        Y
+        Button0,
+        Button1,
+        Button2,
+        Button3,
+        Button4,
+        Button5,
+        Button6,
+        Button7,
+        Button8,
+        Button9,
+        Button10,
+        Button11,
+        Button12,
+        Button13,
+        Button14,
+        Button15,
+        Button16,
+        Button17,
+        Button18,
+        Button19,
+        Button20,
+        Axis0,
+        Axis1,
+        Axis2,
+        Axis3,
+        Axis4,
+        Axis5,
+        Hat0Up,
+        Hat0Down,
+        Hat0Left,
+        Hat0Right,
+        Hat1Up,
+        Hat1Down,
+        Hat1Left,
+        Hat1Right,
+        Hat2Up,
+        Hat2Down,
+        Hat2Left,
+        Hat2Right,
     }
 
     public struct NpadControllerLeft
     {
         public ControllerInputId Stick;
         public ControllerInputId StickButton;
+        public ControllerInputId ButtonMinus;
+        public ControllerInputId ButtonL;
+        public ControllerInputId ButtonZl;
         public ControllerInputId DPadUp;
         public ControllerInputId DPadDown;
         public ControllerInputId DPadLeft;
         public ControllerInputId DPadRight;
-        public ControllerInputId ButtonMinus;
-        public ControllerInputId ButtonL;
-        public ControllerInputId ButtonZl;
     }
 
     public struct NpadControllerRight
     {
         public ControllerInputId Stick;
+        public ControllerInputId StickY;
         public ControllerInputId StickButton;
         public ControllerInputId ButtonA;
         public ControllerInputId ButtonB;
@@ -114,29 +135,60 @@ namespace Ryujinx.UI.Input
                 return 0;
             }
 
-            GamePadState gpState = GamePad.GetState(Index);
+            JoystickState jsState = Joystick.GetState(Index);
 
             ControllerButtons buttons = 0;
 
-            if (IsPressed(gpState, LeftJoycon.DPadUp))       buttons |= ControllerButtons.DpadUp;
-            if (IsPressed(gpState, LeftJoycon.DPadDown))     buttons |= ControllerButtons.DpadDown;
-            if (IsPressed(gpState, LeftJoycon.DPadLeft))     buttons |= ControllerButtons.DpadLeft;
-            if (IsPressed(gpState, LeftJoycon.DPadRight))    buttons |= ControllerButtons.DPadRight;
-            if (IsPressed(gpState, LeftJoycon.StickButton))  buttons |= ControllerButtons.StickLeft;
-            if (IsPressed(gpState, LeftJoycon.ButtonMinus))  buttons |= ControllerButtons.Minus;
-            if (IsPressed(gpState, LeftJoycon.ButtonL))      buttons |= ControllerButtons.L;
-            if (IsPressed(gpState, LeftJoycon.ButtonZl))     buttons |= ControllerButtons.Zl;
+            if (IsActivated(jsState, LeftJoycon.DPadUp))       buttons |= ControllerButtons.DpadUp;
+            if (IsActivated(jsState, LeftJoycon.DPadDown))     buttons |= ControllerButtons.DpadDown;
+            if (IsActivated(jsState, LeftJoycon.DPadLeft))     buttons |= ControllerButtons.DpadLeft;
+            if (IsActivated(jsState, LeftJoycon.DPadRight))    buttons |= ControllerButtons.DPadRight;
+            if (IsActivated(jsState, LeftJoycon.StickButton))  buttons |= ControllerButtons.StickLeft;
+            if (IsActivated(jsState, LeftJoycon.ButtonMinus))  buttons |= ControllerButtons.Minus;
+            if (IsActivated(jsState, LeftJoycon.ButtonL))      buttons |= ControllerButtons.L;
+            if (IsActivated(jsState, LeftJoycon.ButtonZl))     buttons |= ControllerButtons.Zl;
 
-            if (IsPressed(gpState, RightJoycon.ButtonA))     buttons |= ControllerButtons.A;
-            if (IsPressed(gpState, RightJoycon.ButtonB))     buttons |= ControllerButtons.B;
-            if (IsPressed(gpState, RightJoycon.ButtonX))     buttons |= ControllerButtons.X;
-            if (IsPressed(gpState, RightJoycon.ButtonY))     buttons |= ControllerButtons.Y;
-            if (IsPressed(gpState, RightJoycon.StickButton)) buttons |= ControllerButtons.StickRight;
-            if (IsPressed(gpState, RightJoycon.ButtonPlus))  buttons |= ControllerButtons.Plus;
-            if (IsPressed(gpState, RightJoycon.ButtonR))     buttons |= ControllerButtons.R;
-            if (IsPressed(gpState, RightJoycon.ButtonZr))    buttons |= ControllerButtons.Zr;
+            if (IsActivated(jsState, RightJoycon.ButtonA))     buttons |= ControllerButtons.A;
+            if (IsActivated(jsState, RightJoycon.ButtonB))     buttons |= ControllerButtons.B;
+            if (IsActivated(jsState, RightJoycon.ButtonX))     buttons |= ControllerButtons.X;
+            if (IsActivated(jsState, RightJoycon.ButtonY))     buttons |= ControllerButtons.Y;
+            if (IsActivated(jsState, RightJoycon.StickButton)) buttons |= ControllerButtons.StickRight;
+            if (IsActivated(jsState, RightJoycon.ButtonPlus))  buttons |= ControllerButtons.Plus;
+            if (IsActivated(jsState, RightJoycon.ButtonR))     buttons |= ControllerButtons.R;
+            if (IsActivated(jsState, RightJoycon.ButtonZr))    buttons |= ControllerButtons.Zr;
 
             return buttons;
+        }
+
+        private bool IsActivated(JoystickState joystickState,ControllerInputId controllerInputId)
+        {
+            if (controllerInputId <= ControllerInputId.Button20)
+                return joystickState.IsButtonDown((int)controllerInputId);
+            else if (controllerInputId <= ControllerInputId.Axis5)
+            {
+                int axis = controllerInputId - ControllerInputId.Axis0;
+
+                return Math.Abs(joystickState.GetAxis(axis)) > Deadzone;
+            }
+            else if(controllerInputId <= ControllerInputId.Hat2Right)
+            {
+                int hat = (controllerInputId - ControllerInputId.Hat0Up) / 4;
+
+                int baseHatId = (int)ControllerInputId.Hat0Up + (hat * 4);
+
+                JoystickHatState hatState = joystickState.GetHat((JoystickHat)hat);
+
+                if (hatState.IsUp    && ((int)controllerInputId % baseHatId == 0))
+                    return true;
+                if (hatState.IsDown  && ((int)controllerInputId % baseHatId == 1))
+                    return true;
+                if (hatState.IsLeft  && ((int)controllerInputId % baseHatId == 2))
+                    return true;
+                if (hatState.IsRight && ((int)controllerInputId % baseHatId == 3))
+                    return true;
+            }
+
+            return false;
         }
 
         public (short, short) GetLeftStick()
@@ -159,21 +211,19 @@ namespace Ryujinx.UI.Input
             return GetStick(RightJoycon.Stick);
         }
 
-        private (short, short) GetStick(ControllerInputId joystick)
+        private (short, short) GetStick(ControllerInputId stickInputId)
         {
-            GamePadState gpState = GamePad.GetState(Index);
+            if (stickInputId < ControllerInputId.Axis0 || stickInputId > ControllerInputId.Axis5)
+                return (0, 0);
 
-            switch (joystick)
-            {
-                case ControllerInputId.LJoystick:
-                    return ApplyDeadzone(gpState.ThumbSticks.Left);
+            JoystickState jsState = Joystick.GetState(Index);
 
-                case ControllerInputId.RJoystick:
-                    return ApplyDeadzone(gpState.ThumbSticks.Right);
+            int xAxis = stickInputId - ControllerInputId.Axis0;
 
-                default:
-                    return (0, 0);
-            }
+            float xValue = jsState.GetAxis(xAxis);
+            float yValue = 0 - jsState.GetAxis(xAxis + 1); // Invert Y-axis
+
+            return ApplyDeadzone(new Vector2(xValue, yValue));
         }
 
         private (short, short) ApplyDeadzone(Vector2 axis)
@@ -191,42 +241,6 @@ namespace Ryujinx.UI.Input
             else
             {
                 return (short)(value * short.MaxValue);
-            }
-        }
-
-        private bool IsPressed(GamePadState gpState, ControllerInputId button)
-        {
-            switch (button)
-            {
-                case ControllerInputId.A:         return gpState.Buttons.A             == ButtonState.Pressed;
-                case ControllerInputId.B:         return gpState.Buttons.B             == ButtonState.Pressed;
-                case ControllerInputId.X:         return gpState.Buttons.X             == ButtonState.Pressed;
-                case ControllerInputId.Y:         return gpState.Buttons.Y             == ButtonState.Pressed;
-                case ControllerInputId.LStick:    return gpState.Buttons.LeftStick     == ButtonState.Pressed;
-                case ControllerInputId.RStick:    return gpState.Buttons.RightStick    == ButtonState.Pressed;
-                case ControllerInputId.LShoulder: return gpState.Buttons.LeftShoulder  == ButtonState.Pressed;
-                case ControllerInputId.RShoulder: return gpState.Buttons.RightShoulder == ButtonState.Pressed;
-                case ControllerInputId.DPadUp:    return gpState.DPad.Up               == ButtonState.Pressed;
-                case ControllerInputId.DPadDown:  return gpState.DPad.Down             == ButtonState.Pressed;
-                case ControllerInputId.DPadLeft:  return gpState.DPad.Left             == ButtonState.Pressed;
-                case ControllerInputId.DPadRight: return gpState.DPad.Right            == ButtonState.Pressed;
-                case ControllerInputId.Start:     return gpState.Buttons.Start         == ButtonState.Pressed;
-                case ControllerInputId.Back:      return gpState.Buttons.Back          == ButtonState.Pressed;
-
-                case ControllerInputId.LTrigger: return gpState.Triggers.Left  >= TriggerThreshold;
-                case ControllerInputId.RTrigger: return gpState.Triggers.Right >= TriggerThreshold;
-
-                // Using thumbsticks as buttons is not common, but it would be nice not to ignore them
-                case ControllerInputId.LJoystick:
-                    return gpState.ThumbSticks.Left.X >= Deadzone ||
-                           gpState.ThumbSticks.Left.Y >= Deadzone;
-
-                case ControllerInputId.RJoystick:
-                    return gpState.ThumbSticks.Right.X >= Deadzone ||
-                           gpState.ThumbSticks.Right.Y >= Deadzone;
-
-                default:
-                    return false;
             }
         }
     }

--- a/Ryujinx/Ui/NpadController.cs
+++ b/Ryujinx/Ui/NpadController.cs
@@ -135,27 +135,27 @@ namespace Ryujinx.UI.Input
                 return 0;
             }
 
-            JoystickState jsState = Joystick.GetState(Index);
+            JoystickState joystickState = Joystick.GetState(Index);
 
             ControllerButtons buttons = 0;
 
-            if (IsActivated(jsState, LeftJoycon.DPadUp))       buttons |= ControllerButtons.DpadUp;
-            if (IsActivated(jsState, LeftJoycon.DPadDown))     buttons |= ControllerButtons.DpadDown;
-            if (IsActivated(jsState, LeftJoycon.DPadLeft))     buttons |= ControllerButtons.DpadLeft;
-            if (IsActivated(jsState, LeftJoycon.DPadRight))    buttons |= ControllerButtons.DPadRight;
-            if (IsActivated(jsState, LeftJoycon.StickButton))  buttons |= ControllerButtons.StickLeft;
-            if (IsActivated(jsState, LeftJoycon.ButtonMinus))  buttons |= ControllerButtons.Minus;
-            if (IsActivated(jsState, LeftJoycon.ButtonL))      buttons |= ControllerButtons.L;
-            if (IsActivated(jsState, LeftJoycon.ButtonZl))     buttons |= ControllerButtons.Zl;
+            if (IsActivated(joystickState, LeftJoycon.DPadUp))       buttons |= ControllerButtons.DpadUp;
+            if (IsActivated(joystickState, LeftJoycon.DPadDown))     buttons |= ControllerButtons.DpadDown;
+            if (IsActivated(joystickState, LeftJoycon.DPadLeft))     buttons |= ControllerButtons.DpadLeft;
+            if (IsActivated(joystickState, LeftJoycon.DPadRight))    buttons |= ControllerButtons.DPadRight;
+            if (IsActivated(joystickState, LeftJoycon.StickButton))  buttons |= ControllerButtons.StickLeft;
+            if (IsActivated(joystickState, LeftJoycon.ButtonMinus))  buttons |= ControllerButtons.Minus;
+            if (IsActivated(joystickState, LeftJoycon.ButtonL))      buttons |= ControllerButtons.L;
+            if (IsActivated(joystickState, LeftJoycon.ButtonZl))     buttons |= ControllerButtons.Zl;
 
-            if (IsActivated(jsState, RightJoycon.ButtonA))     buttons |= ControllerButtons.A;
-            if (IsActivated(jsState, RightJoycon.ButtonB))     buttons |= ControllerButtons.B;
-            if (IsActivated(jsState, RightJoycon.ButtonX))     buttons |= ControllerButtons.X;
-            if (IsActivated(jsState, RightJoycon.ButtonY))     buttons |= ControllerButtons.Y;
-            if (IsActivated(jsState, RightJoycon.StickButton)) buttons |= ControllerButtons.StickRight;
-            if (IsActivated(jsState, RightJoycon.ButtonPlus))  buttons |= ControllerButtons.Plus;
-            if (IsActivated(jsState, RightJoycon.ButtonR))     buttons |= ControllerButtons.R;
-            if (IsActivated(jsState, RightJoycon.ButtonZr))    buttons |= ControllerButtons.Zr;
+            if (IsActivated(joystickState, RightJoycon.ButtonA))     buttons |= ControllerButtons.A;
+            if (IsActivated(joystickState, RightJoycon.ButtonB))     buttons |= ControllerButtons.B;
+            if (IsActivated(joystickState, RightJoycon.ButtonX))     buttons |= ControllerButtons.X;
+            if (IsActivated(joystickState, RightJoycon.ButtonY))     buttons |= ControllerButtons.Y;
+            if (IsActivated(joystickState, RightJoycon.StickButton)) buttons |= ControllerButtons.StickRight;
+            if (IsActivated(joystickState, RightJoycon.ButtonPlus))  buttons |= ControllerButtons.Plus;
+            if (IsActivated(joystickState, RightJoycon.ButtonR))     buttons |= ControllerButtons.R;
+            if (IsActivated(joystickState, RightJoycon.ButtonZr))    buttons |= ControllerButtons.Zr;
 
             return buttons;
         }
@@ -163,14 +163,16 @@ namespace Ryujinx.UI.Input
         private bool IsActivated(JoystickState joystickState,ControllerInputId controllerInputId)
         {
             if (controllerInputId <= ControllerInputId.Button20)
+            {
                 return joystickState.IsButtonDown((int)controllerInputId);
+            }
             else if (controllerInputId <= ControllerInputId.Axis5)
             {
                 int axis = controllerInputId - ControllerInputId.Axis0;
 
                 return Math.Abs(joystickState.GetAxis(axis)) > Deadzone;
             }
-            else if(controllerInputId <= ControllerInputId.Hat2Right)
+            else if (controllerInputId <= ControllerInputId.Hat2Right)
             {
                 int hat = (controllerInputId - ControllerInputId.Hat0Up) / 4;
 
@@ -178,14 +180,10 @@ namespace Ryujinx.UI.Input
 
                 JoystickHatState hatState = joystickState.GetHat((JoystickHat)hat);
 
-                if (hatState.IsUp    && ((int)controllerInputId % baseHatId == 0))
-                    return true;
-                if (hatState.IsDown  && ((int)controllerInputId % baseHatId == 1))
-                    return true;
-                if (hatState.IsLeft  && ((int)controllerInputId % baseHatId == 2))
-                    return true;
-                if (hatState.IsRight && ((int)controllerInputId % baseHatId == 3))
-                    return true;
+                if (hatState.IsUp    && ((int)controllerInputId % baseHatId == 0)) return true;
+                if (hatState.IsDown  && ((int)controllerInputId % baseHatId == 1)) return true;
+                if (hatState.IsLeft  && ((int)controllerInputId % baseHatId == 2)) return true;
+                if (hatState.IsRight && ((int)controllerInputId % baseHatId == 3)) return true;
             }
 
             return false;
@@ -214,7 +212,9 @@ namespace Ryujinx.UI.Input
         private (short, short) GetStick(ControllerInputId stickInputId)
         {
             if (stickInputId < ControllerInputId.Axis0 || stickInputId > ControllerInputId.Axis5)
+            {
                 return (0, 0);
+            }
 
             JoystickState jsState = Joystick.GetState(Index);
 

--- a/Ryujinx/_schema.json
+++ b/Ryujinx/_schema.json
@@ -24,7 +24,7 @@
     "controller_type",
     "enable_keyboard",
     "keyboard_controls",
-    "gamepad_controls"
+    "joystick_controls"
   ],
   "definitions": {
     "key": {
@@ -181,24 +181,45 @@
     "input": {
       "type": "string",
       "enum": [
-        "DPadUp",
-        "DPadDown",
-        "DPadLeft",
-        "DPadRight",
-        "LStick",
-        "RStick",
-        "LShoulder",
-        "RShoulder",
-        "LTrigger",
-        "RTrigger",
-        "LJoystick",
-        "RJoystick",
-        "A",
-        "B",
-        "X",
-        "Y",
-        "Start",
-        "Back"
+        "Button0",
+        "Button1",
+        "Button2",
+        "Button3",
+        "Button4",
+        "Button5",
+        "Button6",
+        "Button7",
+        "Button8",
+        "Button9",
+        "Button10",
+        "Button11",
+        "Button12",
+        "Button13",
+        "Button14",
+        "Button15",
+        "Button16",
+        "Button17",
+        "Button18",
+        "Button19",
+        "Button20",
+        "Axis0",
+        "Axis1",
+        "Axis2",
+        "Axis3",
+        "Axis4",
+        "Axis5",
+        "Hat0Up",
+        "Hat0Down",
+        "Hat0Left",
+        "Hat0Right",
+        "Hat1Up",
+        "Hat1Down",
+        "Hat1Left",
+        "Hat1Right",
+        "Hat2Up",
+        "Hat2Down",
+        "Hat2Left",
+        "Hat2Right"
       ]
     }
   },
@@ -717,19 +738,19 @@
         }
       }
     },
-    "gamepad_controls": {
-      "$id": "#/properties/gamepad_controls",
+    "joystick_controls": {
+      "$id": "#/properties/joystick_controls",
       "type": "object",
-      "title": "GamePad Controls",
+      "title": "Joystick Controls",
       "required": [
         "left_joycon",
         "right_joycon"
       ],
       "properties": {
         "enable": {
-          "$id": "#/properties/gamepad_controls/properties/enable",
+          "$id": "#/properties/joystick_controls/properties/enable",
           "type": "boolean",
-          "title": "Gamepad Enable",
+          "title": "Joystick Enable",
           "description": "Enables or disables controller support",
           "default": true,
           "examples": [
@@ -738,9 +759,9 @@
           ]
         },
         "index": {
-          "$id": "#/properties/gamepad_controls/properties/index",
+          "$id": "#/properties/joystick_controls/properties/index",
           "type": "integer",
-          "title": "Gamepad Index",
+          "title": "Joystick Index",
           "description": "Controller Device Index",
           "default": 0,
           "minimum": 0,
@@ -751,9 +772,9 @@
           ]
         },
         "deadzone": {
-          "$id": "#/properties/gamepad_controls/properties/deadzone",
+          "$id": "#/properties/joystick_controls/properties/deadzone",
           "type": "number",
-          "title": "Gamepad Deadzone",
+          "title": "Joystick Deadzone",
           "description": "Controller Analog Stick Deadzone",
           "default": 0.05,
           "minimum": -32768.0,
@@ -763,7 +784,7 @@
           ]
         },
         "trigger_threshold": {
-          "$id": "#/properties/gamepad_controls/properties/trigger_threshold",
+          "$id": "#/properties/joystick_controls/properties/trigger_threshold",
           "type": "number",
           "title": "Controller Trigger Threshold",
           "description": "The value of how pressed down each trigger has to be in order to register a button press",
@@ -775,7 +796,7 @@
           ]
         },
         "left_joycon": {
-          "$id": "#/properties/gamepad_controls/properties/left_joycon",
+          "$id": "#/properties/joystick_controls/properties/left_joycon",
           "type": "object",
           "title": "Left JoyCon Controls",
           "required": [
@@ -791,63 +812,63 @@
           ],
           "properties": {
             "stick": {
-              "$id": "#/properties/gamepad_controls/properties/left_joycon/properties/stick",
+              "$id": "#/properties/joystick_controls/properties/left_joycon/properties/stick",
               "$ref": "#/definitions/input",
               "title": "Stick",
-              "default": "LJoystick"
+              "default": "Axis0"
             },
             "stick_button": {
-              "$id": "#/properties/gamepad_controls/properties/left_joycon/properties/stick_button",
+              "$id": "#/properties/joystick_controls/properties/left_joycon/properties/stick_button",
               "$ref": "#/definitions/input",
               "title": "Stick Button",
-              "default": "LStick"
+              "default": "Button13"
             },
             "dpad_up": {
-              "$id": "#/properties/gamepad_controls/properties/left_joycon/properties/dpad_up",
+              "$id": "#/properties/joystick_controls/properties/left_joycon/properties/dpad_up",
               "$ref": "#/definitions/input",
               "title": "Dpad Up",
-              "default": "DPadUp"
+              "default": "Hat0Up"
             },
             "dpad_down": {
-              "$id": "#/properties/gamepad_controls/properties/left_joycon/properties/dpad_down",
+              "$id": "#/properties/joystick_controls/properties/left_joycon/properties/dpad_down",
               "$ref": "#/definitions/input",
               "title": "Dpad Down",
-              "default": "DPadDown"
+              "default": "Hat0Down"
             },
             "dpad_left": {
-              "$id": "#/properties/gamepad_controls/properties/left_joycon/properties/dpad_left",
+              "$id": "#/properties/joystick_controls/properties/left_joycon/properties/dpad_left",
               "$ref": "#/definitions/input",
               "title": "Dpad Left",
-              "default": "DPadLeft"
+              "default": "Hat0Left"
             },
             "dpad_right": {
-              "$id": "#/properties/gamepad_controls/properties/left_joycon/properties/dpad_right",
+              "$id": "#/properties/joystick_controls/properties/left_joycon/properties/dpad_right",
               "$ref": "#/definitions/input",
               "title": "Dpad Right",
-              "default": "DPadRight"
+              "default": "Hat0Right"
             },
             "button_minus": {
-              "$id": "#/properties/gamepad_controls/properties/left_joycon/properties/button_minus",
+              "$id": "#/properties/joystick_controls/properties/left_joycon/properties/button_minus",
               "$ref": "#/definitions/input",
               "title": "Button Minus",
-              "default": "Back"
+              "default": "Button10"
             },
             "button_l": {
-              "$id": "#/properties/gamepad_controls/properties/left_joycon/properties/button_l",
+              "$id": "#/properties/joystick_controls/properties/left_joycon/properties/button_l",
               "$ref": "#/definitions/input",
               "title": "Button L",
-              "default": "LShoulder"
+              "default": "Button6"
             },
             "button_zl": {
-              "$id": "#/properties/gamepad_controls/properties/left_joycon/properties/button_zl",
+              "$id": "#/properties/joystick_controls/properties/left_joycon/properties/button_zl",
               "$ref": "#/definitions/input",
               "title": "Button ZL",
-              "default": "LTrigger"
+              "default": "Button8"
             }
           }
         },
         "right_joycon": {
-          "$id": "#/properties/gamepad_controls/properties/right_joycon",
+          "$id": "#/properties/joystick_controls/properties/right_joycon",
           "type": "object",
           "title": "Right JoyCon Controls",
           "required": [
@@ -863,58 +884,58 @@
           ],
           "properties": {
             "stick": {
-              "$id": "#/properties/gamepad_controls/properties/right_joycon/properties/stick",
+              "$id": "#/properties/joystick_controls/properties/right_joycon/properties/stick",
               "$ref": "#/definitions/input",
               "title": "Stick",
-              "default": "RJoystick"
+              "default": "Axis2"
             },
             "stick_button": {
-              "$id": "#/properties/gamepad_controls/properties/right_joycon/properties/stick_button",
+              "$id": "#/properties/joystick_controls/properties/right_joycon/properties/stick_button",
               "$ref": "#/definitions/input",
               "title": "Stick Button",
-              "default": "RStick"
+              "default": "Button14"
             },
             "button_a": {
-              "$id": "#/properties/gamepad_controls/properties/right_joycon/properties/button_a",
+              "$id": "#/properties/joystick_controls/properties/right_joycon/properties/button_a",
               "$ref": "#/definitions/input",
               "title": "Button A",
-              "default": "B"
+              "default": "Button0"
             },
             "button_b": {
-              "$id": "#/properties/gamepad_controls/properties/right_joycon/properties/button_b",
+              "$id": "#/properties/joystick_controls/properties/right_joycon/properties/button_b",
               "$ref": "#/definitions/input",
               "title": "Button B",
-              "default": "A"
+              "default": "Button1"
             },
             "button_x": {
-              "$id": "#/properties/gamepad_controls/properties/right_joycon/properties/button_x",
+              "$id": "#/properties/joystick_controls/properties/right_joycon/properties/button_x",
               "$ref": "#/definitions/input",
               "title": "Button X",
-              "default": "Y"
+              "default": "Button3"
             },
             "button_y": {
-              "$id": "#/properties/gamepad_controls/properties/right_joycon/properties/button_y",
+              "$id": "#/properties/joystick_controls/properties/right_joycon/properties/button_y",
               "$ref": "#/definitions/input",
               "title": "Button Y",
-              "default": "X"
+              "default": "Button4"
             },
             "button_plus": {
-              "$id": "#/properties/gamepad_controls/properties/right_joycon/properties/button_plus",
+              "$id": "#/properties/joystick_controls/properties/right_joycon/properties/button_plus",
               "$ref": "#/definitions/input",
               "title": "Button Plus",
-              "default": "Start"
+              "default": "Button11"
             },
             "button_r": {
-              "$id": "#/properties/gamepad_controls/properties/right_joycon/properties/button_r",
+              "$id": "#/properties/joystick_controls/properties/right_joycon/properties/button_r",
               "$ref": "#/definitions/input",
               "title": "Button R",
-              "default": "RShoulder"
+              "default": "Button7"
             },
             "button_zr": {
-              "$id": "#/properties/gamepad_controls/properties/right_joycon/properties/button_zr",
+              "$id": "#/properties/joystick_controls/properties/right_joycon/properties/button_zr",
               "$ref": "#/definitions/input",
               "title": "Button ZR",
-              "default": "RTrigger"
+              "default": "Button9"
             }
           }
         }


### PR DESCRIPTION
This PR changes game controller input from using the `OpenTK.Input.Gamepad` class to `OpenTK.Input.Joystick`. This should make every DInput and XInput device recognized as a game controller by the OS to work with Ryujinx, instead of only limiting it to recognized and automapped gamepads like before. Other than it improving compatibility, it has the same limitation as before. Although axes can be used for other buttons, both analog sticks can only use axes.
