### PR TITLE
Fix crash when loading via LoadCart (mods)

### DIFF
--- a/Ryujinx.HLE/HOS/ApplicationLoader.cs
+++ b/Ryujinx.HLE/HOS/ApplicationLoader.cs
@@ -69,6 +69,8 @@ namespace Ryujinx.HLE.HOS
 
             Npdm metaData = ReadNpdm(codeFs);
 
+            _fileSystem.ModLoader.CollectMods(TitleId, _fileSystem.GetBaseModsPath());
+
             if (TitleId != 0)
             {
                 EnsureSaveData(new TitleId(TitleId));

--- a/Ryujinx.HLE/HOS/ModLoader.cs
+++ b/Ryujinx.HLE/HOS/ModLoader.cs
@@ -451,8 +451,12 @@ namespace Ryujinx.HLE.HOS
 
         internal bool ApplyNsoPatches(ulong titleId, params IExecutable[] programs)
         {
-            AppMods.TryGetValue(titleId, out ModCache mods);
-            var nsoMods = Patches.NsoPatches.Concat(mods.ExefsDirs);
+            IEnumerable<Mod<DirectoryInfo>> nsoMods = Patches.NsoPatches;
+
+            if (AppMods.TryGetValue(titleId, out ModCache mods))
+            {
+                nsoMods = nsoMods.Concat(mods.ExefsDirs);
+            }
 
             // NSO patches are created with offset 0 according to Atmosphere's patcher module
             // But `Program` doesn't contain the header which is 0x100 bytes. So, we adjust for that here


### PR DESCRIPTION
Fixes emulator crashes due to a missed code-path for mod loading when loading unpacked games.

Thanks to @Thog for pointing this out!