### PR TITLE
Optimize texture format conversion, and MethodCopyBuffer

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/MethodCopyBuffer.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodCopyBuffer.cs
@@ -61,7 +61,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
                 (int dstBaseOffset, int dstSize) = dstCalculator.GetRectangleRange(dst.RegionX, dst.RegionY, cbp.XCount, cbp.YCount);
 
                 ReadOnlySpan<byte> srcSpan = _context.PhysicalMemory.GetSpan(srcBaseAddress + (ulong)srcBaseOffset, srcSize);
-                Span<byte> dstSpan = new Span<byte>(_context.PhysicalMemory.GetSpan(dstBaseAddress + (ulong)dstBaseOffset, dstSize).ToArray());
+                Span<byte> dstSpan = _context.PhysicalMemory.GetSpan(dstBaseAddress + (ulong)dstBaseOffset, dstSize).ToArray();
 
                 bool completeSource = src.RegionX == 0 && src.RegionY == 0 && src.Width == cbp.XCount && src.Height == cbp.YCount;
                 bool completeDest = dst.RegionX == 0 && dst.RegionY == 0 && dst.Width == cbp.XCount && dst.Height == cbp.YCount;

--- a/Ryujinx.Graphics.Gpu/Engine/MethodCopyBuffer.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodCopyBuffer.cs
@@ -7,7 +7,6 @@ namespace Ryujinx.Graphics.Gpu.Engine
 {
     partial class Methods
     {
-
         /// <summary>
         /// Performs a buffer to buffer, or buffer to texture copy.
         /// </summary>

--- a/Ryujinx.Graphics.Gpu/Engine/MethodCopyBuffer.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodCopyBuffer.cs
@@ -76,6 +76,9 @@ namespace Ryujinx.Graphics.Gpu.Engine
                     {
                         fixed (byte* dstPtr = dstSpan, srcPtr = srcSpan)
                         {
+                            byte* dstBase = dstPtr - dstBaseOffset; // Layout offset is relative to the base, so we need to subtract the span's offset.
+                            byte* srcBase = srcPtr - srcBaseOffset;
+
                             for (int y = 0; y < cbp.YCount; y++)
                             {
                                 srcCalculator.SetY(src.RegionY + y);
@@ -83,10 +86,10 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
                                 for (int x = 0; x < cbp.XCount; x++)
                                 {
-                                    int srcOffset = srcBaseOffset + srcCalculator.GetOffset(src.RegionX + x);
-                                    int dstOffset = dstBaseOffset + dstCalculator.GetOffset(dst.RegionX + x);
+                                    int srcOffset = srcCalculator.GetOffset(src.RegionX + x);
+                                    int dstOffset = dstCalculator.GetOffset(dst.RegionX + x);
 
-                                    *(T*)(dstPtr + dstOffset) = *(T*)(srcPtr + srcOffset);
+                                    *(T*)(dstBase + dstOffset) = *(T*)(srcBase + srcOffset);
                                 }
                             }
                         }

--- a/Ryujinx.Graphics.Gpu/Engine/MethodCopyBuffer.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodCopyBuffer.cs
@@ -73,7 +73,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
                 }
                 else 
                 {
-                    unsafe int Convert<T>(Span<byte> dstSpan, ReadOnlySpan<byte> srcSpan) where T : unmanaged
+                    unsafe bool Convert<T>(Span<byte> dstSpan, ReadOnlySpan<byte> srcSpan) where T : unmanaged
                     {
                         fixed (byte* dstPtr = dstSpan, srcPtr = srcSpan)
                         {
@@ -91,10 +91,10 @@ namespace Ryujinx.Graphics.Gpu.Engine
                                 }
                             }
                         }
-                        return 1;
+                        return true;
                     }
 
-                    int _ = srcBpp switch
+                    bool _ = srcBpp switch
                     {
                         1 => Convert<byte>(dstSpan, srcSpan),
                         2 => Convert<ushort>(dstSpan, srcSpan),

--- a/Ryujinx.Graphics.Gpu/Engine/MethodCopyBuffer.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodCopyBuffer.cs
@@ -108,7 +108,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
                     };
                 }
 
-                _context.PhysicalMemory.Write(dstBaseAddress, dstSpan);
+                _context.PhysicalMemory.Write(dstBaseAddress + (ulong)dstBaseOffset, dstSpan);
             }
             else
             {

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -84,6 +84,8 @@ namespace Ryujinx.Graphics.Gpu.Image
 
         private int _sequenceNumber;
 
+        private bool _noSync;
+
         /// <summary>
         /// Constructs a new instance of the cached GPU texture.
         /// </summary>
@@ -301,7 +303,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             // Texture buffers are not handled here, instead they are invalidated (if modified)
             // when the texture is bound. This is handled by the buffer manager.
-            if ((_sequenceNumber == _context.SequenceNumber && _hasData) || Info.Target == Target.TextureBuffer)
+            if ((_sequenceNumber == _context.SequenceNumber && _hasData) || _noSync)
             {
                 return;
             }
@@ -999,6 +1001,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             _depth  = info.GetDepth();
             _layers = info.GetLayers();
+            _noSync = Info.Target == Target.TextureBuffer;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -84,8 +84,6 @@ namespace Ryujinx.Graphics.Gpu.Image
 
         private int _sequenceNumber;
 
-        private bool _noSync;
-
         /// <summary>
         /// Constructs a new instance of the cached GPU texture.
         /// </summary>
@@ -303,7 +301,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             // Texture buffers are not handled here, instead they are invalidated (if modified)
             // when the texture is bound. This is handled by the buffer manager.
-            if ((_sequenceNumber == _context.SequenceNumber && _hasData) || _noSync)
+            if ((_sequenceNumber == _context.SequenceNumber && _hasData) || Info.Target == Target.TextureBuffer)
             {
                 return;
             }
@@ -1001,7 +999,6 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             _depth  = info.GetDepth();
             _layers = info.GetLayers();
-            _noSync = Info.Target == Target.TextureBuffer;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Texture/BlockLinearLayout.cs
+++ b/Ryujinx.Graphics.Texture/BlockLinearLayout.cs
@@ -118,7 +118,11 @@ namespace Ryujinx.Graphics.Texture
 
         public bool LayoutMatches(BlockLinearLayout other)
         {
-            return _robSize == other._robSize && _sliceSize == other._sliceSize && _texBpp == other._texBpp && _bhMask == other._bhMask && _bdMask == other._bdMask;
+            return _robSize == other._robSize &&
+                   _sliceSize == other._sliceSize &&
+                   _texBpp == other._texBpp &&
+                   _bhMask == other._bhMask &&
+                   _bdMask == other._bdMask;
         }
 
         // Functions for built in iteration.

--- a/Ryujinx.Graphics.Texture/BlockLinearLayout.cs
+++ b/Ryujinx.Graphics.Texture/BlockLinearLayout.cs
@@ -102,6 +102,23 @@ namespace Ryujinx.Graphics.Texture
             return offset;
         }
 
+        public (int offset, int size) GetRectangleRange(int x, int y, int width, int height)
+        {
+            // Justification:
+            // The offset is a combination of separate x and y parts.
+            // Both components increase with input and never overlap bits.
+            // Therefore for each component, the minimum input value is the lowest that component can go. Opposite goes for maximum.
+
+            int start = GetOffset(x, y, 0);
+            int end = GetOffset(x + width, y + height, 0);
+            return (start, (end - start) + _texBpp);
+        }
+
+        public bool LayoutMatches(BlockLinearLayout other)
+        {
+            return _robSize == other._robSize && _sliceSize == other._sliceSize && _texBpp == other._texBpp && _bhMask == other._bhMask && _bdMask == other._bdMask;
+        }
+
         // Functions for built in iteration.
         // Components of the offset can be updated separately, and combined to save some time.
 

--- a/Ryujinx.Graphics.Texture/Bpp12Pixel.cs
+++ b/Ryujinx.Graphics.Texture/Bpp12Pixel.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.Graphics.Texture
+{
+    [StructLayout(LayoutKind.Sequential, Pack = 1, Size = 12)]
+    public struct Bpp12Pixel
+    {
+        private ulong _elem1;
+        private uint _elem2;
+    }
+}

--- a/Ryujinx.Graphics.Texture/LayoutConverter.cs
+++ b/Ryujinx.Graphics.Texture/LayoutConverter.cs
@@ -64,7 +64,6 @@ namespace Ryujinx.Graphics.Texture
                 }
 
                 int strideTrunc = BitUtils.AlignDown(w * bytesPerPixel, 16);
-
                 int strideTrunc64 = BitUtils.AlignDown(w * bytesPerPixel, 64);
 
                 int xStart = strideTrunc / bytesPerPixel;
@@ -237,7 +236,6 @@ namespace Ryujinx.Graphics.Texture
                 }
 
                 int strideTrunc = BitUtils.AlignDown(w * bytesPerPixel, 16);
-
                 int strideTrunc64 = BitUtils.AlignDown(w * bytesPerPixel, 64);
 
                 int xStart = strideTrunc / bytesPerPixel;

--- a/Ryujinx.Graphics.Texture/LayoutConverter.cs
+++ b/Ryujinx.Graphics.Texture/LayoutConverter.cs
@@ -297,7 +297,7 @@ namespace Ryujinx.Graphics.Texture
                                         *(Vector128<byte>*)offset4 = value4;
                                     }
 
-                                    for (int x = 0; x < strideTrunc; x += 16, inPtr += 16)
+                                    for (int x = strideTrunc64; x < strideTrunc; x += 16, inPtr += 16)
                                     {
                                         byte* offset = outBaseOffset + layoutConverter.GetOffsetWithLineOffset16(x);
 

--- a/Ryujinx.Graphics.Texture/LayoutConverter.cs
+++ b/Ryujinx.Graphics.Texture/LayoutConverter.cs
@@ -1,6 +1,5 @@
 using Ryujinx.Common;
 using System;
-using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using static Ryujinx.Graphics.Texture.BlockLinearConstants;
 
@@ -10,7 +9,7 @@ namespace Ryujinx.Graphics.Texture
     {
         private const int HostStrideAlignment = 4;
 
-        private static unsafe Span<byte> ConvertBlockLinearToLinear<T>(
+        public static Span<byte> ConvertBlockLinearToLinear(
             int width,
             int height,
             int depth,
@@ -18,14 +17,13 @@ namespace Ryujinx.Graphics.Texture
             int layers,
             int blockWidth,
             int blockHeight,
+            int bytesPerPixel,
             int gobBlocksInY,
             int gobBlocksInZ,
             int gobBlocksInTileX,
             SizeInfo sizeInfo,
-            ReadOnlySpan<byte> data) where T : unmanaged
+            ReadOnlySpan<byte> data)
         {
-            int bytesPerPixel = Unsafe.SizeOf<T>();
-
             int outSize = GetTextureSize(
                 width,
                 height,
@@ -91,87 +89,75 @@ namespace Ryujinx.Graphics.Texture
                     mipGobBlocksInZ,
                     bytesPerPixel);
 
-                fixed (byte* outputPtr = output, dataPtr = data)
+                unsafe bool Convert<T>(Span<byte> output, ReadOnlySpan<byte> data) where T : unmanaged
                 {
-                    byte* outPtr = outputPtr + outOffs;
-                    for (int layer = 0; layer < layers; layer++)
+                    fixed (byte* outputPtr = output, dataPtr = data)
                     {
-                        byte* inBaseOffset = dataPtr + (layer * sizeInfo.LayerSize + sizeInfo.GetMipOffset(level));
-
-                        for (int z = 0; z < d; z++)
+                        byte* outPtr = outputPtr + outOffs;
+                        for (int layer = 0; layer < layers; layer++)
                         {
-                            layoutConverter.SetZ(z);
-                            for (int y = 0; y < h; y++)
+                            byte* inBaseOffset = dataPtr + (layer * sizeInfo.LayerSize + sizeInfo.GetMipOffset(level));
+
+                            for (int z = 0; z < d; z++)
                             {
-                                layoutConverter.SetY(y);
-
-                                for (int x = 0; x < strideTrunc64; x += 64, outPtr += 64)
+                                layoutConverter.SetZ(z);
+                                for (int y = 0; y < h; y++)
                                 {
-                                    byte* offset = inBaseOffset + layoutConverter.GetOffsetWithLineOffset64(x);
-                                    byte* offset2 = offset + 0x20;
-                                    byte* offset3 = offset + 0x100;
-                                    byte* offset4 = offset + 0x120;
+                                    layoutConverter.SetY(y);
 
-                                    Vector128<byte> value = *(Vector128<byte>*)offset;
-                                    Vector128<byte> value2 = *(Vector128<byte>*)offset2;
-                                    Vector128<byte> value3 = *(Vector128<byte>*)offset3;
-                                    Vector128<byte> value4 = *(Vector128<byte>*)offset4;
+                                    for (int x = 0; x < strideTrunc64; x += 64, outPtr += 64)
+                                    {
+                                        byte* offset = inBaseOffset + layoutConverter.GetOffsetWithLineOffset64(x);
+                                        byte* offset2 = offset + 0x20;
+                                        byte* offset3 = offset + 0x100;
+                                        byte* offset4 = offset + 0x120;
 
-                                    *(Vector128<byte>*)outPtr = value;
-                                    *(Vector128<byte>*)(outPtr + 16) = value2;
-                                    *(Vector128<byte>*)(outPtr + 32) = value3;
-                                    *(Vector128<byte>*)(outPtr + 48) = value4;
+                                        Vector128<byte> value = *(Vector128<byte>*)offset;
+                                        Vector128<byte> value2 = *(Vector128<byte>*)offset2;
+                                        Vector128<byte> value3 = *(Vector128<byte>*)offset3;
+                                        Vector128<byte> value4 = *(Vector128<byte>*)offset4;
+
+                                        *(Vector128<byte>*)outPtr = value;
+                                        *(Vector128<byte>*)(outPtr + 16) = value2;
+                                        *(Vector128<byte>*)(outPtr + 32) = value3;
+                                        *(Vector128<byte>*)(outPtr + 48) = value4;
+                                    }
+
+                                    for (int x = strideTrunc64; x < strideTrunc; x += 16, outPtr += 16)
+                                    {
+                                        byte* offset = inBaseOffset + layoutConverter.GetOffsetWithLineOffset16(x);
+
+                                        *(Vector128<byte>*)outPtr = *(Vector128<byte>*)offset;
+                                    }
+
+                                    for (int x = xStart; x < w; x++, outPtr += bytesPerPixel)
+                                    {
+                                        byte* offset = inBaseOffset + layoutConverter.GetOffset(x);
+
+                                        *(T*)outPtr = *(T*)offset;
+                                    }
+
+                                    outPtr += outStrideGap;
                                 }
-
-                                for (int x = strideTrunc64; x < strideTrunc; x += 16, outPtr += 16)
-                                {
-                                    byte* offset = inBaseOffset + layoutConverter.GetOffsetWithLineOffset16(x);
-
-                                    *(Vector128<byte>*)outPtr = *(Vector128<byte>*)offset;
-                                }
-
-                                for (int x = xStart; x < w; x++, outPtr += bytesPerPixel)
-                                {
-                                    byte* offset = inBaseOffset + layoutConverter.GetOffset(x);
-
-                                    *(T*)outPtr = *(T*)offset;
-                                }
-
-                                outPtr += outStrideGap;
                             }
                         }
+                        outOffs += stride * h * d * layers;
                     }
-                    outOffs += stride * h * d * layers;
+                    return true;
                 }
+
+                bool _ = bytesPerPixel switch
+                {
+                    1 => Convert<byte>(output, data),
+                    2 => Convert<ushort>(output, data),
+                    4 => Convert<uint>(output, data),
+                    8 => Convert<ulong>(output, data),
+                    12 => Convert<Bpp12Pixel>(output, data),
+                    16 => Convert<Vector128<byte>>(output, data),
+                    _ => throw new NotSupportedException($"Unable to convert ${bytesPerPixel} bpp pixel format.")
+                };
             }
             return output;
-        }
-
-        public static Span<byte> ConvertBlockLinearToLinear(
-            int width,
-            int height,
-            int depth,
-            int levels,
-            int layers,
-            int blockWidth,
-            int blockHeight,
-            int bytesPerPixel,
-            int gobBlocksInY,
-            int gobBlocksInZ,
-            int gobBlocksInTileX,
-            SizeInfo sizeInfo,
-            ReadOnlySpan<byte> data)
-        {
-            return bytesPerPixel switch
-            {
-                1 => ConvertBlockLinearToLinear<byte>(width, height, depth, levels, layers, blockWidth, blockHeight, gobBlocksInY, gobBlocksInZ, gobBlocksInTileX, sizeInfo, data),
-                2 => ConvertBlockLinearToLinear<ushort>(width, height, depth, levels, layers, blockWidth, blockHeight, gobBlocksInY, gobBlocksInZ, gobBlocksInTileX, sizeInfo, data),
-                4 => ConvertBlockLinearToLinear<uint>(width, height, depth, levels, layers, blockWidth, blockHeight, gobBlocksInY, gobBlocksInZ, gobBlocksInTileX, sizeInfo, data),
-                8 => ConvertBlockLinearToLinear<ulong>(width, height, depth, levels, layers, blockWidth, blockHeight, gobBlocksInY, gobBlocksInZ, gobBlocksInTileX, sizeInfo, data),
-                12 => ConvertBlockLinearToLinear<Bpp12Pixel>(width, height, depth, levels, layers, blockWidth, blockHeight, gobBlocksInY, gobBlocksInZ, gobBlocksInTileX, sizeInfo, data),
-                16 => ConvertBlockLinearToLinear<Vector128<byte>>(width, height, depth, levels, layers, blockWidth, blockHeight, gobBlocksInY, gobBlocksInZ, gobBlocksInTileX, sizeInfo, data),
-                _ => throw new NotSupportedException($"Unable to convert ${bytesPerPixel} bpp pixel format.")
-            };
         }
 
         public static Span<byte> ConvertLinearStridedToLinear(
@@ -205,7 +191,7 @@ namespace Ryujinx.Graphics.Texture
             return output;
         }
 
-        private static unsafe Span<byte> ConvertLinearToBlockLinear<T>(
+        public static Span<byte> ConvertLinearToBlockLinear(
             int width,
             int height,
             int depth,
@@ -213,14 +199,13 @@ namespace Ryujinx.Graphics.Texture
             int layers,
             int blockWidth,
             int blockHeight,
+            int bytesPerPixel,
             int gobBlocksInY,
             int gobBlocksInZ,
             int gobBlocksInTileX,
             SizeInfo sizeInfo,
-            ReadOnlySpan<byte> data) where T : unmanaged
+            ReadOnlySpan<byte> data)
         {
-            int bytesPerPixel = Unsafe.SizeOf<T>();
-
             Span<byte> output = new byte[sizeInfo.TotalSize];
 
             int inOffs = 0;
@@ -276,88 +261,76 @@ namespace Ryujinx.Graphics.Texture
                     mipGobBlocksInZ,
                     bytesPerPixel);
 
-                fixed (byte* outputPtr = output, dataPtr = data)
+                unsafe bool Convert<T>(Span<byte> output, ReadOnlySpan<byte> data) where T : unmanaged
                 {
-                    byte* inPtr = dataPtr + inOffs;
-                    for (int layer = 0; layer < layers; layer++)
+                    fixed (byte* outputPtr = output, dataPtr = data)
                     {
-                        byte* outBaseOffset = outputPtr + (layer * sizeInfo.LayerSize + sizeInfo.GetMipOffset(level));
-
-                        for (int z = 0; z < d; z++)
+                        byte* inPtr = dataPtr + inOffs;
+                        for (int layer = 0; layer < layers; layer++)
                         {
-                            layoutConverter.SetZ(z);
-                            for (int y = 0; y < h; y++)
+                            byte* outBaseOffset = outputPtr + (layer * sizeInfo.LayerSize + sizeInfo.GetMipOffset(level));
+
+                            for (int z = 0; z < d; z++)
                             {
-                                layoutConverter.SetY(y);
-
-                                for (int x = 0; x < strideTrunc64; x += 64, inPtr += 64)
+                                layoutConverter.SetZ(z);
+                                for (int y = 0; y < h; y++)
                                 {
-                                    byte* offset = outBaseOffset + layoutConverter.GetOffsetWithLineOffset64(x);
-                                    byte* offset2 = offset + 0x20;
-                                    byte* offset3 = offset + 0x100;
-                                    byte* offset4 = offset + 0x120;
+                                    layoutConverter.SetY(y);
 
-                                    Vector128<byte> value = *(Vector128<byte>*)inPtr;
-                                    Vector128<byte> value2 = *(Vector128<byte>*)(inPtr + 16);
-                                    Vector128<byte> value3 = *(Vector128<byte>*)(inPtr + 32);
-                                    Vector128<byte> value4 = *(Vector128<byte>*)(inPtr + 48);
+                                    for (int x = 0; x < strideTrunc64; x += 64, inPtr += 64)
+                                    {
+                                        byte* offset = outBaseOffset + layoutConverter.GetOffsetWithLineOffset64(x);
+                                        byte* offset2 = offset + 0x20;
+                                        byte* offset3 = offset + 0x100;
+                                        byte* offset4 = offset + 0x120;
 
-                                    *(Vector128<byte>*)offset = value;
-                                    *(Vector128<byte>*)offset2 = value2;
-                                    *(Vector128<byte>*)offset3 = value3;
-                                    *(Vector128<byte>*)offset4 = value4;
+                                        Vector128<byte> value = *(Vector128<byte>*)inPtr;
+                                        Vector128<byte> value2 = *(Vector128<byte>*)(inPtr + 16);
+                                        Vector128<byte> value3 = *(Vector128<byte>*)(inPtr + 32);
+                                        Vector128<byte> value4 = *(Vector128<byte>*)(inPtr + 48);
+
+                                        *(Vector128<byte>*)offset = value;
+                                        *(Vector128<byte>*)offset2 = value2;
+                                        *(Vector128<byte>*)offset3 = value3;
+                                        *(Vector128<byte>*)offset4 = value4;
+                                    }
+
+                                    for (int x = strideTrunc64; x < strideTrunc; x += 16, inPtr += 16)
+                                    {
+                                        byte* offset = outBaseOffset + layoutConverter.GetOffsetWithLineOffset16(x);
+
+                                        *(Vector128<byte>*)offset = *(Vector128<byte>*)inPtr;
+                                    }
+
+                                    for (int x = xStart; x < w; x++, inPtr += bytesPerPixel)
+                                    {
+                                        byte* offset = outBaseOffset + layoutConverter.GetOffset(x);
+
+                                        *(T*)offset = *(T*)inPtr;
+                                    }
+
+                                    inPtr += inStrideGap;
                                 }
-
-                                for (int x = strideTrunc64; x < strideTrunc; x += 16, inPtr += 16)
-                                {
-                                    byte* offset = outBaseOffset + layoutConverter.GetOffsetWithLineOffset16(x);
-
-                                    *(Vector128<byte>*)offset = *(Vector128<byte>*)inPtr;
-                                }
-
-                                for (int x = xStart; x < w; x++, inPtr += bytesPerPixel)
-                                {
-                                    byte* offset = outBaseOffset + layoutConverter.GetOffset(x);
-
-                                    *(T*)offset = *(T*)inPtr;
-                                }
-
-                                inPtr += inStrideGap;
                             }
                         }
+                        inOffs += stride * h * d * layers;
                     }
-                    inOffs += stride * h * d * layers;
+                    return true;
                 }
+
+                bool _ = bytesPerPixel switch
+                {
+                    1 => Convert<byte>(output, data),
+                    2 => Convert<ushort>(output, data),
+                    4 => Convert<uint>(output, data),
+                    8 => Convert<ulong>(output, data),
+                    12 => Convert<Bpp12Pixel>(output, data),
+                    16 => Convert<Vector128<byte>>(output, data),
+                    _ => throw new NotSupportedException($"Unable to convert ${bytesPerPixel} bpp pixel format.")
+                };
             }
 
             return output;
-        }
-
-        public static Span<byte> ConvertLinearToBlockLinear(
-            int width,
-            int height,
-            int depth,
-            int levels,
-            int layers,
-            int blockWidth,
-            int blockHeight,
-            int bytesPerPixel,
-            int gobBlocksInY,
-            int gobBlocksInZ,
-            int gobBlocksInTileX,
-            SizeInfo sizeInfo,
-            ReadOnlySpan<byte> data)
-        {
-            return bytesPerPixel switch
-            {
-                1 => ConvertLinearToBlockLinear<byte>(width, height, depth, levels, layers, blockWidth, blockHeight, gobBlocksInY, gobBlocksInZ, gobBlocksInTileX, sizeInfo, data),
-                2 => ConvertLinearToBlockLinear<ushort>(width, height, depth, levels, layers, blockWidth, blockHeight, gobBlocksInY, gobBlocksInZ, gobBlocksInTileX, sizeInfo, data),
-                4 => ConvertLinearToBlockLinear<uint>(width, height, depth, levels, layers, blockWidth, blockHeight, gobBlocksInY, gobBlocksInZ, gobBlocksInTileX, sizeInfo, data),
-                8 => ConvertLinearToBlockLinear<ulong>(width, height, depth, levels, layers, blockWidth, blockHeight, gobBlocksInY, gobBlocksInZ, gobBlocksInTileX, sizeInfo, data),
-                12 => ConvertLinearToBlockLinear<Bpp12Pixel>(width, height, depth, levels, layers, blockWidth, blockHeight, gobBlocksInY, gobBlocksInZ, gobBlocksInTileX, sizeInfo, data),
-                16 => ConvertLinearToBlockLinear<Vector128<byte>>(width, height, depth, levels, layers, blockWidth, blockHeight, gobBlocksInY, gobBlocksInZ, gobBlocksInTileX, sizeInfo, data),
-                _ => throw new NotSupportedException($"Unable to convert ${bytesPerPixel} bpp pixel format.")
-            };
         }
 
         public static Span<byte> ConvertLinearToLinearStrided(

--- a/Ryujinx.Graphics.Texture/LayoutConverter.cs
+++ b/Ryujinx.Graphics.Texture/LayoutConverter.cs
@@ -41,14 +41,14 @@ namespace Ryujinx.Graphics.Texture
             int mipGobBlocksInY = gobBlocksInY;
             int mipGobBlocksInZ = gobBlocksInZ;
 
-            int gobWidth = (GobStride / bytesPerPixel) * gobBlocksInTileX;
+            int gobWidth  = (GobStride / bytesPerPixel) * gobBlocksInTileX;
             int gobHeight = gobBlocksInY * GobHeight;
 
             for (int level = 0; level < levels; level++)
             {
-                int w = Math.Max(1, width >> level);
+                int w = Math.Max(1, width  >> level);
                 int h = Math.Max(1, height >> level);
-                int d = Math.Max(1, depth >> level);
+                int d = Math.Max(1, depth  >> level);
 
                 w = BitUtils.DivRoundUp(w, blockWidth);
                 h = BitUtils.DivRoundUp(h, blockHeight);
@@ -344,7 +344,7 @@ namespace Ryujinx.Graphics.Texture
             int bytesPerPixel,
             ReadOnlySpan<byte> data)
         {
-            int w = BitUtils.DivRoundUp(width, blockWidth);
+            int w = BitUtils.DivRoundUp(width,  blockWidth);
             int h = BitUtils.DivRoundUp(height, blockHeight);
 
             int inStride = BitUtils.AlignUp(w * bytesPerPixel, HostStrideAlignment);

--- a/Ryujinx.Graphics.Texture/LayoutConverter.cs
+++ b/Ryujinx.Graphics.Texture/LayoutConverter.cs
@@ -65,9 +65,13 @@ namespace Ryujinx.Graphics.Texture
 
                 int strideTrunc = BitUtils.AlignDown(w * bytesPerPixel, 16);
 
+                int strideTrunc64 = BitUtils.AlignDown(w * bytesPerPixel, 64);
+
                 int xStart = strideTrunc / bytesPerPixel;
 
                 int stride = BitUtils.AlignUp(w * bytesPerPixel, HostStrideAlignment);
+
+                int outStrideGap = stride - w * bytesPerPixel;
 
                 int alignment = gobWidth;
 
@@ -86,13 +90,14 @@ namespace Ryujinx.Graphics.Texture
                     mipGobBlocksInZ,
                     bytesPerPixel);
 
-                unsafe void Convert<T>(Span<byte> output, ReadOnlySpan<byte> data) where T : unmanaged
+                unsafe bool Convert<T>(Span<byte> output, ReadOnlySpan<byte> data) where T : unmanaged
                 {
-                    fixed (byte* outputBPtr = output, dataBPtr = data)
+                    fixed (byte* outputPtr = output, dataPtr = data)
                     {
+                        byte* outPtr = outputPtr + outOffs;
                         for (int layer = 0; layer < layers; layer++)
                         {
-                            int inBaseOffset = layer * sizeInfo.LayerSize + sizeInfo.GetMipOffset(level);
+                            byte* inBaseOffset = dataPtr + (layer * sizeInfo.LayerSize + sizeInfo.GetMipOffset(level));
 
                             for (int z = 0; z < d; z++)
                             {
@@ -100,51 +105,58 @@ namespace Ryujinx.Graphics.Texture
                                 for (int y = 0; y < h; y++)
                                 {
                                     layoutConverter.SetY(y);
-                                    for (int x = 0; x < strideTrunc; x += 16)
-                                    {
-                                        int offset = inBaseOffset + layoutConverter.GetOffsetWithLineOffset(x);
 
-                                        *(Vector128<byte>*)(outputBPtr + outOffs + x) = *(Vector128<byte>*)(dataBPtr + offset);
+                                    for (int x = 0; x < strideTrunc64; x += 64, outPtr += 64)
+                                    {
+                                        byte* offset = inBaseOffset + layoutConverter.GetOffsetWithLineOffset64(x);
+                                        byte* offset2 = offset + 0x20;
+                                        byte* offset3 = offset + 0x100;
+                                        byte* offset4 = offset + 0x120;
+
+                                        Vector128<byte> value = *(Vector128<byte>*)offset;
+                                        Vector128<byte> value2 = *(Vector128<byte>*)offset2;
+                                        Vector128<byte> value3 = *(Vector128<byte>*)offset3;
+                                        Vector128<byte> value4 = *(Vector128<byte>*)offset4;
+
+                                        *(Vector128<byte>*)outPtr = value;
+                                        *(Vector128<byte>*)(outPtr + 16) = value2;
+                                        *(Vector128<byte>*)(outPtr + 32) = value3;
+                                        *(Vector128<byte>*)(outPtr + 48) = value4;
                                     }
 
-                                    for (int x = xStart; x < w; x++)
+                                    for (int x = strideTrunc64; x < strideTrunc; x += 16, outPtr += 16)
                                     {
-                                        int offset = inBaseOffset + layoutConverter.GetOffset(x);
+                                        byte* offset = inBaseOffset + layoutConverter.GetOffsetWithLineOffset16(x);
 
-                                        ((T*)(outputBPtr + outOffs))[x] = *(T*)(dataBPtr + offset);
+                                        *(Vector128<byte>*)outPtr = *(Vector128<byte>*)offset;
                                     }
 
-                                    outOffs += stride;
+                                    for (int x = xStart; x < w; x++, outPtr += bytesPerPixel)
+                                    {
+                                        byte* offset = inBaseOffset + layoutConverter.GetOffset(x);
+
+                                        *(T*)outPtr = *(T*)offset;
+                                    }
+
+                                    outPtr += outStrideGap;
                                 }
                             }
                         }
+                        outOffs += stride * h * d * layers;
                     }
+                    return true;
                 }
 
-                switch (bytesPerPixel)
+                bool _ = bytesPerPixel switch
                 {
-                    case 1:
-                        Convert<byte>(output, data);
-                        break;
-                    case 2:
-                        Convert<ushort>(output, data);
-                        break;
-                    case 4:
-                        Convert<uint>(output, data);
-                        break;
-                    case 8:
-                        Convert<ulong>(output, data);
-                        break;
-                    case 12:
-                        Convert<Bpp12Pixel>(output, data);
-                        break;
-                    case 16:
-                        Convert<Vector128<byte>>(output, data);
-                        break;
-
-                    default:
-                        throw new NotSupportedException($"Unable to convert ${bytesPerPixel} bpp pixel format.");
-                }
+                    1 => Convert<byte>(output, data),
+                    2 => Convert<ushort>(output, data),
+                    4 => Convert<uint>(output, data),
+                    8 => Convert<ulong>(output, data),
+                    12 => Convert<Bpp12Pixel>(output, data),
+                    16 => Convert<Vector128<byte>>(output, data),
+                    _ => throw new NotSupportedException($"Unable to convert ${bytesPerPixel} bpp pixel format.")
+                };
             }
             return output;
         }
@@ -162,52 +174,19 @@ namespace Ryujinx.Graphics.Texture
             int h = BitUtils.DivRoundUp(height, blockHeight);
 
             int outStride = BitUtils.AlignUp(w * bytesPerPixel, HostStrideAlignment);
+            int lineSize = w * bytesPerPixel;
 
             Span<byte> output = new byte[h * outStride];
 
             int outOffs = 0;
+            int inOffs = 0;
 
-            unsafe void Convert<T>(Span<byte> output, ReadOnlySpan<byte> data) where T : unmanaged
+            for (int y = 0; y < h; y++)
             {
-                fixed (byte* outputBPtr = output, dataBPtr = data)
-                {
-                    for (int y = 0; y < h; y++)
-                    {
-                        for (int x = 0; x < w; x++)
-                        {
-                            int offset = y * stride + x * bytesPerPixel;
+                data.Slice(inOffs, lineSize).CopyTo(output.Slice(outOffs, lineSize));
 
-                            ((T*)(outputBPtr + outOffs))[x] = *(T*)(dataBPtr + offset);
-                        }
-
-                        outOffs += outStride;
-                    }
-                }
-            }
-
-            switch (bytesPerPixel)
-            {
-                case 1:
-                    Convert<byte>(output, data);
-                    break;
-                case 2:
-                    Convert<ushort>(output, data);
-                    break;
-                case 4:
-                    Convert<uint>(output, data);
-                    break;
-                case 8:
-                    Convert<ulong>(output, data);
-                    break;
-                case 12:
-                    Convert<Bpp12Pixel>(output, data);
-                    break;
-                case 16:
-                    Convert<Vector128<byte>>(output, data);
-                    break;
-
-                default:
-                    throw new NotSupportedException($"Unable to convert ${bytesPerPixel} bpp pixel format.");
+                inOffs += stride;
+                outOffs += outStride;
             }
 
             return output;
@@ -257,7 +236,15 @@ namespace Ryujinx.Graphics.Texture
                     mipGobBlocksInZ >>= 1;
                 }
 
+                int strideTrunc = BitUtils.AlignDown(w * bytesPerPixel, 16);
+
+                int strideTrunc64 = BitUtils.AlignDown(w * bytesPerPixel, 64);
+
+                int xStart = strideTrunc / bytesPerPixel;
+
                 int stride = BitUtils.AlignUp(w * bytesPerPixel, HostStrideAlignment);
+
+                int inStrideGap = stride - w * bytesPerPixel;
 
                 int alignment = gobWidth;
 
@@ -276,13 +263,14 @@ namespace Ryujinx.Graphics.Texture
                     mipGobBlocksInZ,
                     bytesPerPixel);
 
-                unsafe void Convert<T>(Span<byte> output, ReadOnlySpan<byte> data) where T : unmanaged
+                unsafe bool Convert<T>(Span<byte> output, ReadOnlySpan<byte> data) where T : unmanaged
                 {
-                    fixed (byte* outputBPtr = output, dataBPtr = data)
+                    fixed (byte* outputPtr = output, dataPtr = data)
                     {
+                        byte* inPtr = dataPtr + inOffs;
                         for (int layer = 0; layer < layers; layer++)
                         {
-                            int outBaseOffset = layer * sizeInfo.LayerSize + sizeInfo.GetMipOffset(level);
+                            byte* outBaseOffset = outputPtr + (layer * sizeInfo.LayerSize + sizeInfo.GetMipOffset(level));
 
                             for (int z = 0; z < d; z++)
                             {
@@ -290,44 +278,58 @@ namespace Ryujinx.Graphics.Texture
                                 for (int y = 0; y < h; y++)
                                 {
                                     layoutConverter.SetY(y);
-                                    for (int x = 0; x < w; x++)
-                                    {
-                                        int offset = outBaseOffset + layoutConverter.GetOffset(x);
 
-                                        *(T*)(outputBPtr + offset) = ((T*)(dataBPtr + inOffs))[x];
+                                    for (int x = 0; x < strideTrunc64; x += 64, inPtr += 64)
+                                    {
+                                        byte* offset = outBaseOffset + layoutConverter.GetOffsetWithLineOffset64(x);
+                                        byte* offset2 = offset + 0x20;
+                                        byte* offset3 = offset + 0x100;
+                                        byte* offset4 = offset + 0x120;
+
+                                        Vector128<byte> value = *(Vector128<byte>*)inPtr;
+                                        Vector128<byte> value2 = *(Vector128<byte>*)(inPtr + 16);
+                                        Vector128<byte> value3 = *(Vector128<byte>*)(inPtr + 32);
+                                        Vector128<byte> value4 = *(Vector128<byte>*)(inPtr + 48);
+
+                                        *(Vector128<byte>*)offset = value;
+                                        *(Vector128<byte>*)offset2 = value2;
+                                        *(Vector128<byte>*)offset3 = value3;
+                                        *(Vector128<byte>*)offset4 = value4;
                                     }
 
-                                    inOffs += stride;
+                                    for (int x = 0; x < strideTrunc; x += 16, inPtr += 16)
+                                    {
+                                        byte* offset = outBaseOffset + layoutConverter.GetOffsetWithLineOffset16(x);
+
+                                        *(Vector128<byte>*)offset = *(Vector128<byte>*)inPtr;
+                                    }
+
+                                    for (int x = xStart; x < w; x++, inPtr += bytesPerPixel)
+                                    {
+                                        byte* offset = outBaseOffset + layoutConverter.GetOffset(x);
+
+                                        *(T*)offset = *(T*)inPtr;
+                                    }
+
+                                    inPtr += inStrideGap;
                                 }
                             }
                         }
+                        inOffs += stride * h * d * layers;
                     }
+                    return true;
                 }
 
-                switch (bytesPerPixel)
+                bool _ = bytesPerPixel switch
                 {
-                    case 1:
-                        Convert<byte>(output, data);
-                        break;
-                    case 2:
-                        Convert<ushort>(output, data);
-                        break;
-                    case 4:
-                        Convert<uint>(output, data);
-                        break;
-                    case 8:
-                        Convert<ulong>(output, data);
-                        break;
-                    case 12:
-                        Convert<Bpp12Pixel>(output, data);
-                        break;
-                    case 16:
-                        Convert<Vector128<byte>>(output, data);
-                        break;
-
-                    default:
-                        throw new NotSupportedException($"Unable to convert ${bytesPerPixel} bpp pixel format.");
-                }
+                    1 => Convert<byte>(output, data),
+                    2 => Convert<ushort>(output, data),
+                    4 => Convert<uint>(output, data),
+                    8 => Convert<ulong>(output, data),
+                    12 => Convert<Bpp12Pixel>(output, data),
+                    16 => Convert<Vector128<byte>>(output, data),
+                    _ => throw new NotSupportedException($"Unable to convert ${bytesPerPixel} bpp pixel format.")
+                };
             }
 
             return output;
@@ -342,56 +344,23 @@ namespace Ryujinx.Graphics.Texture
             int bytesPerPixel,
             ReadOnlySpan<byte> data)
         {
-            int w = BitUtils.DivRoundUp(width,  blockWidth);
+            int w = BitUtils.DivRoundUp(width, blockWidth);
             int h = BitUtils.DivRoundUp(height, blockHeight);
 
             int inStride = BitUtils.AlignUp(w * bytesPerPixel, HostStrideAlignment);
+            int lineSize = width * bytesPerPixel;
 
             Span<byte> output = new byte[h * stride];
 
             int inOffs = 0;
+            int outOffs = 0;
 
-            unsafe void Convert<T>(Span<byte> output, ReadOnlySpan<byte> data) where T : unmanaged
+            for (int y = 0; y < h; y++)
             {
-                fixed (byte* outputBPtr = output, dataBPtr = data)
-                {
-                    for (int y = 0; y < h; y++)
-                    {
-                        for (int x = 0; x < w; x++)
-                        {
-                            int offset = y * stride + x * bytesPerPixel;
+                data.Slice(inOffs, lineSize).CopyTo(output.Slice(outOffs, lineSize));
 
-                            *(T*)(outputBPtr + offset) = ((T*)(dataBPtr + inOffs))[x];
-                        }
-
-                        inOffs += inStride;
-                    }
-                }
-            }
-
-            switch (bytesPerPixel)
-            {
-                case 1:
-                    Convert<byte>(output, data);
-                    break;
-                case 2:
-                    Convert<ushort>(output, data);
-                    break;
-                case 4:
-                    Convert<uint>(output, data);
-                    break;
-                case 8:
-                    Convert<ulong>(output, data);
-                    break;
-                case 12:
-                    Convert<Bpp12Pixel>(output, data);
-                    break;
-                case 16:
-                    Convert<Vector128<byte>>(output, data);
-                    break;
-
-                default:
-                    throw new NotSupportedException($"Unable to convert ${bytesPerPixel} bpp pixel format.");
+                inOffs += inStride;
+                outOffs += stride;
             }
 
             return output;

--- a/Ryujinx.Graphics.Texture/LayoutConverter.cs
+++ b/Ryujinx.Graphics.Texture/LayoutConverter.cs
@@ -1,6 +1,5 @@
 using Ryujinx.Common;
 using System;
-using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using static Ryujinx.Graphics.Texture.BlockLinearConstants;
 
@@ -8,13 +7,6 @@ namespace Ryujinx.Graphics.Texture
 {
     public static class LayoutConverter
     {
-        [StructLayout(LayoutKind.Sequential, Pack = 1, Size = 12)]
-        private struct Bpp12Pixel
-        {
-            private ulong _elem1;
-            private uint _elem2;
-        }
-
         private const int HostStrideAlignment = 4;
 
         public static Span<byte> ConvertBlockLinearToLinear(
@@ -288,7 +280,6 @@ namespace Ryujinx.Graphics.Texture
                 {
                     fixed (byte* outputBPtr = output, dataBPtr = data)
                     {
-                        T* outputPtr = (T*)outputBPtr, dataPtr = (T*)dataBPtr;
                         for (int layer = 0; layer < layers; layer++)
                         {
                             int outBaseOffset = layer * sizeInfo.LayerSize + sizeInfo.GetMipOffset(level);

--- a/Ryujinx.Graphics.Texture/OffsetCalculator.cs
+++ b/Ryujinx.Graphics.Texture/OffsetCalculator.cs
@@ -88,7 +88,9 @@ namespace Ryujinx.Graphics.Texture
         {
             if (_isLinear)
             {
-                return (y * _stride + x * _bytesPerPixel, height * _stride);
+                int start = y * _stride + x * _bytesPerPixel;
+                int end = (y + height - 1) * _stride + (x + width) * _bytesPerPixel;
+                return (start, end - start);
             }
             else
             {

--- a/Ryujinx.Graphics.Texture/OffsetCalculator.cs
+++ b/Ryujinx.Graphics.Texture/OffsetCalculator.cs
@@ -1,16 +1,21 @@
 using Ryujinx.Common;
-
+using System.Runtime.CompilerServices;
 using static Ryujinx.Graphics.Texture.BlockLinearConstants;
 
 namespace Ryujinx.Graphics.Texture
 {
     public class OffsetCalculator
     {
+        private int  _width;
+        private int  _height;
         private int  _stride;
         private bool _isLinear;
         private int  _bytesPerPixel;
 
         private BlockLinearLayout _layoutConverter;
+
+        // Variables for built in iteration.
+        private int _yPart;
 
         public OffsetCalculator(
             int  width,
@@ -20,6 +25,8 @@ namespace Ryujinx.Graphics.Texture
             int  gobBlocksInY,
             int  bytesPerPixel)
         {
+            _width         = width;
+            _height        = height;
             _stride        = stride;
             _isLinear      = isLinear;
             _bytesPerPixel = bytesPerPixel;
@@ -40,6 +47,18 @@ namespace Ryujinx.Graphics.Texture
             }
         }
 
+        public void SetY(int y)
+        {
+            if (_isLinear)
+            {
+                _yPart = y * _stride;
+            }
+            else
+            {
+                _layoutConverter.SetY(y);
+            }
+        }
+
         public int GetOffset(int x, int y)
         {
             if (_isLinear)
@@ -49,6 +68,56 @@ namespace Ryujinx.Graphics.Texture
             else
             {
                 return _layoutConverter.GetOffset(x, y, 0);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int GetOffset(int x)
+        {
+            if (_isLinear)
+            {
+                return x * _bytesPerPixel + _yPart;
+            }
+            else
+            {
+                return _layoutConverter.GetOffset(x);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public int GetOffsetWithLineOffset(int x)
+        {
+            if (_isLinear)
+            {
+                return x + _yPart;
+            }
+            else
+            {
+                return _layoutConverter.GetOffsetWithLineOffset(x);
+            }
+        }
+
+        public (int offset, int size) GetRectangleRange(int x, int y, int width, int height)
+        {
+            if (_isLinear)
+            {
+                return (y * _stride + x, height * _stride);
+            }
+            else
+            {
+                return _layoutConverter.GetRectangleRange(x, y, width, height);
+            }
+        }
+
+        public bool LayoutMatches(OffsetCalculator other)
+        {
+            if (_isLinear)
+            {
+                return other._isLinear && _width == other._width && _height == other._height && _stride == other._stride && _bytesPerPixel == other._bytesPerPixel;
+            }
+            else
+            {
+                return !other._isLinear && _layoutConverter.LayoutMatches(other._layoutConverter);
             }
         }
     }

--- a/Ryujinx.Graphics.Texture/OffsetCalculator.cs
+++ b/Ryujinx.Graphics.Texture/OffsetCalculator.cs
@@ -100,7 +100,11 @@ namespace Ryujinx.Graphics.Texture
         {
             if (_isLinear)
             {
-                return other._isLinear && _width == other._width && _height == other._height && _stride == other._stride && _bytesPerPixel == other._bytesPerPixel;
+                return other._isLinear &&
+                       _width == other._width &&
+                       _height == other._height &&
+                       _stride == other._stride &&
+                       _bytesPerPixel == other._bytesPerPixel;
             }
             else
             {

--- a/Ryujinx.Graphics.Texture/OffsetCalculator.cs
+++ b/Ryujinx.Graphics.Texture/OffsetCalculator.cs
@@ -84,24 +84,11 @@ namespace Ryujinx.Graphics.Texture
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public int GetOffsetWithLineOffset(int x)
-        {
-            if (_isLinear)
-            {
-                return x + _yPart;
-            }
-            else
-            {
-                return _layoutConverter.GetOffsetWithLineOffset(x);
-            }
-        }
-
         public (int offset, int size) GetRectangleRange(int x, int y, int width, int height)
         {
             if (_isLinear)
             {
-                return (y * _stride + x, height * _stride);
+                return (y * _stride + x * _bytesPerPixel, height * _stride);
             }
             else
             {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6294155/82759177-8bfd6d00-9de3-11ea-9bc3-73d25b0d12d7.png)

I'd recommend testing this on a few games to make sure nothing terrible happens, as it's pretty easy to make a mistake here. Greatly speeds up texture loading and flushing (though the GPU will still have to stall for this in master).

Most affected games: Nintendo Switch Online: Super Nintendo Entertainment System (and the NES one), any frames that uses nvdec (MK8 menu, SMO menu + tutorials, probably large black screen videos), maybe a bit less GPU related stuttering in games that stream textures.

List of changes:

- LayoutConverter has separate optimizations for LinearStrided and BlockLinear.
  - Block linear now copies using a generic unsafe helper method, that is passed a type representative of the pixel format we're manipulating. This allows us to obtain a function compiled specifically for copying that data type, rather than switching on byte size every time.
    - Similar to the previous BlockLinear -> Linear conversion, 16 byte copies and now 4x16 byte copies are now used when converting to _and_ from BlockLinear. This now uses a direct assignment of one Vector128<byte> to another, which proved to be 5.5x faster than the span copy between two 16 byte slices.
    - The 4x16 copy is performed for larger textures and should prove much faster due to a simpler offset calculation, and the potential for pipelining the loads and stores. Right now we iterate through three copy sizes to attempt to be as efficient as possible for arbitrary line widths: 64 byte copy, 16 byte copy and per-pixel copy.
  - Linear strided now copies entire lines at a time using Span slices, rather than individual pixels.
- MethodCopyBuffer now determines the range that will be affected, and uses a faster per pixel copy and offset calculation.
  - This greatly improves the performance when nvdec videos are present. (keeps the same out of bounds memory read that we had before now)
  - There is a new fast path that copies directly when both src and destination are the same size, crop rectangle = their sizes and have an identical layout.
  - If they were working, then they would already be in the correct format, so I'd imagine they will be able to take the new fast path to go straight to texture without conversion.