### PR TITLE
Fix depth clamp enable bit, unit scale for polygon offset.

### DIFF
--- a/Ryujinx.Graphics.GAL/IPipeline.cs
+++ b/Ryujinx.Graphics.GAL/IPipeline.cs
@@ -27,7 +27,7 @@ namespace Ryujinx.Graphics.GAL
         void SetBlendState(int index, BlendDescriptor blend);
 
         void SetDepthBias(PolygonModeMask enables, float factor, float units, float clamp);
-        void SetDepthClamp(bool clampNear, bool clampFar);
+        void SetDepthClamp(bool clamp);
         void SetDepthMode(DepthMode mode);
         void SetDepthTest(DepthTestDescriptor depthTest);
 

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -394,8 +394,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
         private void UpdateDepthClampState(GpuState state)
         {
             ViewVolumeClipControl clip = state.Get<ViewVolumeClipControl>(MethodOffset.ViewVolumeClipControl);
-            _context.Renderer.Pipeline.SetDepthClamp((clip & ViewVolumeClipControl.DepthClampNear) != 0,
-                                                     (clip & ViewVolumeClipControl.DepthClampFar) != 0);
+            _context.Renderer.Pipeline.SetDepthClamp((clip & ViewVolumeClipControl.DepthClampDisabled) == 0);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/State/ViewVolumeClipControl.cs
+++ b/Ryujinx.Graphics.Gpu/State/ViewVolumeClipControl.cs
@@ -6,7 +6,6 @@ namespace Ryujinx.Graphics.Gpu.State
     enum ViewVolumeClipControl
     {
         ForceDepthRangeZeroToOne = 1 << 0,
-        DepthClampNear           = 1 << 3,
-        DepthClampFar            = 1 << 4,
+        DepthClampDisabled       = 1 << 11,
     }
 }

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -549,17 +549,13 @@ namespace Ryujinx.Graphics.OpenGL
                 return;
             }
 
-            GL.PolygonOffset(factor, units);
+            GL.PolygonOffset(factor, units / 2f);
             // TODO: Enable when GL_EXT_polygon_offset_clamp is supported.
             // GL.PolygonOffsetClamp(factor, units, clamp);
         }
 
-        public void SetDepthClamp(bool clampNear, bool clampFar)
+        public void SetDepthClamp(bool clamp)
         {
-            // TODO: Use GL_AMD_depth_clamp_separate or similar if available?
-            // Currently enables clamping if either is set.
-            bool clamp = clampNear || clampFar;
-
             if (!clamp)
             {
                 GL.Disable(EnableCap.DepthClamp);


### PR DESCRIPTION
Fixes issues introduced by the depth clamp PR (#1120) while preserving all the benefits. (shadows not clipping out of existence) Also halves the polygon offset, as drivers seem to double the input when putting it into the register.

Example of issue caused by using the previous bits:
https://gyazo.com/35de04d5621763181575bda68d21d277
Fixed here, terrible cubemaps unrelated:
https://gyazo.com/e55978c51759214bb43a4c2c5221d26c

The odyssey still has a huge shadow, rather than the one that got cut off pre-depth-clamp.
![image](https://user-images.githubusercontent.com/6294155/80655939-d2c3a580-8a77-11ea-959a-2602c397d082.png)

Verified with deko3d and opengl code. Example:
https://github.com/devkitPro/deko3d/blob/4e47ba0013552e592a86ab7a2510d1e7dadf236a/source/maxwell/gpu_3d_state.cpp#L42