### PR TITLE
Fix issues causing keyboard profiles to throw errors on load.

### DIFF
--- a/Ryujinx/Ui/ControllerWindow.cs
+++ b/Ryujinx/Ui/ControllerWindow.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Reflection;
 using System.Text.Json;
 using System.Threading;
+
 using GUI = Gtk.Builder.ObjectAttribute;
 using Key = Ryujinx.Configuration.Hid.Key;
 

--- a/Ryujinx/Ui/ControllerWindow.cs
+++ b/Ryujinx/Ui/ControllerWindow.cs
@@ -1,17 +1,16 @@
 using Gtk;
 using OpenTK.Input;
+using Ryujinx.Common.Configuration.Hid;
+using Ryujinx.Common.Utilities;
+using Ryujinx.Configuration;
+using Ryujinx.HLE.FileSystem;
 using System;
 using System.IO;
 using System.Reflection;
+using System.Text.Json;
 using System.Threading;
-using Ryujinx.Configuration;
-using Ryujinx.Common.Configuration.Hid;
-using Ryujinx.Common.Utilities;
-using Ryujinx.HLE.FileSystem;
-
 using GUI = Gtk.Builder.ObjectAttribute;
 using Key = Ryujinx.Configuration.Hid.Key;
-using Ryujinx.Common.Logging;
 
 namespace Ryujinx.Ui
 {
@@ -821,20 +820,23 @@ namespace Ryujinx.Ui
                     return;
                 }
 
-                using (Stream stream = File.OpenRead(path))
+                try
                 {
-                    try
+                    using (Stream stream = File.OpenRead(path))
                     {
                         config = JsonHelper.Deserialize<ControllerConfig>(stream);
                     }
-                    catch (ArgumentException)
+                }
+                catch (JsonException)
+                {
+                    try
                     {
-                        try
+                        using (Stream stream = File.OpenRead(path))
                         {
                             config = JsonHelper.Deserialize<KeyboardConfig>(stream);
                         }
-                        catch { }
                     }
+                    catch { }
                 }
             }
 


### PR DESCRIPTION
Fixes a combination of issues that lead to keyboard profiles not loading.

- `System.Text.Json` throws `JsonException` when parsing fails, not `ArgumentException`.
- Stream is closed by `JsonHelper.Deserialize` as it wraps it in a `BinaryReader`, which wraps deserializing in a using block. Closing the `BinaryReader` closes the enclosed `FileStream`.
- The stream does not seek to the beginning again when trying to parse keyboard config.

Changes the exception type, and gives each load attempt its own file stream.

(also sorted usings)