### PR TITLE
Support compute uniform buffers emulated with global memory

### DIFF
--- a/Ryujinx.Graphics.Gpu/Constants.cs
+++ b/Ryujinx.Graphics.Gpu/Constants.cs
@@ -8,11 +8,18 @@ namespace Ryujinx.Graphics.Gpu
         /// <summary>
         /// Maximum number of compute uniform buffers.
         /// </summary>
-        public const int TotalCpUniformBuffers = 8;
+        /// <remarks>
+        /// This does not reflect the hardware count, the API will emulate some constant buffers using
+        /// global memory to make up for the low amount of compute constant buffers supported by hardware (only 8).
+        /// </remarks>
+        public const int TotalCpUniformBuffers = 17; // 8 hardware constant buffers + 9 emulated (14 available to the user).
 
         /// <summary>
-        /// Maximum number of compute storage buffers (this is an API limitation).
+        /// Maximum number of compute storage buffers.
         /// </summary>
+        /// <remarks>
+        /// The maximum number of storage buffers is API limited, the hardware supports a unlimited amount.
+        /// </remarks>
         public const int TotalCpStorageBuffers = 16;
 
         /// <summary>
@@ -21,8 +28,11 @@ namespace Ryujinx.Graphics.Gpu
         public const int TotalGpUniformBuffers = 18;
 
         /// <summary>
-        /// Maximum number of graphics storage buffers (this is an API limitation).
+        /// Maximum number of graphics storage buffers.
         /// </summary>
+        /// <remarks>
+        /// The maximum number of storage buffers is API limited, the hardware supports a unlimited amount.
+        /// </remarks>
         public const int TotalGpStorageBuffers = 16;
 
         /// <summary>

--- a/Ryujinx.Graphics.Shader/Translation/GlobalMemory.cs
+++ b/Ryujinx.Graphics.Shader/Translation/GlobalMemory.cs
@@ -11,6 +11,11 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public const int StorageDescsSize = StorageDescSize * StorageMaxCount;
 
+        public const int UbeBaseOffset = 0x98; // In words.
+        public const int UbeMaxCount   = 9;
+        public const int UbeDescsSize  = StorageDescSize * UbeMaxCount;
+        public const int UbeFirstCbuf  = 8;
+
         public static bool UsesGlobalMemory(Instruction inst)
         {
             return (inst.IsAtomic() && IsGlobalMr(inst)) ||
@@ -30,17 +35,16 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public static int GetStorageBaseCbOffset(ShaderStage stage)
         {
-            switch (stage)
+            return stage switch
             {
-                case ShaderStage.Compute:                return StorageDescsBaseOffset + 2 * StorageDescsSize;
-                case ShaderStage.Vertex:                 return StorageDescsBaseOffset;
-                case ShaderStage.TessellationControl:    return StorageDescsBaseOffset + 1 * StorageDescsSize;
-                case ShaderStage.TessellationEvaluation: return StorageDescsBaseOffset + 2 * StorageDescsSize;
-                case ShaderStage.Geometry:               return StorageDescsBaseOffset + 3 * StorageDescsSize;
-                case ShaderStage.Fragment:               return StorageDescsBaseOffset + 4 * StorageDescsSize;
-            }
-
-            return 0;
+                ShaderStage.Compute                => StorageDescsBaseOffset + 2 * StorageDescsSize,
+                ShaderStage.Vertex                 => StorageDescsBaseOffset,
+                ShaderStage.TessellationControl    => StorageDescsBaseOffset + 1 * StorageDescsSize,
+                ShaderStage.TessellationEvaluation => StorageDescsBaseOffset + 2 * StorageDescsSize,
+                ShaderStage.Geometry               => StorageDescsBaseOffset + 3 * StorageDescsSize,
+                ShaderStage.Fragment               => StorageDescsBaseOffset + 4 * StorageDescsSize,
+                _ => 0
+            };
         }
     }
 }

--- a/Ryujinx.Graphics.Shader/Translation/Lowering.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Lowering.cs
@@ -81,7 +81,7 @@ namespace Ryujinx.Graphics.Shader.Translation
 
             Operand alignMask = Const(-config.QueryInfo(QueryInfoName.StorageBufferOffsetAlignment));
 
-            Operand baseAddrTrunc = PrependOperation(Instruction.BitwiseAnd,    sbBaseAddrLow, Const(-64));
+            Operand baseAddrTrunc = PrependOperation(Instruction.BitwiseAnd,    sbBaseAddrLow, alignMask);
             Operand byteOffset    = PrependOperation(Instruction.Subtract,      addrLow, baseAddrTrunc);
             Operand wordOffset    = PrependOperation(Instruction.ShiftRightU32, byteOffset, Const(2));
 


### PR DESCRIPTION
The hardware only supports 8 constant buffers for compute shader, but the driver seems to expose 14. The driver makes up for the remaining cbufs by "emulating" them using global memory access. This is very similar to what is done for storage buffers.

This adds support for that on the shader, by identifying access to emulated uniform buffers (the same way we do to identify access to storage buffers) and replacing them with the proper uniform buffer access. The GPU side checks and binds the uniform buffers based on the descriptors.