### PR TITLE
Fix regression caused by wrong SB descriptor offset

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Compute.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Compute.cs
@@ -86,7 +86,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
                 ulong cbDescAddress = BufferManager.GetComputeUniformBufferAddress(0);
 
-                int cbDescOffset = 0x260 + cb.Slot * 0x10;
+                int cbDescOffset = 0x260 + (cb.Slot - 8) * 0x10;
 
                 cbDescAddress += (ulong)cbDescOffset;
 


### PR DESCRIPTION
When using certain storage buffers on compute shaders, there is a optimization pass that transform them into uniform buffers, since NVN uses global memory load/store to "emulate" more uniform buffers than the hardware actually supports on compute (hardware only supports 8, NVN exposes 14). It is not possible to use storage buffers for that aswell, because most drivers only supports up to 16 storage buffers.

When reading storage buffer descriptor information (that the shader reads to calculate the LDG/STG address), there was an error that made it calculate the wrong offset, and bind the wrong data on the uniform buffer. The fix is just correcting the calculation.

This fixes a regression caused by #924 on Tokyo Mirage Sessions, reported several months ago by "kakasita". Of course, other games might be affected by this change (like for example SMO), so it's worth testing them aswell.