### PR TITLE
Update bindless to indexed conversion code pattern match

### DIFF
--- a/Ryujinx.Graphics.Shader/Translation/Optimizations/BindlessToIndexed.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Optimizations/BindlessToIndexed.cs
@@ -45,7 +45,12 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
                     continue;
                 }
 
-                if (!(ldcSrc1.AsgOp is Operation addOp))
+                if (!(ldcSrc1.AsgOp is Operation shrOp) || shrOp.Inst != Instruction.ShiftRightU32)
+                {
+                    continue;
+                }
+
+                if (!(shrOp.GetSource(0).AsgOp is Operation addOp) || addOp.Inst != Instruction.Add)
                 {
                     continue;
                 }
@@ -57,7 +62,7 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
                     continue;
                 }
 
-                texOp.TurnIntoIndexed(addSrc1.Value);
+                texOp.TurnIntoIndexed(addSrc1.Value / 4);
 
                 Operand index = Local();
 

--- a/Ryujinx.Graphics.Shader/Translation/Optimizations/BindlessToIndexed.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Optimizations/BindlessToIndexed.cs
@@ -68,9 +68,9 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
 
                 Operand source = addOp.GetSource(0);
 
-                Operation shrBy1 = new Operation(Instruction.ShiftRightU32, index, source, Const(1));
+                Operation shrBy3 = new Operation(Instruction.ShiftRightU32, index, source, Const(3));
 
-                block.Operations.AddBefore(node, shrBy1);
+                block.Operations.AddBefore(node, shrBy3);
 
                 texOp.SetSource(0, index);
             }


### PR DESCRIPTION
This should fix a regression in LM3 caused by #934. The pattern for LDC changed, but the bindless -> indexed code pattern match was not updated to handle that.