### PR TITLE
Support constant attributes (with a value of zero)

### DIFF
--- a/Ryujinx.Graphics.GAL/VertexAttribDescriptor.cs
+++ b/Ryujinx.Graphics.GAL/VertexAttribDescriptor.cs
@@ -5,12 +5,15 @@ namespace Ryujinx.Graphics.GAL
         public int BufferIndex { get; }
         public int Offset      { get; }
 
+        public bool IsZero { get; }
+
         public Format Format { get; }
 
-        public VertexAttribDescriptor(int bufferIndex, int offset, Format format)
+        public VertexAttribDescriptor(int bufferIndex, int offset, bool isZero, Format format)
         {
             BufferIndex = bufferIndex;
             Offset      = offset;
+            IsZero      = isZero;
             Format      = format;
         }
     }

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -506,6 +506,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
                 vertexAttribs[index] = new VertexAttribDescriptor(
                     vertexAttrib.UnpackBufferIndex(),
                     vertexAttrib.UnpackOffset(),
+                    vertexAttrib.UnpackIsConstant(),
                     format);
             }
 

--- a/Ryujinx.Graphics.Gpu/State/VertexAttribState.cs
+++ b/Ryujinx.Graphics.Gpu/State/VertexAttribState.cs
@@ -17,6 +17,15 @@ namespace Ryujinx.Graphics.Gpu.State
         }
 
         /// <summary>
+        /// Unpacks the attribute constant flag.
+        /// </summary>
+        /// <returns>True if the attribute is constant, false otherwise</returns>
+        public bool UnpackIsConstant()
+        {
+            return (Attribute & 0x40) != 0;
+        }
+
+        /// <summary>
         /// Unpacks the offset, in bytes, of the attribute on the vertex buffer.
         /// </summary>
         /// <returns>Attribute offset in bytes</returns>

--- a/Ryujinx.Graphics.OpenGL/VertexArray.cs
+++ b/Ryujinx.Graphics.OpenGL/VertexArray.cs
@@ -69,7 +69,6 @@ namespace Ryujinx.Graphics.OpenGL
                     GL.EnableVertexAttribArray(attribIndex);
                 }
                 
-
                 int offset = attrib.Offset;
                 int size   = fmtInfo.Components;
 

--- a/Ryujinx.Graphics.OpenGL/VertexArray.cs
+++ b/Ryujinx.Graphics.OpenGL/VertexArray.cs
@@ -58,7 +58,17 @@ namespace Ryujinx.Graphics.OpenGL
             {
                 FormatInfo fmtInfo = FormatTable.GetFormatInfo(attrib.Format);
 
-                GL.EnableVertexAttribArray(attribIndex);
+                if (attrib.IsZero)
+                {
+                    // Disabling the attribute causes the shader to read a constant value.
+                    // The value is configurable, but by default is a vector of (0, 0, 0, 1).
+                    GL.DisableVertexAttribArray(attribIndex);
+                }
+                else
+                {
+                    GL.EnableVertexAttribArray(attribIndex);
+                }
+                
 
                 int offset = attrib.Offset;
                 int size   = fmtInfo.Components;
@@ -117,7 +127,7 @@ namespace Ryujinx.Graphics.OpenGL
                     continue;
                 }
 
-                if (_needsAttribsUpdate)
+                if (_needsAttribsUpdate && !attrib.IsZero)
                 {
                     GL.EnableVertexAttribArray(attribIndex);
                 }


### PR DESCRIPTION
When a attribute is not used, NVN sets bit 6 on the attribute, which indicates that it uses a constant value. The emulator was ignoring that bit and assuming all attributes would always point to data inside the vertex buffer. This is incorrect and some games relies on the constant behavior -- basically they use on the shader attributes that are "disabled".

This fixes bug on some tiles on Animal Crossing.
Before:
![image](https://user-images.githubusercontent.com/5624669/77835284-0d10ee80-712a-11ea-8e5f-25b6d7dfb504.png)
After:
![image](https://user-images.githubusercontent.com/5624669/77835292-14d09300-712a-11ea-9714-2a2cb9ef62a5.png)

Recommend testing in a few games to be sure that nothing regressed.