### PR TITLE
Fix the item name cannot be displayed in profiler view

### DIFF
--- a/Ryujinx.Debugger/UI/ProfilerWidget.cs
+++ b/Ryujinx.Debugger/UI/ProfilerWidget.cs
@@ -481,7 +481,7 @@ namespace Ryujinx.Debugger.UI
 
                     float y = GetLineY(yOffset, LineHeight, LinePadding, true, verticalIndex);
 
-                    canvas.DrawText(entry.Key.SessionGroup, new SKPoint(xOffset, y), textFont);
+                    canvas.DrawText(entry.Key.SessionItem, new SKPoint(xOffset, y), textFont);
 
                     columnWidth = textFont.MeasureText(entry.Key.SessionItem);
 


### PR DESCRIPTION
Before
![before](https://user-images.githubusercontent.com/62330325/77398484-f5183280-6dea-11ea-903a-96c3e9d6b850.png)

After
![after](https://user-images.githubusercontent.com/62330325/77398516-05c8a880-6deb-11ea-9b9a-8b5e64f6b339.png)
