### PR TITLE
Update DiscordRichPresence package reference to 1.0.147

### DIFF
--- a/Ryujinx/Ryujinx.csproj
+++ b/Ryujinx/Ryujinx.csproj
@@ -70,7 +70,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DiscordRichPresence" Version="1.0.121" />
+    <PackageReference Include="DiscordRichPresence" Version="1.0.147" />
     <PackageReference Include="GtkSharp" Version="3.22.25.24" />
     <PackageReference Include="GtkSharp.Dependencies" Version="1.1.0" Condition="'$(RuntimeIdentifier)' != 'linux-x64' AND '$(RuntimeIdentifier)' != 'osx-x64'" />
     <PackageReference Include="OpenTK.NetStandard" Version="1.0.4" />


### PR DESCRIPTION
The DiscordRichPresence nuget is finally updated to target .NET core, so upgrading to the latest version gets rid of the build warning that the package was restored using .NET framework.