### PR TITLE
Add 32 bits support to HleProcessDebugger

### DIFF
--- a/Ryujinx.HLE/HOS/Kernel/Process/HleProcessDebugger.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/HleProcessDebugger.cs
@@ -311,7 +311,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
             while ((ulong)symTblAddr < (ulong)strTblAddr)
             {
-                ElfSymbol sym = GetSymbol(memory, symTblAddr, strTblAddr);
+                ElfSymbol sym = isAArch32 ? GetSymbol32(memory, symTblAddr, strTblAddr) : GetSymbol64(memory, symTblAddr, strTblAddr);
 
                 symbols.Add(sym);
 
@@ -324,7 +324,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
             }
         }
 
-        private ElfSymbol GetSymbol(MemoryManager memory, long address, long strTblAddr)
+        private ElfSymbol GetSymbol64(MemoryManager memory, long address, long strTblAddr)
         {
             int  nameIndex = memory.ReadInt32(address + 0);
             int  info      = memory.ReadByte (address + 4);
@@ -332,6 +332,25 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
             int  shIdx     = memory.ReadInt16(address + 6);
             long value     = memory.ReadInt64(address + 8);
             long size      = memory.ReadInt64(address + 16);
+
+            string name = string.Empty;
+
+            for (int chr; (chr = memory.ReadByte(strTblAddr + nameIndex++)) != 0;)
+            {
+                name += (char)chr;
+            }
+
+            return new ElfSymbol(name, info, other, shIdx, value, size);
+        }
+
+        private ElfSymbol GetSymbol32(MemoryManager memory, long address, long strTblAddr)
+        {
+            int  nameIndex = memory.ReadInt32(address + 0);
+            int  info      = memory.ReadByte (address + 4);
+            int  other     = memory.ReadByte (address + 5);
+            int  shIdx     = memory.ReadByte (address + 12);
+            long value     = memory.ReadByte (address + 13);
+            long size      = memory.ReadInt16(address + 14);
 
             string name = string.Empty;
 

--- a/Ryujinx.HLE/HOS/Kernel/Process/HleProcessDebugger.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/HleProcessDebugger.cs
@@ -80,7 +80,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
                 while (framePointer != 0)
                 {
-                    if ((framePointer & 7) != 0 ||
+                    if ((framePointer & 3) != 0 ||
                         !_owner.CpuMemory.IsMapped(framePointer) ||
                         !_owner.CpuMemory.IsMapped(framePointer + 4))
                     {
@@ -100,7 +100,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
                 while (framePointer != 0)
                 {
-                    if ((framePointer & 15) != 0 ||
+                    if ((framePointer & 7) != 0 ||
                         !_owner.CpuMemory.IsMapped(framePointer) ||
                         !_owner.CpuMemory.IsMapped(framePointer + 8))
                     {

--- a/Ryujinx.HLE/Loaders/Elf/ElfSymbol.cs
+++ b/Ryujinx.HLE/Loaders/Elf/ElfSymbol.cs
@@ -17,16 +17,16 @@ namespace Ryujinx.HLE.Loaders.Elf
             Binding == ElfSymbolBinding.StbWeak;
 
         public int  ShIdx { get; private set; }
-        public long Value { get; private set; }
-        public long Size  { get; private set; }
+        public ulong Value { get; private set; }
+        public ulong Size  { get; private set; }
 
         public ElfSymbol(
             string name,
             int    info,
             int    other,
             int    shIdx,
-            long   value,
-            long   size)
+            ulong  value,
+            ulong  size)
         {
             Name       = name;
             Type       = (ElfSymbolType)(info & 0xf);

--- a/Ryujinx.HLE/Loaders/Elf/ElfSymbol32.cs
+++ b/Ryujinx.HLE/Loaders/Elf/ElfSymbol32.cs
@@ -1,0 +1,17 @@
+﻿namespace Ryujinx.HLE.Loaders.Elf
+{
+    struct ElfSymbol32
+    {
+        public uint   NameOffset;
+        public uint   ValueAddress;
+        public uint   Size;
+        public char   Info;
+        public char   Other;
+        public ushort SectionIndex;
+
+        public string GetName()
+        {
+
+        }
+    }
+}

--- a/Ryujinx.HLE/Loaders/Elf/ElfSymbol32.cs
+++ b/Ryujinx.HLE/Loaders/Elf/ElfSymbol32.cs
@@ -8,10 +8,5 @@
         public char   Info;
         public char   Other;
         public ushort SectionIndex;
-
-        public string GetName()
-        {
-
-        }
     }
 }

--- a/Ryujinx.HLE/Loaders/Elf/ElfSymbol64.cs
+++ b/Ryujinx.HLE/Loaders/Elf/ElfSymbol64.cs
@@ -1,0 +1,12 @@
+﻿namespace Ryujinx.HLE.Loaders.Elf
+{
+    struct ElfSymbol64
+    {
+        public uint   NameOffset;
+        public char   Info;
+        public char   Other;
+        public ushort SectionIndex;
+        public ulong  ValueAddress;
+        public ulong  Size;
+    }
+}


### PR DESCRIPTION
This adds stacktrace and symbols parsing for 32 bits binaries.

Stacktrace code based on @riperiperi's work.

===
General system stability improvements to enhance the user's experience.