### PR TITLE
Add Mrs & Msr (Nzcv) Inst., with Tests.

### DIFF
--- a/ARMeilleure/Instructions/InstEmitSystem.cs
+++ b/ARMeilleure/Instructions/InstEmitSystem.cs
@@ -1,5 +1,6 @@
 using ARMeilleure.Decoders;
 using ARMeilleure.IntermediateRepresentation;
+using ARMeilleure.State;
 using ARMeilleure.Translation;
 using System;
 
@@ -32,7 +33,7 @@ namespace ARMeilleure.Instructions
             {
                 case 0b11_011_0000_0000_001: dlg = new _U64(NativeInterface.GetCtrEl0);    break;
                 case 0b11_011_0000_0000_111: dlg = new _U64(NativeInterface.GetDczidEl0);  break;
-                case 0b11_011_0100_0010_000: dlg = new _U64(NativeInterface.GetNzcv);      break;
+                case 0b11_011_0100_0010_000: EmitGetNzcv(context);                         return;
                 case 0b11_011_0100_0100_000: dlg = new _U64(NativeInterface.GetFpcr);      break;
                 case 0b11_011_0100_0100_001: dlg = new _U64(NativeInterface.GetFpsr);      break;
                 case 0b11_011_1101_0000_010: dlg = new _U64(NativeInterface.GetTpidrEl0);  break;
@@ -54,7 +55,7 @@ namespace ARMeilleure.Instructions
 
             switch (GetPackedId(op))
             {
-                case 0b11_011_0100_0010_000: dlg = new _Void_U64(NativeInterface.SetNzcv);     break;
+                case 0b11_011_0100_0010_000: EmitSetNzcv(context);                             return;
                 case 0b11_011_0100_0100_000: dlg = new _Void_U64(NativeInterface.SetFpcr);     break;
                 case 0b11_011_0100_0100_001: dlg = new _Void_U64(NativeInterface.SetFpsr);     break;
                 case 0b11_011_1101_0000_010: dlg = new _Void_U64(NativeInterface.SetTpidrEl0); break;
@@ -111,6 +112,45 @@ namespace ARMeilleure.Instructions
             id |= op.Op0 << 14;
 
             return id;
+        }
+
+        private static void EmitGetNzcv(ArmEmitterContext context)
+        {
+            OpCodeSystem op = (OpCodeSystem)context.CurrOp;
+
+            Operand vSh = context.ShiftLeft(GetFlag(PState.VFlag), Const((int)PState.VFlag));
+            Operand cSh = context.ShiftLeft(GetFlag(PState.CFlag), Const((int)PState.CFlag));
+            Operand zSh = context.ShiftLeft(GetFlag(PState.ZFlag), Const((int)PState.ZFlag));
+            Operand nSh = context.ShiftLeft(GetFlag(PState.NFlag), Const((int)PState.NFlag));
+
+            Operand nzcvSh = context.BitwiseOr(context.BitwiseOr(nSh, zSh), context.BitwiseOr(cSh, vSh));
+
+            SetIntOrZR(context, op.Rt, nzcvSh);
+        }
+
+        private static void EmitSetNzcv(ArmEmitterContext context)
+        {
+            OpCodeSystem op = (OpCodeSystem)context.CurrOp;
+
+            Operand t = GetIntOrZR(context, op.Rt);
+                    t = context.ConvertI64ToI32(t);
+
+            Operand v = context.ShiftRightUI(t, Const((int)PState.VFlag));
+                    v = context.BitwiseAnd  (v, Const(1));
+
+            Operand c = context.ShiftRightUI(t, Const((int)PState.CFlag));
+                    c = context.BitwiseAnd  (c, Const(1));
+
+            Operand z = context.ShiftRightUI(t, Const((int)PState.ZFlag));
+                    z = context.BitwiseAnd  (z, Const(1));
+
+            Operand n = context.ShiftRightUI(t, Const((int)PState.NFlag));
+                    n = context.BitwiseAnd  (n, Const(1));
+
+            SetFlag(context, PState.VFlag, v);
+            SetFlag(context, PState.CFlag, c);
+            SetFlag(context, PState.ZFlag, z);
+            SetFlag(context, PState.NFlag, n);
         }
     }
 }

--- a/ARMeilleure/Instructions/InstEmitSystem.cs
+++ b/ARMeilleure/Instructions/InstEmitSystem.cs
@@ -32,6 +32,7 @@ namespace ARMeilleure.Instructions
             {
                 case 0b11_011_0000_0000_001: dlg = new _U64(NativeInterface.GetCtrEl0);    break;
                 case 0b11_011_0000_0000_111: dlg = new _U64(NativeInterface.GetDczidEl0);  break;
+                case 0b11_011_0100_0010_000: dlg = new _U64(NativeInterface.GetNzcv);      break;
                 case 0b11_011_0100_0100_000: dlg = new _U64(NativeInterface.GetFpcr);      break;
                 case 0b11_011_0100_0100_001: dlg = new _U64(NativeInterface.GetFpsr);      break;
                 case 0b11_011_1101_0000_010: dlg = new _U64(NativeInterface.GetTpidrEl0);  break;
@@ -53,6 +54,7 @@ namespace ARMeilleure.Instructions
 
             switch (GetPackedId(op))
             {
+                case 0b11_011_0100_0010_000: dlg = new _Void_U64(NativeInterface.SetNzcv);     break;
                 case 0b11_011_0100_0100_000: dlg = new _Void_U64(NativeInterface.SetFpcr);     break;
                 case 0b11_011_0100_0100_001: dlg = new _Void_U64(NativeInterface.SetFpsr);     break;
                 case 0b11_011_1101_0000_010: dlg = new _Void_U64(NativeInterface.SetTpidrEl0); break;

--- a/ARMeilleure/Instructions/NativeInterface.cs
+++ b/ARMeilleure/Instructions/NativeInterface.cs
@@ -77,25 +77,6 @@ namespace ARMeilleure.Instructions
             return (ulong)GetContext().DczidEl0;
         }
 
-        public static ulong GetNzcv()
-        {
-            void Insert(ref ulong value, PState bit, bool flag)
-            {
-                value |= (flag ? 1UL : 0UL) << (int)bit;
-            }
-
-            ExecutionContext context = GetContext();
-
-            ulong value = 0UL;
-
-            Insert(ref value, PState.VFlag, context.GetPstateFlag(PState.VFlag));
-            Insert(ref value, PState.CFlag, context.GetPstateFlag(PState.CFlag));
-            Insert(ref value, PState.ZFlag, context.GetPstateFlag(PState.ZFlag));
-            Insert(ref value, PState.NFlag, context.GetPstateFlag(PState.NFlag));
-
-            return value;
-        }
-
         public static ulong GetFpcr()
         {
             return (ulong)GetContext().Fpcr;
@@ -124,25 +105,6 @@ namespace ARMeilleure.Instructions
         public static ulong GetCntpctEl0()
         {
             return GetContext().CntpctEl0;
-        }
-
-        public static void SetNzcv(ulong value)
-        {
-            bool Extract(ulong value, PState bit)
-            {
-                value >>= (int)bit;
-
-                value &= 1UL;
-
-                return value != 0UL;
-            }
-
-            ExecutionContext context = GetContext();
-
-            context.SetPstateFlag(PState.VFlag, Extract(value, PState.VFlag));
-            context.SetPstateFlag(PState.CFlag, Extract(value, PState.CFlag));
-            context.SetPstateFlag(PState.ZFlag, Extract(value, PState.ZFlag));
-            context.SetPstateFlag(PState.NFlag, Extract(value, PState.NFlag));
         }
 
         public static void SetFpcr(ulong value)

--- a/ARMeilleure/Instructions/NativeInterface.cs
+++ b/ARMeilleure/Instructions/NativeInterface.cs
@@ -77,6 +77,25 @@ namespace ARMeilleure.Instructions
             return (ulong)GetContext().DczidEl0;
         }
 
+        public static ulong GetNzcv()
+        {
+            void Insert(ref ulong value, PState bit, bool flag)
+            {
+                value |= (flag ? 1UL : 0UL) << (int)bit;
+            }
+
+            ExecutionContext context = GetContext();
+
+            ulong value = 0UL;
+
+            Insert(ref value, PState.VFlag, context.GetPstateFlag(PState.VFlag));
+            Insert(ref value, PState.CFlag, context.GetPstateFlag(PState.CFlag));
+            Insert(ref value, PState.ZFlag, context.GetPstateFlag(PState.ZFlag));
+            Insert(ref value, PState.NFlag, context.GetPstateFlag(PState.NFlag));
+
+            return value;
+        }
+
         public static ulong GetFpcr()
         {
             return (ulong)GetContext().Fpcr;
@@ -105,6 +124,25 @@ namespace ARMeilleure.Instructions
         public static ulong GetCntpctEl0()
         {
             return GetContext().CntpctEl0;
+        }
+
+        public static void SetNzcv(ulong value)
+        {
+            bool Extract(ulong value, PState bit)
+            {
+                value >>= (int)bit;
+
+                value &= 1UL;
+
+                return value != 0UL;
+            }
+
+            ExecutionContext context = GetContext();
+
+            context.SetPstateFlag(PState.VFlag, Extract(value, PState.VFlag));
+            context.SetPstateFlag(PState.CFlag, Extract(value, PState.CFlag));
+            context.SetPstateFlag(PState.ZFlag, Extract(value, PState.ZFlag));
+            context.SetPstateFlag(PState.NFlag, Extract(value, PState.NFlag));
         }
 
         public static void SetFpcr(ulong value)

--- a/Ryujinx.Tests/Cpu/CpuTestSystem.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestSystem.cs
@@ -1,0 +1,73 @@
+#define System
+
+using ARMeilleure.State;
+
+using NUnit.Framework;
+
+using System.Collections.Generic;
+
+namespace Ryujinx.Tests.Cpu
+{
+    [Category("System")]
+    public sealed class CpuTestSystem : CpuTest
+    {
+#if System
+
+#region "ValueSource (Types)"
+        private static IEnumerable<ulong> _GenNzcv_()
+        {
+            yield return 0x0000000000000000ul;
+            yield return 0x7FFFFFFFFFFFFFFFul;
+            yield return 0x8000000000000000ul;
+            yield return 0xFFFFFFFFFFFFFFFFul;
+
+            bool v = TestContext.CurrentContext.Random.NextBool();
+            bool c = TestContext.CurrentContext.Random.NextBool();
+            bool z = TestContext.CurrentContext.Random.NextBool();
+            bool n = TestContext.CurrentContext.Random.NextBool();
+
+            ulong rnd = 0UL;
+
+            rnd |= (v ? 1UL : 0UL) << (int)PState.VFlag;
+            rnd |= (c ? 1UL : 0UL) << (int)PState.CFlag;
+            rnd |= (z ? 1UL : 0UL) << (int)PState.ZFlag;
+            rnd |= (n ? 1UL : 0UL) << (int)PState.NFlag;
+
+            yield return rnd;
+        }
+#endregion
+
+#region "ValueSource (Opcodes)"
+        private static uint[] _MrsMsr_Nzcv_()
+        {
+            return new uint[]
+            {
+                0xD53B4200u, // MRS X0, NZCV
+                0xD51B4200u  // MSR NZCV, X0
+            };
+        }
+#endregion
+
+        private const int RndCnt = 2;
+
+        [Test, Pairwise]
+        public void MrsMsr_Nzcv([ValueSource("_MrsMsr_Nzcv_")] uint opcodes,
+                                [Values(0u, 1u, 31u)] uint rt,
+                                [ValueSource("_GenNzcv_")] [Random(RndCnt)] ulong xt)
+        {
+            opcodes |= (rt & 31) << 0;
+
+            bool v = TestContext.CurrentContext.Random.NextBool();
+            bool c = TestContext.CurrentContext.Random.NextBool();
+            bool z = TestContext.CurrentContext.Random.NextBool();
+            bool n = TestContext.CurrentContext.Random.NextBool();
+
+            ulong x31 = TestContext.CurrentContext.Random.NextULong();
+
+            SingleOpcode(opcodes, x0: xt, x1: xt, x31: x31, overflow: v, carry: c, zero: z, negative: n);
+
+            CompareAgainstUnicorn();
+        }
+#endif
+    }
+}


### PR DESCRIPTION
Successful unit testing on Windows (debug and release mode).

Closes https://github.com/Ryujinx/Ryujinx/issues/806.

---

`MRS X0, NZCV`:
```assembly
  ...
  mov             ecx, dword ptr [rsp + 0x5c]
  mov             esi, ecx
  shl             esi, 0x1c

  mov             ecx, dword ptr [rsp + 0x60]
  mov             edi, ecx
  shl             edi, 0x1d

  mov             ecx, dword ptr [rsp + 0x64]
  mov             r8d, ecx
  shl             r8d, 0x1e

  mov             ecx, dword ptr [rsp + 0x68]
  mov             r9d, ecx
  shl             r9d, 0x1f

  or              r9d, r8d
  or              edi, esi
  mov             esi, r9d
  or              esi, edi
  mov             esi, esi

  mov             rcx, qword ptr [rsp + 0x54]
  mov             rdi, rcx
  or              rdi, 1

  mov             rcx, qword ptr [rsp + 0x4c]
  mov             r8, rcx
  add             r8, 0
  mov             qword ptr [r8], rsi

  mov             rcx, qword ptr [rsp + 0x4c]
  mov             rsi, rcx

  mov             rax, rdi
  ...
```

`MSR NZCV, X1`:
```assembly
  ...
  mov             rcx, qword ptr [rsp + 0x54]
  mov             esi, ecx

  mov             edi, esi
  shr             edi, 0x1c
  and             edi, 1

  mov             r8d, esi
  shr             r8d, 0x1d
  and             r8d, 1

  mov             r9d, esi
  shr             r9d, 0x1e
  and             r9d, 1

  shr             esi, 0x1f
  and             esi, 1

  mov             rcx, qword ptr [rsp + 0x5c]
  mov             r10, rcx
  or              r10, 1

  mov             rcx, qword ptr [rsp + 0x4c]
  mov             r11, rcx

  mov             r12, r11
  add             r12, 0x370
  mov             dword ptr [r12], edi

  mov             rdi, r11
  add             rdi, 0x374
  mov             dword ptr [rdi], r8d

  mov             rdi, r11
  add             rdi, 0x378
  mov             dword ptr [rdi], r9d

  mov             rdi, r11
  add             rdi, 0x37c
  mov             dword ptr [rdi], esi

  mov             rcx, qword ptr [rsp + 0x4c]
  mov             rsi, rcx

  mov             rax, r10
  ...
```