### PR TITLE
Fold ZeroExtend8/16/32 imm32/64

### DIFF
--- a/ARMeilleure/CodeGen/Optimizations/ConstantFolding.cs
+++ b/ARMeilleure/CodeGen/Optimizations/ConstantFolding.cs
@@ -206,6 +206,39 @@ namespace ARMeilleure.CodeGen.Optimizations
                     }
                     break;
 
+                case Instruction.ZeroExtend16:
+                    if (type == OperandType.I32)
+                    {
+                        EvaluateUnaryI32(operation, (x) => (ushort)x);
+                    }
+                    else if (type == OperandType.I64)
+                    {
+                        EvaluateUnaryI64(operation, (x) => (ushort)x);
+                    }
+                    break;
+
+                case Instruction.ZeroExtend32:
+                    if (type == OperandType.I32)
+                    {
+                        EvaluateUnaryI32(operation, (x) => x);
+                    }
+                    else if (type == OperandType.I64)
+                    {
+                        EvaluateUnaryI64(operation, (x) => (uint)x);
+                    }
+                    break;
+
+                case Instruction.ZeroExtend8:
+                    if (type == OperandType.I32)
+                    {
+                        EvaluateUnaryI32(operation, (x) => (byte)x);
+                    }
+                    else if (type == OperandType.I64)
+                    {
+                        EvaluateUnaryI64(operation, (x) => (byte)x);
+                    }
+                    break;
+
                 case Instruction.Subtract:
                     if (type == OperandType.I32)
                     {

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -20,7 +20,7 @@ namespace ARMeilleure.Translation.PTC
     {
         private const string HeaderMagic = "PTChd";
 
-        private const int InternalVersion = 4; //! To be incremented manually for each change to the ARMeilleure project.
+        private const int InternalVersion = 5; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string BaseDir = "Ryujinx";
 


### PR DESCRIPTION
Can improve codegen of code dealing with a lot of 32 bit integers. For example:

```patch
 block61 (next block62) (branch block63):
- i64 %124 = ZeroExtend32 i32 0x1
- i64 %125 = ZeroExtend32 i32 0x5
- i64 %126 = ZeroExtend32 i32 0x14
- i64 %127 = ZeroExtend32 i32 0x3
  i64 %128 = Add i64 %18, i64 0xE0
  i64 %129 = BitwiseAnd i64 %128, i64 0xFFFFFF8000000000
  BranchIfFalse i64 %129
```

These gets constant folded and copy propagated into their use.