### PR TITLE
Set AArch32 mode in KThread

### DIFF
--- a/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
@@ -162,6 +162,8 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
 
             bool isAarch32 = (Owner.MmuFlags & 1) == 0;
 
+            Context.IsAarch32 = isAarch32;
+
             Context.SetX(0, argsPtr);
 
             if (isAarch32)

--- a/Ryujinx.HLE/HOS/ProgramLoader.cs
+++ b/Ryujinx.HLE/HOS/ProgramLoader.cs
@@ -127,7 +127,7 @@ namespace Ryujinx.HLE.HOS
         {
             if (!metaData.Is64Bits)
             {
-                Logger.PrintWarning(LogClass.Loader, "32-bit application detected.");
+                Logger.PrintWarning(LogClass.Loader, "32-bits application detected.");
             }
 
             ulong argsStart = 0;

--- a/Ryujinx.HLE/HOS/ProgramLoader.cs
+++ b/Ryujinx.HLE/HOS/ProgramLoader.cs
@@ -127,7 +127,7 @@ namespace Ryujinx.HLE.HOS
         {
             if (!metaData.Is64Bits)
             {
-                Logger.PrintWarning(LogClass.Loader, "32-bits application detected!");
+                Logger.PrintWarning(LogClass.Loader, "32-bit application detected.");
             }
 
             ulong argsStart = 0;


### PR DESCRIPTION
Small change is small, but this simply sets AArch32 mode in ARMeilleure when the application is 32-bit.