### PR TITLE
Implement Fast Paths for most A32 SIMD instructions

### DIFF
--- a/ARMeilleure/CodeGen/X86/IntrinsicTable.cs
+++ b/ARMeilleure/CodeGen/X86/IntrinsicTable.cs
@@ -52,6 +52,7 @@ namespace ARMeilleure.CodeGen.X86
             Add(Intrinsic.X86Divss,      new IntrinsicInfo(X86Instruction.Divss,      IntrinsicType.Binary));
             Add(Intrinsic.X86Haddpd,     new IntrinsicInfo(X86Instruction.Haddpd,     IntrinsicType.Binary));
             Add(Intrinsic.X86Haddps,     new IntrinsicInfo(X86Instruction.Haddps,     IntrinsicType.Binary));
+            Add(Intrinsic.X86Insertps,   new IntrinsicInfo(X86Instruction.Insertps,   IntrinsicType.TernaryImm));
             Add(Intrinsic.X86Maxpd,      new IntrinsicInfo(X86Instruction.Maxpd,      IntrinsicType.Binary));
             Add(Intrinsic.X86Maxps,      new IntrinsicInfo(X86Instruction.Maxps,      IntrinsicType.Binary));
             Add(Intrinsic.X86Maxsd,      new IntrinsicInfo(X86Instruction.Maxsd,      IntrinsicType.Binary));

--- a/ARMeilleure/CodeGen/X86/IntrinsicTable.cs
+++ b/ARMeilleure/CodeGen/X86/IntrinsicTable.cs
@@ -63,6 +63,7 @@ namespace ARMeilleure.CodeGen.X86
             Add(Intrinsic.X86Minss,      new IntrinsicInfo(X86Instruction.Minss,      IntrinsicType.Binary));
             Add(Intrinsic.X86Movhlps,    new IntrinsicInfo(X86Instruction.Movhlps,    IntrinsicType.Binary));
             Add(Intrinsic.X86Movlhps,    new IntrinsicInfo(X86Instruction.Movlhps,    IntrinsicType.Binary));
+            Add(Intrinsic.X86Movss,      new IntrinsicInfo(X86Instruction.Movss,      IntrinsicType.Binary));
             Add(Intrinsic.X86Mulpd,      new IntrinsicInfo(X86Instruction.Mulpd,      IntrinsicType.Binary));
             Add(Intrinsic.X86Mulps,      new IntrinsicInfo(X86Instruction.Mulps,      IntrinsicType.Binary));
             Add(Intrinsic.X86Mulsd,      new IntrinsicInfo(X86Instruction.Mulsd,      IntrinsicType.Binary));

--- a/ARMeilleure/Decoders/OpCode32SimdRev.cs
+++ b/ARMeilleure/Decoders/OpCode32SimdRev.cs
@@ -4,6 +4,12 @@
     {
         public OpCode32SimdRev(InstDescriptor inst, ulong address, int opCode) : base(inst, address, opCode)
         {
+            if (Opc + Size >= 3)
+            {
+                Instruction = InstDescriptor.Undefined;
+                return;
+            }
+
             // Currently, this instruction is treated as though it's OPCODE is the true size,
             // which lets us deal with reversing vectors on a single element basis (eg. math magic an I64 rather than insert lots of I8s).
             int tempSize = Size;

--- a/ARMeilleure/Instructions/InstEmitSimdArithmetic.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdArithmetic.cs
@@ -186,9 +186,7 @@ namespace ARMeilleure.Instructions
                 {
                     Operand res = context.AddIntrinsic(Intrinsic.X86Subss, GetVec(op.Rn), GetVec(op.Rm));
 
-                    Operand mask = X86GetScalar(context, -0f);
-
-                    res = context.AddIntrinsic(Intrinsic.X86Andnps, mask, res);
+                    res = EmitFloatAbs(context, res, true, false);
 
                     context.Copy(GetVec(op.Rd), context.VectorZeroUpper96(res));
                 }
@@ -196,9 +194,7 @@ namespace ARMeilleure.Instructions
                 {
                     Operand res = context.AddIntrinsic(Intrinsic.X86Subsd, GetVec(op.Rn), GetVec(op.Rm));
 
-                    Operand mask = X86GetScalar(context, -0d);
-
-                    res = context.AddIntrinsic(Intrinsic.X86Andnpd, mask, res);
+                    res = EmitFloatAbs(context, res, false, false);
 
                     context.Copy(GetVec(op.Rd), context.VectorZeroUpper64(res));
                 }
@@ -226,9 +222,7 @@ namespace ARMeilleure.Instructions
                 {
                     Operand res = context.AddIntrinsic(Intrinsic.X86Subps, GetVec(op.Rn), GetVec(op.Rm));
 
-                    Operand mask = X86GetAllElements(context, -0f);
-
-                    res = context.AddIntrinsic(Intrinsic.X86Andnps, mask, res);
+                    res = EmitFloatAbs(context, res, true, true);
 
                     if (op.RegisterSize == RegisterSize.Simd64)
                     {
@@ -241,9 +235,7 @@ namespace ARMeilleure.Instructions
                 {
                     Operand res = context.AddIntrinsic(Intrinsic.X86Subpd, GetVec(op.Rn), GetVec(op.Rm));
 
-                    Operand mask = X86GetAllElements(context, -0d);
-
-                    res = context.AddIntrinsic(Intrinsic.X86Andnpd, mask, res);
+                    res = EmitFloatAbs(context, res, false, true);
 
                     context.Copy(GetVec(op.Rd), res);
                 }
@@ -267,17 +259,13 @@ namespace ARMeilleure.Instructions
 
                 if (op.Size == 0)
                 {
-                    Operand mask = X86GetScalar(context, -0f);
-
-                    Operand res = context.AddIntrinsic(Intrinsic.X86Andnps, mask, GetVec(op.Rn));
+                    Operand res = EmitFloatAbs(context, GetVec(op.Rn), true, false);
 
                     context.Copy(GetVec(op.Rd), context.VectorZeroUpper96(res));
                 }
                 else /* if (op.Size == 1) */
                 {
-                    Operand mask = X86GetScalar(context, -0d);
-
-                    Operand res = context.AddIntrinsic(Intrinsic.X86Andnpd, mask, GetVec(op.Rn));
+                    Operand res = EmitFloatAbs(context, GetVec(op.Rn), false, false);
 
                     context.Copy(GetVec(op.Rd), context.VectorZeroUpper64(res));
                 }
@@ -299,11 +287,9 @@ namespace ARMeilleure.Instructions
 
                 int sizeF = op.Size & 1;
 
-                 if (sizeF == 0)
+                if (sizeF == 0)
                 {
-                    Operand mask = X86GetAllElements(context, -0f);
-
-                    Operand res = context.AddIntrinsic(Intrinsic.X86Andnps, mask, GetVec(op.Rn));
+                    Operand res = EmitFloatAbs(context, GetVec(op.Rn), true, true);
 
                     if (op.RegisterSize == RegisterSize.Simd64)
                     {
@@ -314,9 +300,7 @@ namespace ARMeilleure.Instructions
                 }
                 else /* if (sizeF == 1) */
                 {
-                    Operand mask = X86GetAllElements(context, -0d);
-
-                    Operand res = context.AddIntrinsic(Intrinsic.X86Andnpd, mask, GetVec(op.Rn));
+                    Operand res = EmitFloatAbs(context, GetVec(op.Rn), false, true);
 
                     context.Copy(GetVec(op.Rd), res);
                 }

--- a/ARMeilleure/Instructions/InstEmitSimdArithmetic.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdArithmetic.cs
@@ -3121,7 +3121,7 @@ namespace ARMeilleure.Instructions
             context.Copy(GetVec(op.Rd), res);
         }
 
-        private static Operand EmitSse2VectorIsQNaNOpF(ArmEmitterContext context, Operand opF)
+        public static Operand EmitSse2VectorIsQNaNOpF(ArmEmitterContext context, Operand opF)
         {
             IOpCodeSimd op = (IOpCodeSimd)context.CurrOp;
 

--- a/ARMeilleure/Instructions/InstEmitSimdArithmetic32.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdArithmetic32.cs
@@ -41,7 +41,11 @@ namespace ARMeilleure.Instructions
 
         public static void Vadd_S(ArmEmitterContext context)
         {
-            if (Optimizations.FastFP)
+            if (Optimizations.FastFP && Optimizations.UseSse2)
+            {
+                EmitScalarBinaryOpF32(context, Intrinsic.X86Addss, Intrinsic.X86Addsd);
+            }
+            else if (Optimizations.FastFP)
             {
                 EmitScalarBinaryOpF32(context, (op1, op2) => context.Add(op1, op2));
             }
@@ -53,7 +57,11 @@ namespace ARMeilleure.Instructions
 
         public static void Vadd_V(ArmEmitterContext context)
         {
-            if (Optimizations.FastFP)
+            if (Optimizations.FastFP && Optimizations.UseSse2)
+            {
+                EmitVectorBinaryOpF32(context, Intrinsic.X86Addps, Intrinsic.X86Addpd);
+            }
+            else if (Optimizations.FastFP)
             {
                 EmitVectorBinaryOpF32(context, (op1, op2) => context.Add(op1, op2));
             } 
@@ -157,7 +165,14 @@ namespace ARMeilleure.Instructions
 
         public static void Vmov_S(ArmEmitterContext context)
         {
-            EmitScalarUnaryOpF32(context, (op1) => op1);
+            if (Optimizations.FastFP && Optimizations.UseSse2)
+            {
+                EmitScalarUnaryOpF32(context, 0, 0);
+            }
+            else
+            {
+                EmitScalarUnaryOpF32(context, (op1) => op1);
+            }
         }
 
         public static void Vmovn(ArmEmitterContext context)
@@ -167,6 +182,7 @@ namespace ARMeilleure.Instructions
 
         public static void Vneg_S(ArmEmitterContext context)
         {
+            //TODO: intrinsic that XORs the sign bit
             EmitScalarUnaryOpF32(context, (op1) => context.Negate(op1));
         }
 
@@ -225,7 +241,11 @@ namespace ARMeilleure.Instructions
 
         public static void Vdiv_S(ArmEmitterContext context)
         {
-            if (Optimizations.FastFP)
+            if (Optimizations.FastFP && Optimizations.UseSse2)
+            {
+                EmitScalarBinaryOpF32(context, Intrinsic.X86Divss, Intrinsic.X86Divsd);
+            }
+            else if (Optimizations.FastFP)
             {
                 EmitScalarBinaryOpF32(context, (op1, op2) => context.Divide(op1, op2));
             }
@@ -260,10 +280,18 @@ namespace ARMeilleure.Instructions
 
         public static void Vmax_V(ArmEmitterContext context)
         {
-            EmitVectorBinaryOpF32(context, (op1, op2) =>
+            if (Optimizations.FastFP && Optimizations.UseSse2)
             {
-                return EmitSoftFloatCallDefaultFpscr(context, SoftFloat32.FPMaxFpscr, SoftFloat64.FPMaxFpscr, op1, op2);
-            });
+                EmitVectorBinaryOpF32(context, Intrinsic.X86Maxps, Intrinsic.X86Maxpd);
+            } 
+            else
+            {
+                EmitVectorBinaryOpF32(context, (op1, op2) =>
+                {
+                    return EmitSoftFloatCallDefaultFpscr(context, SoftFloat32.FPMaxFpscr, SoftFloat64.FPMaxFpscr, op1, op2);
+                });
+            }
+
         }
 
         public static void Vmax_I(ArmEmitterContext context)
@@ -281,10 +309,17 @@ namespace ARMeilleure.Instructions
 
         public static void Vmin_V(ArmEmitterContext context)
         {
-            EmitVectorBinaryOpF32(context, (op1, op2) =>
+            if (Optimizations.FastFP && Optimizations.UseSse2)
             {
-                return EmitSoftFloatCallDefaultFpscr(context, SoftFloat32.FPMinFpscr, SoftFloat64.FPMinFpscr, op1, op2);
-            });
+                EmitVectorBinaryOpF32(context, Intrinsic.X86Minps, Intrinsic.X86Minpd);
+            } 
+            else
+            {
+                EmitVectorBinaryOpF32(context, (op1, op2) =>
+                {
+                    return EmitSoftFloatCallDefaultFpscr(context, SoftFloat32.FPMinFpscr, SoftFloat64.FPMinFpscr, op1, op2);
+                });
+            }
         }
 
         public static void Vmin_I(ArmEmitterContext context)
@@ -302,7 +337,11 @@ namespace ARMeilleure.Instructions
 
         public static void Vmul_S(ArmEmitterContext context)
         {
-            if (Optimizations.FastFP)
+            if (Optimizations.FastFP && Optimizations.UseSse2)
+            {
+                EmitScalarBinaryOpF32(context, Intrinsic.X86Mulss, Intrinsic.X86Mulsd);
+            }
+            else if (Optimizations.FastFP)
             {
                 EmitScalarBinaryOpF32(context, (op1, op2) => context.Multiply(op1, op2));
             }
@@ -317,7 +356,11 @@ namespace ARMeilleure.Instructions
 
         public static void Vmul_V(ArmEmitterContext context)
         {
-            if (Optimizations.FastFP)
+            if (Optimizations.FastFP && Optimizations.UseSse2)
+            {
+                EmitVectorBinaryOpF32(context, Intrinsic.X86Mulps, Intrinsic.X86Mulpd);
+            }
+            else if (Optimizations.FastFP)
             {
                 EmitVectorBinaryOpF32(context, (op1, op2) => context.Multiply(op1, op2));
             }
@@ -359,7 +402,11 @@ namespace ARMeilleure.Instructions
 
         public static void Vmla_S(ArmEmitterContext context)
         {
-            if (Optimizations.FastFP)
+            if (Optimizations.FastFP && Optimizations.UseSse2)
+            {
+                EmitScalarTernaryOpF32(context, Intrinsic.X86Mulss, Intrinsic.X86Mulsd, Intrinsic.X86Addss, Intrinsic.X86Addsd);
+            }
+            else if (Optimizations.FastFP)
             {
                 EmitScalarTernaryOpF32(context, (op1, op2, op3) =>
                 {
@@ -377,7 +424,11 @@ namespace ARMeilleure.Instructions
 
         public static void Vmla_V(ArmEmitterContext context)
         {
-            if (Optimizations.FastFP)
+            if (Optimizations.FastFP && Optimizations.UseSse2)
+            {
+                EmitVectorTernaryOpF32(context, Intrinsic.X86Mulps, Intrinsic.X86Mulpd, Intrinsic.X86Addps, Intrinsic.X86Addpd);
+            }
+            else if (Optimizations.FastFP)
             {
                 EmitVectorTernaryOpF32(context, (op1, op2, op3) => context.Add(op1, context.Multiply(op2, op3)));
             }
@@ -418,7 +469,11 @@ namespace ARMeilleure.Instructions
 
         public static void Vmls_S(ArmEmitterContext context)
         {
-            if (Optimizations.FastFP)
+            if (Optimizations.FastFP && Optimizations.UseSse2)
+            {
+                EmitScalarTernaryOpF32(context, Intrinsic.X86Mulss, Intrinsic.X86Mulsd, Intrinsic.X86Subss, Intrinsic.X86Subsd);
+            }
+            else if (Optimizations.FastFP)
             {
                 EmitScalarTernaryOpF32(context, (op1, op2, op3) =>
                 {
@@ -436,7 +491,11 @@ namespace ARMeilleure.Instructions
 
         public static void Vmls_V(ArmEmitterContext context)
         {
-            if (Optimizations.FastFP)
+            if (Optimizations.FastFP && Optimizations.UseSse2)
+            {
+                EmitVectorTernaryOpF32(context, Intrinsic.X86Mulps, Intrinsic.X86Mulpd, Intrinsic.X86Subps, Intrinsic.X86Subpd);
+            }
+            else if (Optimizations.FastFP)
             {
                 EmitVectorTernaryOpF32(context, (op1, op2, op3) => context.Subtract(op1, context.Multiply(op2, op3)));
             }
@@ -537,10 +596,19 @@ namespace ARMeilleure.Instructions
 
             if (op.F)
             {
-                EmitVectorUnaryOpF32(context, (op1) =>
+                int sizeF = op.Size & 1;
+
+                if (Optimizations.FastFP && Optimizations.UseSse && sizeF == 0)
                 {
-                    return EmitSoftFloatCallDefaultFpscr(context, SoftFloat32.FPRecipEstimateFpscr, SoftFloat64.FPRecipEstimateFpscr, op1);
-                });
+                    EmitVectorUnaryOpF32(context, Intrinsic.X86Rcpps, 0);
+                } 
+                else 
+                {
+                    EmitVectorUnaryOpF32(context, (op1) =>
+                    {
+                        return EmitSoftFloatCallDefaultFpscr(context, SoftFloat32.FPRecipEstimateFpscr, SoftFloat64.FPRecipEstimateFpscr, op1);
+                    });
+                }
             } 
             else
             {
@@ -562,10 +630,19 @@ namespace ARMeilleure.Instructions
 
             if (op.F)
             {
-                EmitVectorUnaryOpF32(context, (op1) =>
+                int sizeF = op.Size & 1;
+
+                if (Optimizations.FastFP && Optimizations.UseSse && sizeF == 0)
                 {
-                    return EmitSoftFloatCallDefaultFpscr(context, SoftFloat32.FPRSqrtEstimateFpscr, SoftFloat64.FPRSqrtEstimateFpscr, op1);
-                });
+                    EmitVectorUnaryOpF32(context, Intrinsic.X86Rsqrtps, 0);
+                }
+                else
+                {
+                    EmitVectorUnaryOpF32(context, (op1) =>
+                    {
+                        return EmitSoftFloatCallDefaultFpscr(context, SoftFloat32.FPRSqrtEstimateFpscr, SoftFloat64.FPRSqrtEstimateFpscr, op1);
+                    });
+                }
             } 
             else
             {
@@ -610,20 +687,41 @@ namespace ARMeilleure.Instructions
 
         public static void Vsqrt_S(ArmEmitterContext context)
         {
-            EmitScalarUnaryOpF32(context, (op1) =>
+            if (Optimizations.FastFP && Optimizations.UseSse2)
             {
-                return EmitSoftFloatCall(context, SoftFloat32.FPSqrt, SoftFloat64.FPSqrt, op1);
-            });
+                EmitScalarUnaryOpF32(context, Intrinsic.X86Sqrtss, Intrinsic.X86Sqrtsd);
+            }
+            else
+            {
+                EmitScalarUnaryOpF32(context, (op1) =>
+                {
+                    return EmitSoftFloatCall(context, SoftFloat32.FPSqrt, SoftFloat64.FPSqrt, op1);
+                });
+            }
         }
 
         public static void Vsub_S(ArmEmitterContext context)
         {
-            EmitScalarBinaryOpF32(context, (op1, op2) => context.Subtract(op1, op2));
+            if (Optimizations.FastFP && Optimizations.UseSse2)
+            {
+                EmitScalarBinaryOpF32(context, Intrinsic.X86Subss, Intrinsic.X86Subsd);
+            }
+            else
+            {
+                EmitScalarBinaryOpF32(context, (op1, op2) => context.Subtract(op1, op2));
+            }
         }
 
         public static void Vsub_V(ArmEmitterContext context)
         {
-            EmitVectorBinaryOpF32(context, (op1, op2) => context.Subtract(op1, op2));
+            if (Optimizations.FastFP && Optimizations.UseSse2)
+            {
+                EmitVectorBinaryOpF32(context, Intrinsic.X86Subps, Intrinsic.X86Subpd);
+            } 
+            else
+            {
+                EmitVectorBinaryOpF32(context, (op1, op2) => context.Subtract(op1, op2));
+            }
         }
 
         public static void Vsub_I(ArmEmitterContext context)

--- a/ARMeilleure/Instructions/InstEmitSimdArithmetic32.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdArithmetic32.cs
@@ -21,16 +21,7 @@ namespace ARMeilleure.Instructions
             {
                 EmitScalarUnaryOpSimd32(context, (m) =>
                 {
-                    if ((op.Size & 1) == 0)
-                    {
-                        Operand mask = X86GetScalar(context, -0f);
-                        return context.AddIntrinsic(Intrinsic.X86Andnps, mask, m);
-                    }
-                    else
-                    {
-                        Operand mask = X86GetScalar(context, -0d);
-                        return context.AddIntrinsic(Intrinsic.X86Andnpd, mask, m);
-                    }
+                    return EmitFloatAbs(context, m, (op.Size & 1) == 0, false);
                 });
             }
             else
@@ -49,16 +40,7 @@ namespace ARMeilleure.Instructions
                 {
                     EmitVectorUnaryOpSimd32(context, (m) =>
                     {
-                        if ((op.Size & 1) == 0)
-                        {
-                            Operand mask = X86GetScalar(context, -0f);
-                            return context.AddIntrinsic(Intrinsic.X86Andnps, mask, m);
-                        }
-                        else
-                        {
-                            Operand mask = X86GetScalar(context, -0d);
-                            return context.AddIntrinsic(Intrinsic.X86Andnpd, mask, m);
-                        }
+                        return EmitFloatAbs(context, m, (op.Size & 1) == 0, true);
                     });
                 }
                 else

--- a/ARMeilleure/Instructions/InstEmitSimdArithmetic32.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdArithmetic32.cs
@@ -873,7 +873,7 @@ namespace ARMeilleure.Instructions
                             return context.AddIntrinsic(Intrinsic.X86Pshufb, op1, mask);
                     }
 
-                    throw new InvalidOperationException("Unknown VREV Opcode + Size combo.");
+                    throw new InvalidOperationException("Invalid VREV Opcode + Size combo."); // Should be unreachable.
                 });
             }
             else
@@ -912,7 +912,7 @@ namespace ARMeilleure.Instructions
                                                         context.ShiftLeft(context.BitwiseAnd(op1, Const(0x00000000fffffffful)), Const(32)));
                     }
 
-                    throw new InvalidOperationException("Unknown VREV Opcode + Size combo.");
+                    throw new InvalidOperationException("Invalid VREV Opcode + Size combo."); // Should be unreachable.
                 });
             }
         }

--- a/ARMeilleure/Instructions/InstEmitSimdArithmetic32.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdArithmetic32.cs
@@ -60,12 +60,12 @@ namespace ARMeilleure.Instructions
                             return context.AddIntrinsic(Intrinsic.X86Andnpd, mask, m);
                         }
                     });
-                } 
+                }
                 else
                 {
                     EmitVectorUnaryOpF32(context, (op1) => EmitUnaryMathCall(context, MathF.Abs, Math.Abs, op1));
                 }
-            } 
+            }
             else
             {
                 EmitVectorUnaryOpSx32(context, (op1) => EmitAbs(context, op1));
@@ -104,7 +104,7 @@ namespace ARMeilleure.Instructions
             else if (Optimizations.FastFP)
             {
                 EmitVectorBinaryOpF32(context, (op1, op2) => context.Add(op1, op2));
-            } 
+            }
             else
             {
                 EmitVectorBinaryOpF32(context, (op1, op2) => EmitSoftFloatCallDefaultFpscr(context, SoftFloat32.FPAddFpscr, SoftFloat64.FPAddFpscr, op1, op2));
@@ -117,7 +117,7 @@ namespace ARMeilleure.Instructions
             {
                 OpCode32SimdReg op = (OpCode32SimdReg)context.CurrOp;
                 EmitVectorBinaryOpSimd32(context, (op1, op2) => context.AddIntrinsic(X86PaddInstruction[op.Size], op1, op2));
-            } 
+            }
             else
             {
                 EmitVectorBinaryOpZx32(context, (op1, op2) => context.Add(op1, op2));
@@ -188,13 +188,13 @@ namespace ARMeilleure.Instructions
             int b = startByte;
             long result = 0;
             long result2 = 0;
-            for (int i=0; i<8; i++)
+            for (int i = 0; i < 8; i++)
             {
                 result |= (long)((i >= end || i < start) ? 0x80 : b++) << (i * 8);
             }
             for (int i = 8; i < 16; i++)
             {
-                result2 |= (long)((i >= end || i < start) ? 0x80 : b++) << ((i-8) * 8);
+                result2 |= (long)((i >= end || i < start) ? 0x80 : b++) << ((i - 8) * 8);
             }
             return (result2, result);
         }
@@ -229,7 +229,7 @@ namespace ARMeilleure.Instructions
 
                     return context.AddIntrinsic(Intrinsic.X86Por, nPart, mPart);
                 });
-            } 
+            }
             else
             {
                 Operand res = GetVecA32(op.Qd);
@@ -433,7 +433,7 @@ namespace ARMeilleure.Instructions
                 {
                     EmitVectorUnaryOpF32(context, (op1) => context.Negate(op1));
                 }
-            } 
+            }
             else
             {
                 EmitVectorUnaryOpSx32(context, (op1) => context.Negate(op1));
@@ -512,7 +512,7 @@ namespace ARMeilleure.Instructions
             if (Optimizations.FastFP && Optimizations.UseSse2)
             {
                 EmitVectorBinaryOpF32(context, Intrinsic.X86Maxps, Intrinsic.X86Maxpd);
-            } 
+            }
             else
             {
                 EmitVectorBinaryOpF32(context, (op1, op2) =>
@@ -536,7 +536,7 @@ namespace ARMeilleure.Instructions
                 {
                     EmitVectorBinaryOpZx32(context, (op1, op2) => context.ConditionalSelect(context.ICompareGreaterUI(op1, op2), op1, op2));
                 }
-            } 
+            }
             else
             {
                 if (Optimizations.UseSse2)
@@ -555,7 +555,7 @@ namespace ARMeilleure.Instructions
             if (Optimizations.FastFP && Optimizations.UseSse2)
             {
                 EmitVectorBinaryOpF32(context, Intrinsic.X86Minps, Intrinsic.X86Minpd);
-            } 
+            }
             else
             {
                 EmitVectorBinaryOpF32(context, (op1, op2) =>
@@ -584,7 +584,7 @@ namespace ARMeilleure.Instructions
             {
                 if (Optimizations.UseSse2)
                 {
-                    EmitVectorBinaryOpSimd32(context, (op1, op2) => context.AddIntrinsic(X86PminuInstruction[op.Size], op1, op2));
+                    EmitVectorBinaryOpSimd32(context, (op1, op2) => context.AddIntrinsic(X86PminsInstruction[op.Size], op1, op2));
                 }
                 else
                 {
@@ -655,7 +655,7 @@ namespace ARMeilleure.Instructions
                 {
                     EmitVectorByScalarOpF32(context, (op1, op2) => EmitSoftFloatCallDefaultFpscr(context, SoftFloat32.FPMulFpscr, SoftFloat64.FPMulFpscr, op1, op2));
                 }
-            } 
+            }
             else
             {
                 EmitVectorByScalarOpI32(context, (op1, op2) => context.Multiply(op1, op2), false);
@@ -806,15 +806,14 @@ namespace ARMeilleure.Instructions
 
         public static void Vpadd_V(ArmEmitterContext context)
         {
-            if (Optimizations.FastFP && Optimizations.UseSse2 && false)
+            if (Optimizations.FastFP && Optimizations.UseSse2)
             {
-                EmitSse2VectorPairwiseOpF32(context, Intrinsic.X86Addps, Intrinsic.X86Addpd);
-            } 
+                EmitSse2VectorPairwiseOpF32(context, Intrinsic.X86Addps);
+            }
             else
             {
                 EmitVectorPairwiseOpF32(context, (op1, op2) => context.Add(op1, op2));
             }
-            
         }
 
         public static void Vpadd_I(ArmEmitterContext context)
@@ -834,7 +833,7 @@ namespace ARMeilleure.Instructions
         public static void Vrev(ArmEmitterContext context)
         {
             OpCode32SimdRev op = (OpCode32SimdRev)context.CurrOp;
-            
+
             if (Optimizations.UseSsse3)
             {
                 EmitVectorUnaryOpSimd32(context, (op1) =>
@@ -843,7 +842,7 @@ namespace ARMeilleure.Instructions
                     switch (op.Size)
                     {
                         case 3:
-                            // rev64
+                            // Rev64
                             switch (op.Opc)
                             {
                                 case 0:
@@ -857,7 +856,7 @@ namespace ARMeilleure.Instructions
                             }
                             break;
                         case 2:
-                            // rev32
+                            // Rev32
                             switch (op.Opc)
                             {
                                 case 0:
@@ -869,14 +868,14 @@ namespace ARMeilleure.Instructions
                             }
                             break;
                         case 1:
-                            // rev16
+                            // Rev16
                             mask = X86GetElements(context, 0x0e0f_0c0d_0a0b_0809L, 0x_0607_0405_0203_0001L);
                             return context.AddIntrinsic(Intrinsic.X86Pshufb, op1, mask);
                     }
 
-                    throw new InvalidOperationException("Unknown VREV Opcode+Size combo.");
+                    throw new InvalidOperationException("Unknown VREV Opcode + Size combo.");
                 });
-            } 
+            }
             else
             {
                 EmitVectorUnaryOpZx32(context, (op1) =>
@@ -886,19 +885,16 @@ namespace ARMeilleure.Instructions
                         case 0:
                             switch (op.Size) // Swap bytes.
                             {
-                                default:
-                                    return op1;
                                 case 1:
                                     return InstEmitAluHelper.EmitReverseBytes16_32Op(context, op1);
                                 case 2:
                                 case 3:
                                     return context.ByteSwap(op1);
                             }
+                            break;
                         case 1:
                             switch (op.Size)
                             {
-                                default:
-                                    return op1;
                                 case 2:
                                     return context.BitwiseOr(context.ShiftRightUI(context.BitwiseAnd(op1, Const(0xffff0000)), Const(16)),
                                                                 context.ShiftLeft(context.BitwiseAnd(op1, Const(0x0000ffff)), Const(16)));
@@ -909,13 +905,14 @@ namespace ARMeilleure.Instructions
                                         context.BitwiseOr(context.ShiftRightUI(context.BitwiseAnd(op1, Const(0x0000ffff00000000ul)), Const(16)),
                                                              context.ShiftLeft(context.BitwiseAnd(op1, Const(0x00000000ffff0000ul)), Const(16))));
                             }
+                            break;
                         case 2:
                             // Swap upper and lower halves.
                             return context.BitwiseOr(context.ShiftRightUI(context.BitwiseAnd(op1, Const(0xffffffff00000000ul)), Const(32)),
                                                         context.ShiftLeft(context.BitwiseAnd(op1, Const(0x00000000fffffffful)), Const(32)));
                     }
 
-                    return op1;
+                    throw new InvalidOperationException("Unknown VREV Opcode + Size combo.");
                 });
             }
         }
@@ -931,15 +928,15 @@ namespace ARMeilleure.Instructions
                 if (Optimizations.FastFP && Optimizations.UseSse2 && sizeF == 0)
                 {
                     EmitVectorUnaryOpF32(context, Intrinsic.X86Rcpps, 0);
-                } 
-                else 
+                }
+                else
                 {
                     EmitVectorUnaryOpF32(context, (op1) =>
                     {
                         return EmitSoftFloatCallDefaultFpscr(context, SoftFloat32.FPRecipEstimateFpscr, SoftFloat64.FPRecipEstimateFpscr, op1);
                     });
                 }
-            } 
+            }
             else
             {
                 throw new NotImplementedException("Integer Vrecpe not currently implemented.");
@@ -952,6 +949,7 @@ namespace ARMeilleure.Instructions
             {
                 OpCode32SimdReg op = (OpCode32SimdReg)context.CurrOp;
                 bool single = (op.Size & 1) == 0;
+
                 // (2 - (n*m))
                 EmitVectorBinaryOpSimd32(context, (n, m) =>
                 {
@@ -972,7 +970,7 @@ namespace ARMeilleure.Instructions
                         return context.AddIntrinsic(Intrinsic.X86Subpd, maskTwo, res);
                     }
                 });
-            } 
+            }
             else
             {
                 EmitVectorBinaryOpF32(context, (op1, op2) =>
@@ -1001,7 +999,7 @@ namespace ARMeilleure.Instructions
                         return EmitSoftFloatCallDefaultFpscr(context, SoftFloat32.FPRSqrtEstimateFpscr, SoftFloat64.FPRSqrtEstimateFpscr, op1);
                     });
                 }
-            } 
+            }
             else
             {
                 throw new NotImplementedException("Integer Vrsqrte not currently implemented.");
@@ -1014,6 +1012,7 @@ namespace ARMeilleure.Instructions
             {
                 OpCode32SimdReg op = (OpCode32SimdReg)context.CurrOp;
                 bool single = (op.Size & 1) == 0;
+
                 // (3 - (n*m)) / 2
                 EmitVectorBinaryOpSimd32(context, (n, m) =>
                 {
@@ -1069,35 +1068,10 @@ namespace ARMeilleure.Instructions
                     break;
             }
 
-            if (false && Optimizations.UseSse2)
+            EmitScalarBinaryOpI32(context, (op1, op2) =>
             {
-                Operand falseLabel = Label();
-                Operand doneLabel = Label();
-
-                context.BranchIfFalse(condition, falseLabel);
-
-                EmitScalarBinaryOpSimd32(context, (op1, op2) =>
-                {
-                    return op1;
-                });
-
-                context.Branch(doneLabel);
-                context.MarkLabel(falseLabel);
-
-                EmitScalarBinaryOpSimd32(context, (op1, op2) =>
-                {
-                    return op2;
-                });
-
-                context.MarkLabel(doneLabel);
-            }
-            else
-            {
-                EmitScalarBinaryOpI32(context, (op1, op2) =>
-                {
-                    return context.ConditionalSelect(condition, op1, op2);
-                });
-            }
+                return context.ConditionalSelect(condition, op1, op2);
+            });
         }
 
         public static void Vsqrt_S(ArmEmitterContext context)
@@ -1132,7 +1106,7 @@ namespace ARMeilleure.Instructions
             if (Optimizations.FastFP && Optimizations.UseSse2)
             {
                 EmitVectorBinaryOpF32(context, Intrinsic.X86Subps, Intrinsic.X86Subpd);
-            } 
+            }
             else
             {
                 EmitVectorBinaryOpF32(context, (op1, op2) => context.Subtract(op1, op2));
@@ -1195,12 +1169,11 @@ namespace ARMeilleure.Instructions
             if (scalar)
             {
                 EmitScalarBinaryOpSimd32(context, genericEmit);
-            } 
+            }
             else
             {
                 EmitVectorBinaryOpSimd32(context, genericEmit);
             }
-            
         }
     }
 }

--- a/ARMeilleure/Instructions/InstEmitSimdCvt.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdCvt.cs
@@ -869,7 +869,7 @@ namespace ARMeilleure.Instructions
             }
         }
 
-        private static Operand EmitSse2CvtDoubleToInt64OpF(ArmEmitterContext context, Operand opF, bool scalar)
+        public static Operand EmitSse2CvtDoubleToInt64OpF(ArmEmitterContext context, Operand opF, bool scalar)
         {
             Debug.Assert(opF.Type == OperandType.V128);
 

--- a/ARMeilleure/Instructions/InstEmitSimdCvt32.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdCvt32.cs
@@ -173,7 +173,6 @@ namespace ARMeilleure.Instructions
                     // TODO: Fast Path.
                     if (roundWithFpscr)
                     {
-                        // These need to get the FPSCR value, so it's worth noting we'd need to do a c# call at some point.
                         if (floatSize == OperandType.FP64)
                         {
                             if (unsigned)
@@ -363,7 +362,6 @@ namespace ARMeilleure.Instructions
             {
                 EmitScalarUnaryOpF32(context, (op1) => EmitUnaryMathCall(context, MathF.Truncate, Math.Truncate, op1));
             }
-            
         }
 
         private static Operand EmitFPConvert(ArmEmitterContext context, Operand value, OperandType type, bool signed)
@@ -382,7 +380,7 @@ namespace ARMeilleure.Instructions
 
         private static void EmitSse41ConvertInt32(ArmEmitterContext context, FPRoundingMode roundMode, bool signed)
         {
-            // a port of the similar round function in InstEmitSimdCvt
+            // A port of the similar round function in InstEmitSimdCvt.
             OpCode32SimdS op = (OpCode32SimdS)context.CurrOp;
 
             bool doubleSize = (op.Size & 1) != 0;
@@ -457,7 +455,7 @@ namespace ARMeilleure.Instructions
                     nRes = context.AddIntrinsic(Intrinsic.X86Pand, nRes, nCmp);
                 }
 
-                long fpMaxVal = 0x41E0000000000000L;  // 2147483648.0000000d    (2147483648)
+                long fpMaxVal = 0x41E0000000000000L;  // 2147483648.0000000d (2147483648)
 
                 Operand fpMaxValMask = X86GetScalar(context, fpMaxVal);
 

--- a/ARMeilleure/Instructions/InstEmitSimdCvt32.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdCvt32.cs
@@ -1,9 +1,11 @@
 ﻿using ARMeilleure.Decoders;
 using ARMeilleure.IntermediateRepresentation;
+using ARMeilleure.State;
 using ARMeilleure.Translation;
 using System;
 using System.Diagnostics;
 
+using static ARMeilleure.Instructions.InstEmitHelper;
 using static ARMeilleure.Instructions.InstEmitSimdHelper;
 using static ARMeilleure.Instructions.InstEmitSimdHelper32;
 using static ARMeilleure.IntermediateRepresentation.OperandHelper;
@@ -63,21 +65,56 @@ namespace ARMeilleure.Instructions
 
             if (toInteger)
             {
-                EmitVectorUnaryOpF32(context, (op1) =>
+                if (Optimizations.UseSse41)
                 {
-                    return EmitSaturateFloatToInt(context, op1, unsigned);
-                });
+                    EmitSse41ConvertVector32(context, FPRoundingMode.TowardsZero, !unsigned);
+                }
+                else
+                {
+                    EmitVectorUnaryOpF32(context, (op1) =>
+                    {
+                        return EmitSaturateFloatToInt(context, op1, unsigned);
+                    });
+                }
             }
             else
             {
-                if (unsigned)
+                if (Optimizations.UseSse2)
                 {
-                    EmitVectorUnaryOpZx32(context, (op1) => EmitFPConvert(context, op1, floatSize, false));
-                } 
+                    EmitVectorUnaryOpSimd32(context, (n) =>
+                    {
+                        if (unsigned)
+                        {
+                            Operand mask = X86GetAllElements(context, 0x47800000);
+
+                            Operand res = context.AddIntrinsic(Intrinsic.X86Psrld, n, Const(16));
+                            res = context.AddIntrinsic(Intrinsic.X86Cvtdq2ps, res);
+                            res = context.AddIntrinsic(Intrinsic.X86Mulps, res, mask);
+
+                            Operand res2 = context.AddIntrinsic(Intrinsic.X86Pslld, n, Const(16));
+                            res2 = context.AddIntrinsic(Intrinsic.X86Psrld, res2, Const(16));
+                            res2 = context.AddIntrinsic(Intrinsic.X86Cvtdq2ps, res2);
+
+                            return context.AddIntrinsic(Intrinsic.X86Addps, res, res2);
+                        } 
+                        else
+                        {
+                            return context.AddIntrinsic(Intrinsic.X86Cvtdq2ps, n);
+                        }
+                    });
+                }
                 else
                 {
-                    EmitVectorUnaryOpSx32(context, (op1) => EmitFPConvert(context, op1, floatSize, true));
+                    if (unsigned)
+                    {
+                        EmitVectorUnaryOpZx32(context, (op1) => EmitFPConvert(context, op1, floatSize, false));
+                    }
+                    else
+                    {
+                        EmitVectorUnaryOpSx32(context, (op1) => EmitFPConvert(context, op1, floatSize, true));
+                    }
                 }
+
             }
             
         }
@@ -123,44 +160,52 @@ namespace ARMeilleure.Instructions
                 bool unsigned = (op.Opc2 & 1) == 0;
                 bool roundWithFpscr = op.Opc != 1;
 
-                Operand toConvert = ExtractScalar(context, floatSize, op.Vm);
-
-                Operand asInteger;
-
-                // TODO: Fast Path.
-                if (roundWithFpscr)
+                if (!roundWithFpscr && Optimizations.UseSse41 && floatSize == OperandType.FP32)
                 {
-                    // These need to get the FPSCR value, so it's worth noting we'd need to do a c# call at some point.
-                    if (floatSize == OperandType.FP64)
-                    {
-                        if (unsigned)
-                        {
-                            asInteger = context.Call(new _U32_F64(SoftFallback.DoubleToUInt32), toConvert);
-                        } 
-                        else
-                        {
-                            asInteger = context.Call(new _S32_F64(SoftFallback.DoubleToInt32), toConvert);
-                        }
-                    } 
-                    else
-                    {
-                        if (unsigned)
-                        {
-                            asInteger = context.Call(new _U32_F32(SoftFallback.FloatToUInt32), toConvert);
-                        } 
-                        else
-                        {
-                            asInteger = context.Call(new _S32_F32(SoftFallback.FloatToInt32), toConvert);
-                        }
-                    }
-                } 
+                    EmitSse41ConvertInt32(context, FPRoundingMode.TowardsZero, !unsigned);
+                }
                 else
                 {
-                    // Round towards zero.
-                    asInteger = EmitSaturateFloatToInt(context, toConvert, unsigned);
-                }
+                    Operand toConvert = ExtractScalar(context, floatSize, op.Vm);
 
-                InsertScalar(context, op.Vd, asInteger);
+                    Operand asInteger;
+
+                    // TODO: Fast Path.
+                    if (roundWithFpscr)
+                    {
+                        // These need to get the FPSCR value, so it's worth noting we'd need to do a c# call at some point.
+                        if (floatSize == OperandType.FP64)
+                        {
+                            if (unsigned)
+                            {
+                                asInteger = context.Call(new _U32_F64(SoftFallback.DoubleToUInt32), toConvert);
+                            }
+                            else
+                            {
+                                asInteger = context.Call(new _S32_F64(SoftFallback.DoubleToInt32), toConvert);
+                            }
+
+                        }
+                        else
+                        {
+                            if (unsigned)
+                            {
+                                asInteger = context.Call(new _U32_F32(SoftFallback.FloatToUInt32), toConvert);
+                            }
+                            else
+                            {
+                                asInteger = context.Call(new _S32_F32(SoftFallback.FloatToInt32), toConvert);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        // Round towards zero.
+                        asInteger = EmitSaturateFloatToInt(context, toConvert, unsigned);
+                    }
+
+                    InsertScalar(context, op.Vd, asInteger);
+                }
             } 
             else
             {
@@ -192,6 +237,24 @@ namespace ARMeilleure.Instructions
             return context.Call(dlg, n, Const((int)roundMode));
         }
 
+        private static FPRoundingMode Opc2ToRoundMode(int opc2)
+        {
+            FPRoundingMode roundMode = FPRoundingMode.ToNearest;
+            switch (opc2)
+            {
+                case 0b01:
+                    roundMode = FPRoundingMode.ToNearest;
+                    break;
+                case 0b10:
+                    roundMode = FPRoundingMode.TowardsPlusInfinity;
+                    break;
+                case 0b11:
+                    roundMode = FPRoundingMode.TowardsMinusInfinity;
+                    break;
+            }
+            return roundMode;
+        }
+
         public static void Vcvt_R(ArmEmitterContext context)
         {
             OpCode32SimdCvtFI op = (OpCode32SimdCvtFI)context.CurrOp;
@@ -200,29 +263,36 @@ namespace ARMeilleure.Instructions
 
             bool unsigned = (op.Opc & 1) == 0;
 
-            Operand toConvert = ExtractScalar(context, floatSize, op.Vm);
-
-            switch (op.Opc2)
+            if (Optimizations.UseSse41 && op.Opc2 != 0b00 && floatSize == OperandType.FP32)
             {
-                case 0b00: // Away
-                    toConvert = EmitRoundMathCall(context, MidpointRounding.AwayFromZero, toConvert);
-                    break;
-                case 0b01: // Nearest
-                    toConvert = EmitRoundMathCall(context, MidpointRounding.ToEven, toConvert);
-                    break;
-                case 0b10: // Towards positive infinity
-                    toConvert = EmitUnaryMathCall(context, MathF.Ceiling, Math.Ceiling, toConvert);
-                    break;
-                case 0b11: // Towards negative infinity
-                    toConvert = EmitUnaryMathCall(context, MathF.Floor, Math.Floor, toConvert);
-                    break;
+                EmitSse41ConvertInt32(context, Opc2ToRoundMode(op.Opc2), !unsigned);
             }
+            else
+            {
+                Operand toConvert = ExtractScalar(context, floatSize, op.Vm);
 
-            Operand asInteger;
+                switch (op.Opc2)
+                {
+                    case 0b00: // Away
+                        toConvert = EmitRoundMathCall(context, MidpointRounding.AwayFromZero, toConvert);
+                        break;
+                    case 0b01: // Nearest
+                        toConvert = EmitRoundMathCall(context, MidpointRounding.ToEven, toConvert);
+                        break;
+                    case 0b10: // Towards positive infinity
+                        toConvert = EmitUnaryMathCall(context, MathF.Ceiling, Math.Ceiling, toConvert);
+                        break;
+                    case 0b11: // Towards negative infinity
+                        toConvert = EmitUnaryMathCall(context, MathF.Floor, Math.Floor, toConvert);
+                        break;
+                }
 
-            asInteger = EmitSaturateFloatToInt(context, toConvert, unsigned);
+                Operand asInteger;
 
-            InsertScalar(context, op.Vd, asInteger);
+                asInteger = EmitSaturateFloatToInt(context, toConvert, unsigned);
+
+                InsertScalar(context, op.Vd, asInteger);
+            }
         }
 
         public static void Vrint_RM(ArmEmitterContext context)
@@ -231,30 +301,69 @@ namespace ARMeilleure.Instructions
 
             OperandType floatSize = op.RegisterSize == RegisterSize.Int64 ? OperandType.FP64 : OperandType.FP32;
 
-            Operand toConvert = ExtractScalar(context, floatSize, op.Vm);
-
-            switch (op.Opc2)
+            if (Optimizations.UseSse2 && op.Opc2 != 0b00)
             {
-                case 0b00: // Away
-                    toConvert = EmitRoundMathCall(context, MidpointRounding.AwayFromZero, toConvert);
-                    break;
-                case 0b01: // Nearest
-                    toConvert = EmitRoundMathCall(context, MidpointRounding.ToEven, toConvert);
-                    break;
-                case 0b10: // Towards positive infinity
-                    toConvert = EmitUnaryMathCall(context, MathF.Ceiling, Math.Ceiling, toConvert);
-                    break;
-                case 0b11: // Towards negative infinity
-                    toConvert = EmitUnaryMathCall(context, MathF.Floor, Math.Floor, toConvert);
-                    break;
-            }
+                EmitScalarUnaryOpSimd32(context, (m) =>
+                {
+                    Intrinsic inst = (op.Size & 1) == 0 ? Intrinsic.X86Roundss : Intrinsic.X86Roundsd;
 
-            InsertScalar(context, op.Vd, toConvert);
+                    FPRoundingMode roundMode = FPRoundingMode.ToNearest;
+                    switch (op.Opc2)
+                    {
+                        case 0b01:
+                            roundMode = FPRoundingMode.ToNearest;
+                            break;
+                        case 0b10:
+                            roundMode = FPRoundingMode.TowardsPlusInfinity;
+                            break;
+                        case 0b11:
+                            roundMode = FPRoundingMode.TowardsMinusInfinity;
+                            break;
+                    }
+                    return context.AddIntrinsic(inst, m, Const(X86GetRoundControl(roundMode)));
+                });
+            }
+            else 
+            {
+                Operand toConvert = ExtractScalar(context, floatSize, op.Vm);
+
+                switch (op.Opc2)
+                {
+                    case 0b00: // Away
+                        toConvert = EmitRoundMathCall(context, MidpointRounding.AwayFromZero, toConvert);
+                        break;
+                    case 0b01: // Nearest
+                        toConvert = EmitRoundMathCall(context, MidpointRounding.ToEven, toConvert);
+                        break;
+                    case 0b10: // Towards positive infinity
+                        toConvert = EmitUnaryMathCall(context, MathF.Ceiling, Math.Ceiling, toConvert);
+                        break;
+                    case 0b11: // Towards negative infinity
+                        toConvert = EmitUnaryMathCall(context, MathF.Floor, Math.Floor, toConvert);
+                        break;
+                }
+
+                InsertScalar(context, op.Vd, toConvert);
+            }
         }
 
         public static void Vrint_Z(ArmEmitterContext context)
         {
-            EmitScalarUnaryOpF32(context, (op1) => EmitUnaryMathCall(context, MathF.Truncate, Math.Truncate, op1));
+            IOpCodeSimd op = (IOpCodeSimd)context.CurrOp;
+
+            if (Optimizations.UseSse2)
+            {
+                EmitScalarUnaryOpSimd32(context, (m) =>
+                {
+                    Intrinsic inst = (op.Size & 1) == 0 ? Intrinsic.X86Roundss : Intrinsic.X86Roundsd;
+                    return context.AddIntrinsic(inst, m, Const(X86GetRoundControl(FPRoundingMode.TowardsZero)));
+                });
+            } 
+            else
+            {
+                EmitScalarUnaryOpF32(context, (op1) => EmitUnaryMathCall(context, MathF.Truncate, Math.Truncate, op1));
+            }
+            
         }
 
         private static Operand EmitFPConvert(ArmEmitterContext context, Operand value, OperandType type, bool signed)
@@ -269,6 +378,212 @@ namespace ARMeilleure.Instructions
             {
                 return context.ConvertToFPUI(type, value);
             }
+        }
+
+        private static void EmitSse41ConvertInt32(ArmEmitterContext context, FPRoundingMode roundMode, bool signed)
+        {
+            // a port of the similar round function in InstEmitSimdCvt
+            OpCode32SimdS op = (OpCode32SimdS)context.CurrOp;
+
+            bool doubleSize = (op.Size & 1) != 0;
+            int shift = doubleSize ? 1 : 2;
+            Operand n = GetVecA32(op.Vm >> shift);
+            n = EmitSwapScalar(context, n, op.Vm, doubleSize);
+
+            if (!doubleSize)
+            {
+                Operand nRes = context.AddIntrinsic(Intrinsic.X86Cmpss, n, n, Const((int)CmpCondition.OrderedQ));
+                nRes = context.AddIntrinsic(Intrinsic.X86Pand, nRes, n);
+
+                nRes = context.AddIntrinsic(Intrinsic.X86Roundss, nRes, Const(X86GetRoundControl(roundMode)));
+
+                Operand zero = context.VectorZero();
+
+                Operand nCmp;
+                Operand nIntOrLong2 = null;
+                if (!signed)
+                {
+                    nCmp = context.AddIntrinsic(Intrinsic.X86Cmpss, nRes, zero, Const((int)CmpCondition.NotLessThanOrEqual));
+                    nRes = context.AddIntrinsic(Intrinsic.X86Pand, nRes, nCmp);
+                }
+
+                int fpMaxVal = 0x4F000000;  // 2.14748365E9f (2147483648)
+
+                Operand fpMaxValMask = X86GetScalar(context, fpMaxVal);
+
+                Operand nIntOrLong = context.AddIntrinsicInt(Intrinsic.X86Cvtss2si, nRes);
+
+                if (!signed)
+                {
+                    nRes = context.AddIntrinsic(Intrinsic.X86Subss, nRes, fpMaxValMask);
+
+                    nCmp = context.AddIntrinsic(Intrinsic.X86Cmpss, nRes, zero, Const((int)CmpCondition.NotLessThanOrEqual));
+                    nRes = context.AddIntrinsic(Intrinsic.X86Pand, nRes, nCmp);
+
+                    nIntOrLong2 = context.AddIntrinsicInt(Intrinsic.X86Cvtss2si, nRes);
+                }
+
+                nRes = context.AddIntrinsic(Intrinsic.X86Cmpss, nRes, fpMaxValMask, Const((int)CmpCondition.NotLessThan));
+
+                Operand nInt = context.AddIntrinsicInt(Intrinsic.X86Cvtsi2si, nRes);
+
+                Operand dRes;
+                if (signed)
+                {
+                    dRes = context.BitwiseExclusiveOr(nIntOrLong, nInt);
+                } 
+                else
+                {
+                    dRes = context.BitwiseExclusiveOr(nIntOrLong2, nInt);
+                    dRes = context.Add(dRes, nIntOrLong);
+                }
+
+                InsertScalar(context, op.Vd, dRes);
+            }
+            else
+            {
+                Operand nRes = context.AddIntrinsic(Intrinsic.X86Cmpsd, n, n, Const((int)CmpCondition.OrderedQ));
+                nRes = context.AddIntrinsic(Intrinsic.X86Pand, nRes, n);
+
+                nRes = context.AddIntrinsic(Intrinsic.X86Roundsd, nRes, Const(X86GetRoundControl(roundMode)));
+
+                Operand zero = context.VectorZero();
+
+                Operand nCmp;
+                Operand nIntOrLong2 = null;
+                if (!signed)
+                {
+                    nCmp = context.AddIntrinsic(Intrinsic.X86Cmpsd, nRes, zero, Const((int)CmpCondition.NotLessThanOrEqual));
+                    nRes = context.AddIntrinsic(Intrinsic.X86Pand, nRes, nCmp);
+                }
+
+                long fpMaxVal = 0x41E0000000000000L;  // 2147483648.0000000d    (2147483648)
+
+                Operand fpMaxValMask = X86GetScalar(context, fpMaxVal);
+
+                Operand nIntOrLong = context.AddIntrinsicInt(Intrinsic.X86Cvtsd2si, nRes);
+
+                if (!signed)
+                {
+                    nRes = context.AddIntrinsic(Intrinsic.X86Subsd, nRes, fpMaxValMask);
+
+                    nCmp = context.AddIntrinsic(Intrinsic.X86Cmpsd, nRes, zero, Const((int)CmpCondition.NotLessThanOrEqual));
+                    nRes = context.AddIntrinsic(Intrinsic.X86Pand, nRes, nCmp);
+
+                    nIntOrLong2 = context.AddIntrinsicInt(Intrinsic.X86Cvtsd2si, nRes);
+                }
+
+                nRes = context.AddIntrinsic(Intrinsic.X86Cmpsd, nRes, fpMaxValMask, Const((int)CmpCondition.NotLessThan));
+
+                Operand nLong = context.AddIntrinsicLong(Intrinsic.X86Cvtsi2si, nRes);
+                nLong = context.ConvertI64ToI32(nLong);
+
+                Operand dRes;
+                if (signed)
+                {
+                    dRes = context.BitwiseExclusiveOr(nIntOrLong, nLong);
+                }
+                else
+                {
+                    dRes = context.BitwiseExclusiveOr(nIntOrLong2, nLong);
+                    dRes = context.Add(dRes, nIntOrLong);
+                }
+
+                InsertScalar(context, op.Vd, dRes);
+            }
+        }
+
+        private static void EmitSse41ConvertVector32(ArmEmitterContext context, FPRoundingMode roundMode, bool signed)
+        {
+            OpCode32Simd op = (OpCode32Simd)context.CurrOp;
+
+            EmitVectorUnaryOpSimd32(context, (n) =>
+            {
+                int sizeF = op.Size & 1;
+
+                if (sizeF == 0)
+                {
+                    Operand nRes = context.AddIntrinsic(Intrinsic.X86Cmpps, n, n, Const((int)CmpCondition.OrderedQ));
+                    nRes = context.AddIntrinsic(Intrinsic.X86Pand, nRes, n);
+
+                    nRes = context.AddIntrinsic(Intrinsic.X86Roundps, nRes, Const(X86GetRoundControl(roundMode)));
+
+                    Operand zero = context.VectorZero();
+                    Operand nCmp;
+                    if (!signed)
+                    {
+                        nCmp = context.AddIntrinsic(Intrinsic.X86Cmpps, nRes, zero, Const((int)CmpCondition.NotLessThanOrEqual));
+                        nRes = context.AddIntrinsic(Intrinsic.X86Pand, nRes, nCmp);
+                    }
+
+                    Operand fpMaxValMask = X86GetAllElements(context, 0x4F000000); // 2.14748365E9f (2147483648)
+
+                    Operand nInt = context.AddIntrinsic(Intrinsic.X86Cvtps2dq, nRes);
+                    Operand nInt2 = null;
+                    if (!signed)
+                    {
+                        nRes = context.AddIntrinsic(Intrinsic.X86Subps, nRes, fpMaxValMask);
+
+                        nCmp = context.AddIntrinsic(Intrinsic.X86Cmpps, nRes, zero, Const((int)CmpCondition.NotLessThanOrEqual));
+                        nRes = context.AddIntrinsic(Intrinsic.X86Pand, nRes, nCmp);
+
+                        nInt2 = context.AddIntrinsic(Intrinsic.X86Cvtps2dq, nRes);
+                    }
+
+                    nRes = context.AddIntrinsic(Intrinsic.X86Cmpps, nRes, fpMaxValMask, Const((int)CmpCondition.NotLessThan));
+
+                    if (signed)
+                    {
+                        return context.AddIntrinsic(Intrinsic.X86Pxor, nInt, nRes);
+                    } 
+                    else
+                    {
+                        Operand dRes = context.AddIntrinsic(Intrinsic.X86Pxor, nInt2, nRes);
+                        return context.AddIntrinsic(Intrinsic.X86Paddd, dRes, nInt);
+                    }
+                }
+                else /* if (sizeF == 1) */
+                {
+                    Operand nRes = context.AddIntrinsic(Intrinsic.X86Cmppd, n, n, Const((int)CmpCondition.OrderedQ));
+                    nRes = context.AddIntrinsic(Intrinsic.X86Pand, nRes, n);
+
+                    nRes = context.AddIntrinsic(Intrinsic.X86Roundpd, nRes, Const(X86GetRoundControl(roundMode)));
+
+                    Operand zero = context.VectorZero();
+                    Operand nCmp;
+                    if (!signed)
+                    {
+                        nCmp = context.AddIntrinsic(Intrinsic.X86Cmppd, nRes, zero, Const((int)CmpCondition.NotLessThanOrEqual));
+                        nRes = context.AddIntrinsic(Intrinsic.X86Pand, nRes, nCmp);
+                    }
+
+                    Operand fpMaxValMask = X86GetAllElements(context, 0x43E0000000000000L); // 9.2233720368547760E18d (9223372036854775808)
+
+                    Operand nLong = InstEmit.EmitSse2CvtDoubleToInt64OpF(context, nRes, false);
+                    Operand nLong2 = null;
+                    if (!signed)
+                    {
+                        nRes = context.AddIntrinsic(Intrinsic.X86Subpd, nRes, fpMaxValMask);
+
+                        nCmp = context.AddIntrinsic(Intrinsic.X86Cmppd, nRes, zero, Const((int)CmpCondition.NotLessThanOrEqual));
+                        nRes = context.AddIntrinsic(Intrinsic.X86Pand, nRes, nCmp);
+
+                        nLong2 = InstEmit.EmitSse2CvtDoubleToInt64OpF(context, nRes, false);
+                    }
+
+                    nRes = context.AddIntrinsic(Intrinsic.X86Cmppd, nRes, fpMaxValMask, Const((int)CmpCondition.NotLessThan));
+
+                    if (signed)
+                    {
+                        return context.AddIntrinsic(Intrinsic.X86Pxor, nLong, nRes);
+                    }
+                    else
+                    {
+                        Operand dRes = context.AddIntrinsic(Intrinsic.X86Pxor, nLong2, nRes);
+                        return context.AddIntrinsic(Intrinsic.X86Paddq, dRes, nLong);
+                    }
+                }
+            });
         }
     }
 }

--- a/ARMeilleure/Instructions/InstEmitSimdCvt32.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdCvt32.cs
@@ -251,7 +251,7 @@ namespace ARMeilleure.Instructions
                     roundMode = FPRoundingMode.TowardsMinusInfinity;
                     break;
                 default:
-                    throw new ArgumentOutOfRangeException($"rm");
+                    throw new ArgumentOutOfRangeException(nameof(rm));
             }
             return roundMode;
         }

--- a/ARMeilleure/Instructions/InstEmitSimdCvt32.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdCvt32.cs
@@ -238,7 +238,7 @@ namespace ARMeilleure.Instructions
 
         private static FPRoundingMode Opc2ToRoundMode(int opc2)
         {
-            FPRoundingMode roundMode = FPRoundingMode.ToNearest;
+            FPRoundingMode roundMode;
             switch (opc2)
             {
                 case 0b01:
@@ -250,6 +250,8 @@ namespace ARMeilleure.Instructions
                 case 0b11:
                     roundMode = FPRoundingMode.TowardsMinusInfinity;
                     break;
+                default:
+                    throw new ArgumentOutOfRangeException($"Round mode {opc2} out of supported range.");
             }
             return roundMode;
         }
@@ -306,19 +308,8 @@ namespace ARMeilleure.Instructions
                 {
                     Intrinsic inst = (op.Size & 1) == 0 ? Intrinsic.X86Roundss : Intrinsic.X86Roundsd;
 
-                    FPRoundingMode roundMode = FPRoundingMode.ToNearest;
-                    switch (op.Opc2)
-                    {
-                        case 0b01:
-                            roundMode = FPRoundingMode.ToNearest;
-                            break;
-                        case 0b10:
-                            roundMode = FPRoundingMode.TowardsPlusInfinity;
-                            break;
-                        case 0b11:
-                            roundMode = FPRoundingMode.TowardsMinusInfinity;
-                            break;
-                    }
+                    FPRoundingMode roundMode = Opc2ToRoundMode(op.Opc2);
+
                     return context.AddIntrinsic(inst, m, Const(X86GetRoundControl(roundMode)));
                 });
             }
@@ -405,7 +396,7 @@ namespace ARMeilleure.Instructions
                     nRes = context.AddIntrinsic(Intrinsic.X86Pand, nRes, nCmp);
                 }
 
-                int fpMaxVal = 0x4F000000;  // 2.14748365E9f (2147483648)
+                int fpMaxVal = 0x4F000000; // 2.14748365E9f (2147483648)
 
                 Operand fpMaxValMask = X86GetScalar(context, fpMaxVal);
 
@@ -455,7 +446,7 @@ namespace ARMeilleure.Instructions
                     nRes = context.AddIntrinsic(Intrinsic.X86Pand, nRes, nCmp);
                 }
 
-                long fpMaxVal = 0x41E0000000000000L;  // 2147483648.0000000d (2147483648)
+                long fpMaxVal = 0x41E0000000000000L; // 2147483648.0000000d (2147483648)
 
                 Operand fpMaxValMask = X86GetScalar(context, fpMaxVal);
 

--- a/ARMeilleure/Instructions/InstEmitSimdCvt32.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdCvt32.cs
@@ -160,7 +160,7 @@ namespace ARMeilleure.Instructions
                 bool unsigned = (op.Opc2 & 1) == 0;
                 bool roundWithFpscr = op.Opc != 1;
 
-                if (!roundWithFpscr && Optimizations.UseSse41 && floatSize == OperandType.FP32)
+                if (!roundWithFpscr && Optimizations.UseSse41)
                 {
                     EmitSse41ConvertInt32(context, FPRoundingMode.TowardsZero, !unsigned);
                 }
@@ -262,7 +262,7 @@ namespace ARMeilleure.Instructions
 
             bool unsigned = (op.Opc & 1) == 0;
 
-            if (Optimizations.UseSse41 && op.Opc2 != 0b00 && floatSize == OperandType.FP32)
+            if (Optimizations.UseSse41 && op.Opc2 != 0b00)
             {
                 EmitSse41ConvertInt32(context, Opc2ToRoundMode(op.Opc2), !unsigned);
             }

--- a/ARMeilleure/Instructions/InstEmitSimdHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdHelper.cs
@@ -1467,6 +1467,14 @@ namespace ARMeilleure.Instructions
             return context.Call(dlg, op1, op2);
         }
 
+        public static Operand EmitFloatAbs(ArmEmitterContext context, Operand value, bool single, bool vector)
+        {
+            Operand mask = vector ? X86GetAllElements(context, -0f) : X86GetScalar(context, -0f);
+
+            Intrinsic op;
+            return context.AddIntrinsic(single ? Intrinsic.X86Andnps : Intrinsic.X86Andnpd, mask, value);
+        }
+
         public static Operand EmitVectorExtractSx(ArmEmitterContext context, int reg, int index, int size)
         {
             return EmitVectorExtract(context, reg, index, size, true);

--- a/ARMeilleure/Instructions/InstEmitSimdHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdHelper.cs
@@ -1469,9 +1469,16 @@ namespace ARMeilleure.Instructions
 
         public static Operand EmitFloatAbs(ArmEmitterContext context, Operand value, bool single, bool vector)
         {
-            Operand mask = vector ? X86GetAllElements(context, -0f) : X86GetScalar(context, -0f);
+            Operand mask;
+            if (single)
+            {
+                mask = vector ? X86GetAllElements(context, -0f) : X86GetScalar(context, -0f);
+            } 
+            else
+            {
+                mask = vector ? X86GetAllElements(context, -0d) : X86GetScalar(context, -0d);
+            }
 
-            Intrinsic op;
             return context.AddIntrinsic(single ? Intrinsic.X86Andnps : Intrinsic.X86Andnpd, mask, value);
         }
 

--- a/ARMeilleure/Instructions/InstEmitSimdHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdHelper.cs
@@ -31,7 +31,7 @@ namespace ARMeilleure.Instructions
             15L << 56 | 14L << 48 | 13L << 40 | 12L << 32 | 07L << 24 | 06L << 16 | 05L << 8 | 04L << 0  // S
         };
 
-        private static readonly long _zeroMask = 128L << 56 | 128L << 48 | 128L << 40 | 128L << 32 | 128L << 24 | 128L << 16 | 128L << 8 | 128L << 0;
+        public static readonly long ZeroMask = 128L << 56 | 128L << 48 | 128L << 40 | 128L << 32 | 128L << 24 | 128L << 16 | 128L << 8 | 128L << 0;
 #endregion
 
 #region "X86 SSE Intrinsics"
@@ -1026,8 +1026,8 @@ namespace ARMeilleure.Instructions
 
             if (op.RegisterSize == RegisterSize.Simd64)
             {
-                Operand zeroEvenMask = X86GetElements(context, _zeroMask, EvenMasks[op.Size]);
-                Operand zeroOddMask  = X86GetElements(context, _zeroMask, OddMasks [op.Size]);
+                Operand zeroEvenMask = X86GetElements(context, ZeroMask, EvenMasks[op.Size]);
+                Operand zeroOddMask  = X86GetElements(context, ZeroMask, OddMasks [op.Size]);
 
                 Operand mN = context.AddIntrinsic(Intrinsic.X86Punpcklqdq, n, m); // m:n
 

--- a/ARMeilleure/Instructions/InstEmitSimdHelper32.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdHelper32.cs
@@ -475,7 +475,7 @@ namespace ARMeilleure.Instructions
 
         // Intrinsic Helpers
 
-        public static Operand EmitSwapDoubleWordToSide(ArmEmitterContext context, Operand input, int originalV, int targetV)
+        public static Operand EmitMoveDoubleWordToSide(ArmEmitterContext context, Operand input, int originalV, int targetV)
         {
             Debug.Assert(input.Type == OperandType.V128);
 
@@ -502,7 +502,7 @@ namespace ARMeilleure.Instructions
             Debug.Assert(target.Type == OperandType.V128 && value.Type == OperandType.V128);
 
             int targetSide = targetV & 1;
-            int shuffleMask = 2 | 0;
+            int shuffleMask = 2;
 
             if (targetSide == 1)
             {
@@ -578,7 +578,7 @@ namespace ARMeilleure.Instructions
 
             if (!op.Q) // Register swap: move relevant doubleword to destination side.
             {
-                m = EmitSwapDoubleWordToSide(context, m, op.Vm, op.Vd);
+                m = EmitMoveDoubleWordToSide(context, m, op.Vm, op.Vd);
             }
 
             Operand res = vectorFunc(m);
@@ -615,8 +615,8 @@ namespace ARMeilleure.Instructions
 
             if (!op.Q) // Register swap: move relevant doubleword to destination side.
             {
-                n = EmitSwapDoubleWordToSide(context, n, op.Vn, side);
-                m = EmitSwapDoubleWordToSide(context, m, op.Vm, side);
+                n = EmitMoveDoubleWordToSide(context, n, op.Vn, side);
+                m = EmitMoveDoubleWordToSide(context, m, op.Vm, side);
             }
 
             Operand res = vectorFunc(n, m);
@@ -625,7 +625,7 @@ namespace ARMeilleure.Instructions
             {
                 if (side != op.Vd)
                 {
-                    res = EmitSwapDoubleWordToSide(context, res, side, op.Vd);
+                    res = EmitMoveDoubleWordToSide(context, res, side, op.Vd);
                 }
                 res = EmitDoubleWordInsert(context, d, res, op.Vd);
             }
@@ -652,13 +652,13 @@ namespace ARMeilleure.Instructions
 
             if (!op.Q) // Register swap: move relevant doubleword to destination side.
             {
-                n = EmitSwapDoubleWordToSide(context, n, op.Vn, op.Vd);
-                m = EmitSwapDoubleWordToSide(context, m, op.Vm, op.Vd);
+                n = EmitMoveDoubleWordToSide(context, n, op.Vn, op.Vd);
+                m = EmitMoveDoubleWordToSide(context, m, op.Vm, op.Vd);
             }
 
             Operand res = vectorFunc(d, n, m);
 
-            if (!op.Q) //register insert
+            if (!op.Q) // Register insert.
             {
                 res = EmitDoubleWordInsert(context, initialD, res, op.Vd);
             }
@@ -793,7 +793,7 @@ namespace ARMeilleure.Instructions
 
             if (!op.Q) // Register swap: move relevant doubleword to destination side.
             {
-                n = EmitSwapDoubleWordToSide(context, n, op.Vn, op.Vd);
+                n = EmitMoveDoubleWordToSide(context, n, op.Vn, op.Vd);
             }
 
             Operand res = vectorFunc(n, m);
@@ -829,7 +829,7 @@ namespace ARMeilleure.Instructions
 
             if (!op.Q) // Register swap: move relevant doubleword to destination side.
             {
-                n = EmitSwapDoubleWordToSide(context, n, op.Vn, op.Vd);
+                n = EmitMoveDoubleWordToSide(context, n, op.Vn, op.Vd);
             }
 
             Operand res = vectorFunc(d, n, m);

--- a/ARMeilleure/Instructions/InstEmitSimdHelper32.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdHelper32.cs
@@ -548,11 +548,7 @@ namespace ARMeilleure.Instructions
             }
             else
             {
-                long low = (index < 2) ? (1L << (index * 32 + 31)) : 0;
-                long high = (index > 1) ? (1L << (index * 32 - 33)) : 0;
-                Operand mask = X86GetElements(context, high, low);
-                value = EmitSwapScalar(context, value, reg, doubleWidth);
-                return context.AddIntrinsic(Intrinsic.X86Blendvps, target, value, mask);
+                return context.AddIntrinsic(Intrinsic.X86Insertps, target, value, Const(index << 4));
             }
         }
 
@@ -565,14 +561,14 @@ namespace ARMeilleure.Instructions
             Operand m = GetVecA32(op.Qm);
             Operand d = GetVecA32(op.Qd);
 
-            if (!op.Q) //register swap: move relevant doubleword to destination side
+            if (!op.Q) // Register swap: move relevant doubleword to destination side.
             {
                 m = EmitSwapDoubleWordToSide(context, m, op.Vm, op.Vd);
             }
 
             Operand res = vectorFunc(m);
 
-            if (!op.Q) //register insert
+            if (!op.Q) // Register insert.
             {
                 res = EmitDoubleWordInsert(context, d, res, op.Vd);
             }
@@ -599,7 +595,7 @@ namespace ARMeilleure.Instructions
 
             if (side == -1) side = op.Vd;
 
-            if (!op.Q) //register swap: move relevant doubleword to destination side
+            if (!op.Q) // Register swap: move relevant doubleword to destination side.
             {
                 n = EmitSwapDoubleWordToSide(context, n, op.Vn, side);
                 m = EmitSwapDoubleWordToSide(context, m, op.Vm, side);
@@ -607,7 +603,7 @@ namespace ARMeilleure.Instructions
 
             Operand res = vectorFunc(n, m);
 
-            if (!op.Q) //register insert
+            if (!op.Q) // Register insert.
             {
                 if (side != op.Vd) EmitSwapDoubleWordToSide(context, m, side, op.Vd);
                 res = EmitDoubleWordInsert(context, d, res, op.Vd);
@@ -633,7 +629,7 @@ namespace ARMeilleure.Instructions
             Operand d = GetVecA32(op.Qd);
             Operand initialD = d;
 
-            if (!op.Q) //register swap: move relevant doubleword to destination side
+            if (!op.Q) // Register swap: move relevant doubleword to destination side.
             {
                 n = EmitSwapDoubleWordToSide(context, n, op.Vn, op.Vd);
                 m = EmitSwapDoubleWordToSide(context, m, op.Vm, op.Vd);
@@ -676,15 +672,8 @@ namespace ARMeilleure.Instructions
 
             Operand res = scalarFunc(m);
 
-            if (false) // op.Vd == op.Vm) //small optimisation: can just swap it back for the result
-            {
-                res = EmitSwapScalar(context, res, op.Vd, doubleSize);
-            } 
-            else
-            {
-                // insert scalar into vector
-                res = EmitInsertScalar(context, d, res, op.Vd, doubleSize);
-            }
+            // Insert scalar into vector.
+            res = EmitInsertScalar(context, d, res, op.Vd, doubleSize);
 
             context.Copy(d, res);
         }
@@ -713,15 +702,8 @@ namespace ARMeilleure.Instructions
 
             Operand res = scalarFunc(n, m);
 
-            if (false) // //small optimisation: can just swap it back for the result
-            {
-                res = EmitSwapScalar(context, res, op.Vd, doubleSize);
-            }
-            else
-            {
-                // insert scalar into vector
-                res = EmitInsertScalar(context, d, res, op.Vd, doubleSize);
-            }
+            // Insert scalar into vector.
+            res = EmitInsertScalar(context, d, res, op.Vd, doubleSize);
 
             context.Copy(d, res);
         }
@@ -752,7 +734,7 @@ namespace ARMeilleure.Instructions
 
             Operand res = scalarFunc(d, n, m);
 
-            // insert scalar into vector
+            // Insert scalar into vector.
             res = EmitInsertScalar(context, initialD, res, op.Vd, doubleSize);
 
             context.Copy(initialD, res);
@@ -788,14 +770,14 @@ namespace ARMeilleure.Instructions
             Operand m = GetVecA32(op.Vm >> 2);
             m = context.AddIntrinsic(Intrinsic.X86Shufps, m, m, Const(dupeMask));
 
-            if (!op.Q) //register swap: move relevant doubleword to destination side
+            if (!op.Q) // Register swap: move relevant doubleword to destination side.
             {
                 n = EmitSwapDoubleWordToSide(context, n, op.Vn, op.Vd);
             }
 
             Operand res = vectorFunc(n, m);
 
-            if (!op.Q) //register insert
+            if (!op.Q) // Register insert.
             {
                 res = EmitDoubleWordInsert(context, d, res, op.Vd);
             }
@@ -824,14 +806,14 @@ namespace ARMeilleure.Instructions
             Operand m = GetVecA32(op.Vm >> 2);
             m = context.AddIntrinsic(Intrinsic.X86Shufps, m, m, Const(dupeMask));
 
-            if (!op.Q) //register swap: move relevant doubleword to destination side
+            if (!op.Q) // Register swap: move relevant doubleword to destination side.
             {
                 n = EmitSwapDoubleWordToSide(context, n, op.Vn, op.Vd);
             }
 
             Operand res = vectorFunc(d, n, m);
 
-            if (!op.Q) //register insert
+            if (!op.Q) // Register insert.
             {
                 res = EmitDoubleWordInsert(context, initialD, res, op.Vd);
             }
@@ -911,7 +893,7 @@ namespace ARMeilleure.Instructions
                     Operand mN = context.AddIntrinsic(Intrinsic.X86Punpcklqdq, n, m); // m:n
 
                     Operand left = context.AddIntrinsic(Intrinsic.X86Pshufb, mN, zeroEvenMask); // 0:even from m:n
-                    Operand right = context.AddIntrinsic(Intrinsic.X86Pshufb, mN, zeroOddMask);  // 0:odd  from m:n
+                    Operand right = context.AddIntrinsic(Intrinsic.X86Pshufb, mN, zeroOddMask); // 0:odd  from m:n
 
                     return context.AddIntrinsic(inst[op.Size], left, right);
                 }

--- a/ARMeilleure/Instructions/InstEmitSimdLogical32.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdLogical32.cs
@@ -1,4 +1,5 @@
 ﻿using ARMeilleure.Decoders;
+using ARMeilleure.IntermediateRepresentation;
 using ARMeilleure.Translation;
 
 using static ARMeilleure.Instructions.InstEmitSimdHelper32;
@@ -9,7 +10,14 @@ namespace ARMeilleure.Instructions
     {
         public static void Vand_I(ArmEmitterContext context)
         {
-            EmitVectorBinaryOpZx32(context, (op1, op2) => context.BitwiseAnd(op1, op2));
+            if (Optimizations.UseSse2)
+            {
+                EmitVectorBinaryOpF32(context, Intrinsic.X86Pand, Intrinsic.X86Pand);
+            }
+            else
+            {
+                EmitVectorBinaryOpZx32(context, (op1, op2) => context.BitwiseAnd(op1, op2));
+            }
         }
 
         public static void Vbif(ArmEmitterContext context)
@@ -24,33 +32,64 @@ namespace ARMeilleure.Instructions
 
         public static void Vbsl(ArmEmitterContext context)
         {
-            EmitVectorTernaryOpZx32(context, (op1, op2, op3) =>
+            if (Optimizations.UseSse2)
             {
-                return context.BitwiseExclusiveOr(
-                    context.BitwiseAnd(op1,
-                    context.BitwiseExclusiveOr(op2, op3)), op3);
-            });
+                EmitVectorTernaryOpSimd32(context, (d, n, m) =>
+                {
+                    Operand res = context.AddIntrinsic(Intrinsic.X86Pxor, n, m);
+                    res = context.AddIntrinsic(Intrinsic.X86Pand, res, d);
+                    return context.AddIntrinsic(Intrinsic.X86Pxor, res, m);
+                });
+            }
+            else
+            {
+                EmitVectorTernaryOpZx32(context, (op1, op2, op3) =>
+                {
+                    return context.BitwiseExclusiveOr(
+                        context.BitwiseAnd(op1,
+                        context.BitwiseExclusiveOr(op2, op3)), op3);
+                });
+            }
         }
 
         public static void Vorr_I(ArmEmitterContext context)
         {
-            EmitVectorBinaryOpZx32(context, (op1, op2) => context.BitwiseOr(op1, op2));
+            if (Optimizations.UseSse2)
+            {
+                EmitVectorBinaryOpF32(context, Intrinsic.X86Por, Intrinsic.X86Por);
+            }
+            else
+            {
+                EmitVectorBinaryOpZx32(context, (op1, op2) => context.BitwiseOr(op1, op2));
+            }
         }
 
         private static void EmitBifBit(ArmEmitterContext context, bool notRm)
         {
             OpCode32SimdReg op = (OpCode32SimdReg)context.CurrOp;
 
-            EmitVectorTernaryOpZx32(context, (d, n, m) =>
+            if (Optimizations.UseSse2)
             {
-                if (notRm)
+                EmitVectorTernaryOpSimd32(context, (d, n, m) =>
                 {
-                    m = context.BitwiseNot(m);
-                }
-                return context.BitwiseExclusiveOr(
-                    context.BitwiseAnd(m,
-                    context.BitwiseExclusiveOr(d, n)), d);
-            });
+                    Operand res = context.AddIntrinsic(Intrinsic.X86Pxor, n, d);
+                    res = context.AddIntrinsic((notRm) ? Intrinsic.X86Pandn : Intrinsic.X86Pand, m, res);
+                    return context.AddIntrinsic(Intrinsic.X86Pxor, d, res);
+                });
+            }
+            else
+            {
+                EmitVectorTernaryOpZx32(context, (d, n, m) =>
+                {
+                    if (notRm)
+                    {
+                        m = context.BitwiseNot(m);
+                    }
+                    return context.BitwiseExclusiveOr(
+                        context.BitwiseAnd(m,
+                        context.BitwiseExclusiveOr(d, n)), d);
+                });
+            }
         }
     }
 }

--- a/ARMeilleure/Instructions/InstEmitSimdMove32.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdMove32.cs
@@ -1,6 +1,7 @@
 ﻿using ARMeilleure.Decoders;
 using ARMeilleure.IntermediateRepresentation;
 using ARMeilleure.Translation;
+using System;
 
 using static ARMeilleure.Instructions.InstEmitHelper;
 using static ARMeilleure.Instructions.InstEmitSimdHelper;
@@ -11,6 +12,21 @@ namespace ARMeilleure.Instructions
 {
     static partial class InstEmit32
     {
+        #region "Masks"
+        // same as InstEmitSimdMove, as the instruction do the same thing.
+        private static readonly long[] _masksE0_Uzp = new long[]
+        {
+            13L << 56 | 09L << 48 | 05L << 40 | 01L << 32 | 12L << 24 | 08L << 16 | 04L << 8 | 00L << 0,
+            11L << 56 | 10L << 48 | 03L << 40 | 02L << 32 | 09L << 24 | 08L << 16 | 01L << 8 | 00L << 0
+        };
+
+        private static readonly long[] _masksE1_Uzp = new long[]
+        {
+            15L << 56 | 11L << 48 | 07L << 40 | 03L << 32 | 14L << 24 | 10L << 16 | 06L << 8 | 02L << 0,
+            15L << 56 | 14L << 48 | 07L << 40 | 06L << 32 | 13L << 24 | 12L << 16 | 05L << 8 | 04L << 0
+        };
+        #endregion
+
         public static void Vmov_I(ArmEmitterContext context)
         {
             EmitVectorImmUnaryOp32(context, (op1) => op1);
@@ -128,114 +144,202 @@ namespace ARMeilleure.Instructions
             OpCode32SimdTbl op = (OpCode32SimdTbl)context.CurrOp;
 
             bool extension = op.Opc == 1;
-
-            int elems = op.GetBytesCount() >> op.Size;
-
             int length = op.Length + 1;
 
-            (int Qx, int Ix)[] tableTuples = new (int, int)[length];
-            for (int i = 0; i < length; i++)
+            if (Optimizations.UseSsse3)
             {
-                (int vn, int en) = GetQuadwordAndSubindex(op.Vn + i, op.RegisterSize);
-                tableTuples[i] = (vn, en);
-            }
+                Operand d = GetVecA32(op.Qd);
+                Operand m = EmitSwapDoubleWordToSide(context, GetVecA32(op.Qm), op.Vm, 0);
 
-            int byteLength = length * 8;
+                Operand res;
+                Operand mask = X86GetAllElements(context, 0x0707070707070707L);
 
-            Operand res = GetVecA32(op.Qd);
-            Operand m = GetVecA32(op.Qm);
-
-            for (int index = 0; index < elems; index++)
-            {
-                Operand selectedIndex = context.ZeroExtend8(OperandType.I32, context.VectorExtract8(m, index + op.Im));
-
-                Operand inRange = context.ICompareLess(selectedIndex, Const(byteLength));
-                Operand elemRes = null; // Note: This is I64 for ease of calculation.
-
-                // TODO: Branching rather than conditional select.
-
-                // Get indexed byte.
-                // To simplify (ha) the il, we get bytes from every vector and use a nested conditional select to choose the right result.
-                // This does have to extract `length` times for every element but certainly not as bad as it could be.
-
-                // Which vector number is the index on.
-                Operand vecIndex = context.ShiftRightUI(selectedIndex, Const(3));
-                // What should we shift by to extract it.
-                Operand subVecIndexShift = context.ShiftLeft(context.BitwiseAnd(selectedIndex, Const(7)), Const(3));
-
-                for (int i = 0; i < length; i++)
+                // Fast path for single register table.
                 {
-                    (int qx, int ix) = tableTuples[i];
-                    // Get the whole vector, we'll get a byte out of it.
-                    Operand lookupResult;
-                    if (qx == op.Qd)
-                    {
-                        // Result contains the current state of the vector.
-                        lookupResult = context.VectorExtract(OperandType.I64, res, ix);
-                    } 
-                    else
-                    {
-                        lookupResult = EmitVectorExtract32(context, qx, ix, 3, false); // I64
-                    }
-                    
-                    lookupResult = context.ShiftRightUI(lookupResult, subVecIndexShift); // Get the relevant byte from this vector.
+                    Operand n = EmitSwapDoubleWordToSide(context, GetVecA32(op.Qn), op.Vn, 0);
 
-                    if (i == 0)
-                    {
-                        elemRes = lookupResult; // First result is always default.
-                    } 
-                    else
-                    {
-                        Operand isThisElem = context.ICompareEqual(vecIndex, Const(i));
-                        elemRes = context.ConditionalSelect(isThisElem, lookupResult, elemRes);
-                    }
+                    Operand mMask = context.AddIntrinsic(Intrinsic.X86Pcmpgtb, m, mask);
+                    mMask = context.AddIntrinsic(Intrinsic.X86Por, mMask, m);
+
+                    res = context.AddIntrinsic(Intrinsic.X86Pshufb, n, mMask);
                 }
 
-                Operand fallback = (extension) ? context.ZeroExtend32(OperandType.I64, EmitVectorExtract32(context, op.Qd, index + op.Id, 0, false)) : Const(0L); 
+                for (int index = 1; index < length; index++)
+                {
+                    int newVn = (op.Vn + index) & 0x1F;
+                    (int qn, int ind) = GetQuadwordAndSubindex(newVn, op.RegisterSize);
+                    Operand ni = EmitSwapDoubleWordToSide(context, GetVecA32(qn), newVn, 0);
 
-                res = EmitVectorInsert(context, res, context.ConditionalSelect(inRange, elemRes, fallback), index + op.Id, 0);
+                    Operand idxMask = X86GetAllElements(context, 0x0808080808080808L * index);
+
+                    Operand mSubMask = context.AddIntrinsic(Intrinsic.X86Psubb, m, idxMask);
+
+                    Operand mMask = context.AddIntrinsic(Intrinsic.X86Pcmpgtb, mSubMask, mask);
+                    mMask = context.AddIntrinsic(Intrinsic.X86Por, mMask, mSubMask);
+
+                    Operand res2 = context.AddIntrinsic(Intrinsic.X86Pshufb, ni, mMask);
+
+                    res = context.AddIntrinsic(Intrinsic.X86Por, res, res2);
+                }
+
+                if (extension)
+                {
+                    Operand idxMask = X86GetAllElements(context, (0x0808080808080808L * length) - 0x0101010101010101L);
+                    Operand zeroMask = context.VectorZero();
+
+                    Operand mPosMask = context.AddIntrinsic(Intrinsic.X86Pcmpgtb, m, idxMask);
+                    Operand mNegMask = context.AddIntrinsic(Intrinsic.X86Pcmpgtb, zeroMask, m);
+
+                    Operand mMask = context.AddIntrinsic(Intrinsic.X86Por, mPosMask, mNegMask);
+
+                    Operand dMask = context.AddIntrinsic(Intrinsic.X86Pand, EmitSwapDoubleWordToSide(context, d, op.Vd, 0), mMask);
+
+                    res = context.AddIntrinsic(Intrinsic.X86Por, res, dMask);
+                }
+
+                res = EmitSwapDoubleWordToSide(context, res, 0, op.Vd);
+
+                context.Copy(d, EmitDoubleWordInsert(context, d, res, op.Vd));
             }
+            else
+            {
+                int elems = op.GetBytesCount() >> op.Size;
 
-            context.Copy(GetVecA32(op.Qd), res);
+                (int Qx, int Ix)[] tableTuples = new (int, int)[length];
+                for (int i = 0; i < length; i++)
+                {
+                    (int vn, int en) = GetQuadwordAndSubindex(op.Vn + i, op.RegisterSize);
+                    tableTuples[i] = (vn, en);
+                }
+
+                int byteLength = length * 8;
+
+                Operand res = GetVecA32(op.Qd);
+                Operand m = GetVecA32(op.Qm);
+
+                for (int index = 0; index < elems; index++)
+                {
+                    Operand selectedIndex = context.ZeroExtend8(OperandType.I32, context.VectorExtract8(m, index + op.Im));
+
+                    Operand inRange = context.ICompareLess(selectedIndex, Const(byteLength));
+                    Operand elemRes = null; // Note: This is I64 for ease of calculation.
+
+                    // TODO: Branching rather than conditional select.
+
+                    // Get indexed byte.
+                    // To simplify (ha) the il, we get bytes from every vector and use a nested conditional select to choose the right result.
+                    // This does have to extract `length` times for every element but certainly not as bad as it could be.
+
+                    // Which vector number is the index on.
+                    Operand vecIndex = context.ShiftRightUI(selectedIndex, Const(3));
+                    // What should we shift by to extract it.
+                    Operand subVecIndexShift = context.ShiftLeft(context.BitwiseAnd(selectedIndex, Const(7)), Const(3));
+
+                    for (int i = 0; i < length; i++)
+                    {
+                        (int qx, int ix) = tableTuples[i];
+                        // Get the whole vector, we'll get a byte out of it.
+                        Operand lookupResult;
+                        if (qx == op.Qd)
+                        {
+                            // Result contains the current state of the vector.
+                            lookupResult = context.VectorExtract(OperandType.I64, res, ix);
+                        }
+                        else
+                        {
+                            lookupResult = EmitVectorExtract32(context, qx, ix, 3, false); // I64
+                        }
+
+                        lookupResult = context.ShiftRightUI(lookupResult, subVecIndexShift); // Get the relevant byte from this vector.
+
+                        if (i == 0)
+                        {
+                            elemRes = lookupResult; // First result is always default.
+                        }
+                        else
+                        {
+                            Operand isThisElem = context.ICompareEqual(vecIndex, Const(i));
+                            elemRes = context.ConditionalSelect(isThisElem, lookupResult, elemRes);
+                        }
+                    }
+
+                    Operand fallback = (extension) ? context.ZeroExtend32(OperandType.I64, EmitVectorExtract32(context, op.Qd, index + op.Id, 0, false)) : Const(0L); 
+
+                    res = EmitVectorInsert(context, res, context.ConditionalSelect(inRange, elemRes, fallback), index + op.Id, 0);
+                }
+
+                context.Copy(GetVecA32(op.Qd), res);
+            }
         }
 
         public static void Vtrn(ArmEmitterContext context)
         {
             OpCode32SimdCmpZ op = (OpCode32SimdCmpZ)context.CurrOp;
 
-            int elems = op.GetBytesCount() >> op.Size;
-            int pairs = elems >> 1;
-
-            bool overlap = op.Qm == op.Qd;
-
-            Operand resD = GetVecA32(op.Qd);
-            Operand resM = GetVecA32(op.Qm);
-
-            for (int index = 0; index < pairs; index++)
+            if (Optimizations.UseSsse3)
             {
-                int pairIndex = index << 1;
-                Operand d2 = EmitVectorExtract32(context, op.Qd, pairIndex + 1 + op.Id, op.Size, false);
-                Operand m1 = EmitVectorExtract32(context, op.Qm, pairIndex + op.Im, op.Size, false);
-
-                resD = EmitVectorInsert(context, resD, m1, pairIndex + 1 + op.Id, op.Size);
-
-                if (overlap)
+                EmitVectorShuffleOpSimd32(context, (m, d) =>
                 {
-                    resM = resD;
-                }
+                    Operand mask = null;
 
-                resM = EmitVectorInsert(context, resM, d2, pairIndex + op.Im, op.Size);
+                    if (op.Size < 3)
+                    {
+                        long maskE0 = EvenMasks[op.Size];
+                        long maskE1 = OddMasks[op.Size];
 
-                if (overlap)
-                {
-                    resD = resM;
-                }
+                        mask = X86GetScalar(context, maskE0);
+
+                        mask = EmitVectorInsert(context, mask, Const(maskE1), 1, 3);
+                    }
+
+                    if (op.Size < 3)
+                    {
+                        d = context.AddIntrinsic(Intrinsic.X86Pshufb, d, mask);
+                        m = context.AddIntrinsic(Intrinsic.X86Pshufb, m, mask);
+                    }
+
+                    Operand resD = context.AddIntrinsic(X86PunpcklInstruction[op.Size], d, m);
+                    Operand resM = context.AddIntrinsic(X86PunpckhInstruction[op.Size], d, m);
+
+                    return (resM, resD);
+                });
             }
-
-            context.Copy(GetVecA32(op.Qd), resD);
-            if (!overlap)
+            else
             {
-                context.Copy(GetVecA32(op.Qm), resM);
+                int elems = op.GetBytesCount() >> op.Size;
+                int pairs = elems >> 1;
+
+                bool overlap = op.Qm == op.Qd;
+
+                Operand resD = GetVecA32(op.Qd);
+                Operand resM = GetVecA32(op.Qm);
+
+                for (int index = 0; index < pairs; index++)
+                {
+                    int pairIndex = index << 1;
+                    Operand d2 = EmitVectorExtract32(context, op.Qd, pairIndex + 1 + op.Id, op.Size, false);
+                    Operand m1 = EmitVectorExtract32(context, op.Qm, pairIndex + op.Im, op.Size, false);
+
+                    resD = EmitVectorInsert(context, resD, m1, pairIndex + 1 + op.Id, op.Size);
+
+                    if (overlap)
+                    {
+                        resM = resD;
+                    }
+
+                    resM = EmitVectorInsert(context, resM, d2, pairIndex + op.Im, op.Size);
+
+                    if (overlap)
+                    {
+                        resD = resM;
+                    }
+                }
+
+                context.Copy(GetVecA32(op.Qd), resD);
+                if (!overlap)
+                {
+                    context.Copy(GetVecA32(op.Qm), resM);
+                }
             }
         }
 
@@ -243,44 +347,68 @@ namespace ARMeilleure.Instructions
         {
             OpCode32SimdCmpZ op = (OpCode32SimdCmpZ)context.CurrOp;
 
-            int elems = op.GetBytesCount() >> op.Size;
-            int pairs = elems >> 1;
-
-            bool overlap = op.Qm == op.Qd;
-
-            Operand resD = GetVecA32(op.Qd);
-            Operand resM = GetVecA32(op.Qm);
-
-            for (int index = 0; index < pairs; index++)
+            if (Optimizations.UseSse2)
             {
-                int pairIndex = index << 1;
-                Operand dRowD = EmitVectorExtract32(context, op.Qd, index + op.Id, op.Size, false);
-                Operand mRowD = EmitVectorExtract32(context, op.Qm, index + op.Im, op.Size, false);
-
-                Operand dRowM = EmitVectorExtract32(context, op.Qd, index + op.Id + pairs, op.Size, false);
-                Operand mRowM = EmitVectorExtract32(context, op.Qm, index + op.Im + pairs, op.Size, false);
-
-                resD = EmitVectorInsert(context, resD, dRowD, pairIndex + op.Id, op.Size);
-                resD = EmitVectorInsert(context, resD, mRowD, pairIndex + 1 + op.Id, op.Size);
-
-                if (overlap)
+                EmitVectorShuffleOpSimd32(context, (m, d) =>
                 {
-                    resM = resD;
-                }
+                    if (op.RegisterSize == RegisterSize.Simd128)
+                    {
+                        Operand resD = context.AddIntrinsic(X86PunpcklInstruction[op.Size], d, m);
+                        Operand resM = context.AddIntrinsic(X86PunpckhInstruction[op.Size], d, m);
 
-                resM = EmitVectorInsert(context, resM, dRowM, pairIndex + op.Im, op.Size);
-                resM = EmitVectorInsert(context, resM, mRowM, pairIndex + 1 + op.Im, op.Size);
+                        return (resM, resD);
+                    } 
+                    else
+                    {
+                        Operand res = context.AddIntrinsic(X86PunpcklInstruction[op.Size], d, m);
 
-                if (overlap)
-                {
-                    resD = resM;
-                }
+                        Operand resD = context.AddIntrinsic(Intrinsic.X86Punpcklqdq, res, context.VectorZero());
+                        Operand resM = context.AddIntrinsic(Intrinsic.X86Punpckhqdq, res, context.VectorZero());
+                        return (resM, resD);
+                    }
+                });
             }
-
-            context.Copy(GetVecA32(op.Qd), resD);
-            if (!overlap)
+            else
             {
-                context.Copy(GetVecA32(op.Qm), resM);
+                int elems = op.GetBytesCount() >> op.Size;
+                int pairs = elems >> 1;
+
+                bool overlap = op.Qm == op.Qd;
+
+                Operand resD = GetVecA32(op.Qd);
+                Operand resM = GetVecA32(op.Qm);
+
+                for (int index = 0; index < pairs; index++)
+                {
+                    int pairIndex = index << 1;
+                    Operand dRowD = EmitVectorExtract32(context, op.Qd, index + op.Id, op.Size, false);
+                    Operand mRowD = EmitVectorExtract32(context, op.Qm, index + op.Im, op.Size, false);
+
+                    Operand dRowM = EmitVectorExtract32(context, op.Qd, index + op.Id + pairs, op.Size, false);
+                    Operand mRowM = EmitVectorExtract32(context, op.Qm, index + op.Im + pairs, op.Size, false);
+
+                    resD = EmitVectorInsert(context, resD, dRowD, pairIndex + op.Id, op.Size);
+                    resD = EmitVectorInsert(context, resD, mRowD, pairIndex + 1 + op.Id, op.Size);
+
+                    if (overlap)
+                    {
+                        resM = resD;
+                    }
+
+                    resM = EmitVectorInsert(context, resM, dRowM, pairIndex + op.Im, op.Size);
+                    resM = EmitVectorInsert(context, resM, mRowM, pairIndex + 1 + op.Im, op.Size);
+
+                    if (overlap)
+                    {
+                        resD = resM;
+                    }
+                }
+
+                context.Copy(GetVecA32(op.Qd), resD);
+                if (!overlap)
+                {
+                    context.Copy(GetVecA32(op.Qm), resM);
+                }
             }
         }
 
@@ -288,49 +416,135 @@ namespace ARMeilleure.Instructions
         {
             OpCode32SimdCmpZ op = (OpCode32SimdCmpZ)context.CurrOp;
 
-            int elems = op.GetBytesCount() >> op.Size;
-            int pairs = elems >> 1;
+            if (Optimizations.UseSsse3)
+            {
+                EmitVectorShuffleOpSimd32(context, (m, d) =>
+                {
+                    if (op.RegisterSize == RegisterSize.Simd128)
+                    {
+                        Operand mask = null;
+
+                        if (op.Size < 3)
+                        {
+                            long maskE0 = EvenMasks[op.Size];
+                            long maskE1 = OddMasks[op.Size];
+
+                            mask = X86GetScalar(context, maskE0);
+
+                            mask = EmitVectorInsert(context, mask, Const(maskE1), 1, 3);
+                        }
+
+                        if (op.Size < 3)
+                        {
+                            d = context.AddIntrinsic(Intrinsic.X86Pshufb, d, mask);
+                            m = context.AddIntrinsic(Intrinsic.X86Pshufb, m, mask);
+                        }
+
+                        Operand resD = context.AddIntrinsic(Intrinsic.X86Punpcklqdq, d, m);
+                        Operand resM = context.AddIntrinsic(Intrinsic.X86Punpckhqdq, d, m);
+
+                        return (resM, resD);
+                    }
+                    else
+                    {
+                        Intrinsic punpcklInst = X86PunpcklInstruction[op.Size];
+
+                        Operand res = context.AddIntrinsic(punpcklInst, d, m);
+
+                        if (op.Size < 2)
+                        {
+                            long maskE0 = _masksE0_Uzp[op.Size];
+                            long maskE1 = _masksE1_Uzp[op.Size];
+
+                            Operand mask = X86GetScalar(context, maskE0);
+
+                            mask = EmitVectorInsert(context, mask, Const(maskE1), 1, 3);
+
+                            res = context.AddIntrinsic(Intrinsic.X86Pshufb, res, mask);
+                        }
+
+                        Operand resD = context.AddIntrinsic(Intrinsic.X86Punpcklqdq, res, context.VectorZero());
+                        Operand resM = context.AddIntrinsic(Intrinsic.X86Punpckhqdq, res, context.VectorZero());
+
+                        return (resM, resD);
+                    }
+                });
+            }
+            else
+            {
+                int elems = op.GetBytesCount() >> op.Size;
+                int pairs = elems >> 1;
+
+                bool overlap = op.Qm == op.Qd;
+
+                Operand resD = GetVecA32(op.Qd);
+                Operand resM = GetVecA32(op.Qm);
+
+                for (int index = 0; index < elems; index++)
+                {
+                    Operand dIns, mIns;
+                    if (index >= pairs)
+                    {
+                        int pind = index - pairs;
+                        dIns = EmitVectorExtract32(context, op.Qm, (pind << 1) + op.Im, op.Size, false);
+                        mIns = EmitVectorExtract32(context, op.Qm, ((pind << 1) | 1) + op.Im, op.Size, false);
+                    }
+                    else
+                    {
+                        dIns = EmitVectorExtract32(context, op.Qd, (index << 1) + op.Id, op.Size, false);
+                        mIns = EmitVectorExtract32(context, op.Qd, ((index << 1) | 1) + op.Id, op.Size, false);
+                    }
+
+                    resD = EmitVectorInsert(context, resD, dIns, index + op.Id, op.Size);
+
+                    if (overlap)
+                    {
+                        resM = resD;
+                    }
+
+                    resM = EmitVectorInsert(context, resM, mIns, index + op.Im, op.Size);
+
+                    if (overlap)
+                    {
+                        resD = resM;
+                    }
+                }
+
+                context.Copy(GetVecA32(op.Qd), resD);
+                if (!overlap)
+                {
+                    context.Copy(GetVecA32(op.Qm), resM);
+                }
+            }
+        }
+
+        public static void EmitVectorShuffleOpSimd32(ArmEmitterContext context, Func<Operand, Operand, (Operand, Operand)> shuffleFunc)
+        {
+            OpCode32Simd op = (OpCode32Simd)context.CurrOp;
+
+            Operand m = GetVecA32(op.Qm);
+            Operand d = GetVecA32(op.Qd);
+            Operand initialM = m;
+            Operand initialD = d;
+
+            if (!op.Q) //register swap: move relevant doubleword to side 0, for consistency
+            {
+                m = EmitSwapDoubleWordToSide(context, m, op.Vm, 0);
+                d = EmitSwapDoubleWordToSide(context, d, op.Vd, 0);
+            }
+
+            (Operand resM, Operand resD) = shuffleFunc(m, d);
 
             bool overlap = op.Qm == op.Qd;
 
-            Operand resD = GetVecA32(op.Qd);
-            Operand resM = GetVecA32(op.Qm);
-
-            for (int index = 0; index < elems; index++)
+            if (!op.Q) //register insert
             {
-                Operand dIns, mIns;
-                if (index >= pairs)
-                {
-                    int pind = index - pairs;
-                    dIns = EmitVectorExtract32(context, op.Qm, (pind << 1) + op.Im, op.Size, false);
-                    mIns = EmitVectorExtract32(context, op.Qm, ((pind << 1) | 1) + op.Im, op.Size, false);
-                } 
-                else
-                {
-                    dIns = EmitVectorExtract32(context, op.Qd, (index << 1) + op.Id, op.Size, false);
-                    mIns = EmitVectorExtract32(context, op.Qd, ((index << 1) | 1) + op.Id, op.Size, false);
-                }
-
-                resD = EmitVectorInsert(context, resD, dIns, index + op.Id, op.Size);
-
-                if (overlap)
-                {
-                    resM = resD;
-                }
-
-                resM = EmitVectorInsert(context, resM, mIns, index + op.Im, op.Size);
-
-                if (overlap)
-                {
-                    resD = resM;
-                }
+                resM = EmitDoubleWordInsert(context, initialM, EmitSwapDoubleWordToSide(context, resM, 0, op.Vm), op.Vm);
+                resD = EmitDoubleWordInsert(context, overlap ? resM : initialD, EmitSwapDoubleWordToSide(context, resD, 0, op.Vd), op.Vd);
             }
 
-            context.Copy(GetVecA32(op.Qd), resD);
-            if (!overlap)
-            {
-                context.Copy(GetVecA32(op.Qm), resM);
-            }
+            if (!overlap) context.Copy(initialM, resM);
+            context.Copy(initialD, resD);
         }
     }
 }

--- a/ARMeilleure/Instructions/InstEmitSimdMove32.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdMove32.cs
@@ -13,7 +13,7 @@ namespace ARMeilleure.Instructions
     static partial class InstEmit32
     {
         #region "Masks"
-        // same as InstEmitSimdMove, as the instruction do the same thing.
+        // Same as InstEmitSimdMove, as the instructions do the same thing.
         private static readonly long[] _masksE0_Uzp = new long[]
         {
             13L << 56 | 09L << 48 | 05L << 40 | 01L << 32 | 12L << 24 | 08L << 16 | 04L << 8 | 00L << 0,
@@ -47,7 +47,7 @@ namespace ARMeilleure.Instructions
                 // To general purpose.
                 Operand value = context.VectorExtract(OperandType.I32, vec, op.Vn & 0x3);
                 SetIntA32(context, op.Rt, value);
-            } 
+            }
             else
             {
                 // From general purpose.
@@ -104,7 +104,7 @@ namespace ARMeilleure.Instructions
                 if (sameOwnerVec)
                 {
                     context.Copy(vec, context.VectorInsert(resultVec, highValue, vm1 & 3));
-                } 
+                }
                 else
                 {
                     context.Copy(vec, resultVec);
@@ -263,7 +263,7 @@ namespace ARMeilleure.Instructions
                         }
                     }
 
-                    Operand fallback = (extension) ? context.ZeroExtend32(OperandType.I64, EmitVectorExtract32(context, op.Qd, index + op.Id, 0, false)) : Const(0L); 
+                    Operand fallback = (extension) ? context.ZeroExtend32(OperandType.I64, EmitVectorExtract32(context, op.Qd, index + op.Id, 0, false)) : Const(0L);
 
                     res = EmitVectorInsert(context, res, context.ConditionalSelect(inRange, elemRes, fallback), index + op.Id, 0);
                 }
@@ -357,7 +357,7 @@ namespace ARMeilleure.Instructions
                         Operand resM = context.AddIntrinsic(X86PunpckhInstruction[op.Size], d, m);
 
                         return (resM, resD);
-                    } 
+                    }
                     else
                     {
                         Operand res = context.AddIntrinsic(X86PunpcklInstruction[op.Size], d, m);
@@ -527,7 +527,7 @@ namespace ARMeilleure.Instructions
             Operand initialM = m;
             Operand initialD = d;
 
-            if (!op.Q) //register swap: move relevant doubleword to side 0, for consistency
+            if (!op.Q) // Register swap: move relevant doubleword to side 0, for consistency.
             {
                 m = EmitSwapDoubleWordToSide(context, m, op.Vm, 0);
                 d = EmitSwapDoubleWordToSide(context, d, op.Vd, 0);
@@ -537,13 +537,17 @@ namespace ARMeilleure.Instructions
 
             bool overlap = op.Qm == op.Qd;
 
-            if (!op.Q) //register insert
+            if (!op.Q) // Register insert.
             {
                 resM = EmitDoubleWordInsert(context, initialM, EmitSwapDoubleWordToSide(context, resM, 0, op.Vm), op.Vm);
                 resD = EmitDoubleWordInsert(context, overlap ? resM : initialD, EmitSwapDoubleWordToSide(context, resD, 0, op.Vd), op.Vd);
             }
 
-            if (!overlap) context.Copy(initialM, resM);
+            if (!overlap)
+            {
+                context.Copy(initialM, resM);
+            }
+
             context.Copy(initialD, resD);
         }
     }

--- a/ARMeilleure/IntermediateRepresentation/Intrinsic.cs
+++ b/ARMeilleure/IntermediateRepresentation/Intrinsic.cs
@@ -41,6 +41,7 @@ namespace ARMeilleure.IntermediateRepresentation
         X86Divss,
         X86Haddpd,
         X86Haddps,
+        X86Insertps,
         X86Maxpd,
         X86Maxps,
         X86Maxsd,

--- a/ARMeilleure/IntermediateRepresentation/Intrinsic.cs
+++ b/ARMeilleure/IntermediateRepresentation/Intrinsic.cs
@@ -52,6 +52,7 @@ namespace ARMeilleure.IntermediateRepresentation
         X86Minss,
         X86Movhlps,
         X86Movlhps,
+        X86Movss,
         X86Mulpd,
         X86Mulps,
         X86Mulsd,


### PR DESCRIPTION
This PR adds x86 intrinsic paths to most of the A32 SIMD instructions. This should bring performance more in line with A64, and the slow/non SSE paths should not be affected.

Since this adds fast paths for most instructions I'll go over the omissions instead. 

Omissions:
- Memory instructions.
- VABS+VNEG integer, VDUP, integer multiply (and fused variants) *
- Vector by scalar for integer *
- Narrow ops (there are only like 2 right now)
- VRECPE.f64, VRSQRTE.f64 (integer is not implemented at all, 64 has no x86 intrinsic)
- VCVT f32<->f64. *
- VCVT f32/64 to integer when using fpscr for rounding mode.
- VCVT integer to f32/64. *
- Anything with round mode "away from zero"
- Move immediate. *
- Shift instructions.
- Integer compare instructions.

Everything else should be covered.

Starred ommissions are ones that don't really have any complicated reason to avoid implementing them. Due to the extract/insert experience you have to go through for using scalars in A32, implementing the scalar forms probably won't be much faster.

Two new intrinsics have been added to the list to allow easier movement of scalar values, since A32 allows you to access them from indexed locations within a V128 and x86 does not:

- insertps
- movss

No tests have been added in this version, though all existing ones (that don't require fastfp = false) should pass. Some tests were added to a32-wip alongside the development of these intrinsics to ensure they were correct, which are currently in master.