### PR TITLE
Use the jump table for HighCq tail continues.

### DIFF
--- a/ARMeilleure/Instructions/InstEmitFlowHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitFlowHelper.cs
@@ -235,7 +235,7 @@ namespace ARMeilleure.Instructions
                 {
                     if (allowRejit)
                     {
-                        address = context.BitwiseOr(address, Const(1L));
+                        address = context.BitwiseOr(address, Const(CallFlag));
                     }
 
                     Operand fallbackAddr = context.Call(new _U64_U64(NativeInterface.GetFunctionAddress), address);

--- a/ARMeilleure/Instructions/InstEmitFlowHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitFlowHelper.cs
@@ -225,14 +225,23 @@ namespace ARMeilleure.Instructions
             bool useTailContinue = true; // Left option here as it may be useful if we need to return to managed rather than tail call in future. (eg. for debug)
             if (useTailContinue)
             {
-                if (allowRejit)
+                if (context.HighCq)
                 {
-                    address = context.BitwiseOr(address, Const(1L));
+                    // If we're doing a tail continue in HighCq, reserve a space in the jump table to avoid calling back to the translator.
+                    // This will always try to get a HighCq version of our continue target as well.
+                    EmitJumpTableBranch(context, address, true);
+                } 
+                else
+                {
+                    if (allowRejit)
+                    {
+                        address = context.BitwiseOr(address, Const(1L));
+                    }
+
+                    Operand fallbackAddr = context.Call(new _U64_U64(NativeInterface.GetFunctionAddress), address);
+
+                    EmitNativeCall(context, fallbackAddr, true);
                 }
-
-                Operand fallbackAddr = context.Call(new _U64_U64(NativeInterface.GetFunctionAddress), address);
-
-                EmitNativeCall(context, fallbackAddr, true);
             } 
             else
             {


### PR DESCRIPTION
This path is always reached when a function larger than our current length limit (currently 5000 instructions) is compiled. It can add quite a few entries to the jump table, but it is insignificant compared to our maximum capacity.

Essentially, the situation is that the decoder has a hard upper cap on the number of instructions it will decode at once. If this is reached, it will leave a branch with a target block as "null", which causes us to emit a tail continue when emitting that branch, which would find and execute the next code block. Before, this would always go back to GetOrTranslate, and typically return a LowCq function.

Also made the call flag here use CallFlag instead of 1L.

Reduces CPU load on games that generally have large functions.