### PR TITLE
Workaround for AMD and Intel view format bug

### DIFF
--- a/Ryujinx.Graphics.OpenGL/Debugger.cs
+++ b/Ryujinx.Graphics.OpenGL/Debugger.cs
@@ -34,7 +34,7 @@ namespace Ryujinx.Graphics.OpenGL
             switch (type)
             {
                 case DebugType.DebugTypeError:
-                    Logger.PrintDebug(LogClass.Gpu, fullMessage);
+                    Logger.PrintError(LogClass.Gpu, fullMessage);
                     break;
                 case DebugType.DebugTypePerformance:
                     Logger.PrintWarning(LogClass.Gpu, fullMessage);

--- a/Ryujinx.Graphics.OpenGL/Framebuffer.cs
+++ b/Ryujinx.Graphics.OpenGL/Framebuffer.cs
@@ -10,9 +10,13 @@ namespace Ryujinx.Graphics.OpenGL
 
         private FramebufferAttachment _lastDsAttachment;
 
+        private readonly TextureView[] _colors;
+
         public Framebuffer()
         {
             Handle = GL.GenFramebuffer();
+
+            _colors = new TextureView[8];
         }
 
         public void Bind()
@@ -22,11 +26,18 @@ namespace Ryujinx.Graphics.OpenGL
 
         public void AttachColor(int index, TextureView color)
         {
-            GL.FramebufferTexture(
-                FramebufferTarget.Framebuffer,
-                FramebufferAttachment.ColorAttachment0 + index,
-                color?.Handle ?? 0,
-                0);
+            FramebufferAttachment attachment = FramebufferAttachment.ColorAttachment0 + index;
+
+            if (HwCapabilities.IsIntelDriver)
+            {
+                GL.FramebufferTexture(FramebufferTarget.Framebuffer, attachment, color?.GetIntelWarViewHandle() ?? 0, 0);
+
+                _colors[index] = color;
+            }
+            else
+            {
+                GL.FramebufferTexture(FramebufferTarget.Framebuffer, attachment, color?.Handle ?? 0, 0);
+            }
         }
 
         public void AttachDepthStencil(TextureView depthStencil)
@@ -65,6 +76,20 @@ namespace Ryujinx.Graphics.OpenGL
             else
             {
                 _lastDsAttachment = 0;
+            }
+        }
+
+        public void SignalModified()
+        {
+            if (HwCapabilities.IsIntelDriver)
+            {
+                for (int i = 0; i < 8; i++)
+                {
+                    if (_colors[i] != null)
+                    {
+                        _colors[i].SignalModified();
+                    }
+                }
             }
         }
 

--- a/Ryujinx.Graphics.OpenGL/Framebuffer.cs
+++ b/Ryujinx.Graphics.OpenGL/Framebuffer.cs
@@ -28,9 +28,10 @@ namespace Ryujinx.Graphics.OpenGL
         {
             FramebufferAttachment attachment = FramebufferAttachment.ColorAttachment0 + index;
 
-            if (HwCapabilities.IsIntelDriver)
+            if (HwCapabilities.Vendor == HwCapabilities.GpuVendor.Amd ||
+                HwCapabilities.Vendor == HwCapabilities.GpuVendor.Intel)
             {
-                GL.FramebufferTexture(FramebufferTarget.Framebuffer, attachment, color?.GetIntelWarViewHandle() ?? 0, 0);
+                GL.FramebufferTexture(FramebufferTarget.Framebuffer, attachment, color?.GetIncompatibleFormatViewHandle() ?? 0, 0);
 
                 _colors[index] = color;
             }
@@ -81,7 +82,8 @@ namespace Ryujinx.Graphics.OpenGL
 
         public void SignalModified()
         {
-            if (HwCapabilities.IsIntelDriver)
+            if (HwCapabilities.Vendor == HwCapabilities.GpuVendor.Amd ||
+                HwCapabilities.Vendor == HwCapabilities.GpuVendor.Intel)
             {
                 for (int i = 0; i < 8; i++)
                 {

--- a/Ryujinx.Graphics.OpenGL/HwCapabilities.cs
+++ b/Ryujinx.Graphics.OpenGL/HwCapabilities.cs
@@ -10,16 +10,17 @@ namespace Ryujinx.Graphics.OpenGL
         private static readonly Lazy<int> _maximumComputeSharedMemorySize = new Lazy<int>(() => GetLimit(All.MaxComputeSharedMemorySize));
         private static readonly Lazy<int> _storageBufferOffsetAlignment   = new Lazy<int>(() => GetLimit(All.ShaderStorageBufferOffsetAlignment));
 
-        private enum GpuVendor
+        public enum GpuVendor
         {
             Unknown,
+            Amd,
             Intel,
             Nvidia
         }
 
         private static readonly Lazy<GpuVendor> _gpuVendor = new Lazy<GpuVendor>(GetGpuVendor);
 
-        public static bool IsIntelDriver => _gpuVendor.Value == GpuVendor.Intel;
+        public static GpuVendor Vendor => _gpuVendor.Value;
 
         public static bool SupportsAstcCompression          => _supportsAstcCompression.Value;
         public static bool SupportsNonConstantTextureOffset => _gpuVendor.Value == GpuVendor.Nvidia;
@@ -49,15 +50,19 @@ namespace Ryujinx.Graphics.OpenGL
 
         private static GpuVendor GetGpuVendor()
         {
-            string vendor = GL.GetString(StringName.Vendor);
+            string vendor = GL.GetString(StringName.Vendor).ToLower();
 
-            if (vendor == "NVIDIA Corporation")
+            if (vendor == "nvidia corporation")
             {
                 return GpuVendor.Nvidia;
             }
-            else if (vendor == "Intel")
+            else if (vendor == "intel")
             {
                 return GpuVendor.Intel;
+            }
+            else if (vendor == "ati technologies inc." || vendor == "advanced micro devices, inc.")
+            {
+                return GpuVendor.Amd;
             }
             else
             {

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -19,21 +19,21 @@ namespace Ryujinx.Graphics.OpenGL
 
         private PrimitiveType _primitiveType;
 
-        private int  _stencilFrontMask;
+        private int _stencilFrontMask;
         private bool _depthMask;
         private bool _depthTest;
         private bool _hasDepthBuffer;
 
         private TextureView _unit0Texture;
 
-        private ClipOrigin    _clipOrigin;
+        private ClipOrigin _clipOrigin;
         private ClipDepthMode _clipDepthMode;
 
         private uint[] _componentMasks;
 
         internal Pipeline()
         {
-            _clipOrigin    = ClipOrigin.LowerLeft;
+            _clipOrigin = ClipOrigin.LowerLeft;
             _clipDepthMode = ClipDepthMode.NegativeOneToOne;
         }
 
@@ -56,6 +56,8 @@ namespace Ryujinx.Graphics.OpenGL
             GL.ClearBuffer(ClearBuffer.Color, index, colors);
 
             RestoreComponentMask(index);
+
+            _framebuffer.SignalModified();
         }
 
         public void ClearRenderTargetDepthStencil(float depthValue, bool depthMask, int stencilValue, int stencilMask)
@@ -98,6 +100,8 @@ namespace Ryujinx.Graphics.OpenGL
             {
                 GL.DepthMask(_depthMask);
             }
+
+            _framebuffer.SignalModified();
         }
 
         public void DispatchCompute(int groupsX, int groupsY, int groupsZ)
@@ -137,6 +141,8 @@ namespace Ryujinx.Graphics.OpenGL
             {
                 DrawImpl(vertexCount, instanceCount, firstVertex, firstInstance);
             }
+
+            _framebuffer.SignalModified();
         }
 
         private void DrawQuadsImpl(
@@ -247,7 +253,7 @@ namespace Ryujinx.Graphics.OpenGL
             switch (_elementsType)
             {
                 case DrawElementsType.UnsignedShort: indexElemSize = 2; break;
-                case DrawElementsType.UnsignedInt:   indexElemSize = 4; break;
+                case DrawElementsType.UnsignedInt: indexElemSize = 4; break;
             }
 
             IntPtr indexBaseOffset = _indexBaseOffset + firstIndex * indexElemSize;
@@ -281,15 +287,17 @@ namespace Ryujinx.Graphics.OpenGL
                     firstVertex,
                     firstInstance);
             }
+
+            _framebuffer.SignalModified();
         }
 
         private void DrawQuadsIndexedImpl(
-            int    indexCount,
-            int    instanceCount,
+            int indexCount,
+            int instanceCount,
             IntPtr indexBaseOffset,
-            int    indexElemSize,
-            int    firstVertex,
-            int    firstInstance)
+            int indexElemSize,
+            int firstVertex,
+            int firstInstance)
         {
             int quadsCount = indexCount / 4;
 
@@ -363,12 +371,12 @@ namespace Ryujinx.Graphics.OpenGL
         }
 
         private void DrawQuadStripIndexedImpl(
-            int    indexCount,
-            int    instanceCount,
+            int indexCount,
+            int instanceCount,
             IntPtr indexBaseOffset,
-            int    indexElemSize,
-            int    firstVertex,
-            int    firstInstance)
+            int indexElemSize,
+            int firstVertex,
+            int firstInstance)
         {
             // TODO: Instanced rendering.
             int quadsCount = (indexCount - 2) / 2;
@@ -404,11 +412,11 @@ namespace Ryujinx.Graphics.OpenGL
         }
 
         private void DrawIndexedImpl(
-            int    indexCount,
-            int    instanceCount,
+            int indexCount,
+            int instanceCount,
             IntPtr indexBaseOffset,
-            int    firstVertex,
-            int    firstInstance)
+            int firstVertex,
+            int firstInstance)
         {
             if (firstInstance == 0 && firstVertex == 0 && instanceCount == 1)
             {

--- a/Ryujinx.Graphics.OpenGL/TextureCopyUnscaled.cs
+++ b/Ryujinx.Graphics.OpenGL/TextureCopyUnscaled.cs
@@ -7,22 +7,30 @@ namespace Ryujinx.Graphics.OpenGL
 {
     static class TextureCopyUnscaled
     {
-        public static void Copy(TextureView src, TextureView dst, int dstLayer, int dstLevel)
+        public static void Copy(
+            TextureCreateInfo srcInfo,
+            TextureCreateInfo dstInfo,
+            int srcHandle,
+            int dstHandle,
+            int srcLayer,
+            int dstLayer,
+            int srcLevel,
+            int dstLevel)
         {
-            int srcWidth  = src.Width;
-            int srcHeight = src.Height;
-            int srcDepth  = src.DepthOrLayers;
-            int srcLevels = src.Levels;
+            int srcWidth  = srcInfo.Width;
+            int srcHeight = srcInfo.Height;
+            int srcDepth  = srcInfo.GetDepthOrLayers();
+            int srcLevels = srcInfo.Levels;
 
-            int dstWidth  = dst.Width;
-            int dstHeight = dst.Height;
-            int dstDepth  = dst.DepthOrLayers;
-            int dstLevels = dst.Levels;
+            int dstWidth  = dstInfo.Width;
+            int dstHeight = dstInfo.Height;
+            int dstDepth  = dstInfo.GetDepthOrLayers();
+            int dstLevels = dstInfo.Levels;
 
             dstWidth = Math.Max(1, dstWidth >> dstLevel);
             dstHeight = Math.Max(1, dstHeight >> dstLevel);
 
-            if (dst.Target == Target.Texture3D)
+            if (dstInfo.Target == Target.Texture3D)
             {
                 dstDepth = Math.Max(1, dstDepth >> dstLevel);
             }
@@ -31,15 +39,15 @@ namespace Ryujinx.Graphics.OpenGL
             // the non-compressed texture will have the size of the texture
             // in blocks (not in texels), so we must adjust that size to
             // match the size in texels of the compressed texture.
-            if (!src.IsCompressed && dst.IsCompressed)
+            if (!srcInfo.IsCompressed && dstInfo.IsCompressed)
             {
-                dstWidth  = BitUtils.DivRoundUp(dstWidth,  dst.BlockWidth);
-                dstHeight = BitUtils.DivRoundUp(dstHeight, dst.BlockHeight);
+                dstWidth  = BitUtils.DivRoundUp(dstWidth,  dstInfo.BlockWidth);
+                dstHeight = BitUtils.DivRoundUp(dstHeight, dstInfo.BlockHeight);
             }
-            else if (src.IsCompressed && !dst.IsCompressed)
+            else if (srcInfo.IsCompressed && !dstInfo.IsCompressed)
             {
-                dstWidth  *= dst.BlockWidth;
-                dstHeight *= dst.BlockHeight;
+                dstWidth  *= dstInfo.BlockWidth;
+                dstHeight *= dstInfo.BlockHeight;
             }
 
             int width  = Math.Min(srcWidth,  dstWidth);
@@ -50,20 +58,20 @@ namespace Ryujinx.Graphics.OpenGL
             for (int level = 0; level < levels; level++)
             {
                 // Stop copy if we are already out of the levels range.
-                if (level >= src.Levels || dstLevel + level >= dst.Levels)
+                if (level >= srcInfo.Levels || dstLevel + level >= dstInfo.Levels)
                 {
                     break;
                 }
 
                 GL.CopyImageSubData(
-                    src.Handle,
-                    src.Target.ConvertToImageTarget(),
-                    level,
+                    srcHandle,
+                    srcInfo.Target.ConvertToImageTarget(),
+                    srcLevel + level,
                     0,
                     0,
-                    0,
-                    dst.Handle,
-                    dst.Target.ConvertToImageTarget(),
+                    srcLayer,
+                    dstHandle,
+                    dstInfo.Target.ConvertToImageTarget(),
                     dstLevel + level,
                     0,
                     0,
@@ -72,10 +80,10 @@ namespace Ryujinx.Graphics.OpenGL
                     height,
                     depth);
 
-                width  = Math.Max(1, width  >> 1);
+                width = Math.Max(1, width >> 1);
                 height = Math.Max(1, height >> 1);
 
-                if (src.Target == Target.Texture3D)
+                if (srcInfo.Target == Target.Texture3D)
                 {
                     depth = Math.Max(1, depth >> 1);
                 }

--- a/Ryujinx.Graphics.OpenGL/TextureStorage.cs
+++ b/Ryujinx.Graphics.OpenGL/TextureStorage.cs
@@ -8,18 +8,16 @@ namespace Ryujinx.Graphics.OpenGL
     {
         public int Handle { get; private set; }
 
+        public TextureCreateInfo Info { get; }
+
         private readonly Renderer _renderer;
-
-        private readonly TextureCreateInfo _info;
-
-        public Target Target => _info.Target;
 
         private int _viewsCount;
 
         public TextureStorage(Renderer renderer, TextureCreateInfo info)
         {
             _renderer = renderer;
-            _info     = info;
+            Info      = info;
 
             Handle = GL.GenTexture();
 
@@ -28,13 +26,13 @@ namespace Ryujinx.Graphics.OpenGL
 
         private void CreateImmutableStorage()
         {
-            TextureTarget target = _info.Target.Convert();
+            TextureTarget target = Info.Target.Convert();
 
             GL.ActiveTexture(TextureUnit.Texture0);
 
             GL.BindTexture(target, Handle);
 
-            FormatInfo format = FormatTable.GetFormatInfo(_info.Format);
+            FormatInfo format = FormatTable.GetFormatInfo(Info.Format);
 
             SizedInternalFormat internalFormat;
 
@@ -47,92 +45,92 @@ namespace Ryujinx.Graphics.OpenGL
                 internalFormat = (SizedInternalFormat)format.PixelInternalFormat;
             }
 
-            switch (_info.Target)
+            switch (Info.Target)
             {
                 case Target.Texture1D:
                     GL.TexStorage1D(
                         TextureTarget1d.Texture1D,
-                        _info.Levels,
+                        Info.Levels,
                         internalFormat,
-                        _info.Width);
+                        Info.Width);
                     break;
 
                 case Target.Texture1DArray:
                     GL.TexStorage2D(
                         TextureTarget2d.Texture1DArray,
-                        _info.Levels,
+                        Info.Levels,
                         internalFormat,
-                        _info.Width,
-                        _info.Height);
+                        Info.Width,
+                        Info.Height);
                     break;
 
                 case Target.Texture2D:
                     GL.TexStorage2D(
                         TextureTarget2d.Texture2D,
-                        _info.Levels,
+                        Info.Levels,
                         internalFormat,
-                        _info.Width,
-                        _info.Height);
+                        Info.Width,
+                        Info.Height);
                     break;
 
                 case Target.Texture2DArray:
                     GL.TexStorage3D(
                         TextureTarget3d.Texture2DArray,
-                        _info.Levels,
+                        Info.Levels,
                         internalFormat,
-                        _info.Width,
-                        _info.Height,
-                        _info.Depth);
+                        Info.Width,
+                        Info.Height,
+                        Info.Depth);
                     break;
 
                 case Target.Texture2DMultisample:
                     GL.TexStorage2DMultisample(
                         TextureTargetMultisample2d.Texture2DMultisample,
-                        _info.Samples,
+                        Info.Samples,
                         internalFormat,
-                        _info.Width,
-                        _info.Height,
+                        Info.Width,
+                        Info.Height,
                         true);
                     break;
 
                 case Target.Texture2DMultisampleArray:
                     GL.TexStorage3DMultisample(
                         TextureTargetMultisample3d.Texture2DMultisampleArray,
-                        _info.Samples,
+                        Info.Samples,
                         internalFormat,
-                        _info.Width,
-                        _info.Height,
-                        _info.Depth,
+                        Info.Width,
+                        Info.Height,
+                        Info.Depth,
                         true);
                     break;
 
                 case Target.Texture3D:
                     GL.TexStorage3D(
                         TextureTarget3d.Texture3D,
-                        _info.Levels,
+                        Info.Levels,
                         internalFormat,
-                        _info.Width,
-                        _info.Height,
-                        _info.Depth);
+                        Info.Width,
+                        Info.Height,
+                        Info.Depth);
                     break;
 
                 case Target.Cubemap:
                     GL.TexStorage2D(
                         TextureTarget2d.TextureCubeMap,
-                        _info.Levels,
+                        Info.Levels,
                         internalFormat,
-                        _info.Width,
-                        _info.Height);
+                        Info.Width,
+                        Info.Height);
                     break;
 
                 case Target.CubemapArray:
                     GL.TexStorage3D(
                         (TextureTarget3d)All.TextureCubeMapArray,
-                        _info.Levels,
+                        Info.Levels,
                         internalFormat,
-                        _info.Width,
-                        _info.Height,
-                        _info.Depth);
+                        Info.Width,
+                        Info.Height,
+                        Info.Depth);
                     break;
 
                 default:
@@ -143,7 +141,7 @@ namespace Ryujinx.Graphics.OpenGL
 
         public ITexture CreateDefaultView()
         {
-            return CreateView(_info, 0, 0);
+            return CreateView(Info, 0, 0);
         }
 
         public ITexture CreateView(TextureCreateInfo info, int firstLayer, int firstLevel)

--- a/Ryujinx.Graphics.OpenGL/TextureView.cs
+++ b/Ryujinx.Graphics.OpenGL/TextureView.cs
@@ -433,6 +433,13 @@ namespace Ryujinx.Graphics.OpenGL
 
         public void Dispose()
         {
+            if (_intelWarView != null)
+            {
+                _intelWarView.Dispose();
+
+                _intelWarView = null;
+            }
+
             if (Handle != 0)
             {
                 GL.DeleteTexture(Handle);

--- a/Ryujinx.Graphics.OpenGL/TextureView.cs
+++ b/Ryujinx.Graphics.OpenGL/TextureView.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.Graphics.OpenGL
 
         private TextureView _emulatedViewParent;
 
-        private TextureView _intelWarView;
+        private TextureView _incompatibleFormatView;
 
         private readonly TextureCreateInfo _info;
 
@@ -125,22 +125,22 @@ namespace Ryujinx.Graphics.OpenGL
             }
         }
 
-        public int GetIntelWarViewHandle()
+        public int GetIncompatibleFormatViewHandle()
         {
-            // Intel has a bug where the view format is always ignored,
+            // AMD and Intel has a bug where the view format is always ignored,
             // it uses the parent format instead.
             // As workaround we create a new texture with the correct
             // format, and then do a copy after the draw.
             if (_parent.Info.Format != Format)
             {
-                if (_intelWarView == null)
+                if (_incompatibleFormatView == null)
                 {
-                    _intelWarView = (TextureView)_renderer.CreateTexture(_info);
+                    _incompatibleFormatView = (TextureView)_renderer.CreateTexture(_info);
                 }
 
-                TextureCopyUnscaled.Copy(_parent.Info, _intelWarView._info, _parent.Handle, _intelWarView.Handle, FirstLayer, 0, FirstLevel, 0);
+                TextureCopyUnscaled.Copy(_parent.Info, _incompatibleFormatView._info, _parent.Handle, _incompatibleFormatView.Handle, FirstLayer, 0, FirstLevel, 0);
 
-                return _intelWarView.Handle;
+                return _incompatibleFormatView.Handle;
             }
 
             return Handle;
@@ -148,9 +148,9 @@ namespace Ryujinx.Graphics.OpenGL
 
         public void SignalModified()
         {
-            if (_intelWarView != null)
+            if (_incompatibleFormatView != null)
             {
-                TextureCopyUnscaled.Copy(_intelWarView._info, _parent.Info, _intelWarView.Handle, _parent.Handle, 0, FirstLayer, 0, FirstLevel);
+                TextureCopyUnscaled.Copy(_incompatibleFormatView._info, _parent.Info, _incompatibleFormatView.Handle, _parent.Handle, 0, FirstLayer, 0, FirstLevel);
             }
         }
 
@@ -433,11 +433,11 @@ namespace Ryujinx.Graphics.OpenGL
 
         public void Dispose()
         {
-            if (_intelWarView != null)
+            if (_incompatibleFormatView != null)
             {
-                _intelWarView.Dispose();
+                _incompatibleFormatView.Dispose();
 
-                _intelWarView = null;
+                _incompatibleFormatView = null;
             }
 
             if (Handle != 0)


### PR DESCRIPTION
Intel has a bug where trying to render to a texture view with a format different from it's parent will still use the parent format.

As workaround, this creates a intermmediate texture, copies -> intermmediate, renders and copies intermmediate -> parent.