### PR TITLE
Update GLWidget to 1.0.2

### DIFF
--- a/Ryujinx/Ryujinx.csproj
+++ b/Ryujinx/Ryujinx.csproj
@@ -75,7 +75,7 @@
 
   <ItemGroup>
     <PackageReference Include="DiscordRichPresence" Version="1.0.150" />
-    <PackageReference Include="GLWidget" Version="1.0.1" />
+    <PackageReference Include="GLWidget" Version="1.0.2" />
     <PackageReference Include="GtkSharp" Version="3.22.25.56" />
     <PackageReference Include="GtkSharp.Dependencies" Version="1.1.0" Condition="'$(RuntimeIdentifier)' != 'linux-x64' AND '$(RuntimeIdentifier)' != 'osx-x64'" />
     <PackageReference Include="OpenTK.NetStandard" Version="1.0.5.12" />


### PR DESCRIPTION
This release should fix OpenGL context creation on OSX (using Cocoa).

NOTE: As macOS doesn't support OpenGL 4.3, the emulator will probably not work but this fix the hard crash when starting any games/homebrew.