### PR TITLE
Implement Depth Clamping

### DIFF
--- a/Ryujinx.Graphics.GAL/IPipeline.cs
+++ b/Ryujinx.Graphics.GAL/IPipeline.cs
@@ -29,6 +29,7 @@ namespace Ryujinx.Graphics.GAL
         void SetBlendColor(ColorF color);
 
         void SetDepthBias(PolygonModeMask enables, float factor, float units, float clamp);
+        void SetDepthClamp(bool clampNear, bool clampFar);
         void SetDepthMode(DepthMode mode);
         void SetDepthTest(DepthTestDescriptor depthTest);
 

--- a/Ryujinx.Graphics.Gpu/State/MethodOffset.cs
+++ b/Ryujinx.Graphics.Gpu/State/MethodOffset.cs
@@ -75,6 +75,7 @@ namespace Ryujinx.Graphics.Gpu.State
         VertexBufferInstanced           = 0x620,
         FaceState                       = 0x646,
         ViewportTransformEnable         = 0x64b,
+        ViewVolumeClipControl           = 0x64f,
         Clear                           = 0x674,
         RtColorMask                     = 0x680,
         ReportState                     = 0x6c0,

--- a/Ryujinx.Graphics.Gpu/State/ViewVolumeClipControl.cs
+++ b/Ryujinx.Graphics.Gpu/State/ViewVolumeClipControl.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Ryujinx.Graphics.Gpu.State
+{
+    [Flags]
+    enum ViewVolumeClipControl
+    {
+        ForceDepthRangeZeroToOne = (1<<0),
+        DepthClampNear           = (1<<3),
+        DepthClampFar            = (1<<4),
+    }
+}

--- a/Ryujinx.Graphics.Gpu/State/ViewVolumeClipControl.cs
+++ b/Ryujinx.Graphics.Gpu/State/ViewVolumeClipControl.cs
@@ -5,8 +5,8 @@ namespace Ryujinx.Graphics.Gpu.State
     [Flags]
     enum ViewVolumeClipControl
     {
-        ForceDepthRangeZeroToOne = (1<<0),
-        DepthClampNear           = (1<<3),
-        DepthClampFar            = (1<<4),
+        ForceDepthRangeZeroToOne = 1 << 0,
+        DepthClampNear           = 1 << 3,
+        DepthClampFar            = 1 << 4,
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/YControl.cs
+++ b/Ryujinx.Graphics.Gpu/State/YControl.cs
@@ -5,7 +5,7 @@ namespace Ryujinx.Graphics.Gpu.State
     [Flags]
     enum YControl
     {
-        NegateY          = (1<<0),
-        TriangleRastFlip = (1<<4)
+        NegateY          = 1 << 0,
+        TriangleRastFlip = 1 << 4
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/YControl.cs
+++ b/Ryujinx.Graphics.Gpu/State/YControl.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Ryujinx.Graphics.Gpu.State
+{
+    [Flags]
+    enum YControl
+    {
+        NegateY          = (1<<0),
+        TriangleRastFlip = (1<<4)
+    }
+}

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -546,6 +546,21 @@ namespace Ryujinx.Graphics.OpenGL
             // GL.PolygonOffsetClamp(factor, units, clamp);
         }
 
+        public void SetDepthClamp(bool clampNear, bool clampFar)
+        {
+            // TODO: Use GL_AMD_depth_clamp_separate or similar if available?
+            // Currently enables clamping if either is set.
+            bool clamp = clampNear || clampFar;
+
+            if (!clamp)
+            {
+                GL.Disable(EnableCap.DepthClamp);
+                return;
+            }
+
+            GL.Enable(EnableCap.DepthClamp);
+        }
+
         public void SetDepthMode(DepthMode mode)
         {
             ClipDepthMode depthMode = mode.Convert();


### PR DESCRIPTION
Also adds misc enums

Seems to fix fog issue in BOTW

Before:
![botw-depthclamp-before](https://user-images.githubusercontent.com/62494521/79338469-fdc0dc00-7f44-11ea-8279-dd884ff8bcb6.png)


After:
![botw-depthclamp-after](https://user-images.githubusercontent.com/62494521/79338375-ceaa6a80-7f44-11ea-8e95-628b26e9b300.png)


Depth clamping is also used for stenciled shadow implementations. So, please check for fixes in shadows as well.

Tested on NVIDIA only.