### PR TITLE
Implement aoc:u and support loading AddOnContent

### DIFF
--- a/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
+++ b/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
@@ -1,10 +1,10 @@
 using LibHac;
 using LibHac.Common;
 using LibHac.Fs;
-using LibHac.FsService.Creators;
 using LibHac.FsSystem;
 using LibHac.FsSystem.NcaUtils;
 using LibHac.Ncm;
+using LibHac.Spl;
 using Ryujinx.Common.Logging;
 using Ryujinx.HLE.Exceptions;
 using Ryujinx.HLE.HOS.Services.Time;
@@ -199,6 +199,8 @@ namespace Ryujinx.HLE.FileSystem.Content
         // fs must contain AOC nca files in its root
         public void AddAocData(IFileSystem fs, string containerPath, ulong aocBaseId)
         {
+            _virtualFileSystem.ImportTickets(fs);
+
             foreach (var ncaPath in fs.EnumerateEntries("*.cnmt.nca", SearchOptions.Default))
             {
                 fs.OpenFile(out IFile ncaFile, ncaPath.FullPath.ToU8Span(), OpenMode.Read);
@@ -231,7 +233,7 @@ namespace Ryujinx.HLE.FileSystem.Content
                         {
                             Logger.PrintInfo(LogClass.Application, $"Found AddOnContent with TitleId {cnmt.TitleId:X16}");
                         }
-                    }   
+                    }
                 }
             }
         }

--- a/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
+++ b/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
@@ -210,11 +210,14 @@ namespace Ryujinx.HLE.FileSystem.Content
                     if (nca.Header.ContentType != NcaContentType.Meta)
                     {
                         Logger.PrintWarning(LogClass.Application, $"{ncaPath} is not a valid metadata file");
+
                         continue;
                     }
 
                     using var pfs0 = nca.OpenFileSystem(0, Switch.GetIntegrityCheckLevel());
+
                     pfs0.OpenFile(out IFile cnmtFile, pfs0.EnumerateEntries().Single().FullPath.ToU8Span(), OpenMode.Read);
+
                     using (cnmtFile)
                     {
                         var cnmt = new Cnmt(cnmtFile.AsStream());
@@ -245,11 +248,13 @@ namespace Ryujinx.HLE.FileSystem.Content
         public bool GetAocDataStorage(ulong aocTitleId, out IStorage aocStorage)
         {
             aocStorage = null;
+
             if (_aocData.TryGetValue(aocTitleId, out AocItem aoc) && aoc.Enabled)
             {
                 var file = new FileStream(aoc.ContainerPath, FileMode.Open, FileAccess.Read);
                 PartitionFileSystem pfs;
                 IFile ncaFile;
+
                 switch (Path.GetExtension(aoc.ContainerPath))
                 {
                     case ".xci":
@@ -263,7 +268,9 @@ namespace Ryujinx.HLE.FileSystem.Content
                     default:
                         return false; // Print error?
                 }
+
                 aocStorage = new Nca(_virtualFileSystem.KeySet, ncaFile.AsStorage()).OpenStorage(NcaSectionType.Data, Switch.GetIntegrityCheckLevel());
+                
                 return true;
             }
 

--- a/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
+++ b/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
@@ -241,6 +241,8 @@ namespace Ryujinx.HLE.FileSystem.Content
             }
         }
 
+        public void ClearAocData() => _aocData.Clear();
+
         public int GetAocCount() => _aocData.Where(e => e.Value.Enabled).Count();
 
         public IList<ulong> GetAocTitleIds() => _aocData.Where(e => e.Value.Enabled).Select(e => e.Key).ToList();

--- a/Ryujinx.HLE/HOS/ApplicationLoader.cs
+++ b/Ryujinx.HLE/HOS/ApplicationLoader.cs
@@ -113,6 +113,8 @@ namespace Ryujinx.HLE.HOS
 
             Xci xci = new Xci(_fileSystem.KeySet, file.AsStorage());
 
+            _contentManager.SetGameCard(file.AsStorage());
+
             if (!xci.HasPartition(XciPartitionType.Secure))
             {
                 Logger.PrintError(LogClass.Loader, "Unable to load XCI: Could not find XCI secure partition");
@@ -145,6 +147,8 @@ namespace Ryujinx.HLE.HOS
             }
 
             _contentManager.LoadEntries(_device);
+
+            _contentManager.AddAocData(securePartition, mainNca.Header.TitleId, ContentPath.GamecardContents);
 
             LoadNca(mainNca, patchNca, controlNca);
         }

--- a/Ryujinx.HLE/HOS/ApplicationLoader.cs
+++ b/Ryujinx.HLE/HOS/ApplicationLoader.cs
@@ -149,7 +149,7 @@ namespace Ryujinx.HLE.HOS
             _contentManager.AddAocData(securePartition, xciFile, mainNca.Header.TitleId);
 
             // Check all nsp's in the base directory for AOC
-            foreach(var fn in new FileInfo(xciFile).Directory.EnumerateFiles("*.nsp"))
+            foreach (var fn in new FileInfo(xciFile).Directory.EnumerateFiles("*.nsp"))
             {
                 _contentManager.AddAocData(new PartitionFileSystem(fn.OpenRead().AsStorage()), fn.FullName, mainNca.Header.TitleId);
             }
@@ -190,9 +190,10 @@ namespace Ryujinx.HLE.HOS
                 _contentManager.AddAocData(nsp, nspFile, mainNca.Header.TitleId);
 
                 // Check all nsp's in the base directory for AOC
-                foreach(var fn in new FileInfo(nspFile).Directory.EnumerateFiles("*.nsp"))
+                foreach (var fn in new FileInfo(nspFile).Directory.EnumerateFiles("*.nsp"))
                 {
-                    if(fn.FullName == nspFile) continue;
+                    if (fn.FullName == nspFile) continue;
+                    
                     _contentManager.AddAocData(new PartitionFileSystem(fn.OpenRead().AsStorage()), fn.FullName, mainNca.Header.TitleId);
                 }
 

--- a/Ryujinx.HLE/HOS/ApplicationLoader.cs
+++ b/Ryujinx.HLE/HOS/ApplicationLoader.cs
@@ -157,11 +157,11 @@ namespace Ryujinx.HLE.HOS
             LoadNca(mainNca, patchNca, controlNca);
         }
 
-        public void LoadNsp(string nspPath)
+        public void LoadNsp(string nspFile)
         {
-            FileStream nspFile = new FileStream(nspPath, FileMode.Open, FileAccess.Read);
+            FileStream file = new FileStream(nspFile, FileMode.Open, FileAccess.Read);
 
-            PartitionFileSystem pfs = new PartitionFileSystem(nspFile.AsStorage());
+            PartitionFileSystem nsp = new PartitionFileSystem(file.AsStorage());
 
             Nca mainNca = null;
             Nca patchNca = null;
@@ -169,7 +169,7 @@ namespace Ryujinx.HLE.HOS
 
             try
             {
-                (mainNca, patchNca, controlNca) = GetGameData(pfs);
+                (mainNca, patchNca, controlNca) = GetGameData(nsp);
             }
             catch (Exception e)
             {
@@ -187,12 +187,12 @@ namespace Ryujinx.HLE.HOS
 
             if (mainNca != null)
             {
-                _contentManager.AddAocData(pfs, nspPath, mainNca.Header.TitleId);
+                _contentManager.AddAocData(nsp, nspFile, mainNca.Header.TitleId);
 
                 // Check all nsp's in the base directory for AOC
-                foreach(var fn in new FileInfo(nspPath).Directory.EnumerateFiles("*.nsp"))
+                foreach(var fn in new FileInfo(nspFile).Directory.EnumerateFiles("*.nsp"))
                 {
-                    if(fn.FullName == nspPath) continue;
+                    if(fn.FullName == nspFile) continue;
                     _contentManager.AddAocData(new PartitionFileSystem(fn.OpenRead().AsStorage()), fn.FullName, mainNca.Header.TitleId);
                 }
 
@@ -202,7 +202,7 @@ namespace Ryujinx.HLE.HOS
             }
 
             // This is not a normal NSP, it's actually a ExeFS as a NSP
-            LoadExeFs(pfs, out _);
+            LoadExeFs(nsp, out _);
         }
 
         public void LoadNca(string ncaFile)

--- a/Ryujinx.HLE/HOS/ApplicationLoader.cs
+++ b/Ryujinx.HLE/HOS/ApplicationLoader.cs
@@ -148,6 +148,12 @@ namespace Ryujinx.HLE.HOS
 
             _contentManager.AddAocData(securePartition, xciFile, mainNca.Header.TitleId);
 
+            // Check all nsp's in the base directory for AOC
+            foreach(var fn in new FileInfo(xciFile).Directory.EnumerateFiles("*.nsp"))
+            {
+                _contentManager.AddAocData(new PartitionFileSystem(fn.OpenRead().AsStorage()), fn.FullName, mainNca.Header.TitleId);
+            }
+
             LoadNca(mainNca, patchNca, controlNca);
         }
 
@@ -182,6 +188,13 @@ namespace Ryujinx.HLE.HOS
             if (mainNca != null)
             {
                 _contentManager.AddAocData(pfs, nspPath, mainNca.Header.TitleId);
+
+                // Check all nsp's in the base directory for AOC
+                foreach(var fn in new FileInfo(nspPath).Directory.EnumerateFiles("*.nsp"))
+                {
+                    if(fn.FullName == nspPath) continue;
+                    _contentManager.AddAocData(new PartitionFileSystem(fn.OpenRead().AsStorage()), fn.FullName, mainNca.Header.TitleId);
+                }
 
                 LoadNca(mainNca, patchNca, controlNca);
 

--- a/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
@@ -377,7 +377,9 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             if (context.Device.System.ContentManager.GetAocDataStorage((ulong)titleId, out LibHac.Fs.IStorage aocStorage))
             {
                 Logger.PrintInfo(LogClass.Loader, $"Opened AddOnContent Data TitleID={titleId:X16}");
+
                 MakeObject(context, new FileSystemProxy.IStorage(aocStorage));
+                
                 return ResultCode.Success;
             }
 

--- a/Ryujinx.HLE/HOS/Services/Ns/IAddOnContentManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Ns/IAddOnContentManager.cs
@@ -1,34 +1,190 @@
 using Ryujinx.Common.Logging;
+using Ryujinx.HLE.HOS.Ipc;
+using Ryujinx.HLE.HOS.Kernel.Common;
+using Ryujinx.HLE.HOS.Kernel.Threading;
+
+using System;
 
 namespace Ryujinx.HLE.HOS.Services.Ns
 {
     [Service("aoc:u")]
     class IAddOnContentManager : IpcService
     {
-        public IAddOnContentManager(ServiceCtx context) { }
+
+        KEvent _addOnContentListChangedEvent;
+
+        public IAddOnContentManager(ServiceCtx context)
+        {
+            _addOnContentListChangedEvent = new KEvent(context.Device.System.KernelContext);
+        }
 
         [Command(2)]
-        // CountAddOnContent(u64, pid) -> u32
+        // CountAddOnContent(pid) -> u32
         public static ResultCode CountAddOnContent(ServiceCtx context)
         {
-            context.ResponseData.Write(0);
+            ulong pid = context.RequestData.ReadUInt64();
 
-            Logger.PrintStub(LogClass.ServiceNs);
+            // Official code checks ApplicationControlProperty.RuntimeAddOnContentInstall 
+            // if true calls ns:am ListAvailableAddOnContent again to get updated count
+
+            byte runtimeAddOnContentInstall = context.Device.Application.ControlData.Value.RuntimeAddOnContentInstall;
+            if(runtimeAddOnContentInstall != 0)
+            {
+                Logger.PrintWarning(LogClass.ServiceNs, $"RuntimeAddOnContentInstall is true. Some DLC may be missing");;
+            }
+
+            uint aocCount = CountAddOnContentImpl(context);
+
+            context.ResponseData.Write(aocCount);
+
+            Logger.PrintDebug(LogClass.ServiceNs, $"pid={pid} count={aocCount} RuntimeInstall={runtimeAddOnContentInstall}");
 
             return ResultCode.Success;
+        }
+
+        private static uint CountAddOnContentImpl(ServiceCtx context)
+        {
+            return (uint)context.Device.System.ContentManager.GetAocCount();
         }
 
         [Command(3)]
-        // ListAddOnContent(u32, u32, u64, pid) -> (u32, buffer<u32, 6>)
+        // ListAddOnContent(u32, u32, pid) -> (u32, buffer<u32>)
         public static ResultCode ListAddOnContent(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceNs);
+            uint startIndex = context.RequestData.ReadUInt32();
+            uint bufferSize = context.RequestData.ReadUInt32();
+            ulong pid = context.RequestData.ReadUInt64();
 
-            // TODO: This is supposed to write a u32 array aswell.
-            // It's unknown what it contains.
-            context.ResponseData.Write(0);
+            var aocTitleIds = context.Device.System.ContentManager.GetAocTitleIds();
+
+            uint aocCount = CountAddOnContentImpl(context);
+
+            if (aocCount <= startIndex)
+            {
+                context.ResponseData.Write((uint)0);
+                return ResultCode.Success;
+            }
+
+            aocCount = Math.Min(aocCount - startIndex, bufferSize);
+
+            context.ResponseData.Write(aocCount);
+
+            ulong bufAddr = (ulong)context.Request.ReceiveBuff[0].Position;
+
+            ulong aocBaseId = GetAddOnContentBaseIdImpl(context);
+
+            for (int i = 0; i < aocCount; ++i)
+            {
+                context.Memory.Write(bufAddr + (ulong)i * 4, (int)(aocTitleIds[i + (int)startIndex] - aocBaseId));
+            }
+
+            Logger.PrintDebug(LogClass.ServiceNs, $"pid={pid} bufferSize={bufferSize} start={startIndex} aocCount={aocCount}");
 
             return ResultCode.Success;
         }
+
+        [Command(5)]
+        // GetAddOnContentBaseId(pid) -> u64
+        public static ResultCode GetAddonContentBaseId(ServiceCtx context)
+        {
+            ulong pid = context.RequestData.ReadUInt64();
+
+            // Official code calls arp:r GetApplicationControlProperty to get AddOnContentBaseId
+            // If the call fails, calls arp:r GetApplicationLaunchProperty to get App TitleId
+            ulong aocBaseId = GetAddOnContentBaseIdImpl(context);
+
+            context.ResponseData.Write(aocBaseId);
+
+            Logger.PrintDebug(LogClass.ServiceNs, $"pid={pid} aocBaseId=0{aocBaseId:x}");
+
+            // ResultCode will be error code of GetApplicationLaunchProperty if it fails
+            return ResultCode.Success;
+        }
+
+        private static ulong GetAddOnContentBaseIdImpl(ServiceCtx context)
+        {
+            ulong aocBaseId = context.Device.Application.ControlData.Value.AddOnContentBaseId;
+
+            if (aocBaseId == 0)
+            {
+                aocBaseId = context.Device.Application.TitleId + 0x1000;
+            }
+
+            return aocBaseId;
+        }
+
+        [Command(7)]
+        // PrepareAddOnContent(u32, pid)
+        public static ResultCode PrepareAddOnContent(ServiceCtx context)
+        {
+            uint aocIndex = context.RequestData.ReadUInt32();
+            ulong pid = context.RequestData.ReadUInt64();
+
+            // Official Code calls a bunch of functions from arp:r for aocBaseId
+            // and ns:am RegisterContentsExternalKey?, GetOwnedApplicationContentMetaStatus? etc...
+
+            // Ideally, this should probably initialize the AocData values for the specified index
+
+            Logger.PrintStub(LogClass.ServiceNs, $"pid={pid} aocIndex={aocIndex}");
+
+            return ResultCode.Success;
+        }
+
+        [Command(8)]
+        // GetAddOnContentListChangedEvent() -> handle<copy>
+        public ResultCode GetAddOnContentListChangedEvent(ServiceCtx context)
+        {
+            // Official code seems to make an internal call to ns:am Cmd 84 GetDynamicCommitEvent()
+
+            if (context.Process.HandleTable.GenerateHandle(_addOnContentListChangedEvent.ReadableEvent, out int handle) != KernelResult.Success)
+            {
+                throw new InvalidOperationException("Out of handles!");
+            }
+
+            context.Response.HandleDesc = IpcHandleDesc.MakeCopy(handle);
+
+            Logger.PrintStub(LogClass.ServiceNs);
+
+            return ResultCode.Success;
+        }
+
+
+        [Command(9)]
+        // [10.0.0+] GetAddOnContentLostErrorCode() -> u64
+        public static ResultCode GetAddOnContentLostErrorCode(ServiceCtx context)
+        {
+            // Seems to read from static addr=&(0x7d0a4 << 32)?
+            // ((ulonglong)*addr & 0x1ff) + 2000 | (ulonglong)(*addr >> 9 & 0x1fff) << 0x20
+            context.ResponseData.Write(0);
+
+            Logger.PrintStub(LogClass.ServiceNs);
+
+            return ResultCode.Success;
+        }
+
+        [Command(100)]
+        // CreateEcPurchasedEventManager() -> object<nn::ec::IPurchaseEventManager>
+        public static ResultCode CreateEcPurchasedEventManager(ServiceCtx context)
+        {
+            MakeObject(context, new IPurchaseEventManager());
+
+            Logger.PrintStub(LogClass.ServiceNs);
+
+            return ResultCode.Success;
+        }
+
+        [Command(101)]
+        // CreatePermanentEcPurchasedEventManager() -> object<nn::ec::IPurchaseEventManager>
+        public static ResultCode CreatePermanentEcPurchasedEventManager(ServiceCtx context)
+        {
+            // Very similar to CreateEcPurchasedEventManager but with some extra code
+
+            MakeObject(context, new IPurchaseEventManager());
+
+            Logger.PrintStub(LogClass.ServiceNs);
+
+            return ResultCode.Success;
+        }
+
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Ns/IAddOnContentManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Ns/IAddOnContentManager.cs
@@ -2,7 +2,6 @@ using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Kernel.Common;
 using Ryujinx.HLE.HOS.Kernel.Threading;
-
 using System;
 
 namespace Ryujinx.HLE.HOS.Services.Ns
@@ -10,7 +9,6 @@ namespace Ryujinx.HLE.HOS.Services.Ns
     [Service("aoc:u")]
     class IAddOnContentManager : IpcService
     {
-
         KEvent _addOnContentListChangedEvent;
 
         public IAddOnContentManager(ServiceCtx context)
@@ -95,7 +93,7 @@ namespace Ryujinx.HLE.HOS.Services.Ns
 
             context.ResponseData.Write(aocBaseId);
 
-            Logger.PrintDebug(LogClass.ServiceNs, $"pid={pid} aocBaseId=0{aocBaseId:x}");
+            Logger.PrintDebug(LogClass.ServiceNs, $"pid={pid} aocBaseId={aocBaseId:X16}");
 
             // ResultCode will be error code of GetApplicationLaunchProperty if it fails
             return ResultCode.Success;
@@ -153,9 +151,9 @@ namespace Ryujinx.HLE.HOS.Services.Ns
         // [10.0.0+] GetAddOnContentLostErrorCode() -> u64
         public static ResultCode GetAddOnContentLostErrorCode(ServiceCtx context)
         {
-            // Seems to read from static addr=&(0x7d0a4 << 32)?
-            // ((ulonglong)*addr & 0x1ff) + 2000 | (ulonglong)(*addr >> 9 & 0x1fff) << 0x20
-            context.ResponseData.Write(0);
+            // Seems to calculate ((value & 0x1ff)) + 2000 on 0x7d0a4
+            // which gives 0x874 (2000+164). 164 being Module ID of `EC (Shop)`
+            context.ResponseData.Write(2164L);
 
             Logger.PrintStub(LogClass.ServiceNs);
 

--- a/Ryujinx.HLE/HOS/Services/Ns/IAddOnContentManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Ns/IAddOnContentManager.cs
@@ -184,6 +184,5 @@ namespace Ryujinx.HLE.HOS.Services.Ns
 
             return ResultCode.Success;
         }
-
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Ns/IPurchaseEventManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Ns/IPurchaseEventManager.cs
@@ -1,0 +1,8 @@
+namespace Ryujinx.HLE.HOS.Services.Ns
+{
+    class IPurchaseEventManager : IpcService
+    {
+        // TODO: Implement this
+        // Size seems to be atleast 0x7a8
+    }
+}


### PR DESCRIPTION
Implements most of `IAddOnContentManager` based on fw 9.2.0 RE and a little bit from 10.0.0.
~~Also adds support for reading AddOnContent embedded in XCI.~~

This is my first RE work in this project so please be extra critical.

Supersedes #1218 (Sorry @AcK77 !)
Fixes #636

**EDIT:**
Now supports reading embedded AOC from XCI and NSP. Also, automatically loads any AOC NSPs in the game's base directory.
With some GUI work, custom AOC paths can be added and toggled.

~~Depends on #1236~~