### PR TITLE
Implement user-defined clipping (gl_ClipDistance) on GL state pipeline

### DIFF
--- a/Ryujinx.Graphics.GAL/IPipeline.cs
+++ b/Ryujinx.Graphics.GAL/IPipeline.cs
@@ -67,6 +67,8 @@ namespace Ryujinx.Graphics.GAL
 
         void SetUniformBuffer(int index, ShaderStage stage, BufferRange buffer);
 
+        void SetUserClipDistance(int index, bool enableClip);
+
         void SetVertexAttribs(VertexAttribDescriptor[] vertexAttribs);
         void SetVertexBuffers(VertexBufferDescriptor[] vertexBuffers);
 

--- a/Ryujinx.Graphics.Gpu/Constants.cs
+++ b/Ryujinx.Graphics.Gpu/Constants.cs
@@ -54,5 +54,10 @@ namespace Ryujinx.Graphics.Gpu
         /// Maximum number of viewports.
         /// </summary>
         public const int TotalViewports = 16;
+
+        /// <summary>
+        /// Maximum size of gl_ClipDistance array in shaders.
+        /// </summary>
+        public const int TotalClipDistances = 8;
     }
 }

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -108,6 +108,11 @@ namespace Ryujinx.Graphics.Gpu.Engine
                 UpdateShaderState(state);
             }
 
+            if (state.QueryModified(MethodOffset.ClipDistanceEnable))
+            {
+                UpdateUserClipState(state);
+            }
+
             if (state.QueryModified(MethodOffset.RasterizeEnable))
             {
                 UpdateRasterizerState(state);
@@ -861,6 +866,20 @@ namespace Ryujinx.Graphics.Gpu.Engine
             }
 
             _context.Renderer.Pipeline.SetProgram(gs.HostProgram);
+        }
+
+        /// <summary>
+        /// Updates user-defined clipping based on the guest GPU state.
+        /// </summary>
+        /// <param name="state">Current GPU state</param>
+        private void UpdateUserClipState(GpuState state)
+        {
+            int clipMask = state.Get<int>(MethodOffset.ClipDistanceEnable);
+
+            for (int i = 0; i < Constants.TotalClipDistances; ++i)
+            {
+                _context.Renderer.Pipeline.SetUserClipDistance(i, (clipMask & (1 << i)) != 0);
+            }
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/State/MethodOffset.cs
+++ b/Ryujinx.Graphics.Gpu/State/MethodOffset.cs
@@ -55,6 +55,7 @@ namespace Ryujinx.Graphics.Gpu.State
         YControl                        = 0x4eb,
         FirstVertex                     = 0x50d,
         FirstInstance                   = 0x50e,
+        ClipDistanceEnable              = 0x544,
         PointSize                       = 0x546,
         ResetCounter                    = 0x54c,
         RtDepthStencilEnable            = 0x54e,

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -792,6 +792,17 @@ namespace Ryujinx.Graphics.OpenGL
             SetBuffer(index, stage, buffer, isStorage: false);
         }
 
+        public void SetUserClipDistance(int index, bool enableClip)
+        {
+            if (!enableClip)
+            {
+                GL.Disable(EnableCap.ClipDistance0 + index);
+                return;
+            }
+
+            GL.Enable(EnableCap.ClipDistance0 + index);
+        }
+
         public void SetVertexAttribs(VertexAttribDescriptor[] vertexAttribs)
         {
             EnsureVertexArray();


### PR DESCRIPTION
Complements PR #680 

> Note that, despite redeclaring the output, you still have to glEnable the specific clip distances you intend to use. If you enable a clip distance, but do not write to it from the last vertex processing stage, you get undefined behavior. 

[Source](https://www.khronos.org/opengl/wiki/Vertex_Post-Processing#User-defined_clipping)

Games I tested set clip mask to `0xff`. I just hope that all games redeclare `gl_ClipDistance` properly.

Tested on NVIDIA only.