### PR TITLE
Fix branch with CC and predicate, and a case of SSY/PBK propagation

### DIFF
--- a/Ryujinx.Graphics.Shader/Decoders/Decoder.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/Decoder.cs
@@ -390,7 +390,14 @@ namespace Ryujinx.Graphics.Shader.Decoders
 
             void Push(PathBlockState pbs)
             {
-                if (pbs.Block == null || visited.Add(pbs.Block))
+                // When block is null, this means we are pushing a restore operation.
+                // Restore operations are used to undo the work done inside a block
+                // when we return from it, for example it pops addresses pushed by
+                // SSY/PBK instructions inside the block, and pushes addresses poped
+                // by SYNC/BRK.
+                // For blocks, if it's already visited, we just ignore to avoid going
+                // around in circles and getting stuck here.
+                if (pbs.Block == null || !visited.Contains(pbs.Block))
                 {
                     workQueue.Push(pbs);
                 }
@@ -408,6 +415,14 @@ namespace Ryujinx.Graphics.Shader.Decoders
                 }
 
                 Block current = pbs.Block;
+
+                // If the block was already processed, we just ignore it, otherwise
+                // we would push the same child blocks of an already processed block,
+                // and go around in circles until memory is exhausted.
+                if (!visited.Add(current))
+                {
+                    continue;
+                }
 
                 int pushOpsCount = current.PushOpCodes.Count;
 
@@ -434,7 +449,9 @@ namespace Ryujinx.Graphics.Shader.Decoders
                 }
                 else if (current.GetLastOp() is OpCodeBranchIndir brIndir)
                 {
-                    foreach (Block possibleTarget in brIndir.PossibleTargets)
+                    // By adding them in descending order (sorted by address), we process the blocks
+                    // in order (of ascending address), since we work with a LIFO.
+                    foreach (Block possibleTarget in brIndir.PossibleTargets.OrderByDescending(x => x.Address))
                     {
                         Push(new PathBlockState(possibleTarget));
                     }
@@ -453,6 +470,10 @@ namespace Ryujinx.Graphics.Shader.Decoders
                     }
                     else
                     {
+                        // First we push the target address (this will be used to push the
+                        // address back into the SSY/PBK stack when we return from that block),
+                        // then we push the block itself into the work "queue" (well, it's a stack)
+                        // for processing.
                         Push(new PathBlockState(targetAddress));
                         Push(new PathBlockState(blocks[targetAddress]));
                     }

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitFlow.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitFlow.cs
@@ -145,10 +145,24 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
             if (op is OpCodeBranch opBranch && opBranch.Condition != Condition.Always)
             {
-                pred = context.BitwiseAnd(pred, GetCondition(context, opBranch.Condition));
-            }
+                Operand cond = GetCondition(context, opBranch.Condition);
 
-            if (op.Predicate.IsPT)
+                if (op.Predicate.IsPT)
+                {
+                    pred = cond;
+                }
+                else if (op.InvertPredicate)
+                {
+                    pred = context.BitwiseAnd(context.BitwiseNot(pred), cond);
+                }
+                else
+                {
+                    pred = context.BitwiseAnd(pred, cond);
+                }
+
+                context.BranchIfTrue(label, pred);
+            }
+            else if (op.Predicate.IsPT)
             {
                 context.Branch(label);
             }


### PR DESCRIPTION
This fixes two things:

First, it had a bug for branches using both a predicate and CC condition. When the predicate was inverted, it was inverting the whole expression, not just the predicate. I'm not aware of any specific issue caused by this bug, I just found it while I was looking at the code and decided to fix.

The other one is more complicated. When the shader has BRX instruction (which is basically a indirect branch with address from a register), we currently try to guess the possible targets. It assumes that the BRX is used for switch jump table optimization, and in this case the possible targets can be guessed by finding the common block that all the target branches to (the switch break). This doesn't work very well when PBK/SSY -> BRK/SYNC sequences are used, because the target address is unknown in this case. For this case it could include wrong targets, and this causes the second pass (after decoding/CFG build) that propagates PBK/SSY addresses to their respective BRK/SYNC instructions to not reach some places that are supposed to be reachable. This in turn causes wrong branches to be inserted on the code. It caused a regression on Crash Team Racing, a infinite loop on the shader that probably happened after BRX support was implemented.

To fix the above issue I changed it to delay as much as possible adding the BRX targets on the list of visited block, to allow them to be visited through the SYNC instruction inside the BRX target block, rather than be considered as BRX target up front and then never be visited again.