### PR TITLE
audren: implement Renderer Info output informations

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Audio/AudioRendererManager/Types/RendererInfoOut.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioRendererManager/Types/RendererInfoOut.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Audio.AudioRendererManager
+{
+    [StructLayout(LayoutKind.Sequential, Size = 0x10, Pack = 4)]
+    struct RendererInfoOut
+    {
+        public ulong ElapsedFrameCount;
+        public ulong Reserved;
+    }
+}

--- a/Ryujinx.HLE/Utilities/StructWriter.cs
+++ b/Ryujinx.HLE/Utilities/StructWriter.cs
@@ -21,5 +21,10 @@ namespace Ryujinx.HLE.Utilities
 
             Position += Marshal.SizeOf<T>();
         }
+
+        public void SkipBytes(long count)
+        {
+            Position += count;
+        }
     }
 }


### PR DESCRIPTION
This implement the rendering information output of
RequestUpdate.

This is needed by some games to keep track of the count of update on the
DSP.