### PR TITLE
Add Legacy Attributes gl_Color and gl_TexCoord

### DIFF
--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
         public static void Declare(CodeGenContext context, StructuredProgramInfo info)
         {
-            context.AppendLine("#version 420 core");
+            context.AppendLine("#version 420 compatibility");
             context.AppendLine("#extension GL_ARB_gpu_shader_int64 : enable");
             context.AppendLine("#extension GL_ARB_shader_ballot : enable");
             context.AppendLine("#extension GL_ARB_shader_group_vote : enable");

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
@@ -196,15 +196,9 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
                         }
                     }
 
-                    if (isOutAttr)
+                    if (isOutAttr && (value & ~15) == AttributeConsts.ColorX)
                     {
-                        switch (value & ~3)
-                        {
-                            case AttributeConsts.ColorX: return isFragment ? "gl_FragColor.x" : "gl_FrontColor.x";
-                            case AttributeConsts.ColorY: return isFragment ? "gl_FragColor.y" : "gl_FrontColor.y";
-                            case AttributeConsts.ColorZ: return isFragment ? "gl_FragColor.z" : "gl_FrontColor.z";
-                            case AttributeConsts.ColorW: return isFragment ? "gl_FragColor.w" : "gl_FrontColor.w";
-                        }
+                        return isFragment ? $"gl_FragColor.{swzMask}" : $"gl_FrontColor.{swzMask}";
                     }
 
                     string name = builtInAttr.Name;

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
@@ -34,6 +34,10 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
             { AttributeConsts.PositionY,           new BuiltInAttribute("gl_Position.y",      VariableType.F32)  },
             { AttributeConsts.PositionZ,           new BuiltInAttribute("gl_Position.z",      VariableType.F32)  },
             { AttributeConsts.PositionW,           new BuiltInAttribute("gl_Position.w",      VariableType.F32)  },
+            { AttributeConsts.ColorX,              new BuiltInAttribute("gl_Color.x",         VariableType.F32)  },
+            { AttributeConsts.ColorY,              new BuiltInAttribute("gl_Color.y",         VariableType.F32)  },
+            { AttributeConsts.ColorZ,              new BuiltInAttribute("gl_Color.z",         VariableType.F32)  },
+            { AttributeConsts.ColorW,              new BuiltInAttribute("gl_Color.w",         VariableType.F32)  },
             { AttributeConsts.ClipDistance0,       new BuiltInAttribute("gl_ClipDistance[0]", VariableType.F32)  },
             { AttributeConsts.ClipDistance1,       new BuiltInAttribute("gl_ClipDistance[1]", VariableType.F32)  },
             { AttributeConsts.ClipDistance2,       new BuiltInAttribute("gl_ClipDistance[2]", VariableType.F32)  },
@@ -169,10 +173,19 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
                     return $"{DefaultNames.OAttributePrefix}{(value >> 4)}.{swzMask}";
                 }
+                else if (value >= AttributeConsts.TexCoordAttributeBase &&
+                         value < AttributeConsts.TexCoordAttributeEnd)
+                {
+                    value -= AttributeConsts.TexCoordAttributeBase;
+
+                    return $"gl_TexCoord[{value >> 6}].{swzMask}";
+                }
                 else if (_builtInAttributes.TryGetValue(value & ~3, out BuiltInAttribute builtInAttr))
                 {
                     // TODO: There must be a better way to handle this...
-                    if (stage == ShaderStage.Fragment)
+                    bool isFragment = stage == ShaderStage.Fragment;
+
+                    if (isFragment)
                     {
                         switch (value & ~3)
                         {
@@ -180,6 +193,17 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
                             case AttributeConsts.PositionY: return "gl_FragCoord.y";
                             case AttributeConsts.PositionZ: return "gl_FragCoord.z";
                             case AttributeConsts.PositionW: return "1.0";
+                        }
+                    }
+
+                    if (isOutAttr)
+                    {
+                        switch (value & ~3)
+                        {
+                            case AttributeConsts.ColorX: return isFragment ? "gl_FragColor.x" : "gl_FrontColor.x";
+                            case AttributeConsts.ColorY: return isFragment ? "gl_FragColor.y" : "gl_FrontColor.y";
+                            case AttributeConsts.ColorZ: return isFragment ? "gl_FragColor.z" : "gl_FrontColor.z";
+                            case AttributeConsts.ColorW: return isFragment ? "gl_FragColor.w" : "gl_FrontColor.w";
                         }
                     }
 

--- a/Ryujinx.Graphics.Shader/Translation/AttributeConsts.cs
+++ b/Ryujinx.Graphics.Shader/Translation/AttributeConsts.cs
@@ -8,6 +8,10 @@ namespace Ryujinx.Graphics.Shader.Translation
         public const int PositionY     = 0x074;
         public const int PositionZ     = 0x078;
         public const int PositionW     = 0x07c;
+        public const int ColorX        = 0x280;
+        public const int ColorY        = 0x284;
+        public const int ColorZ        = 0x288;
+        public const int ColorW        = 0x28c;
         public const int ClipDistance0 = 0x2c0;
         public const int ClipDistance1 = 0x2c4;
         public const int ClipDistance2 = 0x2c8;
@@ -28,6 +32,9 @@ namespace Ryujinx.Graphics.Shader.Translation
         public const int UserAttributeBase   = 0x80;
         public const int UserAttributeEnd    = UserAttributeBase + UserAttributesCount * 16;
 
+        public const int TexCoordAttributesCount = 8;
+        public const int TexCoordAttributeBase = 0x300;
+        public const int TexCoordAttributeEnd = TexCoordAttributeBase + TexCoordAttributesCount * 16;
 
         // Note: Those attributes are used internally by the translator
         // only, they don't exist on Maxwell.


### PR DESCRIPTION
Used by Xash3D. (also needs an implementation of Ushl_S to get into the campaign). The game's skinned models don't work yet, but that's likely an issue with it doing really quick back to back immediate draws of generated data (that are quickly replaced with index/vertex data for the next draw).

![image](https://user-images.githubusercontent.com/6294155/76568599-12730580-64a9-11ea-8fcd-861426beba42.png)

Draft PR because I don't know what adverse affects this might have on some games/gpus. There doesn't seem to be an issue on what I have tested. A better solution might be to make use of these attributes trigger a flag in the context which changes the shader between `core` and `compatibility` dynamically, but I wasn't aware of any appropriate location to set such a flag, and the context is inaccessible when getting a variable name.