### PR TITLE
Fix GTK window crash by using 24 bit surface on unix, 32 bit on windows.

### DIFF
--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -51,7 +51,7 @@ namespace Ryujinx.Ui
         private Input.NpadController _primaryController;
 
         public GLRenderer(Switch device)
-            : base (new GraphicsMode(new ColorFormat()),
+            : base (new GraphicsMode(Environment.OSVersion.Platform == PlatformID.Unix ? new ColorFormat(24) : new ColorFormat()),
             3, 3,
             GraphicsContextFlags.ForwardCompatible)
         {

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -51,7 +51,7 @@ namespace Ryujinx.Ui
         private Input.NpadController _primaryController;
 
         public GLRenderer(Switch device)
-            : base (new GraphicsMode(Environment.OSVersion.Platform == PlatformID.Unix ? new ColorFormat(24) : new ColorFormat()),
+            : base (GetGraphicsMode(),
             3, 3,
             GraphicsContextFlags.ForwardCompatible)
         {
@@ -78,6 +78,16 @@ namespace Ryujinx.Ui
                           | Gdk.EventMask.KeyReleaseMask));
 
             this.Shown += Renderer_Shown;
+        }
+
+        private static GraphicsMode GetGraphicsMode()
+        {
+            if (Environment.OSVersion.Platform == PlatformID.Unix)
+            {
+                return new GraphicsMode(new ColorFormat(24));
+            }
+
+            return new GraphicsMode(new ColorFormat());
         }
 
         private void GLRenderer_ShuttingDown(object sender, EventArgs args)


### PR DESCRIPTION
Just a quick fix to get linux working again. This shouldn't reintroduce transparency issues, as I don't think the 24 bit surface had any. (we made it 32 bit to combat issues on windows)