### PR TITLE
Compare shader code using a span instead of individual reads.

### DIFF
--- a/Ryujinx.Graphics.Gpu/Memory/MemoryAccessor.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryAccessor.cs
@@ -41,7 +41,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         {
             ulong processVa = _context.MemoryManager.Translate(gpuVa);
 
-            ulong size = Math.Min(_context.MemoryManager.GetSubSize(gpuVa), maxSize);
+            ulong size = Math.Min(_context.MemoryManager.GetSubSize(gpuVa, maxSize), maxSize);
 
             return _context.PhysicalMemory.GetSpan(processVa, size);
         }

--- a/Ryujinx.Graphics.Gpu/Memory/MemoryAccessor.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryAccessor.cs
@@ -41,7 +41,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         {
             ulong processVa = _context.MemoryManager.Translate(gpuVa);
 
-            ulong size = Math.Min(_context.MemoryManager.GetSubSize(gpuVa, maxSize), maxSize);
+            ulong size = _context.MemoryManager.GetSubSize(gpuVa, maxSize);
 
             return _context.PhysicalMemory.GetSpan(processVa, size);
         }

--- a/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
@@ -238,13 +238,17 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// </summary>
         /// <param name="gpuVa">Start GPU virtual address of the region</param>
         /// <returns>Mapped size in bytes of the specified region</returns>
-        internal ulong GetSubSize(ulong gpuVa)
+        internal ulong GetSubSize(ulong gpuVa, ulong maxSize)
         {
             ulong size = 0;
 
             while (GetPte(gpuVa + size) != PteUnmapped)
             {
                 size += PageSize;
+                if (size >= maxSize)
+                {
+                    return maxSize;
+                }
             }
 
             return size;

--- a/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
@@ -237,6 +237,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// Gets the number of mapped or reserved pages on a given region.
         /// </summary>
         /// <param name="gpuVa">Start GPU virtual address of the region</param>
+        /// <param name="maxSize">Maximum size of the data</param>
         /// <returns>Mapped size in bytes of the specified region</returns>
         internal ulong GetSubSize(ulong gpuVa, ulong maxSize)
         {

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -235,15 +235,9 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 return false;
             }
 
-            for (int index = 0; index < shader.Code.Length; index++)
-            {
-                if (_context.MemoryAccessor.ReadInt32(gpuVa + (ulong)index * 4) != shader.Code[index])
-                {
-                    return true;
-                }
-            }
+            ReadOnlySpan<byte> memoryCode = _context.MemoryAccessor.GetSpan(gpuVa, (ulong)shader.Code.Length * 4);
 
-            return false;
+            return !MemoryMarshal.Cast<byte, int>(memoryCode).SequenceEqual(shader.Code);
         }
 
         /// <summary>


### PR DESCRIPTION
This was causing a bottleneck in a few games. The cost of `UpdateShaderState` is now more in line with the other state changes (though it still wins out). (6% -> 0.7% total cpu in same situation)

`GetSubSize` has been updated with a `maxSize` parameter to prevent it from scanning the whole memory space when the caller expects a small size.