### PR TITLE
[WIP] Implement triangle_rast_flip bit in YControl

### DIFF
--- a/Ryujinx.Graphics.GAL/IPipeline.cs
+++ b/Ryujinx.Graphics.GAL/IPipeline.cs
@@ -27,7 +27,7 @@ namespace Ryujinx.Graphics.GAL
         void SetBlendState(int index, BlendDescriptor blend);
 
         void SetDepthBias(PolygonModeMask enables, float factor, float units, float clamp);
-        void SetDepthClamp(bool clampNear, bool clampFar);
+        void SetDepthClamp(bool clamp);
         void SetDepthMode(DepthMode mode);
         void SetDepthTest(DepthTestDescriptor depthTest);
 

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -394,8 +394,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
         private void UpdateDepthClampState(GpuState state)
         {
             ViewVolumeClipControl clip = state.Get<ViewVolumeClipControl>(MethodOffset.ViewVolumeClipControl);
-            _context.Renderer.Pipeline.SetDepthClamp((clip & ViewVolumeClipControl.DepthClampNear) != 0,
-                                                     (clip & ViewVolumeClipControl.DepthClampFar) != 0);
+            _context.Renderer.Pipeline.SetDepthClamp((clip & ViewVolumeClipControl.DepthClampDisabled) == 0);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -708,9 +708,9 @@ namespace Ryujinx.Graphics.Gpu.Engine
         private void UpdateFaceState(GpuState state)
         {
             var face = state.Get<FaceState>(MethodOffset.FaceState);
-            var flip = (state.Get<int>(MethodOffset.YControl) & (1 << 4)) != 0;
+            var triangleRastFlip = (state.Get<int>(MethodOffset.YControl) & (1 << 4)) != 0;
 
-            if (flip)
+            if (triangleRastFlip)
             {
                 switch (face.FrontFace)
                 {

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -218,7 +218,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
                 UpdateVertexBufferState(state);
             }
 
-            if (state.QueryModified(MethodOffset.FaceState))
+            if (state.QueryModified(MethodOffset.FaceState, MethodOffset.YControl))
             {
                 UpdateFaceState(state);
             }
@@ -708,6 +708,18 @@ namespace Ryujinx.Graphics.Gpu.Engine
         private void UpdateFaceState(GpuState state)
         {
             var face = state.Get<FaceState>(MethodOffset.FaceState);
+            var flip = (state.Get<int>(MethodOffset.YControl) & (1 << 4)) != 0;
+
+            if (flip)
+            {
+                switch (face.CullFace)
+                {
+                    case Face.Front:
+                        face.CullFace = Face.Back; break;
+                    case Face.Back:
+                        face.CullFace = Face.Front; break;
+                }
+            }
 
             _context.Renderer.Pipeline.SetFaceCulling(face.CullEnable, face.CullFace);
 

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -708,7 +708,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
         private void UpdateFaceState(GpuState state)
         {
             var face = state.Get<FaceState>(MethodOffset.FaceState);
-            var triangleRastFlip = (state.Get<int>(MethodOffset.YControl) & (1 << 4)) != 0;
+            var triangleRastFlip = (state.Get<YControl>(MethodOffset.YControl) & YControl.TriangleRastFlip) != 0;
 
             if (triangleRastFlip)
             {

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -712,12 +712,12 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
             if (flip)
             {
-                switch (face.CullFace)
+                switch (face.FrontFace)
                 {
-                    case Face.Front:
-                        face.CullFace = Face.Back; break;
-                    case Face.Back:
-                        face.CullFace = Face.Front; break;
+                    case FrontFace.Clockwise:
+                        face.FrontFace = FrontFace.CounterClockwise; break;
+                    case FrontFace.CounterClockwise:
+                        face.FrontFace = FrontFace.Clockwise; break;
                 }
             }
 

--- a/Ryujinx.Graphics.Gpu/State/ViewVolumeClipControl.cs
+++ b/Ryujinx.Graphics.Gpu/State/ViewVolumeClipControl.cs
@@ -6,7 +6,6 @@ namespace Ryujinx.Graphics.Gpu.State
     enum ViewVolumeClipControl
     {
         ForceDepthRangeZeroToOne = 1 << 0,
-        DepthClampNear           = 1 << 3,
-        DepthClampFar            = 1 << 4,
+        DepthClampDisabled       = 1 << 11,
     }
 }

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -549,17 +549,13 @@ namespace Ryujinx.Graphics.OpenGL
                 return;
             }
 
-            GL.PolygonOffset(factor, units);
+            GL.PolygonOffset(factor, units / 2f);
             // TODO: Enable when GL_EXT_polygon_offset_clamp is supported.
             // GL.PolygonOffsetClamp(factor, units, clamp);
         }
 
-        public void SetDepthClamp(bool clampNear, bool clampFar)
+        public void SetDepthClamp(bool clamp)
         {
-            // TODO: Use GL_AMD_depth_clamp_separate or similar if available?
-            // Currently enables clamping if either is set.
-            bool clamp = clampNear || clampFar;
-
             if (!clamp)
             {
                 GL.Disable(EnableCap.DepthClamp);


### PR DESCRIPTION
Flips triangle front faces when the triangle_rast_flip flag is set on YControl. Combined with #910, fixes the graphics in Xenoblade Chronicles 2 (mostly). 

![image](https://user-images.githubusercontent.com/6294155/73492197-20ad0c80-43a8-11ea-908f-f874e823f3da.png)

This is WIP because I don't have enough games to make sure this doesn't cause regressions - the trigger for doing this is more complicated and we could use more examples. Testing is appreciated.

**Known improvements**
- Xenoblade Chronicles 2: Fixes 3D element cull direction. _YControl 0x10, Viewport Swizzle not used, negative viewport height._
- Arc of Alchemist: Fixes 3D element cull direction.
- Disgaea 4 Complete+: Fixes 3D element cull direction. (some were correct already, this flips the ones that weren't)

**Known unchanged**
- Super Mario Odyssey
- Splatoon 2
- Mario Kart 8 Deluxe
- Captain Toad Treasure Tracker

**Known issues**
- Cave Story +: Only background colour drawn. _YControl 0x10, Viewport Swizzle not used, negative viewport height._
- Pokemon Sword/Shield: All 3D elements missing. (likely culling applied during post processing)
- Troll and I: Culling is incorrectly flipped.
- Pokemon Let's Go! Eevee: Culling is incorrectly flipped.
- Mario Tennis Aces: Culling is incorrectly flipped.