### PR TITLE
Sign-extend shader memory instruction offsets

### DIFF
--- a/Ryujinx.Graphics.Shader/Decoders/OpCodeLdc.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/OpCodeLdc.cs
@@ -17,7 +17,7 @@ namespace Ryujinx.Graphics.Shader.Decoders
             Rd = new Register(opCode.Extract(0, 8), RegisterType.Gpr);
             Ra = new Register(opCode.Extract(8, 8), RegisterType.Gpr);
 
-            Offset = opCode.Extract(22, 14);
+            Offset = (opCode.Extract(20, 16) << 16) >> 16;
             Slot   = opCode.Extract(36, 5);
 
             Size = (IntegerSize)opCode.Extract(48, 3);

--- a/Ryujinx.Graphics.Shader/Decoders/OpCodeMemory.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/OpCodeMemory.cs
@@ -18,7 +18,7 @@ namespace Ryujinx.Graphics.Shader.Decoders
             Rd = new Register(opCode.Extract(0, 8), RegisterType.Gpr);
             Ra = new Register(opCode.Extract(8, 8), RegisterType.Gpr);
 
-            Offset = opCode.Extract(20, 24);
+            Offset = (opCode.Extract(20, 24) << 8) >> 8;
 
             Extended = opCode.Extract(45);
 

--- a/Ryujinx.Graphics.Shader/Decoders/OpCodeRed.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/OpCodeRed.cs
@@ -24,7 +24,7 @@ namespace Ryujinx.Graphics.Shader.Decoders
 
             AtomicOp = (AtomicOp)opCode.Extract(23, 3);
 
-            Offset = opCode.Extract(28, 20);
+            Offset = (opCode.Extract(28, 20) << 12) >> 12;
 
             Extended = opCode.Extract(48);
         }

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitMemory.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitMemory.cs
@@ -138,11 +138,11 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
             int count = op.Size == IntegerSize.B64 ? 2 : 1;
 
-            Operand wordOffset = context.ShiftRightU32(GetSrcA(context), Const(2));
+            Operand addr = context.IAdd(GetSrcA(context), Const(op.Offset));
 
-            wordOffset = context.IAdd(wordOffset, Const(op.Offset));
+            Operand wordOffset = context.ShiftRightU32(addr, Const(2));
 
-            Operand bitOffset = GetBitOffset(context, GetSrcA(context));
+            Operand bitOffset = GetBitOffset(context, addr);
 
             for (int index = 0; index < count; index++)
             {


### PR DESCRIPTION
This was missing sign-extension, which was causing it to use the wrong offset when the offset is negative. Also correct LDC offset that is a byte offset, not a word offset.