### PR TITLE
Extend range of constant buffers used to search for storage buffer descriptors on compute shaders

### DIFF
--- a/Ryujinx.Graphics.Gpu/Constants.cs
+++ b/Ryujinx.Graphics.Gpu/Constants.cs
@@ -13,7 +13,7 @@ namespace Ryujinx.Graphics.Gpu
         /// <summary>
         /// Maximum number of compute storage buffers (this is an API limitation).
         /// </summary>
-        public const int TotalCpStorageBuffers = 16;
+        public const int TotalCpStorageBuffers = 32;
 
         /// <summary>
         /// Maximum number of graphics uniform buffers.

--- a/Ryujinx.Graphics.Gpu/Engine/Compute.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Compute.cs
@@ -77,7 +77,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
                 ulong sbDescAddress = BufferManager.GetComputeUniformBufferAddress(0);
 
-                int sbDescOffset = 0x310 + sb.Slot * 0x10;
+                int sbDescOffset = 0x210 + sb.Slot * 0x10;
 
                 sbDescAddress += (ulong)sbDescOffset;
 

--- a/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -393,7 +393,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         {
             uint enableMask = _cpStorageBuffers.EnableMask;
 
-            for (int index = 0; (enableMask >> index) != 0; index++)
+            for (int index = 0; (enableMask >> index) != 0 && index < 32; index++)
             {
                 if ((enableMask & (1u << index)) == 0)
                 {
@@ -414,7 +414,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
             enableMask = _cpUniformBuffers.EnableMask;
 
-            for (int index = 0; (enableMask >> index) != 0; index++)
+            for (int index = 0; (enableMask >> index) != 0 && index < 32; index++)
             {
                 if ((enableMask & (1u << index)) == 0)
                 {
@@ -467,7 +467,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
                 VertexBufferDescriptor[] vertexBuffers = new VertexBufferDescriptor[Constants.TotalVertexBuffers];
 
-                for (int index = 0; (vbEnableMask >> index) != 0; index++)
+                for (int index = 0; (vbEnableMask >> index) != 0 && index < 32; index++)
                 {
                     VertexBuffer vb = _vertexBuffers[index];
 
@@ -485,7 +485,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
             }
             else
             {
-                for (int index = 0; (vbEnableMask >> index) != 0; index++)
+                for (int index = 0; (vbEnableMask >> index) != 0 && index < 32; index++)
                 {
                     VertexBuffer vb = _vertexBuffers[index];
 

--- a/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgram.cs
+++ b/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgram.cs
@@ -81,7 +81,7 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
                 }
                 else if (UsesStorage(inst))
                 {
-                    AddSBufferUse(context.Info.SBuffers, operation);
+                    AddSBufferUse(context.Info.SBuffers, operation, context.Config.Stage);
                 }
 
                 AstAssignment assignment;
@@ -160,7 +160,7 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
             {
                 if (UsesStorage(inst))
                 {
-                    AddSBufferUse(context.Info.SBuffers, operation);
+                    AddSBufferUse(context.Info.SBuffers, operation, context.Config.Stage);
                 }
 
                 context.AddNode(new AstOperation(inst, operation.Index, sources));
@@ -195,7 +195,7 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
             }
         }
 
-        private static void AddSBufferUse(HashSet<int> sBuffers, Operation operation)
+        private static void AddSBufferUse(HashSet<int> sBuffers, Operation operation, ShaderStage stage)
         {
             Operand slot = operation.GetSource(0);
 
@@ -208,7 +208,7 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
                 // If the value is not constant, then we don't know
                 // how many storage buffers are used, so we assume
                 // all of them are used.
-                for (int index = 0; index < GlobalMemory.StorageMaxCount; index++)
+                for (int index = 0; index < GlobalMemory.GetStorageMaxCount(stage); index++)
                 {
                     sBuffers.Add(index);
                 }

--- a/Ryujinx.Graphics.Shader/Translation/GlobalMemory.cs
+++ b/Ryujinx.Graphics.Shader/Translation/GlobalMemory.cs
@@ -7,9 +7,9 @@ namespace Ryujinx.Graphics.Shader.Translation
         private const int StorageDescsBaseOffset = 0x44; // In words.
 
         public const int StorageDescSize = 4; // In words.
-        public const int StorageMaxCount = 16;
+        private const int StorageMaxCount = 16;
 
-        public const int StorageDescsSize = StorageDescSize * StorageMaxCount;
+        private const int StorageDescsSize = StorageDescSize * StorageMaxCount;
 
         public static bool UsesGlobalMemory(Instruction inst)
         {
@@ -32,7 +32,7 @@ namespace Ryujinx.Graphics.Shader.Translation
         {
             switch (stage)
             {
-                case ShaderStage.Compute:                return StorageDescsBaseOffset + 2 * StorageDescsSize;
+                case ShaderStage.Compute:                return StorageDescsBaseOffset + 1 * StorageDescsSize;
                 case ShaderStage.Vertex:                 return StorageDescsBaseOffset;
                 case ShaderStage.TessellationControl:    return StorageDescsBaseOffset + 1 * StorageDescsSize;
                 case ShaderStage.TessellationEvaluation: return StorageDescsBaseOffset + 2 * StorageDescsSize;
@@ -41,6 +41,16 @@ namespace Ryujinx.Graphics.Shader.Translation
             }
 
             return 0;
+        }
+
+        public static int GetStorageDescriptorsSize(ShaderStage stage)
+        {
+            return GetStorageMaxCount(stage) * StorageDescSize;
+        }
+
+        public static int GetStorageMaxCount(ShaderStage stage)
+        {
+            return stage == ShaderStage.Compute ? 32 : 16;
         }
     }
 }

--- a/Ryujinx.Graphics.Shader/Translation/Lowering.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Lowering.cs
@@ -81,7 +81,7 @@ namespace Ryujinx.Graphics.Shader.Translation
 
             Operand alignMask = Const(-config.QueryInfo(QueryInfoName.StorageBufferOffsetAlignment));
 
-            Operand baseAddrTrunc = PrependOperation(Instruction.BitwiseAnd,    sbBaseAddrLow, Const(-64));
+            Operand baseAddrTrunc = PrependOperation(Instruction.BitwiseAnd,    sbBaseAddrLow, alignMask);
             Operand byteOffset    = PrependOperation(Instruction.Subtract,      addrLow, baseAddrTrunc);
             Operand wordOffset    = PrependOperation(Instruction.ShiftRightU32, byteOffset, Const(2));
 

--- a/Ryujinx.Graphics.Shader/Translation/Lowering.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Lowering.cs
@@ -56,7 +56,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             Operand sbBaseAddrLow = Const(0);
             Operand sbSlot        = Const(0);
 
-            for (int slot = 0; slot < StorageMaxCount; slot++)
+            for (int slot = 0; slot < GetStorageMaxCount(config.Stage); slot++)
             {
                 int cbOffset = GetStorageCbOffset(config.Stage, slot);
 

--- a/Ryujinx.Graphics.Shader/Translation/Optimizations/GlobalToStorage.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Optimizations/GlobalToStorage.cs
@@ -12,7 +12,7 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
         {
             int sbStart = GetStorageBaseCbOffset(config.Stage);
 
-            int sbEnd = sbStart + StorageDescsSize;
+            int sbEnd = sbStart + GetStorageDescriptorsSize(config.Stage);
 
             for (LinkedListNode<INode> node = block.Operations.First; node != null; node = node.Next)
             {


### PR DESCRIPTION
This improves the codegen and also fixes some shaders where it uses previously ignored constant buffer ranges to store address and size information of the storage buffers.