### PR TITLE
prepo: Implement RequestImmediateTransmission and GetTransmissionStatus

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Prepo/IPrepoService.cs
+++ b/Ryujinx.HLE/HOS/Services/Prepo/IPrepoService.cs
@@ -53,7 +53,7 @@ namespace Ryujinx.HLE.HOS.Services.Prepo
         // RequestImmediateTransmission()
         public ResultCode RequestImmediateTransmission(ServiceCtx context)
         {
-            // It signals an event of nn::prepo::detail::service::core::TransmissionStatusManager that requets the transmission of the report.
+            // It signals an event of nn::prepo::detail::service::core::TransmissionStatusManager that requests the transmission of the report.
             // Since we don't use reports it's fine to do nothing.
 
             return ResultCode.Success;

--- a/Ryujinx.HLE/HOS/Services/Prepo/IPrepoService.cs
+++ b/Ryujinx.HLE/HOS/Services/Prepo/IPrepoService.cs
@@ -49,6 +49,27 @@ namespace Ryujinx.HLE.HOS.Services.Prepo
             return ProcessReport(context, withUserID: true);
         }
 
+        [Command(10200)]
+        // RequestImmediateTransmission()
+        public ResultCode RequestImmediateTransmission(ServiceCtx context)
+        {
+            // It signals an event of nn::prepo::detail::service::core::TransmissionStatusManager that requets the transmission of the report.
+            // Since we don't use reports it's fine to do nothing.
+
+            return ResultCode.Success;
+        }
+
+        [Command(10300)]
+        // GetTransmissionStatus() -> u32
+        public ResultCode GetTransmissionStatus(ServiceCtx context)
+        {
+            // It returns the transmission result of nn::prepo::detail::service::core::TransmissionStatusManager.
+            // Since we don't use reports it's fine to return ResultCode.Success.
+            context.ResponseData.Write((int)ResultCode.Success);
+
+            return ResultCode.Success;
+        }
+
         private ResultCode ProcessReport(ServiceCtx context, bool withUserID)
         {
             UserId  userId   = withUserID ? context.RequestData.ReadStruct<UserId>() : new UserId();


### PR DESCRIPTION
This implement RequestImmediateTransmission and GetTransmissionStatus of the prepo service accurately to RE.
Since we don't use reports, I've explained what the calls do in the real service.

Close #958