### PR TITLE
Initial support for FS Patching

### DIFF
--- a/ARMeilleure/Memory/IMemoryManager.cs
+++ b/ARMeilleure/Memory/IMemoryManager.cs
@@ -10,6 +10,7 @@ namespace ARMeilleure.Memory
 
         T Read<T>(ulong va) where T : unmanaged;
         void Write<T>(ulong va, T value) where T : unmanaged;
+        void Write(ulong va, ReadOnlySpan<byte> data);
 
         ref T GetRef<T>(ulong va) where T : unmanaged;
         ref T GetRefNoChecks<T>(ulong va) where T : unmanaged;

--- a/Ryujinx.HLE/Loaders/ExePatchers/IPSPatcher.cs
+++ b/Ryujinx.HLE/Loaders/ExePatchers/IPSPatcher.cs
@@ -1,0 +1,117 @@
+using Ryujinx.Common.Logging;
+using System;
+using System.IO;
+using System.Text;
+
+namespace Ryujinx.HLE.Loaders.ExePatchers
+{
+    class IpsPatcher
+    {
+        MemPatch _patches;
+
+        public IpsPatcher(BinaryReader reader)
+        {
+            _patches = ParseIps(reader);
+            if (_patches != null)
+            {
+                Logger.PrintInfo(LogClass.Loader, "IPS patch loaded successfully");
+            }
+        }
+
+        private static MemPatch ParseIps(BinaryReader reader)
+        {
+            Span<byte> IpsHeaderMagic = Encoding.ASCII.GetBytes("PATCH").AsSpan();
+            Span<byte> IpsTailMagic = Encoding.ASCII.GetBytes("EOF").AsSpan();
+            Span<byte> Ips32HeaderMagic = Encoding.ASCII.GetBytes("IPS32").AsSpan();
+            Span<byte> Ips32TailMagic = Encoding.ASCII.GetBytes("EEOF").AsSpan();
+
+            MemPatch patches = new MemPatch();
+            var header = reader.ReadBytes(IpsHeaderMagic.Length).AsSpan();
+
+            if (header.Length != IpsHeaderMagic.Length)
+            {
+                return null;
+            }
+
+            bool is32;
+            Span<byte> tailSpan;
+
+            if (header.SequenceEqual(IpsHeaderMagic))
+            {
+                is32 = false;
+                tailSpan = IpsTailMagic;
+            }
+            else if (header.SequenceEqual(Ips32HeaderMagic))
+            {
+                is32 = true;
+                tailSpan = Ips32TailMagic;
+            }
+            else
+            {
+                return null;
+            }
+
+            byte[] buf = new byte[tailSpan.Length];
+
+            bool ReadNext(int size) => reader.Read(buf, 0, size) != size;
+
+            while (true)
+            {
+                if (ReadNext(buf.Length))
+                {
+                    return null;
+                }
+
+                if (buf.AsSpan().SequenceEqual(tailSpan))
+                {
+                    break;
+                }
+
+                int patchOffset = is32 ? buf[0] << 24 | buf[1] << 16 | buf[2] << 8 | buf[3]
+                                  : buf[0] << 16 | buf[1] << 8 | buf[2];
+
+                if (ReadNext(2))
+                {
+                    return null;
+                }
+
+                int patchSize = buf[0] << 8 | buf[1];
+
+                if (patchSize == 0)                     // RLE/Fill mode
+                {
+                    if (ReadNext(2))
+                    {
+                        return null;
+                    }
+
+                    int fillLength = buf[0] << 8 | buf[1];
+
+                    if (ReadNext(1))
+                    {
+                        return null;
+                    }
+
+                    patches.AddFill((uint)patchOffset, fillLength, buf[0]);
+                }
+                else                                    // Copy mode
+                {
+                    var patch = reader.ReadBytes(patchSize);
+
+                    if (patch.Length != patchSize)
+                    {
+                        return null;
+                    }
+
+                    patches.Add((uint)patchOffset, patch);
+                }
+            }
+
+            return patches;
+        }
+
+        public void AddPatches(MemPatch patches)
+        {
+            patches.AddFrom(_patches);
+        }
+    }
+}

--- a/Ryujinx.HLE/Loaders/ExePatchers/IPSwitchPatcher.cs
+++ b/Ryujinx.HLE/Loaders/ExePatchers/IPSwitchPatcher.cs
@@ -1,0 +1,246 @@
+using Ryujinx.Common.Logging;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Ryujinx.HLE.Loaders.ExePatchers
+{
+    class IPSwitchPatcher
+    {
+        readonly StreamReader _reader;
+        public string BuildId { get; }
+
+        const string BidHeader = "@nsobid-";
+
+        public IPSwitchPatcher(StreamReader reader)
+        {
+            string header = reader.ReadLine().Trim();
+            if (header == null || !header.StartsWith(BidHeader))
+            {
+                return;
+            }
+
+            _reader = reader;
+            BuildId = header.Substring(BidHeader.Length);
+        }
+
+        private enum Token
+        {
+            Normal,
+            String,
+            EscapeChar,
+            Comment
+        }
+
+        // Uncomments line and unescapes C style strings within
+        private static string PreprocessLine(string line)
+        {
+            StringBuilder str = new StringBuilder();
+            Token state = Token.Normal;
+
+            for (int i = 0; i < line.Length; ++i)
+            {
+                char c = line[i];
+                char la = i + 1 != line.Length ? line[i + 1] : '\0';
+
+                switch (state)
+                {
+                    case Token.Normal:
+                        state = c == '"' ? Token.String :
+                                c == '/' && la == '/' ? Token.Comment :
+                                c == '/' && la != '/' ? Token.Comment : // Ignore error and stop parsing
+                                Token.Normal;
+                        break;
+                    case Token.String:
+                        state = c switch
+                        {
+                            '"' => Token.Normal,
+                            '\\' => Token.EscapeChar,
+                            _ => Token.String
+                        };
+                        break;
+                    case Token.EscapeChar:
+                        state = Token.String;
+                        c = c switch
+                        {
+                            'a' => '\a',
+                            'b' => '\b',
+                            'f' => '\f',
+                            'n' => '\n',
+                            'r' => '\r',
+                            't' => '\t',
+                            'v' => '\v',
+                            '\\' => '\\',
+                            _ => '?'
+                        };
+                        break;
+                }
+
+                if (state == Token.Comment) break;
+
+                if (state < Token.EscapeChar)
+                {
+                    str.Append(c);
+                }
+            }
+
+            return str.ToString().Trim();
+        }
+
+        static int ParseHexByte(byte c)
+        {
+            if (c >= '0' && c <= '9')
+            {
+                return c - '0';
+            }
+            else if (c >= 'A' && c <= 'F')
+            {
+                return c - 'A' + 10;
+            }
+            else if (c >= 'a' && c <= 'f')
+            {
+                return c - 'a' + 10;
+            }
+            else
+            {
+                return 0;
+            }
+        }
+
+        // Big Endian
+        static byte[] Hex2ByteArrayBE(string hexstr)
+        {
+            if ((hexstr.Length & 1) == 1) return null;
+
+            byte[] bytes = new byte[hexstr.Length >> 1];
+
+            for (int i = 0; i < hexstr.Length; i += 2)
+            {
+                int high = ParseHexByte((byte)hexstr[i]);
+                int low = ParseHexByte((byte)hexstr[i + 1]);
+                bytes[i >> 1] = (byte)((high << 4) | low);
+            }
+
+            return bytes;
+        }
+
+        private MemPatch Parse()
+        {
+            if (_reader == null)
+            {
+                return null;
+            }
+
+            MemPatch patches = new MemPatch();
+
+            bool enabled = true;
+            bool printValues = false;
+            int offset_shift = 0;
+
+            string line;
+            int lineNum = 0;
+
+            static void Print(string s) => Logger.PrintInfo(LogClass.Loader, $"IPSwitch:    {s}");
+
+            void ParseWarn() => Logger.PrintWarning(LogClass.Loader, $"IPSwitch:    Parse error at line {lineNum} for bid={BuildId}");
+
+            while ((line = _reader.ReadLine()) != null)
+            {
+                line = PreprocessLine(line);
+                lineNum += 1;
+
+                if (line.Length == 0)
+                {
+                    continue;
+                }
+                else if (line.StartsWith("#"))
+                {
+                    Print(line);
+                }
+                else if (line.StartsWith("@stop"))
+                {
+                    break;
+                }
+                else if (line.StartsWith("@enabled"))
+                {
+                    enabled = true;
+                }
+                else if (line.StartsWith("@disabled"))
+                {
+                    enabled = false;
+                }
+                else if (line.StartsWith("@flag"))
+                {
+                    var tokens = line.Split(' ', 3, StringSplitOptions.RemoveEmptyEntries);
+
+                    if (tokens.Length < 2)
+                    {
+                        ParseWarn();
+                        continue;
+                    }
+
+                    if (tokens[1] == "offset_shift" && tokens.Length == 3 &&
+                        Int32.TryParse(tokens[2], System.Globalization.NumberStyles.HexNumber, null, out int shift))
+                    {
+                        offset_shift = shift;
+                    }
+                    else if (tokens[1] == "print_values")
+                    {
+                        printValues = true;
+                    }
+                }
+                else if (line.StartsWith("@"))
+                {
+                    // Ignore
+                }
+                else
+                {
+                    if (!enabled)
+                    {
+                        continue;
+                    }
+
+                    var tokens = line.Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
+
+                    if (tokens.Length < 2)
+                    {
+                        ParseWarn();
+                        continue;
+                    }
+
+                    if (!Int32.TryParse(tokens[0], System.Globalization.NumberStyles.HexNumber, null, out int offset))
+                    {
+                        ParseWarn();
+                        continue;
+                    }
+
+                    offset += offset_shift;
+
+                    if (printValues)
+                    {
+                        Print($"print_values 0x{offset:x} <= {tokens[1]}");
+                    }
+
+                    if (tokens[1][0] == '"')
+                    {
+                        var patch = Encoding.ASCII.GetBytes(tokens[1].Trim('"'));
+                        patches.Add((uint)offset, patch);
+                    }
+                    else
+                    {
+                        var patch = Hex2ByteArrayBE(tokens[1]);
+                        patches.Add((uint)offset, patch);
+                    }
+                }
+            }
+
+            return patches;
+        }
+
+        public void AddPatches(MemPatch patches)
+        {
+            patches.AddFrom(Parse());
+        }
+    }
+}

--- a/Ryujinx.HLE/Loaders/ExePatchers/MemPatch.cs
+++ b/Ryujinx.HLE/Loaders/ExePatchers/MemPatch.cs
@@ -1,0 +1,92 @@
+using ARMeilleure.Memory;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Ryujinx.Common.Logging;
+
+namespace Ryujinx.HLE.Loaders.ExePatchers
+{
+    class MemPatch
+    {
+        readonly Dictionary<uint, byte[]> _patches = new Dictionary<uint, byte[]>();
+
+        /// <summary>
+        /// Adds a patch to specified offset. Overwrites if already present. 
+        /// </summary>
+        /// <param name="offset">Memory offset</param>
+        /// <param name="patch">The patch to add</param>
+        public void Add(uint offset, byte[] patch)
+        {
+            _patches[offset] = patch;
+        }
+
+        /// <summary>
+        /// Adds all patches from an existing mempatch
+        /// </summary>
+        /// <param name="patches">The MemPatch patches to add</param>
+        public void AddFrom(MemPatch patches)
+        {
+            if (patches == null)
+            {
+                return;
+            }
+
+            foreach (var (patchOffset, patch) in patches._patches)
+            {
+                _patches[patchOffset] = patch;
+            }
+        }
+
+        /// <summary>
+        /// Adds a patch in the form of an RLE/Fill mode.
+        /// </summary>
+        /// <param name="offset">Memory offset</param>
+        /// <param name="length"The fill length</param>
+        /// <param name="filler">The byte to fill</param>
+        public void AddFill(uint offset, int length, byte filler)
+        {
+            // TODO: Can be made space efficient by changing `_patches`
+            // Should suffice for now
+            byte[] patch = new byte[length];
+            patch.AsSpan().Fill(filler);
+            _patches[offset] = patch;
+        }
+
+        /// <summary>
+        /// Applies all the patches added to this instance via the IMemoryManager.
+        /// </summary>
+        /// <remarks>
+        /// The patches are applied in ascending order of offsets to guarantee
+        /// overlapping patches always apply the same way.
+        /// </remarks>
+        /// <param name="mem">IMemoryManager</param>
+        /// <param name="baseAddress">The base address of memory used for the offsets</param>
+        /// <param name="maxSize">The maximum size of the slice of patchable memory</param>
+        /// <param name="protectedOffset">A secondary offset used in special cases (NSO header)</param>
+        public void Apply(IMemoryManager mem, ulong baseAddress, int maxSize, int protectedOffset = 0)
+        {
+            foreach (var (offset, patch) in _patches.OrderBy(item => item.Key))
+            {
+                int patchOffset = (int)offset;
+                int patchSize = patch.Length;
+
+                if (patchOffset < protectedOffset)
+                {
+                    continue; // Add warning?
+                }
+
+                patchOffset -= protectedOffset;
+
+                if (patchOffset + patchSize > maxSize)
+                {
+                    patchSize = maxSize - (int)patchOffset; // Add warning?
+                }
+
+                Logger.PrintInfo(LogClass.Loader, $"Patching address 0x{baseAddress:x}+{patchOffset:x} <= {BitConverter.ToString(patch).Replace('-', ' ')} len={patchSize}");
+
+                mem.Write(baseAddress + (uint)patchOffset, patch.AsSpan().Slice(0, patchSize));
+            }
+        }
+    }
+}

--- a/Ryujinx.HLE/Loaders/ExePatchers/PatchUtils.cs
+++ b/Ryujinx.HLE/Loaders/ExePatchers/PatchUtils.cs
@@ -28,24 +28,43 @@ namespace Ryujinx.HLE.Loaders.ExePatchers
                 switch (Path.GetExtension(file))
                 {
                     case ".ips":
-                        string filename = Path.GetFileNameWithoutExtension(file).Split('.')[0];
-                        string buildId = filename.TrimEnd('0');
-
-                        int index = GetIndex(buildId);
-                        if (index == -1)
                         {
-                            continue;
-                        }
+                            string filename = Path.GetFileNameWithoutExtension(file).Split('.')[0];
+                            string buildId = filename.TrimEnd('0');
 
-                        Logger.PrintInfo(LogClass.Loader, $"Found matching IpsPatch for bid={buildId} - {file}");
+                            int index = GetIndex(buildId);
+                            if (index == -1)
+                            {
+                                continue;
+                            }
 
-                        using (var fs = File.OpenRead(file))
-                        using (var reader = new BinaryReader(fs))
-                        {
+                            Logger.PrintInfo(LogClass.Loader, $"Found matching IPS patch for bid={buildId} - {file}");
+
+                            using var fs = File.OpenRead(file);
+                            using var reader = new BinaryReader(fs);
+
                             var patcher = new IpsPatcher(reader);
                             patcher.AddPatches(patches[index]);
-                        }
 
+                        }
+                        break;
+
+                    case ".pchtxt":
+                        using (var fs = File.OpenRead(file))
+                        using (var reader = new StreamReader(fs))
+                        {
+                            var patcher = new IPSwitchPatcher(reader);
+
+                            int index = GetIndex(patcher.BuildId);
+                            if (index == -1)
+                            {
+                                continue;
+                            }
+
+                            Logger.PrintInfo(LogClass.Loader, $"Found matching IPSwitch patch for bid={patcher.BuildId} - {file}");
+
+                            patcher.AddPatches(patches[index]);
+                        }
                         break;
                 }
             }

--- a/Ryujinx.HLE/Loaders/ExePatchers/PatchUtils.cs
+++ b/Ryujinx.HLE/Loaders/ExePatchers/PatchUtils.cs
@@ -1,0 +1,56 @@
+using System;
+using System.IO;
+using System.Collections.Generic;
+
+using Ryujinx.Common.Logging;
+
+namespace Ryujinx.HLE.Loaders.ExePatchers
+{
+    class PatchUtils
+    {
+        public static MemPatch[] CollectNsoPatches(string dirPath, List<string> buildIds)
+        {
+            if (!Directory.Exists(dirPath))
+            {
+                throw new ArgumentException("dirPath must be a valid directory");
+            }
+
+            var patches = new MemPatch[buildIds.Count];
+            for (int i = 0; i < patches.Length; ++i)
+            {
+                patches[i] = new MemPatch();
+            }
+
+            int GetIndex(string buildId) => buildIds.FindIndex(id => id == buildId); // O(n) but list is small
+
+            foreach (var file in Directory.EnumerateFiles(dirPath, "*.*", SearchOption.AllDirectories))
+            {
+                switch (Path.GetExtension(file))
+                {
+                    case ".ips":
+                        string filename = Path.GetFileNameWithoutExtension(file).Split('.')[0];
+                        string buildId = filename.TrimEnd('0');
+
+                        int index = GetIndex(buildId);
+                        if (index == -1)
+                        {
+                            continue;
+                        }
+
+                        Logger.PrintInfo(LogClass.Loader, $"Found matching IpsPatch for bid={buildId} - {file}");
+
+                        using (var fs = File.OpenRead(file))
+                        using (var reader = new BinaryReader(fs))
+                        {
+                            var patcher = new IpsPatcher(reader);
+                            patcher.AddPatches(patches[index]);
+                        }
+
+                        break;
+                }
+            }
+
+            return patches;
+        }
+    }
+}


### PR DESCRIPTION
Currently implements IPS/IPSwitch patching on NSO load filtered by Build IDs (aka exefs patching). 
IPS based on Atmosphere's implementation. 
IPSwitch, my own, from the readme description and some samples.
The framework should be generic enough for more creative uses in the future.

This PR is currently Draft as the storage location for patches has to be decided.

~~Depends on #856 (`mem`)~~ (Merged now)

### Notes for testers
For now, create a directory named `nsopatches` in your Ryujinx userdir and place all your patches in it.
Patches can be placed in the root or in any hierarchy of directories inside.

#### IPSwitch
Files must have `.pchtxt` extension and have an `@nsobid-` header as the first line.

#### IPS
The file names should be like so-

`<nso_build_id>[.anything_you_want].ips`

Examples:

```
5786...859F.ips
5786...859F.myfix.ips
9ABCDE....123.resolution.ips
9ABCDE....123.2.ips
...
```

If everything's correct, you should be seeing Info logs like the following-

```
Found matching IPS patch for bid=... - <path>.ips
Found matching IPS patch for bid=... - <path>.ips
...
Patching address 0x8007000 +0ab0f0 <= 1F 20 03 D5 len=4
Patching address 0x8007000 +0ab1b0 <= 1F 20 03 D5 len=4
...
```