### PR TITLE
Fix ReactiveObject initial event not being propagated with boolean types

### DIFF
--- a/Ryujinx.Common/ReactiveObject.cs
+++ b/Ryujinx.Common/ReactiveObject.cs
@@ -6,8 +6,8 @@ namespace Ryujinx.Common
     public class ReactiveObject<T>
     {
         private ReaderWriterLock _readerWriterLock = new ReaderWriterLock();
-        private bool             _isInitialized      = false;
-        private T                _value;
+        private bool _isInitialized = false;
+        private T _value;
 
         public event EventHandler<ReactiveEventArgs<T>> Event;
 

--- a/Ryujinx.Common/ReactiveObject.cs
+++ b/Ryujinx.Common/ReactiveObject.cs
@@ -6,6 +6,7 @@ namespace Ryujinx.Common
     public class ReactiveObject<T>
     {
         private ReaderWriterLock _readerWriterLock = new ReaderWriterLock();
+        private bool             _isInitialized      = false;
         private T                _value;
 
         public event EventHandler<ReactiveEventArgs<T>> Event;
@@ -25,12 +26,15 @@ namespace Ryujinx.Common
                 _readerWriterLock.AcquireWriterLock(Timeout.Infinite);
 
                 T oldValue = _value;
-                
-                _value = value;
+
+                bool oldIsInitialized = _isInitialized;
+
+                _isInitialized = true;
+                _value         = value;
 
                 _readerWriterLock.ReleaseWriterLock();
 
-                if (oldValue == null || !oldValue.Equals(_value))
+                if (!oldIsInitialized || !oldValue.Equals(_value))
                 {
                     Event?.Invoke(this, new ReactiveEventArgs<T>(oldValue, value));
                 }


### PR DESCRIPTION
This fix the logger configuration initial state being ignored.

===
General system stability improvements to enhance the user's experience.