### PR TITLE
Implement Zero-Configuration Resolution Scaling

### DIFF
--- a/Ryujinx.Common/Configuration/ConfigurationFileFormat.cs
+++ b/Ryujinx.Common/Configuration/ConfigurationFileFormat.cs
@@ -13,9 +13,19 @@ namespace Ryujinx.Configuration
         /// <summary>
         /// The current version of the file format
         /// </summary>
-        public const int CurrentVersion = 10;
+        public const int CurrentVersion = 11;
 
         public int Version { get; set; }
+
+        /// <summary>
+        /// Resolution Scale. An integer scale applied to applicable render targets. Values 1-4, or -1 to use a custom floating point scale instead.
+        /// </summary>
+        public int ResScale { get; set; }
+
+        /// <summary>
+        /// Custom Resolution Scale. A custom floating point scale applied to applicable render targets. Only active when Resolution Scale is -1.
+        /// </summary>
+        public float ResScaleCustom { get; set; }
 
         /// <summary>
         /// Max Anisotropy. Values range from 0 - 16. Set to -1 to let the game decide.

--- a/Ryujinx.Graphics.GAL/Format.cs
+++ b/Ryujinx.Graphics.GAL/Format.cs
@@ -214,5 +214,49 @@ namespace Ryujinx.Graphics.GAL
 
             return false;
         }
+
+        public static bool IsDepthOrStencil(this Format format)
+        {
+            switch (format)
+            {
+                case Format.D16Unorm:
+                case Format.D24UnormS8Uint:
+                case Format.D24X8Unorm:
+                case Format.D32Float:
+                case Format.D32FloatS8Uint:
+                case Format.S8Uint:
+                    return true;
+            }
+
+            return false;
+        }
+
+        public static bool HasOneComponent(this Format format)
+        {
+            switch (format)
+            {
+                case Format.R8Unorm:
+                case Format.R8Snorm:
+                case Format.R8Uint:
+                case Format.R8Sint:
+                case Format.R16Float:
+                case Format.R16Unorm:
+                case Format.R16Snorm:
+                case Format.R16Uint:
+                case Format.R16Sint:
+                case Format.R32Float:
+                case Format.R32Uint:
+                case Format.R32Sint:
+                case Format.R8Uscaled:
+                case Format.R8Sscaled:
+                case Format.R16Uscaled:
+                case Format.R16Sscaled:
+                case Format.R32Uscaled:
+                case Format.R32Sscaled:
+                    return true;
+            }
+
+            return false;
+        }
     }
 }

--- a/Ryujinx.Graphics.GAL/Format.cs
+++ b/Ryujinx.Graphics.GAL/Format.cs
@@ -252,6 +252,78 @@ namespace Ryujinx.Graphics.GAL
         }
 
         /// <summary>
+        /// Checks if the texture format is an unsigned integer color format.
+        /// </summary>
+        /// <param name="format">Texture format</param>
+        /// <returns>True if the texture format is an unsigned integer color format, false otherwise</returns>
+        public static bool IsUint(this Format format)
+        {
+            switch (format)
+            {
+                case Format.R8Uint:
+                case Format.R16Uint:
+                case Format.R32Uint:
+                case Format.R8G8Uint:
+                case Format.R16G16Uint:
+                case Format.R32G32Uint:
+                case Format.R8G8B8Uint:
+                case Format.R16G16B16Uint:
+                case Format.R32G32B32Uint:
+                case Format.R8G8B8A8Uint:
+                case Format.R16G16B16A16Uint:
+                case Format.R32G32B32A32Uint:
+                case Format.R10G10B10A2Uint:
+                case Format.R8G8B8X8Uint:
+                case Format.R16G16B16X16Uint:
+                case Format.R32G32B32X32Uint:
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks if the texture format is a signed integer color format.
+        /// </summary>
+        /// <param name="format">Texture format</param>
+        /// <returns>True if the texture format is a signed integer color format, false otherwise</returns>
+        public static bool IsSint(this Format format)
+        {
+            switch (format)
+            {
+                case Format.R8Sint:
+                case Format.R16Sint:
+                case Format.R32Sint:
+                case Format.R8G8Sint:
+                case Format.R16G16Sint:
+                case Format.R32G32Sint:
+                case Format.R8G8B8Sint:
+                case Format.R16G16B16Sint:
+                case Format.R32G32B32Sint:
+                case Format.R8G8B8A8Sint:
+                case Format.R16G16B16A16Sint:
+                case Format.R32G32B32A32Sint:
+                case Format.R10G10B10A2Sint:
+                case Format.R8G8B8X8Sint:
+                case Format.R16G16B16X16Sint:
+                case Format.R32G32B32X32Sint:
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks if the texture format is an integer color format.
+        /// </summary>
+        /// <param name="format">Texture format</param>
+        /// <returns>True if the texture format is an integer color format, false otherwise</returns>
+        public static bool IsInteger(this Format format)
+        {
+            return format.IsUint() || format.IsSint();
+        }
+
+        /// <summary>
         /// Checks if the texture format only has one component.
         /// </summary>
         /// <param name="format">Texture format</param>

--- a/Ryujinx.Graphics.GAL/Format.cs
+++ b/Ryujinx.Graphics.GAL/Format.cs
@@ -162,11 +162,21 @@ namespace Ryujinx.Graphics.GAL
 
     public static class FormatExtensions
     {
+        /// <summary>
+        /// Checks if the texture format is an ASTC format.
+        /// </summary>
+        /// <param name="format">Texture format</param>
+        /// <returns>True if the texture format is an ASTC format, false otherwise</returns>
         public static bool IsAstc(this Format format)
         {
             return format.IsAstcUnorm() || format.IsAstcSrgb();
         }
 
+        /// <summary>
+        /// Checks if the texture format is an ASTC Unorm format.
+        /// </summary>
+        /// <param name="format">Texture format</param>
+        /// <returns>True if the texture format is an ASTC Unorm format, false otherwise</returns>
         public static bool IsAstcUnorm(this Format format)
         {
             switch (format)
@@ -191,6 +201,11 @@ namespace Ryujinx.Graphics.GAL
             return false;
         }
 
+        /// <summary>
+        /// Checks if the texture format is an ASTC SRGB format.
+        /// </summary>
+        /// <param name="format">Texture format</param>
+        /// <returns>True if the texture format is an ASTC SRGB format, false otherwise</returns>
         public static bool IsAstcSrgb(this Format format)
         {
             switch (format)
@@ -215,6 +230,11 @@ namespace Ryujinx.Graphics.GAL
             return false;
         }
 
+        /// <summary>
+        /// Checks if the texture format is a depth, stencil or depth-stencil format.
+        /// </summary>
+        /// <param name="format">Texture format</param>
+        /// <returns>True if the format is a depth, stencil or depth-stencil format, false otherwise</returns>
         public static bool IsDepthOrStencil(this Format format)
         {
             switch (format)
@@ -231,6 +251,11 @@ namespace Ryujinx.Graphics.GAL
             return false;
         }
 
+        /// <summary>
+        /// Checks if the texture format only has one component.
+        /// </summary>
+        /// <param name="format">Texture format</param>
+        /// <returns>True if the texture format only has one component, false otherwise</returns>
         public static bool HasOneComponent(this Format format)
         {
             switch (format)

--- a/Ryujinx.Graphics.GAL/IPipeline.cs
+++ b/Ryujinx.Graphics.GAL/IPipeline.cs
@@ -54,6 +54,8 @@ namespace Ryujinx.Graphics.GAL
 
         void SetRasterizerDiscard(bool discard);
 
+        void SetRenderScale(float scale);
+
         void SetRenderTargetColorMasks(ReadOnlySpan<uint> componentMask);
 
         void SetRenderTargets(ITexture[] colors, ITexture depthStencil);

--- a/Ryujinx.Graphics.GAL/IPipeline.cs
+++ b/Ryujinx.Graphics.GAL/IPipeline.cs
@@ -54,7 +54,7 @@ namespace Ryujinx.Graphics.GAL
 
         void SetRasterizerDiscard(bool discard);
 
-        void SetRenderScale(float scale);
+        void SetRenderTargetScale(float scale);
 
         void SetRenderTargetColorMasks(ReadOnlySpan<uint> componentMask);
 
@@ -86,5 +86,7 @@ namespace Ryujinx.Graphics.GAL
         bool TryHostConditionalRendering(ICounterEvent value, ulong compare, bool isEqual);
         bool TryHostConditionalRendering(ICounterEvent value, ICounterEvent compare, bool isEqual);
         void EndHostConditionalRendering();
+
+        void UpdateRenderScale(ShaderStage stage, int textureCount);
     }
 }

--- a/Ryujinx.Graphics.GAL/IRenderer.cs
+++ b/Ryujinx.Graphics.GAL/IRenderer.cs
@@ -16,7 +16,7 @@ namespace Ryujinx.Graphics.GAL
         IProgram CreateProgram(IShader[] shaders);
 
         ISampler CreateSampler(SamplerCreateInfo info);
-        ITexture CreateTexture(TextureCreateInfo info);
+        ITexture CreateTexture(TextureCreateInfo info, float scale);
 
         void DeleteBuffer(BufferHandle buffer);
 

--- a/Ryujinx.Graphics.GAL/ITexture.cs
+++ b/Ryujinx.Graphics.GAL/ITexture.cs
@@ -4,6 +4,10 @@ namespace Ryujinx.Graphics.GAL
 {
     public interface ITexture : IDisposable
     {
+        int Width { get; }
+        int Height { get; }
+        float ScaleFactor { get; }
+
         void CopyTo(ITexture destination, int firstLayer, int firstLevel);
         void CopyTo(ITexture destination, Extents2D srcRegion, Extents2D dstRegion, bool linearFilter);
 

--- a/Ryujinx.Graphics.Gpu/Engine/Compute.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Compute.cs
@@ -132,11 +132,11 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
                 if (descriptor.IsBindless)
                 {
-                    textureBindings[index] = new TextureBindingInfo(target, descriptor.CbufOffset, descriptor.CbufSlot);
+                    textureBindings[index] = new TextureBindingInfo(target, descriptor.CbufOffset, descriptor.CbufSlot, descriptor.Flags);
                 }
                 else
                 {
-                    textureBindings[index] = new TextureBindingInfo(target, descriptor.HandleIndex);
+                    textureBindings[index] = new TextureBindingInfo(target, descriptor.HandleIndex, descriptor.Flags);
                 }
             }
 
@@ -150,7 +150,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
                 Target target = GetTarget(descriptor.Type);
 
-                imageBindings[index] = new TextureBindingInfo(target, descriptor.HandleIndex);
+                imageBindings[index] = new TextureBindingInfo(target, descriptor.HandleIndex, descriptor.Flags);
             }
 
             TextureManager.SetComputeImages(imageBindings);

--- a/Ryujinx.Graphics.Gpu/Engine/MethodClear.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodClear.cs
@@ -26,7 +26,9 @@ namespace Ryujinx.Graphics.Gpu.Engine
                 UpdateScissorState(state);
             }
 
-            UpdateRenderTargetState(state, useControl: false);
+            int index = (argument >> 6) & 0xf;
+
+            UpdateRenderTargetState(state, useControl: false, singleUse: index);
 
             TextureManager.CommitGraphicsBindings();
 
@@ -34,8 +36,6 @@ namespace Ryujinx.Graphics.Gpu.Engine
             bool clearStencil = (argument & 2) != 0;
 
             uint componentMask = (uint)((argument >> 2) & 0xf);
-
-            int index = (argument >> 6) & 0xf;
 
             if (componentMask != 0)
             {

--- a/Ryujinx.Graphics.Gpu/Engine/MethodCopyTexture.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodCopyTexture.cs
@@ -1,5 +1,6 @@
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.State;
+using System;
 
 namespace Ryujinx.Graphics.Gpu.Engine
 {
@@ -32,11 +33,19 @@ namespace Ryujinx.Graphics.Gpu.Engine
                 dstCopyTexture.Format = RtFormat.D32Float;
             }
 
-            Texture dstTexture = TextureManager.FindOrCreateTexture(dstCopyTexture);
+            Texture dstTexture = TextureManager.FindOrCreateTexture(dstCopyTexture, srcTexture.Rescaled);
 
             if (dstTexture == null)
             {
                 return;
+            }
+
+            // Make sure the textures are the same scale. Prefer the worse scale.
+            if (srcTexture.ScaleFactor != dstTexture.ScaleFactor)
+            {
+                float preferredScale = Math.Min(srcTexture.ScaleFactor, dstTexture.ScaleFactor);
+                srcTexture.SetScale(preferredScale);
+                dstTexture.SetScale(preferredScale);
             }
 
             var control = state.Get<CopyTextureControl>(MethodOffset.CopyTextureControl);
@@ -55,17 +64,19 @@ namespace Ryujinx.Graphics.Gpu.Engine
             int dstX2 = region.DstX + region.DstWidth;
             int dstY2 = region.DstY + region.DstHeight;
 
+            float scale = srcTexture.ScaleFactor; // src and dest scales are identical now.
+
             Extents2D srcRegion = new Extents2D(
-                srcX1 / srcTexture.Info.SamplesInX,
-                srcY1 / srcTexture.Info.SamplesInY,
-                srcX2 / srcTexture.Info.SamplesInX,
-                srcY2 / srcTexture.Info.SamplesInY);
+                (int)Math.Ceiling(scale * (srcX1 / srcTexture.Info.SamplesInX)),
+                (int)Math.Ceiling(scale * (srcY1 / srcTexture.Info.SamplesInY)),
+                (int)Math.Ceiling(scale * (srcX2 / srcTexture.Info.SamplesInX)),
+                (int)Math.Ceiling(scale * (srcY2 / srcTexture.Info.SamplesInY)));
 
             Extents2D dstRegion = new Extents2D(
-                dstX1 / dstTexture.Info.SamplesInX,
-                dstY1 / dstTexture.Info.SamplesInY,
-                dstX2 / dstTexture.Info.SamplesInX,
-                dstY2 / dstTexture.Info.SamplesInY);
+                (int)Math.Ceiling(scale * (dstX1 / dstTexture.Info.SamplesInX)),
+                (int)Math.Ceiling(scale * (dstY1 / dstTexture.Info.SamplesInY)),
+                (int)Math.Ceiling(scale * (dstX2 / dstTexture.Info.SamplesInX)),
+                (int)Math.Ceiling(scale * (dstY2 / dstTexture.Info.SamplesInY)));
 
             bool linearFilter = control.UnpackLinearFilter();
 
@@ -79,17 +90,18 @@ namespace Ryujinx.Graphics.Gpu.Engine
             // the second handles the region outside of the bounds).
             // We must also extend the source texture by one line to ensure we can wrap on the last line.
             // This is required by the (guest) OpenGL driver.
-            if (srcRegion.X2 > srcTexture.Info.Width)
+            if (srcX2 / srcTexture.Info.SamplesInX > srcTexture.Info.Width)
             {
                 srcCopyTexture.Height++;
 
-                srcTexture = TextureManager.FindOrCreateTexture(srcCopyTexture);
+                srcTexture = TextureManager.FindOrCreateTexture(srcCopyTexture, srcTexture.Rescaled);
+                srcTexture.SetScale(scale);
 
                 srcRegion = new Extents2D(
-                    srcRegion.X1 - srcTexture.Info.Width,
-                    srcRegion.Y1 + 1,
-                    srcRegion.X2 - srcTexture.Info.Width,
-                    srcRegion.Y2 + 1);
+                    (int)Math.Ceiling(scale * ((srcX1 / srcTexture.Info.SamplesInX) - srcTexture.Info.Width)),
+                    (int)Math.Ceiling(scale * ((srcY1 / srcTexture.Info.SamplesInY) + 1)),
+                    (int)Math.Ceiling(scale * ((srcX2 / srcTexture.Info.SamplesInX) - srcTexture.Info.Width)),
+                    (int)Math.Ceiling(scale * ((srcY2 / srcTexture.Info.SamplesInY) + 1)));
 
                 srcTexture.HostTexture.CopyTo(dstTexture.HostTexture, srcRegion, dstRegion, linearFilter);
             }

--- a/Ryujinx.Graphics.Gpu/Engine/MethodCopyTexture.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodCopyTexture.cs
@@ -33,19 +33,16 @@ namespace Ryujinx.Graphics.Gpu.Engine
                 dstCopyTexture.Format = RtFormat.D32Float;
             }
 
-            Texture dstTexture = TextureManager.FindOrCreateTexture(dstCopyTexture, srcTexture.Rescaled);
+            Texture dstTexture = TextureManager.FindOrCreateTexture(dstCopyTexture, srcTexture.ScaleMode == Image.TextureScaleMode.Scaled);
 
             if (dstTexture == null)
             {
                 return;
             }
 
-            // Make sure the textures are the same scale. Prefer the worse scale.
             if (srcTexture.ScaleFactor != dstTexture.ScaleFactor)
             {
-                float preferredScale = Math.Min(srcTexture.ScaleFactor, dstTexture.ScaleFactor);
-                srcTexture.SetScale(preferredScale);
-                dstTexture.SetScale(preferredScale);
+                srcTexture.PropagateScale(dstTexture);
             }
 
             var control = state.Get<CopyTextureControl>(MethodOffset.CopyTextureControl);
@@ -94,8 +91,11 @@ namespace Ryujinx.Graphics.Gpu.Engine
             {
                 srcCopyTexture.Height++;
 
-                srcTexture = TextureManager.FindOrCreateTexture(srcCopyTexture, srcTexture.Rescaled);
-                srcTexture.SetScale(scale);
+                srcTexture = TextureManager.FindOrCreateTexture(srcCopyTexture, srcTexture.ScaleMode == Image.TextureScaleMode.Scaled);
+                if (srcTexture.ScaleFactor != dstTexture.ScaleFactor)
+                {
+                    srcTexture.PropagateScale(dstTexture);
+                }
 
                 srcRegion = new Extents2D(
                     (int)Math.Ceiling(scale * ((srcX1 / srcTexture.Info.SamplesInX) - srcTexture.Info.Width)),

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -364,7 +364,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
             changedScale |= TextureManager.SetRenderTargetDepthStencil(depthStencil);
 
-            if (changedScale || changedScale)
+            if (changedScale)
             {
                 TextureManager.UpdateRenderTargetScale(singleUse);
                 _context.Renderer.Pipeline.SetRenderTargetScale(TextureManager.RenderTargetScale);

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -324,7 +324,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
             int samplesInX = msaaMode.SamplesInX();
             int samplesInY = msaaMode.SamplesInY();
 
-            bool changedColorScale = false;
+            bool changedScale = false;
 
             for (int index = 0; index < Constants.TotalRenderTargets; index++)
             {
@@ -334,14 +334,14 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
                 if (index >= count || !IsRtEnabled(colorState))
                 {
-                    changedColorScale |= TextureManager.SetRenderTargetColor(index, null);
+                    changedScale |= TextureManager.SetRenderTargetColor(index, null);
 
                     continue;
                 }
 
                 Texture color = TextureManager.FindOrCreateTexture(colorState, samplesInX, samplesInY);
 
-                changedColorScale |= TextureManager.SetRenderTargetColor(index, color);
+                changedScale |= TextureManager.SetRenderTargetColor(index, color);
 
                 if (color != null)
                 {
@@ -361,12 +361,12 @@ namespace Ryujinx.Graphics.Gpu.Engine
                 depthStencil = TextureManager.FindOrCreateTexture(dsState, dsSize, samplesInX, samplesInY);
             }
 
-            bool changedScale = TextureManager.SetRenderTargetDepthStencil(depthStencil);
+            changedScale |= TextureManager.SetRenderTargetDepthStencil(depthStencil);
 
-            if (changedScale || changedColorScale)
+            if (changedScale || changedScale)
             {
                 TextureManager.UpdateRtScale(singleUse);
-                _context.Renderer.Pipeline.SetRenderScale(TextureManager.RtScale);
+                _context.Renderer.Pipeline.SetRenderTargetScale(TextureManager.RtScale);
 
                 UpdateViewportTransform(state);
                 UpdateScissorState(state);

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -943,11 +943,11 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
                     if (descriptor.IsBindless)
                     {
-                        textureBindings[index] = new TextureBindingInfo(target, descriptor.CbufSlot, descriptor.CbufOffset);
+                        textureBindings[index] = new TextureBindingInfo(target, descriptor.CbufSlot, descriptor.CbufOffset, descriptor.Flags);
                     }
                     else
                     {
-                        textureBindings[index] = new TextureBindingInfo(target, descriptor.HandleIndex);
+                        textureBindings[index] = new TextureBindingInfo(target, descriptor.HandleIndex, descriptor.Flags);
                     }
                 }
 
@@ -961,7 +961,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
                     Target target = GetTarget(descriptor.Type);
 
-                    imageBindings[index] = new TextureBindingInfo(target, descriptor.HandleIndex);
+                    imageBindings[index] = new TextureBindingInfo(target, descriptor.HandleIndex, descriptor.Flags);
                 }
 
                 TextureManager.SetGraphicsImages(stage, imageBindings);

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -313,6 +313,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
         /// </summary>
         /// <param name="state">Current GPU state</param>
         /// <param name="useControl">Use draw buffers information from render target control register</param>
+        /// <param name="singleUse">If this is not -1, it indicates that only the given indexed target will be used.</param> 
         private void UpdateRenderTargetState(GpuState state, bool useControl, int singleUse = -1)
         {
             var rtControl = state.Get<RtControl>(MethodOffset.RtControl);
@@ -365,8 +366,8 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
             if (changedScale || changedScale)
             {
-                TextureManager.UpdateRtScale(singleUse);
-                _context.Renderer.Pipeline.SetRenderTargetScale(TextureManager.RtScale);
+                TextureManager.UpdateRenderTargetScale(singleUse);
+                _context.Renderer.Pipeline.SetRenderTargetScale(TextureManager.RenderTargetScale);
 
                 UpdateViewportTransform(state);
                 UpdateScissorState(state);
@@ -410,7 +411,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
                     int width = scissor.X2 - x;
                     int height = scissor.Y2 - y;
 
-                    float scale = TextureManager.RtScale;
+                    float scale = TextureManager.RenderTargetScale;
                     if (scale != 1f)
                     {
                         x = (int)(x * scale);
@@ -485,7 +486,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
                 float width  = MathF.Abs(transform.ScaleX) * 2;
                 float height = MathF.Abs(transform.ScaleY) * 2;
 
-                float scale = TextureManager.RtScale;
+                float scale = TextureManager.RenderTargetScale;
                 if (scale != 1f)
                 {
                     x *= scale;

--- a/Ryujinx.Graphics.Gpu/GraphicsConfig.cs
+++ b/Ryujinx.Graphics.Gpu/GraphicsConfig.cs
@@ -6,6 +6,11 @@ namespace Ryujinx.Graphics.Gpu
     public static class GraphicsConfig
     {
         /// <summary>
+        /// Resolution scale.
+        /// </summary>
+        public static float ResScale = 1f;
+
+        /// <summary>
         /// Max Anisotropy. Values range from 0 - 16. Set to -1 to let the game decide.
         /// </summary>
         public static float MaxAnisotropy;

--- a/Ryujinx.Graphics.Gpu/GraphicsConfig.cs
+++ b/Ryujinx.Graphics.Gpu/GraphicsConfig.cs
@@ -27,11 +27,5 @@ namespace Ryujinx.Graphics.Gpu
         /// This can avoid lower resolution on some games when GPU performance is poor.
         /// </summary>
         public static bool FastGpuTime = true;
-
-        /// <summary>
-        /// If a texture is equal or below this threshold, it will be blacklisted for scaling. 
-        /// Small textures are generally used for cubemaps and 3D textures, and end up scaling back down anyways.
-        /// </summary>
-        public static float ResScaleThreshold = 64f;
     }
 }

--- a/Ryujinx.Graphics.Gpu/GraphicsConfig.cs
+++ b/Ryujinx.Graphics.Gpu/GraphicsConfig.cs
@@ -27,5 +27,11 @@ namespace Ryujinx.Graphics.Gpu
         /// This can avoid lower resolution on some games when GPU performance is poor.
         /// </summary>
         public static bool FastGpuTime = true;
+
+        /// <summary>
+        /// If a texture is equal or below this threshold, it will be blacklisted for scaling. 
+        /// Small textures are generally used for cubemaps and 3D textures, and end up scaling back down anyways.
+        /// </summary>
+        public static float ResScaleThreshold = 64f;
     }
 }

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -331,7 +331,10 @@ namespace Ryujinx.Graphics.Gpu.Image
             }
             else
             {
-                float sharedScale = Math.Max(ScaleFactor, other.ScaleFactor);
+                // Prefer the configured scale if present. If not, prefer the max.
+                float targetScale = GraphicsConfig.ResScale;
+                float sharedScale = (ScaleFactor == targetScale || other.ScaleFactor == targetScale) ? targetScale : Math.Max(ScaleFactor, other.ScaleFactor);
+
                 SetScale(sharedScale);
                 other.SetScale(sharedScale);
             }

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -482,9 +482,14 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             int modifiedCount = _context.PhysicalMemory.QueryModified(Address, Size, ResourceName.Texture, _modifiedRanges);
 
-            if (modifiedCount == 0 && _hasData)
+            if (_hasData)
             {
-                return;
+                if (modifiedCount == 0)
+                {
+                    return;
+                }
+
+                BlacklistScale();
             }
 
             ReadOnlySpan<byte> data = _context.PhysicalMemory.GetSpan(Address, (int)Size);

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -438,7 +438,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 foreach (var view in _views)
                 {
-                    Logger.PrintDebug(LogClass.Gpu, $"  Recreating view ${Info.Width}x${Info.Height} ${Info.FormatInfo.Format.ToString()}.");
+                    Logger.PrintDebug(LogClass.Gpu, $"  Recreating view {Info.Width}x{Info.Height} {Info.FormatInfo.Format.ToString()}.");
                     view.ScaleFactor = scale;
 
                     TextureCreateInfo viewCreateInfo = TextureManager.GetCreateInfo(view.Info, _context.Capabilities);

--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingInfo.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingInfo.cs
@@ -48,6 +48,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         /// <param name="target">The shader sampler target type</param>
         /// <param name="handle">The shader texture handle (read index into the texture constant buffer)</param>
+        /// <param name="flags">The texture's usage flags, indicating how it is used in the shader</param>
         public TextureBindingInfo(Target target, int handle, TextureUsageFlags flags)
         {
             Target = target;
@@ -67,6 +68,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="target">The shader sampler target type</param>
         /// <param name="cbufSlot">Constant buffer slot where the bindless texture handle is located</param>
         /// <param name="cbufOffset">Constant buffer offset of the bindless texture handle</param>
+        /// <param name="flags">The texture's usage flags, indicating how it is used in the shader</param>
         public TextureBindingInfo(Target target, int cbufSlot, int cbufOffset, TextureUsageFlags flags)
         {
             Target = target;

--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingInfo.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingInfo.cs
@@ -1,4 +1,5 @@
 using Ryujinx.Graphics.GAL;
+using Ryujinx.Graphics.Shader;
 
 namespace Ryujinx.Graphics.Gpu.Image
 {
@@ -38,11 +39,16 @@ namespace Ryujinx.Graphics.Gpu.Image
         public int CbufOffset { get; }
 
         /// <summary>
+        /// Flags from the texture descriptor that indicate how the texture is used.
+        /// </summary>
+        public TextureUsageFlags Flags { get; }
+
+        /// <summary>
         /// Constructs the texture binding information structure.
         /// </summary>
         /// <param name="target">The shader sampler target type</param>
         /// <param name="handle">The shader texture handle (read index into the texture constant buffer)</param>
-        public TextureBindingInfo(Target target, int handle)
+        public TextureBindingInfo(Target target, int handle, TextureUsageFlags flags)
         {
             Target = target;
             Handle = handle;
@@ -51,6 +57,8 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             CbufSlot   = 0;
             CbufOffset = 0;
+
+            Flags = flags;
         }
 
         /// <summary>
@@ -59,7 +67,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="target">The shader sampler target type</param>
         /// <param name="cbufSlot">Constant buffer slot where the bindless texture handle is located</param>
         /// <param name="cbufOffset">Constant buffer offset of the bindless texture handle</param>
-        public TextureBindingInfo(Target target, int cbufSlot, int cbufOffset)
+        public TextureBindingInfo(Target target, int cbufSlot, int cbufOffset, TextureUsageFlags flags)
         {
             Target = target;
             Handle = 0;
@@ -68,6 +76,8 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             CbufSlot   = cbufSlot;
             CbufOffset = cbufOffset;
+
+            Flags = flags;
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -218,7 +218,6 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 Texture texture = pool.Get(textureId);
 
-                // TODO: Support texelFetch scaling in compute.
                 if ((binding.Flags & TextureUsageFlags.ResScaleUnsupported) > 0)
                 {
                     texture?.BlacklistScale();

--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -216,6 +216,11 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 Texture texture = pool.Get(textureId);
 
+                if ((binding.Flags & TextureUsageFlags.ResScaleUnsupported) > 0)
+                {
+                    texture?.BlacklistScale();
+                }
+
                 ITexture hostTexture = texture?.GetTargetTexture(binding.Target);
 
                 if (_textureState[stageIndex][index].Texture != hostTexture || _rebind)
@@ -268,6 +273,11 @@ namespace Ryujinx.Graphics.Gpu.Image
                 int textureId = UnpackTextureId(packedId);
 
                 Texture texture = pool.Get(textureId);
+
+                if ((binding.Flags & TextureUsageFlags.ResScaleUnsupported) > 0)
+                {
+                    texture?.BlacklistScale();
+                }
 
                 ITexture hostTexture = texture?.GetTargetTexture(binding.Target);
 

--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -218,7 +218,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 Texture texture = pool.Get(textureId);
 
-                if ((binding.Flags & TextureUsageFlags.ResScaleUnsupported) > 0)
+                if ((binding.Flags & TextureUsageFlags.ResScaleUnsupported) != 0)
                 {
                     texture?.BlacklistScale();
                 }
@@ -283,7 +283,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 Texture texture = pool.Get(textureId);
 
-                if ((binding.Flags & TextureUsageFlags.ResScaleUnsupported) > 0)
+                if ((binding.Flags & TextureUsageFlags.ResScaleUnsupported) != 0)
                 {
                     texture?.BlacklistScale();
                 }

--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -174,6 +174,8 @@ namespace Ryujinx.Graphics.Gpu.Image
                 return;
             }
 
+            bool changed = false;
+
             for (int index = 0; index < _textureBindings[stageIndex].Length; index++)
             {
                 TextureBindingInfo binding = _textureBindings[stageIndex][index];
@@ -217,7 +219,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 Texture texture = pool.Get(textureId);
 
                 // TODO: Support texelFetch scaling in compute.
-                if ((binding.Flags & TextureUsageFlags.ResScaleUnsupported) > 0 && stage != ShaderStage.Compute)
+                if ((binding.Flags & TextureUsageFlags.ResScaleUnsupported) > 0)
                 {
                     texture?.BlacklistScale();
                 }
@@ -229,6 +231,8 @@ namespace Ryujinx.Graphics.Gpu.Image
                     _textureState[stageIndex][index].Texture = hostTexture;
 
                     _context.Renderer.Pipeline.SetTexture(index, stage, hostTexture);
+
+                    changed = true;
                 }
 
                 if (hostTexture != null && texture.Info.Target == Target.TextureBuffer)
@@ -249,6 +253,11 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                     _context.Renderer.Pipeline.SetSampler(index, stage, hostSampler);
                 }
+            }
+
+            if (changed)
+            {
+                _context.Renderer.Pipeline.UpdateRenderScale(stage, _textureBindings[stageIndex].Length);
             }
         }
 

--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -216,7 +216,8 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 Texture texture = pool.Get(textureId);
 
-                if ((binding.Flags & TextureUsageFlags.ResScaleUnsupported) > 0)
+                // TODO: Support texelFetch scaling in compute.
+                if ((binding.Flags & TextureUsageFlags.ResScaleUnsupported) > 0 && stage != ShaderStage.Compute)
                 {
                     texture?.BlacklistScale();
                 }

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -385,12 +385,6 @@ namespace Ryujinx.Graphics.Gpu.Image
             if (!(info.FormatInfo.Format.IsDepthOrStencil() || info.FormatInfo.Format.HasOneComponent()))
             {
                 // Discount square or small textures that aren't depth-stencil like. (excludes game textures, cubemap faces, most 3D texture LUT, texture atlas)
-
-                if (Math.Max(info.Width, info.Height) <= GraphicsConfig.ResScaleThreshold)
-                {
-                    return false;
-                }
-
                 // Detect if the texture is possibly square. Widths may be aligned, so to remove the uncertainty we align both the width and height.
 
                 int widthAlignment = (info.IsLinear ? 32 : 64) / info.FormatInfo.BytesPerPixel;

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -382,7 +382,13 @@ namespace Ryujinx.Graphics.Gpu.Image
             // While upscaling works for all targets defined by IsUpscaleCompatible, we additionally blacklist targets here that
             // may have undesirable results (upscaling blur textures) or simply waste GPU resources (upscaling texture atlas).
 
-            if (info.Width / 8 == info.Height / 8 && !(info.FormatInfo.Format.IsDepthOrStencil() || info.FormatInfo.Format.HasOneComponent()))
+            // Detect if the texture is possibly square. Widths may be aligned, so to remove the uncertainty we align both the width and height.
+
+            int widthAlignment = (info.IsLinear ? 32 : 64) / info.FormatInfo.BytesPerPixel;
+
+            bool possiblySquare = BitUtils.AlignUp(info.Width, widthAlignment) == BitUtils.AlignUp(info.Height, widthAlignment);
+
+            if (possiblySquare && !(info.FormatInfo.Format.IsDepthOrStencil() || info.FormatInfo.Format.HasOneComponent()))
             {
                 // Discount square textures that aren't depth-stencil like. (excludes game textures, cubemap faces, texture atlas)
                 return false;

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -195,7 +195,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 switch (target.ScaleMode)
                 {
                     case TextureScaleMode.Blacklisted:
-                        mismatch |= (scale != targetScale);
+                        mismatch |= (scale != 1f);
                         blacklisted = true;
                         break;
                     case TextureScaleMode.Eligible:

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -171,12 +171,14 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         /// <param name="index">The index of the color buffer to set (up to 8)</param>
         /// <param name="color">The color buffer texture</param>
+        /// <returns>True if render target scale must be updated.</returns>
         public bool SetRenderTargetColor(int index, Texture color)
         {
-            bool bindChanged = (color == null) != (_rtColors[index] == null);
-            bool changesScale = bindChanged || (color != null && RtScale != color.ScaleFactor);
+            bool hasValue = color != null;
+            bool changesScale = (hasValue != (_rtColors[index] != null)) || (hasValue && RtScale != color.ScaleFactor);
             _rtColors[index] = color;
-            return changesScale || (color?.ScaleMode != TextureScaleMode.Blacklisted && color?.ScaleFactor != GraphicsConfig.ResScale);
+
+            return changesScale || (hasValue && color.ScaleMode != TextureScaleMode.Blacklisted && color.ScaleFactor != GraphicsConfig.ResScale);
         }
 
         public void UpdateRtScale(int singleUse)
@@ -195,7 +197,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 switch (target.ScaleMode)
                 {
                     case TextureScaleMode.Blacklisted:
-                        mismatch |= (scale != 1f);
+                        mismatch |= scale != 1f;
                         blacklisted = true;
                         break;
                     case TextureScaleMode.Eligible:
@@ -203,7 +205,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                         break;
                     case TextureScaleMode.Scaled:
                         hasUpscaled = true;
-                        mismatch |= (scale != targetScale); // If the target scale has changed, reset the scale for all targets.
+                        mismatch |= scale != targetScale; // If the target scale has changed, reset the scale for all targets.
                         break;
                 }
             }
@@ -261,12 +263,14 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Sets the render target depth-stencil buffer.
         /// </summary>
         /// <param name="depthStencil">The depth-stencil buffer texture</param>
+        /// <returns>True if render target scale must be updated.</returns>
         public bool SetRenderTargetDepthStencil(Texture depthStencil)
         {
-            bool bindChanged = (depthStencil == null) != (_rtDepthStencil == null);
-            bool changesScale = bindChanged || (depthStencil != null && RtScale != depthStencil.ScaleFactor);
+            bool hasValue = depthStencil != null;
+            bool changesScale = (hasValue != (_rtDepthStencil != null)) || (hasValue && RtScale != depthStencil.ScaleFactor);
             _rtDepthStencil = depthStencil;
-            return changesScale || (depthStencil?.ScaleMode != TextureScaleMode.Blacklisted && depthStencil?.ScaleFactor != GraphicsConfig.ResScale);
+
+            return changesScale || (hasValue && depthStencil.ScaleMode != TextureScaleMode.Blacklisted && depthStencil.ScaleFactor != GraphicsConfig.ResScale);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -384,7 +384,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             if (!(info.FormatInfo.Format.IsDepthOrStencil() || info.FormatInfo.Format.HasOneComponent()))
             {
-                // Discount square or small textures that aren't depth-stencil like. (excludes game textures, cubemap faces, most 3D texture LUT, texture atlas)
+                // Discount square textures that aren't depth-stencil like. (excludes game textures, cubemap faces, most 3D texture LUT, texture atlas)
                 // Detect if the texture is possibly square. Widths may be aligned, so to remove the uncertainty we align both the width and height.
 
                 int widthAlignment = (info.IsLinear ? 32 : 64) / info.FormatInfo.BytesPerPixel;

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -198,7 +198,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             bool hasUpscaled = false;
             float targetScale = GraphicsConfig.ResScale;
 
-            void considerTarget(Texture target)
+            void ConsiderTarget(Texture target)
             {
                 if (target == null) return;
                 float scale = target.ScaleFactor;
@@ -728,11 +728,8 @@ namespace Ryujinx.Graphics.Gpu.Image
                         {
                             // A bit tricky, our new texture may need to contain an existing texture that is upscaled, but isn't itself. 
                             // In that case, we prefer the higher scale only if our format is render-target-like, otherwise we scale the view down before copy.
-                            texture.PropagateScale(overlap);
 
-                            //float preferredScale = IsUpscaleCompatible(info) ? Math.Max(texture.ScaleFactor, overlap.ScaleFactor) : 1f;
-                            //texture.SetScale(preferredScale);
-                            //overlap.SetScale(preferredScale);
+                            texture.PropagateScale(overlap);
                         }
 
                         ITexture newView = texture.HostTexture.CreateView(createInfo, firstLayer, firstLevel);

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -222,17 +222,17 @@ namespace Ryujinx.Graphics.Gpu.Image
             if (singleUse != -1)
             {
                 // If only one target is in use (by a clear, for example) the others do not need to be checked for mismatching scale.
-                considerTarget(_rtColors[singleUse]);
+                ConsiderTarget(_rtColors[singleUse]);
             }
             else
             {
                 foreach (Texture color in _rtColors)
                 {
-                    considerTarget(color);
+                    ConsiderTarget(color);
                 }
             }
 
-            considerTarget(_rtDepthStencil);
+            ConsiderTarget(_rtDepthStencil);
 
             mismatch |= blacklisted && hasUpscaled;
 

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -174,7 +174,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 swizzleB,
                 swizzleA);
 
-            if (IsDepthStencil(formatInfo.Format))
+            if (formatInfo.Format.IsDepthOrStencil())
             {
                 swizzleR = SwizzleComponent.Red;
                 swizzleG = SwizzleComponent.Red;
@@ -261,26 +261,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             return component == SwizzleComponent.Red ||
                    component == SwizzleComponent.Green;
-        }
-
-        /// <summary>
-        /// Checks if the texture format is a depth, stencil or depth-stencil format.
-        /// </summary>
-        /// <param name="format">Texture format</param>
-        /// <returns>True if the format is a depth, stencil or depth-stencil format, false otherwise</returns>
-        private static bool IsDepthStencil(Format format)
-        {
-            switch (format)
-            {
-                case Format.D16Unorm:
-                case Format.D24UnormS8Uint:
-                case Format.D24X8Unorm:
-                case Format.D32Float:
-                case Format.D32FloatS8Uint:
-                    return true;
-            }
-
-            return false;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureScaleMode.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureScaleMode.cs
@@ -1,5 +1,10 @@
 ﻿namespace Ryujinx.Graphics.Gpu.Image
 {
+    /// <summary>
+    /// The scale mode for a given texture.
+    /// Blacklisted textures cannot be scaled, Eligible textures have not been scaled yet,
+    /// and Scaled textures have been scaled already.
+    /// </summary>
     enum TextureScaleMode
     {
         Eligible = 0,

--- a/Ryujinx.Graphics.Gpu/Image/TextureScaleMode.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureScaleMode.cs
@@ -1,0 +1,9 @@
+﻿namespace Ryujinx.Graphics.Gpu.Image
+{
+    enum TextureScaleMode
+    {
+        Eligible = 0,
+        Scaled = 1,
+        Blacklisted = 2
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Image/TextureSearchFlags.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureSearchFlags.cs
@@ -11,6 +11,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         None     = 0,
         IgnoreMs = 1 << 0,
         Strict   = 1 << 1 | Sampler,
-        Sampler  = 1 << 2
+        Sampler  = 1 << 2,
+        WithUpscale = 1 << 4
     }
 }

--- a/Ryujinx.Graphics.Gpu/Image/TextureSearchFlags.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureSearchFlags.cs
@@ -12,6 +12,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         IgnoreMs = 1 << 0,
         Strict   = 1 << 1 | Sampler,
         Sampler  = 1 << 2,
-        WithUpscale = 1 << 4
+        WithUpscale = 1 << 3
     }
 }

--- a/Ryujinx.Graphics.Gpu/Window.cs
+++ b/Ryujinx.Graphics.Gpu/Window.cs
@@ -146,7 +146,7 @@ namespace Ryujinx.Graphics.Gpu
             {
                 pt.AcquireCallback(_context, pt.UserObj);
 
-                Texture texture = _context.Methods.TextureManager.FindOrCreateTexture(pt.Info);
+                Texture texture = _context.Methods.TextureManager.FindOrCreateTexture(pt.Info, TextureSearchFlags.WithUpscale);
 
                 texture.SynchronizeMemory();
 

--- a/Ryujinx.Graphics.OpenGL/Image/TextureBase.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureBase.cs
@@ -1,5 +1,6 @@
 ﻿using OpenTK.Graphics.OpenGL;
 using Ryujinx.Graphics.GAL;
+using System;
 
 namespace Ryujinx.Graphics.OpenGL.Image
 {
@@ -9,15 +10,19 @@ namespace Ryujinx.Graphics.OpenGL.Image
 
         protected TextureCreateInfo Info { get; }
 
-        public int Width => Info.Width;
-        public int Height => Info.Height;
+        public int Width { get; }
+        public int Height { get; }
+        public float ScaleFactor { get; }
 
         public Target Target => Info.Target;
         public Format Format => Info.Format;
 
-        public TextureBase(TextureCreateInfo info)
+        public TextureBase(TextureCreateInfo info, float scaleFactor = 1f)
         {
             Info = info;
+            Width = (int)Math.Ceiling(Info.Width * scaleFactor);
+            Height = (int)Math.Ceiling(Info.Height * scaleFactor);
+            ScaleFactor = scaleFactor;
 
             Handle = GL.GenTexture();
         }

--- a/Ryujinx.Graphics.OpenGL/Image/TextureCopy.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureCopy.cs
@@ -33,6 +33,11 @@ namespace Ryujinx.Graphics.OpenGL.Image
 
             ClearBufferMask mask = GetMask(src.Format);
 
+            if ((mask & (ClearBufferMask.DepthBufferBit | ClearBufferMask.StencilBufferBit)) > 0)
+            {
+                linearFilter = false;
+            }
+
             BlitFramebufferFilter filter = linearFilter
                 ? BlitFramebufferFilter.Linear
                 : BlitFramebufferFilter.Nearest;
@@ -54,6 +59,9 @@ namespace Ryujinx.Graphics.OpenGL.Image
                 dstRegion.Y2,
                 mask,
                 filter);
+
+            Attach(FramebufferTarget.ReadFramebuffer, src.Format, 0);
+            Attach(FramebufferTarget.DrawFramebuffer, dst.Format, 0);
 
             GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, oldReadFramebufferHandle);
             GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, oldDrawFramebufferHandle);

--- a/Ryujinx.Graphics.OpenGL/Image/TextureCopy.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureCopy.cs
@@ -33,7 +33,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
 
             ClearBufferMask mask = GetMask(src.Format);
 
-            if ((mask & (ClearBufferMask.DepthBufferBit | ClearBufferMask.StencilBufferBit)) > 0)
+            if ((mask & (ClearBufferMask.DepthBufferBit | ClearBufferMask.StencilBufferBit)) != 0)
             {
                 linearFilter = false;
             }

--- a/Ryujinx.Graphics.OpenGL/Image/TextureCopy.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureCopy.cs
@@ -33,7 +33,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
 
             ClearBufferMask mask = GetMask(src.Format);
 
-            if ((mask & (ClearBufferMask.DepthBufferBit | ClearBufferMask.StencilBufferBit)) != 0)
+            if ((mask & (ClearBufferMask.DepthBufferBit | ClearBufferMask.StencilBufferBit)) != 0 || src.Format.IsInteger())
             {
                 linearFilter = false;
             }

--- a/Ryujinx.Graphics.OpenGL/Image/TextureCopyUnscaled.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureCopyUnscaled.cs
@@ -15,15 +15,16 @@ namespace Ryujinx.Graphics.OpenGL.Image
             int srcLayer,
             int dstLayer,
             int srcLevel,
-            int dstLevel)
+            int dstLevel,
+            float scaleFactor = 1f)
         {
-            int srcWidth  = srcInfo.Width;
-            int srcHeight = srcInfo.Height;
+            int srcWidth  = (int)Math.Ceiling(srcInfo.Width * scaleFactor);
+            int srcHeight = (int)Math.Ceiling(srcInfo.Height * scaleFactor);
             int srcDepth  = srcInfo.GetDepthOrLayers();
             int srcLevels = srcInfo.Levels;
 
-            int dstWidth  = dstInfo.Width;
-            int dstHeight = dstInfo.Height;
+            int dstWidth  = (int)Math.Ceiling(dstInfo.Width * scaleFactor);
+            int dstHeight = (int)Math.Ceiling(dstInfo.Height * scaleFactor);
             int dstDepth  = dstInfo.GetDepthOrLayers();
             int dstLevels = dstInfo.Levels;
 

--- a/Ryujinx.Graphics.OpenGL/Image/TextureStorage.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureStorage.cs
@@ -1,12 +1,14 @@
 using OpenTK.Graphics.OpenGL;
 using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.GAL;
+using System;
 
 namespace Ryujinx.Graphics.OpenGL.Image
 {
     class TextureStorage
     {
         public int Handle { get; private set; }
+        public float ScaleFactor { get; private set; }
 
         public TextureCreateInfo Info { get; }
 
@@ -14,12 +16,13 @@ namespace Ryujinx.Graphics.OpenGL.Image
 
         private int _viewsCount;
 
-        public TextureStorage(Renderer renderer, TextureCreateInfo info)
+        public TextureStorage(Renderer renderer, TextureCreateInfo info, float scaleFactor)
         {
             _renderer = renderer;
             Info      = info;
 
             Handle = GL.GenTexture();
+            ScaleFactor = scaleFactor;
 
             CreateImmutableStorage();
         }
@@ -31,6 +34,9 @@ namespace Ryujinx.Graphics.OpenGL.Image
             GL.ActiveTexture(TextureUnit.Texture0);
 
             GL.BindTexture(target, Handle);
+
+            int width = (int)Math.Ceiling(Info.Width * ScaleFactor);
+            int height = (int)Math.Ceiling(Info.Height * ScaleFactor);
 
             FormatInfo format = FormatTable.GetFormatInfo(Info.Format);
 
@@ -52,7 +58,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
                         TextureTarget1d.Texture1D,
                         Info.Levels,
                         internalFormat,
-                        Info.Width);
+                        width);
                     break;
 
                 case Target.Texture1DArray:
@@ -60,8 +66,8 @@ namespace Ryujinx.Graphics.OpenGL.Image
                         TextureTarget2d.Texture1DArray,
                         Info.Levels,
                         internalFormat,
-                        Info.Width,
-                        Info.Height);
+                        width,
+                        height);
                     break;
 
                 case Target.Texture2D:
@@ -69,8 +75,8 @@ namespace Ryujinx.Graphics.OpenGL.Image
                         TextureTarget2d.Texture2D,
                         Info.Levels,
                         internalFormat,
-                        Info.Width,
-                        Info.Height);
+                        width,
+                        height);
                     break;
 
                 case Target.Texture2DArray:
@@ -78,8 +84,8 @@ namespace Ryujinx.Graphics.OpenGL.Image
                         TextureTarget3d.Texture2DArray,
                         Info.Levels,
                         internalFormat,
-                        Info.Width,
-                        Info.Height,
+                        width,
+                        height,
                         Info.Depth);
                     break;
 
@@ -88,8 +94,8 @@ namespace Ryujinx.Graphics.OpenGL.Image
                         TextureTargetMultisample2d.Texture2DMultisample,
                         Info.Samples,
                         internalFormat,
-                        Info.Width,
-                        Info.Height,
+                        width,
+                        height,
                         true);
                     break;
 
@@ -98,8 +104,8 @@ namespace Ryujinx.Graphics.OpenGL.Image
                         TextureTargetMultisample3d.Texture2DMultisampleArray,
                         Info.Samples,
                         internalFormat,
-                        Info.Width,
-                        Info.Height,
+                        width,
+                        height,
                         Info.Depth,
                         true);
                     break;
@@ -109,8 +115,8 @@ namespace Ryujinx.Graphics.OpenGL.Image
                         TextureTarget3d.Texture3D,
                         Info.Levels,
                         internalFormat,
-                        Info.Width,
-                        Info.Height,
+                        width,
+                        height,
                         Info.Depth);
                     break;
 
@@ -119,8 +125,8 @@ namespace Ryujinx.Graphics.OpenGL.Image
                         TextureTarget2d.TextureCubeMap,
                         Info.Levels,
                         internalFormat,
-                        Info.Width,
-                        Info.Height);
+                        width,
+                        height);
                     break;
 
                 case Target.CubemapArray:
@@ -128,8 +134,8 @@ namespace Ryujinx.Graphics.OpenGL.Image
                         (TextureTarget3d)All.TextureCubeMapArray,
                         Info.Levels,
                         internalFormat,
-                        Info.Width,
-                        Info.Height,
+                        width,
+                        height,
                         Info.Depth);
                     break;
 

--- a/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
             TextureStorage    parent,
             TextureCreateInfo info,
             int               firstLayer,
-            int               firstLevel) : base(info)
+            int               firstLevel) : base(info, parent.ScaleFactor)
         {
             _renderer = renderer;
             _parent   = parent;
@@ -101,7 +101,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
                 // So we emulate that here with a texture copy (see the first CopyTo overload).
                 // However right now it only does a single copy right after the view is created,
                 // so it doesn't work for all cases.
-                TextureView emulatedView = (TextureView)_renderer.CreateTexture(info);
+                TextureView emulatedView = (TextureView)_renderer.CreateTexture(info, ScaleFactor);
 
                 emulatedView._emulatedViewParent = this;
 
@@ -122,10 +122,10 @@ namespace Ryujinx.Graphics.OpenGL.Image
             {
                 if (_incompatibleFormatView == null)
                 {
-                    _incompatibleFormatView = (TextureView)_renderer.CreateTexture(Info);
+                    _incompatibleFormatView = (TextureView)_renderer.CreateTexture(Info, ScaleFactor);
                 }
 
-                TextureCopyUnscaled.Copy(_parent.Info, _incompatibleFormatView.Info, _parent.Handle, _incompatibleFormatView.Handle, FirstLayer, 0, FirstLevel, 0);
+                TextureCopyUnscaled.Copy(_parent.Info, _incompatibleFormatView.Info, _parent.Handle, _incompatibleFormatView.Handle, FirstLayer, 0, FirstLevel, 0, ScaleFactor);
 
                 return _incompatibleFormatView.Handle;
             }
@@ -137,7 +137,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
         {
             if (_incompatibleFormatView != null)
             {
-                TextureCopyUnscaled.Copy(_incompatibleFormatView.Info, _parent.Info, _incompatibleFormatView.Handle, _parent.Handle, 0, FirstLayer, 0, FirstLevel);
+                TextureCopyUnscaled.Copy(_incompatibleFormatView.Info, _parent.Info, _incompatibleFormatView.Handle, _parent.Handle, 0, FirstLayer, 0, FirstLevel, ScaleFactor);
             }
         }
 
@@ -145,7 +145,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
         {
             TextureView destinationView = (TextureView)destination;
 
-            TextureCopyUnscaled.Copy(Info, destinationView.Info, Handle, destinationView.Handle, 0, firstLayer, 0, firstLevel);
+            TextureCopyUnscaled.Copy(Info, destinationView.Info, Handle, destinationView.Handle, 0, firstLayer, 0, firstLevel, ScaleFactor);
 
             if (destinationView._emulatedViewParent != null)
             {
@@ -157,7 +157,8 @@ namespace Ryujinx.Graphics.OpenGL.Image
                     0,
                     destinationView.FirstLayer,
                     0,
-                    destinationView.FirstLevel);
+                    destinationView.FirstLevel,
+                    ScaleFactor);
             }
         }
 

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -31,6 +31,8 @@ namespace Ryujinx.Graphics.OpenGL
         private int _boundDrawFramebuffer;
         private int _boundReadFramebuffer;
 
+        private float _renderScale = 1f;
+
         private TextureBase _unit0Texture;
 
         private ClipOrigin _clipOrigin;
@@ -685,6 +687,7 @@ namespace Ryujinx.Graphics.OpenGL
         {
             _program = (Program)program;
             _program.Bind();
+            SetRenderScale(_renderScale);
         }
 
         public void SetRasterizerDiscard(bool discard)
@@ -699,6 +702,15 @@ namespace Ryujinx.Graphics.OpenGL
             }
 
             _rasterizerDiscard = discard;
+        }
+
+        public void SetRenderScale(float scale)
+        {
+            _renderScale = scale;
+            if (_program != null && _program.RenderScaleUniform != -1)
+            {
+                GL.Uniform1(_program.RenderScaleUniform, scale);
+            }
         }
 
         public void SetRenderTargetColorMasks(ReadOnlySpan<uint> componentMasks)

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -34,6 +34,8 @@ namespace Ryujinx.Graphics.OpenGL
         private float[] _renderScale = new float[33];
 
         private TextureBase _unit0Texture;
+        private TextureBase _rtColor0Texture;
+        private TextureBase _rtDepthTexture;
 
         private ClipOrigin _clipOrigin;
         private ClipDepthMode _clipDepthMode;
@@ -732,6 +734,9 @@ namespace Ryujinx.Graphics.OpenGL
         {
             EnsureFramebuffer();
 
+            _rtColor0Texture = (TextureBase)colors[0];
+            _rtDepthTexture = (TextureBase)depthStencil;
+
             for (int index = 0; index < colors.Length; index++)
             {
                 TextureView color = (TextureView)colors[index];
@@ -849,14 +854,14 @@ namespace Ryujinx.Graphics.OpenGL
                     // Only update and send sampled texture scales if the shader uses them.
                     bool interpolate = false;
                     float scale = texture.ScaleFactor;
+
                     if (scale != 1)
                     {
-                        int unscaledWidth = (int)(texture.Width / texture.ScaleFactor);
-                        int unscaledHeight = (int)(texture.Height / texture.ScaleFactor);
+                        TextureBase activeTarget = _rtColor0Texture ?? _rtDepthTexture;
 
-                        if ((unscaledWidth == 1920 && unscaledHeight == 1080) || (unscaledWidth == 1280 && unscaledHeight == 720))
+                        if (activeTarget.Width / (float)texture.Width == activeTarget.Height / (float)texture.Height)
                         {
-                            // If the texture's size matches the viewport size, enable interpolation using gl_FragCoord. (helps "invent" new integer values between scaled pixels)
+                            // If the texture's size is a multiple of the sampler size, enable interpolation using gl_FragCoord. (helps "invent" new integer values between scaled pixels)
                             interpolate = true;
                         }
                     }

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -859,7 +859,7 @@ namespace Ryujinx.Graphics.OpenGL
                     {
                         TextureBase activeTarget = _rtColor0Texture ?? _rtDepthTexture;
 
-                        if (activeTarget.Width / (float)texture.Width == activeTarget.Height / (float)texture.Height)
+                        if (activeTarget != null && activeTarget.Width / (float)texture.Width == activeTarget.Height / (float)texture.Height)
                         {
                             // If the texture's size is a multiple of the sampler size, enable interpolation using gl_FragCoord. (helps "invent" new integer values between scaled pixels)
                             interpolate = true;

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -717,7 +717,7 @@ namespace Ryujinx.Graphics.OpenGL
         {
             _fpRenderScale[0] = scale;
 
-            if (_program != null && _program.FragmentRenderScaleUniform != 1)
+            if (_program != null && _program.FragmentRenderScaleUniform != -1)
             {
                 GL.Uniform1(_program.FragmentRenderScaleUniform, 1, _fpRenderScale); // Just the first element.
             }
@@ -857,7 +857,7 @@ namespace Ryujinx.Graphics.OpenGL
                 switch (stage)
                 {
                     case ShaderStage.Fragment:
-                        if (_program.FragmentRenderScaleUniform != 0)
+                        if (_program.FragmentRenderScaleUniform != -1)
                         {
                             // Only update and send sampled texture scales if the shader uses them.
                             bool interpolate = false;
@@ -1153,14 +1153,14 @@ namespace Ryujinx.Graphics.OpenGL
                 switch (stage)
                 {
                     case ShaderStage.Fragment:
-                        if (_program.FragmentRenderScaleUniform != 1)
+                        if (_program.FragmentRenderScaleUniform != -1)
                         {
                             GL.Uniform1(_program.FragmentRenderScaleUniform, textureCount + 1, _fpRenderScale);
                         }
                         break;
 
                     case ShaderStage.Compute:
-                        if (_program.ComputeRenderScaleUniform != 1)
+                        if (_program.ComputeRenderScaleUniform != -1)
                         {
                             GL.Uniform1(_program.ComputeRenderScaleUniform, textureCount, _cpRenderScale);
                         }

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -64,6 +64,11 @@ namespace Ryujinx.Graphics.OpenGL
             {
                 _fpRenderScale[index] = 1f;
             }
+
+            for (int index = 0; index < _cpRenderScale.Length; index++)
+            {
+                _cpRenderScale[index] = 1f;
+            }
         }
 
         public void Barrier()

--- a/Ryujinx.Graphics.OpenGL/Program.cs
+++ b/Ryujinx.Graphics.OpenGL/Program.cs
@@ -21,7 +21,8 @@ namespace Ryujinx.Graphics.OpenGL
 
         public int Handle { get; private set; }
 
-        public int RenderScaleUniform { get; }
+        public int FragmentRenderScaleUniform { get; }
+        public int ComputeRenderScaleUniform { get; }
 
         public bool IsLinked { get; private set; }
 
@@ -165,7 +166,8 @@ namespace Ryujinx.Graphics.OpenGL
                 }
             }
 
-            RenderScaleUniform = GL.GetUniformLocation(Handle, "renderScale");
+            FragmentRenderScaleUniform = GL.GetUniformLocation(Handle, "fp_renderScale");
+            ComputeRenderScaleUniform = GL.GetUniformLocation(Handle, "cp_renderScale");
         }
 
         public void Bind()

--- a/Ryujinx.Graphics.OpenGL/Program.cs
+++ b/Ryujinx.Graphics.OpenGL/Program.cs
@@ -21,6 +21,8 @@ namespace Ryujinx.Graphics.OpenGL
 
         public int Handle { get; private set; }
 
+        public int RenderScaleUniform { get; }
+
         public bool IsLinked { get; private set; }
 
         private int[] _ubBindingPoints;
@@ -162,6 +164,8 @@ namespace Ryujinx.Graphics.OpenGL
                     imageUnit++;
                 }
             }
+
+            RenderScaleUniform = GL.GetUniformLocation(Handle, "renderScale");
         }
 
         public void Bind()

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -54,9 +54,9 @@ namespace Ryujinx.Graphics.OpenGL
             return new Sampler(info);
         }
 
-        public ITexture CreateTexture(TextureCreateInfo info)
+        public ITexture CreateTexture(TextureCreateInfo info, float scaleFactor)
         {
-            return info.Target == Target.TextureBuffer ? new TextureBuffer(info) : new TextureStorage(this, info).CreateDefaultView();
+            return info.Target == Target.TextureBuffer ? new TextureBuffer(info) : new TextureStorage(this, info, scaleFactor).CreateDefaultView();
         }
 
         public void DeleteBuffer(BufferHandle buffer)

--- a/Ryujinx.Graphics.OpenGL/Window.cs
+++ b/Ryujinx.Graphics.OpenGL/Window.cs
@@ -65,11 +65,12 @@ namespace Ryujinx.Graphics.OpenGL
             GL.Clear(ClearBufferMask.ColorBufferBit);
 
             int srcX0, srcX1, srcY0, srcY1;
+            float scale = view.ScaleFactor;
 
             if (crop.Left == 0 && crop.Right == 0)
             {
                 srcX0 = 0;
-                srcX1 = view.Width;
+                srcX1 = (int)(view.Width / scale);
             }
             else
             {
@@ -80,12 +81,20 @@ namespace Ryujinx.Graphics.OpenGL
             if (crop.Top == 0 && crop.Bottom == 0)
             {
                 srcY0 = 0;
-                srcY1 = view.Height;
+                srcY1 = (int)(view.Height / scale);
             }
             else
             {
                 srcY0 = crop.Top;
                 srcY1 = crop.Bottom;
+            }
+
+            if (scale != 1f)
+            {
+                srcX0 = (int)(srcX0 * scale);
+                srcY0 = (int)(srcY0 * scale);
+                srcX1 = (int)Math.Ceiling(srcX1 * scale);
+                srcY1 = (int)Math.Ceiling(srcY1 * scale);
             }
 
             float ratioX = MathF.Min(1f, (_height * (float)NativeWidth)  / ((float)NativeHeight * _width));

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/CodeGenContext.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/CodeGenContext.cs
@@ -1,3 +1,5 @@
+using Ryujinx.Graphics.Shader.IntermediateRepresentation;
+using Ryujinx.Graphics.Shader.StructuredIr;
 using Ryujinx.Graphics.Shader.Translation;
 using System.Collections.Generic;
 using System.Text;
@@ -73,6 +75,21 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
             UpdateIndentation();
 
             AppendLine("}" + suffix);
+        }
+
+        public int FindTextureDescriptorIndex(AstTextureOperation texOp)
+        {
+            AstOperand operand = texOp.GetSource(0) as AstOperand;
+            bool bindless = (texOp.Flags & TextureFlags.Bindless) > 0;
+
+            int cBufSlot = bindless ? operand.CbufSlot : 0;
+            int cBufOffset = bindless ? operand.CbufOffset : 0;
+
+            return TextureDescriptors.FindIndex(descriptor => 
+                descriptor.Type == texOp.Type && 
+                descriptor.HandleIndex == texOp.Handle && 
+                descriptor.CbufSlot == cBufSlot &&
+                descriptor.CbufOffset == cBufOffset);
         }
 
         private void UpdateIndentation()

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
@@ -229,7 +229,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
         private static bool DeclareRenderScale(CodeGenContext context)
         {
-            if ((context.Config.UsedFeatures & (FeatureFlags.FragCoordXY | FeatureFlags.IntegerSampling)) > 0)
+            if ((context.Config.UsedFeatures & (FeatureFlags.FragCoordXY | FeatureFlags.IntegerSampling)) != 0)
             {
                 string stage = OperandManager.GetShaderStagePrefix(context.Config.Stage);
 

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
@@ -86,6 +86,13 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
                 context.AppendLine();
             }
 
+            if (context.Config.Stage == ShaderStage.Fragment)
+            {
+                DeclareRenderScale(context);
+
+                context.AppendLine();
+            }
+
             if (info.SBuffers.Count != 0)
             {
                 DeclareStorages(context, info);
@@ -217,6 +224,11 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
                 context.LeaveScope(";");
             }
+        }
+
+        private static void DeclareRenderScale(CodeGenContext context)
+        {
+            context.AppendLine("uniform float renderScale = 1.0;");
         }
 
         private static void DeclareStorages(CodeGenContext context, StructuredProgramInfo info)

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
@@ -237,7 +237,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
                 
                 if (context.Config.Stage == ShaderStage.Fragment)
                 {
-                    scaleElements += 1; // Also includes render target scale, for gl_FragCoord.
+                    scaleElements++; // Also includes render target scale, for gl_FragCoord.
                 }
 
                 context.AppendLine($"uniform float {stage}_renderScale[{scaleElements}];");

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale.glsl
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale.glsl
@@ -1,0 +1,11 @@
+﻿ivec2 Helper_TexelFetchScale(ivec2 inputVec, int samplerIndex) {
+    float scale = renderScale[1 + samplerIndex];
+    if (scale == 1.0) {
+        return inputVec;
+    }
+    if (scale < 0.0) { // If less than 0, try interpolate between texels by using the screen position.
+        return ivec2(vec2(inputVec) * (-scale) + mod(gl_FragCoord.xy, -scale));
+    } else {
+        return ivec2(vec2(inputVec) * scale);
+    }
+}

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_cp.glsl
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_cp.glsl
@@ -1,0 +1,7 @@
+﻿ivec2 Helper_TexelFetchScale(ivec2 inputVec, int samplerIndex) {
+    float scale = cp_renderScale[samplerIndex];
+    if (scale == 1.0) {
+        return inputVec;
+    }
+    return ivec2(vec2(inputVec) * scale);
+}

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_fp.glsl
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_fp.glsl
@@ -1,5 +1,5 @@
 ﻿ivec2 Helper_TexelFetchScale(ivec2 inputVec, int samplerIndex) {
-    float scale = renderScale[1 + samplerIndex];
+    float scale = fp_renderScale[1 + samplerIndex];
     if (scale == 1.0) {
         return inputVec;
     }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
@@ -390,7 +390,18 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
                 }
             }
 
-            Append(AssemblePVector(pCount));
+            string ApplyScaling(string vector)
+            {
+                if (intCoords && context.Config.Stage == ShaderStage.Fragment && (texOp.Flags & TextureFlags.Bindless) == 0 && texOp.Type != SamplerType.Indexed && pCount == 2)
+                {
+                    int index = context.TextureDescriptors.FindIndex(descriptor => descriptor.HandleIndex == texOp.Handle);
+                    return "texelFetchScale(" + vector + ", " + index + ")";
+                }
+
+                return vector;
+            }
+
+            Append(ApplyScaling(AssemblePVector(pCount)));
 
             string AssembleDerivativesVector(int count)
             {

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
@@ -396,7 +396,10 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
                 {
                     int index = context.FindTextureDescriptorIndex(texOp);
 
-                    if (context.Config.Stage == ShaderStage.Fragment && (texOp.Flags & TextureFlags.Bindless) == 0 && texOp.Type != SamplerType.Indexed && pCount == 2)
+                    if ((context.Config.Stage == ShaderStage.Fragment || context.Config.Stage == ShaderStage.Compute) &&
+                        (texOp.Flags & TextureFlags.Bindless) == 0 &&
+                        texOp.Type != SamplerType.Indexed &&
+                        pCount == 2)
                     {
                         return "Helper_TexelFetchScale(" + vector + ", " + index + ")";
                     }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
@@ -185,8 +185,8 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
                     {
                         switch (value & ~3)
                         {
-                            case AttributeConsts.PositionX: return "(gl_FragCoord.x / renderScale[0])";
-                            case AttributeConsts.PositionY: return "(gl_FragCoord.y / renderScale[0])";
+                            case AttributeConsts.PositionX: return "(gl_FragCoord.x / fp_renderScale[0])";
+                            case AttributeConsts.PositionY: return "(gl_FragCoord.y / fp_renderScale[0])";
                             case AttributeConsts.PositionZ: return "gl_FragCoord.z";
                             case AttributeConsts.PositionW: return "gl_FragCoord.w";
                         }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
@@ -185,8 +185,8 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
                     {
                         switch (value & ~3)
                         {
-                            case AttributeConsts.PositionX: return "(gl_FragCoord.x / renderScale)";
-                            case AttributeConsts.PositionY: return "(gl_FragCoord.y / renderScale)";
+                            case AttributeConsts.PositionX: return "(gl_FragCoord.x / renderScale[0])";
+                            case AttributeConsts.PositionY: return "(gl_FragCoord.y / renderScale[0])";
                             case AttributeConsts.PositionZ: return "gl_FragCoord.z";
                             case AttributeConsts.PositionW: return "gl_FragCoord.w";
                         }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
@@ -185,8 +185,8 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
                     {
                         switch (value & ~3)
                         {
-                            case AttributeConsts.PositionX: return "gl_FragCoord.x";
-                            case AttributeConsts.PositionY: return "gl_FragCoord.y";
+                            case AttributeConsts.PositionX: return "(gl_FragCoord.x / renderScale)";
+                            case AttributeConsts.PositionY: return "(gl_FragCoord.y / renderScale)";
                             case AttributeConsts.PositionZ: return "gl_FragCoord.z";
                             case AttributeConsts.PositionW: return "gl_FragCoord.w";
                         }

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitMemory.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitMemory.cs
@@ -32,6 +32,8 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
                 Operand src = Attribute(op.AttributeOffset + index * 4);
 
+                context.FlagAttributeRead(src.Value);
+
                 context.Copy(Register(rd), context.LoadAttribute(src, primVertex));
             }
         }
@@ -95,6 +97,8 @@ namespace Ryujinx.Graphics.Shader.Instructions
         public static void Ipa(EmitterContext context)
         {
             OpCodeIpa op = (OpCodeIpa)context.CurrOp;
+
+            context.FlagAttributeRead(op.AttributeOffset);
 
             Operand res = Attribute(op.AttributeOffset);
 

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
@@ -283,11 +283,15 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
         public static void Tld(EmitterContext context)
         {
+            context.UsedFeatures |= FeatureFlags.IntegerSampling;
+
             EmitTextureSample(context, TextureFlags.IntCoords);
         }
 
         public static void TldB(EmitterContext context)
         {
+            context.UsedFeatures |= FeatureFlags.IntegerSampling;
+
             EmitTextureSample(context, TextureFlags.IntCoords | TextureFlags.Bindless);
         }
 
@@ -427,6 +431,8 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
                     return;
                 }
+
+                context.UsedFeatures |= FeatureFlags.IntegerSampling;
 
                 flags = ConvertTextureFlags(tldsOp.Target) | TextureFlags.IntCoords;
 

--- a/Ryujinx.Graphics.Shader/Ryujinx.Graphics.Shader.csproj
+++ b/Ryujinx.Graphics.Shader/Ryujinx.Graphics.Shader.csproj
@@ -1,6 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <None Remove="CodeGen\Glsl\HelperFunctions\TexelFetchScale.glsl" />
+  </ItemGroup>
+
+  <ItemGroup>
     <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\MultiplyHighS32.glsl" />
     <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\MultiplyHighU32.glsl" />
     <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\Shuffle.glsl" />
@@ -8,6 +12,7 @@
     <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\ShuffleUp.glsl" />
     <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\ShuffleXor.glsl" />
     <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\SwizzleAdd.glsl" />
+    <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\TexelFetchScale.glsl" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Ryujinx.Graphics.Shader/Ryujinx.Graphics.Shader.csproj
+++ b/Ryujinx.Graphics.Shader/Ryujinx.Graphics.Shader.csproj
@@ -1,11 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <None Remove="CodeGen\Glsl\HelperFunctions\TexelFetchScale_cp.glsl" />
-    <None Remove="CodeGen\Glsl\HelperFunctions\TexelFetchScale_fp.glsl" />
-  </ItemGroup>
-
-  <ItemGroup>
     <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\MultiplyHighS32.glsl" />
     <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\MultiplyHighU32.glsl" />
     <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\Shuffle.glsl" />

--- a/Ryujinx.Graphics.Shader/Ryujinx.Graphics.Shader.csproj
+++ b/Ryujinx.Graphics.Shader/Ryujinx.Graphics.Shader.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <None Remove="CodeGen\Glsl\HelperFunctions\TexelFetchScale.glsl" />
+    <None Remove="CodeGen\Glsl\HelperFunctions\TexelFetchScale_cp.glsl" />
+    <None Remove="CodeGen\Glsl\HelperFunctions\TexelFetchScale_fp.glsl" />
   </ItemGroup>
 
   <ItemGroup>
@@ -12,7 +13,8 @@
     <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\ShuffleUp.glsl" />
     <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\ShuffleXor.glsl" />
     <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\SwizzleAdd.glsl" />
-    <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\TexelFetchScale.glsl" />
+    <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\TexelFetchScale_fp.glsl" />
+    <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\TexelFetchScale_cp.glsl" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Ryujinx.Graphics.Shader/TextureDescriptor.cs
+++ b/Ryujinx.Graphics.Shader/TextureDescriptor.cs
@@ -13,6 +13,8 @@ namespace Ryujinx.Graphics.Shader
         public int CbufSlot   { get; }
         public int CbufOffset { get; }
 
+        public TextureUsageFlags Flags { get; set; }
+
         public TextureDescriptor(string name, SamplerType type, int handleIndex)
         {
             Name        = name;
@@ -23,6 +25,8 @@ namespace Ryujinx.Graphics.Shader
 
             CbufSlot   = 0;
             CbufOffset = 0;
+
+            Flags = TextureUsageFlags.None;
         }
 
         public TextureDescriptor(string name, SamplerType type, int cbufSlot, int cbufOffset)
@@ -35,6 +39,8 @@ namespace Ryujinx.Graphics.Shader
 
             CbufSlot   = cbufSlot;
             CbufOffset = cbufOffset;
+
+            Flags = TextureUsageFlags.None;
         }
     }
 }

--- a/Ryujinx.Graphics.Shader/TextureUsageFlags.cs
+++ b/Ryujinx.Graphics.Shader/TextureUsageFlags.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Ryujinx.Graphics.Shader
+{
+    [Flags]
+    public enum TextureUsageFlags
+    {
+        None = 0,
+
+        // Integer sampled textures must be noted for resolution scaling.
+        ResScaleUnsupported = 1 << 0
+    }
+}

--- a/Ryujinx.Graphics.Shader/TextureUsageFlags.cs
+++ b/Ryujinx.Graphics.Shader/TextureUsageFlags.cs
@@ -2,6 +2,9 @@
 
 namespace Ryujinx.Graphics.Shader
 {
+    /// <summary>
+    /// Flags that indicate how a texture will be used in a shader.
+    /// </summary>
     [Flags]
     public enum TextureUsageFlags
     {

--- a/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -11,6 +11,8 @@ namespace Ryujinx.Graphics.Shader.Translation
         public Block  CurrBlock { get; set; }
         public OpCode CurrOp    { get; set; }
 
+        public FeatureFlags UsedFeatures { get; set; }
+
         public ShaderConfig Config { get; }
 
         private List<Operation> _operations;
@@ -38,6 +40,20 @@ namespace Ryujinx.Graphics.Shader.Translation
         public void Add(Operation operation)
         {
             _operations.Add(operation);
+        }
+
+        public void FlagAttributeRead(int attribute)
+        {
+            if (Config.Stage == ShaderStage.Fragment)
+            {
+                switch (attribute)
+                {
+                    case AttributeConsts.PositionX:
+                    case AttributeConsts.PositionY:
+                        UsedFeatures |= FeatureFlags.FragCoordXY;
+                        break;
+                }
+            }
         }
 
         public void MarkLabel(Operand label)

--- a/Ryujinx.Graphics.Shader/Translation/FeatureFlags.cs
+++ b/Ryujinx.Graphics.Shader/Translation/FeatureFlags.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Ryujinx.Graphics.Shader.Translation
+{
+    /// <summary>
+    /// Features used by the shader that are important for the code generator to know in advance.
+    /// These typically change the declarations in the shader header.
+    /// </summary>
+    [Flags]
+    public enum FeatureFlags
+    {
+        None            = 0,
+
+        // Affected by resolution scaling.
+        FragCoordXY     = 1 << 1,
+        IntegerSampling = 1 << 0
+    }
+}

--- a/Ryujinx.Graphics.Shader/Translation/FeatureFlags.cs
+++ b/Ryujinx.Graphics.Shader/Translation/FeatureFlags.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Graphics.Shader.Translation
     [Flags]
     public enum FeatureFlags
     {
-        None            = 0,
+        None = 0,
 
         // Affected by resolution scaling.
         FragCoordXY     = 1 << 1,

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -22,6 +22,8 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public TranslationFlags Flags { get; }
 
+        public FeatureFlags UsedFeatures { get; set; }
+
         public ShaderConfig(IGpuAccessor gpuAccessor, TranslationFlags flags)
         {
             Stage             = ShaderStage.Compute;
@@ -34,6 +36,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             OmapDepth         = false;
             GpuAccessor       = gpuAccessor;
             Flags             = flags;
+            UsedFeatures      = FeatureFlags.None;
         }
 
         public ShaderConfig(ShaderHeader header, IGpuAccessor gpuAccessor, TranslationFlags flags)
@@ -48,6 +51,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             OmapDepth         = header.OmapDepth;
             GpuAccessor       = gpuAccessor;
             Flags             = flags;
+            UsedFeatures      = FeatureFlags.None;
         }
 
         public int GetDepthRegister()

--- a/Ryujinx/Config.json
+++ b/Ryujinx/Config.json
@@ -1,5 +1,7 @@
 {
   "version": 11,
+  "res_scale": 2,
+  "res_scale_custom": 1,
   "max_anisotropy": -1,
   "graphics_shaders_dump_path": "",
   "logging_enable_debug": false,

--- a/Ryujinx/Config.json
+++ b/Ryujinx/Config.json
@@ -1,5 +1,5 @@
 {
-  "version": 10,
+  "version": 11,
   "max_anisotropy": -1,
   "graphics_shaders_dump_path": "",
   "logging_enable_debug": false,

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -328,6 +328,11 @@ namespace Ryujinx.Ui
                 }
 
                 string dockedMode = ConfigurationState.Instance.System.EnableDockedMode ? "Docked" : "Handheld";
+                float scale = Graphics.Gpu.GraphicsConfig.ResScale;
+                if (scale != 1)
+                {
+                    dockedMode += $" ({scale}x)";
+                }
 
                 if (_ticks >= _ticksPerFrame)
                 {

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -390,9 +390,7 @@ namespace Ryujinx.Ui
 
                 HLE.Switch device = InitializeSwitchInstance();
 
-                // TODO: Move this somewhere else + reloadable?
-                Graphics.Gpu.GraphicsConfig.MaxAnisotropy   = ConfigurationState.Instance.Graphics.MaxAnisotropy;
-                Graphics.Gpu.GraphicsConfig.ShadersDumpPath = ConfigurationState.Instance.Graphics.ShadersDumpPath;
+                UpdateGraphicsConfig();
 
                 Logger.PrintInfo(LogClass.Application, $"Using Firmware Version: {_contentManager.GetCurrentFirmwareVersion()?.VersionString}");
 
@@ -603,6 +601,15 @@ namespace Ryujinx.Ui
                     appMetadata.TimePlayed += Math.Round(sessionTimePlayed, MidpointRounding.AwayFromZero);
                 });
             }
+        }
+
+        public static void UpdateGraphicsConfig()
+        {
+            int resScale = ConfigurationState.Instance.Graphics.ResScale;
+            float resScaleCustom = ConfigurationState.Instance.Graphics.ResScaleCustom;
+            Graphics.Gpu.GraphicsConfig.ResScale = (resScale == -1) ? resScaleCustom : resScale;
+            Graphics.Gpu.GraphicsConfig.MaxAnisotropy = ConfigurationState.Instance.Graphics.MaxAnisotropy;
+            Graphics.Gpu.GraphicsConfig.ShadersDumpPath = ConfigurationState.Instance.Graphics.ShadersDumpPath;
         }
 
         public static void SaveConfig()

--- a/Ryujinx/Ui/SettingsWindow.cs
+++ b/Ryujinx/Ui/SettingsWindow.cs
@@ -63,6 +63,8 @@ namespace Ryujinx.Ui
         [GUI] Entry        _addGameDirBox;
         [GUI] Entry        _graphicsShadersDumpPath;
         [GUI] ComboBoxText _anisotropy;
+        [GUI] ComboBoxText _resScaleCombo;
+        [GUI] Entry        _resScaleText;
         [GUI] ToggleButton _configureController1;
         [GUI] ToggleButton _configureController2;
         [GUI] ToggleButton _configureController3;
@@ -94,6 +96,8 @@ namespace Ryujinx.Ui
             _configureController7.Pressed += (sender, args) => ConfigureController_Pressed(sender, args, PlayerIndex.Player7);
             _configureController8.Pressed += (sender, args) => ConfigureController_Pressed(sender, args, PlayerIndex.Player8);
             _configureControllerH.Pressed += (sender, args) => ConfigureController_Pressed(sender, args, PlayerIndex.Handheld);
+
+            _resScaleCombo.Changed += (sender, args) => _resScaleText.Visible = _resScaleCombo.ActiveId == "-1";
 
             //Setup Currents
             if (ConfigurationState.Instance.Logger.EnableFileLog)
@@ -204,9 +208,12 @@ namespace Ryujinx.Ui
             _systemRegionSelect.SetActiveId(ConfigurationState.Instance.System.Region.Value.ToString());
             _audioBackendSelect.SetActiveId(ConfigurationState.Instance.System.AudioBackend.Value.ToString());
             _systemTimeZoneSelect.SetActiveId(timeZoneContentManager.SanityCheckDeviceLocationName());
+            _resScaleCombo.SetActiveId(ConfigurationState.Instance.Graphics.ResScale.Value.ToString());
             _anisotropy.SetActiveId(ConfigurationState.Instance.Graphics.MaxAnisotropy.Value.ToString());
 
             _custThemePath.Buffer.Text           = ConfigurationState.Instance.Ui.CustomThemePath;
+            _resScaleText.Buffer.Text            = ConfigurationState.Instance.Graphics.ResScaleCustom.Value.ToString();
+            _resScaleText.Visible                = _resScaleCombo.ActiveId == "-1";
             _graphicsShadersDumpPath.Buffer.Text = ConfigurationState.Instance.Graphics.ShadersDumpPath;
             _fsLogSpinAdjustment.Value           = ConfigurationState.Instance.System.FsGlobalAccessLogMode;
             _systemTimeOffset                    = ConfigurationState.Instance.System.SystemTimeOffset;
@@ -408,6 +415,12 @@ namespace Ryujinx.Ui
                 _gameDirsBoxStore.IterNext(ref treeIter);
             }
 
+            float resScaleCustom;
+            if (!float.TryParse(_resScaleText.Buffer.Text, out resScaleCustom) || resScaleCustom <= 0.0f)
+            {
+                resScaleCustom = 1.0f;
+            }
+
             ConfigurationState.Instance.Logger.EnableError.Value               = _errorLogToggle.Active;
             ConfigurationState.Instance.Logger.EnableWarn.Value                = _warningLogToggle.Active;
             ConfigurationState.Instance.Logger.EnableInfo.Value                = _infoLogToggle.Active;
@@ -435,8 +448,11 @@ namespace Ryujinx.Ui
             ConfigurationState.Instance.Ui.GameDirs.Value                      = gameDirs;
             ConfigurationState.Instance.System.FsGlobalAccessLogMode.Value     = (int)_fsLogSpinAdjustment.Value;
             ConfigurationState.Instance.Graphics.MaxAnisotropy.Value           = float.Parse(_anisotropy.ActiveId);
+            ConfigurationState.Instance.Graphics.ResScale.Value                = int.Parse(_resScaleCombo.ActiveId);
+            ConfigurationState.Instance.Graphics.ResScaleCustom.Value          = resScaleCustom;
 
             MainWindow.SaveConfig();
+            MainWindow.UpdateGraphicsConfig();
             MainWindow.ApplyTheme();
             Dispose();
         }

--- a/Ryujinx/Ui/SettingsWindow.glade
+++ b/Ryujinx/Ui/SettingsWindow.glade
@@ -1687,6 +1687,70 @@
                                       <object class="GtkLabel">
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
+                                        <property name="tooltip_text" translatable="yes">Resolution Scale applied to applicable render targets.</property>
+                                        <property name="label" translatable="yes">Resolution Scale:</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="padding">5</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBoxText" id="_resScaleCombo">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="tooltip_text" translatable="yes">Resolution Scale applied to applicable render targets.</property>
+                                        <property name="active_id">1</property>
+                                        <items>
+                                          <item id="1" translatable="yes">Native (720p/1080p)</item>
+                                          <item id="2" translatable="yes">2x (1440p/2160p)</item>
+                                          <item id="3" translatable="yes">3x (2160p/3240p)</item>
+                                          <item id="4" translatable="yes">4x (2880p/4320p)</item>
+                                          <item id="-1" translatable="yes">Custom (not recommended)</item>
+                                        </items>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkEntry" id="_resScaleText">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="tooltip_text" translatable="yes">Floating point resolution scale, such as 1.5. Non-integral scales are more likely to cause issues or crash.</property>
+                                        <property name="valign">center</property>
+                                        <property name="caps_lock_warning">False</property>
+                                        <property name="placeholder-text">1.0</property>
+                                        <property name="input-purpose">GTK_INPUT_PURPOSE_NUMBER</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">5</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_top">5</property>
+                                    <property name="margin_bottom">5</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
                                         <property name="tooltip_text" translatable="yes">Level of Anisotropic Filtering (set to Auto to use the value requested by the game)</property>
                                         <property name="label" translatable="yes">Anisotropic Filtering:</property>
                                       </object>
@@ -1722,7 +1786,7 @@
                                     <property name="expand">False</property>
                                     <property name="fill">True</property>
                                     <property name="padding">5</property>
-                                    <property name="position">0</property>
+                                    <property name="position">1</property>
                                   </packing>
                                 </child>
                               </object>

--- a/Ryujinx/_schema.json
+++ b/Ryujinx/_schema.json
@@ -700,6 +700,27 @@
     }
   },
   "properties": {
+    "res_scale": {
+      "$id": "#/properties/res_scale",
+      "type": "integer",
+      "title": "Resolution Scale",
+      "description": "An integer scale applied to applicable render targets. Values 1-4, or -1 to use a custom floating point scale instead.",
+      "default": -1,
+      "examples": [
+        -1,
+        1,
+        2,
+        3,
+        4
+      ]
+    },
+    "res_scale_custom": {
+      "$id": "#/properties/res_scale_custom",
+      "type": "number",
+      "title": "Custom Resolution Scale",
+      "description": "A custom floating point scale applied to applicable render targets. Only active when Resolution Scale is -1.",
+      "default": 1.0,
+    },
     "max_anisotropy": {
       "$id": "#/properties/max_anisotropy",
       "type": "integer",
@@ -1211,7 +1232,7 @@
             "button_sr": "Unbound"
           }
         }
-      ] 
+      ]
     },
     "controller_config": {
       "$id": "#/properties/controller_config",


### PR DESCRIPTION
![sand](https://user-images.githubusercontent.com/6294155/86522441-b5cf9800-be55-11ea-9c25-bc569f917e16.jpg)
Click for a surprise.

# A note to the users

If you're using a **1080p screen**, I recommend **2x scaling** (don't go above, you will lose super sampling). For **4K**, I recommend **2x or greater** - though you should only go higher when your GPU can definitely handle it. Remember, 4x (8K) is _16x the switch's pixel count!_

All of this is very much a work in progress and will improve over time. In cases where the scaling fails, your game will likely just run at 1x. If your game has some weird issue when scaled up ~(like LM3's black screen)~ _(fixed!)_, then try booting with native res and switching when ingame - it may work. Make sure to point out edge cases so that they can be fixed in future!

If your target game has a form of anti aliasing, you probably want to make a mod to disable it so you can get the raw upscaled resolution.

# Zero-Configuration Resolution Scaling

This PR introduces a feature and configuration option that lets you scale compatible render targets in a game using a single multiplier value, which you can set via a combo list from 1x to 4x... or if you're feeling brave, any floating point number.

The goal is to scale shadows and screen-bound render targets using the scaling factor.

![image](https://user-images.githubusercontent.com/6294155/86523088-17483480-be5f-11ea-8738-1fcceb185237.png)
![4a3cac36fadba7d4943ec79d1e9bb55d](https://user-images.githubusercontent.com/6294155/86523096-3646c680-be5f-11ea-8ac4-b00028c98b10.gif)
https://gyazo.com/4a3cac36fadba7d4943ec79d1e9bb55d

You can change this value while emulation is running to get a feel for how it affects game graphics and performance. The changes are applied instantly, so have fun with it.

## Method
Block chain AI machine learning on the cloud. Just kidding, it's really simple.

Any Texture2D or Texture2DArray format texture is immediately _eligible_ for scaling. When the texture is taken as a render target and it is still eligible (or its first request is as a render target), its host texture is copied to a new one with the configured scale.

Textures have a variety of ways they can become _blacklisted_ from scaling. Any texture that is not of the two formats specified above is immediately blacklisted, and any texture that is a view of a blacklisted texture will also become blacklisted itself. 

Since textures can become views of each other _after_ they are created, this means that a texture could be scaled before it becomes a view. Textures that are modified on the CPU memory after their creation or flushed back to it also become blacklisted before promising the change. When a texture is blacklisted _after_ it is scaled, it is copied back to a host texture with 1x scale. If this happens to a view, its parent will be scaled to 1x and _all views_ will be recreated and blacklisted.

When rendering to a texture, we need to make sure that the scales of all bound targets are equal. To facilitate this, all eligible targets are scaled, we ensure that all _scaled targets_ match the scale in the configuration (that can be changed at runtime, mind), and if one target is blacklisted, then all of them are. This scale is used for a few things:

- Scaling all Viewports
- Scaling all Scissor Rectangles
- Sent to the Fragment Shader (fp_renderScale[0])

When using a scaled texture in a shader, thankfully there are only a few cases in which the scale of the texture can negatively affect anything:

- `gl_FragCoord.xy`: This is in screen space. As in, it is measured in pixels. If we render to a larger target, the values returned by this will be multiplied by the scaling factor, whereas the shaders that the game uses will be expecting the original, unmodified scale. To solve this problem, simply divide by the scaling factor `(fp_renderScale[0])`. Problem solved.
- `texelFetch`: This method of sampling a texture samples using an integer vector. The unit is pixels. Repeat what I said above, but this time we need scaling factors for _each texture passed to the shader_. The texture descriptor index is used to index the renderScale array, which contains scales for bound textures starting at index 1.
  - There are cases where we don't currently allow scaling for shaders that use this feature. See below for details.

## Related Gpu Changes
A few changes were put into place to facilitate this change, and a few others that I'm planning or could be useful in the future. There were also a few texture related bugs that I ran into when ensuring runtime switching worked as intended.

- Fixed a bug where scaled copy's source/destination region would be affected by targets previously bound to the copy framebuffers (eg. an old depth stencil was active during a future copy of a colour texture of different size). Now, they unset their texture after the copy.
- Fixed a bug where transforming a texture to a view after its creation would not set its `_firstLayer`, `_firstLevel` information.
- Added `FeatureFlags` to the IR stage of translation, for consumption in the CodeGenerator. These will typically be used to change the declarations used in the shader on the backend. Here, we use it to add the renderScale uniform and the TexelFetchScale helper when needed.
- Added `TextureUsageFlags` to texture descriptors, set based on how they are used in the texture, and intended for use when the texture is bound. This PR sets and uses a flag to blacklist textures that use texelFetch in unsupported situations.
- Width and Height for the host texture now reflects its scaled width and height.

## Compatibility notes
- Games that use spatially aware effects aggressively (such as Xenoblade's AO) will likely only work correctly with power of two scales (1, 2, 4) - with others they will run into unusual issues. Games that use texelFetch will run into issues in general with non integral scales. With the games I have played, these issues are few and far between.
- Games that use a form of Anti Aliasing will still _think_ they are running at 1x, and will likely blur the image. For these games (such as xenoblade... again) you should use a LayeredFS mod to remove the AA. For completeness, I have attached a mod for XC:DE to this PR.
- Scales of less than 1 can reduce texture quality on rendered textures as well. You have been warned!

## Drawbacks
While every game is technically supported, there are cases where the game will fall back to 1x on targets you might not want to, and the game might have some graphical issues in the worst case. Here's some specific information:

- Only non-indexed textures on the fragment+compute shaders are fully supported for texelFetch scaling. If a texture outside of this category uses texelFetch, the texture will be blacklisted for scaling, as described above.
- Bindless textures are not fully supported, and do not have a blacklist fallback. If they are used with texelFetch, the scale on the texture _will_ be incorrect.
- If a game uses a render target to store data (such as the output of a fragment shader DXT compression algorithm), scaling will not work correctly on it. You can only hope that it will blacklist and render the target again at a later point. This is a theory as I haven't tested any games that do this.

## Screenshots
Here are some pictures at 4K. A lot of these are taken at 4x (8K) downsampled to 4K, which results in a supersampling effect on NVIDIA. Note that you should not run at more than double your output resolution if you want a supersampling effect, so use 2x for 1080p.

[Astral Chain Comparison](https://cdn.knightlab.com/libs/juxtapose/latest/embed/index.html?uid=8b116232-bfcd-11ea-bf88-a15b6c7adf9a)
![astraljd](https://user-images.githubusercontent.com/6294155/86540105-495aa480-befa-11ea-933e-1ce8bfadf85e.jpg)
![lm3](https://user-images.githubusercontent.com/6294155/86540030-79ee0e80-bef9-11ea-847a-9650adf9357e.jpg)
**(LM3 _must_ start in 1x scaling mode, then you can change the scale from settings ingame. This is being investigated :) )**
![ac4x](https://user-images.githubusercontent.com/6294155/86523120-8d4c9b80-be5f-11ea-8140-36b7017b4926.jpg)
![bigjpg](https://user-images.githubusercontent.com/6294155/86523122-95a4d680-be5f-11ea-9254-8f388cab60ce.jpg)
![bokeh](https://user-images.githubusercontent.com/6294155/86523124-9d647b00-be5f-11ea-973f-983a7cb2e457.jpg)
![castle2](https://user-images.githubusercontent.com/6294155/86523127-a6ede300-be5f-11ea-9433-debd6abad71e.jpg)
![mk8](https://user-images.githubusercontent.com/6294155/86540110-4eb7ef00-befa-11ea-9a73-4d250d03fbfa.jpg)

Finally, here's the "remove aa" mod I made for Xenoblade, so you can replicate these results (need to merge `mageven`'s PR)
[XenobladeDE remove-aa.zip](https://github.com/Ryujinx/Ryujinx/files/4875408/XenobladeDE.remove-aa.zip)
