### PR TITLE
Implement CNTVCT_EL0

### DIFF
--- a/ARMeilleure/Instructions/InstEmitSystem.cs
+++ b/ARMeilleure/Instructions/InstEmitSystem.cs
@@ -40,6 +40,7 @@ namespace ARMeilleure.Instructions
                 case 0b11_011_1101_0000_011: dlg = new _U64(NativeInterface.GetTpidr);     break;
                 case 0b11_011_1110_0000_000: dlg = new _U64(NativeInterface.GetCntfrqEl0); break;
                 case 0b11_011_1110_0000_001: dlg = new _U64(NativeInterface.GetCntpctEl0); break;
+                case 0b11_011_1110_0000_010: dlg = new _U64(NativeInterface.GetCntvctEl0); break;
 
                 default: throw new NotImplementedException($"Unknown MRS 0x{op.RawOpCode:X8} at 0x{op.Address:X16}.");
             }

--- a/ARMeilleure/Instructions/NativeInterface.cs
+++ b/ARMeilleure/Instructions/NativeInterface.cs
@@ -136,6 +136,11 @@ namespace ARMeilleure.Instructions
             return GetContext().CntpctEl0;
         }
 
+        public static ulong GetCntvctEl0()
+        {
+            return GetContext().CntvctEl0;
+        }
+
         public static void SetFpcr(ulong value)
         {
             GetContext().Fpcr = (FPCR)value;

--- a/ARMeilleure/State/ExecutionContext.cs
+++ b/ARMeilleure/State/ExecutionContext.cs
@@ -33,7 +33,7 @@ namespace ARMeilleure.State
         }
 
         // CNTVCT_EL0 = CNTPCT_EL0 - CNTVOFF_EL2
-        // Since CNTVOFF_EL2 cannot be accessed in EL0, it is treated as 0.
+        // Since EL2 isn't implemented, CNTVOFF_EL2 = 0
         public ulong CntvctEl0 => CntpctEl0;
 
         public static TimeSpan ElapsedTime => _tickCounter.Elapsed;

--- a/ARMeilleure/State/ExecutionContext.cs
+++ b/ARMeilleure/State/ExecutionContext.cs
@@ -32,6 +32,10 @@ namespace ARMeilleure.State
             }
         }
 
+        // CNTVCT_EL0 = CNTPCT_EL0 - CNTVOFF_EL2
+        // Since CNTVOFF_EL2 cannot be accessed in EL0, it is treated as 0.
+        public ulong CntvctEl0 => CntpctEl0;
+
         public static TimeSpan ElapsedTime => _tickCounter.Elapsed;
 
         public long TpidrEl0 { get; set; }


### PR DESCRIPTION
This implements MRS load from `CNTVCT_EL0`. Not sure why a game needs to read a virtual timer, but ~~unprivileged access means `CNTVCT_EL0 = CNTPCT_EL0`.~~ since EL2 isn't implemented,  `CNTVCT_EL0 = CNTPCT_EL0`


Should Fix launch crash in https://github.com/Ryujinx/Ryujinx-Games-List/issues/1309