### PR TITLE
Support for frame defined swap intervals.

### DIFF
--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/NvFlinger.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/NvFlinger.cs
@@ -153,6 +153,8 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
                 context.Device.VsyncEvent.WaitOne();
             }
 
+            context.Device.NextSwapInterval = queueBufferObject.SwapInterval;
+
             return MakeReplyParcel(context, 1280, 720, 0, 0, 0);
         }
 

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/NvFlinger.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/NvFlinger.cs
@@ -150,10 +150,11 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
             if (context.Device.EnableDeviceVsync)
             {
-                context.Device.VsyncEvent.WaitOne();
+                for (int i = 0; i < queueBufferObject.SwapInterval; i++)
+                {
+                    context.Device.VsyncEvent.WaitOne();
+                }
             }
-
-            context.Device.NextSwapInterval = queueBufferObject.SwapInterval;
 
             return MakeReplyParcel(context, 1280, 720, 0, 0, 0);
         }

--- a/Ryujinx.HLE/Switch.cs
+++ b/Ryujinx.HLE/Switch.cs
@@ -34,8 +34,6 @@ namespace Ryujinx.HLE
 
         public AutoResetEvent VsyncEvent { get; private set; }
 
-        public int NextSwapInterval { get; set; }
-
         public event EventHandler Finish;
 
         public Switch(VirtualFileSystem fileSystem, ContentManager contentManager, IRenderer renderer, IAalOutput audioOut)

--- a/Ryujinx.HLE/Switch.cs
+++ b/Ryujinx.HLE/Switch.cs
@@ -34,6 +34,8 @@ namespace Ryujinx.HLE
 
         public AutoResetEvent VsyncEvent { get; private set; }
 
+        public int NextSwapInterval { get; set; }
+
         public event EventHandler Finish;
 
         public Switch(VirtualFileSystem fileSystem, ContentManager contentManager, IRenderer renderer, IAalOutput audioOut)


### PR DESCRIPTION
Add support for swap interval defined by the buffer sent to the surface flinger. This should solve issues with 30fps games like FE3H running at 60fps and thus, slowing down internally.