### PR TITLE
Change Console Logging to discard on overflow

### DIFF
--- a/Ryujinx.Common/Logging/Logger.cs
+++ b/Ryujinx.Common/Logging/Logger.cs
@@ -42,7 +42,7 @@ namespace Ryujinx.Common.Logging
             AddTarget(new AsyncLogTargetWrapper(
                 new ConsoleLogTarget("console"),
                 1000,
-                AsyncLogTargetOverflowAction.Block));
+                AsyncLogTargetOverflowAction.Discard));
         }
 
         public static void RestartTime()


### PR DESCRIPTION
This can reduces cases where the game locks-up/crashes because the console is in Select mode or manually scrolled.

File log seems to work as usual.