### PR TITLE
Fix MME shadow RAM implementation

### DIFF
--- a/Ryujinx.Graphics.Gpu/NvGpuFifo.cs
+++ b/Ryujinx.Graphics.Gpu/NvGpuFifo.cs
@@ -62,13 +62,13 @@ namespace Ryujinx.Graphics.Gpu
             /// </summary>
             /// <param name="mme">Program code</param>
             /// <param name="state">Current GPU state</param>
-            public void Execute(int[] mme, ShadowRamControl shadowCtrl, GpuState state, GpuState shadowState)
+            public void Execute(int[] mme, ShadowRamControl shadowCtrl, GpuState state)
             {
                 if (_executionPending)
                 {
                     _executionPending = false;
 
-                    _interpreter?.Execute(mme, Position, _argument, shadowCtrl, state, shadowState);
+                    _interpreter?.Execute(mme, Position, _argument, shadowCtrl, state);
                 }
             }
 
@@ -102,11 +102,6 @@ namespace Ryujinx.Graphics.Gpu
             public GpuState State { get; }
 
             /// <summary>
-            /// Sub-channel shadow GPU state (used as backup storage to restore MME changes).
-            /// </summary>
-            public GpuState ShadowState { get; }
-
-            /// <summary>
             /// Engine bound to the sub-channel.
             /// </summary>
             public ClassId  Class { get; set; }
@@ -117,7 +112,6 @@ namespace Ryujinx.Graphics.Gpu
             public SubChannel()
             {
                 State = new GpuState();
-                ShadowState = new GpuState();
             }
         }
 
@@ -208,11 +202,7 @@ namespace Ryujinx.Graphics.Gpu
             }
             else if (meth.Method < 0xe00)
             {
-                SubChannel sc = _subChannels[meth.SubChannel];
-
-                sc.ShadowState.Write(meth.Method, meth.Argument);
-
-                sc.State.CallMethod(meth);
+                _subChannels[meth.SubChannel].State.CallMethod(meth, _shadowCtrl);
             }
             else
             {
@@ -229,9 +219,7 @@ namespace Ryujinx.Graphics.Gpu
 
                 if (meth.IsLastCall)
                 {
-                    SubChannel sc = _subChannels[meth.SubChannel];
-
-                    _macros[macroIndex].Execute(_mme, _shadowCtrl, sc.State, sc.ShadowState);
+                    _macros[macroIndex].Execute(_mme, _shadowCtrl, _subChannels[meth.SubChannel].State);
 
                     _context.Methods.PerformDeferredDraws();
                 }

--- a/Ryujinx.Graphics.Gpu/State/GpuState.cs
+++ b/Ryujinx.Graphics.Gpu/State/GpuState.cs
@@ -12,7 +12,8 @@ namespace Ryujinx.Graphics.Gpu.State
 
         public delegate void MethodCallback(GpuState state, int argument);
 
-        private int[] _backingMemory;
+        private readonly int[] _memory;
+        private readonly int[] _shadow;
 
         /// <summary>
         /// GPU register information.
@@ -29,14 +30,15 @@ namespace Ryujinx.Graphics.Gpu.State
             public bool Modified;
         }
 
-        private Register[] _registers;
+        private readonly Register[] _registers;
 
         /// <summary>
         /// Creates a new instance of the GPU state.
         /// </summary>
         public GpuState()
         {
-            _backingMemory = new int[RegistersCount];
+            _memory = new int[RegistersCount];
+            _shadow = new int[RegistersCount];
 
             _registers = new Register[RegistersCount];
 
@@ -62,25 +64,40 @@ namespace Ryujinx.Graphics.Gpu.State
                 }
             }
 
-            InitializeDefaultState();
+            InitializeDefaultState(_memory);
+            InitializeDefaultState(_shadow);
         }
 
         /// <summary>
         /// Calls a GPU method, using this state.
         /// </summary>
         /// <param name="meth">The GPU method to be called</param>
-        public void CallMethod(MethodParams meth)
+        /// <param name="shadowCtrl">Shadow RAM control register value</param>
+        public void CallMethod(MethodParams meth, ShadowRamControl shadowCtrl)
         {
+            int value = meth.Argument;
+
+            // TODO: Figure out what TrackWithFilter does, compared to Track.
+            if (shadowCtrl == ShadowRamControl.Track ||
+                shadowCtrl == ShadowRamControl.TrackWithFilter)
+            {
+                _shadow[meth.Method] = value;
+            }
+            else if (shadowCtrl == ShadowRamControl.Replay)
+            {
+                value = _shadow[meth.Method];
+            }
+
             Register register = _registers[meth.Method];
 
-            if (_backingMemory[meth.Method] != meth.Argument)
+            if (_memory[meth.Method] != value)
             {
                 _registers[(int)register.BaseOffset].Modified = true;
             }
 
-            _backingMemory[meth.Method] = meth.Argument;
+            _memory[meth.Method] = value;
 
-            register.Callback?.Invoke(this, meth.Argument);
+            register.Callback?.Invoke(this, value);
         }
 
         /// <summary>
@@ -90,7 +107,7 @@ namespace Ryujinx.Graphics.Gpu.State
         /// <returns>Data at the register</returns>
         public int Read(int offset)
         {
-            return _backingMemory[offset];
+            return _memory[offset];
         }
 
         /// <summary>
@@ -100,7 +117,7 @@ namespace Ryujinx.Graphics.Gpu.State
         /// <param name="value">Value to be written</param>
         public void Write(int offset, int value)
         {
-            _backingMemory[offset] = value;
+            _memory[offset] = value;
         }
 
         /// <summary>
@@ -109,34 +126,34 @@ namespace Ryujinx.Graphics.Gpu.State
         /// <param name="offset">The offset to be written</param>
         public void SetUniformBufferOffset(int offset)
         {
-            _backingMemory[(int)MethodOffset.UniformBufferState + 3] = offset;
+            _memory[(int)MethodOffset.UniformBufferState + 3] = offset;
         }
 
         /// <summary>
         /// Initializes registers with the default state.
         /// </summary>
-        private void InitializeDefaultState()
+        private static void InitializeDefaultState(int[] memory)
         {
             // Enable Rasterizer
-            _backingMemory[(int)MethodOffset.RasterizeEnable] = 1;
+            memory[(int)MethodOffset.RasterizeEnable] = 1;
 
             // Depth ranges.
             for (int index = 0; index < Constants.TotalViewports; index++)
             {
-                _backingMemory[(int)MethodOffset.ViewportExtents + index * 4 + 2] = 0;
-                _backingMemory[(int)MethodOffset.ViewportExtents + index * 4 + 3] = 0x3F800000;
+                memory[(int)MethodOffset.ViewportExtents + index * 4 + 2] = 0;
+                memory[(int)MethodOffset.ViewportExtents + index * 4 + 3] = 0x3F800000;
             }
 
             // Viewport transform enable.
-            _backingMemory[(int)MethodOffset.ViewportTransformEnable] = 1;
+            memory[(int)MethodOffset.ViewportTransformEnable] = 1;
 
             // Default front stencil mask.
-            _backingMemory[0x4e7] = 0xff;
+            memory[0x4e7] = 0xff;
 
             // Default color mask.
             for (int index = 0; index < Constants.TotalRenderTargets; index++)
             {
-                _backingMemory[(int)MethodOffset.RtColorMask + index] = 0x1111;
+                memory[(int)MethodOffset.RtColorMask + index] = 0x1111;
             }
         }
 
@@ -296,7 +313,7 @@ namespace Ryujinx.Graphics.Gpu.State
         /// <returns>The data at the specified location</returns>
         public T Get<T>(MethodOffset offset) where T : struct
         {
-            return MemoryMarshal.Cast<int, T>(_backingMemory.AsSpan().Slice((int)offset))[0];
+            return MemoryMarshal.Cast<int, T>(_memory.AsSpan().Slice((int)offset))[0];
         }
     }
 }


### PR DESCRIPTION
This in an improvement of #987, the shadow ram control affects all writes, not only those coming from MME.
In addition to the linked PR, this fixes more issues with some games, like for example stencil mask being destroyed by a stencil clear.
This fixes for examlpe, stencil logo effect on Kill la Kill.

Before:
![image](https://user-images.githubusercontent.com/5624669/77711423-c0a1a380-6faf-11ea-8dc9-35bb9d949f4e.png)
After:
![image](https://user-images.githubusercontent.com/5624669/77711209-1de92500-6faf-11ea-966a-c54815bd00c8.png)

Thanks again to @fincs for clarifying that.