### PR TITLE
Call EnsureApplicationSaveData when launching a game

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Arp/ApplicationLaunchProperty.cs
+++ b/Ryujinx.HLE/HOS/Services/Arp/ApplicationLaunchProperty.cs
@@ -1,12 +1,10 @@
 ﻿using Ryujinx.HLE.FileSystem;
-using Ryujinx.HLE.Utilities;
-using System;
 
 namespace Ryujinx.HLE.HOS.Services.Arp
 {
     class ApplicationLaunchProperty
     {
-        public long  TitleId;
+        public ulong TitleId;
         public int   Version;
         public byte  BaseGameStorageId;
         public byte  UpdateGameStorageId;
@@ -33,7 +31,7 @@ namespace Ryujinx.HLE.HOS.Services.Arp
 
             return new ApplicationLaunchProperty
             {
-                TitleId             = BitConverter.ToInt64(StringUtils.HexToBytes(context.Device.System.TitleId), 0),
+                TitleId             = context.Device.System.TitleId,
                 Version             = 0x00,
                 BaseGameStorageId   = (byte)StorageId.NandSystem,
                 UpdateGameStorageId = (byte)StorageId.None

--- a/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
@@ -133,6 +133,20 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             SaveDataCreateInfo createInfo     = context.RequestData.ReadStruct<SaveDataCreateInfo>();
             SaveMetaCreateInfo metaCreateInfo = context.RequestData.ReadStruct<SaveMetaCreateInfo>();
 
+            // TODO: There's currently no program registry for FS to reference.
+            // Workaround that by setting the application ID and owner ID if they're not already set
+            if (attribute.TitleId == TitleId.Zero)
+            {
+                attribute.TitleId = new TitleId(context.Process.TitleId);
+            }
+
+            if (createInfo.OwnerId == TitleId.Zero)
+            {
+                createInfo.OwnerId = new TitleId(context.Process.TitleId);
+            }
+
+            Logger.PrintInfo(LogClass.ServiceFs, $"Creating save with title ID {attribute.TitleId.Value:x16}");
+
             Result result = _baseFileSystemProxy.CreateSaveDataFileSystem(ref attribute, ref createInfo, ref metaCreateInfo);
 
             return (ResultCode)result.Value;
@@ -196,6 +210,18 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             SaveMetaCreateInfo metaCreateInfo = context.RequestData.ReadStruct<SaveMetaCreateInfo>();
             HashSalt           hashSalt       = context.RequestData.ReadStruct<HashSalt>();
 
+            // TODO: There's currently no program registry for FS to reference.
+            // Workaround that by setting the application ID and owner ID if they're not already set
+            if (attribute.TitleId == TitleId.Zero)
+            {
+                attribute.TitleId = new TitleId(context.Process.TitleId);
+            }
+
+            if (createInfo.OwnerId == TitleId.Zero)
+            {
+                createInfo.OwnerId = new TitleId(context.Process.TitleId);
+            }
+
             Result result = _baseFileSystemProxy.CreateSaveDataFileSystemWithHashSalt(ref attribute, ref createInfo, ref metaCreateInfo, ref hashSalt);
 
             return (ResultCode)result.Value;
@@ -208,6 +234,8 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             SaveDataSpaceId   spaceId   = (SaveDataSpaceId)context.RequestData.ReadInt64();
             SaveDataAttribute attribute = context.RequestData.ReadStruct<SaveDataAttribute>();
 
+            // TODO: There's currently no program registry for FS to reference.
+            // Workaround that by setting the application ID if it's not already set
             if (attribute.TitleId == TitleId.Zero)
             {
                 attribute.TitleId = new TitleId(context.Process.TitleId);
@@ -247,6 +275,8 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             SaveDataSpaceId spaceId = (SaveDataSpaceId)context.RequestData.ReadInt64();
             SaveDataAttribute attribute = context.RequestData.ReadStruct<SaveDataAttribute>();
 
+            // TODO: There's currently no program registry for FS to reference.
+            // Workaround that by setting the application ID if it's not already set
             if (attribute.TitleId == TitleId.Zero)
             {
                 attribute.TitleId = new TitleId(context.Process.TitleId);

--- a/Ryujinx/Ui/GLScreen.cs
+++ b/Ryujinx/Ui/GLScreen.cs
@@ -307,10 +307,10 @@ namespace Ryujinx.Ui
             string titleNameSection = string.IsNullOrWhiteSpace(_device.System.TitleName) ? string.Empty
                 : " | " + _device.System.TitleName;
 
-            string titleIDSection = string.IsNullOrWhiteSpace(_device.System.TitleId) ? string.Empty
-                : " | " + _device.System.TitleId.ToUpper();
+            string titleIdSection = string.IsNullOrWhiteSpace(_device.System.TitleIdText) ? string.Empty
+                : " | " + _device.System.TitleIdText.ToUpper();
 
-            _newTitle = $"Ryujinx{titleNameSection}{titleIDSection} | Host FPS: {hostFps:0.0} | Game FPS: {gameFps:0.0} | " +
+            _newTitle = $"Ryujinx{titleNameSection}{titleIdSection} | Host FPS: {hostFps:0.0} | Game FPS: {gameFps:0.0} | " +
                 $"Game Vsync: {(_device.EnableDeviceVsync ? "On" : "Off")}";
 
             _titleEvent = true;

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -305,9 +305,9 @@ namespace Ryujinx.Ui
                 _firmwareInstallFile.Sensitive      = false;
                 _firmwareInstallDirectory.Sensitive = false;
 
-                DiscordIntegrationModule.SwitchToPlayingState(_device.System.TitleId, _device.System.TitleName);
+                DiscordIntegrationModule.SwitchToPlayingState(_device.System.TitleIdText, _device.System.TitleName);
 
-                ApplicationLibrary.LoadAndSaveMetaData(_device.System.TitleId, appMetadata =>
+                ApplicationLibrary.LoadAndSaveMetaData(_device.System.TitleIdText, appMetadata =>
                 {
                     appMetadata.LastPlayed = DateTime.UtcNow.ToString();
                 });
@@ -337,7 +337,7 @@ namespace Ryujinx.Ui
 
             if (_gameLoaded)
             {
-                ApplicationLibrary.LoadAndSaveMetaData(_device.System.TitleId, appMetadata =>
+                ApplicationLibrary.LoadAndSaveMetaData(_device.System.TitleIdText, appMetadata =>
                 {
                     DateTime lastPlayedDateTime = DateTime.Parse(appMetadata.LastPlayed);
                     double sessionTimePlayed = DateTime.UtcNow.Subtract(lastPlayedDateTime).TotalSeconds;


### PR DESCRIPTION
qlaunch calls EnsureApplicationSaveData when launching an application, so we need to do the same.

Also workaround the lack of a program registry by manually setting the program ID if needed when calling some savedata functions.