### PR TITLE
Generalize tail continues

### DIFF
--- a/ARMeilleure/Decoders/Block.cs
+++ b/ARMeilleure/Decoders/Block.cs
@@ -12,6 +12,7 @@ namespace ARMeilleure.Decoders
         public Block Branch { get; set; }
 
         public bool TailCall { get; set; }
+        public bool Exit     { get; set; }
 
         public List<OpCode> OpCodes { get; private set; }
 
@@ -29,7 +30,7 @@ namespace ARMeilleure.Decoders
         {
             int splitIndex = BinarySearch(OpCodes, rightBlock.Address);
 
-            if ((ulong)OpCodes[splitIndex].Address < rightBlock.Address)
+            if (OpCodes[splitIndex].Address < rightBlock.Address)
             {
                 splitIndex++;
             }

--- a/ARMeilleure/Decoders/Decoder.cs
+++ b/ARMeilleure/Decoders/Decoder.cs
@@ -139,7 +139,7 @@ namespace ARMeilleure.Decoders
 
             if (!singleBlock)
             {
-                TailCallRemover.RunPass(address, blocks);
+                return TailCallRemover.RunPass(address, blocks);
             }
 
             return blocks.ToArray();

--- a/ARMeilleure/Decoders/Decoder.cs
+++ b/ARMeilleure/Decoders/Decoder.cs
@@ -17,17 +17,7 @@ namespace ARMeilleure.Decoders
         // For lower code quality translation, we set a lower limit since we're blocking execution.
         private const int MaxInstsPerFunctionLowCq = 500;
 
-        public static Block[] DecodeBasicBlock(IMemoryManager memory, ulong address, ExecutionMode mode)
-        {
-            return Decode(memory, address, mode, highCq: false, singleBlock: true);
-        }
-
-        public static Block[] DecodeFunction(IMemoryManager memory, ulong address, ExecutionMode mode, bool highCq)
-        {
-            return Decode(memory, address, mode, highCq, singleBlock: false);
-        }
-
-        private static Block[] Decode(IMemoryManager memory, ulong address, ExecutionMode mode, bool highCq, bool singleBlock)
+        public static Block[] Decode(IMemoryManager memory, ulong address, ExecutionMode mode, bool highCq, bool singleBlock)
         {
             List<Block> blocks = new List<Block>();
 

--- a/ARMeilleure/Decoders/Decoder.cs
+++ b/ARMeilleure/Decoders/Decoder.cs
@@ -132,6 +132,11 @@ namespace ARMeilleure.Decoders
                 }
             }
 
+            if (blocks.Count == 0)
+            {
+                throw new InvalidOperationException($"Decoded 0 blocks. Entry point = 0x{address:X}.");
+            }
+
             if (!singleBlock)
             {
                 TailCallRemover.RunPass(address, blocks);

--- a/ARMeilleure/Decoders/Optimizations/TailCallRemover.cs
+++ b/ARMeilleure/Decoders/Optimizations/TailCallRemover.cs
@@ -1,5 +1,4 @@
-﻿using ARMeilleure.Decoders;
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace ARMeilleure.Decoders.Optimizations
@@ -10,7 +9,7 @@ namespace ARMeilleure.Decoders.Optimizations
         {
             // Detect tail calls:
             // - Assume this function spans the space covered by contiguous code blocks surrounding the entry address.
-            // - Unconditional jump to an area outside this contiguous region will be treated as a tail call.
+            // - A jump to an area outside this contiguous region will be treated as an exit block.
             // - Include a small allowance for jumps outside the contiguous range.
 
             if (!Decoder.BinarySearch(blocks, entryAddress, out int entryBlockId))
@@ -19,33 +18,38 @@ namespace ARMeilleure.Decoders.Optimizations
             }
 
             const ulong allowance = 4;
+
             Block entryBlock = blocks[entryBlockId];
-            int startBlockIndex = entryBlockId;
+
             Block startBlock = entryBlock;
-            int endBlockIndex = entryBlockId;
-            Block endBlock = entryBlock;
+            Block endBlock   = entryBlock;
+
+            int startBlockIndex = entryBlockId;
+            int endBlockIndex   = entryBlockId;
 
             for (int i = entryBlockId + 1; i < blocks.Count; i++) // Search forwards.
             {
                 Block block = blocks[i];
+
                 if (endBlock.EndAddress < block.Address - allowance)
                 {
                     break; // End of contiguous function.
                 }
 
-                endBlock = block;
+                endBlock      = block;
                 endBlockIndex = i;
             }
 
             for (int i = entryBlockId - 1; i >= 0; i--) // Search backwards.
             {
                 Block block = blocks[i];
+
                 if (startBlock.Address > block.EndAddress + allowance)
                 {
                     break; // End of contiguous function.
                 }
 
-                startBlock = block;
+                startBlock      = block;
                 startBlockIndex = i;
             }
 
@@ -54,22 +58,32 @@ namespace ARMeilleure.Decoders.Optimizations
                 return; // Nothing to do here.
             }
 
-            // Replace all branches to blocks outside the range with null, and force a tail call.
+            static void RemoveDeadBlocks(List<Block> blocks, int start, int end)
+            {
+                for (int i = start; i <= end; i++)
+                {
+                    if (!blocks[i].Exit)
+                    {
+                        blocks[i] = null;
+                    }
+                }
+            }
 
+            // Mark branches outside of contiguous region as exit blocks.
             for (int i = startBlockIndex; i <= endBlockIndex; i++)
             {
                 Block block = blocks[i];
+
                 if (block.Branch != null && (block.Branch.Address > endBlock.EndAddress || block.Branch.EndAddress < startBlock.Address))
                 {
-                    block.Branch = null;
-                    block.TailCall = true;
+                    block.Branch.Exit     = true;
+                    block.Branch.TailCall = true;
                 }
             }
 
             // Finally, delete all blocks outside the contiguous range.
-
-            blocks.RemoveRange(endBlockIndex + 1, (blocks.Count - endBlockIndex) - 1);
-            blocks.RemoveRange(0, startBlockIndex);
+            RemoveDeadBlocks(blocks, 0, startBlockIndex - 1);
+            RemoveDeadBlocks(blocks, endBlockIndex + 1, blocks.Count - 1);
         }
     }
 }

--- a/ARMeilleure/Instructions/InstEmitException.cs
+++ b/ARMeilleure/Instructions/InstEmitException.cs
@@ -27,11 +27,6 @@ namespace ARMeilleure.Instructions
             context.Call(typeof(NativeInterface).GetMethod(name), Const(op.Address), Const(op.Id));
 
             context.LoadFromContext();
-
-            if (context.CurrBlock.Next == null)
-            {
-                EmitTailContinue(context, Const(op.Address + 4));
-            }
         }
 
         public static void Und(ArmEmitterContext context)
@@ -45,11 +40,6 @@ namespace ARMeilleure.Instructions
             context.Call(typeof(NativeInterface).GetMethod(name), Const(op.Address), Const(op.RawOpCode));
 
             context.LoadFromContext();
-
-            if (context.CurrBlock.Next == null)
-            {
-                EmitTailContinue(context, Const(op.Address + 4));
-            }
         }
     }
 }

--- a/ARMeilleure/Instructions/InstEmitException32.cs
+++ b/ARMeilleure/Instructions/InstEmitException32.cs
@@ -27,11 +27,6 @@ namespace ARMeilleure.Instructions
             context.Call(typeof(NativeInterface).GetMethod(name), Const(op.Address), Const(op.Id));
 
             context.LoadFromContext();
-
-            if (context.CurrBlock.Next == null)
-            {
-                EmitTailContinue(context, Const(op.Address + 4));
-            }
         }
     }
 }

--- a/ARMeilleure/Instructions/InstEmitFlow.cs
+++ b/ARMeilleure/Instructions/InstEmitFlow.cs
@@ -15,14 +15,7 @@ namespace ARMeilleure.Instructions
         {
             OpCodeBImmAl op = (OpCodeBImmAl)context.CurrOp;
 
-            if (context.CurrBlock.Branch != null)
-            {
-                context.Branch(context.GetLabel((ulong)op.Immediate));
-            }
-            else
-            {
-                EmitTailContinue(context, Const(op.Immediate), context.CurrBlock.TailCall);
-            }
+            context.Branch(context.GetLabel((ulong)op.Immediate));
         }
 
         public static void B_Cond(ArmEmitterContext context)
@@ -92,69 +85,22 @@ namespace ARMeilleure.Instructions
         {
             OpCodeBImm op = (OpCodeBImm)context.CurrOp;
 
-            if (context.CurrBlock.Branch != null)
-            {
-                EmitCondBranch(context, context.GetLabel((ulong)op.Immediate), cond);
-
-                if (context.CurrBlock.Next == null)
-                {
-                    EmitTailContinue(context, Const(op.Address + 4));
-                }
-            }
-            else
-            {
-                Operand lblTaken = Label();
-
-                EmitCondBranch(context, lblTaken, cond);
-
-                EmitTailContinue(context, Const(op.Address + 4));
-
-                context.MarkLabel(lblTaken);
-
-                EmitTailContinue(context, Const(op.Immediate));
-            }
+            EmitCondBranch(context, context.GetLabel((ulong)op.Immediate), cond);
         }
 
         private static void EmitBranch(ArmEmitterContext context, Operand value, bool onNotZero)
         {
             OpCodeBImm op = (OpCodeBImm)context.CurrOp;
 
-            if (context.CurrBlock.Branch != null)
+            Operand lblTarget = context.GetLabel((ulong)op.Immediate);
+
+            if (onNotZero)
             {
-                Operand lblTarget = context.GetLabel((ulong)op.Immediate);
-
-                if (onNotZero)
-                {
-                    context.BranchIfTrue(lblTarget, value);
-                }
-                else
-                {
-                    context.BranchIfFalse(lblTarget, value);
-                }
-
-                if (context.CurrBlock.Next == null)
-                {
-                    EmitTailContinue(context, Const(op.Address + 4));
-                }
+                context.BranchIfTrue(lblTarget, value);
             }
             else
             {
-                Operand lblTaken = Label();
-
-                if (onNotZero)
-                {
-                    context.BranchIfTrue(lblTaken, value);
-                }
-                else
-                {
-                    context.BranchIfFalse(lblTaken, value);
-                }
-
-                EmitTailContinue(context, Const(op.Address + 4));
-
-                context.MarkLabel(lblTaken);
-
-                EmitTailContinue(context, Const(op.Immediate));
+                context.BranchIfFalse(lblTarget, value);
             }
         }
     }

--- a/ARMeilleure/Instructions/InstEmitFlow32.cs
+++ b/ARMeilleure/Instructions/InstEmitFlow32.cs
@@ -15,14 +15,7 @@ namespace ARMeilleure.Instructions
         {
             IOpCode32BImm op = (IOpCode32BImm)context.CurrOp;
 
-            if (context.CurrBlock.Branch != null)
-            {
-                context.Branch(context.GetLabel((ulong)op.Immediate));
-            }
-            else
-            {
-                EmitTailContinue(context, Const(op.Immediate));
-            }
+            context.Branch(context.GetLabel((ulong)op.Immediate));
         }
 
         public static void Bl(ArmEmitterContext context)

--- a/ARMeilleure/Translation/Translator.cs
+++ b/ARMeilleure/Translation/Translator.cs
@@ -271,7 +271,7 @@ namespace ARMeilleure.Translation
 
                         bool isLastOp = opcIndex == block.OpCodes.Count - 1;
 
-                        if (isLastOp && block.Branch != null && block.Branch.Address <= block.Address)
+                        if (isLastOp && block.Branch != null && !block.Branch.Exit && block.Branch.Address <= block.Address)
                         {
                             EmitSynchronization(context);
                         }

--- a/ARMeilleure/Translation/Translator.cs
+++ b/ARMeilleure/Translation/Translator.cs
@@ -297,16 +297,6 @@ namespace ARMeilleure.Translation
                         if (lblPredicateSkip != null)
                         {
                             context.MarkLabel(lblPredicateSkip);
-
-                            // If this is the last op on the block, and there's no "next" block
-                            // after this one, then we have to return right now, with the address
-                            // of the next instruction to be executed (in the case that the condition
-                            // is false, and the branch was not taken, as all basic blocks should end
-                            // with some kind of branch).
-                            if (isLastOp && block.Next == null)
-                            {
-                                InstEmitFlowHelper.EmitTailContinue(context, Const(opCode.Address + (ulong)opCode.OpCodeSizeInBytes));
-                            }
                         }
                     }
                 }

--- a/ARMeilleure/Translation/Translator.cs
+++ b/ARMeilleure/Translation/Translator.cs
@@ -191,19 +191,9 @@ namespace ARMeilleure.Translation
 
             EmitSynchronization(context);
 
-            for (int i = 0; i < blocks.Length; i++)
+            if (blocks[0].Address != address)
             {
-                Block block = blocks[i];
-
-                if (block != null)
-                {
-                    if (block.Address != address)
-                    {
-                        context.Branch(context.GetLabel(address));
-                    }
-
-                    break;
-                }
+                context.Branch(context.GetLabel(address));
             }
 
             ControlFlowGraph cfg = EmitAndGetCFG(context, blocks);
@@ -247,11 +237,6 @@ namespace ARMeilleure.Translation
             for (int blkIndex = 0; blkIndex < blocks.Length; blkIndex++)
             {
                 Block block = blocks[blkIndex];
-
-                if (block == null)
-                {
-                    continue;
-                }
 
                 context.CurrBlock = block;
 

--- a/ARMeilleure/Translation/Translator.cs
+++ b/ARMeilleure/Translation/Translator.cs
@@ -183,7 +183,7 @@ namespace ARMeilleure.Translation
 
             Logger.StartPass(PassName.Decoding);
 
-            Block[] blocks = Decoder.DecodeFunction(memory, address, mode, highCq);
+            Block[] blocks = Decoder.Decode(memory, address, mode, highCq, singleBlock: false);
 
             Logger.EndPass(PassName.Decoding);
 


### PR DESCRIPTION
Introduce "Exit" blocks (essentially pseudo blocks) which represents a continuation.

The `Branch` and `Next` which would be null (before this PR) are now created as "Exit" blocks and are inserted into the ordered decoded block list. The `Translator` then emits tail continues for these "Exit" blocks and branch instructions can be emitted without the null checks as the "Exit" blocks are address labeled.

Reduces redundant tail continues. For example:
```asm
0x8000ac0:      C8 02 40 F9            ldr	x8, [x22]
0x8000ac4:      1F 1D 00 F1            cmp	x8, #7
0x8000ac8:      E8 17 9F 1A            cset	w8, eq
0x8000acc:      68 C2 00 39            strb	w8, [x19, #0x30]
0x8000ad0:      C8 02 40 F9            ldr	x8, [x22]
0x8000ad4:      1F 1D 00 F1            cmp	x8, #7
0x8000ad8:      20 FB FF 54            b.eq	loc_8000a3c ; <- Exit Block #0
0x8000adc:      1F 45 00 F1            cmp	x8, #0x11
0x8000ae0:      E0 FA FF 54            b.eq	loc_8000a3c ; <- Exit Block #0
0x8000ae4:      49 00 00 14            b	loc_8000c08 ; <- Exit Block #1
```
Before, anything after the first `b.eq	loc_8000a3c` would not be generated (becomes tail continues), and if that was fixed the two `b.eq	loc_8000a3c` would become 2 different tail continues even though they branch to the same address. This PR fixes both of these.

This works by inserting an exit block with address `8000a3c` in the ordered list of decoded blocks and so it is just another block in the block stream. The `Translator` then emits a tail continue for `8000a3c` (as it is an exit block). The two `b.eq	loc_8000a3c` branch instructions can then branch to same IR block.

Should reduce number of compilations by number of conditional branch fall through reached.

Supersedes #1246.