### PR TITLE
Improve IRDumper

### DIFF
--- a/ARMeilleure/Common/BitMap.cs
+++ b/ARMeilleure/Common/BitMap.cs
@@ -1,3 +1,4 @@
+using ARMeilleure.Diagnostics;
 using System.Collections;
 using System.Collections.Generic;
 using System.Numerics;

--- a/ARMeilleure/Common/BitMap.cs
+++ b/ARMeilleure/Common/BitMap.cs
@@ -1,4 +1,3 @@
-using ARMeilleure.Diagnostics;
 using System.Collections;
 using System.Collections.Generic;
 using System.Numerics;

--- a/ARMeilleure/Diagnostics/IRDumper.cs
+++ b/ARMeilleure/Diagnostics/IRDumper.cs
@@ -269,17 +269,16 @@ namespace ARMeilleure.Diagnostics
 
         private static string GetTypeName(OperandType type)
         {
-            switch (type)
+            return type switch
             {
-                case OperandType.FP32: return "f32";
-                case OperandType.FP64: return "f64";
-                case OperandType.I32:  return "i32";
-                case OperandType.I64:  return "i64";
-                case OperandType.None: return "none";
-                case OperandType.V128: return "v128";
-            }
-
-            throw new ArgumentException($"Invalid operand type \"{type}\".");
+                OperandType.None => "none",
+                OperandType.I32 => "i32",
+                OperandType.I64 => "i64",
+                OperandType.FP32 => "f32",
+                OperandType.FP64 => "f64",
+                OperandType.V128 => "v128",
+                _ => throw new ArgumentException($"Invalid operand type \"{type}\"."),
+            };
         }
     }
 }

--- a/ARMeilleure/Diagnostics/IRDumper.cs
+++ b/ARMeilleure/Diagnostics/IRDumper.cs
@@ -82,6 +82,13 @@ namespace ARMeilleure.Diagnostics
                         }
 
                         instName = operation.Instruction.ToString();
+
+                        if (operation.Instruction == Instruction.Extended)
+                        {
+                            var intrinsicOperation = (IntrinsicOperation)operation;
+
+                            instName += "." + intrinsicOperation.Intrinsic.ToString();
+                        }
                     }
 
                     string allSources = string.Join(", ", sources);
@@ -141,7 +148,35 @@ namespace ARMeilleure.Diagnostics
             }
             else if (operand.Kind == OperandKind.Constant)
             {
-                name = "0x" + operand.Value.ToString("X");
+                name = Symbols.Get(operand.Value);
+
+                if (name == null)
+                {
+                    name = "0x" + operand.Value.ToString("X");
+                }
+            }
+            else if (operand.Kind == OperandKind.Memory)
+            {
+                var memOp = (MemoryOperand)operand;
+
+                name = "[" + GetOperandName(memOp.BaseAddress, localNames);
+
+                if (memOp.Index != null)
+                {
+                    name += " + " + GetOperandName(memOp.Index, localNames);
+
+                    if (memOp.Scale > Multiplier.x1)
+                    {
+                        name += "*" + memOp.Scale.ToString()[1];
+                    }
+                }
+
+                if (memOp.Displacement != 0)
+                {
+                    name += " + 0x" + memOp.Displacement.ToString("X");
+                }
+
+                name += "]";
             }
             else
             {

--- a/ARMeilleure/Diagnostics/IRDumper.cs
+++ b/ARMeilleure/Diagnostics/IRDumper.cs
@@ -159,19 +159,18 @@ namespace ARMeilleure.Diagnostics
 
         private void DumpNode(Node node)
         {
-            if (node.DestinationsCount > 0)
+            for (int index = 0; index < node.DestinationsCount; index++)
             {
-                for (int index = 0; index < node.DestinationsCount; index++)
+                DumpOperand(node.GetDestination(index));
+
+                if (index == node.DestinationsCount - 1)
                 {
-                    DumpOperand(node.GetDestination(index));
-
-                    if (index < node.DestinationsCount - 1)
-                    {
-                        _builder.Append(", ");
-                    }
+                    _builder.Append(" = ");
                 }
-
-                _builder.Append(" = ");
+                else
+                {
+                    _builder.Append(", ");
+                }
             }
 
             switch (node)

--- a/ARMeilleure/Diagnostics/IRDumper.cs
+++ b/ARMeilleure/Diagnostics/IRDumper.cs
@@ -85,9 +85,9 @@ namespace ARMeilleure.Diagnostics
 
                         if (operation.Instruction == Instruction.Extended)
                         {
-                            var intrinsicOperation = (IntrinsicOperation)operation;
+                            var intrinsOp = (IntrinsicOperation)operation;
 
-                            instName += "." + intrinsicOperation.Intrinsic.ToString();
+                            instName += "." + intrinsOp.Intrinsic.ToString();
                         }
                     }
 
@@ -158,25 +158,30 @@ namespace ARMeilleure.Diagnostics
             else if (operand.Kind == OperandKind.Memory)
             {
                 var memOp = (MemoryOperand)operand;
+                var sb = new StringBuilder();
 
-                name = "[" + GetOperandName(memOp.BaseAddress, localNames);
+                sb.Append('[').Append(GetOperandName(memOp.BaseAddress, localNames));
 
                 if (memOp.Index != null)
                 {
-                    name += " + " + GetOperandName(memOp.Index, localNames);
+                    sb.Append(" + ").Append(GetOperandName(memOp.Index, localNames));
 
-                    if (memOp.Scale > Multiplier.x1)
+                    switch (memOp.Scale)
                     {
-                        name += "*" + memOp.Scale.ToString()[1];
+                        case Multiplier.x2: sb.Append("*2"); break;
+                        case Multiplier.x4: sb.Append("*4"); break;
+                        case Multiplier.x8: sb.Append("*8"); break;
                     }
                 }
 
                 if (memOp.Displacement != 0)
                 {
-                    name += " + 0x" + memOp.Displacement.ToString("X");
+                    sb.Append(" + 0x").Append(memOp.Displacement.ToString("X"));
                 }
 
-                name += "]";
+                sb.Append(']');
+
+                name = sb.ToString();
             }
             else
             {

--- a/ARMeilleure/Diagnostics/IRDumper.cs
+++ b/ARMeilleure/Diagnostics/IRDumper.cs
@@ -114,7 +114,7 @@ namespace ARMeilleure.Diagnostics
                 case OperandKind.Constant:
                     string symbolName = Symbols.Get(operand.Value);
 
-                    if (symbolName != null)
+                    if (symbolName != null && !_symbolNames.ContainsKey(operand.Value))
                     {
                         _symbolNames.Add(operand.Value, symbolName);
                     }

--- a/ARMeilleure/Diagnostics/IRDumper.cs
+++ b/ARMeilleure/Diagnostics/IRDumper.cs
@@ -85,9 +85,9 @@ namespace ARMeilleure.Diagnostics
 
                         if (operation.Instruction == Instruction.Extended)
                         {
-                            var intrinsOp = (IntrinsicOperation)operation;
+                            var intrinOp = (IntrinsicOperation)operation;
 
-                            instName += "." + intrinsOp.Intrinsic.ToString();
+                            instName += "." + intrinOp.Intrinsic.ToString();
                         }
                     }
 

--- a/ARMeilleure/Diagnostics/IRDumper.cs
+++ b/ARMeilleure/Diagnostics/IRDumper.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 namespace ARMeilleure.Diagnostics
 {
-    struct IRDumper
+    class IRDumper
     {
         private const string Indentation = " ";
 
@@ -242,7 +242,7 @@ namespace ARMeilleure.Diagnostics
 
         public static string GetDump(ControlFlowGraph cfg)
         {
-            IRDumper dumper = new IRDumper(1);
+            var dumper = new IRDumper(1);
 
             for (BasicBlock block = cfg.Blocks.First; block != null; block = block.ListNext)
             {

--- a/ARMeilleure/Diagnostics/Symbols.cs
+++ b/ARMeilleure/Diagnostics/Symbols.cs
@@ -16,7 +16,12 @@ namespace ARMeilleure.Diagnostics
 
         public static string Get(ulong address)
         {
-            if (!_symbols.TryGetValue(address, out string result))
+            if (_symbols.TryGetValue(address, out string result))
+            {
+                return result;
+            }
+
+            lock (_rangedSymbols)
             {
                 foreach ((ulong Start, ulong End, ulong ElementSize, string Name) in _rangedSymbols)
                 {
@@ -27,7 +32,7 @@ namespace ARMeilleure.Diagnostics
                 }
             }
 
-            return result;
+            return null;
         }
 
         public static void Add(ulong address, string name)
@@ -37,7 +42,10 @@ namespace ARMeilleure.Diagnostics
 
         public static void Add(ulong address, ulong size, ulong elemSize, string name)
         {
-            _rangedSymbols.Add((address, address + size, elemSize, name));
+            lock (_rangedSymbols)
+            {
+                _rangedSymbols.Add((address, address + size, elemSize, name));
+            }
         }
     }
 }

--- a/ARMeilleure/Diagnostics/Symbols.cs
+++ b/ARMeilleure/Diagnostics/Symbols.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Concurrent;
+﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -33,7 +34,9 @@ namespace ARMeilleure.Diagnostics
 
         public static string Get(ulong address)
         {
-            if (_symbols.TryGetValue(address, out string result))
+            string result;
+
+            if (_symbols.TryGetValue(address, out result))
             {
                 return result;
             }
@@ -44,7 +47,19 @@ namespace ARMeilleure.Diagnostics
                 {
                     if (address >= symbol.Start && address <= symbol.End)
                     {
-                        return symbol.Name + "_" + (address - symbol.Start) / symbol.ElementSize;
+                        ulong diff = address - symbol.Start;
+                        ulong rem = diff % symbol.ElementSize;
+
+                        result = symbol.Name + "_" + diff / symbol.ElementSize;
+
+                        if (rem != 0)
+                        {
+                            result += "+" + rem;
+                        }
+
+                        _symbols.TryAdd(address, result);
+
+                        return result;
                     }
                 }
             }

--- a/ARMeilleure/Diagnostics/Symbols.cs
+++ b/ARMeilleure/Diagnostics/Symbols.cs
@@ -1,10 +1,11 @@
-﻿using System.Collections.Concurrent;
-using System.Collections.Generic;
-
-namespace ARMeilleure.Diagnostics
+﻿namespace ARMeilleure.Diagnostics
 {
     static class Symbols
     {
+#if M_DEBUG
+        using System.Collections.Concurrent;
+        using System.Collections.Generic;
+
         private static readonly ConcurrentDictionary<ulong, string> _symbols;
         private static readonly List<(ulong Start, ulong End, ulong ElementSize, string Name)> _rangedSymbols;
 
@@ -13,9 +14,11 @@ namespace ARMeilleure.Diagnostics
             _symbols = new ConcurrentDictionary<ulong, string>();
             _rangedSymbols = new List<(ulong Start, ulong End, ulong ElementSize, string Name)>();
         }
+#endif
 
         public static string Get(ulong address)
         {
+#if M_DEBUG
             if (_symbols.TryGetValue(address, out string result))
             {
                 return result;
@@ -31,21 +34,26 @@ namespace ARMeilleure.Diagnostics
                     }
                 }
             }
+#endif
 
             return null;
         }
 
         public static void Add(ulong address, string name)
         {
+#if M_DEBUG
             _symbols.TryAdd(address, name);
+#endif
         }
 
         public static void Add(ulong address, ulong size, ulong elemSize, string name)
         {
+#if M_DEBUG
             lock (_rangedSymbols)
             {
                 _rangedSymbols.Add((address, address + size, elemSize, name));
             }
+#endif
         }
     }
 }

--- a/ARMeilleure/Diagnostics/Symbols.cs
+++ b/ARMeilleure/Diagnostics/Symbols.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 

--- a/ARMeilleure/Diagnostics/Symbols.cs
+++ b/ARMeilleure/Diagnostics/Symbols.cs
@@ -1,10 +1,13 @@
-﻿namespace ARMeilleure.Diagnostics
+﻿#if M_DEBUG
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+#endif
+
+namespace ARMeilleure.Diagnostics
 {
     static class Symbols
     {
 #if M_DEBUG
-        using System.Collections.Concurrent;
-        using System.Collections.Generic;
 
         private static readonly ConcurrentDictionary<ulong, string> _symbols;
         private static readonly List<(ulong Start, ulong End, ulong ElementSize, string Name)> _rangedSymbols;

--- a/ARMeilleure/Diagnostics/Symbols.cs
+++ b/ARMeilleure/Diagnostics/Symbols.cs
@@ -1,14 +1,11 @@
-﻿#if M_DEBUG
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
-#endif
+using System.Diagnostics;
 
 namespace ARMeilleure.Diagnostics
 {
     static class Symbols
     {
-#if M_DEBUG
-
         private static readonly ConcurrentDictionary<ulong, string> _symbols;
         private static readonly List<(ulong Start, ulong End, ulong ElementSize, string Name)> _rangedSymbols;
 
@@ -17,11 +14,9 @@ namespace ARMeilleure.Diagnostics
             _symbols = new ConcurrentDictionary<ulong, string>();
             _rangedSymbols = new List<(ulong Start, ulong End, ulong ElementSize, string Name)>();
         }
-#endif
 
         public static string Get(ulong address)
         {
-#if M_DEBUG
             if (_symbols.TryGetValue(address, out string result))
             {
                 return result;
@@ -37,26 +32,23 @@ namespace ARMeilleure.Diagnostics
                     }
                 }
             }
-#endif
 
             return null;
         }
 
+        [Conditional("M_DEBUG")]
         public static void Add(ulong address, string name)
         {
-#if M_DEBUG
             _symbols.TryAdd(address, name);
-#endif
         }
 
+        [Conditional("M_DEBUG")]
         public static void Add(ulong address, ulong size, ulong elemSize, string name)
         {
-#if M_DEBUG
             lock (_rangedSymbols)
             {
                 _rangedSymbols.Add((address, address + size, elemSize, name));
             }
-#endif
         }
     }
 }

--- a/ARMeilleure/Diagnostics/Symbols.cs
+++ b/ARMeilleure/Diagnostics/Symbols.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace ARMeilleure.Diagnostics
+{
+    static class Symbols
+    {
+        private static readonly ConcurrentDictionary<ulong, string> _symbols;
+        private static readonly List<(ulong Start, ulong End, ulong ElementSize, string Name)> _rangedSymbols;
+
+        static Symbols()
+        {
+            _symbols = new ConcurrentDictionary<ulong, string>();
+            _rangedSymbols = new List<(ulong Start, ulong End, ulong ElementSize, string Name)>();
+        }
+
+        public static string Get(ulong address)
+        {
+            if (!_symbols.TryGetValue(address, out string result))
+            {
+                foreach ((ulong Start, ulong End, ulong ElementSize, string Name) in _rangedSymbols)
+                {
+                    if (address >= Start && address <= End)
+                    {
+                        return Name + "_" + (address - Start) / ElementSize;
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        public static void Add(ulong address, string name)
+        {
+            _symbols.TryAdd(address, name);
+        }
+
+        public static void Add(ulong address, ulong size, ulong elemSize, string name)
+        {
+            _rangedSymbols.Add((address, address + size, elemSize, name));
+        }
+    }
+}

--- a/ARMeilleure/Translation/EmitterContext.cs
+++ b/ARMeilleure/Translation/EmitterContext.cs
@@ -1,3 +1,4 @@
+using ARMeilleure.Diagnostics;
 using ARMeilleure.IntermediateRepresentation;
 using ARMeilleure.State;
 using System;
@@ -84,6 +85,8 @@ namespace ARMeilleure.Translation
             func = DelegateCache.GetOrAdd(func);
 
             IntPtr ptr = Marshal.GetFunctionPointerForDelegate<Delegate>(func);
+
+            Symbols.Add((ulong)ptr.ToInt64(), func.Method.Name);
 
             OperandType returnType = GetOperandType(func.Method.ReturnType);
 

--- a/ARMeilleure/Translation/JumpTable.cs
+++ b/ARMeilleure/Translation/JumpTable.cs
@@ -70,7 +70,7 @@ namespace ARMeilleure.Translation
             _dependants = new ConcurrentDictionary<ulong, LinkedList<int>>();
 
             Symbols.Add((ulong)_jumpRegion.Pointer.ToInt64(), JumpTableByteSize, JumpTableStride, "JMP_TABLE");
-            Symbols.Add((ulong)_dynamicRegion.Pointer.ToInt64(), DynamicTableByteSize, DynamicTableStride, "JMP_TABLE");
+            Symbols.Add((ulong)_dynamicRegion.Pointer.ToInt64(), DynamicTableByteSize, DynamicTableStride, "DYN_TABLE");
         }
 
         public void RegisterFunction(ulong address, TranslatedFunction func) {

--- a/ARMeilleure/Translation/JumpTable.cs
+++ b/ARMeilleure/Translation/JumpTable.cs
@@ -1,4 +1,5 @@
-﻿using ARMeilleure.Memory;
+﻿using ARMeilleure.Diagnostics;
+using ARMeilleure.Memory;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -67,6 +68,9 @@ namespace ARMeilleure.Translation
 
             _targets = new ConcurrentDictionary<ulong, TranslatedFunction>();
             _dependants = new ConcurrentDictionary<ulong, LinkedList<int>>();
+
+            Symbols.Add((ulong)_jumpRegion.Pointer.ToInt64(), JumpTableByteSize, JumpTableStride, "JMP_TABLE");
+            Symbols.Add((ulong)_dynamicRegion.Pointer.ToInt64(), DynamicTableByteSize, DynamicTableStride, "JMP_TABLE");
         }
 
         public void RegisterFunction(ulong address, TranslatedFunction func) {


### PR DESCRIPTION
Improves IRDumper to now dump:

MemoryOperand
```wasm
i64 r0 = Load i64 [i64 r1 + i64 r0*8]
```

IntrinsicOperation
```wasm
v128 v1 = Extended.X86Shufps v128 v1, v128 v0, i32 0xF0
```

Jump Table & Dynamic Table
```wasm
i64 %299 = Load i64 0x1DFFBB80018 ;; JMP_TABLE_1+8
...
i64 %289 = Copy i64 0x1DFFCB80010 ;; DYN_TABLE_1
i64 %295 = Copy i64 0x1DFFCB80018 ;; DYN_TABLE_1+8
```

Function names
```wasm
i64 %794 = Copy i64 0x7FFA30A038C4 ;; GetFunctionAddress
```

Multiple destinations
```wasm
i32 r0, i32 r3, i32 r1, i32 r2 = CpuId i32 r0
```