### PR TITLE
Fix folding of ConvertI64ToI32 imm64

### DIFF
--- a/ARMeilleure/CodeGen/Optimizations/ConstantFolding.cs
+++ b/ARMeilleure/CodeGen/Optimizations/ConstantFolding.cs
@@ -81,9 +81,7 @@ namespace ARMeilleure.CodeGen.Optimizations
                 case Instruction.ConvertI64ToI32:
                     if (type == OperandType.I32)
                     {
-                        long x = operation.GetSource(0).AsInt64();
-
-                        operation.TurnIntoCopy(Const((int)x));
+                        EvaluateUnaryI32(operation, (x) => x);
                     }
                     break;
 

--- a/ARMeilleure/CodeGen/Optimizations/ConstantFolding.cs
+++ b/ARMeilleure/CodeGen/Optimizations/ConstantFolding.cs
@@ -81,7 +81,9 @@ namespace ARMeilleure.CodeGen.Optimizations
                 case Instruction.ConvertI64ToI32:
                     if (type == OperandType.I32)
                     {
-                        EvaluateUnaryI64(operation, (x) => (int)x);
+                        long x = operation.GetSource(0).AsInt64();
+
+                        operation.TurnIntoCopy(Const((int)x));
                     }
                     break;
 

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -20,7 +20,7 @@ namespace ARMeilleure.Translation.PTC
     {
         private const string HeaderMagic = "PTChd";
 
-        private const int InternalVersion = 6; //! To be incremented manually for each change to the ARMeilleure project.
+        private const int InternalVersion = 7; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string BaseDir = "Ryujinx";
 


### PR DESCRIPTION
Fixes an issue with #1359 where by the operand types can get mismatched. For example:

This
```wasm
i32 %52 = ConvertI64ToI32 i64 0x0
```
would become this
```wasm
i32 %52 = Copy i64 0x0
```
Then on the second pass of the optimizer on the block, `ConstantFolding` transforms it to
```wasm
i32 %52 = Copy i32 0x0
```

This can cause asserts in the assembler to be fired (because of src/dst type mismatch) when the optimizer does not do another pass after the folding of `ConvertI64ToI32`. This can happen when a ConvertI64ToI32 got constant folded but no copy propagation or removal of unused nodes has occurred. So `modified` remains false and the pass to retype the copies never happens.