### PR TITLE
Use correct swizzle on depth-stencil textures

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -179,6 +179,22 @@ namespace Ryujinx.Graphics.Gpu.Image
                 swizzleB,
                 swizzleA);
 
+            if (IsDepthStencil(formatInfo.Format))
+            {
+                swizzleR = SwizzleComponent.Red;
+                swizzleG = SwizzleComponent.Red;
+                swizzleB = SwizzleComponent.Red;
+
+                if (depthStencilMode == DepthStencilMode.Depth)
+                {
+                    swizzleA = SwizzleComponent.One;
+                }
+                else
+                {
+                    swizzleA = SwizzleComponent.Red;
+                }
+            }
+
             return new TextureInfo(
                 address,
                 width,
@@ -250,6 +266,26 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             return component == SwizzleComponent.Red ||
                    component == SwizzleComponent.Green;
+        }
+
+        /// <summary>
+        /// Checks if the texture format is a depth, stencil or depth-stencil format.
+        /// </summary>
+        /// <param name="format">Texture format</param>
+        /// <returns>True if the format is a depth, stencil or depth-stencil format, false otherwise</returns>
+        private static bool IsDepthStencil(Format format)
+        {
+            switch (format)
+            {
+                case Format.D16Unorm:
+                case Format.D24UnormS8Uint:
+                case Format.D24X8Unorm:
+                case Format.D32Float:
+                case Format.D32FloatS8Uint:
+                    return true;
+            }
+
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
NVN uses special swizzle values for depth/stencil textures. Apparently R is Depth, and G is Stencil, while on 24-bit depth format, it is inverted (R is Stencil and G is Depth). This is something specific to the NVIDIA GPU, and we shouldn't pass this swizzle to the host, as setting the component to G breaks sampling the depth value. So, instead of passing the swizzle directly, now it fixes it up and passes the correct values. This does the same thing that NVN does, that is, (value, value, value, 1) for depth, and (value, value, value, value) for stencil.

This should fix issues like shadows not working on non-NVIDIA GPUs, or even on NVIDIA depending on the driver or context created.