### PR TITLE
Fix Fcmge_S/V & Fcmgt_S/V Inst.s

### DIFF
--- a/ARMeilleure/CodeGen/X86/Assembler.cs
+++ b/ARMeilleure/CodeGen/X86/Assembler.cs
@@ -94,7 +94,7 @@ namespace ARMeilleure.CodeGen.X86
             Add(X86Instruction.Cvtpd2ps,   new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x00000f5a, InstructionFlags.Vex | InstructionFlags.Prefix66));
             Add(X86Instruction.Cvtps2dq,   new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x00000f5b, InstructionFlags.Vex | InstructionFlags.Prefix66));
             Add(X86Instruction.Cvtps2pd,   new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x00000f5a, InstructionFlags.Vex));
-            Add(X86Instruction.Cvtsd2si,   new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x00000f2c, InstructionFlags.Vex | InstructionFlags.PrefixF2));
+            Add(X86Instruction.Cvtsd2si,   new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x00000f2d, InstructionFlags.Vex | InstructionFlags.PrefixF2));
             Add(X86Instruction.Cvtsd2ss,   new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x00000f5a, InstructionFlags.Vex | InstructionFlags.PrefixF2));
             Add(X86Instruction.Cvtsi2sd,   new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x00000f2a, InstructionFlags.Vex | InstructionFlags.PrefixF2));
             Add(X86Instruction.Cvtsi2ss,   new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x00000f2a, InstructionFlags.Vex | InstructionFlags.PrefixF3));

--- a/ARMeilleure/CodeGen/X86/CodeGenerator.cs
+++ b/ARMeilleure/CodeGen/X86/CodeGenerator.cs
@@ -265,7 +265,21 @@ namespace ARMeilleure.CodeGen.X86
 
                         Debug.Assert(dest.Type.IsInteger() && !source.Type.IsInteger());
 
-                        context.Assembler.WriteInstruction(info.Inst, dest, source, dest.Type);
+                        if (intrinOp.Intrinsic == Intrinsic.X86Cvtsi2si)
+                        {
+                            if (dest.Type == OperandType.I32)
+                            {
+                                context.Assembler.Movd(dest, source); // int _mm_cvtsi128_si32
+                            }
+                            else /* if (dest.Type == OperandType.I64) */
+                            {
+                                context.Assembler.Movq(dest, source); // __int64 _mm_cvtsi128_si64
+                            }
+                        }
+                        else
+                        {
+                            context.Assembler.WriteInstruction(info.Inst, dest, source, dest.Type);
+                        }
 
                         break;
                     }

--- a/ARMeilleure/CodeGen/X86/HardwareCapabilities.cs
+++ b/ARMeilleure/CodeGen/X86/HardwareCapabilities.cs
@@ -26,7 +26,7 @@ namespace ARMeilleure.CodeGen.X86
 
         public static bool ForceLegacySse { get; set; }
 
-        public static bool SupportsVexEncoding => !ForceLegacySse && SupportsAvx;
+        public static bool SupportsVexEncoding => SupportsAvx && !ForceLegacySse;
 
         static HardwareCapabilities()
         {

--- a/ARMeilleure/CodeGen/X86/IntrinsicTable.cs
+++ b/ARMeilleure/CodeGen/X86/IntrinsicTable.cs
@@ -37,6 +37,7 @@ namespace ARMeilleure.CodeGen.X86
             Add(Intrinsic.X86Cvtps2pd,   new IntrinsicInfo(X86Instruction.Cvtps2pd,   IntrinsicType.Unary));
             Add(Intrinsic.X86Cvtsd2si,   new IntrinsicInfo(X86Instruction.Cvtsd2si,   IntrinsicType.UnaryToGpr));
             Add(Intrinsic.X86Cvtsd2ss,   new IntrinsicInfo(X86Instruction.Cvtsd2ss,   IntrinsicType.Binary));
+            Add(Intrinsic.X86Cvtsi2si,   new IntrinsicInfo(X86Instruction.Movd,       IntrinsicType.UnaryToGpr));
             Add(Intrinsic.X86Cvtss2sd,   new IntrinsicInfo(X86Instruction.Cvtss2sd,   IntrinsicType.Binary));
             Add(Intrinsic.X86Divpd,      new IntrinsicInfo(X86Instruction.Divpd,      IntrinsicType.Binary));
             Add(Intrinsic.X86Divps,      new IntrinsicInfo(X86Instruction.Divps,      IntrinsicType.Binary));

--- a/ARMeilleure/Instructions/InstEmitSimdCmp.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdCmp.cs
@@ -426,22 +426,6 @@ namespace ARMeilleure.Instructions
             EmitFcmpOrFcmpe(context, signalNaNs: true);
         }
 
-        private enum CmpCondition
-        {
-            // Legacy Sse.
-            Equal              = 0, // Ordered, non-signaling.
-            LessThan           = 1, // Ordered, signaling.
-            LessThanOrEqual    = 2, // Ordered, signaling.
-            NotLessThan        = 5, // Unordered, signaling.
-            NotLessThanOrEqual = 6, // Unordered, signaling.
-            OrderedQ           = 7, // Non-signaling.
-
-            // Vex.
-            GreaterThanOrEqual = 13, // Ordered, signaling.
-            GreaterThan        = 14, // Ordered, signaling.
-            OrderedS           = 23  // Signaling.
-        }
-
         private static void EmitFccmpOrFccmpe(ArmEmitterContext context, bool signalNaNs)
         {
             OpCodeSimdFcond op = (OpCodeSimdFcond)context.CurrOp;

--- a/ARMeilleure/Instructions/InstEmitSimdCvt.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdCvt.cs
@@ -732,8 +732,7 @@ namespace ARMeilleure.Instructions
             Debug.Assert(value.Type == OperandType.I32 || value.Type == OperandType.I64);
             Debug.Assert((uint)size < 2);
 
-            OperandType type = size == 0 ? OperandType.FP32
-                                         : OperandType.FP64;
+            OperandType type = size == 0 ? OperandType.FP32 : OperandType.FP64;
 
             if (signed)
             {
@@ -837,15 +836,12 @@ namespace ARMeilleure.Instructions
 
             Operand n = GetVec(op.Rn);
 
-            const int cmpGreaterThanOrEqual = 5;
-            const int cmpOrdered            = 7;
-
             // sizeF == ((OpCodeSimdShImm64)op).Size - 2
             int sizeF = op.Size & 1;
 
             if (sizeF == 0)
             {
-                Operand nMask = context.AddIntrinsic(Intrinsic.X86Cmpps, n, n, Const(cmpOrdered));
+                Operand nMask = context.AddIntrinsic(Intrinsic.X86Cmpps, n, n, Const((int)CmpCondition.OrderedQ));
 
                 Operand nScaled = context.AddIntrinsic(Intrinsic.X86Pand, nMask, n);
 
@@ -867,7 +863,7 @@ namespace ARMeilleure.Instructions
 
                 Operand mask = X86GetAllElements(context, 0x4F000000); // 2.14748365E9f (2147483648)
 
-                Operand mask2 = context.AddIntrinsic(Intrinsic.X86Cmpps, nRnd, mask, Const(cmpGreaterThanOrEqual));
+                Operand mask2 = context.AddIntrinsic(Intrinsic.X86Cmpps, nRnd, mask, Const((int)CmpCondition.NotLessThan));
 
                 Operand res = context.AddIntrinsic(Intrinsic.X86Pxor, nInt, mask2);
 
@@ -884,7 +880,7 @@ namespace ARMeilleure.Instructions
             }
             else /* if (sizeF == 1) */
             {
-                Operand nMask = context.AddIntrinsic(Intrinsic.X86Cmppd, n, n, Const(cmpOrdered));
+                Operand nMask = context.AddIntrinsic(Intrinsic.X86Cmppd, n, n, Const((int)CmpCondition.OrderedQ));
 
                 Operand nScaled = context.AddIntrinsic(Intrinsic.X86Pand, nMask, n);
 
@@ -920,7 +916,7 @@ namespace ARMeilleure.Instructions
 
                 Operand mask = X86GetAllElements(context, 0x43E0000000000000L); // 9.2233720368547760E18d (9223372036854775808)
 
-                Operand mask2 = context.AddIntrinsic(Intrinsic.X86Cmppd, nRnd, mask, Const(cmpGreaterThanOrEqual));
+                Operand mask2 = context.AddIntrinsic(Intrinsic.X86Cmppd, nRnd, mask, Const((int)CmpCondition.NotLessThan));
 
                 Operand res = context.AddIntrinsic(Intrinsic.X86Pxor, nInt, mask2);
 
@@ -939,16 +935,12 @@ namespace ARMeilleure.Instructions
 
             Operand n = GetVec(op.Rn);
 
-            const int cmpGreaterThanOrEqual = 5;
-            const int cmpGreaterThan        = 6;
-            const int cmpOrdered            = 7;
-
             // sizeF == ((OpCodeSimdShImm)op).Size - 2
             int sizeF = op.Size & 1;
 
             if (sizeF == 0)
             {
-                Operand nMask = context.AddIntrinsic(Intrinsic.X86Cmpps, n, n, Const(cmpOrdered));
+                Operand nMask = context.AddIntrinsic(Intrinsic.X86Cmpps, n, n, Const((int)CmpCondition.OrderedQ));
 
                 Operand nScaled = context.AddIntrinsic(Intrinsic.X86Pand, nMask, n);
 
@@ -966,7 +958,7 @@ namespace ARMeilleure.Instructions
 
                 Operand nRnd = context.AddIntrinsic(Intrinsic.X86Roundps, nScaled, Const(X86GetRoundControl(roundMode)));
 
-                Operand nRndMask = context.AddIntrinsic(Intrinsic.X86Cmpps, nRnd, context.VectorZero(), Const(cmpGreaterThan));
+                Operand nRndMask = context.AddIntrinsic(Intrinsic.X86Cmpps, nRnd, context.VectorZero(), Const((int)CmpCondition.NotLessThanOrEqual));
 
                 Operand nRndMasked = context.AddIntrinsic(Intrinsic.X86Pand, nRnd, nRndMask);
 
@@ -976,13 +968,13 @@ namespace ARMeilleure.Instructions
 
                 Operand res = context.AddIntrinsic(Intrinsic.X86Subps, nRndMasked, mask);
 
-                Operand mask2 = context.AddIntrinsic(Intrinsic.X86Cmpps, res, context.VectorZero(), Const(cmpGreaterThan));
+                Operand mask2 = context.AddIntrinsic(Intrinsic.X86Cmpps, res, context.VectorZero(), Const((int)CmpCondition.NotLessThanOrEqual));
 
                 Operand resMasked = context.AddIntrinsic(Intrinsic.X86Pand, res, mask2);
 
                 res = context.AddIntrinsic(Intrinsic.X86Cvtps2dq, resMasked);
 
-                Operand mask3 = context.AddIntrinsic(Intrinsic.X86Cmpps, resMasked, mask, Const(cmpGreaterThanOrEqual));
+                Operand mask3 = context.AddIntrinsic(Intrinsic.X86Cmpps, resMasked, mask, Const((int)CmpCondition.NotLessThan));
 
                 res = context.AddIntrinsic(Intrinsic.X86Pxor, res, mask3);
                 res = context.AddIntrinsic(Intrinsic.X86Paddd, res, nInt);
@@ -1000,7 +992,7 @@ namespace ARMeilleure.Instructions
             }
             else /* if (sizeF == 1) */
             {
-                Operand nMask = context.AddIntrinsic(Intrinsic.X86Cmppd, n, n, Const(cmpOrdered));
+                Operand nMask = context.AddIntrinsic(Intrinsic.X86Cmppd, n, n, Const((int)CmpCondition.OrderedQ));
 
                 Operand nScaled = context.AddIntrinsic(Intrinsic.X86Pand, nMask, n);
 
@@ -1018,7 +1010,7 @@ namespace ARMeilleure.Instructions
 
                 Operand nRnd = context.AddIntrinsic(Intrinsic.X86Roundpd, nScaled, Const(X86GetRoundControl(roundMode)));
 
-                Operand nRndMask = context.AddIntrinsic(Intrinsic.X86Cmppd, nRnd, context.VectorZero(), Const(cmpGreaterThan));
+                Operand nRndMask = context.AddIntrinsic(Intrinsic.X86Cmppd, nRnd, context.VectorZero(), Const((int)CmpCondition.NotLessThanOrEqual));
 
                 Operand nRndMasked = context.AddIntrinsic(Intrinsic.X86Pand, nRnd, nRndMask);
 
@@ -1042,7 +1034,7 @@ namespace ARMeilleure.Instructions
 
                 Operand res = context.AddIntrinsic(Intrinsic.X86Subpd, nRndMasked, mask);
 
-                Operand mask2 = context.AddIntrinsic(Intrinsic.X86Cmppd, res, context.VectorZero(), Const(cmpGreaterThan));
+                Operand mask2 = context.AddIntrinsic(Intrinsic.X86Cmppd, res, context.VectorZero(), Const((int)CmpCondition.NotLessThanOrEqual));
 
                 Operand resMasked = context.AddIntrinsic(Intrinsic.X86Pand, res, mask2);
 
@@ -1056,7 +1048,7 @@ namespace ARMeilleure.Instructions
 
                 res = EmitVectorLongCreate(context, low, high);
 
-                Operand mask3 = context.AddIntrinsic(Intrinsic.X86Cmppd, resMasked, mask, Const(cmpGreaterThanOrEqual));
+                Operand mask3 = context.AddIntrinsic(Intrinsic.X86Cmppd, resMasked, mask, Const((int)CmpCondition.NotLessThan));
 
                 res = context.AddIntrinsic(Intrinsic.X86Pxor, res, mask3);
                 res = context.AddIntrinsic(Intrinsic.X86Paddq, res, nInt);

--- a/ARMeilleure/Instructions/InstEmitSimdHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdHelper.cs
@@ -1108,6 +1108,21 @@ namespace ARMeilleure.Instructions
             }
         }
 
+        public enum CmpCondition
+        {
+            // Legacy Sse.
+            Equal              = 0, // Ordered, non-signaling.
+            LessThan           = 1, // Ordered, signaling.
+            LessThanOrEqual    = 2, // Ordered, signaling.
+            NotLessThan        = 5, // Unordered, signaling.
+            NotLessThanOrEqual = 6, // Unordered, signaling.
+            OrderedQ           = 7, // Non-signaling.
+
+            // Vex.
+            GreaterThanOrEqual = 13, // Ordered, signaling.
+            GreaterThan        = 14, // Ordered, signaling.
+            OrderedS           = 23  // Signaling.
+        }
 
         [Flags]
         public enum SaturatingFlags

--- a/ARMeilleure/IntermediateRepresentation/Intrinsic.cs
+++ b/ARMeilleure/IntermediateRepresentation/Intrinsic.cs
@@ -26,6 +26,7 @@ namespace ARMeilleure.IntermediateRepresentation
         X86Cvtps2pd,
         X86Cvtsd2si,
         X86Cvtsd2ss,
+        X86Cvtsi2si,
         X86Cvtss2sd,
         X86Divpd,
         X86Divps,

--- a/ARMeilleure/Optimizations.cs
+++ b/ARMeilleure/Optimizations.cs
@@ -15,6 +15,7 @@ namespace ARMeilleure
         public static bool UseSse41IfAvailable  { get; set; } = true;
         public static bool UseSse42IfAvailable  { get; set; } = true;
         public static bool UsePopCntIfAvailable { get; set; } = true;
+        public static bool UseAvxIfAvailable    { get; set; } = true;
 
         public static bool ForceLegacySse
         {
@@ -29,5 +30,6 @@ namespace ARMeilleure
         internal static bool UseSse41  => UseSse41IfAvailable  && HardwareCapabilities.SupportsSse41;
         internal static bool UseSse42  => UseSse42IfAvailable  && HardwareCapabilities.SupportsSse42;
         internal static bool UsePopCnt => UsePopCntIfAvailable && HardwareCapabilities.SupportsPopcnt;
+        internal static bool UseAvx    => UseAvxIfAvailable    && HardwareCapabilities.SupportsAvx && !ForceLegacySse;
     }
 }

--- a/Ryujinx.Tests.Unicorn/Ryujinx.Tests.Unicorn.csproj
+++ b/Ryujinx.Tests.Unicorn/Ryujinx.Tests.Unicorn.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
   </ItemGroup>
 
 </Project>

--- a/Ryujinx.Tests/Ryujinx.Tests.csproj
+++ b/Ryujinx.Tests/Ryujinx.Tests.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
   </ItemGroup>


### PR DESCRIPTION
Fix `Fcmge_S/V` & `Fcmgt_S/V` Inst.s; thanks to jduncanator for narrowing the issue (see Ryujinx/Ryujinx-Games-List#207)
Optimize `Fccmp*_S` & `Fcmp*_S` Inst.s
Fix `Cvtsd2si` Opcode

Follow-up `Fcm**_S/V` & `Fc*mp*_S` Inst.s
Improve `CmpCondition` enum and its uses
Nits

Successful unit testing on Windows

---

Optimize `Fccmp*_S` & `Fcmp*_S` Inst.s:

`FCCMP  S1, S2, #0, EQ`:
```diff
  LOC_0x2:
  mov             eax, dword ptr [rsp + 0x60]
  mov             ecx, dword ptr [rsp + 0x5c]
  cmp             eax, ecx
  setne           bpl
  movzx           ebp, bpl
  test            ebp, ebp
  jne             LOC_0x3
- mov             ebp, 1
+ mov             eax, 1
- and             ebp, 0
- mov             eax, ebp
  mov             dword ptr [rsp + 0x5c], eax
- xor             ebp, ebp
+ mov             eax, 1
- shr             ebp, 1
- and             ebp, 1
- mov             eax, ebp
  mov             dword ptr [rsp + 0x90], eax
- xor             ebp, ebp
+ mov             eax, 1
- shr             ebp, 2
- and             ebp, 1
- mov             eax, ebp
  mov             dword ptr [rsp + 0x94], eax
- xor             ebp, ebp
+ xor             eax, eax
- shr             ebp, 3
- and             ebp, 1
- mov             eax, ebp
  mov             dword ptr [rsp + 0x60], eax
  jmp             LOC_0x5
```

`FCMP  S1, S2`:
```diff
  LOC_0x2:
  vmovdqu         xmm0, xmmword ptr [rsp + 0x5c]
  vmovdqu         xmm1, xmmword ptr [rsp + 0x6c]
  vcmpordss       xmm4, xmm0, xmm1
- vpextrw         ebp, xmm4, 0
+ vmovd           ebp, xmm4
  test            ebp, ebp
  je              LOC_0x3
```
`FCMP  D1, D2`:
```diff
  LOC_0x2:
  vmovdqu         xmm0, xmmword ptr [rsp + 0x5c]
  vmovdqu         xmm1, xmmword ptr [rsp + 0x6c]
  vcmpordsd       xmm4, xmm0, xmm1
- vpextrw         ebp, xmm4, 0
- test            ebp, ebp
+ vmovq           rbp, xmm4
+ test            rbp, rbp
  je              LOC_0x3
```