### PR TITLE
Omit image format if possible, and fix BA bit

### DIFF
--- a/Ryujinx.Graphics.GAL/Capabilities.cs
+++ b/Ryujinx.Graphics.GAL/Capabilities.cs
@@ -3,6 +3,7 @@ namespace Ryujinx.Graphics.GAL
     public struct Capabilities
     {
         public bool SupportsAstcCompression          { get; }
+        public bool SupportsImageLoadStoreFormatted  { get; }
         public bool SupportsNonConstantTextureOffset { get; }
 
         public int MaximumComputeSharedMemorySize { get; }
@@ -12,12 +13,14 @@ namespace Ryujinx.Graphics.GAL
 
         public Capabilities(
             bool  supportsAstcCompression,
+            bool  supportsImageLoadStoreFormatted,
             bool  supportsNonConstantTextureOffset,
             int   maximumComputeSharedMemorySize,
             int   storageBufferOffsetAlignment,
             float maxSupportedAnisotropy)
         {
             SupportsAstcCompression          = supportsAstcCompression;
+            SupportsImageLoadStoreFormatted  = supportsImageLoadStoreFormatted;
             SupportsNonConstantTextureOffset = supportsNonConstantTextureOffset;
             MaximumComputeSharedMemorySize   = maximumComputeSharedMemorySize;
             StorageBufferOffsetAlignment     = storageBufferOffsetAlignment;

--- a/Ryujinx.Graphics.GAL/Capabilities.cs
+++ b/Ryujinx.Graphics.GAL/Capabilities.cs
@@ -3,7 +3,7 @@ namespace Ryujinx.Graphics.GAL
     public struct Capabilities
     {
         public bool SupportsAstcCompression          { get; }
-        public bool SupportsImageLoadStoreFormatted  { get; }
+        public bool SupportsImageLoadFormatted       { get; }
         public bool SupportsNonConstantTextureOffset { get; }
 
         public int MaximumComputeSharedMemorySize { get; }
@@ -13,14 +13,14 @@ namespace Ryujinx.Graphics.GAL
 
         public Capabilities(
             bool  supportsAstcCompression,
-            bool  supportsImageLoadStoreFormatted,
+            bool  supportsImageLoadFormatted,
             bool  supportsNonConstantTextureOffset,
             int   maximumComputeSharedMemorySize,
             int   storageBufferOffsetAlignment,
             float maxSupportedAnisotropy)
         {
             SupportsAstcCompression          = supportsAstcCompression;
-            SupportsImageLoadStoreFormatted  = supportsImageLoadStoreFormatted;
+            SupportsImageLoadFormatted       = supportsImageLoadFormatted;
             SupportsNonConstantTextureOffset = supportsNonConstantTextureOffset;
             MaximumComputeSharedMemorySize   = maximumComputeSharedMemorySize;
             StorageBufferOffsetAlignment     = storageBufferOffsetAlignment;

--- a/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
@@ -178,8 +178,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Queries host support for readable images without a explicit format declaration on the shader.
         /// </summary>
-        /// <returns>True if formatted image load/store is supported, false otherwise</returns>
-        public bool QuerySupportsImageLoadStoreFormatted() => _context.Capabilities.SupportsImageLoadStoreFormatted;
+        /// <returns>True if formatted image load is supported, false otherwise</returns>
+        public bool QuerySupportsImageLoadFormatted() => _context.Capabilities.SupportsImageLoadFormatted;
 
         /// <summary>
         /// Queries host GPU non-constant texture offset support.

--- a/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
@@ -176,6 +176,12 @@ namespace Ryujinx.Graphics.Gpu.Shader
         public int QueryStorageBufferOffsetAlignment() => _context.Capabilities.StorageBufferOffsetAlignment;
 
         /// <summary>
+        /// Queries host support for readable images without a explicit format declaration on the shader.
+        /// </summary>
+        /// <returns>True if formatted image load/store is supported, false otherwise</returns>
+        public bool QuerySupportsImageLoadStoreFormatted() => _context.Capabilities.SupportsImageLoadStoreFormatted;
+
+        /// <summary>
         /// Queries host GPU non-constant texture offset support.
         /// </summary>
         /// <returns>True if the GPU and driver supports non-constant texture offsets, false otherwise</returns>

--- a/Ryujinx.Graphics.OpenGL/HwCapabilities.cs
+++ b/Ryujinx.Graphics.OpenGL/HwCapabilities.cs
@@ -5,7 +5,8 @@ namespace Ryujinx.Graphics.OpenGL
 {
     static class HwCapabilities
     {
-        private static readonly Lazy<bool> _supportsAstcCompression = new Lazy<bool>(() => HasExtension("GL_KHR_texture_compression_astc_ldr"));
+        private static readonly Lazy<bool> _supportsAstcCompression         = new Lazy<bool>(() => HasExtension("GL_KHR_texture_compression_astc_ldr"));
+        private static readonly Lazy<bool> _supportsImageLoadStoreFormatted = new Lazy<bool>(() => HasExtension("GL_EXT_shader_image_load_formatted"));
 
         private static readonly Lazy<int> _maximumComputeSharedMemorySize = new Lazy<int>(() => GetLimit(All.MaxComputeSharedMemorySize));
         private static readonly Lazy<int> _storageBufferOffsetAlignment   = new Lazy<int>(() => GetLimit(All.ShaderStorageBufferOffsetAlignment));
@@ -25,6 +26,7 @@ namespace Ryujinx.Graphics.OpenGL
         private static Lazy<float> _maxSupportedAnisotropy = new Lazy<float>(GL.GetFloat((GetPName)All.MaxTextureMaxAnisotropy));
 
         public static bool SupportsAstcCompression          => _supportsAstcCompression.Value;
+        public static bool SupportsImageLoadStoreFormatted  => _supportsImageLoadStoreFormatted.Value;
         public static bool SupportsNonConstantTextureOffset => _gpuVendor.Value == GpuVendor.Nvidia;
 
         public static int MaximumComputeSharedMemorySize => _maximumComputeSharedMemorySize.Value;

--- a/Ryujinx.Graphics.OpenGL/HwCapabilities.cs
+++ b/Ryujinx.Graphics.OpenGL/HwCapabilities.cs
@@ -5,8 +5,8 @@ namespace Ryujinx.Graphics.OpenGL
 {
     static class HwCapabilities
     {
-        private static readonly Lazy<bool> _supportsAstcCompression         = new Lazy<bool>(() => HasExtension("GL_KHR_texture_compression_astc_ldr"));
-        private static readonly Lazy<bool> _supportsImageLoadStoreFormatted = new Lazy<bool>(() => HasExtension("GL_EXT_shader_image_load_formatted"));
+        private static readonly Lazy<bool> _supportsAstcCompression    = new Lazy<bool>(() => HasExtension("GL_KHR_texture_compression_astc_ldr"));
+        private static readonly Lazy<bool> _supportsImageLoadFormatted = new Lazy<bool>(() => HasExtension("GL_EXT_shader_image_load_formatted"));
 
         private static readonly Lazy<int> _maximumComputeSharedMemorySize = new Lazy<int>(() => GetLimit(All.MaxComputeSharedMemorySize));
         private static readonly Lazy<int> _storageBufferOffsetAlignment   = new Lazy<int>(() => GetLimit(All.ShaderStorageBufferOffsetAlignment));
@@ -26,7 +26,7 @@ namespace Ryujinx.Graphics.OpenGL
         private static Lazy<float> _maxSupportedAnisotropy = new Lazy<float>(GL.GetFloat((GetPName)All.MaxTextureMaxAnisotropy));
 
         public static bool SupportsAstcCompression          => _supportsAstcCompression.Value;
-        public static bool SupportsImageLoadStoreFormatted  => _supportsImageLoadStoreFormatted.Value;
+        public static bool SupportsImageLoadFormatted       => _supportsImageLoadFormatted.Value;
         public static bool SupportsNonConstantTextureOffset => _gpuVendor.Value == GpuVendor.Nvidia;
 
         public static int MaximumComputeSharedMemorySize => _maximumComputeSharedMemorySize.Value;

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -73,7 +73,7 @@ namespace Ryujinx.Graphics.OpenGL
         {
             return new Capabilities(
                 HwCapabilities.SupportsAstcCompression,
-                HwCapabilities.SupportsImageLoadStoreFormatted,
+                HwCapabilities.SupportsImageLoadFormatted,
                 HwCapabilities.SupportsNonConstantTextureOffset,
                 HwCapabilities.MaximumComputeSharedMemorySize,
                 HwCapabilities.StorageBufferOffsetAlignment,

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -73,6 +73,7 @@ namespace Ryujinx.Graphics.OpenGL
         {
             return new Capabilities(
                 HwCapabilities.SupportsAstcCompression,
+                HwCapabilities.SupportsImageLoadStoreFormatted,
                 HwCapabilities.SupportsNonConstantTextureOffset,
                 HwCapabilities.MaximumComputeSharedMemorySize,
                 HwCapabilities.StorageBufferOffsetAlignment,

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
@@ -19,6 +19,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
             context.AppendLine("#extension GL_ARB_gpu_shader_int64 : enable");
             context.AppendLine("#extension GL_ARB_shader_ballot : enable");
             context.AppendLine("#extension GL_ARB_shader_group_vote : enable");
+            context.AppendLine("#extension GL_EXT_shader_image_load_formatted : enable");
 
             if (context.Config.Stage == ShaderStage.Compute)
             {

--- a/Ryujinx.Graphics.Shader/Decoders/OpCodeImage.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/OpCodeImage.cs
@@ -37,7 +37,7 @@ namespace Ryujinx.Graphics.Shader.Decoders
                 Size = (IntegerSize)opCode.Extract(20, 4);
             }
 
-            ByteAddress = !opCode.Extract(23);
+            ByteAddress = opCode.Extract(23);
 
             Dimensions = (ImageDimensions)opCode.Extract(33, 3);
 

--- a/Ryujinx.Graphics.Shader/IGpuAccessor.cs
+++ b/Ryujinx.Graphics.Shader/IGpuAccessor.cs
@@ -54,6 +54,11 @@
             return 16;
         }
 
+        public bool QuerySupportsImageLoadStoreFormatted()
+        {
+            return true;
+        }
+
         public bool QuerySupportsNonConstantTextureOffset()
         {
             return true;

--- a/Ryujinx.Graphics.Shader/IGpuAccessor.cs
+++ b/Ryujinx.Graphics.Shader/IGpuAccessor.cs
@@ -54,7 +54,7 @@
             return 16;
         }
 
-        public bool QuerySupportsImageLoadStoreFormatted()
+        public bool QuerySupportsImageLoadFormatted()
         {
             return true;
         }

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
@@ -1217,9 +1217,9 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
         private static TextureFormat GetTextureFormat(EmitterContext context, int handle)
         {
-            // If the formatted load store extension is supported, we don't need to
+            // When the formatted load extension is supported, we don't need to
             // specify a format, we can just declare it without a format and the GPU will handle it.
-            if (context.Config.GpuAccessor.QuerySupportsImageLoadStoreFormatted())
+            if (context.Config.GpuAccessor.QuerySupportsImageLoadFormatted())
             {
                 return TextureFormat.Unknown;
             }

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
@@ -1217,6 +1217,13 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
         private static TextureFormat GetTextureFormat(EmitterContext context, int handle)
         {
+            // If the formatted load store extension is supported, we don't need to
+            // specify a format, we can just declare it without a format and the GPU will handle it.
+            if (context.Config.GpuAccessor.QuerySupportsImageLoadStoreFormatted())
+            {
+                return TextureFormat.Unknown;
+            }
+
             var format = context.Config.GpuAccessor.QueryTextureFormat(handle);
 
             if (format == TextureFormat.Unknown)


### PR DESCRIPTION
When `EXT_shader_image_load_formatted` is supported, we don't need to specify the image format. In the future this will prevent shader recompilations due to image format changes. For now it can fix cases where a wrong/old image format was being used.

Additionally, fix the BA bit of the SULD/SUST instructions that was wrong aswell.