### PR TITLE
svc: Implement `ref` parameters

### DIFF
--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcTable.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcTable.cs
@@ -231,7 +231,16 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
 
                     if (!methodArgs[index].IsOut)
                     {
-                        throw new InvalidOperationException($"Method \"{svcName}\" has a invalid ref type \"{argType.Name}\".");
+                        generator.Emit(OpCodes.Ldarg_1);
+                        generator.Emit(OpCodes.Ldc_I4, index);
+
+                        MethodInfo info = typeof(IExecutionContext).GetMethod(nameof(IExecutionContext.GetX));
+
+                        generator.Emit(OpCodes.Call, info);
+
+                        ConvertToArgType(argType);
+
+                        generator.Emit(OpCodes.Stloc, local);
                     }
 
                     generator.Emit(OpCodes.Ldloca, local);


### PR DESCRIPTION
Allows passing data into and out of the same registers when calling via the Kernel ABI. This allows implementing specific supervisor calls like "CallSecureMonitor", that expect their args and results in the same registers.

For example:

```cs
public void CallSecureMonitor64(ref ulong x0, ref ulong x1, ref ulong x2, ref ulong x3, ref ulong x4, ref ulong x5, ref ulong x6, ref ulong x7)
{
    var X = new[] { x0, x1, x2, x3, x4, x5, x6, x7 };

    Logger.PrintInfo(LogClass.KernelSvc, "CallSecureMonitor was called.");
    Logger.PrintInfo(LogClass.KernelSvc, $"In  X[0] = {X[0]:X16}");
    Logger.PrintInfo(LogClass.KernelSvc, $"In  X[1] = {X[1]:X16}");
    Logger.PrintInfo(LogClass.KernelSvc, $"In  X[2] = {X[2]:X16}");
    Logger.PrintInfo(LogClass.KernelSvc, $"In  X[3] = {X[3]:X16}");
    Logger.PrintInfo(LogClass.KernelSvc, $"In  X[4] = {X[4]:X16}");
    Logger.PrintInfo(LogClass.KernelSvc, $"In  X[5] = {X[5]:X16}");
    Logger.PrintInfo(LogClass.KernelSvc, $"In  X[6] = {X[6]:X16}");
    Logger.PrintInfo(LogClass.KernelSvc, $"In  X[7] = {X[7]:X16}");

    // Handle
    for (var i = 0; i < 8; i++)
    {
        X[i] = i;
    }

    Logger.PrintInfo(LogClass.KernelSvc, $"Out X[0] = {X[0]:X16}");
    Logger.PrintInfo(LogClass.KernelSvc, $"Out X[1] = {X[1]:X16}");
    Logger.PrintInfo(LogClass.KernelSvc, $"Out X[2] = {X[2]:X16}");
    Logger.PrintInfo(LogClass.KernelSvc, $"Out X[3] = {X[3]:X16}");
    Logger.PrintInfo(LogClass.KernelSvc, $"Out X[4] = {X[4]:X16}");
    Logger.PrintInfo(LogClass.KernelSvc, $"Out X[5] = {X[5]:X16}");
    Logger.PrintInfo(LogClass.KernelSvc, $"Out X[6] = {X[6]:X16}");
    Logger.PrintInfo(LogClass.KernelSvc, $"Out X[7] = {X[7]:X16}");

    x0 = X[0];
    x1 = X[1];
    x2 = X[2];
    x3 = X[3];
    x4 = X[4];
    x5 = X[5];
    x6 = X[6];
    x7 = X[7];
}
```