### PR TITLE
Update KEYS.md to use a new dumping guide and correct title.key formatting

### DIFF
--- a/KEYS.md
+++ b/KEYS.md
@@ -3,8 +3,7 @@
 Keys are required for decrypting most of the file formats used by the Nintendo Switch.
 
 Keysets are stored as text files. These 3 filenames are automatically read:  
-* `prod.keys` - Contains common keys used by all Nintendo Switch devices.  
-* `console.keys` - Contains console-unique keys.  
+* `prod.keys` - Contains common keys used by all Nintendo Switch devices.
 * `title.keys` - Contains game-specific keys.
 
 Ryujinx will first look for keys in `RyuFS/system`, and if it doesn't find any there it will look in `$HOME/.switch`.
@@ -22,29 +21,6 @@ To dump your `prod.keys` and `title.keys` please follow these following steps.
 11. Copy these files and paste them in `RyuFS/system`.
 And you're done!
 
-## Common keys
-
-Here is a template for a key file containing the main keys Ryujinx uses to read content files.  
-Both `prod.keys` and `console.keys` use this format.
-
-```
-master_key_00                         = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-master_key_01                         = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-master_key_02                         = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-master_key_03                         = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-master_key_04                         = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-master_key_05                         = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-
-titlekek_source                       = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-key_area_key_application_source       = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-key_area_key_ocean_source             = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-key_area_key_system_source            = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-aes_kek_generation_source             = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-aes_key_generation_source             = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-header_kek_source                     = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-header_key_source                     = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-```
-
 ## Title keys
 
 Title keys are stored in the format `rights_id = key`.
@@ -55,61 +31,4 @@ For example:
 01000000000100000000000000000003 = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 01000000000108000000000000000003 = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 01000000000108000000000000000004 = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-```
-
-## Complete key list
-Below is a complete list of keys that are currently recognized.  
-\## represents a hexadecimal number between 00 and 1F  
-@@ represents a hexadecimal number between 00 and 03
-
-### Common keys
-
-```
-master_key_source
-keyblob_mac_key_source
-package2_key_source
-aes_kek_generation_source
-aes_key_generation_source
-key_area_key_application_source
-key_area_key_ocean_source
-key_area_key_system_source
-titlekek_source
-header_kek_source
-header_key_source
-sd_card_kek_source
-sd_card_nca_key_source
-sd_card_save_key_source
-retail_specific_aes_key_source
-per_console_key_source
-bis_kek_source
-bis_key_source_@@
-
-header_key
-xci_header_key
-eticket_rsa_kek
-
-master_key_##
-package1_key_##
-package2_key_##
-titlekek_##
-key_area_key_application_##
-key_area_key_ocean_##
-key_area_key_system_##
-keyblob_key_source_##
-keyblob_##
-```
-
-### Console-unique keys
-
-```
-secure_boot_key
-tsec_key
-device_key
-bis_key_@@
-
-keyblob_key_##
-keyblob_mac_key_##
-encrypted_keyblob_##
-
-sd_seed
 ```

--- a/KEYS.md
+++ b/KEYS.md
@@ -35,6 +35,6 @@ For example:
 01000000000108000000000000000004 = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ```
 
-##Prod keys
+## Prod keys
 
 These are typically used to decrypt system files and encrypted game files. These keys get changed in about every major system update, so make sure to keep your keys up-to-date if you want to play newer games!

--- a/KEYS.md
+++ b/KEYS.md
@@ -8,8 +8,19 @@ Keysets are stored as text files. These 3 filenames are automatically read:
 `title.keys` - Contains game-specific keys.
 
 Ryujinx will first look for keys in `RyuFS/system`, and if it doesn't find any there it will look in `$HOME/.switch`.
-
-A guide to assist with dumping your own keys can be found [here](https://gist.github.com/roblabla/d8358ab058bbe3b00614740dcba4f208).
+To dump your `prod.keys` and `title.keys` please follow these following steps.
+1.	First off learn how to boot into RCM mode and inject payloads if you haven't already. This can be done [here](https://switch.homebrew.guide/).
+2.	Make sure you have an SD card with the latest release of [https://github.com/AtlasNX/Kosmos/releases](https://github.com/AtlasNX/Kosmos/releases) inserted into your Nintendo Switch.
+3.	Download the latest release of [Lockpick_RCM](https://github.com/shchmue/Lockpick_RCM/releases).
+4.	Boot into RCM mode.
+5.	Inject the `Lockpick_RCM.bin` that you have downloaded at `Step 3.` using your preffered payload injector. We recommend [TegraRCMGUI](https://github.com/eliboa/TegraRcmGUI/releases) as it easy to use and has cool feautures.
+6.	Using the `Vol+/-` buttons to navigate and the `Power` button to select, select `Dump from SysNAND | Key generation: X` ("X" depends on your Nintendo Switch's firmware version)
+7.	The dumping process may take a while depending on how many titles you have installed.
+8.	After its completion press any button to return to the main menu of Lockpick_RCM.
+9.	Navigate to and select `Power off` if you have an SD card reader. Or you could Navigate and select `Reboot (RCM)` if you want to mount your SD card using `TegraRCMGUI > Tools > Memloader V3 > MMC - SD Card`.
+10.	You can find your keys in `sd:/switch/prod.keys` and `sd:/switch/title.keys` respectively.
+11. Copy these files and paste them in `RyuFS/system`.
+And you're done!
 
 ## Common keys
 
@@ -41,9 +52,9 @@ Title keys are stored in the format `rights_id,key`.
 For example:
 
 ```
-01000000000100000000000000000003,XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-01000000000108000000000000000003,XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-01000000000108000000000000000004,XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+01000000000100000000000000000003 = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+01000000000108000000000000000003 = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+01000000000108000000000000000004 = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ```
 
 ## Complete key list

--- a/KEYS.md
+++ b/KEYS.md
@@ -12,7 +12,7 @@ To dump your `prod.keys` and `title.keys` please follow these following steps.
 2.	Make sure you have an SD card with the latest release of [Atmosphere](https://github.com/Atmosphere-NX/Atmosphere/releases) inserted into your Nintendo Switch.
 3.	Download the latest release of [Lockpick_RCM](https://github.com/shchmue/Lockpick_RCM/releases).
 4.	Boot into RCM mode.
-5.	Inject the `Lockpick_RCM.bin` that you have downloaded at `Step 3.` using your preferred payload injector. We recommend [TegraRCMGUI](https://github.com/eliboa/TegraRcmGUI/releases) as it easy to use and has a decent feature set.
+5.	Inject the `Lockpick_RCM.bin` that you have downloaded at `Step 3.` using your preferred payload injector. We recommend [TegraRCMGUI](https://github.com/eliboa/TegraRcmGUI/releases) as it is easy to use and has a decent feature set.
 6.	Using the `Vol+/-` buttons to navigate and the `Power` button to select, select `Dump from SysNAND | Key generation: X` ("X" depends on your Nintendo Switch's firmware version)
 7.	The dumping process may take a while depending on how many titles you have installed.
 8.	After its completion press any button to return to the main menu of Lockpick_RCM.

--- a/KEYS.md
+++ b/KEYS.md
@@ -3,17 +3,17 @@
 Keys are required for decrypting most of the file formats used by the Nintendo Switch.
 
 Keysets are stored as text files. These 3 filenames are automatically read:  
-`prod.keys` - Contains common keys usedy by all Switch devices.  
-`console.keys` - Contains console-unique keys.  
-`title.keys` - Contains game-specific keys.
+* `prod.keys` - Contains common keys used by all Nintendo Switch devices.  
+* `console.keys` - Contains console-unique keys.  
+* `title.keys` - Contains game-specific keys.
 
 Ryujinx will first look for keys in `RyuFS/system`, and if it doesn't find any there it will look in `$HOME/.switch`.
 To dump your `prod.keys` and `title.keys` please follow these following steps.
-1.	First off learn how to boot into RCM mode and inject payloads if you haven't already. This can be done [here](https://switch.homebrew.guide/).
-2.	Make sure you have an SD card with the latest release of [https://github.com/AtlasNX/Kosmos/releases](https://github.com/AtlasNX/Kosmos/releases) inserted into your Nintendo Switch.
+1.	First off learn how to boot into RCM mode and inject payloads if you haven't already. This can be done [here](https://nh-server.github.io/switch-guide/).
+2.	Make sure you have an SD card with the latest release of [Atmosphere](https://github.com/Atmosphere-NX/Atmosphere/releases) inserted into your Nintendo Switch.
 3.	Download the latest release of [Lockpick_RCM](https://github.com/shchmue/Lockpick_RCM/releases).
 4.	Boot into RCM mode.
-5.	Inject the `Lockpick_RCM.bin` that you have downloaded at `Step 3.` using your preffered payload injector. We recommend [TegraRCMGUI](https://github.com/eliboa/TegraRcmGUI/releases) as it easy to use and has cool feautures.
+5.	Inject the `Lockpick_RCM.bin` that you have downloaded at `Step 3.` using your preferred payload injector. We recommend [TegraRCMGUI](https://github.com/eliboa/TegraRcmGUI/releases) as it easy to use and has a decent feature set.
 6.	Using the `Vol+/-` buttons to navigate and the `Power` button to select, select `Dump from SysNAND | Key generation: X` ("X" depends on your Nintendo Switch's firmware version)
 7.	The dumping process may take a while depending on how many titles you have installed.
 8.	After its completion press any button to return to the main menu of Lockpick_RCM.
@@ -47,7 +47,7 @@ header_key_source                     = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 ## Title keys
 
-Title keys are stored in the format `rights_id,key`.
+Title keys are stored in the format `rights_id = key`.
 
 For example:
 

--- a/KEYS.md
+++ b/KEYS.md
@@ -32,3 +32,11 @@ For example:
 01000000000108000000000000000003 = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 01000000000108000000000000000004 = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ```
+
+#About keys
+There are 2 types of key files:
+`prod.keys` and `title.keys`.
+* `prod.keys`
+These are typically used to decrypt system files and encrypted game files. Almost every major firmware update adds a new `master_key` so be sure to keep your keys updated if you want to play newer games!
+* `title.keys`
+These are only used for games that are not dumped from cartridges but from games downloaded from the Nintendo eShop, these are also only used if the eShop dump does *not* have a `ticket`. If the game does have a ticket, Ryujinx will read the key directly from that ticket.

--- a/KEYS.md
+++ b/KEYS.md
@@ -23,6 +23,8 @@ And you're done!
 
 ## Title keys
 
+These are only used for games that are not dumped from cartridges but from games downloaded from the Nintendo eShop, these are also only used if the eShop dump does *not* have a `ticket`. If the game does have a ticket, Ryujinx will read the key directly from that ticket.
+
 Title keys are stored in the format `rights_id = key`.
 
 For example:
@@ -33,10 +35,6 @@ For example:
 01000000000108000000000000000004 = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ```
 
-#About keys
-There are 2 types of key files:
-`prod.keys` and `title.keys`.
-* `prod.keys`
-These are typically used to decrypt system files and encrypted game files. Almost every major firmware update adds a new `master_key` so be sure to keep your keys updated if you want to play newer games!
-* `title.keys`
-These are only used for games that are not dumped from cartridges but from games downloaded from the Nintendo eShop, these are also only used if the eShop dump does *not* have a `ticket`. If the game does have a ticket, Ryujinx will read the key directly from that ticket.
+##Prod keys
+
+These are typically used to decrypt system files and encrypted game files. These keys get changed in about every major system update, so make sure to keep your keys up-to-date if you want to play newer games!

--- a/KEYS.md
+++ b/KEYS.md
@@ -2,7 +2,7 @@
 
 Keys are required for decrypting most of the file formats used by the Nintendo Switch.
 
-Keysets are stored as text files. These 3 filenames are automatically read:  
+ Keysets are stored as text files. These 2 filenames are automatically read:  
 * `prod.keys` - Contains common keys used by all Nintendo Switch devices.
 * `title.keys` - Contains game-specific keys.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The latest automatic build for Windows, macOS, and Linux can be found on the [Of
 
  - **Switch Keys**
 
-   Everything on the Switch is encrypted, so if you want to run anything other than homebrew, you have to dump encryption keys from your console. To get more information please take a look at our [Keys Documentation](KEYS.md) *(Outdated)*.
+   Everything on the Switch is encrypted, so if you want to run anything other than homebrew, you have to dump encryption keys from your console. To get more information please take a look at our [Keys Documentation](KEYS.md).
 
  - **FFmpeg Dependencies**
 


### PR DESCRIPTION
To be honest the previous guide was ancient. This guide is easy to follow and quick if done correctly.
Furthermore, I've have corrected the formatting of `title.keys` documentation as that was outdated too.