### PR TITLE
Reduce copy destination size by target mipmap level, rather than source size.

### DIFF
--- a/Ryujinx.Graphics.OpenGL/TextureCopyUnscaled.cs
+++ b/Ryujinx.Graphics.OpenGL/TextureCopyUnscaled.cs
@@ -14,18 +14,18 @@ namespace Ryujinx.Graphics.OpenGL
             int srcDepth  = src.DepthOrLayers;
             int srcLevels = src.Levels;
 
-            srcWidth  = Math.Max(1, srcWidth  >> dstLevel);
-            srcHeight = Math.Max(1, srcHeight >> dstLevel);
-
-            if (src.Target == Target.Texture3D)
-            {
-                srcDepth = Math.Max(1, srcDepth >> dstLevel);
-            }
-
             int dstWidth  = dst.Width;
             int dstHeight = dst.Height;
             int dstDepth  = dst.DepthOrLayers;
             int dstLevels = dst.Levels;
+
+            dstWidth = Math.Max(1, dstWidth >> dstLevel);
+            dstHeight = Math.Max(1, dstHeight >> dstLevel);
+
+            if (src.Target == Target.Texture3D)
+            {
+                dstDepth = Math.Max(1, dstDepth >> dstLevel);
+            }
 
             // When copying from a compressed to a non-compressed format,
             // the non-compressed texture will have the size of the texture

--- a/Ryujinx.Graphics.OpenGL/TextureCopyUnscaled.cs
+++ b/Ryujinx.Graphics.OpenGL/TextureCopyUnscaled.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.OpenGL
             dstWidth = Math.Max(1, dstWidth >> dstLevel);
             dstHeight = Math.Max(1, dstHeight >> dstLevel);
 
-            if (src.Target == Target.Texture3D)
+            if (dst.Target == Target.Texture3D)
             {
                 dstDepth = Math.Max(1, dstDepth >> dstLevel);
             }


### PR DESCRIPTION
This specifically affected the case where a texture was being copied into some non-zero target level on the destination texture. In this case, the source texture will already be the correct size to fit into the mip level, but the destination's size will still be that of mip level 0. By scaling the destination's size using the target mip level, we get the real size of where the texture should be copied to. The final copy takes the minimum of both sizes, but ideally they should both be equal.

Before, we would scale the source texture's size, essentially applying the mip scaling twice and causing only a small region of the texture to be copied into the destination. This doesn't cause any fatal errors, but caused Mario Kart's cubemap mipmaps to barely work at all.

Before:
![image](https://user-images.githubusercontent.com/6294155/75612977-7c41f580-5b20-11ea-97ad-61b23ab167c6.png)
After:
![image](https://user-images.githubusercontent.com/6294155/75612980-8532c700-5b20-11ea-973c-43282c416c03.png)

Example of scaling behaviour before change:
https://i.gyazo.com/7b21816bdbf422280bbbe0ffc05a4adc.mp4

This fixes cube mipmaps in character select in Mario Kart. It does improve ingame cube mipmaps, but there is another issue where only one face of the course mipmaps are used that has to be resolved separately.