### PR TITLE
Enable stencil texturing

### DIFF
--- a/Ryujinx.Graphics.OpenGL/EnumConversion.cs
+++ b/Ryujinx.Graphics.OpenGL/EnumConversion.cs
@@ -193,9 +193,9 @@ namespace Ryujinx.Graphics.OpenGL
             switch (mode)
             {
                 case DepthStencilMode.Depth:
-                    return All.Depth;
+                    return All.DepthComponent;
                 case DepthStencilMode.Stencil:
-                    return All.Stencil;
+                    return All.StencilIndex;
             }
 
             Logger.PrintDebug(LogClass.Gpu, $"Invalid {nameof(DepthStencilMode)} enum value: {mode}.");

--- a/Ryujinx.Graphics.OpenGL/TextureView.cs
+++ b/Ryujinx.Graphics.OpenGL/TextureView.cs
@@ -100,9 +100,7 @@ namespace Ryujinx.Graphics.OpenGL
             }
 
             GL.TexParameter(target, TextureParameterName.TextureMaxLevel, maxLevel);
-
-            // TODO: This requires ARB_stencil_texturing, we should uncomment and test this.
-            // GL.TexParameter(target, TextureParameterName.DepthStencilTextureMode, (int)_info.DepthStencilMode.Convert());
+            GL.TexParameter(target, TextureParameterName.DepthStencilTextureMode, (int)_info.DepthStencilMode.Convert());
         }
 
         public ITexture CreateView(TextureCreateInfo info, int firstLayer, int firstLevel)


### PR DESCRIPTION
Fix some rendering issues on Xenoblade Chronicles 2 and probably other games.

Fix #866 