### PR TITLE
Import DLC title key from ticket when loading into content manager

### DIFF
--- a/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
+++ b/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
@@ -249,6 +249,12 @@ namespace Ryujinx.HLE.FileSystem.Content
             else
             {
                 Logger.PrintInfo(LogClass.Application, $"Found AddOnContent with TitleId {titleId:X16}");
+
+                using (FileStream fileStream = File.OpenRead(containerPath))
+                using (PartitionFileSystem pfs = new PartitionFileSystem(fileStream.AsStorage()))
+                {
+                    _virtualFileSystem.ImportTickets(pfs);
+                }
             }
         }
 


### PR DESCRIPTION
My previous PR didn't import title key from ticket when loading DLC which means the DLC could not be decrypted, resulting in an exception. This PR fixes that issue.