### PR TITLE
Fix depth stencil formats copy by matching equivalent color formats

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -189,7 +189,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// This will update scale to match the configured scale, scale textures that are eligible but not scaled,
         /// and propagate blacklisted status from one texture to the ones bound with it.
         /// </summary>
-        /// <param name="singleUse">If this is not -1, it indicates that only the given indexed target will be used.</param> 
+        /// <param name="singleUse">If this is not -1, it indicates that only the given indexed target will be used.</param>
         public void UpdateRenderTargetScale(int singleUse)
         {
             // Make sure all scales for render targets are at the highest they should be. Blacklisted targets should propagate their scale to the other targets.
@@ -454,7 +454,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 Target.Texture2D,
                 formatInfo);
 
-            TextureSearchFlags flags = TextureSearchFlags.IgnoreMs;
+            TextureSearchFlags flags = TextureSearchFlags.ForCopy;
 
             if (preferScaling)
             {
@@ -608,7 +608,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>The texture</returns>
         public Texture FindOrCreateTexture(TextureInfo info, TextureSearchFlags flags = TextureSearchFlags.None)
         {
-            bool isSamplerTexture = (flags & TextureSearchFlags.Sampler) != 0;
+            bool isSamplerTexture = (flags & TextureSearchFlags.ForSampler) != 0;
 
             bool isScalable = IsUpscaleCompatible(info);
 
@@ -735,7 +735,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                         if (texture.ScaleFactor != overlap.ScaleFactor)
                         {
-                            // A bit tricky, our new texture may need to contain an existing texture that is upscaled, but isn't itself. 
+                            // A bit tricky, our new texture may need to contain an existing texture that is upscaled, but isn't itself.
                             // In that case, we prefer the higher scale only if our format is render-target-like, otherwise we scale the view down before copy.
 
                             texture.PropagateScale(overlap);

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -59,7 +59,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     return null;
                 }
 
-                texture = Context.Methods.TextureManager.FindOrCreateTexture(info, TextureSearchFlags.Sampler);
+                texture = Context.Methods.TextureManager.FindOrCreateTexture(info, TextureSearchFlags.ForSampler);
 
                 texture.IncrementReferenceCount();
 

--- a/Ryujinx.Graphics.Gpu/Image/TextureSearchFlags.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureSearchFlags.cs
@@ -8,10 +8,10 @@ namespace Ryujinx.Graphics.Gpu.Image
     [Flags]
     enum TextureSearchFlags
     {
-        None     = 0,
-        IgnoreMs = 1 << 0,
-        Strict   = 1 << 1 | Sampler,
-        Sampler  = 1 << 2,
+        None        = 0,
+        Strict      = 1 << 0,
+        ForSampler  = 1 << 1,
+        ForCopy     = 1 << 2,
         WithUpscale = 1 << 3
     }
 }


### PR DESCRIPTION
The 2D engine does not support depth-stencil formats, so equivalent color formats are used for the copy. This modifies the compatibility check to match equivalent color formats when searching for copy textures.

Should fix broken fog on Pokémon Sword/Shield.

I recommend testing on a few games to ensure no regressions. It might be also worth revisiting this in the future, I don't like this approach to be honest.

