### PR TITLE
Do not compute dominance information when not in SSA

### DIFF
--- a/ARMeilleure/Translation/Compiler.cs
+++ b/ARMeilleure/Translation/Compiler.cs
@@ -22,8 +22,11 @@ namespace ARMeilleure.Translation
         {
             Logger.StartPass(PassName.Dominance);
 
-            Dominance.FindDominators(cfg);
-            Dominance.FindDominanceFrontiers(cfg);
+            if ((options & CompilerOptions.SsaForm) != 0)
+            {
+                Dominance.FindDominators(cfg);
+                Dominance.FindDominanceFrontiers(cfg);
+            }
 
             Logger.EndPass(PassName.Dominance);
 


### PR DESCRIPTION
Dominance information is not used when not in SSA form. So this should slightly improve the throughput of LCQ.