### PR TITLE
ui: Fix segfault on Linux when passing a program via command line

### DIFF
--- a/Ryujinx/Program.cs
+++ b/Ryujinx/Program.cs
@@ -30,6 +30,11 @@ namespace Ryujinx
             gtkApplication.AddWindow(mainWindow);
             mainWindow.Show();
 
+            if (args.Length == 1)
+            {
+                mainWindow.LoadApplication(args[0]);
+            }
+
             Application.Run();
         }
 

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -131,8 +131,6 @@ namespace Ryujinx.UI
 
                 UpdateGameTable();
                 // Temporary code section end
-
-                LoadApplication(args[0]);
             }
             else
             {
@@ -202,7 +200,7 @@ namespace Ryujinx.UI
             StyleContext.AddProviderForScreen(Gdk.Screen.Default, cssProvider, 800);
         }
 
-        private void LoadApplication(string path)
+        internal void LoadApplication(string path)
         {
             if (_gameLoaded)
             {


### PR DESCRIPTION
GTK context MUST be fully initialized before initializing OpenTK because a possible conflcit between OpenTK's SDL2 backend and GTK.

This PR move the load LoadApplication call outside of MainWindow constructor to fix this issue.