### PR TITLE
Fix shader output color buffer index when non-sequential render targets are used

### DIFF
--- a/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -82,7 +82,7 @@ namespace Ryujinx.Graphics.Shader.Translation
                     {
                         if (target.ComponentEnabled(component))
                         {
-                            Operand dest = Attribute(AttributeConsts.FragmentOutputColorBase + regIndex * 4);
+                            Operand dest = Attribute(AttributeConsts.FragmentOutputColorBase + attachment * 16 + component * 4);
 
                             Operand src = Register(regIndex, RegisterType.Gpr);
 


### PR DESCRIPTION
This fix resolves the issue with the skybox on Captain Toad.

![image](https://user-images.githubusercontent.com/1518948/72671451-775c4180-3a9e-11ea-80f5-50f3c9225e3d.png)
