### PR TITLE
Improved Logger

### DIFF
--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -123,7 +123,7 @@ namespace ARMeilleure.Translation.PTC
                 return;
             }
 
-            Logger.PrintInfo(LogClass.Ptc, $"Initializing Profiled Persistent Translation Cache (enabled: {enabled}).");
+            Logger.Info?.Print(LogClass.Ptc, $"Initializing Profiled Persistent Translation Cache (enabled: {enabled}).");
 
             TitleIdText = titleIdText;
             DisplayVersion = !String.IsNullOrEmpty(displayVersion) ? displayVersion : DisplayVersionDefault;
@@ -621,11 +621,11 @@ namespace ARMeilleure.Translation.PTC
 
             do
             {
-                Logger.PrintInfo(LogClass.Ptc, $"{funcsCount + _translateCount} of {ProfiledFuncsCount} functions to translate - {_rejitCount} functions rejited");
+                Logger.Info?.Print(LogClass.Ptc, $"{funcsCount + _translateCount} of {ProfiledFuncsCount} functions to translate - {_rejitCount} functions rejited");
             }
             while (!_loggerEvent.WaitOne(refreshRate * 1000));
 
-            Logger.PrintInfo(LogClass.Ptc, $"{funcsCount + _translateCount} of {ProfiledFuncsCount} functions to translate - {_rejitCount} functions rejited");
+            Logger.Info?.Print(LogClass.Ptc, $"{funcsCount + _translateCount} of {ProfiledFuncsCount} functions to translate - {_rejitCount} functions rejited");
         }
 
         internal static void WriteInfoCodeReloc(long address, bool highCq, PtcInfo ptcInfo)

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -98,9 +98,6 @@ namespace ARMeilleure.Translation.PTC
             CachePathBackup = string.Empty;
 
             Disable();
-
-            AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
-            AppDomain.CurrentDomain.ProcessExit += CurrentDomain_ProcessExit;
         }
 
         public static void Initialize(string titleIdText, string displayVersion, bool enabled)
@@ -732,9 +729,6 @@ namespace ARMeilleure.Translation.PTC
             {
                 _disposed = true;
 
-                AppDomain.CurrentDomain.UnhandledException -= CurrentDomain_UnhandledException;
-                AppDomain.CurrentDomain.ProcessExit -= CurrentDomain_ProcessExit;
-
                 Wait();
                 _waitEvent.Dispose();
 
@@ -745,24 +739,6 @@ namespace ARMeilleure.Translation.PTC
                 _relocsStream.Dispose();
                 _unwindInfosStream.Dispose();
             }
-        }
-
-        private static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
-        {
-            Close();
-            PtcProfiler.Stop();
-
-            if (e.IsTerminating)
-            {
-                Dispose();
-                PtcProfiler.Dispose();
-            }
-        }
-
-        private static void CurrentDomain_ProcessExit(object sender, EventArgs e)
-        {
-            Dispose();
-            PtcProfiler.Dispose();
         }
     }
 }

--- a/Ryujinx.Common/Configuration/ConfigurationState.cs
+++ b/Ryujinx.Common/Configuration/ConfigurationState.cs
@@ -532,7 +532,7 @@ namespace Ryujinx.Configuration
 
             if (configurationFileFormat.Version < 0 || configurationFileFormat.Version > ConfigurationFileFormat.CurrentVersion)
             {
-                Common.Logging.Logger.PrintWarning(LogClass.Application, $"Unsupported configuration version {configurationFileFormat.Version}, loading default.");
+                Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Unsupported configuration version {configurationFileFormat.Version}, loading default.");
 
                 LoadDefault();
 
@@ -541,7 +541,7 @@ namespace Ryujinx.Configuration
 
             if (configurationFileFormat.Version < 2)
             {
-                Common.Logging.Logger.PrintWarning(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 2.");
+                Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 2.");
 
                 configurationFileFormat.SystemRegion = Region.USA;
 
@@ -550,7 +550,7 @@ namespace Ryujinx.Configuration
 
             if (configurationFileFormat.Version < 3)
             {
-                Common.Logging.Logger.PrintWarning(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 3.");
+                Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 3.");
 
                 configurationFileFormat.SystemTimeZone = "UTC";
 
@@ -559,7 +559,7 @@ namespace Ryujinx.Configuration
 
             if (configurationFileFormat.Version < 4)
             {
-                Common.Logging.Logger.PrintWarning(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 4.");
+                Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 4.");
 
                 configurationFileFormat.MaxAnisotropy = -1;
 
@@ -568,7 +568,7 @@ namespace Ryujinx.Configuration
 
             if (configurationFileFormat.Version < 5)
             {
-                Common.Logging.Logger.PrintWarning(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 5.");
+                Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 5.");
 
                 configurationFileFormat.SystemTimeOffset = 0;
 
@@ -577,7 +577,7 @@ namespace Ryujinx.Configuration
 
             if (configurationFileFormat.Version < 6)
             {
-                Common.Logging.Logger.PrintWarning(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 6.");
+                Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 6.");
 
                 configurationFileFormat.ControllerConfig = new List<ControllerConfig>();
                 configurationFileFormat.KeyboardConfig   = new List<KeyboardConfig>
@@ -630,7 +630,7 @@ namespace Ryujinx.Configuration
             // Only needed for version 6 configurations.
             if (configurationFileFormat.Version == 6)
             {
-                Common.Logging.Logger.PrintWarning(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 7.");
+                Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 7.");
 
                 for (int i = 0; i < configurationFileFormat.KeyboardConfig.Count; i++)
                 {
@@ -643,7 +643,7 @@ namespace Ryujinx.Configuration
 
             if (configurationFileFormat.Version < 8)
             {
-                Common.Logging.Logger.PrintWarning(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 8.");
+                Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 8.");
 
                 configurationFileFormat.EnablePtc = false;
 
@@ -652,7 +652,7 @@ namespace Ryujinx.Configuration
 
             if (configurationFileFormat.Version < 9)
             {
-                Common.Logging.Logger.PrintWarning(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 9.");
+                Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 9.");
 
                 configurationFileFormat.ColumnSort = new ColumnSort
                 {
@@ -670,7 +670,7 @@ namespace Ryujinx.Configuration
 
             if (configurationFileFormat.Version < 10)
             {
-                Common.Logging.Logger.PrintWarning(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 10.");
+                Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 10.");
 
                 configurationFileFormat.AudioBackend = AudioBackend.OpenAl;
 
@@ -679,7 +679,7 @@ namespace Ryujinx.Configuration
 
             if (configurationFileFormat.Version < 11)
             {
-                Common.Logging.Logger.PrintWarning(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 11.");
+                Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 11.");
 
                 configurationFileFormat.ResScale = 1;
                 configurationFileFormat.ResScaleCustom = 1.0f;
@@ -689,7 +689,7 @@ namespace Ryujinx.Configuration
 
             if (configurationFileFormat.Version < 12)
             {
-                Common.Logging.Logger.PrintWarning(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 12.");
+                Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 12.");
 
                 configurationFileFormat.LoggingGraphicsDebugLevel = GraphicsDebugLevel.None;
 
@@ -750,7 +750,7 @@ namespace Ryujinx.Configuration
             {
                 ToFileFormat().SaveConfig(configurationFilePath);
 
-                Common.Logging.Logger.PrintWarning(LogClass.Application, "Configuration file has been updated!");
+                Common.Logging.Logger.Warning?.Print(LogClass.Application, "Configuration file has been updated!");
             }
         }
 

--- a/Ryujinx.Common/Configuration/LoggerModule.cs
+++ b/Ryujinx.Common/Configuration/LoggerModule.cs
@@ -9,9 +9,6 @@ namespace Ryujinx.Configuration
     {
         public static void Initialize()
         {
-            AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
-            AppDomain.CurrentDomain.ProcessExit        += CurrentDomain_ProcessExit;
-
             ConfigurationState.Instance.Logger.EnableDebug.Event       += ReloadEnableDebug;
             ConfigurationState.Instance.Logger.EnableStub.Event        += ReloadEnableStub;
             ConfigurationState.Instance.Logger.EnableInfo.Event        += ReloadEnableInfo;
@@ -86,23 +83,6 @@ namespace Ryujinx.Configuration
             else
             {
                 Logger.RemoveTarget("file");
-            }
-        }
-
-        private static void CurrentDomain_ProcessExit(object sender, EventArgs e)
-        {
-            Logger.Shutdown();
-        }
-
-        private static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
-        {
-            var exception = e.ExceptionObject as Exception;
-
-            Logger.PrintError(LogClass.Emulation, $"Unhandled exception caught: {exception}");
-
-            if (e.IsTerminating)
-            {
-                Logger.Shutdown();
             }
         }
     }

--- a/Ryujinx.Common/Logging/Formatters/DefaultLogFormatter.cs
+++ b/Ryujinx.Common/Logging/Formatters/DefaultLogFormatter.cs
@@ -17,7 +17,7 @@ namespace Ryujinx.Common.Logging
                 sb.Clear();
 
                 sb.AppendFormat(@"{0:hh\:mm\:ss\.fff}", args.Time);
-                sb.Append(" | ");
+                sb.Append($" |{args.Level.ToString()[0]}| ");
 
                 if (args.ThreadName != null)
                 {

--- a/Ryujinx.Common/Logging/Formatters/DefaultLogFormatter.cs
+++ b/Ryujinx.Common/Logging/Formatters/DefaultLogFormatter.cs
@@ -31,7 +31,7 @@ namespace Ryujinx.Common.Logging
                 {
                     PropertyInfo[] props = args.Data.GetType().GetProperties();
 
-                    sb.Append(' ');
+                    sb.Append(" {");
 
                     foreach (var prop in props)
                     {
@@ -40,28 +40,33 @@ namespace Ryujinx.Common.Logging
 
                         if (typeof(Array).IsAssignableFrom(prop.PropertyType))
                         {
-                            Array enumerable = (Array)prop.GetValue(args.Data);
-                            foreach (var item in enumerable)
+                            Array array = (Array)prop.GetValue(args.Data);
+                            foreach (var item in array)
                             {
                                 sb.Append(item.ToString());
                                 sb.Append(", ");
                             }
 
-                            sb.Remove(sb.Length - 2, 2);
+                            if (array.Length > 0)
+                            {
+                                sb.Remove(sb.Length - 2, 2);
+                            }
                         }
                         else
                         {
                             sb.Append(prop.GetValue(args.Data));
                         }
 
-                        sb.Append(" - ");
+                        sb.Append(" ; ");
                     }
 
-                    // We remove the final '-' from the string
+                    // We remove the final ';' from the string
                     if (props.Length > 0)
                     {
                         sb.Remove(sb.Length - 3, 3);
                     }
+
+                    sb.Append('}');
                 }
 
                 return sb.ToString();

--- a/Ryujinx.Common/Logging/LogEventArgs.cs
+++ b/Ryujinx.Common/Logging/LogEventArgs.cs
@@ -4,12 +4,12 @@ namespace Ryujinx.Common.Logging
 {
     public class LogEventArgs : EventArgs
     {
-        public LogLevel Level      { get; private set; }
-        public TimeSpan Time       { get; private set; }
-        public string   ThreadName { get; private set; }
+        public readonly LogLevel Level;
+        public readonly TimeSpan Time;
+        public readonly string   ThreadName;
 
-        public string Message { get; private set; }
-        public object Data    { get; private set; }
+        public readonly string Message;
+        public readonly object Data;
 
         public LogEventArgs(LogLevel level, TimeSpan time, string threadName, string message)
         {

--- a/Ryujinx.Common/Logging/LogLevel.cs
+++ b/Ryujinx.Common/Logging/LogLevel.cs
@@ -8,6 +8,7 @@ namespace Ryujinx.Common.Logging
         Warning,
         Error,
         Guest,
-        AccessLog
+        AccessLog,
+        Notice
     }
 }

--- a/Ryujinx.Common/Logging/Logger.cs
+++ b/Ryujinx.Common/Logging/Logger.cs
@@ -56,7 +56,6 @@ namespace Ryujinx.Common.Logging
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public void PrintStub(LogClass logClass, string message = "", [CallerMemberName] string caller = "")
             {
-                // if (_level != LogLevel.Stub) throw new InvalidOperationException("PrintStub must be called Stub log level");
                 if (m_EnabledClasses[(int)logClass])
                 {
                     Updated?.Invoke(null, new LogEventArgs(_level, m_Time.Elapsed, Thread.CurrentThread.Name, FormatMessage(logClass, caller, "Stubbed. " + message)));
@@ -66,17 +65,15 @@ namespace Ryujinx.Common.Logging
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public void PrintStub(LogClass logClass, object data, [CallerMemberName] string caller = "")
             {
-                // if (_level != LogLevel.Stub) throw new InvalidOperationException("PrintStub must be called Stub log level");
                 if (m_EnabledClasses[(int)logClass])
                 {
-                    Updated?.Invoke(null, new LogEventArgs(_level, m_Time.Elapsed, Thread.CurrentThread.Name, FormatMessage(logClass, caller, "Stubbed. "), data));
+                    Updated?.Invoke(null, new LogEventArgs(_level, m_Time.Elapsed, Thread.CurrentThread.Name, FormatMessage(logClass, caller, "Stubbed."), data));
                 }
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public void PrintStub(LogClass logClass, string message, object data, [CallerMemberName] string caller = "")
             {
-                // if (_level != LogLevel.Stub) throw new InvalidOperationException("PrintStub must be called Stub log level");
                 if (m_EnabledClasses[(int)logClass])
                 {
                     Updated?.Invoke(null, new LogEventArgs(_level, m_Time.Elapsed, Thread.CurrentThread.Name, FormatMessage(logClass, caller, "Stubbed. " + message), data));

--- a/Ryujinx.Common/Logging/Logger.cs
+++ b/Ryujinx.Common/Logging/Logger.cs
@@ -18,11 +18,11 @@ namespace Ryujinx.Common.Logging
 
         public struct Log
         {
-            private readonly LogLevel _level;
+            internal readonly LogLevel Level;
 
             internal Log(LogLevel level)
             {
-                _level = level;
+                Level = level;
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -30,7 +30,7 @@ namespace Ryujinx.Common.Logging
             {
                 if (m_EnabledClasses[(int)logClass])
                 {
-                    Updated?.Invoke(null, new LogEventArgs(_level, m_Time.Elapsed, Thread.CurrentThread.Name, FormatMessage(logClass, "", message)));
+                    Updated?.Invoke(null, new LogEventArgs(Level, m_Time.Elapsed, Thread.CurrentThread.Name, FormatMessage(logClass, "", message)));
                 }
             }
 
@@ -39,7 +39,7 @@ namespace Ryujinx.Common.Logging
             {
                 if (m_EnabledClasses[(int)logClass])
                 {
-                    Updated?.Invoke(null, new LogEventArgs(_level, m_Time.Elapsed, Thread.CurrentThread.Name, FormatMessage(logClass, caller, message)));
+                    Updated?.Invoke(null, new LogEventArgs(Level, m_Time.Elapsed, Thread.CurrentThread.Name, FormatMessage(logClass, caller, message)));
                 }
             }
 
@@ -48,7 +48,7 @@ namespace Ryujinx.Common.Logging
             {
                 if (m_EnabledClasses[(int)logClass])
                 {
-                    Updated?.Invoke(null, new LogEventArgs(_level, m_Time.Elapsed, Thread.CurrentThread.Name, FormatMessage(logClass, caller, message), data));
+                    Updated?.Invoke(null, new LogEventArgs(Level, m_Time.Elapsed, Thread.CurrentThread.Name, FormatMessage(logClass, caller, message), data));
                 }
             }
 
@@ -57,7 +57,7 @@ namespace Ryujinx.Common.Logging
             {
                 if (m_EnabledClasses[(int)logClass])
                 {
-                    Updated?.Invoke(null, new LogEventArgs(_level, m_Time.Elapsed, Thread.CurrentThread.Name, FormatMessage(logClass, caller, "Stubbed. " + message)));
+                    Updated?.Invoke(null, new LogEventArgs(Level, m_Time.Elapsed, Thread.CurrentThread.Name, FormatMessage(logClass, caller, "Stubbed. " + message)));
                 }
             }
 
@@ -66,7 +66,7 @@ namespace Ryujinx.Common.Logging
             {
                 if (m_EnabledClasses[(int)logClass])
                 {
-                    Updated?.Invoke(null, new LogEventArgs(_level, m_Time.Elapsed, Thread.CurrentThread.Name, FormatMessage(logClass, caller, "Stubbed."), data));
+                    Updated?.Invoke(null, new LogEventArgs(Level, m_Time.Elapsed, Thread.CurrentThread.Name, FormatMessage(logClass, caller, "Stubbed."), data));
                 }
             }
 
@@ -75,7 +75,7 @@ namespace Ryujinx.Common.Logging
             {
                 if (m_EnabledClasses[(int)logClass])
                 {
-                    Updated?.Invoke(null, new LogEventArgs(_level, m_Time.Elapsed, Thread.CurrentThread.Name, FormatMessage(logClass, caller, "Stubbed. " + message), data));
+                    Updated?.Invoke(null, new LogEventArgs(Level, m_Time.Elapsed, Thread.CurrentThread.Name, FormatMessage(logClass, caller, "Stubbed. " + message), data));
                 }
             }            
 
@@ -163,6 +163,21 @@ namespace Ryujinx.Common.Logging
             }
 
             m_LogTargets.Clear();
+        }
+
+        public static IReadOnlyCollection<LogLevel> GetEnabledLevels()
+        {
+            var logs = new Log?[] { Debug, Info, Warning, Error, Guest, AccessLog, Stub };
+            List<LogLevel> levels = new List<LogLevel>(logs.Length);
+            foreach (var log in logs)
+            {
+                if (log.HasValue)
+                {
+                    levels.Add(log.Value.Level);
+                }
+            }
+
+            return levels;
         }
 
         public static void SetEnable(LogLevel logLevel, bool enabled)

--- a/Ryujinx.Common/Logging/Logger.cs
+++ b/Ryujinx.Common/Logging/Logger.cs
@@ -8,26 +8,96 @@ namespace Ryujinx.Common.Logging
 {
     public static class Logger
     {
-        private static Stopwatch m_Time;
+        private static readonly Stopwatch m_Time;
 
-        private static readonly bool[] m_EnabledLevels;
         private static readonly bool[] m_EnabledClasses;
 
         private static readonly List<ILogTarget> m_LogTargets;
 
         public static event EventHandler<LogEventArgs> Updated;
 
+
+        public struct Log
+        {
+            private readonly LogLevel _level;
+
+            internal Log(LogLevel level)
+            {
+                _level = level;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void PrintMsg(LogClass logClass, string message)
+            {
+                if (m_EnabledClasses[(int)logClass])
+                {
+                    Updated?.Invoke(null, new LogEventArgs(_level, m_Time.Elapsed, Thread.CurrentThread.Name, FormatMessage(logClass, "", message)));
+                }
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void Print(LogClass logClass, string message, [CallerMemberName] string caller = "")
+            {
+                if (m_EnabledClasses[(int)logClass])
+                {
+                    Updated?.Invoke(null, new LogEventArgs(_level, m_Time.Elapsed, Thread.CurrentThread.Name, FormatMessage(logClass, caller, message)));
+                }
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void Print(LogClass logClass, string message, object data, [CallerMemberName] string caller = "")
+            {
+                if (m_EnabledClasses[(int)logClass])
+                {
+                    Updated?.Invoke(null, new LogEventArgs(_level, m_Time.Elapsed, Thread.CurrentThread.Name, FormatMessage(logClass, caller, message), data));
+                }
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void PrintStub(LogClass logClass, string message = "", [CallerMemberName] string caller = "")
+            {
+                // if (_level != LogLevel.Stub) throw new InvalidOperationException("PrintStub must be called Stub log level");
+                if (m_EnabledClasses[(int)logClass])
+                {
+                    Updated?.Invoke(null, new LogEventArgs(_level, m_Time.Elapsed, Thread.CurrentThread.Name, FormatMessage(logClass, caller, "Stubbed. " + message)));
+                }
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void PrintStub(LogClass logClass, object data, [CallerMemberName] string caller = "")
+            {
+                // if (_level != LogLevel.Stub) throw new InvalidOperationException("PrintStub must be called Stub log level");
+                if (m_EnabledClasses[(int)logClass])
+                {
+                    Updated?.Invoke(null, new LogEventArgs(_level, m_Time.Elapsed, Thread.CurrentThread.Name, FormatMessage(logClass, caller, "Stubbed. "), data));
+                }
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void PrintStub(LogClass logClass, string message, object data, [CallerMemberName] string caller = "")
+            {
+                // if (_level != LogLevel.Stub) throw new InvalidOperationException("PrintStub must be called Stub log level");
+                if (m_EnabledClasses[(int)logClass])
+                {
+                    Updated?.Invoke(null, new LogEventArgs(_level, m_Time.Elapsed, Thread.CurrentThread.Name, FormatMessage(logClass, caller, "Stubbed. " + message), data));
+                }
+            }            
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static string FormatMessage(LogClass Class, string Caller, string Message) => $"{Class} {Caller}: {Message}";
+        }
+
+        public static Log? Debug     { get; private set; }
+        public static Log? Info      { get; private set; }
+        public static Log? Warning   { get; private set; }
+        public static Log? Error     { get; private set; }
+        public static Log? Guest     { get; private set; }
+        public static Log? AccessLog { get; private set; }
+        public static Log? Stub      { get; private set; }
+
         static Logger()
         {
-            m_EnabledLevels  = new bool[Enum.GetNames(typeof(LogLevel)).Length];
             m_EnabledClasses = new bool[Enum.GetNames(typeof(LogClass)).Length];
-
-            m_EnabledLevels[(int)LogLevel.Stub]      = true;
-            m_EnabledLevels[(int)LogLevel.Info]      = true;
-            m_EnabledLevels[(int)LogLevel.Warning]   = true;
-            m_EnabledLevels[(int)LogLevel.Error]     = true;
-            m_EnabledLevels[(int)LogLevel.Guest]     = true;
-            m_EnabledLevels[(int)LogLevel.AccessLog] = true;
 
             for (int index = 0; index < m_EnabledClasses.Length; index++)
             {
@@ -88,7 +158,7 @@ namespace Ryujinx.Common.Logging
         {
             Updated = null;
 
-            foreach(var target in m_LogTargets)
+            foreach (var target in m_LogTargets)
             {
                 target.Dispose();
             }
@@ -98,78 +168,22 @@ namespace Ryujinx.Common.Logging
 
         public static void SetEnable(LogLevel logLevel, bool enabled)
         {
-            m_EnabledLevels[(int)logLevel] = enabled;
+            switch (logLevel)
+            {
+                case LogLevel.Debug    : Debug     = enabled ? new Log(LogLevel.Debug)    : new Log?(); break;
+                case LogLevel.Info     : Info      = enabled ? new Log(LogLevel.Info)     : new Log?(); break;
+                case LogLevel.Warning  : Warning   = enabled ? new Log(LogLevel.Warning)  : new Log?(); break;
+                case LogLevel.Error    : Error     = enabled ? new Log(LogLevel.Error)    : new Log?(); break;
+                case LogLevel.Guest    : Guest     = enabled ? new Log(LogLevel.Guest)    : new Log?(); break;
+                case LogLevel.AccessLog: AccessLog = enabled ? new Log(LogLevel.AccessLog): new Log?(); break;
+                case LogLevel.Stub     : Stub      = enabled ? new Log(LogLevel.Stub)     : new Log?(); break;
+                default: throw new ArgumentException("Unknown Log Level");
+            }
         }
 
         public static void SetEnable(LogClass logClass, bool enabled)
         {
             m_EnabledClasses[(int)logClass] = enabled;
-        }
-
-        public static void PrintDebug(LogClass logClass, string message, [CallerMemberName] string caller = "")
-        {
-            Print(LogLevel.Debug, logClass, GetFormattedMessage(logClass, message, caller));
-        }
-
-        public static void PrintInfo(LogClass logClass, string message, [CallerMemberName] string Caller = "")
-        {
-            Print(LogLevel.Info, logClass, GetFormattedMessage(logClass, message, Caller));
-        }
-
-        public static void PrintWarning(LogClass logClass, string message, [CallerMemberName] string Caller = "")
-        {
-            Print(LogLevel.Warning, logClass, GetFormattedMessage(logClass, message, Caller));
-        }
-
-        public static void PrintError(LogClass logClass, string message, [CallerMemberName] string Caller = "")
-        {
-            Print(LogLevel.Error, logClass, GetFormattedMessage(logClass, message, Caller));
-        }
-
-        public static void PrintStub(LogClass logClass, string message = "", [CallerMemberName] string caller = "")
-        {
-            Print(LogLevel.Stub, logClass, GetFormattedMessage(logClass, "Stubbed. " + message, caller));
-        }
-
-        public static void PrintStub<T>(LogClass logClass, T obj, [CallerMemberName] string caller = "")
-        {
-            Print(LogLevel.Stub, logClass, GetFormattedMessage(logClass, "Stubbed.", caller), obj);
-        }
-
-        public static void PrintStub<T>(LogClass logClass, string message, T obj, [CallerMemberName] string caller = "")
-        {
-            Print(LogLevel.Stub, logClass, GetFormattedMessage(logClass, "Stubbed. " + message, caller), obj);
-        }
-
-        public static void PrintGuest(LogClass logClass, string message, [CallerMemberName] string caller = "")
-        {
-            Print(LogLevel.Guest, logClass, GetFormattedMessage(logClass, message, caller));
-        }
-
-        public static void PrintAccessLog(LogClass logClass, string message)
-        {
-            Print(LogLevel.AccessLog, logClass, message);
-        }
-
-        private static void Print(LogLevel logLevel, LogClass logClass, string message)
-        {
-            if (m_EnabledLevels[(int)logLevel] && m_EnabledClasses[(int)logClass])
-            {
-                Updated?.Invoke(null, new LogEventArgs(logLevel, m_Time.Elapsed, Thread.CurrentThread.Name, message));
-            }
-        }
-
-        private static void Print(LogLevel logLevel, LogClass logClass, string message, object data)
-        {
-            if (m_EnabledLevels[(int)logLevel] && m_EnabledClasses[(int)logClass])
-            {
-                Updated?.Invoke(null, new LogEventArgs(logLevel, m_Time.Elapsed, Thread.CurrentThread.Name, message, data));
-            }
-        }
-
-        private static string GetFormattedMessage(LogClass Class, string Message, string Caller)
-        {
-            return $"{Class} {Caller}: {Message}";
         }
     }
 }

--- a/Ryujinx.Common/Logging/Logger.cs
+++ b/Ryujinx.Common/Logging/Logger.cs
@@ -16,7 +16,6 @@ namespace Ryujinx.Common.Logging
 
         public static event EventHandler<LogEventArgs> Updated;
 
-
         public struct Log
         {
             private readonly LogLevel _level;

--- a/Ryujinx.Common/Logging/Logger.cs
+++ b/Ryujinx.Common/Logging/Logger.cs
@@ -90,6 +90,7 @@ namespace Ryujinx.Common.Logging
         public static Log? Guest     { get; private set; }
         public static Log? AccessLog { get; private set; }
         public static Log? Stub      { get; private set; }
+        public static Log  Notice    { get; } // Always enabled
 
         static Logger()
         {
@@ -109,6 +110,8 @@ namespace Ryujinx.Common.Logging
                 new ConsoleLogTarget("console"),
                 1000,
                 AsyncLogTargetOverflowAction.Discard));
+
+            Notice = new Log(LogLevel.Notice);
         }
 
         public static void RestartTime()

--- a/Ryujinx.Common/Logging/Logger.cs
+++ b/Ryujinx.Common/Logging/Logger.cs
@@ -184,13 +184,13 @@ namespace Ryujinx.Common.Logging
         {
             switch (logLevel)
             {
-                case LogLevel.Debug    : Debug     = enabled ? new Log(LogLevel.Debug)    : new Log?(); break;
-                case LogLevel.Info     : Info      = enabled ? new Log(LogLevel.Info)     : new Log?(); break;
-                case LogLevel.Warning  : Warning   = enabled ? new Log(LogLevel.Warning)  : new Log?(); break;
-                case LogLevel.Error    : Error     = enabled ? new Log(LogLevel.Error)    : new Log?(); break;
-                case LogLevel.Guest    : Guest     = enabled ? new Log(LogLevel.Guest)    : new Log?(); break;
-                case LogLevel.AccessLog: AccessLog = enabled ? new Log(LogLevel.AccessLog): new Log?(); break;
-                case LogLevel.Stub     : Stub      = enabled ? new Log(LogLevel.Stub)     : new Log?(); break;
+                case LogLevel.Debug     : Debug     = enabled ? new Log(LogLevel.Debug)    : new Log?(); break;
+                case LogLevel.Info      : Info      = enabled ? new Log(LogLevel.Info)     : new Log?(); break;
+                case LogLevel.Warning   : Warning   = enabled ? new Log(LogLevel.Warning)  : new Log?(); break;
+                case LogLevel.Error     : Error     = enabled ? new Log(LogLevel.Error)    : new Log?(); break;
+                case LogLevel.Guest     : Guest     = enabled ? new Log(LogLevel.Guest)    : new Log?(); break;
+                case LogLevel.AccessLog : AccessLog = enabled ? new Log(LogLevel.AccessLog): new Log?(); break;
+                case LogLevel.Stub      : Stub      = enabled ? new Log(LogLevel.Stub)     : new Log?(); break;
                 default: throw new ArgumentException("Unknown Log Level");
             }
         }

--- a/Ryujinx.Common/Logging/Targets/ConsoleLogTarget.cs
+++ b/Ryujinx.Common/Logging/Targets/ConsoleLogTarget.cs
@@ -5,23 +5,20 @@ namespace Ryujinx.Common.Logging
 {
     public class ConsoleLogTarget : ILogTarget
     {
-        private static readonly ConcurrentDictionary<LogLevel, ConsoleColor> _logColors;
-
         private readonly ILogFormatter _formatter;
 
         private readonly string _name;
 
         string ILogTarget.Name { get => _name; }
 
-        static ConsoleLogTarget()
-        {
-            _logColors = new ConcurrentDictionary<LogLevel, ConsoleColor> {
-                [ LogLevel.Stub    ] = ConsoleColor.DarkGray,
-                [ LogLevel.Info    ] = ConsoleColor.White,
-                [ LogLevel.Warning ] = ConsoleColor.Yellow,
-                [ LogLevel.Error   ] = ConsoleColor.Red
-            };
-        }
+        private static ConsoleColor GetLogColor(LogLevel level) => level switch {
+            LogLevel.Info    => ConsoleColor.White,
+            LogLevel.Warning => ConsoleColor.Yellow,
+            LogLevel.Error   => ConsoleColor.Red,
+            LogLevel.Stub    => ConsoleColor.DarkGray,
+            LogLevel.Notice  => ConsoleColor.Cyan,
+            _                => ConsoleColor.Gray,
+        };
 
         public ConsoleLogTarget(string name)
         {
@@ -31,18 +28,9 @@ namespace Ryujinx.Common.Logging
 
         public void Log(object sender, LogEventArgs args)
         {
-            if (_logColors.TryGetValue(args.Level, out ConsoleColor color))
-            {
-                Console.ForegroundColor = color;
-
-                Console.WriteLine(_formatter.Format(args));
-
-                Console.ResetColor();
-            }
-            else
-            {
-                Console.WriteLine(_formatter.Format(args));
-            }
+            Console.ForegroundColor = GetLogColor(args.Level);
+            Console.WriteLine(_formatter.Format(args));
+            Console.ResetColor();
         }
 
         public void Dispose()

--- a/Ryujinx.Common/SystemInfo/MacOSSysteminfo.cs
+++ b/Ryujinx.Common/SystemInfo/MacOSSysteminfo.cs
@@ -75,7 +75,7 @@ namespace Ryujinx.Common.SystemInfo
             }
             else
             {
-                Logger.PrintError(LogClass.Application, $"Cannot get memory size, sysctlbyname error: {res}");
+                Logger.Error?.Print(LogClass.Application, $"Cannot get memory size, sysctlbyname error: {res}");
 
                 RamSize = 0;
             }
@@ -88,7 +88,7 @@ namespace Ryujinx.Common.SystemInfo
             }
             else
             {
-                Logger.PrintError(LogClass.Application, $"Cannot get CPU name, sysctlbyname error: {res}");
+                Logger.Error?.Print(LogClass.Application, $"Cannot get CPU name, sysctlbyname error: {res}");
 
                 CpuName = "Unknown";
             }

--- a/Ryujinx.Common/SystemInfo/WindowsSystemInfo.cs
+++ b/Ryujinx.Common/SystemInfo/WindowsSystemInfo.cs
@@ -37,7 +37,7 @@ namespace Ryujinx.Common.SystemInfo
 
             if (wmiNotAvailable)
             {
-                Logger.PrintError(LogClass.Application, "WMI isn't available, system informations will use default values.");
+                Logger.Error?.Print(LogClass.Application, "WMI isn't available, system informations will use default values.");
 
                 CpuName = "Unknown";
             }

--- a/Ryujinx.Graphics.Gpu/Engine/MME/MacroInterpreter.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MME/MacroInterpreter.cs
@@ -364,7 +364,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
         {
             if (!Fifo.TryDequeue(out int value))
             {
-                Logger.PrintWarning(LogClass.Gpu, "Macro attempted to fetch an inexistent argument.");
+                Logger.Warning?.Print(LogClass.Gpu, "Macro attempted to fetch an inexistent argument.");
 
                 return 0;
             }

--- a/Ryujinx.Graphics.Gpu/Engine/MME/MacroJitContext.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MME/MacroJitContext.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
         {
             if (!Fifo.TryDequeue(out int value))
             {
-                Logger.PrintWarning(LogClass.Gpu, "Macro attempted to fetch an inexistent argument.");
+                Logger.Warning?.Print(LogClass.Gpu, "Macro attempted to fetch an inexistent argument.");
 
                 return 0;
             }

--- a/Ryujinx.Graphics.Gpu/Engine/MethodConditionalRendering.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodConditionalRendering.cs
@@ -37,7 +37,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
                     return CounterCompare(condState.Address.Pack(), false);
             }
 
-            Logger.PrintWarning(LogClass.Gpu, $"Invalid conditional render condition \"{condState.Condition}\".");
+            Logger.Warning?.Print(LogClass.Gpu, $"Invalid conditional render condition \"{condState.Condition}\".");
 
             return ConditionalRenderEnabled.True;
         }

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -692,7 +692,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
                 if (!FormatTable.TryGetAttribFormat(vertexAttrib.UnpackFormat(), out Format format))
                 {
-                    Logger.PrintDebug(LogClass.Gpu, $"Invalid attribute format 0x{vertexAttrib.UnpackFormat():X}.");
+                    Logger.Debug?.Print(LogClass.Gpu, $"Invalid attribute format 0x{vertexAttrib.UnpackFormat():X}.");
 
                     format = Format.R32G32B32A32Float;
                 }
@@ -1114,7 +1114,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
                     return Target.CubemapArray;
             }
 
-            Logger.PrintWarning(LogClass.Gpu, $"Invalid sampler type \"{type}\".");
+            Logger.Warning?.Print(LogClass.Gpu, $"Invalid sampler type \"{type}\".");
 
             return Target.Texture2D;
         }

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -414,7 +414,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             if (ScaleFactor != scale)
             {
-                Logger.PrintDebug(LogClass.Gpu, $"Rescaling {Info.Width}x{Info.Height} {Info.FormatInfo.Format.ToString()} to ({ScaleFactor} to {scale}). ");
+                Logger.Debug?.Print(LogClass.Gpu, $"Rescaling {Info.Width}x{Info.Height} {Info.FormatInfo.Format.ToString()} to ({ScaleFactor} to {scale}). ");
                 TextureCreateInfo createInfo = TextureManager.GetCreateInfo(Info, _context.Capabilities);
 
                 ScaleFactor = scale;
@@ -430,7 +430,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     HostTexture.CopyTo(newStorage, new Extents2D(0, 0, HostTexture.Width, HostTexture.Height), new Extents2D(0, 0, newStorage.Width, newStorage.Height), true);
                 }
 
-                Logger.PrintDebug(LogClass.Gpu, $"  Copy performed: {HostTexture.Width}x{HostTexture.Height} to {newStorage.Width}x{newStorage.Height}");
+                Logger.Debug?.Print(LogClass.Gpu, $"  Copy performed: {HostTexture.Width}x{HostTexture.Height} to {newStorage.Width}x{newStorage.Height}");
 
                 ReplaceStorage(newStorage);
 
@@ -438,7 +438,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 foreach (var view in _views)
                 {
-                    Logger.PrintDebug(LogClass.Gpu, $"  Recreating view {Info.Width}x{Info.Height} {Info.FormatInfo.Format.ToString()}.");
+                    Logger.Debug?.Print(LogClass.Gpu, $"  Recreating view {Info.Width}x{Info.Height} {Info.FormatInfo.Format.ToString()}.");
                     view.ScaleFactor = scale;
 
                     TextureCreateInfo viewCreateInfo = TextureManager.GetCreateInfo(view.Info, _context.Capabilities);
@@ -590,7 +590,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 {
                     string texInfo = $"{Info.Target} {Info.FormatInfo.Format} {Info.Width}x{Info.Height}x{Info.DepthOrLayers} levels {Info.Levels}";
 
-                    Logger.PrintDebug(LogClass.Gpu, $"Invalid ASTC texture at 0x{Info.Address:X} ({texInfo}).");
+                    Logger.Debug?.Print(LogClass.Gpu, $"Invalid ASTC texture at 0x{Info.Address:X} ({texInfo}).");
                 }
 
                 data = decoded;

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -151,7 +151,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             {
                 if ((long)address > 0L && (int)format > 0)
                 {
-                    Logger.PrintError(LogClass.Gpu, $"Invalid texture format 0x{format:X} (sRGB: {srgb}).");
+                    Logger.Error?.Print(LogClass.Gpu, $"Invalid texture format 0x{format:X} (sRGB: {srgb}).");
                 }
 
                 formatInfo = FormatInfo.Default;

--- a/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
@@ -70,7 +70,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <param name="message">Message to print</param>
         public void Log(string message)
         {
-            Logger.PrintWarning(LogClass.Gpu, $"Shader translator: {message}");
+            Logger.Warning?.Print(LogClass.Gpu, $"Shader translator: {message}");
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Synchronization/SynchronizationManager.cs
+++ b/Ryujinx.Graphics.Gpu/Synchronization/SynchronizationManager.cs
@@ -131,7 +131,7 @@ namespace Ryujinx.Graphics.Gpu.Synchronization
 
                 if (!signaled && info != null)
                 {
-                    Logger.PrintError(LogClass.Gpu, $"Wait on syncpoint {id} for threshold {threshold} took more than {timeout.TotalMilliseconds}ms, resuming execution...");
+                    Logger.Error?.Print(LogClass.Gpu, $"Wait on syncpoint {id} for threshold {threshold} took more than {timeout.TotalMilliseconds}ms, resuming execution...");
 
                     _syncpoints[id].UnregisterCallback(info);
                 }

--- a/Ryujinx.Graphics.Host1x/Host1xDevice.cs
+++ b/Ryujinx.Graphics.Host1x/Host1xDevice.cs
@@ -104,7 +104,7 @@ namespace Ryujinx.Graphics.Host1x
                     DeviceWrite(_offset, data);
                     break;
                 default:
-                    Logger.PrintError(LogClass.Host1x, $"Unsupported opcode \"{opCode}\".");
+                    Logger.Error?.Print(LogClass.Host1x, $"Unsupported opcode \"{opCode}\".");
                     break;
             }
         }

--- a/Ryujinx.Graphics.Nvdec/NvdecDevice.cs
+++ b/Ryujinx.Graphics.Nvdec/NvdecDevice.cs
@@ -42,7 +42,7 @@ namespace Ryujinx.Graphics.Nvdec
                     Vp9Decoder.Decode(this, _rm, ref _state.State);
                     break;
                 default:
-                    Logger.PrintError(LogClass.Nvdec, $"Unsupported codec \"{codecId}\".");
+                    Logger.Error?.Print(LogClass.Nvdec, $"Unsupported codec \"{codecId}\".");
                     break;
             }
         }

--- a/Ryujinx.Graphics.OpenGL/Debugger.cs
+++ b/Ryujinx.Graphics.OpenGL/Debugger.cs
@@ -47,7 +47,7 @@ namespace Ryujinx.Graphics.OpenGL
 
             GL.DebugMessageCallback(_debugCallback, IntPtr.Zero);
 
-            Logger.PrintWarning(LogClass.Gpu, "OpenGL Debugging is enabled. Performance will be negatively impacted.");
+            Logger.Warning?.Print(LogClass.Gpu, "OpenGL Debugging is enabled. Performance will be negatively impacted.");
         }
 
         private static void GLDebugHandler(
@@ -63,18 +63,18 @@ namespace Ryujinx.Graphics.OpenGL
 
             switch (type)
             {
-                case DebugType.DebugTypeError      : Logger.PrintError(LogClass.Gpu, $"{severity}: {msg}\nCallStack={Environment.StackTrace}", "GLERROR"); break;
-                case DebugType.DebugTypePerformance: Logger.PrintWarning(LogClass.Gpu, $"{severity}: {msg}", "GLPERF"); break;
-                case DebugType.DebugTypePushGroup  : Logger.PrintInfo(LogClass.Gpu, $"{{ ({id}) {severity}: {msg}", "GLINFO"); break;
-                case DebugType.DebugTypePopGroup   : Logger.PrintInfo(LogClass.Gpu, $"}} ({id}) {severity}: {msg}", "GLINFO"); break;
+                case DebugType.DebugTypeError      : Logger.Error?.Print(LogClass.Gpu, $"{severity}: {msg}\nCallStack={Environment.StackTrace}", "GLERROR"); break;
+                case DebugType.DebugTypePerformance: Logger.Warning?.Print(LogClass.Gpu, $"{severity}: {msg}", "GLPERF"); break;
+                case DebugType.DebugTypePushGroup  : Logger.Info?.Print(LogClass.Gpu, $"{{ ({id}) {severity}: {msg}", "GLINFO"); break;
+                case DebugType.DebugTypePopGroup   : Logger.Info?.Print(LogClass.Gpu, $"}} ({id}) {severity}: {msg}", "GLINFO"); break;
                 default:
                     if (source == DebugSource.DebugSourceApplication)
                     {
-                        Logger.PrintInfo(LogClass.Gpu, $"{type} {severity}: {msg}", "GLINFO");
+                        Logger.Info?.Print(LogClass.Gpu, $"{type} {severity}: {msg}", "GLINFO");
                     }
                     else
                     {
-                        Logger.PrintDebug(LogClass.Gpu, $"{type} {severity}: {msg}", "GLDEBUG");
+                        Logger.Debug?.Print(LogClass.Gpu, $"{type} {severity}: {msg}", "GLDEBUG");
                     }
                     break;
             }

--- a/Ryujinx.Graphics.OpenGL/EnumConversion.cs
+++ b/Ryujinx.Graphics.OpenGL/EnumConversion.cs
@@ -28,7 +28,7 @@ namespace Ryujinx.Graphics.OpenGL
                     return TextureWrapMode.ClampToEdge;
             }
 
-            Logger.PrintDebug(LogClass.Gpu, $"Invalid {nameof(AddressMode)} enum value: {mode}.");
+            Logger.Debug?.Print(LogClass.Gpu, $"Invalid {nameof(AddressMode)} enum value: {mode}.");
 
             return TextureWrapMode.Clamp;
         }
@@ -92,7 +92,7 @@ namespace Ryujinx.Graphics.OpenGL
                     return All.OneMinusConstantAlpha;
             }
 
-            Logger.PrintDebug(LogClass.Gpu, $"Invalid {nameof(BlendFactor)} enum value: {factor}.");
+            Logger.Debug?.Print(LogClass.Gpu, $"Invalid {nameof(BlendFactor)} enum value: {factor}.");
 
             return All.Zero;
         }
@@ -118,7 +118,7 @@ namespace Ryujinx.Graphics.OpenGL
                     return BlendEquationMode.Max;
             }
 
-            Logger.PrintDebug(LogClass.Gpu, $"Invalid {nameof(BlendOp)} enum value: {op}.");
+            Logger.Debug?.Print(LogClass.Gpu, $"Invalid {nameof(BlendOp)} enum value: {op}.");
 
             return BlendEquationMode.FuncAdd;
         }
@@ -133,7 +133,7 @@ namespace Ryujinx.Graphics.OpenGL
                     return TextureCompareMode.CompareRToTexture;
             }
 
-            Logger.PrintDebug(LogClass.Gpu, $"Invalid {nameof(CompareMode)} enum value: {mode}.");
+            Logger.Debug?.Print(LogClass.Gpu, $"Invalid {nameof(CompareMode)} enum value: {mode}.");
 
             return TextureCompareMode.None;
         }
@@ -168,7 +168,7 @@ namespace Ryujinx.Graphics.OpenGL
                     return All.Always;
             }
 
-            Logger.PrintDebug(LogClass.Gpu, $"Invalid {nameof(CompareOp)} enum value: {op}.");
+            Logger.Debug?.Print(LogClass.Gpu, $"Invalid {nameof(CompareOp)} enum value: {op}.");
 
             return All.Never;
         }
@@ -183,7 +183,7 @@ namespace Ryujinx.Graphics.OpenGL
                     return ClipDepthMode.ZeroToOne;
             }
 
-            Logger.PrintDebug(LogClass.Gpu, $"Invalid {nameof(DepthMode)} enum value: {mode}.");
+            Logger.Debug?.Print(LogClass.Gpu, $"Invalid {nameof(DepthMode)} enum value: {mode}.");
 
             return ClipDepthMode.NegativeOneToOne;
         }
@@ -198,7 +198,7 @@ namespace Ryujinx.Graphics.OpenGL
                     return All.StencilIndex;
             }
 
-            Logger.PrintDebug(LogClass.Gpu, $"Invalid {nameof(DepthStencilMode)} enum value: {mode}.");
+            Logger.Debug?.Print(LogClass.Gpu, $"Invalid {nameof(DepthStencilMode)} enum value: {mode}.");
 
             return All.Depth;
         }
@@ -215,7 +215,7 @@ namespace Ryujinx.Graphics.OpenGL
                     return CullFaceMode.FrontAndBack;
             }
 
-            Logger.PrintDebug(LogClass.Gpu, $"Invalid {nameof(Face)} enum value: {face}.");
+            Logger.Debug?.Print(LogClass.Gpu, $"Invalid {nameof(Face)} enum value: {face}.");
 
             return CullFaceMode.Back;
         }
@@ -230,7 +230,7 @@ namespace Ryujinx.Graphics.OpenGL
                     return FrontFaceDirection.Ccw;
             }
 
-            Logger.PrintDebug(LogClass.Gpu, $"Invalid {nameof(FrontFace)} enum value: {frontFace}.");
+            Logger.Debug?.Print(LogClass.Gpu, $"Invalid {nameof(FrontFace)} enum value: {frontFace}.");
 
             return FrontFaceDirection.Cw;
         }
@@ -247,7 +247,7 @@ namespace Ryujinx.Graphics.OpenGL
                     return DrawElementsType.UnsignedInt;
             }
 
-            Logger.PrintDebug(LogClass.Gpu, $"Invalid {nameof(IndexType)} enum value: {type}.");
+            Logger.Debug?.Print(LogClass.Gpu, $"Invalid {nameof(IndexType)} enum value: {type}.");
 
             return DrawElementsType.UnsignedByte;
         }
@@ -262,7 +262,7 @@ namespace Ryujinx.Graphics.OpenGL
                     return TextureMagFilter.Linear;
             }
 
-            Logger.PrintDebug(LogClass.Gpu, $"Invalid {nameof(MagFilter)} enum value: {filter}.");
+            Logger.Debug?.Print(LogClass.Gpu, $"Invalid {nameof(MagFilter)} enum value: {filter}.");
 
             return TextureMagFilter.Nearest;
         }
@@ -285,7 +285,7 @@ namespace Ryujinx.Graphics.OpenGL
                     return TextureMinFilter.LinearMipmapLinear;
             }
 
-            Logger.PrintDebug(LogClass.Gpu, $"Invalid {nameof(MinFilter)} enum value: {filter}.");
+            Logger.Debug?.Print(LogClass.Gpu, $"Invalid {nameof(MinFilter)} enum value: {filter}.");
 
             return TextureMinFilter.Nearest;
         }
@@ -326,7 +326,7 @@ namespace Ryujinx.Graphics.OpenGL
                     return PrimitiveType.Patches;
             }
 
-            Logger.PrintDebug(LogClass.Gpu, $"Invalid {nameof(PrimitiveTopology)} enum value: {topology}.");
+            Logger.Debug?.Print(LogClass.Gpu, $"Invalid {nameof(PrimitiveTopology)} enum value: {topology}.");
 
             return PrimitiveType.Points;
         }
@@ -351,7 +351,7 @@ namespace Ryujinx.Graphics.OpenGL
                     return TransformFeedbackPrimitiveType.Triangles;
             }
 
-            Logger.PrintDebug(LogClass.Gpu, $"Invalid {nameof(PrimitiveTopology)} enum value: {topology}.");
+            Logger.Debug?.Print(LogClass.Gpu, $"Invalid {nameof(PrimitiveTopology)} enum value: {topology}.");
 
             return TransformFeedbackPrimitiveType.Points;
         }
@@ -378,7 +378,7 @@ namespace Ryujinx.Graphics.OpenGL
                     return OpenTK.Graphics.OpenGL.StencilOp.DecrWrap;
             }
 
-            Logger.PrintDebug(LogClass.Gpu, $"Invalid {nameof(GAL.StencilOp)} enum value: {op}.");
+            Logger.Debug?.Print(LogClass.Gpu, $"Invalid {nameof(GAL.StencilOp)} enum value: {op}.");
 
             return OpenTK.Graphics.OpenGL.StencilOp.Keep;
         }
@@ -401,7 +401,7 @@ namespace Ryujinx.Graphics.OpenGL
                     return All.Alpha;
             }
 
-            Logger.PrintDebug(LogClass.Gpu, $"Invalid {nameof(SwizzleComponent)} enum value: {swizzleComponent}.");
+            Logger.Debug?.Print(LogClass.Gpu, $"Invalid {nameof(SwizzleComponent)} enum value: {swizzleComponent}.");
 
             return All.Zero;
         }
@@ -437,7 +437,7 @@ namespace Ryujinx.Graphics.OpenGL
                     return TextureTarget.TextureBuffer;
             }
 
-            Logger.PrintDebug(LogClass.Gpu, $"Invalid {nameof(Target)} enum value: {target}.");
+            Logger.Debug?.Print(LogClass.Gpu, $"Invalid {nameof(Target)} enum value: {target}.");
 
             return TextureTarget.Texture2D;
         }
@@ -464,7 +464,7 @@ namespace Ryujinx.Graphics.OpenGL
                     return NvViewportSwizzle.ViewportSwizzleNegativeWNv;
             }
 
-            Logger.PrintDebug(LogClass.Gpu, $"Invalid {nameof(ViewportSwizzle)} enum value: {swizzle}.");
+            Logger.Debug?.Print(LogClass.Gpu, $"Invalid {nameof(ViewportSwizzle)} enum value: {swizzle}.");
 
             return NvViewportSwizzle.ViewportSwizzlePositiveXNv;
         }
@@ -507,7 +507,7 @@ namespace Ryujinx.Graphics.OpenGL
                     return All.Set;
             }
 
-            Logger.PrintDebug(LogClass.Gpu, $"Invalid {nameof(LogicalOp)} enum value: {op}.");
+            Logger.Debug?.Print(LogClass.Gpu, $"Invalid {nameof(LogicalOp)} enum value: {op}.");
 
             return All.Never;
         }

--- a/Ryujinx.Graphics.OpenGL/Image/TextureStorage.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureStorage.cs
@@ -140,7 +140,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
                     break;
 
                 default:
-                    Logger.PrintDebug(LogClass.Gpu, $"Invalid or unsupported texture target: {target}.");
+                    Logger.Debug?.Print(LogClass.Gpu, $"Invalid or unsupported texture target: {target}.");
                     break;
             }
         }

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -156,7 +156,7 @@ namespace Ryujinx.Graphics.OpenGL
         {
             if (!_program.IsLinked)
             {
-                Logger.PrintDebug(LogClass.Gpu, "Dispatch error, shader not linked.");
+                Logger.Debug?.Print(LogClass.Gpu, "Dispatch error, shader not linked.");
                 return;
             }
 
@@ -169,7 +169,7 @@ namespace Ryujinx.Graphics.OpenGL
         {
             if (!_program.IsLinked)
             {
-                Logger.PrintDebug(LogClass.Gpu, "Draw error, shader not linked.");
+                Logger.Debug?.Print(LogClass.Gpu, "Draw error, shader not linked.");
                 return;
             }
 
@@ -287,7 +287,7 @@ namespace Ryujinx.Graphics.OpenGL
         {
             if (!_program.IsLinked)
             {
-                Logger.PrintDebug(LogClass.Gpu, "Draw error, shader not linked.");
+                Logger.Debug?.Print(LogClass.Gpu, "Draw error, shader not linked.");
                 return;
             }
 

--- a/Ryujinx.Graphics.OpenGL/Program.cs
+++ b/Ryujinx.Graphics.OpenGL/Program.cs
@@ -256,7 +256,7 @@ namespace Ryujinx.Graphics.OpenGL
             if (status == 0)
             {
                 // Use GL.GetProgramInfoLog(Handle), it may be too long to print on the log.
-                Logger.PrintDebug(LogClass.Gpu, "Shader linking failed.");
+                Logger.Debug?.Print(LogClass.Gpu, "Shader linking failed.");
             }
             else
             {

--- a/Ryujinx.Graphics.OpenGL/Queries/BufferedQuery.cs
+++ b/Ryujinx.Graphics.OpenGL/Queries/BufferedQuery.cs
@@ -87,7 +87,7 @@ namespace Ryujinx.Graphics.OpenGL.Queries
 
                 if (iterations >= MaxQueryRetries)
                 {
-                    Logger.PrintError(LogClass.Gpu, $"Error: Query result timed out. Took more than {MaxQueryRetries} tries.");
+                    Logger.Error?.Print(LogClass.Gpu, $"Error: Query result timed out. Took more than {MaxQueryRetries} tries.");
                 }
             }
 

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -112,7 +112,7 @@ namespace Ryujinx.Graphics.OpenGL
             GpuRenderer = GL.GetString(StringName.Renderer);
             GpuVersion  = GL.GetString(StringName.Version);
 
-            Logger.PrintInfo(LogClass.Gpu, $"{GpuVendor} {GpuRenderer} ({GpuVersion})");
+            Logger.Notice.Print(LogClass.Gpu, $"{GpuVendor} {GpuRenderer} ({GpuVersion})");
         }
 
         public void ResetCounter(CounterType type)

--- a/Ryujinx.Graphics.Vic/Image/SurfaceReader.cs
+++ b/Ryujinx.Graphics.Vic/Image/SurfaceReader.cs
@@ -19,7 +19,7 @@ namespace Ryujinx.Graphics.Vic.Image
                 case PixelFormat.Y8___V8U8_N420: return ReadNv12(rm, ref config, ref offsets);
             }
 
-            Logger.PrintError(LogClass.Vic, $"Unsupported pixel format \"{config.SlotPixelFormat}\".");
+            Logger.Error?.Print(LogClass.Vic, $"Unsupported pixel format \"{config.SlotPixelFormat}\".");
 
             int lw = config.SlotLumaWidth + 1;
             int lh = config.SlotLumaHeight + 1;

--- a/Ryujinx.Graphics.Vic/Image/SurfaceWriter.cs
+++ b/Ryujinx.Graphics.Vic/Image/SurfaceWriter.cs
@@ -24,7 +24,7 @@ namespace Ryujinx.Graphics.Vic.Image
                     WriteNv12(rm, input, ref config, ref offsets);
                     break;
                 default:
-                    Logger.PrintError(LogClass.Vic, $"Unsupported pixel format \"{config.OutPixelFormat}\".");
+                    Logger.Error?.Print(LogClass.Vic, $"Unsupported pixel format \"{config.OutPixelFormat}\".");
                     break;
             }
         }

--- a/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
+++ b/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
@@ -208,7 +208,7 @@ namespace Ryujinx.HLE.FileSystem.Content
                     var nca = new Nca(_virtualFileSystem.KeySet, ncaFile.AsStorage());
                     if (nca.Header.ContentType != NcaContentType.Meta)
                     {
-                        Logger.PrintWarning(LogClass.Application, $"{ncaPath} is not a valid metadata file");
+                        Logger.Warning?.Print(LogClass.Application, $"{ncaPath} is not a valid metadata file");
 
                         continue;
                     }
@@ -229,11 +229,11 @@ namespace Ryujinx.HLE.FileSystem.Content
                         string ncaId = BitConverter.ToString(cnmt.ContentEntries[0].NcaId).Replace("-", "").ToLower();
                         if (!_aocData.TryAdd(cnmt.TitleId, new AocItem(containerPath, $"{ncaId}.nca", true)))
                         {
-                            Logger.PrintWarning(LogClass.Application, $"Duplicate AddOnContent detected. TitleId {cnmt.TitleId:X16}");
+                            Logger.Warning?.Print(LogClass.Application, $"Duplicate AddOnContent detected. TitleId {cnmt.TitleId:X16}");
                         }
                         else
                         {
-                            Logger.PrintInfo(LogClass.Application, $"Found AddOnContent with TitleId {cnmt.TitleId:X16}");
+                            Logger.Info?.Print(LogClass.Application, $"Found AddOnContent with TitleId {cnmt.TitleId:X16}");
                         }
                     }
                 }
@@ -244,11 +244,11 @@ namespace Ryujinx.HLE.FileSystem.Content
         {
             if (!_aocData.TryAdd(titleId, new AocItem(containerPath, ncaPath, enabled)))
             {
-                Logger.PrintWarning(LogClass.Application, $"Duplicate AddOnContent detected. TitleId {titleId:X16}");
+                Logger.Warning?.Print(LogClass.Application, $"Duplicate AddOnContent detected. TitleId {titleId:X16}");
             }
             else
             {
-                Logger.PrintInfo(LogClass.Application, $"Found AddOnContent with TitleId {titleId:X16}");
+                Logger.Info?.Print(LogClass.Application, $"Found AddOnContent with TitleId {titleId:X16}");
 
                 using (FileStream fileStream = File.OpenRead(containerPath))
                 using (PartitionFileSystem pfs = new PartitionFileSystem(fileStream.AsStorage()))

--- a/Ryujinx.HLE/HOS/Applets/Browser/BrowserApplet.cs
+++ b/Ryujinx.HLE/HOS/Applets/Browser/BrowserApplet.cs
@@ -34,17 +34,17 @@ namespace Ryujinx.HLE.HOS.Applets.Browser
 
             _commonArguments = IApplet.ReadStruct<CommonArguments>(_normalSession.Pop());
 
-            Logger.PrintStub(LogClass.ServiceAm, $"WebApplet version: 0x{_commonArguments.AppletVersion:x8}");
+            Logger.Stub?.PrintStub(LogClass.ServiceAm, $"WebApplet version: 0x{_commonArguments.AppletVersion:x8}");
 
             ReadOnlySpan<byte> webArguments = _normalSession.Pop();
 
             (_shimKind, _arguments) = BrowserArgument.ParseArguments(webArguments);
 
-            Logger.PrintStub(LogClass.ServiceAm, $"Web Arguments: {_arguments.Count}");
+            Logger.Stub?.PrintStub(LogClass.ServiceAm, $"Web Arguments: {_arguments.Count}");
 
             foreach (BrowserArgument argument in _arguments)
             {
-                Logger.PrintStub(LogClass.ServiceAm, $"{argument.Type}: {argument.GetValue()}");
+                Logger.Stub?.PrintStub(LogClass.ServiceAm, $"{argument.Type}: {argument.GetValue()}");
             }
 
             if ((_commonArguments.AppletVersion >= 0x80000 && _shimKind == ShimKind.Web) || (_commonArguments.AppletVersion >= 0x30000 && _shimKind == ShimKind.Share))

--- a/Ryujinx.HLE/HOS/Applets/Controller/ControllerApplet.cs
+++ b/Ryujinx.HLE/HOS/Applets/Controller/ControllerApplet.cs
@@ -32,7 +32,7 @@ namespace Ryujinx.HLE.HOS.Applets
             byte[] controllerSupportArgPrivate = _normalSession.Pop();
             ControllerSupportArgPrivate privateArg = IApplet.ReadStruct<ControllerSupportArgPrivate>(controllerSupportArgPrivate);
 
-            Logger.PrintStub(LogClass.ServiceHid, $"ControllerApplet ArgPriv {privateArg.PrivateSize} {privateArg.ArgSize} {privateArg.Mode}" +
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, $"ControllerApplet ArgPriv {privateArg.PrivateSize} {privateArg.ArgSize} {privateArg.Mode}" +
                         $"HoldType:{(NpadJoyHoldType)privateArg.NpadJoyHoldType} StyleSets:{(ControllerType)privateArg.NpadStyleSet}");
 
             if (privateArg.Mode != ControllerSupportMode.ShowControllerSupport)
@@ -55,19 +55,19 @@ namespace Ryujinx.HLE.HOS.Applets
             }
             else
             {
-                Logger.PrintStub(LogClass.ServiceHid, $"Unknown revision of ControllerSupportArg.");
+                Logger.Stub?.PrintStub(LogClass.ServiceHid, $"Unknown revision of ControllerSupportArg.");
 
                 argHeader = IApplet.ReadStruct<ControllerSupportArgHeader>(controllerSupportArg); // Read just the header
             }
 
-            Logger.PrintStub(LogClass.ServiceHid, $"ControllerApplet Arg {argHeader.PlayerCountMin} {argHeader.PlayerCountMax} {argHeader.EnableTakeOverConnection} {argHeader.EnableSingleMode}");
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, $"ControllerApplet Arg {argHeader.PlayerCountMin} {argHeader.PlayerCountMax} {argHeader.EnableTakeOverConnection} {argHeader.EnableSingleMode}");
 
             // Currently, the only purpose of this applet is to help 
             // choose the primary input controller for the game
             // TODO: Ideally should hook back to HID.Controller. When applet is called, can choose appropriate controller and attach to appropriate id.
             if (argHeader.PlayerCountMin > 1)
             {
-                Logger.PrintWarning(LogClass.ServiceHid, "More than one controller was requested.");
+                Logger.Warning?.Print(LogClass.ServiceHid, "More than one controller was requested.");
             }
 
             ControllerSupportResultInfo result = new ControllerSupportResultInfo
@@ -76,7 +76,7 @@ namespace Ryujinx.HLE.HOS.Applets
                 SelectedId = (uint)GetNpadIdTypeFromIndex(_system.Device.Hid.Npads.PrimaryController)
             };
 
-            Logger.PrintStub(LogClass.ServiceHid, $"ControllerApplet ReturnResult {result.PlayerCount} {result.SelectedId}");
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, $"ControllerApplet ReturnResult {result.PlayerCount} {result.SelectedId}");
 
             _normalSession.Push(BuildResponse(result));
             AppletStateChanged?.Invoke(this, null);

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardApplet.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardApplet.cs
@@ -49,7 +49,7 @@ namespace Ryujinx.HLE.HOS.Applets
 
             if (keyboardConfig.Length < Marshal.SizeOf<SoftwareKeyboardConfig>())
             {
-                Logger.PrintError(LogClass.ServiceAm, $"SoftwareKeyboardConfig size mismatch. Expected {Marshal.SizeOf<SoftwareKeyboardConfig>():x}. Got {keyboardConfig.Length:x}");
+                Logger.Error?.Print(LogClass.ServiceAm, $"SoftwareKeyboardConfig size mismatch. Expected {Marshal.SizeOf<SoftwareKeyboardConfig>():x}. Got {keyboardConfig.Length:x}");
             }
             else
             {
@@ -58,7 +58,7 @@ namespace Ryujinx.HLE.HOS.Applets
 
             if (!_normalSession.TryPop(out _transferMemory))
             {
-                Logger.PrintError(LogClass.ServiceAm, "SwKbd Transfer Memory is null");
+                Logger.Error?.Print(LogClass.ServiceAm, "SwKbd Transfer Memory is null");
             }
 
             if (_keyboardConfig.UseUtf8)
@@ -110,7 +110,7 @@ namespace Ryujinx.HLE.HOS.Applets
             // Call the configured GUI handler to get user's input
             if (_device.UiHandler == null)
             {
-                Logger.PrintWarning(LogClass.Application, $"GUI Handler is not set. Falling back to default");
+                Logger.Warning?.Print(LogClass.Application, $"GUI Handler is not set. Falling back to default");
                 _okPressed = true;
             }
             else

--- a/Ryujinx.HLE/HOS/ApplicationLoader.cs
+++ b/Ryujinx.HLE/HOS/ApplicationLoader.cs
@@ -123,7 +123,7 @@ namespace Ryujinx.HLE.HOS
 
             if (!xci.HasPartition(XciPartitionType.Secure))
             {
-                Logger.PrintError(LogClass.Loader, "Unable to load XCI: Could not find XCI secure partition");
+                Logger.Error?.Print(LogClass.Loader, "Unable to load XCI: Could not find XCI secure partition");
 
                 return;
             }
@@ -140,14 +140,14 @@ namespace Ryujinx.HLE.HOS
             }
             catch (Exception e)
             {
-                Logger.PrintError(LogClass.Loader, $"Unable to load XCI: {e.Message}");
+                Logger.Error?.Print(LogClass.Loader, $"Unable to load XCI: {e.Message}");
 
                 return;
             }
 
             if (mainNca == null)
             {
-                Logger.PrintError(LogClass.Loader, "Unable to load XCI: Could not find Main NCA");
+                Logger.Error?.Print(LogClass.Loader, "Unable to load XCI: Could not find Main NCA");
 
                 return;
             }
@@ -176,14 +176,14 @@ namespace Ryujinx.HLE.HOS
             }
             catch (Exception e)
             {
-                Logger.PrintError(LogClass.Loader, $"Unable to load NSP: {e.Message}");
+                Logger.Error?.Print(LogClass.Loader, $"Unable to load NSP: {e.Message}");
 
                 return;
             }
 
             if (mainNca == null)
             {
-                Logger.PrintError(LogClass.Loader, "Unable to load NSP: Could not find Main NCA");
+                Logger.Error?.Print(LogClass.Loader, "Unable to load NSP: Could not find Main NCA");
 
                 return;
             }
@@ -215,7 +215,7 @@ namespace Ryujinx.HLE.HOS
         {
             if (mainNca.Header.ContentType != NcaContentType.Program)
             {
-                Logger.PrintError(LogClass.Loader, "Selected NCA is not a \"Program\" NCA");
+                Logger.Error?.Print(LogClass.Loader, "Selected NCA is not a \"Program\" NCA");
 
                 return;
             }
@@ -303,7 +303,7 @@ namespace Ryujinx.HLE.HOS
 
             if (codeFs == null)
             {
-                Logger.PrintError(LogClass.Loader, "No ExeFS found in NCA");
+                Logger.Error?.Print(LogClass.Loader, "No ExeFS found in NCA");
 
                 return;
             }
@@ -323,7 +323,7 @@ namespace Ryujinx.HLE.HOS
 
             if (dataStorage == null)
             {
-                Logger.PrintWarning(LogClass.Loader, "No RomFS found in NCA");
+                Logger.Warning?.Print(LogClass.Loader, "No RomFS found in NCA");
             }
             else
             {
@@ -338,7 +338,7 @@ namespace Ryujinx.HLE.HOS
 
             LoadExeFs(codeFs, metaData);
 
-            Logger.PrintInfo(LogClass.Loader, $"Application Loaded: {TitleName} v{DisplayVersion} [{TitleIdText}] [{(TitleIs64Bit ? "64-bit" : "32-bit")}]");
+            Logger.Info?.Print(LogClass.Loader, $"Application Loaded: {TitleName} v{DisplayVersion} [{TitleIdText}] [{(TitleIs64Bit ? "64-bit" : "32-bit")}]");
         }
 
         // Sets TitleId, so be sure to call before using it
@@ -349,7 +349,7 @@ namespace Ryujinx.HLE.HOS
 
             if (ResultFs.PathNotFound.Includes(result))
             {
-                Logger.PrintWarning(LogClass.Loader, "NPDM file not found, using default values!");
+                Logger.Warning?.Print(LogClass.Loader, "NPDM file not found, using default values!");
 
                 metaData = GetDefaultNpdm();
             }
@@ -414,7 +414,7 @@ namespace Ryujinx.HLE.HOS
                         continue;
                     }
 
-                    Logger.PrintInfo(LogClass.Loader, $"Loading {file.Name}...");
+                    Logger.Info?.Print(LogClass.Loader, $"Loading {file.Name}...");
 
                     codeFs.OpenFile(out IFile nsoFile, file.FullPath.ToU8Span(), OpenMode.Read).ThrowIfFailure();
 
@@ -435,7 +435,7 @@ namespace Ryujinx.HLE.HOS
 
             if (EnablePtc && modified)
             {
-                Logger.PrintWarning(LogClass.Ptc, $"Detected exefs modifications. PPTC disabled.");
+                Logger.Warning?.Print(LogClass.Ptc, $"Detected exefs modifications. PPTC disabled.");
             }
 
             Ptc.Initialize(TitleIdText, DisplayVersion, EnablePtc && !modified);
@@ -520,7 +520,7 @@ namespace Ryujinx.HLE.HOS
                         }
                         else
                         {
-                            Logger.PrintWarning(LogClass.Loader, $"Unsupported ASET header version found \"{asetVersion}\"");
+                            Logger.Warning?.Print(LogClass.Loader, $"Unsupported ASET header version found \"{asetVersion}\"");
                         }
                     }
                 }
@@ -551,7 +551,7 @@ namespace Ryujinx.HLE.HOS
 
         private Result EnsureSaveData(TitleId titleId)
         {
-            Logger.PrintInfo(LogClass.Application, "Ensuring required savedata exists.");
+            Logger.Info?.Print(LogClass.Application, "Ensuring required savedata exists.");
 
             Uid user = _device.System.State.Account.LastOpenedUser.UserId.ToLibHacUid();
 
@@ -567,7 +567,7 @@ namespace Ryujinx.HLE.HOS
                 control.UserAccountSaveDataSize = 0x4000;
                 control.UserAccountSaveDataJournalSize = 0x4000;
 
-                Logger.PrintWarning(LogClass.Application,
+                Logger.Warning?.Print(LogClass.Application,
                     "No control file was found for this game. Using a dummy one instead. This may cause inaccuracies in some games.");
             }
 
@@ -577,7 +577,7 @@ namespace Ryujinx.HLE.HOS
 
             if (rc.IsFailure())
             {
-                Logger.PrintError(LogClass.Application, $"Error calling EnsureApplicationCacheStorage. Result code {rc.ToStringWithName()}");
+                Logger.Error?.Print(LogClass.Application, $"Error calling EnsureApplicationCacheStorage. Result code {rc.ToStringWithName()}");
 
                 return rc;
             }
@@ -586,7 +586,7 @@ namespace Ryujinx.HLE.HOS
 
             if (rc.IsFailure())
             {
-                Logger.PrintError(LogClass.Application, $"Error calling EnsureApplicationSaveData. Result code {rc.ToStringWithName()}");
+                Logger.Error?.Print(LogClass.Application, $"Error calling EnsureApplicationSaveData. Result code {rc.ToStringWithName()}");
             }
 
             return rc;

--- a/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
@@ -1097,7 +1097,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
         {
             KernelContext.Scheduler.GetCurrentThreadOrNull()?.PrintGuestStackTrace();
 
-            Logger.PrintError(LogClass.Cpu, $"Invalid memory access at virtual address 0x{va:X16}.");
+            Logger.Error?.Print(LogClass.Cpu, $"Invalid memory access at virtual address 0x{va:X16}.");
 
             return false;
         }

--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
@@ -153,7 +153,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             }
             else
             {
-                Logger.PrintWarning(LogClass.KernelSvc, $"Invalid session handle 0x{handle:x8}!");
+                Logger.Warning?.Print(LogClass.KernelSvc, $"Invalid session handle 0x{handle:x8}!");
 
                 return KernelResult.InvalidHandle;
             }
@@ -1381,7 +1381,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             }
             else
             {
-                Logger.PrintDebug(LogClass.KernelSvc, "Debugger triggered.");
+                Logger.Debug?.Print(LogClass.KernelSvc, "Debugger triggered.");
             }
         }
 
@@ -1391,7 +1391,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
 
             string str = MemoryHelper.ReadAsciiString(process.CpuMemory, (long)strPtr, (long)size);
 
-            Logger.PrintWarning(LogClass.KernelSvc, str);
+            Logger.Warning?.Print(LogClass.KernelSvc, str);
         }
 
         public KernelResult GetInfo(uint id, int handle, long subId, out long value)

--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SyscallTable.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SyscallTable.cs
@@ -441,11 +441,11 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
         {
             if (argValues != null)
             {
-                Logger.PrintDebug(LogClass.KernelSvc, string.Format(formatOrSvcName, argValues));
+                Logger.Debug?.Print(LogClass.KernelSvc, string.Format(formatOrSvcName, argValues));
             }
             else
             {
-                Logger.PrintDebug(LogClass.KernelSvc, formatOrSvcName);
+                Logger.Debug?.Print(LogClass.KernelSvc, formatOrSvcName);
             }
         }
 
@@ -456,11 +456,11 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
                 result != KernelResult.Cancelled &&
                 result != KernelResult.InvalidState)
             {
-                Logger.PrintWarning(LogClass.KernelSvc, $"{svcName} returned error {result}.");
+                Logger.Warning?.Print(LogClass.KernelSvc, $"{svcName} returned error {result}.");
             }
             else
             {
-                Logger.PrintDebug(LogClass.KernelSvc, $"{svcName} returned result {result}.");
+                Logger.Debug?.Print(LogClass.KernelSvc, $"{svcName} returned result {result}.");
             }
         }
     }

--- a/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
@@ -1131,7 +1131,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
 
         public void PrintGuestStackTrace()
         {
-            Logger.Guest?.Print(LogClass.Cpu, $"Guest stack trace:\n{GetGuestStackTrace()}\n");
+            Logger.Info?.Print(LogClass.Cpu, $"Guest stack trace:\n{GetGuestStackTrace()}\n");
         }
 
         public void Execute()

--- a/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
@@ -1131,12 +1131,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
 
         public void PrintGuestStackTrace()
         {
-            StringBuilder trace = new StringBuilder();
-
-            trace.AppendLine("Guest stack trace:");
-            trace.AppendLine(GetGuestStackTrace());
-
-            Logger.PrintInfo(LogClass.Cpu, trace.ToString());
+            Logger.Guest?.Print(LogClass.Cpu, $"Guest stack trace:\n{GetGuestStackTrace()}\n");
         }
 
         public void Execute()

--- a/Ryujinx.HLE/HOS/ModLoader.cs
+++ b/Ryujinx.HLE/HOS/ModLoader.cs
@@ -126,7 +126,7 @@ namespace Ryujinx.HLE.HOS
 
             if (titleModsPath == null)
             {
-                Logger.PrintInfo(LogClass.ModLoader, $"Creating mods dir for Title {titleId.ToUpper()}");
+                Logger.Info?.Print(LogClass.ModLoader, $"Creating mods dir for Title {titleId.ToUpper()}");
                 titleModsPath = contentsDir.CreateSubdirectory(titleId);
             }
 
@@ -149,7 +149,7 @@ namespace Ryujinx.HLE.HOS
             foreach (var modDir in patchDir.EnumerateDirectories())
             {
                 patches.Add(new Mod<DirectoryInfo>(modDir.Name, modDir));
-                Logger.PrintInfo(LogClass.ModLoader, $"Found {type} patch '{modDir.Name}'");
+                Logger.Info?.Print(LogClass.ModLoader, $"Found {type} patch '{modDir.Name}'");
             }
         }
 
@@ -202,7 +202,7 @@ namespace Ryujinx.HLE.HOS
                     }
                 }
 
-                if (types.Length > 0) Logger.PrintInfo(LogClass.ModLoader, $"Found mod '{mod.Name}' [{types}]");
+                if (types.Length > 0) Logger.Info?.Print(LogClass.ModLoader, $"Found mod '{mod.Name}' [{types}]");
             }
         }
 
@@ -210,7 +210,7 @@ namespace Ryujinx.HLE.HOS
         {
             if (!contentsDir.Exists) return;
 
-            Logger.PrintInfo(LogClass.ModLoader, $"Searching mods for Title {titleId:X16}");
+            Logger.Info?.Print(LogClass.ModLoader, $"Searching mods for Title {titleId:X16}");
 
             var titleDir = FindTitleDir(contentsDir, $"{titleId:x16}");
 
@@ -252,7 +252,7 @@ namespace Ryujinx.HLE.HOS
                 var dir = new DirectoryInfo(path);
                 if (!dir.Exists)
                 {
-                    Logger.PrintWarning(LogClass.ModLoader, $"Mod Search Dir '{dir.FullName}' doesn't exist");
+                    Logger.Warning?.Print(LogClass.ModLoader, $"Mod Search Dir '{dir.FullName}' doesn't exist");
                     continue;
                 }
 
@@ -290,7 +290,7 @@ namespace Ryujinx.HLE.HOS
             var builder = new RomFsBuilder();
             int count = 0;
 
-            Logger.PrintInfo(LogClass.ModLoader, $"Applying RomFS mods for Title {titleId:X16}");
+            Logger.Info?.Print(LogClass.ModLoader, $"Applying RomFS mods for Title {titleId:X16}");
 
             // Prioritize loose files first
             foreach (var mod in mods.RomfsDirs)
@@ -305,7 +305,7 @@ namespace Ryujinx.HLE.HOS
             // Then files inside images
             foreach (var mod in mods.RomfsContainers)
             {
-                Logger.PrintInfo(LogClass.ModLoader, $"Found 'romfs.bin' for Title {titleId:X16}");
+                Logger.Info?.Print(LogClass.ModLoader, $"Found 'romfs.bin' for Title {titleId:X16}");
                 using (IFileSystem fs = new RomFsFileSystem(mod.Path.OpenRead().AsStorage()))
                 {
                     AddFiles(fs, mod.Name, fileSet, builder);
@@ -315,12 +315,12 @@ namespace Ryujinx.HLE.HOS
 
             if (fileSet.Count == 0)
             {
-                Logger.PrintInfo(LogClass.ModLoader, "No files found. Using base RomFS");
+                Logger.Info?.Print(LogClass.ModLoader, "No files found. Using base RomFS");
 
                 return baseStorage;
             }
 
-            Logger.PrintInfo(LogClass.ModLoader, $"Replaced {fileSet.Count} file(s) over {count} mod(s). Processing base storage...");
+            Logger.Info?.Print(LogClass.ModLoader, $"Replaced {fileSet.Count} file(s) over {count} mod(s). Processing base storage...");
 
             // And finally, the base romfs
             var baseRom = new RomFsFileSystem(baseStorage);
@@ -332,9 +332,9 @@ namespace Ryujinx.HLE.HOS
                 builder.AddFile(entry.FullPath, file);
             }
 
-            Logger.PrintInfo(LogClass.ModLoader, "Building new RomFS...");
+            Logger.Info?.Print(LogClass.ModLoader, "Building new RomFS...");
             IStorage newStorage = builder.Build();
-            Logger.PrintInfo(LogClass.ModLoader, "Using modded RomFS");
+            Logger.Info?.Print(LogClass.ModLoader, "Using modded RomFS");
 
             return newStorage;
         }
@@ -352,7 +352,7 @@ namespace Ryujinx.HLE.HOS
                 }
                 else
                 {
-                    Logger.PrintWarning(LogClass.ModLoader, $"    Skipped duplicate file '{entry.FullPath}' from '{modName}'", "ApplyRomFsMods");
+                    Logger.Warning?.Print(LogClass.ModLoader, $"    Skipped duplicate file '{entry.FullPath}' from '{modName}'", "ApplyRomFsMods");
                 }
             }
         }
@@ -366,10 +366,10 @@ namespace Ryujinx.HLE.HOS
 
             if (mods.ExefsContainers.Count > 1)
             {
-                Logger.PrintWarning(LogClass.ModLoader, "Multiple ExeFS partition replacements detected");
+                Logger.Warning?.Print(LogClass.ModLoader, "Multiple ExeFS partition replacements detected");
             }
 
-            Logger.PrintInfo(LogClass.ModLoader, $"Using replacement ExeFS partition");
+            Logger.Info?.Print(LogClass.ModLoader, $"Using replacement ExeFS partition");
 
             exefs = new PartitionFileSystem(mods.ExefsContainers[0].Path.OpenRead().AsStorage());
 
@@ -407,14 +407,14 @@ namespace Ryujinx.HLE.HOS
                     {
                         if (repls[1 << i])
                         {
-                            Logger.PrintWarning(LogClass.ModLoader, $"Multiple replacements to '{nsoName}'");
+                            Logger.Warning?.Print(LogClass.ModLoader, $"Multiple replacements to '{nsoName}'");
                             continue;
                         }
 
                         repls[1 << i] = true;
 
                         nsos[i] = new NsoExecutable(nsoFile.OpenRead().AsStorage(), nsoName);
-                        Logger.PrintInfo(LogClass.ModLoader, $"NSO '{nsoName}' replaced");
+                        Logger.Info?.Print(LogClass.ModLoader, $"NSO '{nsoName}' replaced");
 
                         replaced = true;
 
@@ -429,7 +429,7 @@ namespace Ryujinx.HLE.HOS
             {
                 if (stubs[1 << i] && !repls[1 << i]) // Prioritizes replacements over stubs
                 {
-                    Logger.PrintInfo(LogClass.ModLoader, $"    NSO '{nsos[i].Name}' stubbed");
+                    Logger.Info?.Print(LogClass.ModLoader, $"    NSO '{nsos[i].Name}' stubbed");
                     nsos.RemoveAt(i);
                     replaced = true;
                 }
@@ -500,7 +500,7 @@ namespace Ryujinx.HLE.HOS
                             continue;
                         }
 
-                        Logger.PrintInfo(LogClass.ModLoader, $"Matching IPS patch '{patchFile.Name}' in '{mod.Name}' bid={buildId}");
+                        Logger.Info?.Print(LogClass.ModLoader, $"Matching IPS patch '{patchFile.Name}' in '{mod.Name}' bid={buildId}");
 
                         using var fs = patchFile.OpenRead();
                         using var reader = new BinaryReader(fs);
@@ -521,7 +521,7 @@ namespace Ryujinx.HLE.HOS
                             continue;
                         }
 
-                        Logger.PrintInfo(LogClass.ModLoader, $"Matching IPSwitch patch '{patchFile.Name}' in '{mod.Name}' bid={patcher.BuildId}");
+                        Logger.Info?.Print(LogClass.ModLoader, $"Matching IPSwitch patch '{patchFile.Name}' in '{mod.Name}' bid={patcher.BuildId}");
 
                         patcher.AddPatches(patches[index]);
                     }

--- a/Ryujinx.HLE/HOS/ProgramLoader.cs
+++ b/Ryujinx.HLE/HOS/ProgramLoader.cs
@@ -75,7 +75,7 @@ namespace Ryujinx.HLE.HOS
 
             if (result != KernelResult.Success)
             {
-                Logger.PrintError(LogClass.Loader, $"Process initialization returned error \"{result}\".");
+                Logger.Error?.Print(LogClass.Loader, $"Process initialization returned error \"{result}\".");
 
                 return false;
             }
@@ -91,7 +91,7 @@ namespace Ryujinx.HLE.HOS
 
             if (result != KernelResult.Success)
             {
-                Logger.PrintError(LogClass.Loader, $"Process initialization returned error \"{result}\".");
+                Logger.Error?.Print(LogClass.Loader, $"Process initialization returned error \"{result}\".");
 
                 return false;
             }
@@ -100,7 +100,7 @@ namespace Ryujinx.HLE.HOS
 
             if (result != KernelResult.Success)
             {
-                Logger.PrintError(LogClass.Loader, $"Process initialization returned error \"{result}\".");
+                Logger.Error?.Print(LogClass.Loader, $"Process initialization returned error \"{result}\".");
 
                 return false;
             }
@@ -111,7 +111,7 @@ namespace Ryujinx.HLE.HOS
 
             if (result != KernelResult.Success)
             {
-                Logger.PrintError(LogClass.Loader, $"Process start returned error \"{result}\".");
+                Logger.Error?.Print(LogClass.Loader, $"Process start returned error \"{result}\".");
 
                 return false;
             }
@@ -201,7 +201,7 @@ namespace Ryujinx.HLE.HOS
 
             if (result != KernelResult.Success)
             {
-                Logger.PrintError(LogClass.Loader, $"Process initialization failed setting resource limit values.");
+                Logger.Error?.Print(LogClass.Loader, $"Process initialization failed setting resource limit values.");
 
                 return false;
             }
@@ -212,7 +212,7 @@ namespace Ryujinx.HLE.HOS
 
             if (memoryRegion > MemoryRegion.NvServices)
             {
-                Logger.PrintError(LogClass.Loader, $"Process initialization failed due to invalid ACID flags.");
+                Logger.Error?.Print(LogClass.Loader, $"Process initialization failed due to invalid ACID flags.");
 
                 return false;
             }
@@ -225,20 +225,20 @@ namespace Ryujinx.HLE.HOS
 
             if (result != KernelResult.Success)
             {
-                Logger.PrintError(LogClass.Loader, $"Process initialization returned error \"{result}\".");
+                Logger.Error?.Print(LogClass.Loader, $"Process initialization returned error \"{result}\".");
 
                 return false;
             }
 
             for (int index = 0; index < executables.Length; index++)
             {
-                Logger.PrintInfo(LogClass.Loader, $"Loading image {index} at 0x{nsoBase[index]:x16}...");
+                Logger.Info?.Print(LogClass.Loader, $"Loading image {index} at 0x{nsoBase[index]:x16}...");
 
                 result = LoadIntoMemory(process, executables[index], nsoBase[index]);
 
                 if (result != KernelResult.Success)
                 {
-                    Logger.PrintError(LogClass.Loader, $"Process initialization returned error \"{result}\".");
+                    Logger.Error?.Print(LogClass.Loader, $"Process initialization returned error \"{result}\".");
 
                     return false;
                 }
@@ -250,7 +250,7 @@ namespace Ryujinx.HLE.HOS
 
             if (result != KernelResult.Success)
             {
-                Logger.PrintError(LogClass.Loader, $"Process start returned error \"{result}\".");
+                Logger.Error?.Print(LogClass.Loader, $"Process start returned error \"{result}\".");
 
                 return false;
             }

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
@@ -101,7 +101,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
 
             if (!context.Device.System.State.Account.TryGetUser(userId, out UserProfile userProfile))
             {
-                Logger.PrintWarning(LogClass.ServiceAcc, $"User 0x{userId} not found!");
+                Logger.Warning?.Print(LogClass.ServiceAcc, $"User 0x{userId} not found!");
 
                 return ResultCode.UserNotFound;
             }
@@ -143,7 +143,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
                 // This checks something related to baas (online), and then return an invalid UserId if the check in baas returns an error code.
                 // In our case, we can just log it for now.
 
-                Logger.PrintStub(LogClass.ServiceAcc, new { baasCheck });
+                Logger.Stub?.PrintStub(LogClass.ServiceAcc, new { baasCheck });
             }
 
             // As we returned an invalid UserId if there is more than one user earlier, now we can return only the first one.
@@ -182,7 +182,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
                 _applicationLaunchProperty = ApplicationLaunchProperty.GetByPid(context);
             }
 
-            Logger.PrintStub(LogClass.ServiceAcc, new { unknown });
+            Logger.Stub?.PrintStub(LogClass.ServiceAcc, new { unknown });
 
             return ResultCode.Success;
         }
@@ -246,7 +246,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
 
             // TODO: Store thumbnailBuffer somewhere, in save data 0x8000000000000010 ?
 
-            Logger.PrintStub(LogClass.ServiceAcc);
+            Logger.Stub?.PrintStub(LogClass.ServiceAcc);
 
             return ResultCode.Success;
         }
@@ -269,7 +269,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
 
             // TODO: Clear the Thumbnail somewhere, in save data 0x8000000000000010 ?
 
-            Logger.PrintStub(LogClass.ServiceAcc);
+            Logger.Stub?.PrintStub(LogClass.ServiceAcc);
 
             return ResultCode.Success;
         }
@@ -291,7 +291,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
 
             context.ResponseData.Write(context.Device.Application.ControlData.Value.UserAccountSwitchLock);
 
-            Logger.PrintStub(LogClass.ServiceAcc);
+            Logger.Stub?.PrintStub(LogClass.ServiceAcc);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/IManagerForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/IManagerForApplication.cs
@@ -20,7 +20,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
         // CheckAvailability()
         public ResultCode CheckAvailability(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceAcc);
+            Logger.Stub?.PrintStub(LogClass.ServiceAcc);
 
             return ResultCode.Success;
         }
@@ -29,7 +29,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
         // GetAccountId() -> nn::account::NetworkServiceAccountId
         public ResultCode GetAccountId(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceAcc, new { NetworkServiceAccountId });
+            Logger.Stub?.PrintStub(LogClass.ServiceAcc, new { NetworkServiceAccountId });
 
             context.ResponseData.Write(NetworkServiceAccountId);
 
@@ -40,7 +40,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
         // GetNintendoAccountUserResourceCacheForApplication() -> (nn::account::NintendoAccountId, buffer<nn::account::nas::NasUserBaseForApplication, 0x1a>, buffer<bytes, 6>)
         public ResultCode GetNintendoAccountUserResourceCacheForApplication(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceAcc, new { NetworkServiceAccountId });
+            Logger.Stub?.PrintStub(LogClass.ServiceAcc, new { NetworkServiceAccountId });
 
             context.ResponseData.Write(NetworkServiceAccountId);
 

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/IProfile.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/IProfile.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
         // Get() -> (nn::account::profile::ProfileBase, buffer<nn::account::profile::UserData, 0x1a>)
         public ResultCode Get(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceAcc);
+            Logger.Stub?.PrintStub(LogClass.ServiceAcc);
 
             long position = context.Request.ReceiveBuff[0].Position;
 

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/LibraryAppletCreator/ILibraryAppletAccessor.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/LibraryAppletCreator/ILibraryAppletAccessor.cs
@@ -33,7 +33,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Lib
             _normalSession.DataAvailable      += OnNormalOutData;
             _interactiveSession.DataAvailable += OnInteractiveOutData;
             
-            Logger.PrintInfo(LogClass.ServiceAm, $"Applet '{appletId}' created.");
+            Logger.Info?.Print(LogClass.ServiceAm, $"Applet '{appletId}' created.");
         }
 
         private void OnAppletStateChanged(object sender, EventArgs e)
@@ -194,7 +194,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Lib
 
             context.ResponseData.Write(indirectLayerConsumerHandle);
 
-            Logger.PrintStub(LogClass.ServiceAm, new { indirectLayerConsumerHandle });
+            Logger.Stub?.PrintStub(LogClass.ServiceAm, new { indirectLayerConsumerHandle });
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/IAudioController.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/IAudioController.cs
@@ -13,7 +13,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             float appletVolume        = context.RequestData.ReadSingle();
             float libraryAppletVolume = context.RequestData.ReadSingle();
 
-            Logger.PrintStub(LogClass.ServiceAm);
+            Logger.Stub?.PrintStub(LogClass.ServiceAm);
 
             return ResultCode.Success;
         }
@@ -24,7 +24,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         {
             context.ResponseData.Write(1f);
 
-            Logger.PrintStub(LogClass.ServiceAm);
+            Logger.Stub?.PrintStub(LogClass.ServiceAm);
 
             return ResultCode.Success;
         }
@@ -35,7 +35,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         {
             context.ResponseData.Write(1f);
 
-            Logger.PrintStub(LogClass.ServiceAm);
+            Logger.Stub?.PrintStub(LogClass.ServiceAm);
 
             return ResultCode.Success;
         }
@@ -47,7 +47,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             float unknown0 = context.RequestData.ReadSingle();
             long  unknown1 = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceAm);
+            Logger.Stub?.PrintStub(LogClass.ServiceAm);
 
             return ResultCode.Success;
         }
@@ -58,7 +58,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         {
             float unknown0 = context.RequestData.ReadSingle();
 
-            Logger.PrintStub(LogClass.ServiceAm);
+            Logger.Stub?.PrintStub(LogClass.ServiceAm);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
@@ -76,7 +76,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         {
             context.ResponseData.Write((byte)0); //Unknown value.
 
-            Logger.PrintStub(LogClass.ServiceAm);
+            Logger.Stub?.PrintStub(LogClass.ServiceAm);
 
             return ResultCode.Success;
         }
@@ -120,7 +120,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
 
             context.Response.HandleDesc = IpcHandleDesc.MakeCopy(handle);
 
-            Logger.PrintStub(LogClass.ServiceAm);
+            Logger.Stub?.PrintStub(LogClass.ServiceAm);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/IHomeMenuFunctions.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/IHomeMenuFunctions.cs
@@ -20,7 +20,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // RequestToGetForeground()
         public ResultCode RequestToGetForeground(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceAm);
+            Logger.Stub?.PrintStub(LogClass.ServiceAm);
 
             return ResultCode.Success;
         }
@@ -36,7 +36,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
 
             context.Response.HandleDesc = IpcHandleDesc.MakeCopy(handle);
 
-            Logger.PrintStub(LogClass.ServiceAm);
+            Logger.Stub?.PrintStub(LogClass.ServiceAm);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ILibraryAppletCreator.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ILibraryAppletCreator.cs
@@ -43,7 +43,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
 
             if (transferMem == null)
             {
-                Logger.PrintWarning(LogClass.ServiceAm, $"Invalid TransferMemory Handle: {handle:X}");
+                Logger.Warning?.Print(LogClass.ServiceAm, $"Invalid TransferMemory Handle: {handle:X}");
 
                 return ResultCode.Success; // TODO: Find correct error code
             }

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ISelfController.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ISelfController.cs
@@ -41,7 +41,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // Exit()
         public ResultCode Exit(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceAm);
+            Logger.Stub?.PrintStub(LogClass.ServiceAm);
 
             return ResultCode.Success;
         }
@@ -50,7 +50,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // LockExit()
         public ResultCode LockExit(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceAm);
+            Logger.Stub?.PrintStub(LogClass.ServiceAm);
 
             return ResultCode.Success;
         }
@@ -59,7 +59,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // UnlockExit()
         public ResultCode UnlockExit(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceAm);
+            Logger.Stub?.PrintStub(LogClass.ServiceAm);
 
             return ResultCode.Success;
         }
@@ -110,7 +110,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
 
             context.Response.HandleDesc = IpcHandleDesc.MakeCopy(handle);
 
-            Logger.PrintStub(LogClass.ServiceAm);
+            Logger.Stub?.PrintStub(LogClass.ServiceAm);
 
             return ResultCode.Success;
         }
@@ -121,7 +121,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         {
             bool screenShotPermission = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServiceAm, new { screenShotPermission });
+            Logger.Stub?.PrintStub(LogClass.ServiceAm, new { screenShotPermission });
 
             _screenShotPermission = screenShotPermission;
 
@@ -134,7 +134,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         {
             bool operationModeChangedNotification = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServiceAm, new { operationModeChangedNotification });
+            Logger.Stub?.PrintStub(LogClass.ServiceAm, new { operationModeChangedNotification });
 
             _operationModeChangedNotification = operationModeChangedNotification;
 
@@ -147,7 +147,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         {
             bool performanceModeChangedNotification = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServiceAm, new { performanceModeChangedNotification });
+            Logger.Stub?.PrintStub(LogClass.ServiceAm, new { performanceModeChangedNotification });
 
             _performanceModeChangedNotification = performanceModeChangedNotification;
 
@@ -162,7 +162,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             bool unknownFlag2 = context.RequestData.ReadBoolean();
             bool unknownFlag3 = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServiceAm, new { unknownFlag1, unknownFlag2, unknownFlag3 });
+            Logger.Stub?.PrintStub(LogClass.ServiceAm, new { unknownFlag1, unknownFlag2, unknownFlag3 });
 
             return ResultCode.Success;
         }
@@ -173,7 +173,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         {
             bool restartMessageEnabled = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServiceAm, new { restartMessageEnabled });
+            Logger.Stub?.PrintStub(LogClass.ServiceAm, new { restartMessageEnabled });
 
             _restartMessageEnabled = restartMessageEnabled;
 
@@ -186,7 +186,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         {
             bool outOfFocusSuspendingEnabled = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServiceAm, new { outOfFocusSuspendingEnabled });
+            Logger.Stub?.PrintStub(LogClass.ServiceAm, new { outOfFocusSuspendingEnabled });
 
             _outOfFocusSuspendingEnabled = outOfFocusSuspendingEnabled;
 
@@ -199,7 +199,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         {
             uint screenShotImageOrientation = context.RequestData.ReadUInt32();
 
-            Logger.PrintStub(LogClass.ServiceAm, new { screenShotImageOrientation });
+            Logger.Stub?.PrintStub(LogClass.ServiceAm, new { screenShotImageOrientation });
 
             _screenShotImageOrientation = screenShotImageOrientation;
 
@@ -212,7 +212,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         {
             bool handlesRequestToDisplay = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServiceAm, new { handlesRequestToDisplay });
+            Logger.Stub?.PrintStub(LogClass.ServiceAm, new { handlesRequestToDisplay });
 
             _handlesRequestToDisplay = handlesRequestToDisplay;
 
@@ -225,7 +225,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         {
             uint idleTimeDetectionExtension = context.RequestData.ReadUInt32();
 
-            Logger.PrintStub(LogClass.ServiceAm, new { idleTimeDetectionExtension });
+            Logger.Stub?.PrintStub(LogClass.ServiceAm, new { idleTimeDetectionExtension });
 
             _idleTimeDetectionExtension = idleTimeDetectionExtension;
 
@@ -238,7 +238,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         {
             context.ResponseData.Write(_idleTimeDetectionExtension);
 
-            Logger.PrintStub(LogClass.ServiceAm, new { _idleTimeDetectionExtension });
+            Logger.Stub?.PrintStub(LogClass.ServiceAm, new { _idleTimeDetectionExtension });
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/IWindowController.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/IWindowController.cs
@@ -10,7 +10,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // GetAppletResourceUserId() -> nn::applet::AppletResourceUserId
         public ResultCode GetAppletResourceUserId(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceAm);
+            Logger.Stub?.PrintStub(LogClass.ServiceAm);
 
             context.ResponseData.Write(0L);
 
@@ -21,7 +21,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // AcquireForegroundRights()
         public ResultCode AcquireForegroundRights(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceAm);
+            Logger.Stub?.PrintStub(LogClass.ServiceAm);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
@@ -65,7 +65,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
                 control.UserAccountSaveDataSize        = 0x4000;
                 control.UserAccountSaveDataJournalSize = 0x4000;
 
-                Logger.PrintWarning(LogClass.ServiceAm,
+                Logger.Warning?.Print(LogClass.ServiceAm,
                     "No control file was found for this game. Using a dummy one instead. This may cause inaccuracies in some games.");
             }
 
@@ -93,7 +93,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
 
             if (firstSupported > (int)SystemState.TitleLanguage.Chinese)
             {
-                Logger.PrintWarning(LogClass.ServiceAm, "Application has zero supported languages");
+                Logger.Warning?.Print(LogClass.ServiceAm, "Application has zero supported languages");
 
                 context.ResponseData.Write(desiredLanguageCode);
 
@@ -107,7 +107,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
                 SystemLanguage newLanguage = Enum.Parse<SystemLanguage>(Enum.GetName(typeof(SystemState.TitleLanguage), firstSupported));
                 desiredLanguageCode = SystemStateMgr.GetLanguageCode((int)newLanguage);
 
-                Logger.PrintInfo(LogClass.ServiceAm, $"Application doesn't support configured language. Using {newLanguage}");
+                Logger.Info?.Print(LogClass.ServiceAm, $"Application doesn't support configured language. Using {newLanguage}");
             }
 
             context.ResponseData.Write(desiredLanguageCode);
@@ -121,7 +121,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
         {
             Result result = new Result(context.RequestData.ReadUInt32());
 
-            Logger.PrintInfo(LogClass.ServiceAm, $"Result = 0x{result.Value:x8} ({result.ToStringWithName()}).");
+            Logger.Info?.Print(LogClass.ServiceAm, $"Result = 0x{result.Value:x8} ({result.ToStringWithName()}).");
 
             return ResultCode.Success;
         }
@@ -149,7 +149,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             // TODO: We return a size of 2GB as we use a directory based save system. This should be enough for most of the games.
             context.ResponseData.Write(2000000000u);
 
-            Logger.PrintStub(LogClass.ServiceAm, new { saveDataType, userId });
+            Logger.Stub?.PrintStub(LogClass.ServiceAm, new { saveDataType, userId });
 
             return ResultCode.Success;
         }
@@ -170,7 +170,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             context.ResponseData.Write(0L);
             context.ResponseData.Write(0L);
 
-            Logger.PrintStub(LogClass.ServiceAm);
+            Logger.Stub?.PrintStub(LogClass.ServiceAm);
 
             return ResultCode.Success;
         }
@@ -179,7 +179,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
         // InitializeGamePlayRecording(u64, handle<copy>)
         public ResultCode InitializeGamePlayRecording(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceAm);
+            Logger.Stub?.PrintStub(LogClass.ServiceAm);
 
             return ResultCode.Success;
         }
@@ -190,7 +190,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
         {
             int state = context.RequestData.ReadInt32();
 
-            Logger.PrintStub(LogClass.ServiceAm, new { state });
+            Logger.Stub?.PrintStub(LogClass.ServiceAm, new { state });
 
             return ResultCode.Success;
         }
@@ -201,7 +201,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
         {
             bool applicationCrashReportEnabled = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServiceAm, new { applicationCrashReportEnabled });
+            Logger.Stub?.PrintStub(LogClass.ServiceAm, new { applicationCrashReportEnabled });
 
             return ResultCode.Success;
         }
@@ -246,7 +246,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             {
                 // TODO: Initialize buffer and object.
 
-                Logger.PrintStub(LogClass.ServiceAm, new { transferMemoryAddress, transferMemorySize, width, height });
+                Logger.Stub?.PrintStub(LogClass.ServiceAm, new { transferMemoryAddress, transferMemorySize, width, height });
 
                 resultCode = ResultCode.Success;
             }
@@ -282,7 +282,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
                 }
             }
 
-            Logger.PrintStub(LogClass.ServiceAm, new { frameBufferPos, frameBufferSize, x, y, width, height, windowOriginMode });
+            Logger.Stub?.PrintStub(LogClass.ServiceAm, new { frameBufferPos, frameBufferSize, x, y, width, height, windowOriginMode });
 
             return resultCode;
         }
@@ -296,7 +296,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             }
             */
 
-            Logger.PrintStub(LogClass.ServiceAm, new { x, y, width, height, frameBufferPos, frameBufferSize, windowOriginMode });
+            Logger.Stub?.PrintStub(LogClass.ServiceAm, new { x, y, width, height, frameBufferPos, frameBufferSize, windowOriginMode });
 
             return ResultCode.Success;
         }
@@ -307,7 +307,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
         {
             bool visible = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServiceAm, new { visible });
+            Logger.Stub?.PrintStub(LogClass.ServiceAm, new { visible });
 
             // NOTE: It sets an internal field and return ResultCode.Success in all case.
 
@@ -341,7 +341,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
 
             context.ResponseData.Write(previousProgramIndex);
 
-            Logger.PrintStub(LogClass.ServiceAm, new { previousProgramIndex });
+            Logger.Stub?.PrintStub(LogClass.ServiceAm, new { previousProgramIndex });
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Apm/ISession.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/ISession.cs
@@ -24,7 +24,7 @@ namespace Ryujinx.HLE.HOS.Services.Apm
 
             context.ResponseData.Write((uint)PerformanceConfiguration.PerformanceConfiguration1);
 
-            Logger.PrintStub(LogClass.ServiceApm);
+            Logger.Stub?.PrintStub(LogClass.ServiceApm);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioRendererManager/IAudioDevice.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioRendererManager/IAudioDevice.cs
@@ -39,7 +39,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRendererManager
 
                 if ((position - basePosition) + buffer.Length > size)
                 {
-                    Logger.PrintError(LogClass.ServiceAudio, $"Output buffer size {size} too small!");
+                    Logger.Error?.Print(LogClass.ServiceAudio, $"Output buffer size {size} too small!");
 
                     break;
                 }
@@ -67,7 +67,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRendererManager
 
             string deviceName = Encoding.ASCII.GetString(deviceNameBuffer);
 
-            Logger.PrintStub(LogClass.ServiceAudio);
+            Logger.Stub?.PrintStub(LogClass.ServiceAudio);
 
             return ResultCode.Success;
         }
@@ -89,7 +89,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRendererManager
             }
             else
             {
-                Logger.PrintError(LogClass.ServiceAudio, $"Output buffer size {size} too small!");
+                Logger.Error?.Print(LogClass.ServiceAudio, $"Output buffer size {size} too small!");
             }
 
             return ResultCode.Success;
@@ -106,7 +106,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRendererManager
 
             context.Response.HandleDesc = IpcHandleDesc.MakeCopy(handle);
 
-            Logger.PrintStub(LogClass.ServiceAudio);
+            Logger.Stub?.PrintStub(LogClass.ServiceAudio);
 
             return ResultCode.Success;
         }
@@ -117,7 +117,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRendererManager
         {
             context.ResponseData.Write(2);
 
-            Logger.PrintStub(LogClass.ServiceAudio);
+            Logger.Stub?.PrintStub(LogClass.ServiceAudio);
 
             return ResultCode.Success;
         }
@@ -140,7 +140,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRendererManager
 
                 if ((position - basePosition) + buffer.Length > size)
                 {
-                    Logger.PrintError(LogClass.ServiceAudio, $"Output buffer size {size} too small!");
+                    Logger.Error?.Print(LogClass.ServiceAudio, $"Output buffer size {size} too small!");
 
                     break;
                 }
@@ -167,7 +167,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRendererManager
 
             string deviceName = Encoding.UTF8.GetString(deviceNameBuffer);
 
-            Logger.PrintStub(LogClass.ServiceAudio);
+            Logger.Stub?.PrintStub(LogClass.ServiceAudio);
 
             return ResultCode.Success;
         }
@@ -178,7 +178,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRendererManager
         {
             context.ResponseData.Write(1f);
 
-            Logger.PrintStub(LogClass.ServiceAudio);
+            Logger.Stub?.PrintStub(LogClass.ServiceAudio);
 
             return ResultCode.Success;
         }
@@ -199,7 +199,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRendererManager
             }
             else
             {
-                Logger.PrintError(LogClass.ServiceAudio, $"Output buffer size {size} too small!");
+                Logger.Error?.Print(LogClass.ServiceAudio, $"Output buffer size {size} too small!");
             }
 
             return ResultCode.Success;
@@ -216,7 +216,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRendererManager
 
             context.Response.HandleDesc = IpcHandleDesc.MakeCopy(handle);
 
-            Logger.PrintStub(LogClass.ServiceAudio);
+            Logger.Stub?.PrintStub(LogClass.ServiceAudio);
 
             return ResultCode.Success;
         }
@@ -232,7 +232,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRendererManager
 
             context.Response.HandleDesc = IpcHandleDesc.MakeCopy(handle);
 
-            Logger.PrintStub(LogClass.ServiceAudio);
+            Logger.Stub?.PrintStub(LogClass.ServiceAudio);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioRendererManager/IAudioRenderer.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioRendererManager/IAudioRenderer.cs
@@ -105,7 +105,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRendererManager
         {
             context.ResponseData.Write((int)_playState);
 
-            Logger.PrintStub(LogClass.ServiceAudio, new { State = Enum.GetName(typeof(PlayState), _playState) });
+            Logger.Stub?.PrintStub(LogClass.ServiceAudio, new { State = Enum.GetName(typeof(PlayState), _playState) });
 
             return ResultCode.Success;
         }
@@ -287,7 +287,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRendererManager
         // Start()
         public ResultCode StartAudioRenderer(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceAudio);
+            Logger.Stub?.PrintStub(LogClass.ServiceAudio);
 
             _playState = PlayState.Playing;
 
@@ -298,7 +298,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRendererManager
         // Stop()
         public ResultCode StopAudioRenderer(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceAudio);
+            Logger.Stub?.PrintStub(LogClass.ServiceAudio);
 
             _playState = PlayState.Stopped;
 

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioRendererManager/PerformanceManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioRendererManager/PerformanceManager.cs
@@ -18,7 +18,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRendererManager
 
             if (performanceMetricsDataFormat != 1)
             {
-                Logger.PrintWarning(LogClass.ServiceAudio, $"PerformanceMetricsDataFormat: {performanceMetricsDataFormat} is not supported!");
+                Logger.Warning?.Print(LogClass.ServiceAudio, $"PerformanceMetricsDataFormat: {performanceMetricsDataFormat} is not supported!");
             }
 
             return (((parameters.VoiceCount  + 

--- a/Ryujinx.HLE/HOS/Services/Audio/IAudioOutManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/IAudioOutManager.cs
@@ -78,7 +78,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             }
             else
             {
-                Logger.PrintError(LogClass.ServiceAudio, $"Output buffer size {size} too small!");
+                Logger.Error?.Print(LogClass.ServiceAudio, $"Output buffer size {size} too small!");
             }
 
             context.ResponseData.Write(nameCount);
@@ -100,7 +100,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
 
             if (deviceName != DefaultAudioOutput)
             {
-                Logger.PrintWarning(LogClass.Audio, "Invalid device name!");
+                Logger.Warning?.Print(LogClass.Audio, "Invalid device name!");
 
                 return ResultCode.DeviceNotFound;
             }
@@ -113,7 +113,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             }
             else
             {
-                Logger.PrintError(LogClass.ServiceAudio, $"Output buffer size {receiveSize} too small!");
+                Logger.Error?.Print(LogClass.ServiceAudio, $"Output buffer size {receiveSize} too small!");
             }
 
             int sampleRate = context.RequestData.ReadInt32();
@@ -126,7 +126,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
 
             if (sampleRate != DefaultSampleRate)
             {
-                Logger.PrintWarning(LogClass.Audio, "Invalid sample rate!");
+                Logger.Warning?.Print(LogClass.Audio, "Invalid sample rate!");
 
                 return ResultCode.UnsupportedSampleRate;
             }

--- a/Ryujinx.HLE/HOS/Services/Audio/IAudioRendererManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/IAudioRendererManager.cs
@@ -86,7 +86,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
 
                 context.ResponseData.Write(size);
 
-                Logger.PrintDebug(LogClass.ServiceAudio, $"WorkBufferSize is 0x{size:x16}.");
+                Logger.Debug?.Print(LogClass.ServiceAudio, $"WorkBufferSize is 0x{size:x16}.");
 
                 return ResultCode.Success;
             }
@@ -94,7 +94,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             {
                 context.ResponseData.Write(0L);
 
-                Logger.PrintWarning(LogClass.ServiceAudio, $"Library Revision REV{AudioRendererCommon.GetRevisionVersion(parameters.Revision)} is not supported!");
+                Logger.Warning?.Print(LogClass.ServiceAudio, $"Library Revision REV{AudioRendererCommon.GetRevisionVersion(parameters.Revision)} is not supported!");
 
                 return ResultCode.UnsupportedRevision;
             }
@@ -140,7 +140,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             int  revisionInfo         = context.RequestData.ReadInt32();
             long appletResourceUserId = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceAudio, new { appletResourceUserId, revisionInfo });
+            Logger.Stub?.PrintStub(LogClass.ServiceAudio, new { appletResourceUserId, revisionInfo });
 
             return GetAudioDeviceService(context);
         }

--- a/Ryujinx.HLE/HOS/Services/Bcat/ServiceCreator/IDeliveryCacheProgressService.cs
+++ b/Ryujinx.HLE/HOS/Services/Bcat/ServiceCreator/IDeliveryCacheProgressService.cs
@@ -29,7 +29,7 @@ namespace Ryujinx.HLE.HOS.Services.Bcat.ServiceCreator
 
             context.Response.HandleDesc = IpcHandleDesc.MakeCopy(handle);
 
-            Logger.PrintStub(LogClass.ServiceBcat);
+            Logger.Stub?.PrintStub(LogClass.ServiceBcat);
 
             return ResultCode.Success;
         }
@@ -46,7 +46,7 @@ namespace Ryujinx.HLE.HOS.Services.Bcat.ServiceCreator
 
             WriteDeliveryCacheProgressImpl(context, context.Request.RecvListBuff[0], deliveryCacheProgress);
 
-            Logger.PrintStub(LogClass.ServiceBcat);
+            Logger.Stub?.PrintStub(LogClass.ServiceBcat);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/BluetoothManager/BtmUser/IBtmUserCore.cs
+++ b/Ryujinx.HLE/HOS/Services/BluetoothManager/BtmUser/IBtmUserCore.cs
@@ -36,7 +36,7 @@ namespace Ryujinx.HLE.HOS.Services.BluetoothManager.BtmUser
                 if (result != KernelResult.Success)
                 {
                     // NOTE: We use a Logging instead of an exception because the call return a boolean if succeed or not.
-                    Logger.PrintError(LogClass.ServiceBsd, "Out of handles!");
+                    Logger.Error?.Print(LogClass.ServiceBsd, "Out of handles!");
                 }
             }
 
@@ -62,7 +62,7 @@ namespace Ryujinx.HLE.HOS.Services.BluetoothManager.BtmUser
                 if (result != KernelResult.Success)
                 {
                     // NOTE: We use a Logging instead of an exception because the call return a boolean if succeed or not.
-                    Logger.PrintError(LogClass.ServiceBsd, "Out of handles!");
+                    Logger.Error?.Print(LogClass.ServiceBsd, "Out of handles!");
                 }
             }
 
@@ -88,7 +88,7 @@ namespace Ryujinx.HLE.HOS.Services.BluetoothManager.BtmUser
                 if (result != KernelResult.Success)
                 {
                     // NOTE: We use a Logging instead of an exception because the call return a boolean if succeed or not.
-                    Logger.PrintError(LogClass.ServiceBsd, "Out of handles!");
+                    Logger.Error?.Print(LogClass.ServiceBsd, "Out of handles!");
                 }
             }
 
@@ -114,7 +114,7 @@ namespace Ryujinx.HLE.HOS.Services.BluetoothManager.BtmUser
                 if (result != KernelResult.Success)
                 {
                     // NOTE: We use a Logging instead of an exception because the call return a boolean if succeed or not.
-                    Logger.PrintError(LogClass.ServiceBsd, "Out of handles!");
+                    Logger.Error?.Print(LogClass.ServiceBsd, "Out of handles!");
                 }
             }
 

--- a/Ryujinx.HLE/HOS/Services/Friend/ServiceCreator/IFriendService.cs
+++ b/Ryujinx.HLE/HOS/Services/Friend/ServiceCreator/IFriendService.cs
@@ -45,7 +45,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
             // There are no friends online, so we return 0 because the nn::account::NetworkServiceAccountId array is empty.
             context.ResponseData.Write(0);
 
-            Logger.PrintStub(LogClass.ServiceFriend, new
+            Logger.Stub?.PrintStub(LogClass.ServiceFriend, new
             {
                 UserId = userId.ToString(),
                 offset,
@@ -84,7 +84,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
             // There are no friends online, so we return 0 because the nn::account::NetworkServiceAccountId array is empty.
             context.ResponseData.Write(0);
 
-            Logger.PrintStub(LogClass.ServiceFriend, new {
+            Logger.Stub?.PrintStub(LogClass.ServiceFriend, new {
                 UserId = userId.ToString(),
                 offset,
                 filter.PresenceStatus,
@@ -112,7 +112,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
             // There are no friends blocked, so we return 0 because the nn::account::NetworkServiceAccountId array is empty.
             context.ResponseData.Write(0);
 
-            Logger.PrintStub(LogClass.ServiceFriend, new { offset, UserId = userId.ToString() });
+            Logger.Stub?.PrintStub(LogClass.ServiceFriend, new { offset, UserId = userId.ToString() });
 
             return ResultCode.Success;
         }
@@ -133,7 +133,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
                 profile.OnlinePlayState = AccountState.Open;
             }
 
-            Logger.PrintStub(LogClass.ServiceFriend, new { UserId = userId.ToString(), profile.OnlinePlayState });
+            Logger.Stub?.PrintStub(LogClass.ServiceFriend, new { UserId = userId.ToString(), profile.OnlinePlayState });
 
             return ResultCode.Success;
         }
@@ -154,7 +154,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
                 profile.OnlinePlayState = AccountState.Closed;
             }
 
-            Logger.PrintStub(LogClass.ServiceFriend, new { UserId = userId.ToString(), profile.OnlinePlayState });
+            Logger.Stub?.PrintStub(LogClass.ServiceFriend, new { UserId = userId.ToString(), profile.OnlinePlayState });
 
             return ResultCode.Success;
         }
@@ -186,7 +186,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
             {
                 UserPresence[] userPresenceInputArray = bufferReader.ReadStructArray<UserPresence>(elementCount);
 
-                Logger.PrintStub(LogClass.ServiceFriend, new { UserId = uuid.ToString(), userPresenceInputArray });
+                Logger.Stub?.PrintStub(LogClass.ServiceFriend, new { UserId = uuid.ToString(), userPresenceInputArray });
             }
 
             return ResultCode.Success;

--- a/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
@@ -146,7 +146,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
                 creationInfo.OwnerId = new TitleId(context.Process.TitleId);
             }
 
-            Logger.PrintInfo(LogClass.ServiceFs, $"Creating save with title ID {attribute.TitleId.Value:x16}");
+            Logger.Info?.Print(LogClass.ServiceFs, $"Creating save with title ID {attribute.TitleId.Value:x16}");
 
             Result result = _baseFileSystemProxy.CreateSaveDataFileSystem(ref attribute, ref creationInfo, ref metaCreateInfo);
 
@@ -359,7 +359,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
         [Command(71)]
         public ResultCode ReadSaveDataFileSystemExtraDataWithMaskBySaveDataAttribute(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceFs);
+            Logger.Stub?.PrintStub(LogClass.ServiceFs);
 
             MemoryHelper.FillWithZeros(context.Memory, context.Request.ReceiveBuff[0].Position, (int)context.Request.ReceiveBuff[0].Size);
 
@@ -387,7 +387,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             // This is because AOC can be distributed over multiple containers in the emulator.
             if (context.Device.System.ContentManager.GetAocDataStorage((ulong)titleId, out LibHac.Fs.IStorage aocStorage))
             {
-                Logger.PrintInfo(LogClass.Loader, $"Opened AddOnContent Data TitleID={titleId:X16}");
+                Logger.Info?.Print(LogClass.Loader, $"Opened AddOnContent Data TitleID={titleId:X16}");
 
                 MakeObject(context, new FileSystemProxy.IStorage(aocStorage));
                 
@@ -517,7 +517,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             string message = ReadUtf8StringSend(context);
 
             // FS ends each line with a newline. Remove it because Ryujinx logging adds its own newline
-            Logger.PrintAccessLog(LogClass.ServiceFs, message.TrimEnd('\n'));
+            Logger.AccessLog?.PrintMsg(LogClass.ServiceFs, message.TrimEnd('\n'));
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Hid/HidDevices/NpadDevices.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/HidDevices/NpadDevices.cs
@@ -102,7 +102,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
                 if ((config.ConfiguredType & _supportedStyleSets) == 0)
                 {
-                    Logger.PrintWarning(LogClass.Hid, $"ControllerType {config.ConfiguredType} (connected to {(PlayerIndex)i}) not supported by game. Removing...");
+                    Logger.Warning?.Print(LogClass.Hid, $"ControllerType {config.ConfiguredType} (connected to {(PlayerIndex)i}) not supported by game. Removing...");
 
                     config.State = FilterState.Configured;
                     _device.Hid.SharedMemory.Npads[i] = new ShMemNpad(); // Zero it
@@ -124,7 +124,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
                     ControllerType controllerType = npadsTypeList[i];
                     if ((controllerType & _supportedStyleSets) != 0)
                     {
-                        Logger.PrintWarning(LogClass.Hid, $"No matching controllers found. Reassigning input as ControllerType {controllerType}...");
+                        Logger.Warning?.Print(LogClass.Hid, $"No matching controllers found. Reassigning input as ControllerType {controllerType}...");
 
                         InitController(controllerType == ControllerType.Handheld ? PlayerIndex.Handheld : PlayerIndex.Player1, controllerType);
 
@@ -132,7 +132,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
                     }
                 }
 
-                Logger.PrintError(LogClass.Hid, "Couldn't find any appropriate controller.");
+                Logger.Error?.Print(LogClass.Hid, "Couldn't find any appropriate controller.");
             }
         }
 
@@ -226,7 +226,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             _styleSetUpdateEvents[(int)player].ReadableEvent.Signal();
 
-            Logger.PrintInfo(LogClass.Hid, $"Connected ControllerType {type} to PlayerIndex {player}");
+            Logger.Info?.Print(LogClass.Hid, $"Connected ControllerType {type} to PlayerIndex {player}");
         }
 
         private static NpadLayoutsIndex ControllerTypeToLayout(ControllerType controllerType)

--- a/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
@@ -69,7 +69,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             long appletResourceUserId = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
 
             return ResultCode.Success;
         }
@@ -82,7 +82,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             context.Device.Hid.Touchscreen.Active = true;
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
 
             return ResultCode.Success;
         }
@@ -95,7 +95,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             context.Device.Hid.Mouse.Active = true;
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
 
             return ResultCode.Success;
         }
@@ -108,7 +108,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             context.Device.Hid.Keyboard.Active = true;
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
 
             return ResultCode.Success;
         }
@@ -121,7 +121,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             // NOTE: This signal the keyboard driver about lock events.
 
-            Logger.PrintStub(LogClass.ServiceHid, new { flags });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { flags });
 
             return ResultCode.Success;
         }
@@ -139,7 +139,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             context.Response.HandleDesc = IpcHandleDesc.MakeCopy(_xpadIdEventHandle);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { xpadId });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { xpadId });
 
             return ResultCode.Success;
         }
@@ -152,7 +152,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             context.Process.HandleTable.CloseHandle(_xpadIdEventHandle);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { xpadId });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { xpadId });
 
             return ResultCode.Success;
         }
@@ -164,7 +164,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             int  basicXpadId          = context.RequestData.ReadInt32();
             long appletResourceUserId = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, basicXpadId });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, basicXpadId });
 
             return ResultCode.Success;
         }
@@ -176,7 +176,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             // There is any Xpad, so we return 0 and write nothing inside the type-0xa buffer.
             context.ResponseData.Write(0L);
 
-            Logger.PrintStub(LogClass.ServiceHid);
+            Logger.Stub?.PrintStub(LogClass.ServiceHid);
 
             return ResultCode.Success;
         }
@@ -187,7 +187,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             int joyXpadId = context.RequestData.ReadInt32();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { joyXpadId });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { joyXpadId });
 
             return ResultCode.Success;
         }
@@ -202,7 +202,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             context.Response.HandleDesc = IpcHandleDesc.MakeCopy(handle);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { joyXpadId });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { joyXpadId });
 
             return ResultCode.Success;
         }
@@ -214,7 +214,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             // There is any JoyXpad, so we return 0 and write nothing inside the type-0xa buffer.
             context.ResponseData.Write(0L);
 
-            Logger.PrintStub(LogClass.ServiceHid);
+            Logger.Stub?.PrintStub(LogClass.ServiceHid);
 
             return ResultCode.Success;
         }
@@ -225,7 +225,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             int basicXpadId = context.RequestData.ReadInt32();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { basicXpadId });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { basicXpadId });
 
             return ResultCode.Success;
         }
@@ -236,7 +236,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             int basicXpadId = context.RequestData.ReadInt32();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { basicXpadId });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { basicXpadId });
 
             return ResultCode.Success;
         }
@@ -251,7 +251,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             context.Response.HandleDesc = IpcHandleDesc.MakeCopy(handle);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { basicXpadId });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { basicXpadId });
 
             return ResultCode.Success;
         }
@@ -262,7 +262,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             int joyXpadId = context.RequestData.ReadInt32();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { joyXpadId });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { joyXpadId });
 
             return ResultCode.Success;
         }
@@ -273,7 +273,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             int joyXpadId = context.RequestData.ReadInt32();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { joyXpadId });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { joyXpadId });
 
             return ResultCode.Success;
         }
@@ -288,7 +288,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             context.Response.HandleDesc = IpcHandleDesc.MakeCopy(handle);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { joyXpadId });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { joyXpadId });
 
             return ResultCode.Success;
         }
@@ -300,7 +300,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             int  sixAxisSensorHandle  = context.RequestData.ReadInt32();
             long appletResourceUserId = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle });
 
             return ResultCode.Success;
         }
@@ -312,7 +312,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             int  sixAxisSensorHandle  = context.RequestData.ReadInt32();
             long appletResourceUserId = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle });
 
             return ResultCode.Success;
         }
@@ -326,7 +326,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             context.ResponseData.Write(_sixAxisSensorFusionEnabled);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _sixAxisSensorFusionEnabled });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _sixAxisSensorFusionEnabled });
 
             return ResultCode.Success;
         }
@@ -339,7 +339,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             int  sixAxisSensorHandle    = context.RequestData.ReadInt32();
             long appletResourceUserId   = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _sixAxisSensorFusionEnabled });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _sixAxisSensorFusionEnabled });
 
             return ResultCode.Success;
         }
@@ -358,7 +358,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             long appletResourceUserId = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _sensorFusionParams.RevisePower, _sensorFusionParams.ReviseRange });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _sensorFusionParams.RevisePower, _sensorFusionParams.ReviseRange });
 
             return ResultCode.Success;
         }
@@ -373,7 +373,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             context.ResponseData.Write(_sensorFusionParams.RevisePower);
             context.ResponseData.Write(_sensorFusionParams.ReviseRange);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _sensorFusionParams.RevisePower, _sensorFusionParams.ReviseRange });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _sensorFusionParams.RevisePower, _sensorFusionParams.ReviseRange });
 
             return ResultCode.Success;
         }
@@ -388,7 +388,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             _sensorFusionParams.RevisePower = 0;
             _sensorFusionParams.ReviseRange = 0;
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _sensorFusionParams.RevisePower, _sensorFusionParams.ReviseRange });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _sensorFusionParams.RevisePower, _sensorFusionParams.ReviseRange });
 
             return ResultCode.Success;
         }
@@ -407,7 +407,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             long appletResourceUserId = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _accelerometerParams.X, _accelerometerParams.Y });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _accelerometerParams.X, _accelerometerParams.Y });
 
             return ResultCode.Success;
         }
@@ -422,7 +422,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             context.ResponseData.Write(_accelerometerParams.X);
             context.ResponseData.Write(_accelerometerParams.Y);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _accelerometerParams.X, _accelerometerParams.Y });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _accelerometerParams.X, _accelerometerParams.Y });
 
             return ResultCode.Success;
         }
@@ -437,7 +437,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             _accelerometerParams.X = 0;
             _accelerometerParams.Y = 0;
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _accelerometerParams.X, _accelerometerParams.Y });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _accelerometerParams.X, _accelerometerParams.Y });
 
             return ResultCode.Success;
         }
@@ -450,7 +450,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
                  _accelerometerPlayMode = context.RequestData.ReadUInt32();
             long appletResourceUserId   = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _accelerometerPlayMode });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _accelerometerPlayMode });
 
             return ResultCode.Success;
         }
@@ -464,7 +464,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             context.ResponseData.Write(_accelerometerPlayMode);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _accelerometerPlayMode });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _accelerometerPlayMode });
 
             return ResultCode.Success;
         }
@@ -478,7 +478,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             _accelerometerPlayMode = 0;
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _accelerometerPlayMode });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _accelerometerPlayMode });
 
             return ResultCode.Success;
         }
@@ -491,7 +491,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
                  _gyroscopeZeroDriftMode = (HidGyroscopeZeroDriftMode)context.RequestData.ReadInt32();
             long appletResourceUserId    = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _gyroscopeZeroDriftMode });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _gyroscopeZeroDriftMode });
 
             return ResultCode.Success;
         }
@@ -505,7 +505,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             context.ResponseData.Write((int)_gyroscopeZeroDriftMode);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _gyroscopeZeroDriftMode });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _gyroscopeZeroDriftMode });
 
             return ResultCode.Success;
         }
@@ -519,7 +519,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             _gyroscopeZeroDriftMode = HidGyroscopeZeroDriftMode.Standard;
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _gyroscopeZeroDriftMode });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, _gyroscopeZeroDriftMode });
 
             return ResultCode.Success;
         }
@@ -535,7 +535,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             context.ResponseData.Write(isAtRest);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, isAtRest });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, sixAxisSensorHandle, isAtRest });
 
             return ResultCode.Success;
         }
@@ -547,7 +547,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             long appletResourceUserId = context.RequestData.ReadInt64();
             int  unknown0             = context.RequestData.ReadInt32();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, unknown0 });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, unknown0 });
 
             return ResultCode.Success;
         }
@@ -559,7 +559,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             ControllerType type = (ControllerType)context.RequestData.ReadInt32();
             long appletResourceUserId = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { 
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { 
                     appletResourceUserId, 
                     type 
                 });
@@ -577,7 +577,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             context.ResponseData.Write((int)context.Device.Hid.Npads.SupportedStyleSets);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { 
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { 
                     appletResourceUserId,
                     context.Device.Hid.Npads.SupportedStyleSets 
                 });
@@ -599,7 +599,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
                 supportedPlayerIds[i] = context.Memory.Read<NpadIdType>((ulong)(context.Request.PtrBuff[0].Position + i * 4));
             }
 
-            Logger.PrintStub(LogClass.ServiceHid, $"{arraySize} " + string.Join(",", supportedPlayerIds));
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, $"{arraySize} " + string.Join(",", supportedPlayerIds));
 
             return ResultCode.Success;
         }
@@ -611,7 +611,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             long appletResourceUserId = context.RequestData.ReadInt64();
 
             context.Device.Hid.Npads.Active = true;
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
 
             return ResultCode.Success;
         }
@@ -623,7 +623,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             long appletResourceUserId = context.RequestData.ReadInt64();
 
             context.Device.Hid.Npads.Active = false;
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
 
             return ResultCode.Success;
         }
@@ -644,7 +644,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             context.Response.HandleDesc = IpcHandleDesc.MakeCopy(handle);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, npadId, npadStyleSet });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, npadId, npadStyleSet });
 
             return ResultCode.Success;
         }
@@ -656,7 +656,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             NpadIdType npadIdType           = (NpadIdType)context.RequestData.ReadInt32();
             long       appletResourceUserId = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, npadIdType });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, npadIdType });
 
             return ResultCode.Success;
         }
@@ -671,7 +671,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             context.ResponseData.Write(ledPattern);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { npadId, ledPattern });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { npadId, ledPattern });
 
             return ResultCode.Success;
         }
@@ -683,7 +683,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             int  revision             = context.RequestData.ReadInt32();
             long appletResourceUserId = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, revision });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, revision });
 
             return ResultCode.Success;
         }
@@ -695,7 +695,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             long appletResourceUserId = context.RequestData.ReadInt64();
             context.Device.Hid.Npads.JoyHold = (NpadJoyHoldType)context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { 
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { 
                     appletResourceUserId, 
                     context.Device.Hid.Npads.JoyHold 
                 });
@@ -711,7 +711,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             context.ResponseData.Write((long)context.Device.Hid.Npads.JoyHold);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { 
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { 
                     appletResourceUserId, 
                     context.Device.Hid.Npads.JoyHold 
                 });
@@ -728,7 +728,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             _npadJoyAssignmentMode = HidNpadJoyAssignmentMode.Single;
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, hidControllerId, _npadJoyAssignmentMode });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, hidControllerId, _npadJoyAssignmentMode });
 
             return ResultCode.Success;
         }
@@ -743,7 +743,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             _npadJoyAssignmentMode = HidNpadJoyAssignmentMode.Single;
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, hidControllerId, hidNpadJoyDeviceType, _npadJoyAssignmentMode });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, hidControllerId, hidNpadJoyDeviceType, _npadJoyAssignmentMode });
 
             return ResultCode.Success;
         }
@@ -757,7 +757,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             _npadJoyAssignmentMode = HidNpadJoyAssignmentMode.Dual;
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, hidControllerId, _npadJoyAssignmentMode });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, hidControllerId, _npadJoyAssignmentMode });
 
             return ResultCode.Success;
         }
@@ -770,7 +770,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             long singleJoyId1         = context.RequestData.ReadInt32();
             long appletResourceUserId = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, singleJoyId0, singleJoyId1 });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, singleJoyId0, singleJoyId1 });
 
             return ResultCode.Success;
         }
@@ -781,7 +781,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             long appletResourceUserId = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
 
             return ResultCode.Success;
         }
@@ -792,7 +792,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             long appletResourceUserId = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
 
             return ResultCode.Success;
         }
@@ -804,7 +804,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             long appletResourceUserId   = context.RequestData.ReadInt64();
             _npadHandheldActivationMode = (HidNpadHandheldActivationMode)context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, _npadHandheldActivationMode });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, _npadHandheldActivationMode });
 
             return ResultCode.Success;
         }
@@ -817,7 +817,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             context.ResponseData.Write((long)_npadHandheldActivationMode);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, _npadHandheldActivationMode });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, _npadHandheldActivationMode });
 
             return ResultCode.Success;
         }
@@ -830,7 +830,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             int  newNpadAssignment    = context.RequestData.ReadInt32();
             long appletResourceUserId = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, oldNpadAssignment, newNpadAssignment });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, oldNpadAssignment, newNpadAssignment });
 
             return ResultCode.Success;
         }
@@ -844,7 +844,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             context.ResponseData.Write(_unintendedHomeButtonInputProtectionEnabled);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, unknown0, _unintendedHomeButtonInputProtectionEnabled });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, unknown0, _unintendedHomeButtonInputProtectionEnabled });
 
             return ResultCode.Success;
         }
@@ -857,7 +857,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             uint  unknown0                              = context.RequestData.ReadUInt32();
             long appletResourceUserId                   = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, unknown0, _unintendedHomeButtonInputProtectionEnabled });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, unknown0, _unintendedHomeButtonInputProtectionEnabled });
 
             return ResultCode.Success;
         }
@@ -875,7 +875,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             context.ResponseData.Write(0); //Unknown0
             context.ResponseData.Write(0); //Unknown1
 
-            Logger.PrintStub(LogClass.ServiceHid, new {
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new {
                 appletResourceUserId,
                 hidControllerId,
                 hidNpadJoyDeviceType,
@@ -902,7 +902,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             context.ResponseData.Write((int)deviceInfo.DeviceType);
             context.ResponseData.Write((int)deviceInfo.Position);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { vibrationDeviceHandle, deviceInfo.DeviceType, deviceInfo.Position });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { vibrationDeviceHandle, deviceInfo.DeviceType, deviceInfo.Position });
 
             return ResultCode.Success;
         }
@@ -947,7 +947,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             context.ResponseData.Write(_vibrationValue.AmplitudeHigh);
             context.ResponseData.Write(_vibrationValue.FrequencyHigh);
 
-            Logger.PrintStub(LogClass.ServiceHid, new {
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new {
                 appletResourceUserId,
                 vibrationDeviceHandle,
                 _vibrationValue.AmplitudeLow,
@@ -974,7 +974,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             _vibrationPermitted = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { _vibrationPermitted });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { _vibrationPermitted });
 
             return ResultCode.Success;
         }
@@ -985,7 +985,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             context.ResponseData.Write(_vibrationPermitted);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { _vibrationPermitted });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { _vibrationPermitted });
 
             return ResultCode.Success;
         }
@@ -1023,7 +1023,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             long vibrationGcErmCommand = context.RequestData.ReadInt64();
             long appletResourceUserId  = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, vibrationDeviceHandle, vibrationGcErmCommand });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, vibrationDeviceHandle, vibrationGcErmCommand });
 
             return ResultCode.Success;
         }
@@ -1037,7 +1037,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             context.ResponseData.Write(_vibrationGcErmCommand);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, vibrationDeviceHandle, _vibrationGcErmCommand });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, vibrationDeviceHandle, _vibrationGcErmCommand });
 
             return ResultCode.Success;
         }
@@ -1048,7 +1048,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             long appletResourceUserId = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
 
             return ResultCode.Success;
         }
@@ -1057,7 +1057,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         // EndPermitVibrationSession()
         public ResultCode EndPermitVibrationSession(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceHid);
+            Logger.Stub?.PrintStub(LogClass.ServiceHid);
 
             return ResultCode.Success;
         }
@@ -1068,7 +1068,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             long appletResourceUserId = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
 
             return ResultCode.Success;
         }
@@ -1080,7 +1080,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             int  consoleSixAxisSensorHandle = context.RequestData.ReadInt32();
             long appletResourceUserId       = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, consoleSixAxisSensorHandle });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, consoleSixAxisSensorHandle });
 
             return ResultCode.Success;
         }
@@ -1092,7 +1092,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             int  consoleSixAxisSensorHandle = context.RequestData.ReadInt32();
             long appletResourceUserId       = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, consoleSixAxisSensorHandle });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, consoleSixAxisSensorHandle });
 
             return ResultCode.Success;
         }
@@ -1103,7 +1103,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             long appletResourceUserId = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
 
             return ResultCode.Success;
         }
@@ -1114,7 +1114,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             long appletResourceUserId = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
 
             return ResultCode.Success;
         }
@@ -1125,7 +1125,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             long appletResourceUserId = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
 
             return ResultCode.Success;
         }
@@ -1140,7 +1140,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             // TODO: Determine if array<nn::sf::NativeHandle> is a buffer or not...
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, counter0, counter1 });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, counter0, counter1 });
 
             return ResultCode.Success;
         }
@@ -1151,7 +1151,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             long appletResourceUserId = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId });
 
             return ResultCode.Success;
         }
@@ -1163,7 +1163,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
                  _sevenSixAxisSensorFusionStrength = context.RequestData.ReadSingle();
             long appletResourceUserId              = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, _sevenSixAxisSensorFusionStrength });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, _sevenSixAxisSensorFusionStrength });
 
             return ResultCode.Success;
         }
@@ -1176,7 +1176,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             context.ResponseData.Write(_sevenSixAxisSensorFusionStrength);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, _sevenSixAxisSensorFusionStrength });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, _sevenSixAxisSensorFusionStrength });
 
             return ResultCode.Success;
         }
@@ -1187,7 +1187,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             context.ResponseData.Write(_usbFullKeyControllerEnabled);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { _usbFullKeyControllerEnabled });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { _usbFullKeyControllerEnabled });
 
             return ResultCode.Success;
         }
@@ -1198,7 +1198,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             _usbFullKeyControllerEnabled = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { _usbFullKeyControllerEnabled });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { _usbFullKeyControllerEnabled });
 
             return ResultCode.Success;
         }
@@ -1211,7 +1211,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             context.ResponseData.Write(true); //FullKeyController is always connected ?
 
-            Logger.PrintStub(LogClass.ServiceHid, new { unknown0, Connected = true });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { unknown0, Connected = true });
 
             return ResultCode.Success;
         }
@@ -1224,7 +1224,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             context.ResponseData.Write(true); //Npad always got a battery ?
 
-            Logger.PrintStub(LogClass.ServiceHid, new { npadId, HasBattery = true });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { npadId, HasBattery = true });
 
             return ResultCode.Success;
         }
@@ -1238,7 +1238,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             context.ResponseData.Write(true); //Npad always got a left battery ?
             context.ResponseData.Write(true); //Npad always got a right battery ?
 
-            Logger.PrintStub(LogClass.ServiceHid, new { npadId, HasLeftBattery = true, HasRightBattery = true });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { npadId, HasLeftBattery = true, HasRightBattery = true });
 
             return ResultCode.Success;
         }
@@ -1251,7 +1251,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             context.ResponseData.Write((byte)0);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { npadId, NpadInterfaceType = 0 });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { npadId, NpadInterfaceType = 0 });
 
             return ResultCode.Success;
         }
@@ -1265,7 +1265,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             context.ResponseData.Write((byte)0);
             context.ResponseData.Write((byte)0);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { npadId, LeftInterfaceType = 0, RightInterfaceType = 0 });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { npadId, LeftInterfaceType = 0, RightInterfaceType = 0 });
 
             return ResultCode.Success;
         }
@@ -1281,7 +1281,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             context.ResponseData.Write(palmaConnectionHandle);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId , unknown0, palmaConnectionHandle });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId , unknown0, palmaConnectionHandle });
 
             return ResultCode.Success;
         }
@@ -1292,7 +1292,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             int palmaConnectionHandle = context.RequestData.ReadInt32();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { palmaConnectionHandle });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { palmaConnectionHandle });
 
             _palmaOperationCompleteEvent.ReadableEvent.Signal();
 
@@ -1312,7 +1312,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             context.Response.HandleDesc = IpcHandleDesc.MakeCopy(handle);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { palmaConnectionHandle });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { palmaConnectionHandle });
 
             return ResultCode.Success;
         }
@@ -1327,7 +1327,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             context.ResponseData.Write(unknown0);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { palmaConnectionHandle, unknown0 });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { palmaConnectionHandle, unknown0 });
 
             return ResultCode.Success;
         }
@@ -1339,7 +1339,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             int  palmaConnectionHandle = context.RequestData.ReadInt32();
             long unknown0              = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { palmaConnectionHandle, unknown0 });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { palmaConnectionHandle, unknown0 });
 
             _palmaOperationCompleteEvent.ReadableEvent.Signal();
 
@@ -1353,7 +1353,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             int  palmaConnectionHandle = context.RequestData.ReadInt32();
             long frModeType            = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { palmaConnectionHandle, frModeType });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { palmaConnectionHandle, frModeType });
 
             _palmaOperationCompleteEvent.ReadableEvent.Signal();
 
@@ -1366,7 +1366,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             int palmaConnectionHandle = context.RequestData.ReadInt32();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { palmaConnectionHandle });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { palmaConnectionHandle });
 
             return ResultCode.Success;
         }
@@ -1378,7 +1378,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             int  palmaConnectionHandle = context.RequestData.ReadInt32();
             bool enabledPalmaStep      = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { palmaConnectionHandle, enabledPalmaStep });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { palmaConnectionHandle, enabledPalmaStep });
 
             _palmaOperationCompleteEvent.ReadableEvent.Signal();
 
@@ -1391,7 +1391,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             int palmaConnectionHandle = context.RequestData.ReadInt32();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { palmaConnectionHandle });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { palmaConnectionHandle });
 
             _palmaOperationCompleteEvent.ReadableEvent.Signal();
 
@@ -1406,7 +1406,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             long unknown0              = context.RequestData.ReadInt64();
             long unknown1              = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { palmaConnectionHandle, unknown0, unknown1 });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { palmaConnectionHandle, unknown0, unknown1 });
 
             return ResultCode.Success;
         }
@@ -1420,7 +1420,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             long unknown1              = context.RequestData.ReadInt64();
             // nn::hid::PalmaApplicationSectionAccessBuffer cast is unknown
 
-            Logger.PrintStub(LogClass.ServiceHid, new { palmaConnectionHandle, unknown0, unknown1 });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { palmaConnectionHandle, unknown0, unknown1 });
 
             _palmaOperationCompleteEvent.ReadableEvent.Signal();
 
@@ -1433,7 +1433,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             int palmaConnectionHandle = context.RequestData.ReadInt32();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { palmaConnectionHandle });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { palmaConnectionHandle });
 
             return ResultCode.Success;
         }
@@ -1444,7 +1444,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             int palmaConnectionHandle = context.RequestData.ReadInt32();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { palmaConnectionHandle });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { palmaConnectionHandle });
 
             return ResultCode.Success;
         }
@@ -1456,7 +1456,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             long appletResourceUserId = context.RequestData.ReadInt64();
             long unknownBool          = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, unknownBool });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, unknownBool });
 
             return ResultCode.Success;
         }
@@ -1477,7 +1477,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
                  _npadCommunicationMode = context.RequestData.ReadInt64();
             long appletResourceUserId   = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, _npadCommunicationMode });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, _npadCommunicationMode });
 
             return ResultCode.Success;
         }
@@ -1488,7 +1488,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             context.ResponseData.Write(_npadCommunicationMode);
 
-            Logger.PrintStub(LogClass.ServiceHid, new { _npadCommunicationMode });
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { _npadCommunicationMode });
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
@@ -923,7 +923,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             long appletResourceUserId = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceHid, new {
+            Logger.Debug?.PrintStub(LogClass.ServiceHid, new {
                 appletResourceUserId,
                 vibrationDeviceHandle,
                 _vibrationValue.AmplitudeLow,
@@ -1006,7 +1006,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             // TODO: Read all handles and values from buffer.
 
-            Logger.PrintStub(LogClass.ServiceHid, new {
+            Logger.Debug?.PrintStub(LogClass.ServiceHid, new {
                 appletResourceUserId,
                 VibrationDeviceHandleBufferLength = vibrationDeviceHandleBuffer.Length,
                 VibrationValueBufferLength = vibrationValueBuffer.Length

--- a/Ryujinx.HLE/HOS/Services/Hid/Irs/IIrSensorServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Irs/IIrSensorServer.cs
@@ -19,7 +19,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid.Irs
         {
             long appletResourceUserId = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceIrs, new { appletResourceUserId });
+            Logger.Stub?.PrintStub(LogClass.ServiceIrs, new { appletResourceUserId });
 
             return ResultCode.Success;
         }
@@ -30,7 +30,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid.Irs
         {
             long appletResourceUserId = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceIrs, new { appletResourceUserId });
+            Logger.Stub?.PrintStub(LogClass.ServiceIrs, new { appletResourceUserId });
 
             return ResultCode.Success;
         }
@@ -82,7 +82,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid.Irs
             long appletResourceUserId = context.RequestData.ReadInt64();
             long packedFunctionLevel  = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceIrs, new { appletResourceUserId, packedFunctionLevel });
+            Logger.Stub?.PrintStub(LogClass.ServiceIrs, new { appletResourceUserId, packedFunctionLevel });
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/IpcService.cs
+++ b/Ryujinx.HLE/HOS/Services/IpcService.cs
@@ -109,7 +109,7 @@ namespace Ryujinx.HLE.HOS.Services
 
                 if (serviceExists)
                 {
-                    Logger.PrintDebug(LogClass.KernelIpc, $"{service.GetType().Name}: {processRequest.Name}");
+                    Logger.Debug?.Print(LogClass.KernelIpc, $"{service.GetType().Name}: {processRequest.Name}");
 
                     ProfileConfig profile = Profiles.ServiceCall;
 
@@ -130,7 +130,7 @@ namespace Ryujinx.HLE.HOS.Services
 
                     serviceName = (dummyService == null) ? service.GetType().FullName : dummyService.ServiceName;
 
-                    Logger.PrintWarning(LogClass.KernelIpc, $"Missing service {serviceName}: {commandId} ignored");
+                    Logger.Warning?.Print(LogClass.KernelIpc, $"Missing service {serviceName}: {commandId} ignored");
                 }
 
                 if (_isDomain)

--- a/Ryujinx.HLE/HOS/Services/Ldn/NetworkInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Ldn/NetworkInterface.cs
@@ -27,7 +27,7 @@ namespace Ryujinx.HLE.HOS.Services.Ldn
             //             If the call failed, it returns the result code.
             //             If the call succeed, it signal and clear an event then start a new thread named nn.ldn.NetworkInterfaceMonitor.
 
-            Logger.PrintStub(LogClass.ServiceLdn, new { version });
+            Logger.Stub?.PrintStub(LogClass.ServiceLdn, new { version });
 
             // NOTE: Since we don't support ldn for now, we can return this following result code to make it disabled.
             return ResultCode.DeviceDisabled;
@@ -51,7 +51,7 @@ namespace Ryujinx.HLE.HOS.Services.Ldn
             StateChangeEvent.WritableEvent.Signal();
             StateChangeEvent.WritableEvent.Clear();
 
-            Logger.PrintStub(LogClass.ServiceLdn);
+            Logger.Stub?.PrintStub(LogClass.ServiceLdn);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Lm/LogService/ILogger.cs
+++ b/Ryujinx.HLE/HOS/Services/Lm/LogService/ILogger.cs
@@ -8,9 +8,87 @@ namespace Ryujinx.HLE.HOS.Services.Lm.LogService
     {
         public ILogger() { }
 
+        [Command(0)]
+        // Log(buffer<unknown, 0x21>)
+        public ResultCode Log(ServiceCtx context)
+        {
+            Logger.Guest?.Print(LogClass.ServiceLm, LogImpl(context));
+
+            return ResultCode.Success;
+        }
+
+        private string LogImpl(ServiceCtx context)
+        {
+            (long bufPos, long bufSize) = context.Request.GetBufferType0x21();
+
+            byte[] logBuffer = new byte[bufSize];
+
+            context.Memory.Read((ulong)bufPos, logBuffer);
+
+            using MemoryStream ms = new MemoryStream(logBuffer);
+
+            BinaryReader reader = new BinaryReader(ms);
+
+            long pid = reader.ReadInt64();
+            long threadContext = reader.ReadInt64();
+            short flags = reader.ReadInt16();
+            byte level = reader.ReadByte();
+            byte verbosity = reader.ReadByte();
+            int payloadLength = reader.ReadInt32();
+
+            StringBuilder sb = new StringBuilder();
+
+            sb.AppendLine($"Guest Log:\n  Log level: {(LmLogLevel)level}");
+
+            while (ms.Position < ms.Length)
+            {
+                int type = ReadEncodedInt(reader);
+                int size = ReadEncodedInt(reader);
+
+                LmLogField field = (LmLogField)type;
+
+                string fieldStr = string.Empty;
+
+                if (field == LmLogField.Start)
+                {
+                    reader.ReadBytes(size);
+
+                    continue;
+                }
+                else if (field == LmLogField.Stop)
+                {
+                    break;
+                }
+                else if (field == LmLogField.Line)
+                {
+                    fieldStr = $"{field}: {reader.ReadInt32()}";
+                }
+                else if (field == LmLogField.DropCount)
+                {
+                    fieldStr = $"{field}: {reader.ReadInt64()}";
+                }
+                else if (field == LmLogField.Time)
+                {
+                    fieldStr = $"{field}: {reader.ReadInt64()}s";
+                }
+                else if (field < LmLogField.Count)
+                {
+                    fieldStr = $"{field}: '{Encoding.UTF8.GetString(reader.ReadBytes(size)).TrimEnd()}'";
+                }
+                else
+                {
+                    fieldStr = $"Field{field}: '{Encoding.UTF8.GetString(reader.ReadBytes(size)).TrimEnd()}'";
+                }
+
+                sb.AppendLine($"    {fieldStr}");
+            }
+
+            return sb.ToString();
+        }
+
         private static int ReadEncodedInt(BinaryReader reader)
         {
-            int result   = 0;
+            int result = 0;
             int position = 0;
 
             byte encoded;
@@ -26,84 +104,6 @@ namespace Ryujinx.HLE.HOS.Services.Lm.LogService
             } while ((encoded & 0x80) != 0);
 
             return result;
-        }
-
-        [Command(0)]
-        // Log(buffer<unknown, 0x21>)
-        public ResultCode Log(ServiceCtx context)
-        {
-            (long bufPos, long bufSize) = context.Request.GetBufferType0x21();
-
-            byte[] logBuffer = new byte[bufSize];
-
-            context.Memory.Read((ulong)bufPos, logBuffer);
-
-            using (MemoryStream ms = new MemoryStream(logBuffer))
-            {
-                BinaryReader reader = new BinaryReader(ms);
-
-                long  pid           = reader.ReadInt64();
-                long  threadContext = reader.ReadInt64();
-                short flags         = reader.ReadInt16();
-                byte  level         = reader.ReadByte();
-                byte  verbosity     = reader.ReadByte();
-                int   payloadLength = reader.ReadInt32();
-
-                StringBuilder sb = new StringBuilder();
-
-                sb.AppendLine("Guest log:");
-
-                sb.AppendLine($" Log level: {(LmLogLevel)level}");
-
-                while (ms.Position < ms.Length)
-                {
-                    int type = ReadEncodedInt(reader);
-                    int size = ReadEncodedInt(reader);
-
-                    LmLogField field = (LmLogField)type;
-
-                    string fieldStr = string.Empty;
-
-                    if (field == LmLogField.Start)
-                    {
-                        reader.ReadBytes(size);
-
-                        continue;
-                    }
-                    else if (field == LmLogField.Stop)
-                    {
-                        break;
-                    }
-                    else if (field == LmLogField.Line)
-                    {
-                        fieldStr = $"{field}: {reader.ReadInt32()}";
-                    }
-                    else if (field == LmLogField.DropCount)
-                    {
-                        fieldStr = $"{field}: {reader.ReadInt64()}";
-                    }
-                    else if (field == LmLogField.Time)
-                    {
-                        fieldStr = $"{field}: {reader.ReadInt64()}s";
-                    }
-                    else if (field < LmLogField.Count)
-                    {
-                        fieldStr = $"{field}: '{Encoding.UTF8.GetString(reader.ReadBytes(size)).TrimEnd()}'";
-                    }
-                    else
-                    {
-                        fieldStr = $"Field{field}: '{Encoding.UTF8.GetString(reader.ReadBytes(size)).TrimEnd()}'";
-                    }
-
-                    sb.AppendLine(" " + fieldStr);
-                }
-
-                string text = sb.ToString();
-
-                Logger.PrintGuest(LogClass.ServiceLm, text);
-            }
-
-            return ResultCode.Success;
         }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Mm/IRequest.cs
+++ b/Ryujinx.HLE/HOS/Services/Mm/IRequest.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.HLE.HOS.Services.Mm
             int                     fgmId            = context.RequestData.ReadInt32();
             bool                    isAutoClearEvent = context.RequestData.ReadInt32() != 0;
 
-            Logger.PrintStub(LogClass.ServiceMm, new { operationType, fgmId, isAutoClearEvent });
+            Logger.Stub?.PrintStub(LogClass.ServiceMm, new { operationType, fgmId, isAutoClearEvent });
 
             Register(operationType, fgmId, isAutoClearEvent);
 
@@ -35,7 +35,7 @@ namespace Ryujinx.HLE.HOS.Services.Mm
         {
             MultiMediaOperationType operationType = (MultiMediaOperationType)context.RequestData.ReadUInt32();
 
-            Logger.PrintStub(LogClass.ServiceMm, new { operationType });
+            Logger.Stub?.PrintStub(LogClass.ServiceMm, new { operationType });
 
             lock (_sessionListLock)
             {
@@ -53,7 +53,7 @@ namespace Ryujinx.HLE.HOS.Services.Mm
             uint                    value         = context.RequestData.ReadUInt32();
             int                     timeout       = context.RequestData.ReadInt32();
 
-            Logger.PrintStub(LogClass.ServiceMm, new { operationType, value, timeout });
+            Logger.Stub?.PrintStub(LogClass.ServiceMm, new { operationType, value, timeout });
 
             lock (_sessionListLock)
             {
@@ -69,7 +69,7 @@ namespace Ryujinx.HLE.HOS.Services.Mm
         {
             MultiMediaOperationType operationType = (MultiMediaOperationType)context.RequestData.ReadUInt32();
 
-            Logger.PrintStub(LogClass.ServiceMm, new { operationType });
+            Logger.Stub?.PrintStub(LogClass.ServiceMm, new { operationType });
 
             lock (_sessionListLock)
             {
@@ -91,7 +91,7 @@ namespace Ryujinx.HLE.HOS.Services.Mm
             int                     fgmId            = context.RequestData.ReadInt32();
             bool                    isAutoClearEvent = context.RequestData.ReadInt32() != 0;
 
-            Logger.PrintStub(LogClass.ServiceMm, new { operationType, fgmId, isAutoClearEvent });
+            Logger.Stub?.PrintStub(LogClass.ServiceMm, new { operationType, fgmId, isAutoClearEvent });
 
             uint id = Register(operationType, fgmId, isAutoClearEvent);
 
@@ -106,7 +106,7 @@ namespace Ryujinx.HLE.HOS.Services.Mm
         {
             uint id = context.RequestData.ReadUInt32();
 
-            Logger.PrintStub(LogClass.ServiceMm, new { id });
+            Logger.Stub?.PrintStub(LogClass.ServiceMm, new { id });
 
             lock (_sessionListLock)
             {
@@ -124,7 +124,7 @@ namespace Ryujinx.HLE.HOS.Services.Mm
             uint value   = context.RequestData.ReadUInt32();
             int  timeout = context.RequestData.ReadInt32();
 
-            Logger.PrintStub(LogClass.ServiceMm, new { id, value, timeout });
+            Logger.Stub?.PrintStub(LogClass.ServiceMm, new { id, value, timeout });
 
             lock (_sessionListLock)
             {
@@ -140,7 +140,7 @@ namespace Ryujinx.HLE.HOS.Services.Mm
         {
             uint id = context.RequestData.ReadUInt32();
 
-            Logger.PrintStub(LogClass.ServiceMm, new { id });
+            Logger.Stub?.PrintStub(LogClass.ServiceMm, new { id });
 
             lock (_sessionListLock)
             {

--- a/Ryujinx.HLE/HOS/Services/Nifm/StaticService/IGeneralService.cs
+++ b/Ryujinx.HLE/HOS/Services/Nifm/StaticService/IGeneralService.cs
@@ -50,7 +50,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
             // Doesn't occur in our case.
             // return ResultCode.ObjectIsNull;
 
-            Logger.PrintStub(LogClass.ServiceNifm, new { version });
+            Logger.Stub?.PrintStub(LogClass.ServiceNifm, new { version });
 
             return ResultCode.Success;
         }
@@ -68,7 +68,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
 
             context.ResponseData.WriteStruct(new IpV4Address(unicastAddress.Address));
 
-            Logger.PrintInfo(LogClass.ServiceNifm, $"Console's local IP is \"{unicastAddress.Address}\".");
+            Logger.Info?.Print(LogClass.ServiceNifm, $"Console's local IP is \"{unicastAddress.Address}\".");
 
             return ResultCode.Success;
         }
@@ -84,7 +84,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
                 return ResultCode.NoInternetConnection;
             }
 
-            Logger.PrintInfo(LogClass.ServiceNifm, $"Console's local IP is \"{unicastAddress.Address}\".");
+            Logger.Info?.Print(LogClass.ServiceNifm, $"Console's local IP is \"{unicastAddress.Address}\".");
 
             context.ResponseData.WriteStruct(new IpAddressSetting(interfaceProperties, unicastAddress));
             context.ResponseData.WriteStruct(new DnsSetting(interfaceProperties));

--- a/Ryujinx.HLE/HOS/Services/Nifm/StaticService/IRequest.cs
+++ b/Ryujinx.HLE/HOS/Services/Nifm/StaticService/IRequest.cs
@@ -27,7 +27,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
         {
             context.ResponseData.Write(1);
 
-            Logger.PrintStub(LogClass.ServiceNifm);
+            Logger.Stub?.PrintStub(LogClass.ServiceNifm);
 
             return ResultCode.Success;
         }
@@ -36,7 +36,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
         // GetResult()
         public ResultCode GetResult(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceNifm);
+            Logger.Stub?.PrintStub(LogClass.ServiceNifm);
 
             return GetResultImpl();
         }
@@ -69,7 +69,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
         // Cancel()
         public ResultCode Cancel(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceNifm);
+            Logger.Stub?.PrintStub(LogClass.ServiceNifm);
 
             return ResultCode.Success;
         }
@@ -78,7 +78,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
         // Submit()
         public ResultCode Submit(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceNifm);
+            Logger.Stub?.PrintStub(LogClass.ServiceNifm);
 
             return ResultCode.Success;
         }
@@ -87,7 +87,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
         // SetConnectionConfirmationOption(i8)
         public ResultCode SetConnectionConfirmationOption(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceNifm);
+            Logger.Stub?.PrintStub(LogClass.ServiceNifm);
 
             return ResultCode.Success;
         }
@@ -98,7 +98,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
         {
             uint themeColor = context.RequestData.ReadUInt32();
 
-            Logger.PrintStub(LogClass.ServiceNifm);
+            Logger.Stub?.PrintStub(LogClass.ServiceNifm);
 
             ResultCode result = GetResultImpl();
 

--- a/Ryujinx.HLE/HOS/Services/Nim/IShopServiceAccessServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Nim/IShopServiceAccessServer.cs
@@ -13,7 +13,7 @@ namespace Ryujinx.HLE.HOS.Services.Nim.ShopServiceAccessServerInterface
         {
             MakeObject(context, new IShopServiceAccessor(context.Device.System));
 
-            Logger.PrintStub(LogClass.ServiceNim);
+            Logger.Stub?.PrintStub(LogClass.ServiceNim);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Nim/IShopServiceAccessServerInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Nim/IShopServiceAccessServerInterface.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.HLE.HOS.Services.Nim
         {
             MakeObject(context, new IShopServiceAccessServer());
 
-            Logger.PrintStub(LogClass.ServiceNim);
+            Logger.Stub?.PrintStub(LogClass.ServiceNim);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Nim/IShopServiceAccessor.cs
+++ b/Ryujinx.HLE/HOS/Services/Nim/IShopServiceAccessor.cs
@@ -29,7 +29,7 @@ namespace Ryujinx.HLE.HOS.Services.Nim.ShopServiceAccessServerInterface.ShopServ
 
             context.Response.HandleDesc = IpcHandleDesc.MakeCopy(handle);
 
-            Logger.PrintStub(LogClass.ServiceNim);
+            Logger.Stub?.PrintStub(LogClass.ServiceNim);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Ns/IAddOnContentManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Ns/IAddOnContentManager.cs
@@ -28,14 +28,14 @@ namespace Ryujinx.HLE.HOS.Services.Ns
             byte runtimeAddOnContentInstall = context.Device.Application.ControlData.Value.RuntimeAddOnContentInstall;
             if (runtimeAddOnContentInstall != 0)
             {
-                Logger.PrintWarning(LogClass.ServiceNs, $"RuntimeAddOnContentInstall is true. Some DLC may be missing");
+                Logger.Warning?.Print(LogClass.ServiceNs, $"RuntimeAddOnContentInstall is true. Some DLC may be missing");
             }
 
             uint aocCount = CountAddOnContentImpl(context);
 
             context.ResponseData.Write(aocCount);
 
-            Logger.PrintStub(LogClass.ServiceNs, new { aocCount, runtimeAddOnContentInstall });
+            Logger.Stub?.PrintStub(LogClass.ServiceNs, new { aocCount, runtimeAddOnContentInstall });
 
             return ResultCode.Success;
         }
@@ -77,7 +77,7 @@ namespace Ryujinx.HLE.HOS.Services.Ns
                 context.Memory.Write(bufAddr + (ulong)i * 4, (int)(aocTitleIds[i + (int)startIndex] - aocBaseId));
             }
 
-            Logger.PrintStub(LogClass.ServiceNs, new { bufferSize, startIndex, aocCount });
+            Logger.Stub?.PrintStub(LogClass.ServiceNs, new { bufferSize, startIndex, aocCount });
 
             return ResultCode.Success;
         }
@@ -94,7 +94,7 @@ namespace Ryujinx.HLE.HOS.Services.Ns
 
             context.ResponseData.Write(aocBaseId);
 
-            Logger.PrintStub(LogClass.ServiceNs, $"aocBaseId={aocBaseId:X16}");
+            Logger.Stub?.PrintStub(LogClass.ServiceNs, $"aocBaseId={aocBaseId:X16}");
 
             // ResultCode will be error code of GetApplicationLaunchProperty if it fails
             return ResultCode.Success;
@@ -124,7 +124,7 @@ namespace Ryujinx.HLE.HOS.Services.Ns
 
             // Ideally, this should probably initialize the AocData values for the specified index
 
-            Logger.PrintStub(LogClass.ServiceNs, new { aocIndex });
+            Logger.Stub?.PrintStub(LogClass.ServiceNs, new { aocIndex });
 
             return ResultCode.Success;
         }
@@ -142,7 +142,7 @@ namespace Ryujinx.HLE.HOS.Services.Ns
 
             context.Response.HandleDesc = IpcHandleDesc.MakeCopy(handle);
 
-            Logger.PrintStub(LogClass.ServiceNs);
+            Logger.Stub?.PrintStub(LogClass.ServiceNs);
 
             return ResultCode.Success;
         }
@@ -156,7 +156,7 @@ namespace Ryujinx.HLE.HOS.Services.Ns
             // which gives 0x874 (2000+164). 164 being Module ID of `EC (Shop)`
             context.ResponseData.Write(2164L);
 
-            Logger.PrintStub(LogClass.ServiceNs);
+            Logger.Stub?.PrintStub(LogClass.ServiceNs);
 
             return ResultCode.Success;
         }
@@ -167,7 +167,7 @@ namespace Ryujinx.HLE.HOS.Services.Ns
         {
             MakeObject(context, new IPurchaseEventManager(context.Device.System));
 
-            Logger.PrintStub(LogClass.ServiceNs);
+            Logger.Stub?.PrintStub(LogClass.ServiceNs);
 
             return ResultCode.Success;
         }
@@ -180,7 +180,7 @@ namespace Ryujinx.HLE.HOS.Services.Ns
 
             MakeObject(context, new IPurchaseEventManager(context.Device.System));
 
-            Logger.PrintStub(LogClass.ServiceNs);
+            Logger.Stub?.PrintStub(LogClass.ServiceNs);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Ns/IPurchaseEventManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Ns/IPurchaseEventManager.cs
@@ -30,7 +30,7 @@ namespace Ryujinx.HLE.HOS.Services.Ns
             //       Then it seems to use the buffer content and compare it with a stored linked instrusive list.
             //       Since we don't support purchase from eShop, we can stub it.
 
-            Logger.PrintStub(LogClass.ServiceNs);
+            Logger.Stub?.PrintStub(LogClass.ServiceNs);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Nv/INvDrvServices.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/INvDrvServices.cs
@@ -66,7 +66,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
                 }
                 else
                 {
-                    Logger.PrintWarning(LogClass.ServiceNv, $"Cannot find file device \"{path}\"!");
+                    Logger.Warning?.Print(LogClass.ServiceNv, $"Cannot find file device \"{path}\"!");
                 }
             }
 
@@ -88,7 +88,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
             {
                 arguments = null;
 
-                Logger.PrintWarning(LogClass.ServiceNv, "Ioctl size inconsistency found!");
+                Logger.Warning?.Print(LogClass.ServiceNv, "Ioctl size inconsistency found!");
 
                 return NvResult.InvalidSize;
             }
@@ -99,7 +99,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
                 {
                     arguments = null;
 
-                    Logger.PrintWarning(LogClass.ServiceNv, "Ioctl size inconsistency found!");
+                    Logger.Warning?.Print(LogClass.ServiceNv, "Ioctl size inconsistency found!");
 
                     return NvResult.InvalidSize;
                 }
@@ -145,7 +145,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
 
             if (deviceFile == null)
             {
-                Logger.PrintWarning(LogClass.ServiceNv, $"Invalid file descriptor {fd}");
+                Logger.Warning?.Print(LogClass.ServiceNv, $"Invalid file descriptor {fd}");
 
                 return NvResult.NotImplemented;
             }
@@ -162,7 +162,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
         {
             if (_owner == null)
             {
-                Logger.PrintWarning(LogClass.ServiceNv, "INvDrvServices is not initialized!");
+                Logger.Warning?.Print(LogClass.ServiceNv, "INvDrvServices is not initialized!");
 
                 return NvResult.NotInitialized;
             }
@@ -411,7 +411,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
                 context.ResponseData.WriteStruct(nvStatus);
                 context.ResponseData.Write((uint)NvResult.Success);
 
-                Logger.PrintStub(LogClass.ServiceNv);
+                Logger.Stub?.PrintStub(LogClass.ServiceNv);
             }
             else
             {
@@ -443,7 +443,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
         // DumpGraphicsMemoryInfo()
         public ResultCode DumpGraphicsMemoryInfo(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceNv);
+            Logger.Stub?.PrintStub(LogClass.ServiceNv);
 
             return ResultCode.Success;
         }
@@ -558,7 +558,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
         // FinishInitialize(unknown<8>)
         public ResultCode FinishInitialize(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceNv);
+            Logger.Stub?.PrintStub(LogClass.ServiceNv);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvDeviceFile.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvDeviceFile.cs
@@ -56,7 +56,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices
 
         private static NvInternalResult PrintResult(MethodInfo info, NvInternalResult result)
         {
-            Logger.PrintDebug(LogClass.ServiceNv, $"{info.Name} returned result {result}");
+            Logger.Debug?.Print(LogClass.ServiceNv, $"{info.Name} returned result {result}");
 
             return result;
         }

--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostAsGpu/NvHostAsGpuDeviceFile.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostAsGpu/NvHostAsGpuDeviceFile.cs
@@ -72,7 +72,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostAsGpu
 
         private NvInternalResult BindChannel(ref BindChannelArguments arguments)
         {
-            Logger.PrintStub(LogClass.ServiceNv);
+            Logger.Stub?.PrintStub(LogClass.ServiceNv);
 
             return NvInternalResult.Success;
         }
@@ -102,7 +102,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostAsGpu
                 {
                     arguments.Offset = 0;
 
-                    Logger.PrintWarning(LogClass.ServiceNv, $"Failed to allocate size {size:x16}!");
+                    Logger.Warning?.Print(LogClass.ServiceNv, $"Failed to allocate size {size:x16}!");
 
                     result = NvInternalResult.OutOfMemory;
                 }
@@ -131,7 +131,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostAsGpu
                 }
                 else
                 {
-                    Logger.PrintWarning(LogClass.ServiceNv,
+                    Logger.Warning?.Print(LogClass.ServiceNv,
                         $"Failed to free offset 0x{arguments.Offset:x16} size 0x{size:x16}!");
 
                     result = NvInternalResult.InvalidInput;
@@ -156,7 +156,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostAsGpu
                 }
                 else
                 {
-                    Logger.PrintWarning(LogClass.ServiceNv, $"Invalid buffer offset {arguments.Offset:x16}!");
+                    Logger.Warning?.Print(LogClass.ServiceNv, $"Invalid buffer offset {arguments.Offset:x16}!");
                 }
             }
 
@@ -173,7 +173,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostAsGpu
 
             if (map == null)
             {
-                Logger.PrintWarning(LogClass.ServiceNv, $"Invalid NvMap handle 0x{arguments.NvMapHandle:x8}!");
+                Logger.Warning?.Print(LogClass.ServiceNv, $"Invalid NvMap handle 0x{arguments.NvMapHandle:x8}!");
 
                 return NvInternalResult.InvalidInput;
             }
@@ -201,7 +201,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostAsGpu
                         {
                             string message = string.Format(mapErrorMsg, virtualAddress, arguments.MappingSize, pageSize);
 
-                            Logger.PrintWarning(LogClass.ServiceNv, message);
+                            Logger.Warning?.Print(LogClass.ServiceNv, message);
 
                             return NvInternalResult.InvalidInput;
                         }
@@ -210,7 +210,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostAsGpu
                     }
                     else
                     {
-                        Logger.PrintWarning(LogClass.ServiceNv, $"Address 0x{arguments.Offset:x16} not mapped!");
+                        Logger.Warning?.Print(LogClass.ServiceNv, $"Address 0x{arguments.Offset:x16} not mapped!");
 
                         return NvInternalResult.InvalidInput;
                     }
@@ -244,7 +244,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostAsGpu
                     {
                         string message = string.Format(mapErrorMsg, arguments.Offset, size, pageSize);
 
-                        Logger.PrintWarning(LogClass.ServiceNv, message);
+                        Logger.Warning?.Print(LogClass.ServiceNv, message);
 
                         result = NvInternalResult.InvalidInput;
                     }
@@ -258,7 +258,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostAsGpu
                 {
                     arguments.Offset = 0;
 
-                    Logger.PrintWarning(LogClass.ServiceNv, $"Failed to map size 0x{size:x16}!");
+                    Logger.Warning?.Print(LogClass.ServiceNv, $"Failed to map size 0x{size:x16}!");
 
                     result = NvInternalResult.InvalidInput;
                 }
@@ -273,14 +273,14 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostAsGpu
 
         private NvInternalResult GetVaRegions(ref GetVaRegionsArguments arguments)
         {
-            Logger.PrintStub(LogClass.ServiceNv);
+            Logger.Stub?.PrintStub(LogClass.ServiceNv);
 
             return NvInternalResult.Success;
         }
 
         private NvInternalResult InitializeEx(ref InitializeExArguments arguments)
         {
-            Logger.PrintStub(LogClass.ServiceNv);
+            Logger.Stub?.PrintStub(LogClass.ServiceNv);
 
             return NvInternalResult.Success;
         }
@@ -295,7 +295,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostAsGpu
 
                 if (map == null)
                 {
-                    Logger.PrintWarning(LogClass.ServiceNv, $"Invalid NvMap handle 0x{arguments[index].NvMapHandle:x8}!");
+                    Logger.Warning?.Print(LogClass.ServiceNv, $"Invalid NvMap handle 0x{arguments[index].NvMapHandle:x8}!");
 
                     return NvInternalResult.InvalidInput;
                 }
@@ -307,7 +307,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostAsGpu
 
                 if (result < 0)
                 {
-                    Logger.PrintWarning(LogClass.ServiceNv,
+                    Logger.Warning?.Print(LogClass.ServiceNv,
                         $"Page 0x{arguments[index].GpuOffset:x16} size 0x{arguments[index].Pages:x16} not allocated!");
 
                     return NvInternalResult.InvalidInput;

--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostChannel/NvHostChannelDeviceFile.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostChannel/NvHostChannelDeviceFile.cs
@@ -208,7 +208,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostChannel
         {
             arguments.Value = 0;
 
-            Logger.PrintStub(LogClass.ServiceNv);
+            Logger.Stub?.PrintStub(LogClass.ServiceNv);
 
             return NvInternalResult.Success;
         }
@@ -217,7 +217,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostChannel
         {
             _submitTimeout = submitTimeout;
 
-            Logger.PrintStub(LogClass.ServiceNv);
+            Logger.Stub?.PrintStub(LogClass.ServiceNv);
 
             return NvInternalResult.Success;
         }
@@ -235,7 +235,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostChannel
 
                 if (map == null)
                 {
-                    Logger.PrintWarning(LogClass.ServiceNv, $"Invalid handle 0x{commandBufferEntry.MapHandle:x8}!");
+                    Logger.Warning?.Print(LogClass.ServiceNv, $"Invalid handle 0x{commandBufferEntry.MapHandle:x8}!");
 
                     return NvInternalResult.InvalidInput;
                 }
@@ -267,7 +267,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostChannel
 
                 if (map == null)
                 {
-                    Logger.PrintWarning(LogClass.ServiceNv, $"Invalid handle 0x{commandBufferEntry.MapHandle:x8}!");
+                    Logger.Warning?.Print(LogClass.ServiceNv, $"Invalid handle 0x{commandBufferEntry.MapHandle:x8}!");
 
                     return NvInternalResult.InvalidInput;
                 }
@@ -292,7 +292,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostChannel
 
         private NvInternalResult SetNvMapFd(ref int nvMapFd)
         {
-            Logger.PrintStub(LogClass.ServiceNv);
+            Logger.Stub?.PrintStub(LogClass.ServiceNv);
 
             return NvInternalResult.Success;
         }
@@ -301,7 +301,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostChannel
         {
             _timeout = timeout;
 
-            Logger.PrintStub(LogClass.ServiceNv);
+            Logger.Stub?.PrintStub(LogClass.ServiceNv);
 
             return NvInternalResult.Success;
         }
@@ -317,21 +317,21 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostChannel
 
         private NvInternalResult AllocObjCtx(ref AllocObjCtxArguments arguments)
         {
-            Logger.PrintStub(LogClass.ServiceNv);
+            Logger.Stub?.PrintStub(LogClass.ServiceNv);
 
             return NvInternalResult.Success;
         }
 
         private NvInternalResult ZcullBind(ref ZcullBindArguments arguments)
         {
-            Logger.PrintStub(LogClass.ServiceNv);
+            Logger.Stub?.PrintStub(LogClass.ServiceNv);
 
             return NvInternalResult.Success;
         }
 
         private NvInternalResult SetErrorNotifier(ref SetErrorNotifierArguments arguments)
         {
-            Logger.PrintStub(LogClass.ServiceNv);
+            Logger.Stub?.PrintStub(LogClass.ServiceNv);
 
             return NvInternalResult.Success;
         }
@@ -353,7 +353,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostChannel
                     return NvInternalResult.InvalidInput;
             }
 
-            Logger.PrintStub(LogClass.ServiceNv);
+            Logger.Stub?.PrintStub(LogClass.ServiceNv);
 
             // TODO: disable and preempt channel when GPU scheduler will be implemented.
 
@@ -366,7 +366,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostChannel
 
             arguments.Fence = _channelSyncpoint;
 
-            Logger.PrintStub(LogClass.ServiceNv);
+            Logger.Stub?.PrintStub(LogClass.ServiceNv);
 
             return NvInternalResult.Success;
         }
@@ -377,7 +377,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostChannel
 
             arguments.Fence = _channelSyncpoint;
 
-            Logger.PrintStub(LogClass.ServiceNv);
+            Logger.Stub?.PrintStub(LogClass.ServiceNv);
 
             return NvInternalResult.Success;
         }
@@ -391,7 +391,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostChannel
 
             _timeslice = timeslice; // in micro-seconds
 
-            Logger.PrintStub(LogClass.ServiceNv);
+            Logger.Stub?.PrintStub(LogClass.ServiceNv);
 
             // TODO: disable and preempt channel when GPU scheduler will be implemented.
 
@@ -400,7 +400,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostChannel
 
         private NvInternalResult SetUserData(ref ulong userData)
         {
-            Logger.PrintStub(LogClass.ServiceNv);
+            Logger.Stub?.PrintStub(LogClass.ServiceNv);
 
             return NvInternalResult.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostCtrl/NvHostCtrlDeviceFile.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostCtrl/NvHostCtrlDeviceFile.cs
@@ -185,7 +185,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostCtrl
                 {
                     if (stringValue.Length > 0x100)
                     {
-                        Logger.PrintError(LogClass.ServiceNv, $"{arguments.Domain}!{arguments.Parameter} String value size is too big!");
+                        Logger.Error?.Print(LogClass.ServiceNv, $"{arguments.Domain}!{arguments.Parameter} String value size is too big!");
                     }
                     else
                     {
@@ -205,7 +205,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostCtrl
                     throw new NotImplementedException(nvSetting.GetType().Name);
                 }
 
-                Logger.PrintDebug(LogClass.ServiceNv, $"Got setting {arguments.Domain}!{arguments.Parameter}");
+                Logger.Debug?.Print(LogClass.ServiceNv, $"Got setting {arguments.Domain}!{arguments.Parameter}");
 
                 arguments.Configuration = settingBuffer;
 
@@ -451,11 +451,11 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostCtrl
                         }
                         else
                         {
-                            Logger.PrintError(LogClass.ServiceNv, $"Invalid Event at index {eventIndex} (isWaitEventAsyncCmd: {isWaitEventAsyncCmd}, isWaitEventCmd: {isWaitEventCmd})");
+                            Logger.Error?.Print(LogClass.ServiceNv, $"Invalid Event at index {eventIndex} (isWaitEventAsyncCmd: {isWaitEventAsyncCmd}, isWaitEventCmd: {isWaitEventCmd})");
 
                             if (hostEvent != null)
                             {
-                                Logger.PrintError(LogClass.ServiceNv, hostEvent.DumpState(_device.Gpu));
+                                Logger.Error?.Print(LogClass.ServiceNv, hostEvent.DumpState(_device.Gpu));
                             }
 
                             result = NvInternalResult.InvalidInput;
@@ -464,7 +464,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostCtrl
                 }
                 else
                 {
-                    Logger.PrintError(LogClass.ServiceNv, $"Invalid Event at index {eventIndex} (isWaitEventAsyncCmd: {isWaitEventAsyncCmd}, isWaitEventCmd: {isWaitEventCmd})");
+                    Logger.Error?.Print(LogClass.ServiceNv, $"Invalid Event at index {eventIndex} (isWaitEventAsyncCmd: {isWaitEventAsyncCmd}, isWaitEventCmd: {isWaitEventCmd})");
 
                     result = NvInternalResult.InvalidInput;
                 }
@@ -522,7 +522,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostCtrl
 
         public override void Close()
         {
-            Logger.PrintWarning(LogClass.ServiceNv, "Closing channel");
+            Logger.Warning?.Print(LogClass.ServiceNv, "Closing channel");
 
             lock (_events)
             {

--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostCtrl/Types/NvHostEvent.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostCtrl/Types/NvHostEvent.cs
@@ -119,7 +119,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostCtrl
                 //       This allows to keep GPU and CPU in sync when we are slow.
                 if (_failingCount == FailingCountMax)
                 {
-                    Logger.PrintWarning(LogClass.ServiceNv, "GPU processing thread is too slow, waiting on CPU...");
+                    Logger.Warning?.Print(LogClass.ServiceNv, "GPU processing thread is too slow, waiting on CPU...");
 
                     bool timedOut = Fence.Wait(gpuContext, Timeout.InfiniteTimeSpan);
 

--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostCtrl/Types/NvHostSyncPt.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostCtrl/Types/NvHostSyncPt.cs
@@ -57,7 +57,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostCtrl
                 }
             }
 
-            Logger.PrintError(LogClass.ServiceNv, "Cannot allocate a new syncpoint!");
+            Logger.Error?.Print(LogClass.ServiceNv, "Cannot allocate a new syncpoint!");
 
             return 0;
         }

--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostCtrlGpu/NvHostCtrlGpuDeviceFile.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostCtrlGpu/NvHostCtrlGpuDeviceFile.cs
@@ -140,7 +140,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostCtrlGpu
 
         private NvInternalResult ZbcSetTable(ref ZbcSetTableArguments arguments)
         {
-            Logger.PrintStub(LogClass.ServiceNv);
+            Logger.Stub?.PrintStub(LogClass.ServiceNv);
 
             return NvInternalResult.Success;
         }
@@ -213,7 +213,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostCtrlGpu
 
         private NvInternalResult GetActiveSlotMask(ref GetActiveSlotMaskArguments arguments)
         {
-            Logger.PrintStub(LogClass.ServiceNv);
+            Logger.Stub?.PrintStub(LogClass.ServiceNv);
 
             arguments.Slot = 0x07;
             arguments.Mask = 0x01;

--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvMap/NvMapDeviceFile.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvMap/NvMapDeviceFile.cs
@@ -68,7 +68,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvMap
         {
             if (arguments.Size == 0)
             {
-                Logger.PrintWarning(LogClass.ServiceNv, $"Invalid size 0x{arguments.Size:x8}!");
+                Logger.Warning?.Print(LogClass.ServiceNv, $"Invalid size 0x{arguments.Size:x8}!");
 
                 return NvInternalResult.InvalidInput;
             }
@@ -77,7 +77,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvMap
 
             arguments.Handle = CreateHandleFromMap(new NvMapHandle(size));
 
-            Logger.PrintInfo(LogClass.ServiceNv, $"Created map {arguments.Handle} with size 0x{size:x8}!");
+            Logger.Info?.Print(LogClass.ServiceNv, $"Created map {arguments.Handle} with size 0x{size:x8}!");
 
             return NvInternalResult.Success;
         }
@@ -88,7 +88,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvMap
 
             if (map == null)
             {
-                Logger.PrintWarning(LogClass.ServiceNv, $"Invalid handle 0x{arguments.Handle:x8}!");
+                Logger.Warning?.Print(LogClass.ServiceNv, $"Invalid handle 0x{arguments.Handle:x8}!");
 
                 return NvInternalResult.InvalidInput;
             }
@@ -106,14 +106,14 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvMap
 
             if (map == null)
             {
-                Logger.PrintWarning(LogClass.ServiceNv, $"Invalid handle 0x{arguments.Handle:x8}!");
+                Logger.Warning?.Print(LogClass.ServiceNv, $"Invalid handle 0x{arguments.Handle:x8}!");
 
                 return NvInternalResult.InvalidInput;
             }
 
             if ((arguments.Align & (arguments.Align - 1)) != 0)
             {
-                Logger.PrintWarning(LogClass.ServiceNv, $"Invalid alignment 0x{arguments.Align:x8}!");
+                Logger.Warning?.Print(LogClass.ServiceNv, $"Invalid alignment 0x{arguments.Align:x8}!");
 
                 return NvInternalResult.InvalidInput;
             }
@@ -160,7 +160,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvMap
 
             if (map == null)
             {
-                Logger.PrintWarning(LogClass.ServiceNv, $"Invalid handle 0x{arguments.Handle:x8}!");
+                Logger.Warning?.Print(LogClass.ServiceNv, $"Invalid handle 0x{arguments.Handle:x8}!");
 
                 return NvInternalResult.InvalidInput;
             }
@@ -187,7 +187,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvMap
 
             if (map == null)
             {
-                Logger.PrintWarning(LogClass.ServiceNv, $"Invalid handle 0x{arguments.Handle:x8}!");
+                Logger.Warning?.Print(LogClass.ServiceNv, $"Invalid handle 0x{arguments.Handle:x8}!");
 
                 return NvInternalResult.InvalidInput;
             }
@@ -214,7 +214,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvMap
 
             if (map == null)
             {
-                Logger.PrintWarning(LogClass.ServiceNv, $"Invalid handle 0x{arguments.Handle:x8}!");
+                Logger.Warning?.Print(LogClass.ServiceNv, $"Invalid handle 0x{arguments.Handle:x8}!");
 
                 return NvInternalResult.InvalidInput;
             }
@@ -272,7 +272,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvMap
             {
                 DeleteMapWithHandle(process, handle);
 
-                Logger.PrintInfo(LogClass.ServiceNv, $"Deleted map {handle}!");
+                Logger.Info?.Print(LogClass.ServiceNv, $"Deleted map {handle}!");
 
                 return true;
             }

--- a/Ryujinx.HLE/HOS/Services/Pctl/ParentalControlServiceFactory/IParentalControlService.cs
+++ b/Ryujinx.HLE/HOS/Services/Pctl/ParentalControlServiceFactory/IParentalControlService.cs
@@ -56,7 +56,7 @@ namespace Ryujinx.HLE.HOS.Services.Pctl.ParentalControlServiceFactory
                     {
                         // TODO: Service store TitleId and FreeCommunicationEnabled in another static object.
                         //       When it's done it signal an event in this static object.
-                        Logger.PrintStub(LogClass.ServicePctl);
+                        Logger.Stub?.PrintStub(LogClass.ServicePctl);
                     }
                 }
 
@@ -70,7 +70,7 @@ namespace Ryujinx.HLE.HOS.Services.Pctl.ParentalControlServiceFactory
         // CheckFreeCommunicationPermission()
         public ResultCode CheckFreeCommunicationPermission(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServicePctl);
+            Logger.Stub?.PrintStub(LogClass.ServicePctl);
 
             if (!_freeCommunicationEnabled)
             {

--- a/Ryujinx.HLE/HOS/Services/Prepo/IPrepoService.cs
+++ b/Ryujinx.HLE/HOS/Services/Prepo/IPrepoService.cs
@@ -87,7 +87,7 @@ namespace Ryujinx.HLE.HOS.Services.Prepo
 
             context.Memory.Read((ulong)inputPosition, inputBuffer);
 
-            Logger.PrintInfo(LogClass.ServicePrepo, ReadReportBuffer(inputBuffer, gameRoom, userId));
+            Logger.Info?.Print(LogClass.ServicePrepo, ReadReportBuffer(inputBuffer, gameRoom, userId));
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Ptm/Psm/IPsmServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Ptm/Psm/IPsmServer.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.HLE.HOS.Services.Ptm.Psm
 
             context.ResponseData.Write(chargePercentage);
 
-            Logger.PrintStub(LogClass.ServicePsm, new { chargePercentage });
+            Logger.Stub?.PrintStub(LogClass.ServicePsm, new { chargePercentage });
 
             return ResultCode.Success;
         }
@@ -28,7 +28,7 @@ namespace Ryujinx.HLE.HOS.Services.Ptm.Psm
 
             context.ResponseData.Write((int)chargerType);
 
-            Logger.PrintStub(LogClass.ServicePsm, new { chargerType });
+            Logger.Stub?.PrintStub(LogClass.ServicePsm, new { chargerType });
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Ptm/Psm/IPsmSession.cs
+++ b/Ryujinx.HLE/HOS/Services/Ptm/Psm/IPsmSession.cs
@@ -32,7 +32,7 @@ namespace Ryujinx.HLE.HOS.Services.Ptm.Psm
 
             context.Response.HandleDesc = IpcHandleDesc.MakeCopy(_stateChangeEventHandle);
 
-            Logger.PrintStub(LogClass.ServicePsm);
+            Logger.Stub?.PrintStub(LogClass.ServicePsm);
 
             return ResultCode.Success;
         }
@@ -47,7 +47,7 @@ namespace Ryujinx.HLE.HOS.Services.Ptm.Psm
                 _stateChangeEventHandle = -1;
             }
 
-            Logger.PrintStub(LogClass.ServicePsm);
+            Logger.Stub?.PrintStub(LogClass.ServicePsm);
 
             return ResultCode.Success;
         }
@@ -58,7 +58,7 @@ namespace Ryujinx.HLE.HOS.Services.Ptm.Psm
         {
             bool chargerTypeChangeEventEnabled = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServicePsm, new { chargerTypeChangeEventEnabled });
+            Logger.Stub?.PrintStub(LogClass.ServicePsm, new { chargerTypeChangeEventEnabled });
 
             return ResultCode.Success;
         }
@@ -69,7 +69,7 @@ namespace Ryujinx.HLE.HOS.Services.Ptm.Psm
         {
             bool powerSupplyChangeEventEnabled = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServicePsm, new { powerSupplyChangeEventEnabled });
+            Logger.Stub?.PrintStub(LogClass.ServicePsm, new { powerSupplyChangeEventEnabled });
 
             return ResultCode.Success;
         }
@@ -80,7 +80,7 @@ namespace Ryujinx.HLE.HOS.Services.Ptm.Psm
         {
             bool batteryVoltageStateChangeEventEnabled = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServicePsm, new { batteryVoltageStateChangeEventEnabled });
+            Logger.Stub?.PrintStub(LogClass.ServicePsm, new { batteryVoltageStateChangeEventEnabled });
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Ptm/Ts/IMeasurementServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Ptm/Ts/IMeasurementServer.cs
@@ -16,7 +16,7 @@ namespace Ryujinx.HLE.HOS.Services.Ptm.Ts
         {
             Location location = (Location)context.RequestData.ReadByte();
 
-            Logger.PrintStub(LogClass.ServicePtm, new { location });
+            Logger.Stub?.PrintStub(LogClass.ServicePtm, new { location });
 
             context.ResponseData.Write(DefaultTemperature);
 

--- a/Ryujinx.HLE/HOS/Services/Settings/ISettingsServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Settings/ISettingsServer.cs
@@ -105,7 +105,7 @@ namespace Ryujinx.HLE.HOS.Services.Settings
         {
             context.ResponseData.Write(false);
 
-            Logger.PrintStub(LogClass.ServiceSet);
+            Logger.Stub?.PrintStub(LogClass.ServiceSet);
 
             return ResultCode.Success;
         }
@@ -121,7 +121,7 @@ namespace Ryujinx.HLE.HOS.Services.Settings
         {
             if (context.Request.ReceiveBuff[0].Size != 0x1000)
             {
-                Logger.PrintWarning(LogClass.ServiceSet, "Bad size");
+                Logger.Warning?.Print(LogClass.ServiceSet, "Bad size");
             }
 
             byte[] keyCodeMap;

--- a/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
@@ -186,7 +186,7 @@ namespace Ryujinx.HLE.HOS.Services.Settings
                 {
                     if (stringValue.Length + 1 > replySize)
                     {
-                        Logger.PrintError(LogClass.ServiceSet, $"{askedSetting} String value size is too big!");
+                        Logger.Error?.Print(LogClass.ServiceSet, $"{askedSetting} String value size is too big!");
                     }
                     else
                     {
@@ -209,11 +209,11 @@ namespace Ryujinx.HLE.HOS.Services.Settings
 
                 context.Memory.Write((ulong)replyPos, settingBuffer);
 
-                Logger.PrintDebug(LogClass.ServiceSet, $"{askedSetting} set value: {nxSetting} as {nxSetting.GetType()}");
+                Logger.Debug?.Print(LogClass.ServiceSet, $"{askedSetting} set value: {nxSetting} as {nxSetting.GetType()}");
             }
             else
             {
-                Logger.PrintError(LogClass.ServiceSet, $"{askedSetting} not found!");
+                Logger.Error?.Print(LogClass.ServiceSet, $"{askedSetting} not found!");
             }
 
             return ResultCode.Success;

--- a/Ryujinx.HLE/HOS/Services/Sm/IUserInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Sm/IUserInterface.cs
@@ -88,7 +88,7 @@ namespace Ryujinx.HLE.HOS.Services.Sm
                 {
                     if (ServiceConfiguration.IgnoreMissingServices)
                     {
-                        Logger.PrintWarning(LogClass.Service, $"Missing service {name} ignored");
+                        Logger.Warning?.Print(LogClass.Service, $"Missing service {name} ignored");
 
                         session.ClientSession.Service = new DummyService(name);
                     }
@@ -136,7 +136,7 @@ namespace Ryujinx.HLE.HOS.Services.Sm
                 return ResultCode.InvalidName;
             }
 
-            Logger.PrintInfo(LogClass.ServiceSm, $"Register \"{name}\".");
+            Logger.Info?.Print(LogClass.ServiceSm, $"Register \"{name}\".");
 
             KPort port = new KPort(context.Device.System.KernelContext, maxSessions, isLight, 0);
 

--- a/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
@@ -245,7 +245,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             // bsd_error
             context.ResponseData.Write(0);
 
-            Logger.PrintStub(LogClass.ServiceBsd);
+            Logger.Stub?.PrintStub(LogClass.ServiceBsd);
 
             return ResultCode.Success;
         }
@@ -256,7 +256,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
         {
             ulong unknown0 = context.RequestData.ReadUInt64();
 
-            Logger.PrintStub(LogClass.ServiceBsd, new { unknown0 });
+            Logger.Stub?.PrintStub(LogClass.ServiceBsd, new { unknown0 });
 
             return ResultCode.Success;
         }
@@ -291,7 +291,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
 
             WriteBsdResult(context, -1, LinuxError.EOPNOTSUPP);
 
-            Logger.PrintStub(LogClass.ServiceBsd, new { path, flags });
+            Logger.Stub?.PrintStub(LogClass.ServiceBsd, new { path, flags });
 
             return ResultCode.Success;
         }
@@ -302,7 +302,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
         {
             WriteBsdResult(context, -1, LinuxError.EOPNOTSUPP);
 
-            Logger.PrintStub(LogClass.ServiceBsd);
+            Logger.Stub?.PrintStub(LogClass.ServiceBsd);
 
             return ResultCode.Success;
         }
@@ -380,7 +380,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
 
                 if (!isValidEvent)
                 {
-                    Logger.PrintWarning(LogClass.ServiceBsd, $"Unsupported Poll input event type: {Event.InputEvents}");
+                    Logger.Warning?.Print(LogClass.ServiceBsd, $"Unsupported Poll input event type: {Event.InputEvents}");
                     return WriteBsdResult(context, -1, LinuxError.EINVAL);
                 }
             }
@@ -452,7 +452,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
         {
             WriteBsdResult(context, -1, LinuxError.EOPNOTSUPP);
 
-            Logger.PrintStub(LogClass.ServiceBsd);
+            Logger.Stub?.PrintStub(LogClass.ServiceBsd);
 
             return ResultCode.Success;
         }
@@ -475,7 +475,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                 if (socketFlags != SocketFlags.None && (socketFlags & SocketFlags.OutOfBand) == 0
                     && (socketFlags & SocketFlags.Peek) == 0)
                 {
-                    Logger.PrintWarning(LogClass.ServiceBsd, $"Unsupported Recv flags: {socketFlags}");
+                    Logger.Warning?.Print(LogClass.ServiceBsd, $"Unsupported Recv flags: {socketFlags}");
                     return WriteBsdResult(context, -1, LinuxError.EOPNOTSUPP);
                 }
 
@@ -516,7 +516,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                 if (socketFlags != SocketFlags.None && (socketFlags & SocketFlags.OutOfBand) == 0
                     && (socketFlags & SocketFlags.Peek) == 0)
                 {
-                    Logger.PrintWarning(LogClass.ServiceBsd, $"Unsupported Recv flags: {socketFlags}");
+                    Logger.Warning?.Print(LogClass.ServiceBsd, $"Unsupported Recv flags: {socketFlags}");
 
                     return WriteBsdResult(context, -1, LinuxError.EOPNOTSUPP);
                 }
@@ -559,7 +559,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                 if (socketFlags != SocketFlags.None && socketFlags != SocketFlags.OutOfBand
                     && socketFlags != SocketFlags.Peek && socketFlags != SocketFlags.DontRoute)
                 {
-                    Logger.PrintWarning(LogClass.ServiceBsd, $"Unsupported Send flags: {socketFlags}");
+                    Logger.Warning?.Print(LogClass.ServiceBsd, $"Unsupported Send flags: {socketFlags}");
 
                     return WriteBsdResult(context, -1, LinuxError.EOPNOTSUPP);
                 }
@@ -602,7 +602,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                 if (socketFlags != SocketFlags.None && socketFlags != SocketFlags.OutOfBand
                     && socketFlags != SocketFlags.Peek && socketFlags != SocketFlags.DontRoute)
                 {
-                    Logger.PrintWarning(LogClass.ServiceBsd, $"Unsupported Send flags: {socketFlags}");
+                    Logger.Warning?.Print(LogClass.ServiceBsd, $"Unsupported Send flags: {socketFlags}");
 
                     return WriteBsdResult(context, -1, LinuxError.EOPNOTSUPP);
                 }
@@ -811,7 +811,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                 }
                 else
                 {
-                    Logger.PrintWarning(LogClass.ServiceBsd, $"Unsupported GetSockOpt Level: {(SocketOptionLevel)level}");
+                    Logger.Warning?.Print(LogClass.ServiceBsd, $"Unsupported GetSockOpt Level: {(SocketOptionLevel)level}");
                 }
             }
 
@@ -872,7 +872,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                     default:
                         errno = LinuxError.EOPNOTSUPP;
 
-                        Logger.PrintWarning(LogClass.ServiceBsd, $"Unsupported Ioctl Cmd: {cmd}");
+                        Logger.Warning?.Print(LogClass.ServiceBsd, $"Unsupported Ioctl Cmd: {cmd}");
                         break;
                 }
             }
@@ -946,7 +946,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                         return LinuxError.SUCCESS;
 
                     default:
-                        Logger.PrintWarning(LogClass.ServiceBsd, $"Unsupported SetSockOpt OptionName: {optionName}");
+                        Logger.Warning?.Print(LogClass.ServiceBsd, $"Unsupported SetSockOpt OptionName: {optionName}");
 
                         return LinuxError.EOPNOTSUPP;
                 }
@@ -991,7 +991,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                         return LinuxError.SUCCESS;
 
                     default:
-                        Logger.PrintWarning(LogClass.ServiceBsd, $"Unsupported SetSockOpt OptionName: {optionName}");
+                        Logger.Warning?.Print(LogClass.ServiceBsd, $"Unsupported SetSockOpt OptionName: {optionName}");
 
                         return LinuxError.EOPNOTSUPP;
                 }
@@ -1025,7 +1025,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                 }
                 else
                 {
-                    Logger.PrintWarning(LogClass.ServiceBsd, $"Unsupported SetSockOpt Level: {(SocketOptionLevel)level}");
+                    Logger.Warning?.Print(LogClass.ServiceBsd, $"Unsupported SetSockOpt Level: {(SocketOptionLevel)level}");
                 }
             }
 

--- a/Ryujinx.HLE/HOS/Services/Sockets/Nsd/IManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Nsd/IManager.cs
@@ -221,7 +221,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
             // TODO: Call nn::nsd::detail::fs::ReadSaveDataWithOffset() at offset 0 to write the 
             //       whole savedata inside the buffer.
 
-            Logger.PrintStub(LogClass.ServiceNsd);
+            Logger.Stub?.PrintStub(LogClass.ServiceNsd);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/IResolver.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/IResolver.cs
@@ -147,7 +147,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
             long bufferSize     = context.Request.SendBuff[0].Size;
 
             // TODO: This is stubbed in 2.0.0+, reverse 1.0.0 version for the sake completeness.
-            Logger.PrintStub(LogClass.ServiceSfdnsres, new { unknown0 });
+            Logger.Stub?.PrintStub(LogClass.ServiceSfdnsres, new { unknown0 });
 
             return ResultCode.NotAllocated;
         }
@@ -159,7 +159,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
             uint unknown0 = context.RequestData.ReadUInt32();
 
             // TODO: This is stubbed in 2.0.0+, reverse 1.0.0 version for the sake completeness.
-            Logger.PrintStub(LogClass.ServiceSfdnsres, new { unknown0 });
+            Logger.Stub?.PrintStub(LogClass.ServiceSfdnsres, new { unknown0 });
 
             return ResultCode.NotAllocated;
         }
@@ -361,7 +361,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
 
             context.ResponseData.Write(0);
 
-            Logger.PrintStub(LogClass.ServiceSfdnsres, new { unknown0 });
+            Logger.Stub?.PrintStub(LogClass.ServiceSfdnsres, new { unknown0 });
 
             return ResultCode.Success;
         }
@@ -373,7 +373,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
             uint  unknown0 = context.RequestData.ReadUInt32();
             ulong unknown1 = context.RequestData.ReadUInt64();
 
-            Logger.PrintStub(LogClass.ServiceSfdnsres, new { unknown0, unknown1 });
+            Logger.Stub?.PrintStub(LogClass.ServiceSfdnsres, new { unknown0, unknown1 });
 
             return ResultCode.Success;
         }
@@ -384,7 +384,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
         {
             uint unknown0 = context.RequestData.ReadUInt32();
 
-            Logger.PrintStub(LogClass.ServiceSfdnsres, new { unknown0 });
+            Logger.Stub?.PrintStub(LogClass.ServiceSfdnsres, new { unknown0 });
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Ssl/ISslService.cs
+++ b/Ryujinx.HLE/HOS/Services/Ssl/ISslService.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.HLE.HOS.Services.Ssl
             int  sslVersion = context.RequestData.ReadInt32();
             long unknown    = context.RequestData.ReadInt64();
 
-            Logger.PrintStub(LogClass.ServiceSsl, new { sslVersion, unknown });
+            Logger.Stub?.PrintStub(LogClass.ServiceSsl, new { sslVersion, unknown });
 
             MakeObject(context, new ISslContext(context));
 
@@ -28,7 +28,7 @@ namespace Ryujinx.HLE.HOS.Services.Ssl
         {
             int version = context.RequestData.ReadInt32();
 
-            Logger.PrintStub(LogClass.ServiceSsl, new { version });
+            Logger.Stub?.PrintStub(LogClass.ServiceSsl, new { version });
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Ssl/SslService/ISslContext.cs
+++ b/Ryujinx.HLE/HOS/Services/Ssl/SslService/ISslContext.cs
@@ -18,7 +18,7 @@ namespace Ryujinx.HLE.HOS.Services.Ssl.SslService
 
             context.ResponseData.Write(certificateId);
 
-            Logger.PrintStub(LogClass.ServiceSsl, new { certificateFormat, certificateDataPosition, certificateDataSize });
+            Logger.Stub?.PrintStub(LogClass.ServiceSsl, new { certificateFormat, certificateDataPosition, certificateDataSize });
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/BufferQueueConsumer.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/BufferQueueConsumer.cs
@@ -32,7 +32,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
                 {
                     bufferItem = null;
 
-                    Logger.PrintDebug(LogClass.SurfaceFlinger, $"Max acquired buffer count reached: {numAcquiredBuffers} (max: {Core.MaxAcquiredBufferCount})");
+                    Logger.Debug?.Print(LogClass.SurfaceFlinger, $"Max acquired buffer count reached: {numAcquiredBuffers} (max: {Core.MaxAcquiredBufferCount})");
 
                     return Status.InvalidOperation;
                 }
@@ -102,7 +102,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
                 if (!Core.Slots[slot].RequestBufferCalled)
                 {
-                    Logger.PrintError(LogClass.SurfaceFlinger, $"Slot {slot} was detached without requesting a buffer");
+                    Logger.Error?.Print(LogClass.SurfaceFlinger, $"Slot {slot} was detached without requesting a buffer");
 
                     return Status.BadValue;
                 }
@@ -141,7 +141,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
                 {
                     slot = BufferSlotArray.InvalidBufferSlot;
 
-                    Logger.PrintError(LogClass.SurfaceFlinger, $"Max acquired buffer count reached: {numAcquiredBuffers} (max: {Core.MaxAcquiredBufferCount})");
+                    Logger.Error?.Print(LogClass.SurfaceFlinger, $"Max acquired buffer count reached: {numAcquiredBuffers} (max: {Core.MaxAcquiredBufferCount})");
 
                     return Status.InvalidOperation;
                 }

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/BufferQueueCore.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/BufferQueueCore.cs
@@ -290,7 +290,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
         {
             if (Slots[slot].BufferState != BufferState.Acquired)
             {
-                Logger.PrintError(LogClass.SurfaceFlinger, $"Slot {slot} is not owned by the consumer (state = {Slots[slot].BufferState})");
+                Logger.Error?.Print(LogClass.SurfaceFlinger, $"Slot {slot} is not owned by the consumer (state = {Slots[slot].BufferState})");
 
                 return false;
             }
@@ -302,7 +302,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
         {
             if (Slots[slot].BufferState != BufferState.Dequeued)
             {
-                Logger.PrintError(LogClass.SurfaceFlinger, $"Slot {slot} is not owned by the producer (state = {Slots[slot].BufferState})");
+                Logger.Error?.Print(LogClass.SurfaceFlinger, $"Slot {slot} is not owned by the producer (state = {Slots[slot].BufferState})");
 
                 return false;
             }

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/BufferQueueProducer.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/BufferQueueProducer.cs
@@ -102,7 +102,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
                 }
                 else if (preallocatedBufferCount < bufferCount)
                 {
-                    Logger.PrintError(LogClass.SurfaceFlinger, "Not enough buffers. Try with more pre-allocated buffers");
+                    Logger.Error?.Print(LogClass.SurfaceFlinger, "Not enough buffers. Try with more pre-allocated buffers");
 
                     return Status.Success;
                 }
@@ -163,7 +163,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
                 {
                     fence = AndroidFence.NoFence;
 
-                    Logger.PrintError(LogClass.SurfaceFlinger, "No available buffer slots");
+                    Logger.Error?.Print(LogClass.SurfaceFlinger, "No available buffer slots");
 
                     return Status.Busy;
                 }
@@ -242,7 +242,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
                 if (!Core.Slots[slot].RequestBufferCalled)
                 {
-                    Logger.PrintError(LogClass.SurfaceFlinger, $"Slot {slot} was detached without requesting a buffer");
+                    Logger.Error?.Print(LogClass.SurfaceFlinger, $"Slot {slot} was detached without requesting a buffer");
 
                     return Status.BadValue;
                 }
@@ -313,7 +313,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
                 if (slot == BufferSlotArray.InvalidBufferSlot)
                 {
-                    Logger.PrintError(LogClass.SurfaceFlinger, "No available buffer slots");
+                    Logger.Error?.Print(LogClass.SurfaceFlinger, "No available buffer slots");
 
                     return Status.Busy;
                 }
@@ -372,7 +372,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
                 if (!Core.Slots[slot].RequestBufferCalled)
                 {
-                    Logger.PrintError(LogClass.SurfaceFlinger, $"Slot {slot} was queued without requesting a buffer");
+                    Logger.Error?.Print(LogClass.SurfaceFlinger, $"Slot {slot} was queued without requesting a buffer");
 
                     return Status.BadValue;
                 }
@@ -796,7 +796,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
                     if (newUndequeuedCount < minUndequeuedCount)
                     {
-                        Logger.PrintError(LogClass.SurfaceFlinger, $"Min undequeued buffer count ({minUndequeuedCount}) exceeded (dequeued = {dequeuedCount} undequeued = {newUndequeuedCount})");
+                        Logger.Error?.Print(LogClass.SurfaceFlinger, $"Min undequeued buffer count ({minUndequeuedCount}) exceeded (dequeued = {dequeuedCount} undequeued = {newUndequeuedCount})");
 
                         return Status.InvalidOperation;
                     }

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/BufferQueueProducer.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/BufferQueueProducer.cs
@@ -193,11 +193,10 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
                     }
                     else
                     {
-                        string formattedError = $"Preallocated buffer mismatch - slot {slot}\n" +
-                                                $"available: Width = {graphicBuffer.Width} Height = {graphicBuffer.Height} Format = {graphicBuffer.Format} Usage = {graphicBuffer.Usage:x} " +
-                                                $"requested: Width = {width} Height = {height} Format = {format} Usage = {usage:x}";
-
-                        Logger.PrintError(LogClass.SurfaceFlinger, formattedError);
+                        Logger.Error?.Print(LogClass.SurfaceFlinger, 
+                                            $"Preallocated buffer mismatch - slot {slot}\n" +
+                                            $"available: Width = {graphicBuffer.Width} Height = {graphicBuffer.Height} Format = {graphicBuffer.Format} Usage = {graphicBuffer.Usage:x} " +
+                                            $"requested: Width = {width} Height = {height} Format = {format} Usage = {usage:x}");
 
                         slot  = BufferSlotArray.InvalidBufferSlot;
                         fence = AndroidFence.NoFence;

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/HOSBinderDriverServer.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/HOSBinderDriverServer.cs
@@ -68,7 +68,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
             if (binder == null)
             {
-                Logger.PrintError(LogClass.SurfaceFlinger, $"Invalid binder id {binderId}");
+                Logger.Error?.Print(LogClass.SurfaceFlinger, $"Invalid binder id {binderId}");
 
                 return ResultCode.Success;
             }
@@ -84,7 +84,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
             {
                 readableEvent = null;
 
-                Logger.PrintError(LogClass.SurfaceFlinger, $"Invalid binder id {binderId}");
+                Logger.Error?.Print(LogClass.SurfaceFlinger, $"Invalid binder id {binderId}");
 
                 return;
             }
@@ -98,7 +98,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
             if (binder == null)
             {
-                Logger.PrintError(LogClass.SurfaceFlinger, $"Invalid binder id {binderId}");
+                Logger.Error?.Print(LogClass.SurfaceFlinger, $"Invalid binder id {binderId}");
 
                 return ResultCode.Success;
             }

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/IBinder.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/IBinder.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
             if (!InterfaceToken.Equals(inputInterfaceToken))
             {
-                Logger.PrintError(LogClass.SurfaceFlinger, $"Invalid interface token {inputInterfaceToken} (expected: {InterfaceToken}");
+                Logger.Error?.Print(LogClass.SurfaceFlinger, $"Invalid interface token {inputInterfaceToken} (expected: {InterfaceToken}");
 
                 return ResultCode.Success;
             }

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/IGraphicBufferProducer.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/IGraphicBufferProducer.cs
@@ -269,7 +269,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
             if (status != Status.Success)
             {
-                Logger.PrintError(LogClass.SurfaceFlinger, $"Error returned by transaction {(TransactionCode)code}: {status}");
+                Logger.Error?.Print(LogClass.SurfaceFlinger, $"Error returned by transaction {(TransactionCode)code}: {status}");
             }
         }
 

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
@@ -125,7 +125,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
         {
             lock (Lock)
             {
-                Logger.PrintInfo(LogClass.SurfaceFlinger, $"Creating layer {layerId}");
+                Logger.Info?.Print(LogClass.SurfaceFlinger, $"Creating layer {layerId}");
 
                 BufferQueue.CreateBufferQueue(_device, process, out BufferQueueProducer producer, out BufferQueueConsumer consumer);
 

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/Types/AndroidFence.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/Types/AndroidFence.cs
@@ -45,7 +45,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
             if (hasTimeout)
             {
-                Logger.PrintError(LogClass.SurfaceFlinger, "Android fence didn't signal in 3000 ms");
+                Logger.Error?.Print(LogClass.SurfaceFlinger, "Android fence didn't signal in 3000 ms");
                 Wait(gpuContext, Timeout.InfiniteTimeSpan);
             }
 

--- a/Ryujinx.HLE/HOS/Services/Time/StaticService/ITimeZoneServiceForGlue.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/StaticService/ITimeZoneServiceForGlue.cs
@@ -92,7 +92,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             if (bufferSize != 0x4000)
             {
                 // TODO: find error code here
-                Logger.PrintError(LogClass.ServiceTime, $"TimeZoneRule buffer size is 0x{bufferSize:x} (expected 0x4000)");
+                Logger.Error?.Print(LogClass.ServiceTime, $"TimeZoneRule buffer size is 0x{bufferSize:x} (expected 0x4000)");
 
                 throw new InvalidOperationException();
             }

--- a/Ryujinx.HLE/HOS/Services/Time/StaticService/ITimeZoneServiceForPsc.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/StaticService/ITimeZoneServiceForPsc.cs
@@ -153,7 +153,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             if (timeZoneRuleBufferSize != 0x4000)
             {
                 // TODO: find error code here
-                Logger.PrintError(LogClass.ServiceTime, $"TimeZoneRule buffer size is 0x{timeZoneRuleBufferSize:x} (expected 0x4000)");
+                Logger.Error?.Print(LogClass.ServiceTime, $"TimeZoneRule buffer size is 0x{timeZoneRuleBufferSize:x} (expected 0x4000)");
 
                 throw new InvalidOperationException();
             }
@@ -195,7 +195,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             if (bufferSize != 0x4000)
             {
                 // TODO: find error code here
-                Logger.PrintError(LogClass.ServiceTime, $"TimeZoneRule buffer size is 0x{bufferSize:x} (expected 0x4000)");
+                Logger.Error?.Print(LogClass.ServiceTime, $"TimeZoneRule buffer size is 0x{bufferSize:x} (expected 0x4000)");
 
                 throw new InvalidOperationException();
             }
@@ -240,7 +240,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             if (inBufferSize != 0x4000)
             {
                 // TODO: find error code here
-                Logger.PrintError(LogClass.ServiceTime, $"TimeZoneRule buffer size is 0x{inBufferSize:x} (expected 0x4000)");
+                Logger.Error?.Print(LogClass.ServiceTime, $"TimeZoneRule buffer size is 0x{inBufferSize:x} (expected 0x4000)");
 
                 throw new InvalidOperationException();
             }

--- a/Ryujinx.HLE/HOS/Services/Time/TimeZone/TimeZoneContentManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/TimeZone/TimeZoneContentManager.cs
@@ -55,7 +55,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.TimeZone
                 return locationName;
             }
 
-            Logger.PrintWarning(LogClass.ServiceTime, $"Invalid device TimeZone {locationName}, switching back to UTC");
+            Logger.Warning?.Print(LogClass.ServiceTime, $"Invalid device TimeZone {locationName}, switching back to UTC");
 
             ConfigurationState.Instance.System.TimeZone.Value = "UTC";
 
@@ -114,7 +114,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.TimeZone
             {
                 LocationNameCache = new string[] { "UTC" };
 
-                Logger.PrintError(LogClass.ServiceTime, TimeZoneSystemTitleMissingErrorMessage);
+                Logger.Error?.Print(LogClass.ServiceTime, TimeZoneSystemTitleMissingErrorMessage);
             }
         }
 
@@ -141,7 +141,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.TimeZone
 
                     if (romfs.OpenFile(out IFile tzif, $"/zoneinfo/{locName}".ToU8Span(), OpenMode.Read).IsFailure())
                     {
-                        Logger.PrintError(LogClass.ServiceTime, $"Error opening /zoneinfo/{locName}");
+                        Logger.Error?.Print(LogClass.ServiceTime, $"Error opening /zoneinfo/{locName}");
                         continue;
                     }
 
@@ -168,7 +168,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.TimeZone
                         }
                         else
                         {
-                            Logger.PrintError(LogClass.ServiceTime, $"Couldn't find UTC offset for zone {locName}");
+                            Logger.Error?.Print(LogClass.ServiceTime, $"Couldn't find UTC offset for zone {locName}");
                             continue;
                         }
 

--- a/Ryujinx.HLE/HOS/Services/Vi/RootService/ApplicationDisplayService/IManagerDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/RootService/ApplicationDisplayService/IManagerDisplayService.cs
@@ -48,7 +48,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService.ApplicationDisplayService
         // AddToLayerStack(u32, u64)
         public ResultCode AddToLayerStack(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceVi);
+            Logger.Stub?.PrintStub(LogClass.ServiceVi);
 
             return ResultCode.Success;
         }
@@ -57,7 +57,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService.ApplicationDisplayService
         // SetLayerVisibility(b8, u64)
         public ResultCode SetLayerVisibility(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceVi);
+            Logger.Stub?.PrintStub(LogClass.ServiceVi);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Vi/RootService/ApplicationDisplayService/ISystemDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/RootService/ApplicationDisplayService/ISystemDisplayService.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService.ApplicationDisplayService
         // SetLayerZ(u64, u64)
         public ResultCode SetLayerZ(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceVi);
+            Logger.Stub?.PrintStub(LogClass.ServiceVi);
 
             return ResultCode.Success;
         }
@@ -24,7 +24,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService.ApplicationDisplayService
         // SetLayerVisibility(b8, u64)
         public ResultCode SetLayerVisibility(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceVi);
+            Logger.Stub?.PrintStub(LogClass.ServiceVi);
 
             return ResultCode.Success;
         }
@@ -33,7 +33,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService.ApplicationDisplayService
         // CreateStrayLayer(u32, u64) -> (u64, u64, buffer<bytes, 6>)
         public ResultCode CreateStrayLayer(ServiceCtx context)
         {
-            Logger.PrintStub(LogClass.ServiceVi);
+            Logger.Stub?.PrintStub(LogClass.ServiceVi);
 
             return _applicationDisplayService.CreateStrayLayer(context);
         }

--- a/Ryujinx.HLE/Loaders/Mods/IPSPatcher.cs
+++ b/Ryujinx.HLE/Loaders/Mods/IPSPatcher.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.HLE.Loaders.Mods
             _patches = ParseIps(reader);
             if (_patches != null)
             {
-                Logger.PrintInfo(LogClass.ModLoader, "IPS patch loaded successfully");
+                Logger.Info?.Print(LogClass.ModLoader, "IPS patch loaded successfully");
             }
         }
 

--- a/Ryujinx.HLE/Loaders/Mods/IPSwitchPatcher.cs
+++ b/Ryujinx.HLE/Loaders/Mods/IPSwitchPatcher.cs
@@ -17,7 +17,7 @@ namespace Ryujinx.HLE.Loaders.Mods
             string header = reader.ReadLine();
             if (header == null || !header.StartsWith(BidHeader))
             {
-                Logger.PrintError(LogClass.ModLoader, "IPSwitch:    Malformed PCHTXT file. Skipping...");
+                Logger.Error?.Print(LogClass.ModLoader, "IPSwitch:    Malformed PCHTXT file. Skipping...");
                 return;
             }
 
@@ -154,9 +154,9 @@ namespace Ryujinx.HLE.Loaders.Mods
             string line;
             int lineNum = 0;
 
-            static void Print(string s) => Logger.PrintInfo(LogClass.ModLoader, $"IPSwitch:    {s}");
+            static void Print(string s) => Logger.Info?.Print(LogClass.ModLoader, $"IPSwitch:    {s}");
 
-            void ParseWarn() => Logger.PrintWarning(LogClass.ModLoader, $"IPSwitch:    Parse error at line {lineNum} for bid={BuildId}");
+            void ParseWarn() => Logger.Warning?.Print(LogClass.ModLoader, $"IPSwitch:    Parse error at line {lineNum} for bid={BuildId}");
 
             while ((line = _reader.ReadLine()) != null)
             {

--- a/Ryujinx.HLE/Loaders/Mods/MemPatch.cs
+++ b/Ryujinx.HLE/Loaders/Mods/MemPatch.cs
@@ -85,7 +85,7 @@ namespace Ryujinx.HLE.Loaders.Mods
                     patchSize = memory.Length - (int)patchOffset; // Add warning?
                 }
 
-                Logger.PrintInfo(LogClass.ModLoader, $"Patching address offset {patchOffset:x} <= {BitConverter.ToString(patch).Replace('-', ' ')} len={patchSize}");
+                Logger.Info?.Print(LogClass.ModLoader, $"Patching address offset {patchOffset:x} <= {BitConverter.ToString(patch).Replace('-', ' ')} len={patchSize}");
 
                 patch.AsSpan().Slice(0, patchSize).CopyTo(memory.Slice(patchOffset, patchSize));
 

--- a/Ryujinx/Program.cs
+++ b/Ryujinx/Program.cs
@@ -80,11 +80,7 @@ namespace Ryujinx
                 ConfigurationState.Instance.ToFileFormat().SaveConfig(globalConfigurationPath);
             }
 
-            Logger.Notice.Print(LogClass.Application, $"Ryujinx Version: {Version}");
-
-            Logger.Notice.Print(LogClass.Application, $"Operating System: {SystemInfo.Instance.OsDescription}");
-            Logger.Notice.Print(LogClass.Application, $"CPU: {SystemInfo.Instance.CpuName}");
-            Logger.Notice.Print(LogClass.Application, $"Total RAM: {SystemInfo.Instance.RamSizeInMB}");
+            PrintSystemInfo();
 
             Profile.Initialize();
 
@@ -106,6 +102,18 @@ namespace Ryujinx
             }
 
             Application.Run();
+        }
+
+        private static void PrintSystemInfo()
+        {
+            Logger.Notice.Print(LogClass.Application, $"Ryujinx Version: {Version}");
+
+            Logger.Notice.Print(LogClass.Application, $"Operating System: {SystemInfo.Instance.OsDescription}");
+            Logger.Notice.Print(LogClass.Application, $"CPU: {SystemInfo.Instance.CpuName}");
+            Logger.Notice.Print(LogClass.Application, $"Total RAM: {SystemInfo.Instance.RamSizeInMB}");
+
+            var enabledLogs = Logger.GetEnabledLevels();
+            Logger.Notice.Print(LogClass.Application, $"Logs Enabled: {(enabledLogs.Count == 0 ? "<None>" : string.Join(", ", enabledLogs))}");
         }
 
         private static void ProcessUnhandledException(Exception e, bool isTerminating)

--- a/Ryujinx/Program.cs
+++ b/Ryujinx/Program.cs
@@ -77,11 +77,11 @@ namespace Ryujinx
                 ConfigurationState.Instance.ToFileFormat().SaveConfig(globalConfigurationPath);
             }
 
-            Logger.PrintInfo(LogClass.Application, $"Ryujinx Version: {Version}");
+            Logger.Notice.Print(LogClass.Application, $"Ryujinx Version: {Version}");
 
-            Logger.PrintInfo(LogClass.Application, $"Operating System: {SystemInfo.Instance.OsDescription}");
-            Logger.PrintInfo(LogClass.Application, $"CPU: {SystemInfo.Instance.CpuName}");
-            Logger.PrintInfo(LogClass.Application, $"Total RAM: {SystemInfo.Instance.RamSizeInMB}");
+            Logger.Notice.Print(LogClass.Application, $"Operating System: {SystemInfo.Instance.OsDescription}");
+            Logger.Notice.Print(LogClass.Application, $"CPU: {SystemInfo.Instance.CpuName}");
+            Logger.Notice.Print(LogClass.Application, $"Total RAM: {SystemInfo.Instance.RamSizeInMB}");
 
             Profile.Initialize();
 

--- a/Ryujinx/Ui/ApplicationLibrary.cs
+++ b/Ryujinx/Ui/ApplicationLibrary.cs
@@ -55,7 +55,7 @@ namespace Ryujinx.Ui
                 }
                 catch (UnauthorizedAccessException)
                 {
-                    Logger.PrintWarning(LogClass.Application, $"Failed to get access to directory: \"{dir}\"");
+                    Logger.Warning?.Print(LogClass.Application, $"Failed to get access to directory: \"{dir}\"");
                 }
 
                 if (content.Length > 0)
@@ -70,7 +70,7 @@ namespace Ryujinx.Ui
                 }
                 catch (UnauthorizedAccessException)
                 {
-                    Logger.PrintWarning(LogClass.Application, $"Failed to get access to directory: \"{dir}\"");
+                    Logger.Warning?.Print(LogClass.Application, $"Failed to get access to directory: \"{dir}\"");
                 }
 
                 if (content.Length > 0)
@@ -103,7 +103,7 @@ namespace Ryujinx.Ui
                 
                 if (!Directory.Exists(appDir))
                 {
-                    Logger.PrintWarning(LogClass.Application, $"The \"game_dirs\" section in \"Config.json\" contains an invalid directory: \"{appDir}\"");
+                    Logger.Warning?.Print(LogClass.Application, $"The \"game_dirs\" section in \"Config.json\" contains an invalid directory: \"{appDir}\"");
 
                     continue;
                 }
@@ -265,18 +265,18 @@ namespace Ryujinx.Ui
                             {
                                 applicationIcon = Path.GetExtension(applicationPath).ToLower() == ".xci" ? _xciIcon : _nspIcon;
 
-                                Logger.PrintWarning(LogClass.Application, $"Your key set is missing a key with the name: {exception.Name}");
+                                Logger.Warning?.Print(LogClass.Application, $"Your key set is missing a key with the name: {exception.Name}");
                             }
                             catch (InvalidDataException)
                             {
                                 applicationIcon = Path.GetExtension(applicationPath).ToLower() == ".xci" ? _xciIcon : _nspIcon;
 
-                                Logger.PrintWarning(LogClass.Application, $"The header key is incorrect or missing and therefore the NCA header content type check has failed. Errored File: {applicationPath}");
+                                Logger.Warning?.Print(LogClass.Application, $"The header key is incorrect or missing and therefore the NCA header content type check has failed. Errored File: {applicationPath}");
                             }
                             catch (Exception exception)
                             {
-                                Logger.PrintWarning(LogClass.Application, $"The file encountered was not of a valid type. Errored File: {applicationPath}");
-                                Logger.PrintDebug(LogClass.Application, exception.ToString());
+                                Logger.Warning?.Print(LogClass.Application, $"The file encountered was not of a valid type. Errored File: {applicationPath}");
+                                Logger.Debug?.Print(LogClass.Application, exception.ToString());
 
                                 numApplicationsFound--;
                                 _loadingError = true;
@@ -330,7 +330,7 @@ namespace Ryujinx.Ui
                             }
                             catch
                             {
-                                Logger.PrintWarning(LogClass.Application, $"The file encountered was not of a valid type. Errored File: {applicationPath}");
+                                Logger.Warning?.Print(LogClass.Application, $"The file encountered was not of a valid type. Errored File: {applicationPath}");
 
                                 numApplicationsFound--;
 
@@ -353,11 +353,11 @@ namespace Ryujinx.Ui
                             }
                             catch (InvalidDataException)
                             {
-                                Logger.PrintWarning(LogClass.Application, $"The NCA header content type check has failed. This is usually because the header key is incorrect or missing. Errored File: {applicationPath}");
+                                Logger.Warning?.Print(LogClass.Application, $"The NCA header content type check has failed. This is usually because the header key is incorrect or missing. Errored File: {applicationPath}");
                             }
                             catch
                             {
-                                Logger.PrintWarning(LogClass.Application, $"The file encountered was not of a valid type. Errored File: {applicationPath}");
+                                Logger.Warning?.Print(LogClass.Application, $"The file encountered was not of a valid type. Errored File: {applicationPath}");
 
                                 numApplicationsFound--;
                                 _loadingError = true;
@@ -378,7 +378,7 @@ namespace Ryujinx.Ui
                 }
                 catch (IOException exception)
                 {
-                    Logger.PrintWarning(LogClass.Application, exception.Message);
+                    Logger.Warning?.Print(LogClass.Application, exception.Message);
 
                     numApplicationsFound--;
                     _loadingError = true;
@@ -508,7 +508,7 @@ namespace Ryujinx.Ui
             }
             catch (JsonException)
             {
-                Logger.PrintWarning(LogClass.Application, $"Failed to parse metadata json for {titleId}. Loading defaults.");
+                Logger.Warning?.Print(LogClass.Application, $"Failed to parse metadata json for {titleId}. Loading defaults.");
 
                 appMetadata = new ApplicationMetadata
                 {
@@ -665,14 +665,14 @@ namespace Ryujinx.Ui
                         }
                         catch (InvalidDataException)
                         {
-                            Logger.PrintWarning(LogClass.Application,
+                            Logger.Warning?.Print(LogClass.Application,
                                 $"The header key is incorrect or missing and therefore the NCA header content type check has failed. Errored File: {updatePath}");
 
                             break;
                         }
                         catch (MissingKeyException exception)
                         {
-                            Logger.PrintWarning(LogClass.Application,
+                            Logger.Warning?.Print(LogClass.Application,
                                 $"Your key set is missing a key with the name: {exception.Name}. Errored File: {updatePath}");
 
                             break;

--- a/Ryujinx/Ui/DlcWindow.cs
+++ b/Ryujinx/Ui/DlcWindow.cs
@@ -105,13 +105,13 @@ namespace Ryujinx.Ui
             }
             catch (InvalidDataException exception)
             {
-                Logger.PrintError(LogClass.Application, $"{exception.Message}. Errored File: {containerPath}");
+                Logger.Error?.Print(LogClass.Application, $"{exception.Message}. Errored File: {containerPath}");
 
                 GtkDialog.CreateInfoDialog("Ryujinx - Error", "Add DLC Failed!", "The NCA header content type check has failed. This is usually because the header key is incorrect or missing.");
             }
             catch (MissingKeyException exception)
             {
-                Logger.PrintError(LogClass.Application, $"Your key set is missing a key with the name: {exception.Name}. Errored File: {containerPath}");
+                Logger.Error?.Print(LogClass.Application, $"Your key set is missing a key with the name: {exception.Name}. Errored File: {containerPath}");
 
                 GtkDialog.CreateInfoDialog("Ryujinx - Error", "Add DLC Failed!", $"Your key set is missing a key with the name: {exception.Name}");
             }

--- a/Ryujinx/Ui/GameTableContextMenu.cs
+++ b/Ryujinx/Ui/GameTableContextMenu.cs
@@ -184,7 +184,7 @@ namespace Ryujinx.Ui
                     control.UserAccountSaveDataSize        = 0x4000;
                     control.UserAccountSaveDataJournalSize = 0x4000;
 
-                    Logger.PrintWarning(LogClass.Application,
+                    Logger.Warning?.Print(LogClass.Application,
                         "No control file was found for this game. Using a dummy one instead. This may cause inaccuracies in some games.");
                 }
 
@@ -328,7 +328,7 @@ namespace Ryujinx.Ui
 
                         if (mainNca == null)
                         {
-                            Logger.PrintError(LogClass.Application, "Extraction failed. The main NCA was not present in the selected file.");
+                            Logger.Error?.Print(LogClass.Application, "Extraction failed. The main NCA was not present in the selected file.");
 
                             Gtk.Application.Invoke(delegate
                             {
@@ -389,7 +389,7 @@ namespace Ryujinx.Ui
                         {
                             if (resultCode.Value.IsFailure())
                             {
-                                Logger.PrintError(LogClass.Application, $"LibHac returned error code: {resultCode.Value.ErrorCode}");
+                                Logger.Error?.Print(LogClass.Application, $"LibHac returned error code: {resultCode.Value.ErrorCode}");
 
                                 Gtk.Application.Invoke(delegate
                                 {

--- a/Ryujinx/Ui/GtkHostUiHandler.cs
+++ b/Ryujinx/Ui/GtkHostUiHandler.cs
@@ -51,7 +51,7 @@ namespace Ryujinx.Ui
                 catch (Exception e)
                 {
                     error = true;
-                    Logger.PrintError(LogClass.Application, $"Error displaying Software Keyboard: {e}");
+                    Logger.Error?.Print(LogClass.Application, $"Error displaying Software Keyboard: {e}");
                 }
                 finally
                 {

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -669,6 +669,11 @@ namespace Ryujinx.Ui
             Profile.FinishProfiling();
             DiscordIntegrationModule.Exit();
 
+            Ptc.Dispose();
+            PtcProfiler.Dispose();
+
+            Logger.Shutdown();
+
             Application.Quit();
         }
 

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -405,7 +405,7 @@ namespace Ryujinx.Ui
 
                 UpdateGraphicsConfig();
 
-                Logger.PrintInfo(LogClass.Application, $"Using Firmware Version: {_contentManager.GetCurrentFirmwareVersion()?.VersionString}");
+                Logger.Notice.Print(LogClass.Application, $"Using Firmware Version: {_contentManager.GetCurrentFirmwareVersion()?.VersionString}");
 
                 if (Directory.Exists(path))
                 {

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -249,7 +249,7 @@ namespace Ryujinx.Ui
             }
             else
             {
-                Logger.PrintWarning(LogClass.Application, $"The \"custom_theme_path\" section in \"Config.json\" contains an invalid path: \"{ConfigurationState.Instance.Ui.CustomThemePath}\".");
+                Logger.Warning?.Print(LogClass.Application, $"The \"custom_theme_path\" section in \"Config.json\" contains an invalid path: \"{ConfigurationState.Instance.Ui.CustomThemePath}\".");
             }
         }
 
@@ -418,12 +418,12 @@ namespace Ryujinx.Ui
 
                     if (romFsFiles.Length > 0)
                     {
-                        Logger.PrintInfo(LogClass.Application, "Loading as cart with RomFS.");
+                        Logger.Info?.Print(LogClass.Application, "Loading as cart with RomFS.");
                         device.LoadCart(path, romFsFiles[0]);
                     }
                     else
                     {
-                        Logger.PrintInfo(LogClass.Application, "Loading as cart WITHOUT RomFS.");
+                        Logger.Info?.Print(LogClass.Application, "Loading as cart WITHOUT RomFS.");
                         device.LoadCart(path);
                     }
                 }
@@ -432,34 +432,34 @@ namespace Ryujinx.Ui
                     switch (System.IO.Path.GetExtension(path).ToLowerInvariant())
                     {
                         case ".xci":
-                            Logger.PrintInfo(LogClass.Application, "Loading as XCI.");
+                            Logger.Info?.Print(LogClass.Application, "Loading as XCI.");
                             device.LoadXci(path);
                             break;
                         case ".nca":
-                            Logger.PrintInfo(LogClass.Application, "Loading as NCA.");
+                            Logger.Info?.Print(LogClass.Application, "Loading as NCA.");
                             device.LoadNca(path);
                             break;
                         case ".nsp":
                         case ".pfs0":
-                            Logger.PrintInfo(LogClass.Application, "Loading as NSP.");
+                            Logger.Info?.Print(LogClass.Application, "Loading as NSP.");
                             device.LoadNsp(path);
                             break;
                         default:
-                            Logger.PrintInfo(LogClass.Application, "Loading as homebrew.");
+                            Logger.Info?.Print(LogClass.Application, "Loading as homebrew.");
                             try
                             {
                                 device.LoadProgram(path);
                             }
                             catch (ArgumentOutOfRangeException)
                             {
-                                Logger.PrintError(LogClass.Application, "The file which you have specified is unsupported by Ryujinx.");
+                                Logger.Error?.Print(LogClass.Application, "The file which you have specified is unsupported by Ryujinx.");
                             }
                             break;
                     }
                 }
                 else
                 {
-                    Logger.PrintWarning(LogClass.Application, "Please specify a valid XCI/NCA/NSP/PFS0/NRO file.");
+                    Logger.Warning?.Print(LogClass.Application, "Please specify a valid XCI/NCA/NSP/PFS0/NRO file.");
                     device.Dispose();
 
                     return;
@@ -692,7 +692,7 @@ namespace Ryujinx.Ui
                 }
                 else
                 {
-                    Logger.PrintWarning(LogClass.Audio, "SoundIO is not supported, falling back to dummy audio out.");
+                    Logger.Warning?.Print(LogClass.Audio, "SoundIO is not supported, falling back to dummy audio out.");
                 }
             }
             else if (ConfigurationState.Instance.System.AudioBackend.Value == AudioBackend.OpenAl)
@@ -703,11 +703,11 @@ namespace Ryujinx.Ui
                 }
                 else
                 {
-                    Logger.PrintWarning(LogClass.Audio, "OpenAL is not supported, trying to fall back to SoundIO.");
+                    Logger.Warning?.Print(LogClass.Audio, "OpenAL is not supported, trying to fall back to SoundIO.");
 
                     if (SoundIoAudioOut.IsSupported)
                     {
-                        Logger.PrintWarning(LogClass.Audio, "Found SoundIO, changing configuration.");
+                        Logger.Warning?.Print(LogClass.Audio, "Found SoundIO, changing configuration.");
 
                         ConfigurationState.Instance.System.AudioBackend.Value = AudioBackend.SoundIo;
                         SaveConfig();
@@ -716,7 +716,7 @@ namespace Ryujinx.Ui
                     }
                     else
                     {
-                        Logger.PrintWarning(LogClass.Audio, "SoundIO is not supported, falling back to dummy audio out.");
+                        Logger.Warning?.Print(LogClass.Audio, "SoundIO is not supported, falling back to dummy audio out.");
                     }
                 }
             }
@@ -957,7 +957,7 @@ namespace Ryujinx.Ui
 
                         dialog.SecondaryText = $"A valid system firmware was not found in {filename}.";
 
-                        Logger.PrintError(LogClass.Application, $"A valid system firmware was not found in {filename}.");
+                        Logger.Error?.Print(LogClass.Application, $"A valid system firmware was not found in {filename}.");
 
                         dialog.Run();
                         dialog.Hide();
@@ -994,7 +994,7 @@ namespace Ryujinx.Ui
 
                     if (response == (int)ResponseType.Yes)
                     {
-                        Logger.PrintInfo(LogClass.Application, $"Installing firmware {firmwareVersion.VersionString}");
+                        Logger.Info?.Print(LogClass.Application, $"Installing firmware {firmwareVersion.VersionString}");
                         
                         Thread thread = new Thread(() =>
                         {
@@ -1018,7 +1018,7 @@ namespace Ryujinx.Ui
 
                                     dialog.SecondaryText = $"System version {firmwareVersion.VersionString} successfully installed.";
 
-                                    Logger.PrintInfo(LogClass.Application, $"System version {firmwareVersion.VersionString} successfully installed.");
+                                    Logger.Info?.Print(LogClass.Application, $"System version {firmwareVersion.VersionString} successfully installed.");
 
                                     dialog.Run();
                                     dialog.Dispose();
@@ -1039,7 +1039,7 @@ namespace Ryujinx.Ui
                                     dialog.SecondaryText = $"An error occured while installing system version {firmwareVersion.VersionString}." +
                                      " Please check logs for more info.";
 
-                                    Logger.PrintError(LogClass.Application, ex.Message);
+                                    Logger.Error?.Print(LogClass.Application, ex.Message);
 
                                     dialog.Run();
                                     dialog.Dispose();
@@ -1074,7 +1074,7 @@ namespace Ryujinx.Ui
 
                     dialog.SecondaryText = "An error occured while parsing firmware. Please check the logs for more info.";
 
-                    Logger.PrintError(LogClass.Application, ex.Message);
+                    Logger.Error?.Print(LogClass.Application, ex.Message);
 
                     dialog.Run();
                     dialog.Dispose();

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -668,10 +668,6 @@ namespace Ryujinx.Ui
 
             Profile.FinishProfiling();
             DiscordIntegrationModule.Exit();
-            Logger.Shutdown();
-
-            Ptc.Dispose();
-            PtcProfiler.Dispose();
 
             Application.Quit();
         }

--- a/Ryujinx/Ui/TitleUpdateWindow.cs
+++ b/Ryujinx/Ui/TitleUpdateWindow.cs
@@ -120,7 +120,7 @@ namespace Ryujinx.Ui
                         }
                         catch (InvalidDataException exception)
                         {
-                            Logger.PrintError(LogClass.Application, $"{exception.Message}. Errored File: {path}");
+                            Logger.Error?.Print(LogClass.Application, $"{exception.Message}. Errored File: {path}");
 
                             if (showErrorDialog)
                             {
@@ -131,7 +131,7 @@ namespace Ryujinx.Ui
                         }
                         catch (MissingKeyException exception)
                         {
-                            Logger.PrintError(LogClass.Application, $"Your key set is missing a key with the name: {exception.Name}. Errored File: {path}");
+                            Logger.Error?.Print(LogClass.Application, $"Your key set is missing a key with the name: {exception.Name}. Errored File: {path}");
 
                             if (showErrorDialog)
                             {


### PR DESCRIPTION
The goal for this rewrite was zero-cost disabled logs without:
- losing out on code readability 
- large changes to the entire project.

The new code allows that with minimal changes (2 extra chars per call). Existing PRs can be modified with a script.
Since the condition is checked before `Print` call, no parameters are evaluated. So, no str-format/heap-allocs/func-calls if that log-level is disabled. And there's no race hazards.

```
Logger.PrintError() => Logger.Error?.Print()
...
Logger.PrintStub() => Logger.Stub?.PrintStub() // the only one that's different due to overloads
```

Other approaches tried:
1. `FormattableString` instead of `string` (only reduces format overhead; doesn't play well with function overloads)
2. `Logger.IsXXEnabled` bool guards before each `Logger.PrintXX` (too verbose)
3. `PrintXX` nullable delegates (uglier `XX.?Invoke()` syntax every log call)
4. Turning `PrintDebug` into `Debug.Print` equivalents (unchangeable at runtime, doesn't help other levels)
5. `ILevel` interface with dummy `Print` on disable (virt call still exists, all params are still evaluated)

Unfortunately, as most interpolated messages lie outside the print methods, it's not feasible to calculate the perf impact. So, I have no benchmarks. <br/>
Nominal game testing _might_ show improvements and reduce stutters (with most log levels turned off). <br/>
In the worst case, at least the GC will be happier.

IMO, an extra Log Level might be better to add in the future (say `Diagnostic`?)

I can provide a script for automating changes to PRs if this approach is accepted.

Also, adds a tiny log-level marker to each line to filter them easily in log files (which don't have colors). Sample-

```
00:00:00.010 |N| Application PrintSystemInfo: Ryujinx Version: 1.0.0-dirty
00:00:01.192 |N| Application PrintSystemInfo: Operating System: ...
00:00:01.192 |N| Application PrintSystemInfo: CPU: ...
00:00:01.192 |N| Application PrintSystemInfo: Total RAM: ...
00:00:01.193 |N| Application PrintSystemInfo: Logs Enabled: Info, Warning, Error
00:00:00.405 |N| Application LoadApplication: Using Firmware Version: ...
...
00:00:00.421 |I| Loader LoadExeFs: Loading rtld...
00:00:00.423 |I| Loader LoadExeFs: Loading main...
...
00:00:02.593 |G| ServiceLm Log: Guest Log:
  Log level: Info
    Time: 1s
    Line: 29
    Filename: '...'
    Function: 'nninitStartup'
    Module: ''
    Thread: 'MainThread'
    ProgramName: 'PRJ_036'
    Message: '---- nninitStartup Begin ----'
...
00:00:05.076 |S| ServiceNv SetUserData: Stubbed. 
00:00:05.081 |S| ServiceNv SetTimeslice: Stubbed. 
00:00:05.084 |I| ServiceNv Create: Created map 4 with size 0x00020000!
00:00:05.113 |I| ServiceNv Create: Created map 5 with size 0x0004a000!
...
00:00:19.622 |E| GUI.RenderLoop Gpu GetInfo: Invalid texture format 0x8003F3F3 (sRGB: False).
00:00:19.632 |E| GUI.RenderLoop Gpu GetInfo: Invalid texture format 0x8003F3F3 (sRGB: False).
00:00:19.969 |W| GUI.RenderLoop Gpu Log: Shader translator: Invalid instruction at 0x000030 (0x50F41BA06FF70107).
00:00:19.982 |W| GUI.RenderLoop Gpu Log: Shader translator: Invalid instruction at 0x000028 (0x50F41BA06FF70007).
...
```