### PR TITLE
Implement MME shadow RAM

### DIFF
--- a/Ryujinx.Graphics.Gpu/NvGpuFifoMeth.cs
+++ b/Ryujinx.Graphics.Gpu/NvGpuFifoMeth.cs
@@ -5,11 +5,12 @@ namespace Ryujinx.Graphics.Gpu
     /// </summary>
     enum NvGpuFifoMeth
     {
-        BindChannel           = 0,
-        WaitForIdle           = 0x44,
-        SetMacroUploadAddress = 0x45,
-        SendMacroCodeData     = 0x46,
-        SetMacroBindingIndex  = 0x47,
-        BindMacro             = 0x48
+        BindChannel            = 0,
+        WaitForIdle            = 0x44,
+        SetMacroUploadAddress  = 0x45,
+        SendMacroCodeData      = 0x46,
+        SetMacroBindingIndex   = 0x47,
+        BindMacro              = 0x48,
+        SetMmeShadowRamControl = 0x49
     }
 }

--- a/Ryujinx.Graphics.Gpu/ShadowRamControl.cs
+++ b/Ryujinx.Graphics.Gpu/ShadowRamControl.cs
@@ -1,0 +1,28 @@
+﻿namespace Ryujinx.Graphics.Gpu
+{
+    /// <summary>
+    /// Shadow RAM Control setting.
+    /// </summary>
+    enum ShadowRamControl
+    {
+        /// <summary>
+        /// Track data writes and store them on shadow RAM.
+        /// </summary>
+        Track = 0,
+
+        /// <summary>
+        /// Track data writes and store them on shadow RAM, with filtering.
+        /// </summary>
+        TrackWithFilter = 1,
+
+        /// <summary>
+        /// Writes data directly without storing on shadow RAM.
+        /// </summary>
+        Passthrough = 2,
+
+        /// <summary>
+        /// Ignore data being written and replace with data on shadow RAM instead.
+        /// </summary>
+        Replay = 3
+    }
+}


### PR DESCRIPTION
The MME shadow RAM is used as "backup" storage of the hw register values. It's used by some NVN calls too restore state after a operation that needs to do temporary changes to the states to do some operation.

One example of them is ClearTexture. First it sets the MmeShadowControl  to "Passthrough" to prevent any changes from being written to shadow ram, since they are temporary. It changes render target state to set the texture to be cleared, and then call Clear. After that, it re-runs the macro with MmeShadowControl set to "Replay" to re-load the values from the shadow RAM and write those original values back to the hw register, restoring the previous state.

Other regular macro calls usually have MmeShadowControl set to "TrackWithFilter" that will write the value both to the hw regs and shadow ram, so they can be restored later. Non-macro calls should also behave this way.

This caused a bug on the game Hatsune Miku for the switch were the depth stencil buffer was always disabled (it was disabled by the ClearTexture MME call) and never re-enabled, which in turn causes depth testing to fail and models to be draw on top of each other without any depth testing. This fixes the issue.

Thanks to @fincs for explaining to me how the MME shadow RAM works :)