### PR TITLE
Fix compute restore of previous shader state

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Compute.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Compute.cs
@@ -163,7 +163,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
                 qmd.CtaRasterHeight,
                 qmd.CtaRasterDepth);
 
-            UpdateShaderState(state);
+            _forceShaderUpdate = true;
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -38,6 +38,8 @@ namespace Ryujinx.Graphics.Gpu.Engine
         private bool _isAnyVbInstanced;
         private bool _vsUsesInstanceId;
 
+        private bool _forceShaderUpdate;
+
         /// <summary>
         /// Creates a new instance of the GPU methods class.
         /// </summary>
@@ -121,8 +123,10 @@ namespace Ryujinx.Graphics.Gpu.Engine
             // Shaders must be the first one to be updated if modified, because
             // some of the other state depends on information from the currently
             // bound shaders.
-            if (state.QueryModified(MethodOffset.ShaderBaseAddress, MethodOffset.ShaderState))
+            if (state.QueryModified(MethodOffset.ShaderBaseAddress, MethodOffset.ShaderState) || _forceShaderUpdate)
             {
+                _forceShaderUpdate = false;
+
                 UpdateShaderState(state);
             }
 


### PR DESCRIPTION
After doing compute work, the GPU emulation has to switch back to the previous shader that was set. Currently it does that by calling the `UpdateState` method passing, that will read parameters from the GPU state passed and read shader address etc, then translate the shader (if needed), and bind the shader on the host side, then set all required textures, uniform buffers and others. The problem is that it was doing all that using the state of the compute engine, instead of the 3D engine state. The fix here is simply deferring the update to when it is actually needed (before draw).

Should fix issues on games using compute that does not immediately change graphics shader before doing compute work.

Improves: https://github.com/Ryujinx/Ryujinx-Games-List/issues/1672 (but does not completely fix it).