### PR TITLE
Fix a memory corruption in SoundIO wrapper

### DIFF
--- a/Ryujinx.Audio/Native/libsoundio/SoundIOOutStream.cs
+++ b/Ryujinx.Audio/Native/libsoundio/SoundIOOutStream.cs
@@ -64,7 +64,7 @@ namespace SoundIOSharp
 			get { unsafe { return new SoundIOChannelLayout ((IntPtr) ((void*) ((IntPtr) handle + layout_offset))); } }
 			set {
 				unsafe {
-					Buffer.MemoryCopy ((void*)((IntPtr)handle + layout_offset), (void*)value.Handle,
+					Buffer.MemoryCopy ((void*)value.Handle, (void*)((IntPtr)handle + layout_offset),
 							   Marshal.SizeOf<SoundIoChannelLayout> (), Marshal.SizeOf<SoundIoChannelLayout> ());
 				}
 			}


### PR DESCRIPTION
This fix audio slowdown on Unix based platforms where soundio will try
to switch to mono because of the invalid data written.