### PR TITLE
ipc: Fix error code returned by CloseSession

### DIFF
--- a/Ryujinx.HLE/HOS/Ipc/IpcHandler.cs
+++ b/Ryujinx.HLE/HOS/Ipc/IpcHandler.cs
@@ -96,6 +96,7 @@ namespace Ryujinx.HLE.HOS.Ipc
                 else if (request.Type == IpcMessageType.CloseSession)
                 {
                     // TODO
+                    return KernelResult.PortRemoteClosed;
                 }
                 else
                 {


### PR DESCRIPTION
When we close a session via IPC, we should return an error code.

This fix an assert in some games that are shipped with debug modules.