### PR TITLE
Implement shader LEA instruction and improve bindless image load/store

### DIFF
--- a/Ryujinx.Graphics.Shader/Decoders/BitfieldExtensions.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/BitfieldExtensions.cs
@@ -4,12 +4,12 @@ namespace Ryujinx.Graphics.Shader.Decoders
     {
         public static bool Extract(this int value, int lsb)
         {
-            return ((int)(value >> lsb) & 1) != 0;
+            return ((value >> lsb) & 1) != 0;
         }
 
         public static int Extract(this int value, int lsb, int length)
         {
-            return (int)(value >> lsb) & (int)(uint.MaxValue >> (32 - length));
+            return (value >> lsb) & (int)(uint.MaxValue >> (32 - length));
         }
 
         public static bool Extract(this long value, int lsb)

--- a/Ryujinx.Graphics.Shader/Decoders/OpCodeTable.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/OpCodeTable.cs
@@ -176,6 +176,9 @@ namespace Ryujinx.Graphics.Shader.Decoders
             Set("1110111110010x", InstEmit.Ldc,     typeof(OpCodeLdc));
             Set("1110111011010x", InstEmit.Ldg,     typeof(OpCodeMemory));
             Set("1110111101001x", InstEmit.Lds,     typeof(OpCodeMemory));
+            Set("010010111101xx", InstEmit.Lea,     typeof(OpCodeAluCbuf));
+            Set("0011011x11010x", InstEmit.Lea,     typeof(OpCodeAluImm));
+            Set("0101101111010x", InstEmit.Lea,     typeof(OpCodeAluReg));
             Set("0100110001000x", InstEmit.Lop,     typeof(OpCodeLopCbuf));
             Set("0011100001000x", InstEmit.Lop,     typeof(OpCodeLopImm));
             Set("000001xxxxxxxx", InstEmit.Lop,     typeof(OpCodeLopImm32));

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitAlu.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitAlu.cs
@@ -384,6 +384,27 @@ namespace Ryujinx.Graphics.Shader.Instructions
             context.Copy(Register(op.Predicate0), p1Res);
         }
 
+        public static void Lea(EmitterContext context)
+        {
+            OpCodeAlu op = (OpCodeAlu)context.CurrOp;
+
+            bool negateA = op.RawOpCode.Extract(45);
+
+            int shift = op.RawOpCode.Extract(39, 5);
+
+            Operand srcA = GetSrcA(context);
+            Operand srcB = GetSrcB(context);
+
+            srcA = context.ShiftLeft(srcA, Const(shift));
+            srcA = context.INegate(srcA, negateA);
+
+            Operand res = context.IAdd(srcA, srcB);
+
+            context.Copy(GetDest(context), res);
+
+            // TODO: CC, X
+        }
+
         public static void Lop(EmitterContext context)
         {
             IOpCodeLop op = (IOpCodeLop)context.CurrOp;

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
@@ -99,7 +99,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
                     if (!op.IsBindless)
                     {
-                        operation.Format = GetTextureFormat(context, handle);
+                        operation.Format = context.Config.GetTextureFormat(handle);
                     }
 
                     context.Add(operation);
@@ -228,7 +228,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
                 if (!op.IsBindless)
                 {
-                    format = GetTextureFormat(context, op.Immediate);
+                    format = context.Config.GetTextureFormat(op.Immediate);
                 }
             }
             else
@@ -1221,27 +1221,6 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 IntegerSize.UB128 => 4,
                 _                 => 2
             };
-        }
-
-        private static TextureFormat GetTextureFormat(EmitterContext context, int handle)
-        {
-            // When the formatted load extension is supported, we don't need to
-            // specify a format, we can just declare it without a format and the GPU will handle it.
-            if (context.Config.GpuAccessor.QuerySupportsImageLoadFormatted())
-            {
-                return TextureFormat.Unknown;
-            }
-
-            var format = context.Config.GpuAccessor.QueryTextureFormat(handle);
-
-            if (format == TextureFormat.Unknown)
-            {
-                context.Config.GpuAccessor.Log($"Unknown format for texture {handle}.");
-
-                format = TextureFormat.R8G8B8A8Unorm;
-            }
-
-            return format;
         }
 
         private static TextureFormat GetTextureFormat(IntegerSize size)

--- a/Ryujinx.Graphics.Shader/Translation/Optimizations/Optimizer.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Optimizations/Optimizer.cs
@@ -89,7 +89,7 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
             for (int blkIndex = 0; blkIndex < blocks.Length; blkIndex++)
             {
                 BindlessToIndexed.RunPass(blocks[blkIndex]);
-                BindlessElimination.RunPass(blocks[blkIndex]);
+                BindlessElimination.RunPass(blocks[blkIndex], config);
 
                 // Try to eliminate any operations that are now unused.
                 LinkedListNode<INode> node = blocks[blkIndex].Operations.First;

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -68,5 +68,26 @@ namespace Ryujinx.Graphics.Shader.Translation
             // The depth register is always two registers after the last color output.
             return count + 1;
         }
+
+        public TextureFormat GetTextureFormat(int handle)
+        {
+            // When the formatted load extension is supported, we don't need to
+            // specify a format, we can just declare it without a format and the GPU will handle it.
+            if (GpuAccessor.QuerySupportsImageLoadFormatted())
+            {
+                return TextureFormat.Unknown;
+            }
+
+            var format = GpuAccessor.QueryTextureFormat(handle);
+
+            if (format == TextureFormat.Unknown)
+            {
+                GpuAccessor.Log($"Unknown format for texture {handle}.");
+
+                format = TextureFormat.R8G8B8A8Unorm;
+            }
+
+            return format;
+        }
     }
 }


### PR DESCRIPTION
- Partial implementation of shader LEA (Load Effective Address) instruction, still missing .HI variants (not added to the opcode table, so they will still display as unknown), as handling of CC flags. This is very similar to ISCADD, it scales (left shifts) a value and adds another, useful for indexing offset calculation.
- Extend bindless elimination optimization introduced on #1216 to also match simple patterns used on image load/store, like the following:
```
        /*2e68*/         {         MOV R12, c[0x2][0x120] ;
        /*2ed0*/                   SUST.P.2D.IGN [R8], R0, R12 ;
        /*2f10*/                   SUST.P.2D.IGN [R10], R4, R12 ;
```
We can propagate `c[0x2][0x120]` to the SUST instructions, and bind the image.

This improves rendering on Persona 5 Scramble.
Before:
![image](https://user-images.githubusercontent.com/5624669/86497479-37410080-bd58-11ea-92f9-f380621d0e55.png)
After:
![image](https://user-images.githubusercontent.com/5624669/86497473-3019f280-bd58-11ea-9e68-cf89df4d9f4c.png)
Note: This was tested with #1354, the note on that PR also applies here.