### PR TITLE
Use a Jump Table for direct and indirect calls/jumps, removing transitions to managed

### DIFF
--- a/ARMeilleure/CodeGen/Optimizations/Optimizer.cs
+++ b/ARMeilleure/CodeGen/Optimizations/Optimizer.cs
@@ -136,7 +136,7 @@ namespace ARMeilleure.CodeGen.Optimizations
 
         private static bool HasSideEffects(Node node)
         {
-            return (node is Operation operation) && operation.Instruction == Instruction.Call;
+            return (node is Operation operation) && (operation.Instruction == Instruction.Call || operation.Instruction == Instruction.Tailcall);
         }
 
         private static bool IsPropagableCopy(Operation operation)

--- a/ARMeilleure/CodeGen/Optimizations/Optimizer.cs
+++ b/ARMeilleure/CodeGen/Optimizations/Optimizer.cs
@@ -136,7 +136,9 @@ namespace ARMeilleure.CodeGen.Optimizations
 
         private static bool HasSideEffects(Node node)
         {
-            return (node is Operation operation) && (operation.Instruction == Instruction.Call || operation.Instruction == Instruction.Tailcall);
+            return (node is Operation operation) && (operation.Instruction == Instruction.Call
+                || operation.Instruction == Instruction.Tailcall
+                || operation.Instruction == Instruction.CompareAndSwap);
         }
 
         private static bool IsPropagableCopy(Operation operation)

--- a/ARMeilleure/CodeGen/Optimizations/TailCallRemover.cs
+++ b/ARMeilleure/CodeGen/Optimizations/TailCallRemover.cs
@@ -1,0 +1,75 @@
+﻿using ARMeilleure.Decoders;
+using System;
+using System.Collections.Generic;
+
+namespace ARMeilleure.CodeGen.Optimizations
+{
+    static class TailCallRemover
+    {
+        public static void RunPass(ulong entryAddress, List<Block> blocks)
+        {
+            // Detect tail calls:
+            // - Assume this function spans the space covered by contiguous code blocks surrounding the entry address.
+            // - Unconditional jump to an area outside this contiguous region will be treated as a tail call.
+            // - Include a small allowance for jumps outside the contiguous range.
+
+            if (!Decoder.BinarySearch(blocks, entryAddress, out int entryBlockId))
+            {
+                throw new InvalidOperationException("Function entry point is not contained in a block.");
+            }
+
+            ulong allowance = 4;
+            Block entryBlock = blocks[entryBlockId];
+            int startBlockIndex = entryBlockId;
+            Block startBlock = entryBlock;
+            int endBlockIndex = entryBlockId;
+            Block endBlock = entryBlock;
+
+            for (int i = entryBlockId + 1; i < blocks.Count; i++) // Search forwards.
+            {
+                Block block = blocks[i];
+                if (endBlock.EndAddress < block.Address - allowance)
+                {
+                    break; // End of contiguous function.
+                }
+
+                endBlock = block;
+                endBlockIndex = i;
+            }
+
+            for (int i = entryBlockId - 1; i >= 0; i--) // Search backwards.
+            {
+                Block block = blocks[i];
+                if (startBlock.Address > block.EndAddress + allowance)
+                {
+                    break; // End of contiguous function.
+                }
+
+                startBlock = block;
+                startBlockIndex = i;
+            }
+
+            if (startBlockIndex == 0 && endBlockIndex == blocks.Count - 1)
+            {
+                return; // Nothing to do here.
+            }
+
+            // Replace all branches to blocks outside the range with null, and force a tail call.
+
+            for (int i = startBlockIndex; i <= endBlockIndex; i++)
+            {
+                Block block = blocks[i];
+                if (block.Branch != null && (block.Branch.Address > endBlock.EndAddress || block.Branch.EndAddress < startBlock.Address))
+                {
+                    block.Branch = null;
+                    block.TailCall = true;
+                }
+            }
+
+            // Finally, delete all blocks outside the contiguous range.
+
+            blocks.RemoveRange(endBlockIndex + 1, (blocks.Count - endBlockIndex) - 1);
+            blocks.RemoveRange(0, startBlockIndex);
+        }
+    }
+}

--- a/ARMeilleure/CodeGen/X86/Assembler.cs
+++ b/ARMeilleure/CodeGen/X86/Assembler.cs
@@ -117,6 +117,7 @@ namespace ARMeilleure.CodeGen.X86
             Add(X86Instruction.Imul,       new InstructionInfo(BadOp,      0x0000006b, 0x00000069, BadOp,      0x00000faf, InstructionFlags.None));
             Add(X86Instruction.Imul128,    new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x050000f7, InstructionFlags.None));
             Add(X86Instruction.Insertps,   new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x000f3a21, InstructionFlags.Vex | InstructionFlags.Prefix66));
+            Add(X86Instruction.Jmp,        new InstructionInfo(0x040000ff, BadOp,      BadOp,      BadOp,      BadOp,      InstructionFlags.None));
             Add(X86Instruction.Lea,        new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x0000008d, InstructionFlags.None));
             Add(X86Instruction.Maxpd,      new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x00000f5f, InstructionFlags.Vex | InstructionFlags.Prefix66));
             Add(X86Instruction.Maxps,      new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x00000f5f, InstructionFlags.Vex));
@@ -478,6 +479,11 @@ namespace ARMeilleure.CodeGen.X86
             {
                 throw new ArgumentOutOfRangeException(nameof(offset));
             }
+        }
+
+        public void Jmp(Operand dest)
+        {
+            WriteInstruction(dest, null, OperandType.None, X86Instruction.Jmp);
         }
 
         public void Lea(Operand dest, Operand source, OperandType type)

--- a/ARMeilleure/CodeGen/X86/Assembler.cs
+++ b/ARMeilleure/CodeGen/X86/Assembler.cs
@@ -90,6 +90,7 @@ namespace ARMeilleure.CodeGen.X86
             Add(X86Instruction.Cmpps,      new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x00000fc2, InstructionFlags.Vex));
             Add(X86Instruction.Cmpsd,      new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x00000fc2, InstructionFlags.Vex | InstructionFlags.PrefixF2));
             Add(X86Instruction.Cmpss,      new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x00000fc2, InstructionFlags.Vex | InstructionFlags.PrefixF3));
+            Add(X86Instruction.Cmpxchg,    new InstructionInfo(0x00000fb1, BadOp,      BadOp,      BadOp,      BadOp,      InstructionFlags.None));
             Add(X86Instruction.Cmpxchg16b, new InstructionInfo(0x01000fc7, BadOp,      BadOp,      BadOp,      BadOp,      InstructionFlags.RexW));
             Add(X86Instruction.Comisd,     new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x00000f2f, InstructionFlags.Vex | InstructionFlags.Prefix66));
             Add(X86Instruction.Comiss,     new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x00000f2f, InstructionFlags.Vex));
@@ -327,6 +328,13 @@ namespace ARMeilleure.CodeGen.X86
         {
             WriteByte(0x48);
             WriteByte(0x99);
+        }
+
+        public void Cmpxchg(MemoryOperand memOp, Operand src)
+        {
+            WriteByte(LockPrefix);
+
+            WriteInstruction(memOp, src, src.Type, X86Instruction.Cmpxchg);
         }
 
         public void Cmpxchg16b(MemoryOperand memOp)

--- a/ARMeilleure/CodeGen/X86/CodeGenerator.cs
+++ b/ARMeilleure/CodeGen/X86/CodeGenerator.cs
@@ -34,6 +34,7 @@ namespace ARMeilleure.CodeGen.X86
             Add(Instruction.ByteSwap,                GenerateByteSwap);
             Add(Instruction.Call,                    GenerateCall);
             Add(Instruction.Clobber,                 GenerateClobber);
+            Add(Instruction.CompareAndSwap,          GenerateCompareAndSwap);
             Add(Instruction.CompareAndSwap128,       GenerateCompareAndSwap128);
             Add(Instruction.CompareEqual,            GenerateCompareEqual);
             Add(Instruction.CompareGreater,          GenerateCompareGreater);
@@ -542,6 +543,19 @@ namespace ARMeilleure.CodeGen.X86
         {
             // This is only used to indicate that a register is clobbered to the
             // register allocator, we don't need to produce any code.
+        }
+
+        private static void GenerateCompareAndSwap(CodeGenContext context, Operation operation)
+        {
+            Operand src1 = operation.GetSource(0);
+            Operand src2 = operation.GetSource(1);
+            Operand src3 = operation.GetSource(2);
+
+            EnsureSameType(src2, src3);
+
+            MemoryOperand memOp = MemoryOp(src3.Type, src1);
+
+            context.Assembler.Cmpxchg(memOp, src3);
         }
 
         private static void GenerateCompareAndSwap128(CodeGenContext context, Operation operation)

--- a/ARMeilleure/CodeGen/X86/CodeGenerator.cs
+++ b/ARMeilleure/CodeGen/X86/CodeGenerator.cs
@@ -548,7 +548,7 @@ namespace ARMeilleure.CodeGen.X86
         {
             Operand src1 = operation.GetSource(0);
 
-            if (src1.Type == OperandType.V128)
+            if (operation.SourcesCount == 5) // CompareAndSwap128 has 5 sources, compared to CompareAndSwap64/32's 3.
             {
                 MemoryOperand memOp = new MemoryOperand(OperandType.I64, src1);
 

--- a/ARMeilleure/CodeGen/X86/CodeGenerator.cs
+++ b/ARMeilleure/CodeGen/X86/CodeGenerator.cs
@@ -553,7 +553,7 @@ namespace ARMeilleure.CodeGen.X86
 
             EnsureSameType(src2, src3);
 
-            MemoryOperand memOp = MemoryOp(src3.Type, src1);
+            MemoryOperand memOp = new MemoryOperand(src3.Type, src1);
 
             context.Assembler.Cmpxchg(memOp, src3);
         }

--- a/ARMeilleure/CodeGen/X86/CodeGenerator.cs
+++ b/ARMeilleure/CodeGen/X86/CodeGenerator.cs
@@ -76,6 +76,7 @@ namespace ARMeilleure.CodeGen.X86
             Add(Instruction.Store16,                 GenerateStore16);
             Add(Instruction.Store8,                  GenerateStore8);
             Add(Instruction.Subtract,                GenerateSubtract);
+            Add(Instruction.Tailcall,                GenerateTailcall);
             Add(Instruction.VectorCreateScalar,      GenerateVectorCreateScalar);
             Add(Instruction.VectorExtract,           GenerateVectorExtract);
             Add(Instruction.VectorExtract16,         GenerateVectorExtract16);
@@ -1081,6 +1082,13 @@ namespace ARMeilleure.CodeGen.X86
             {
                 context.Assembler.Subsd(dest, src1, src2);
             }
+        }
+
+        private static void GenerateTailcall(CodeGenContext context, Operation operation)
+        {
+            WriteEpilogue(context);
+
+            context.Assembler.Jmp(operation.GetSource(0));
         }
 
         private static void GenerateVectorCreateScalar(CodeGenContext context, Operation operation)

--- a/ARMeilleure/CodeGen/X86/CodeGenerator.cs
+++ b/ARMeilleure/CodeGen/X86/CodeGenerator.cs
@@ -550,9 +550,7 @@ namespace ARMeilleure.CodeGen.X86
 
             if (src1.Type == OperandType.V128)
             {
-                Operand source = operation.GetSource(0);
-
-                MemoryOperand memOp = new MemoryOperand(OperandType.I64, source);
+                MemoryOperand memOp = new MemoryOperand(OperandType.I64, src1);
 
                 context.Assembler.Cmpxchg16b(memOp);
             }

--- a/ARMeilleure/CodeGen/X86/PreAllocator.cs
+++ b/ARMeilleure/CodeGen/X86/PreAllocator.cs
@@ -213,7 +213,7 @@ namespace ARMeilleure.CodeGen.X86
             {
                 case Instruction.CompareAndSwap:
                 {
-                    OperandType type = operation.GetSource(0).Type;
+                    OperandType type = operation.GetSource(1).Type;
 
                     if (type == OperandType.V128)
                     {

--- a/ARMeilleure/CodeGen/X86/PreAllocator.cs
+++ b/ARMeilleure/CodeGen/X86/PreAllocator.cs
@@ -203,6 +203,27 @@ namespace ARMeilleure.CodeGen.X86
 
             switch (operation.Instruction)
             {
+                case Instruction.CompareAndSwap:
+                    {
+                        // Handle the many restrictions of the compare and exchange (32/64) instruction:
+                        // - The expected value should be in (E/R)AX.
+                        // - The value at the memory location is loaded to (E/R)AX.
+
+                        Operand expected = operation.GetSource(1);
+
+                        Operand rax = Gpr(X86Register.Rax, expected.Type);
+
+                        nodes.AddBefore(node, Operation(Instruction.Copy, rax, expected));
+
+                        operation.SetSources(new Operand[] { operation.GetSource(0), rax, operation.GetSource(2) });
+
+                        node = nodes.AddAfter(node, Operation(Instruction.Copy, dest, rax));
+
+                        operation.Destination = rax;
+
+                        break;
+                    }
+
                 case Instruction.CompareAndSwap128:
                 {
                     // Handle the many restrictions of the compare and exchange (16 bytes) instruction:

--- a/ARMeilleure/CodeGen/X86/PreAllocator.cs
+++ b/ARMeilleure/CodeGen/X86/PreAllocator.cs
@@ -212,25 +212,25 @@ namespace ARMeilleure.CodeGen.X86
             switch (operation.Instruction)
             {
                 case Instruction.CompareAndSwap:
-                    {
-                        // Handle the many restrictions of the compare and exchange (32/64) instruction:
-                        // - The expected value should be in (E/R)AX.
-                        // - The value at the memory location is loaded to (E/R)AX.
+                {
+                    // Handle the many restrictions of the compare and exchange (32/64) instruction:
+                    // - The expected value should be in (E/R)AX.
+                    // - The value at the memory location is loaded to (E/R)AX.
 
-                        Operand expected = operation.GetSource(1);
+                    Operand expected = operation.GetSource(1);
 
-                        Operand rax = Gpr(X86Register.Rax, expected.Type);
+                    Operand rax = Gpr(X86Register.Rax, expected.Type);
 
-                        nodes.AddBefore(node, new Operation(Instruction.Copy, rax, expected));
+                    nodes.AddBefore(node, new Operation(Instruction.Copy, rax, expected));
 
-                        operation.SetSources(new Operand[] { operation.GetSource(0), rax, operation.GetSource(2) });
+                    operation.SetSources(new Operand[] { operation.GetSource(0), rax, operation.GetSource(2) });
 
-                        node = nodes.AddAfter(node, new Operation(Instruction.Copy, dest, rax));
+                    node = nodes.AddAfter(node, new Operation(Instruction.Copy, dest, rax));
 
-                        operation.Destination = rax;
+                    operation.Destination = rax;
 
-                        break;
-                    }
+                    break;
+                }
 
                 case Instruction.CompareAndSwap128:
                 {
@@ -907,8 +907,8 @@ namespace ARMeilleure.CodeGen.X86
                 if (passOnReg)
                 {
                     Operand argReg = source.Type.IsInteger()
-                    ? Gpr(CallingConvention.GetIntArgumentRegister(intCount++), source.Type)
-                    : Xmm(CallingConvention.GetVecArgumentRegister(vecCount++), source.Type);
+                        ? Gpr(CallingConvention.GetIntArgumentRegister(intCount++), source.Type)
+                        : Xmm(CallingConvention.GetVecArgumentRegister(vecCount++), source.Type);
 
                     Operation copyOp = new Operation(Instruction.Copy, argReg, source);
 

--- a/ARMeilleure/CodeGen/X86/X86Instruction.cs
+++ b/ARMeilleure/CodeGen/X86/X86Instruction.cs
@@ -50,6 +50,7 @@ namespace ARMeilleure.CodeGen.X86
         Imul,
         Imul128,
         Insertps,
+        Jmp,
         Lea,
         Maxpd,
         Maxps,

--- a/ARMeilleure/CodeGen/X86/X86Instruction.cs
+++ b/ARMeilleure/CodeGen/X86/X86Instruction.cs
@@ -23,6 +23,7 @@ namespace ARMeilleure.CodeGen.X86
         Cmpps,
         Cmpsd,
         Cmpss,
+        Cmpxchg,
         Cmpxchg16b,
         Comisd,
         Comiss,

--- a/ARMeilleure/Decoders/Block.cs
+++ b/ARMeilleure/Decoders/Block.cs
@@ -10,6 +10,7 @@ namespace ARMeilleure.Decoders
 
         public Block Next   { get; set; }
         public Block Branch { get; set; }
+        public bool TailCall { get; set; }
 
         public List<OpCode> OpCodes { get; private set; }
 

--- a/ARMeilleure/Decoders/Block.cs
+++ b/ARMeilleure/Decoders/Block.cs
@@ -10,6 +10,7 @@ namespace ARMeilleure.Decoders
 
         public Block Next   { get; set; }
         public Block Branch { get; set; }
+
         public bool TailCall { get; set; }
 
         public List<OpCode> OpCodes { get; private set; }

--- a/ARMeilleure/Decoders/Decoder.cs
+++ b/ARMeilleure/Decoders/Decoder.cs
@@ -1,3 +1,4 @@
+using ARMeilleure.CodeGen.Optimizations;
 using ARMeilleure.Instructions;
 using ARMeilleure.Memory;
 using ARMeilleure.State;
@@ -145,78 +146,12 @@ namespace ARMeilleure.Decoders
                 }
             }
 
-            RemoveTailCalls(address, blocks);
+            TailCallRemover.RunPass(address, blocks);
 
             return blocks.ToArray();
         }
 
-        private static void RemoveTailCalls(ulong entryAddress, List<Block> blocks)
-        {
-            // Detect tail calls:
-            // - Assume this function spans the space covered by contiguous code blocks surrounding the entry address.
-            // - Unconditional jump to an area outside this contiguous region will be treated as a tail call.
-            // - Include a small allowance for jumps outside the contiguous range.
-
-            if (!BinarySearch(blocks, entryAddress, out int entryBlockId))
-            {
-                throw new InvalidOperationException("Function entry point is not contained in a block.");
-            }
-
-            ulong allowance = 4;
-            Block entryBlock = blocks[entryBlockId];
-            int startBlockIndex = entryBlockId;
-            Block startBlock = entryBlock;
-            int endBlockIndex = entryBlockId;
-            Block endBlock = entryBlock;
-
-            for (int i = entryBlockId + 1; i < blocks.Count; i++) // Search forwards.
-            {
-                Block block = blocks[i];
-                if (endBlock.EndAddress < block.Address - allowance) 
-                {
-                    break; // End of contiguous function.
-                }
-
-                endBlock = block;
-                endBlockIndex = i;
-            }
-
-            for (int i = entryBlockId - 1; i >= 0; i--) // Search backwards.
-            {
-                Block block = blocks[i];
-                if (startBlock.Address > block.EndAddress + allowance)
-                {
-                    break; // End of contiguous function.
-                }
-
-                startBlock = block;
-                startBlockIndex = i;
-            }
-
-            if (startBlockIndex == 0 && endBlockIndex == blocks.Count - 1)
-            {
-                return; // Nothing to do here.
-            }
-
-            // Replace all branches to blocks outside the range with null, and force a tail call.
-
-            for (int i = startBlockIndex; i <= endBlockIndex; i++)
-            {
-                Block block = blocks[i];
-                if (block.Branch != null && (block.Branch.Address > endBlock.EndAddress || block.Branch.EndAddress < startBlock.Address))
-                {
-                    block.Branch = null;
-                    block.TailCall = true;
-                }
-            }
-
-            // Finally, delete all blocks outside the contiguous range.
-
-            blocks.RemoveRange(endBlockIndex + 1, (blocks.Count - endBlockIndex) - 1);
-            blocks.RemoveRange(0, startBlockIndex);
-        }
-
-        private static bool BinarySearch(List<Block> blocks, ulong address, out int index)
+        public static bool BinarySearch(List<Block> blocks, ulong address, out int index)
         {
             index = 0;
 

--- a/ARMeilleure/Decoders/Decoder.cs
+++ b/ARMeilleure/Decoders/Decoder.cs
@@ -121,7 +121,7 @@ namespace ARMeilleure.Decoders
                         currBlock.Branch = GetBlock((ulong)op.Immediate);
                     }
 
-                    if (!IsUnconditionalBranch(lastOp) /*|| isCall*/)
+                    if (!IsUnconditionalBranch(lastOp) || isCall)
                     {
                         currBlock.Next = GetBlock(currBlock.EndAddress);
                     }

--- a/ARMeilleure/Decoders/Decoder.cs
+++ b/ARMeilleure/Decoders/Decoder.cs
@@ -1,4 +1,4 @@
-using ARMeilleure.CodeGen.Optimizations;
+using ARMeilleure.Decoders.Optimizations;
 using ARMeilleure.Instructions;
 using ARMeilleure.Memory;
 using ARMeilleure.State;

--- a/ARMeilleure/Decoders/Decoder.cs
+++ b/ARMeilleure/Decoders/Decoder.cs
@@ -140,7 +140,75 @@ namespace ARMeilleure.Decoders
                 }
             }
 
+            RemoveTailCalls(address, blocks);
+
             return blocks.ToArray();
+        }
+
+        private static void RemoveTailCalls(ulong entryAddress, List<Block> blocks)
+        {
+            // Detect tail calls:
+            // - Assume this function spans the space covered by contiguous code blocks surrounding the entry address.
+            // - Unconditional jump to an area outside this contiguous region will be treated as a tail call.
+            // - Include a small allowance for jumps outside the contiguous range.
+
+            if (!BinarySearch(blocks, entryAddress, out int entryBlockId))
+            {
+                throw new InvalidOperationException("Function entry point is not contained in a block.");
+            }
+
+            ulong allowance = 4;
+            Block entryBlock = blocks[entryBlockId];
+            int startBlockIndex = entryBlockId;
+            Block startBlock = entryBlock;
+            int endBlockIndex = entryBlockId;
+            Block endBlock = entryBlock;
+
+            for (int i = entryBlockId + 1; i < blocks.Count; i++) // Search forwards.
+            {
+                Block block = blocks[i];
+                if (endBlock.EndAddress < block.Address - allowance) 
+                {
+                    break; // End of contiguous function.
+                }
+
+                endBlock = block;
+                endBlockIndex = i;
+            }
+
+            for (int i = entryBlockId - 1; i >= 0; i--) // Search backwards.
+            {
+                Block block = blocks[i];
+                if (startBlock.Address > block.EndAddress + allowance)
+                {
+                    break; // End of contiguous function.
+                }
+
+                startBlock = block;
+                startBlockIndex = i;
+            }
+
+            if (startBlockIndex == 0 && endBlockIndex == blocks.Count - 1)
+            {
+                return; // Nothing to do here.
+            }
+
+            // Replace all branches to blocks outside the range with null, and force a tail call.
+
+            for (int i = startBlockIndex; i <= endBlockIndex; i++)
+            {
+                Block block = blocks[i];
+                if (block.Branch != null && (block.Branch.Address > endBlock.EndAddress || block.Branch.EndAddress < startBlock.Address))
+                {
+                    block.Branch = null;
+                    block.TailCall = true;
+                }
+            }
+
+            // Finally, delete all blocks outside the contiguous range.
+
+            blocks.RemoveRange(endBlockIndex + 1, (blocks.Count - endBlockIndex) - 1);
+            blocks.RemoveRange(0, startBlockIndex);
         }
 
         private static bool BinarySearch(List<Block> blocks, ulong address, out int index)

--- a/ARMeilleure/Decoders/Optimizations/TailCallRemover.cs
+++ b/ARMeilleure/Decoders/Optimizations/TailCallRemover.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace ARMeilleure.CodeGen.Optimizations
+namespace ARMeilleure.Decoders.Optimizations
 {
     static class TailCallRemover
     {
@@ -18,7 +18,7 @@ namespace ARMeilleure.CodeGen.Optimizations
                 throw new InvalidOperationException("Function entry point is not contained in a block.");
             }
 
-            ulong allowance = 4;
+            const ulong allowance = 4;
             Block entryBlock = blocks[entryBlockId];
             int startBlockIndex = entryBlockId;
             Block startBlock = entryBlock;

--- a/ARMeilleure/Instructions/DelegateTypes.cs
+++ b/ARMeilleure/Instructions/DelegateTypes.cs
@@ -3,6 +3,8 @@ using System;
 
 namespace ARMeilleure.Instructions
 {
+    delegate bool _Bool();
+
     delegate double _F64_F64(double a1);
     delegate double _F64_F64_Bool(double a1, bool a2);
     delegate double _F64_F64_F64(double a1, double a2);

--- a/ARMeilleure/Instructions/InstEmitAluHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitAluHelper.cs
@@ -116,12 +116,14 @@ namespace ARMeilleure.Instructions
         {
             Debug.Assert(value.Type == OperandType.I32);
 
-            context.StoreToContext();
-
             if (IsThumb(context.CurrOp))
             {
-                // Make this count as a call, the translator will ignore the low bit for the address.
-                context.Return(context.ZeroExtend32(OperandType.I64, context.BitwiseOr(value, Const(1))));
+                context.StoreToContext();
+                bool isReturn = IsA32Return(context);
+
+                Operand addr = context.BitwiseOr(value, Const(1));
+
+                InstEmitFlowHelper.EmitVirtualJump(context, addr, isReturn);
             }
             else
             {
@@ -138,18 +140,8 @@ namespace ARMeilleure.Instructions
                 if (setFlags)
                 {
                     // TODO: Load SPSR etc.
-                    Operand isThumb = GetFlag(PState.TFlag);
 
-                    Operand lblThumb = Label();
-
-                    context.BranchIfTrue(lblThumb, isThumb);
-
-                    // Make this count as a call, the translator will ignore the low bit for the address.
-                    context.Return(context.ZeroExtend32(OperandType.I64, context.BitwiseOr(context.BitwiseAnd(value, Const(~3)), Const(1))));
-
-                    context.MarkLabel(lblThumb);
-
-                    context.Return(context.ZeroExtend32(OperandType.I64, context.BitwiseOr(value, Const(1))));
+                    EmitBxWritePc(context, value);
                 }
                 else
                 {

--- a/ARMeilleure/Instructions/InstEmitException.cs
+++ b/ARMeilleure/Instructions/InstEmitException.cs
@@ -2,6 +2,7 @@ using ARMeilleure.Decoders;
 using ARMeilleure.Translation;
 using System;
 
+using static ARMeilleure.Instructions.InstEmitFlowHelper;
 using static ARMeilleure.IntermediateRepresentation.OperandHelper;
 
 namespace ARMeilleure.Instructions
@@ -30,7 +31,7 @@ namespace ARMeilleure.Instructions
 
             if (context.CurrBlock.Next == null)
             {
-                context.Return(Const(op.Address + 4));
+                EmitTailContinue(context, Const(op.Address + 4));
             }
         }
 
@@ -48,7 +49,7 @@ namespace ARMeilleure.Instructions
 
             if (context.CurrBlock.Next == null)
             {
-                context.Return(Const(op.Address + 4));
+                EmitTailContinue(context, Const(op.Address + 4));
             }
         }
     }

--- a/ARMeilleure/Instructions/InstEmitException32.cs
+++ b/ARMeilleure/Instructions/InstEmitException32.cs
@@ -1,6 +1,7 @@
 ﻿using ARMeilleure.Decoders;
 using ARMeilleure.Translation;
 
+using static ARMeilleure.Instructions.InstEmitFlowHelper;
 using static ARMeilleure.IntermediateRepresentation.OperandHelper;
 
 namespace ARMeilleure.Instructions
@@ -29,7 +30,7 @@ namespace ARMeilleure.Instructions
 
             if (context.CurrBlock.Next == null)
             {
-                context.Return(Const(op.Address + 4));
+                EmitTailContinue(context, Const(op.Address + 4));
             }
         }
     }

--- a/ARMeilleure/Instructions/InstEmitFlow.cs
+++ b/ARMeilleure/Instructions/InstEmitFlow.cs
@@ -56,7 +56,7 @@ namespace ARMeilleure.Instructions
         {
             OpCodeBReg op = (OpCodeBReg)context.CurrOp;
 
-            EmitVirtualJump(context, GetIntOrZR(context, op.Rn));
+            EmitVirtualJump(context, GetIntOrZR(context, op.Rn), op.Rn == RegisterAlias.Lr);
         }
 
         public static void Cbnz(ArmEmitterContext context) => EmitCb(context, onNotZero: true);
@@ -71,7 +71,7 @@ namespace ARMeilleure.Instructions
 
         public static void Ret(ArmEmitterContext context)
         {
-            context.Return(context.BitwiseOr(GetIntOrZR(context, RegisterAlias.Lr), Const(CallFlag)));
+            context.Return(GetIntOrZR(context, RegisterAlias.Lr));
         }
 
         public static void Tbnz(ArmEmitterContext context) => EmitTb(context, onNotZero: true);

--- a/ARMeilleure/Instructions/InstEmitFlow.cs
+++ b/ARMeilleure/Instructions/InstEmitFlow.cs
@@ -21,7 +21,7 @@ namespace ARMeilleure.Instructions
             }
             else
             {
-                context.Return(Const(op.Immediate));
+                EmitTailContinue(context, Const(op.Immediate), context.CurrBlock.TailCall);
             }
         }
 
@@ -96,7 +96,7 @@ namespace ARMeilleure.Instructions
 
                 if (context.CurrBlock.Next == null)
                 {
-                    context.Return(Const(op.Address + 4));
+                    EmitTailContinue(context, Const(op.Address + 4));
                 }
             }
             else
@@ -105,11 +105,11 @@ namespace ARMeilleure.Instructions
 
                 EmitCondBranch(context, lblTaken, cond);
 
-                context.Return(Const(op.Address + 4));
+                EmitTailContinue(context, Const(op.Address + 4));
 
                 context.MarkLabel(lblTaken);
 
-                context.Return(Const(op.Immediate));
+                EmitTailContinue(context, Const(op.Immediate));
             }
         }
 
@@ -132,7 +132,7 @@ namespace ARMeilleure.Instructions
 
                 if (context.CurrBlock.Next == null)
                 {
-                    context.Return(Const(op.Address + 4));
+                    EmitTailContinue(context, Const(op.Address + 4));
                 }
             }
             else
@@ -148,11 +148,11 @@ namespace ARMeilleure.Instructions
                     context.BranchIfFalse(lblTaken, value);
                 }
 
-                context.Return(Const(op.Address + 4));
+                EmitTailContinue(context, Const(op.Address + 4));
 
                 context.MarkLabel(lblTaken);
 
-                context.Return(Const(op.Immediate));
+                EmitTailContinue(context, Const(op.Immediate));
             }
         }
     }

--- a/ARMeilleure/Instructions/InstEmitFlow32.cs
+++ b/ARMeilleure/Instructions/InstEmitFlow32.cs
@@ -85,7 +85,7 @@ namespace ARMeilleure.Instructions
         {
             IOpCode32BReg op = (IOpCode32BReg)context.CurrOp;
 
-            EmitBxWritePc(context, GetIntA32(context, op.Rm));
+            EmitBxWritePc(context, GetIntA32(context, op.Rm), op.Rm);
         }
     }
 }

--- a/ARMeilleure/Instructions/InstEmitFlow32.cs
+++ b/ARMeilleure/Instructions/InstEmitFlow32.cs
@@ -5,7 +5,6 @@ using ARMeilleure.Translation;
 
 using static ARMeilleure.Instructions.InstEmitFlowHelper;
 using static ARMeilleure.Instructions.InstEmitHelper;
-using static ARMeilleure.Instructions.InstEmitFlowHelper;
 using static ARMeilleure.IntermediateRepresentation.OperandHelper;
 
 namespace ARMeilleure.Instructions
@@ -22,7 +21,7 @@ namespace ARMeilleure.Instructions
             }
             else
             {
-                context.Return(Const(op.Immediate));
+                EmitTailContinue(context, Const(op.Immediate));
             }
         }
 
@@ -57,7 +56,7 @@ namespace ARMeilleure.Instructions
                 SetFlag(context, PState.TFlag, Const(isThumb ? 0 : 1));
             }
 
-            EmitJumpTableCall(context, Const((int)op.Immediate));
+            EmitCall(context, (ulong)op.Immediate);
         }
 
         public static void Blxr(ArmEmitterContext context)
@@ -79,7 +78,7 @@ namespace ARMeilleure.Instructions
 
             SetFlag(context, PState.TFlag, bitOne);
 
-            EmitJumpTableCall(context, addr);
+            EmitVirtualCall(context, addr);
         }
 
         public static void Bx(ArmEmitterContext context)

--- a/ARMeilleure/Instructions/InstEmitFlowHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitFlowHelper.cs
@@ -190,12 +190,11 @@ namespace ARMeilleure.Instructions
             }
         }
 
-        public static void EmitContinueOrReturnCheck(ArmEmitterContext context, Operand returnAddress)
+        private static void EmitContinueOrReturnCheck(ArmEmitterContext context, Operand returnAddress)
         {
-            // Note: The return value of the called method will be placed
-            // at the Stack, the return value is always a Int64 with the
-            // return address of the function. We check if the address is
-            // correct, if it isn't we keep returning until we reach the dispatcher.
+            // Note: The return value of a translated function is always an Int64 with the
+            // address execution has returned to. We expect this address to be immediately after the
+            // current instruction, if it isn't we keep returning until we reach the dispatcher.
             Operand nextAddr = Const(GetNextOpAddress(context.CurrOp));
 
             // Try to continue within this block.
@@ -250,7 +249,7 @@ namespace ARMeilleure.Instructions
 
         private static void EmitBranchFallback(ArmEmitterContext context, Operand address, bool isJump)
         {
-            address = context.BitwiseOr(address, Const(address.Type, 1)); // Set call flag.
+            address = context.BitwiseOr(address, Const(address.Type, (long)CallFlag)); // Set call flag.
             Operand fallbackAddr = context.Call(new _U64_U64(NativeInterface.GetFunctionAddress), address);
             EmitNativeCall(context, fallbackAddr, isJump);
         }

--- a/ARMeilleure/Instructions/InstEmitFlowHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitFlowHelper.cs
@@ -341,7 +341,7 @@ namespace ARMeilleure.Instructions
                 int jumpOffset = entry * JumpTable.JumpTableStride + 8; // Offset directly to the host address.
 
                 // TODO: Relocatable jump table ptr for AOT. Would prefer a solution to patch this constant into functions as they are loaded rather than calculate at runtime.
-                Operand tableEntryPtr = Const(context.JumpTable.BasePointer.ToInt64() + jumpOffset);
+                Operand tableEntryPtr = Const(context.JumpTable.JumpPointer.ToInt64() + jumpOffset);
 
                 Operand funcAddr = context.Load(OperandType.I64, tableEntryPtr);
 

--- a/ARMeilleure/Instructions/InstEmitFlowHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitFlowHelper.cs
@@ -198,10 +198,11 @@ namespace ARMeilleure.Instructions
             Operand nextAddr = Const(GetNextOpAddress(context.CurrOp));
 
             // Try to continue within this block.
-            // If the return address isn't to our next instruction, we need to return to the JIT can figure out what to do.
+            // If the return address isn't to our next instruction, we need to return so the JIT can figure out what to do.
             Operand lblContinue = Label();
 
-            context.BranchIfTrue(lblContinue, context.ICompareEqual(context.BitwiseAnd(returnAddress, Const(~1L)), nextAddr));
+            // We need to clear out the call flag for the return address before comparing it.
+            context.BranchIfTrue(lblContinue, context.ICompareEqual(context.BitwiseAnd(returnAddress, Const(~CallFlag)), nextAddr));
 
             context.Return(returnAddress);
 

--- a/ARMeilleure/Instructions/InstEmitFlowHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitFlowHelper.cs
@@ -263,7 +263,8 @@ namespace ARMeilleure.Instructions
 
                 // It's ours, so what function is it pointing to?
                 Operand missingFunctionLabel = Label();
-                Operand targetFunction = context.Load(OperandType.I64, context.Add(tableAddress, Const(8)));
+                Operand targetFunctionPtr = context.Add(tableAddress, Const(8));
+                Operand targetFunction = context.Load(OperandType.I64, targetFunctionPtr);
                 context.BranchIfFalse(missingFunctionLabel, targetFunction);
 
                 // Call the function.
@@ -276,7 +277,8 @@ namespace ARMeilleure.Instructions
 
                 context.BranchIfFalse(fallbackLabel, goodCallAddr); // Fallback if it doesn't exist yet.
 
-                // Call the function.
+                // Call and save the function.
+                context.Store(targetFunctionPtr, goodCallAddr);
                 EmitNativeCall(context, goodCallAddr, isJump);
                 context.Branch(endLabel);
 

--- a/ARMeilleure/Instructions/InstEmitFlowHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitFlowHelper.cs
@@ -142,7 +142,33 @@ namespace ARMeilleure.Instructions
 
         public static void EmitCall(ArmEmitterContext context, ulong immediate)
         {
-            context.Return(Const(immediate | CallFlag));
+            EmitJumpTableCall(context, Const(immediate));
+        }
+
+        private static void EmitNativeCall(ArmEmitterContext context, Operand funcAddr, bool isJump = false)
+        {
+            context.StoreToContext();
+            Operand returnAddress;
+            if (isJump)
+            {
+                context.Tailcall(funcAddr, context.LoadArgument(OperandType.I64, 0));
+            } 
+            else
+            {
+                returnAddress = context.Call(funcAddr, OperandType.I64, context.LoadArgument(OperandType.I64, 0));
+                context.LoadFromContext();
+
+                // InstEmitFlowHelper.EmitContinueOrReturnCheck(context, returnAddress);
+
+                // If the return address isn't to our next instruction, we need to return to the JIT can figure out what to do.
+                Operand continueLabel = Label();
+                Operand next = Const(GetNextOpAddress(context.CurrOp));
+                context.BranchIfTrue(continueLabel, context.ICompareEqual(context.BitwiseAnd(returnAddress, Const(~1L)), next));
+
+                context.Return(returnAddress);
+
+                context.MarkLabel(continueLabel);
+            }
         }
 
         public static void EmitVirtualCall(ArmEmitterContext context, Operand target)
@@ -150,17 +176,24 @@ namespace ARMeilleure.Instructions
             EmitVirtualCallOrJump(context, target, isJump: false);
         }
 
-        public static void EmitVirtualJump(ArmEmitterContext context, Operand target)
+        public static void EmitVirtualJump(ArmEmitterContext context, Operand target, bool isReturn)
         {
-            EmitVirtualCallOrJump(context, target, isJump: true);
+            EmitVirtualCallOrJump(context, target, isJump: true, isReturn: isReturn);
         }
 
-        private static void EmitVirtualCallOrJump(ArmEmitterContext context, Operand target, bool isJump)
+        private static void EmitVirtualCallOrJump(ArmEmitterContext context, Operand target, bool isJump, bool isReturn = false)
         {
-            context.Return(context.BitwiseOr(target, Const(target.Type, (long)CallFlag)));
+            if (isReturn)
+            {
+                context.Return(target);
+            }
+            else
+            {
+                EmitJumpTableCall(context, target, isJump);
+            }
         }
 
-        private static void EmitContinueOrReturnCheck(ArmEmitterContext context, Operand retVal)
+        public static void EmitContinueOrReturnCheck(ArmEmitterContext context, Operand retVal)
         {
             // Note: The return value of the called method will be placed
             // at the Stack, the return value is always a Int64 with the
@@ -187,6 +220,136 @@ namespace ARMeilleure.Instructions
         private static ulong GetNextOpAddress(OpCode op)
         {
             return op.Address + (ulong)op.OpCodeSizeInBytes;
+        }
+
+        public static void EmitDynamicTableCall(ArmEmitterContext context, Operand tableAddress, Operand address, bool isJump)
+        {
+            if (address.Type == OperandType.I32)
+            {
+                address = context.ZeroExtend32(OperandType.I64, address);
+            }
+
+            // Loop over elements of the dynamic table. Unrolled loop.
+            // TODO: different reserved size for jumps? Need to do some testing to see what is reasonable.
+
+            Operand endLabel = Label();
+            Operand fallbackLabel = Label();
+
+            for (int i = 0; i < JumpTable.DynamicTableElems; i++) 
+            {
+                // TODO: USE COMPARE AND SWAP I64 TO ENSURE ATOMIC OPERATIONS
+
+                Operand nextLabel = Label();
+
+                // Load this entry from the table. 
+                Operand entry = context.Load(OperandType.I64, tableAddress);
+
+                // If it's 0, we can take this entry in the table.
+                // (TODO: compare and exchange with our address _first_ when implemented, then just check if the entry is ours)
+                Operand hasAddressLabel = Label();
+                Operand gotTableLabel = Label();
+                context.BranchIfTrue(hasAddressLabel, entry);
+
+                // Take the entry.
+                context.Store(tableAddress, address);
+                context.Branch(gotTableLabel);
+
+                context.MarkLabel(hasAddressLabel);
+
+                // If there is an entry here, is it ours?
+                context.BranchIfFalse(nextLabel, context.ICompareEqual(entry, address));
+
+                context.MarkLabel(gotTableLabel);
+
+                // It's ours, so what function is it pointing to?
+                Operand missingFunctionLabel = Label();
+                Operand targetFunction = context.Load(OperandType.I64, context.Add(tableAddress, Const(8)));
+                context.BranchIfFalse(missingFunctionLabel, targetFunction);
+
+                // Call the function.
+                EmitNativeCall(context, targetFunction, isJump);
+                context.Branch(endLabel);
+
+                // We need to find the missing function. This can only be from a list of HighCq functions, which the JumpTable maintains.
+                context.MarkLabel(missingFunctionLabel);
+                Operand goodCallAddr = context.Call(new _U64_U64(context.JumpTable.TryGetFunction), address); // TODO: NativeInterface call to it? (easier to AOT)
+
+                context.BranchIfFalse(fallbackLabel, goodCallAddr); // Fallback if it doesn't exist yet.
+
+                // Call the function.
+                EmitNativeCall(context, goodCallAddr, isJump);
+                context.Branch(endLabel);
+
+                context.MarkLabel(nextLabel);
+                tableAddress = context.Add(tableAddress, Const(16)); // Move to the next table entry.
+            }
+
+            context.MarkLabel(fallbackLabel);
+
+            address = context.BitwiseOr(address, Const(address.Type, 1)); // Set call flag.
+
+            Operand fallbackAddr = context.Call(new _U64_U64(NativeInterface.GetFunctionAddress), address);
+            EmitNativeCall(context, fallbackAddr, isJump);
+
+            context.MarkLabel(endLabel);
+        }
+
+        public static void EmitJumpTableCall(ArmEmitterContext context, Operand address, bool isJump = false)
+        {
+            // Does the call have a constant value, or can it be folded to one?
+            // TODO: Constant folding. Indirect calls are slower in the best case and emit more code so we want to avoid them when possible.
+            bool isConst = address.Kind == OperandKind.Constant;
+            long constAddr = (long)address.Value;
+
+            if (isJump || !isConst || !context.HighCq)
+            {
+                if (context.HighCq)
+                {
+                    // Virtual branch/call - store first used addresses on a small table for fast lookup.
+                    int entry = context.JumpTable.ReserveDynamicEntry();
+
+                    int jumpOffset = entry * JumpTable.JumpTableStride * JumpTable.DynamicTableElems;
+                    Operand dynTablePtr = Const(context.JumpTable.DynamicPointer.ToInt64() + jumpOffset);
+
+                    EmitDynamicTableCall(context, dynTablePtr, address, isJump);
+                }
+                else
+                {
+                    // Don't emit indirect calls or jumps if we're compiling in lowCq mode.
+                    // This avoids wasting space on the jump and indirect tables.
+                    context.Return(context.BitwiseOr(address, Const(address.Type, 1))); // Set call flag.
+                }
+            }
+            else
+            {
+                int entry = context.JumpTable.ReserveTableEntry(context.BaseAddress & (~3L), constAddr);
+
+                int jumpOffset = entry * JumpTable.JumpTableStride + 8; // Offset directly to the host address.
+
+                // TODO: Portable jump table ptr with IR adding of the offset. Will be easy to relocate for things like AOT.
+                Operand tableEntryPtr = Const(context.JumpTable.BasePointer.ToInt64() + jumpOffset);
+
+                Operand funcAddr = context.Load(OperandType.I64, tableEntryPtr);
+
+                Operand directCallLabel = Label();
+                Operand endLabel = Label();
+
+                // Host address in the table is 0 until the function is rejit.
+                context.BranchIfTrue(directCallLabel, funcAddr);
+
+                // Call the function through the translator until it is rejit.
+                address = context.BitwiseOr(address, Const(address.Type, 1)); // Set call flag.
+                Operand fallbackAddr = context.Call(new _U64_U64(NativeInterface.GetFunctionAddress), address);
+                EmitNativeCall(context, fallbackAddr);
+
+                context.Branch(endLabel);
+
+                context.MarkLabel(directCallLabel);
+
+                EmitNativeCall(context, funcAddr); // Call the function directly if it is present in the entry.
+
+                context.MarkLabel(endLabel);
+            }
         }
     }
 }

--- a/ARMeilleure/Instructions/InstEmitHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitHelper.cs
@@ -149,7 +149,7 @@ namespace ARMeilleure.Instructions
             switch (context.CurrOp)
             {
                 case IOpCode32MemMult op:
-                    return true;
+                    return true; // Setting PC using LDM is nearly always a return.
                 case OpCode32AluRsImm op:
                     return op.Rm == RegisterAlias.Aarch32Lr;
                 case OpCode32AluRsReg op:
@@ -157,7 +157,7 @@ namespace ARMeilleure.Instructions
                 case OpCode32AluReg op:
                     return op.Rm == RegisterAlias.Aarch32Lr;
                 case OpCode32Mem op:
-                    return op.Rn == RegisterAlias.Aarch32Sp && op.WBack && !op.Index;
+                    return op.Rn == RegisterAlias.Aarch32Sp && op.WBack && !op.Index; // Setting PC to an address stored on the stack is nearly always a return.
             }
             return false;
         }

--- a/ARMeilleure/Instructions/InstEmitMemoryHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitMemoryHelper.cs
@@ -51,7 +51,7 @@ namespace ARMeilleure.Instructions
                 EmitReadInt(context, address, rt, size);
             }
 
-            if (!isSimd)
+            if (!isSimd && !(context.CurrOp is OpCode32 && rt == State.RegisterAlias.Aarch32Pc))
             {
                 Operand value = GetInt(context, rt);
 

--- a/ARMeilleure/Instructions/NativeInterface.cs
+++ b/ARMeilleure/Instructions/NativeInterface.cs
@@ -408,13 +408,16 @@ namespace ARMeilleure.Instructions
             _context.ExclusiveAddress = ulong.MaxValue;
         }
 
-        public static void CheckSynchronization()
+        public static bool CheckSynchronization()
         {
             Statistics.PauseTimer();
 
-            GetContext().CheckInterrupt();
+            ExecutionContext context = GetContext();
+            context.CheckInterrupt();
 
             Statistics.ResumeTimer();
+
+            return context.Running;
         }
 
         public static ExecutionContext GetContext()

--- a/ARMeilleure/Instructions/NativeInterface.cs
+++ b/ARMeilleure/Instructions/NativeInterface.cs
@@ -390,6 +390,12 @@ namespace ARMeilleure.Instructions
             return (ulong)function.GetPointer().ToInt64();
         }
 
+        public static ulong GetHighCqFunctionAddress(ulong address)
+        {
+            TranslatedFunction function = _context.Translator.TryGetHighCqFunction(address);
+            return (function != null) ? (ulong)function.GetPointer().ToInt64() : 0;
+        }
+
         public static void ClearExclusive()
         {
             _context.ExclusiveAddress = ulong.MaxValue;

--- a/ARMeilleure/IntermediateRepresentation/Instruction.cs
+++ b/ARMeilleure/IntermediateRepresentation/Instruction.cs
@@ -13,7 +13,6 @@ namespace ARMeilleure.IntermediateRepresentation
         ByteSwap,
         Call,
         CompareAndSwap,
-        CompareAndSwap128,
         CompareEqual,
         CompareGreater,
         CompareGreaterOrEqual,

--- a/ARMeilleure/IntermediateRepresentation/Instruction.cs
+++ b/ARMeilleure/IntermediateRepresentation/Instruction.cs
@@ -52,6 +52,7 @@ namespace ARMeilleure.IntermediateRepresentation
         Store16,
         Store8,
         Subtract,
+        Tailcall,
         VectorCreateScalar,
         VectorExtract,
         VectorExtract16,

--- a/ARMeilleure/IntermediateRepresentation/Instruction.cs
+++ b/ARMeilleure/IntermediateRepresentation/Instruction.cs
@@ -12,6 +12,7 @@ namespace ARMeilleure.IntermediateRepresentation
         BranchIfTrue,
         ByteSwap,
         Call,
+        CompareAndSwap,
         CompareAndSwap128,
         CompareEqual,
         CompareGreater,

--- a/ARMeilleure/Memory/MemoryManagement.cs
+++ b/ARMeilleure/Memory/MemoryManagement.cs
@@ -44,6 +44,25 @@ namespace ARMeilleure.Memory
             }
         }
 
+        public static bool Commit(IntPtr address, ulong size)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                IntPtr sizeNint = new IntPtr((long)size);
+
+                return MemoryManagementWindows.Commit(address, sizeNint);
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
+                     RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return MemoryManagementUnix.Commit(address, size);
+            }
+            else
+            {
+                throw new PlatformNotSupportedException();
+            }
+        }
+
         public static void Reprotect(IntPtr address, ulong size, MemoryProtection permission)
         {
             bool result;
@@ -67,6 +86,25 @@ namespace ARMeilleure.Memory
             if (!result)
             {
                 throw new MemoryProtectionException(permission);
+            }
+        }
+
+        public static IntPtr Reserve(ulong size)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                IntPtr sizeNint = new IntPtr((long)size);
+
+                return MemoryManagementWindows.Reserve(sizeNint);
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
+                     RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return MemoryManagementUnix.Reserve(size);
+            }
+            else
+            {
+                throw new PlatformNotSupportedException();
             }
         }
 

--- a/ARMeilleure/Memory/MemoryManagementUnix.cs
+++ b/ARMeilleure/Memory/MemoryManagementUnix.cs
@@ -57,13 +57,6 @@ namespace ARMeilleure.Memory
                 throw new OutOfMemoryException();
             }
 
-            unsafe
-            {
-                ptr = new IntPtr(ptr.ToInt64() + (long)pageSize);
-
-                *((ulong*)ptr - 1) = size;
-            }
-
             return ptr;
         }
 

--- a/ARMeilleure/Memory/MemoryManagementUnix.cs
+++ b/ARMeilleure/Memory/MemoryManagementUnix.cs
@@ -30,11 +30,41 @@ namespace ARMeilleure.Memory
             return ptr;
         }
 
+        public static bool Commit(IntPtr address, ulong size)
+        {
+            return Syscall.mprotect(address, size, MmapProts.PROT_READ | MmapProts.PROT_WRITE) == 0;
+        }
+
         public static bool Reprotect(IntPtr address, ulong size, Memory.MemoryProtection protection)
         {
             MmapProts prot = GetProtection(protection);
 
             return Syscall.mprotect(address, size, prot) == 0;
+        }
+
+        public static IntPtr Reserve(ulong size)
+        {
+            ulong pageSize = (ulong)Syscall.sysconf(SysconfName._SC_PAGESIZE);
+
+            const MmapProts prot = MmapProts.PROT_NONE;
+
+            const MmapFlags flags = MmapFlags.MAP_PRIVATE | MmapFlags.MAP_ANONYMOUS;
+
+            IntPtr ptr = Syscall.mmap(IntPtr.Zero, size + pageSize, prot, flags, -1, 0);
+
+            if (ptr == IntPtr.Zero)
+            {
+                throw new OutOfMemoryException();
+            }
+
+            unsafe
+            {
+                ptr = new IntPtr(ptr.ToInt64() + (long)pageSize);
+
+                *((ulong*)ptr - 1) = size;
+            }
+
+            return ptr;
         }
 
         private static MmapProts GetProtection(Memory.MemoryProtection protection)

--- a/ARMeilleure/Memory/MemoryManagementWindows.cs
+++ b/ARMeilleure/Memory/MemoryManagementWindows.cs
@@ -89,11 +89,34 @@ namespace ARMeilleure.Memory
             return ptr;
         }
 
+        public static bool Commit(IntPtr location, IntPtr size)
+        {
+            const AllocationType flags = AllocationType.Commit;
+
+            IntPtr ptr = VirtualAlloc(location, size, flags, MemoryProtection.ReadWrite);
+
+            return ptr != IntPtr.Zero;
+        }
+
         public static bool Reprotect(IntPtr address, IntPtr size, Memory.MemoryProtection protection)
         {
             MemoryProtection prot = GetProtection(protection);
 
             return VirtualProtect(address, size, prot, out _);
+        }
+
+        public static IntPtr Reserve(IntPtr size)
+        {
+            const AllocationType flags = AllocationType.Reserve;
+
+            IntPtr ptr = VirtualAlloc(IntPtr.Zero, size, flags, MemoryProtection.ReadWrite);
+
+            if (ptr == IntPtr.Zero)
+            {
+                throw new OutOfMemoryException();
+            }
+
+            return ptr;
         }
 
         private static MemoryProtection GetProtection(Memory.MemoryProtection protection)

--- a/ARMeilleure/Memory/MemoryManagerPal.cs
+++ b/ARMeilleure/Memory/MemoryManagerPal.cs
@@ -53,7 +53,7 @@ namespace ARMeilleure.Memory
                 Operand expected = context.LoadArgument(OperandType.V128, 1);
                 Operand desired  = context.LoadArgument(OperandType.V128, 2);
 
-                Operand result = context.CompareAndSwap128(address, expected, desired);
+                Operand result = context.CompareAndSwap(address, expected, desired);
 
                 context.Return(result);
 

--- a/ARMeilleure/Memory/ReservedRegion.cs
+++ b/ARMeilleure/Memory/ReservedRegion.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ARMeilleure.Memory
+{
+    class ReservedRegion
+    {
+        public IntPtr Pointer { get; }
+
+        private ulong _maxSize;
+        private ulong _sizeGranularity;
+        private ulong _currentSize;
+
+        public ReservedRegion(ulong maxSize, ulong granularity)
+        {
+            Pointer = MemoryManagement.Reserve(maxSize);
+            _maxSize = maxSize;
+            _sizeGranularity = granularity;
+            _currentSize = 0;
+        }
+
+        public void ExpandIfNeeded(ulong desiredSize)
+        {
+            if (desiredSize > _maxSize)
+            {
+                throw new OutOfMemoryException();
+            }
+
+            if (desiredSize > _currentSize)
+            {
+                // Lock, and then check again. We only want to commit once.
+                lock (this)
+                {
+                    if (desiredSize >= _currentSize)
+                    {
+                        ulong overflowBytes = desiredSize - _currentSize;
+                        ulong moreToCommit = (((_sizeGranularity - 1) + overflowBytes) / _sizeGranularity) * _sizeGranularity; // Round up.
+                        MemoryManagement.Commit(new IntPtr((long)Pointer + (long)_currentSize), moreToCommit);
+                        _currentSize += moreToCommit;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ARMeilleure/Memory/ReservedRegion.cs
+++ b/ARMeilleure/Memory/ReservedRegion.cs
@@ -6,14 +6,21 @@ namespace ARMeilleure.Memory
 {
     class ReservedRegion
     {
+        private const int DefaultGranularity = 65536; // Mapping granularity in Windows.
+
         public IntPtr Pointer { get; }
 
         private ulong _maxSize;
         private ulong _sizeGranularity;
         private ulong _currentSize;
 
-        public ReservedRegion(ulong maxSize, ulong granularity)
+        public ReservedRegion(ulong maxSize, ulong granularity = 0)
         {
+            if (granularity == 0)
+            {
+                granularity = DefaultGranularity;
+            }
+
             Pointer = MemoryManagement.Reserve(maxSize);
             _maxSize = maxSize;
             _sizeGranularity = granularity;

--- a/ARMeilleure/State/ExecutionContext.cs
+++ b/ARMeilleure/State/ExecutionContext.cs
@@ -5,7 +5,7 @@ namespace ARMeilleure.State
 {
     public class ExecutionContext
     {
-        private const int MinCountForCheck = 40000;
+        private const int MinCountForCheck = 4000;
 
         private NativeContext _nativeContext;
 
@@ -124,6 +124,12 @@ namespace ARMeilleure.State
         internal void OnUndefined(ulong address, int opCode)
         {
             Undefined?.Invoke(this, new InstUndefinedEventArgs(address, opCode));
+        }
+
+        public void StopRunning()
+        {
+            Running = false;
+            _nativeContext.SetCounter(0);
         }
 
         public void Dispose()

--- a/ARMeilleure/State/ExecutionContext.cs
+++ b/ARMeilleure/State/ExecutionContext.cs
@@ -57,7 +57,7 @@ namespace ARMeilleure.State
             }
         }
 
-        public bool Running { get; set; }
+        internal bool Running { get; private set; }
 
         public event EventHandler<EventArgs>              Interrupt;
         public event EventHandler<InstExceptionEventArgs> Break;

--- a/ARMeilleure/State/NativeContext.cs
+++ b/ARMeilleure/State/NativeContext.cs
@@ -10,7 +10,7 @@ namespace ARMeilleure.State
         private const int IntSize   = 8;
         private const int VecSize   = 16;
         private const int FlagSize  = 4;
-        private const int ExtraSize = 4;
+        private const int ExtraSize = 8;
 
         private const int TotalSize = RegisterConsts.IntRegsCount * IntSize  +
                                       RegisterConsts.VecRegsCount * VecSize  +
@@ -181,6 +181,14 @@ namespace ARMeilleure.State
                    RegisterConsts.VecRegsCount * VecSize  +
                    RegisterConsts.FlagsCount   * FlagSize +
                    RegisterConsts.FpFlagsCount * FlagSize;
+        }
+
+        public static int GetCallAddressOffset()
+        {
+            return RegisterConsts.IntRegsCount * IntSize  +
+                   RegisterConsts.VecRegsCount * VecSize  +
+                   RegisterConsts.FlagsCount   * FlagSize +
+                   RegisterConsts.FpFlagsCount * FlagSize + 4;
         }
 
         public void Dispose()

--- a/ARMeilleure/Translation/ArmEmitterContext.cs
+++ b/ARMeilleure/Translation/ArmEmitterContext.cs
@@ -41,10 +41,19 @@ namespace ARMeilleure.Translation
 
         public Aarch32Mode Mode { get; }
 
-        public ArmEmitterContext(MemoryManager memory, Aarch32Mode mode)
+        public JumpTable JumpTable { get; }
+
+        public long BaseAddress { get; }
+
+        public bool HighCq { get; }
+
+        public ArmEmitterContext(MemoryManager memory, JumpTable jumpTable, long baseAddress, bool highCq, Aarch32Mode mode)
         {
-            Memory = memory;
-            Mode   = mode;
+            Memory      = memory;
+            JumpTable   = jumpTable;
+            BaseAddress = baseAddress;
+            HighCq      = highCq;
+            Mode        = mode;
 
             _labels = new Dictionary<ulong, Operand>();
         }

--- a/ARMeilleure/Translation/DirectCallStubs.cs
+++ b/ARMeilleure/Translation/DirectCallStubs.cs
@@ -3,6 +3,7 @@ using ARMeilleure.IntermediateRepresentation;
 using ARMeilleure.State;
 using System;
 using System.Runtime.InteropServices;
+
 using static ARMeilleure.IntermediateRepresentation.OperandHelper;
 
 namespace ARMeilleure.Translation

--- a/ARMeilleure/Translation/DirectCallStubs.cs
+++ b/ARMeilleure/Translation/DirectCallStubs.cs
@@ -1,0 +1,130 @@
+﻿using ARMeilleure.Instructions;
+using ARMeilleure.IntermediateRepresentation;
+using ARMeilleure.State;
+using System;
+using System.Runtime.InteropServices;
+using static ARMeilleure.IntermediateRepresentation.OperandHelper;
+
+namespace ARMeilleure.Translation
+{
+    static class DirectCallStubs
+    {
+        private delegate long GuestFunction(IntPtr nativeContextPtr);
+
+        private static GuestFunction _directCallStub;
+        private static GuestFunction _directTailCallStub;
+        private static GuestFunction _indirectCallStub;
+        private static GuestFunction _indirectTailCallStub;
+
+        private static object _lock;
+        private static bool _initialized;
+
+        static DirectCallStubs()
+        {
+            _lock = new object();
+        }
+
+        public static void InitializeStubs()
+        {
+            if (_initialized) return;
+            lock (_lock)
+            {
+                if (_initialized) return;
+                _directCallStub = GenerateDirectCallStub(false);
+                _directTailCallStub = GenerateDirectCallStub(true);
+                _indirectCallStub = GenerateIndirectCallStub(false);
+                _indirectTailCallStub = GenerateIndirectCallStub(true);
+                _initialized = true;
+            }
+        }
+
+        public static IntPtr DirectCallStub(bool tailCall)
+        {
+            return Marshal.GetFunctionPointerForDelegate(tailCall ? _directTailCallStub : _directCallStub);
+        }
+
+        public static IntPtr IndirectCallStub(bool tailCall)
+        {
+            return Marshal.GetFunctionPointerForDelegate(tailCall ? _indirectTailCallStub : _indirectCallStub);
+        }
+
+        private static void EmitCall(EmitterContext context, Operand address, bool tailCall)
+        {
+            if (tailCall)
+            {
+                context.Tailcall(address, context.LoadArgument(OperandType.I64, 0));
+            }
+            else
+            {
+                context.Return(context.Call(address, OperandType.I64, context.LoadArgument(OperandType.I64, 0)));
+            }
+        }
+
+        /// <summary>
+        /// Generates a stub that is used to find function addresses. Used for direct calls when their jump table does not have the host address yet.
+        /// Takes a NativeContext like a translated guest function, and extracts the target address from the NativeContext.
+        /// When the target function is compiled in highCq, all table entries are updated to point to that function instead of this stub by the translator.
+        /// </summary>
+        private static GuestFunction GenerateDirectCallStub(bool tailCall)
+        {
+            EmitterContext context = new EmitterContext();
+
+            Operand nativeContextPtr = context.LoadArgument(OperandType.I64, 0);
+
+            Operand address = context.Load(OperandType.I64, context.Add(nativeContextPtr, Const((long)NativeContext.GetCallAddressOffset())));
+
+            address = context.BitwiseOr(address, Const(address.Type, 1)); // Set call flag.
+            Operand functionAddr = context.Call(new _U64_U64(NativeInterface.GetFunctionAddress), address);
+            EmitCall(context, functionAddr, tailCall);
+
+            ControlFlowGraph cfg = context.GetControlFlowGraph();
+
+            OperandType[] argTypes = new OperandType[]
+            {
+                OperandType.I64
+            };
+
+            return Compiler.Compile<GuestFunction>(
+                cfg,
+                argTypes,
+                OperandType.I64,
+                CompilerOptions.HighCq);
+        }
+
+        /// <summary>
+        /// Generates a stub that is used to find function addresses and add them to an indirect table. 
+        /// Used for indirect calls entries (already claimed) when their jump table does not have the host address yet.
+        /// Takes a NativeContext like a translated guest function, and extracts the target indirect table entry from the NativeContext.
+        /// If the function we find is highCq, the entry in the table us updated to point to that function rather than this stub.
+        /// </summary>
+        private static GuestFunction GenerateIndirectCallStub(bool tailCall)
+        {
+            EmitterContext context = new EmitterContext();
+
+            Operand nativeContextPtr = context.LoadArgument(OperandType.I64, 0);
+
+            Operand entryAddress = context.Load(OperandType.I64, context.Add(nativeContextPtr, Const((long)NativeContext.GetCallAddressOffset())));
+            Operand address = context.Load(OperandType.I64, entryAddress);
+
+            // We need to find the missing function. If the function is HighCq, then it replaces this stub in the indirect table.
+            // Either way, we call it afterwards.
+            Operand functionAddr = context.Call(new _U64_U64_U64(NativeInterface.GetIndirectFunctionAddress), address, entryAddress);
+
+            // Call and save the function.
+            EmitCall(context, functionAddr, tailCall);
+
+            ControlFlowGraph cfg = context.GetControlFlowGraph();
+
+            OperandType[] argTypes = new OperandType[]
+            {
+                    OperandType.I64
+            };
+
+            return Compiler.Compile<GuestFunction>(
+                cfg,
+                argTypes,
+                OperandType.I64,
+                CompilerOptions.HighCq);
+        }
+    }
+}

--- a/ARMeilleure/Translation/DirectCallStubs.cs
+++ b/ARMeilleure/Translation/DirectCallStubs.cs
@@ -96,7 +96,7 @@ namespace ARMeilleure.Translation
         /// Generates a stub that is used to find function addresses and add them to an indirect table. 
         /// Used for indirect calls entries (already claimed) when their jump table does not have the host address yet.
         /// Takes a NativeContext like a translated guest function, and extracts the target indirect table entry from the NativeContext.
-        /// If the function we find is highCq, the entry in the table us updated to point to that function rather than this stub.
+        /// If the function we find is highCq, the entry in the table is updated to point to that function rather than this stub.
         /// </summary>
         private static GuestFunction GenerateIndirectCallStub(bool tailCall)
         {

--- a/ARMeilleure/Translation/DirectCallStubs.cs
+++ b/ARMeilleure/Translation/DirectCallStubs.cs
@@ -118,7 +118,7 @@ namespace ARMeilleure.Translation
 
             OperandType[] argTypes = new OperandType[]
             {
-                    OperandType.I64
+                OperandType.I64
             };
 
             return Compiler.Compile<GuestFunction>(

--- a/ARMeilleure/Translation/EmitterContext.cs
+++ b/ARMeilleure/Translation/EmitterContext.cs
@@ -158,14 +158,7 @@ namespace ARMeilleure.Translation
 
         public Operand CompareAndSwap(Operand address, Operand expected, Operand desired)
         {
-            if (desired.Type == OperandType.V128)
-            {
-                return Add(Instruction.CompareAndSwap128, Local(OperandType.V128), address, expected, desired);
-            }
-            else
-            {
-                return Add(Instruction.CompareAndSwap, Local(desired.Type), address, expected, desired);
-            }
+            return Add(Instruction.CompareAndSwap, Local(desired.Type), address, expected, desired);
         }
 
         public Operand ConditionalSelect(Operand op1, Operand op2, Operand op3)

--- a/ARMeilleure/Translation/EmitterContext.cs
+++ b/ARMeilleure/Translation/EmitterContext.cs
@@ -156,6 +156,11 @@ namespace ARMeilleure.Translation
             _needsNewBlock = true;
         }
 
+        public Operand CompareAndSwap(Operand address, Operand expected, Operand desired)
+        {
+            return Add(Instruction.CompareAndSwap, Local(desired.Type), address, expected, desired);
+        }
+
         public Operand CompareAndSwap128(Operand address, Operand expected, Operand desired)
         {
             return Add(Instruction.CompareAndSwap128, Local(OperandType.V128), address, expected, desired);

--- a/ARMeilleure/Translation/EmitterContext.cs
+++ b/ARMeilleure/Translation/EmitterContext.cs
@@ -143,6 +143,19 @@ namespace ARMeilleure.Translation
             }
         }
 
+        public void Tailcall(Operand address, params Operand[] callArgs)
+        {
+            Operand[] args = new Operand[callArgs.Length + 1];
+
+            args[0] = address;
+
+            Array.Copy(callArgs, 0, args, 1, callArgs.Length);
+
+            Add(Instruction.Tailcall, null, args);
+
+            _needsNewBlock = true;
+        }
+
         public Operand CompareAndSwap128(Operand address, Operand expected, Operand desired)
         {
             return Add(Instruction.CompareAndSwap128, Local(OperandType.V128), address, expected, desired);

--- a/ARMeilleure/Translation/EmitterContext.cs
+++ b/ARMeilleure/Translation/EmitterContext.cs
@@ -158,12 +158,14 @@ namespace ARMeilleure.Translation
 
         public Operand CompareAndSwap(Operand address, Operand expected, Operand desired)
         {
-            return Add(Instruction.CompareAndSwap, Local(desired.Type), address, expected, desired);
-        }
-
-        public Operand CompareAndSwap128(Operand address, Operand expected, Operand desired)
-        {
-            return Add(Instruction.CompareAndSwap128, Local(OperandType.V128), address, expected, desired);
+            if (desired.Type == OperandType.V128)
+            {
+                return Add(Instruction.CompareAndSwap128, Local(OperandType.V128), address, expected, desired);
+            }
+            else
+            {
+                return Add(Instruction.CompareAndSwap, Local(desired.Type), address, expected, desired);
+            }
         }
 
         public Operand ConditionalSelect(Operand op1, Operand op2, Operand op3)

--- a/ARMeilleure/Translation/JitCache.cs
+++ b/ARMeilleure/Translation/JitCache.cs
@@ -13,9 +13,11 @@ namespace ARMeilleure.Translation
 
         private const int CodeAlignment = 4; // Bytes
 
-        private const int CacheSize = 512 * 1024 * 1024;
+        private const int CacheSize = 2047 * 1024 * 1024;
 
-        private static IntPtr _basePointer;
+        private static ReservedRegion _jitRegion;
+
+        private static IntPtr _basePointer => _jitRegion.Pointer;
 
         private static int _offset;
 
@@ -25,10 +27,11 @@ namespace ARMeilleure.Translation
 
         static JitCache()
         {
-            _basePointer = MemoryManagement.Allocate(CacheSize);
+            _jitRegion = new ReservedRegion(CacheSize, 65536);
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
+                _jitRegion.ExpandIfNeeded(PageSize);
                 JitUnwindWindows.InstallFunctionTableHandler(_basePointer, CacheSize);
 
                 // The first page is used for the table based SEH structs.
@@ -96,6 +99,8 @@ namespace ARMeilleure.Translation
             int allocOffset = _offset;
 
             _offset += codeSize;
+
+            _jitRegion.ExpandIfNeeded((ulong)_offset);
 
             if ((ulong)(uint)_offset > CacheSize)
             {

--- a/ARMeilleure/Translation/JitCache.cs
+++ b/ARMeilleure/Translation/JitCache.cs
@@ -27,7 +27,7 @@ namespace ARMeilleure.Translation
 
         static JitCache()
         {
-            _jitRegion = new ReservedRegion(CacheSize, 65536);
+            _jitRegion = new ReservedRegion(CacheSize);
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {

--- a/ARMeilleure/Translation/JumpTable.cs
+++ b/ARMeilleure/Translation/JumpTable.cs
@@ -38,7 +38,7 @@ namespace ARMeilleure.Translation
         // If it is 0, NativeInterface is called to find the rejited address of the call.
         // If none is found, the hostAddress entry stays at 0. Otherwise, the new address is placed in the entry.
 
-        // If the table size is exhausted and we didn't find our desired address, we fall back to doing requesting 
+        // If the table size is exhausted and we didn't find our desired address, we fall back to requesting 
         // the function from the JIT.
 
         private const int DynamicTableSize = 1048576;
@@ -76,7 +76,8 @@ namespace ARMeilleure.Translation
 
             // Update all jump table entries that target this address.
             LinkedList<int> myDependants;
-            if (_dependants.TryGetValue(address, out myDependants)) {
+            if (_dependants.TryGetValue(address, out myDependants)) 
+            {
                 lock (myDependants)
                 {
                     foreach (var entry in myDependants)
@@ -93,7 +94,7 @@ namespace ARMeilleure.Translation
             int entry = Interlocked.Increment(ref _dynTableEnd);
             if (entry >= DynamicTableSize)
             {
-                throw new OutOfMemoryException("JIT Dynamic Jump Table Exhausted.");
+                throw new OutOfMemoryException("JIT Dynamic Jump Table exhausted.");
             }
 
             _dynamicRegion.ExpandIfNeeded((ulong)((entry + 1) * DynamicTableStride));
@@ -116,7 +117,7 @@ namespace ARMeilleure.Translation
             int entry = Interlocked.Increment(ref _tableEnd);
             if (entry >= JumpTableSize)
             {
-                throw new OutOfMemoryException("JIT Direct Jump Table Exhausted.");
+                throw new OutOfMemoryException("JIT Direct Jump Table exhausted.");
             }
 
             _jumpRegion.ExpandIfNeeded((ulong)((entry + 1) * JumpTableStride));

--- a/ARMeilleure/Translation/JumpTable.cs
+++ b/ARMeilleure/Translation/JumpTable.cs
@@ -62,8 +62,8 @@ namespace ARMeilleure.Translation
 
         public JumpTable()
         {
-            _jumpRegion = new ReservedRegion(JumpTableByteSize, 65536);
-            _dynamicRegion = new ReservedRegion(DynamicTableByteSize, 65536);
+            _jumpRegion = new ReservedRegion(JumpTableByteSize);
+            _dynamicRegion = new ReservedRegion(DynamicTableByteSize);
 
             _targets = new ConcurrentDictionary<ulong, TranslatedFunction>();
             _dependants = new ConcurrentDictionary<ulong, LinkedList<int>>();

--- a/ARMeilleure/Translation/JumpTable.cs
+++ b/ARMeilleure/Translation/JumpTable.cs
@@ -36,7 +36,7 @@ namespace ARMeilleure.Translation
 
         private const int DynamicTableSize = 1048576;
 
-        public const int DynamicTableElems = 10;
+        public const int DynamicTableElems = 1;
 
         private const int DynamicTableByteSize = DynamicTableSize * JumpTableStride * DynamicTableElems;
 
@@ -77,14 +77,14 @@ namespace ARMeilleure.Translation
             }
         }
 
-        public ulong TryGetFunction(ulong address)
+        public TranslatedFunction TryGetFunction(ulong address)
         {
             TranslatedFunction result;
             if (_targets.TryGetValue(address, out result))
             {
-                return (ulong)result.GetPointer().ToInt64();
+                return result;
             }
-            return 0;
+            return null;
         }
 
         public int ReserveDynamicEntry()

--- a/ARMeilleure/Translation/JumpTable.cs
+++ b/ARMeilleure/Translation/JumpTable.cs
@@ -1,0 +1,128 @@
+﻿using ARMeilleure.Memory;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace ARMeilleure.Translation
+{
+    class JumpTable
+    {
+        // The jump table is a block of (guestAddress, hostAddress) function mappings.
+        // Each entry corresponds to one branch in a JIT compiled function. The entries are
+        // reserved specifically for each call.
+        // The _dependants dictionary can be used to update the hostAddress for any functions that change.
+
+        public const int JumpTableStride = 16; // 8 byte guest address, 8 byte host address
+
+        private const int JumpTableSize = 1048576;
+
+        private const int JumpTableByteSize = JumpTableSize * JumpTableStride;
+
+        // The dynamic table is also a block of (guestAddress, hostAddress) function mappings.
+        // The main difference is that indirect calls and jumps reserve _multiple_ entries on the table.
+        // These start out as all 0. When an indirect call is made, it tries to find the guest address on the table.
+
+        // If we get to an empty address, the guestAddress is set to the call that we want.
+
+        // If we get to a guestAddress that matches our own (or we just claimed it), the hostAddress is read.
+        // If it is non-zero, we immediately branch or call the host function.
+        // If it is 0, NativeInterface is called to find the rejited address of the call.
+        // If none is found, the hostAddress entry stays at 0. Otherwise, the new address is placed in the entry.
+
+        // If the table size is exhausted and we didn't find our desired address, we fall back to doing requesting 
+        // the function from the JIT.
+
+        private const int DynamicTableSize = 1048576;
+
+        public const int DynamicTableElems = 10;
+
+        private const int DynamicTableByteSize = DynamicTableSize * JumpTableStride * DynamicTableElems;
+
+        private int _tableEnd = 0;
+        private int _dynTableEnd = 0;
+
+        private ConcurrentDictionary<ulong, TranslatedFunction> _targets;
+        private ConcurrentDictionary<ulong, LinkedList<int>> _dependants; // TODO: Attach to TranslatedFunction or a wrapper class.
+
+        public IntPtr BasePointer { get; }
+        public IntPtr DynamicPointer { get; }
+
+        public JumpTable()
+        {
+            BasePointer = MemoryManagement.Allocate(JumpTableByteSize);
+            DynamicPointer = MemoryManagement.Allocate(DynamicTableByteSize);
+
+            _targets = new ConcurrentDictionary<ulong, TranslatedFunction>();
+            _dependants = new ConcurrentDictionary<ulong, LinkedList<int>>();
+        }
+
+        public void RegisterFunction(ulong address, TranslatedFunction func) {
+            address &= ~3UL;
+            _targets.AddOrUpdate(address, func, (key, oldFunc) => func);
+            long funcPtr = func.GetPointer().ToInt64();
+
+            // Update all jump table entries that target this address.
+            LinkedList<int> myDependants;
+            if (_dependants.TryGetValue(address, out myDependants)) {
+                lock (myDependants)
+                {
+                    foreach (var entry in myDependants)
+                    {
+                        IntPtr addr = BasePointer + entry * JumpTableStride;
+                        Marshal.WriteInt64(addr, 8, funcPtr);
+                    }
+                }
+            }
+        }
+
+        public ulong TryGetFunction(ulong address)
+        {
+            TranslatedFunction result;
+            if (_targets.TryGetValue(address, out result))
+            {
+                return (ulong)result.GetPointer().ToInt64();
+            }
+            return 0;
+        }
+
+        public int ReserveDynamicEntry()
+        {
+            int entry = Interlocked.Increment(ref _dynTableEnd);
+            if (entry >= DynamicTableSize)
+            {
+                throw new OutOfMemoryException("JIT Dynamic Jump Table Exhausted.");
+            }
+            return entry;
+        }
+
+        public int ReserveTableEntry(long ownerAddress, long address)
+        {
+            int entry = Interlocked.Increment(ref _tableEnd);
+            if (entry >= JumpTableSize)
+            {
+                throw new OutOfMemoryException("JIT Direct Jump Table Exhausted.");
+            }
+
+            // Is the address we have already registered? If so, put the function address in the jump table.
+            long value = 0;
+            TranslatedFunction func;
+            if (_targets.TryGetValue((ulong)address, out func))
+            {
+                value = func.GetPointer().ToInt64();
+            }
+
+            // Make sure changes to the function at the target address update this jump table entry.
+            LinkedList<int> targetDependants = _dependants.GetOrAdd((ulong)address, (addr) => new LinkedList<int>());
+            targetDependants.AddLast(entry);
+
+            IntPtr addr = BasePointer + entry * JumpTableStride;
+
+            Marshal.WriteInt64(addr, 0, address);
+            Marshal.WriteInt64(addr, 8, value);
+
+            return entry;
+        }
+    }
+}

--- a/ARMeilleure/Translation/TranslatedFunction.cs
+++ b/ARMeilleure/Translation/TranslatedFunction.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace ARMeilleure.Translation
@@ -25,6 +27,11 @@ namespace ARMeilleure.Translation
         public bool ShouldRejit()
         {
             return _rejit && Interlocked.Increment(ref _callCount) == MinCallsForRejit;
+        }
+
+        public IntPtr GetPointer()
+        {
+            return Marshal.GetFunctionPointerForDelegate(_func);
         }
     }
 }

--- a/ARMeilleure/Translation/TranslatedFunction.cs
+++ b/ARMeilleure/Translation/TranslatedFunction.cs
@@ -13,6 +13,8 @@ namespace ARMeilleure.Translation
         private bool _rejit;
         private int  _callCount;
 
+        public bool HighCq => !_rejit;
+
         public TranslatedFunction(GuestFunction func, bool rejit)
         {
             _func  = func;

--- a/ARMeilleure/Translation/Translator.cs
+++ b/ARMeilleure/Translation/Translator.cs
@@ -20,6 +20,8 @@ namespace ARMeilleure.Translation
 
         private ConcurrentDictionary<ulong, TranslatedFunction> _funcs;
 
+        private JumpTable _jumpTable;
+
         private PriorityQueue<RejitRequest> _backgroundQueue;
 
         private AutoResetEvent _backgroundTranslatorEvent;
@@ -31,6 +33,8 @@ namespace ARMeilleure.Translation
             _memory = memory;
 
             _funcs = new ConcurrentDictionary<ulong, TranslatedFunction>();
+
+            _jumpTable = new JumpTable();
 
             _backgroundQueue = new PriorityQueue<RejitRequest>(2);
 
@@ -46,6 +50,7 @@ namespace ARMeilleure.Translation
                     TranslatedFunction func = Translate(request.Address, request.Mode, highCq: true);
 
                     _funcs.AddOrUpdate(request.Address, func, (key, oldFunc) => func);
+                    _jumpTable.RegisterFunction(request.Address, func);
                 }
                 else
                 {
@@ -69,7 +74,7 @@ namespace ARMeilleure.Translation
 
             Statistics.InitializeTimer();
 
-            NativeInterface.RegisterThread(context, _memory);
+            NativeInterface.RegisterThread(context, _memory, this);
 
             do
             {
@@ -98,7 +103,7 @@ namespace ARMeilleure.Translation
             return nextAddr;
         }
 
-        private TranslatedFunction GetOrTranslate(ulong address, ExecutionMode mode)
+        internal TranslatedFunction GetOrTranslate(ulong address, ExecutionMode mode)
         {
             // TODO: Investigate how we should handle code at unaligned addresses.
             // Currently, those low bits are used to store special flags.
@@ -124,7 +129,7 @@ namespace ARMeilleure.Translation
 
         private TranslatedFunction Translate(ulong address, ExecutionMode mode, bool highCq)
         {
-            ArmEmitterContext context = new ArmEmitterContext(_memory, Aarch32Mode.User);
+            ArmEmitterContext context = new ArmEmitterContext(_memory, _jumpTable, (long)address, highCq, Aarch32Mode.User);
 
             Logger.StartPass(PassName.Decoding);
 

--- a/ARMeilleure/Translation/Translator.cs
+++ b/ARMeilleure/Translation/Translator.cs
@@ -39,6 +39,8 @@ namespace ARMeilleure.Translation
             _backgroundQueue = new PriorityQueue<RejitRequest>(2);
 
             _backgroundTranslatorEvent = new AutoResetEvent(false);
+
+            DirectCallStubs.InitializeStubs();
         }
 
         private void TranslateQueuedSubs()
@@ -125,11 +127,6 @@ namespace ARMeilleure.Translation
             }
 
             return func;
-        }
-
-        internal TranslatedFunction TryGetHighCqFunction(ulong address)
-        {
-            return _jumpTable.TryGetFunction(address);
         }
 
         private TranslatedFunction Translate(ulong address, ExecutionMode mode, bool highCq)

--- a/ARMeilleure/Translation/Translator.cs
+++ b/ARMeilleure/Translation/Translator.cs
@@ -61,6 +61,7 @@ namespace ARMeilleure.Translation
                     _backgroundTranslatorEvent.WaitOne();
                 }
             }
+            _backgroundTranslatorEvent.Set(); // Wake up any other background translator threads, to encourage them to exit.
         }
 
         public void Execute(State.ExecutionContext context, ulong address)

--- a/ARMeilleure/Translation/Translator.cs
+++ b/ARMeilleure/Translation/Translator.cs
@@ -65,13 +65,19 @@ namespace ARMeilleure.Translation
         {
             if (Interlocked.Increment(ref _threadCount) == 1)
             {
-                Thread backgroundTranslatorThread = new Thread(TranslateQueuedSubs)
+                // Simple heurisic, should probably be user configurable. (1 for 4 core/ht or less, 2 for 6 core/ht etc).
+                // TODO: probably use physical cores rather than logical. This only really makes sense for processors with hyperthreading.
+                int threadCount = Math.Max(1, Math.Min(4, (Environment.ProcessorCount - 6) / 3));
+                for (int i = 0; i < threadCount; i++)
                 {
-                    Name     = "CPU.BackgroundTranslatorThread",
-                    Priority = ThreadPriority.Lowest
-                };
+                    Thread backgroundTranslatorThread = new Thread(TranslateQueuedSubs)
+                    {
+                        Name = "CPU.BackgroundTranslatorThread." + i,
+                        Priority = ThreadPriority.Lowest
+                    };
 
-                backgroundTranslatorThread.Start();
+                    backgroundTranslatorThread.Start();
+                }
             }
 
             Statistics.InitializeTimer();

--- a/ARMeilleure/Translation/Translator.cs
+++ b/ARMeilleure/Translation/Translator.cs
@@ -141,7 +141,7 @@ namespace ARMeilleure.Translation
             bool alwaysFunctions = true;
 
             Block[] blocks = alwaysFunctions
-                ? Decoder.DecodeFunction  (_memory, address, mode)
+                ? Decoder.DecodeFunction  (_memory, address, mode, highCq)
                 : Decoder.DecodeBasicBlock(_memory, address, mode);
 
             Logger.EndPass(PassName.Decoding);

--- a/ARMeilleure/Translation/Translator.cs
+++ b/ARMeilleure/Translation/Translator.cs
@@ -70,7 +70,7 @@ namespace ARMeilleure.Translation
                 // If we only have one rejit thread, it should be normal priority as highCq code is performance critical.
                 // TODO: Use physical cores rather than logical. This only really makes sense for processors with hyperthreading. Requires OS specific code.
                 int unboundedThreadCount = Math.Max(1, (Environment.ProcessorCount - 6) / 3);
-                int threadCount = Math.Min(4, unboundedThreadCount);
+                int threadCount = Math.Min(3, unboundedThreadCount);
                 for (int i = 0; i < threadCount; i++)
                 {
                     bool last = i != 0 && i == unboundedThreadCount - 1;

--- a/ARMeilleure/Translation/Translator.cs
+++ b/ARMeilleure/Translation/Translator.cs
@@ -257,7 +257,11 @@ namespace ARMeilleure.Translation
 
             context.BranchIfTrue(lblNonZero, count);
 
-            context.Call(new _Void(NativeInterface.CheckSynchronization));
+            Operand running = context.Call(new _Bool(NativeInterface.CheckSynchronization));
+
+            context.BranchIfTrue(lblExit, running);
+
+            context.Return(Const(0L));
 
             context.Branch(lblExit);
 

--- a/ARMeilleure/Translation/Translator.cs
+++ b/ARMeilleure/Translation/Translator.cs
@@ -127,13 +127,20 @@ namespace ARMeilleure.Translation
             return func;
         }
 
+        internal TranslatedFunction TryGetHighCqFunction(ulong address)
+        {
+            return _jumpTable.TryGetFunction(address);
+        }
+
         private TranslatedFunction Translate(ulong address, ExecutionMode mode, bool highCq)
         {
             ArmEmitterContext context = new ArmEmitterContext(_memory, _jumpTable, (long)address, highCq, Aarch32Mode.User);
 
             Logger.StartPass(PassName.Decoding);
 
-            Block[] blocks = highCq
+            bool alwaysFunctions = true;
+
+            Block[] blocks = alwaysFunctions
                 ? Decoder.DecodeFunction  (_memory, address, mode)
                 : Decoder.DecodeBasicBlock(_memory, address, mode);
 
@@ -221,7 +228,7 @@ namespace ARMeilleure.Translation
                         // with some kind of branch).
                         if (isLastOp && block.Next == null)
                         {
-                            context.Return(Const(opCode.Address + (ulong)opCode.OpCodeSizeInBytes));
+                            InstEmitFlowHelper.EmitTailContinue(context, Const(opCode.Address + (ulong)opCode.OpCodeSizeInBytes));
                         }
                     }
                 }

--- a/ARMeilleure/Translation/Translator.cs
+++ b/ARMeilleure/Translation/Translator.cs
@@ -16,6 +16,8 @@ namespace ARMeilleure.Translation
     {
         private const ulong CallFlag = InstEmitFlowHelper.CallFlag;
 
+        private const bool AlwaysTranslateFunctions = true; // If false, only translates a single block for lowCq.
+
         private MemoryManager _memory;
 
         private ConcurrentDictionary<ulong, TranslatedFunction> _funcs;
@@ -145,9 +147,7 @@ namespace ARMeilleure.Translation
 
             Logger.StartPass(PassName.Decoding);
 
-            bool alwaysFunctions = true;
-
-            Block[] blocks = alwaysFunctions
+            Block[] blocks = AlwaysTranslateFunctions
                 ? Decoder.DecodeFunction  (_memory, address, mode, highCq)
                 : Decoder.DecodeBasicBlock(_memory, address, mode);
 

--- a/ARMeilleure/Translation/Translator.cs
+++ b/ARMeilleure/Translation/Translator.cs
@@ -34,7 +34,7 @@ namespace ARMeilleure.Translation
 
             _funcs = new ConcurrentDictionary<ulong, TranslatedFunction>();
 
-            _jumpTable = new JumpTable();
+            _jumpTable = JumpTable.Instance;
 
             _backgroundQueue = new PriorityQueue<RejitRequest>(2);
 

--- a/Ryujinx.HLE/HOS/Kernel/Threading/HleScheduler.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Threading/HleScheduler.cs
@@ -137,7 +137,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
 
         public void ExitThread(KThread thread)
         {
-            thread.Context.Running = false;
+            thread.Context.StopRunning();
 
             CoreManager.Exit(thread.HostThread);
         }

--- a/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
@@ -1141,9 +1141,9 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
         {
             Owner.Translator.Execute(Context, entrypoint);
 
-            Context.Dispose();
-
             ThreadExit();
+
+            Context.Dispose();
         }
 
         private void ThreadExit()


### PR DESCRIPTION
**_While this PR is not WIP, I recommend testing on as many games as possible before merging._**

This PR changes execution flow in the ARM translator to attempt to find and directly call compiled functions rather than fall back to ExecuteSingle. Thanks to this, rather than returning to a separate function starting from the return point of a call, execution seamlessly returns to the middle of the caller function without any overhead or additional translation. Additionally, calls, indirect calls and indirect jumps now cache the host function address to avoid calling back to managed to get it.

### Extra Features
Direct calls come with a few drawbacks so I've included a few extra features to mitigate them:

- Background translation can now run on up to 4 threads, based on your logical processor count. HighCq code now takes longer to compile, so to mitigate that on stronger processors we compile with more threads.
- The JitCache now dynamically resizes as more code is added to it, to a limit about 4x as large. This is because lowCq code is taking up more space, though this shouldn't be a concern for too much longer (cache eviction and gdk's x86 opts should help).

### Benefits
In CPU limited games, you should see around a **1.25x to 1.75x** increase in performance on average. Some games are more affected than others (specifically ones limited by guest CPU performance). Super Mario Odyssey (with query hack to remove GPU limit), Toad Tracker, Mario Kart 8 see the upper end of this boost, whereas games such as Pokemon Sw/Sh, Zelda Botw and Splatoon 2 will see a more modest boost in select areas. All games should run at least a little bit faster.

In general, CPU emulation speed is now nearly entirely down to code quality, as the main bottleneck around execution itself has been removed.

Specifically, benefits of the approach of using jump tables:
- Solves the problem of returning to managed to find the next code block, which is faster regardless of approach.
- Entirely implemented in IR - so should be portable if other backends are implemented.
- The table is easy to serialize or deserialize for use in future execution. Loading the table is as easy as storing new function host addresses for the tabled function guest addresses. It can even be relocatable if you pass a base address with the NativeContext. You may need to save and register the same dependant functions to better track usage and fill in functions that you don't have later on in execution.

### Drawbacks
~~**Important note: There is an issue where the emulator will crash when attempting to close the game. I don't know enough about the Horizion threading model to know what's going on, but it seems like a synchronisation issue.**~~ Temporary solution implemented, see comments.

Games will likely boot a wee bit slower and take a while to speed up after getting ingame until optimizations to the JIT compiler are made. (separate PRs) This is because the JIT compiler has more work to do both for initial compilation and high quality background compilation. Before, the translator would stop translating a function once it reached a call instruction, as the return would not be able to rejoin to the existing function anyways. Now, it continues past it (after a sanity check), as we know that the function we called will return to the next instruction. Compile time scales much worse than linearly for an increase in function size, though, so despite an increase in execution performance it will take longer to compile these functions.

As a mitigation, the existing limit of 5000 instructions per function call remains for highCq code. Testing showed that compiling lowCq code as functions rather than blocks showed a marginal increase in boot time and pre-rejit performance with an instruction limit of around 500. This could cause retranslation of blocks in certain functions, though I have not seen any serious case of this happening yet.

**One drawback of doing this at all is that ARM function profiling does not work anymore.** Execution does not return to ExecuteSingle unless an exceptional return happens. This means it is also harder to track when functions are used, which will complicate things for #740. Signalling for this will need to be done in IR, which could impact performance, but we only need to do it for lowCq.

Specifically, drawbacks of the approach of using jump tables:
- Locality of reference: Each jump or call that is made has to pull data off the jump table at a fixed address. This could be fine if your CPU has enough cache to hold the code, jump table, page table and whatever the game is doing in there all at once, but it'll definitely strain things if you have less cache or the game is doing lots of random jumps/accesses. (still need to somehow gauge how much of an issue this is)
- More instructions: Loading from memory and calling is a tad slower from just going for a branch directly. Note that this definitely isn't a problem right now, and won't be for a while or only in very specific cases.

### Jump Tables
Before this PR, transitions to other blocks of code were done via a call to a managed function which did a ConcurrentDictionary lookup. This ended up making up a lot of a program's execution time, so we needed a solution that would work entirely without transitioning to managed in the best case, and that would be as close to the speed of a direct jump/call as it possibly could be. 

The solution was to allocate and manage two jump tables - contiguous memory regions filled with (guestAddress, hostAddress) tuples for identifying the translated function we jump to. Each jump/call made in a HighCq function reserves a space on a table, which is loaded and jumped to as directly as possible (see below). Initially, each entry is populated with the address of a stub - which does the slow function lookup as before - for when the target function is not available in highCq. When HighCq versions of functions are compiled, they are filled into the relevant entries (using a fast "dependants" list built during entry reservation) over the stub so that jumps/calls can be made without touching managed at all.

Direct calls and jumps are simple enough - the compiled function completely ignores the `guestAddress` section of the table and jumps directly to whatever `hostAddress` is at the time (it is modified by the translator when it compiles the function). Indirect calls and jumps (to addresses that are not constant) follow a similar, but different pattern. They use a separate table called the "Dynamic" table, which stores a _list_ of entries for each jump/call. The difference is that these entries _do not start with a guest address set_, as we do not know what address the code will end up calling. When the guest does a call, it attempts to _find or reserve_ a spot on the table for the guest address it is calling, using a compare and swap instruction. If the entry is taken by another guest address, it continues... otherwise, it calls the function in the hostAddress part of the entry directly. If the function found is HighCq, it is placed in the table over the stub so that it can be found much quicker in future.

If an indirect call/jump address cannot be found on its table, then it begrudgingly falls back to looking up the address using the managed dictionary. Right now, the table size is set to 1 to reduce code size and compile time, as this does not have much of an impact on most games. Ideally we should be able to hook LowCq functions to track what addresses they call and guess a better table size (and initial population?) for each function when we get to compiling them in HighCq.

For both direct and indirect calls, the target guest address is passed through on the NativeContext so that the dictionary lookup can be performed if we end up calling the stub.

The jump table can only reference highCq functions, as it is expected that they will never change so that we can put the address in the table when it is available and never have to worry about updating it. Also, only highCq functions can reserve space on the jump table at all, to prevent wasting space and time on code that will eventually be succeeded by a higher quality compilation.

The dynamic table has support for caching multiple function calls from one instruction, though table size has currently been limited to 1. Higher values currently don't see much increase in performance, and the volume of IR emitted greatly slows down compliation time.

Note that the result of all this HighCq/LowCq separation is that all HighCq code _only_ references other HighCq code, making it safe to remove LowCq functions when we don't need them. (separate PR)

### Tail Call rather than Return (lowCq or functions with gaps)

This changes how flow works drastically when using the ARM translator. Rather than relying on returning an address to continue from, the native code itself calls the translator to look up a function address, then Tail Calls it without leaving native.

Only things detected as a function return will use the context.Return(address) function. 
In A64, these are:
- BR LR
- RET
In A32, these are:
- BX LR
- LDM {...PC}
- LDx PC, [SP], #0x4
- Any ALU operation that writes to PC, and uses LR as a register input.

Note that we greatly prefers false positives to false negatives - that is we'd rather return on something that may not really be a return than Tail Call the return. The former can cause the guest stack to be thrown out and slow things down, the latter can (eventually) stack overflow and crash the application if no valid return happens later on. See below for more information.

### The curious case of programs that abuse LR

Not all programs return nicely, specifically A64 RTLD has one particularly nasty instance where it branch links to an address, which then modifies LR and returns to a *different end point*.

This is where the return values come in. Around every native function call, there is a guard making sure that the function exited at the right point. If it didn't, we'll bubble that address down the stack until either:
 - We find the stack frame it returned to. The case in RTLD jumps two stack frames down, so it is easily salvagable.
 - We end up returning to GetOrTranslate.

This can cause a huge performance penalty, as exceptional returns like this have to lowCq from the return point. Specifically - before Tail Call was used for joining lowCq blocks, games would typically tank performance while a new game function was being used, but had not been admitted to highCq yet. In the games I have, these exceptional returns happen very rarely, but they are still a concern and appear to be handled correctly with this approach.

### Interop with other PRs
- Should work immediately with X86 optimizations.
- Reasonably separate from Pooling optimizations (to come in a future PR, which will improve multithreaded translation)
- AOT support is more difficult, but thanks to avoiding ever patching functions or baking in function addresses, it should be easy to store the address tables and repopulate them with - the relocated host functions.
- Support for removing unused functions from the cache requires some nuance for tracking uses. It's also important to note that only lowCq functions should be removed, and relocating - functions in memory may be difficult.