### PR TITLE
Report more realistic GPU timestamps when FastGpuTime is enabled

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/MethodReport.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodReport.cs
@@ -11,8 +11,6 @@ namespace Ryujinx.Graphics.Gpu.Engine
         private const int NsToTicksFractionNumerator   = 384;
         private const int NsToTicksFractionDenominator = 625;
 
-        private ulong _runningCounter;
-
         /// <summary>
         /// Writes a GPU counter to guest memory.
         /// </summary>
@@ -81,15 +79,13 @@ namespace Ryujinx.Graphics.Gpu.Engine
                     break;
             }
 
-            ulong ticks;
+            ulong ticks = ConvertNanosecondsToTicks((ulong)PerformanceCounter.ElapsedNanoseconds);
 
             if (GraphicsConfig.FastGpuTime)
             {
-                ticks = _runningCounter++;
-            }
-            else
-            {
-                ticks = ConvertNanosecondsToTicks((ulong)PerformanceCounter.ElapsedNanoseconds);
+                // Divide by some amount to report time as if operations were performed faster than they really are.
+                // This can prevent some games from switching to a lower resolution because rendering is too slow.
+                ticks /= 256;
             }
 
             counterData.Counter   = counter;


### PR DESCRIPTION
Currently FastGpuTime will simply use a counter that is incremented each time ReportCounter is called. This causes games to behave as if operations were completed pretty much instantly, and this breaks some UE4 games, presumably because they divide the nanoseconds timestamp by some constant, and after the division to change in time is not registered (`currentTimestamp - previousTimestamp` would  always return 0). The fix I decided to use here is just dividing the host timestamp by a fixed amount.

This gives the illusion to the game that operations are completed faster than they really are, which is the purpose of this setting.

There's nothing special about the value 256, I just used it because it is a power of 2 (allowing the division to be optimized to shift), and because it seemed like a reasonable amount.