### PR TITLE
Improve V128

### DIFF
--- a/ARMeilleure/Instructions/NativeInterface.cs
+++ b/ARMeilleure/Instructions/NativeInterface.cs
@@ -245,8 +245,8 @@ namespace ARMeilleure.Instructions
             V128 value = _context.Memory.AtomicLoadInt128((long)address);
 
             _context.ExclusiveAddress   = GetMaskedExclusiveAddress(address);
-            _context.ExclusiveValueLow  = value.GetUInt64(0);
-            _context.ExclusiveValueHigh = value.GetUInt64(1);
+            _context.ExclusiveValueLow  = value.Get<ulong>(0);
+            _context.ExclusiveValueHigh = value.Get<ulong>(1);
 
             return value;
         }

--- a/ARMeilleure/Instructions/NativeInterface.cs
+++ b/ARMeilleure/Instructions/NativeInterface.cs
@@ -245,8 +245,8 @@ namespace ARMeilleure.Instructions
             V128 value = _context.Memory.AtomicLoadInt128((long)address);
 
             _context.ExclusiveAddress   = GetMaskedExclusiveAddress(address);
-            _context.ExclusiveValueLow  = value.Get<ulong>(0);
-            _context.ExclusiveValueHigh = value.Get<ulong>(1);
+            _context.ExclusiveValueLow  = value.Extract<ulong>(0);
+            _context.ExclusiveValueHigh = value.Extract<ulong>(1);
 
             return value;
         }

--- a/ARMeilleure/Instructions/SoftFallback.cs
+++ b/ARMeilleure/Instructions/SoftFallback.cs
@@ -1017,15 +1017,15 @@ namespace ARMeilleure.Instructions
         {
             for (int e = 0; e <= 3; e++)
             {
-                uint t = ShaChoose(hash_abcd.GetUInt32(1),
-                                   hash_abcd.GetUInt32(2),
-                                   hash_abcd.GetUInt32(3));
+                uint t = ShaChoose(hash_abcd.Get<uint>(1),
+                                   hash_abcd.Get<uint>(2),
+                                   hash_abcd.Get<uint>(3));
 
-                hash_e += Rol(hash_abcd.GetUInt32(0), 5) + t + wk.GetUInt32(e);
+                hash_e += Rol(hash_abcd.Get<uint>(0), 5) + t + wk.Get<uint>(e);
 
-                t = Rol(hash_abcd.GetUInt32(1), 30);
+                t = Rol(hash_abcd.Get<uint>(1), 30);
 
-                hash_abcd.Insert(1, t);
+                hash_abcd.Set(1, t);
 
                 Rol32_160(ref hash_e, ref hash_abcd);
             }
@@ -1042,15 +1042,15 @@ namespace ARMeilleure.Instructions
         {
             for (int e = 0; e <= 3; e++)
             {
-                uint t = ShaMajority(hash_abcd.GetUInt32(1),
-                                     hash_abcd.GetUInt32(2),
-                                     hash_abcd.GetUInt32(3));
+                uint t = ShaMajority(hash_abcd.Get<uint>(1),
+                                     hash_abcd.Get<uint>(2),
+                                     hash_abcd.Get<uint>(3));
 
-                hash_e += Rol(hash_abcd.GetUInt32(0), 5) + t + wk.GetUInt32(e);
+                hash_e += Rol(hash_abcd.Get<uint>(0), 5) + t + wk.Get<uint>(e);
 
-                t = Rol(hash_abcd.GetUInt32(1), 30);
+                t = Rol(hash_abcd.Get<uint>(1), 30);
 
-                hash_abcd.Insert(1, t);
+                hash_abcd.Set(1, t);
 
                 Rol32_160(ref hash_e, ref hash_abcd);
             }
@@ -1062,15 +1062,15 @@ namespace ARMeilleure.Instructions
         {
             for (int e = 0; e <= 3; e++)
             {
-                uint t = ShaParity(hash_abcd.GetUInt32(1),
-                                   hash_abcd.GetUInt32(2),
-                                   hash_abcd.GetUInt32(3));
+                uint t = ShaParity(hash_abcd.Get<uint>(1),
+                                   hash_abcd.Get<uint>(2),
+                                   hash_abcd.Get<uint>(3));
 
-                hash_e += Rol(hash_abcd.GetUInt32(0), 5) + t + wk.GetUInt32(e);
+                hash_e += Rol(hash_abcd.Get<uint>(0), 5) + t + wk.Get<uint>(e);
 
-                t = Rol(hash_abcd.GetUInt32(1), 30);
+                t = Rol(hash_abcd.Get<uint>(1), 30);
 
-                hash_abcd.Insert(1, t);
+                hash_abcd.Set(1, t);
 
                 Rol32_160(ref hash_e, ref hash_abcd);
             }
@@ -1080,8 +1080,8 @@ namespace ARMeilleure.Instructions
 
         public static V128 Sha1SchedulePart1(V128 w0_3, V128 w4_7, V128 w8_11)
         {
-            ulong t2 = w4_7.GetUInt64(0);
-            ulong t1 = w0_3.GetUInt64(1);
+            ulong t2 = w4_7.Get<ulong>(0);
+            ulong t1 = w0_3.Get<ulong>(1);
 
             V128 result = new V128(t1, t2);
 
@@ -1092,20 +1092,20 @@ namespace ARMeilleure.Instructions
         {
             V128 t = tw0_3 ^ (w12_15 >> 32);
 
-            uint tE0 = t.GetUInt32(0);
-            uint tE1 = t.GetUInt32(1);
-            uint tE2 = t.GetUInt32(2);
-            uint tE3 = t.GetUInt32(3);
+            uint tE0 = t.Get<uint>(0);
+            uint tE1 = t.Get<uint>(1);
+            uint tE2 = t.Get<uint>(2);
+            uint tE3 = t.Get<uint>(3);
 
             return new V128(tE0.Rol(1), tE1.Rol(1), tE2.Rol(1), tE3.Rol(1) ^ tE0.Rol(2));
         }
 
         private static void Rol32_160(ref uint y, ref V128 x)
         {
-            uint xE3 = x.GetUInt32(3);
+            uint xE3 = x.Get<uint>(3);
 
             x <<= 32;
-            x.Insert(0, y);
+            x.Set(0, y);
 
             y = xE3;
         }
@@ -1148,13 +1148,13 @@ namespace ARMeilleure.Instructions
 
             for (int e = 0; e <= 3; e++)
             {
-                uint elt = (e <= 2 ? w0_3 : w4_7).GetUInt32(e <= 2 ? e + 1 : 0);
+                uint elt = (e <= 2 ? w0_3 : w4_7).Get<uint>(e <= 2 ? e + 1 : 0);
 
                 elt = elt.Ror(7) ^ elt.Ror(18) ^ elt.Lsr(3);
 
-                elt += w0_3.GetUInt32(e);
+                elt += w0_3.Get<uint>(e);
 
-                result.Insert(e, elt);
+                result.Set(e, elt);
             }
 
             return result;
@@ -1164,7 +1164,7 @@ namespace ARMeilleure.Instructions
         {
             V128 result = new V128();
 
-            ulong t1 = w12_15.GetUInt64(1);
+            ulong t1 = w12_15.Get<ulong>(1);
 
             for (int e = 0; e <= 1; e++)
             {
@@ -1172,12 +1172,12 @@ namespace ARMeilleure.Instructions
 
                 elt = elt.Ror(17) ^ elt.Ror(19) ^ elt.Lsr(10);
 
-                elt += w0_3.GetUInt32(e) + w8_11.GetUInt32(e + 1);
+                elt += w0_3.Get<uint>(e) + w8_11.Get<uint>(e + 1);
 
-                result.Insert(e, elt);
+                result.Set(e, elt);
             }
 
-            t1 = result.GetUInt64(0);
+            t1 = result.Get<ulong>(0);
 
             for (int e = 2; e <= 3; e++)
             {
@@ -1185,9 +1185,9 @@ namespace ARMeilleure.Instructions
 
                 elt = elt.Ror(17) ^ elt.Ror(19) ^ elt.Lsr(10);
 
-                elt += w0_3.GetUInt32(e) + (e == 2 ? w8_11 : w12_15).GetUInt32(e == 2 ? 3 : 0);
+                elt += w0_3.Get<uint>(e) + (e == 2 ? w8_11 : w12_15).Get<uint>(e == 2 ? 3 : 0);
 
-                result.Insert(e, elt);
+                result.Set(e, elt);
             }
 
             return result;
@@ -1197,23 +1197,23 @@ namespace ARMeilleure.Instructions
         {
             for (int e = 0; e <= 3; e++)
             {
-                uint chs = ShaChoose(y.GetUInt32(0),
-                                     y.GetUInt32(1),
-                                     y.GetUInt32(2));
+                uint chs = ShaChoose(y.Get<uint>(0),
+                                     y.Get<uint>(1),
+                                     y.Get<uint>(2));
 
-                uint maj = ShaMajority(x.GetUInt32(0),
-                                       x.GetUInt32(1),
-                                       x.GetUInt32(2));
+                uint maj = ShaMajority(x.Get<uint>(0),
+                                       x.Get<uint>(1),
+                                       x.Get<uint>(2));
 
-                uint t1 = y.GetUInt32(3) + ShaHashSigma1(y.GetUInt32(0)) + chs + w.GetUInt32(e);
+                uint t1 = y.Get<uint>(3) + ShaHashSigma1(y.Get<uint>(0)) + chs + w.Get<uint>(e);
 
-                uint t2 = t1 + x.GetUInt32(3);
+                uint t2 = t1 + x.Get<uint>(3);
 
-                x.Insert(3, t2);
+                x.Set(3, t2);
 
-                t2 = t1 + ShaHashSigma0(x.GetUInt32(0)) + maj;
+                t2 = t1 + ShaHashSigma0(x.Get<uint>(0)) + maj;
 
-                y.Insert(3, t2);
+                y.Set(3, t2);
 
                 Rol32_256(ref y, ref x);
             }
@@ -1223,14 +1223,14 @@ namespace ARMeilleure.Instructions
 
         private static void Rol32_256(ref V128 y, ref V128 x)
         {
-            uint yE3 = y.GetUInt32(3);
-            uint xE3 = x.GetUInt32(3);
+            uint yE3 = y.Get<uint>(3);
+            uint xE3 = x.Get<uint>(3);
 
             y <<= 32;
             x <<= 32;
 
-            y.Insert(0, xE3);
-            x.Insert(0, yE3);
+            y.Set(0, xE3);
+            x.Set(0, yE3);
         }
 
         private static uint ShaHashSigma0(uint x)

--- a/ARMeilleure/Instructions/SoftFallback.cs
+++ b/ARMeilleure/Instructions/SoftFallback.cs
@@ -1017,15 +1017,15 @@ namespace ARMeilleure.Instructions
         {
             for (int e = 0; e <= 3; e++)
             {
-                uint t = ShaChoose(hash_abcd.Get<uint>(1),
-                                   hash_abcd.Get<uint>(2),
-                                   hash_abcd.Get<uint>(3));
+                uint t = ShaChoose(hash_abcd.Extract<uint>(1),
+                                   hash_abcd.Extract<uint>(2),
+                                   hash_abcd.Extract<uint>(3));
 
-                hash_e += Rol(hash_abcd.Get<uint>(0), 5) + t + wk.Get<uint>(e);
+                hash_e += Rol(hash_abcd.Extract<uint>(0), 5) + t + wk.Extract<uint>(e);
 
-                t = Rol(hash_abcd.Get<uint>(1), 30);
+                t = Rol(hash_abcd.Extract<uint>(1), 30);
 
-                hash_abcd.Set(1, t);
+                hash_abcd.Insert(1, t);
 
                 Rol32_160(ref hash_e, ref hash_abcd);
             }
@@ -1042,15 +1042,15 @@ namespace ARMeilleure.Instructions
         {
             for (int e = 0; e <= 3; e++)
             {
-                uint t = ShaMajority(hash_abcd.Get<uint>(1),
-                                     hash_abcd.Get<uint>(2),
-                                     hash_abcd.Get<uint>(3));
+                uint t = ShaMajority(hash_abcd.Extract<uint>(1),
+                                     hash_abcd.Extract<uint>(2),
+                                     hash_abcd.Extract<uint>(3));
 
-                hash_e += Rol(hash_abcd.Get<uint>(0), 5) + t + wk.Get<uint>(e);
+                hash_e += Rol(hash_abcd.Extract<uint>(0), 5) + t + wk.Extract<uint>(e);
 
-                t = Rol(hash_abcd.Get<uint>(1), 30);
+                t = Rol(hash_abcd.Extract<uint>(1), 30);
 
-                hash_abcd.Set(1, t);
+                hash_abcd.Insert(1, t);
 
                 Rol32_160(ref hash_e, ref hash_abcd);
             }
@@ -1062,15 +1062,15 @@ namespace ARMeilleure.Instructions
         {
             for (int e = 0; e <= 3; e++)
             {
-                uint t = ShaParity(hash_abcd.Get<uint>(1),
-                                   hash_abcd.Get<uint>(2),
-                                   hash_abcd.Get<uint>(3));
+                uint t = ShaParity(hash_abcd.Extract<uint>(1),
+                                   hash_abcd.Extract<uint>(2),
+                                   hash_abcd.Extract<uint>(3));
 
-                hash_e += Rol(hash_abcd.Get<uint>(0), 5) + t + wk.Get<uint>(e);
+                hash_e += Rol(hash_abcd.Extract<uint>(0), 5) + t + wk.Extract<uint>(e);
 
-                t = Rol(hash_abcd.Get<uint>(1), 30);
+                t = Rol(hash_abcd.Extract<uint>(1), 30);
 
-                hash_abcd.Set(1, t);
+                hash_abcd.Insert(1, t);
 
                 Rol32_160(ref hash_e, ref hash_abcd);
             }
@@ -1080,8 +1080,8 @@ namespace ARMeilleure.Instructions
 
         public static V128 Sha1SchedulePart1(V128 w0_3, V128 w4_7, V128 w8_11)
         {
-            ulong t2 = w4_7.Get<ulong>(0);
-            ulong t1 = w0_3.Get<ulong>(1);
+            ulong t2 = w4_7.Extract<ulong>(0);
+            ulong t1 = w0_3.Extract<ulong>(1);
 
             V128 result = new V128(t1, t2);
 
@@ -1092,20 +1092,20 @@ namespace ARMeilleure.Instructions
         {
             V128 t = tw0_3 ^ (w12_15 >> 32);
 
-            uint tE0 = t.Get<uint>(0);
-            uint tE1 = t.Get<uint>(1);
-            uint tE2 = t.Get<uint>(2);
-            uint tE3 = t.Get<uint>(3);
+            uint tE0 = t.Extract<uint>(0);
+            uint tE1 = t.Extract<uint>(1);
+            uint tE2 = t.Extract<uint>(2);
+            uint tE3 = t.Extract<uint>(3);
 
             return new V128(tE0.Rol(1), tE1.Rol(1), tE2.Rol(1), tE3.Rol(1) ^ tE0.Rol(2));
         }
 
         private static void Rol32_160(ref uint y, ref V128 x)
         {
-            uint xE3 = x.Get<uint>(3);
+            uint xE3 = x.Extract<uint>(3);
 
             x <<= 32;
-            x.Set(0, y);
+            x.Insert(0, y);
 
             y = xE3;
         }
@@ -1148,13 +1148,13 @@ namespace ARMeilleure.Instructions
 
             for (int e = 0; e <= 3; e++)
             {
-                uint elt = (e <= 2 ? w0_3 : w4_7).Get<uint>(e <= 2 ? e + 1 : 0);
+                uint elt = (e <= 2 ? w0_3 : w4_7).Extract<uint>(e <= 2 ? e + 1 : 0);
 
                 elt = elt.Ror(7) ^ elt.Ror(18) ^ elt.Lsr(3);
 
-                elt += w0_3.Get<uint>(e);
+                elt += w0_3.Extract<uint>(e);
 
-                result.Set(e, elt);
+                result.Insert(e, elt);
             }
 
             return result;
@@ -1164,7 +1164,7 @@ namespace ARMeilleure.Instructions
         {
             V128 result = new V128();
 
-            ulong t1 = w12_15.Get<ulong>(1);
+            ulong t1 = w12_15.Extract<ulong>(1);
 
             for (int e = 0; e <= 1; e++)
             {
@@ -1172,12 +1172,12 @@ namespace ARMeilleure.Instructions
 
                 elt = elt.Ror(17) ^ elt.Ror(19) ^ elt.Lsr(10);
 
-                elt += w0_3.Get<uint>(e) + w8_11.Get<uint>(e + 1);
+                elt += w0_3.Extract<uint>(e) + w8_11.Extract<uint>(e + 1);
 
-                result.Set(e, elt);
+                result.Insert(e, elt);
             }
 
-            t1 = result.Get<ulong>(0);
+            t1 = result.Extract<ulong>(0);
 
             for (int e = 2; e <= 3; e++)
             {
@@ -1185,9 +1185,9 @@ namespace ARMeilleure.Instructions
 
                 elt = elt.Ror(17) ^ elt.Ror(19) ^ elt.Lsr(10);
 
-                elt += w0_3.Get<uint>(e) + (e == 2 ? w8_11 : w12_15).Get<uint>(e == 2 ? 3 : 0);
+                elt += w0_3.Extract<uint>(e) + (e == 2 ? w8_11 : w12_15).Extract<uint>(e == 2 ? 3 : 0);
 
-                result.Set(e, elt);
+                result.Insert(e, elt);
             }
 
             return result;
@@ -1197,23 +1197,23 @@ namespace ARMeilleure.Instructions
         {
             for (int e = 0; e <= 3; e++)
             {
-                uint chs = ShaChoose(y.Get<uint>(0),
-                                     y.Get<uint>(1),
-                                     y.Get<uint>(2));
+                uint chs = ShaChoose(y.Extract<uint>(0),
+                                     y.Extract<uint>(1),
+                                     y.Extract<uint>(2));
 
-                uint maj = ShaMajority(x.Get<uint>(0),
-                                       x.Get<uint>(1),
-                                       x.Get<uint>(2));
+                uint maj = ShaMajority(x.Extract<uint>(0),
+                                       x.Extract<uint>(1),
+                                       x.Extract<uint>(2));
 
-                uint t1 = y.Get<uint>(3) + ShaHashSigma1(y.Get<uint>(0)) + chs + w.Get<uint>(e);
+                uint t1 = y.Extract<uint>(3) + ShaHashSigma1(y.Extract<uint>(0)) + chs + w.Extract<uint>(e);
 
-                uint t2 = t1 + x.Get<uint>(3);
+                uint t2 = t1 + x.Extract<uint>(3);
 
-                x.Set(3, t2);
+                x.Insert(3, t2);
 
-                t2 = t1 + ShaHashSigma0(x.Get<uint>(0)) + maj;
+                t2 = t1 + ShaHashSigma0(x.Extract<uint>(0)) + maj;
 
-                y.Set(3, t2);
+                y.Insert(3, t2);
 
                 Rol32_256(ref y, ref x);
             }
@@ -1223,14 +1223,14 @@ namespace ARMeilleure.Instructions
 
         private static void Rol32_256(ref V128 y, ref V128 x)
         {
-            uint yE3 = y.Get<uint>(3);
-            uint xE3 = x.Get<uint>(3);
+            uint yE3 = y.Extract<uint>(3);
+            uint xE3 = x.Extract<uint>(3);
 
             y <<= 32;
             x <<= 32;
 
-            y.Set(0, xE3);
-            x.Set(0, yE3);
+            y.Insert(0, xE3);
+            x.Insert(0, yE3);
         }
 
         private static uint ShaHashSigma0(uint x)

--- a/ARMeilleure/Memory/MemoryManager.cs
+++ b/ARMeilleure/Memory/MemoryManager.cs
@@ -663,8 +663,8 @@ namespace ARMeilleure.Memory
 
         public void WriteVector128(long position, V128 value)
         {
-            WriteUInt64(position + 0, value.GetUInt64(0));
-            WriteUInt64(position + 8, value.GetUInt64(1));
+            WriteUInt64(position + 0, value.Get<ulong>(0));
+            WriteUInt64(position + 8, value.Get<ulong>(1));
         }
 
         public void WriteBytes(long position, byte[] data)

--- a/ARMeilleure/Memory/MemoryManager.cs
+++ b/ARMeilleure/Memory/MemoryManager.cs
@@ -663,8 +663,8 @@ namespace ARMeilleure.Memory
 
         public void WriteVector128(long position, V128 value)
         {
-            WriteUInt64(position + 0, value.Get<ulong>(0));
-            WriteUInt64(position + 8, value.Get<ulong>(1));
+            WriteUInt64(position + 0, value.Extract<ulong>(0));
+            WriteUInt64(position + 8, value.Extract<ulong>(1));
         }
 
         public void WriteBytes(long position, byte[] data)

--- a/ARMeilleure/State/NativeContext.cs
+++ b/ARMeilleure/State/NativeContext.cs
@@ -67,8 +67,8 @@ namespace ARMeilleure.State
 
             int offset = RegisterConsts.IntRegsCount * IntSize + index * VecSize;
 
-            Marshal.WriteInt64(BasePtr, offset + 0, value.GetInt64(0));
-            Marshal.WriteInt64(BasePtr, offset + 8, value.GetInt64(1));
+            Marshal.WriteInt64(BasePtr, offset + 0, value.Get<long>(0));
+            Marshal.WriteInt64(BasePtr, offset + 8, value.Get<long>(1));
         }
 
         public bool GetPstateFlag(PState flag)

--- a/ARMeilleure/State/NativeContext.cs
+++ b/ARMeilleure/State/NativeContext.cs
@@ -67,8 +67,8 @@ namespace ARMeilleure.State
 
             int offset = RegisterConsts.IntRegsCount * IntSize + index * VecSize;
 
-            Marshal.WriteInt64(BasePtr, offset + 0, value.Get<long>(0));
-            Marshal.WriteInt64(BasePtr, offset + 8, value.Get<long>(1));
+            Marshal.WriteInt64(BasePtr, offset + 0, value.Extract<long>(0));
+            Marshal.WriteInt64(BasePtr, offset + 8, value.Extract<long>(1));
         }
 
         public bool GetPstateFlag(PState flag)

--- a/ARMeilleure/State/V128.cs
+++ b/ARMeilleure/State/V128.cs
@@ -1,20 +1,27 @@
 using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace ARMeilleure.State
 {
+     [StructLayout(LayoutKind.Explicit, Size = 16)]
     public struct V128 : IEquatable<V128>
     {
+        [FieldOffset(0)]
         private ulong _e0;
+        [FieldOffset(8)]
         private ulong _e1;
 
-        private static V128 _zero = new V128(0, 0);
-
-        public static V128 Zero => _zero;
-
-        public V128(float value) : this(value, 0, 0, 0) { }
+        public static V128 Zero => new V128(0, 0);
 
         public V128(double value) : this(value, 0) { }
+        public V128(double e0, double e1)
+        {
+            _e0 = (ulong)BitConverter.DoubleToInt64Bits(e0);
+            _e1 = (ulong)BitConverter.DoubleToInt64Bits(e1);
+        }
 
+        public V128(float value) : this(value, 0, 0, 0) { }
         public V128(float e0, float e1, float e2, float e3)
         {
             _e0  = (ulong)(uint)BitConverter.SingleToInt32Bits(e0) << 0;
@@ -23,20 +30,14 @@ namespace ARMeilleure.State
             _e1 |= (ulong)(uint)BitConverter.SingleToInt32Bits(e3) << 32;
         }
 
-        public V128(double e0, double e1)
+        public V128(long e0, long e1) : this((ulong)e0, (ulong)e1) { }
+        public V128(ulong e0, ulong e1)
         {
-            _e0 = (ulong)BitConverter.DoubleToInt64Bits(e0);
-            _e1 = (ulong)BitConverter.DoubleToInt64Bits(e1);
+            _e0 = e0;
+            _e1 = e1;
         }
 
-        public V128(int e0, int e1, int e2, int e3)
-        {
-            _e0  = (ulong)(uint)e0 << 0;
-            _e0 |= (ulong)(uint)e1 << 32;
-            _e1  = (ulong)(uint)e2 << 0;
-            _e1 |= (ulong)(uint)e3 << 32;
-        }
-
+        public V128(int e0, int e1, int e2, int e3) : this((uint)e0, (uint)e1, (uint)e2, (uint)e3) { }
         public V128(uint e0, uint e1, uint e2, uint e3)
         {
             _e0  = (ulong)e0 << 0;
@@ -45,131 +46,60 @@ namespace ARMeilleure.State
             _e1 |= (ulong)e3 << 32;
         }
 
-        public V128(long e0, long e1)
-        {
-            _e0 = (ulong)e0;
-            _e1 = (ulong)e1;
-        }
-
-        public V128(ulong e0, ulong e1)
-        {
-            _e0 = e0;
-            _e1 = e1;
-        }
-
         public V128(byte[] data)
         {
             _e0 = (ulong)BitConverter.ToInt64(data, 0);
             _e1 = (ulong)BitConverter.ToInt64(data, 8);
         }
 
-        public void Insert(int index, uint value)
-        {
-            switch (index)
-            {
-                case 0: _e0 = (_e0 & 0xffffffff00000000) | ((ulong)value << 0);  break;
-                case 1: _e0 = (_e0 & 0x00000000ffffffff) | ((ulong)value << 32); break;
-                case 2: _e1 = (_e1 & 0xffffffff00000000) | ((ulong)value << 0);  break;
-                case 3: _e1 = (_e1 & 0x00000000ffffffff) | ((ulong)value << 32); break;
-
-                default: throw new ArgumentOutOfRangeException(nameof(index));
-            }
-        }
-
-        public void Insert(int index, ulong value)
-        {
-            switch (index)
-            {
-                case 0: _e0 = value; break;
-                case 1: _e1 = value; break;
-
-                default: throw new ArgumentOutOfRangeException(nameof(index));
-            }
-        }
-
-        public float AsFloat()
-        {
-            return GetFloat(0);
-        }
-
-        public double AsDouble()
-        {
-            return GetDouble(0);
-        }
-
-        public float GetFloat(int index)
-        {
-            return BitConverter.Int32BitsToSingle(GetInt32(index));
-        }
-
-        public double GetDouble(int index)
-        {
-            return BitConverter.Int64BitsToDouble(GetInt64(index));
-        }
-
-        public int  GetInt32(int index) => (int)GetUInt32(index);
-        public long GetInt64(int index) => (long)GetUInt64(index);
+        public float  AsFloat()            => GetFloat(0);
+        public double AsDouble()           => GetDouble(0);
+        public float  GetFloat(int index)  => BitConverter.Int32BitsToSingle(GetInt32(index));
+        public double GetDouble(int index) => BitConverter.Int64BitsToDouble(GetInt64(index));
+        public int    GetInt32(int index)  => (int)GetUInt32(index);
+        public long   GetInt64(int index)  => (long)GetUInt64(index);
 
         public uint GetUInt32(int index)
         {
-            switch (index)
-            {
-                case 0: return (uint)(_e0 >> 0);
-                case 1: return (uint)(_e0 >> 32);
-                case 2: return (uint)(_e1 >> 0);
-                case 3: return (uint)(_e1 >> 32);
-            }
+            if ((uint)index > 3U)
+                ThrowIndexOutOfRange();
 
-            throw new ArgumentOutOfRangeException(nameof(index));
+            return Unsafe.Add(ref Unsafe.As<ulong, uint>(ref _e0), index);
         }
 
         public ulong GetUInt64(int index)
         {
-            switch (index)
-            {
-                case 0: return _e0;
-                case 1: return _e1;
-            }
+            if ((uint)index > 1U)
+                ThrowIndexOutOfRange();
 
-            throw new ArgumentOutOfRangeException(nameof(index));
+            return Unsafe.Add(ref _e0, index);
+        }
+
+        public void Insert(int index, uint value)
+        {
+            if ((uint)index > 3U)
+                ThrowIndexOutOfRange();
+
+            Unsafe.Add(ref Unsafe.As<ulong, uint>(ref _e0), index) = value;
+        }
+
+        public void Insert(int index, ulong value)
+        {
+            if ((uint)index > 1U)
+                ThrowIndexOutOfRange();
+
+            Unsafe.Add(ref _e0, index) = value;
         }
 
         public byte[] ToArray()
         {
-            byte[] e0Data = BitConverter.GetBytes(_e0);
-            byte[] e1Data = BitConverter.GetBytes(_e1);
+            byte[]     data = new byte[16];
+            Span<byte> span = data;
 
-            byte[] data = new byte[16];
-
-            Buffer.BlockCopy(e0Data, 0, data, 0, 8);
-            Buffer.BlockCopy(e1Data, 0, data, 8, 8);
+            BitConverter.TryWriteBytes(span, _e0);
+            BitConverter.TryWriteBytes(span.Slice(8), _e1);
 
             return data;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(_e0, _e1);
-        }
-
-        public static V128 operator ~(V128 x)
-        {
-            return new V128(~x._e0, ~x._e1);
-        }
-
-        public static V128 operator &(V128 x, V128 y)
-        {
-            return new V128(x._e0 & y._e0, x._e1 & y._e1);
-        }
-
-        public static V128 operator |(V128 x, V128 y)
-        {
-            return new V128(x._e0 | y._e0, x._e1 | y._e1);
-        }
-
-        public static V128 operator ^(V128 x, V128 y)
-        {
-            return new V128(x._e0 ^ y._e0, x._e1 ^ y._e1);
         }
 
         public static V128 operator <<(V128 x, int shift)
@@ -186,29 +116,20 @@ namespace ARMeilleure.State
             return new V128((x._e0 >> shift) | (shiftOut << (64 - shift)), x._e1 >> shift);
         }
 
-        public static bool operator ==(V128 x, V128 y)
-        {
-            return x.Equals(y);
-        }
+        public static V128 operator ~(V128 x)          => new V128(~x._e0, ~x._e1);
+        public static V128 operator &(V128 x, V128 y)  => new V128(x._e0 & y._e0, x._e1 & y._e1);
+        public static V128 operator |(V128 x, V128 y)  => new V128(x._e0 | y._e0, x._e1 | y._e1);
+        public static V128 operator ^(V128 x, V128 y)  => new V128(x._e0 ^ y._e0, x._e1 ^ y._e1);
 
-        public static bool operator !=(V128 x, V128 y)
-        {
-            return !x.Equals(y);
-        }
+        public static bool operator ==(V128 x, V128 y) =>  x.Equals(y);
+        public static bool operator !=(V128 x, V128 y) => !x.Equals(y);
 
-        public override bool Equals(object obj)
-        {
-            return obj is V128 vector && Equals(vector);
-        }
+        public          bool Equals(V128 other) => other._e0 == _e0   && other._e1 == _e1;
+        public override bool Equals(object obj) => obj is V128 vector && Equals(vector);
 
-        public bool Equals(V128 other)
-        {
-            return other._e0 == _e0 && other._e1 == _e1;
-        }
+        public override int    GetHashCode() => HashCode.Combine(_e0, _e1);
+        public override string ToString()    => $"0x{_e1:X16}{_e0:X16}";
 
-        public override string ToString()
-        {
-            return $"0x{_e1:X16}{_e0:X16}";
-        }
+        private static void ThrowIndexOutOfRange() => throw new ArgumentOutOfRangeException("index");
     }
 }

--- a/ARMeilleure/State/V128.cs
+++ b/ARMeilleure/State/V128.cs
@@ -4,12 +4,10 @@ using System.Runtime.InteropServices;
 
 namespace ARMeilleure.State
 {
-     [StructLayout(LayoutKind.Explicit, Size = 16)]
+    [StructLayout(LayoutKind.Sequential, Size = 16)]
     public struct V128 : IEquatable<V128>
     {
-        [FieldOffset(0)]
         private ulong _e0;
-        [FieldOffset(8)]
         private ulong _e1;
 
         public static V128 Zero => new V128(0, 0);

--- a/ARMeilleure/State/V128.cs
+++ b/ARMeilleure/State/V128.cs
@@ -52,10 +52,10 @@ namespace ARMeilleure.State
 
         public T As<T>() where T : unmanaged
         {
-            return Get<T>(0);
+            return Extract<T>(0);
         }
 
-        public T Get<T>(int index) where T : unmanaged
+        public T Extract<T>(int index) where T : unmanaged
         {
             if ((uint)index >= GetElementCount<T>())
                 ThrowIndexOutOfRange();
@@ -63,7 +63,7 @@ namespace ARMeilleure.State
             return Unsafe.Add(ref Unsafe.As<V128, T>(ref this), index);
         }
 
-        public void Set<T>(int index, T value) where T : unmanaged
+        public void Insert<T>(int index, T value) where T : unmanaged
         {
             if ((uint)index >= GetElementCount<T>())
                 ThrowIndexOutOfRange();

--- a/ARMeilleure/State/V128.cs
+++ b/ARMeilleure/State/V128.cs
@@ -4,22 +4,55 @@ using System.Runtime.InteropServices;
 
 namespace ARMeilleure.State
 {
+    /// <summary>
+    /// Represents a 128-bit vector.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential, Size = 16)]
     public struct V128 : IEquatable<V128>
     {
+        // _e0 & _e1 could be marked as readonly, however they are not readonly because we modify them through the Unsafe
+        // APIs. This also means that one should be careful when changing the layout of this struct.
+
         private ulong _e0;
         private ulong _e1;
 
+        /// <summary>
+        /// Gets a new <see cref="V128"/> with all bits set to zero.
+        /// </summary>
         public static V128 Zero => new V128(0, 0);
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="V128"/> struct with the specified <see cref="double"/> value
+        /// as a scalar.
+        /// </summary>
+        /// <param name="value">Scalar value.</param>
         public V128(double value) : this(value, 0) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="V128"/> struct with the specified <see cref="double"/> elements.
+        /// </summary>
+        /// <param name="e0">Element 0</param>
+        /// <param name="e1">Element 1</param>
         public V128(double e0, double e1)
         {
             _e0 = (ulong)BitConverter.DoubleToInt64Bits(e0);
             _e1 = (ulong)BitConverter.DoubleToInt64Bits(e1);
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="V128"/> struct with the specified <see cref="float"/> value as a
+        /// scalar.
+        /// </summary>
+        /// <param name="value">Scalar value</param>
         public V128(float value) : this(value, 0, 0, 0) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="V128"/> struct with the specified <see cref="float"/> elements.
+        /// </summary>
+        /// <param name="e0">Element 0</param>
+        /// <param name="e1">Element 1</param>
+        /// <param name="e2">Element 2</param>
+        /// <param name="e3">Element 3</param>
         public V128(float e0, float e1, float e2, float e3)
         {
             _e0  = (ulong)(uint)BitConverter.SingleToInt32Bits(e0) << 0;
@@ -28,14 +61,41 @@ namespace ARMeilleure.State
             _e1 |= (ulong)(uint)BitConverter.SingleToInt32Bits(e3) << 32;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="V128"/> struct with the specified <see cref="ulong"/>
+        /// elements.
+        /// </summary>
+        /// <param name="e0">Element 0</param>
+        /// <param name="e1">Element 1</param>
         public V128(long e0, long e1) : this((ulong)e0, (ulong)e1) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="V128"/> struct with the specified <see cref="long"/> elements.
+        /// </summary>
+        /// <param name="e0">Element 0</param>
+        /// <param name="e1">Element 1</param>
         public V128(ulong e0, ulong e1)
         {
             _e0 = e0;
             _e1 = e1;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="V128"/> struct with the specified <see cref="int"/> elements.
+        /// </summary>
+        /// <param name="e0">Element 0</param>
+        /// <param name="e1">Element 1</param>
+        /// <param name="e2">Element 2</param>
+        /// <param name="e3">Element 3</param>
         public V128(int e0, int e1, int e2, int e3) : this((uint)e0, (uint)e1, (uint)e2, (uint)e3) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="V128"/> struct with the specified <see cref="uint"/> elements.
+        /// </summary>
+        /// <param name="e0">Element 0</param>
+        /// <param name="e1">Element 1</param>
+        /// <param name="e2">Element 2</param>
+        /// <param name="e3">Element 3</param>
         public V128(uint e0, uint e1, uint e2, uint e3)
         {
             _e0  = (ulong)e0 << 0;
@@ -44,38 +104,69 @@ namespace ARMeilleure.State
             _e1 |= (ulong)e3 << 32;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="V128"/> struct from the specified <see cref="byte"/> array.
+        /// </summary>
+        /// <param name="data"><see cref="byte"/> array to use</param>
         public V128(byte[] data)
         {
             _e0 = (ulong)BitConverter.ToInt64(data, 0);
             _e1 = (ulong)BitConverter.ToInt64(data, 8);
         }
 
+        /// <summary>
+        /// Returns the value of the <see cref="V128"/> as a <typeparamref name="T"/> scalar.
+        /// </summary>
+        /// <typeparam name="T">Type of scalar</typeparam>
+        /// <returns>Value of the <see cref="V128"/> as a <typeparamref name="T"/> scalar</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Size of <typeparamref name="T"/> is larger than 16 bytes</exception>
         public T As<T>() where T : unmanaged
         {
             return Extract<T>(0);
         }
 
+        /// <summary>
+        /// Extracts the element at the specified index as a <typeparamref name="T"/> from the <see cref="V128"/>.
+        /// </summary>
+        /// <typeparam name="T">Element type</typeparam>
+        /// <param name="index">Index of element</param>
+        /// <returns>Element at the specified index as a <typeparamref name="T"/> from the <see cref="V128"/></returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="index"/> is out of bound or the size of <typeparamref name="T"/> is larger than 16 bytes
+        /// </exception>
         public T Extract<T>(int index) where T : unmanaged
         {
             if ((uint)index >= GetElementCount<T>())
                 ThrowIndexOutOfRange();
 
+            // Performs:
+            //  return *((*T)this + index);
             return Unsafe.Add(ref Unsafe.As<V128, T>(ref this), index);
         }
 
+        /// <summary>
+        /// Inserts the specified value into the element at the specified index in the <see cref="V128"/>.
+        /// </summary>
+        /// <typeparam name="T">Element type</typeparam>
+        /// <param name="index">Index of element</param>
+        /// <param name="value">Value to insert</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="index"/> is out of bound or the size of <typeparamref name="T"/> is larger than 16 bytes
+        /// </exception>
         public void Insert<T>(int index, T value) where T : unmanaged
         {
             if ((uint)index >= GetElementCount<T>())
                 ThrowIndexOutOfRange();
 
+            // Performs:
+            //  *((*T)this + index) = value;
             Unsafe.Add(ref Unsafe.As<V128, T>(ref this), index) = value;
         }
 
-        private uint GetElementCount<T>() where T : unmanaged
-        {
-            return (uint)(Unsafe.SizeOf<V128>() / Unsafe.SizeOf<T>());
-        }
-
+        /// <summary>
+        /// Returns a new <see cref="byte"/> array which represents the <see cref="V128"/>.
+        /// </summary>
+        /// <returns>A new <see cref="byte"/> array which represents the <see cref="V128"/></returns>
         public byte[] ToArray()
         {
             byte[]     data = new byte[16];
@@ -87,6 +178,15 @@ namespace ARMeilleure.State
             return data;
         }
 
+        /// <summary>
+        /// Performs a bitwise logical left shift on the specified <see cref="V128"/> by the specified shift count.
+        /// </summary>
+        /// <param name="x"><see cref="V128"/> instance</param>
+        /// <param name="shift">Number of shifts</param>
+        /// <returns>Result of left shift</returns>
+        /// <remarks>
+        /// This supports shift counts up to 63; anything above may result in unexpected behaviour.
+        /// </remarks>
         public static V128 operator <<(V128 x, int shift)
         {
             ulong shiftOut = x._e0 >> (64 - shift);
@@ -94,6 +194,15 @@ namespace ARMeilleure.State
             return new V128(x._e0 << shift, (x._e1 << shift) | shiftOut);
         }
 
+        /// <summary>
+        /// Performs a bitwise logical right shift on the specified <see cref="V128"/> by the specified shift count.
+        /// </summary>
+        /// <param name="x"><see cref="V128"/> instance</param>
+        /// <param name="shift">Number of shifts</param>
+        /// <returns>Result of right shift</returns>
+        /// <remarks>
+        /// This supports shift counts up to 63; anything above may result in unexpected behaviour.
+        /// </remarks>
         public static V128 operator >>(V128 x, int shift)
         {
             ulong shiftOut = x._e1 & ((1UL << shift) - 1);
@@ -101,20 +210,93 @@ namespace ARMeilleure.State
             return new V128((x._e0 >> shift) | (shiftOut << (64 - shift)), x._e1 >> shift);
         }
 
-        public static V128 operator ~(V128 x)          => new V128(~x._e0, ~x._e1);
-        public static V128 operator &(V128 x, V128 y)  => new V128(x._e0 & y._e0, x._e1 & y._e1);
-        public static V128 operator |(V128 x, V128 y)  => new V128(x._e0 | y._e0, x._e1 | y._e1);
-        public static V128 operator ^(V128 x, V128 y)  => new V128(x._e0 ^ y._e0, x._e1 ^ y._e1);
+        /// <summary>
+        /// Performs a bitwise not on the specified <see cref="V128"/>.
+        /// </summary>
+        /// <param name="x">Target <see cref="V128"/></param>
+        /// <returns>Result of not operation</returns>
+        public static V128 operator ~(V128 x) => new V128(~x._e0, ~x._e1);
 
-        public static bool operator ==(V128 x, V128 y) =>  x.Equals(y);
+        /// <summary>
+        /// Performs a bitwise and on the specified <see cref="V128"/> instances.
+        /// </summary>
+        /// <param name="x">First instance</param>
+        /// <param name="y">Second instance</param>
+        /// <returns>Result of and operation</returns>
+        public static V128 operator &(V128 x, V128 y) => new V128(x._e0 & y._e0, x._e1 & y._e1);
+
+        /// <summary>
+        /// Performs a bitwise or on the specified <see cref="V128"/> instances.
+        /// </summary>
+        /// <param name="x">First instance</param>
+        /// <param name="y">Second instance</param>
+        /// <returns>Result of or operation</returns>
+        public static V128 operator |(V128 x, V128 y) => new V128(x._e0 | y._e0, x._e1 | y._e1);
+
+        /// <summary>
+        /// Performs a bitwise exlusive or on the specified <see cref="V128"/> instances.
+        /// </summary>
+        /// <param name="x">First instance</param>
+        /// <param name="y">Second instance</param>
+        /// <returns>Result of exclusive or operation</returns>
+        public static V128 operator ^(V128 x, V128 y) => new V128(x._e0 ^ y._e0, x._e1 ^ y._e1);
+
+        /// <summary>
+        /// Determines if the specified <see cref="V128"/> instances are equal.
+        /// </summary>
+        /// <param name="x">First instance</param>
+        /// <param name="y">Second instance</param>
+        /// <returns>true if equal; otherwise false</returns>
+        public static bool operator ==(V128 x, V128 y) => x.Equals(y);
+
+        /// <summary>
+        /// Determines if the specified <see cref="V128"/> instances are not equal.
+        /// </summary>
+        /// <param name="x">First instance</param>
+        /// <param name="y">Second instance</param>
+        /// <returns>true if not equal; otherwise false</returns>
         public static bool operator !=(V128 x, V128 y) => !x.Equals(y);
 
-        public          bool Equals(V128 other) => other._e0 == _e0   && other._e1 == _e1;
-        public override bool Equals(object obj) => obj is V128 vector && Equals(vector);
+        /// <summary>
+        /// Determines if the specified <see cref="V128"/> is equal to this <see cref="V128"/> instance.
+        /// </summary>
+        /// <param name="other">Other <see cref="V128"/> instance</param>
+        /// <returns>true if equal; otherwise false</returns>
+        public bool Equals(V128 other)
+        {
+            return other._e0 == _e0 && other._e1 == _e1;
+        }
 
-        public override int    GetHashCode() => HashCode.Combine(_e0, _e1);
-        public override string ToString()    => $"0x{_e1:X16}{_e0:X16}";
+        /// <summary>
+        /// Determines if the specified <see cref="object"/> is equal to this <see cref="V128"/> instance.
+        /// </summary>
+        /// <param name="obj">Other <see cref="object"/> instance</param>
+        /// <returns>true if equal; otherwise false</returns>
+        public override bool Equals(object obj)
+        {
+            return obj is V128 vector && Equals(vector);
+        }
 
-        private static void ThrowIndexOutOfRange() => throw new ArgumentOutOfRangeException("index");
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(_e0, _e1);
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return $"0x{_e1:X16}{_e0:X16}";
+        }
+
+        private uint GetElementCount<T>() where T : unmanaged
+        {
+            return (uint)(Unsafe.SizeOf<V128>() / Unsafe.SizeOf<T>());
+        }
+
+        private static void ThrowIndexOutOfRange()
+        {
+            throw new ArgumentOutOfRangeException("index");
+        }
     }
 }

--- a/ARMeilleure/State/V128.cs
+++ b/ARMeilleure/State/V128.cs
@@ -25,7 +25,7 @@ namespace ARMeilleure.State
         /// Initializes a new instance of the <see cref="V128"/> struct with the specified <see cref="double"/> value
         /// as a scalar.
         /// </summary>
-        /// <param name="value">Scalar value.</param>
+        /// <param name="value">Scalar value</param>
         public V128(double value) : this(value, 0) { }
 
         /// <summary>

--- a/ARMeilleure/State/V128.cs
+++ b/ARMeilleure/State/V128.cs
@@ -50,43 +50,30 @@ namespace ARMeilleure.State
             _e1 = (ulong)BitConverter.ToInt64(data, 8);
         }
 
-        public float  AsFloat()            => GetFloat(0);
-        public double AsDouble()           => GetDouble(0);
-        public float  GetFloat(int index)  => BitConverter.Int32BitsToSingle(GetInt32(index));
-        public double GetDouble(int index) => BitConverter.Int64BitsToDouble(GetInt64(index));
-        public int    GetInt32(int index)  => (int)GetUInt32(index);
-        public long   GetInt64(int index)  => (long)GetUInt64(index);
-
-        public uint GetUInt32(int index)
+        public T As<T>() where T : unmanaged
         {
-            if ((uint)index > 3U)
-                ThrowIndexOutOfRange();
-
-            return Unsafe.Add(ref Unsafe.As<ulong, uint>(ref _e0), index);
+            return Get<T>(0);
         }
 
-        public ulong GetUInt64(int index)
+        public T Get<T>(int index) where T : unmanaged
         {
-            if ((uint)index > 1U)
+            if ((uint)index >= GetElementCount<T>())
                 ThrowIndexOutOfRange();
 
-            return Unsafe.Add(ref _e0, index);
+            return Unsafe.Add(ref Unsafe.As<V128, T>(ref this), index);
         }
 
-        public void Insert(int index, uint value)
+        public void Set<T>(int index, T value) where T : unmanaged
         {
-            if ((uint)index > 3U)
+            if ((uint)index >= GetElementCount<T>())
                 ThrowIndexOutOfRange();
 
-            Unsafe.Add(ref Unsafe.As<ulong, uint>(ref _e0), index) = value;
+            Unsafe.Add(ref Unsafe.As<V128, T>(ref this), index) = value;
         }
 
-        public void Insert(int index, ulong value)
+        private uint GetElementCount<T>() where T : unmanaged
         {
-            if ((uint)index > 1U)
-                ThrowIndexOutOfRange();
-
-            Unsafe.Add(ref _e0, index) = value;
+            return (uint)(Unsafe.SizeOf<V128>() / Unsafe.SizeOf<T>());
         }
 
         public byte[] ToArray()

--- a/Ryujinx.Tests/Cpu/CpuTest.cs
+++ b/Ryujinx.Tests/Cpu/CpuTest.cs
@@ -420,9 +420,9 @@ namespace Ryujinx.Tests.Cpu
                             Is.EqualTo(_unicornEmu.Q[0].GetFloat(0)).Within(1).Ulps);
                         Assert.That   (_context.GetV(0).Get<float>(1),
                             Is.EqualTo(_unicornEmu.Q[0].GetFloat(1)).Within(1).Ulps);
-                        Assert.That   (_context.GetV(0).Get<float>(1),
+                        Assert.That   (_context.GetV(0).Get<float>(2),
                             Is.EqualTo(_unicornEmu.Q[0].GetFloat(2)).Within(1).Ulps);
-                        Assert.That   (_context.GetV(0).Get<float>(1),
+                        Assert.That   (_context.GetV(0).Get<float>(3),
                             Is.EqualTo(_unicornEmu.Q[0].GetFloat(3)).Within(1).Ulps);
 
                         Console.WriteLine(fpTolerances);

--- a/Ryujinx.Tests/Cpu/CpuTest.cs
+++ b/Ryujinx.Tests/Cpu/CpuTest.cs
@@ -416,13 +416,13 @@ namespace Ryujinx.Tests.Cpu
                     if (IsNormalOrSubnormalS(_unicornEmu.Q[0].AsFloat()) &&
                         IsNormalOrSubnormalS(_context.GetV(0).As<float>()))
                     {
-                        Assert.That   (_context.GetV(0).Get<float>(0),
+                        Assert.That   (_context.GetV(0).Extract<float>(0),
                             Is.EqualTo(_unicornEmu.Q[0].GetFloat(0)).Within(1).Ulps);
-                        Assert.That   (_context.GetV(0).Get<float>(1),
+                        Assert.That   (_context.GetV(0).Extract<float>(1),
                             Is.EqualTo(_unicornEmu.Q[0].GetFloat(1)).Within(1).Ulps);
-                        Assert.That   (_context.GetV(0).Get<float>(2),
+                        Assert.That   (_context.GetV(0).Extract<float>(2),
                             Is.EqualTo(_unicornEmu.Q[0].GetFloat(2)).Within(1).Ulps);
-                        Assert.That   (_context.GetV(0).Get<float>(3),
+                        Assert.That   (_context.GetV(0).Extract<float>(3),
                             Is.EqualTo(_unicornEmu.Q[0].GetFloat(3)).Within(1).Ulps);
 
                         Console.WriteLine(fpTolerances);
@@ -438,9 +438,9 @@ namespace Ryujinx.Tests.Cpu
                     if (IsNormalOrSubnormalD(_unicornEmu.Q[0].AsDouble()) &&
                         IsNormalOrSubnormalD(_context.GetV(0).As<double>()))
                     {
-                        Assert.That   (_context.GetV(0).Get<double>(0),
+                        Assert.That   (_context.GetV(0).Extract<double>(0),
                             Is.EqualTo(_unicornEmu.Q[0].GetDouble(0)).Within(1).Ulps);
-                        Assert.That   (_context.GetV(0).Get<double>(1),
+                        Assert.That   (_context.GetV(0).Extract<double>(1),
                             Is.EqualTo(_unicornEmu.Q[0].GetDouble(1)).Within(1).Ulps);
 
                         Console.WriteLine(fpTolerances);
@@ -455,7 +455,7 @@ namespace Ryujinx.Tests.Cpu
 
         private static SimdValue V128ToSimdValue(V128 value)
         {
-            return new SimdValue(value.Get<ulong>(0), value.Get<ulong>(1));
+            return new SimdValue(value.Extract<ulong>(0), value.Extract<ulong>(1));
         }
 
         protected static V128 MakeVectorScalar(float value)  => new V128(value);
@@ -466,8 +466,8 @@ namespace Ryujinx.Tests.Cpu
 
         protected static V128 MakeVectorE0E1(ulong e0, ulong e1) => new V128(e0, e1);
 
-        protected static ulong GetVectorE0(V128 vector) => vector.Get<ulong>(0);
-        protected static ulong GetVectorE1(V128 vector) => vector.Get<ulong>(1);
+        protected static ulong GetVectorE0(V128 vector) => vector.Extract<ulong>(0);
+        protected static ulong GetVectorE1(V128 vector) => vector.Extract<ulong>(1);
 
         protected static ushort GenNormalH()
         {

--- a/Ryujinx.Tests/Cpu/CpuTest.cs
+++ b/Ryujinx.Tests/Cpu/CpuTest.cs
@@ -414,15 +414,15 @@ namespace Ryujinx.Tests.Cpu
                 if (fpTolerances == FpTolerances.UpToOneUlpsS)
                 {
                     if (IsNormalOrSubnormalS(_unicornEmu.Q[0].AsFloat()) &&
-                        IsNormalOrSubnormalS(_context.GetV(0).AsFloat()))
+                        IsNormalOrSubnormalS(_context.GetV(0).As<float>()))
                     {
-                        Assert.That   (_context.GetV(0).GetFloat(0),
+                        Assert.That   (_context.GetV(0).Get<float>(0),
                             Is.EqualTo(_unicornEmu.Q[0].GetFloat(0)).Within(1).Ulps);
-                        Assert.That   (_context.GetV(0).GetFloat(1),
+                        Assert.That   (_context.GetV(0).Get<float>(1),
                             Is.EqualTo(_unicornEmu.Q[0].GetFloat(1)).Within(1).Ulps);
-                        Assert.That   (_context.GetV(0).GetFloat(2),
+                        Assert.That   (_context.GetV(0).Get<float>(1),
                             Is.EqualTo(_unicornEmu.Q[0].GetFloat(2)).Within(1).Ulps);
-                        Assert.That   (_context.GetV(0).GetFloat(3),
+                        Assert.That   (_context.GetV(0).Get<float>(1),
                             Is.EqualTo(_unicornEmu.Q[0].GetFloat(3)).Within(1).Ulps);
 
                         Console.WriteLine(fpTolerances);
@@ -436,11 +436,11 @@ namespace Ryujinx.Tests.Cpu
                 if (fpTolerances == FpTolerances.UpToOneUlpsD)
                 {
                     if (IsNormalOrSubnormalD(_unicornEmu.Q[0].AsDouble()) &&
-                        IsNormalOrSubnormalD(_context.GetV(0).AsDouble()))
+                        IsNormalOrSubnormalD(_context.GetV(0).As<double>()))
                     {
-                        Assert.That   (_context.GetV(0).GetDouble(0),
+                        Assert.That   (_context.GetV(0).Get<double>(0),
                             Is.EqualTo(_unicornEmu.Q[0].GetDouble(0)).Within(1).Ulps);
-                        Assert.That   (_context.GetV(0).GetDouble(1),
+                        Assert.That   (_context.GetV(0).Get<double>(1),
                             Is.EqualTo(_unicornEmu.Q[0].GetDouble(1)).Within(1).Ulps);
 
                         Console.WriteLine(fpTolerances);
@@ -455,7 +455,7 @@ namespace Ryujinx.Tests.Cpu
 
         private static SimdValue V128ToSimdValue(V128 value)
         {
-            return new SimdValue(value.GetUInt64(0), value.GetUInt64(1));
+            return new SimdValue(value.Get<ulong>(0), value.Get<ulong>(1));
         }
 
         protected static V128 MakeVectorScalar(float value)  => new V128(value);
@@ -466,8 +466,8 @@ namespace Ryujinx.Tests.Cpu
 
         protected static V128 MakeVectorE0E1(ulong e0, ulong e1) => new V128(e0, e1);
 
-        protected static ulong GetVectorE0(V128 vector) => vector.GetUInt64(0);
-        protected static ulong GetVectorE1(V128 vector) => vector.GetUInt64(1);
+        protected static ulong GetVectorE0(V128 vector) => vector.Get<ulong>(0);
+        protected static ulong GetVectorE1(V128 vector) => vector.Get<ulong>(1);
 
         protected static ushort GenNormalH()
         {

--- a/Ryujinx.Tests/Cpu/CpuTest32.cs
+++ b/Ryujinx.Tests/Cpu/CpuTest32.cs
@@ -411,15 +411,15 @@ namespace Ryujinx.Tests.Cpu
                 if (fpTolerances == FpTolerances.UpToOneUlpsS)
                 {
                     if (IsNormalOrSubnormalS(_unicornEmu.Q[0].AsFloat()) &&
-                        IsNormalOrSubnormalS(_context.GetV(0).AsFloat()))
+                        IsNormalOrSubnormalS(_context.GetV(0).As<float>()))
                     {
-                        Assert.That(_context.GetV(0).GetFloat(0),
+                        Assert.That(_context.GetV(0).Get<float>(0),
                             Is.EqualTo(_unicornEmu.Q[0].GetFloat(0)).Within(1).Ulps);
-                        Assert.That(_context.GetV(0).GetFloat(1),
+                        Assert.That(_context.GetV(0).Get<float>(1),
                             Is.EqualTo(_unicornEmu.Q[0].GetFloat(1)).Within(1).Ulps);
-                        Assert.That(_context.GetV(0).GetFloat(2),
+                        Assert.That(_context.GetV(0).Get<float>(2),
                             Is.EqualTo(_unicornEmu.Q[0].GetFloat(2)).Within(1).Ulps);
-                        Assert.That(_context.GetV(0).GetFloat(3),
+                        Assert.That(_context.GetV(0).Get<float>(3),
                             Is.EqualTo(_unicornEmu.Q[0].GetFloat(3)).Within(1).Ulps);
 
                         Console.WriteLine(fpTolerances);
@@ -433,11 +433,11 @@ namespace Ryujinx.Tests.Cpu
                 if (fpTolerances == FpTolerances.UpToOneUlpsD)
                 {
                     if (IsNormalOrSubnormalD(_unicornEmu.Q[0].AsDouble()) &&
-                        IsNormalOrSubnormalD(_context.GetV(0).AsDouble()))
+                        IsNormalOrSubnormalD(_context.GetV(0).As<double>()))
                     {
-                        Assert.That(_context.GetV(0).GetDouble(0),
+                        Assert.That(_context.GetV(0).Get<double>(0),
                             Is.EqualTo(_unicornEmu.Q[0].GetDouble(0)).Within(1).Ulps);
-                        Assert.That(_context.GetV(0).GetDouble(1),
+                        Assert.That(_context.GetV(0).Get<double>(1),
                             Is.EqualTo(_unicornEmu.Q[0].GetDouble(1)).Within(1).Ulps);
 
                         Console.WriteLine(fpTolerances);
@@ -452,7 +452,7 @@ namespace Ryujinx.Tests.Cpu
 
         private static SimdValue V128ToSimdValue(V128 value)
         {
-            return new SimdValue(value.GetUInt64(0), value.GetUInt64(1));
+            return new SimdValue(value.Get<ulong>(0), value.Get<ulong>(1));
         }
 
         protected static V128 MakeVectorScalar(float value) => new V128(value);
@@ -463,8 +463,8 @@ namespace Ryujinx.Tests.Cpu
 
         protected static V128 MakeVectorE0E1(ulong e0, ulong e1) => new V128(e0, e1);
 
-        protected static ulong GetVectorE0(V128 vector) => vector.GetUInt64(0);
-        protected static ulong GetVectorE1(V128 vector) => vector.GetUInt64(1);
+        protected static ulong GetVectorE0(V128 vector) => vector.Get<ulong>(0);
+        protected static ulong GetVectorE1(V128 vector) => vector.Get<ulong>(1);
 
         protected static ushort GenNormalH()
         {

--- a/Ryujinx.Tests/Cpu/CpuTest32.cs
+++ b/Ryujinx.Tests/Cpu/CpuTest32.cs
@@ -413,13 +413,13 @@ namespace Ryujinx.Tests.Cpu
                     if (IsNormalOrSubnormalS(_unicornEmu.Q[0].AsFloat()) &&
                         IsNormalOrSubnormalS(_context.GetV(0).As<float>()))
                     {
-                        Assert.That(_context.GetV(0).Get<float>(0),
+                        Assert.That(_context.GetV(0).Extract<float>(0),
                             Is.EqualTo(_unicornEmu.Q[0].GetFloat(0)).Within(1).Ulps);
-                        Assert.That(_context.GetV(0).Get<float>(1),
+                        Assert.That(_context.GetV(0).Extract<float>(1),
                             Is.EqualTo(_unicornEmu.Q[0].GetFloat(1)).Within(1).Ulps);
-                        Assert.That(_context.GetV(0).Get<float>(2),
+                        Assert.That(_context.GetV(0).Extract<float>(2),
                             Is.EqualTo(_unicornEmu.Q[0].GetFloat(2)).Within(1).Ulps);
-                        Assert.That(_context.GetV(0).Get<float>(3),
+                        Assert.That(_context.GetV(0).Extract<float>(3),
                             Is.EqualTo(_unicornEmu.Q[0].GetFloat(3)).Within(1).Ulps);
 
                         Console.WriteLine(fpTolerances);
@@ -435,9 +435,9 @@ namespace Ryujinx.Tests.Cpu
                     if (IsNormalOrSubnormalD(_unicornEmu.Q[0].AsDouble()) &&
                         IsNormalOrSubnormalD(_context.GetV(0).As<double>()))
                     {
-                        Assert.That(_context.GetV(0).Get<double>(0),
+                        Assert.That(_context.GetV(0).Extract<double>(0),
                             Is.EqualTo(_unicornEmu.Q[0].GetDouble(0)).Within(1).Ulps);
-                        Assert.That(_context.GetV(0).Get<double>(1),
+                        Assert.That(_context.GetV(0).Extract<double>(1),
                             Is.EqualTo(_unicornEmu.Q[0].GetDouble(1)).Within(1).Ulps);
 
                         Console.WriteLine(fpTolerances);
@@ -452,7 +452,7 @@ namespace Ryujinx.Tests.Cpu
 
         private static SimdValue V128ToSimdValue(V128 value)
         {
-            return new SimdValue(value.Get<ulong>(0), value.Get<ulong>(1));
+            return new SimdValue(value.Extract<ulong>(0), value.Extract<ulong>(1));
         }
 
         protected static V128 MakeVectorScalar(float value) => new V128(value);
@@ -463,8 +463,8 @@ namespace Ryujinx.Tests.Cpu
 
         protected static V128 MakeVectorE0E1(ulong e0, ulong e1) => new V128(e0, e1);
 
-        protected static ulong GetVectorE0(V128 vector) => vector.Get<ulong>(0);
-        protected static ulong GetVectorE1(V128 vector) => vector.Get<ulong>(1);
+        protected static ulong GetVectorE0(V128 vector) => vector.Extract<ulong>(0);
+        protected static ulong GetVectorE1(V128 vector) => vector.Extract<ulong>(1);
 
         protected static ushort GenNormalH()
         {

--- a/Ryujinx.Tests/Cpu/CpuTestMisc.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestMisc.cs
@@ -190,7 +190,7 @@ namespace Ryujinx.Tests.Cpu
             Opcode(0xD65F03C0);
             ExecuteOpcodes();
 
-            Assert.That(GetContext().GetV(0).AsFloat(), Is.EqualTo(16f));
+            Assert.That(GetContext().GetV(0).As<float>(), Is.EqualTo(16f));
         }
 
         [Explicit]
@@ -236,7 +236,7 @@ namespace Ryujinx.Tests.Cpu
             Opcode(0xD65F03C0);
             ExecuteOpcodes();
 
-            Assert.That(GetContext().GetV(0).AsDouble(), Is.EqualTo(16d));
+            Assert.That(GetContext().GetV(0).As<double>(), Is.EqualTo(16d));
         }
 
         [Test, Ignore("The Tester supports only one return point.")]


### PR DESCRIPTION
This new implementation takes advantage of `_e0` and `_e1` being contiguous in memory and turns the accesses into essentially array indexing, through the use of `Unsafe`.

The RyuJIT can now inline most of the methods, unlike before where it would complain.

Inline decisions of RyuJIT before:
```
[0 IL=0000 TR=000000 06000001] [FAILED: ldsfld of value class] V128:get_Zero():V128
[0 IL=0002 TR=000135 06000014] [FAILED: too many basic blocks] V128:GetUInt64(int):long:this
[0 IL=0002 TR=000157 06000013] [FAILED: has switch] V128:GetUInt32(int):int:this
[0 IL=0193 TR=000107 0600000B] [FAILED: too many il bytes] V128:Insert(int,int):this
[0 IL=0209 TR=000117 0600000C] [FAILED: too many basic blocks] V128:Insert(int,long):this
```
Since `GetUInt64` and `GetUInt32` are the leaf methods and they themselves don't inline, `GetFloat` and friends don't inline deeply (or completely).

Inline decisions of RyuJIT after:
```
[1 IL=0000 TR=000000 06000001] [below ALWAYS_INLINE size] V128:get_Zero():V128
[12 IL=0002 TR=000251 06000014] [profitable inline] V128:GetUInt64(int):long:this
[20 IL=0002 TR=000326 06000011] [profitable inline] V128:GetUInt32(int):int:this
[70 IL=0193 TR=000107 06000013] [profitable inline] V128:Insert(int,int):this
[76 IL=0209 TR=000117 06000014] [profitable inline] V128:Insert(int,long):this
```
This should affect other methods working with `V128`. For example:
https://github.com/Ryujinx/Ryujinx/blob/b8e3909d800ff5947683bb169d8efda2ef63d697/ARMeilleure/Memory/MemoryManager.cs#L664-L668
The calls to `GetUInt64` are not currently getting inlined, with this PR it does.

When I have time, I'll try to grab some benchmark numbers.

Also, let me know if the code here is not inline with the coding style of the project. :>