### PR TITLE
Improve shader sampler type selection

### DIFF
--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
@@ -254,7 +254,11 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
         {
             Dictionary<string, AstTextureOperation> samplers = new Dictionary<string, AstTextureOperation>();
 
-            foreach (AstTextureOperation texOp in info.Samplers.OrderBy(x => x.Handle))
+            // Texture instructions other than TextureSample (like TextureSize)
+            // may have incomplete sampler type information. In those cases,
+            // we prefer instead the more accurate information from the
+            // TextureSample instruction, if both are available.
+            foreach (AstTextureOperation texOp in info.Samplers.OrderBy(x => x.Handle * 2 + (x.Inst == Instruction.TextureSample ? 0 : 1)))
             {
                 string indexExpr = NumberFormatter.FormatInt(texOp.ArraySize);
 


### PR DESCRIPTION
Some shader instruction (such as TXQ/Texture Query) has incomplete type information, because it is not needed. For example, a texture query operation only needs to know the texture dimensions. It does not need to know for example, if the texture is used for Depth Comparison. Depth comparison sampler type has the `Shadow` suffix, this is required for regular samples with depth comparison.

Basically, the problem is that the shader translator would sometimes use incomplete type information (from a TXQ instruction) to write the sampler type on the output program. This in turn causes a mismatch between the sampler type that texture sample instructions expects, and what was declared, and the shader fails to compile.

The fix I used is simply changing the order that the texture instructions are processed. It gives preference to `TextureSample` instructions to ensure that it will always use the most complete type information. If anyone has better suggestion to fix this issue, please let me know.

This fix some bugs on the game LoveR Kiss.