### PR TITLE
Add missing error code to Time

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Time/ResultCode.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/ResultCode.cs
@@ -7,15 +7,16 @@
 
         Success = 0,
 
-        PermissionDenied         = (1   << ErrorCodeShift) | ModuleId,
-        TimeMismatch             = (102 << ErrorCodeShift) | ModuleId,
-        UninitializedClock       = (103 << ErrorCodeShift) | ModuleId,
-        TimeNotFound             = (200 << ErrorCodeShift) | ModuleId,
-        Overflow                 = (201 << ErrorCodeShift) | ModuleId,
-        LocationNameTooLong      = (801 << ErrorCodeShift) | ModuleId,
-        OutOfRange               = (902 << ErrorCodeShift) | ModuleId,
-        TimeZoneConversionFailed = (903 << ErrorCodeShift) | ModuleId,
-        TimeZoneNotFound         = (989 << ErrorCodeShift) | ModuleId,
-        NotImplemented           = (990 << ErrorCodeShift) | ModuleId,
+        TimeServiceNotInitialized = (0   << ErrorCodeShift) | ModuleId,
+        PermissionDenied          = (1   << ErrorCodeShift) | ModuleId,
+        TimeMismatch              = (102 << ErrorCodeShift) | ModuleId,
+        UninitializedClock        = (103 << ErrorCodeShift) | ModuleId,
+        TimeNotFound              = (200 << ErrorCodeShift) | ModuleId,
+        Overflow                  = (201 << ErrorCodeShift) | ModuleId,
+        LocationNameTooLong       = (801 << ErrorCodeShift) | ModuleId,
+        OutOfRange                = (902 << ErrorCodeShift) | ModuleId,
+        TimeZoneConversionFailed  = (903 << ErrorCodeShift) | ModuleId,
+        TimeZoneNotFound          = (989 << ErrorCodeShift) | ModuleId,
+        NotImplemented            = (990 << ErrorCodeShift) | ModuleId,
     }
 }


### PR DESCRIPTION
The error code was taken from Switchbrew (https://switchbrew.org/wiki/Error_codes)

Even if TimeServiceNotInitialized's "description" is 0, the result "value" of "(0 << ErrorCodeShift) | ModuleId" is 0x74 so it is not the same as "Success" (0)