### PR TITLE
Implement texture buffers

### DIFF
--- a/Ryujinx.Graphics.GAL/ITexture.cs
+++ b/Ryujinx.Graphics.GAL/ITexture.cs
@@ -12,5 +12,6 @@ namespace Ryujinx.Graphics.GAL
         byte[] GetData();
 
         void SetData(ReadOnlySpan<byte> data);
+        void SetStorage(BufferRange buffer);
     }
 }

--- a/Ryujinx.Graphics.Gpu/Engine/MethodReport.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodReport.cs
@@ -12,8 +12,6 @@ namespace Ryujinx.Graphics.Gpu.Engine
         private const int NsToTicksFractionNumerator   = 384;
         private const int NsToTicksFractionDenominator = 625;
 
-        private ulong _runningCounter;
-
         private readonly CounterCache _counterCache = new CounterCache();
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -258,7 +258,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
         {
             UpdateStorageBuffers();
 
-            BufferManager.CommitBindings();
+            BufferManager.CommitGraphicsBindings();
             TextureManager.CommitGraphicsBindings();
         }
 

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -366,36 +366,33 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>Converted data</returns>
         private ReadOnlySpan<byte> ConvertToHostCompatibleFormat(ReadOnlySpan<byte> data)
         {
-            if (Info.Target != Target.TextureBuffer)
+            if (Info.IsLinear)
             {
-                if (Info.IsLinear)
-                {
-                    data = LayoutConverter.ConvertLinearStridedToLinear(
-                        Info.Width,
-                        Info.Height,
-                        Info.FormatInfo.BlockWidth,
-                        Info.FormatInfo.BlockHeight,
-                        Info.Stride,
-                        Info.FormatInfo.BytesPerPixel,
-                        data);
-                }
-                else
-                {
-                    data = LayoutConverter.ConvertBlockLinearToLinear(
-                        Info.Width,
-                        Info.Height,
-                        _depth,
-                        Info.Levels,
-                        _layers,
-                        Info.FormatInfo.BlockWidth,
-                        Info.FormatInfo.BlockHeight,
-                        Info.FormatInfo.BytesPerPixel,
-                        Info.GobBlocksInY,
-                        Info.GobBlocksInZ,
-                        Info.GobBlocksInTileX,
-                        _sizeInfo,
-                        data);
-                }
+                data = LayoutConverter.ConvertLinearStridedToLinear(
+                    Info.Width,
+                    Info.Height,
+                    Info.FormatInfo.BlockWidth,
+                    Info.FormatInfo.BlockHeight,
+                    Info.Stride,
+                    Info.FormatInfo.BytesPerPixel,
+                    data);
+            }
+            else
+            {
+                data = LayoutConverter.ConvertBlockLinearToLinear(
+                    Info.Width,
+                    Info.Height,
+                    _depth,
+                    Info.Levels,
+                    _layers,
+                    Info.FormatInfo.BlockWidth,
+                    Info.FormatInfo.BlockHeight,
+                    Info.FormatInfo.BytesPerPixel,
+                    Info.GobBlocksInY,
+                    Info.GobBlocksInZ,
+                    Info.GobBlocksInTileX,
+                    _sizeInfo,
+                    data);
             }
 
             if (!_context.Capabilities.SupportsAstcCompression && Info.FormatInfo.Format.IsAstc())

--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -69,7 +69,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         public void SetTextures(int stage, TextureBindingInfo[] bindings)
         {
             _textureBindings[stage] = bindings;
-
             _textureState[stage] = new TextureStatePerStage[bindings.Length];
         }
 
@@ -81,7 +80,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         public void SetImages(int stage, TextureBindingInfo[] bindings)
         {
             _imageBindings[stage] = bindings;
-
             _imageState[stage] = new TextureStatePerStage[bindings.Length];
         }
 
@@ -201,7 +199,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 }
                 else
                 {
-                    packedId = ReadPackedId(stageIndex, binding.Handle);
+                    packedId = ReadPackedId(stageIndex, binding.Handle, _textureBufferIndex);
                 }
 
                 int textureId = UnpackTextureId(packedId);
@@ -225,6 +223,14 @@ namespace Ryujinx.Graphics.Gpu.Image
                     _textureState[stageIndex][index].Texture = hostTexture;
 
                     _context.Renderer.Pipeline.SetTexture(index, stage, hostTexture);
+                }
+
+                if (hostTexture != null && texture.Info.Target == Target.TextureBuffer)
+                {
+                    // Ensure that the buffer texture is using the correct buffer as storage.
+                    // Buffers are frequently re-created to accomodate larger data, so we need to re-bind
+                    // to ensure we're not using a old buffer that was already deleted.
+                    _context.Methods.BufferManager.SetBufferTextureStorage(hostTexture, texture.Address, texture.Size, _isCompute);
                 }
 
                 Sampler sampler = _samplerPool.Get(samplerId);
@@ -258,8 +264,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             {
                 TextureBindingInfo binding = _imageBindings[stageIndex][index];
 
-                int packedId = ReadPackedId(stageIndex, binding.Handle);
-
+                int packedId = ReadPackedId(stageIndex, binding.Handle, _textureBufferIndex);
                 int textureId = UnpackTextureId(packedId);
 
                 Texture texture = pool.Get(textureId);
@@ -284,8 +289,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>The texture descriptor for the specified texture</returns>
         public TextureDescriptor GetTextureDescriptor(GpuState state, int stageIndex, int handle)
         {
-            int packedId = ReadPackedId(stageIndex, handle);
-
+            int packedId = ReadPackedId(stageIndex, handle, state.Get<int>(MethodOffset.TextureBufferIndex));
             int textureId = UnpackTextureId(packedId);
 
             var poolState = state.Get<PoolState>(MethodOffset.TexturePoolState);
@@ -303,8 +307,9 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         /// <param name="stageIndex">The number of the shader stage where the texture is bound</param>
         /// <param name="wordOffset">A word offset of the handle on the buffer (the "fake" shader handle)</param>
+        /// <param name="textureBufferIndex">Index of the constant buffer holding the texture handles</param>
         /// <returns>The packed texture and sampler ID (the real texture handle)</returns>
-        private int ReadPackedId(int stageIndex, int wordOffset)
+        private int ReadPackedId(int stageIndex, int wordOffset, int textureBufferIndex)
         {
             ulong address;
 
@@ -312,11 +317,11 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             if (_isCompute)
             {
-                address = bufferManager.GetComputeUniformBufferAddress(_textureBufferIndex);
+                address = bufferManager.GetComputeUniformBufferAddress(textureBufferIndex);
             }
             else
             {
-                address = bufferManager.GetGraphicsUniformBufferAddress(stageIndex, _textureBufferIndex);
+                address = bufferManager.GetGraphicsUniformBufferAddress(stageIndex, textureBufferIndex);
             }
 
             address += (uint)wordOffset * 4;

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -489,7 +489,11 @@ namespace Ryujinx.Graphics.Gpu.Image
             // Calculate texture sizes, used to find all overlapping textures.
             SizeInfo sizeInfo;
 
-            if (info.IsLinear)
+            if (info.Target == Target.TextureBuffer)
+            {
+                sizeInfo = new SizeInfo(info.Width * info.FormatInfo.BytesPerPixel);
+            }
+            else if (info.IsLinear)
             {
                 sizeInfo = SizeCalculator.GetLinearTextureSize(
                     info.Stride,

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -26,7 +26,7 @@ namespace Ryujinx.Graphics.OpenGL
         private bool _depthTest;
         private bool _hasDepthBuffer;
 
-        private TextureView _unit0Texture;
+        private TextureBase _unit0Texture;
 
         private ClipOrigin _clipOrigin;
         private ClipDepthMode _clipDepthMode;
@@ -608,13 +608,13 @@ namespace Ryujinx.Graphics.OpenGL
 
             if (unit != -1 && texture != null)
             {
-                TextureView view = (TextureView)texture;
+                TextureBase texBase = (TextureBase)texture;
 
-                FormatInfo formatInfo = FormatTable.GetFormatInfo(view.Format);
+                FormatInfo formatInfo = FormatTable.GetFormatInfo(texBase.Format);
 
                 SizedInternalFormat format = (SizedInternalFormat)formatInfo.PixelInternalFormat;
 
-                GL.BindImageTexture(unit, view.Handle, 0, true, 0, TextureAccess.ReadWrite, format);
+                GL.BindImageTexture(unit, texBase.Handle, 0, true, 0, TextureAccess.ReadWrite, format);
             }
         }
 
@@ -793,11 +793,11 @@ namespace Ryujinx.Graphics.OpenGL
             {
                 if (unit == 0)
                 {
-                    _unit0Texture = ((TextureView)texture);
+                    _unit0Texture = (TextureBase)texture;
                 }
                 else
                 {
-                    ((TextureView)texture).Bind(unit);
+                    ((TextureBase)texture).Bind(unit);
                 }
             }
         }

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -20,19 +20,14 @@ namespace Ryujinx.Graphics.OpenGL
         internal TextureCopy TextureCopy { get; }
 
         public string GpuVendor { get; private set; }
-
         public string GpuRenderer { get; private set; }
-
         public string GpuVersion { get; private set; }
 
         public Renderer()
         {
             _pipeline = new Pipeline();
-
             _counters = new Counters();
-
             _window = new Window(this);
-
             TextureCopy = new TextureCopy(this);
         }
 
@@ -58,7 +53,7 @@ namespace Ryujinx.Graphics.OpenGL
 
         public ITexture CreateTexture(TextureCreateInfo info)
         {
-            return new TextureStorage(this, info).CreateDefaultView();
+            return info.Target == Target.TextureBuffer ? new TextureBuffer(info) : new TextureStorage(this, info).CreateDefaultView();
         }
 
         public Capabilities GetCapabilities()

--- a/Ryujinx.Graphics.OpenGL/TextureBase.cs
+++ b/Ryujinx.Graphics.OpenGL/TextureBase.cs
@@ -1,0 +1,39 @@
+﻿using OpenTK.Graphics.OpenGL;
+using Ryujinx.Graphics.GAL;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ryujinx.Graphics.OpenGL
+{
+    class TextureBase
+    {
+        public int Handle { get; protected set; }
+
+        protected TextureCreateInfo Info { get; }
+
+        public int Width => Info.Width;
+        public int Height => Info.Height;
+
+        public Target Target => Info.Target;
+        public Format Format => Info.Format;
+
+        public TextureBase(TextureCreateInfo info)
+        {
+            Info = info;
+
+            Handle = GL.GenTexture();
+        }
+
+        public void Bind(int unit)
+        {
+            Bind(Target.Convert(), unit);
+        }
+
+        protected void Bind(TextureTarget target, int unit)
+        {
+            GL.ActiveTexture(TextureUnit.Texture0 + unit);
+            GL.BindTexture(target, Handle);
+        }
+    }
+}

--- a/Ryujinx.Graphics.OpenGL/TextureBuffer.cs
+++ b/Ryujinx.Graphics.OpenGL/TextureBuffer.cs
@@ -15,17 +15,17 @@ namespace Ryujinx.Graphics.OpenGL
 
         public void CopyTo(ITexture destination, int firstLayer, int firstLevel)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         public void CopyTo(ITexture destination, Extents2D srcRegion, Extents2D dstRegion, bool linearFilter)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         public ITexture CreateView(TextureCreateInfo info, int firstLayer, int firstLevel)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         public byte[] GetData()
@@ -47,13 +47,13 @@ namespace Ryujinx.Graphics.OpenGL
                 return;
             }
 
+            _buffer = (Buffer)buffer.Buffer;
+            _bufferOffset = buffer.Offset;
+            _bufferSize = buffer.Size;
+
             Bind(0);
 
             SizedInternalFormat format = (SizedInternalFormat)FormatTable.GetFormatInfo(Info.Format).PixelInternalFormat;
-
-            _bufferOffset = buffer.Offset;
-            _bufferSize = buffer.Size;
-            _buffer = (Buffer)buffer.Buffer;
 
             GL.TexBufferRange(TextureBufferTarget.TextureBuffer, format, _buffer.Handle, (IntPtr)buffer.Offset, buffer.Size);
         }

--- a/Ryujinx.Graphics.OpenGL/TextureBuffer.cs
+++ b/Ryujinx.Graphics.OpenGL/TextureBuffer.cs
@@ -1,0 +1,71 @@
+﻿using OpenTK.Graphics.OpenGL;
+using Ryujinx.Graphics.GAL;
+using System;
+
+namespace Ryujinx.Graphics.OpenGL
+{
+    class TextureBuffer : TextureBase, ITexture
+    {
+        private int _bufferOffset;
+        private int _bufferSize;
+
+        private Buffer _buffer;
+
+        public TextureBuffer(TextureCreateInfo info) : base(info) {}
+
+        public void CopyTo(ITexture destination, int firstLayer, int firstLevel)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void CopyTo(ITexture destination, Extents2D srcRegion, Extents2D dstRegion, bool linearFilter)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ITexture CreateView(TextureCreateInfo info, int firstLayer, int firstLevel)
+        {
+            throw new NotImplementedException();
+        }
+
+        public byte[] GetData()
+        {
+            return _buffer?.GetData(_bufferOffset, _bufferSize);
+        }
+
+        public void SetData(ReadOnlySpan<byte> data)
+        {
+            _buffer?.SetData(_bufferOffset, data.Slice(0, Math.Min(data.Length, _bufferSize)));
+        }
+
+        public void SetStorage(BufferRange buffer)
+        {
+            if (buffer.Buffer == _buffer &&
+                buffer.Offset == _bufferOffset &&
+                buffer.Size == _bufferSize)
+            {
+                return;
+            }
+
+            Bind(0);
+
+            SizedInternalFormat format = (SizedInternalFormat)FormatTable.GetFormatInfo(Info.Format).PixelInternalFormat;
+
+            _bufferOffset = buffer.Offset;
+            _bufferSize = buffer.Size;
+            _buffer = (Buffer)buffer.Buffer;
+
+            GL.TexBufferRange(TextureBufferTarget.TextureBuffer, format, _buffer.Handle, (IntPtr)buffer.Offset, buffer.Size);
+        }
+
+        public void Dispose()
+        {
+            if (Handle != 0)
+            {
+                GL.DeleteTexture(Handle);
+
+                Handle = 0;
+            }
+        }
+    }
+}

--- a/Ryujinx.Graphics.OpenGL/TextureView.cs
+++ b/Ryujinx.Graphics.OpenGL/TextureView.cs
@@ -4,10 +4,8 @@ using System;
 
 namespace Ryujinx.Graphics.OpenGL
 {
-    class TextureView : ITexture
+    class TextureView : TextureBase, ITexture
     {
-        public int Handle { get; private set; }
-
         private readonly Renderer _renderer;
 
         private readonly TextureStorage _parent;
@@ -16,32 +14,21 @@ namespace Ryujinx.Graphics.OpenGL
 
         private TextureView _incompatibleFormatView;
 
-        private readonly TextureCreateInfo _info;
-
         public int FirstLayer { get; private set; }
         public int FirstLevel { get; private set; }
-
-        public int Width  => _info.Width;
-        public int Height => _info.Height;
-
-        public Target Target => _info.Target;
-        public Format Format => _info.Format;
 
         public TextureView(
             Renderer          renderer,
             TextureStorage    parent,
             TextureCreateInfo info,
             int               firstLayer,
-            int               firstLevel)
+            int               firstLevel) : base(info)
         {
             _renderer = renderer;
             _parent   = parent;
-            _info     = info;
 
             FirstLayer = firstLayer;
             FirstLevel = firstLevel;
-
-            Handle = GL.GenTexture();
 
             CreateView();
         }
@@ -50,7 +37,7 @@ namespace Ryujinx.Graphics.OpenGL
         {
             TextureTarget target = Target.Convert();
 
-            FormatInfo format = FormatTable.GetFormatInfo(_info.Format);
+            FormatInfo format = FormatTable.GetFormatInfo(Info.Format);
 
             PixelInternalFormat pixelInternalFormat;
 
@@ -69,9 +56,9 @@ namespace Ryujinx.Graphics.OpenGL
                 _parent.Handle,
                 pixelInternalFormat,
                 FirstLevel,
-                _info.Levels,
+                Info.Levels,
                 FirstLayer,
-                _info.GetLayers());
+                Info.GetLayers());
 
             GL.ActiveTexture(TextureUnit.Texture0);
 
@@ -79,15 +66,15 @@ namespace Ryujinx.Graphics.OpenGL
 
             int[] swizzleRgba = new int[]
             {
-                (int)_info.SwizzleR.Convert(),
-                (int)_info.SwizzleG.Convert(),
-                (int)_info.SwizzleB.Convert(),
-                (int)_info.SwizzleA.Convert()
+                (int)Info.SwizzleR.Convert(),
+                (int)Info.SwizzleG.Convert(),
+                (int)Info.SwizzleB.Convert(),
+                (int)Info.SwizzleA.Convert()
             };
 
             GL.TexParameter(target, TextureParameterName.TextureSwizzleRgba, swizzleRgba);
 
-            int maxLevel = _info.Levels - 1;
+            int maxLevel = Info.Levels - 1;
 
             if (maxLevel < 0)
             {
@@ -95,12 +82,12 @@ namespace Ryujinx.Graphics.OpenGL
             }
 
             GL.TexParameter(target, TextureParameterName.TextureMaxLevel, maxLevel);
-            GL.TexParameter(target, TextureParameterName.DepthStencilTextureMode, (int)_info.DepthStencilMode.Convert());
+            GL.TexParameter(target, TextureParameterName.DepthStencilTextureMode, (int)Info.DepthStencilMode.Convert());
         }
 
         public ITexture CreateView(TextureCreateInfo info, int firstLayer, int firstLevel)
         {
-            if (_info.IsCompressed == info.IsCompressed)
+            if (Info.IsCompressed == info.IsCompressed)
             {
                 firstLayer += FirstLayer;
                 firstLevel += FirstLevel;
@@ -135,10 +122,10 @@ namespace Ryujinx.Graphics.OpenGL
             {
                 if (_incompatibleFormatView == null)
                 {
-                    _incompatibleFormatView = (TextureView)_renderer.CreateTexture(_info);
+                    _incompatibleFormatView = (TextureView)_renderer.CreateTexture(Info);
                 }
 
-                TextureCopyUnscaled.Copy(_parent.Info, _incompatibleFormatView._info, _parent.Handle, _incompatibleFormatView.Handle, FirstLayer, 0, FirstLevel, 0);
+                TextureCopyUnscaled.Copy(_parent.Info, _incompatibleFormatView.Info, _parent.Handle, _incompatibleFormatView.Handle, FirstLayer, 0, FirstLevel, 0);
 
                 return _incompatibleFormatView.Handle;
             }
@@ -150,7 +137,7 @@ namespace Ryujinx.Graphics.OpenGL
         {
             if (_incompatibleFormatView != null)
             {
-                TextureCopyUnscaled.Copy(_incompatibleFormatView._info, _parent.Info, _incompatibleFormatView.Handle, _parent.Handle, 0, FirstLayer, 0, FirstLevel);
+                TextureCopyUnscaled.Copy(_incompatibleFormatView.Info, _parent.Info, _incompatibleFormatView.Handle, _parent.Handle, 0, FirstLayer, 0, FirstLevel);
             }
         }
 
@@ -158,13 +145,13 @@ namespace Ryujinx.Graphics.OpenGL
         {
             TextureView destinationView = (TextureView)destination;
 
-            TextureCopyUnscaled.Copy(_info, destinationView._info, Handle, destinationView.Handle, 0, firstLayer, 0, firstLevel);
+            TextureCopyUnscaled.Copy(Info, destinationView.Info, Handle, destinationView.Handle, 0, firstLayer, 0, firstLevel);
 
             if (destinationView._emulatedViewParent != null)
             {
                 TextureCopyUnscaled.Copy(
-                    _info,
-                    destinationView._emulatedViewParent._info,
+                    Info,
+                    destinationView._emulatedViewParent.Info,
                     Handle,
                     destinationView._emulatedViewParent.Handle,
                     0,
@@ -183,9 +170,9 @@ namespace Ryujinx.Graphics.OpenGL
         {
             int size = 0;
 
-            for (int level = 0; level < _info.Levels; level++)
+            for (int level = 0; level < Info.Levels; level++)
             {
-                size += _info.GetMipSize(level);
+                size += Info.GetMipSize(level);
             }
 
             byte[] data = new byte[size];
@@ -207,7 +194,7 @@ namespace Ryujinx.Graphics.OpenGL
 
             Bind(target, 0);
 
-            FormatInfo format = FormatTable.GetFormatInfo(_info.Format);
+            FormatInfo format = FormatTable.GetFormatInfo(Info.Format);
 
             int faces = 1;
 
@@ -218,11 +205,11 @@ namespace Ryujinx.Graphics.OpenGL
                 faces = 6;
             }
 
-            for (int level = 0; level < _info.Levels; level++)
+            for (int level = 0; level < Info.Levels; level++)
             {
                 for (int face = 0; face < faces; face++)
                 {
-                    int faceOffset = face * _info.GetMipSize2D(level);
+                    int faceOffset = face * Info.GetMipSize2D(level);
 
                     if (format.IsCompressed)
                     {
@@ -239,7 +226,7 @@ namespace Ryujinx.Graphics.OpenGL
                     }
                 }
 
-                ptr += _info.GetMipSize(level);
+                ptr += Info.GetMipSize(level);
             }
         }
 
@@ -260,17 +247,17 @@ namespace Ryujinx.Graphics.OpenGL
 
             Bind(target, 0);
 
-            FormatInfo format = FormatTable.GetFormatInfo(_info.Format);
+            FormatInfo format = FormatTable.GetFormatInfo(Info.Format);
 
-            int width  = _info.Width;
-            int height = _info.Height;
-            int depth  = _info.Depth;
+            int width  = Info.Width;
+            int height = Info.Height;
+            int depth  = Info.Depth;
 
             int offset = 0;
 
-            for (int level = 0; level < _info.Levels; level++)
+            for (int level = 0; level < Info.Levels; level++)
             {
-                int mipSize = _info.GetMipSize(level);
+                int mipSize = Info.GetMipSize(level);
 
                 int endOffset = offset + mipSize;
 
@@ -279,7 +266,7 @@ namespace Ryujinx.Graphics.OpenGL
                     return;
                 }
 
-                switch (_info.Target)
+                switch (Info.Target)
                 {
                     case Target.Texture1D:
                         if (format.IsCompressed)
@@ -419,16 +406,9 @@ namespace Ryujinx.Graphics.OpenGL
             }
         }
 
-        public void Bind(int unit)
+        public void SetStorage(BufferRange buffer)
         {
-            Bind(Target.Convert(), unit);
-        }
-
-        private void Bind(TextureTarget target, int unit)
-        {
-            GL.ActiveTexture(TextureUnit.Texture0 + unit);
-
-            GL.BindTexture(target, Handle);
+            throw new NotSupportedException();
         }
 
         public void Dispose()

--- a/Ryujinx.Graphics.Shader/Decoders/OpCodeTable.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/OpCodeTable.cs
@@ -166,7 +166,7 @@ namespace Ryujinx.Graphics.Shader.Decoders
             Set("000101xxxxxxxx", InstEmit.Iscadd,  typeof(OpCodeAluImm32));
             Set("0101110000011x", InstEmit.Iscadd,  typeof(OpCodeAluReg));
             Set("010010110101xx", InstEmit.Iset,    typeof(OpCodeSetCbuf));
-            Set("001101100101xx", InstEmit.Iset,    typeof(OpCodeSetImm));
+            Set("0011011x0101xx", InstEmit.Iset,    typeof(OpCodeSetImm));
             Set("010110110101xx", InstEmit.Iset,    typeof(OpCodeSetReg));
             Set("010010110110xx", InstEmit.Isetp,   typeof(OpCodeSetCbuf));
             Set("0011011x0110xx", InstEmit.Isetp,   typeof(OpCodeSetImm));

--- a/Ryujinx.Graphics.Texture/SizeInfo.cs
+++ b/Ryujinx.Graphics.Texture/SizeInfo.cs
@@ -1,19 +1,27 @@
-using Ryujinx.Common;
 using System;
 
 namespace Ryujinx.Graphics.Texture
 {
     public struct SizeInfo
     {
-        private int[] _mipOffsets;
-        private int[] _allOffsets;
+        private readonly int[] _mipOffsets;
+        private readonly int[] _allOffsets;
 
-        private int _levels;
+        private readonly int _levels;
 
         public int LayerSize { get; }
         public int TotalSize { get; }
 
-        public SizeInfo(
+        public SizeInfo(int size)
+        {
+            _mipOffsets = new int[] { 0 };
+            _allOffsets = new int[] { 0 };
+            _levels     = 1;
+            LayerSize   = size;
+            TotalSize   = size;
+        }
+
+        internal SizeInfo(
             int[] mipOffsets,
             int[] allOffsets,
             int   levels,
@@ -29,7 +37,7 @@ namespace Ryujinx.Graphics.Texture
 
         public int GetMipOffset(int level)
         {
-            if ((uint)level > _mipOffsets.Length)
+            if ((uint)level >= _mipOffsets.Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(level));
             }


### PR DESCRIPTION
This implements texture/image buffer support required by some games, and also fixes some bugs here and there, like:
- ISET instruction immediate variant not being decoded in some cases (single line change, found it while testing a game).
- TEXS.1D.LZ missing the LOD level constant argument, could throw `ArgumentOutOfRangeException` during GLSL code generation.
- Bounds check on `SizeInfo` struct `GetMipOffset` method.