### PR TITLE
audout:u: Implement SetAudioOutVolume and GetAudioOutVolume

### DIFF
--- a/Ryujinx.Audio/IAalOutput.cs
+++ b/Ryujinx.Audio/IAalOutput.cs
@@ -15,7 +15,12 @@ namespace Ryujinx.Audio
         void AppendBuffer<T>(int trackId, long bufferTag, T[] buffer)  where T : struct;
 
         void Start(int trackId);
+
         void Stop(int trackId);
+
+        float GetVolume();
+
+        void SetVolume(float volume);
 
         PlaybackState GetState(int trackId);
     }

--- a/Ryujinx.Audio/IAalOutput.cs
+++ b/Ryujinx.Audio/IAalOutput.cs
@@ -20,7 +20,7 @@ namespace Ryujinx.Audio
 
         float GetVolume();
 
-        void SetVolume(float gain);
+        void SetVolume(float volume);
 
         PlaybackState GetState(int trackId);
     }

--- a/Ryujinx.Audio/IAalOutput.cs
+++ b/Ryujinx.Audio/IAalOutput.cs
@@ -20,7 +20,7 @@ namespace Ryujinx.Audio
 
         float GetVolume();
 
-        void SetVolume(float volume);
+        void SetVolume(float gain);
 
         PlaybackState GetState(int trackId);
     }

--- a/Ryujinx.Audio/Renderers/DummyAudioOut.cs
+++ b/Ryujinx.Audio/Renderers/DummyAudioOut.cs
@@ -83,9 +83,9 @@ namespace Ryujinx.Audio
 
         public float GetVolume() => _volume;
 
-        public void SetVolume(float volume)
+        public void SetVolume(float gain)
         {
-            _volume = Math.Clamp(_volume - (_volume * volume), 0.0f, 1.0f);
+            _volume = Math.Clamp(_volume - (_volume * gain), 0.0f, 1.0f);
         }
 
         public void Dispose()

--- a/Ryujinx.Audio/Renderers/DummyAudioOut.cs
+++ b/Ryujinx.Audio/Renderers/DummyAudioOut.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 namespace Ryujinx.Audio
@@ -8,17 +9,18 @@ namespace Ryujinx.Audio
     /// </summary>
     public class DummyAudioOut : IAalOutput
     {
-        private int lastTrackId = 1;
+        private int   _lastTrackId = 1;
+        private float _volume      = 1.0f;
 
-        private ConcurrentQueue<int> m_TrackIds;
-        private ConcurrentQueue<long> m_Buffers;
-        private ConcurrentDictionary<int, ReleaseCallback> m_ReleaseCallbacks;
+        private ConcurrentQueue<int> _trackIds;
+        private ConcurrentQueue<long> _buffers;
+        private ConcurrentDictionary<int, ReleaseCallback> _releaseCallbacks;
 
         public DummyAudioOut()
         {
-            m_Buffers          = new ConcurrentQueue<long>();
-            m_TrackIds         = new ConcurrentQueue<int>();
-            m_ReleaseCallbacks = new ConcurrentDictionary<int, ReleaseCallback>();
+            _buffers          = new ConcurrentQueue<long>();
+            _trackIds         = new ConcurrentQueue<int>();
+            _releaseCallbacks = new ConcurrentDictionary<int, ReleaseCallback>();
         }
 
         /// <summary>
@@ -30,38 +32,23 @@ namespace Ryujinx.Audio
 
         public int OpenTrack(int sampleRate, int channels, ReleaseCallback callback)
         {
-            int trackId;
-
-            if (!m_TrackIds.TryDequeue(out trackId))
+            if (!_trackIds.TryDequeue(out int trackId))
             {
-                trackId = ++lastTrackId;
+                trackId = ++_lastTrackId;
             }
 
-            m_ReleaseCallbacks[trackId] = callback;
+            _releaseCallbacks[trackId] = callback;
 
             return trackId;
         }
 
         public void CloseTrack(int trackId)
         {
-            m_TrackIds.Enqueue(trackId);
-            m_ReleaseCallbacks.Remove(trackId, out _);
+            _trackIds.Enqueue(trackId);
+            _releaseCallbacks.Remove(trackId, out _);
         }
 
-        public void Start(int trackId) { }
-
-        public void Stop(int trackId) { }
-
-        public void AppendBuffer<T>(int trackID, long bufferTag, T[] buffer)
-            where T : struct
-        {
-            m_Buffers.Enqueue(bufferTag);
-
-            if (m_ReleaseCallbacks.TryGetValue(trackID, out var callback))
-            {
-                callback?.Invoke();
-            }
-        }
+        public bool ContainsBuffer(int trackID, long bufferTag) => false;
 
         public long[] GetReleasedBuffers(int trackId, int maxCount)
         {
@@ -69,7 +56,7 @@ namespace Ryujinx.Audio
 
             for (int i = 0; i < maxCount; i++)
             {
-                if (!m_Buffers.TryDequeue(out long tag))
+                if (!_buffers.TryDequeue(out long tag))
                 {
                     break;
                 }
@@ -80,11 +67,30 @@ namespace Ryujinx.Audio
             return bufferTags.ToArray();
         }
 
-        public bool ContainsBuffer(int trackID, long bufferTag) => false;
+        public void AppendBuffer<T>(int trackID, long bufferTag, T[] buffer) where T : struct
+        {
+            _buffers.Enqueue(bufferTag);
+
+            if (_releaseCallbacks.TryGetValue(trackID, out var callback))
+            {
+                callback?.Invoke();
+            }
+        }
+
+        public void Start(int trackId) { }
+
+        public void Stop(int trackId) { }
+
+        public float GetVolume() => _volume;
+
+        public void SetVolume(float volume)
+        {
+            _volume = Math.Clamp(_volume - (_volume * volume), 0.0f, 1.0f);
+        }
 
         public void Dispose()
         {
-            m_Buffers.Clear();
+            _buffers.Clear();
         }
     }
 }

--- a/Ryujinx.Audio/Renderers/DummyAudioOut.cs
+++ b/Ryujinx.Audio/Renderers/DummyAudioOut.cs
@@ -83,9 +83,9 @@ namespace Ryujinx.Audio
 
         public float GetVolume() => _volume;
 
-        public void SetVolume(float gain)
+        public void SetVolume(float volume)
         {
-            _volume = Math.Clamp(_volume - (_volume * gain), 0.0f, 1.0f);
+            _volume = volume;
         }
 
         public void Dispose()

--- a/Ryujinx.Audio/Renderers/OpenAL/OpenALAudioOut.cs
+++ b/Ryujinx.Audio/Renderers/OpenAL/OpenALAudioOut.cs
@@ -2,7 +2,6 @@ using OpenTK.Audio;
 using OpenTK.Audio.OpenAL;
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading;
 
@@ -13,174 +12,38 @@ namespace Ryujinx.Audio
     /// </summary>
     public class OpenALAudioOut : IAalOutput, IDisposable
     {
+        /// <summary>
+        /// The maximum amount of tracks we can issue simultaneously
+        /// </summary>
         private const int MaxTracks = 256;
 
-        private const int MaxReleased = 32;
-
-        private AudioContext Context;
-
-        private class Track : IDisposable
-        {
-            public int SourceId { get; private set; }
-
-            public int SampleRate { get; private set; }
-
-            public ALFormat Format { get; private set; }
-
-            private ReleaseCallback Callback;
-
-            public PlaybackState State { get; set; }
-
-            private ConcurrentDictionary<long, int> Buffers;
-
-            private Queue<long> QueuedTagsQueue;
-
-            private Queue<long> ReleasedTagsQueue;
-
-            private bool Disposed;
-
-            public Track(int SampleRate, ALFormat Format, ReleaseCallback Callback)
-            {
-                this.SampleRate = SampleRate;
-                this.Format     = Format;
-                this.Callback   = Callback;
-
-                State = PlaybackState.Stopped;
-
-                SourceId = AL.GenSource();
-
-                Buffers = new ConcurrentDictionary<long, int>();
-
-                QueuedTagsQueue = new Queue<long>();
-
-                ReleasedTagsQueue = new Queue<long>();
-            }
-
-            public bool ContainsBuffer(long Tag)
-            {
-                foreach (long QueuedTag in QueuedTagsQueue)
-                {
-                    if (QueuedTag == Tag)
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
-            }
-
-            public long[] GetReleasedBuffers(int Count)
-            {
-                AL.GetSource(SourceId, ALGetSourcei.BuffersProcessed, out int ReleasedCount);
-
-                ReleasedCount += ReleasedTagsQueue.Count;
-
-                if (Count > ReleasedCount)
-                {
-                    Count = ReleasedCount;
-                }
-
-                List<long> Tags = new List<long>();
-
-                while (Count-- > 0 && ReleasedTagsQueue.TryDequeue(out long Tag))
-                {
-                    Tags.Add(Tag);
-                }
-
-                while (Count-- > 0 && QueuedTagsQueue.TryDequeue(out long Tag))
-                {
-                    AL.SourceUnqueueBuffers(SourceId, 1);
-
-                    Tags.Add(Tag);
-                }
-
-                return Tags.ToArray();
-            }
-
-            public int AppendBuffer(long Tag)
-            {
-                if (Disposed)
-                {
-                    throw new ObjectDisposedException(nameof(Track));
-                }
-
-                int Id = AL.GenBuffer();
-
-                Buffers.AddOrUpdate(Tag, Id, (Key, OldId) =>
-                {
-                    AL.DeleteBuffer(OldId);
-
-                    return Id;
-                });
-
-                QueuedTagsQueue.Enqueue(Tag);
-
-                return Id;
-            }
-
-            public void CallReleaseCallbackIfNeeded()
-            {
-                AL.GetSource(SourceId, ALGetSourcei.BuffersProcessed, out int ReleasedCount);
-
-                if (ReleasedCount > 0)
-                {
-                    // If we signal, then we also need to have released buffers available
-                    // to return when GetReleasedBuffers is called.
-                    // If playback needs to be re-started due to all buffers being processed,
-                    // then OpenAL zeros the counts (ReleasedCount), so we keep it on the queue.
-                    while (ReleasedCount-- > 0 && QueuedTagsQueue.TryDequeue(out long Tag))
-                    {
-                        AL.SourceUnqueueBuffers(SourceId, 1);
-
-                        ReleasedTagsQueue.Enqueue(Tag);
-                    }
-
-                    Callback();
-                }
-            }
-
-            public void Dispose()
-            {
-                Dispose(true);
-            }
-
-            protected virtual void Dispose(bool Disposing)
-            {
-                if (Disposing && !Disposed)
-                {
-                    Disposed = true;
-
-                    AL.DeleteSource(SourceId);
-
-                    foreach (int Id in Buffers.Values)
-                    {
-                        AL.DeleteBuffer(Id);
-                    }
-                }
-            }
-        }
-
-        private ConcurrentDictionary<int, Track> Tracks;
-
-        private Thread AudioPollerThread;
-
-        private bool KeepPolling;
-
-        public OpenALAudioOut()
-        {
-            Context = new AudioContext();
-
-            Tracks = new ConcurrentDictionary<int, Track>();
-
-            KeepPolling = true;
-
-            AudioPollerThread = new Thread(AudioPollerWork);
-
-            AudioPollerThread.Start();
-        }
+        /// <summary>
+        /// The <see cref="OpenTK.Audio"/> audio context
+        /// </summary>
+        private AudioContext _context;
 
         /// <summary>
-        /// True if OpenAL is supported on the device.
+        /// An object pool containing <see cref="OpenALAudioTrack"/> objects
+        /// </summary>
+        private ConcurrentDictionary<int, OpenALAudioTrack> _tracks;
+
+        /// <summary>
+        /// True if the thread need to keep polling
+        /// </summary>
+        private bool _keepPolling;
+
+        /// <summary>
+        /// The poller thread audio context
+        /// </summary>
+        private Thread _audioPollerThread;
+
+        /// <summary>
+        /// The volume of audio renderer
+        /// </summary>
+        private float _volume = 1.0f;
+
+        /// <summary>
+        /// True if OpenAL is supported on the device
         /// </summary>
         public static bool IsSupported
         {
@@ -197,157 +60,223 @@ namespace Ryujinx.Audio
             }
         }
 
+        public OpenALAudioOut()
+        {
+            _context           = new AudioContext();
+            _tracks            = new ConcurrentDictionary<int, OpenALAudioTrack>();
+            _keepPolling       = true;
+            _audioPollerThread = new Thread(AudioPollerWork);
+
+            _audioPollerThread.Start();
+        }
+
         private void AudioPollerWork()
         {
             do
             {
-                foreach (Track Td in Tracks.Values)
+                foreach (OpenALAudioTrack track in _tracks.Values)
                 {
-                    lock (Td)
+                    lock (track)
                     {
-                        Td.CallReleaseCallbackIfNeeded();
+                        track.CallReleaseCallbackIfNeeded();
                     }
                 }
 
-                // If it's not slept it will waste cycles.
+                // NOTE: If it's not slept it will waste cycles.
                 Thread.Sleep(10);
             }
-            while (KeepPolling);
+            while (_keepPolling);
 
-            foreach (Track Td in Tracks.Values)
+            foreach (OpenALAudioTrack track in _tracks.Values)
             {
-                Td.Dispose();
+                track.Dispose();
             }
 
-            Tracks.Clear();
+            _tracks.Clear();
         }
 
-        public int OpenTrack(int SampleRate, int Channels, ReleaseCallback Callback)
+        /// <summary>
+        /// Creates a new audio track with the specified parameters
+        /// </summary>
+        /// <param name="sampleRate">The requested sample rate</param>
+        /// <param name="channels">The requested channels</param>
+        /// <param name="callback">A <see cref="ReleaseCallback" /> that represents the delegate to invoke when a buffer has been released by the audio track</param>
+        public int OpenTrack(int sampleRate, int channels, ReleaseCallback callback)
         {
-            Track Td = new Track(SampleRate, GetALFormat(Channels), Callback);
+            OpenALAudioTrack track = new OpenALAudioTrack(sampleRate, GetALFormat(channels), callback);
 
-            for (int Id = 0; Id < MaxTracks; Id++)
+            for (int id = 0; id < MaxTracks; id++)
             {
-                if (Tracks.TryAdd(Id, Td))
+                if (_tracks.TryAdd(id, track))
                 {
-                    return Id;
+                    return id;
                 }
             }
 
             return -1;
         }
 
-        private ALFormat GetALFormat(int Channels)
+        private ALFormat GetALFormat(int channels)
         {
-            switch (Channels)
+            switch (channels)
             {
                 case 1: return ALFormat.Mono16;
                 case 2: return ALFormat.Stereo16;
                 case 6: return ALFormat.Multi51Chn16Ext;
             }
 
-            throw new ArgumentOutOfRangeException(nameof(Channels));
+            throw new ArgumentOutOfRangeException(nameof(channels));
         }
 
-        public void CloseTrack(int Track)
+        /// <summary>
+        /// Stops playback and closes the track specified by <paramref name="trackId"/>
+        /// </summary>
+        /// <param name="trackId">The ID of the track to close</param>
+        public void CloseTrack(int trackId)
         {
-            if (Tracks.TryRemove(Track, out Track Td))
+            if (_tracks.TryRemove(trackId, out OpenALAudioTrack track))
             {
-                lock (Td)
+                lock (track)
                 {
-                    Td.Dispose();
+                    track.Dispose();
                 }
             }
         }
 
-        public bool ContainsBuffer(int Track, long Tag)
+        /// <summary>
+        /// Returns a value indicating whether the specified buffer is currently reserved by the specified track
+        /// </summary>
+        /// <param name="trackId">The track to check</param>
+        /// <param name="bufferTag">The buffer tag to check</param>
+        public bool ContainsBuffer(int trackId, long bufferTag)
         {
-            if (Tracks.TryGetValue(Track, out Track Td))
+            if (_tracks.TryGetValue(trackId, out OpenALAudioTrack track))
             {
-                lock (Td)
+                lock (track)
                 {
-                    return Td.ContainsBuffer(Tag);
+                    return track.ContainsBuffer(bufferTag);
                 }
             }
 
             return false;
         }
 
-        public long[] GetReleasedBuffers(int Track, int MaxCount)
+        /// <summary>
+        /// Gets a list of buffer tags the specified track is no longer reserving
+        /// </summary>
+        /// <param name="trackId">The track to retrieve buffer tags from</param>
+        /// <param name="maxCount">The maximum amount of buffer tags to retrieve</param>
+        /// <returns>Buffers released by the specified track</returns>
+        public long[] GetReleasedBuffers(int trackId, int maxCount)
         {
-            if (Tracks.TryGetValue(Track, out Track Td))
+            if (_tracks.TryGetValue(trackId, out OpenALAudioTrack track))
             {
-                lock (Td)
+                lock (track)
                 {
-                    return Td.GetReleasedBuffers(MaxCount);
+                    return track.GetReleasedBuffers(maxCount);
                 }
             }
 
             return null;
         }
 
-        public void AppendBuffer<T>(int Track, long Tag, T[] Buffer) where T : struct
+        /// <summary>
+        /// Appends an audio buffer to the specified track
+        /// </summary>
+        /// <typeparam name="T">The sample type of the buffer</typeparam>
+        /// <param name="trackId">The track to append the buffer to</param>
+        /// <param name="bufferTag">The internal tag of the buffer</param>
+        /// <param name="buffer">The buffer to append to the track</param>
+        public void AppendBuffer<T>(int trackId, long bufferTag, T[] buffer) where T : struct
         {
-            if (Tracks.TryGetValue(Track, out Track Td))
+            if (_tracks.TryGetValue(trackId, out OpenALAudioTrack track))
             {
-                lock (Td)
+                lock (track)
                 {
-                    int BufferId = Td.AppendBuffer(Tag);
+                    int bufferId = track.AppendBuffer(bufferTag);
 
-                    int Size = Buffer.Length * Marshal.SizeOf<T>();
+                    int size = buffer.Length * Marshal.SizeOf<T>();
 
-                    AL.BufferData<T>(BufferId, Td.Format, Buffer, Size, Td.SampleRate);
+                    AL.BufferData(bufferId, track.Format, buffer, size, track.SampleRate);
 
-                    AL.SourceQueueBuffer(Td.SourceId, BufferId);
+                    AL.SourceQueueBuffer(track.SourceId, bufferId);
 
-                    StartPlaybackIfNeeded(Td);
+                    StartPlaybackIfNeeded(track);
                 }
             }
         }
 
-        public void Start(int Track)
+        /// <summary>
+        /// Starts playback
+        /// </summary>
+        /// <param name="trackId">The ID of the track to start playback on</param>
+        public void Start(int trackId)
         {
-            if (Tracks.TryGetValue(Track, out Track Td))
+            if (_tracks.TryGetValue(trackId, out OpenALAudioTrack track))
             {
-                lock (Td)
+                lock (track)
                 {
-                    Td.State = PlaybackState.Playing;
+                    track.State = PlaybackState.Playing;
 
-                    StartPlaybackIfNeeded(Td);
+                    StartPlaybackIfNeeded(track);
                 }
             }
         }
 
-        private void StartPlaybackIfNeeded(Track Td)
+        private void StartPlaybackIfNeeded(OpenALAudioTrack track)
         {
-            AL.GetSource(Td.SourceId, ALGetSourcei.SourceState, out int StateInt);
+            AL.GetSource(track.SourceId, ALGetSourcei.SourceState, out int stateInt);
 
-            ALSourceState State = (ALSourceState)StateInt;
+            ALSourceState State = (ALSourceState)stateInt;
 
-            if (State != ALSourceState.Playing && Td.State == PlaybackState.Playing)
+            if (State != ALSourceState.Playing && track.State == PlaybackState.Playing)
             {
-                AL.SourcePlay(Td.SourceId);
+                AL.Source(track.SourceId, ALSourcef.Gain, _volume);
+
+                AL.SourcePlay(track.SourceId);
             }
         }
 
-        public void Stop(int Track)
+        /// <summary>
+        /// Stops playback
+        /// </summary>
+        /// <param name="trackId">The ID of the track to stop playback on</param>
+        public void Stop(int trackId)
         {
-            if (Tracks.TryGetValue(Track, out Track Td))
+            if (_tracks.TryGetValue(trackId, out OpenALAudioTrack track))
             {
-                lock (Td)
+                lock (track)
                 {
-                    Td.State = PlaybackState.Stopped;
+                    track.State = PlaybackState.Stopped;
 
-                    AL.SourceStop(Td.SourceId);
+                    AL.SourceStop(track.SourceId);
                 }
             }
         }
 
-        public PlaybackState GetState(int Track)
+        /// <summary>
+        /// Get playback volume
+        /// </summary>
+        public float GetVolume() => _volume;
+
+        /// <summary>
+        /// Set playback volume
+        /// </summary>
+        /// <param name="volume">The volume of the playback</param>
+        public void SetVolume(float volume)
         {
-            if (Tracks.TryGetValue(Track, out Track Td))
+            _volume = Math.Clamp(_volume - (_volume * volume), 0.0f, 1.0f);
+        }
+
+        /// <summary>
+        /// Gets the current playback state of the specified track
+        /// </summary>
+        /// <param name="trackId">The track to retrieve the playback state for</param>
+        public PlaybackState GetState(int trackId)
+        {
+            if (_tracks.TryGetValue(trackId, out OpenALAudioTrack track))
             {
-                return Td.State;
+                return track.State;
             }
 
             return PlaybackState.Stopped;
@@ -358,11 +287,11 @@ namespace Ryujinx.Audio
             Dispose(true);
         }
 
-        protected virtual void Dispose(bool Disposing)
+        protected virtual void Dispose(bool disposing)
         {
-            if (Disposing)
+            if (disposing)
             {
-                KeepPolling = false;
+                _keepPolling = false;
             }
         }
     }

--- a/Ryujinx.Audio/Renderers/OpenAL/OpenALAudioOut.cs
+++ b/Ryujinx.Audio/Renderers/OpenAL/OpenALAudioOut.cs
@@ -272,16 +272,12 @@ namespace Ryujinx.Audio
         /// <summary>
         /// Set playback volume
         /// </summary>
-        /// <param name="gain">The gain of the playback</param>
-        public void SetVolume(float gain)
+        /// <param name="volume">The volume of the playback</param>
+        public void SetVolume(float volume)
         {
             if (!_volumeChanged)
             {
-                // Games send a gain value here, so we need to apply it on the current volume value.
-                // In that way we have to multiply the gain by the volume to get the real gain value.
-                // And then we substract the real gain value to our current volume value.
-                _volume = Math.Clamp(_volume - (_volume * gain), 0.0f, 1.0f);
-
+                _volume        = volume;
                 _volumeChanged = true;
             }
         }

--- a/Ryujinx.Audio/Renderers/OpenAL/OpenALAudioTrack.cs
+++ b/Ryujinx.Audio/Renderers/OpenAL/OpenALAudioTrack.cs
@@ -1,0 +1,142 @@
+﻿using OpenTK.Audio.OpenAL;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace Ryujinx.Audio
+{
+    internal class OpenALAudioTrack : IDisposable
+    {
+        public int           SourceId   { get; private set; }
+        public int           SampleRate { get; private set; }
+        public ALFormat      Format     { get; private set; }
+        public PlaybackState State      { get; set; }
+
+        private ReleaseCallback _callback;
+
+        private ConcurrentDictionary<long, int> _buffers;
+
+        private Queue<long> _queuedTagsQueue;
+        private Queue<long> _releasedTagsQueue;
+
+        private bool _disposed;
+
+        public OpenALAudioTrack(int sampleRate, ALFormat format, ReleaseCallback callback)
+        {
+            SampleRate = sampleRate;
+            Format     = format;
+            State      = PlaybackState.Stopped;
+            SourceId   = AL.GenSource();
+
+            _callback = callback;
+
+            _buffers = new ConcurrentDictionary<long, int>();
+
+            _queuedTagsQueue   = new Queue<long>();
+            _releasedTagsQueue = new Queue<long>();
+        }
+
+        public bool ContainsBuffer(long tag)
+        {
+            foreach (long queuedTag in _queuedTagsQueue)
+            {
+                if (queuedTag == tag)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public long[] GetReleasedBuffers(int count)
+        {
+            AL.GetSource(SourceId, ALGetSourcei.BuffersProcessed, out int releasedCount);
+
+            releasedCount += _releasedTagsQueue.Count;
+
+            if (count > releasedCount)
+            {
+                count = releasedCount;
+            }
+
+            List<long> tags = new List<long>();
+
+            while (count-- > 0 && _releasedTagsQueue.TryDequeue(out long tag))
+            {
+                tags.Add(tag);
+            }
+
+            while (count-- > 0 && _queuedTagsQueue.TryDequeue(out long tag))
+            {
+                AL.SourceUnqueueBuffers(SourceId, 1);
+
+                tags.Add(tag);
+            }
+
+            return tags.ToArray();
+        }
+
+        public int AppendBuffer(long tag)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(GetType().Name);
+            }
+
+            int id = AL.GenBuffer();
+
+            _buffers.AddOrUpdate(tag, id, (key, oldId) =>
+            {
+                AL.DeleteBuffer(oldId);
+
+                return id;
+            });
+
+            _queuedTagsQueue.Enqueue(tag);
+
+            return id;
+        }
+
+        public void CallReleaseCallbackIfNeeded()
+        {
+            AL.GetSource(SourceId, ALGetSourcei.BuffersProcessed, out int releasedCount);
+
+            if (releasedCount > 0)
+            {
+                // NOTE: If we signal, then we also need to have released buffers available
+                // to return when GetReleasedBuffers is called.
+                // If playback needs to be re-started due to all buffers being processed,
+                // then OpenAL zeros the counts (ReleasedCount), so we keep it on the queue.
+                while (releasedCount-- > 0 && _queuedTagsQueue.TryDequeue(out long tag))
+                {
+                    AL.SourceUnqueueBuffers(SourceId, 1);
+
+                    _releasedTagsQueue.Enqueue(tag);
+                }
+
+                _callback();
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing && !_disposed)
+            {
+                _disposed = true;
+
+                AL.DeleteSource(SourceId);
+
+                foreach (int id in _buffers.Values)
+                {
+                    AL.DeleteBuffer(id);
+                }
+            }
+        }
+    }
+}

--- a/Ryujinx.Audio/Renderers/OpenAL/OpenALAudioTrack.cs
+++ b/Ryujinx.Audio/Renderers/OpenAL/OpenALAudioTrack.cs
@@ -104,7 +104,7 @@ namespace Ryujinx.Audio
 
             if (releasedCount > 0)
             {
-                // NOTE: If we signal, then we also need to have released buffers available
+                // If we signal, then we also need to have released buffers available
                 // to return when GetReleasedBuffers is called.
                 // If playback needs to be re-started due to all buffers being processed,
                 // then OpenAL zeros the counts (ReleasedCount), so we keep it on the queue.

--- a/Ryujinx.Audio/Renderers/SoundIo/SoundIoAudioOut.cs
+++ b/Ryujinx.Audio/Renderers/SoundIo/SoundIoAudioOut.cs
@@ -193,16 +193,12 @@ namespace Ryujinx.Audio
         /// <summary>
         /// Set playback volume
         /// </summary>
-        /// <param name="gain">The gain of the playback</param>
-        public void SetVolume(float gain)
+        /// <param name="volume">The volume of the playback</param>
+        public void SetVolume(float volume)
         {
             if (!_volumeChanged)
             {
-                // Games send a gain value here, so we need to apply it on the current volume value.
-                // In that way we have to multiply the gain by the volume to get the real gain value.
-                // And then we substract the real gain value to our current volume value.
-                _volume = Math.Clamp(_volume - (_volume * gain), 0.0f, 1.0f);
-
+                _volume        = volume;
                 _volumeChanged = true;
             }
         }

--- a/Ryujinx.Audio/Renderers/SoundIo/SoundIoAudioOut.cs
+++ b/Ryujinx.Audio/Renderers/SoundIo/SoundIoAudioOut.cs
@@ -1,5 +1,6 @@
 ﻿using Ryujinx.Audio.SoundIo;
 using SoundIOSharp;
+using System;
 using System.Collections.Generic;
 
 namespace Ryujinx.Audio
@@ -15,22 +16,27 @@ namespace Ryujinx.Audio
         private const int MaximumTracks = 256;
 
         /// <summary>
+        /// The volume of audio renderer
+        /// </summary>
+        private float _volume = 1.0f;
+
+        /// <summary>
         /// The <see cref="SoundIO"/> audio context
         /// </summary>
-        private SoundIO m_AudioContext;
+        private SoundIO _audioContext;
 
         /// <summary>
         /// The <see cref="SoundIODevice"/> audio device
         /// </summary>
-        private SoundIODevice m_AudioDevice;
+        private SoundIODevice _audioDevice;
 
         /// <summary>
         /// An object pool containing <see cref="SoundIoAudioTrack"/> objects
         /// </summary>
-        private SoundIoAudioTrackPool m_TrackPool;
+        private SoundIoAudioTrackPool _trackPool;
 
         /// <summary>
-        /// True if SoundIO is supported on the device.
+        /// True if SoundIO is supported on the device
         /// </summary>
         public static bool IsSupported
         {
@@ -45,27 +51,13 @@ namespace Ryujinx.Audio
         /// </summary>
         public SoundIoAudioOut()
         {
-            m_AudioContext = new SoundIO();
+            _audioContext = new SoundIO();
 
-            m_AudioContext.Connect();
-            m_AudioContext.FlushEvents();
+            _audioContext.Connect();
+            _audioContext.FlushEvents();
 
-            m_AudioDevice = FindNonRawDefaultAudioDevice(m_AudioContext, true);
-            m_TrackPool = new SoundIoAudioTrackPool(m_AudioContext, m_AudioDevice, MaximumTracks);
-        }
-
-        /// <summary>
-        /// Gets the current playback state of the specified track
-        /// </summary>
-        /// <param name="trackId">The track to retrieve the playback state for</param>
-        public PlaybackState GetState(int trackId)
-        {
-            if (m_TrackPool.TryGet(trackId, out SoundIoAudioTrack track))
-            {
-                return track.State;
-            }
-
-            return PlaybackState.Stopped;
+            _audioDevice = FindNonRawDefaultAudioDevice(_audioContext, true);
+            _trackPool   = new SoundIoAudioTrackPool(_audioContext, _audioDevice, MaximumTracks);
         }
 
         /// <summary>
@@ -77,12 +69,12 @@ namespace Ryujinx.Audio
         /// <returns>The created track's Track ID</returns>
         public int OpenTrack(int sampleRate, int channels, ReleaseCallback callback)
         {
-            if (!m_TrackPool.TryGet(out SoundIoAudioTrack track))
+            if (!_trackPool.TryGet(out SoundIoAudioTrack track))
             {
                 return -1;
             }
 
-            // Open the output. We currently only support 16-bit signed LE
+            // NOTE: Open the output. We currently only support 16-bit signed LE
             track.Open(sampleRate, channels, callback, SoundIOFormat.S16LE);
 
             return track.TrackID;
@@ -94,53 +86,13 @@ namespace Ryujinx.Audio
         /// <param name="trackId">The ID of the track to close</param>
         public void CloseTrack(int trackId)
         {
-            if (m_TrackPool.TryGet(trackId, out SoundIoAudioTrack track))
+            if (_trackPool.TryGet(trackId, out SoundIoAudioTrack track))
             {
-                // Close and dispose of the track
+                // NOTE: Close and dispose of the track
                 track.Close();
 
-                // Recycle the track back into the pool
-                m_TrackPool.Put(track);
-            }
-        }
-
-        /// <summary>
-        /// Starts playback
-        /// </summary>
-        /// <param name="trackId">The ID of the track to start playback on</param>
-        public void Start(int trackId)
-        {
-            if (m_TrackPool.TryGet(trackId, out SoundIoAudioTrack track))
-            {
-                track.Start();
-            }
-        }
-
-        /// <summary>
-        /// Stops playback
-        /// </summary>
-        /// <param name="trackId">The ID of the track to stop playback on</param>
-        public void Stop(int trackId)
-        {
-            if (m_TrackPool.TryGet(trackId, out SoundIoAudioTrack track))
-            {
-                track.Stop();
-            }
-        }
-
-        /// <summary>
-        /// Appends an audio buffer to the specified track
-        /// </summary>
-        /// <typeparam name="T">The sample type of the buffer</typeparam>
-        /// <param name="trackId">The track to append the buffer to</param>
-        /// <param name="bufferTag">The internal tag of the buffer</param>
-        /// <param name="buffer">The buffer to append to the track</param>
-        public void AppendBuffer<T>(int trackId, long bufferTag, T[] buffer)
-            where T : struct
-        {
-            if (m_TrackPool.TryGet(trackId, out SoundIoAudioTrack track))
-            {
-                track.AppendBuffer(bufferTag, buffer);
+                // NOTE: Recycle the track back into the pool
+                _trackPool.Put(track);
             }
         }
 
@@ -151,7 +103,7 @@ namespace Ryujinx.Audio
         /// <param name="bufferTag">The buffer tag to check</param>
         public bool ContainsBuffer(int trackId, long bufferTag)
         {
-            if (m_TrackPool.TryGet(trackId, out SoundIoAudioTrack track))
+            if (_trackPool.TryGet(trackId, out SoundIoAudioTrack track))
             {
                 return track.ContainsBuffer(bufferTag);
             }
@@ -167,7 +119,7 @@ namespace Ryujinx.Audio
         /// <returns>Buffers released by the specified track</returns>
         public long[] GetReleasedBuffers(int trackId, int maxCount)
         {
-            if (m_TrackPool.TryGet(trackId, out SoundIoAudioTrack track))
+            if (_trackPool.TryGet(trackId, out SoundIoAudioTrack track))
             {
                 List<long> bufferTags = new List<long>();
 
@@ -183,13 +135,81 @@ namespace Ryujinx.Audio
         }
 
         /// <summary>
+        /// Appends an audio buffer to the specified track
+        /// </summary>
+        /// <typeparam name="T">The sample type of the buffer</typeparam>
+        /// <param name="trackId">The track to append the buffer to</param>
+        /// <param name="bufferTag">The internal tag of the buffer</param>
+        /// <param name="buffer">The buffer to append to the track</param>
+        public void AppendBuffer<T>(int trackId, long bufferTag, T[] buffer) where T : struct
+        {
+            if (_trackPool.TryGet(trackId, out SoundIoAudioTrack track))
+            {
+                track.AudioStream.SetVolume(_volume);
+                track.AppendBuffer(bufferTag, buffer);
+            }
+        }
+
+        /// <summary>
+        /// Starts playback
+        /// </summary>
+        /// <param name="trackId">The ID of the track to start playback on</param>
+        public void Start(int trackId)
+        {
+            if (_trackPool.TryGet(trackId, out SoundIoAudioTrack track))
+            {
+                track.Start();
+            }
+        }
+
+        /// <summary>
+        /// Stops playback
+        /// </summary>
+        /// <param name="trackId">The ID of the track to stop playback on</param>
+        public void Stop(int trackId)
+        {
+            if (_trackPool.TryGet(trackId, out SoundIoAudioTrack track))
+            {
+                track.Stop();
+            }
+        }
+
+        /// <summary>
+        /// Get playback volume
+        /// </summary>
+        public float GetVolume() => _volume;
+
+        /// <summary>
+        /// Set playback volume
+        /// </summary>
+        /// <param name="volume">The volume of the playback</param>
+        public void SetVolume(float volume)
+        {
+            _volume = Math.Clamp(_volume - (_volume * volume), 0.0f, 1.0f);
+        }
+
+        /// <summary>
+        /// Gets the current playback state of the specified track
+        /// </summary>
+        /// <param name="trackId">The track to retrieve the playback state for</param>
+        public PlaybackState GetState(int trackId)
+        {
+            if (_trackPool.TryGet(trackId, out SoundIoAudioTrack track))
+            {
+                return track.State;
+            }
+
+            return PlaybackState.Stopped;
+        }
+
+        /// <summary>
         /// Releases the unmanaged resources used by the <see cref="SoundIoAudioOut" />
         /// </summary>
         public void Dispose()
         {
-            m_TrackPool.Dispose();
-            m_AudioContext.Disconnect();
-            m_AudioContext.Dispose();
+            _trackPool.Dispose();
+            _audioContext.Disconnect();
+            _audioContext.Dispose();
         }
 
         /// <summary>
@@ -233,10 +253,12 @@ namespace Ryujinx.Audio
 
             try
             {
-                context = new SoundIO();
-
-                context.OnBackendDisconnect = (i) => {
-                    backendDisconnected = true;
+                context = new SoundIO
+                {
+                    OnBackendDisconnect = (i) =>
+                    {
+                        backendDisconnected = true;
+                    }
                 };
 
                 context.Connect();

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioOutManager/IAudioOut.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioOutManager/IAudioOut.cs
@@ -147,6 +147,28 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioOutManager
             return ResultCode.Success;
         }
 
+        [Command(12)] // 6.0.0+
+        // SetAudioOutVolume(s32)
+        public ResultCode SetAudioOutVolume(ServiceCtx context)
+        {
+            float volume = context.RequestData.ReadSingle();
+
+            _audioOut.SetVolume(volume);
+
+            return ResultCode.Success;
+        }
+
+        [Command(13)] // 6.0.0+
+        // GetAudioOutVolume() -> s32
+        public ResultCode GetAudioOutVolume(ServiceCtx context)
+        {
+            float volume = _audioOut.GetVolume();
+
+            context.ResponseData.Write(volume);
+
+            return ResultCode.Success;
+        }
+
         public void Dispose()
         {
             Dispose(true);

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioOutManager/IAudioOut.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioOutManager/IAudioOut.cs
@@ -151,9 +151,13 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioOutManager
         // SetAudioOutVolume(s32)
         public ResultCode SetAudioOutVolume(ServiceCtx context)
         {
-            float volume = context.RequestData.ReadSingle();
+            // Games send a gain value here, so we need to apply it on the current volume value.
 
-            _audioOut.SetVolume(volume);
+            float gain          = context.RequestData.ReadSingle();
+            float currentVolume = _audioOut.GetVolume();
+            float newVolume     = Math.Clamp(currentVolume + gain, 0.0f, 1.0f);
+
+            _audioOut.SetVolume(newVolume);
 
             return ResultCode.Success;
         }


### PR DESCRIPTION
- Implementation of `audout:u` SetAudioOutVolume and GetAudioOutVolume (checked with RE). 
- Add Get and Set for Volume into audio backends.
- Cleanup of all audio backends to follow the `IAalOutput` structure and .NET standard.
- Split OpenAL backend into 2 files for consistency.

close #777.