### PR TITLE
Suppress warnings from fields never used or never assigned (CS0169 and CS0649)

### DIFF
--- a/ARMeilleure/Diagnostics/Logger.cs
+++ b/ARMeilleure/Diagnostics/Logger.cs
@@ -6,9 +6,11 @@ namespace ARMeilleure.Diagnostics
 {
     static class Logger
     {
+#pragma warning disable CS0169
         private static long _startTime;
 
         private static long[] _accumulatedTime;
+#pragma warning restore CS0196
 
         static Logger()
         {

--- a/ARMeilleure/Statistics.cs
+++ b/ARMeilleure/Statistics.cs
@@ -11,8 +11,10 @@ namespace ARMeilleure
     {
         private const int ReportMaxFunctions = 100;
 
+#pragma warning disable CS0169
         [ThreadStatic]
         private static Stopwatch _executionTimer;
+#pragma warning restore CS0169
 
         private static ConcurrentDictionary<ulong, long> _ticksPerFunction;
 

--- a/Ryujinx.Debugger/Profiler/Profile.cs
+++ b/Ryujinx.Debugger/Profiler/Profile.cs
@@ -11,7 +11,9 @@ namespace Ryujinx.Debugger.Profiler
         public static float UpdateRate    => _settings.UpdateRate;
         public static long  HistoryLength => _settings.History;
 
+#pragma warning disable CS0649
         private static InternalProfile  _profileInstance;
+#pragma warning restore CS0649
         private static ProfilerSettings _settings;
 
         [Conditional("USE_DEBUGGING")]

--- a/Ryujinx.Debugger/UI/DebuggerWidget.cs
+++ b/Ryujinx.Debugger/UI/DebuggerWidget.cs
@@ -9,7 +9,9 @@ namespace Ryujinx.Debugger.UI
         public event EventHandler DebuggerEnabled;
         public event EventHandler DebuggerDisabled;
 
+#pragma warning disable CS0649
         [GUI] Notebook _widgetNotebook;
+#pragma warning restore CS0649
 
         public DebuggerWidget() : this(new Builder("Ryujinx.Debugger.UI.DebuggerWidget.glade")) { }
 

--- a/Ryujinx.Debugger/UI/ProfilerWidget.cs
+++ b/Ryujinx.Debugger/UI/ProfilerWidget.cs
@@ -289,7 +289,7 @@ namespace Ryujinx.Debugger.UI
                                 _sortedProfileData = _sortedProfileData.Where((pair => filterRegex.IsMatch(pair.Key.Search))).ToList();
                             }
                         }
-                        catch (ArgumentException argException)
+                        catch (ArgumentException)
                         {
                             // Skip filtering for invalid regex
                         }

--- a/Ryujinx.Debugger/UI/ProfilerWidget.cs
+++ b/Ryujinx.Debugger/UI/ProfilerWidget.cs
@@ -81,6 +81,7 @@ namespace Ryujinx.Debugger.UI
 
         private SkRenderer _renderer;
 
+#pragma warning disable CS0649
         [GUI] ScrolledWindow _scrollview;
         [GUI] CheckButton    _enableCheckbutton;
         [GUI] Scrollbar      _outputScrollbar;
@@ -90,6 +91,7 @@ namespace Ryujinx.Debugger.UI
         [GUI] CheckButton    _showInactive;
         [GUI] Button         _stepButton;
         [GUI] CheckButton    _pauseCheckbutton;
+#pragma warning restore CS0649
 
         public ProfilerWidget() : this(new Builder("Ryujinx.Debugger.UI.ProfilerWidget.glade")) { }
 

--- a/Ryujinx.Graphics.Gpu/DmaPusher.cs
+++ b/Ryujinx.Graphics.Gpu/DmaPusher.cs
@@ -214,6 +214,8 @@ namespace Ryujinx.Graphics.Gpu
                 }
                 else if (_state.MethodCount != 0)
                 {
+                    CallMethod(word);
+
                     if (!_state.NonIncrementing)
                     {
                         _state.Method++;

--- a/Ryujinx.Graphics.Gpu/DmaPusher.cs
+++ b/Ryujinx.Graphics.Gpu/DmaPusher.cs
@@ -81,9 +81,6 @@ namespace Ryujinx.Graphics.Gpu
 
         private DmaState _state;
 
-        private bool _sliEnable;
-        private bool _sliActive;
-
         private bool _ibEnable;
 
         private GpuContext _context;
@@ -217,11 +214,6 @@ namespace Ryujinx.Graphics.Gpu
                 }
                 else if (_state.MethodCount != 0)
                 {
-                    if (!_sliEnable || _sliActive)
-                    {
-                        CallMethod(word);
-                    }
-
                     if (!_state.NonIncrementing)
                     {
                         _state.Method++;

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -790,10 +790,12 @@ namespace Ryujinx.Graphics.Gpu.Engine
         /// </summary>
         private struct SbDescriptor
         {
+#pragma warning disable CS0649
             public uint AddressLow;
             public uint AddressHigh;
             public int  Size;
             public int  Padding;
+#pragma warning restore CS0649
 
             public ulong PackAddress()
             {

--- a/Ryujinx.Graphics.Gpu/Image/SamplerDescriptor.cs
+++ b/Ryujinx.Graphics.Gpu/Image/SamplerDescriptor.cs
@@ -51,6 +51,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
         private const float Frac8ToF32 = 1.0f / 256.0f;
 
+#pragma warning disable CS0649
         public uint Word0;
         public uint Word1;
         public uint Word2;
@@ -59,6 +60,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         public float BorderColorG;
         public float BorderColorB;
         public float BorderColorA;
+#pragma warning restore CS0649
 
         /// <summary>
         /// Unpacks the texture wrap mode along the X axis.

--- a/Ryujinx.Graphics.Gpu/Image/TextureDescriptor.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureDescriptor.cs
@@ -5,6 +5,7 @@ namespace Ryujinx.Graphics.Gpu.Image
     /// </summary>
     struct TextureDescriptor
     {
+#pragma warning disable CS0649
         public uint Word0;
         public uint Word1;
         public uint Word2;
@@ -13,6 +14,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         public uint Word5;
         public uint Word6;
         public uint Word7;
+#pragma warning restore CS0649
 
         /// <summary>
         /// Unpacks Maxwell texture format integer.

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderAddresses.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderAddresses.cs
@@ -7,12 +7,14 @@ namespace Ryujinx.Graphics.Gpu.Shader
     /// </summary>
     struct ShaderAddresses : IEquatable<ShaderAddresses>
     {
+#pragma warning disable CS0649
         public ulong VertexA;
         public ulong Vertex;
         public ulong TessControl;
         public ulong TessEvaluation;
         public ulong Geometry;
         public ulong Fragment;
+#pragma warning restore CS0649
 
         /// <summary>
         /// Check if the addresses are equal.

--- a/Ryujinx.Graphics.Gpu/State/BlendState.cs
+++ b/Ryujinx.Graphics.Gpu/State/BlendState.cs
@@ -7,6 +7,7 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct BlendState
     {
+#pragma warning disable CS0649
         public Boolean32   SeparateAlpha;
         public BlendOp     ColorOp;
         public BlendFactor ColorSrcFactor;
@@ -15,5 +16,6 @@ namespace Ryujinx.Graphics.Gpu.State
         public BlendFactor AlphaSrcFactor;
         public BlendFactor AlphaDstFactor;
         public uint        Padding;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/BlendStateCommon.cs
+++ b/Ryujinx.Graphics.Gpu/State/BlendStateCommon.cs
@@ -7,6 +7,7 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct BlendStateCommon
     {
+#pragma warning disable CS0649
         public Boolean32   SeparateAlpha;
         public BlendOp     ColorOp;
         public BlendFactor ColorSrcFactor;
@@ -15,5 +16,6 @@ namespace Ryujinx.Graphics.Gpu.State
         public BlendFactor AlphaSrcFactor;
         public uint        Unknown0x1354;
         public BlendFactor AlphaDstFactor;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/Boolean32.cs
+++ b/Ryujinx.Graphics.Gpu/State/Boolean32.cs
@@ -5,7 +5,9 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct Boolean32
     {
+#pragma warning disable CS0649
         private uint _value;
+#pragma warning restore CS0649
 
         public static implicit operator bool(Boolean32 value)
         {

--- a/Ryujinx.Graphics.Gpu/State/ClearColors.cs
+++ b/Ryujinx.Graphics.Gpu/State/ClearColors.cs
@@ -5,9 +5,11 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct ClearColors
     {
+#pragma warning disable CS0649
         public float Red;
         public float Green;
         public float Blue;
         public float Alpha;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/ConditionState.cs
+++ b/Ryujinx.Graphics.Gpu/State/ConditionState.cs
@@ -5,7 +5,9 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct ConditionState
     {
+#pragma warning disable CS0649
         public GpuVa     Address;
         public Condition Condition;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/CopyBufferParams.cs
+++ b/Ryujinx.Graphics.Gpu/State/CopyBufferParams.cs
@@ -5,9 +5,9 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct CopyBufferParams
     {
+#pragma warning disable CS0649
         public GpuVa SrcAddress;
         public GpuVa DstAddress;
-#pragma warning disable CS0649
         public int   SrcStride;
         public int   DstStride;
         public int   XCount;

--- a/Ryujinx.Graphics.Gpu/State/CopyBufferParams.cs
+++ b/Ryujinx.Graphics.Gpu/State/CopyBufferParams.cs
@@ -7,9 +7,11 @@ namespace Ryujinx.Graphics.Gpu.State
     {
         public GpuVa SrcAddress;
         public GpuVa DstAddress;
+#pragma warning disable CS0649
         public int   SrcStride;
         public int   DstStride;
         public int   XCount;
         public int   YCount;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/CopyBufferSwizzle.cs
+++ b/Ryujinx.Graphics.Gpu/State/CopyBufferSwizzle.cs
@@ -5,7 +5,6 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct CopyBufferSwizzle
     {
-
 #pragma warning disable CS0649
         public uint Swizzle;
 #pragma warning restore CS0649

--- a/Ryujinx.Graphics.Gpu/State/CopyBufferSwizzle.cs
+++ b/Ryujinx.Graphics.Gpu/State/CopyBufferSwizzle.cs
@@ -5,7 +5,10 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct CopyBufferSwizzle
     {
+
+#pragma warning disable CS0649
         public uint Swizzle;
+#pragma warning restore CS0649
 
         /// <summary>
         /// Unpacks the size of each vector component of the copy.

--- a/Ryujinx.Graphics.Gpu/State/CopyBufferTexture.cs
+++ b/Ryujinx.Graphics.Gpu/State/CopyBufferTexture.cs
@@ -5,8 +5,8 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct CopyBufferTexture
     {
-        public MemoryLayout MemoryLayout;
 #pragma warning disable CS0649
+        public MemoryLayout MemoryLayout;
         public int          Width;
         public int          Height;
         public int          Depth;

--- a/Ryujinx.Graphics.Gpu/State/CopyBufferTexture.cs
+++ b/Ryujinx.Graphics.Gpu/State/CopyBufferTexture.cs
@@ -6,11 +6,13 @@ namespace Ryujinx.Graphics.Gpu.State
     struct CopyBufferTexture
     {
         public MemoryLayout MemoryLayout;
+#pragma warning disable CS0649
         public int          Width;
         public int          Height;
         public int          Depth;
         public int          RegionZ;
         public ushort       RegionX;
         public ushort       RegionY;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/CopyRegion.cs
+++ b/Ryujinx.Graphics.Gpu/State/CopyRegion.cs
@@ -5,6 +5,7 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct CopyRegion
     {
+#pragma warning disable CS0649
         public int  DstX;
         public int  DstY;
         public int  DstWidth;
@@ -13,5 +14,6 @@ namespace Ryujinx.Graphics.Gpu.State
         public long SrcHeightRF;
         public long SrcXF;
         public long SrcYF;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/CopyTexture.cs
+++ b/Ryujinx.Graphics.Gpu/State/CopyTexture.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.Graphics.Gpu.State
         public int          Stride;
         public int          Width;
         public int          Height;
-#pragma warning restore CS0649
         public GpuVa        Address;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/CopyTexture.cs
+++ b/Ryujinx.Graphics.Gpu/State/CopyTexture.cs
@@ -6,13 +6,15 @@ namespace Ryujinx.Graphics.Gpu.State
     struct CopyTexture
     {
         public RtFormat     Format;
-        public Boolean32    LinearLayout;
         public MemoryLayout MemoryLayout;
+#pragma warning disable CS0649
+        public Boolean32    LinearLayout;
         public int          Depth;
         public int          Layer;
         public int          Stride;
         public int          Width;
         public int          Height;
+#pragma warning restore CS0649
         public GpuVa        Address;
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/CopyTexture.cs
+++ b/Ryujinx.Graphics.Gpu/State/CopyTexture.cs
@@ -6,9 +6,11 @@ namespace Ryujinx.Graphics.Gpu.State
     struct CopyTexture
     {
         public RtFormat     Format;
-        public MemoryLayout MemoryLayout;
 #pragma warning disable CS0649
         public Boolean32    LinearLayout;
+#pragma warning restore CS0649
+        public MemoryLayout MemoryLayout;
+#pragma warning disable CS0649
         public int          Depth;
         public int          Layer;
         public int          Stride;

--- a/Ryujinx.Graphics.Gpu/State/CopyTexture.cs
+++ b/Ryujinx.Graphics.Gpu/State/CopyTexture.cs
@@ -5,12 +5,10 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct CopyTexture
     {
+#pragma warning disable CS0649
         public RtFormat     Format;
-#pragma warning disable CS0649
         public Boolean32    LinearLayout;
-#pragma warning restore CS0649
         public MemoryLayout MemoryLayout;
-#pragma warning disable CS0649
         public int          Depth;
         public int          Layer;
         public int          Stride;

--- a/Ryujinx.Graphics.Gpu/State/CopyTextureControl.cs
+++ b/Ryujinx.Graphics.Gpu/State/CopyTextureControl.cs
@@ -5,7 +5,9 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct CopyTextureControl
     {
+#pragma warning disable CS0649
         public uint Packed;
+#pragma warning restore CS0649
 
         public bool UnpackLinearFilter()
         {

--- a/Ryujinx.Graphics.Gpu/State/DepthBiasState.cs
+++ b/Ryujinx.Graphics.Gpu/State/DepthBiasState.cs
@@ -5,8 +5,10 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct DepthBiasState
     {
+#pragma warning disable CS0649
         public Boolean32 PointEnable;
         public Boolean32 LineEnable;
         public Boolean32 FillEnable;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/FaceState.cs
+++ b/Ryujinx.Graphics.Gpu/State/FaceState.cs
@@ -7,8 +7,10 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct FaceState
     {
+#pragma warning disable CS0649
         public Boolean32 CullEnable;
         public FrontFace FrontFace;
         public Face      CullFace;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/GpuVa.cs
+++ b/Ryujinx.Graphics.Gpu/State/GpuVa.cs
@@ -5,8 +5,10 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct GpuVa
     {
+#pragma warning disable CS0649
         public uint High;
         public uint Low;
+#pragma warning restore CS0649
 
         /// <summary>
         /// Packs the split address into a 64-bits address value.

--- a/Ryujinx.Graphics.Gpu/State/IndexBufferState.cs
+++ b/Ryujinx.Graphics.Gpu/State/IndexBufferState.cs
@@ -9,9 +9,11 @@ namespace Ryujinx.Graphics.Gpu.State
     struct IndexBufferState
     {
         public GpuVa     Address;
+#pragma warning disable CS0649
         public GpuVa     EndAddress;
         public IndexType Type;
         public int       First;
         public int       Count;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/IndexBufferState.cs
+++ b/Ryujinx.Graphics.Gpu/State/IndexBufferState.cs
@@ -8,8 +8,8 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct IndexBufferState
     {
-        public GpuVa     Address;
 #pragma warning disable CS0649
+        public GpuVa     Address;
         public GpuVa     EndAddress;
         public IndexType Type;
         public int       First;

--- a/Ryujinx.Graphics.Gpu/State/Inline2MemoryParams.cs
+++ b/Ryujinx.Graphics.Gpu/State/Inline2MemoryParams.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.Graphics.Gpu.State
         public int          DstStride;
 #pragma warning restore CS0649
         public MemoryLayout DstMemoryLayout;
-#pragma warning restore CS0649
+#pragma warning disable CS0649
         public int          DstWidth;
         public int          DstHeight;
         public int          DstDepth;

--- a/Ryujinx.Graphics.Gpu/State/Inline2MemoryParams.cs
+++ b/Ryujinx.Graphics.Gpu/State/Inline2MemoryParams.cs
@@ -5,16 +5,18 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct Inline2MemoryParams
     {
-        public int          LineLengthIn;
-        public int          LineCount;
-        public GpuVa        DstAddress;
-        public int          DstStride;
         public MemoryLayout DstMemoryLayout;
+        public GpuVa        DstAddress;
+#pragma warning disable CS0649
+        public int          DstStride;
         public int          DstWidth;
         public int          DstHeight;
         public int          DstDepth;
         public int          DstZ;
         public int          DstX;
         public int          DstY;
+        public int          LineLengthIn;
+        public int          LineCount;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/Inline2MemoryParams.cs
+++ b/Ryujinx.Graphics.Gpu/State/Inline2MemoryParams.cs
@@ -8,13 +8,9 @@ namespace Ryujinx.Graphics.Gpu.State
 #pragma warning disable CS0649
         public int          LineLengthIn;
         public int          LineCount;
-#pragma warning restore CS0649
         public GpuVa        DstAddress;
-#pragma warning disable CS0649
         public int          DstStride;
-#pragma warning restore CS0649
         public MemoryLayout DstMemoryLayout;
-#pragma warning disable CS0649
         public int          DstWidth;
         public int          DstHeight;
         public int          DstDepth;

--- a/Ryujinx.Graphics.Gpu/State/Inline2MemoryParams.cs
+++ b/Ryujinx.Graphics.Gpu/State/Inline2MemoryParams.cs
@@ -5,18 +5,22 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct Inline2MemoryParams
     {
-        public MemoryLayout DstMemoryLayout;
+#pragma warning disable CS0649
+        public int          LineLengthIn;
+        public int          LineCount;
+#pragma warning restore CS0649
         public GpuVa        DstAddress;
 #pragma warning disable CS0649
         public int          DstStride;
+#pragma warning restore CS0649
+        public MemoryLayout DstMemoryLayout;
+#pragma warning restore CS0649
         public int          DstWidth;
         public int          DstHeight;
         public int          DstDepth;
         public int          DstZ;
         public int          DstX;
         public int          DstY;
-        public int          LineLengthIn;
-        public int          LineCount;
 #pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/MemoryLayout.cs
+++ b/Ryujinx.Graphics.Gpu/State/MemoryLayout.cs
@@ -5,7 +5,9 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct MemoryLayout
     {
+#pragma warning disable CS0649
         public uint Packed;
+#pragma warning restore CS0649
 
         public int UnpackGobBlocksInX()
         {

--- a/Ryujinx.Graphics.Gpu/State/PoolState.cs
+++ b/Ryujinx.Graphics.Gpu/State/PoolState.cs
@@ -6,6 +6,8 @@ namespace Ryujinx.Graphics.Gpu.State
     struct PoolState
     {
         public GpuVa Address;
+#pragma warning disable CS0649
         public int   MaximumId;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/PoolState.cs
+++ b/Ryujinx.Graphics.Gpu/State/PoolState.cs
@@ -5,8 +5,8 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct PoolState
     {
-        public GpuVa Address;
 #pragma warning disable CS0649
+        public GpuVa Address;
         public int   MaximumId;
 #pragma warning restore CS0649
     }

--- a/Ryujinx.Graphics.Gpu/State/PrimitiveRestartState.cs
+++ b/Ryujinx.Graphics.Gpu/State/PrimitiveRestartState.cs
@@ -5,7 +5,9 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct PrimitiveRestartState
     {
+#pragma warning disable CS0649
         public Boolean32 Enable;
         public int       Index;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/ReportState.cs
+++ b/Ryujinx.Graphics.Gpu/State/ReportState.cs
@@ -5,8 +5,8 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct ReportState
     {
-        public GpuVa Address;
 #pragma warning disable CS0649
+        public GpuVa Address;
         public int   Payload;
         public uint  Control;
 #pragma warning restore CS0649

--- a/Ryujinx.Graphics.Gpu/State/ReportState.cs
+++ b/Ryujinx.Graphics.Gpu/State/ReportState.cs
@@ -6,7 +6,9 @@ namespace Ryujinx.Graphics.Gpu.State
     struct ReportState
     {
         public GpuVa Address;
+#pragma warning disable CS0649
         public int   Payload;
         public uint  Control;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/RtColorMask.cs
+++ b/Ryujinx.Graphics.Gpu/State/RtColorMask.cs
@@ -6,7 +6,9 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct RtColorMask
     {
+#pragma warning disable CS0649
         public uint Packed;
+#pragma warning restore CS0649
 
         /// <summary>
         /// Unpacks red channel enable.

--- a/Ryujinx.Graphics.Gpu/State/RtColorState.cs
+++ b/Ryujinx.Graphics.Gpu/State/RtColorState.cs
@@ -5,14 +5,12 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct RtColorState
     {
-        public GpuVa        Address;
 #pragma warning disable CS0649
+        public GpuVa        Address;
         public int          WidthOrStride;
         public int          Height;
         public RtFormat     Format;
-#pragma warning restore CS0649
         public MemoryLayout MemoryLayout;
-#pragma warning disable CS0649
         public int          Depth;
         public int          LayerSize;
         public int          BaseLayer;

--- a/Ryujinx.Graphics.Gpu/State/RtColorState.cs
+++ b/Ryujinx.Graphics.Gpu/State/RtColorState.cs
@@ -6,11 +6,13 @@ namespace Ryujinx.Graphics.Gpu.State
     struct RtColorState
     {
         public GpuVa        Address;
-        public MemoryLayout MemoryLayout;
 #pragma warning disable CS0649
         public int          WidthOrStride;
         public int          Height;
         public RtFormat     Format;
+#pragma warning restore CS0649
+        public MemoryLayout MemoryLayout;
+#pragma warning disable CS0649
         public int          Depth;
         public int          LayerSize;
         public int          BaseLayer;

--- a/Ryujinx.Graphics.Gpu/State/RtColorState.cs
+++ b/Ryujinx.Graphics.Gpu/State/RtColorState.cs
@@ -6,10 +6,11 @@ namespace Ryujinx.Graphics.Gpu.State
     struct RtColorState
     {
         public GpuVa        Address;
+        public MemoryLayout MemoryLayout;
+#pragma warning disable CS0649
         public int          WidthOrStride;
         public int          Height;
         public RtFormat     Format;
-        public MemoryLayout MemoryLayout;
         public int          Depth;
         public int          LayerSize;
         public int          BaseLayer;
@@ -20,5 +21,6 @@ namespace Ryujinx.Graphics.Gpu.State
         public int          Padding3;
         public int          Padding4;
         public int          Padding5;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/RtControl.cs
+++ b/Ryujinx.Graphics.Gpu/State/RtControl.cs
@@ -5,7 +5,9 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct RtControl
     {
+#pragma warning disable CS0649
         public uint Packed;
+#pragma warning restore CS0649
 
         /// <summary>
         /// Unpacks the number of active draw buffers.

--- a/Ryujinx.Graphics.Gpu/State/RtDepthStencilState.cs
+++ b/Ryujinx.Graphics.Gpu/State/RtDepthStencilState.cs
@@ -6,9 +6,11 @@ namespace Ryujinx.Graphics.Gpu.State
     struct RtDepthStencilState
     {
         public GpuVa        Address;
-        public MemoryLayout MemoryLayout;
 #pragma warning disable CS0649
         public RtFormat     Format;
+#pragma warning restore CS0649
+        public MemoryLayout MemoryLayout;
+#pragma warning disable CS0649
         public int          LayerSize;
 #pragma warning restore CS0649
     }

--- a/Ryujinx.Graphics.Gpu/State/RtDepthStencilState.cs
+++ b/Ryujinx.Graphics.Gpu/State/RtDepthStencilState.cs
@@ -5,12 +5,10 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct RtDepthStencilState
     {
+#pragma warning disable CS0649
         public GpuVa        Address;
-#pragma warning disable CS0649
         public RtFormat     Format;
-#pragma warning restore CS0649
         public MemoryLayout MemoryLayout;
-#pragma warning disable CS0649
         public int          LayerSize;
 #pragma warning restore CS0649
     }

--- a/Ryujinx.Graphics.Gpu/State/RtDepthStencilState.cs
+++ b/Ryujinx.Graphics.Gpu/State/RtDepthStencilState.cs
@@ -6,8 +6,10 @@ namespace Ryujinx.Graphics.Gpu.State
     struct RtDepthStencilState
     {
         public GpuVa        Address;
-        public RtFormat     Format;
         public MemoryLayout MemoryLayout;
+#pragma warning disable CS0649
+        public RtFormat     Format;
         public int          LayerSize;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/ScissorState.cs
+++ b/Ryujinx.Graphics.Gpu/State/ScissorState.cs
@@ -2,11 +2,13 @@
 {
     struct ScissorState
     {
+#pragma warning disable CS0649
         public Boolean32 Enable;
         public ushort X1;
         public ushort X2;
         public ushort Y1;
         public ushort Y2;
         public uint Padding;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/ShaderState.cs
+++ b/Ryujinx.Graphics.Gpu/State/ShaderState.cs
@@ -5,6 +5,7 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct ShaderState
     {
+#pragma warning disable CS0649
         public uint       Control;
         public uint       Offset;
         public uint       Unknown0x8;
@@ -21,6 +22,7 @@ namespace Ryujinx.Graphics.Gpu.State
         public uint       Unknown0x34;
         public uint       Unknown0x38;
         public uint       Unknown0x3c;
+#pragma warning restore CS0649
 
         /// <summary>
         /// Unpacks shader enable information.

--- a/Ryujinx.Graphics.Gpu/State/Size3D.cs
+++ b/Ryujinx.Graphics.Gpu/State/Size3D.cs
@@ -5,8 +5,10 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct Size3D
     {
+#pragma warning disable CS0649
         public int Width;
         public int Height;
         public int Depth;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/StencilBackMasks.cs
+++ b/Ryujinx.Graphics.Gpu/State/StencilBackMasks.cs
@@ -5,8 +5,10 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct StencilBackMasks
     {
+#pragma warning disable CS0649
         public int FuncRef;
         public int Mask;
         public int FuncMask;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/StencilBackTestState.cs
+++ b/Ryujinx.Graphics.Gpu/State/StencilBackTestState.cs
@@ -7,10 +7,12 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct StencilBackTestState
     {
+#pragma warning disable CS0649
         public Boolean32 TwoSided;
         public StencilOp BackSFail;
         public StencilOp BackDpFail;
         public StencilOp BackDpPass;
         public CompareOp BackFunc;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/StencilTestState.cs
+++ b/Ryujinx.Graphics.Gpu/State/StencilTestState.cs
@@ -7,6 +7,7 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct StencilTestState
     {
+#pragma warning disable CS0649
         public Boolean32 Enable;
         public StencilOp FrontSFail;
         public StencilOp FrontDpFail;
@@ -15,5 +16,6 @@ namespace Ryujinx.Graphics.Gpu.State
         public int       FrontFuncRef;
         public int       FrontFuncMask;
         public int       FrontMask;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/UniformBufferState.cs
+++ b/Ryujinx.Graphics.Gpu/State/UniformBufferState.cs
@@ -7,9 +7,7 @@ namespace Ryujinx.Graphics.Gpu.State
     {
 #pragma warning disable CS0649
         public int   Size;
-#pragma warning restore CS0649
         public GpuVa Address;
-#pragma warning disable CS0649
         public int   Offset;
 #pragma warning restore CS0649
     }

--- a/Ryujinx.Graphics.Gpu/State/UniformBufferState.cs
+++ b/Ryujinx.Graphics.Gpu/State/UniformBufferState.cs
@@ -5,8 +5,10 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct UniformBufferState
     {
-        public int   Size;
         public GpuVa Address;
+#pragma warning disable CS0649
+        public int   Size;
         public int   Offset;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/UniformBufferState.cs
+++ b/Ryujinx.Graphics.Gpu/State/UniformBufferState.cs
@@ -5,9 +5,11 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct UniformBufferState
     {
-        public GpuVa Address;
 #pragma warning disable CS0649
         public int   Size;
+#pragma warning restore CS0649
+        public GpuVa Address;
+#pragma warning disable CS0649
         public int   Offset;
 #pragma warning restore CS0649
     }

--- a/Ryujinx.Graphics.Gpu/State/VertexAttribState.cs
+++ b/Ryujinx.Graphics.Gpu/State/VertexAttribState.cs
@@ -5,7 +5,9 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct VertexAttribState
     {
+#pragma warning disable CS0649
         public uint Attribute;
+#pragma warning restore CS0649
 
         /// <summary>
         /// Unpacks the index of the vertex buffer this attribute belongs to.

--- a/Ryujinx.Graphics.Gpu/State/VertexBufferDrawState.cs
+++ b/Ryujinx.Graphics.Gpu/State/VertexBufferDrawState.cs
@@ -5,7 +5,9 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct VertexBufferDrawState
     {
+#pragma warning disable CS0649
         public int First;
         public int Count;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/VertexBufferState.cs
+++ b/Ryujinx.Graphics.Gpu/State/VertexBufferState.cs
@@ -5,9 +5,11 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct VertexBufferState
     {
-        public uint  Control;
         public GpuVa Address;
+#pragma warning disable CS0649
+        public uint  Control;
         public int   Divisor;
+#pragma warning restore CS0649
 
         /// <summary>
         /// Vertex buffer stride, defined as the number of bytes occupied by each vertex in memory.

--- a/Ryujinx.Graphics.Gpu/State/VertexBufferState.cs
+++ b/Ryujinx.Graphics.Gpu/State/VertexBufferState.cs
@@ -7,9 +7,7 @@ namespace Ryujinx.Graphics.Gpu.State
     {
 #pragma warning disable CS0649
         public uint  Control;
-#pragma warning restore CS0649
         public GpuVa Address;
-#pragma warning disable CS0649
         public int   Divisor;
 #pragma warning restore CS0649
 

--- a/Ryujinx.Graphics.Gpu/State/VertexBufferState.cs
+++ b/Ryujinx.Graphics.Gpu/State/VertexBufferState.cs
@@ -5,9 +5,11 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct VertexBufferState
     {
-        public GpuVa Address;
 #pragma warning disable CS0649
         public uint  Control;
+#pragma warning restore CS0649
+        public GpuVa Address;
+#pragma warning disable CS0649
         public int   Divisor;
 #pragma warning restore CS0649
 

--- a/Ryujinx.Graphics.Gpu/State/ViewportExtents.cs
+++ b/Ryujinx.Graphics.Gpu/State/ViewportExtents.cs
@@ -5,11 +5,13 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct ViewportExtents
     {
+#pragma warning disable CS0649
         public ushort X;
         public ushort Width;
         public ushort Y;
         public ushort Height;
         public float  DepthNear;
         public float  DepthFar;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/ViewportTransform.cs
+++ b/Ryujinx.Graphics.Gpu/State/ViewportTransform.cs
@@ -7,6 +7,7 @@ namespace Ryujinx.Graphics.Gpu.State
     /// </summary>
     struct ViewportTransform
     {
+#pragma warning disable CS0649
         public float ScaleX;
         public float ScaleY;
         public float ScaleZ;
@@ -15,6 +16,7 @@ namespace Ryujinx.Graphics.Gpu.State
         public float TranslateZ;
         public uint  Swizzle;
         public uint  SubpixelPrecisionBias;
+#pragma warning restore CS0649
 
         /// <summary>
         /// Unpacks viewport swizzle of the position X component.

--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -114,7 +114,9 @@ namespace Ryujinx.HLE.HOS
 
         public Keyset KeySet => Device.FileSystem.KeySet;
 
+#pragma warning disable CS0649
         private bool _hasStarted;
+#pragma warning restore CS0649
         private bool _isDisposed;
 
         public BlitStruct<ApplicationControlProperty> ControlData { get; set; }

--- a/Ryujinx.HLE/HOS/Kernel/Ipc/KLightSession.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Ipc/KLightSession.cs
@@ -7,14 +7,10 @@ namespace Ryujinx.HLE.HOS.Kernel.Ipc
         public KLightServerSession ServerSession { get; }
         public KLightClientSession ClientSession { get; }
 
-        private bool _hasBeenInitialized;
-
         public KLightSession(Horizon system) : base(system)
         {
             ServerSession = new KLightServerSession(system, this);
             ClientSession = new KLightClientSession(system, this);
-
-            _hasBeenInitialized = true;
         }
     }
 }

--- a/Ryujinx.HLE/HOS/Kernel/Memory/KMemoryManager.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Memory/KMemoryManager.cs
@@ -62,7 +62,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
         private bool _aslrDisabled;
 
         public int AddrSpaceWidth { get; private set; }
-        
+
         private bool _isKernel;
 
         private bool _aslrEnabled;

--- a/Ryujinx.HLE/HOS/Kernel/Memory/KMemoryManager.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Memory/KMemoryManager.cs
@@ -62,6 +62,8 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
         private bool _aslrDisabled;
 
         public int AddrSpaceWidth { get; private set; }
+        
+        private bool _isKernel;
 
         private bool _aslrEnabled;
 
@@ -77,6 +79,8 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
             _cpuMemory = cpuMemory;
 
             _blocks = new LinkedList<KMemoryBlock>();
+
+            _isKernel = false;
         }
 
         private static readonly int[] AddrSpaceSizes = new int[] { 32, 36, 32, 39 };
@@ -2640,7 +2644,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
 
             ulong regionEndAddr = regionStart + regionPagesCount * PageSize;
 
-            ulong reservedPagesCount = 4UL;
+            ulong reservedPagesCount = _isKernel ? 1UL : 4UL;
 
             if (_aslrEnabled)
             {

--- a/Ryujinx.HLE/HOS/Kernel/Memory/KMemoryManager.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Memory/KMemoryManager.cs
@@ -63,7 +63,6 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
 
         public int AddrSpaceWidth { get; private set; }
 
-        private bool _isKernel;
         private bool _aslrEnabled;
 
         private KMemoryBlockAllocator _blockAllocator;
@@ -2641,7 +2640,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
 
             ulong regionEndAddr = regionStart + regionPagesCount * PageSize;
 
-            ulong reservedPagesCount = _isKernel ? 1UL : 4UL;
+            ulong reservedPagesCount = 4UL;
 
             if (_aslrEnabled)
             {

--- a/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
@@ -66,7 +66,9 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
 
         private long _affinityMaskOverride;
         private int  _preferredCoreOverride;
+#pragma warning disable CS0649
         private int  _affinityOverrideCount;
+#pragma warning restore CS0649
 
         public ThreadSchedState SchedFlags { get; private set; }
 

--- a/Ryujinx.HLE/HOS/Services/Arp/ApplicationLaunchProperty.cs
+++ b/Ryujinx.HLE/HOS/Services/Arp/ApplicationLaunchProperty.cs
@@ -8,6 +8,9 @@ namespace Ryujinx.HLE.HOS.Services.Arp
         public int   Version;
         public byte  BaseGameStorageId;
         public byte  UpdateGameStorageId;
+#pragma warning disable CS0649
+        public short Padding;
+#pragma warning restore CS0649
 
         public static ApplicationLaunchProperty Default
         {

--- a/Ryujinx.HLE/HOS/Services/Arp/ApplicationLaunchProperty.cs
+++ b/Ryujinx.HLE/HOS/Services/Arp/ApplicationLaunchProperty.cs
@@ -8,7 +8,6 @@ namespace Ryujinx.HLE.HOS.Services.Arp
         public int   Version;
         public byte  BaseGameStorageId;
         public byte  UpdateGameStorageId;
-        public short Padding;
 
         public static ApplicationLaunchProperty Default
         {

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioRendererManager/Types/UpdateDataHeader.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioRendererManager/Types/UpdateDataHeader.cs
@@ -2,29 +2,23 @@
 {
     struct UpdateDataHeader
     {
+#pragma warning disable CS0649
         public int Revision;
         public int BehaviorSize;
         public int MemoryPoolSize;
         public int VoiceSize;
-#pragma warning disable CS0649
         public int VoiceResourceSize;
-#pragma warning restore CS0649
         public int EffectSize;
-#pragma warning disable CS0649
         public int MixSize;
-#pragma warning restore CS0649
         public int SinkSize;
         public int PerformanceManagerSize;
-#pragma warning disable CS0649
         public int Unknown24;
-#pragma warning restore CS0649
         public int ElapsedFrameCountInfoSize;
-#pragma warning disable CS0649
         public int Unknown2C;
         public int Unknown30;
         public int Unknown34;
         public int Unknown38;
-#pragma warning restore CS0649
         public int TotalSize;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioRendererManager/Types/UpdateDataHeader.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioRendererManager/Types/UpdateDataHeader.cs
@@ -6,17 +6,19 @@
         public int BehaviorSize;
         public int MemoryPoolSize;
         public int VoiceSize;
-        public int VoiceResourceSize;
         public int EffectSize;
-        public int MixSize;
         public int SinkSize;
+        public int TotalSize;
         public int PerformanceManagerSize;
-        public int Unknown24;
         public int ElapsedFrameCountInfoSize;
+#pragma warning disable CS0649
+        public int VoiceResourceSize;
+        public int MixSize;
+        public int Unknown24;
         public int Unknown2C;
         public int Unknown30;
         public int Unknown34;
         public int Unknown38;
-        public int TotalSize;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioRendererManager/Types/UpdateDataHeader.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioRendererManager/Types/UpdateDataHeader.cs
@@ -6,19 +6,25 @@
         public int BehaviorSize;
         public int MemoryPoolSize;
         public int VoiceSize;
-        public int EffectSize;
-        public int SinkSize;
-        public int TotalSize;
-        public int PerformanceManagerSize;
-        public int ElapsedFrameCountInfoSize;
 #pragma warning disable CS0649
         public int VoiceResourceSize;
+#pragma warning restore CS0649
+        public int EffectSize;
+#pragma warning disable CS0649
         public int MixSize;
+#pragma warning restore CS0649
+        public int SinkSize;
+        public int PerformanceManagerSize;
+#pragma warning disable CS0649
         public int Unknown24;
+#pragma warning restore CS0649
+        public int ElapsedFrameCountInfoSize;
+#pragma warning disable CS0649
         public int Unknown2C;
         public int Unknown30;
         public int Unknown34;
         public int Unknown38;
 #pragma warning restore CS0649
+        public int TotalSize;
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Bluetooth/IBluetoothDriver.cs
+++ b/Ryujinx.HLE/HOS/Services/Bluetooth/IBluetoothDriver.cs
@@ -56,7 +56,7 @@ namespace Ryujinx.HLE.HOS.Services.Bluetooth
             else
             {
                 _unknownLowEnergy = "low_energy";
-                
+
                 if (BluetoothEventManager.InitializeBleEventHandle == 0)
                 {
                     BluetoothEventManager.InitializeBleEvent = new KEvent(context.Device.System);

--- a/Ryujinx.HLE/HOS/Services/Bluetooth/IBluetoothDriver.cs
+++ b/Ryujinx.HLE/HOS/Services/Bluetooth/IBluetoothDriver.cs
@@ -9,13 +9,11 @@ namespace Ryujinx.HLE.HOS.Services.Bluetooth
     [Service("btdrv")]
     class IBluetoothDriver : IpcService
     {
-        private string _unknownLowEnergy;
-
         public IBluetoothDriver(ServiceCtx context) { }
 
         [Command(46)]
         // InitializeBluetoothLe() -> handle<copy>
-        public ResultCode InitializeBluetoothLe(ServiceCtx context)
+        public ResultCode InitializeBluetoothLe(ServiceCtx context) // not used, used for later ?
         {
             NxSettings.Settings.TryGetValue("bluetooth_debug!skip_boot", out object debugMode);
 
@@ -53,8 +51,6 @@ namespace Ryujinx.HLE.HOS.Services.Bluetooth
             }
             else
             {
-                _unknownLowEnergy = "low_energy";
-
                 if (BluetoothEventManager.InitializeBleEventHandle == 0)
                 {
                     BluetoothEventManager.InitializeBleEvent = new KEvent(context.Device.System);

--- a/Ryujinx.HLE/HOS/Services/Bluetooth/IBluetoothDriver.cs
+++ b/Ryujinx.HLE/HOS/Services/Bluetooth/IBluetoothDriver.cs
@@ -55,6 +55,8 @@ namespace Ryujinx.HLE.HOS.Services.Bluetooth
             }
             else
             {
+                _unknownLowEnergy = "low_energy";
+                
                 if (BluetoothEventManager.InitializeBleEventHandle == 0)
                 {
                     BluetoothEventManager.InitializeBleEvent = new KEvent(context.Device.System);

--- a/Ryujinx.HLE/HOS/Services/Bluetooth/IBluetoothDriver.cs
+++ b/Ryujinx.HLE/HOS/Services/Bluetooth/IBluetoothDriver.cs
@@ -13,7 +13,7 @@ namespace Ryujinx.HLE.HOS.Services.Bluetooth
 
         [Command(46)]
         // InitializeBluetoothLe() -> handle<copy>
-        public ResultCode InitializeBluetoothLe(ServiceCtx context) // not used, used for later ?
+        public ResultCode InitializeBluetoothLe(ServiceCtx context)
         {
             NxSettings.Settings.TryGetValue("bluetooth_debug!skip_boot", out object debugMode);
 

--- a/Ryujinx.HLE/HOS/Services/Bluetooth/IBluetoothDriver.cs
+++ b/Ryujinx.HLE/HOS/Services/Bluetooth/IBluetoothDriver.cs
@@ -9,6 +9,10 @@ namespace Ryujinx.HLE.HOS.Services.Bluetooth
     [Service("btdrv")]
     class IBluetoothDriver : IpcService
     {
+#pragma warning disable CS0169
+        private string _unknownLowEnergy;
+#pragma warning restore CS0169
+
         public IBluetoothDriver(ServiceCtx context) { }
 
         [Command(46)]

--- a/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
@@ -26,7 +26,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
         private long  _npadCommunicationMode;
         private uint  _accelerometerPlayMode;
+#pragma warning disable CS0649
         private long  _vibrationGcErmCommand;
+#pragma warning restore CS0649
         private float _sevenSixAxisSensorFusionStrength;
 
         private HidSensorFusionParameters  _sensorFusionParams;

--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostAsGpu/NvHostAsGpuDeviceFile.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostAsGpu/NvHostAsGpuDeviceFile.cs
@@ -1,12 +1,10 @@
-﻿using Ryujinx.Common;
-using Ryujinx.Common.Logging;
+﻿using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.Gpu.Memory;
 using Ryujinx.HLE.HOS.Kernel.Process;
 using Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostAsGpu.Types;
 using Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvMap;
 using System;
 using System.Collections.Concurrent;
-using System.Diagnostics;
 
 namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostAsGpu
 {

--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostAsGpu/Types/UnmapBufferArguments.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostAsGpu/Types/UnmapBufferArguments.cs
@@ -2,6 +2,8 @@
 {
     struct UnmapBufferArguments
     {
+#pragma warning disable CS0649
         public long Offset;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostChannel/Types/NvChannel.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostChannel/Types/NvChannel.cs
@@ -2,8 +2,10 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostChannel
 {
     class NvChannel
     {
+#pragma warning disable CS0649
         public int Timeout;
         public int SubmitTimeout;
         public int Timeslice;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostCtrlGpu/NvHostCtrlGpuDeviceFile.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostCtrlGpu/NvHostCtrlGpuDeviceFile.cs
@@ -1,6 +1,5 @@
 ﻿using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Kernel.Common;
-using Ryujinx.HLE.HOS.Kernel.Process;
 using Ryujinx.HLE.HOS.Kernel.Threading;
 using Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostCtrlGpu.Types;
 using System;

--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostCtrlGpu/Types/GetCharacteristicsArguments.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostCtrlGpu/Types/GetCharacteristicsArguments.cs
@@ -45,7 +45,9 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostCtrlGpu.Types
     struct CharacteristicsHeader
     {
         public long BufferSize;
+#pragma warning disable CS0649
         public long BufferAddress;
+#pragma warning restore CS0649
     }
 
     [StructLayout(LayoutKind.Sequential)]

--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostCtrlGpu/Types/GetCharacteristicsArguments.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostCtrlGpu/Types/GetCharacteristicsArguments.cs
@@ -44,8 +44,8 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostCtrlGpu.Types
 
     struct CharacteristicsHeader
     {
-        public long BufferSize;
 #pragma warning disable CS0649
+        public long BufferSize;
         public long BufferAddress;
 #pragma warning restore CS0649
     }

--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvMap/Types/NvMapHandle.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvMap/Types/NvMapHandle.cs
@@ -4,8 +4,10 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvMap
 {
     class NvMapHandle
     {
+#pragma warning disable CS0649
         public int  Handle;
         public int  Id;
+#pragma warning restore CS0649
         public int  Size;
         public int  Align;
         public int  Kind;

--- a/Ryujinx.HLE/Loaders/Elf/ElfSymbol32.cs
+++ b/Ryujinx.HLE/Loaders/Elf/ElfSymbol32.cs
@@ -2,11 +2,13 @@
 {
     struct ElfSymbol32
     {
+#pragma warning disable CS0649
         public uint   NameOffset;
         public uint   ValueAddress;
         public uint   Size;
         public char   Info;
         public char   Other;
         public ushort SectionIndex;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.HLE/Loaders/Elf/ElfSymbol64.cs
+++ b/Ryujinx.HLE/Loaders/Elf/ElfSymbol64.cs
@@ -2,11 +2,13 @@
 {
     struct ElfSymbol64
     {
+#pragma warning disable CS0649
         public uint   NameOffset;
         public char   Info;
         public char   Other;
         public ushort SectionIndex;
         public ulong  ValueAddress;
         public ulong  Size;
+#pragma warning restore CS0649
     }
 }

--- a/Ryujinx.HLE/Switch.cs
+++ b/Ryujinx.HLE/Switch.cs
@@ -34,8 +34,6 @@ namespace Ryujinx.HLE
 
         public AutoResetEvent VsyncEvent { get; private set; }
 
-        public event EventHandler Finish;
-
         public Switch(VirtualFileSystem fileSystem, ContentManager contentManager, IRenderer renderer, IAalOutput audioOut)
         {
             if (renderer == null)

--- a/Ryujinx.HLE/Utilities/FontUtils.cs
+++ b/Ryujinx.HLE/Utilities/FontUtils.cs
@@ -8,7 +8,7 @@ namespace Ryujinx.HLE.Utilities
 
         public static byte[] DecryptFont(Stream bfttfStream)
         {
-            uint KXor(uint In) => In ^ 0x06186249;
+            uint KXor(uint In) => In ^ FontKey;
 
             using (BinaryReader reader = new BinaryReader(bfttfStream))
             {

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -16,11 +16,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Utf8Json;
-using Utf8Json.Resolvers;
 
 using GUI = Gtk.Builder.ObjectAttribute;
 
@@ -42,14 +39,17 @@ namespace Ryujinx.Ui
         private static bool _updatingGameTable;
         private static bool _gameLoaded;
         private static bool _ending;
+#pragma warning disable CS0169
         private static bool _debuggerOpened;
+#pragma warning restore CS0169
 
         private static TreeView _treeView;
 
+#pragma warning disable CS0169
         private static Ryujinx.Debugger.Debugger _debugger;
+#pragma warning restore CS0169
 
-#pragma warning disable CS0649
-#pragma warning disable IDE0044
+#pragma warning disable CS0169, CS0649, IDE0044
 
         [GUI] Window         _mainWin;
         [GUI] MenuBar        _menuBar;
@@ -83,8 +83,7 @@ namespace Ryujinx.Ui
         [GUI] Label          _vSyncStatus;
         [GUI] Box            _listStatusBox;
 
-#pragma warning restore CS0649
-#pragma warning restore IDE0044
+#pragma warning restore CS0649, IDE0044, CS0169
 
         public MainWindow() : this(new Builder("Ryujinx.Ui.MainWindow.glade")) { }
 

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -1,5 +1,4 @@
 using Gtk;
-using JsonPrettyPrinterPlus;
 using LibHac.Common;
 using LibHac.Ns;
 using Ryujinx.Audio;
@@ -12,7 +11,6 @@ using Ryujinx.HLE.FileSystem;
 using Ryujinx.HLE.FileSystem.Content;
 using Ryujinx.HLE.HOS.Services.Hid;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;


### PR DESCRIPTION
Fix #879.

From what I'm seeing it's only useful for HLE and Graphics.Gpu. IMHO it's better to limit the use of those rules on the minimum of projects inside the solution.