### PR TITLE
Fix tailcall case in EmitterContext

### DIFF
--- a/ARMeilleure/Translation/EmitterContext.cs
+++ b/ARMeilleure/Translation/EmitterContext.cs
@@ -609,15 +609,10 @@ namespace ARMeilleure.Translation
 
         private static bool EndsWithUnconditional(BasicBlock block)
         {
-            Operation lastOp = block.GetLastOp() as Operation;
-
-            if (lastOp == null)
-            {
-                return false;
-            }
-
-            return lastOp.Instruction == Instruction.Branch ||
-                   lastOp.Instruction == Instruction.Return;
+            return block.Operations.Last is Operation lastOp &&
+                   (lastOp.Instruction == Instruction.Branch ||
+                    lastOp.Instruction == Instruction.Return ||
+                    lastOp.Instruction == Instruction.Tailcall);
         }
 
         public ControlFlowGraph GetControlFlowGraph()


### PR DESCRIPTION
Previously blocks ending with a tailcall would still be linked to the next block, with this patch it does not.

This has the effect of unreachable blocks getting removed. Which causes quite a substantial diff, most of it is dead code removal. This should still improve both CQ and throughput, because in some cases there are much less variables to handle which helps the register allocators, and less IR to traverse.

I checked the diffs, but I could not see anything which gave me a thonk moment. Here are some sample diffs. IR is after Translation phase.
1. [IR](https://www.diffchecker.com/JmCNDoPl) - [CodeGen](https://www.diffchecker.com/a3NMobna)
2. [IR](https://www.diffchecker.com/9QKBWg26) - [CodeGen](https://www.diffchecker.com/reYdjtdJ)

If you need the full diff I can upload it here. I believe most of the diff is caused when the tailcall remover set the `Branch` of a decoder block to null, the fallthrough of a conditional branch becomes a tail continuation, so the rest of the translation is essentially dead code.

Fixes #1228