### PR TITLE
System firmware installer

### DIFF
--- a/Ryujinx.HLE/Exceptions/InvalidFirmwarePackageException.cs
+++ b/Ryujinx.HLE/Exceptions/InvalidFirmwarePackageException.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Ryujinx.HLE.Exceptions
+{
+    class InvalidFirmwarePackageException : Exception
+    {
+        public InvalidFirmwarePackageException(string message) : base(message) { }
+    }
+}

--- a/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
+++ b/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
@@ -1,10 +1,9 @@
 using LibHac;
 using LibHac.Fs;
-using LibHac.FsService;
 using LibHac.FsSystem;
 using LibHac.FsSystem.NcaUtils;
 using LibHac.Ncm;
-using Ryujinx.HLE.HOS.Font;
+using Ryujinx.HLE.Exceptions;
 using Ryujinx.HLE.HOS.Services.Time;
 using Ryujinx.HLE.Utilities;
 using System;
@@ -12,8 +11,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
-
-using static Ryujinx.Common.HexUtils;
 
 namespace Ryujinx.HLE.FileSystem.Content
 {
@@ -367,7 +364,7 @@ namespace Ryujinx.HLE.FileSystem.Content
                         InstallFromCart(xci, temporaryDirectory);
                         break;
                     default:
-                        throw new FormatException("Input file is not a valid firmware package");
+                        throw new InvalidFirmwarePackageException("Input file is not a valid firmware package");
                 }
 
                 FinishInstallation(temporaryDirectory, registeredDirectory);
@@ -523,7 +520,10 @@ namespace Ryujinx.HLE.FileSystem.Content
                             return VerifyAndGetVersion(partition);
                         }
                         else
-                            throw new InvalidDataException("Update not found in xci file.");
+                        {
+                            throw new InvalidFirmwarePackageException("Update not found in xci file.");
+                        }
+
                     default:
                         break;
                 }
@@ -684,7 +684,7 @@ namespace Ryujinx.HLE.FileSystem.Content
                             }
                         }
 
-                        throw new InvalidDataException($"Firmware package contains unrelated archives. Please remove these paths: \n{extraNcas}");
+                        throw new InvalidFirmwarePackageException($"Firmware package contains unrelated archives. Please remove these paths: \n{extraNcas}");
                     }
                 }
                 else
@@ -815,7 +815,7 @@ namespace Ryujinx.HLE.FileSystem.Content
                         }
                     }
 
-                    throw new InvalidDataException($"Firmware package contains unrelated archives. Please remove these paths: \n{extraNcas}");
+                    throw new InvalidFirmwarePackageException($"Firmware package contains unrelated archives. Please remove these paths: \n{extraNcas}");
                 }
 
                 return systemVersion;

--- a/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
+++ b/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
@@ -523,7 +523,6 @@ namespace Ryujinx.HLE.FileSystem.Content
                         {
                             throw new InvalidFirmwarePackageException("Update not found in xci file.");
                         }
-
                     default:
                         break;
                 }
@@ -684,7 +683,7 @@ namespace Ryujinx.HLE.FileSystem.Content
                             }
                         }
 
-                        throw new InvalidFirmwarePackageException($"Firmware package contains unrelated archives. Please remove these paths: \n{extraNcas}");
+                        throw new InvalidFirmwarePackageException($"Firmware package contains unrelated archives. Please remove these paths: {Environment.NewLine}{extraNcas}");
                     }
                 }
                 else
@@ -815,7 +814,7 @@ namespace Ryujinx.HLE.FileSystem.Content
                         }
                     }
 
-                    throw new InvalidFirmwarePackageException($"Firmware package contains unrelated archives. Please remove these paths: \n{extraNcas}");
+                    throw new InvalidFirmwarePackageException($"Firmware package contains unrelated archives. Please remove these paths: {Environment.NewLine}{extraNcas}");
                 }
 
                 return systemVersion;

--- a/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
+++ b/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
@@ -56,7 +56,7 @@ namespace Ryujinx.HLE.FileSystem.Content
             _device = device;
         }
 
-        public void LoadEntries()
+        public void LoadEntries(bool ignoreMissingFonts = false)
         {
             _contentDictionary = new SortedDictionary<(ulong, NcaContentType), string>();
             _locationEntries   = new Dictionary<StorageId, LinkedList<LocationEntry>>();
@@ -154,7 +154,7 @@ namespace Ryujinx.HLE.FileSystem.Content
 
             TimeManager.Instance.InitializeTimeZone(_device);
 
-            _device.System.Font.Initialize(this);
+            _device.System.Font.Initialize(this, ignoreMissingFonts);
         }
 
         public void ClearEntry(long titleId, NcaContentType contentType, StorageId storageId)
@@ -815,7 +815,7 @@ namespace Ryujinx.HLE.FileSystem.Content
 
         public SystemVersion GetCurrentFirmwareVersion()
         {
-            LoadEntries();
+            LoadEntries(true);
 
             var locationEnties = _locationEntries[StorageId.NandSystem];
 

--- a/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
+++ b/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
@@ -746,11 +746,20 @@ namespace Ryujinx.HLE.FileSystem.Content
                 {
                     if (updateNcas.TryGetValue(metaEntry.TitleId, out var ncaEntry))
                     {
-                        var metaNcaEntry    = ncaEntry.Find(x => x.Item1 == NcaContentType.Meta);
-                        var contentNcaEntry = ncaEntry.Find(x => x.Item1 != NcaContentType.Meta);
+                        var metaNcaEntry   = ncaEntry.Find(x => x.Item1 == NcaContentType.Meta);
+                        string contentPath = ncaEntry.Find(x => x.Item1 != NcaContentType.Meta).Item2;
+
+
+                        // Nintendo in 9.0.0, removed PPC and only kept the meta nca of it.
+                        // This is a perfect valid case, so we should just ignore the missing content nca and continue.
+                        if (contentPath == null)
+                        {
+                            updateNcas.Remove(metaEntry.TitleId);
+                            continue;
+                        }
 
                         IStorage metaStorage = OpenPossibleFragmentedFile(filesystem, metaNcaEntry.Item2, OpenMode.Read).AsStorage();
-                        IStorage contentStorage = OpenPossibleFragmentedFile(filesystem, contentNcaEntry.Item2, OpenMode.Read).AsStorage();
+                        IStorage contentStorage = OpenPossibleFragmentedFile(filesystem, contentPath, OpenMode.Read).AsStorage();
 
                         Nca metaNca = new Nca(_device.System.KeySet, metaStorage);
 

--- a/Ryujinx.HLE/FileSystem/Content/SystemVersion.cs
+++ b/Ryujinx.HLE/FileSystem/Content/SystemVersion.cs
@@ -6,19 +6,19 @@ namespace Ryujinx.HLE.FileSystem.Content
 {
     public class SystemVersion
     {
-        public byte   Major          { get; set; }
-        public byte   Minor          { get; set; }
-        public byte   Micro          { get; set; }
-        public byte   RevisionMajor  { get; set; }
-        public byte   RevisionMinor  { get; set; }
-        public string PlatformString { get; set; }
-        public string Hex            { get; set; }
-        public string VersionString  { get; set; }
-        public string VersionTitle   { get; set; }
+        public byte   Major          { get; }
+        public byte   Minor          { get; }
+        public byte   Micro          { get; }
+        public byte   RevisionMajor  { get; }
+        public byte   RevisionMinor  { get; }
+        public string PlatformString { get; }
+        public string Hex            { get; }
+        public string VersionString  { get; }
+        public string VersionTitle   { get; }
 
         public SystemVersion(Stream systemVersionFile)
         {
-            using(BinaryReader reader = new BinaryReader(systemVersionFile))
+            using (BinaryReader reader = new BinaryReader(systemVersionFile))
             {
                 Major = reader.ReadByte();
                 Minor = reader.ReadByte();

--- a/Ryujinx.HLE/FileSystem/Content/SystemVersion.cs
+++ b/Ryujinx.HLE/FileSystem/Content/SystemVersion.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace Ryujinx.HLE.FileSystem.Content
+{
+    public class SystemVersion
+    {
+        public byte   Major          { get; set; }
+        public byte   Minor          { get; set; }
+        public byte   Micro          { get; set; }
+        public byte   RevisionMajor  { get; set; }
+        public byte   RevisionMinor  { get; set; }
+        public string PlatformString { get; set; }
+        public string Hex            { get; set; }
+        public string VersionString  { get; set; }
+        public string VersionTitle   { get; set; }
+
+        public SystemVersion(Stream systemVersionFile)
+        {
+            using(BinaryReader reader = new BinaryReader(systemVersionFile))
+            {
+                Major = reader.ReadByte();
+                Minor = reader.ReadByte();
+                Micro = reader.ReadByte();
+
+                reader.ReadByte(); // Padding
+
+                RevisionMajor = reader.ReadByte();
+                RevisionMinor = reader.ReadByte();
+
+                reader.ReadBytes(2); // Padding
+
+                PlatformString = Encoding.ASCII.GetString(reader.ReadBytes(0x20)).TrimEnd('\0');
+                Hex            = Encoding.ASCII.GetString(reader.ReadBytes(0x40)).TrimEnd('\0');
+                VersionString  = Encoding.ASCII.GetString(reader.ReadBytes(0x18)).TrimEnd('\0');
+                VersionTitle   = Encoding.ASCII.GetString(reader.ReadBytes(0x80)).TrimEnd('\0');
+            }
+        }
+    }
+}

--- a/Ryujinx.HLE/HOS/Font/SharedFontManager.cs
+++ b/Ryujinx.HLE/HOS/Font/SharedFontManager.cs
@@ -120,7 +120,7 @@ namespace Ryujinx.HLE.HOS.Font
 
                         return info;
                     }
-                    else if(!ignoreMissingFonts)
+                    else if (!ignoreMissingFonts)
                     {
                         throw new InvalidSystemResourceException($"Font \"{name}.ttf\" not found. Please provide it in \"{_fontsPath}\".");
                     }

--- a/Ryujinx.HLE/HOS/Font/SharedFontManager.cs
+++ b/Ryujinx.HLE/HOS/Font/SharedFontManager.cs
@@ -44,15 +44,15 @@ namespace Ryujinx.HLE.HOS.Font
             _fontsPath = Path.Combine(device.FileSystem.GetSystemPath(), "fonts");
         }
 
-        public void Initialize(ContentManager contentManager)
+        public void Initialize(ContentManager contentManager, bool ignoreMissingFonts)
         {
             _fontData?.Clear();
             _fontData = null;
 
-            EnsureInitialized(contentManager);
+            EnsureInitialized(contentManager, ignoreMissingFonts);
         }
 
-        public void EnsureInitialized(ContentManager contentManager)
+        public void EnsureInitialized(ContentManager contentManager, bool ignoreMissingFonts)
         {
             if (_fontData == null)
             {
@@ -120,10 +120,12 @@ namespace Ryujinx.HLE.HOS.Font
 
                         return info;
                     }
-                    else
+                    else if(!ignoreMissingFonts)
                     {
                         throw new InvalidSystemResourceException($"Font \"{name}.ttf\" not found. Please provide it in \"{_fontsPath}\".");
                     }
+
+                    return new FontInfo();
                 }
 
                 _fontData = new Dictionary<SharedFontType, FontInfo>
@@ -136,7 +138,7 @@ namespace Ryujinx.HLE.HOS.Font
                     { SharedFontType.NintendoEx,          CreateFont("FontNintendoExtended")          }
                 };
 
-                if (fontOffset > Horizon.FontSize)
+                if (fontOffset > Horizon.FontSize && !ignoreMissingFonts)
                 {
                     throw new InvalidSystemResourceException(
                         $"The sum of all fonts size exceed the shared memory size. " +
@@ -159,14 +161,14 @@ namespace Ryujinx.HLE.HOS.Font
 
         public int GetFontSize(SharedFontType fontType)
         {
-            EnsureInitialized(_device.System.ContentManager);
+            EnsureInitialized(_device.System.ContentManager, false);
 
             return _fontData[fontType].Size;
         }
 
         public int GetSharedMemoryAddressOffset(SharedFontType fontType)
         {
-            EnsureInitialized(_device.System.ContentManager);
+            EnsureInitialized(_device.System.ContentManager, false);
 
             return _fontData[fontType].Offset + 8;
         }

--- a/Ryujinx.HLE/HOS/Font/SharedFontManager.cs
+++ b/Ryujinx.HLE/HOS/Font/SharedFontManager.cs
@@ -44,6 +44,14 @@ namespace Ryujinx.HLE.HOS.Font
             _fontsPath = Path.Combine(device.FileSystem.GetSystemPath(), "fonts");
         }
 
+        public void Initialize(ContentManager contentManager)
+        {
+            _fontData?.Clear();
+            _fontData = null;
+
+            EnsureInitialized(contentManager);
+        }
+
         public void EnsureInitialized(ContentManager contentManager)
         {
             if (_fontData == null)

--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -715,6 +715,21 @@ namespace Ryujinx.HLE.HOS
             }
         }
 
+        public SystemVersion VerifyFirmwarePackage(string firmwarePackage)
+        {
+            return ContentManager.VerifyFirmwarePackage(firmwarePackage);
+        }
+
+        public SystemVersion GetCurrentFirmwareVersion()
+        {
+            return ContentManager.GetCurrentFirmwareVersion();
+        }
+
+        public void InstallFirmware(string firmwarePackage)
+        {
+            ContentManager.InstallFirmware(firmwarePackage);
+        }
+
         public void SignalVsync()
         {
             VsyncEvent.ReadableEvent.Signal();

--- a/Ryujinx.HLE/HOS/Services/Sdb/Pl/ISharedFontManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Sdb/Pl/ISharedFontManager.cs
@@ -61,7 +61,7 @@ namespace Ryujinx.HLE.HOS.Services.Sdb.Pl
         // GetSharedMemoryNativeHandle() -> handle<copy>
         public ResultCode GetSharedMemoryNativeHandle(ServiceCtx context)
         {
-            context.Device.System.Font.EnsureInitialized(context.Device.System.ContentManager);
+            context.Device.System.Font.EnsureInitialized(context.Device.System.ContentManager, false);
 
             if (context.Process.HandleTable.GenerateHandle(context.Device.System.FontSharedMem, out int handle) != KernelResult.Success)
             {

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -59,6 +59,7 @@ namespace Ryujinx.Ui
         [GUI] TreeView      _gameTable;
         [GUI] TreeSelection _gameTableSelection;
         [GUI] Label         _progressLabel;
+        [GUI] Label         _firmwareVersionLabel;
         [GUI] LevelBar      _progressBar;
 #pragma warning restore CS0649
 #pragma warning restore IDE0044
@@ -137,6 +138,8 @@ namespace Ryujinx.Ui
 #pragma warning disable CS4014
             UpdateGameTable();
 #pragma warning restore CS4014
+
+            Task.Run(RefreshFirmwareLabel);
         }
 
         internal static void ApplyTheme()
@@ -592,6 +595,18 @@ namespace Ryujinx.Ui
             HandleInstallerDialog(directoryChooser);
         }
 
+        private void RefreshFirmwareLabel()
+        {
+            var currentFirmware = _device.System.GetCurrentFirmwareVersion();
+
+            GLib.Idle.Add(new GLib.IdleHandler(() =>
+            {
+                _firmwareVersionLabel.Text = currentFirmware != null ? currentFirmware.VersionString : "0.0.0";
+
+                return false;
+            }));
+        }
+
         private void HandleInstallerDialog(FileChooserDialog fileChooser)
         {
             if (fileChooser.Run() == (int)ResponseType.Accept)
@@ -629,7 +644,7 @@ namespace Ryujinx.Ui
 
                     if (currentVersion != null)
                     {
-                        dialogMessage += $"This will replace the current system version {currentVersion.VersionString}.";
+                        dialogMessage += $"This will replace the current system version {currentVersion.VersionString}. ";
                     }
 
                     dialogMessage += "Do you want to continue?";
@@ -694,7 +709,7 @@ namespace Ryujinx.Ui
                                     dialog.Text = $"Install Firmware {firmwareVersion.VersionString} Failed.";
 
                                     dialog.SecondaryText = $"An error occured while installing system version {firmwareVersion.VersionString}." +
-                                     "Please check logs for more info.";
+                                     " Please check logs for more info.";
 
                                     Logger.PrintError(LogClass.Application, ex.Message);
 
@@ -703,6 +718,10 @@ namespace Ryujinx.Ui
 
                                     return false;
                                 }));
+                            }
+                            finally
+                            {
+                                RefreshFirmwareLabel();
                             }
                         });
 

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -297,8 +297,8 @@ namespace Ryujinx.Ui
                 new Thread(CreateGameWindow).Start();
 #endif
 
-                _gameLoaded                = true;
-                _stopEmulation.Sensitive   = true;
+                _gameLoaded              = true;
+                _stopEmulation.Sensitive = true;
 
                 _firmwareInstallFile.Sensitive      = false;
                 _firmwareInstallDirectory.Sensitive = false;
@@ -565,12 +565,12 @@ namespace Ryujinx.Ui
         private void Installer_File_Pressed(object o, EventArgs args)
         {
             FileChooserDialog fileChooser = new FileChooserDialog("Choose the firmware file to open",
-                                                                    this,
-                                                                    FileChooserAction.Open,
-                                                                    "Cancel",
-                                                                    ResponseType.Cancel,
-                                                                    "Open",
-                                                                    ResponseType.Accept);
+                                                                  this,
+                                                                  FileChooserAction.Open,
+                                                                  "Cancel",
+                                                                  ResponseType.Cancel,
+                                                                  "Open",
+                                                                  ResponseType.Accept);
 
             fileChooser.Filter = new FileFilter();
             fileChooser.Filter.AddPattern("*.zip");
@@ -582,12 +582,12 @@ namespace Ryujinx.Ui
         private void Installer_Directory_Pressed(object o, EventArgs args)
         {
             FileChooserDialog directoryChooser = new FileChooserDialog("Choose the firmware directory to open",
-                                                                    this,
-                                                                    FileChooserAction.SelectFolder,
-                                                                    "Cancel",
-                                                                    ResponseType.Cancel,
-                                                                    "Open",
-                                                                    ResponseType.Accept);
+                                                                       this,
+                                                                       FileChooserAction.SelectFolder,
+                                                                       "Cancel",
+                                                                       ResponseType.Cancel,
+                                                                       "Open",
+                                                                       ResponseType.Accept);
 
             HandleInstallerDialog(directoryChooser);
         }
@@ -606,14 +606,9 @@ namespace Ryujinx.Ui
 
                     var firmwareVersion = _device.System.VerifyFirmwarePackage(filename);
 
-                    if(firmwareVersion == null)
+                    if (firmwareVersion == null)
                     {
-                        dialog = new MessageDialog(this,
-                                        DialogFlags.Modal,
-                                        MessageType.Info,
-                                        ButtonsType.Ok,
-                                        false,
-                                        "");
+                        dialog = new MessageDialog(this, DialogFlags.Modal, MessageType.Info, ButtonsType.Ok, false, "");
 
                         dialog.Text = "Firmware not found.";
 
@@ -622,31 +617,24 @@ namespace Ryujinx.Ui
                         Logger.PrintError(LogClass.Application, $"A valid system firmware was not found in {filename}.");
 
                         dialog.Run();
-
                         dialog.Hide();
-
                         dialog.Dispose();
 
                         return;
                     }
 
-                    var currentVersion  = _device.System.GetCurrentFirmwareVersion();
+                    var currentVersion = _device.System.GetCurrentFirmwareVersion();
 
-                    string dialogMessage = $"System version {firmwareVersion.VersionString} will be installed. ";
+                    string dialogMessage = $"System version {firmwareVersion.VersionString} will be installed.";
 
                     if (currentVersion != null)
                     {
-                        dialogMessage += $"This will replace the current system version {currentVersion.VersionString}. ";
+                        dialogMessage += $"This will replace the current system version {currentVersion.VersionString}.";
                     }
 
                     dialogMessage += "Do you want to continue?";
 
-                    dialog = new MessageDialog(this,
-                                    DialogFlags.Modal,
-                                    MessageType.Question,
-                                    ButtonsType.YesNo,
-                                    false,
-                                    "");
+                    dialog = new MessageDialog(this, DialogFlags.Modal, MessageType.Question, ButtonsType.YesNo, false, "");
 
                     dialog.Text = $"Install Firmware {firmwareVersion.VersionString}";
                     dialog.SecondaryText = dialogMessage;
@@ -655,12 +643,7 @@ namespace Ryujinx.Ui
 
                     dialog.Dispose();
 
-                    dialog = new MessageDialog(this,
-                                    DialogFlags.Modal,
-                                    MessageType.Info,
-                                    ButtonsType.None,
-                                    false,
-                                    "");
+                    dialog = new MessageDialog(this, DialogFlags.Modal, MessageType.Info, ButtonsType.None, false, "");
 
                     dialog.Text = $"Install Firmware {firmwareVersion.VersionString}";
 
@@ -686,12 +669,7 @@ namespace Ryujinx.Ui
                                 {
                                     dialog.Dispose();
 
-                                    dialog = new MessageDialog(this,
-                                                    DialogFlags.Modal,
-                                                    MessageType.Info,
-                                                    ButtonsType.Ok,
-                                                    false,
-                                                    "");
+                                    dialog = new MessageDialog(this, DialogFlags.Modal, MessageType.Info, ButtonsType.Ok, false, "");
 
                                     dialog.Text = $"Install Firmware {firmwareVersion.VersionString}";
 
@@ -707,17 +685,11 @@ namespace Ryujinx.Ui
                             }
                             catch (Exception ex)
                             {
-
                                 GLib.Idle.Add(new GLib.IdleHandler(() =>
                                 {
                                     dialog.Dispose();
 
-                                    dialog = new MessageDialog(this,
-                                                        DialogFlags.Modal,
-                                                        MessageType.Info,
-                                                        ButtonsType.Ok,
-                                                        false,
-                                                        "");
+                                    dialog = new MessageDialog(this, DialogFlags.Modal, MessageType.Info, ButtonsType.Ok, false, "");
 
                                     dialog.Text = $"Install Firmware {firmwareVersion.VersionString} Failed.";
 
@@ -725,8 +697,10 @@ namespace Ryujinx.Ui
                                      "Please check logs for more info.";
 
                                     Logger.PrintError(LogClass.Application, ex.Message);
+
                                     dialog.Run();
                                     dialog.Dispose();
+
                                     return false;
                                 }));
                             }
@@ -735,22 +709,18 @@ namespace Ryujinx.Ui
                         thread.Start();
                     }
                     else
+                    {
                         dialog.Dispose();
+                    }
                 }
                 catch (Exception ex)
                 {
-
                     if (dialog != null)
                     {
                         dialog.Dispose();
                     }
 
-                    dialog = new MessageDialog(this,
-                                                DialogFlags.Modal,
-                                                MessageType.Info,
-                                                ButtonsType.Ok,
-                                                false,
-                                                "");
+                    dialog = new MessageDialog(this, DialogFlags.Modal, MessageType.Info, ButtonsType.Ok, false, "");
 
                     dialog.Text = "Parsing Firmware Failed.";
 
@@ -759,7 +729,6 @@ namespace Ryujinx.Ui
                     Logger.PrintError(LogClass.Application, ex.Message);
 
                     dialog.Run();
-
                     dialog.Dispose();
                 }
             }

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -45,7 +45,8 @@ namespace Ryujinx.Ui
         [GUI] CheckMenuItem _fullScreen;
         [GUI] MenuItem      _stopEmulation;
         [GUI] CheckMenuItem _favToggle;
-        [GUI] MenuItem      _firmwareInstall;
+        [GUI] MenuItem      _firmwareInstallFile;
+        [GUI] MenuItem      _firmwareInstallDirectory;
         [GUI] CheckMenuItem _iconToggle;
         [GUI] CheckMenuItem _appToggle;
         [GUI] CheckMenuItem _developerToggle;
@@ -298,7 +299,9 @@ namespace Ryujinx.Ui
 
                 _gameLoaded                = true;
                 _stopEmulation.Sensitive   = true;
-                _firmwareInstall.Sensitive = false;
+
+                _firmwareInstallFile.Sensitive      = false;
+                _firmwareInstallDirectory.Sensitive = false;
 
                 DiscordIntegrationModule.SwitchToPlayingState(_device.System.TitleId, _device.System.TitleName);
 
@@ -558,18 +561,40 @@ namespace Ryujinx.Ui
 
             _gameLoaded = false;
         }
-        
-        private void Installer_Pressed(object o, EventArgs args)
+
+        private void Installer_File_Pressed(object o, EventArgs args)
         {
-            FileChooserDialog fileChooser = new FileChooserDialog("Choose the folder to open",
-                                                                    this, 
+            FileChooserDialog fileChooser = new FileChooserDialog("Choose the firmware file to open",
+                                                                    this,
                                                                     FileChooserAction.Open,
                                                                     "Cancel",
-                                                                    ResponseType.Cancel, 
+                                                                    ResponseType.Cancel,
                                                                     "Open",
                                                                     ResponseType.Accept);
-            
-            if(fileChooser.Run() == (int)ResponseType.Accept)
+
+            fileChooser.Filter = new FileFilter();
+            fileChooser.Filter.AddPattern("*.zip");
+            fileChooser.Filter.AddPattern("*.xci");
+
+            HandleInstallerDialog(fileChooser);
+        }
+
+        private void Installer_Directory_Pressed(object o, EventArgs args)
+        {
+            FileChooserDialog directoryChooser = new FileChooserDialog("Choose the firmware directory to open",
+                                                                    this,
+                                                                    FileChooserAction.SelectFolder,
+                                                                    "Cancel",
+                                                                    ResponseType.Cancel,
+                                                                    "Open",
+                                                                    ResponseType.Accept);
+
+            HandleInstallerDialog(directoryChooser);
+        }
+
+        private void HandleInstallerDialog(FileChooserDialog fileChooser)
+        {
+            if (fileChooser.Run() == (int)ResponseType.Accept)
             {
                 MessageDialog dialog = null;
 
@@ -581,7 +606,7 @@ namespace Ryujinx.Ui
 
                     var firmwareVersion = _device.System.VerifyFirmwarePackage(filename);
 
-                    if(firmwareVersion== null)
+                    if(firmwareVersion == null)
                     {
                         dialog = new MessageDialog(this,
                                         DialogFlags.Modal,

--- a/Ryujinx/Ui/MainWindow.glade
+++ b/Ryujinx/Ui/MainWindow.glade
@@ -268,12 +268,35 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <child>
-                      <object class="GtkMenuItem" id="_firmwareInstall">
+                      <object class="GtkMenuItem" id="FirmwareSubMenu">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="label" translatable="yes">Install Firmware</property>
                         <property name="use_underline">True</property>
-                        <signal name="activate" handler="Installer_Pressed" swapped="no"/>
+                        <child type="submenu">
+                          <object class="GtkMenu">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkMenuItem" id="_firmwareInstallFile">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Install a firmware from XCI or ZIP</property>
+                                <property name="use_underline">True</property>
+                                <signal name="activate" handler="Installer_File_Pressed" swapped="no"/>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkMenuItem" id="_firmwareInstallDirectory">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">Install a firmware from a directory</property>
+                                <property name="use_underline">True</property>
+                                <signal name="activate" handler="Installer_Directory_Pressed" swapped="no"/>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
                       </object>
                     </child>
                   </object>

--- a/Ryujinx/Ui/MainWindow.glade
+++ b/Ryujinx/Ui/MainWindow.glade
@@ -263,6 +263,21 @@
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Tools</property>
                 <property name="use_underline">True</property>
+                <child type="submenu">
+                  <object class="GtkMenu">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkMenuItem" id="_firmwareInstall">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Install Firmware</property>
+                        <property name="use_underline">True</property>
+                        <signal name="activate" handler="Installer_Pressed" swapped="no"/>
+                      </object>
+                    </child>
+                  </object>
+                </child>
               </object>
             </child>
             <child>

--- a/Ryujinx/Ui/MainWindow.glade
+++ b/Ryujinx/Ui/MainWindow.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.21.0 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkApplicationWindow" id="_mainWin">
@@ -8,9 +8,6 @@
     <property name="window_position">center</property>
     <property name="default_width">1280</property>
     <property name="default_height">750</property>
-    <child>
-      <placeholder/>
-    </child>
     <child>
       <object class="GtkBox" id="_box">
         <property name="visible">True</property>
@@ -408,7 +405,7 @@
                   <object class="GtkLabel" id="_progressLabel">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="margin_left">5</property>
+                    <property name="margin_left">10</property>
                     <property name="margin_right">5</property>
                     <property name="margin_top">2</property>
                     <property name="margin_bottom">2</property>
@@ -426,13 +423,64 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">start</property>
-                    <property name="margin_left">5</property>
+                    <property name="margin_left">10</property>
                     <property name="margin_right">5</property>
                   </object>
                   <packing>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
                     <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSeparator">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">5</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">System Version</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="_firmwareVersionLabel">
+                        <property name="width_request">50</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_left">5</property>
+                        <property name="margin_right">5</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="pack_type">end</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="pack_type">end</property>
+                    <property name="position">4</property>
                   </packing>
                 </child>
               </object>
@@ -450,6 +498,9 @@
           </packing>
         </child>
       </object>
+    </child>
+    <child type="titlebar">
+      <placeholder/>
     </child>
   </object>
 </interface>


### PR DESCRIPTION
This adds support for installing firmware backups and updates. Supported formats include a non-trimmed game card dump(XCI), a firmware update package in nsp format, or a zip archive of the system content registered directory from a switch. The installer can be access through the "Tools" menu. Do note, you would still need the necessary keys for the firmware you are installing.

This PR is ready for testing and reviews.