### PR TITLE
Set the minimum width of the window to 854px

### DIFF
--- a/Ryujinx/Ui/MainWindow.glade
+++ b/Ryujinx/Ui/MainWindow.glade
@@ -399,7 +399,7 @@
             </child>
             <child>
               <object class="GtkBox" id="_footerBox">
-                <property name="width_request">1280</property>
+                <property name="width_request">854</property>
                 <property name="height_request">19</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>


### PR DESCRIPTION
This allows the window size to fit perfectly on monitors that are less than 1280px wide, like 1024x768 in my case.

**Before:**
![Screenshot_20200313_114755](https://user-images.githubusercontent.com/12377383/76637185-a7fdac00-6520-11ea-81e3-65e4eabc8da1.png)

**After:**
![Screenshot_20200313_115004](https://user-images.githubusercontent.com/12377383/76637268-cfed0f80-6520-11ea-91ee-31b13d90f924.png)
