### PR TITLE
Fix EphemeralNetworkSystemClock using the wrong steady clock

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Time/TimeManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/TimeManager.cs
@@ -48,7 +48,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             StandardNetworkSystemClock  = new StandardNetworkSystemClockCore(StandardSteadyClock);
             StandardUserSystemClock     = new StandardUserSystemClockCore(StandardLocalSystemClock, StandardNetworkSystemClock);
             TimeZone                    = new TimeZoneContentManager();
-            EphemeralNetworkSystemClock = new EphemeralNetworkSystemClockCore(StandardSteadyClock);
+            EphemeralNetworkSystemClock = new EphemeralNetworkSystemClockCore(TickBasedSteadyClock);
             SharedMemory                = new TimeSharedMemory();
             LocalClockContextWriter     = new LocalSystemClockContextWriter(SharedMemory);
             NetworkClockContextWriter   = new NetworkSystemClockContextWriter(SharedMemory);


### PR DESCRIPTION
Found this diff while looking at my reversing of PSC, oops.

===
General system stability improvements to enhance the user's experience.