### PR TITLE
Remove CpuId IR instruction

### DIFF
--- a/ARMeilleure/CodeGen/X86/CodeGenerator.cs
+++ b/ARMeilleure/CodeGen/X86/CodeGenerator.cs
@@ -53,7 +53,6 @@ namespace ARMeilleure.CodeGen.X86
             Add(Instruction.ConvertToFP,             GenerateConvertToFP);
             Add(Instruction.Copy,                    GenerateCopy);
             Add(Instruction.CountLeadingZeros,       GenerateCountLeadingZeros);
-            Add(Instruction.CpuId,                   GenerateCpuId);
             Add(Instruction.Divide,                  GenerateDivide);
             Add(Instruction.DivideUI,                GenerateDivideUI);
             Add(Instruction.Fill,                    GenerateFill);
@@ -763,11 +762,6 @@ namespace ARMeilleure.CodeGen.X86
             // return the number of 0 bits on the high end. So, we invert the result
             // of the BSR using XOR to get the correct value.
             context.Assembler.Xor(dest, Const(operandMask), OperandType.I32);
-        }
-
-        private static void GenerateCpuId(CodeGenContext context, Operation operation)
-        {
-            context.Assembler.Cpuid();
         }
 
         private static void GenerateDivide(CodeGenContext context, Operation operation)

--- a/ARMeilleure/CodeGen/X86/PreAllocator.cs
+++ b/ARMeilleure/CodeGen/X86/PreAllocator.cs
@@ -265,38 +265,6 @@ namespace ARMeilleure.CodeGen.X86
                     break;
                 }
 
-                case Instruction.CpuId:
-                {
-                    // Handle the many restrictions of the CPU Id instruction:
-                    // - EAX controls the information returned by this instruction.
-                    // - When EAX is 1, feature information is returned.
-                    // - The information is written to registers EAX, EBX, ECX and EDX.
-                    Debug.Assert(dest.Type == OperandType.I64);
-
-                    Operand eax = Gpr(X86Register.Rax, OperandType.I32);
-                    Operand ebx = Gpr(X86Register.Rbx, OperandType.I32);
-                    Operand ecx = Gpr(X86Register.Rcx, OperandType.I32);
-                    Operand edx = Gpr(X86Register.Rdx, OperandType.I32);
-
-                    // Value 0x01 = Version, family and feature information.
-                    nodes.AddBefore(node, Operation(Instruction.Copy, eax, Const(1)));
-
-                    // Copy results to the destination register.
-                    // The values are split into 2 32-bits registers, we merge them
-                    // into a single 64-bits register.
-                    Operand rcx = Gpr(X86Register.Rcx, OperandType.I64);
-
-                    node = nodes.AddAfter(node, Operation(Instruction.ZeroExtend32, dest, edx));
-                    node = nodes.AddAfter(node, Operation(Instruction.ShiftLeft,    dest, dest, Const(32)));
-                    node = nodes.AddAfter(node, Operation(Instruction.BitwiseOr,    dest, dest, rcx));
-
-                    operation.SetDestinations(new Operand[] { eax, ebx, ecx, edx });
-
-                    operation.SetSources(new Operand[] { eax });
-
-                    break;
-                }
-
                 case Instruction.Divide:
                 case Instruction.DivideUI:
                 {

--- a/ARMeilleure/IntermediateRepresentation/Instruction.cs
+++ b/ARMeilleure/IntermediateRepresentation/Instruction.cs
@@ -69,7 +69,6 @@ namespace ARMeilleure.IntermediateRepresentation
         ZeroExtend8,
 
         Clobber,
-        CpuId,
         Extended,
         Fill,
         LoadFromContext,

--- a/ARMeilleure/Translation/EmitterContext.cs
+++ b/ARMeilleure/Translation/EmitterContext.cs
@@ -209,11 +209,6 @@ namespace ARMeilleure.Translation
             return Add(Instruction.CountLeadingZeros, Local(op1.Type), op1);
         }
 
-        internal Operand CpuId()
-        {
-            return Add(Instruction.CpuId, Local(OperandType.I64));
-        }
-
         public Operand Divide(Operand op1, Operand op2)
         {
             return Add(Instruction.Divide, Local(op1.Type), op1, op2);


### PR DESCRIPTION
#856 removed the uses of such instruction, and instead checks `System.Runtime.Intrinsics.X86.*` for availability of the various x86 extensions. This removes the now unused IR instruction. There is still support on the assembler, so if we need to read CPUID again, we can generate code directly using the assembler, which is imo a better solution. Plus there are plans to expose CPUID on .NET (see: https://github.com/dotnet/runtime/issues/785) so hopefully that will not be necessary at all in the future.