### PR TITLE
Implement game card mounting and loading

### DIFF
--- a/Ryujinx.Common/Configuration/ConfigurationFileFormat.cs
+++ b/Ryujinx.Common/Configuration/ConfigurationFileFormat.cs
@@ -19,7 +19,7 @@ namespace Ryujinx.Configuration
         /// <summary>
         /// The current version of the file format
         /// </summary>
-        public const int CurrentVersion = 4;
+        public const int CurrentVersion = 5;
 
         public int Version { get; set; }
 
@@ -127,6 +127,11 @@ namespace Ryujinx.Configuration
         /// Enable or disable ignoring missing services
         /// </summary>
         public bool IgnoreMissingServices { get; set; }
+
+        /// <summary>
+        /// Path used to mount a virtual game card
+        /// </summary>
+        public string GameCardPath { get; set; }
 
         /// <summary>
         ///  The primary controller's type

--- a/Ryujinx.Common/Configuration/ConfigurationState.cs
+++ b/Ryujinx.Common/Configuration/ConfigurationState.cs
@@ -183,6 +183,11 @@ namespace Ryujinx.Configuration
             /// </summary>
             public ReactiveObject<bool> IgnoreMissingServices { get; private set; }
 
+            /// <summary>
+            /// Path used to mount a virtual game card
+            /// </summary>
+            public ReactiveObject<string> GameCardPath { get; private set; }
+
             public SystemSection()
             {
                 Language                  = new ReactiveObject<Language>();
@@ -193,6 +198,7 @@ namespace Ryujinx.Configuration
                 EnableFsIntegrityChecks   = new ReactiveObject<bool>();
                 FsGlobalAccessLogMode     = new ReactiveObject<int>();
                 IgnoreMissingServices     = new ReactiveObject<bool>();
+                GameCardPath              = new ReactiveObject<string>();
             }
         }
 
@@ -329,6 +335,7 @@ namespace Ryujinx.Configuration
                 EnableFsIntegrityChecks   = System.EnableFsIntegrityChecks,
                 FsGlobalAccessLogMode     = System.FsGlobalAccessLogMode,
                 IgnoreMissingServices     = System.IgnoreMissingServices,
+                GameCardPath              = System.GameCardPath,
                 ControllerType            = Hid.ControllerType,
                 GuiColumns                = new GuiColumns()
                 {
@@ -377,6 +384,7 @@ namespace Ryujinx.Configuration
             System.EnableFsIntegrityChecks.Value   = true;
             System.FsGlobalAccessLogMode.Value     = 0;
             System.IgnoreMissingServices.Value     = false;
+            System.GameCardPath.Value              = "";
             Hid.ControllerType.Value               = ControllerType.Handheld;
             Ui.GuiColumns.FavColumn.Value          = true;
             Ui.GuiColumns.IconColumn.Value         = true;
@@ -504,6 +512,15 @@ namespace Ryujinx.Configuration
                 configurationFileUpdated = true;
             }
 
+            if (configurationFileFormat.Version < 5)
+            {
+                Common.Logging.Logger.PrintWarning(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 5.");
+
+                configurationFileFormat.GameCardPath = "";
+
+                configurationFileUpdated = true;
+            }
+
             Graphics.MaxAnisotropy.Value           = configurationFileFormat.MaxAnisotropy;
             Graphics.ShadersDumpPath.Value         = configurationFileFormat.GraphicsShadersDumpPath;
             Logger.EnableDebug.Value               = configurationFileFormat.LoggingEnableDebug;
@@ -526,6 +543,7 @@ namespace Ryujinx.Configuration
             System.EnableFsIntegrityChecks.Value   = configurationFileFormat.EnableFsIntegrityChecks;
             System.FsGlobalAccessLogMode.Value     = configurationFileFormat.FsGlobalAccessLogMode;
             System.IgnoreMissingServices.Value     = configurationFileFormat.IgnoreMissingServices;
+            System.GameCardPath.Value              = configurationFileFormat.GameCardPath;
             Hid.ControllerType.Value               = configurationFileFormat.ControllerType;
             Ui.GuiColumns.FavColumn.Value          = configurationFileFormat.GuiColumns.FavColumn;
             Ui.GuiColumns.IconColumn.Value         = configurationFileFormat.GuiColumns.IconColumn;

--- a/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
+++ b/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
@@ -222,6 +222,12 @@ namespace Ryujinx.HLE.FileSystem
 
             FsServer = new FileSystemServer(fsServerConfig);
             FsClient = FsServer.CreateFileSystemClient();
+
+            if (File.Exists(Configuration.ConfigurationState.Instance.System.GameCardPath.Value))
+            {
+                IStorage cardImageStorage = new FileStream(Configuration.ConfigurationState.Instance.System.GameCardPath.Value, FileMode.Open, FileAccess.Read).AsStorage();
+                GameCard.InsertGameCard(cardImageStorage);
+            }
         }
 
 

--- a/Ryujinx.HLE/Switch.cs
+++ b/Ryujinx.HLE/Switch.cs
@@ -96,6 +96,11 @@ namespace Ryujinx.HLE
                 : IntegrityCheckLevel.None;
         }
 
+        public void LoadGameCard()
+        {
+            System.LoadGameCard();
+        }
+
         public void LoadCart(string exeFsDir, string romFsFile = null)
         {
             System.LoadCart(exeFsDir, romFsFile);

--- a/Ryujinx/Config.json
+++ b/Ryujinx/Config.json
@@ -1,5 +1,5 @@
 {
-    "version": 4,
+    "version": 5,
     "max_anisotropy": -1,
     "graphics_shaders_dump_path": "",
     "logging_enable_debug": false,
@@ -21,6 +21,7 @@
     "enable_fs_integrity_checks": true,
     "fs_global_access_log_mode": 0,
     "ignore_missing_services": false,
+    "game_card_path": "",
     "controller_type": "Handheld",
     "gui_columns": {
         "fav_column": true,

--- a/Ryujinx/Ui/MainWindow.glade
+++ b/Ryujinx/Ui/MainWindow.glade
@@ -24,6 +24,7 @@
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">File</property>
                 <property name="use_underline">True</property>
+                <signal name="activate" handler="FileMenu_Pressed" swapped="no"/>
                 <child type="submenu">
                   <object class="GtkMenu">
                     <property name="visible">True</property>
@@ -46,6 +47,16 @@
                         <property name="label" translatable="yes">Load Unpacked Game</property>
                         <property name="use_underline">True</property>
                         <signal name="activate" handler="Load_Application_Folder" swapped="no"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkMenuItem" id="_loadApplicationGameCard">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="tooltip_text" translatable="yes">Loads the application on the mounted game card</property>
+                        <property name="label" translatable="yes">Load Application from Game Card</property>
+                        <property name="use_underline">True</property>
+                        <signal name="activate" handler="Load_Application_GameCard" swapped="no"/>
                       </object>
                     </child>
                     <child>
@@ -240,6 +251,47 @@
                       </object>
                     </child>
                     <child>
+                      <object class="GtkMenuItem" id="GameCardMenu">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Game Card</property>
+                        <property name="use_underline">True</property>
+                        <signal name="activate" handler="GameCardMenu_Pressed" swapped="no"/>
+                        <child type="submenu">
+                          <object class="GtkMenu">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkMenuItem" id="_insertGameCard">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="tooltip_text" translatable="yes">Loads a virtual game card into the emulator</property>
+                                <property name="label" translatable="yes">Insert Game Card</property>
+                                <property name="use_underline">True</property>
+                                <signal name="activate" handler="InsertGameCard_Pressed" swapped="no"/>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkMenuItem" id="_ejectGameCard">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="tooltip_text" translatable="yes">Unloads the virtual game card if there is one loaded</property>
+                                <property name="label" translatable="yes">Eject Game Card</property>
+                                <property name="use_underline">True</property>
+                                <signal name="activate" handler="EjectGameCard_Pressed" swapped="no"/>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkSeparatorMenuItem">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                    </child>
+                    <child>
                       <object class="GtkMenuItem" id="SettingsMenu">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
@@ -254,7 +306,7 @@
               </object>
             </child>
             <child>
-              <object class="GtkMenuItem" id="_toolsMenu">
+              <object class="GtkMenuItem" id="ToolsMenu">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Tools</property>


### PR DESCRIPTION
This PR allows you to mount/dismount an xci file into/from the virtual game card. You can also load an application from the virtual game card, `File > Load Application from Game Card`

However, there is a bug somewhere, possibly in my implementation or elsewhere, where game card dumper homebrew fail to dump the cart.

![image](https://user-images.githubusercontent.com/7204422/78682176-90c69a00-78e5-11ea-85ba-cbfcfb7199d1.png)
