### PR TITLE
Only enumerate cached textures that are modified when flushing.

### DIFF
--- a/Ryujinx.Common/ReferenceEqualityComparer.cs
+++ b/Ryujinx.Common/ReferenceEqualityComparer.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Ryujinx.Common
+{
+    public class ReferenceEqualityComparer<T> : IEqualityComparer<T>
+        where T : class
+    {
+        public bool Equals(T x, T y)
+        {
+            return x == y;
+        }
+
+        public int GetHashCode([DisallowNull] T obj)
+        {
+            return obj.GetHashCode();
+        }
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Engine/MethodCopyTexture.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodCopyTexture.cs
@@ -94,7 +94,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
                 srcTexture.HostTexture.CopyTo(dstTexture.HostTexture, srcRegion, dstRegion, linearFilter);
             }
 
-            dstTexture.Modified = true;
+            dstTexture.SignalModified();
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -286,7 +286,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
                 if (color != null)
                 {
-                    color.Modified = true;
+                    color.SignalModified();
                 }
             }
 
@@ -306,7 +306,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
             if (depthStencil != null)
             {
-                depthStencil.Modified = true;
+                depthStencil.SignalModified();
             }
         }
 

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -54,9 +54,9 @@ namespace Ryujinx.Graphics.Gpu.Image
         public LinkedListNode<Texture> CacheNode { get; set; }
 
         /// <summary>
-        /// Texture data modified by the GPU.
+        /// Event to fire when texture data modified by the GPU.
         /// </summary>
-        public bool Modified { get; set; }
+        public event Action<Texture> Modified;
 
         /// <summary>
         /// Start address of the texture in guest memory.
@@ -931,6 +931,14 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             _depth  = info.GetDepth();
             _layers = info.GetLayers();
+        }
+
+        /// <summary>
+        /// Signals that the texture has been modified.
+        /// </summary>
+        public void SignalModified()
+        {
+            Modified?.Invoke(this);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -54,9 +54,14 @@ namespace Ryujinx.Graphics.Gpu.Image
         public LinkedListNode<Texture> CacheNode { get; set; }
 
         /// <summary>
-        /// Event to fire when texture data modified by the GPU.
+        /// Event to fire when texture data is modified by the GPU.
         /// </summary>
         public event Action<Texture> Modified;
+
+        /// <summary>
+        /// Event to fire when texture data is disposed.
+        /// </summary>
+        public event Action<Texture> Disposed;
 
         /// <summary>
         /// Start address of the texture in guest memory.
@@ -1020,6 +1025,8 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             _arrayViewTexture?.Dispose();
             _arrayViewTexture = null;
+
+            Disposed?.Invoke(this);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -61,7 +61,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             _cache = new AutoDeleteCache();
 
-            _modified = new HashSet<Texture>();
+            _modified = new HashSet<Texture>(new ReferenceEqualityComparer<Texture>());
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -600,10 +600,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="texture">The texture that was modified.</param>
         private void CacheTextureModified(Texture texture)
         {
-            lock (_modified)
-            {
-                _modified.Add(texture);
-            }
+            _modified.Add(texture);
         }
 
         /// <summary>
@@ -740,16 +737,12 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         public void Flush()
         {
-            lock (_modified)
+            foreach (Texture texture in _modified)
             {
-                foreach (Texture texture in _modified)
+                if (texture.Info.IsLinear)
                 {
-                    if (texture.Info.IsLinear)
-                    {
-                        texture.Flush();
-                    }
+                    texture.Flush();
                 }
-                _modified.Clear();
             }
         }
 
@@ -760,17 +753,14 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="size">The range size</param>
         public void Flush(ulong address, ulong size)
         {
-            lock (_modified)
+            foreach (Texture texture in _modified)
             {
-                foreach (Texture texture in _modified)
+                if (texture.OverlapsWith(address, size))
                 {
-                    if (texture.OverlapsWith(address, size))
-                    {
-                        texture.Flush();
-                    }
+                    texture.Flush();
                 }
-                _modified.Clear();
             }
+            _modified.Clear();
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -585,6 +585,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             {
                 _cache.Add(texture);
                 texture.Modified += CacheTextureModified;
+                texture.Disposed += CacheTextureDisposed;
             }
 
             _textures.Add(texture);
@@ -601,6 +602,15 @@ namespace Ryujinx.Graphics.Gpu.Image
         private void CacheTextureModified(Texture texture)
         {
             _modified.Add(texture);
+        }
+
+        /// <summary>
+        /// Signaled when a cache texture is disposed, so it can be removed from the set of modified textures if present.
+        /// </summary>
+        /// <param name="texture">The texture that was diosposed.</param>
+        private void CacheTextureDisposed(Texture texture)
+        {
+            _modified.Remove(texture);
         }
 
         /// <summary>
@@ -785,6 +795,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             foreach (Texture texture in _textures)
             {
+                _modified.Remove(texture);
                 texture.Dispose();
             }
         }

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -744,6 +744,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     texture.Flush();
                 }
             }
+            _modified.Clear();
         }
 
         /// <summary>


### PR DESCRIPTION
Before this change, all items on the `_cache` would be enumerated when flushing. I was getting an absurdly high CPU usage rivalling that of MacroInterpreter in situations with lots of draw calls.

Question: is the locking necessary? I wasn't able to verify if the GPU textures are ever modified from another thread, so I added it in for safety.