### PR TITLE
am: Implement ICommonStateGetter::SetCpuBoostMode

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Am/ICommonStateGetter.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/ICommonStateGetter.cs
@@ -10,6 +10,8 @@ namespace Ryujinx.HLE.HOS.Services.Am
     {
         private KEvent _displayResolutionChangeEvent;
 
+        private Apm.CpuBoostMode _cpuBoostMode = Apm.CpuBoostMode.Disabled;
+
         public ICommonStateGetter(Horizon system)
         {
             _displayResolutionChangeEvent = new KEvent(system);
@@ -113,6 +115,25 @@ namespace Ryujinx.HLE.HOS.Services.Am
             context.Response.HandleDesc = IpcHandleDesc.MakeCopy(handle);
 
             Logger.PrintStub(LogClass.ServiceAm);
+
+            return ResultCode.Success;
+        }
+
+        [Command(66)] // 6.0.0+
+        // SetCpuBoostMode(u32 cpu_boost_mode)
+        public ResultCode SetCpuBoostMode(ServiceCtx context)
+        {
+            uint cpuBoostMode = context.RequestData.ReadUInt32();
+
+            if (cpuBoostMode > 1)
+            {
+                return ResultCode.CpuBoostModeInvalid;
+            }
+
+            _cpuBoostMode = (Apm.CpuBoostMode)cpuBoostMode;
+
+            // NOTE: There is a condition variable after the assignment, probably waiting something with apm:sys service (SetCpuBoostMode call?).
+            //       Since we will probably never support CPU boost things, it's not needed to implement more.
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Am/ResultCode.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/ResultCode.cs
@@ -7,6 +7,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
 
         Success = 0,
 
-        NoMessages = (3 << ErrorCodeShift) | ModuleId
+        NoMessages          = (3   << ErrorCodeShift) | ModuleId,
+        CpuBoostModeInvalid = (506 << ErrorCodeShift) | ModuleId
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Apm/CpuBoostMode.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/CpuBoostMode.cs
@@ -1,0 +1,9 @@
+﻿namespace Ryujinx.HLE.HOS.Services.Apm
+{
+    enum CpuBoostMode
+    {
+        Disabled = 0,
+        Mode1    = 1, // Use PerformanceConfiguration13 and PerformanceConfiguration14, or PerformanceConfiguration15 and PerformanceConfiguration16
+        Mode2    = 2  // Use PerformanceConfiguration15 and PerformanceConfiguration16.
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Apm/PerformanceConfiguration.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/PerformanceConfiguration.cs
@@ -1,18 +1,22 @@
 ﻿namespace Ryujinx.HLE.HOS.Services.Apm
 {
-    enum PerformanceConfiguration : uint
-    {
-        PerformanceConfiguration1  = 0x00010000,
-        PerformanceConfiguration2  = 0x00010001,
-        PerformanceConfiguration3  = 0x00010002,
-        PerformanceConfiguration4  = 0x00020000,
-        PerformanceConfiguration5  = 0x00020001,
-        PerformanceConfiguration6  = 0x00020002,
-        PerformanceConfiguration7  = 0x00020003,
-        PerformanceConfiguration8  = 0x00020004,
-        PerformanceConfiguration9  = 0x00020005,
-        PerformanceConfiguration10 = 0x00020006,
-        PerformanceConfiguration11 = 0x92220007,
-        PerformanceConfiguration12 = 0x92220008
+    enum PerformanceConfiguration : uint         // Clocks are all in MHz.
+    {                                            // CPU  | GPU   | RAM    | NOTE
+        PerformanceConfiguration1  = 0x00010000, // 1020 | 384   | 1600   | Only available while docked.
+        PerformanceConfiguration2  = 0x00010001, // 1020 | 768   | 1600   | Only available while docked.
+        PerformanceConfiguration3  = 0x00010002, // 1224 | 691.2 | 1600   | Only available for SDEV units.
+        PerformanceConfiguration4  = 0x00020000, // 1020 | 230.4 | 1600   | Only available for SDEV units.
+        PerformanceConfiguration5  = 0x00020001, // 1020 | 307.2 | 1600   |
+        PerformanceConfiguration6  = 0x00020002, // 1224 | 230.4 | 1600   |
+        PerformanceConfiguration7  = 0x00020003, // 1020 | 307   | 1331.2 |
+        PerformanceConfiguration8  = 0x00020004, // 1020 | 384   | 1331.2 |
+        PerformanceConfiguration9  = 0x00020005, // 1020 | 307.2 | 1065.6 |
+        PerformanceConfiguration10 = 0x00020006, // 1020 | 384   | 1065.6 |
+        PerformanceConfiguration11 = 0x92220007, // 1020 | 460.8 | 1600   |
+        PerformanceConfiguration12 = 0x92220008, // 1020 | 460.8 | 1331.2 |
+        PerformanceConfiguration13 = 0x92220009, // 1785 | 768   | 1600   | 7.0.0+
+        PerformanceConfiguration14 = 0x9222000A, // 1785 | 768   | 1331.2 | 7.0.0+
+        PerformanceConfiguration15 = 0x9222000B, // 1020 | 768   | 1600   | 7.0.0+
+        PerformanceConfiguration16 = 0x9222000C  // 1020 | 768   | 1331.2 | 7.0.0+
     }
 }


### PR DESCRIPTION
- Implement am call `ICommonStateGetter::SetCpuBoostMode` according to the RE:

```c++
signed __int64 __fastcall nn::ICommonStateGetter::SetCpuBoostModeImpl(__int64 this, unsigned int cpu_boost_mode)
{
  if ( cpu_boost_mode > 1 )
  {
    return 0x3F480LL;
  }

  __int64 v2 = *(_QWORD *)(this + 0x38);
  __int64 v3 = *(_QWORD *)(*(_QWORD *)(v2 + 8) + 0x298LL);

  nnLock((_DWORD *)(v3 + 0x104));

  __int64 v5 = *(_QWORD *)(v2 + 0x18);
  bool unk_bool = *(unsigned __int8 *)(v5 + 0x7C);

  *(_DWORD *)(v5 + 0x80) = cpu_boost_mode;

  if (!unk_bool)
  {
    *(_BYTE *)(v5 + 0x7C) = 1;
  }

  wait_condvar(v3 + 0xA8);
  nnUnlock((_DWORD *)(v3 + 0x104));

  return 0LL;
}
```

- Add enum for apm `CpuBoostMode`
- Add missing values in apm `PerformanceConfiguration` with some comments.
- Close issue #717