### PR TITLE
Make HLE disposable safely

### DIFF
--- a/Ryujinx.HLE/HOS/Kernel/Process/KHandleTable.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/KHandleTable.cs
@@ -272,6 +272,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
                             disposableObj.Dispose();
                         }
 
+                        entry.Obj.DecrementReferenceCount();
                         entry.Obj  = null;
                         entry.Next = _nextFreeEntry;
 

--- a/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
@@ -38,7 +38,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
         public ulong PersonalMmHeapPagesCount { get; private set; }
 
-        private ProcessState _state;
+        public ProcessState State { get; private set; }
 
         private object _processLock;
         private object _threadingLock;
@@ -383,7 +383,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
             Name = creationInfo.Name;
 
-            _state = ProcessState.Created;
+            State = ProcessState.Created;
 
             _creationTimestamp = PerformanceCounter.ElapsedMilliseconds;
 
@@ -579,7 +579,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
         {
             lock (_processLock)
             {
-                if (_state > ProcessState.CreatedAttached)
+                if (State > ProcessState.CreatedAttached)
                 {
                     return KernelResult.InvalidState;
                 }
@@ -733,8 +733,8 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
                 mainThread.SetEntryArguments(0, mainThreadHandle);
 
-                ProcessState oldState = _state;
-                ProcessState newState = _state != ProcessState.Created
+                ProcessState oldState = State;
+                ProcessState newState = State != ProcessState.Created
                     ? ProcessState.Attached
                     : ProcessState.Started;
 
@@ -768,9 +768,9 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
         private void SetState(ProcessState newState)
         {
-            if (_state != newState)
+            if (State != newState)
             {
-                _state    = newState;
+                State     = newState;
                 _signaled = true;
 
                 Signal();
@@ -818,6 +818,20 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
             {
                 Terminate();
             }
+        }
+
+        public void DecrementToZeroWhileTerminatingCurrent()
+        {
+            System.ThreadCounter.Signal();
+
+            while (Interlocked.Decrement(ref _threadCount) != 0)
+            {
+                Destroy();
+                TerminateCurrentProcess();
+            }
+
+            // Nintendo panic here because if it reaches this point, the current thread should be already dead.
+            // As we handle the death of the therad in the post SVC handler and inside the CPU emulator, we don't panic here.
         }
 
         public ulong GetMemoryCapacity()
@@ -909,12 +923,12 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
             lock (_processLock)
             {
-                if (_state >= ProcessState.Started)
+                if (State >= ProcessState.Started)
                 {
-                    if (_state == ProcessState.Started  ||
-                        _state == ProcessState.Crashed  ||
-                        _state == ProcessState.Attached ||
-                        _state == ProcessState.DebugSuspended)
+                    if (State == ProcessState.Started  ||
+                        State == ProcessState.Crashed  ||
+                        State == ProcessState.Attached ||
+                        State == ProcessState.DebugSuspended)
                     {
                         SetState(ProcessState.Exiting);
 
@@ -933,23 +947,96 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
             if (shallTerminate)
             {
-                // UnpauseAndTerminateAllThreadsExcept(System.Scheduler.GetCurrentThread());
+                UnpauseAndTerminateAllThreadsExcept(System.Scheduler.GetCurrentThread());
 
                 HandleTable.Destroy();
 
-                SignalExitForDebugEvent();
+                SignalExitToDebugTerminated();
                 SignalExit();
             }
 
             return result;
         }
 
-        private void UnpauseAndTerminateAllThreadsExcept(KThread thread)
+        public void TerminateCurrentProcess()
         {
-            // TODO.
+            bool shallTerminate = false;
+
+            System.CriticalSection.Enter();
+
+            lock (_processLock)
+            {
+                if (State >= ProcessState.Started)
+                {
+                    if (State == ProcessState.Started ||
+                        State == ProcessState.Attached ||
+                        State == ProcessState.DebugSuspended)
+                    {
+                        SetState(ProcessState.Exiting);
+
+                        shallTerminate = true;
+                    }
+                }
+            }
+
+            System.CriticalSection.Leave();
+
+            if (shallTerminate)
+            {
+                UnpauseAndTerminateAllThreadsExcept(System.Scheduler.GetCurrentThread());
+
+                HandleTable.Destroy();
+
+                // NOTE: this is supposed to be called in receiving of the mailbox.
+                SignalExitToDebugExited();
+                SignalExit();
+            }
         }
 
-        private void SignalExitForDebugEvent()
+        private void UnpauseAndTerminateAllThreadsExcept(KThread currentThread)
+        {
+            lock (_threadingLock)
+            {
+                System.CriticalSection.Enter();
+                foreach (KThread thread in _threads)
+                {
+                    if ((thread.SchedFlags & ThreadSchedState.LowMask) != ThreadSchedState.TerminationPending)
+                    {
+                        thread.PrepareForTermination();
+                    }
+                }
+                System.CriticalSection.Leave();
+            }
+
+            KThread blockedThread = null;
+
+            lock (_threadingLock)
+            {
+                foreach (KThread thread in _threads)
+                {
+                    if (thread != currentThread && (thread.SchedFlags & ThreadSchedState.LowMask) != ThreadSchedState.TerminationPending)
+                    {
+                        thread.IncrementReferenceCount();
+
+                        blockedThread = thread;
+                        break;
+                    }
+                }
+            }
+
+            if (blockedThread != null)
+            {
+                blockedThread.Terminate();
+                blockedThread.DecrementReferenceCount();
+            }
+        }
+
+        private void SignalExitToDebugTerminated()
+        {
+            // TODO: Debug events.
+        }
+
+        private void SignalExitToDebugExited()
         {
             // TODO: Debug events.
         }
@@ -976,7 +1063,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
             lock (_processLock)
             {
-                if (_state != ProcessState.Exited && _signaled)
+                if (State != ProcessState.Exited && _signaled)
                 {
                     _signaled = false;
 
@@ -999,7 +1086,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
             {
                 foreach (KThread thread in _threads)
                 {
-                    thread.Context.Running = false;
+                    System.Scheduler.ExitThread(thread);
 
                     System.Scheduler.CoreManager.Set(thread.HostThread);
                 }

--- a/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
@@ -831,7 +831,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
             }
 
             // Nintendo panic here because if it reaches this point, the current thread should be already dead.
-            // As we handle the death of the therad in the post SVC handler and inside the CPU emulator, we don't panic here.
+            // As we handle the death of the thread in the post SVC handler and inside the CPU emulator, we don't panic here.
         }
 
         public ulong GetMemoryCapacity()

--- a/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
@@ -998,6 +998,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
             lock (_threadingLock)
             {
                 System.CriticalSection.Enter();
+
                 foreach (KThread thread in _threads)
                 {
                     if ((thread.SchedFlags & ThreadSchedState.LowMask) != ThreadSchedState.TerminationPending)
@@ -1005,6 +1006,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
                         thread.PrepareForTermination();
                     }
                 }
+
                 System.CriticalSection.Leave();
             }
 

--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcHandler.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcHandler.cs
@@ -1,5 +1,6 @@
 using ARMeilleure.State;
 using Ryujinx.HLE.HOS.Kernel.Process;
+using Ryujinx.HLE.HOS.Kernel.Threading;
 using System;
 
 namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
@@ -29,6 +30,15 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             ExecutionContext context = (ExecutionContext)sender;
 
             svcFunc(this, context);
+
+            PostSvcHandler(context);
+        }
+
+        private void PostSvcHandler(ExecutionContext context)
+        {
+            KThread currentThread = _system.Scheduler.GetCurrentThread();
+
+            currentThread.HandlePostSyscall();
         }
     }
 }

--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcHandler.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcHandler.cs
@@ -31,10 +31,10 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
 
             svcFunc(this, context);
 
-            PostSvcHandler(context);
+            PostSvcHandler();
         }
 
-        private void PostSvcHandler(ExecutionContext context)
+        private void PostSvcHandler()
         {
             KThread currentThread = _system.Scheduler.GetCurrentThread();
 

--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcTable.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcTable.cs
@@ -74,7 +74,8 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
                 { 0x72, nameof(SvcHandler.ConnectToPort64)                 },
                 { 0x73, nameof(SvcHandler.SetProcessMemoryPermission64)    },
                 { 0x77, nameof(SvcHandler.MapProcessCodeMemory64)          },
-                { 0x78, nameof(SvcHandler.UnmapProcessCodeMemory64)        }
+                { 0x78, nameof(SvcHandler.UnmapProcessCodeMemory64)        },
+                { 0x7B, nameof(SvcHandler.TerminateProcess64)              }
             };
 
             _svcTable64 = new Action<SvcHandler, ExecutionContext>[0x80];


### PR DESCRIPTION
This fix the oldest issue with the HLE code: the kernel side
disposability.

Changelog:

- Implement KProcess::UnpauseAndTerminateAllThreadsExcept, KThread::Terminate, KThread::TerminateCurrentProcess, KThread::PrepareForTermiation and the svc post handler accurately.
- Implement svcTerminateProcess and svcExitProcess. (both untested)
- Fix KHandleTable::Destroy not decrementing refcount of all objects stored in the table.
- Spawn a custom KProcess with the maximum priority to terminate every guest KProcess. (terminating kernel emulation safely)
- General system stability improvements to enhance the user's experience.

PS: This based on @TuxSH's reversing of kernel 6.0.0