### PR TITLE
Suppress CS0169 CS0649 warns from HID structs

### DIFF
--- a/ARMeilleure/Diagnostics/Logger.cs
+++ b/ARMeilleure/Diagnostics/Logger.cs
@@ -10,7 +10,7 @@ namespace ARMeilleure.Diagnostics
         private static long _startTime;
 
         private static long[] _accumulatedTime;
-#pragma warning restore CS0196
+#pragma warning restore CS0169
 
         static Logger()
         {

--- a/Ryujinx.HLE/HOS/Applets/Controller/ControllerSupportArg.cs
+++ b/Ryujinx.HLE/HOS/Applets/Controller/ControllerSupportArg.cs
@@ -1,5 +1,6 @@
 namespace Ryujinx.HLE.HOS.Applets
 {
+#pragma warning disable CS0649
     // (8.0.0+ version)
     unsafe struct ControllerSupportArg
     {
@@ -8,4 +9,5 @@ namespace Ryujinx.HLE.HOS.Applets
         public byte EnableExplainText;
         public fixed byte ExplainText[8 * 0x81];
     }
+#pragma warning restore CS0649
 }

--- a/Ryujinx.HLE/HOS/Applets/Controller/ControllerSupportArgHeader.cs
+++ b/Ryujinx.HLE/HOS/Applets/Controller/ControllerSupportArgHeader.cs
@@ -1,5 +1,6 @@
 namespace Ryujinx.HLE.HOS.Applets
 {
+#pragma warning disable CS0649
     struct ControllerSupportArgHeader
     {
         public sbyte PlayerCountMin;
@@ -10,4 +11,5 @@ namespace Ryujinx.HLE.HOS.Applets
         public byte EnableSingleMode;
         public byte EnableIdentificationColor;
     }
+#pragma warning restore CS0649
 }

--- a/Ryujinx.HLE/HOS/Applets/Controller/ControllerSupportArgPrivate.cs
+++ b/Ryujinx.HLE/HOS/Applets/Controller/ControllerSupportArgPrivate.cs
@@ -1,5 +1,6 @@
 namespace Ryujinx.HLE.HOS.Applets
 {
+#pragma warning disable CS0649
     struct ControllerSupportArgPrivate
     {
         public uint PrivateSize;
@@ -11,4 +12,5 @@ namespace Ryujinx.HLE.HOS.Applets
         public uint NpadStyleSet;
         public uint NpadJoyHoldType;
     }
+#pragma warning restore CS0649
 }

--- a/Ryujinx.HLE/HOS/Applets/Controller/ControllerSupportResultInfo.cs
+++ b/Ryujinx.HLE/HOS/Applets/Controller/ControllerSupportResultInfo.cs
@@ -1,5 +1,6 @@
 namespace Ryujinx.HLE.HOS.Applets
 {
+#pragma warning disable CS0649
     unsafe struct ControllerSupportResultInfo
     {
         public sbyte PlayerCount;
@@ -7,4 +8,5 @@ namespace Ryujinx.HLE.HOS.Applets
         public uint SelectedId;
         public uint Result;
     }
+#pragma warning restore CS0649
 }

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMem/StructArrayHelpers.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMem/StructArrayHelpers.cs
@@ -2,6 +2,7 @@ using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Hid
 {
+#pragma warning disable CS0169
     struct Array2<T> where T : unmanaged
     {
         T e0, e1;
@@ -50,4 +51,5 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         public ref T this[int index] => ref MemoryMarshal.CreateSpan(ref e0, 17)[index];
         public int Length => 17;
     }
+#pragma warning restore CS0169
 }


### PR DESCRIPTION
Adds warning suppressions missed in #919. 
Also fix a pragma restore typo.