### PR TITLE
Rework SVC handling

### DIFF
--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/RAttribute.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/RAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
+{
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false)]
+    public class RAttribute : Attribute
+    {
+        public readonly int Index;
+
+        public RAttribute(int index)
+        {
+            Index = index;
+        }
+    }
+}

--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcHandler.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcHandler.cs
@@ -20,14 +20,14 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
 
         public void SvcCall(object sender, InstExceptionEventArgs e)
         {
-            Action<SvcHandler, ExecutionContext> svcFunc = SvcTable.GetSvcFunc(e.Id);
+            ExecutionContext context = (ExecutionContext)sender;
+
+            Action<SvcHandler, ExecutionContext> svcFunc = context.IsAarch32 ? SvcTable.SvcTable32[e.Id] : SvcTable.SvcTable64[e.Id];
 
             if (svcFunc == null)
             {
                 throw new NotImplementedException($"SVC 0x{e.Id:X4} is not implemented.");
             }
-
-            ExecutionContext context = (ExecutionContext)sender;
 
             svcFunc(this, context);
 

--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcIpc.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcIpc.cs
@@ -30,7 +30,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             }
         }
 
-        public KernelResult ConnectToNamedPort64(ulong namePtr, out int handle)
+        public KernelResult ConnectToNamedPort64([R(1)] ulong namePtr, [R(1)] out int handle)
         {
             return ConnectToNamedPort(namePtr, out handle);
         }
@@ -81,12 +81,12 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return result;
         }
 
-        public KernelResult SendSyncRequest64(int handle)
+        public KernelResult SendSyncRequest64([R(0)] int handle)
         {
             return SendSyncRequest((ulong)_system.Scheduler.GetCurrentThread().Context.Tpidr, 0x100, handle);
         }
 
-        public KernelResult SendSyncRequestWithUserBuffer64(ulong messagePtr, ulong size, int handle)
+        public KernelResult SendSyncRequestWithUserBuffer64([R(0)] ulong messagePtr, [R(1)] ulong size, [R(2)] int handle)
         {
             return SendSyncRequest(messagePtr, size, handle);
         }
@@ -168,10 +168,10 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
         }
 
         public KernelResult CreateSession64(
-            bool    isLight,
-            ulong   namePtr,
-            out int serverSessionHandle,
-            out int clientSessionHandle)
+            [R(2)] bool    isLight,
+            [R(3)] ulong   namePtr,
+            [R(1)] out int serverSessionHandle,
+            [R(2)] out int clientSessionHandle)
         {
             return CreateSession(isLight, namePtr, out serverSessionHandle, out clientSessionHandle);
         }
@@ -242,7 +242,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return result;
         }
 
-        public KernelResult AcceptSession64(int portHandle, out int sessionHandle)
+        public KernelResult AcceptSession64([R(1)] int portHandle, [R(1)] out int sessionHandle)
         {
             return AcceptSession(portHandle, out sessionHandle);
         }
@@ -299,11 +299,11 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
         }
 
         public KernelResult ReplyAndReceive64(
-            ulong   handlesPtr,
-            int     handlesCount,
-            int     replyTargetHandle,
-            long    timeout,
-            out int handleIndex)
+            [R(1)] ulong   handlesPtr,
+            [R(2)] int     handlesCount,
+            [R(3)] int     replyTargetHandle,
+            [R(4)] long    timeout,
+            [R(1)] out int handleIndex)
         {
             handleIndex = 0;
 
@@ -385,11 +385,11 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
         }
 
         public KernelResult CreatePort64(
-            int     maxSessions,
-            bool    isLight,
-            ulong   namePtr,
-            out int serverPortHandle,
-            out int clientPortHandle)
+            [R(2)] int     maxSessions,
+            [R(3)] bool    isLight,
+            [R(4)] ulong   namePtr,
+            [R(1)] out int serverPortHandle,
+            [R(2)] out int clientPortHandle)
         {
             return CreatePort(maxSessions, isLight, namePtr, out serverPortHandle, out clientPortHandle);
         }
@@ -429,7 +429,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return result;
         }
 
-        public KernelResult ManageNamedPort64(ulong namePtr, int maxSessions, out int handle)
+        public KernelResult ManageNamedPort64([R(1)] ulong namePtr, [R(2)] int maxSessions, [R(1)] out int handle)
         {
             return ManageNamedPort(namePtr, maxSessions, out handle);
         }
@@ -474,7 +474,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return result;
         }
 
-        public KernelResult ConnectToPort64(int clientPortHandle, out int clientSessionHandle)
+        public KernelResult ConnectToPort64([R(1)] int clientPortHandle, [R(1)] out int clientSessionHandle)
         {
             return ConnectToPort(clientPortHandle, out clientSessionHandle);
         }

--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcMemory.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcMemory.cs
@@ -143,12 +143,12 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return _process.MemoryManager.Unmap(dst, src, size);
         }
 
-        public KernelResult QueryMemory64([R(0)] ulong infoPtr, [R(1)] ulong x1, [R(2)] ulong position)
+        public KernelResult QueryMemory64([R(0)] ulong infoPtr, [R(2)] ulong position, [R(1)] out ulong pageInfo)
         {
-            return QueryMemory(infoPtr, position);
+            return QueryMemory(infoPtr, position, out pageInfo);
         }
 
-        private KernelResult QueryMemory(ulong infoPtr, ulong position)
+        private KernelResult QueryMemory(ulong infoPtr, ulong position, out ulong pageInfo)
         {
             KMemoryInfo blkInfo = _process.MemoryManager.QueryMemory(position);
 
@@ -160,6 +160,8 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             _process.CpuMemory.WriteInt32 ((long)infoPtr + 0x1c, blkInfo.IpcRefCount);
             _process.CpuMemory.WriteInt32 ((long)infoPtr + 0x20, blkInfo.DeviceRefCount);
             _process.CpuMemory.WriteInt32 ((long)infoPtr + 0x24, 0);
+
+            pageInfo = 0;
 
             return KernelResult.Success;
         }

--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcMemory.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcMemory.cs
@@ -6,7 +6,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
 {
     partial class SvcHandler
     {
-        public KernelResult SetHeapSize64(ulong size, out ulong position)
+        public KernelResult SetHeapSize64([R(1)] ulong size, [R(1)] out ulong position)
         {
             return SetHeapSize(size, out position);
         }
@@ -24,10 +24,10 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
         }
 
         public KernelResult SetMemoryAttribute64(
-            ulong           position,
-            ulong           size,
-            MemoryAttribute attributeMask,
-            MemoryAttribute attributeValue)
+            [R(0)] ulong           position,
+            [R(1)] ulong           size,
+            [R(2)] MemoryAttribute attributeMask,
+            [R(3)] MemoryAttribute attributeValue)
         {
             return SetMemoryAttribute(position, size, attributeMask, attributeValue);
         }
@@ -65,7 +65,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return result;
         }
 
-        public KernelResult MapMemory64(ulong dst, ulong src, ulong size)
+        public KernelResult MapMemory64([R(0)] ulong dst, [R(1)] ulong src, [R(2)] ulong size)
         {
             return MapMemory(dst, src, size);
         }
@@ -104,7 +104,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return _process.MemoryManager.Map(dst, src, size);
         }
 
-        public KernelResult UnmapMemory64(ulong dst, ulong src, ulong size)
+        public KernelResult UnmapMemory64([R(0)] ulong dst, [R(1)] ulong src, [R(2)] ulong size)
         {
             return UnmapMemory(dst, src, size);
         }
@@ -143,7 +143,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return _process.MemoryManager.Unmap(dst, src, size);
         }
 
-        public KernelResult QueryMemory64(ulong infoPtr, ulong x1, ulong position)
+        public KernelResult QueryMemory64([R(0)] ulong infoPtr, [R(1)] ulong x1, [R(2)] ulong position)
         {
             return QueryMemory(infoPtr, position);
         }
@@ -164,7 +164,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return KernelResult.Success;
         }
 
-        public KernelResult MapSharedMemory64(int handle, ulong address, ulong size, MemoryPermission permission)
+        public KernelResult MapSharedMemory64([R(0)] int handle, [R(1)] ulong address, [R(2)] ulong size, [R(3)] MemoryPermission permission)
         {
             return MapSharedMemory(handle, address, size, permission);
         }
@@ -215,7 +215,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
                 permission);
         }
 
-        public KernelResult UnmapSharedMemory64(int handle, ulong address, ulong size)
+        public KernelResult UnmapSharedMemory64([R(0)] int handle, [R(1)] ulong address, [R(2)] ulong size)
         {
             return UnmapSharedMemory(handle, address, size);
         }
@@ -261,10 +261,10 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
         }
 
         public KernelResult CreateTransferMemory64(
-            ulong            address,
-            ulong            size,
-            MemoryPermission permission,
-            out int          handle)
+            [R(1)] ulong            address,
+            [R(2)] ulong            size,
+            [R(3)] MemoryPermission permission,
+            [R(1)] out int          handle)
         {
             return CreateTransferMemory(address, size, permission, out handle);
         }
@@ -305,7 +305,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return _process.HandleTable.GenerateHandle(transferMemory, out handle);
         }
 
-        public KernelResult MapPhysicalMemory64(ulong address, ulong size)
+        public KernelResult MapPhysicalMemory64([R(0)] ulong address, [R(1)] ulong size)
         {
             return MapPhysicalMemory(address, size);
         }
@@ -343,7 +343,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return _process.MemoryManager.MapPhysicalMemory(address, size);
         }
 
-        public KernelResult UnmapPhysicalMemory64(ulong address, ulong size)
+        public KernelResult UnmapPhysicalMemory64([R(0)] ulong address, [R(1)] ulong size)
         {
             return UnmapPhysicalMemory(address, size);
         }
@@ -381,7 +381,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return _process.MemoryManager.UnmapPhysicalMemory(address, size);
         }
 
-        public KernelResult MapProcessCodeMemory64(int handle, ulong dst, ulong src, ulong size)
+        public KernelResult MapProcessCodeMemory64([R(0)] int handle, [R(1)] ulong dst, [R(2)] ulong src, [R(3)] ulong size)
         {
             return MapProcessCodeMemory(handle, dst, src, size);
         }
@@ -423,7 +423,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return targetProcess.MemoryManager.MapProcessCodeMemory(dst, src, size);
         }
 
-        public KernelResult UnmapProcessCodeMemory64(int handle, ulong dst, ulong src, ulong size)
+        public KernelResult UnmapProcessCodeMemory64([R(0)] int handle, [R(1)] ulong dst, [R(2)] ulong src, [R(3)] ulong size)
         {
             return UnmapProcessCodeMemory(handle, dst, src, size);
         }
@@ -465,7 +465,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return targetProcess.MemoryManager.UnmapProcessCodeMemory(dst, src, size);
         }
 
-        public KernelResult SetProcessMemoryPermission64(int handle, ulong src, ulong size, MemoryPermission permission)
+        public KernelResult SetProcessMemoryPermission64([R(0)] int handle, [R(1)] ulong src, [R(2)] ulong size, [R(3)] MemoryPermission permission)
         {
             return SetProcessMemoryPermission(handle, src, size, permission);
         }

--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcSystem.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcSystem.cs
@@ -17,7 +17,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             ExitProcess();
         }
 
-        public KernelResult TerminateProcess64(int handle)
+        public KernelResult TerminateProcess64([R(0)] int handle)
         {
             return TerminateProcess(handle);
         }
@@ -54,7 +54,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             _system.Scheduler.GetCurrentProcess().TerminateCurrentProcess();
         }
 
-        public KernelResult SignalEvent64(int handle)
+        public KernelResult SignalEvent64([R(0)] int handle)
         {
             return SignalEvent(handle);
         }
@@ -79,7 +79,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return result;
         }
 
-        public KernelResult ClearEvent64(int handle)
+        public KernelResult ClearEvent64([R(0)] int handle)
         {
             return ClearEvent(handle);
         }
@@ -104,7 +104,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return result;
         }
 
-        public KernelResult CloseHandle64(int handle)
+        public KernelResult CloseHandle64([R(0)] int handle)
         {
             return CloseHandle(handle);
         }
@@ -134,7 +134,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return KernelResult.Success;
         }
 
-        public KernelResult ResetSignal64(int handle)
+        public KernelResult ResetSignal64([R(0)] int handle)
         {
             return ResetSignal(handle);
         }
@@ -173,7 +173,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return _system.Scheduler.GetCurrentThread().Context.CntpctEl0;
         }
 
-        public KernelResult GetProcessId64(int handle, out long pid)
+        public KernelResult GetProcessId64([R(1)] int handle, [R(1)] out long pid)
         {
             return GetProcessId(handle, out pid);
         }
@@ -203,7 +203,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
                 : KernelResult.InvalidHandle;
         }
 
-        public void Break64(ulong reason, ulong x1, ulong info)
+        public void Break64([R(0)] ulong reason, [R(1)] ulong x1, [R(2)] ulong info)
         {
             Break(reason);
         }
@@ -235,7 +235,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             }
         }
 
-        public void OutputDebugString64(ulong strPtr, ulong size)
+        public void OutputDebugString64([R(0)] ulong strPtr, [R(1)] ulong size)
         {
             OutputDebugString(strPtr, size);
         }
@@ -247,7 +247,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             Logger.PrintWarning(LogClass.KernelSvc, str);
         }
 
-        public KernelResult GetInfo64(uint id, int handle, long subId, out long value)
+        public KernelResult GetInfo64([R(1)] uint id, [R(2)] int handle, [R(3)] long subId, [R(1)] out long value)
         {
             return GetInfo(id, handle, subId, out value);
         }
@@ -478,7 +478,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return KernelResult.Success;
         }
 
-        public KernelResult CreateEvent64(out int wEventHandle, out int rEventHandle)
+        public KernelResult CreateEvent64([R(1)] out int wEventHandle, [R(2)] out int rEventHandle)
         {
             return CreateEvent(out wEventHandle, out rEventHandle);
         }
@@ -506,7 +506,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return result;
         }
 
-        public KernelResult GetProcessList64(ulong address, int maxCount, out int count)
+        public KernelResult GetProcessList64([R(1)] ulong address, [R(2)] int maxCount, [R(1)] out int count)
         {
             return GetProcessList(address, maxCount, out count);
         }
@@ -560,7 +560,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return KernelResult.Success;
         }
 
-        public KernelResult GetSystemInfo64(uint id, int handle, long subId, out long value)
+        public KernelResult GetSystemInfo64([R(1)] uint id, [R(2)] int handle, [R(3)] long subId, [R(1)] out long value)
         {
             return GetSystemInfo(id, handle, subId, out value);
         }

--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcTable.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcTable.cs
@@ -108,7 +108,6 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             MethodInfo methodInfo = typeof(SvcHandler).GetMethod(svcName);
 
             ParameterInfo[] methodArgs = methodInfo.GetParameters();
-            int numArgs = methodArgs.Count(x => !x.IsOut);
 
             ILGenerator generator = method.GetILGenerator();
 

--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcTable.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcTable.cs
@@ -331,7 +331,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
 
                 generator.Emit(OpCodes.Call, info);
 
-                registerInUse |= 1u << locals[index].Item2.Index;
+                registerInUse |= 1u << attribute.Index;
             }
 
             // Zero out the remaining unused registers.

--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcThread.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcThread.cs
@@ -9,12 +9,12 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
     partial class SvcHandler
     {
         public KernelResult CreateThread64(
-            ulong   entrypoint,
-            ulong   argsPtr,
-            ulong   stackTop,
-            int     priority,
-            int     cpuCore,
-            out int handle)
+            [R(1)] ulong   entrypoint,
+            [R(2)] ulong   argsPtr,
+            [R(3)] ulong   stackTop,
+            [R(4)] int     priority,
+            [R(5)] int     cpuCore,
+            [R(1)] out int handle)
         {
             return CreateThread(entrypoint, argsPtr, stackTop, priority, cpuCore, out handle);
         }
@@ -78,7 +78,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return result;
         }
 
-        public KernelResult StartThread64(int handle)
+        public KernelResult StartThread64([R(0)] int handle)
         {
             return StartThread(handle);
         }
@@ -122,7 +122,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             currentThread.Exit();
         }
 
-        public void SleepThread64(long timeout)
+        public void SleepThread64([R(0)] long timeout)
         {
             SleepThread(timeout);
         }
@@ -146,7 +146,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             }
         }
 
-        public KernelResult GetThreadPriority64(int handle, out int priority)
+        public KernelResult GetThreadPriority64([R(1)] int handle, [R(1)] out int priority)
         {
             return GetThreadPriority(handle, out priority);
         }
@@ -169,7 +169,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             }
         }
 
-        public KernelResult SetThreadPriority64(int handle, int priority)
+        public KernelResult SetThreadPriority64([R(0)] int handle, [R(1)] int priority)
         {
             return SetThreadPriority(handle, priority);
         }
@@ -190,7 +190,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return KernelResult.Success;
         }
 
-        public KernelResult GetThreadCoreMask64(int handle, out int preferredCore, out long affinityMask)
+        public KernelResult GetThreadCoreMask64([R(2)] int handle, [R(1)] out int preferredCore, [R(2)] out long affinityMask)
         {
             return GetThreadCoreMask(handle, out preferredCore, out affinityMask);
         }
@@ -215,7 +215,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             }
         }
 
-        public KernelResult SetThreadCoreMask64(int handle, int preferredCore, long affinityMask)
+        public KernelResult SetThreadCoreMask64([R(0)] int handle, [R(1)] int preferredCore, [R(2)] long affinityMask)
         {
             return SetThreadCoreMask(handle, preferredCore, affinityMask);
         }
@@ -271,7 +271,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return _system.Scheduler.GetCurrentThread().CurrentCore;
         }
 
-        public KernelResult GetThreadId64(int handle, out long threadUid)
+        public KernelResult GetThreadId64([R(1)] int handle, [R(1)] out long threadUid)
         {
             return GetThreadId(handle, out threadUid);
         }
@@ -294,7 +294,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             }
         }
 
-        public KernelResult SetThreadActivity64(int handle, bool pause)
+        public KernelResult SetThreadActivity64([R(0)] int handle, [R(1)] bool pause)
         {
             return SetThreadActivity(handle, pause);
         }
@@ -321,7 +321,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return thread.SetActivity(pause);
         }
 
-        public KernelResult GetThreadContext364(ulong address, int handle)
+        public KernelResult GetThreadContext364([R(0)] ulong address, [R(1)] int handle)
         {
             return GetThreadContext3(address, handle);
         }

--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcThreadSync.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SvcThreadSync.cs
@@ -7,7 +7,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
 {
     partial class SvcHandler
     {
-        public KernelResult WaitSynchronization64(ulong handlesPtr, int handlesCount, long timeout, out int handleIndex)
+        public KernelResult WaitSynchronization64([R(1)] ulong handlesPtr, [R(2)] int handlesCount, [R(3)] long timeout, [R(1)] out int handleIndex)
         {
             return WaitSynchronization(handlesPtr, handlesCount, timeout, out handleIndex);
         }
@@ -40,7 +40,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return _system.Synchronization.WaitFor(syncObjs.ToArray(), timeout, out handleIndex);
         }
 
-        public KernelResult CancelSynchronization64(int handle)
+        public KernelResult CancelSynchronization64([R(0)] int handle)
         {
             return CancelSynchronization(handle);
         }
@@ -59,7 +59,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return KernelResult.Success;
         }
 
-        public KernelResult ArbitrateLock64(int ownerHandle, ulong mutexAddress, int requesterHandle)
+        public KernelResult ArbitrateLock64([R(0)] int ownerHandle, [R(1)] ulong mutexAddress, [R(2)] int requesterHandle)
         {
             return ArbitrateLock(ownerHandle, mutexAddress, requesterHandle);
         }
@@ -81,7 +81,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return currentProcess.AddressArbiter.ArbitrateLock(ownerHandle, mutexAddress, requesterHandle);
         }
 
-        public KernelResult ArbitrateUnlock64(ulong mutexAddress)
+        public KernelResult ArbitrateUnlock64([R(0)] ulong mutexAddress)
         {
             return ArbitrateUnlock(mutexAddress);
         }
@@ -104,10 +104,10 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
         }
 
         public KernelResult WaitProcessWideKeyAtomic64(
-            ulong mutexAddress,
-            ulong condVarAddress,
-            int   handle,
-            long  timeout)
+            [R(0)] ulong mutexAddress,
+            [R(1)] ulong condVarAddress,
+            [R(2)] int   handle,
+            [R(3)] long  timeout)
         {
             return WaitProcessWideKeyAtomic(mutexAddress, condVarAddress, handle, timeout);
         }
@@ -137,7 +137,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
                 timeout);
         }
 
-        public KernelResult SignalProcessWideKey64(ulong address, int count)
+        public KernelResult SignalProcessWideKey64([R(0)] ulong address, [R(1)] int count)
         {
             return SignalProcessWideKey(address, count);
         }
@@ -151,7 +151,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return KernelResult.Success;
         }
 
-        public KernelResult WaitForAddress64(ulong address, ArbitrationType type, int value, long timeout)
+        public KernelResult WaitForAddress64([R(0)] ulong address, [R(1)] ArbitrationType type, [R(2)] int value, [R(3)] long timeout)
         {
             return WaitForAddress(address, type, value, timeout);
         }
@@ -194,7 +194,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return result;
         }
 
-        public KernelResult SignalToAddress64(ulong address, SignalType type, int value, int count)
+        public KernelResult SignalToAddress64([R(0)] ulong address, [R(1)] SignalType type, [R(2)] int value, [R(3)] int count)
         {
             return SignalToAddress(address, type, value, count);
         }


### PR DESCRIPTION
This PR rework the svc handling system to prepare for 32 bits support.

Changelog:

- Add RAttribute to handle arguments positioning manually. (needed for 32 bits support)
- Enforce usage of RAttribute.
- Add 32 bits codepath for SVC handling.
- Pre-generate all SVC handler in the static constructor.
