### PR TITLE
Implement textureQueryLevels

### DIFF
--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
@@ -15,11 +15,10 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
         public static void Declare(CodeGenContext context, StructuredProgramInfo info)
         {
-            context.AppendLine("#version 420 core");
+            context.AppendLine("#version 430 core");
             context.AppendLine("#extension GL_ARB_gpu_shader_int64 : enable");
             context.AppendLine("#extension GL_ARB_shader_ballot : enable");
             context.AppendLine("#extension GL_ARB_shader_group_vote : enable");
-            context.AppendLine("#extension GL_ARB_shader_storage_buffer_object : enable");
 
             if (context.Config.Stage == ShaderStage.Compute)
             {

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
@@ -494,7 +494,14 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
 
             string lodExpr = GetSoureExpr(context, lod, GetSrcVarType(operation.Inst, lodSrcIndex));
 
-            return $"textureSize({samplerName}, {lodExpr}){GetMask(texOp.Index)}";
+            if (texOp.Index == 3)
+            {
+                return $"textureQueryLevels({samplerName})";
+            }
+            else
+            {
+                return $"textureSize({samplerName}, {lodExpr}){GetMask(texOp.Index)}";
+            }
         }
 
         private static string GetStorageBufferAccessor(string slotExpr, string offsetExpr, ShaderStage stage)


### PR DESCRIPTION
Requires GLSL 4.3.0+ or the respective extension, so I decided to just increase the required version on the shader. Also removed shader storage buffer requirement since it is always available with version 4.3.