### PR TITLE
Increase IPC buffer size

### DIFF
--- a/Ryujinx.HLE/HOS/Ipc/IpcHandler.cs
+++ b/Ryujinx.HLE/HOS/Ipc/IpcHandler.cs
@@ -67,7 +67,7 @@ namespace Ryujinx.HLE.HOS.Ipc
 
                         case 3:
                         {
-                            request = FillResponse(response, 0, 0x500);
+                            request = FillResponse(response, 0, 0x1000);
 
                             break;
                         }


### PR DESCRIPTION
This is a hack, but it works for now. We should really determine a way to automatically calculate the required buffer size to avoid situations where specific IPC calls "overflow" this arbitrary size, or determine by means of reverse engineering if there really is a fixed "maximum size" that we could implement here.