### PR TITLE
SettingsWindow: Add the ability to add multiple game directories at once

### DIFF
--- a/Ryujinx/Ui/SettingsWindow.cs
+++ b/Ryujinx/Ui/SettingsWindow.cs
@@ -313,7 +313,9 @@ namespace Ryujinx.Ui
                         }
 
                         if (!directoryAdded)
+                        {
                             _gameDirsBoxStore.AppendValues(directory);
+                        }
                     }
                 }
 

--- a/Ryujinx/Ui/SettingsWindow.cs
+++ b/Ryujinx/Ui/SettingsWindow.cs
@@ -289,11 +289,17 @@ namespace Ryujinx.Ui
             }
             else
             {
-                FileChooserDialog fileChooser = new FileChooserDialog("Choose the game directory to add to the list", this, FileChooserAction.SelectFolder, "Cancel", ResponseType.Cancel, "Add", ResponseType.Accept);
+                FileChooserDialog fileChooser = new FileChooserDialog("Choose the game directory to add to the list", this, FileChooserAction.SelectFolder, "Cancel", ResponseType.Cancel, "Add", ResponseType.Accept)
+                {
+                    SelectMultiple = true
+                };
 
                 if (fileChooser.Run() == (int)ResponseType.Accept)
                 {
-                    _gameDirsBoxStore.AppendValues(fileChooser.Filename);
+                    foreach (string directory in fileChooser.Filenames)
+                    {
+                        _gameDirsBoxStore.AppendValues(directory);
+                    }
                 }
 
                 fileChooser.Dispose();

--- a/Ryujinx/Ui/SettingsWindow.cs
+++ b/Ryujinx/Ui/SettingsWindow.cs
@@ -298,7 +298,18 @@ namespace Ryujinx.Ui
                 {
                     foreach (string directory in fileChooser.Filenames)
                     {
-                        _gameDirsBoxStore.AppendValues(directory);
+                        bool directoryAdded = false;
+                        
+                        _gameDirsBoxStore.GetIterFirst(out TreeIter treeIter);
+                        for (int i = 0; i < _gameDirsBoxStore.IterNChildren(); i++)
+                        {
+                            if (directory.Equals((string)_gameDirsBoxStore.GetValue(treeIter, 0)))
+                                directoryAdded = true;
+                            _gameDirsBoxStore.IterNext(ref treeIter);
+                        }
+
+                        if (!directoryAdded)
+                            _gameDirsBoxStore.AppendValues(directory);
                     }
                 }
 

--- a/Ryujinx/Ui/SettingsWindow.cs
+++ b/Ryujinx/Ui/SettingsWindow.cs
@@ -300,12 +300,16 @@ namespace Ryujinx.Ui
                     {
                         bool directoryAdded = false;
                         
-                        _gameDirsBoxStore.GetIterFirst(out TreeIter treeIter);
-                        for (int i = 0; i < _gameDirsBoxStore.IterNChildren(); i++)
+                        if (_gameDirsBoxStore.GetIterFirst(out TreeIter treeIter))
                         {
-                            if (directory.Equals((string)_gameDirsBoxStore.GetValue(treeIter, 0)))
-                                directoryAdded = true;
-                            _gameDirsBoxStore.IterNext(ref treeIter);
+                            do
+                            {
+                                if (directory.Equals((string)_gameDirsBoxStore.GetValue(treeIter, 0)))
+                                {
+                                    directoryAdded = true;
+                                    break;
+                                }
+                            } while(_gameDirsBoxStore.IterNext(ref treeIter));
                         }
 
                         if (!directoryAdded)


### PR DESCRIPTION
The default way Ryujinx does this is one directory at a time. This PR makes it so you can choose to add as many directories as you want at once.