### PR TITLE
Fix buffer to 3D texture copy

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/MethodCopyBuffer.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodCopyBuffer.cs
@@ -44,6 +44,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
                     cbp.SrcStride,
                     srcLinear,
                     src.MemoryLayout.UnpackGobBlocksInY(),
+                    src.MemoryLayout.UnpackGobBlocksInZ(),
                     srcBpp);
 
                 var dstCalculator = new OffsetCalculator(
@@ -52,6 +53,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
                     cbp.DstStride,
                     dstLinear,
                     dst.MemoryLayout.UnpackGobBlocksInY(),
+                    dst.MemoryLayout.UnpackGobBlocksInZ(),
                     dstBpp);
 
                 ulong srcBaseAddress = _context.MemoryManager.Translate(cbp.SrcAddress.Pack());
@@ -70,7 +72,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
                 {
                     srcSpan.CopyTo(dstSpan); // No layout conversion has to be performed, just copy the data entirely.
                 }
-                else 
+                else
                 {
                     unsafe bool Convert<T>(Span<byte> dstSpan, ReadOnlySpan<byte> srcSpan) where T : unmanaged
                     {

--- a/Ryujinx.Graphics.Texture/BlockLinearLayout.cs
+++ b/Ryujinx.Graphics.Texture/BlockLinearLayout.cs
@@ -41,7 +41,6 @@ namespace Ryujinx.Graphics.Texture
         public BlockLinearLayout(
             int width,
             int height,
-            int depth,
             int gobBlocksInY,
             int gobBlocksInZ,
             int bpp)

--- a/Ryujinx.Graphics.Texture/LayoutConverter.cs
+++ b/Ryujinx.Graphics.Texture/LayoutConverter.cs
@@ -84,7 +84,6 @@ namespace Ryujinx.Graphics.Texture
                 BlockLinearLayout layoutConverter = new BlockLinearLayout(
                     wAligned,
                     h,
-                    d,
                     mipGobBlocksInY,
                     mipGobBlocksInZ,
                     bytesPerPixel);
@@ -256,7 +255,6 @@ namespace Ryujinx.Graphics.Texture
                 BlockLinearLayout layoutConverter = new BlockLinearLayout(
                     wAligned,
                     h,
-                    d,
                     mipGobBlocksInY,
                     mipGobBlocksInZ,
                     bytesPerPixel);

--- a/Ryujinx.Graphics.Texture/OffsetCalculator.cs
+++ b/Ryujinx.Graphics.Texture/OffsetCalculator.cs
@@ -23,6 +23,7 @@ namespace Ryujinx.Graphics.Texture
             int  stride,
             bool isLinear,
             int  gobBlocksInY,
+            int  gobBlocksInZ,
             int  bytesPerPixel)
         {
             _width         = width;
@@ -40,11 +41,20 @@ namespace Ryujinx.Graphics.Texture
                 _layoutConverter = new BlockLinearLayout(
                     wAligned,
                     height,
-                    1,
                     gobBlocksInY,
-                    1,
+                    gobBlocksInZ,
                     bytesPerPixel);
             }
+        }
+
+        public OffsetCalculator(
+            int width,
+            int height,
+            int stride,
+            bool isLinear,
+            int gobBlocksInY,
+            int bytesPerPixel) : this(width, height, stride, isLinear, gobBlocksInY, 1, bytesPerPixel)
+        {
         }
 
         public void SetY(int y)


### PR DESCRIPTION
Fixes copy from a buffer to a 3D texture (when used for linear to block linear conversion). Previously the Depth in GOBs was being ignored.

Improves rendering on games like Persona 5 Scramble:
Before:
![image](https://user-images.githubusercontent.com/5624669/86497080-8a19b880-bd56-11ea-849f-e3b45012b5f5.png)
After:
![image](https://user-images.githubusercontent.com/5624669/86497090-9140c680-bd56-11ea-9611-a36ef4790ace.png)
Notes: Used the trick to bypass lockup at the start to test.