### PR TITLE
Make max anisotropy configurable

### DIFF
--- a/Ryujinx.Common/Configuration/ConfigurationFileFormat.cs
+++ b/Ryujinx.Common/Configuration/ConfigurationFileFormat.cs
@@ -19,9 +19,14 @@ namespace Ryujinx.Configuration
         /// <summary>
         /// The current version of the file format
         /// </summary>
-        public const int CurrentVersion = 3;
+        public const int CurrentVersion = 4;
 
         public int Version { get; set; }
+
+        /// <summary>
+        /// Max Anisotropy. Values range from 0 - 16. Set to -1 to let the game decide.
+        /// </summary>
+        public float MaxAnisotropy { get; set; }
 
         /// <summary>
         /// Dumps shaders in this local directory

--- a/Ryujinx.Common/Configuration/ConfigurationState.cs
+++ b/Ryujinx.Common/Configuration/ConfigurationState.cs
@@ -236,6 +236,11 @@ namespace Ryujinx.Configuration
         public class GraphicsSection
         {
             /// <summary>
+            /// Max Anisotropy. Values range from 0 - 16. Set to -1 to let the game decide.
+            /// </summary>
+            public ReactiveObject<float> MaxAnisotropy { get; private set; }
+
+            /// <summary>
             /// Dumps shaders in this local directory
             /// </summary>
             public ReactiveObject<string> ShadersDumpPath { get; private set; }
@@ -247,6 +252,7 @@ namespace Ryujinx.Configuration
 
             public GraphicsSection()
             {
+                MaxAnisotropy   = new ReactiveObject<float>();
                 ShadersDumpPath = new ReactiveObject<string>();
                 EnableVsync     = new ReactiveObject<bool>();
             }
@@ -302,6 +308,7 @@ namespace Ryujinx.Configuration
             ConfigurationFileFormat configurationFile = new ConfigurationFileFormat
             {
                 Version                   = ConfigurationFileFormat.CurrentVersion,
+                MaxAnisotropy             = Graphics.MaxAnisotropy,
                 GraphicsShadersDumpPath   = Graphics.ShadersDumpPath,
                 LoggingEnableDebug        = Logger.EnableDebug,
                 LoggingEnableStub         = Logger.EnableStub,
@@ -349,6 +356,7 @@ namespace Ryujinx.Configuration
 
         public void LoadDefault()
         {
+            Graphics.MaxAnisotropy.Value           = -1;
             Graphics.ShadersDumpPath.Value         = "";
             Logger.EnableDebug.Value               = false;
             Logger.EnableStub.Value                = true;
@@ -487,6 +495,16 @@ namespace Ryujinx.Configuration
                 configurationFileUpdated = true;
             }
 
+            if (configurationFileFormat.Version < 4)
+            {
+                Common.Logging.Logger.PrintWarning(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 4.");
+
+                configurationFileFormat.MaxAnisotropy = -1;
+
+                configurationFileUpdated = true;
+            }
+
+            Graphics.MaxAnisotropy.Value           = configurationFileFormat.MaxAnisotropy;
             Graphics.ShadersDumpPath.Value         = configurationFileFormat.GraphicsShadersDumpPath;
             Logger.EnableDebug.Value               = configurationFileFormat.LoggingEnableDebug;
             Logger.EnableStub.Value                = configurationFileFormat.LoggingEnableStub;

--- a/Ryujinx.Graphics.GAL/Capabilities.cs
+++ b/Ryujinx.Graphics.GAL/Capabilities.cs
@@ -8,16 +8,20 @@ namespace Ryujinx.Graphics.GAL
         public int MaximumComputeSharedMemorySize { get; }
         public int StorageBufferOffsetAlignment   { get; }
 
+        public float MaxSupportedAnisotropy { get; }
+
         public Capabilities(
-            bool supportsAstcCompression,
-            bool supportsNonConstantTextureOffset,
-            int  maximumComputeSharedMemorySize,
-            int  storageBufferOffsetAlignment)
+            bool  supportsAstcCompression,
+            bool  supportsNonConstantTextureOffset,
+            int   maximumComputeSharedMemorySize,
+            int   storageBufferOffsetAlignment,
+            float maxSupportedAnisotropy)
         {
             SupportsAstcCompression          = supportsAstcCompression;
             SupportsNonConstantTextureOffset = supportsNonConstantTextureOffset;
             MaximumComputeSharedMemorySize   = maximumComputeSharedMemorySize;
             StorageBufferOffsetAlignment     = storageBufferOffsetAlignment;
+            MaxSupportedAnisotropy           = maxSupportedAnisotropy;
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/GraphicsConfig.cs
+++ b/Ryujinx.Graphics.Gpu/GraphicsConfig.cs
@@ -6,6 +6,11 @@ namespace Ryujinx.Graphics.Gpu
     public static class GraphicsConfig
     {
         /// <summary>
+        /// Max Anisotropy. Values range from 0 - 16. Set to -1 to let the game decide.
+        /// </summary>
+        public static float MaxAnisotropy;
+
+        /// <summary>
         /// Base directory used to write shader code dumps.
         /// Set to null to disable code dumping.
         /// </summary>

--- a/Ryujinx.Graphics.Gpu/Image/Sampler.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Sampler.cs
@@ -1,4 +1,3 @@
-using OpenTK.Graphics.OpenGL;
 using Ryujinx.Graphics.GAL;
 using System;
 
@@ -42,7 +41,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             float mipLodBias = descriptor.UnpackMipLodBias();
 
             float maxRequestedAnisotropy = GraphicsConfig.MaxAnisotropy >= 0 && GraphicsConfig.MaxAnisotropy <= 16 ? GraphicsConfig.MaxAnisotropy : descriptor.UnpackMaxAnisotropy();
-            float maxSupportedAnisotropy = GL.GetFloat((GetPName)All.MaxTextureMaxAnisotropy);
+            float maxSupportedAnisotropy = context.Capabilities.MaxSupportedAnisotropy;
 
             if (maxRequestedAnisotropy > maxSupportedAnisotropy)
                 maxRequestedAnisotropy = maxSupportedAnisotropy;

--- a/Ryujinx.Graphics.Gpu/Image/Sampler.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Sampler.cs
@@ -1,3 +1,4 @@
+using OpenTK.Graphics.OpenGL;
 using Ryujinx.Graphics.GAL;
 using System;
 
@@ -40,7 +41,11 @@ namespace Ryujinx.Graphics.Gpu.Image
             float maxLod     = descriptor.UnpackMaxLod();
             float mipLodBias = descriptor.UnpackMipLodBias();
 
-            float maxAnisotropy = descriptor.UnpackMaxAnisotropy();
+            float maxRequestedAnisotropy = GraphicsConfig.MaxAnisotropy >= 0 && GraphicsConfig.MaxAnisotropy <= 16 ? GraphicsConfig.MaxAnisotropy : descriptor.UnpackMaxAnisotropy();
+            float maxSupportedAnisotropy = GL.GetFloat((GetPName)All.MaxTextureMaxAnisotropy);
+
+            if (maxRequestedAnisotropy > maxSupportedAnisotropy)
+                maxRequestedAnisotropy = maxSupportedAnisotropy;
 
             HostSampler = context.Renderer.CreateSampler(new SamplerCreateInfo(
                 minFilter,
@@ -54,7 +59,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 minLod,
                 maxLod,
                 mipLodBias,
-                maxAnisotropy));
+                maxRequestedAnisotropy));
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.OpenGL/HwCapabilities.cs
+++ b/Ryujinx.Graphics.OpenGL/HwCapabilities.cs
@@ -22,11 +22,15 @@ namespace Ryujinx.Graphics.OpenGL
 
         public static GpuVendor Vendor => _gpuVendor.Value;
 
+        private static Lazy<float> _maxSupportedAnisotropy = new Lazy<float>(GL.GetFloat((GetPName)All.MaxTextureMaxAnisotropy));
+
         public static bool SupportsAstcCompression          => _supportsAstcCompression.Value;
         public static bool SupportsNonConstantTextureOffset => _gpuVendor.Value == GpuVendor.Nvidia;
 
         public static int MaximumComputeSharedMemorySize => _maximumComputeSharedMemorySize.Value;
         public static int StorageBufferOffsetAlignment   => _storageBufferOffsetAlignment.Value;
+
+        public static float MaxSupportedAnisotropy => _maxSupportedAnisotropy.Value;
 
         private static bool HasExtension(string name)
         {

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -67,7 +67,8 @@ namespace Ryujinx.Graphics.OpenGL
                 HwCapabilities.SupportsAstcCompression,
                 HwCapabilities.SupportsNonConstantTextureOffset,
                 HwCapabilities.MaximumComputeSharedMemorySize,
-                HwCapabilities.StorageBufferOffsetAlignment);
+                HwCapabilities.StorageBufferOffsetAlignment,
+                HwCapabilities.MaxSupportedAnisotropy);
         }
 
         public ulong GetCounter(CounterType type)

--- a/Ryujinx/Config.json
+++ b/Ryujinx/Config.json
@@ -1,5 +1,6 @@
 {
-    "version": 2,
+    "version": 4,
+    "max_anisotropy": -1,
     "graphics_shaders_dump_path": "",
     "logging_enable_debug": false,
     "logging_enable_stub": true,
@@ -12,6 +13,7 @@
     "enable_file_log": true,
     "system_language": "AmericanEnglish",
     "system_region": "USA",
+    "system_time_zone": "UTC",
     "docked_mode": false,
     "enable_discord_integration": true,
     "enable_vsync": true,

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -308,6 +308,7 @@ namespace Ryujinx.Ui
                 HLE.Switch device = InitializeSwitchInstance();
 
                 // TODO: Move this somewhere else + reloadable?
+                Graphics.Gpu.GraphicsConfig.MaxAnisotropy   = ConfigurationState.Instance.Graphics.MaxAnisotropy;
                 Graphics.Gpu.GraphicsConfig.ShadersDumpPath = ConfigurationState.Instance.Graphics.ShadersDumpPath;
 
                 if (Directory.Exists(path))

--- a/Ryujinx/Ui/SwitchSettings.cs
+++ b/Ryujinx/Ui/SwitchSettings.cs
@@ -52,6 +52,7 @@ namespace Ryujinx.Ui
         [GUI] ToggleButton _browseDir;
         [GUI] ToggleButton _removeDir;
         [GUI] Entry        _graphicsShadersDumpPath;
+        [GUI] ComboBoxText _anisotropy;
         [GUI] Image        _controller1Image;
 
         [GUI] ComboBoxText _controller1Type;
@@ -215,6 +216,7 @@ namespace Ryujinx.Ui
             _systemLanguageSelect.SetActiveId(ConfigurationState.Instance.System.Language.Value.ToString());
             _systemRegionSelect  .SetActiveId(ConfigurationState.Instance.System.Region.Value.ToString());
             _systemTimeZoneSelect.SetActiveId(timeZoneContentManager.SanityCheckDeviceLocationName());
+            _anisotropy          .SetActiveId(ConfigurationState.Instance.Graphics.MaxAnisotropy.Value.ToString());
             _controller1Type     .SetActiveId(ConfigurationState.Instance.Hid.ControllerType.Value.ToString());
             Controller_Changed(null, null, _controller1Type.ActiveId, _controller1Image);
 
@@ -458,6 +460,7 @@ namespace Ryujinx.Ui
 
             ConfigurationState.Instance.System.Language.Value              = (Language)Enum.Parse(typeof(Language), _systemLanguageSelect.ActiveId);
             ConfigurationState.Instance.System.Region.Value                = (Configuration.System.Region)Enum.Parse(typeof(Configuration.System.Region), _systemRegionSelect.ActiveId);
+            ConfigurationState.Instance.Graphics.MaxAnisotropy.Value       = float.Parse(_anisotropy.ActiveId);
             ConfigurationState.Instance.Hid.ControllerType.Value           = (ControllerType)Enum.Parse(typeof(ControllerType), _controller1Type.ActiveId);
             ConfigurationState.Instance.Ui.CustomThemePath.Value           = _custThemePath.Buffer.Text;
             ConfigurationState.Instance.Graphics.ShadersDumpPath.Value     = _graphicsShadersDumpPath.Buffer.Text;

--- a/Ryujinx/Ui/SwitchSettings.glade
+++ b/Ryujinx/Ui/SwitchSettings.glade
@@ -177,8 +177,8 @@
                                       <packing>
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
-                                        <property name="position">2</property>
                                         <property name="padding">5</property>
+                                        <property name="position">2</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -247,6 +247,11 @@
                                           </packing>
                                         </child>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
                                     </child>
                                   </object>
                                   <packing>
@@ -1447,6 +1452,52 @@
                                       </object>
                                       <packing>
                                         <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">5</property>
+                                    <property name="position">3</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="tooltip_text" translatable="yes">Graphics Shaders Dump Path</property>
+                                        <property name="label" translatable="yes">Anisotropic Filtering:</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="padding">5</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBoxText" id="_anisotropy">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="tooltip_text" translatable="yes">Change System TimeZone</property>
+                                        <property name="active_id">-1</property>
+                                        <items>
+                                          <item id="-1" translatable="yes">Auto</item>
+                                          <item id="2" translatable="yes">2x</item>
+                                          <item id="4" translatable="yes">4x</item>
+                                          <item id="8" translatable="yes">8x</item>
+                                          <item id="16" translatable="yes">16x</item>
+                                        </items>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
                                         <property name="fill">True</property>
                                         <property name="position">1</property>
                                       </packing>


### PR DESCRIPTION
This PR exposes a config option to make the max anisotropy configurable. The value can be 0-16 or -1 to let the game decide the level of anisotropy. The value is set to -1 by default.