### PR TITLE
SurfaceFlinger: Invalid GraphicBuffer in SetPreallocatedBuffer

### DIFF
--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/BufferQueueProducer.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/BufferQueueProducer.cs
@@ -593,6 +593,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
                 Core.Slots[slot].BufferState           = BufferState.Free;
                 Core.Slots[slot].Fence                 = AndroidFence.NoFence;
                 Core.Slots[slot].RequestBufferCalled   = false;
+                Core.Slots[slot].AcquireCalled         = false;
                 Core.Slots[slot].NeedsCleanupOnRelease = false;
                 Core.Slots[slot].FrameNumber           = 0;
 


### PR DESCRIPTION
This invalidate the GraphicBuffer on the consumer side when
SetPreallocatedBuffer is called on a buffer slot.

This fix rendering issues on games with a dynamic resolution like Yoshi
Crafted World.