### PR TITLE
Fix wrong face culling once and for all

### DIFF
--- a/Ryujinx.Graphics.GAL/Capabilities.cs
+++ b/Ryujinx.Graphics.GAL/Capabilities.cs
@@ -5,26 +5,28 @@ namespace Ryujinx.Graphics.GAL
         public bool SupportsAstcCompression          { get; }
         public bool SupportsImageLoadFormatted       { get; }
         public bool SupportsNonConstantTextureOffset { get; }
+        public bool SupportsViewportSwizzle          { get; }
 
-        public int MaximumComputeSharedMemorySize { get; }
-        public int StorageBufferOffsetAlignment   { get; }
-
-        public float MaxSupportedAnisotropy { get; }
+        public int   MaximumComputeSharedMemorySize { get; }
+        public float MaximumSupportedAnisotropy     { get; }
+        public int   StorageBufferOffsetAlignment   { get; }
 
         public Capabilities(
             bool  supportsAstcCompression,
             bool  supportsImageLoadFormatted,
             bool  supportsNonConstantTextureOffset,
+            bool  supportsViewportSwizzle,
             int   maximumComputeSharedMemorySize,
-            int   storageBufferOffsetAlignment,
-            float maxSupportedAnisotropy)
+            float maximumSupportedAnisotropy,
+            int   storageBufferOffsetAlignment)
         {
             SupportsAstcCompression          = supportsAstcCompression;
             SupportsImageLoadFormatted       = supportsImageLoadFormatted;
             SupportsNonConstantTextureOffset = supportsNonConstantTextureOffset;
+            SupportsViewportSwizzle          = supportsViewportSwizzle;
             MaximumComputeSharedMemorySize   = maximumComputeSharedMemorySize;
+            MaximumSupportedAnisotropy       = maximumSupportedAnisotropy;
             StorageBufferOffsetAlignment     = storageBufferOffsetAlignment;
-            MaxSupportedAnisotropy           = maxSupportedAnisotropy;
         }
     }
 }

--- a/Ryujinx.Graphics.GAL/IPipeline.cs
+++ b/Ryujinx.Graphics.GAL/IPipeline.cs
@@ -42,6 +42,8 @@ namespace Ryujinx.Graphics.GAL
 
         void SetImage(int index, ShaderStage stage, ITexture texture);
 
+        void SetOrigin(Origin origin);
+
         void SetPointSize(float size);
 
         void SetPrimitiveRestart(bool enable, int index);

--- a/Ryujinx.Graphics.GAL/Origin.cs
+++ b/Ryujinx.Graphics.GAL/Origin.cs
@@ -1,0 +1,8 @@
+﻿namespace Ryujinx.Graphics.GAL
+{
+    public enum Origin
+    {
+        UpperLeft,
+        LowerLeft
+    }
+}

--- a/Ryujinx.Graphics.GAL/ViewportSwizzle.cs
+++ b/Ryujinx.Graphics.GAL/ViewportSwizzle.cs
@@ -2,13 +2,15 @@ namespace Ryujinx.Graphics.GAL
 {
     public enum ViewportSwizzle
     {
-        PositiveX,
-        NegativeX,
-        PositiveY,
-        NegativeY,
-        PositiveZ,
-        NegativeZ,
-        PositiveW,
-        NegativeW
+        PositiveX = 0,
+        NegativeX = 1,
+        PositiveY = 2,
+        NegativeY = 3,
+        PositiveZ = 4,
+        NegativeZ = 5,
+        PositiveW = 6,
+        NegativeW = 7,
+
+        NegativeFlag = 1
     }
 }

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -422,7 +422,13 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
             _context.Renderer.Pipeline.SetDepthMode(depthMode);
 
-            bool flipY = (state.Get<YControl>(MethodOffset.YControl) & YControl.NegateY) != 0;
+            int yControl = state.Get<int>(MethodOffset.YControl);
+
+            bool   flipY  = (yControl & 0b00001) != 0;
+            Origin origin = (yControl & 0b10000) != 0 ? Origin.LowerLeft : Origin.UpperLeft;
+
+            _context.Renderer.Pipeline.SetOrigin(origin);
+
             float yFlip = flipY ? -1 : 1;
 
             Viewport[] viewports = new Viewport[Constants.TotalViewports];

--- a/Ryujinx.Graphics.Gpu/Image/Sampler.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Sampler.cs
@@ -41,7 +41,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             float mipLodBias = descriptor.UnpackMipLodBias();
 
             float maxRequestedAnisotropy = GraphicsConfig.MaxAnisotropy >= 0 && GraphicsConfig.MaxAnisotropy <= 16 ? GraphicsConfig.MaxAnisotropy : descriptor.UnpackMaxAnisotropy();
-            float maxSupportedAnisotropy = context.Capabilities.MaxSupportedAnisotropy;
+            float maxSupportedAnisotropy = context.Capabilities.MaximumSupportedAnisotropy;
 
             if (maxRequestedAnisotropy > maxSupportedAnisotropy)
                 maxRequestedAnisotropy = maxSupportedAnisotropy;

--- a/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
@@ -3,6 +3,7 @@ using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Image;
 using Ryujinx.Graphics.Gpu.State;
 using Ryujinx.Graphics.Shader;
+using System;
 
 namespace Ryujinx.Graphics.Gpu.Shader
 {
@@ -188,6 +189,12 @@ namespace Ryujinx.Graphics.Gpu.Shader
         public bool QuerySupportsNonConstantTextureOffset() => _context.Capabilities.SupportsNonConstantTextureOffset;
 
         /// <summary>
+        /// Queries host GPU viewport swizzle support.
+        /// </summary>
+        /// <returns>True if the GPU and driver supports viewport swizzle, false otherwise</returns>
+        public bool QuerySupportsViewportSwizzle() => _context.Capabilities.SupportsViewportSwizzle;
+
+        /// <summary>
         /// Queries texture format information, for shaders using image load or store.
         /// </summary>
         /// <remarks>
@@ -247,6 +254,24 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 Format.R10G10B10A2Uint   => TextureFormat.R10G10B10A2Uint,
                 Format.R11G11B10Float    => TextureFormat.R11G11B10Float,
                 _                        => TextureFormat.Unknown
+            };
+        }
+
+        public int QueryViewportSwizzle(int component)
+        {
+            YControl yControl = _state.Get<YControl>(MethodOffset.YControl);
+
+            bool flipY = yControl.HasFlag(YControl.NegateY) ^ !yControl.HasFlag(YControl.TriangleRastFlip);
+
+            ViewportTransform transform = _state.Get<ViewportTransform>(MethodOffset.ViewportTransform, 0);
+
+            return component switch
+            {
+                0 => (int)(transform.UnpackSwizzleX() ^ (transform.ScaleX < 0 ? ViewportSwizzle.NegativeFlag : 0)),
+                1 => (int)(transform.UnpackSwizzleY() ^ (transform.ScaleY < 0 ? ViewportSwizzle.NegativeFlag : 0) ^ (flipY ? ViewportSwizzle.NegativeFlag : 0)),
+                2 => (int)(transform.UnpackSwizzleZ() ^ (transform.ScaleZ < 0 ? ViewportSwizzle.NegativeFlag : 0)),
+                3 => (int)transform.UnpackSwizzleW(),
+                _ => throw new ArgumentOutOfRangeException(nameof(component))
             };
         }
 

--- a/Ryujinx.Graphics.Gpu/State/GpuState.cs
+++ b/Ryujinx.Graphics.Gpu/State/GpuState.cs
@@ -146,6 +146,10 @@ namespace Ryujinx.Graphics.Gpu.State
             {
                 memory[(int)MethodOffset.ViewportExtents + index * 4 + 2] = 0;
                 memory[(int)MethodOffset.ViewportExtents + index * 4 + 3] = 0x3F800000;
+                memory[(int)MethodOffset.ViewportExtents + index * 4 + 3] = 0x3F800000;
+
+                // Set swizzle to +XYZW
+                memory[(int)MethodOffset.ViewportTransform + index * 8 + 6] = 0x6420;
             }
 
             // Viewport transform enable.

--- a/Ryujinx.Graphics.Gpu/State/GpuState.cs
+++ b/Ryujinx.Graphics.Gpu/State/GpuState.cs
@@ -146,7 +146,6 @@ namespace Ryujinx.Graphics.Gpu.State
             {
                 memory[(int)MethodOffset.ViewportExtents + index * 4 + 2] = 0;
                 memory[(int)MethodOffset.ViewportExtents + index * 4 + 3] = 0x3F800000;
-                memory[(int)MethodOffset.ViewportExtents + index * 4 + 3] = 0x3F800000;
 
                 // Set swizzle to +XYZW
                 memory[(int)MethodOffset.ViewportTransform + index * 8 + 6] = 0x6420;

--- a/Ryujinx.Graphics.OpenGL/EnumConversion.cs
+++ b/Ryujinx.Graphics.OpenGL/EnumConversion.cs
@@ -416,5 +416,32 @@ namespace Ryujinx.Graphics.OpenGL
 
             return TextureTarget.Texture2D;
         }
+
+        public static NvViewportSwizzle Convert(this ViewportSwizzle swizzle)
+        {
+            switch (swizzle)
+            {
+                case ViewportSwizzle.PositiveX:
+                    return NvViewportSwizzle.ViewportSwizzlePositiveXNv;
+                case ViewportSwizzle.PositiveY:
+                    return NvViewportSwizzle.ViewportSwizzlePositiveYNv;
+                case ViewportSwizzle.PositiveZ:
+                    return NvViewportSwizzle.ViewportSwizzlePositiveZNv;
+                case ViewportSwizzle.PositiveW:
+                    return NvViewportSwizzle.ViewportSwizzlePositiveWNv;
+                case ViewportSwizzle.NegativeX:
+                    return NvViewportSwizzle.ViewportSwizzleNegativeXNv;
+                case ViewportSwizzle.NegativeY:
+                    return NvViewportSwizzle.ViewportSwizzleNegativeYNv;
+                case ViewportSwizzle.NegativeZ:
+                    return NvViewportSwizzle.ViewportSwizzleNegativeZNv;
+                case ViewportSwizzle.NegativeW:
+                    return NvViewportSwizzle.ViewportSwizzleNegativeWNv;
+            }
+
+            Logger.PrintDebug(LogClass.Gpu, $"Invalid {nameof(ViewportSwizzle)} enum value: {swizzle}.");
+
+            return NvViewportSwizzle.ViewportSwizzlePositiveXNv;
+        }
     }
 }

--- a/Ryujinx.Graphics.OpenGL/HwCapabilities.cs
+++ b/Ryujinx.Graphics.OpenGL/HwCapabilities.cs
@@ -7,6 +7,7 @@ namespace Ryujinx.Graphics.OpenGL
     {
         private static readonly Lazy<bool> _supportsAstcCompression    = new Lazy<bool>(() => HasExtension("GL_KHR_texture_compression_astc_ldr"));
         private static readonly Lazy<bool> _supportsImageLoadFormatted = new Lazy<bool>(() => HasExtension("GL_EXT_shader_image_load_formatted"));
+        private static readonly Lazy<bool> _supportsViewportSwizzle    = new Lazy<bool>(() => HasExtension("GL_NV_viewport_swizzle"));
 
         private static readonly Lazy<int> _maximumComputeSharedMemorySize = new Lazy<int>(() => GetLimit(All.MaxComputeSharedMemorySize));
         private static readonly Lazy<int> _storageBufferOffsetAlignment   = new Lazy<int>(() => GetLimit(All.ShaderStorageBufferOffsetAlignment));
@@ -27,12 +28,13 @@ namespace Ryujinx.Graphics.OpenGL
 
         public static bool SupportsAstcCompression          => _supportsAstcCompression.Value;
         public static bool SupportsImageLoadFormatted       => _supportsImageLoadFormatted.Value;
+        public static bool SupportsViewportSwizzle          => _supportsViewportSwizzle.Value;
         public static bool SupportsNonConstantTextureOffset => _gpuVendor.Value == GpuVendor.Nvidia;
 
         public static int MaximumComputeSharedMemorySize => _maximumComputeSharedMemorySize.Value;
         public static int StorageBufferOffsetAlignment   => _storageBufferOffsetAlignment.Value;
 
-        public static float MaxSupportedAnisotropy => _maxSupportedAnisotropy.Value;
+        public static float MaximumSupportedAnisotropy => _maxSupportedAnisotropy.Value;
 
         private static bool HasExtension(string name)
         {

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -650,6 +650,13 @@ namespace Ryujinx.Graphics.OpenGL
             _vertexArray.SetIndexBuffer(buffer.Handle);
         }
 
+        public void SetOrigin(Origin origin)
+        {
+            ClipOrigin clipOrigin = origin == Origin.UpperLeft ? ClipOrigin.UpperLeft : ClipOrigin.LowerLeft;
+
+            SetOrigin(clipOrigin);
+        }
+
         public void SetPointSize(float size)
         {
             GL.PointSize(size);
@@ -854,8 +861,6 @@ namespace Ryujinx.Graphics.OpenGL
 
         public void SetViewports(int first, ReadOnlySpan<Viewport> viewports)
         {
-            bool flipY = false;
-
             float[] viewportArray = new float[viewports.Length * 4];
 
             double[] depthRangeArray = new double[viewports.Length * 2];
@@ -869,18 +874,29 @@ namespace Ryujinx.Graphics.OpenGL
                 viewportArray[viewportElemIndex + 0] = viewport.Region.X;
                 viewportArray[viewportElemIndex + 1] = viewport.Region.Y;
 
-                // OpenGL does not support per-viewport flipping, so
-                // instead we decide that based on the viewport 0 value.
-                // It will apply to all viewports.
-                if (index == 0)
-                {
-                    flipY = viewport.Region.Height < 0;
-                }
+                // If we already set the clip origin to upper left, then all
+                // viewports are already going to be flipped, so we set flip Y
+                // to true in this case to compensate.
+                bool flipY = _clipOrigin == ClipOrigin.UpperLeft;
 
-                if (viewport.SwizzleY == ViewportSwizzle.NegativeY)
+                if (viewport.Region.Height < 0)
                 {
                     flipY = !flipY;
                 }
+
+                ViewportSwizzle swizzleY = viewport.SwizzleY;
+
+                if (flipY)
+                {
+                    swizzleY ^= ViewportSwizzle.NegativeFlag;
+                }
+
+                GL.NV.ViewportSwizzle(
+                    index,
+                    viewport.SwizzleX.Convert(),
+                    swizzleY.Convert(),
+                    viewport.SwizzleZ.Convert(),
+                    viewport.SwizzleW.Convert());
 
                 viewportArray[viewportElemIndex + 2] = MathF.Abs(viewport.Region.Width);
                 viewportArray[viewportElemIndex + 3] = MathF.Abs(viewport.Region.Height);
@@ -892,8 +908,6 @@ namespace Ryujinx.Graphics.OpenGL
             GL.ViewportArray(first, viewports.Length, viewportArray);
 
             GL.DepthRangeArray(first, viewports.Length, depthRangeArray);
-
-            SetOrigin(flipY ? ClipOrigin.UpperLeft : ClipOrigin.LowerLeft);
         }
 
         public void TextureBarrier()

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -874,29 +874,15 @@ namespace Ryujinx.Graphics.OpenGL
                 viewportArray[viewportElemIndex + 0] = viewport.Region.X;
                 viewportArray[viewportElemIndex + 1] = viewport.Region.Y;
 
-                // If we already set the clip origin to upper left, then all
-                // viewports are already going to be flipped, so we set flip Y
-                // to true in this case to compensate.
-                bool flipY = _clipOrigin == ClipOrigin.UpperLeft;
-
-                if (viewport.Region.Height < 0)
+                if (HwCapabilities.SupportsViewportSwizzle)
                 {
-                    flipY = !flipY;
+                    GL.NV.ViewportSwizzle(
+                        index,
+                        viewport.SwizzleX.Convert(),
+                        viewport.SwizzleY.Convert(),
+                        viewport.SwizzleZ.Convert(),
+                        viewport.SwizzleW.Convert());
                 }
-
-                ViewportSwizzle swizzleY = viewport.SwizzleY;
-
-                if (flipY)
-                {
-                    swizzleY ^= ViewportSwizzle.NegativeFlag;
-                }
-
-                GL.NV.ViewportSwizzle(
-                    index,
-                    viewport.SwizzleX.Convert(),
-                    swizzleY.Convert(),
-                    viewport.SwizzleZ.Convert(),
-                    viewport.SwizzleW.Convert());
 
                 viewportArray[viewportElemIndex + 2] = MathF.Abs(viewport.Region.Width);
                 viewportArray[viewportElemIndex + 3] = MathF.Abs(viewport.Region.Height);

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -75,9 +75,10 @@ namespace Ryujinx.Graphics.OpenGL
                 HwCapabilities.SupportsAstcCompression,
                 HwCapabilities.SupportsImageLoadFormatted,
                 HwCapabilities.SupportsNonConstantTextureOffset,
+                HwCapabilities.SupportsViewportSwizzle,
                 HwCapabilities.MaximumComputeSharedMemorySize,
-                HwCapabilities.StorageBufferOffsetAlignment,
-                HwCapabilities.MaxSupportedAnisotropy);
+                HwCapabilities.MaximumSupportedAnisotropy,
+                HwCapabilities.StorageBufferOffsetAlignment);
         }
 
         public void SetBufferData(BufferHandle buffer, int offset, ReadOnlySpan<byte> data)

--- a/Ryujinx.Graphics.Shader/IGpuAccessor.cs
+++ b/Ryujinx.Graphics.Shader/IGpuAccessor.cs
@@ -64,9 +64,22 @@
             return true;
         }
 
+        public bool QuerySupportsViewportSwizzle()
+        {
+            return true;
+        }
+
         public TextureFormat QueryTextureFormat(int handle)
         {
             return TextureFormat.R8G8B8A8Unorm;
+        }
+
+        public int QueryViewportSwizzle(int component)
+        {
+            // Bit 0: Negate flag.
+            // Bits 2-1: Component.
+            // Example: 0b110 = W, 0b111 = -W, 0b000 = X, 0b010 = Y etc.
+            return component << 1;
         }
     }
 }

--- a/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -11,9 +11,7 @@ namespace Ryujinx.Graphics.Shader.Translation
         public Block  CurrBlock { get; set; }
         public OpCode CurrOp    { get; set; }
 
-        private ShaderConfig _config;
-
-        public ShaderConfig Config => _config;
+        public ShaderConfig Config { get; }
 
         private List<Operation> _operations;
 
@@ -21,7 +19,7 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public EmitterContext(ShaderConfig config)
         {
-            _config = config;
+            Config = config;
 
             _operations = new List<Operation>();
 
@@ -61,13 +59,40 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public void PrepareForReturn()
         {
-            if (_config.Stage == ShaderStage.Fragment)
+            if (Config.Stage == ShaderStage.Vertex && (Config.Flags & TranslationFlags.VertexA) == 0)
             {
-                if (_config.OmapDepth)
+                // Here we attempt to implement viewport swizzle on the vertex shader.
+                // Perform permutation and negation of the output gl_Position components.
+                // Note that per-viewport swizzling can't be supported using thhis approach.
+                int swizzleX = Config.GpuAccessor.QueryViewportSwizzle(0);
+                int swizzleY = Config.GpuAccessor.QueryViewportSwizzle(1);
+                int swizzleZ = Config.GpuAccessor.QueryViewportSwizzle(2);
+                int swizzleW = Config.GpuAccessor.QueryViewportSwizzle(3);
+
+                bool nonStandardSwizzle = swizzleX != 0 || swizzleY != 2 || swizzleZ != 4 || swizzleW != 6;
+
+                if (!Config.GpuAccessor.QuerySupportsViewportSwizzle() && nonStandardSwizzle)
+                {
+                    Operand[] temp = new Operand[4];
+
+                    temp[0] = this.Copy(Attribute(AttributeConsts.PositionX));
+                    temp[1] = this.Copy(Attribute(AttributeConsts.PositionY));
+                    temp[2] = this.Copy(Attribute(AttributeConsts.PositionZ));
+                    temp[3] = this.Copy(Attribute(AttributeConsts.PositionW));
+
+                    this.Copy(Attribute(AttributeConsts.PositionX), this.FPNegate(temp[(swizzleX >> 1) & 3], (swizzleX & 1) != 0));
+                    this.Copy(Attribute(AttributeConsts.PositionY), this.FPNegate(temp[(swizzleY >> 1) & 3], (swizzleY & 1) != 0));
+                    this.Copy(Attribute(AttributeConsts.PositionZ), this.FPNegate(temp[(swizzleZ >> 1) & 3], (swizzleZ & 1) != 0));
+                    this.Copy(Attribute(AttributeConsts.PositionW), this.FPNegate(temp[(swizzleW >> 1) & 3], (swizzleW & 1) != 0));
+                }
+            }
+            else if (Config.Stage == ShaderStage.Fragment)
+            {
+                if (Config.OmapDepth)
                 {
                     Operand dest = Attribute(AttributeConsts.FragmentOutputDepth);
 
-                    Operand src = Register(_config.GetDepthRegister(), RegisterType.Gpr);
+                    Operand src = Register(Config.GetDepthRegister(), RegisterType.Gpr);
 
                     this.Copy(dest, src);
                 }
@@ -76,7 +101,7 @@ namespace Ryujinx.Graphics.Shader.Translation
 
                 for (int attachment = 0; attachment < 8; attachment++)
                 {
-                    OmapTarget target = _config.OmapTargets[attachment];
+                    OmapTarget target = Config.OmapTargets[attachment];
 
                     for (int component = 0; component < 4; component++)
                     {

--- a/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -63,7 +63,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             {
                 // Here we attempt to implement viewport swizzle on the vertex shader.
                 // Perform permutation and negation of the output gl_Position components.
-                // Note that per-viewport swizzling can't be supported using thhis approach.
+                // Note that per-viewport swizzling can't be supported using this approach.
                 int swizzleX = Config.GpuAccessor.QueryViewportSwizzle(0);
                 int swizzleY = Config.GpuAccessor.QueryViewportSwizzle(1);
                 int swizzleZ = Config.GpuAccessor.QueryViewportSwizzle(2);

--- a/Ryujinx.Graphics.Shader/Translation/TranslationFlags.cs
+++ b/Ryujinx.Graphics.Shader/Translation/TranslationFlags.cs
@@ -7,7 +7,8 @@ namespace Ryujinx.Graphics.Shader.Translation
     {
         None = 0,
 
-        Compute   = 1 << 0,
-        DebugMode = 1 << 1
+        VertexA   = 1 << 0,
+        Compute   = 1 << 1,
+        DebugMode = 1 << 2
     }
 }

--- a/Ryujinx.Graphics.Shader/Translation/Translator.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Translator.cs
@@ -23,7 +23,7 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public static ShaderProgram Translate(ulong addressA, ulong addressB, IGpuAccessor gpuAccessor, TranslationFlags flags)
         {
-            Operation[] opsA = DecodeShader(addressA, gpuAccessor, flags, out _, out int sizeA);
+            Operation[] opsA = DecodeShader(addressA, gpuAccessor, flags | TranslationFlags.VertexA, out _, out int sizeA);
             Operation[] opsB = DecodeShader(addressB, gpuAccessor, flags, out ShaderConfig config, out int sizeB);
 
             return Translate(Combine(opsA, opsB), config, sizeB, sizeA);


### PR DESCRIPTION
NVN exposes a function that allows the application to set the origin of the window. It can be set to upper left (following Direct3D conventions), or lower left (following OpenGL). This should be directly equivalent to glClipControl on OpenGL.

The way how this is actually implemented on the GPU, however, is not directly equivalent. The GPU has a bit that changes something on the rasterization stage to take the different origin into account (nouveau calls this bit TriangleRastFlip). It does not flip the viewport, however. Flipping the viewport is done by using a negative value for the viewport scale.

So when the UpperLeft mode is used, NVN does 2 things:
- Negates the viewport Y scale value. This effectively flips the viewport, so all the geometry is flipped on the Y direction. This also affects face culling as the orientation of the triangles will change if you flip them.
- It sets the TriangleRastFlip bit to 0 (to indicate the UpperLeft origin is being used,  LowerLeft is 1). This negates the effects that the above viewport flipping would have on the face culling, as it changes something during rasterization.

So in most cases, directly setting origin to UpperLeft or LowerLeft using glClipControl should be safe and equivalent to NVN behavior, as long the above conditions holds (that is, either TriangleRastFlip is 0 and the viewport scale Y is negative, or TriangleRastFlip is 1 and viewport scale Y is positive). However, some games cheats and this may not be the case.

One example of such a game is Xenoblade. It manages to bypass the step where NVN sets the TriangleRastFlip bit to 0 by only setting the origin to upper left *after* queue initialization. This effectively causes NVN to still use negative viewport scale Y values, while not setting triangle rast flip to 0, because during queue initialization, origin was still lower left.

**Approach used to fix the issue**

We can still use ARB_clip_control to emulate TriangleRastFlip behavior, however the viewport flipping might be undesirable. We can negate that part by flipping the viewport again. To my knowledge, per-viewport flipping is possible, but only using NVIDIA [NV_viewport_swizzle](https://www.khronos.org/registry/OpenGL/extensions/NV/NV_viewport_swizzle.txt) extension, only available on Maxwell and newer. For GPUs without the support, we can still do the flipping on the vertex shader, but it affects all the viewports.

The fix here uses NV_viewport_swizzle (or shader emulation) to flip the viewport as needed. glClipControl is still used, but origin is now set to LowerLeft or UpperLeft based on the value of TriangleRastFlip bit. The various combinations of bits and values that may flip it in the Y direction (negative Y scale, Y negate etc) are propagated to the viewport swizzle Y component.

Note: The shader implementation currently has another issue, on top of not supporting per-viewport flipping. Since we don't recompile shaders when the state changes, the shader may be assuming a stale/incorrect viewport swizzle state. However this is a existing issue.

--------

I recommend testing this on a few games, including the ones that had culling issues, and games that used to work fine, to ensure it does not regress anything. If you find issues, please also note the GPU it was tested on (basically, we need to know if its using NV_viewport_swizzle or the shader implementation).

Should fix culling issues on Xenoblade 2, and maybe other games.

This supersedes #912 