### PR TITLE
Fix GetAudioDeviceServiceWithRevisionInfo logging

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Audio/IAudioRendererManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/IAudioRendererManager.cs
@@ -134,7 +134,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
         }
 
         [Command(4)] // 4.0.0+
-        // GetAudioDeviceServiceWithRevisionInfo(nn::applet::AppletResourceUserId, u32) -> object<nn::audio::detail::IAudioDevice>
+        // GetAudioDeviceServiceWithRevisionInfo(u32 revision_info, nn::applet::AppletResourceUserId) -> object<nn::audio::detail::IAudioDevice>
         public ResultCode GetAudioDeviceServiceWithRevisionInfo(ServiceCtx context)
         {
             int  revisionInfo         = context.RequestData.ReadInt32();

--- a/Ryujinx.HLE/HOS/Services/Audio/IAudioRendererManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/IAudioRendererManager.cs
@@ -137,8 +137,8 @@ namespace Ryujinx.HLE.HOS.Services.Audio
         // GetAudioDeviceServiceWithRevisionInfo(nn::applet::AppletResourceUserId, u32) -> object<nn::audio::detail::IAudioDevice>
         public ResultCode GetAudioDeviceServiceWithRevisionInfo(ServiceCtx context)
         {
-            long appletResourceUserId = context.RequestData.ReadInt64();
             int  revisionInfo         = context.RequestData.ReadInt32();
+            long appletResourceUserId = context.RequestData.ReadInt64();
 
             Logger.PrintStub(LogClass.ServiceAudio, new { appletResourceUserId, revisionInfo });
 


### PR DESCRIPTION
`revisionInfo` and `appletResourceUserId` were read in the wrong order.