### PR TITLE
prepo: Update implementation for 10.x changes

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Prepo/IPrepoService.cs
+++ b/Ryujinx.HLE/HOS/Services/Prepo/IPrepoService.cs
@@ -87,8 +87,8 @@ namespace Ryujinx.HLE.HOS.Services.Prepo
 
         private ResultCode ProcessReport(ServiceCtx context, bool withUserID)
         {
-            UserId  userId   = withUserID ? context.RequestData.ReadStruct<UserId>() : new UserId();
-            string  gameRoom = StringUtils.ReadUtf8String(context);
+            UserId userId   = withUserID ? context.RequestData.ReadStruct<UserId>() : new UserId();
+            string gameRoom = StringUtils.ReadUtf8String(context);
 
             if (withUserID)
             {
@@ -130,7 +130,7 @@ namespace Ryujinx.HLE.HOS.Services.Prepo
 
             if (!userId.IsNull)
             {
-                builder.AppendLine($" UserId: {userId.ToString()}");
+                builder.AppendLine($" UserId: {userId}");
             }
 
             builder.AppendLine($" Room: {room}");

--- a/Ryujinx.HLE/HOS/Services/Prepo/IPrepoService.cs
+++ b/Ryujinx.HLE/HOS/Services/Prepo/IPrepoService.cs
@@ -32,7 +32,23 @@ namespace Ryujinx.HLE.HOS.Services.Prepo
             return ProcessReport(context, withUserID: true);
         }
 
-        [Command(10102)] // 6.0.0+
+        [Command(10102)] // 6.0.0-9.2.0
+        // SaveReportOld2(u64, pid, buffer<u8, 9>, buffer<bytes, 5>)
+        public ResultCode SaveReportOld2(ServiceCtx context)
+        {
+            // We don't care about the differences since we don't use the play report.
+            return ProcessReport(context, withUserID: false);
+        }
+
+        [Command(10103)] // 6.0.0-9.2.0
+        // SaveReportWithUserOld2(nn::account::Uid, u64, pid, buffer<u8, 9>, buffer<bytes, 5>)
+        public ResultCode SaveReportWithUserOld2(ServiceCtx context)
+        {
+            // We don't care about the differences since we don't use the play report.
+            return ProcessReport(context, withUserID: true);
+        }
+
+        [Command(10104)] // 10.0.0+
         // SaveReport(u64, pid, buffer<u8, 9>, buffer<bytes, 5>)
         public ResultCode SaveReport(ServiceCtx context)
         {
@@ -40,7 +56,7 @@ namespace Ryujinx.HLE.HOS.Services.Prepo
             return ProcessReport(context, withUserID: false);
         }
 
-        [Command(10103)] // 6.0.0+
+        [Command(10105)] // 10.0.0+
         // SaveReportWithUser(nn::account::Uid, u64, pid, buffer<u8, 9>, buffer<bytes, 5>)
         public ResultCode SaveReportWithUser(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Prepo/IPrepoService.cs
+++ b/Ryujinx.HLE/HOS/Services/Prepo/IPrepoService.cs
@@ -17,37 +17,7 @@ namespace Ryujinx.HLE.HOS.Services.Prepo
         public IPrepoService(ServiceCtx context) { }
 
         [Command(10100)] // 1.0.0-5.1.0
-        // SaveReport(u64, pid, buffer<u8, 9>, buffer<bytes, 5>)
-        public ResultCode SaveReportOld(ServiceCtx context)
-        {
-            // We don't care about the differences since we don't use the play report.
-            return ProcessReport(context, withUserID: false);
-        }
-
-        [Command(10101)] // 1.0.0-5.1.0
-        // SaveReportWithUserOld(nn::account::Uid, u64, pid, buffer<u8, 9>, buffer<bytes, 5>)
-        public ResultCode SaveReportWithUserOld(ServiceCtx context)
-        {
-            // We don't care about the differences since we don't use the play report.
-            return ProcessReport(context, withUserID: true);
-        }
-
         [Command(10102)] // 6.0.0-9.2.0
-        // SaveReportOld2(u64, pid, buffer<u8, 9>, buffer<bytes, 5>)
-        public ResultCode SaveReportOld2(ServiceCtx context)
-        {
-            // We don't care about the differences since we don't use the play report.
-            return ProcessReport(context, withUserID: false);
-        }
-
-        [Command(10103)] // 6.0.0-9.2.0
-        // SaveReportWithUserOld2(nn::account::Uid, u64, pid, buffer<u8, 9>, buffer<bytes, 5>)
-        public ResultCode SaveReportWithUserOld2(ServiceCtx context)
-        {
-            // We don't care about the differences since we don't use the play report.
-            return ProcessReport(context, withUserID: true);
-        }
-
         [Command(10104)] // 10.0.0+
         // SaveReport(u64, pid, buffer<u8, 9>, buffer<bytes, 5>)
         public ResultCode SaveReport(ServiceCtx context)
@@ -56,6 +26,8 @@ namespace Ryujinx.HLE.HOS.Services.Prepo
             return ProcessReport(context, withUserID: false);
         }
 
+        [Command(10101)] // 1.0.0-5.1.0
+        [Command(10103)] // 6.0.0-9.2.0
         [Command(10105)] // 10.0.0+
         // SaveReportWithUser(nn::account::Uid, u64, pid, buffer<u8, 9>, buffer<bytes, 5>)
         public ResultCode SaveReportWithUser(ServiceCtx context)


### PR DESCRIPTION
On 10.x, Nintendo changed yet another time the prepo SaveReport &
SaveReportWithUser command ids.

This PR add support for command 10104 & 10105 and update naming of the
old variants to match switchbrew.

This fix any game using 10.x based sdknso and telemetry. (like AC:NH 1.3.0)