### PR TITLE
SoftwareKeyboard: Interactive data size should include size field.

### DIFF
--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardApplet.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardApplet.cs
@@ -166,9 +166,9 @@ namespace Ryujinx.HLE.HOS.Applets
                 }
                 else
                 {
-                    // In interactive mode, we write the length of the text
-                    // as a long, rather than a result code.
-                    writer.Write((long)output.Length);
+                    // In interactive mode, we write the length of the text as a long, rather than
+                    // a result code. This field is inclusive of the 64-bit size.
+                    writer.Write((long)output.Length + 8);
                 }
 
                 writer.Write(output);


### PR DESCRIPTION
The size field reported back from the Software Keyboard applet is wrong. I noticed this while debugging an issue with Little Town Hero in yuzu. In Ryujinx, the game does not actually accept the inputted text, but the error is ignored (see code in https://github.com/Ryujinx/Ryujinx/blob/master/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardApplet.cs#L132). With this change, the game accepts the entered text.