### PR TITLE
Add error code for denied internet request in Account

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Account/ResultCode.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/ResultCode.cs
@@ -13,6 +13,7 @@ namespace Ryujinx.HLE.HOS.Services.Account
         InvalidInputBufferSize               = (31  << ErrorCodeShift) | ModuleId,
         InvalidInputBuffer                   = (32  << ErrorCodeShift) | ModuleId,
         ApplicationLaunchPropertyAlreadyInit = (41  << ErrorCodeShift) | ModuleId,
+        InternetRequestDenied                = (59 << ErrorCodeShift)  | ModuleId,
         UserNotFound                         = (100 << ErrorCodeShift) | ModuleId,
         NullObject                           = (302 << ErrorCodeShift) | ModuleId,
         UnknownError1                        = (341 << ErrorCodeShift) | ModuleId


### PR DESCRIPTION
InternetRequestDenied (I can't find a better name) was taken from Switchbrew (switchbrew.org/wiki/Error_codes)
Regarding this error, SwitchBrew notes: "IsAnyInternetRequestAccepted with the output from GetClientId returned false."