### PR TITLE
Fix session service disposal and improve transfer memory implementation

### DIFF
--- a/Ryujinx.HLE/HOS/Kernel/Ipc/KClientSession.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Ipc/KClientSession.cs
@@ -2,6 +2,7 @@ using Ryujinx.HLE.HOS.Kernel.Common;
 using Ryujinx.HLE.HOS.Kernel.Process;
 using Ryujinx.HLE.HOS.Kernel.Threading;
 using Ryujinx.HLE.HOS.Services;
+using System;
 
 namespace Ryujinx.HLE.HOS.Kernel.Ipc
 {
@@ -83,6 +84,11 @@ namespace Ryujinx.HLE.HOS.Kernel.Ipc
         {
             _parent.DisconnectClient();
             _parent.DecrementReferenceCount();
+
+            if (Service is IDisposable disposableObj)
+            {
+                disposableObj.Dispose();
+            }
         }
     }
 }

--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
@@ -991,16 +991,43 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
 
             KProcess process = _context.Scheduler.GetCurrentProcess();
 
-            KernelResult result = process.MemoryManager.ReserveTransferMemory(address, size, permission);
+            KResourceLimit resourceLimit = process.ResourceLimit;
+
+            if (resourceLimit != null && !resourceLimit.Reserve(LimitableResource.TransferMemory, 1))
+            {
+                return KernelResult.ResLimitExceeded;
+            }
+
+            void CleanUpForError()
+            {
+                resourceLimit?.Release(LimitableResource.TransferMemory, 1);
+            }
+
+            if (!process.MemoryManager.InsideAddrSpace(address, size))
+            {
+                CleanUpForError();
+
+                return KernelResult.InvalidMemState;
+            }
+
+            KTransferMemory transferMemory = new KTransferMemory(_context);
+
+            KernelResult result = transferMemory.Initialize(address, size, permission);
 
             if (result != KernelResult.Success)
             {
+                CleanUpForError();
+
                 return result;
             }
 
-            KTransferMemory transferMemory = new KTransferMemory(_context, address, size);
+            resourceLimit = null;
 
-            return process.HandleTable.GenerateHandle(transferMemory, out handle);
+            result = process.HandleTable.GenerateHandle(transferMemory, out handle);
+
+            transferMemory.DecrementReferenceCount();
+
+            return result;
         }
 
         public KernelResult MapPhysicalMemory(ulong address, ulong size)
@@ -1271,29 +1298,9 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
 
         public KernelResult CloseHandle(int handle)
         {
-            KProcess process = _context.Scheduler.GetCurrentProcess();
+            KProcess currentProcess = _context.Scheduler.GetCurrentProcess();
 
-            KAutoObject obj = process.HandleTable.GetObject<KAutoObject>(handle);
-
-            process.HandleTable.CloseHandle(handle);
-
-            if (obj == null)
-            {
-                return KernelResult.InvalidHandle;
-            }
-
-            if (obj is KSession session)
-            {
-                session.Dispose();
-            }
-            else if (obj is KTransferMemory transferMemory)
-            {
-                process.MemoryManager.ResetTransferMemory(
-                    transferMemory.Address,
-                    transferMemory.Size);
-            }
-
-            return KernelResult.Success;
+            return currentProcess.HandleTable.CloseHandle(handle) ? KernelResult.Success : KernelResult.InvalidHandle;
         }
 
         public KernelResult ResetSignal(int handle)

--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
@@ -1021,8 +1021,6 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
                 return result;
             }
 
-            resourceLimit = null;
-
             result = process.HandleTable.GenerateHandle(transferMemory, out handle);
 
             transferMemory.DecrementReferenceCount();

--- a/Ryujinx.HLE/HOS/Services/Sm/IUserInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Sm/IUserInterface.cs
@@ -104,6 +104,9 @@ namespace Ryujinx.HLE.HOS.Services.Sm
                 throw new InvalidOperationException("Out of handles!");
             }
 
+            session.ServerSession.DecrementReferenceCount();
+            session.ClientSession.DecrementReferenceCount();
+
             context.Response.HandleDesc = IpcHandleDesc.MakeMove(handle);
 
             return ResultCode.Success;


### PR DESCRIPTION
- Improve implementation of `CreateTransferMemory` and `CloseHandle` syscalls. It now matches N kernel.
- Fix session services not being disposed. They are not disposed on the `Destroy` method of `KClientSession`, called when the reference count reaches 0, instead of being called on `CloseHandle` for `KSession`.
- Decrement references server/client session on SM `GetService` function. This was done to match what is done on the `CreateSession` syscall. Since we can't use the syscall on SM yet, it is necessary to replicate the behavior there.

This should not have any negative effect on games, but could potentially break something as the `CreateTransferMemory` syscall was changed, which games uses.