### PR TITLE
Fix ILogger type and size decoding

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Lm/LogService/ILogger.cs
+++ b/Ryujinx.HLE/HOS/Services/Lm/LogService/ILogger.cs
@@ -8,7 +8,7 @@ namespace Ryujinx.HLE.HOS.Services.Lm.LogService
     {
         public ILogger() { }
 
-        private int ReadEncodedInt(BinaryReader reader)
+        private static int ReadEncodedInt(BinaryReader reader)
         {
             int result   = 0;
             int position = 0;
@@ -23,7 +23,7 @@ namespace Ryujinx.HLE.HOS.Services.Lm.LogService
 
                 position++;
 
-            } while ((encoded & -128) != 0);
+            } while ((encoded & 0x80) != 0);
 
             return result;
         }

--- a/Ryujinx.HLE/HOS/Services/Lm/LogService/ILogger.cs
+++ b/Ryujinx.HLE/HOS/Services/Lm/LogService/ILogger.cs
@@ -8,6 +8,26 @@ namespace Ryujinx.HLE.HOS.Services.Lm.LogService
     {
         public ILogger() { }
 
+        private int ReadEncodedInt(BinaryReader reader)
+        {
+            int result   = 0;
+            int position = 0;
+
+            byte encoded;
+
+            do
+            {
+                encoded = reader.ReadByte();
+
+                result += (encoded & 0x7F) << (7 * position);
+
+                position++;
+
+            } while ((encoded & -128) != 0);
+
+            return result;
+        }
+
         [Command(0)]
         // Log(buffer<unknown, 0x21>)
         public ResultCode Log(ServiceCtx context)
@@ -34,8 +54,8 @@ namespace Ryujinx.HLE.HOS.Services.Lm.LogService
 
                 while (ms.Position < ms.Length)
                 {
-                    byte type = reader.ReadByte();
-                    byte size = reader.ReadByte();
+                    int type = ReadEncodedInt(reader);
+                    int size = ReadEncodedInt(reader);
 
                     LmLogField field = (LmLogField)type;
 


### PR DESCRIPTION
The type and size are custom encoded integer, not byte.

This fix crashes on games that send messages longer than 127 characters.