### PR TITLE
Fix kernel memory allocator block coalescing

### DIFF
--- a/Ryujinx.HLE/HOS/Kernel/Memory/KMemoryRegionBlock.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Memory/KMemoryRegionBlock.cs
@@ -12,30 +12,77 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
         public int   Order;
         public int   NextOrder;
 
-        public bool TryCoalesce(int index, int size)
+        public bool TryCoalesce(int index, int count)
         {
-            long mask = ((1L << size) - 1) << (index & 63);
+            long mask = ((1L << count) - 1) << (index & 63);
 
             index /= 64;
 
-            if ((mask & ~Masks[MaxLevel - 1][index]) != 0)
+            if (count >= 64)
             {
-                return false;
-            }
+                int remaining = count;
+                int tempIdx = index;
 
-            Masks[MaxLevel - 1][index] &= ~mask;
-
-            for (int level = MaxLevel - 2; level >= 0; level--, index /= 64)
-            {
-                Masks[level][index / 64] &= ~(1L << (index & 63));
-
-                if (Masks[level][index / 64] != 0)
+                do
                 {
-                    break;
+                    if (Masks[MaxLevel - 1][tempIdx++] != -1L)
+                    {
+                        return false;
+                    }
+
+                    remaining -= 64;
+                }
+                while (remaining != 0);
+
+                remaining = count;
+                tempIdx = index;
+
+                do
+                {
+                    Masks[MaxLevel - 1][tempIdx++] = 0;
+
+                    for (int level = MaxLevel - 2; level >= 0; level--, index /= 64)
+                    {
+                        Masks[level][index / 64] &= ~(1L << (index & 63));
+
+                        if (Masks[level][index / 64] != 0)
+                        {
+                            break;
+                        }
+                    }
+
+                    remaining -= 64;
+                }
+                while (remaining != 0);
+            }
+            else
+            {
+                long value = Masks[MaxLevel - 1][index];
+
+                if ((mask & ~value) != 0)
+                {
+                    return false;
+                }
+
+                value &= ~mask;
+
+                Masks[MaxLevel - 1][index] = value;
+
+                if (value == 0)
+                {
+                    for (int level = MaxLevel - 2; level >= 0; level--, index /= 64)
+                    {
+                        Masks[level][index / 64] &= ~(1L << (index & 63));
+
+                        if (Masks[level][index / 64] != 0)
+                        {
+                            break;
+                        }
+                    }
                 }
             }
 
-            FreeCount -= (ulong)size;
+            FreeCount -= (ulong)count;
 
             return true;
         }

--- a/Ryujinx.HLE/HOS/Kernel/Memory/KMemoryRegionBlock.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Memory/KMemoryRegionBlock.cs
@@ -39,17 +39,9 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
 
                 do
                 {
-                    Masks[MaxLevel - 1][tempIdx++] = 0;
+                    Masks[MaxLevel - 1][tempIdx] = 0;
 
-                    for (int level = MaxLevel - 2; level >= 0; level--, index /= 64)
-                    {
-                        Masks[level][index / 64] &= ~(1L << (index & 63));
-
-                        if (Masks[level][index / 64] != 0)
-                        {
-                            break;
-                        }
-                    }
+                    ClearMaskBit(MaxLevel - 2, tempIdx++);
 
                     remaining -= 64;
                 }
@@ -70,21 +62,26 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
 
                 if (value == 0)
                 {
-                    for (int level = MaxLevel - 2; level >= 0; level--, index /= 64)
-                    {
-                        Masks[level][index / 64] &= ~(1L << (index & 63));
-
-                        if (Masks[level][index / 64] != 0)
-                        {
-                            break;
-                        }
-                    }
+                    ClearMaskBit(MaxLevel - 2, index);
                 }
             }
 
             FreeCount -= (ulong)count;
 
             return true;
+        }
+
+        public void ClearMaskBit(int startLevel, int index)
+        {
+            for (int level = startLevel; level >= 0; level--, index /= 64)
+            {
+                Masks[level][index / 64] &= ~(1L << (index & 63));
+
+                if (Masks[level][index / 64] != 0)
+                {
+                    break;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This should fix the block coalescing implementation. The previous implementation was incomplete, missing the `count >= 64`. I probably thought it was some sort of compiler optimization that could be omitted at the time. I rechecked the kernel implementation and implemented the missing parts.

Also thanks to SciresM for mesosphere, an open source implementation of Horizon kernel that helped me double check that the memory allocator implementation was correct.

This should fix `OutOfMemory` error being returned by some games that does allocation frequently using (Un)MapPhysicalMemory syscalls.