### PR TITLE
Modify TranslatedFunction.GetPointer () to optimize performance

### DIFF
--- a/ARMeilleure/Translation/TranslatedFunction.cs
+++ b/ARMeilleure/Translation/TranslatedFunction.cs
@@ -9,6 +9,7 @@ namespace ARMeilleure.Translation
         private const int MinCallsForRejit = 100;
 
         private GuestFunction _func;
+        private IntPtr _funcPtr;
 
         private bool _rejit;
         private int  _callCount;
@@ -33,7 +34,9 @@ namespace ARMeilleure.Translation
 
         public IntPtr GetPointer()
         {
-            return Marshal.GetFunctionPointerForDelegate(_func);
+            if (_funcPtr == IntPtr.Zero)
+                _funcPtr = Marshal.GetFunctionPointerForDelegate(_func);
+            return _funcPtr;
         }
     }
 }

--- a/ARMeilleure/Translation/TranslatedFunction.cs
+++ b/ARMeilleure/Translation/TranslatedFunction.cs
@@ -35,7 +35,10 @@ namespace ARMeilleure.Translation
         public IntPtr GetPointer()
         {
             if (_funcPtr == IntPtr.Zero)
+            {
                 _funcPtr = Marshal.GetFunctionPointerForDelegate(_func);
+            }
+
             return _funcPtr;
         }
     }


### PR DESCRIPTION
Add local var to reduce calling Marshal.GetFunctionPointerForDelegate, Can slightly improve performance.