### PR TITLE
Simple GPU fixes

### DIFF
--- a/Ryujinx.Graphics.GAL/IPipeline.cs
+++ b/Ryujinx.Graphics.GAL/IPipeline.cs
@@ -48,6 +48,8 @@ namespace Ryujinx.Graphics.GAL
 
         void SetProgram(IProgram program);
 
+        void SetRasterizerDiscard(bool discard);
+
         void SetRenderTargetColorMasks(uint[] componentMask);
 
         void SetRenderTargets(ITexture[] colors, ITexture depthStencil);

--- a/Ryujinx.Graphics.Gpu/Constants.cs
+++ b/Ryujinx.Graphics.Gpu/Constants.cs
@@ -53,6 +53,6 @@ namespace Ryujinx.Graphics.Gpu
         /// <summary>
         /// Maximum number of viewports.
         /// </summary>
-        public const int TotalViewports = 8;
+        public const int TotalViewports = 16;
     }
 }

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -216,10 +216,14 @@ namespace Ryujinx.Graphics.Gpu.Engine
             CommitBindings();
         }
 
+        /// <summary>
+        /// Updates Rasterizer primitive discard state based on guest gpu state.
+        /// </summary>
+        /// <param name="state">Current GPU state</param>
         private void UpdateRasterizerState(GpuState state)
         {
-            int enable = state.Get<int>(MethodOffset.RasterizeEnable);
-            _context.Renderer.Pipeline.SetRasterizerDiscard(enable == 0);
+            Boolean32 enable = state.Get<Boolean32>(MethodOffset.RasterizeEnable);
+            _context.Renderer.Pipeline.SetRasterizerDiscard(!enable);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -108,6 +108,11 @@ namespace Ryujinx.Graphics.Gpu.Engine
                 UpdateShaderState(state);
             }
 
+            if (state.QueryModified(MethodOffset.RasterizeEnable))
+            {
+                UpdateRasterizerState(state);
+            }
+
             if (state.QueryModified(MethodOffset.RtColorState,
                                     MethodOffset.RtDepthStencilState,
                                     MethodOffset.RtControl,
@@ -209,6 +214,12 @@ namespace Ryujinx.Graphics.Gpu.Engine
             }
 
             CommitBindings();
+        }
+
+        private void UpdateRasterizerState(GpuState state)
+        {
+            int enable = state.Get<int>(MethodOffset.RasterizeEnable);
+            _context.Renderer.Pipeline.SetRasterizerDiscard(enable == 0);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/State/GpuState.cs
+++ b/Ryujinx.Graphics.Gpu/State/GpuState.cs
@@ -117,6 +117,9 @@ namespace Ryujinx.Graphics.Gpu.State
         /// </summary>
         private void InitializeDefaultState()
         {
+            // Enable Rasterizer
+            _backingMemory[(int)MethodOffset.RasterizeEnable] = 1;
+
             // Depth ranges.
             for (int index = 0; index < 8; index++)
             {

--- a/Ryujinx.Graphics.Gpu/State/GpuStateTable.cs
+++ b/Ryujinx.Graphics.Gpu/State/GpuStateTable.cs
@@ -53,11 +53,11 @@ namespace Ryujinx.Graphics.Gpu.State
         public static TableItem[] Table = new TableItem[]
         {
             new TableItem(MethodOffset.RtColorState,           typeof(RtColorState),          8),
-            new TableItem(MethodOffset.ViewportTransform,      typeof(ViewportTransform),     8),
-            new TableItem(MethodOffset.ViewportExtents,        typeof(ViewportExtents),       8),
+            new TableItem(MethodOffset.ViewportTransform,      typeof(ViewportTransform),     Constants.TotalViewports),
+            new TableItem(MethodOffset.ViewportExtents,        typeof(ViewportExtents),       Constants.TotalViewports),
             new TableItem(MethodOffset.VertexBufferDrawState,  typeof(VertexBufferDrawState), 1),
             new TableItem(MethodOffset.DepthBiasState,         typeof(DepthBiasState),        1),
-            new TableItem(MethodOffset.ScissorState,           typeof(ScissorState),          8),
+            new TableItem(MethodOffset.ScissorState,           typeof(ScissorState),          Constants.TotalViewports),
             new TableItem(MethodOffset.StencilBackMasks,       typeof(StencilBackMasks),      1),
             new TableItem(MethodOffset.RtDepthStencilState,    typeof(RtDepthStencilState),   1),
             new TableItem(MethodOffset.VertexAttribState,      typeof(VertexAttribState),     16),

--- a/Ryujinx.Graphics.Gpu/State/MethodOffset.cs
+++ b/Ryujinx.Graphics.Gpu/State/MethodOffset.cs
@@ -16,6 +16,7 @@ namespace Ryujinx.Graphics.Gpu.State
         DispatchParamsAddress           = 0xad,
         Dispatch                        = 0xaf,
         CopyBuffer                      = 0xc0,
+        RasterizeEnable                 = 0xdf,
         CopyBufferParams                = 0x100,
         CopyBufferSwizzle               = 0x1c2,
         CopyBufferDstTexture            = 0x1c3,

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -10,6 +10,8 @@ namespace Ryujinx.Graphics.OpenGL
     {
         private Program _program;
 
+        private bool _rasterizerDiscard;
+
         private VertexArray _vertexArray;
         private Framebuffer _framebuffer;
 
@@ -35,6 +37,7 @@ namespace Ryujinx.Graphics.OpenGL
 
         internal Pipeline()
         {
+            _rasterizerDiscard = false;
             _clipOrigin = ClipOrigin.LowerLeft;
             _clipDepthMode = ClipDepthMode.NegativeOneToOne;
         }
@@ -652,6 +655,8 @@ namespace Ryujinx.Graphics.OpenGL
             {
                 GL.Disable(EnableCap.RasterizerDiscard);
             }
+
+            _rasterizerDiscard = discard;
         }
 
         public void SetRenderTargetColorMasks(uint[] componentMasks)
@@ -977,6 +982,14 @@ namespace Ryujinx.Graphics.OpenGL
             if (_scissor0Enable)
             {
                 GL.Enable(IndexedEnableCap.ScissorTest, 0);
+            }
+        }
+
+        public void RestoreRasterizerDiscard()
+        {
+            if (_rasterizerDiscard)
+            {
+                GL.Enable(EnableCap.RasterizerDiscard);
             }
         }
 

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -31,15 +31,12 @@ namespace Ryujinx.Graphics.OpenGL
 
         private uint[] _componentMasks;
 
-        private const int MaxViewports = 16;
-        private readonly bool[] _scissorEnable;
+        private bool _scissor0Enable = false;
 
         internal Pipeline()
         {
             _clipOrigin = ClipOrigin.LowerLeft;
             _clipDepthMode = ClipDepthMode.NegativeOneToOne;
-
-            _scissorEnable = new bool[MaxViewports];
         }
 
         public void Barrier()
@@ -710,7 +707,10 @@ namespace Ryujinx.Graphics.OpenGL
                 GL.Disable(IndexedEnableCap.ScissorTest, index);
             }
 
-            _scissorEnable[index] = enable;
+            if (index == 0)
+            {
+                _scissor0Enable = enable;
+            }
         }
 
         public void SetScissor(int index, int x, int y, int width, int height)
@@ -972,14 +972,11 @@ namespace Ryujinx.Graphics.OpenGL
             }
         }
 
-        public void RestoreScissorEnable()
+        public void RestoreScissor0Enable()
         {
-            for (int index = 0; index < _scissorEnable.Length; index++)
+            if (_scissor0Enable)
             {
-                if (_scissorEnable[index])
-                {
-                    GL.Enable(IndexedEnableCap.ScissorTest, index);
-                }
+                GL.Enable(IndexedEnableCap.ScissorTest, 0);
             }
         }
 

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -644,6 +644,18 @@ namespace Ryujinx.Graphics.OpenGL
             _program.Bind();
         }
 
+        public void SetRasterizerDiscard(bool discard)
+        {
+            if (discard)
+            {
+                GL.Enable(EnableCap.RasterizerDiscard);
+            }
+            else
+            {
+                GL.Disable(EnableCap.RasterizerDiscard);
+            }
+        }
+
         public void SetRenderTargetColorMasks(uint[] componentMasks)
         {
             _componentMasks = (uint[])componentMasks.Clone();

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -31,6 +31,7 @@ namespace Ryujinx.Graphics.OpenGL
 
         private uint[] _componentMasks;
 
+        private const int MaxViewports = 16;
         private readonly bool[] _scissorEnable;
 
         internal Pipeline()
@@ -38,7 +39,7 @@ namespace Ryujinx.Graphics.OpenGL
             _clipOrigin = ClipOrigin.LowerLeft;
             _clipDepthMode = ClipDepthMode.NegativeOneToOne;
 
-            _scissorEnable = new bool[8];
+            _scissorEnable = new bool[MaxViewports];
         }
 
         public void Barrier()
@@ -973,7 +974,7 @@ namespace Ryujinx.Graphics.OpenGL
 
         public void RestoreScissorEnable()
         {
-            for (int index = 0; index < 8; index++)
+            for (int index = 0; index < _scissorEnable.Length; index++)
             {
                 if (_scissorEnable[index])
                 {

--- a/Ryujinx.Graphics.OpenGL/TextureCopy.cs
+++ b/Ryujinx.Graphics.OpenGL/TextureCopy.cs
@@ -41,6 +41,7 @@ namespace Ryujinx.Graphics.OpenGL
             GL.ReadBuffer(ReadBufferMode.ColorAttachment0);
             GL.DrawBuffer(DrawBufferMode.ColorAttachment0);
 
+            GL.Disable(EnableCap.RasterizerDiscard);
             GL.Disable(IndexedEnableCap.ScissorTest, 0);
 
             GL.BlitFramebuffer(
@@ -59,6 +60,7 @@ namespace Ryujinx.Graphics.OpenGL
             GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, oldDrawFramebufferHandle);
 
             ((Pipeline)_renderer.Pipeline).RestoreScissor0Enable();
+            ((Pipeline)_renderer.Pipeline).RestoreRasterizerDiscard();
         }
 
         private static void Attach(FramebufferTarget target, Format format, int handle)

--- a/Ryujinx.Graphics.OpenGL/TextureCopy.cs
+++ b/Ryujinx.Graphics.OpenGL/TextureCopy.cs
@@ -41,7 +41,7 @@ namespace Ryujinx.Graphics.OpenGL
             GL.ReadBuffer(ReadBufferMode.ColorAttachment0);
             GL.DrawBuffer(DrawBufferMode.ColorAttachment0);
 
-            GL.Disable(EnableCap.ScissorTest);
+            GL.Disable(IndexedEnableCap.ScissorTest, 0);
 
             GL.BlitFramebuffer(
                 srcRegion.X1,
@@ -58,7 +58,7 @@ namespace Ryujinx.Graphics.OpenGL
             GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, oldReadFramebufferHandle);
             GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, oldDrawFramebufferHandle);
 
-            ((Pipeline)_renderer.Pipeline).RestoreScissorEnable();
+            ((Pipeline)_renderer.Pipeline).RestoreScissor0Enable();
         }
 
         private static void Attach(FramebufferTarget target, Format format, int handle)

--- a/Ryujinx.Graphics.OpenGL/Window.cs
+++ b/Ryujinx.Graphics.OpenGL/Window.cs
@@ -59,6 +59,7 @@ namespace Ryujinx.Graphics.OpenGL
 
             GL.ReadBuffer(ReadBufferMode.ColorAttachment0);
 
+            GL.Disable(EnableCap.RasterizerDiscard);
             GL.Disable(EnableCap.ScissorTest);
 
             GL.Clear(ClearBufferMask.ColorBufferBit);

--- a/Ryujinx.Graphics.OpenGL/Window.cs
+++ b/Ryujinx.Graphics.OpenGL/Window.cs
@@ -128,6 +128,7 @@ namespace Ryujinx.Graphics.OpenGL
             GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, oldDrawFramebufferHandle);
 
             ((Pipeline)_renderer.Pipeline).RestoreScissor0Enable();
+            ((Pipeline)_renderer.Pipeline).RestoreRasterizerDiscard();
         }
 
         private int GetCopyFramebufferHandleLazy()

--- a/Ryujinx.Graphics.OpenGL/Window.cs
+++ b/Ryujinx.Graphics.OpenGL/Window.cs
@@ -60,7 +60,7 @@ namespace Ryujinx.Graphics.OpenGL
             GL.ReadBuffer(ReadBufferMode.ColorAttachment0);
 
             GL.Disable(EnableCap.RasterizerDiscard);
-            GL.Disable(EnableCap.ScissorTest);
+            GL.Disable(IndexedEnableCap.ScissorTest, 0);
 
             GL.Clear(ClearBufferMask.ColorBufferBit);
 
@@ -127,7 +127,7 @@ namespace Ryujinx.Graphics.OpenGL
             GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, oldReadFramebufferHandle);
             GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, oldDrawFramebufferHandle);
 
-            ((Pipeline)_renderer.Pipeline).RestoreScissorEnable();
+            ((Pipeline)_renderer.Pipeline).RestoreScissor0Enable();
         }
 
         private int GetCopyFramebufferHandleLazy()


### PR DESCRIPTION
### 1. Implement RasterizeEnable
Implements RasterizeEnable register using `GL_RASTERIZER_DISCARD`. Fixes the micro black hole that appears in XC2 menu and opening sequence.

Before (the small dot near the top of the image)-
![xc2-before](https://user-images.githubusercontent.com/62494521/78522863-65ac4f80-77ec-11ea-9f3f-23a710b0338d.png)
After-
![xc2-after](https://user-images.githubusercontent.com/62494521/78522870-693fd680-77ec-11ea-9529-3e999fce4acb.png)

RasterizeEnable is set to 1 on init as described in nouveau/mesa/deko3d.
`GL_RASTERIZER_DISCARD` causes `glClear`s to be ignored so it is disabled before host clears ~but not at other places. I think this is the right behavior. [Wiki Source](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glEnable.xhtml)~

EDIT: Apparently it affects blits on some vendors (NVIDIA). Thanks to @gdkchan for promptly testing.

### 2. Match viewport count to hardware
Viewport counts were set to 8 previously. Switch hardware supports max of 16.

### 3. Simplify ScissorTest tracking around Blits
Blittting only uses Viewport 0 according to [wiki](https://www.khronos.org/opengl/wiki/Framebuffer#Blitting). So, simplified the state tracking.


Closes #875 

Thanks to @ReinUsesLisp for the detailed description in the issue and @gdkchan for clarifications.

Please test this PR thoroughly as it is my first GPU PR.