### PR TITLE
Implement GPU scissors

### DIFF
--- a/Ryujinx.Graphics.GAL/IPipeline.cs
+++ b/Ryujinx.Graphics.GAL/IPipeline.cs
@@ -1,4 +1,5 @@
 using Ryujinx.Graphics.Shader;
+using System;
 
 namespace Ryujinx.Graphics.GAL
 {
@@ -29,9 +30,7 @@ namespace Ryujinx.Graphics.GAL
         void SetBlendColor(ColorF color);
 
         void SetDepthBias(PolygonModeMask enables, float factor, float units, float clamp);
-
         void SetDepthMode(DepthMode mode);
-
         void SetDepthTest(DepthTestDescriptor depthTest);
 
         void SetFaceCulling(bool enable, Face face);
@@ -55,6 +54,9 @@ namespace Ryujinx.Graphics.GAL
         void SetRenderTargets(ITexture[] colors, ITexture depthStencil);
 
         void SetSampler(int index, ShaderStage stage, ISampler sampler);
+
+        void SetScissorEnable(int index, bool enable);
+        void SetScissor(int index, int x, int y, int width, int height);
 
         void SetStencilTest(StencilTestDescriptor stencilTest);
 

--- a/Ryujinx.Graphics.GAL/IPipeline.cs
+++ b/Ryujinx.Graphics.GAL/IPipeline.cs
@@ -1,5 +1,4 @@
 using Ryujinx.Graphics.Shader;
-using System;
 
 namespace Ryujinx.Graphics.GAL
 {

--- a/Ryujinx.Graphics.Gpu/Engine/MethodClear.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodClear.cs
@@ -13,6 +13,12 @@ namespace Ryujinx.Graphics.Gpu.Engine
         /// <param name="argument">Method call argument</param>
         private void Clear(GpuState state, int argument)
         {
+            // Scissor affects clears aswell.
+            if (state.QueryModified(MethodOffset.ScissorState))
+            {
+                UpdateScissorState(state);
+            }
+
             UpdateRenderTargetState(state, useControl: false);
 
             TextureManager.CommitGraphicsBindings();

--- a/Ryujinx.Graphics.Gpu/State/GpuStateTable.cs
+++ b/Ryujinx.Graphics.Gpu/State/GpuStateTable.cs
@@ -57,6 +57,7 @@ namespace Ryujinx.Graphics.Gpu.State
             new TableItem(MethodOffset.ViewportExtents,        typeof(ViewportExtents),       8),
             new TableItem(MethodOffset.VertexBufferDrawState,  typeof(VertexBufferDrawState), 1),
             new TableItem(MethodOffset.DepthBiasState,         typeof(DepthBiasState),        1),
+            new TableItem(MethodOffset.ScissorState,           typeof(ScissorState),          8),
             new TableItem(MethodOffset.StencilBackMasks,       typeof(StencilBackMasks),      1),
             new TableItem(MethodOffset.RtDepthStencilState,    typeof(RtDepthStencilState),   1),
             new TableItem(MethodOffset.VertexAttribState,      typeof(VertexAttribState),     16),

--- a/Ryujinx.Graphics.Gpu/State/MethodOffset.cs
+++ b/Ryujinx.Graphics.Gpu/State/MethodOffset.cs
@@ -33,6 +33,7 @@ namespace Ryujinx.Graphics.Gpu.State
         ClearStencilValue               = 0x368,
         DepthBiasState                  = 0x370,
         TextureBarrier                  = 0x378,
+        ScissorState                    = 0x380,
         StencilBackMasks                = 0x3d5,
         InvalidateTextures              = 0x3dd,
         TextureBarrierTiled             = 0x3df,

--- a/Ryujinx.Graphics.Gpu/State/ScissorState.cs
+++ b/Ryujinx.Graphics.Gpu/State/ScissorState.cs
@@ -1,0 +1,12 @@
+﻿namespace Ryujinx.Graphics.Gpu.State
+{
+    struct ScissorState
+    {
+        public Boolean32 Enable;
+        public ushort X1;
+        public ushort X2;
+        public ushort Y1;
+        public ushort Y2;
+        public uint Padding;
+    }
+}

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -31,10 +31,14 @@ namespace Ryujinx.Graphics.OpenGL
 
         private uint[] _componentMasks;
 
+        private readonly bool[] _scissorEnable;
+
         internal Pipeline()
         {
             _clipOrigin    = ClipOrigin.LowerLeft;
             _clipDepthMode = ClipDepthMode.NegativeOneToOne;
+
+            _scissorEnable = new bool[8];
         }
 
         public void Barrier()
@@ -674,6 +678,25 @@ namespace Ryujinx.Graphics.OpenGL
             }
         }
 
+        public void SetScissorEnable(int index, bool enable)
+        {
+            if (enable)
+            {
+                GL.Enable(IndexedEnableCap.ScissorTest, index);
+            }
+            else
+            {
+                GL.Disable(IndexedEnableCap.ScissorTest, index);
+            }
+
+            _scissorEnable[index] = enable;
+        }
+
+        public void SetScissor(int index, int x, int y, int width, int height)
+        {
+            GL.ScissorIndexed(index, x, y, width, height);
+        }
+
         public void SetStencilTest(StencilTestDescriptor stencilTest)
         {
             if (!stencilTest.TestEnable)
@@ -925,6 +948,17 @@ namespace Ryujinx.Graphics.OpenGL
                     (_componentMasks[index] & 2u) != 0,
                     (_componentMasks[index] & 4u) != 0,
                     (_componentMasks[index] & 8u) != 0);
+            }
+        }
+
+        public void RestoreScissorEnable()
+        {
+            for (int index = 0; index < 8; index++)
+            {
+                if (_scissorEnable[index])
+                {
+                    GL.Enable(IndexedEnableCap.ScissorTest, index);
+                }
             }
         }
 

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -7,7 +7,7 @@ namespace Ryujinx.Graphics.OpenGL
 {
     public sealed class Renderer : IRenderer
     {
-        private Pipeline _pipeline;
+        private readonly Pipeline _pipeline;
 
         public IPipeline Pipeline => _pipeline;
 
@@ -31,9 +31,9 @@ namespace Ryujinx.Graphics.OpenGL
 
             _counters = new Counters();
 
-            _window = new Window();
+            _window = new Window(this);
 
-            TextureCopy = new TextureCopy();
+            TextureCopy = new TextureCopy(this);
         }
 
         public IShader CompileShader(ShaderProgram shader)

--- a/Ryujinx.Graphics.OpenGL/TextureCopy.cs
+++ b/Ryujinx.Graphics.OpenGL/TextureCopy.cs
@@ -6,8 +6,15 @@ namespace Ryujinx.Graphics.OpenGL
 {
     class TextureCopy : IDisposable
     {
+        private readonly Renderer _renderer;
+
         private int _srcFramebuffer;
         private int _dstFramebuffer;
+
+        public TextureCopy(Renderer renderer)
+        {
+            _renderer = renderer;
+        }
 
         public void Copy(
             TextureView src,
@@ -34,6 +41,8 @@ namespace Ryujinx.Graphics.OpenGL
             GL.ReadBuffer(ReadBufferMode.ColorAttachment0);
             GL.DrawBuffer(DrawBufferMode.ColorAttachment0);
 
+            GL.Disable(EnableCap.ScissorTest);
+
             GL.BlitFramebuffer(
                 srcRegion.X1,
                 srcRegion.Y1,
@@ -48,6 +57,8 @@ namespace Ryujinx.Graphics.OpenGL
 
             GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, oldReadFramebufferHandle);
             GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, oldDrawFramebufferHandle);
+
+            ((Pipeline)_renderer.Pipeline).RestoreScissorEnable();
         }
 
         private static void Attach(FramebufferTarget target, Format format, int handle)

--- a/Ryujinx.Graphics.OpenGL/Window.cs
+++ b/Ryujinx.Graphics.OpenGL/Window.cs
@@ -9,13 +9,17 @@ namespace Ryujinx.Graphics.OpenGL
         private const int NativeWidth  = 1280;
         private const int NativeHeight = 720;
 
+        private readonly Renderer _renderer;
+
         private int _width;
         private int _height;
 
         private int _copyFramebufferHandle;
 
-        public Window()
+        public Window(Renderer renderer)
         {
+            _renderer = renderer;
+
             _width  = NativeWidth;
             _height = NativeHeight;
         }
@@ -35,13 +39,13 @@ namespace Ryujinx.Graphics.OpenGL
             _height = height;
         }
 
-
         private void CopyTextureToFrameBufferRGB(int drawFramebuffer, int readFramebuffer, TextureView view, ImageCrop crop)
         {
             bool[] oldFramebufferColorWritemask = new bool[4];
 
             int oldReadFramebufferHandle = GL.GetInteger(GetPName.ReadFramebufferBinding);
             int oldDrawFramebufferHandle = GL.GetInteger(GetPName.DrawFramebufferBinding);
+
             GL.GetBoolean(GetIndexedPName.ColorWritemask, drawFramebuffer, oldFramebufferColorWritemask);
 
             GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, drawFramebuffer);
@@ -54,6 +58,8 @@ namespace Ryujinx.Graphics.OpenGL
                 0);
 
             GL.ReadBuffer(ReadBufferMode.ColorAttachment0);
+
+            GL.Disable(EnableCap.ScissorTest);
 
             GL.Clear(ClearBufferMask.ColorBufferBit);
 
@@ -119,6 +125,8 @@ namespace Ryujinx.Graphics.OpenGL
 
             GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, oldReadFramebufferHandle);
             GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, oldDrawFramebufferHandle);
+
+            ((Pipeline)_renderer.Pipeline).RestoreScissorEnable();
         }
 
         private int GetCopyFramebufferHandleLazy()


### PR DESCRIPTION
This implements ✂️ support on the GPU.
Fixes bugs in a few games, like animal crossing customization screen:
Before (image not mine):
![image](https://user-images.githubusercontent.com/5624669/77804546-91963b00-705e-11ea-9148-d444261c03bf.png)
After:
![image](https://user-images.githubusercontent.com/5624669/77804460-54ca4400-705e-11ea-83c6-b1db74ea0d6f.png)
![image](https://user-images.githubusercontent.com/5624669/77804465-58f66180-705e-11ea-82df-fe90839aa1eb.png)
