### PR TITLE
Fold ConvertI64ToI32 imm64

### DIFF
--- a/ARMeilleure/CodeGen/Optimizations/ConstantFolding.cs
+++ b/ARMeilleure/CodeGen/Optimizations/ConstantFolding.cs
@@ -78,6 +78,13 @@ namespace ARMeilleure.CodeGen.Optimizations
                     }
                     break;
 
+                case Instruction.ConvertI64ToI32:
+                    if (type == OperandType.I32)
+                    {
+                        EvaluateUnaryI64(operation, (x) => (int)x);
+                    }
+                    break;
+
                 case Instruction.Copy:
                     if (type == OperandType.I32)
                     {

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -20,7 +20,7 @@ namespace ARMeilleure.Translation.PTC
     {
         private const string HeaderMagic = "PTChd";
 
-        private const int InternalVersion = 3; //! To be incremented manually for each change to the ARMeilleure project.
+        private const int InternalVersion = 4; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string BaseDir = "Ryujinx";
 

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -20,7 +20,7 @@ namespace ARMeilleure.Translation.PTC
     {
         private const string HeaderMagic = "PTChd";
 
-        private const int InternalVersion = 2; //! To be incremented manually for each change to the ARMeilleure project.
+        private const int InternalVersion = 3; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string BaseDir = "Ryujinx";
 


### PR DESCRIPTION
Creates more opportunities for copy propagation. For example:

```patch
 block82 (branch block85):
- i32 %179 = ConvertI64ToI32 i64 0x0
- Call i64 0x7FF85FA30444, i64 %177, i32 %179 ;; WriteByte
+ Call i64 0x7FF888910444, i64 %171, i32 0x0 ;; WriteByte
  Branch
```