### PR TITLE
Implement modding support

### DIFF
--- a/Ryujinx.Common/Logging/LogClass.cs
+++ b/Ryujinx.Common/Logging/LogClass.cs
@@ -14,6 +14,7 @@ namespace Ryujinx.Common.Logging
         KernelScheduler,
         KernelSvc,
         Loader,
+        ModLoader,
         Ptc,
         Service,
         ServiceAcc,

--- a/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
+++ b/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
@@ -30,9 +30,12 @@ namespace Ryujinx.HLE.FileSystem
         public EmulatedGameCard GameCard { get; private set; }
         public EmulatedSdCard   SdCard   { get; private set; }
 
+        public ModLoader ModLoader {get; private set;}
+
         private VirtualFileSystem()
         {
             Reload();
+            ModLoader = new ModLoader(); // Should only be created once
         }
 
         public Stream RomFs { get; private set; }

--- a/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
+++ b/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
@@ -17,11 +17,12 @@ namespace Ryujinx.HLE.FileSystem
         public const string NandPath   = "bis";
         public const string SdCardPath = "sdcard";
         public const string SystemPath = "system";
+        public const string ModsPath   = "mods";
 
         public static string SafeNandPath   = Path.Combine(NandPath, "safe");
         public static string SystemNandPath = Path.Combine(NandPath, "system");
         public static string UserNandPath   = Path.Combine(NandPath, "user");
-
+        
         private static bool _isInitialized = false;
 
         public Keyset           KeySet   { get; private set; }
@@ -74,6 +75,14 @@ namespace Ryujinx.HLE.FileSystem
             }
 
             return fullPath;
+        }
+
+        public string GetBaseModsPath()
+        {
+            var baseModsDir = Path.Combine(GetBasePath(), "mods");
+            ModLoader.EnsureBaseDirStructure(baseModsDir);
+
+            return baseModsDir;
         }
 
         public string GetSdCardPath() => MakeFullPath(SdCardPath);

--- a/Ryujinx.HLE/HOS/ApplicationLoader.cs
+++ b/Ryujinx.HLE/HOS/ApplicationLoader.cs
@@ -31,7 +31,7 @@ namespace Ryujinx.HLE.HOS
         private readonly ContentManager _contentManager;
         private readonly VirtualFileSystem _fileSystem;
 
-        public BlitStruct<ApplicationControlProperty> ControlData { get; set; }        
+        public BlitStruct<ApplicationControlProperty> ControlData { get; set; }
 
         public string TitleName { get; private set; }
         public string DisplayVersion { get; private set; }
@@ -44,7 +44,7 @@ namespace Ryujinx.HLE.HOS
         public bool EnablePtc => _device.System.EnablePtc;
 
         // Binaries from exefs are loaded into mem in this order. Do not change.
-        private static readonly string[] ExeFsPrefixes = {"rtld", "main", "subsdk*", "sdk"};
+        private static readonly string[] ExeFsPrefixes = { "rtld", "main", "subsdk*", "sdk" };
 
         public ApplicationLoader(Switch device, VirtualFileSystem fileSystem, ContentManager contentManager)
         {
@@ -394,7 +394,7 @@ namespace Ryujinx.HLE.HOS
 
         private void LoadExeFs(IFileSystem codeFs, Npdm metaData = null)
         {
-            if(_fileSystem.ModLoader.ReplaceExefsPartition(TitleId, ref codeFs))
+            if (_fileSystem.ModLoader.ReplaceExefsPartition(TitleId, ref codeFs))
             {
                 metaData = null; //TODO: Check if we should retain old npdm
             }
@@ -403,7 +403,7 @@ namespace Ryujinx.HLE.HOS
 
             List<NsoExecutable> nsos = new List<NsoExecutable>();
 
-            foreach(string exePrefix in ExeFsPrefixes) // Load binaries with standard prefixes
+            foreach (string exePrefix in ExeFsPrefixes) // Load binaries with standard prefixes
             {
                 foreach (DirectoryEntryEx file in codeFs.EnumerateEntries("/", exePrefix))
                 {
@@ -431,7 +431,7 @@ namespace Ryujinx.HLE.HOS
 
             _contentManager.LoadEntries(_device);
 
-            if(EnablePtc && modified)
+            if (EnablePtc && modified)
             {
                 Logger.PrintWarning(LogClass.Ptc, $"Detected exefs modifications. PPTC disabled.");
             }

--- a/Ryujinx.HLE/HOS/ApplicationLoader.cs
+++ b/Ryujinx.HLE/HOS/ApplicationLoader.cs
@@ -413,17 +413,20 @@ namespace Ryujinx.HLE.HOS
             }
 
             // ExeFs file replacements
-            _fileSystem.ModLoader.ApplyExefsReplacements(TitleId, nsos);
+            bool modified = _fileSystem.ModLoader.ApplyExefsReplacements(TitleId, nsos);
 
             var programs = nsos.ToArray();
 
-
-            _fileSystem.ModLoader.ApplyNsoPatches(TitleId, programs);
+            modified |= _fileSystem.ModLoader.ApplyNsoPatches(TitleId, programs);
 
             _contentManager.LoadEntries(_device);
 
+            if(EnablePtc && modified)
+            {
+                Logger.PrintWarning(LogClass.Ptc, $"Detected exefs modifications. PPTC disabled.");
+            }
 
-            Ptc.Initialize(TitleIdText, DisplayVersion, EnablePtc);
+            Ptc.Initialize(TitleIdText, DisplayVersion, EnablePtc && !modified);
 
             ProgramLoader.LoadNsos(_device.System.KernelContext, metaData, executables: programs);
         }

--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -184,11 +184,11 @@ namespace Ryujinx.HLE.HOS
             InitLibHacHorizon();
         }
 
-        public void LoadKip(string kipFile)
+        public void LoadKip(string kipPath)
         {
-            using IStorage fs = new LocalStorage(kipFile, FileAccess.Read);
+            using IFile kipFile = new LocalFile(kipPath, OpenMode.Read);
 
-            ProgramLoader.LoadKip(KernelContext, new KipExecutable(fs));
+            ProgramLoader.LoadKip(KernelContext, new KipExecutable(kipFile.AsStorage()));
         }
 
         private void InitLibHacHorizon()

--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -186,9 +186,9 @@ namespace Ryujinx.HLE.HOS
 
         public void LoadKip(string kipPath)
         {
-            using IFile kipFile = new LocalFile(kipPath, OpenMode.Read);
+            using IStorage kipFile = new LocalStorage(kipPath, FileAccess.Read);
 
-            ProgramLoader.LoadKip(KernelContext, new KipExecutable(kipFile.AsStorage()));
+            ProgramLoader.LoadKip(KernelContext, new KipExecutable(kipFile));
         }
 
         private void InitLibHacHorizon()

--- a/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
@@ -66,7 +66,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
         private ulong _imageSize;
         private ulong _mainThreadStackSize;
         private ulong _memoryUsageCapacity;
-        private int   _category;
+        private int   _version;
 
         public KHandleTable HandleTable { get; private set; }
 
@@ -377,7 +377,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
             _creationTimestamp = PerformanceCounter.ElapsedMilliseconds;
 
             MmuFlags    = creationInfo.MmuFlags;
-            _category   = creationInfo.Category;
+            _version   = creationInfo.Version;
             TitleId     = creationInfo.TitleId;
             _entrypoint = creationInfo.CodeAddress;
             _imageSize  = (ulong)creationInfo.CodePagesCount * KMemoryManager.PageSize;

--- a/Ryujinx.HLE/HOS/Kernel/Process/ProcessCreationInfo.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/ProcessCreationInfo.cs
@@ -4,7 +4,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
     {
         public string Name { get; private set; }
 
-        public int   Category { get; private set; }
+        public int   Version { get; private set; }
         public ulong TitleId  { get; private set; }
 
         public ulong CodeAddress    { get; private set; }
@@ -25,7 +25,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
             int    personalMmHeapPagesCount)
         {
             Name                     = name;
-            Category                 = category;
+            Version                  = category;
             TitleId                  = titleId;
             CodeAddress              = codeAddress;
             CodePagesCount           = codePagesCount;

--- a/Ryujinx.HLE/HOS/ModLoader.cs
+++ b/Ryujinx.HLE/HOS/ModLoader.cs
@@ -1,0 +1,427 @@
+using LibHac.Common;
+using LibHac.Fs;
+using LibHac.FsSystem;
+using LibHac.FsSystem.RomFs;
+using Ryujinx.Common.Logging;
+using Ryujinx.HLE.FileSystem;
+using Ryujinx.HLE.Loaders.Mods;
+using Ryujinx.HLE.Loaders.Executables;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.IO;
+
+namespace Ryujinx.HLE.HOS
+{
+    public class ModLoader
+    {
+        private const string RomfsDir = "romfs";
+        private const string RomfsStorageFile = "romfs.storage";
+        private const string ExefsDir = "exefs";
+        private const string StubExtension = ".stub";
+
+        private const string NsoPatchesDir = "exefs_patches";
+        private const string NroPatchesDir = "nro_patches";
+
+        public enum ModType
+        {
+            TitleMod,
+            NsoMod,
+            NroMod
+        }
+
+        public class Mod
+        {
+            public readonly ulong TitleId;
+            public readonly ModType Type;
+            public readonly DirectoryInfo Dir;
+            public readonly DirectoryInfo Exefs;
+            public readonly DirectoryInfo Romfs;
+            public readonly FileInfo RomfsFile;
+
+            public bool Enabled;
+
+            public static Mod MakeMod(DirectoryInfo dir, ModType type, ulong titleId = ulong.MaxValue, bool enabled = true)
+            {
+                if (type == ModType.TitleMod && titleId == ulong.MaxValue)
+                {
+                    Logger.PrintWarning(LogClass.Application, $"Orphaned {type} without TitleId '{dir.Name}'");
+                    return null;
+                }
+
+                Mod m = new Mod(dir, type, titleId, enabled);
+
+                bool check = type == ModType.TitleMod ? m.Exefs.Exists || m.Romfs.Exists || m.RomfsFile.Exists : m.Exefs.Exists;
+
+                if (!check)
+                {
+                    Logger.PrintWarning(LogClass.Application, $"Invalid/Empty {type} '{m.Dir.Name}'");
+                    return null;
+                }
+
+                string status = (m.Exefs.Exists ? "[E" : "[") +
+                                ((m.RomfsFile?.Exists ?? false) ? "r" : "") +
+                                ((m.Romfs?.Exists ?? false) ? "R] " : "] ") +
+                                (type == ModType.TitleMod ? $"[{titleId:X16}]" : "");
+
+                Logger.PrintInfo(LogClass.Application, $"Found {type} '{m.Dir.Name}' {status}");
+
+                return m;
+            }
+
+            private Mod(DirectoryInfo dir, ModType type, ulong titleId, bool enabled = true)
+            {
+                Dir = dir;
+                Type = type;
+                Enabled = enabled;
+
+                switch (type)
+                {
+                    case ModType.NroMod:
+                    case ModType.NsoMod:
+                        Exefs = Dir; // No exefs needed for this type. Mods are directly under <mod-name>.
+                        break;
+                    default:
+                        TitleId = titleId;
+                        Exefs = new DirectoryInfo(Path.Combine(dir.FullName, ExefsDir));
+                        Romfs = new DirectoryInfo(Path.Combine(dir.FullName, RomfsDir));
+                        RomfsFile = new FileInfo(Path.Combine(dir.FullName, RomfsStorageFile));
+                        break;
+                }
+            }
+
+            // Useful when collect and processing are separated
+            public bool Check()
+            {
+                if (!Enabled)
+                {
+                    return false;
+                }
+
+                Dir.Refresh();
+
+                if (Type == ModType.TitleMod)
+                {
+                    Exefs.Refresh();
+                    Romfs.Refresh();
+                    RomfsFile.Refresh();
+                }
+
+                return Dir.Exists;
+            }
+        }
+
+        public readonly Dictionary<ulong, List<Mod>> TitleMods;
+        public readonly Dictionary<string, Mod> NsoMods;
+        public readonly Dictionary<string, Mod> NroMods;
+
+        public ModLoader()
+        {
+            TitleMods = new Dictionary<ulong, List<Mod>>();
+            NsoMods = new Dictionary<string, Mod>();
+            NroMods = new Dictionary<string, Mod>();
+        }
+
+        public void Clear()
+        {
+            TitleMods.Clear();
+            NsoMods.Clear();
+            NroMods.Clear();
+        }
+
+        // Check if searchDir is NsoPatchesDir
+        // Check if searchDir is NroPatchesDir
+        // Check if searchDir is a TitleId
+        // Finally, check if searchDir is a RootDir of above
+        public void SearchMods(DirectoryInfo searchDir)
+        {
+            bool TrySearch(DirectoryInfo dir)
+            {
+                if (NsoPatchesDir.Equals(dir.Name, StringComparison.OrdinalIgnoreCase))
+                {
+                    AddPatchMods(dir, ModType.NsoMod);
+                }
+                else if (NroPatchesDir.Equals(dir.Name, StringComparison.OrdinalIgnoreCase))
+                {
+                    AddPatchMods(dir, ModType.NroMod);
+                }
+                else if (dir.Name.Length >= 16 && ulong.TryParse(dir.Name.Substring(0, 16), System.Globalization.NumberStyles.HexNumber, null, out ulong titleId))
+                {
+                    AddTitleMods(dir, titleId);
+                }
+                else
+                {
+                    return false;
+                }
+
+                return true;
+            }
+
+            if (searchDir.Exists && !TrySearch(searchDir))
+            {
+                foreach (var dir in searchDir.EnumerateDirectories())
+                {
+                    TrySearch(dir);
+                }
+            }
+        }
+
+        public void AddTitleMods(DirectoryInfo modsDir, ulong titleId)
+        {
+            foreach (var modDir in modsDir.EnumerateDirectories())
+            {
+                var mod = Mod.MakeMod(modDir, ModType.TitleMod, titleId);
+                if (mod == null) continue;
+
+                if (TitleMods.TryGetValue(titleId, out var mods))
+                {
+                    mods.Add(mod);
+                }
+                else
+                {
+                    TitleMods[titleId] = new List<Mod> { mod };
+                }
+            }
+        }
+
+        public void AddPatchMods(DirectoryInfo patchesDir, ModType type)
+        {
+            foreach (var modDir in patchesDir.EnumerateDirectories())
+            {
+                var mod = Mod.MakeMod(modDir, type);
+                if (mod == null) continue;
+
+                (type == ModType.NroMod ? NroMods : NsoMods).TryAdd(modDir.Name, mod);
+            }
+        }
+
+        // Apply helpers
+        internal IStorage ApplyRomFsMods(ulong titleId, IStorage baseStorage)
+        {
+            if (!TitleMods.TryGetValue(titleId, out var titleMods))
+            {
+                return baseStorage;
+            }
+
+            var fileSet = new HashSet<string>();
+            var builder = new RomFsBuilder();
+
+            Logger.PrintInfo(LogClass.Loader, "Collecting RomFS mods...");
+
+            int count = GatherRomFsMods(titleMods, fileSet, builder);
+            if (count == 0)
+            {
+                Logger.PrintInfo(LogClass.Loader, "Using base RomFS");
+                return baseStorage;
+            }
+
+            Logger.PrintInfo(LogClass.Loader, $"Found {fileSet.Count} modded files over {count} mods. Processing base storage...");
+
+            var baseRom = new RomFsFileSystem(baseStorage);
+            foreach (var entry in baseRom.EnumerateEntries()
+                                         .Where(f => f.Type == DirectoryEntryType.File && !fileSet.Contains(f.FullPath))
+                                         .OrderBy(f => f.FullPath, StringComparer.Ordinal))
+            {
+                baseRom.OpenFile(out IFile file, entry.FullPath.ToU8Span(), OpenMode.Read).ThrowIfFailure();
+                builder.AddFile(entry.FullPath, file);
+            }
+
+            Logger.PrintInfo(LogClass.Loader, "Building new RomFS...");
+            IStorage newStorage = builder.Build();
+            Logger.PrintInfo(LogClass.Loader, "Using modded RomFS");
+
+            return newStorage;
+        }
+
+        private static int GatherRomFsMods(IEnumerable<Mod> titleMods, HashSet<string> fileSet, RomFsBuilder builder)
+        {
+            int modCount = 0;
+
+            foreach (var mod in titleMods.Where(mod => mod.Check())) // Filter enabled and existing
+            {
+                IFileSystem fs;
+                if (mod.RomfsFile.Exists) // Prioritize RomFS file
+                {
+                    fs = new RomFsFileSystem(mod.RomfsFile.OpenRead().AsStorage());
+                }
+                else if (mod.Romfs.Exists)
+                {
+                    fs = new LocalFileSystem(mod.Romfs.FullName);
+                }
+                else
+                {
+                    continue;
+                }
+
+                using (fs)
+                {
+                    foreach (var entry in fs.EnumerateEntries()
+                                        .Where(f => f.Type == DirectoryEntryType.File)
+                                        .OrderBy(f => f.FullPath, StringComparer.Ordinal))
+                    {
+                        fs.OpenFile(out IFile file, entry.FullPath.ToU8Span(), OpenMode.Read).ThrowIfFailure();
+                        if (fileSet.Add(entry.FullPath))
+                        {
+                            builder.AddFile(entry.FullPath, file);
+                        }
+                        else
+                        {
+                            Logger.PrintWarning(LogClass.Loader, $"    Skipped duplicate file '{entry.FullPath}' from '{mod.Dir.Name}'");
+                        }
+                    }
+                }
+
+                modCount++;
+            }
+
+            return modCount;
+        }
+
+        internal void ApplyExefsReplacements(ulong titleId, List<NsoExecutable> nsos)
+        {
+            if (!TitleMods.TryGetValue(titleId, out var titleMods))
+            {
+                return;
+            }
+
+            if (nsos.Count > 32)
+            {
+                throw new ArgumentOutOfRangeException("NSO Count is more than 32");
+            }
+
+            var exefsDirs = titleMods.Where(mod => mod.Check() && mod.Exefs.Exists)
+                            .Select(mod => mod.Exefs);
+
+            BitVector32 stubs = new BitVector32();
+            BitVector32 repls = new BitVector32();
+
+            foreach (var exefsDir in exefsDirs)
+            {
+                for (int i = 0; i < nsos.Count; ++i)
+                {
+                    var nso = nsos[i];
+                    var nsoName = nso.Name;
+
+                    FileInfo nsoFile = new FileInfo(Path.Combine(exefsDir.FullName, nsoName));
+                    if (nsoFile.Exists)
+                    {
+                        if (repls[1 << i])
+                        {
+                            Logger.PrintWarning(LogClass.Loader, $"Multiple replacements to '{nsoName}'");
+                            continue;
+                        }
+
+                        repls[1 << i] = true;
+
+                        nsos[i] = new NsoExecutable(nsoFile.OpenRead().AsStorage(), nsoName);
+                        Logger.PrintInfo(LogClass.Loader, $"NSO '{nsoName}' replaced");
+
+                        continue;
+                    }
+
+                    stubs[1 << i] |= File.Exists(Path.Combine(exefsDir.FullName, nsoName + StubExtension));
+                }
+            }
+
+            for (int i = nsos.Count - 1; i >= 0; --i)
+            {
+                if (stubs[1 << i] && !repls[1 << i]) // Prioritizes replacements over stubs
+                {
+                    Logger.PrintInfo(LogClass.Loader, $"NSO '{nsos[i].Name}' stubbed");
+                    nsos.RemoveAt(i);
+                }
+            }
+        }
+
+        internal void ApplyNroPatches(NroExecutable nro)
+        {
+            var nroPatches = NroMods.Values.Where(mod => mod.Check() && mod.Exefs.Exists);
+
+            // NRO patches aren't offset relative to header unlike NSO
+            // according to Atmosphere's ro patcher module
+            ApplyProgramPatches(nroPatches, 0, nro);
+        }
+
+        internal void ApplyNsoPatches(ulong titleId, params IExecutable[] programs)
+        {
+            var nsoMods = NsoMods.Values
+                          .Concat(TitleMods.TryGetValue(titleId, out var titleMods) ? titleMods : Enumerable.Empty<Mod>())
+                          .Where(mod => mod.Check() && mod.Exefs.Exists);
+
+            // NSO patches are created with offset 0 according to Atmosphere's patcher module
+            // But `Program` doesn't contain the header which is 0x100 bytes. So, we adjust for that here
+            ApplyProgramPatches(nsoMods, 0x100, programs);
+        }
+
+        private void ApplyProgramPatches(IEnumerable<Mod> mods, int protectedOffset, params IExecutable[] programs)
+        {
+            MemPatch[] patches = new MemPatch[programs.Length];
+
+            for (int i = 0; i < patches.Length; ++i)
+            {
+                patches[i] = new MemPatch();
+            }
+
+            var buildIds = programs.Select(p => p switch
+            {
+                NsoExecutable nso => BitConverter.ToString(nso.BuildId.Bytes.ToArray()).Replace("-", "").TrimEnd('0'),
+                NroExecutable nro => BitConverter.ToString(nro.Header.BuildId).Replace("-", "").TrimEnd('0'),
+                _ => string.Empty
+            }).ToList();
+
+            int GetIndex(string buildId) => buildIds.FindIndex(id => id == buildId); // O(n) but list is small
+
+            // Collect patches
+            foreach (var mod in mods)
+            {
+                var patchDir = mod.Exefs;
+                foreach (var patchFile in patchDir.EnumerateFiles())
+                {
+                    if (string.Equals(".ips", patchFile.Extension, StringComparison.OrdinalIgnoreCase)) // IPS|IPS32
+                    {
+                        string filename = Path.GetFileNameWithoutExtension(patchFile.FullName).Split('.')[0];
+                        string buildId = filename.TrimEnd('0');
+
+                        int index = GetIndex(buildId);
+                        if (index == -1)
+                        {
+                            continue;
+                        }
+
+                        Logger.PrintInfo(LogClass.Loader, $"Found IPS patch '{patchFile.Name}' in '{mod.Dir.Name}' bid={buildId}");
+
+                        using var fs = patchFile.OpenRead();
+                        using var reader = new BinaryReader(fs);
+
+                        var patcher = new IpsPatcher(reader);
+                        patcher.AddPatches(patches[index]);
+                    }
+                    else if (string.Equals(".pchtxt", patchFile.Extension, StringComparison.OrdinalIgnoreCase)) // IPSwitch
+                    {
+                        using var fs = patchFile.OpenRead();
+                        using var reader = new StreamReader(fs);
+
+                        var patcher = new IPSwitchPatcher(reader);
+
+                        int index = GetIndex(patcher.BuildId);
+                        if (index == -1)
+                        {
+                            continue;
+                        }
+
+                        Logger.PrintInfo(LogClass.Loader, $"Found IPSwitch patch '{patchFile.Name}' in '{mod.Dir.Name}' bid={patcher.BuildId}");
+
+                        patcher.AddPatches(patches[index]);
+                    }
+                }
+            }
+
+            // Apply patches
+            for (int i = 0; i < programs.Length; ++i)
+            {
+                patches[i].Patch(programs[i].Program, protectedOffset);
+            }
+        }
+    }
+}

--- a/Ryujinx.HLE/HOS/ModLoader.cs
+++ b/Ryujinx.HLE/HOS/ModLoader.cs
@@ -120,7 +120,7 @@ namespace Ryujinx.HLE.HOS
             foreach (var modDir in patchDir.EnumerateDirectories())
             {
                 patches.Add(new Mod<DirectoryInfo>(modDir.Name, modDir));
-                Logger.PrintInfo(LogClass.Loader, $"Found {type} patch '{modDir.Name}'");
+                Logger.PrintInfo(LogClass.ModLoader, $"Found {type} patch '{modDir.Name}'");
             }
         }
 
@@ -173,7 +173,7 @@ namespace Ryujinx.HLE.HOS
                     }
                 }
 
-                if (types.Length > 0) Logger.PrintInfo(LogClass.Loader, $"Found mod '{mod.Name}' [{types}]");
+                if (types.Length > 0) Logger.PrintInfo(LogClass.ModLoader, $"Found mod '{mod.Name}' [{types}]");
             }
         }
 
@@ -181,7 +181,7 @@ namespace Ryujinx.HLE.HOS
         {
             if (!contentsDir.Exists) return;
 
-            Logger.PrintInfo(LogClass.Loader, $"Searching mods for Title {titleId:X16}");
+            Logger.PrintInfo(LogClass.ModLoader, $"Searching mods for Title {titleId:X16}");
 
             var titleDir = new DirectoryInfo(Path.Combine(contentsDir.FullName, $"{titleId:x16}"));
             QueryTitleDir(mods, titleDir);
@@ -219,7 +219,7 @@ namespace Ryujinx.HLE.HOS
                 var dir = new DirectoryInfo(path);
                 if(!dir.Exists)
                 {
-                    Logger.PrintWarning(LogClass.Loader, $"Mod Search Dir '{dir.FullName}' doesn't exist");
+                    Logger.PrintWarning(LogClass.ModLoader, $"Mod Search Dir '{dir.FullName}' doesn't exist");
                     continue;
                 }
 
@@ -257,7 +257,7 @@ namespace Ryujinx.HLE.HOS
             var builder = new RomFsBuilder();
             int count = 0;
 
-            Logger.PrintInfo(LogClass.Loader, $"Applying RomFS mods for Title {titleId:X16}");
+            Logger.PrintInfo(LogClass.ModLoader, $"Applying RomFS mods for Title {titleId:X16}");
 
             // Prioritize loose files first
             foreach (var mod in mods.RomfsDirs)
@@ -281,12 +281,12 @@ namespace Ryujinx.HLE.HOS
 
             if (fileSet.Count == 0)
             {
-                Logger.PrintInfo(LogClass.Loader, "No files found. Using base RomFS");
+                Logger.PrintInfo(LogClass.ModLoader, "No files found. Using base RomFS");
 
                 return baseStorage;
             }
 
-            Logger.PrintInfo(LogClass.Loader, $"Replaced {fileSet.Count} file(s) over {count} mod(s). Processing base storage...");
+            Logger.PrintInfo(LogClass.ModLoader, $"Replaced {fileSet.Count} file(s) over {count} mod(s). Processing base storage...");
 
             // And finally, the base romfs
             var baseRom = new RomFsFileSystem(baseStorage);
@@ -298,9 +298,9 @@ namespace Ryujinx.HLE.HOS
                 builder.AddFile(entry.FullPath, file);
             }
 
-            Logger.PrintInfo(LogClass.Loader, "Building new RomFS...");
+            Logger.PrintInfo(LogClass.ModLoader, "Building new RomFS...");
             IStorage newStorage = builder.Build();
-            Logger.PrintInfo(LogClass.Loader, "Using modded RomFS");
+            Logger.PrintInfo(LogClass.ModLoader, "Using modded RomFS");
 
             return newStorage;
         }
@@ -318,7 +318,7 @@ namespace Ryujinx.HLE.HOS
                 }
                 else
                 {
-                    Logger.PrintWarning(LogClass.Loader, $"    Skipped duplicate file '{entry.FullPath}' from '{modName}'", "ApplyRomFsMods");
+                    Logger.PrintWarning(LogClass.ModLoader, $"    Skipped duplicate file '{entry.FullPath}' from '{modName}'", "ApplyRomFsMods");
                 }
             }
         }
@@ -332,10 +332,10 @@ namespace Ryujinx.HLE.HOS
 
             if (mods.ExefsContainers.Count > 1)
             {
-                Logger.PrintWarning(LogClass.Loader, "Multiple ExeFS partition replacements detected");
+                Logger.PrintWarning(LogClass.ModLoader, "Multiple ExeFS partition replacements detected");
             }
 
-            Logger.PrintInfo(LogClass.Loader, $"Using replacement ExeFS partition");
+            Logger.PrintInfo(LogClass.ModLoader, $"Using replacement ExeFS partition");
 
             exefs = new PartitionFileSystem(mods.ExefsContainers[0].Path.OpenRead().AsStorage());
 
@@ -373,14 +373,14 @@ namespace Ryujinx.HLE.HOS
                     {
                         if (repls[1 << i])
                         {
-                            Logger.PrintWarning(LogClass.Loader, $"Multiple replacements to '{nsoName}'");
+                            Logger.PrintWarning(LogClass.ModLoader, $"Multiple replacements to '{nsoName}'");
                             continue;
                         }
 
                         repls[1 << i] = true;
 
                         nsos[i] = new NsoExecutable(nsoFile.OpenRead().AsStorage(), nsoName);
-                        Logger.PrintInfo(LogClass.Loader, $"NSO '{nsoName}' replaced");
+                        Logger.PrintInfo(LogClass.ModLoader, $"NSO '{nsoName}' replaced");
 
                         replaced = true;
 
@@ -395,7 +395,7 @@ namespace Ryujinx.HLE.HOS
             {
                 if (stubs[1 << i] && !repls[1 << i]) // Prioritizes replacements over stubs
                 {
-                    Logger.PrintInfo(LogClass.Loader, $"    NSO '{nsos[i].Name}' stubbed");
+                    Logger.PrintInfo(LogClass.ModLoader, $"    NSO '{nsos[i].Name}' stubbed");
                     nsos.RemoveAt(i);
                     replaced = true;
                 }
@@ -462,7 +462,7 @@ namespace Ryujinx.HLE.HOS
                             continue;
                         }
 
-                        Logger.PrintInfo(LogClass.Loader, $"Matching IPS patch '{patchFile.Name}' in '{mod.Name}' bid={buildId}");
+                        Logger.PrintInfo(LogClass.ModLoader, $"Matching IPS patch '{patchFile.Name}' in '{mod.Name}' bid={buildId}");
 
                         using var fs = patchFile.OpenRead();
                         using var reader = new BinaryReader(fs);
@@ -483,7 +483,7 @@ namespace Ryujinx.HLE.HOS
                             continue;
                         }
 
-                        Logger.PrintInfo(LogClass.Loader, $"Matching IPSwitch patch '{patchFile.Name}' in '{mod.Name}' bid={patcher.BuildId}");
+                        Logger.PrintInfo(LogClass.ModLoader, $"Matching IPSwitch patch '{patchFile.Name}' in '{mod.Name}' bid={patcher.BuildId}");
 
                         patcher.AddPatches(patches[index]);
                     }

--- a/Ryujinx.HLE/HOS/ModLoader.cs
+++ b/Ryujinx.HLE/HOS/ModLoader.cs
@@ -117,6 +117,23 @@ namespace Ryujinx.HLE.HOS
             // modsDir.CreateSubdirectory(AmsKipPatchDir); // uncomment when KIPs are supported
         }
 
+        private static DirectoryInfo FindTitleDir(DirectoryInfo contentsDir, string titleId)
+            => contentsDir.EnumerateDirectories($"{titleId}*", _dirEnumOptions).FirstOrDefault();
+
+        public string GetTitleDir(string modsBasePath, string titleId)
+        {
+            var contentsDir = new DirectoryInfo(Path.Combine(modsBasePath, AmsContentsDir));
+            var titleModsPath = FindTitleDir(contentsDir, titleId);
+
+            if (titleModsPath == null)
+            {
+                Logger.PrintInfo(LogClass.ModLoader, $"Creating mods dir for Title {titleId.ToUpper()}");
+                titleModsPath = contentsDir.CreateSubdirectory(titleId);
+            }
+
+            return titleModsPath.FullName;
+        }
+
         // Static Query Methods
         public static void QueryPatchDirs(PatchCache cache, DirectoryInfo patchDir, DirectoryInfo searchDir)
         {
@@ -196,7 +213,7 @@ namespace Ryujinx.HLE.HOS
 
             Logger.PrintInfo(LogClass.ModLoader, $"Searching mods for Title {titleId:X16}");
 
-            var titleDir = contentsDir.EnumerateDirectories($"{titleId:x16}*", _dirEnumOptions).FirstOrDefault();
+            var titleDir = FindTitleDir(contentsDir, $"{titleId:x16}");
 
             if (titleDir != null)
             {

--- a/Ryujinx.HLE/HOS/ModLoader.cs
+++ b/Ryujinx.HLE/HOS/ModLoader.cs
@@ -3,7 +3,6 @@ using LibHac.Fs;
 using LibHac.FsSystem;
 using LibHac.FsSystem.RomFs;
 using Ryujinx.Common.Logging;
-using Ryujinx.HLE.FileSystem;
 using Ryujinx.HLE.Loaders.Mods;
 using Ryujinx.HLE.Loaders.Executables;
 using System;

--- a/Ryujinx.HLE/HOS/ProgramLoader.cs
+++ b/Ryujinx.HLE/HOS/ProgramLoader.cs
@@ -179,7 +179,7 @@ namespace Ryujinx.HLE.HOS
 
             ProcessCreationInfo creationInfo = new ProcessCreationInfo(
                 metaData.TitleName,
-                metaData.ProcessCategory,
+                metaData.Version,
                 metaData.Aci0.TitleId,
                 codeStart,
                 codePagesCount,

--- a/Ryujinx.HLE/Loaders/Executables/IExecutable.cs
+++ b/Ryujinx.HLE/Loaders/Executables/IExecutable.cs
@@ -1,10 +1,13 @@
+using System;
+
 namespace Ryujinx.HLE.Loaders.Executables
 {
     interface IExecutable
     {
-        byte[] Text { get; }
-        byte[] Ro   { get; }
-        byte[] Data { get; }
+        byte[] Program { get; }        
+        Span<byte> Text { get; }
+        Span<byte> Ro   { get; }
+        Span<byte> Data { get; }
 
         int TextOffset { get; }
         int RoOffset   { get; }

--- a/Ryujinx.HLE/Loaders/Executables/NroExecutable.cs
+++ b/Ryujinx.HLE/Loaders/Executables/NroExecutable.cs
@@ -1,67 +1,38 @@
-using System.IO;
+using LibHac;
+using LibHac.Fs;
+using System;
 
 namespace Ryujinx.HLE.Loaders.Executables
 {
-    class NroExecutable : IExecutable
+    class NroExecutable : Nro, IExecutable
     {
-        public byte[] Text { get; private set; }
-        public byte[] Ro   { get; private set; }
-        public byte[] Data { get; private set; }
+        public byte[] Program { get; }
+        public Span<byte> Text => Program.AsSpan().Slice(TextOffset, (int)Header.NroSegments[0].Size);
+        public Span<byte> Ro   => Program.AsSpan().Slice(RoOffset,   (int)Header.NroSegments[1].Size);
+        public Span<byte> Data => Program.AsSpan().Slice(DataOffset, (int)Header.NroSegments[2].Size);
 
-        public int Mod0Offset { get; private set; }
-        public int TextOffset { get; private set; }
-        public int RoOffset   { get; private set; }
-        public int DataOffset { get; private set; }
-        public int BssSize    { get; private set; }
-        public int FileSize   { get; private set; }
+        public int TextOffset => (int)Header.NroSegments[0].FileOffset;
+        public int RoOffset   => (int)Header.NroSegments[1].FileOffset;
+        public int DataOffset => (int)Header.NroSegments[2].FileOffset;
+        public int BssOffset  => DataOffset + Data.Length;     
+        public int BssSize    => (int)Header.BssSize;
 
-        public int BssOffset => DataOffset + Data.Length;
+        public int Mod0Offset => Start.Mod0Offset;
+        public int FileSize   => (int)Header.Size;
 
         public ulong SourceAddress { get; private set; }
         public ulong BssAddress    { get; private set; }
 
-        public NroExecutable(Stream input, ulong sourceAddress = 0, ulong bssAddress = 0)
+        public NroExecutable(IStorage inStorage, ulong sourceAddress = 0, ulong bssAddress = 0) : base(inStorage)
         {
+            Program = new byte[FileSize];
+
             SourceAddress = sourceAddress;
             BssAddress    = bssAddress;
 
-            BinaryReader reader = new BinaryReader(input);
-
-            input.Seek(4, SeekOrigin.Begin);
-
-            int mod0Offset = reader.ReadInt32();
-            int padding8   = reader.ReadInt32();
-            int paddingC   = reader.ReadInt32();
-            int nroMagic   = reader.ReadInt32();
-            int unknown14  = reader.ReadInt32();
-            int fileSize   = reader.ReadInt32();
-            int unknown1C  = reader.ReadInt32();
-            int textOffset = reader.ReadInt32();
-            int textSize   = reader.ReadInt32();
-            int roOffset   = reader.ReadInt32();
-            int roSize     = reader.ReadInt32();
-            int dataOffset = reader.ReadInt32();
-            int dataSize   = reader.ReadInt32();
-            int bssSize    = reader.ReadInt32();
-
-            Mod0Offset = mod0Offset;
-            TextOffset = textOffset;
-            RoOffset   = roOffset;
-            DataOffset = dataOffset;
-            BssSize    = bssSize;
-
-            byte[] Read(long position, int size)
-            {
-                input.Seek(position, SeekOrigin.Begin);
-
-                return reader.ReadBytes(size);
-            }
-
-            Text = Read(textOffset, textSize);
-            Ro   = Read(roOffset,   roSize);
-            Data = Read(dataOffset, dataSize);
-
-            FileSize = fileSize;
+            OpenNroSegment(NroSegmentType.Text, false).Read(0, Text);
+            OpenNroSegment(NroSegmentType.Ro  , false).Read(0, Ro);
+            OpenNroSegment(NroSegmentType.Data, false).Read(0, Data);
         }
     }
 }

--- a/Ryujinx.HLE/Loaders/Mods/IPSPatcher.cs
+++ b/Ryujinx.HLE/Loaders/Mods/IPSPatcher.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.HLE.Loaders.Mods
             _patches = ParseIps(reader);
             if (_patches != null)
             {
-                Logger.PrintInfo(LogClass.Loader, "IPS patch loaded successfully");
+                Logger.PrintInfo(LogClass.ModLoader, "IPS patch loaded successfully");
             }
         }
 

--- a/Ryujinx.HLE/Loaders/Mods/IPSPatcher.cs
+++ b/Ryujinx.HLE/Loaders/Mods/IPSPatcher.cs
@@ -77,7 +77,7 @@ namespace Ryujinx.HLE.Loaders.Mods
 
                 int patchSize = buf[0] << 8 | buf[1];
 
-                if (patchSize == 0)                     // RLE/Fill mode
+                if (patchSize == 0) // RLE/Fill mode
                 {
                     if (ReadNext(2))
                     {
@@ -93,7 +93,7 @@ namespace Ryujinx.HLE.Loaders.Mods
 
                     patches.AddFill((uint)patchOffset, fillLength, buf[0]);
                 }
-                else                                    // Copy mode
+                else // Copy mode
                 {
                     var patch = reader.ReadBytes(patchSize);
 

--- a/Ryujinx.HLE/Loaders/Mods/IPSPatcher.cs
+++ b/Ryujinx.HLE/Loaders/Mods/IPSPatcher.cs
@@ -1,0 +1,117 @@
+using Ryujinx.Common.Logging;
+using System;
+using System.IO;
+using System.Text;
+
+namespace Ryujinx.HLE.Loaders.Mods
+{
+    class IpsPatcher
+    {
+        MemPatch _patches;
+
+        public IpsPatcher(BinaryReader reader)
+        {
+            _patches = ParseIps(reader);
+            if (_patches != null)
+            {
+                Logger.PrintInfo(LogClass.Loader, "IPS patch loaded successfully");
+            }
+        }
+
+        private static MemPatch ParseIps(BinaryReader reader)
+        {
+            Span<byte> IpsHeaderMagic = Encoding.ASCII.GetBytes("PATCH").AsSpan();
+            Span<byte> IpsTailMagic = Encoding.ASCII.GetBytes("EOF").AsSpan();
+            Span<byte> Ips32HeaderMagic = Encoding.ASCII.GetBytes("IPS32").AsSpan();
+            Span<byte> Ips32TailMagic = Encoding.ASCII.GetBytes("EEOF").AsSpan();
+
+            MemPatch patches = new MemPatch();
+            var header = reader.ReadBytes(IpsHeaderMagic.Length).AsSpan();
+
+            if (header.Length != IpsHeaderMagic.Length)
+            {
+                return null;
+            }
+
+            bool is32;
+            Span<byte> tailSpan;
+
+            if (header.SequenceEqual(IpsHeaderMagic))
+            {
+                is32 = false;
+                tailSpan = IpsTailMagic;
+            }
+            else if (header.SequenceEqual(Ips32HeaderMagic))
+            {
+                is32 = true;
+                tailSpan = Ips32TailMagic;
+            }
+            else
+            {
+                return null;
+            }
+
+            byte[] buf = new byte[tailSpan.Length];
+
+            bool ReadNext(int size) => reader.Read(buf, 0, size) != size;
+
+            while (true)
+            {
+                if (ReadNext(buf.Length))
+                {
+                    return null;
+                }
+
+                if (buf.AsSpan().SequenceEqual(tailSpan))
+                {
+                    break;
+                }
+
+                int patchOffset = is32 ? buf[0] << 24 | buf[1] << 16 | buf[2] << 8 | buf[3]
+                                  : buf[0] << 16 | buf[1] << 8 | buf[2];
+
+                if (ReadNext(2))
+                {
+                    return null;
+                }
+
+                int patchSize = buf[0] << 8 | buf[1];
+
+                if (patchSize == 0)                     // RLE/Fill mode
+                {
+                    if (ReadNext(2))
+                    {
+                        return null;
+                    }
+
+                    int fillLength = buf[0] << 8 | buf[1];
+
+                    if (ReadNext(1))
+                    {
+                        return null;
+                    }
+
+                    patches.AddFill((uint)patchOffset, fillLength, buf[0]);
+                }
+                else                                    // Copy mode
+                {
+                    var patch = reader.ReadBytes(patchSize);
+
+                    if (patch.Length != patchSize)
+                    {
+                        return null;
+                    }
+
+                    patches.Add((uint)patchOffset, patch);
+                }
+            }
+
+            return patches;
+        }
+
+        public void AddPatches(MemPatch patches)
+        {
+            patches.AddFrom(_patches);
+        }
+    }
+}

--- a/Ryujinx.HLE/Loaders/Mods/IPSwitchPatcher.cs
+++ b/Ryujinx.HLE/Loaders/Mods/IPSwitchPatcher.cs
@@ -1,0 +1,262 @@
+using Ryujinx.Common.Logging;
+using System;
+using System.IO;
+using System.Text;
+
+namespace Ryujinx.HLE.Loaders.Mods
+{
+    class IPSwitchPatcher
+    {
+        readonly StreamReader _reader;
+        public string BuildId { get; }
+
+        const string BidHeader = "@nsobid-";
+
+        public IPSwitchPatcher(StreamReader reader)
+        {
+            string header = reader.ReadLine();
+            if (header == null || !header.StartsWith(BidHeader))
+            {
+                Logger.PrintError(LogClass.Loader, "IPSwitch:    Malformed PCHTXT file. Skipping...");
+                return;
+            }
+
+            _reader = reader;
+            BuildId = header.Substring(BidHeader.Length).TrimEnd();
+        }
+
+        private enum Token
+        {
+            Normal,
+            String,
+            EscapeChar,
+            Comment
+        }
+
+        // Uncomments line and unescapes C style strings within
+        private static string PreprocessLine(string line)
+        {
+            StringBuilder str = new StringBuilder();
+            Token state = Token.Normal;
+
+            for (int i = 0; i < line.Length; ++i)
+            {
+                char c = line[i];
+                char la = i + 1 != line.Length ? line[i + 1] : '\0';
+
+                switch (state)
+                {
+                    case Token.Normal:
+                        state = c == '"' ? Token.String :
+                                c == '/' && la == '/' ? Token.Comment :
+                                c == '/' && la != '/' ? Token.Comment : // Ignore error and stop parsing
+                                Token.Normal;
+                        break;
+                    case Token.String:
+                        state = c switch
+                        {
+                            '"' => Token.Normal,
+                            '\\' => Token.EscapeChar,
+                            _ => Token.String
+                        };
+                        break;
+                    case Token.EscapeChar:
+                        state = Token.String;
+                        c = c switch
+                        {
+                            'a' => '\a',
+                            'b' => '\b',
+                            'f' => '\f',
+                            'n' => '\n',
+                            'r' => '\r',
+                            't' => '\t',
+                            'v' => '\v',
+                            '\\' => '\\',
+                            _ => '?'
+                        };
+                        break;
+                }
+
+                if (state == Token.Comment) break;
+
+                if (state < Token.EscapeChar)
+                {
+                    str.Append(c);
+                }
+            }
+
+            return str.ToString().Trim();
+        }
+
+        static int ParseHexByte(byte c)
+        {
+            if (c >= '0' && c <= '9')
+            {
+                return c - '0';
+            }
+            else if (c >= 'A' && c <= 'F')
+            {
+                return c - 'A' + 10;
+            }
+            else if (c >= 'a' && c <= 'f')
+            {
+                return c - 'a' + 10;
+            }
+            else
+            {
+                return 0;
+            }
+        }
+
+        // Big Endian
+        static byte[] Hex2ByteArrayBE(string hexstr)
+        {
+            if ((hexstr.Length & 1) == 1) return null;
+
+            byte[] bytes = new byte[hexstr.Length >> 1];
+
+            for (int i = 0; i < hexstr.Length; i += 2)
+            {
+                int high = ParseHexByte((byte)hexstr[i]);
+                int low = ParseHexByte((byte)hexstr[i + 1]);
+                bytes[i >> 1] = (byte)((high << 4) | low);
+            }
+
+            return bytes;
+        }
+
+        // Auto base discovery
+        private static bool ParseInt(string str, out int value)
+        {
+            if (str[0] == '0' && (str[1] == 'x' || str[1] == 'X'))
+            {
+                return Int32.TryParse(str.Substring(2), System.Globalization.NumberStyles.HexNumber, null, out value);
+            }
+            else
+            {
+                return Int32.TryParse(str, System.Globalization.NumberStyles.Integer, null, out value);
+            }
+        }
+
+        private MemPatch Parse()
+        {
+            if (_reader == null)
+            {
+                return null;
+            }
+
+            MemPatch patches = new MemPatch();
+
+            bool enabled = true;
+            bool printValues = false;
+            int offset_shift = 0;
+
+            string line;
+            int lineNum = 0;
+
+            static void Print(string s) => Logger.PrintInfo(LogClass.Loader, $"IPSwitch:    {s}");
+
+            void ParseWarn() => Logger.PrintWarning(LogClass.Loader, $"IPSwitch:    Parse error at line {lineNum} for bid={BuildId}");
+
+            while ((line = _reader.ReadLine()) != null)
+            {
+                line = PreprocessLine(line);
+                lineNum += 1;
+
+                if (line.Length == 0)
+                {
+                    continue;
+                }
+                else if (line.StartsWith('#'))
+                {
+                    Print(line);
+                }
+                else if (line.StartsWith("@stop"))
+                {
+                    break;
+                }
+                else if (line.StartsWith("@enabled"))
+                {
+                    enabled = true;
+                }
+                else if (line.StartsWith("@disabled"))
+                {
+                    enabled = false;
+                }
+                else if (line.StartsWith("@flag"))
+                {
+                    var tokens = line.Split(' ', 3, StringSplitOptions.RemoveEmptyEntries);
+
+                    if (tokens.Length < 2)
+                    {
+                        ParseWarn();
+                        continue;
+                    }
+
+                    if (tokens[1] == "offset_shift")
+                    {
+                        if (tokens.Length != 3 || !ParseInt(tokens[2], out offset_shift))
+                        {
+                            ParseWarn();
+                            continue;
+                        }
+                    }
+                    else if (tokens[1] == "print_values")
+                    {
+                        printValues = true;
+                    }
+                }
+                else if (line.StartsWith('@'))
+                {
+                    // Ignore
+                }
+                else
+                {
+                    if (!enabled)
+                    {
+                        continue;
+                    }
+
+                    var tokens = line.Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
+
+                    if (tokens.Length < 2)
+                    {
+                        ParseWarn();
+                        continue;
+                    }
+
+                    if (!Int32.TryParse(tokens[0], System.Globalization.NumberStyles.HexNumber, null, out int offset))
+                    {
+                        ParseWarn();
+                        continue;
+                    }
+
+                    offset += offset_shift;
+
+                    if (printValues)
+                    {
+                        Print($"print_values 0x{offset:x} <= {tokens[1]}");
+                    }
+
+                    if (tokens[1][0] == '"')
+                    {
+                        var patch = Encoding.ASCII.GetBytes(tokens[1].Trim('"'));
+                        patches.Add((uint)offset, patch);
+                    }
+                    else
+                    {
+                        var patch = Hex2ByteArrayBE(tokens[1]);
+                        patches.Add((uint)offset, patch);
+                    }
+                }
+            }
+
+            return patches;
+        }
+
+        public void AddPatches(MemPatch patches)
+        {
+            patches.AddFrom(Parse());
+        }
+    }
+}

--- a/Ryujinx.HLE/Loaders/Mods/IPSwitchPatcher.cs
+++ b/Ryujinx.HLE/Loaders/Mods/IPSwitchPatcher.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.HLE.Loaders.Mods
             }
 
             _reader = reader;
-            BuildId = header.Substring(BidHeader.Length).TrimEnd();
+            BuildId = header.Substring(BidHeader.Length).TrimEnd().TrimEnd('0');
         }
 
         private enum Token

--- a/Ryujinx.HLE/Loaders/Mods/IPSwitchPatcher.cs
+++ b/Ryujinx.HLE/Loaders/Mods/IPSwitchPatcher.cs
@@ -17,7 +17,7 @@ namespace Ryujinx.HLE.Loaders.Mods
             string header = reader.ReadLine();
             if (header == null || !header.StartsWith(BidHeader))
             {
-                Logger.PrintError(LogClass.Loader, "IPSwitch:    Malformed PCHTXT file. Skipping...");
+                Logger.PrintError(LogClass.ModLoader, "IPSwitch:    Malformed PCHTXT file. Skipping...");
                 return;
             }
 
@@ -154,9 +154,9 @@ namespace Ryujinx.HLE.Loaders.Mods
             string line;
             int lineNum = 0;
 
-            static void Print(string s) => Logger.PrintInfo(LogClass.Loader, $"IPSwitch:    {s}");
+            static void Print(string s) => Logger.PrintInfo(LogClass.ModLoader, $"IPSwitch:    {s}");
 
-            void ParseWarn() => Logger.PrintWarning(LogClass.Loader, $"IPSwitch:    Parse error at line {lineNum} for bid={BuildId}");
+            void ParseWarn() => Logger.PrintWarning(LogClass.ModLoader, $"IPSwitch:    Parse error at line {lineNum} for bid={BuildId}");
 
             while ((line = _reader.ReadLine()) != null)
             {

--- a/Ryujinx.HLE/Loaders/Mods/MemPatch.cs
+++ b/Ryujinx.HLE/Loaders/Mods/MemPatch.cs
@@ -85,7 +85,7 @@ namespace Ryujinx.HLE.Loaders.Mods
                     patchSize = memory.Length - (int)patchOffset; // Add warning?
                 }
 
-                Logger.PrintInfo(LogClass.Loader, $"Patching address offset {patchOffset:x} <= {BitConverter.ToString(patch).Replace('-', ' ')} len={patchSize}");
+                Logger.PrintInfo(LogClass.ModLoader, $"Patching address offset {patchOffset:x} <= {BitConverter.ToString(patch).Replace('-', ' ')} len={patchSize}");
 
                 patch.AsSpan().Slice(0, patchSize).CopyTo(memory.Slice(patchOffset, patchSize));
 

--- a/Ryujinx.HLE/Loaders/Mods/MemPatch.cs
+++ b/Ryujinx.HLE/Loaders/Mods/MemPatch.cs
@@ -1,0 +1,92 @@
+using Ryujinx.Cpu;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Ryujinx.Common.Logging;
+
+namespace Ryujinx.HLE.Loaders.Mods
+{
+    public class MemPatch
+    {
+        readonly Dictionary<uint, byte[]> _patches = new Dictionary<uint, byte[]>();
+
+        /// <summary>
+        /// Adds a patch to specified offset. Overwrites if already present. 
+        /// </summary>
+        /// <param name="offset">Memory offset</param>
+        /// <param name="patch">The patch to add</param>
+        public void Add(uint offset, byte[] patch)
+        {
+            _patches[offset] = patch;
+        }
+
+        /// <summary>
+        /// Adds a patch in the form of an RLE (Fill mode).
+        /// </summary>
+        /// <param name="offset">Memory offset</param>
+        /// <param name="length"The fill length</param>
+        /// <param name="filler">The byte to fill</param>
+        public void AddFill(uint offset, int length, byte filler)
+        {
+            // TODO: Can be made space efficient by changing `_patches`
+            // Should suffice for now
+            byte[] patch = new byte[length];
+            patch.AsSpan().Fill(filler);
+
+            _patches[offset] = patch;
+        }
+
+        /// <summary>
+        /// Adds all patches from an existing MemPatch
+        /// </summary>
+        /// <param name="patches">The patches to add</param>
+        public void AddFrom(MemPatch patches)
+        {
+            if (patches == null)
+            {
+                return;
+            }
+
+            foreach (var (patchOffset, patch) in patches._patches)
+            {
+                _patches[patchOffset] = patch;
+            }
+        }
+
+        /// <summary>
+        /// Applies all the patches added to this instance.
+        /// </summary>
+        /// <remarks>
+        /// Patches are applied in ascending order of offsets to guarantee
+        /// overlapping patches always apply the same way.
+        /// </remarks>
+        /// <param name="memory">The span of bytes to patch</param>
+        /// <param name="maxSize">The maximum size of the slice of patchable memory</param>
+        /// <param name="protectedOffset">A secondary offset used in special cases (NSO header)</param>
+        public void Patch(Span<byte> memory, int protectedOffset = 0)
+        {
+            foreach (var (offset, patch) in _patches.OrderBy(item => item.Key))
+            {
+                int patchOffset = (int)offset;
+                int patchSize = patch.Length;
+
+                if (patchOffset < protectedOffset || patchOffset > memory.Length)
+                {
+                    continue; // Add warning?
+                }
+
+                patchOffset -= protectedOffset;
+
+                if (patchOffset + patchSize > memory.Length)
+                {
+                    patchSize = memory.Length - (int)patchOffset; // Add warning?
+                }
+
+                Logger.PrintInfo(LogClass.Loader, $"Patching address offset {patchOffset:x} <= {BitConverter.ToString(patch).Replace('-', ' ')} len={patchSize}");
+
+                patch.AsSpan().Slice(0, patchSize).CopyTo(memory.Slice(patchOffset, patchSize));
+            }
+        }
+    }
+}

--- a/Ryujinx.HLE/Loaders/Mods/MemPatch.cs
+++ b/Ryujinx.HLE/Loaders/Mods/MemPatch.cs
@@ -64,8 +64,10 @@ namespace Ryujinx.HLE.Loaders.Mods
         /// <param name="memory">The span of bytes to patch</param>
         /// <param name="maxSize">The maximum size of the slice of patchable memory</param>
         /// <param name="protectedOffset">A secondary offset used in special cases (NSO header)</param>
-        public void Patch(Span<byte> memory, int protectedOffset = 0)
+        /// <returns>Successful patches count</returns>
+        public int Patch(Span<byte> memory, int protectedOffset = 0)
         {
+            int count = 0;
             foreach (var (offset, patch) in _patches.OrderBy(item => item.Key))
             {
                 int patchOffset = (int)offset;
@@ -86,7 +88,11 @@ namespace Ryujinx.HLE.Loaders.Mods
                 Logger.PrintInfo(LogClass.Loader, $"Patching address offset {patchOffset:x} <= {BitConverter.ToString(patch).Replace('-', ' ')} len={patchSize}");
 
                 patch.AsSpan().Slice(0, patchSize).CopyTo(memory.Slice(patchOffset, patchSize));
+
+                count++;
             }
+
+            return count;
         }
     }
 }

--- a/Ryujinx.HLE/Loaders/Npdm/Npdm.cs
+++ b/Ryujinx.HLE/Loaders/Npdm/Npdm.cs
@@ -16,7 +16,7 @@ namespace Ryujinx.HLE.Loaders.Npdm
         public byte   MainThreadPriority  { get; private set; }
         public byte   DefaultCpuId        { get; private set; }
         public int    PersonalMmHeapSize  { get; private set; }
-        public int    ProcessCategory     { get; private set; }
+        public int    Version             { get; private set; }
         public int    MainThreadStackSize { get; private set; }
         public string TitleName           { get;         set; }
         public byte[] ProductCode         { get; private set; }
@@ -48,7 +48,7 @@ namespace Ryujinx.HLE.Loaders.Npdm
 
             PersonalMmHeapSize = reader.ReadInt32();
 
-            ProcessCategory = reader.ReadInt32();
+            Version = reader.ReadInt32();
 
             MainThreadStackSize = reader.ReadInt32();
 

--- a/Ryujinx/Ui/GameTableContextMenu.cs
+++ b/Ryujinx/Ui/GameTableContextMenu.cs
@@ -45,29 +45,34 @@ namespace Ryujinx.Ui
             MenuItem openSaveUserDir = new MenuItem("Open User Save Directory")
             {
                 Sensitive   = !Util.IsEmpty(controlData.ByteSpan) && controlData.Value.UserAccountSaveDataSize > 0,
-                TooltipText = "Open the folder where the User save for the application is loaded"
+                TooltipText = "Open the directory which contains Application's User Saves."
             };
 
             MenuItem openSaveDeviceDir = new MenuItem("Open Device Save Directory")
             {
                 Sensitive   = !Util.IsEmpty(controlData.ByteSpan) && controlData.Value.DeviceSaveDataSize > 0,
-                TooltipText = "Open the folder where the Device save for the application is loaded"
+                TooltipText = "Open the directory which contains Application's Device Saves."
             };
 
             MenuItem openSaveBcatDir = new MenuItem("Open BCAT Save Directory")
             {
                 Sensitive   = !Util.IsEmpty(controlData.ByteSpan) && controlData.Value.BcatDeliveryCacheStorageSize > 0,
-                TooltipText = "Open the folder where the BCAT save for the application is loaded"
+                TooltipText = "Open the directory which contains Application's BCAT Saves."
             };
 
             MenuItem manageTitleUpdates = new MenuItem("Manage Title Updates")
             {
-                TooltipText = "Open the title update management window"
+                TooltipText = "Open the Title Update management window"
             };
 
             MenuItem manageDlc = new MenuItem("Manage DLC")
             {
                 TooltipText = "Open the DLC management window"
+            };
+
+            MenuItem openTitleModDir = new MenuItem("Open Mods Directory")
+            {
+                TooltipText = "Open the directory which contains Application's Mods."
             };
 
             string ext    = System.IO.Path.GetExtension(_gameTableStore.GetValue(_rowIter, 9).ToString()).ToLower();
@@ -78,19 +83,19 @@ namespace Ryujinx.Ui
             MenuItem extractRomFs = new MenuItem("RomFS")
             {
                 Sensitive   = hasNca,
-                TooltipText = "Extract the RomFs section present in the main NCA"
+                TooltipText = "Extract the RomFS section from Application's current config (including updates)."
             };
 
             MenuItem extractExeFs = new MenuItem("ExeFS")
             {
                 Sensitive   = hasNca,
-                TooltipText = "Extract the ExeFs section present in the main NCA"
+                TooltipText = "Extract the ExeFS section from Application's current config (including updates)."
             };
 
             MenuItem extractLogo = new MenuItem("Logo")
             {
                 Sensitive   = hasNca,
-                TooltipText = "Extract the Logo section present in the main NCA"
+                TooltipText = "Extract the Logo section from Application's current config (including updates)."
             };
 
             Menu extractSubMenu = new Menu();
@@ -103,14 +108,14 @@ namespace Ryujinx.Ui
 
             MenuItem managePtcMenu = new MenuItem("Cache Management");
 
-            MenuItem purgePtcCache = new MenuItem("Purge the PPTC cache")
+            MenuItem purgePtcCache = new MenuItem("Purge PPTC cache")
             {
-                TooltipText = "Delete the PPTC cache of the game"
+                TooltipText = "Delete the Application's PPTC cache."
             };
             
-            MenuItem openPtcDir = new MenuItem("Open the PPTC directory")
+            MenuItem openPtcDir = new MenuItem("Open PPTC directory")
             {
-                TooltipText = "Open the PPTC directory in the file explorer"
+                TooltipText = "Open the directory which contains Application's PPTC cache."
             };
             
             Menu managePtcSubMenu = new Menu();
@@ -125,6 +130,7 @@ namespace Ryujinx.Ui
             openSaveBcatDir.Activated    += OpenSaveBcatDir_Clicked;
             manageTitleUpdates.Activated += ManageTitleUpdates_Clicked;
             manageDlc.Activated          += ManageDlc_Clicked;
+            openTitleModDir.Activated    += OpenTitleModDir_Clicked;
             extractRomFs.Activated       += ExtractRomFs_Clicked;
             extractExeFs.Activated       += ExtractExeFs_Clicked;
             extractLogo.Activated        += ExtractLogo_Clicked;
@@ -137,6 +143,7 @@ namespace Ryujinx.Ui
             this.Add(new SeparatorMenuItem());
             this.Add(manageTitleUpdates);
             this.Add(manageDlc);
+            this.Add(openTitleModDir);
             this.Add(new SeparatorMenuItem());
             this.Add(managePtcMenu);
             this.Add(extractMenu);
@@ -600,6 +607,21 @@ namespace Ryujinx.Ui
 
             DlcWindow dlcWindow = new DlcWindow(titleId, titleName, _virtualFileSystem);
             dlcWindow.Show();
+        }
+
+        private void OpenTitleModDir_Clicked(object sender, EventArgs args)
+        {
+            string titleId = _gameTableStore.GetValue(_rowIter, 2).ToString().Split("\n")[1].ToLower();
+
+            var modsBasePath = _virtualFileSystem.GetBaseModsPath();
+            var titleModsPath = _virtualFileSystem.ModLoader.GetTitleDir(modsBasePath, titleId);
+
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = titleModsPath,
+                UseShellExecute = true,
+                Verb = "open"
+            });
         }
 
         private void ExtractRomFs_Clicked(object sender, EventArgs args)

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -335,10 +335,6 @@ namespace Ryujinx.Ui
                 ApplicationLibrary.LoadApplications(ConfigurationState.Instance.Ui.GameDirs,
                     _virtualFileSystem, ConfigurationState.Instance.System.Language);
 
-                // TODO: Add more paths after GUI's in place
-                _virtualFileSystem.ModLoader.Clear();
-                _virtualFileSystem.ModLoader.SearchMods(new DirectoryInfo(System.IO.Path.Combine(_virtualFileSystem.GetBasePath(),"mods")));
-
                 _updatingGameTable = false;
             });
             applicationLibraryThread.Name = "GUI.ApplicationLibraryThread";

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -335,6 +335,10 @@ namespace Ryujinx.Ui
                 ApplicationLibrary.LoadApplications(ConfigurationState.Instance.Ui.GameDirs,
                     _virtualFileSystem, ConfigurationState.Instance.System.Language);
 
+                // TODO: Add more paths after GUI's in place
+                _virtualFileSystem.ModLoader.Clear();
+                _virtualFileSystem.ModLoader.SearchMods(new DirectoryInfo(System.IO.Path.Combine(_virtualFileSystem.GetBasePath(),"mods")));
+
                 _updatingGameTable = false;
             });
             applicationLibraryThread.Name = "GUI.ApplicationLibraryThread";


### PR DESCRIPTION
# Implement modding support

This PR adds full support for mods. It follows [Atmosphère's](https://github.com/Atmosphere-NX/Atmosphere) structure with some enhancements for host FS and emulators convenience.

# At a glance
```
// named file replacers [RECOMMENDED]
@mods/contents/<program id>/<mod dir>/romfs/*   [loose files]
@mods/contents/<program id>/<mod dir>/exefs/*   [loose files]

// named patches [RECOMMENDED]
@mods/exefs_patches/<mod dir>/<build id>.ips|*.pchtxt
@mods/nro_patches  /<mod dir>/<build id>.ips|*.pchtxt
@mods/kip_patches  /<mod dir>/<KIP SHA256>.ips

// named title-specific patches [ENHANCEMENT]
@mods/contents/<program id>/<mod dir>/exefs/<build id>.ips|*.pchtxt

// global replacers [COMPATIBILITY, with ams]
@mods/contents/<program id>/romfs.bin
@mods/contents/<program id>/exefs.nsp
@mods/contents/<program id>/romfs/*   [loose files]
@mods/contents/<program id>/exefs/*   [loose files]
```

# Usage Details

Currently `@mods` is set to use `@RyujinxAppData/mods` as base mods path. You can directly access the title mods directory from the right-click context menu in the GUI.

Title-based mods (romfs and exefs files) go into `contents/` with specific dirs. Title names are pretty flexible. As long as the first 16 characters match a unique title-id, mods are picked up from it.

Patches can be placed in per-title dirs in `contents/` or in the more simpler `*_patches` dirs shown [At a glance](#at-a-glance).

All applicable mods are searched/loaded only when an Application is started for efficiency.

With a little more code in the future (GUI), mods can be searched from additional directories.

# Feature Set

1. ExeFS Partition Replacement
2. ExeFS File Replacement
3. ExeFS Patching
4. RomFS Partition Replacement
5. RomFS File Replacement

### 1. ExeFS Partition Replacement

If an `exefs.nsp` is located for an Application, it is used instead of base ExeFS.

### 2. ExeFS File Replacement

Allows replacing the standard NSO files in an Application's ExeFS. For eg., `sdk`.
Stubbing is also supported. Just create an empty file like so- `sdk.stub`.

Current limitations: Does not replace `main.npdm`.

### 3. ExeFS Patching

Patch Dirs can contain any number of `.ips` (Supports IPS and IPS32) and `.pchtxt` (IPSwitch) patches.

It's sometimes easier to dump all patches into `exefs_patches` as you don't have to worry about Title IDs. The mod loader will select the applicable patches automatically.

**IPS/IPS32:** File names should be like so: `<nso_build_id>[.anything_you_want].ips`

**IPSwitch:** Files must have `.pchtxt` extension and have an `@nsobid-` header as the first line.

`nro_patches/` and `kip_patches/` follow `exefs_patches`. KIP patches, while searched, don't apply yet (as KIPs aren't used).

### More about ExeFS

For more info on exefs features, see Atmosphere's [loader docs](https://github.com/Atmosphere-NX/Atmosphere/blob/master/docs/components/modules/loader.md).

### 4 & 5. RomFS Patching

RomFS mods are either loose files placed in `romfs/` or inside a single container `romfs.bin`. 

The files are replaced in a layered fashion. Loose files are prioritized over any files inside `romfs.bin` which in return, are prioritized over the files in the base RomFS of the Application (same as Atmosphere). See [At a glance](#at-a-glance)

As an aside, to create a `romfs.bin` file one can use [`hactoolnet`](https://github.com/Thealexbarney/LibHac/releases). Just pass the romfs directory as input and it should create a storage file. Here's an example invocation:

```
hactoolnet.exe -t romfsbuild --outfile romfs.bin mymod/romfs
```

## Example Structure
```
Ryujinx
    - bis
    - games
    ...
    + mods
        + contents
            + 0100E95012348000 (My game name)
                + My combined mod
                    + exefs
                        = 123456789ABCDEF...ips
                        = main.stub
                    + romfs
                        = <*> [loose game files]
                + My resolution mod
                    - exefs
                + My romfs mod
                    - romfs
                ...
            + 01006a805678e000
                = exefs.nsp
                = romfs.bin
            - 01006A585fF8E000-some-name-here
            ...
        + exefs_patches
            + my game patch
                = 123456789ABCDEF...ips
                = some-test-patch.pchtxt
            - patch for another game
            ...
        - nro_patches [same as exefs_patches]
        - kip_patches [same as exefs_patches]

```

## Sample Logs
```
00:00:00.412 | Application LoadApplication: Loading as XCI.
00:00:00.449 | ModLoader QueryContentsDir: Searching mods for Title 0100E95012348000
00:00:00.451 | ModLoader QueryTitleDir: Found mod 'force-max-resolution' [E]
00:00:00.451 | ModLoader QueryTitleDir: Found mod 'hq-textures' [R]
00:00:00.452 | ModLoader QueryPatchDirs: Found NSO patch 'my-game-mod-no-outlines'
00:00:00.456 | ModLoader ApplyRomFsMods: Applying RomFS mods for Title 0100E95012348000
00:00:00.466 | ModLoader ApplyRomFsMods: Replaced 45 file(s) over 2 mod(s). Processing base storage...
00:00:00.715 | ModLoader ApplyRomFsMods: Building new RomFS...
00:00:00.737 | ModLoader ApplyRomFsMods: Using modded RomFS
00:00:01.273 | ModLoader ApplyProgramPatches: Matching IPSwitch patch '1.0.0.pchtxt' in 'force-max-resolution' bid=C2C016016115BE3D616281E67E59A7918DAFEDBB
00:00:01.274 | ModLoader Parse: IPSwitch:    # Mandatory Comment
00:00:01.274 | ModLoader Parse: IPSwitch:    print_values 0x7e767e <= 1F2003D5
00:00:01.317 | Ptc LoadExeFs: Detected exefs modifications. PPTC disabled.
00:00:01.319 | Ptc Initialize: Initializing Profiled Persistent Translation Cache (enabled: False).
```

# Dev Details

IPS based on Atmosphere's implementation.<br/>
IPSwitch, my own, from the readme description and some samples.

NRO Patching is untested with actual patches (couldn't find any).

`romfs.bin` can be useful in cases where there's a ton of files to patch. Currently when a romfs mod is loaded, all the files in it will have open handles until emulation has ended. To reduce this number to one, a single-file approach is useful. This also bypasses the OS's filesystem routines and may reduce overhead.

While LayeredFS is more accurate, it was slow to build in my tests, so currently a single RomFs instance is maintained where files are added/replaced. We can revisit adding "true" LayeredFS at a later date. They don't seem as useful for now. I'm open to suggestions.

Tangentially related to modding, there's some under-the-hood changes:

- All mod logs have their own LogClass `ModLoader`

- Executables have been re-written to use a contiguous block of memory (to make proper patching possible) and Spans are used to access segments.

- ExeFs, Npdm, ControlData and SaveData calls have been reordered as discussed with @gdkchan.

**Note:** PPTC is automatically disabled when valid changes to exefs are detected (romfs mods are still ok). It's possible for PPTC to work with mods, but the code changes currently required for a proper solution (changes to JIT and PTC) are beyond the scope of this PR. Current warning message is shown in [sample logs](#sample-logs).

## Things for the future

- Reimplement IPSwitch patches with new spec
- Add cheats support
- Working PPTC with exefs mods
- A potential GUI

## Special Thanks
Thanks to all of Ryujinx team for providing so many valuable suggestions and knowledge. And thanks to all the testers too.