### PR TITLE
Fix gpu vendor name parsing

### DIFF
--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -335,17 +335,11 @@ namespace Ryujinx.Ui
 
                     _device.Statistics.RecordSystemFrameTime();
 
-                    string gpuVendor = "Unknown";
-
-                    if (_renderer.GpuVendor.ToLower().Contains("nvidia ")) gpuVendor = "NVIDIA";
-                    if (_renderer.GpuVendor.ToLower().Contains("amd ") || _renderer.GpuVendor.ToLower().Contains("ati ")) gpuVendor = "AMD";
-                    if (_renderer.GpuVendor.ToLower().Contains("intel ")) gpuVendor = "Intel";
-
                     StatusUpdatedEvent?.Invoke(this, new StatusUpdatedEventArgs(
                         _device.EnableDeviceVsync, 
                         $"Host: {_device.Statistics.GetSystemFrameRate():00.00} FPS", 
                         $"Game: {_device.Statistics.GetGameFrameRate():00.00} FPS",
-                        $"GPU: {gpuVendor}"));
+                        $"GPU: {_renderer.GpuVendor}"));
 
                     _device.System.SignalVsync();
 

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -337,9 +337,9 @@ namespace Ryujinx.Ui
 
                     string gpuVendor = "Unknown";
 
-                    if (_renderer.GpuVendor.ToLower().Contains("nvidia")) gpuVendor = "NVIDIA";
-                    if (_renderer.GpuVendor.ToLower().Contains("amd") || _renderer.GpuVendor.ToLower().Contains("ati")) gpuVendor = "AMD";
-                    if (_renderer.GpuVendor.ToLower().Contains("intel")) gpuVendor = "Intel";
+                    if (_renderer.GpuVendor.ToLower().Contains("nvidia ")) gpuVendor = "NVIDIA";
+                    if (_renderer.GpuVendor.ToLower().Contains("amd ") || _renderer.GpuVendor.ToLower().Contains("ati ")) gpuVendor = "AMD";
+                    if (_renderer.GpuVendor.ToLower().Contains("intel ")) gpuVendor = "Intel";
 
                     StatusUpdatedEvent?.Invoke(this, new StatusUpdatedEventArgs(
                         _device.EnableDeviceVsync, 


### PR DESCRIPTION
This fix an issue who write the wrong GPU vendor in status bar because of the "ati" in "Corporation".