### PR TITLE
Do not print guest stack trace for svcBreak debug calls

### DIFF
--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
@@ -1376,9 +1376,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             }
             else
             {
-                Logger.PrintInfo(LogClass.KernelSvc, "Debugger triggered.");
-
-                currentThread.PrintGuestStackTrace();
+                Logger.PrintDebug(LogClass.KernelSvc, "Debugger triggered.");
             }
         }
 


### PR DESCRIPTION
Some games call svcBreak with the debug flag set (which is normal, probably just used for debugging). In those cases we currently print the guest stack trace. However it is not adding any value as this is not a error, plus the unwinding could slow down a bit some games that calls it constantly, and it causes issues on some games as the unwinding code is sometimes throwing. So this change removes the log.