### PR TITLE
Remove buffer invalidation

### DIFF
--- a/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
@@ -47,8 +47,6 @@ namespace Ryujinx.Graphics.Gpu.Memory
             HostBuffer = context.Renderer.CreateBuffer((int)size);
 
             _sequenceNumbers = new int[size / MemoryManager.PageSize];
-
-            Invalidate();
         }
 
         /// <summary>
@@ -150,14 +148,6 @@ namespace Ryujinx.Graphics.Gpu.Memory
             byte[] data = HostBuffer.GetData(offset, (int)size);
 
             _context.PhysicalMemory.Write(address, data);
-        }
-
-        /// <summary>
-        /// Invalidates all the buffer data, causing it to be read from guest memory.
-        /// </summary>
-        public void Invalidate()
-        {
-            HostBuffer.SetData(0, _context.PhysicalMemory.GetSpan(Address, Size));
         }
 
         /// <summary>


### PR DESCRIPTION
Invalidating the buffer on creation is not necessary, because `SynchronizeMemory` already invalidates all modified ranges. And for a newly created buffer, the entire range should be considered as "modified" since no check was performed before for the new ranges.