### PR TITLE
Avoid temporaries when pre-allocating Store %x, imm8/16/32

### DIFF
--- a/ARMeilleure/CodeGen/X86/PreAllocator.cs
+++ b/ARMeilleure/CodeGen/X86/PreAllocator.cs
@@ -1375,6 +1375,9 @@ namespace ARMeilleure.CodeGen.X86
                 case Instruction.ShiftLeft:
                 case Instruction.ShiftRightSI:
                 case Instruction.ShiftRightUI:
+                case Instruction.Store:
+                case Instruction.Store16:
+                case Instruction.Store8:
                 case Instruction.Subtract:
                 case Instruction.VectorExtract:
                 case Instruction.VectorExtract16:


### PR DESCRIPTION
IR after PreAllocation pass:
```patch
  block5:
-  i64 %9 = Copy i64 %0
-  i64 %10 = Copy i64 0x11
-  Store i64 %9, i64 %10
-  i64 %11 = Copy i64 0x8
-  Store i64 memory, i64 %11
-  i64 %12 = Copy i64 0x4
-  Store i64 memory, i64 %12
-  i64 %13 = Copy i64 0x1
-  Store i64 memory, i64 %13
-  i64 r0 = Copy i64 %2
+  i64 r0 = Copy i64 r3
+  Store i64 r0, i64 0x11
+  Store i64 memory, i64 0x8
+  Store i64 memory, i64 0x4
+  Store i64 memory, i64 0x1
+  i64 r0 = Copy i64 r5
   Return
```

CodeGen:
```patch
 mov	rax, rbx
-mov	rcx, 0x11
-mov	qword ptr [rax], rcx
-mov	rcx, 8
-mov	qword ptr [rax + 8], rcx
-mov	rcx, 4
-mov	qword ptr [rax + 0x10], rcx
-mov	rcx, 1
-mov	qword ptr [rax + 0x18], rcx
+mov	qword ptr [rax], 0x11
+mov	qword ptr [rax + 8], 8
+mov	qword ptr [rax + 0x10], 4
+mov	qword ptr [rax + 0x18], 1
 mov	rax, rbp
 add	rsp, 0x48
```

~~This currently does not work for negative immediates because `CodeGenCommon.IsLongConst` checks the signedness.~~

~~I figure fixing this belongs to another PR.~~