### PR TITLE
Moved all DLL references to a sub-folder

### DIFF
--- a/Ryujinx/Ryujinx.csproj
+++ b/Ryujinx/Ryujinx.csproj
@@ -77,7 +77,7 @@
     <PackageReference Include="GLWidget" Version="1.0.0" />
     <PackageReference Include="GtkSharp" Version="3.22.25.56" />
     <PackageReference Include="GtkSharp.Dependencies" Version="1.1.0" Condition="'$(RuntimeIdentifier)' != 'linux-x64' AND '$(RuntimeIdentifier)' != 'osx-x64'" />
-    <PackageReference Include="nulastudio.NetCoreBeauty" Version="1.2.3" />
+    <PackageReference Include="nulastudio.NetCoreBeauty" Version="1.2.4" />
     <PackageReference Include="OpenTK.NetStandard" Version="1.0.5.12" />
   </ItemGroup>
 

--- a/Ryujinx/Ryujinx.csproj
+++ b/Ryujinx/Ryujinx.csproj
@@ -7,6 +7,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Configurations>Debug;Release;Profile Debug;Profile Release</Configurations>
     <Version>1.0.0-dirty</Version>
+    <ForceBeauty>True</ForceBeauty>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Profile Release|AnyCPU'">
@@ -76,6 +77,7 @@
     <PackageReference Include="GLWidget" Version="1.0.0" />
     <PackageReference Include="GtkSharp" Version="3.22.25.56" />
     <PackageReference Include="GtkSharp.Dependencies" Version="1.1.0" Condition="'$(RuntimeIdentifier)' != 'linux-x64' AND '$(RuntimeIdentifier)' != 'osx-x64'" />
+    <PackageReference Include="nulastudio.NetCoreBeauty" Version="1.2.3" />
     <PackageReference Include="OpenTK.NetStandard" Version="1.0.5.12" />
   </ItemGroup>
 


### PR DESCRIPTION
By using the Package "NetCoreBeauty", all required DLLs from .NET Core are now in a sub-folder called "runtimes", making Ryujinx waaaay cleaner than before.

Here is a comparison of the changes it makes:

![before](https://user-images.githubusercontent.com/6260159/75156036-3e3b7080-56df-11ea-9906-2672cd98e119.PNG)

![after](https://user-images.githubusercontent.com/6260159/75156038-41366100-56df-11ea-9844-d3d1e114b953.PNG)