### PR TITLE
Remove old functions from jit cache

### DIFF
--- a/ARMeilleure/Translation/JitCache.cs
+++ b/ARMeilleure/Translation/JitCache.cs
@@ -93,9 +93,9 @@ namespace ARMeilleure.Translation
             return allocOffset;
         }
 
-        public static void Free(ulong address)
+        public static void Free(IntPtr address)
         {
-            ulong offset = address - (ulong)_basePointer;
+            ulong offset = (ulong)address - (ulong)_basePointer;
 
             lock (_lock)
             {
@@ -119,7 +119,7 @@ namespace ARMeilleure.Translation
         {
             lock (_lock)
             {
-                if(_cacheEntries.TryGetValue(offset, out entry))
+                if (_cacheEntries.TryGetValue(offset, out entry))
                 {
                     return true;
                 }

--- a/ARMeilleure/Translation/JitCacheMemoryAllocator.cs
+++ b/ARMeilleure/Translation/JitCacheMemoryAllocator.cs
@@ -77,7 +77,7 @@ namespace ARMeilleure.Translation
         {
             if ((uint)offset >= (ulong)_size)
             {
-                throw new ArgumentOutOfRangeException();
+                throw new ArgumentOutOfRangeException("offset");
             }
 
             var node = _memoryRanges.First;
@@ -86,7 +86,7 @@ namespace ARMeilleure.Translation
             {
                 if (node == null)
                 {
-                    throw new ArgumentOutOfRangeException();
+                    throw new ArgumentOutOfRangeException("offset");
                 }
 
                 if (offset <= node.Value.End)

--- a/ARMeilleure/Translation/JitCacheMemoryAllocator.cs
+++ b/ARMeilleure/Translation/JitCacheMemoryAllocator.cs
@@ -77,7 +77,7 @@ namespace ARMeilleure.Translation
         {
             if ((uint)offset >= (ulong)_size)
             {
-                throw new ArgumentOutOfRangeException("offset");
+                throw new ArgumentOutOfRangeException(nameof(offset));
             }
 
             var node = _memoryRanges.First;
@@ -86,7 +86,7 @@ namespace ARMeilleure.Translation
             {
                 if (node == null)
                 {
-                    throw new ArgumentOutOfRangeException("offset");
+                    throw new ArgumentOutOfRangeException(nameof(offset));
                 }
 
                 if (offset <= node.Value.End)
@@ -103,6 +103,5 @@ namespace ARMeilleure.Translation
 
             node.Value = (node.Value.Start, offset - 1);
         }
-
     }
 }

--- a/ARMeilleure/Translation/JitCacheMemoryAllocator.cs
+++ b/ARMeilleure/Translation/JitCacheMemoryAllocator.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ARMeilleure.Translation
+{
+    class JitCacheMemoryAllocator
+    {
+        private int _size;
+
+        private LinkedList<(int Start, int End)> _memoryRanges;
+
+        public JitCacheMemoryAllocator(int size, int startPosition)
+        {
+            _size = size;
+
+            _memoryRanges = new LinkedList<(int start, int end)>();
+
+            _memoryRanges.AddFirst((startPosition, startPosition - 1));
+        }
+
+        public int Allocate(int size)
+        {
+            var node = _memoryRanges.First;
+
+            int offset;
+
+            while (true)
+            {
+                if (node.Value.End > (_size - 1) - size)
+                {
+                    throw new OutOfMemoryException();
+                }
+
+                if (node.Next == null)
+                {
+                    offset = node.Value.End + 1;
+
+                    node.Value = (node.Value.Start, node.Value.End + size);
+
+                    break;
+                }
+                else
+                {
+                    if (node.Next.Value.Start - node.Value.End <= 1)
+                    {
+                        node.Value = (node.Value.Start, node.Next.Value.End);
+
+                        _memoryRanges.Remove(node.Next);
+                    }
+
+                    if (node.Next.Value.Start - size > node.Value.End)
+                    {
+                        offset = node.Value.End + 1;
+
+                        if (node.Next.Value.Start - offset == size)
+                        {
+                            node.Value = (node.Value.Start, node.Next.Value.End);
+
+                            _memoryRanges.Remove(node.Next);
+
+                            break;
+                        }
+
+                        node.Value = (node.Value.Start, offset + size - 1);
+
+                        break;
+                    }
+
+                    node = node.Next;
+                }
+            }
+
+            return offset;
+        }
+
+        public void Free(int offset, int size)
+        {
+            if ((uint)offset >= (ulong)_size)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            var node = _memoryRanges.First;
+
+            while (true)
+            {
+                if (node == null)
+                {
+                    throw new ArgumentOutOfRangeException();
+                }
+
+                if (offset <= node.Value.End)
+                {
+                    int newRangeStart = offset + size;
+
+                    _memoryRanges.AddAfter(node, (newRangeStart, node.Value.End));
+
+                    break;
+                }
+
+                node = node.Next;
+            }
+
+            node.Value = (node.Value.Start, offset - 1);
+        }
+
+    }
+}

--- a/ARMeilleure/Translation/TranslatedFunction.cs
+++ b/ARMeilleure/Translation/TranslatedFunction.cs
@@ -6,7 +6,7 @@ namespace ARMeilleure.Translation
 {
     class TranslatedFunction
     {
-        public ulong Pointer => (ulong)Marshal.GetFunctionPointerForDelegate(_func);
+        public IntPtr Pointer => Marshal.GetFunctionPointerForDelegate(_func);
 
         public int EntryCount;
 
@@ -20,8 +20,9 @@ namespace ARMeilleure.Translation
 
         public TranslatedFunction(GuestFunction func, ulong address, bool rejit)
         {
-            _func  = func;
+            _func = func;
             _rejit = rejit;
+            _address = address;
         }
 
         public ulong Execute(State.ExecutionContext context)


### PR DESCRIPTION
This allows removing old functions from the jit cache, and reusing their memory fro new functions.
The allocator has been reworked to use a linked list to keep track of current allocations.