### PR TITLE
Fix GetDesiredLanguage

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
@@ -102,9 +102,9 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             if (((1 << (int)context.Device.System.State.DesiredTitleLanguage) & supportedLanguages) == 0)
             {
                 // Find first supported language from TitleLanguage. TODO: In the future, a GUI could enable user-specified search priority
-                int setIndex = 1;
+                int setIndex = 0;
 
-                while ((supportedLanguages & 1) != 0) // This call isn't perf critical, so no need for bit hacks
+                while ((supportedLanguages & 1) == 0) // This call isn't perf critical, so no need for bit hacks
                 {
                     supportedLanguages >>= 1; setIndex++;
                 }

--- a/Ryujinx.HLE/HOS/SystemState/SystemStateMgr.cs
+++ b/Ryujinx.HLE/HOS/SystemState/SystemStateMgr.cs
@@ -37,6 +37,8 @@ namespace Ryujinx.HLE.HOS.SystemState
 
         internal long DesiredKeyboardLayout { get; private set; }
 
+        internal SystemLanguage DesiredSystemLanguage { get; private set; }
+
         internal long DesiredLanguageCode { get; private set; }
 
         internal uint DesiredRegionCode { get; private set; }
@@ -68,7 +70,8 @@ namespace Ryujinx.HLE.HOS.SystemState
 
         public void SetLanguage(SystemLanguage language)
         {
-            DesiredLanguageCode = GetLanguageCode((int)language);
+            DesiredSystemLanguage = language;
+            DesiredLanguageCode = GetLanguageCode((int)DesiredSystemLanguage);
 
             switch (language)
             {

--- a/Ryujinx.HLE/HOS/SystemState/TitleLanguage.cs
+++ b/Ryujinx.HLE/HOS/SystemState/TitleLanguage.cs
@@ -16,6 +16,8 @@
         Russian,
         Korean,
         Taiwanese,
-        Chinese        
+        Chinese,
+        
+        MaxLength
     }
 }

--- a/Ryujinx.HLE/HOS/SystemState/TitleLanguage.cs
+++ b/Ryujinx.HLE/HOS/SystemState/TitleLanguage.cs
@@ -16,8 +16,6 @@
         Russian,
         Korean,
         Taiwanese,
-        Chinese,
-        
-        MaxLength
+        Chinese
     }
 }


### PR DESCRIPTION
Fixes wrong language selection when application doesn't support set system language.

XC2
![xc2-lang-fix](https://user-images.githubusercontent.com/62494521/82831854-2c808980-9ed7-11ea-9970-c142d4c6dd27.PNG)

Splatoon 2
![splatoon2-lang-fix](https://user-images.githubusercontent.com/62494521/82831857-2db1b680-9ed7-11ea-9588-ca6db188d082.PNG)


Before the fix, the above screens would show Japanese.

Please close this PR if it doesn't meet your standards. Just wrote a quick fix as it was annoying me. I've no interest in expanding this for now.

~~I give up. Can't even name the operation right~~ (Reworded 2nd commit to give proper name)