### PR TITLE
Add version in all window titles

### DIFF
--- a/Ryujinx/Program.cs
+++ b/Ryujinx/Program.cs
@@ -22,9 +22,9 @@ namespace Ryujinx
                 EnableHighResolution = true
             });
 
-            Console.Title = "Ryujinx Console";
-
             Version = Assembly.GetEntryAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+
+            Console.Title = $"Ryujinx Console {Version}";
 
             string systemPath = Environment.GetEnvironmentVariable("Path", EnvironmentVariableTarget.Machine);
             Environment.SetEnvironmentVariable("Path", $"{Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "bin")};{systemPath}");

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -118,6 +118,7 @@ namespace Ryujinx.Ui
             ApplyTheme();
 
             _mainWin.Icon            = new Gdk.Pixbuf(Assembly.GetExecutingAssembly(), "Ryujinx.Ui.assets.Icon.png");
+            _mainWin.Title           = $"Ryujinx {Program.Version}";
             _stopEmulation.Sensitive = false;
 
             if (ConfigurationState.Instance.Ui.GuiColumns.FavColumn)        _favToggle.Active        = true;
@@ -427,7 +428,7 @@ namespace Ryujinx.Ui
 
                 _gameTableWindow.Expand = true;
 
-                this.Window.Title = "Ryujinx";
+                this.Window.Title = $"Ryujinx {Program.Version}";
 
                 _emulationContext = null;
                 _gameLoaded       = false;


### PR DESCRIPTION
This add the AppVeyor build version (added in #927) in the console window title and in the GUI title (when you are on the games list or when an emulated game is closed).