### PR TITLE
Remove profiled build task from AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,6 @@ environment:
   matrix:
     - config: Release
       config_name: '-'
-
-    - config: Profile Release
-      config_name: '-profiled-'
 build_script:
 - ps: >-
     dotnet --version


### PR DESCRIPTION
As it was removed on the website on https://github.com/Ryujinx/Ryujinx-Website/commit/fb46709fda8a1a9137647037fc0f6d8bd1103ef7, we don't need to build it anymore.

This also cut the build time and allow us more flexibility for hotfixes if needed.