### PR TITLE
Stub nifm IRequest GetAppletInfo

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Nifm/ResultCode.cs
+++ b/Ryujinx.HLE/HOS/Services/Nifm/ResultCode.cs
@@ -7,6 +7,8 @@ namespace Ryujinx.HLE.HOS.Services.Nifm
 
         Success = 0,
 
+        Unknown112           = (112 << ErrorCodeShift) | ModuleId, // IRequest::GetResult
+        Unknown180           = (180 << ErrorCodeShift) | ModuleId, // IRequest::GetAppletInfo
         NoInternetConnection = (300 << ErrorCodeShift) | ModuleId,
         ObjectIsNull         = (350 << ErrorCodeShift) | ModuleId
     }

--- a/Ryujinx.HLE/HOS/Services/Nifm/StaticService/IRequest.cs
+++ b/Ryujinx.HLE/HOS/Services/Nifm/StaticService/IRequest.cs
@@ -38,6 +38,11 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
         {
             Logger.PrintStub(LogClass.ServiceNifm);
 
+            return GetResultImpl();
+        }
+
+        private ResultCode GetResultImpl()
+        {
             return ResultCode.Success;
         }
 
@@ -83,6 +88,33 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
         public ResultCode SetConnectionConfirmationOption(ServiceCtx context)
         {
             Logger.PrintStub(LogClass.ServiceNifm);
+
+            return ResultCode.Success;
+        }
+
+        [Command(21)]
+        // GetAppletInfo(u32) -> (u32, u32, u32, buffer<bytes, 6>)
+        public ResultCode GetAppletInfo(ServiceCtx context)
+        {
+            uint themeColor = context.RequestData.ReadUInt32();
+
+            Logger.PrintStub(LogClass.ServiceNifm);
+
+            ResultCode result = GetResultImpl();
+
+            if(result == 0 || ((int)result & 0x3fffff) == 0xe06e)
+            {
+                return (ResultCode)0x1686e;
+            }
+
+            // Returns appletId, libraryAppletMode, outSize and a buffer. 
+            // Returned applet ids- (0x19, 0xf, 0xe)
+            // libraryAppletMode seems to be 0 for all applets supported.
+
+            // TODO: check order
+            context.ResponseData.Write(0xe); // Use error applet as default for now
+            context.ResponseData.Write(0); // libraryAppletMode
+            context.ResponseData.Write(0); // outSize
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Nifm/StaticService/IRequest.cs
+++ b/Ryujinx.HLE/HOS/Services/Nifm/StaticService/IRequest.cs
@@ -102,7 +102,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
 
             ResultCode result = GetResultImpl();
 
-            if(result == 0 || ((int)result & 0x3fffff) == 0xe06e)
+            if (result == ResultCode.Success || ((int)result & 0x3fffff) == 0xe06e)
             {
                 return (ResultCode)0x1686e;
             }

--- a/Ryujinx.HLE/HOS/Services/Nifm/StaticService/IRequest.cs
+++ b/Ryujinx.HLE/HOS/Services/Nifm/StaticService/IRequest.cs
@@ -102,9 +102,9 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
 
             ResultCode result = GetResultImpl();
 
-            if (result == ResultCode.Success || ((int)result & 0x3fffff) == 0xe06e)
+            if (result == ResultCode.Success || (ResultCode)((int)result & 0x3fffff) == ResultCode.Unknown112)
             {
-                return (ResultCode)0x1686e;
+                return ResultCode.Unknown180;
             }
 
             // Returns appletId, libraryAppletMode, outSize and a buffer. 


### PR DESCRIPTION
Stubs `GetAppletInfo` to be consistent with current `GetResult` implementation.
Fix #671