### PR TITLE
Don't decode blocks starting outside mapped memory & undefined instead of throw on invalid sysreg coprocessor

### DIFF
--- a/ARMeilleure/Decoders/Decoder.cs
+++ b/ARMeilleure/Decoders/Decoder.cs
@@ -47,7 +47,7 @@ namespace ARMeilleure.Decoders
             {
                 if (!visited.TryGetValue(blkAddress, out Block block))
                 {
-                    if (opsCount > MaxInstsPerFunction)
+                    if (opsCount > MaxInstsPerFunction || !memory.IsMapped((long)blkAddress))
                     {
                         return null;
                     }

--- a/ARMeilleure/Instructions/InstEmitSystem32.cs
+++ b/ARMeilleure/Instructions/InstEmitSystem32.cs
@@ -17,7 +17,7 @@ namespace ARMeilleure.Instructions
 
             if (op.Coproc != 15)
             {
-                EmitUndefined(context);
+                InstEmit.Und(context);
                 return;
             }
 
@@ -71,7 +71,7 @@ namespace ARMeilleure.Instructions
 
             if (op.Coproc != 15)
             {
-                EmitUndefined(context);
+                InstEmit.Und(context);
                 return;
             }
 
@@ -121,7 +121,7 @@ namespace ARMeilleure.Instructions
 
             if (op.Coproc != 15)
             {
-                EmitUndefined(context);
+                InstEmit.Und(context);
                 return;
             }
 
@@ -231,12 +231,6 @@ namespace ARMeilleure.Instructions
             SetFlag(context, PState.CFlag, c);
             SetFlag(context, PState.ZFlag, z);
             SetFlag(context, PState.NFlag, n);
-        }
-
-        private static void EmitUndefined(ArmEmitterContext context)
-        {
-            OpCode32 op = (OpCode32)context.CurrOp;
-            context.Call(new _Void_U64_S32(NativeInterface.Undefined), Const(op.Address), Const(op.RawOpCode));
         }
     }
 }

--- a/ARMeilleure/Instructions/InstEmitSystem32.cs
+++ b/ARMeilleure/Instructions/InstEmitSystem32.cs
@@ -17,7 +17,8 @@ namespace ARMeilleure.Instructions
 
             if (op.Coproc != 15)
             {
-                throw new NotImplementedException($"Unknown MRC Coprocessor ID 0x{op.Coproc:X16} at 0x{op.Address:X16}.");
+                EmitUndefined(context);
+                return;
             }
 
             if (op.Opc1 != 0)
@@ -70,7 +71,8 @@ namespace ARMeilleure.Instructions
 
             if (op.Coproc != 15)
             {
-                throw new NotImplementedException($"Unknown MRC Coprocessor ID 0x{op.Coproc:X16} at 0x{op.Address:X16}.");
+                EmitUndefined(context);
+                return;
             }
 
             if (op.Opc1 != 0)
@@ -119,7 +121,8 @@ namespace ARMeilleure.Instructions
 
             if (op.Coproc != 15)
             {
-                throw new NotImplementedException($"Unknown MRC Coprocessor ID 0x{op.Coproc:X16} at 0x{op.Address:X16}.");
+                EmitUndefined(context);
+                return;
             }
 
             var opc = op.MrrcOp;
@@ -228,6 +231,12 @@ namespace ARMeilleure.Instructions
             SetFlag(context, PState.CFlag, c);
             SetFlag(context, PState.ZFlag, z);
             SetFlag(context, PState.NFlag, n);
+        }
+
+        private static void EmitUndefined(ArmEmitterContext context)
+        {
+            OpCode32 op = (OpCode32)context.CurrOp;
+            context.Call(new _Void_U64_S32(NativeInterface.Undefined), Const(op.Address), Const(op.RawOpCode));
         }
     }
 }


### PR DESCRIPTION
This PR specifically targets a pattern seen in MK8 v1.7.1, where based on the result of a function, many locations would conditionally jump to data. Of course, the game never takes these branches, but our decoder and translator still follow them, which will cause a crash when they encounter any issues or code that deliberately throws (eg. if a specific variant of an instruction is not implemented)

The specific case this targets is data that is interpreted as a branch immediate instruction. This causes a special problem since we analyze branches when doing highCq code compilation, and try to follow and compile them into one whole function. It's very likely that the immediate branch location will be hilariously out of bounds, which will cause an exception when the decoder attempts to read the first instruction in the target block. 

This PR checks if the start address of a block is in a mapped region before attempting to decode it. If it is not in a mapped region, the block will not translate and the function will have to return to the translator if it wants to take that path. Note that if it does this, it will crash unless something mapped that region since initial translation.

## InstEmitSystem32 change

In most cases, data interpreted as an instruction is generally well defined or undefined... however, there is a small surface of instructions that are defined, but throw if given an unexpected or unimplemented value. The problem is that this throws during translation, so if the game is fuzz testing our translator then the game will crash regardless of whether or not the instruction actually runs.

An additional change has been included for A32 system register functions, which generates code which calls undefined rather than throwing in the translator when the coprocessor id is not recognised. This fixes one very specific case where code interpreted as data would throw in MK8, but doesn't do anything comprehensive as the whole approach to system registers might be subject to change soon anyways.