### PR TITLE
Revert SwKbd Applet ReadStruct

### DIFF
--- a/Ryujinx.HLE/HOS/Applets/IApplet.cs
+++ b/Ryujinx.HLE/HOS/Applets/IApplet.cs
@@ -13,7 +13,7 @@ namespace Ryujinx.HLE.HOS.Applets
 
         ResultCode GetResult();
 
-        static T ReadStruct<T>(ReadOnlySpan<byte> data) where T : struct
+        static T ReadStruct<T>(ReadOnlySpan<byte> data) where T : unmanaged
         {
             return MemoryMarshal.Cast<byte, T>(data)[0];
         }

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardApplet.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardApplet.cs
@@ -41,7 +41,7 @@ namespace Ryujinx.HLE.HOS.Applets
             var keyboardConfig = _normalSession.Pop();
             var transferMemory = _normalSession.Pop();
 
-            _keyboardConfig = IApplet.ReadStruct<SoftwareKeyboardConfig>(keyboardConfig);
+            _keyboardConfig = ReadStruct<SoftwareKeyboardConfig>(keyboardConfig);
 
             if (_keyboardConfig.UseUtf8)
             {
@@ -174,6 +174,21 @@ namespace Ryujinx.HLE.HOS.Applets
                 writer.Write(output);
 
                 return stream.ToArray();
+            }
+        }
+
+        private static T ReadStruct<T>(byte[] data)
+            where T : struct
+        {
+            GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);
+
+            try
+            {    
+                return Marshal.PtrToStructure<T>(handle.AddrOfPinnedObject());
+            }
+            finally
+            {
+                handle.Free();
             }
         }
     }


### PR DESCRIPTION
Also, fix IApplet's `ReadStruct` signature to catch bad uses at compile time.

Fixes regression where SoftwareKeyboard is unusable.