### PR TITLE
Optimize %x ^ %x = 0

### DIFF
--- a/ARMeilleure/CodeGen/Optimizations/Simplification.cs
+++ b/ARMeilleure/CodeGen/Optimizations/Simplification.cs
@@ -24,7 +24,7 @@ namespace ARMeilleure.CodeGen.Optimizations
                     break;
 
                 case Instruction.BitwiseExclusiveOr:
-                    TryEliminateBitwiseExlusiveOr(operation);
+                    TryEliminateBitwiseExclusiveOr(operation);
                     break;
 
                 case Instruction.ConditionalSelect:
@@ -92,7 +92,7 @@ namespace ARMeilleure.CodeGen.Optimizations
             }
         }
 
-        private static void TryEliminateBitwiseExlusiveOr(Operation operation)
+        private static void TryEliminateBitwiseExclusiveOr(Operation operation)
         {
             // Try to recognize and optimize those 2 patterns (in order):
             // x ^ y == 0x00000000 when x == y

--- a/ARMeilleure/CodeGen/Optimizations/Simplification.cs
+++ b/ARMeilleure/CodeGen/Optimizations/Simplification.cs
@@ -12,7 +12,6 @@ namespace ARMeilleure.CodeGen.Optimizations
             switch (operation.Instruction)
             {
                 case Instruction.Add:
-                case Instruction.BitwiseExclusiveOr:
                     TryEliminateBinaryOpComutative(operation, 0);
                     break;
 
@@ -22,6 +21,10 @@ namespace ARMeilleure.CodeGen.Optimizations
 
                 case Instruction.BitwiseOr:
                     TryEliminateBitwiseOr(operation);
+                    break;
+
+                case Instruction.BitwiseExclusiveOr:
+                    TryEliminateBitwiseExlusiveOr(operation);
                     break;
 
                 case Instruction.ConditionalSelect:
@@ -86,6 +89,24 @@ namespace ARMeilleure.CodeGen.Optimizations
             else if (IsConstEqual(x, AllOnes(x.Type)) || IsConstEqual(y, AllOnes(y.Type)))
             {
                 operation.TurnIntoCopy(Const(AllOnes(x.Type)));
+            }
+        }
+
+        private static void TryEliminateBitwiseExlusiveOr(Operation operation)
+        {
+            // Try to recognize and optimize those 2 patterns (in order):
+            // x ^ y == 0x00000000  when x == y
+            // 0x00000000 ^ y == y, x ^ 0x00000000 == x
+            Operand x = operation.GetSource(0);
+            Operand y = operation.GetSource(1);
+
+            if (x == y && x.Type.IsInteger())
+            {
+                operation.TurnIntoCopy(Const(0));
+            }
+            else
+            {
+                TryEliminateBinaryOpComutative(operation, 0);
             }
         }
 

--- a/ARMeilleure/CodeGen/Optimizations/Simplification.cs
+++ b/ARMeilleure/CodeGen/Optimizations/Simplification.cs
@@ -95,14 +95,14 @@ namespace ARMeilleure.CodeGen.Optimizations
         private static void TryEliminateBitwiseExlusiveOr(Operation operation)
         {
             // Try to recognize and optimize those 2 patterns (in order):
-            // x ^ y == 0x00000000  when x == y
+            // x ^ y == 0x00000000 when x == y
             // 0x00000000 ^ y == y, x ^ 0x00000000 == x
             Operand x = operation.GetSource(0);
             Operand y = operation.GetSource(1);
 
             if (x == y && x.Type.IsInteger())
             {
-                operation.TurnIntoCopy(Const(0));
+                operation.TurnIntoCopy(Const(x.Type, 0));
             }
             else
             {


### PR DESCRIPTION
Simplify `BitwiseExclusiveOr %x %x` to 0 which incurs a modest diff.

IR:
```patch
-  i64 %12 = BitwiseExclusiveOr i64 %1, i64 %1
-  i64 %13 = BitwiseAnd i64 %12, i64 %1
-  i32 %14 = CompareLess i64 %13, i64 0x0
-  i32 %15 = CompareNotEqual i64 %1, i64 0x0
-  BranchIfTrue i32 %15
+  i32 %12 = CompareLess i64 0x0, i64 0x0
+  i32 %13 = CompareNotEqual i64 %1, i64 0x0
+  BranchIfTrue i32 %13
```

CodeGen:
```patch
 cmp    rbp,0x0
 setae  dl
 movzx  edx,dl
-mov    rcx,rbp
-xor    rcx,rbp
-and    rcx,rbp
+xor    ecx,ecx
 cmp    rcx,0x0
 setl   r8b
 movzx  r8d,r8b
```

In large translations, it can save a few local variables which affects register usage and the amount of spills.

`CompareLess` and friends are not constant folded currently, so the ` cmp    rcx,0x0` remains.