### PR TITLE
Fix ghost users bug.

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
@@ -63,19 +63,25 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             long outputPosition = context.Request.RecvListBuff[0].Position;
             long outputSize     = context.Request.RecvListBuff[0].Size;
 
-            ulong offset = 0;
+            ulong offset = 0UL;
 
             foreach (UserProfile userProfile in profiles)
             {
-                if (offset + 0x10 > (ulong)outputSize)
+                if (offset + 0x10UL > (ulong)outputSize)
                 {
                     break;
                 }
 
-                context.Memory.WriteInt64(outputPosition + (long)offset,     userProfile.UserId.Low);
-                context.Memory.WriteInt64(outputPosition + (long)offset + 8, userProfile.UserId.High);
+                context.Memory.WriteInt64(outputPosition + (long)offset,      userProfile.UserId.Low);
+                context.Memory.WriteInt64(outputPosition + (long)offset + 8L, userProfile.UserId.High);
 
                 offset += 0x10;
+            }
+
+            for ( ; offset + 0x10UL <= (ulong)outputSize; offset += 0x10UL)
+            {
+                context.Memory.WriteInt64(outputPosition + (long)offset,      0L);
+                context.Memory.WriteInt64(outputPosition + (long)offset + 8L, 0L);
             }
 
             return ResultCode.Success;

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
@@ -70,7 +70,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
 
             foreach (UserProfile userProfile in profiles)
             {
-                if (offset + 0x10UL > (ulong)outputSize)
+                if (offset + 0x10 > (ulong)outputSize)
                 {
                     break;
                 }
@@ -78,7 +78,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
                 context.Memory.WriteInt64(outputPosition + (long)offset,      userProfile.UserId.Low);
                 context.Memory.WriteInt64(outputPosition + (long)offset + 8L, userProfile.UserId.High);
 
-                offset += 0x10UL;
+                offset += 0x10;
             }
 
             return ResultCode.Success;

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
@@ -1,3 +1,4 @@
+using ARMeilleure.Memory;
 using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Services.Arp;
 using Ryujinx.HLE.Utilities;

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
@@ -66,7 +66,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
 
             MemoryHelper.FillWithZeros(context.Memory, outputPosition, (int)outputSize);
 
-            ulong offset = 0UL;
+            ulong offset = 0;
 
             foreach (UserProfile userProfile in profiles)
             {
@@ -75,8 +75,8 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
                     break;
                 }
 
-                context.Memory.WriteInt64(outputPosition + (long)offset,      userProfile.UserId.Low);
-                context.Memory.WriteInt64(outputPosition + (long)offset + 8L, userProfile.UserId.High);
+                context.Memory.WriteInt64(outputPosition + (long)offset,     userProfile.UserId.Low);
+                context.Memory.WriteInt64(outputPosition + (long)offset + 8, userProfile.UserId.High);
 
                 offset += 0x10;
             }

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
@@ -63,6 +63,8 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             long outputPosition = context.Request.RecvListBuff[0].Position;
             long outputSize     = context.Request.RecvListBuff[0].Size;
 
+            MemoryHelper.FillWithZeros(context.Memory, outputPosition, (int)outputSize);
+
             ulong offset = 0UL;
 
             foreach (UserProfile userProfile in profiles)
@@ -75,13 +77,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
                 context.Memory.WriteInt64(outputPosition + (long)offset,      userProfile.UserId.Low);
                 context.Memory.WriteInt64(outputPosition + (long)offset + 8L, userProfile.UserId.High);
 
-                offset += 0x10;
-            }
-
-            for ( ; offset + 0x10UL <= (ulong)outputSize; offset += 0x10UL)
-            {
-                context.Memory.WriteInt64(outputPosition + (long)offset,      0L);
-                context.Memory.WriteInt64(outputPosition + (long)offset + 8L, 0L);
+                offset += 0x10UL;
             }
 
             return ResultCode.Success;


### PR DESCRIPTION
The output buffer for sequential writing of the 8 potential `User Id` (for a total of 128 bytes), for the commands `ListAllUsers` and `ListOpenUsers`, must always be cleaned for a smaller number of `User Id` (generally 1); in order to avoid that the potential random values contained in it may be misinterpreted as true `User Id` by the `GetUserExistence` commands and avoid the Sdk failure of EnsureSaveData.