### PR TITLE
nvservice: add a lock around NvHostEvent and remove release fence on SFv2

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/MethodFifo.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodFifo.cs
@@ -66,7 +66,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
             if (operation == FenceActionOperation.Acquire)
             {
-                _context.Synchronization.WaitOnSyncpoint(syncpointId, threshold, Timeout.InfiniteTimeSpan);
+                _context.Synchronization.WaitOnSyncpoint(syncpointId, threshold, TimeSpan.FromSeconds(1));
             }
             else if (operation == FenceActionOperation.Increment)
             {

--- a/Ryujinx.Graphics.Gpu/Engine/MethodFifo.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodFifo.cs
@@ -66,7 +66,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
             if (operation == FenceActionOperation.Acquire)
             {
-                _context.Synchronization.WaitOnSyncpoint(syncpointId, threshold, TimeSpan.FromSeconds(1));
+                _context.Synchronization.WaitOnSyncpoint(syncpointId, threshold, Timeout.InfiniteTimeSpan);
             }
             else if (operation == FenceActionOperation.Increment)
             {

--- a/Ryujinx.Graphics.Gpu/Synchronization/SynchronizationManager.cs
+++ b/Ryujinx.Graphics.Gpu/Synchronization/SynchronizationManager.cs
@@ -112,16 +112,6 @@ namespace Ryujinx.Graphics.Gpu.Synchronization
                 throw new ArgumentOutOfRangeException(nameof(id));
             }
 
-            bool warnAboutTimeout = false;
-
-            // TODO: Remove this when GPU channel scheduling will be implemented.
-            if (timeout == Timeout.InfiniteTimeSpan)
-            {
-                timeout = TimeSpan.FromSeconds(1);
-
-                warnAboutTimeout = true;
-            }
-
             using (ManualResetEvent waitEvent = new ManualResetEvent(false))
             {
                 var info = _syncpoints[id].RegisterCallback(threshold, () => waitEvent.Set());
@@ -135,10 +125,7 @@ namespace Ryujinx.Graphics.Gpu.Synchronization
 
                 if (!signaled && info != null)
                 {
-                    if (warnAboutTimeout)
-                    {
-                        Logger.PrintError(LogClass.Gpu, $"Wait on syncpoint {id} for threshold {threshold} took more than {timeout.TotalMilliseconds}ms, resuming execution...");
-                    }
+                    Logger.PrintError(LogClass.Gpu, $"Wait on syncpoint {id} for threshold {threshold} took more than {timeout.TotalMilliseconds}ms, resuming execution...");
 
                     _syncpoints[id].UnregisterCallback(info);
                 }

--- a/Ryujinx.Graphics.Gpu/Synchronization/SynchronizationManager.cs
+++ b/Ryujinx.Graphics.Gpu/Synchronization/SynchronizationManager.cs
@@ -112,6 +112,12 @@ namespace Ryujinx.Graphics.Gpu.Synchronization
                 throw new ArgumentOutOfRangeException(nameof(id));
             }
 
+            // TODO: Remove this when GPU channel scheduling will be implemented.
+            if (timeout == Timeout.InfiniteTimeSpan)
+            {
+                timeout = TimeSpan.FromSeconds(1);
+            }
+
             using (ManualResetEvent waitEvent = new ManualResetEvent(false))
             {
                 var info = _syncpoints[id].RegisterCallback(threshold, () => waitEvent.Set());

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
@@ -305,7 +305,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
             {
                 Layer = layer,
                 Item  = item,
-                Fence = _vblankFence
+                Fence = AndroidFence.NoFence
             };
 
             _device.Gpu.Window.EnqueueFrameThreadSafe(

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
@@ -26,8 +26,6 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
         private Stopwatch _chrono;
 
-        private AndroidFence _vblankFence;
-
         private long _ticks;
         private long _ticksPerFrame;
 
@@ -49,7 +47,6 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
         {
             public Layer        Layer;
             public BufferItem   Item;
-            public AndroidFence Fence;
         }
 
         public SurfaceFlinger(Switch device)
@@ -68,13 +65,6 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
             _ticks = 0;
 
             UpdateSwapInterval(1);
-
-            _vblankFence = AndroidFence.NoFence;
-            _vblankFence.AddFence(new NvFence
-            {
-                Id    = NvHostSyncpt.VBlank0SyncpointId,
-                Value = 0
-            });
 
             _composerThread.Start();
         }
@@ -222,8 +212,6 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
         {
             lock (Lock)
             {
-                _vblankFence.NvFences[0].Increment(_device.Gpu);
-
                 // TODO: support multilayers (& multidisplay ?)
                 if (_layers.Count == 0)
                 {
@@ -298,14 +286,10 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
                 flipX,
                 flipY);
 
-            // Enforce that dequeueBuffer wait for the next vblank
-            _vblankFence.NvFences[0].Value++;
-
             TextureCallbackInformation textureCallbackInformation = new TextureCallbackInformation
             {
                 Layer = layer,
                 Item  = item,
-                Fence = AndroidFence.NoFence
             };
 
             _device.Gpu.Window.EnqueueFrameThreadSafe(
@@ -330,7 +314,9 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
         private void ReleaseBuffer(TextureCallbackInformation information)
         {
-            information.Layer.Consumer.ReleaseBuffer(information.Item, ref information.Fence);
+            AndroidFence fence = AndroidFence.NoFence;
+
+            information.Layer.Consumer.ReleaseBuffer(information.Item, ref fence);
         }
 
         private void AcquireBuffer(GpuContext ignored, object obj)


### PR DESCRIPTION
Classic mistake.. this adds a lock inside NvHostEvent and on the events array as those could be manipulated asynchronously.

This should fix some weird race condition happening (example: event id 0 sometime being invalid between 7PM and 8PM on AC:NH when starting, ect)