### PR TITLE
Fix negation of HADD2 constant buffer source

### DIFF
--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitFArith.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitFArith.cs
@@ -203,7 +203,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
             bool saturate = op.RawOpCode.Extract(op is IOpCodeReg ? 32 : 52);
 
             Operand[] srcA = GetHalfSrcA(context, isAdd);
-            Operand[] srcB = GetHalfSrcB(context);
+            Operand[] srcB = GetHalfSrcB(context, !isAdd);
 
             Operand[] res = new Operand[2];
 

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitHelper.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitHelper.cs
@@ -173,7 +173,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
             return FPAbsNeg(context, operands, absoluteA, negateA);
         }
 
-        public static Operand[] GetHalfSrcB(EmitterContext context)
+        public static Operand[] GetHalfSrcB(EmitterContext context, bool isMul = false)
         {
             OpCode op = context.CurrOp;
 
@@ -193,6 +193,11 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 swizzle = FPHalfSwizzle.FP32;
 
                 absoluteB = op.RawOpCode.Extract(54);
+
+                if (!isMul)
+                {
+                    negateB = op.RawOpCode.Extract(56);
+                }
             }
 
             Operand[] operands = GetHalfUnpacked(context, GetSrcB(context), swizzle);


### PR DESCRIPTION
It was not reading the negation bit. The fix should also apply to HSET2 and HSETP2, in addition to HADD2, it seems that the only instruction that doesn't support negation of the constant buffer is HMUL2.