### PR TITLE
Remove output interpolation qualifier

### DIFF
--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
@@ -400,9 +400,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
         {
             for (int attr = 0; attr < MaxAttributes; attr++)
             {
-                string iq = $"{DefineNames.OutQualifierPrefixName}{attr} ";
-
-                context.AppendLine($"layout (location = {attr}) {iq}out vec4 {DefaultNames.OAttributePrefix}{attr};");
+                context.AppendLine($"layout (location = {attr}) out vec4 {DefaultNames.OAttributePrefix}{attr};");
             }
 
             foreach (int attr in info.OAttributes.OrderBy(x => x).Where(x => x >= MaxAttributes))

--- a/Ryujinx.Graphics.Shader/DefineNames.cs
+++ b/Ryujinx.Graphics.Shader/DefineNames.cs
@@ -1,7 +1,0 @@
-namespace Ryujinx.Graphics.Shader
-{
-    public static class DefineNames
-    {
-        public const string OutQualifierPrefixName = "S_OUT_QUALIFIER";
-    }
-}

--- a/Ryujinx.Graphics.Shader/InterpolationQualifier.cs
+++ b/Ryujinx.Graphics.Shader/InterpolationQualifier.cs
@@ -3,7 +3,7 @@ using System;
 namespace Ryujinx.Graphics.Shader
 {
     [Flags]
-    public enum InterpolationQualifier
+    enum InterpolationQualifier
     {
         None = 0,
 
@@ -17,18 +17,17 @@ namespace Ryujinx.Graphics.Shader
         FlagsMask = Centroid | Sample
     }
 
-    public static class InterpolationQualifierExtensions
+    static class InterpolationQualifierExtensions
     {
         public static string ToGlslQualifier(this InterpolationQualifier iq)
         {
-            string output = string.Empty;
-
-            switch (iq & ~InterpolationQualifier.FlagsMask)
+            string output = (iq & ~InterpolationQualifier.FlagsMask) switch
             {
-                case InterpolationQualifier.Flat:          output = "flat";          break;
-                case InterpolationQualifier.NoPerspective: output = "noperspective"; break;
-                case InterpolationQualifier.Smooth:        output = "smooth";        break;
-            }
+                InterpolationQualifier.Flat => "flat",
+                InterpolationQualifier.NoPerspective => "noperspective",
+                InterpolationQualifier.Smooth => "smooth",
+                _ => string.Empty
+            };
 
             if ((iq & InterpolationQualifier.Centroid) != 0)
             {

--- a/Ryujinx.Graphics.Shader/ShaderProgramInfo.cs
+++ b/Ryujinx.Graphics.Shader/ShaderProgramInfo.cs
@@ -10,24 +10,19 @@ namespace Ryujinx.Graphics.Shader
         public ReadOnlyCollection<TextureDescriptor> Textures { get; }
         public ReadOnlyCollection<TextureDescriptor> Images   { get; }
 
-        public ReadOnlyCollection<InterpolationQualifier> InterpolationQualifiers { get; }
-
         public bool UsesInstanceId { get; }
 
         internal ShaderProgramInfo(
-            BufferDescriptor[]       cBuffers,
-            BufferDescriptor[]       sBuffers,
-            TextureDescriptor[]      textures,
-            TextureDescriptor[]      images,
-            InterpolationQualifier[] interpolationQualifiers,
-            bool                     usesInstanceId)
+            BufferDescriptor[]  cBuffers,
+            BufferDescriptor[]  sBuffers,
+            TextureDescriptor[] textures,
+            TextureDescriptor[] images,
+            bool                usesInstanceId)
         {
             CBuffers = Array.AsReadOnly(cBuffers);
             SBuffers = Array.AsReadOnly(sBuffers);
             Textures = Array.AsReadOnly(textures);
             Images   = Array.AsReadOnly(images);
-
-            InterpolationQualifiers = Array.AsReadOnly(interpolationQualifiers);
 
             UsesInstanceId = usesInstanceId;
         }

--- a/Ryujinx.Graphics.Shader/Translation/Translator.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Translator.cs
@@ -79,7 +79,6 @@ namespace Ryujinx.Graphics.Shader.Translation
                 program.SBufferDescriptors,
                 program.TextureDescriptors,
                 program.ImageDescriptors,
-                sInfo.InterpolationQualifiers,
                 sInfo.UsesInstanceId);
 
             string glslCode = program.Code;


### PR DESCRIPTION
This remove code used to propagate interpolation qualifier from the fragment shader stages to the previous stages. Older GLSL versions requires that, but since 4.3.0, the spec says that only the fragment shader input qualifiers matters, so since we require this version now, we don't need it anymore.

From the spec:
> When interpolation or auxiliary qualifiers do not match, those provided in the fragment shader supersede those provided in previous stages. If any such qualifiers are completely missing in the fragment shaders, then the default is used, rather than any qualifiers that may have been declared in previous stages. That is, what matters is what is declared in the fragment shaders, not what is declared in shaders in previous stages.

https://www.khronos.org/registry/OpenGL/specs/gl/GLSLangSpec.4.60.html