### PR TITLE
nvdrv: Partially implementation of GetStatus

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Nv/INvDrvServices.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/INvDrvServices.cs
@@ -43,6 +43,8 @@ namespace Ryujinx.HLE.HOS.Services.Nv
 
         private KProcess _owner;
 
+        private bool _transferMemInitialized = false;
+
         public INvDrvServices(ServiceCtx context)
         {
             _owner = null;
@@ -315,6 +317,9 @@ namespace Ryujinx.HLE.HOS.Services.Nv
             long transferMemSize   = context.RequestData.ReadInt64();
             int  transferMemHandle = context.Request.HandleDesc.ToCopy[0];
 
+            // TODO: When transfer memory will be implemented, this could be removed.
+            _transferMemInitialized = true;
+
             _owner = context.Process;
 
             context.ResponseData.Write((uint)NvResult.Success);
@@ -389,7 +394,29 @@ namespace Ryujinx.HLE.HOS.Services.Nv
         // GetStatus() -> (unknown<0x20>, u32 error_code)
         public ResultCode GetStatus(ServiceCtx context)
         {
-            throw new ServiceNotImplementedException(context);
+            // TODO: When transfer memory will be implemented, check if it's mapped instead.
+            if (_transferMemInitialized)
+            {
+                // TODO: Populate values when more RE will be done.
+                NvStatus nvStatus = new NvStatus
+                {
+                    MemoryValue1 = 0, // GetMemStats(transfer_memory + 0x60, 3)
+                    MemoryValue2 = 0, // GetMemStats(transfer_memory + 0x60, 5)
+                    MemoryValue3 = 0, // transfer_memory + 0x78
+                    MemoryValue4 = 0  // transfer_memory + 0x80
+                };
+
+                context.ResponseData.WriteStruct(nvStatus);
+                context.ResponseData.Write((uint)NvResult.Success);
+
+                Logger.PrintStub(LogClass.ServiceNv);
+            }
+            else
+            {
+                context.ResponseData.Write((uint)NvResult.NotInitialized);
+            }
+
+            return ResultCode.Success;
         }
 
         [Command(7)]

--- a/Ryujinx.HLE/HOS/Services/Nv/Types/NvStatus.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/Types/NvStatus.cs
@@ -1,0 +1,15 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Nv.Types
+{
+    [StructLayout(LayoutKind.Sequential, Size = 0x20, CharSet = CharSet.Ansi)]
+    struct NvStatus
+    {
+        public uint MemoryValue1;
+        public uint MemoryValue2;
+        public uint MemoryValue3;
+        public uint MemoryValue4;
+        public long Padding1;
+        public long Padding2;
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Nv/Types/NvStatus.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/Types/NvStatus.cs
@@ -2,7 +2,7 @@
 
 namespace Ryujinx.HLE.HOS.Services.Nv.Types
 {
-    [StructLayout(LayoutKind.Sequential, Size = 0x20, CharSet = CharSet.Ansi)]
+    [StructLayout(LayoutKind.Sequential, Size = 0x20)]
     struct NvStatus
     {
         public uint MemoryValue1;


### PR DESCRIPTION
This implement GetStatus call according to RE.
Since we don't handle tranfert memory on the initialize of the service, it's fine sets fields at 0 for now.
Tested on Undertale.

Fix #635