### PR TITLE
Add sampler border color support on the GPU

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/Sampler.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Sampler.cs
@@ -30,7 +30,11 @@ namespace Ryujinx.Graphics.Gpu.Image
             CompareMode compareMode = descriptor.UnpackCompareMode();
             CompareOp   compareOp   = descriptor.UnpackCompareOp();
 
-            ColorF color = new ColorF(0, 0, 0, 0);
+            ColorF color = new ColorF(
+                descriptor.BorderColorR,
+                descriptor.BorderColorG,
+                descriptor.BorderColorB,
+                descriptor.BorderColorA);
 
             float minLod     = descriptor.UnpackMinLod();
             float maxLod     = descriptor.UnpackMaxLod();

--- a/Ryujinx.Graphics.Gpu/Image/SamplerDescriptor.cs
+++ b/Ryujinx.Graphics.Gpu/Image/SamplerDescriptor.cs
@@ -55,10 +55,10 @@ namespace Ryujinx.Graphics.Gpu.Image
         public uint Word1;
         public uint Word2;
         public uint Word3;
-        public uint BorderColorR;
-        public uint BorderColorG;
-        public uint BorderColorB;
-        public uint BorderColorA;
+        public float BorderColorR;
+        public float BorderColorG;
+        public float BorderColorB;
+        public float BorderColorA;
 
         /// <summary>
         /// Unpacks the texture wrap mode along the X axis.


### PR DESCRIPTION
This fixes rendering of shadows in a number of games including Mario Tennis Aces.