### PR TITLE
Fix behaviour when an analog trigger is assigned to a button.

### DIFF
--- a/Ryujinx/Ui/NpadController.cs
+++ b/Ryujinx/Ui/NpadController.cs
@@ -170,7 +170,7 @@ namespace Ryujinx.UI.Input
             {
                 int axis = controllerInputId - ControllerInputId.Axis0;
 
-                return Math.Abs(joystickState.GetAxis(axis)) > Deadzone;
+                return joystickState.GetAxis(axis) > TriggerThreshold;
             }
             else if (controllerInputId <= ControllerInputId.Hat2Right)
             {


### PR DESCRIPTION
This PR fixes the behaviour when a button is set to an analog input, such as an analog trigger. 

Before, IsActivated would return true if abs(value) were greater than Deadzone, which matches behaviour for analog stick deadzone. For buttons (the only use of IsActivated), this returns true when the value is Deadzone away from 0.

However, analog _triggers_ on controllers like the Xbox 360 actually have -1 for off, and 1 for on. That means that by default, the buttons were activating whenever the trigger was not half pressed. That, and the "TriggerThreshold" variable in config was not being used at all.

Note that there is still a use case where a button could be assigned to a specific analog _stick_ direction, eg. dpad right to analog horizontal +, but you couldn't do that before as you weren't able to specify a direction. That's work for the future.

Testing config:
```json
    "joystick_controls": {
        "enabled": true,
        "index": 0,
        "deadzone": 0.05,
        "trigger_threshold": 0.5,
        "left_joycon": {
            "stick": "Axis0",
            "stick_button": "Button8",
            "button_minus": "Button6",
            "button_l": "Button4",
            "button_zl": "Axis2",
            "dpad_up": "Hat0Up",
            "dpad_down": "Hat0Down",
            "dpad_left": "Hat0Left",
            "dpad_right": "Hat0Right"
        },
        "right_joycon": {
            "stick": "Axis3",
            "stick_y": "Button0",
            "stick_button": "Button9",
            "button_a": "Button0",
            "button_b": "Button1",
            "button_x": "Button2",
            "button_y": "Button3",
            "button_plus": "Button7",
            "button_r": "Button5",
            "button_zr": "Axis5"
        }
    }
```