### PR TITLE
Set Undefined instruction emitter for Undefined property on InstDescriptor

### DIFF
--- a/ARMeilleure/Decoders/InstDescriptor.cs
+++ b/ARMeilleure/Decoders/InstDescriptor.cs
@@ -4,7 +4,7 @@ namespace ARMeilleure.Decoders
 {
     struct InstDescriptor
     {
-        public static InstDescriptor Undefined => new InstDescriptor(InstName.Und, null);
+        public static InstDescriptor Undefined => new InstDescriptor(InstName.Und, InstEmit.Und);
 
         public InstName    Name    { get; }
         public InstEmitter Emitter { get; }


### PR DESCRIPTION
Fix a bug when a "semi-valid" instruction encoding is used.