### PR TITLE
Update window title to include title architecture

### DIFF
--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -87,6 +87,8 @@ namespace Ryujinx.Graphics.OpenGL
             GpuVendor   = GL.GetString(StringName.Vendor);
             GpuRenderer = GL.GetString(StringName.Renderer);
             GpuVersion  = GL.GetString(StringName.Version);
+
+            Logger.PrintInfo(LogClass.Gpu, $"{GpuVendor} {GpuRenderer} ({GpuVersion})");
         }
 
         public void ResetCounter(CounterType type)

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -19,6 +19,12 @@ namespace Ryujinx.Graphics.OpenGL
 
         internal TextureCopy TextureCopy { get; }
 
+        public string GpuVendor { get; private set; }
+
+        public string GpuRenderer { get; private set; }
+
+        public string GpuVersion { get; private set; }
+
         public Renderer()
         {
             _pipeline = new Pipeline();
@@ -71,18 +77,16 @@ namespace Ryujinx.Graphics.OpenGL
 
         public void Initialize()
         {
-            PrintGpuInformation();
+            GetGpuInformation();
 
             _counters.Initialize();
         }
 
-        private void PrintGpuInformation()
+        private void GetGpuInformation()
         {
-            string gpuVendor   = GL.GetString(StringName.Vendor);
-            string gpuRenderer = GL.GetString(StringName.Renderer);
-            string gpuVersion  = GL.GetString(StringName.Version);
-
-            Logger.PrintInfo(LogClass.Gpu, $"{gpuVendor} {gpuRenderer} ({gpuVersion})");
+            GpuVendor   = GL.GetString(StringName.Vendor);
+            GpuRenderer = GL.GetString(StringName.Renderer);
+            GpuVersion  = GL.GetString(StringName.Version);
         }
 
         public void ResetCounter(CounterType type)

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -88,7 +88,7 @@ namespace Ryujinx.Graphics.OpenGL
             GpuRenderer = GL.GetString(StringName.Renderer);
             GpuVersion  = GL.GetString(StringName.Version);
 
-            Logger.PrintInfo(LogClass.Gpu, $"{GpuVendor} {GpuRenderer} ({GpuVersion})");
+            Logger.PrintInfo(LogClass.Gpu, $"{GpuVendor} {GpuRenderer} ({GpuVersion})", "GpuInformation");
         }
 
         public void ResetCounter(CounterType type)

--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -117,6 +117,8 @@ namespace Ryujinx.HLE.HOS
         public ulong  TitleId { get; private set; }
         public string TitleIdText => TitleId.ToString("x16");
 
+        public string TitleArchitecture { get; private set; }
+
         public IntegrityCheckLevel FsIntegrityCheckLevel { get; set; }
 
         public int GlobalAccessLogMode { get; set; }
@@ -498,7 +500,8 @@ namespace Ryujinx.HLE.HOS
 
             LoadExeFs(codeFs, out Npdm metaData);
             
-            TitleId = metaData.Aci0.TitleId;
+            TitleId           = metaData.Aci0.TitleId;
+            TitleArchitecture = metaData.Is64Bit ? "64-bit" : "32-bit";
 
             if (controlNca != null)
             {
@@ -551,7 +554,8 @@ namespace Ryujinx.HLE.HOS
                 }
             }
 
-            TitleId = metaData.Aci0.TitleId;
+            TitleId           = metaData.Aci0.TitleId;
+            TitleArchitecture = metaData.Is64Bit ? "64-bit" : "32-bit";
 
             LoadNso("rtld");
             LoadNso("main");
@@ -653,8 +657,9 @@ namespace Ryujinx.HLE.HOS
 
             ContentManager.LoadEntries(Device);
 
-            TitleName = metaData.TitleName;
-            TitleId   = metaData.Aci0.TitleId;
+            TitleName         = metaData.TitleName;
+            TitleId           = metaData.Aci0.TitleId;
+            TitleArchitecture = metaData.Is64Bit ? "64-bit" : "32-bit";
 
             ProgramLoader.LoadStaticObjects(this, metaData, new IExecutable[] { staticObject });
         }

--- a/Ryujinx.HLE/HOS/ProgramLoader.cs
+++ b/Ryujinx.HLE/HOS/ProgramLoader.cs
@@ -125,14 +125,9 @@ namespace Ryujinx.HLE.HOS
             IExecutable[] staticObjects,
             byte[]        arguments = null)
         {
-            if (!metaData.Is64Bits)
-            {
-                Logger.PrintWarning(LogClass.Loader, "32-bits application detected.");
-            }
-
             ulong argsStart = 0;
             int   argsSize  = 0;
-            ulong codeStart = metaData.Is64Bits ? 0x8000000UL : 0x200000UL;
+            ulong codeStart = metaData.Is64Bit ? 0x8000000UL : 0x200000UL;
             int   codeSize  = 0;
 
             ulong[] nsoBase = new ulong[staticObjects.Length];

--- a/Ryujinx.HLE/HOS/ProgramLoader.cs
+++ b/Ryujinx.HLE/HOS/ProgramLoader.cs
@@ -125,6 +125,8 @@ namespace Ryujinx.HLE.HOS
             IExecutable[] staticObjects,
             byte[]        arguments = null)
         {
+            Logger.PrintInfo(LogClass.Loader, metaData.Is64Bit ? "64-bit" : "32-bit", "TitleArchitecture");
+
             ulong argsStart = 0;
             int   argsSize  = 0;
             ulong codeStart = metaData.Is64Bit ? 0x8000000UL : 0x200000UL;

--- a/Ryujinx.HLE/Loaders/Npdm/Npdm.cs
+++ b/Ryujinx.HLE/Loaders/Npdm/Npdm.cs
@@ -12,7 +12,7 @@ namespace Ryujinx.HLE.Loaders.Npdm
         private const int MetaMagic = 'M' << 0 | 'E' << 8 | 'T' << 16 | 'A' << 24;
 
         public byte   MmuFlags            { get; private set; }
-        public bool   Is64Bits            { get; private set; }
+        public bool   Is64Bit             { get; private set; }
         public byte   MainThreadPriority  { get; private set; }
         public byte   DefaultCpuId        { get; private set; }
         public int    PersonalMmHeapSize  { get; private set; }
@@ -37,7 +37,7 @@ namespace Ryujinx.HLE.Loaders.Npdm
 
             MmuFlags = reader.ReadByte();
 
-            Is64Bits = (MmuFlags & 1) != 0;
+            Is64Bit = (MmuFlags & 1) != 0;
 
             reader.ReadByte();
 

--- a/Ryujinx/Program.cs
+++ b/Ryujinx/Program.cs
@@ -26,7 +26,7 @@ namespace Ryujinx
 
             Version = Assembly.GetEntryAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
 
-            Console.Title = $"Ryujinx Console {Version}";
+            Console.Title = $"Ryujinx [Console, {Version}]";
 
             string systemPath = Environment.GetEnvironmentVariable("Path", EnvironmentVariableTarget.Machine);
             Environment.SetEnvironmentVariable("Path", $"{Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "bin")};{systemPath}");

--- a/Ryujinx/Program.cs
+++ b/Ryujinx/Program.cs
@@ -26,7 +26,7 @@ namespace Ryujinx
 
             Version = Assembly.GetEntryAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
 
-            Console.Title = $"Ryujinx [Console, {Version}]";
+            Console.Title = $"Ryujinx (Console)";
 
             string systemPath = Environment.GetEnvironmentVariable("Path", EnvironmentVariableTarget.Machine);
             Environment.SetEnvironmentVariable("Path", $"{Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "bin")};{systemPath}");

--- a/Ryujinx/Program.cs
+++ b/Ryujinx/Program.cs
@@ -26,7 +26,7 @@ namespace Ryujinx
 
             Version = Assembly.GetEntryAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
 
-            Console.Title = $"Ryujinx (Console)";
+            Console.Title = $"Ryujinx {Version} (Console)";
 
             string systemPath = Environment.GetEnvironmentVariable("Path", EnvironmentVariableTarget.Machine);
             Environment.SetEnvironmentVariable("Path", $"{Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "bin")};{systemPath}");

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -298,18 +298,6 @@ namespace Ryujinx.Ui
 
             _renderer.Initialize();
 
-            // Add GPU information to title, after renderer has been initialized.
-            Gtk.Window parent = this.Toplevel as Gtk.Window;
-
-            Gtk.Application.Invoke(delegate
-            {
-                string[] gpuVersion = _renderer.GpuVersion.Trim().Split(' ');
-
-                string gpuInfoSection = $" [{_renderer.GpuVendor.Trim().Split(' ')[0]} {_renderer.GpuRenderer.Trim().Split('/')[0]}, {gpuVersion[gpuVersion.Length - 1]}]";
-
-                parent.Title += gpuInfoSection;
-            });
-
             // Make sure the first frame is not transparent.
             GL.ClearColor(OpenTK.Color.Black);
             GL.Clear(ClearBufferMask.ColorBufferBit);

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -181,10 +181,10 @@ namespace Ryujinx.Ui
                 string titleNameSection = string.IsNullOrWhiteSpace(_device.System.TitleName) ? " - Application"
                     : $" - {_device.System.TitleName}";
 
-                string titleIdSection = string.IsNullOrWhiteSpace(_device.System.TitleIdText) ? $" ({_device.System.TitleArchitecture})"
+                string titleInfoSection = string.IsNullOrWhiteSpace(_device.System.TitleIdText) ? $" ({_device.System.TitleArchitecture})"
                     : $" ({_device.System.TitleIdText.ToUpper()}, {_device.System.TitleArchitecture})";
 
-                parent.Title = $"Ryujinx [GUI, {Program.Version}]{titleNameSection}{titleIdSection}";
+                parent.Title = $"Ryujinx {Program.Version}{titleNameSection}{titleInfoSection}";
             });
 
             Thread renderLoopThread = new Thread(Render)
@@ -297,6 +297,18 @@ namespace Ryujinx.Ui
             GraphicsContext.MakeCurrent(WindowInfo);
 
             _renderer.Initialize();
+
+            // Add GPU information to title, after renderer has been initialized.
+            Gtk.Window parent = this.Toplevel as Gtk.Window;
+
+            Gtk.Application.Invoke(delegate
+            {
+                string[] gpuVersion = _renderer.GpuVersion.Trim().Split(' ');
+
+                string gpuInfoSection = $" [{_renderer.GpuVendor.Trim().Split(' ')[0]} {_renderer.GpuRenderer.Trim().Split('/')[0]}, {gpuVersion[gpuVersion.Length - 1]}]";
+
+                parent.Title += gpuInfoSection;
+            });
 
             // Make sure the first frame is not transparent.
             GL.ClearColor(OpenTK.Color.Black);

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -178,13 +178,13 @@ namespace Ryujinx.Ui
             {
                 parent.Present();
 
-                string titleNameSection = string.IsNullOrWhiteSpace(_device.System.TitleName) ? string.Empty
-                    : " | " + _device.System.TitleName;
+                string titleNameSection = string.IsNullOrWhiteSpace(_device.System.TitleName) ? " - Application"
+                    : $" - {_device.System.TitleName}";
 
-                string titleIdSection = string.IsNullOrWhiteSpace(_device.System.TitleIdText) ? string.Empty
-                    : " | " + _device.System.TitleIdText.ToUpper();
+                string titleIdSection = string.IsNullOrWhiteSpace(_device.System.TitleIdText) ? $" ({_device.System.TitleArchitecture})"
+                    : $" ({_device.System.TitleIdText.ToUpper()}, {_device.System.TitleArchitecture})";
 
-                parent.Title = $"Ryujinx {Program.Version}{titleNameSection}{titleIdSection}";
+                parent.Title = $"Ryujinx [GUI, {Program.Version}]{titleNameSection}{titleIdSection}";
             });
 
             Thread renderLoopThread = new Thread(Render)

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -124,7 +124,7 @@ namespace Ryujinx.Ui
             ApplyTheme();
 
             _mainWin.Icon            = new Gdk.Pixbuf(Assembly.GetExecutingAssembly(), "Ryujinx.Ui.assets.Icon.png");
-            _mainWin.Title           = $"Ryujinx {Program.Version}";
+            _mainWin.Title           = $"Ryujinx [GUI, {Program.Version}]";
             _stopEmulation.Sensitive = false;
 
             if (ConfigurationState.Instance.Ui.GuiColumns.FavColumn)        _favToggle.Active        = true;
@@ -434,7 +434,7 @@ namespace Ryujinx.Ui
 
                 _gameTableWindow.Expand = true;
 
-                this.Window.Title = $"Ryujinx {Program.Version}";
+                this.Window.Title = $"Ryujinx [GUI, {Program.Version}]";
 
                 _emulationContext = null;
                 _gameLoaded       = false;

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -124,7 +124,7 @@ namespace Ryujinx.Ui
             ApplyTheme();
 
             _mainWin.Icon            = new Gdk.Pixbuf(Assembly.GetExecutingAssembly(), "Ryujinx.Ui.assets.Icon.png");
-            _mainWin.Title           = $"Ryujinx [GUI, {Program.Version}]";
+            _mainWin.Title           = $"Ryujinx {Program.Version}";
             _stopEmulation.Sensitive = false;
 
             if (ConfigurationState.Instance.Ui.GuiColumns.FavColumn)        _favToggle.Active        = true;
@@ -434,7 +434,7 @@ namespace Ryujinx.Ui
 
                 _gameTableWindow.Expand = true;
 
-                this.Window.Title = $"Ryujinx [GUI, {Program.Version}]";
+                this.Window.Title = $"Ryujinx {Program.Version}";
 
                 _emulationContext = null;
                 _gameLoaded       = false;


### PR DESCRIPTION
Also clarifies the GUI window a bit more, just like the Console window.
![image](https://user-images.githubusercontent.com/24927193/76475357-f1d97b80-63d4-11ea-88b7-6b235975bb4c.png)

Additionally, it removes the 32-bit application warning because the titlebar shows what architecture the application is now.