### PR TITLE
Flush GL commands before inevitably waiting for a query result.

### DIFF
--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -1067,11 +1067,15 @@ namespace Ryujinx.Graphics.OpenGL
                 }
             }
 
-            return false; // The GPU will flush the queries to CPU and evaluate the condition there instead.
+            // The GPU will flush the queries to CPU and evaluate the condition there instead.
+
+            GL.Flush(); // The thread will be stalled manually flushing the counter, so flush GL commands now.
+            return false; 
         }
 
         public bool TryHostConditionalRendering(ICounterEvent value, ICounterEvent compare, bool isEqual)
         {
+            GL.Flush(); // The GPU thread will be stalled manually flushing the counter, so flush GL commands now.
             return false; // We don't currently have a way to compare two counters for conditional rendering.
         }
 


### PR DESCRIPTION
It seemed that when busy looping for a query result, we'd be stuck waiting forever as the GL command to write the result to the buffer never went through. This forces a glFlush before we manually read off a query result that has not already been flushed, so that it is definitely written.

Should fix a freeze in Yo-Kai Watch 4. (gdk will need to verify)