### PR TITLE
Some fixes for the new GLRenderer

### DIFF
--- a/Ryujinx.Graphics.OpenGL/Window.cs
+++ b/Ryujinx.Graphics.OpenGL/Window.cs
@@ -22,15 +22,30 @@ namespace Ryujinx.Graphics.OpenGL
 
         public void Present(ITexture texture, ImageCrop crop)
         {
-            TextureView view = (TextureView)texture;
-
             GL.Disable(EnableCap.FramebufferSrgb);
+
+            CopyTextureToFrameBufferRGB(0, GetCopyFramebufferHandleLazy(), (TextureView)texture, crop);
+
+            GL.Enable(EnableCap.FramebufferSrgb);
+        }
+
+        public void SetSize(int width, int height)
+        {
+            _width  = width;
+            _height = height;
+        }
+
+
+        private void CopyTextureToFrameBufferRGB(int drawFramebuffer, int readFramebuffer, TextureView view, ImageCrop crop)
+        {
+            bool[] oldFramebufferColorWritemask = new bool[4];
 
             int oldReadFramebufferHandle = GL.GetInteger(GetPName.ReadFramebufferBinding);
             int oldDrawFramebufferHandle = GL.GetInteger(GetPName.DrawFramebufferBinding);
+            GL.GetBoolean(GetIndexedPName.ColorWritemask, drawFramebuffer, oldFramebufferColorWritemask);
 
-            GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, 0);
-            GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, GetCopyFramebufferHandleLazy());
+            GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, drawFramebuffer);
+            GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, readFramebuffer);
 
             GL.FramebufferTexture(
                 FramebufferTarget.ReadFramebuffer,
@@ -93,16 +108,17 @@ namespace Ryujinx.Graphics.OpenGL
                 ClearBufferMask.ColorBufferBit,
                 BlitFramebufferFilter.Linear);
 
+            // Remove Alpha channel
+            GL.ColorMask(drawFramebuffer, false, false, false, true);
+            GL.ClearBuffer(ClearBuffer.Color, 0, new float[] { 0.0f, 0.0f, 0.0f, 1.0f });
+            GL.ColorMask(drawFramebuffer,
+                oldFramebufferColorWritemask[0],
+                oldFramebufferColorWritemask[1],
+                oldFramebufferColorWritemask[2],
+                oldFramebufferColorWritemask[3]);
+
             GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, oldReadFramebufferHandle);
             GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, oldDrawFramebufferHandle);
-
-            GL.Enable(EnableCap.FramebufferSrgb);
-        }
-
-        public void SetSize(int width, int height)
-        {
-            _width  = width;
-            _height = height;
         }
 
         private int GetCopyFramebufferHandleLazy()

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -53,7 +53,7 @@ namespace Ryujinx.Ui
         private Input.NpadController _primaryController;
 
         public GLRenderer(Switch device) 
-            : base (new GraphicsMode(new ColorFormat(24)), 
+            : base (new GraphicsMode(new ColorFormat()),
             3, 3, 
             GraphicsContextFlags.ForwardCompatible)
         {

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -283,11 +283,6 @@ namespace Ryujinx.Ui
 
                     if (_ticks >= _ticksPerFrame)
                     {
-                        // Ensure that the content is Opaque.
-                        GL.ColorMask(false, false, false, true);
-                        GL.ClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-                        GL.ColorMask(true, true, true, true);
-
                         _device.PresentFrame(SwapBuffers);
 
                         _device.Statistics.RecordSystemFrameTime();

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -400,7 +400,7 @@ namespace Ryujinx.Ui
                 _viewBox.Child = _gLWidget;
 
                 _gLWidget.ShowAll();
-                _listStatusBox.Hide();
+                ClearFooterForGameRender();
             });
 
             _gLWidget.WaitEvent.WaitOne();
@@ -435,7 +435,7 @@ namespace Ryujinx.Ui
 
                 DiscordIntegrationModule.SwitchToMainMenu();
 
-                _listStatusBox.ShowAll();
+                RecreateFooterForMenu();
 
                 UpdateColumns();
                 UpdateGameTable();
@@ -447,6 +447,17 @@ namespace Ryujinx.Ui
                 _firmwareInstallDirectory.Sensitive = true;
             });
         }
+
+        private void RecreateFooterForMenu()
+        {
+            _footerBox.Add(_listStatusBox);
+        }
+
+        private void ClearFooterForGameRender()
+        {
+            _footerBox.Remove(_listStatusBox);
+        }
+
 
         public void ToggleExtraWidgets(bool show)
         {
@@ -874,13 +885,13 @@ namespace Ryujinx.Ui
             {
                 Fullscreen();
 
-                ToggleExtraWidgets(true);
+                ToggleExtraWidgets(false);
             }
             else
             {
                 Unfullscreen();
 
-                ToggleExtraWidgets(false);
+                ToggleExtraWidgets(true);
             }
         }
 

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -31,7 +31,7 @@ namespace Ryujinx.Ui
 
         private static GLRenderer _gLWidget;
 
-        private static AutoResetEvent _screenExitStatus = new AutoResetEvent(false);
+        private static AutoResetEvent _deviceExitStatus = new AutoResetEvent(false);
 
         private static ListStore _tableStore;
 
@@ -356,7 +356,7 @@ namespace Ryujinx.Ui
 
                 _emulationContext = device;
 
-                _screenExitStatus.Reset();
+                _deviceExitStatus.Reset();
 
 #if MACOS_BUILD
                 CreateGameWindow(device);
@@ -391,8 +391,6 @@ namespace Ryujinx.Ui
         {
             device.Hid.InitializePrimaryController(ConfigurationState.Instance.Hid.ControllerType);
 
-            _gLWidget?.Exit();
-            _gLWidget?.Dispose();
             _gLWidget = new GLRenderer(_emulationContext);
 
             Application.Invoke(delegate
@@ -409,6 +407,10 @@ namespace Ryujinx.Ui
 
             _gLWidget.Start();
 
+            device.Dispose();
+            _deviceExitStatus.Set();
+
+            // NOTE: Everything that is here will not be executed when you close the UI.
             Application.Invoke(delegate
             {
                 _viewBox.Remove(_gLWidget);
@@ -419,11 +421,19 @@ namespace Ryujinx.Ui
                     _gLWidget.Window.Dispose();
                 }
 
+                _gLWidget.Dispose();
+
                 _viewBox.Add(_gameTableWindow);
 
                 _gameTableWindow.Expand = true;
 
                 this.Window.Title = "Ryujinx";
+
+                _emulationContext = null;
+                _gameLoaded       = false;
+                _gLWidget         = null;
+
+                DiscordIntegrationModule.SwitchToMainMenu();
 
                 _listStatusBox.ShowAll();
 
@@ -431,24 +441,11 @@ namespace Ryujinx.Ui
                 UpdateGameTable();
 
                 Task.Run(RefreshFirmwareLabel);
-            });
 
-            device.Dispose();
-
-            _emulationContext = null;
-            _gameLoaded       = false;
-            _gLWidget         = null;
-
-            DiscordIntegrationModule.SwitchToMainMenu();
-
-            Application.Invoke(delegate
-            {
                 _stopEmulation.Sensitive            = false;
                 _firmwareInstallFile.Sensitive      = true;
                 _firmwareInstallDirectory.Sensitive = true;
             });
-
-            _screenExitStatus.Set();
         }
 
         public void ToggleExtraWidgets(bool show)
@@ -469,7 +466,7 @@ namespace Ryujinx.Ui
 
             bool fullScreenToggled = this.Window.State.HasFlag(Gdk.WindowState.Fullscreen);
 
-            _fullScreen.Label = !fullScreenToggled ? "Exit Fullscreen" : "Enter Fullscreen";
+            _fullScreen.Label = fullScreenToggled ? "Exit Fullscreen" : "Enter Fullscreen";
         }
 
         private static void UpdateGameMetadata(string titleId)
@@ -506,8 +503,11 @@ namespace Ryujinx.Ui
 
                 if (_gLWidget != null)
                 {
+                    // We tell the widget that we are exiting
                     _gLWidget.Exit();
-                    _screenExitStatus.WaitOne();
+
+                    // Wait for the other thread to dispose the HLE context before exiting.
+                    _deviceExitStatus.WaitOne();
                 }
             }
 
@@ -874,17 +874,13 @@ namespace Ryujinx.Ui
             {
                 Fullscreen();
 
-                _fullScreen.Label = "Exit Fullscreen";
-
-                ToggleExtraWidgets(false);
+                ToggleExtraWidgets(true);
             }
             else
             {
                 Unfullscreen();
 
-                _fullScreen.Label = "Enter Fullscreen";
-
-                ToggleExtraWidgets(true);
+                ToggleExtraWidgets(false);
             }
         }
 

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -458,7 +458,6 @@ namespace Ryujinx.Ui
             _footerBox.Remove(_listStatusBox);
         }
 
-
         public void ToggleExtraWidgets(bool show)
         {
             if (_gLWidget != null)

--- a/Ryujinx/Ui/MainWindow.glade
+++ b/Ryujinx/Ui/MainWindow.glade
@@ -7,7 +7,7 @@
     <property name="title" translatable="yes">Ryujinx</property>
     <property name="window_position">center</property>
     <property name="default_width">1280</property>
-    <property name="default_height">750</property>
+    <property name="default_height">760</property>
     <child type="titlebar">
       <placeholder/>
     </child>
@@ -357,7 +357,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkBox" id="MainBox">
+          <object class="GtkBox" id="_mainBox">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="orientation">vertical</property>
@@ -403,6 +403,8 @@
               <object class="GtkBox" id="_footerBox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="width_request">1280</property>
+                <property name="height_request">19</property>
                 <child>
                   <object class="GtkBox" id="_listStatusBox">
                     <property name="visible">True</property>


### PR DESCRIPTION
Changelog:
- Fix transparency of the window on some games on Windows.
- Fix escape key not being able to exit emulation.
- Fix inverted logic in fullscreen event handling.
- Fix a race condition when stoping emulation causing a hang.
- Fix a memory leak of the OpenGL context when stoping emulation (saving ~200MB of RAM when stoping emulation).
- Simplify and document behaviours when exiting the emulator while the
emulation is running.