### PR TITLE
SurfaceFlinger: fix SetPreallocatedBuffer correctness

### DIFF
--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/BufferQueueCore.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/BufferQueueCore.cs
@@ -43,7 +43,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
             IsAbandoned              = false;
             OverrideMaxBufferCount   = 0;
             DequeueBufferCannotBlock = false;
-            UseAsyncBuffer           = false;
+            UseAsyncBuffer           = true;
             DefaultWidth             = 1;
             DefaultHeight            = 1;
             DefaultMaxBufferCount    = 2;

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/BufferQueueProducer.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/BufferQueueProducer.cs
@@ -604,6 +604,19 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
                     Core.Slots[slot].GraphicBuffer.Object.Buffer.Usage &= (int)Core.ConsumerUsageBits;
                 }
 
+                int bufferCount = 0;
+
+                for (int i = 0; i < Core.Slots.Length; i++)
+                {
+                    if (!Core.Slots[i].GraphicBuffer.IsNull)
+                    {
+                        bufferCount++;
+                    }
+                }
+
+                Core.OverrideMaxBufferCount = bufferCount;
+                Core.UseAsyncBuffer = false;
+
                 bool cleared = false;
 
                 if (!graphicBuffer.IsNull)


### PR DESCRIPTION
Nintendo sets the buffer count in SetPreallocatedBuffer too.

This fix triple buffering on all games and finally fix SSBU flickering.