### PR TITLE
Mask shift constants on x86 backend

### DIFF
--- a/ARMeilleure/CodeGen/X86/Assembler.cs
+++ b/ARMeilleure/CodeGen/X86/Assembler.cs
@@ -882,6 +882,10 @@ namespace ARMeilleure.CodeGen.X86
 
                 source = null;
             }
+            else if (source.Kind == OperandKind.Constant)
+            {
+                source = source.With((uint)source.Value & (dest.Type == OperandType.I32 ? 0x1f : 0x3f));
+            }
 
             WriteInstruction(dest, source, type, inst);
         }

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -20,7 +20,7 @@ namespace ARMeilleure.Translation.PTC
     {
         private const string HeaderMagic = "PTChd";
 
-        private const int InternalVersion = 5; //! To be incremented manually for each change to the ARMeilleure project.
+        private const int InternalVersion = 6; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string BaseDir = "Ryujinx";
 


### PR DESCRIPTION
#1358 allows some zero extension operations to be constant folded, with this optimization, some now (considered invalid as they are >= 32/64) are now propagated to shift instructions. That was making the x86 backend throw when trying to encode such shift instructions.

Example of problematic code:
```
  i32 %2193 = ZeroExtend8 i32 0x17056D0
  i32 %2194 = CompareEqual i32 %2193, i32 0x0
  i32 %2195 = CompareGreaterOrEqual i32 %2193, i32 0x20
  i32 %2196 = ShiftLeft i32 r12, i32 %2193
  i32 %2197 = ConditionalSelect i32 %2195, i32 0x0, i32 %2196
```
After optimizations:
```
  i32 r0 = Copy i32 0x0
  i32 r0 = CompareEqual i32 r0, i32 0xD0
  i32 r1 = Copy i32 0xD0
  i32 r1 = CompareGreaterOrEqual i32 r1, i32 0x20
  i32 r8 = Copy i32 r11
  i32 r8 = ShiftLeft i32 r8, i32 0xD0
  i32 r9 = Copy i32 0x0
  i32 r8 = Copy i32 r8
  i32 r8 = ConditionalSelect i32 r1, i32 r9, i32 r8
```
The code already has check in place to put 0 on result when shift is >= 32, so in those cases the shift result doesn't matter. I decided to fix the problem by simply masking the shift value, and only keeping the lower 5 or 6 bits (depending on the destination type). Masking is also the CPU behavior when such "invalid" shift values are used.