### PR TITLE
Implement NCA section extractors in the GUI

### DIFF
--- a/Ryujinx/Ui/GameTableContextMenu.cs
+++ b/Ryujinx/Ui/GameTableContextMenu.cs
@@ -154,7 +154,7 @@ namespace Ryujinx.Ui
         {
             FileChooserDialog fileChooser = new FileChooserDialog("Choose the folder to extract into", null, FileChooserAction.SelectFolder, "Cancel", ResponseType.Cancel, "Extract", ResponseType.Accept);
             
-            int response       = fileChooser.Run();
+            int    response    = fileChooser.Run();
             string destination = fileChooser.Filename;
             
             fileChooser.Dispose();
@@ -246,7 +246,7 @@ namespace Ryujinx.Ui
                         int index = Nca.GetSectionIndexFromType(ncaSectionType, mainNca.Header.ContentType);
 
                         IFileSystem ncaFileSystem = patchNca != null ? mainNca.OpenFileSystemWithPatch(patchNca, index, IntegrityCheckLevel.ErrorOnInvalid)
-                            : mainNca.OpenFileSystem(index, IntegrityCheckLevel.ErrorOnInvalid);
+                                                                     : mainNca.OpenFileSystem(index, IntegrityCheckLevel.ErrorOnInvalid);
 
                         FileSystemClient fsClient = _virtualFileSystem.FsClient;
 
@@ -285,6 +285,7 @@ namespace Ryujinx.Ui
                                     SecondaryText  = "Extraction has completed successfully.",
                                     WindowPosition = WindowPosition.Center
                                 };
+
                                 dialog.Run();
                                 dialog.Dispose();
                             });
@@ -294,6 +295,7 @@ namespace Ryujinx.Ui
                         fsClient.Unmount(output);
                     }
                 });
+
                 extractorThread.Name         = "GUI.NcaSectionExtractorThread";
                 extractorThread.IsBackground = true;
                 extractorThread.Start();

--- a/Ryujinx/Ui/GameTableContextMenu.cs
+++ b/Ryujinx/Ui/GameTableContextMenu.cs
@@ -2,27 +2,34 @@
 using LibHac;
 using LibHac.Fs;
 using LibHac.Fs.Shim;
+using LibHac.FsSystem;
+using LibHac.FsSystem.NcaUtils;
 using LibHac.Ncm;
 using Ryujinx.HLE.FileSystem;
 using System;
+using System.Buffers;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
-
+using LibHac.Common;
+using Ryujinx.Common.Logging;
 using GUI = Gtk.Builder.ObjectAttribute;
 
 namespace Ryujinx.Ui
 {
     public class GameTableContextMenu : Menu
     {
-        private static ListStore _gameTableStore;
-        private static TreeIter  _rowIter;
+        private static ListStore  _gameTableStore;
+        private static TreeIter   _rowIter;
         private VirtualFileSystem _virtualFileSystem;
 
 #pragma warning disable CS0649
 #pragma warning disable IDE0044
         [GUI] MenuItem _openSaveDir;
+        [GUI] MenuItem _extractRomFs;
+        [GUI] MenuItem _extractExeFs;
+        [GUI] MenuItem _extractLogo;
 #pragma warning restore CS0649
 #pragma warning restore IDE0044
 
@@ -33,32 +40,14 @@ namespace Ryujinx.Ui
         {
             builder.Autoconnect(this);
 
-            _openSaveDir.Activated += OpenSaveDir_Clicked;
+            _openSaveDir.Activated  += OpenSaveDir_Clicked;
+            _extractRomFs.Activated += ExtractRomFs_Clicked;
+            _extractExeFs.Activated += ExtractExeFs_Clicked;
+            _extractLogo.Activated  += ExtractLogo_Clicked;
 
             _gameTableStore    = gameTableStore;
             _rowIter           = rowIter;
             _virtualFileSystem = virtualFileSystem;
-        }
-
-        //Events
-        private void OpenSaveDir_Clicked(object sender, EventArgs args)
-        {
-            string titleName = _gameTableStore.GetValue(_rowIter, 2).ToString().Split("\n")[0];
-            string titleId   = _gameTableStore.GetValue(_rowIter, 2).ToString().Split("\n")[1].ToLower();
-
-            if (!TryFindSaveData(titleName, titleId, out ulong saveDataId))
-            {
-                return;
-            }
-
-            string saveDir = GetSaveDataDirectory(saveDataId);
-
-            Process.Start(new ProcessStartInfo()
-            {
-                FileName        = saveDir,
-                UseShellExecute = true,
-                Verb            = "open"
-            });
         }
 
         private bool TryFindSaveData(string titleName, string titleIdText, out ulong saveDataId)
@@ -131,7 +120,7 @@ namespace Ryujinx.Ui
             }
 
             string committedPath = System.IO.Path.Combine(saveRootPath, "0");
-            string workingPath = System.IO.Path.Combine(saveRootPath, "1");
+            string workingPath   = System.IO.Path.Combine(saveRootPath, "1");
 
             // If the committed directory exists, that path will be loaded the next time the savedata is mounted
             if (Directory.Exists(committedPath))
@@ -147,6 +136,206 @@ namespace Ryujinx.Ui
             }
 
             return workingPath;
+        }
+
+        private void ExtractSection(NcaSectionType ncaSectionType)
+        {
+            FileChooserDialog fileChooser = new FileChooserDialog("Choose the folder to extract into", null, FileChooserAction.SelectFolder, "Cancel", ResponseType.Cancel, "Extract", ResponseType.Accept);
+
+            if (fileChooser.Run() == (int)ResponseType.Accept)
+            {
+                string path = _gameTableStore.GetValue(_rowIter, 9).ToString();
+
+                using (FileStream file = new FileStream(path, FileMode.Open, FileAccess.Read))
+                {
+                    Nca mainNca  = null;
+                    Nca patchNca = null;
+
+                    if ((System.IO.Path.GetExtension(path).ToLower() == ".nsp") ||
+                        (System.IO.Path.GetExtension(path).ToLower() == ".pfs0") ||
+                        (System.IO.Path.GetExtension(path).ToLower() == ".xci"))
+                    {
+                        PartitionFileSystem pfs;
+
+                        if (System.IO.Path.GetExtension(path) == ".xci")
+                        {
+                            Xci xci = new Xci(_virtualFileSystem.KeySet, file.AsStorage());
+
+                            pfs = xci.OpenPartition(XciPartitionType.Secure);
+                        }
+                        else
+                        {
+                            pfs = new PartitionFileSystem(file.AsStorage());
+                        }
+
+                        foreach (DirectoryEntryEx fileEntry in pfs.EnumerateEntries("/", "*.nca"))
+                        {
+                            pfs.OpenFile(out IFile ncaFile, fileEntry.FullPath, OpenMode.Read).ThrowIfFailure();
+
+                            Nca nca = new Nca(_virtualFileSystem.KeySet, ncaFile.AsStorage());
+
+                            if (nca.Header.ContentType == NcaContentType.Program)
+                            {
+                                int dataIndex = Nca.GetSectionIndexFromType(NcaSectionType.Data, NcaContentType.Program);
+
+                                if (nca.Header.GetFsHeader(dataIndex).IsPatchSection())
+                                {
+                                    patchNca = nca;
+                                }
+                                else
+                                {
+                                    mainNca = nca;
+                                }
+                            }
+                        }
+                    }
+                    else if (System.IO.Path.GetExtension(path).ToLower() == ".nca")
+                    {
+                        mainNca = new Nca(_virtualFileSystem.KeySet, file.AsStorage());
+                    }
+
+                    if (mainNca == null)
+                    {
+                        Logger.PrintError(LogClass.Application, "Extraction failed. The main NCA was not present in the selected file.");
+
+                        fileChooser.Dispose();
+                        return;
+                    }
+
+                    int index = Nca.GetSectionIndexFromType(ncaSectionType, mainNca.Header.ContentType);
+
+                    IFileSystem ncaFileSystem;
+                    if (patchNca != null)
+                    {
+                        ncaFileSystem = mainNca.OpenFileSystemWithPatch(patchNca, index, IntegrityCheckLevel.ErrorOnInvalid);
+                    }
+                    else
+                    {
+                        ncaFileSystem = mainNca.OpenFileSystem(index, IntegrityCheckLevel.ErrorOnInvalid);
+                    }
+
+                    _virtualFileSystem.FsClient.Register(ncaSectionType.ToString().ToU8Span(), ncaFileSystem);
+                    _virtualFileSystem.FsClient.Register("output".ToU8Span(), new LocalFileSystem(fileChooser.Filename));
+
+                    CopyDirectory(_virtualFileSystem.FsClient, $"{ncaSectionType}:/", "output:/");
+
+                    _virtualFileSystem.FsClient.Unmount(ncaSectionType.ToString());
+                    _virtualFileSystem.FsClient.Unmount("output");
+                }
+            }
+
+            fileChooser.Dispose();
+        }
+
+        private static void CopyDirectory(FileSystemClient fs, string sourcePath, string destPath)
+        {
+            fs.OpenDirectory(out DirectoryHandle sourceHandle, sourcePath, OpenDirectoryMode.All).ThrowIfFailure();
+
+            using (sourceHandle)
+            {
+                foreach (DirectoryEntryEx entry in fs.EnumerateEntries(sourcePath, "*", SearchOptions.Default))
+                {
+                    string subSrcPath = PathTools.Normalize(PathTools.Combine(sourcePath, entry.Name));
+                    string subDstPath = PathTools.Normalize(PathTools.Combine(destPath, entry.Name));
+
+                    if (entry.Type == DirectoryEntryType.Directory)
+                    {
+                        fs.EnsureDirectoryExists(subDstPath);
+
+                        CopyDirectory(fs, subSrcPath, subDstPath);
+                    }
+
+                    if (entry.Type == DirectoryEntryType.File)
+                    {
+                        fs.CreateOrOverwriteFile(subDstPath, entry.Size);
+
+                        CopyFile(fs, subSrcPath, subDstPath);
+                    }
+                }
+            }
+        }
+
+        public static Result CopyFile(FileSystemClient fs, string sourcePath, string destPath)
+        {
+            Result rc = fs.OpenFile(out FileHandle sourceHandle, sourcePath, OpenMode.Read);
+            if (rc.IsFailure()) return rc;
+
+            using (sourceHandle)
+            {
+                rc = fs.OpenFile(out FileHandle destHandle, destPath, OpenMode.Write | OpenMode.AllowAppend);
+                if (rc.IsFailure()) return rc;
+
+                using (destHandle)
+                {
+                    const int maxBufferSize = 1024 * 1024;
+
+                    rc = fs.GetFileSize(out long fileSize, sourceHandle);
+                    if (rc.IsFailure()) return rc;
+
+                    int bufferSize = (int)Math.Min(maxBufferSize, fileSize);
+
+                    byte[] buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
+                    try
+                    {
+                        for (long offset = 0; offset < fileSize; offset += bufferSize)
+                        {
+                            int toRead = (int)Math.Min(fileSize - offset, bufferSize);
+                            Span<byte> buf = buffer.AsSpan(0, toRead);
+
+                            rc = fs.ReadFile(out long _, sourceHandle, offset, buf);
+                            if (rc.IsFailure()) return rc;
+
+                            rc = fs.WriteFile(destHandle, offset, buf);
+                            if (rc.IsFailure()) return rc;
+                        }
+                    }
+                    finally
+                    {
+                        ArrayPool<byte>.Shared.Return(buffer);
+                    }
+
+                    rc = fs.FlushFile(destHandle);
+                    if (rc.IsFailure()) return rc;
+                }
+            }
+
+            return Result.Success;
+        }
+
+        // Events
+        private void OpenSaveDir_Clicked(object sender, EventArgs args)
+        {
+            string titleName = _gameTableStore.GetValue(_rowIter, 2).ToString().Split("\n")[0];
+            string titleId   = _gameTableStore.GetValue(_rowIter, 2).ToString().Split("\n")[1].ToLower();
+
+            if (!TryFindSaveData(titleName, titleId, out ulong saveDataId))
+            {
+                return;
+            }
+
+            string saveDir = GetSaveDataDirectory(saveDataId);
+
+            Process.Start(new ProcessStartInfo()
+            {
+                FileName        = saveDir,
+                UseShellExecute = true,
+                Verb            = "open"
+            });
+        }
+
+        private void ExtractRomFs_Clicked(object sender, EventArgs args)
+        {
+            ExtractSection(NcaSectionType.Data);
+        }
+
+        private void ExtractExeFs_Clicked(object sender, EventArgs args)
+        {
+            ExtractSection(NcaSectionType.Code);
+        }
+
+        private void ExtractLogo_Clicked(object sender, EventArgs args)
+        {
+            ExtractSection(NcaSectionType.Logo);
         }
     }
 }

--- a/Ryujinx/Ui/GameTableContextMenu.cs
+++ b/Ryujinx/Ui/GameTableContextMenu.cs
@@ -22,6 +22,8 @@ namespace Ryujinx.Ui
 {
     public class GameTableContextMenu : Menu
     {
+        public static Result OperationCancelled = new Result(468, 1357);
+
         private ListStore         _gameTableStore;
         private TreeIter          _rowIter;
         private VirtualFileSystem _virtualFileSystem;
@@ -250,8 +252,8 @@ namespace Ryujinx.Ui
 
                         FileSystemClient fsClient = _virtualFileSystem.FsClient;
 
-                        string source = new Random().Next(0, 999999999).ToString();
-                        string output = new Random().Next(0, 999999999).ToString();
+                        string source = DateTime.Now.ToFileTime().ToString().Substring(10);
+                        string output = DateTime.Now.ToFileTime().ToString().Substring(10);
 
                         fsClient.Register(source.ToU8Span(), ncaFileSystem);
                         fsClient.Register(output.ToU8Span(), new LocalFileSystem(destination));
@@ -260,7 +262,7 @@ namespace Ryujinx.Ui
 
                         if (resultCode.IsFailure())
                         {
-                            if (resultCode.ErrorCode != "2468-1357")
+                            if (resultCode != OperationCancelled)
                             {
                                 Logger.PrintError(LogClass.Application, $"LibHac returned error code: {resultCode.ErrorCode}");
 
@@ -311,8 +313,11 @@ namespace Ryujinx.Ui
             {
                 foreach (DirectoryEntryEx entry in fs.EnumerateEntries(sourcePath, "*", SearchOptions.Default))
                 {
-                    if (_cancel) return new Result(468, 1357);
-                    
+                    if (_cancel)
+                    {
+                        return OperationCancelled;
+                    }
+
                     string subSrcPath = PathTools.Normalize(PathTools.Combine(sourcePath, entry.Name));
                     string subDstPath = PathTools.Normalize(PathTools.Combine(destPath, entry.Name));
 

--- a/Ryujinx/Ui/GameTableContextMenu.glade
+++ b/Ryujinx/Ui/GameTableContextMenu.glade
@@ -24,7 +24,7 @@
       <object class="GtkMenuItem" id="_extractRomFs">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="label" translatable="yes">Extract RomFS</property>
+        <property name="label" translatable="yes">Extract RomFS Section</property>
         <property name="use_underline">True</property>
       </object>
     </child>
@@ -32,7 +32,7 @@
       <object class="GtkMenuItem" id="_extractExeFs">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="label" translatable="yes">Extract ExeFS</property>
+        <property name="label" translatable="yes">Extract ExeFS Section</property>
         <property name="use_underline">True</property>
       </object>
     </child>
@@ -40,7 +40,7 @@
       <object class="GtkMenuItem" id="_extractLogo">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="label" translatable="yes">Extract Logo</property>
+        <property name="label" translatable="yes">Extract Logo Section</property>
         <property name="use_underline">True</property>
       </object>
     </child>

--- a/Ryujinx/Ui/GameTableContextMenu.glade
+++ b/Ryujinx/Ui/GameTableContextMenu.glade
@@ -14,5 +14,35 @@
         <property name="use_underline">True</property>
       </object>
     </child>
+    <child>
+      <object class="GtkSeparatorMenuItem">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="_extractRomFs">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">Extract RomFS</property>
+        <property name="use_underline">True</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="_extractExeFs">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">Extract ExeFS</property>
+        <property name="use_underline">True</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="_extractLogo">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">Extract Logo</property>
+        <property name="use_underline">True</property>
+      </object>
+    </child>
   </object>
 </interface>

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -547,6 +547,7 @@ namespace Ryujinx.Ui
             if (treeIter.UserData == IntPtr.Zero) return;
 
             GameTableContextMenu contextMenu = new GameTableContextMenu(_tableStore, treeIter, _virtualFileSystem);
+
             contextMenu.ShowAll();
             contextMenu.PopupAtPointer(null);
         }

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -547,7 +547,6 @@ namespace Ryujinx.Ui
             if (treeIter.UserData == IntPtr.Zero) return;
 
             GameTableContextMenu contextMenu = new GameTableContextMenu(_tableStore, treeIter, _virtualFileSystem);
-
             contextMenu.ShowAll();
             contextMenu.PopupAtPointer(null);
         }


### PR DESCRIPTION
Add options to the context menu in the GUI to extract the ExeFs, RomFs and Logo sections from an NCA file or an NSP/PFS0/XCI containing NCA files.

Source:
https://github.com/Thealexbarney/LibHac/blob/master/src/hactoolnet/FsUtils.cs#L26
https://github.com/Thealexbarney/LibHac/blob/master/src/hactoolnet/FsUtils.cs#L68
https://github.com/Thealexbarney/LibHac/blob/master/src/hactoolnet/ProcessNca.cs