### PR TITLE
Fix remap ioctl map offset

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostAsGpu/NvHostAsGpuDeviceFile.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostAsGpu/NvHostAsGpuDeviceFile.cs
@@ -293,13 +293,15 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostAsGpu
                     return NvInternalResult.InvalidInput;
                 }
 
-                long result = vmm.Map(map.Address, (long)arguments[index].Offset << 16,
-                                                   (long)arguments[index].Pages << 16);
+                long result = vmm.Map(
+                    ((long)arguments[index].MapOffset << 16) + map.Address,
+                    (long)arguments[index].GpuOffset << 16,
+                    (long)arguments[index].Pages << 16);
 
                 if (result < 0)
                 {
                     Logger.PrintWarning(LogClass.ServiceNv,
-                        $"Page 0x{arguments[index].Offset:x16} size 0x{arguments[index].Pages:x16} not allocated!");
+                        $"Page 0x{arguments[index].GpuOffset:x16} size 0x{arguments[index].Pages:x16} not allocated!");
 
                     return NvInternalResult.InvalidInput;
                 }

--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostAsGpu/Types/RemapArguments.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostAsGpu/Types/RemapArguments.cs
@@ -8,8 +8,8 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostAsGpu.Types
         public ushort Flags;
         public ushort Kind;
         public int    NvMapHandle;
-        public int    Padding;
-        public uint   Offset;
+        public int    MapOffset;
+        public uint   GpuOffset;
         public uint   Pages;
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostAsGpu/Types/RemapArguments.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostAsGpu/Types/RemapArguments.cs
@@ -8,7 +8,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostAsGpu.Types
         public ushort Flags;
         public ushort Kind;
         public int    NvMapHandle;
-        public int    MapOffset;
+        public uint   MapOffset;
         public uint   GpuOffset;
         public uint   Pages;
     }


### PR DESCRIPTION
The struct on switchbrew is wrong, the field at 0x8 is not padding. I confirmed looking at nvservices that it is indeed used as a offset, multiplied by some page size.