### PR TITLE
Texture/Buffer Memory Management Improvements

### DIFF
--- a/Ryujinx.Cpu/MemoryManager.cs
+++ b/Ryujinx.Cpu/MemoryManager.cs
@@ -145,10 +145,36 @@ namespace Ryujinx.Cpu
                 return;
             }
 
+            MarkRegionAsModified(va, (ulong)data.Length);
+
+            WriteImpl(va, data);
+        }
+
+        /// <summary>
+        /// Writes data to CPU mapped memory, without tracking.
+        /// </summary>
+        /// <param name="va">Virtual address to write the data into</param>
+        /// <param name="data">Data to be written</param>
+        public void WriteUntracked(ulong va, ReadOnlySpan<byte> data)
+        {
+            if (data.Length == 0)
+            {
+                return;
+            }
+
+            WriteImpl(va, data);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        /// <summary>
+        /// Writes data to CPU mapped memory.
+        /// </summary>
+        /// <param name="va">Virtual address to write the data into</param>
+        /// <param name="data">Data to be written</param>
+        private void WriteImpl(ulong va, ReadOnlySpan<byte> data)
+        {
             try
             {
-                MarkRegionAsModified(va, (ulong)data.Length);
-
                 if (IsContiguousAndMapped(va, data.Length))
                 {
                     data.CopyTo(_backingMemory.GetSpan(GetPhysicalAddressInternal(va), data.Length));

--- a/Ryujinx.Graphics.GAL/IRenderer.cs
+++ b/Ryujinx.Graphics.GAL/IRenderer.cs
@@ -29,6 +29,8 @@ namespace Ryujinx.Graphics.GAL
 
         void UpdateCounters();
 
+        void PreFrame();
+
         ICounterEvent ReportCounter(CounterType type, EventHandler<ulong> resultHandler);
 
         void ResetCounter(CounterType type);

--- a/Ryujinx.Graphics.GAL/ITexture.cs
+++ b/Ryujinx.Graphics.GAL/ITexture.cs
@@ -17,5 +17,6 @@ namespace Ryujinx.Graphics.GAL
 
         void SetData(ReadOnlySpan<byte> data);
         void SetStorage(BufferRange buffer);
+        void Release();
     }
 }

--- a/Ryujinx.Graphics.GAL/ITexture.cs
+++ b/Ryujinx.Graphics.GAL/ITexture.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Ryujinx.Graphics.GAL
 {
-    public interface ITexture : IDisposable
+    public interface ITexture
     {
         int Width { get; }
         int Height { get; }

--- a/Ryujinx.Graphics.GAL/TextureCreateInfo.cs
+++ b/Ryujinx.Graphics.GAL/TextureCreateInfo.cs
@@ -119,7 +119,7 @@ namespace Ryujinx.Graphics.GAL
 
         public override int GetHashCode()
         {
-            return Width | (Height << 16);
+            return HashCode.Combine(Width, Height);
         }
 
         bool IEquatable<TextureCreateInfo>.Equals(TextureCreateInfo other)

--- a/Ryujinx.Graphics.GAL/TextureCreateInfo.cs
+++ b/Ryujinx.Graphics.GAL/TextureCreateInfo.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Ryujinx.Graphics.GAL
 {
-    public struct TextureCreateInfo
+    public struct TextureCreateInfo : IEquatable<TextureCreateInfo>
     {
         public int Width         { get; }
         public int Height        { get; }
@@ -115,6 +115,30 @@ namespace Ryujinx.Graphics.GAL
         private static int GetLevelSize(int size, int level)
         {
             return Math.Max(1, size >> level);
+        }
+
+        public override int GetHashCode()
+        {
+            return Width | (Height << 16);
+        }
+
+        bool IEquatable<TextureCreateInfo>.Equals(TextureCreateInfo other)
+        {
+            return Width == other.Width &&
+                   Height == other.Height &&
+                   Depth == other.Depth &&
+                   Levels == other.Levels &&
+                   Samples == other.Samples &&
+                   BlockWidth == other.BlockWidth &&
+                   BlockHeight == other.BlockHeight &&
+                   BytesPerPixel == other.BytesPerPixel &&
+                   Format == other.Format &&
+                   DepthStencilMode == other.DepthStencilMode &&
+                   Target == other.Target &&
+                   SwizzleR == other.SwizzleR &&
+                   SwizzleG == other.SwizzleG &&
+                   SwizzleB == other.SwizzleB &&
+                   SwizzleA == other.SwizzleA;
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -58,6 +58,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
             TextureManager = new TextureManager(context);
 
             context.MemoryManager.MemoryUnmapped += _counterCache.MemoryUnmappedHandler;
+            context.MemoryManager.MemoryUnmapped += TextureManager.MemoryUnmappedHandler;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
@@ -82,11 +82,11 @@ namespace Ryujinx.Graphics.Gpu.Image
             }
         }
 
-        public void Remove(Texture texture, bool flush)
+        public bool Remove(Texture texture, bool flush)
         {
             if (texture.CacheNode == null)
             {
-                return;
+                return false;
             }
 
             // Remove our reference to this texture.
@@ -97,9 +97,9 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             _textures.Remove(texture.CacheNode);
 
-            texture.DecrementReferenceCount();
-
             texture.CacheNode = null;
+
+            return texture.DecrementReferenceCount();
         }
 
         public IEnumerator<Texture> GetEnumerator()

--- a/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
@@ -45,7 +45,10 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 if (oldestTexture.IsModified)
                 {
-                    oldestTexture.Flush(false); // The texture must be flushed if it falls out of the auto delete cache.
+                    // The texture must be flushed if it falls out of the auto delete cache.
+                    // Flushes out of the auto delete cache do not trigger write tracking,
+                    // as it is expected that other overlapping textures exist that have more up-to-date contents.
+                    oldestTexture.Flush(false); 
                 }
 
                 _textures.RemoveFirst();

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -172,7 +172,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Initializes the data for a texture. Can optionally initialize the texture with or without data.
         /// If the texture is a view, it will initialize memory tracking to be non-dirty.
         /// </summary>
-        /// <param name="isView">True if the texture is a view or not</param>
+        /// <param name="isView">True if the texture is a view, false otherwise</param>
         /// <param name="withData">True if the texture is to be initialized with data</param>
         public void InitializeData(bool isView, bool withData = false)
         {

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -278,6 +278,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             width  <<= _firstLevel;
             height <<= _firstLevel;
+            int blockWidth = Info.FormatInfo.BlockWidth;
+            int blockHeight = Info.FormatInfo.BlockHeight;
 
             if (Info.Target == Target.Texture3D)
             {
@@ -288,7 +290,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 depthOrLayers = _viewStorage.Info.DepthOrLayers;
             }
 
-            _viewStorage.RecreateStorageOrView(width, height, depthOrLayers);
+            _viewStorage.RecreateStorageOrView(width, height, blockWidth, blockHeight, depthOrLayers);
 
             foreach (Texture view in _viewStorage._views)
             {
@@ -306,8 +308,26 @@ namespace Ryujinx.Graphics.Gpu.Image
                     viewDepthOrLayers = view.Info.DepthOrLayers;
                 }
 
-                view.RecreateStorageOrView(viewWidth, viewHeight, viewDepthOrLayers);
+                view.RecreateStorageOrView(viewWidth, viewHeight, blockWidth, blockHeight, viewDepthOrLayers);
             }
+        }
+
+        /// <summary>
+        /// Recreates the texture storage (or view, in the case of child textures) of this texture.
+        /// This allows recreating the texture with a new size.
+        /// A copy is automatically performed from the old to the new texture.
+        /// </summary>
+        /// <param name="width">The new texture width</param>
+        /// <param name="height">The new texture height</param>
+        /// <param name="width">The block width related to the given width</param>
+        /// <param name="height">The block height related to the given height</param>
+        /// <param name="depthOrLayers">The new texture depth (for 3D textures) or layers (for layered textures)</param>
+        private void RecreateStorageOrView(int width, int height, int blockWidth, int blockHeight, int depthOrLayers)
+        {
+            RecreateStorageOrView(
+                BitUtils.DivRoundUp(width * Info.FormatInfo.BlockWidth, blockWidth),
+                BitUtils.DivRoundUp(height * Info.FormatInfo.BlockHeight, blockHeight), 
+                depthOrLayers);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -1021,7 +1021,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Decrements the texture reference count.
         /// When the reference count hits zero, the texture may be deleted and can't be used anymore.
         /// </summary>
-        public void DecrementReferenceCount()
+        /// <returns>True if the texture is now referenceless, false otherwise</returns>
+        public bool DecrementReferenceCount()
         {
             int newRefCount = --_referenceCount;
 
@@ -1038,6 +1039,8 @@ namespace Ryujinx.Graphics.Gpu.Image
             Debug.Assert(newRefCount >= 0);
 
             DeleteIfNotUsed();
+
+            return newRefCount == 0;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -657,7 +657,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Be aware that this is an expensive operation, avoid calling it unless strictly needed.
         /// This may cause data corruption if the memory is already being used for something else on the CPU side.
         /// </summary>
-        public void Flush(bool blacklist = true)
+        /// <param name="tracked">Whether or not the flush triggers write tracking. If it doesn't, the texture will not be blacklisted for scaling either.</param>
+        public void Flush(bool tracked = true)
         {
             IsModified = false;
 
@@ -666,7 +667,14 @@ namespace Ryujinx.Graphics.Gpu.Image
                 return; // Flushing this format is not supported, as it may have been converted to another host format.
             }
 
-            _context.PhysicalMemory.WriteUntracked(Address, GetTextureDataFromGpu(blacklist));
+            if (tracked)
+            {
+                _context.PhysicalMemory.Write(Address, GetTextureDataFromGpu(tracked));
+            }
+            else
+            {
+                _context.PhysicalMemory.WriteUntracked(Address, GetTextureDataFromGpu(tracked));
+            }
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -276,10 +276,11 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="depthOrLayers">The new texture depth (for 3D textures) or layers (for layered textures)</param>
         public void ChangeSize(int width, int height, int depthOrLayers)
         {
-            width  <<= _firstLevel;
-            height <<= _firstLevel;
             int blockWidth = Info.FormatInfo.BlockWidth;
             int blockHeight = Info.FormatInfo.BlockHeight;
+
+            width  <<= _firstLevel;
+            height <<= _firstLevel;
 
             if (Info.Target == Target.Texture3D)
             {
@@ -1078,7 +1079,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             DeleteIfNotUsed();
 
-            return newRefCount == 0;
+            return newRefCount <= 0;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -168,20 +168,25 @@ namespace Ryujinx.Graphics.Gpu.Image
             _views = new List<Texture>();
         }
 
+        /// <summary>
+        /// Initializes the data for a texture. Can optionally initialize the texture with or without data.
+        /// If the texture is a view, it will initialize memory tracking to be non-dirty.
+        /// </summary>
+        /// <param name="isView">True if the texture is a view or not</param>
+        /// <param name="withData">True if the texture is to be initialized with data</param>
         public void InitializeData(bool isView, bool withData = false)
         {
             if (withData)
             {
-                if (!isView)
-                {
-                    TextureCreateInfo createInfo = TextureManager.GetCreateInfo(Info, _context.Capabilities);
-                    HostTexture = _context.Renderer.CreateTexture(createInfo, ScaleFactor);
+                Debug.Assert(!isView);
 
-                    SynchronizeMemory(); // Load the data.
-                    if (ScaleMode == TextureScaleMode.Scaled)
-                    {
-                        SetScale(GraphicsConfig.ResScale); // Scale the data up.
-                    }
+                TextureCreateInfo createInfo = TextureManager.GetCreateInfo(Info, _context.Capabilities);
+                HostTexture = _context.Renderer.CreateTexture(createInfo, ScaleFactor);
+
+                SynchronizeMemory(); // Load the data.
+                if (ScaleMode == TextureScaleMode.Scaled)
+                {
+                    SetScale(GraphicsConfig.ResScale); // Scale the data up.
                 }
             }
             else
@@ -661,11 +666,6 @@ namespace Ryujinx.Graphics.Gpu.Image
                 return; // Flushing this format is not supported, as it may have been converted to another host format.
             }
 
-            if (Info.FormatInfo.IsCompressed)
-            {
-                Logger.Error?.PrintMsg(LogClass.Gpu, "Flushing compressed texture!");
-            }
-
             _context.PhysicalMemory.WriteUntracked(Address, GetTextureDataFromGpu(blacklist));
         }
 
@@ -824,7 +824,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             result = TextureCompatibility.PropagateViewCompatability(result, TextureCompatibility.ViewTargetCompatible(Info, info));
 
             return (Info.SamplesInX == info.SamplesInX &&
-                   Info.SamplesInY == info.SamplesInY) ? result : TextureViewCompatibility.Incompatible;
+                    Info.SamplesInY == info.SamplesInY) ? result : TextureViewCompatibility.Incompatible;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -420,8 +420,8 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 from.CopyTo(to, new Extents2D(0, 0, from.Width, from.Height), new Extents2D(0, 0, to.Width, to.Height), true);
 
-                from.Dispose();
-                to.Dispose();
+                from.Release();
+                to.Release();
             }
         }
 
@@ -1065,9 +1065,9 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         private void DisposeTextures()
         {
-            HostTexture.Dispose();
+            HostTexture.Release();
 
-            _arrayViewTexture?.Dispose();
+            _arrayViewTexture?.Release();
             _arrayViewTexture = null;
         }
 

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -848,8 +848,8 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             TextureViewCompatibility result = TextureViewCompatibility.Full;
 
-            result = TextureCompatibility.PropagateViewCompatability(result, TextureCompatibility.ViewSizeMatches(Info, info, firstLevel));
-            result = TextureCompatibility.PropagateViewCompatability(result, TextureCompatibility.ViewTargetCompatible(Info, info));
+            result = TextureCompatibility.PropagateViewCompatibility(result, TextureCompatibility.ViewSizeMatches(Info, info, firstLevel));
+            result = TextureCompatibility.PropagateViewCompatibility(result, TextureCompatibility.ViewTargetCompatible(Info, info));
 
             return (Info.SamplesInX == info.SamplesInX &&
                     Info.SamplesInY == info.SamplesInY) ? result : TextureViewCompatibility.Incompatible;

--- a/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -147,28 +147,51 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Checks if the view sizes of a two given texture informations match.
+        /// Obtain the minimum compatibility level of two provided view compatibility results.
+        /// </summary>
+        /// <param name="first">The first compatibility level</param>
+        /// <param name="second">The second compatibility level</param>
+        /// <returns>The minimum compatibility level of two provided view compatibility results</returns>
+        public static TextureViewCompatibility PropagateViewCompatability(TextureViewCompatibility first, TextureViewCompatibility second)
+        {
+            if (first == TextureViewCompatibility.Incompatible || second == TextureViewCompatibility.Incompatible)
+            {
+                return TextureViewCompatibility.Incompatible;
+            }
+            else if (first == TextureViewCompatibility.CopyOnly || second == TextureViewCompatibility.CopyOnly)
+            {
+                return TextureViewCompatibility.CopyOnly;
+            }
+            else
+            {
+                return TextureViewCompatibility.Full;
+            }
+        }
+
+        /// <summary>
+        /// Checks if the sizes of two given textures are view compatible.
         /// </summary>
         /// <param name="lhs">Texture information of the texture view</param>
         /// <param name="rhs">Texture information of the texture view to match against</param>
         /// <param name="level">Mipmap level of the texture view in relation to this texture</param>
-        /// <param name="isCopy">True to check for copy compatibility rather than view compatibility</param>
         /// <returns>True if the sizes are compatible, false otherwise</returns>
-        public static bool ViewSizeMatches(TextureInfo lhs, TextureInfo rhs, int level, bool isCopy)
+        public static TextureViewCompatibility ViewSizeMatches(TextureInfo lhs, TextureInfo rhs, int level)
         {
             Size size = GetAlignedSize(lhs, level);
 
             Size otherSize = GetAlignedSize(rhs);
 
+            TextureViewCompatibility result = TextureViewCompatibility.Full;
+
             // For copies, we can copy a subset of the 3D texture slices,
             // so the depth may be different in this case.
-            if (!isCopy && rhs.Target == Target.Texture3D && size.Depth != otherSize.Depth)
+            if (rhs.Target == Target.Texture3D && size.Depth != otherSize.Depth)
             {
-                return false;
+                result = TextureViewCompatibility.CopyOnly;
             }
 
-            return size.Width  == otherSize.Width &&
-                   size.Height == otherSize.Height;
+            return (size.Width  == otherSize.Width &&
+                    size.Height == otherSize.Height) ? result : TextureViewCompatibility.Incompatible;
         }
 
         /// <summary>
@@ -330,38 +353,48 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="rhs">Texture information of the texture view</param>
         /// <param name="isCopy">True to check for copy rather than view compatibility</param>
         /// <returns>True if the targets are compatible, false otherwise</returns>
-        public static bool ViewTargetCompatible(TextureInfo lhs, TextureInfo rhs, bool isCopy)
+        public static TextureViewCompatibility ViewTargetCompatible(TextureInfo lhs, TextureInfo rhs)
         {
+            bool result = false;
             switch (lhs.Target)
             {
                 case Target.Texture1D:
                 case Target.Texture1DArray:
-                    return rhs.Target == Target.Texture1D ||
-                           rhs.Target == Target.Texture1DArray;
+                    result = rhs.Target == Target.Texture1D ||
+                             rhs.Target == Target.Texture1DArray;
+                    break;
 
                 case Target.Texture2D:
-                    return rhs.Target == Target.Texture2D ||
-                           rhs.Target == Target.Texture2DArray;
+                    result = rhs.Target == Target.Texture2D ||
+                             rhs.Target == Target.Texture2DArray;
+                    break;
 
                 case Target.Texture2DArray:
                 case Target.Cubemap:
                 case Target.CubemapArray:
-                    return rhs.Target == Target.Texture2D ||
-                           rhs.Target == Target.Texture2DArray ||
-                           rhs.Target == Target.Cubemap ||
-                           rhs.Target == Target.CubemapArray;
+                    result = rhs.Target == Target.Texture2D ||
+                             rhs.Target == Target.Texture2DArray ||
+                             rhs.Target == Target.Cubemap ||
+                             rhs.Target == Target.CubemapArray;
+                    break;
 
                 case Target.Texture2DMultisample:
                 case Target.Texture2DMultisampleArray:
-                    return rhs.Target == Target.Texture2DMultisample ||
-                           rhs.Target == Target.Texture2DMultisampleArray;
+                    result = rhs.Target == Target.Texture2DMultisample ||
+                             rhs.Target == Target.Texture2DMultisampleArray;
+                    break;
 
                 case Target.Texture3D:
-                    return rhs.Target == Target.Texture3D ||
-                          (rhs.Target == Target.Texture2D && isCopy);
+                    if (rhs.Target == Target.Texture2D)
+                    {
+                        return TextureViewCompatibility.CopyOnly;
+                    }
+
+                    result = rhs.Target == Target.Texture3D;
+                    break;
             }
 
-            return false;
+            return result ? TextureViewCompatibility.Full : TextureViewCompatibility.Incompatible;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -152,7 +152,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="first">The first compatibility level</param>
         /// <param name="second">The second compatibility level</param>
         /// <returns>The minimum compatibility level of two provided view compatibility results</returns>
-        public static TextureViewCompatibility PropagateViewCompatability(TextureViewCompatibility first, TextureViewCompatibility second)
+        public static TextureViewCompatibility PropagateViewCompatibility(TextureViewCompatibility first, TextureViewCompatibility second)
         {
             if (first == TextureViewCompatibility.Incompatible || second == TextureViewCompatibility.Incompatible)
             {

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -1,4 +1,5 @@
 using Ryujinx.Common;
+using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Image;
 using Ryujinx.Graphics.Gpu.Memory;
@@ -9,11 +10,18 @@ using System.Collections.Generic;
 
 namespace Ryujinx.Graphics.Gpu.Image
 {
+
     /// <summary>
     /// Texture manager.
     /// </summary>
     class TextureManager : IDisposable
     {
+        private struct OverlapInfo
+        {
+            public int FirstLayer;
+            public int FirstLevel;
+        }
+
         private const int OverlapsBufferInitialCapacity = 10;
         private const int OverlapsBufferMaxCapacity     = 10000;
 
@@ -33,6 +41,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         private readonly RangeList<Texture> _textures;
 
         private Texture[] _textureOverlaps;
+        private OverlapInfo[] _overlapInfo;
 
         private readonly AutoDeleteCache _cache;
 
@@ -64,6 +73,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             _textures = new RangeList<Texture>();
 
             _textureOverlaps = new Texture[OverlapsBufferInitialCapacity];
+            _overlapInfo = new OverlapInfo[OverlapsBufferInitialCapacity];
 
             _cache = new AutoDeleteCache();
 
@@ -408,6 +418,27 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Handles removal of textures written to a memory region being unmapped.
+        /// </summary>
+        /// <param name="sender">Sender object</param>
+        /// <param name="e">Event arguments</param>
+        public void MemoryUnmappedHandler(object sender, UnmapEventArgs e)
+        {
+            Texture[] overlaps = new Texture[10];
+            int overlapCount;
+
+            lock (_textures)
+            {
+                overlapCount = _textures.FindOverlaps(_context.MemoryManager.Translate(e.Address), e.Size, ref overlaps);
+            }
+
+            for (int i = 0; i < overlapCount; i++)
+            {
+                overlaps[i].Unmapped();
+            }
+        }
+
+        /// <summary>
         /// Tries to find an existing texture, or create a new one if not found.
         /// </summary>
         /// <param name="copyTexture">Copy texture to find or create</param>
@@ -618,8 +649,13 @@ namespace Ryujinx.Graphics.Gpu.Image
                 scaleMode = (flags & TextureSearchFlags.WithUpscale) != 0 ? TextureScaleMode.Scaled : TextureScaleMode.Eligible;
             }
 
-            // Try to find a perfect texture match, with the same address and parameters.
-            int sameAddressOverlapsCount = _textures.FindOverlaps(info.Address, ref _textureOverlaps);
+            int sameAddressOverlapsCount;
+
+            lock (_textures)
+            {
+                // Try to find a perfect texture match, with the same address and parameters.
+                sameAddressOverlapsCount = _textures.FindOverlaps(info.Address, ref _textureOverlaps);
+            }
 
             for (int index = 0; index < sameAddressOverlapsCount; index++)
             {
@@ -681,8 +717,12 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             // Find view compatible matches.
             ulong size = (ulong)sizeInfo.TotalSize;
+            int overlapsCount;
 
-            int overlapsCount = _textures.FindOverlaps(info.Address, size, ref _textureOverlaps);
+            lock (_textures)
+            {
+                overlapsCount = _textures.FindOverlaps(info.Address, size, ref _textureOverlaps);
+            }
 
             Texture texture = null;
 
@@ -701,7 +741,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                     if (IsTextureModified(overlap))
                     {
-                        CacheTextureModified(texture);
+                        texture.SignalModified();
                     }
 
                     // The size only matters (and is only really reliable) when the
@@ -721,48 +761,87 @@ namespace Ryujinx.Graphics.Gpu.Image
             {
                 texture = new Texture(_context, info, sizeInfo, scaleMode);
 
-                // We need to synchronize before copying the old view data to the texture,
-                // otherwise the copied data would be overwritten by a future synchronization.
-                texture.SynchronizeMemory();
+                // Step 1: Find textures that are view compatible with the new texture.
+                // Any textures that are incompatible will contain garbage data, so they should be removed where possible.
+
+                int viewCompatible = 0;
+                bool setData = isSamplerTexture || overlapsCount == 0;
 
                 for (int index = 0; index < overlapsCount; index++)
                 {
                     Texture overlap = _textureOverlaps[index];
 
-                    if (texture.IsViewCompatible(overlap.Info, overlap.Size, out int firstLayer, out int firstLevel))
+                    if (texture.IsViewCompatible(overlap.Info, overlap.Size, true, out int firstLayer, out int firstLevel) || overlap.Info.Target == Target.Texture3D)
                     {
-                        TextureInfo overlapInfo = AdjustSizes(texture, overlap.Info, firstLevel);
-
-                        TextureCreateInfo createInfo = GetCreateInfo(overlapInfo, _context.Capabilities);
-
-                        if (texture.ScaleFactor != overlap.ScaleFactor)
+                        if (_overlapInfo.Length != _textureOverlaps.Length)
                         {
-                            // A bit tricky, our new texture may need to contain an existing texture that is upscaled, but isn't itself.
-                            // In that case, we prefer the higher scale only if our format is render-target-like, otherwise we scale the view down before copy.
-
-                            texture.PropagateScale(overlap);
+                            Array.Resize(ref _overlapInfo, _textureOverlaps.Length);
                         }
 
-                        ITexture newView = texture.HostTexture.CreateView(createInfo, firstLayer, firstLevel);
-
-                        overlap.HostTexture.CopyTo(newView, 0, 0);
-
-                        // Inherit modification from overlapping texture, do that before replacing
-                        // the view since the replacement operation removes it from the list.
-                        if (IsTextureModified(overlap))
-                        {
-                            CacheTextureModified(texture);
-                        }
-
-                        overlap.ReplaceView(texture, overlapInfo, newView, firstLayer, firstLevel);
+                        _overlapInfo[viewCompatible] = new OverlapInfo { FirstLayer = firstLayer, FirstLevel = firstLevel };
+                        _textureOverlaps[viewCompatible++] = overlap;
                     }
+                    else
+                    {
+                        // The overlap texture is going to contain garbage data after we draw, or is generally incompatible.
+                        // If the texture cannot be entirely contained in the new address space, and one of its view children is compatible with us,
+                        // it must be flushed before removal, so that the data is not lost.
+
+                        bool flush = (overlap.Address < texture.Address || overlap.EndAddress > texture.EndAddress) && overlap.HasViewCompatibleChild(texture);
+
+                        // If the texture was modified since its last use, then that data is probably meant to go into this texture.
+                        setData |= overlap.ConsumeModified();
+
+                        Logger.PrintWarning(LogClass.Gpu, $"Removed overlapping texture {overlap.Info.Target} {overlap.Info.Width}x{overlap.Info.Height}x{overlap.Info.DepthOrLayers}");
+                        _cache.Remove(overlap, flush);
+                    }
+                }
+
+                // We need to synchronize before copying the old view data to the texture,
+                // otherwise the copied data would be overwritten by a future synchronization.
+                texture.InitializeData(false, setData);
+
+                for (int index = 0; index < viewCompatible; index++)
+                {
+                    Texture overlap = _textureOverlaps[index];
+                    OverlapInfo oInfo = _overlapInfo[index];
+
+                    if (!texture.IsViewCompatible(overlap.Info, overlap.Size, out int firstLayer, out int firstLevel))
+                    {
+                        continue; // 3D texture copy. TODO: make less bad.
+                    }
+
+                    TextureInfo overlapInfo = AdjustSizes(texture, overlap.Info, oInfo.FirstLevel);
+
+                    TextureCreateInfo createInfo = GetCreateInfo(overlapInfo, _context.Capabilities);
+
+                    if (texture.ScaleFactor != overlap.ScaleFactor)
+                    {
+                        // A bit tricky, our new texture may need to contain an existing texture that is upscaled, but isn't itself.
+                        // In that case, we prefer the higher scale only if our format is render-target-like, otherwise we scale the view down before copy.
+
+                        texture.PropagateScale(overlap);
+                    }
+
+                    ITexture newView = texture.HostTexture.CreateView(createInfo, oInfo.FirstLayer, oInfo.FirstLevel);
+
+                    overlap.HostTexture.CopyTo(newView, 0, 0);
+
+                    // Inherit modification from overlapping texture, do that before replacing
+                    // the view since the replacement operation removes it from the list.
+                    if (IsTextureModified(overlap))
+                    {
+                        texture.SignalModified();
+                    }
+
+                    overlap.ReplaceView(texture, overlapInfo, newView, oInfo.FirstLayer, oInfo.FirstLevel);
                 }
 
                 // If the texture is a 3D texture, we need to additionally copy any slice
                 // of the 3D texture to the newly created 3D texture.
                 if (info.Target == Target.Texture3D)
                 {
-                    for (int index = 0; index < overlapsCount; index++)
+                    for (int index = 0; index < viewCompatible; index++)
                     {
                         Texture overlap = _textureOverlaps[index];
 
@@ -779,7 +858,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                             if (IsTextureModified(overlap))
                             {
-                                CacheTextureModified(texture);
+                                texture.SignalModified();
                             }
                         }
                     }
@@ -795,7 +874,10 @@ namespace Ryujinx.Graphics.Gpu.Image
                 texture.Disposed += CacheTextureDisposed;
             }
 
-            _textures.Add(texture);
+            lock (_textures)
+            {
+                _textures.Add(texture);
+            }
 
             ShrinkOverlapsBufferIfNeeded();
 
@@ -818,6 +900,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="texture">The texture that was modified.</param>
         private void CacheTextureModified(Texture texture)
         {
+            texture.IsModified = true;
             _modified.Add(texture);
 
             if (texture.Info.IsLinear)
@@ -992,7 +1075,10 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             foreach (Texture texture in _modifiedLinear)
             {
-                texture.Flush();
+                if (texture.IsModified)
+                {
+                    texture.Flush();
+                }
             }
 
             _modifiedLinear.Clear();
@@ -1007,7 +1093,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             foreach (Texture texture in _modified)
             {
-                if (texture.OverlapsWith(address, size))
+                if (texture.OverlapsWith(address, size) && texture.IsModified)
                 {
                     texture.Flush();
                 }
@@ -1024,7 +1110,10 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="texture">The texture to be removed</param>
         public void RemoveTextureFromCache(Texture texture)
         {
-            _textures.Remove(texture);
+            lock (_textures)
+            {
+                _textures.Remove(texture);
+            }
         }
 
         /// <summary>
@@ -1033,10 +1122,13 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         public void Dispose()
         {
-            foreach (Texture texture in _textures)
+            lock (_textures)
             {
-                _modified.Remove(texture);
-                texture.Dispose();
+                foreach (Texture texture in _textures)
+                {
+                    _modified.Remove(texture);
+                    texture.Dispose();
+                }
             }
         }
     }

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -1,5 +1,4 @@
 using Ryujinx.Common;
-using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Image;
 using Ryujinx.Graphics.Gpu.Memory;
@@ -10,7 +9,6 @@ using System.Collections.Generic;
 
 namespace Ryujinx.Graphics.Gpu.Image
 {
-
     /// <summary>
     /// Texture manager.
     /// </summary>
@@ -21,6 +19,13 @@ namespace Ryujinx.Graphics.Gpu.Image
             public TextureViewCompatibility Compatibility;
             public int FirstLayer;
             public int FirstLevel;
+
+            public OverlapInfo(TextureViewCompatibility compatibility, int firstLayer, int firstLevel)
+            {
+                Compatibility = compatibility;
+                FirstLayer = firstLayer;
+                FirstLevel = firstLevel;
+            }
         }
 
         private const int OverlapsBufferInitialCapacity = 10;
@@ -782,7 +787,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                             Array.Resize(ref _overlapInfo, _textureOverlaps.Length);
                         }
 
-                        _overlapInfo[viewCompatible] = new OverlapInfo { Compatibility = compatibility, FirstLayer = firstLayer, FirstLevel = firstLevel };
+                        _overlapInfo[viewCompatible] = new OverlapInfo(compatibility, firstLayer, firstLevel);
                         _textureOverlaps[viewCompatible++] = overlap;
                     }
                     else if (overlapInCache || !setData)

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -16,9 +16,9 @@ namespace Ryujinx.Graphics.Gpu.Image
     {
         private struct OverlapInfo
         {
-            public TextureViewCompatibility Compatibility;
-            public int FirstLayer;
-            public int FirstLevel;
+            public TextureViewCompatibility Compatibility { get; }
+            public int FirstLayer { get; }
+            public int FirstLevel { get; }
 
             public OverlapInfo(TextureViewCompatibility compatibility, int firstLayer, int firstLevel)
             {

--- a/Ryujinx.Graphics.Gpu/Image/TextureViewCompatibility.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureViewCompatibility.cs
@@ -1,0 +1,13 @@
+﻿namespace Ryujinx.Graphics.Gpu.Image
+{
+    /// <summary>
+    /// The level of view compatibility one texture has to another. 
+    /// Values are increasing in compatibility from 0 (incompatible).
+    /// </summary>
+    enum TextureViewCompatibility
+    {
+        Incompatible = 0,
+        CopyOnly,
+        Full
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
@@ -151,7 +151,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
             byte[] data = _context.Renderer.GetBufferData(Handle, offset, (int)size);
 
-            _context.PhysicalMemory.Write(address, data);
+            _context.PhysicalMemory.WriteUntracked(address, data);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
@@ -151,6 +151,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
             byte[] data = _context.Renderer.GetBufferData(Handle, offset, (int)size);
 
+            // TODO: When write tracking shaders, they will need to be aware of changes in overlapping buffers.
             _context.PhysicalMemory.WriteUntracked(address, data);
         }
 

--- a/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
@@ -68,6 +68,16 @@ namespace Ryujinx.Graphics.Gpu.Memory
         }
 
         /// <summary>
+        /// Writes data to the application process, without any tracking
+        /// </summary>
+        /// <param name="address">Address to write into</param>
+        /// <param name="data">Data to be written</param>
+        public void WriteUntracked(ulong address, ReadOnlySpan<byte> data)
+        {
+            _cpuMemory.WriteUntracked(address, data);
+        }
+
+        /// <summary>
         /// Checks if a specified virtual memory region has been modified by the CPU since the last call.
         /// </summary>
         /// <param name="address">CPU virtual address of the region</param>

--- a/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
@@ -68,7 +68,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         }
 
         /// <summary>
-        /// Writes data to the application process, without any tracking
+        /// Writes data to the application process, without any tracking.
         /// </summary>
         /// <param name="address">Address to write into</param>
         /// <param name="data">Data to be written</param>

--- a/Ryujinx.Graphics.OpenGL/Image/TextureBuffer.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureBuffer.cs
@@ -67,5 +67,10 @@ namespace Ryujinx.Graphics.OpenGL.Image
                 Handle = 0;
             }
         }
+
+        public void Release()
+        {
+            Dispose();
+        }
     }
 }

--- a/Ryujinx.Graphics.OpenGL/Image/TextureStorage.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureStorage.cs
@@ -177,14 +177,18 @@ namespace Ryujinx.Graphics.OpenGL.Image
                 }
                 else
                 {
+                    // If our default view still exists, we can put it into the resource cache so we can be used later.
                     Release();
                 }
             }
         }
 
+        /// <summary>
+        /// Release the TextureStorage to the resource cache without disposing its handle.
+        /// </summary>
         public void Release()
         {
-            _viewsCount = 1; // Has the default view.
+            _viewsCount = 1; // When we are used again, we will have the default view.
 
             _renderer.ResourceCache.AddTexture((TextureView)DefaultView);
         }

--- a/Ryujinx.Graphics.OpenGL/Image/TextureStorage.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureStorage.cs
@@ -177,20 +177,20 @@ namespace Ryujinx.Graphics.OpenGL.Image
                 }
                 else
                 {
-                    // If our default view still exists, we can put it into the resource cache so we can be used later.
+                    // If our default view still exists, we can put it into the resource pool so we can be used later.
                     Release();
                 }
             }
         }
 
         /// <summary>
-        /// Release the TextureStorage to the resource cache without disposing its handle.
+        /// Release the TextureStorage to the resource pool without disposing its handle.
         /// </summary>
         public void Release()
         {
             _viewsCount = 1; // When we are used again, we will have the default view.
 
-            _renderer.ResourceCache.AddTexture((TextureView)DefaultView);
+            _renderer.ResourcePool.AddTexture((TextureView)DefaultView);
         }
 
         public void DeleteDefault()

--- a/Ryujinx.Graphics.OpenGL/Image/TextureStorage.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureStorage.cs
@@ -16,7 +16,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
 
         private int _viewsCount;
 
-        internal ITexture _defaultView;
+        internal ITexture DefaultView { get; private set; }
 
         public TextureStorage(Renderer renderer, TextureCreateInfo info, float scaleFactor)
         {
@@ -149,9 +149,9 @@ namespace Ryujinx.Graphics.OpenGL.Image
 
         public ITexture CreateDefaultView()
         {
-            _defaultView = CreateView(Info, 0, 0);
+            DefaultView = CreateView(Info, 0, 0);
 
-            return _defaultView;
+            return DefaultView;
         }
 
         public ITexture CreateView(TextureCreateInfo info, int firstLayer, int firstLevel)
@@ -171,7 +171,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
             // If we don't have any views, then the storage is now useless, delete it.
             if (--_viewsCount == 0)
             {
-                if (_defaultView == null)
+                if (DefaultView == null)
                 {
                     Dispose();
                 }
@@ -186,17 +186,17 @@ namespace Ryujinx.Graphics.OpenGL.Image
         {
             _viewsCount = 1; // Has the default view.
 
-            _renderer.ResourceCache.AddTexture((TextureView)_defaultView);
+            _renderer.ResourceCache.AddTexture((TextureView)DefaultView);
         }
 
         public void DeleteDefault()
         {
-            _defaultView = null;
+            DefaultView = null;
         }
 
         public void Dispose()
         {
-            _defaultView = null;
+            DefaultView = null;
 
             if (Handle != 0)
             {

--- a/Ryujinx.Graphics.OpenGL/Image/TextureStorage.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureStorage.cs
@@ -177,7 +177,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
                 }
                 else
                 {
-                    // If our default view still exists, we can put it into the resource pool so we can be used later.
+                    // If the default view still exists, we can put it into the resource pool.
                     Release();
                 }
             }

--- a/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
@@ -453,7 +453,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
 
         /// <summary>
         /// Release the view without necessarily disposing the parent if we are the default view.
-        /// This allows it to be added to the resource cache and reused later.
+        /// This allows it to be added to the resource pool and reused later.
         /// </summary>
         public void Release()
         {

--- a/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
@@ -436,6 +436,10 @@ namespace Ryujinx.Graphics.OpenGL.Image
 
         public void Dispose()
         {
+            // TODO: this is really "release".
+
+            bool isDefault = _parent._defaultView == this;
+
             if (_incompatibleFormatView != null)
             {
                 _incompatibleFormatView.Dispose();
@@ -443,14 +447,31 @@ namespace Ryujinx.Graphics.OpenGL.Image
                 _incompatibleFormatView = null;
             }
 
-            if (Handle != 0)
+            if (isDefault)
             {
-                GL.DeleteTexture(Handle);
-
-                _parent.DecrementViewsCount();
-
-                Handle = 0;
+                if (Handle != 0)
+                {
+                    _parent.DecrementViewsCount();
+                }
             }
+            else
+            {
+                if (Handle != 0)
+                {
+                    GL.DeleteTexture(Handle);
+
+                    _parent.DecrementViewsCount();
+
+                    Handle = 0;
+                }
+            }
+        }
+
+        public void TrueDispose()
+        {
+            _parent.DeleteDefault();
+
+            Dispose();
         }
     }
 }

--- a/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
@@ -451,6 +451,10 @@ namespace Ryujinx.Graphics.OpenGL.Image
             }
         }
 
+        /// <summary>
+        /// Release the view without necessarily disposing the parent if we are the default view.
+        /// This allows it to be added to the resource cache and reused later.
+        /// </summary>
         public void Release()
         {
             bool hadHandle = Handle != 0;

--- a/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
@@ -434,10 +434,8 @@ namespace Ryujinx.Graphics.OpenGL.Image
             throw new NotSupportedException();
         }
 
-        public void Dispose()
+        public void Release()
         {
-            // TODO: this is really "release".
-
             bool isDefault = _parent._defaultView == this;
 
             if (_incompatibleFormatView != null)
@@ -467,11 +465,11 @@ namespace Ryujinx.Graphics.OpenGL.Image
             }
         }
 
-        public void TrueDispose()
+        public void Dispose()
         {
             _parent.DeleteDefault();
 
-            Dispose();
+            Release();
         }
     }
 }

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -23,7 +23,7 @@ namespace Ryujinx.Graphics.OpenGL
 
         internal TextureCopy TextureCopy { get; }
 
-        internal ResourceCache ResourceCache { get; }
+        internal ResourcePool ResourcePool { get; }
 
         public string GpuVendor { get; private set; }
         public string GpuRenderer { get; private set; }
@@ -35,7 +35,7 @@ namespace Ryujinx.Graphics.OpenGL
             _counters = new Counters();
             _window = new Window(this);
             TextureCopy = new TextureCopy(this);
-            ResourceCache = new ResourceCache();
+            ResourcePool = new ResourcePool();
         }
 
         public IShader CompileShader(ShaderProgram shader)
@@ -66,7 +66,7 @@ namespace Ryujinx.Graphics.OpenGL
             }
             else
             {
-                return ResourceCache.TryGetTexture(info, scaleFactor) ?? new TextureStorage(this, info, scaleFactor).CreateDefaultView();
+                return ResourcePool.TryGetTexture(info, scaleFactor) ?? new TextureStorage(this, info, scaleFactor).CreateDefaultView();
             }
         }
 
@@ -104,7 +104,7 @@ namespace Ryujinx.Graphics.OpenGL
 
         public void PreFrame()
         {
-            ResourceCache.Tick();
+            ResourcePool.Tick();
         }
 
         public ICounterEvent ReportCounter(CounterType type, EventHandler<ulong> resultHandler)

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -23,6 +23,8 @@ namespace Ryujinx.Graphics.OpenGL
 
         internal TextureCopy TextureCopy { get; }
 
+        internal DisposedResourceCache ResourceCache { get; }
+
         public string GpuVendor { get; private set; }
         public string GpuRenderer { get; private set; }
         public string GpuVersion { get; private set; }
@@ -33,6 +35,7 @@ namespace Ryujinx.Graphics.OpenGL
             _counters = new Counters();
             _window = new Window(this);
             TextureCopy = new TextureCopy(this);
+            ResourceCache = new DisposedResourceCache();
         }
 
         public IShader CompileShader(ShaderProgram shader)
@@ -57,7 +60,14 @@ namespace Ryujinx.Graphics.OpenGL
 
         public ITexture CreateTexture(TextureCreateInfo info, float scaleFactor)
         {
-            return info.Target == Target.TextureBuffer ? new TextureBuffer(info) : new TextureStorage(this, info, scaleFactor).CreateDefaultView();
+            if (info.Target == Target.TextureBuffer)
+            {
+                return new TextureBuffer(info);
+            }
+            else
+            {
+                return ResourceCache.TryGetTexture(info, scaleFactor) ?? new TextureStorage(this, info, scaleFactor).CreateDefaultView();
+            }
         }
 
         public void DeleteBuffer(BufferHandle buffer)
@@ -90,6 +100,11 @@ namespace Ryujinx.Graphics.OpenGL
         public void UpdateCounters()
         {
             _counters.Update();
+        }
+
+        public void PreFrame()
+        {
+            ResourceCache.Tick();
         }
 
         public ICounterEvent ReportCounter(CounterType type, EventHandler<ulong> resultHandler)

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -66,7 +66,7 @@ namespace Ryujinx.Graphics.OpenGL
             }
             else
             {
-                return ResourcePool.TryGetTexture(info, scaleFactor) ?? new TextureStorage(this, info, scaleFactor).CreateDefaultView();
+                return ResourcePool.GetTextureOrNull(info, scaleFactor) ?? new TextureStorage(this, info, scaleFactor).CreateDefaultView();
             }
         }
 
@@ -138,6 +138,7 @@ namespace Ryujinx.Graphics.OpenGL
         public void Dispose()
         {
             TextureCopy.Dispose();
+            ResourcePool.Dispose();
             _pipeline.Dispose();
             _window.Dispose();
             _counters.Dispose();

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -23,7 +23,7 @@ namespace Ryujinx.Graphics.OpenGL
 
         internal TextureCopy TextureCopy { get; }
 
-        internal DisposedResourceCache ResourceCache { get; }
+        internal ResourceCache ResourceCache { get; }
 
         public string GpuVendor { get; private set; }
         public string GpuRenderer { get; private set; }
@@ -35,7 +35,7 @@ namespace Ryujinx.Graphics.OpenGL
             _counters = new Counters();
             _window = new Window(this);
             TextureCopy = new TextureCopy(this);
-            ResourceCache = new DisposedResourceCache();
+            ResourceCache = new ResourceCache();
         }
 
         public IShader CompileShader(ShaderProgram shader)

--- a/Ryujinx.Graphics.OpenGL/ResourceCache.cs
+++ b/Ryujinx.Graphics.OpenGL/ResourceCache.cs
@@ -1,0 +1,88 @@
+﻿using Ryujinx.Graphics.GAL;
+using Ryujinx.Graphics.OpenGL.Image;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Ryujinx.Graphics.OpenGL
+{
+    class DisposedTexture
+    {
+        public TextureCreateInfo Info;
+        public TextureView View;
+        public float ScaleFactor;
+        public int RemainingFrames;
+    }
+
+    class ResourceCache
+    {
+        private const int DisposedCacheFrames = 2;
+
+        private object _lock = new object();
+        private Dictionary<uint, List<DisposedTexture>> _textures = new Dictionary<uint, List<DisposedTexture>>();
+
+        private uint GetTextureKey(TextureCreateInfo info)
+        {
+            return ((uint)info.Width) | ((uint)info.Height << 16);
+        }
+
+        public void AddTexture(TextureView view)
+        {
+            uint key = GetTextureKey(view.Info);
+
+            List<DisposedTexture> list;
+            if (!_textures.TryGetValue(key, out list))
+            {
+                list = new List<DisposedTexture>();
+                _textures.Add(key, list);
+            }
+
+            list.Add(new DisposedTexture()
+            {
+                Info = view.Info,
+                View = view,
+                ScaleFactor = view.ScaleFactor,
+                RemainingFrames = DisposedCacheFrames
+            });
+        }
+
+        public TextureView TryGetTexture(TextureCreateInfo info, float scaleFactor)
+        {
+            uint key = GetTextureKey(info);
+
+            List<DisposedTexture> list;
+            if (!_textures.TryGetValue(key, out list))
+            {
+                return null;
+            }
+
+            foreach (DisposedTexture texture in list)
+            {
+                if (texture.View.Info.Equals(info) && scaleFactor == texture.ScaleFactor)
+                {
+                    // TODO: prepare?
+                    list.Remove(texture);
+                    return texture.View;
+                }
+            }
+
+            return null;
+        }
+
+        public void Tick()
+        {
+            foreach (List<DisposedTexture> list in _textures.Values)
+            {
+                for (int i = 0; i < list.Count; i++)
+                {
+                    DisposedTexture tex = list[i];
+
+                    if (--tex.RemainingFrames < 0)
+                    {
+                        tex.View.TrueDispose();
+                        list.RemoveAt(i--);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Ryujinx.Graphics.OpenGL/ResourceCache.cs
+++ b/Ryujinx.Graphics.OpenGL/ResourceCache.cs
@@ -78,7 +78,7 @@ namespace Ryujinx.Graphics.OpenGL
 
                     if (--tex.RemainingFrames < 0)
                     {
-                        tex.View.TrueDispose();
+                        tex.View.Dispose();
                         list.RemoveAt(i--);
                     }
                 }

--- a/Ryujinx.Graphics.OpenGL/ResourceCache.cs
+++ b/Ryujinx.Graphics.OpenGL/ResourceCache.cs
@@ -13,6 +13,9 @@ namespace Ryujinx.Graphics.OpenGL
         public int RemainingFrames;
     }
 
+    /// <summary>
+    /// A structure for caching resources that can be reused without recreation, such as textures.
+    /// </summary>
     class ResourceCache
     {
         private const int DisposedCacheFrames = 2;
@@ -25,61 +28,83 @@ namespace Ryujinx.Graphics.OpenGL
             return ((uint)info.Width) | ((uint)info.Height << 16);
         }
 
+        /// <summary>
+        /// Add a texture that is not being used anymore to the resource cache to be used later.
+        /// Both the texture's view and storage should be completely unused.
+        /// </summary>
+        /// <param name="view">The texture's view</param>
         public void AddTexture(TextureView view)
         {
-            uint key = GetTextureKey(view.Info);
-
-            List<DisposedTexture> list;
-            if (!_textures.TryGetValue(key, out list))
+            lock (_lock)
             {
-                list = new List<DisposedTexture>();
-                _textures.Add(key, list);
+                uint key = GetTextureKey(view.Info);
+
+                List<DisposedTexture> list;
+                if (!_textures.TryGetValue(key, out list))
+                {
+                    list = new List<DisposedTexture>();
+                    _textures.Add(key, list);
+                }
+
+                list.Add(new DisposedTexture()
+                {
+                    Info = view.Info,
+                    View = view,
+                    ScaleFactor = view.ScaleFactor,
+                    RemainingFrames = DisposedCacheFrames
+                });
             }
-
-            list.Add(new DisposedTexture()
-            {
-                Info = view.Info,
-                View = view,
-                ScaleFactor = view.ScaleFactor,
-                RemainingFrames = DisposedCacheFrames
-            });
         }
 
+        /// <summary>
+        /// Attempt to obtain a texture from the resource cache with the desired parameters.
+        /// </summary>
+        /// <param name="info">The creation info for the desired texture</param>
+        /// <param name="scaleFactor">The scale factor for the desired texture</param>
+        /// <returns>A TextureView with the description specified, or null if one was not found.</returns>
         public TextureView TryGetTexture(TextureCreateInfo info, float scaleFactor)
         {
-            uint key = GetTextureKey(info);
-
-            List<DisposedTexture> list;
-            if (!_textures.TryGetValue(key, out list))
+            lock (_lock)
             {
+                uint key = GetTextureKey(info);
+
+                List<DisposedTexture> list;
+                if (!_textures.TryGetValue(key, out list))
+                {
+                    return null;
+                }
+
+                foreach (DisposedTexture texture in list)
+                {
+                    if (texture.View.Info.Equals(info) && scaleFactor == texture.ScaleFactor)
+                    {
+                        list.Remove(texture);
+                        return texture.View;
+                    }
+                }
+
                 return null;
             }
-
-            foreach (DisposedTexture texture in list)
-            {
-                if (texture.View.Info.Equals(info) && scaleFactor == texture.ScaleFactor)
-                {
-                    // TODO: prepare?
-                    list.Remove(texture);
-                    return texture.View;
-                }
-            }
-
-            return null;
         }
 
+        /// <summary>
+        /// Update the cache, removing any resources that have expired.
+        /// </summary>
         public void Tick()
         {
-            foreach (List<DisposedTexture> list in _textures.Values)
+            lock (_lock)
             {
-                for (int i = 0; i < list.Count; i++)
+                foreach (List<DisposedTexture> list in _textures.Values)
                 {
-                    DisposedTexture tex = list[i];
-
-                    if (--tex.RemainingFrames < 0)
+                    for (int i = 0; i < list.Count; i++)
                     {
-                        tex.View.Dispose();
-                        list.RemoveAt(i--);
+                        DisposedTexture tex = list[i];
+
+                        if (--tex.RemainingFrames < 0)
+                        {
+                            tex.View.Dispose();
+                            list.RemoveAt(i--);
+                        }
                     }
                 }
             }

--- a/Ryujinx.Graphics.OpenGL/ResourcePool.cs
+++ b/Ryujinx.Graphics.OpenGL/ResourcePool.cs
@@ -14,11 +14,11 @@ namespace Ryujinx.Graphics.OpenGL
     }
 
     /// <summary>
-    /// A structure for caching resources that can be reused without recreation, such as textures.
+    /// A structure for pooling resources that can be reused without recreation, such as textures.
     /// </summary>
-    class ResourceCache
+    class ResourcePool
     {
-        private const int DisposedCacheFrames = 2;
+        private const int DisposedLiveFrames = 2;
 
         private object _lock = new object();
         private Dictionary<uint, List<DisposedTexture>> _textures = new Dictionary<uint, List<DisposedTexture>>();
@@ -29,7 +29,7 @@ namespace Ryujinx.Graphics.OpenGL
         }
 
         /// <summary>
-        /// Add a texture that is not being used anymore to the resource cache to be used later.
+        /// Add a texture that is not being used anymore to the resource pool to be used later.
         /// Both the texture's view and storage should be completely unused.
         /// </summary>
         /// <param name="view">The texture's view</param>
@@ -51,7 +51,7 @@ namespace Ryujinx.Graphics.OpenGL
                     Info = view.Info,
                     View = view,
                     ScaleFactor = view.ScaleFactor,
-                    RemainingFrames = DisposedCacheFrames
+                    RemainingFrames = DisposedLiveFrames
                 });
             }
         }
@@ -88,7 +88,7 @@ namespace Ryujinx.Graphics.OpenGL
         }
 
         /// <summary>
-        /// Update the cache, removing any resources that have expired.
+        /// Update the pool, removing any resources that have expired.
         /// </summary>
         public void Tick()
         {

--- a/Ryujinx.HLE/Switch.cs
+++ b/Ryujinx.HLE/Switch.cs
@@ -159,6 +159,8 @@ namespace Ryujinx.HLE
 
         public void ProcessFrame()
         {
+            Gpu.Renderer.PreFrame();
+
             Gpu.GPFifo.DispatchCalls();
         }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6294155/87986387-f88ba400-cad4-11ea-85c9-032753ae448e.png)

This PR aims to make texture and buffer memory management better in a few areas, so that we can do things like flush textures without worrying about data corruption, and thus fix a few issues with our AutoDeleteCache having a limited size. The course pictured above generally has the ground incredibly dark, as the course shadow map and lighting cube for the floor are both dropped out of the AutoDeleteCache during loading. No such problem in the screenshot. 😌 

All of these changes are related, which is why they're all part of one PR. There is one change that needs to be here to make this more stable, but more on that later.

1. Overlapping textures that are not  are now removed from the AutoDeleteCache. This gives us a guarantee that no unrelated overlapping textures can flush out of order, when we get around to flushing them, and it also cleans out the texture cache so that it's not a huge mess of tangled overlaps. It can also remove some dead textures, which can help with memory usage.
2. When textures fall out of the AutoDeleteCache, they are now flushed rather than lost. The alternative would be an infinite size texture cache, but then we would need you to have a 32GB page file or something. So reworking things to better facilitate flushing wins.
3. Modification flag is unset when a texture's memory is unmapped. This will stop textures from flushing when their memory is definitely used for something else.
4. Buffer and Texture flushing now writes to memory _without_ triggering write tracking. This avoids textures from setting each other as dirty when flushing to memory - which allows us to flush textures in the auto delete cache in order of use without any repercussions. It has been extended to buffers as it seems to improve performance and remove vertex explosions.
5. An OpenGL resource cache now exists so that textures that are deleted and immediately reused can just use the old texture resource. **This mostly exists as a mitigation to some games aggressively reusing memory used for screen render targets.**
6. With the new overlap rules, we can detect whether or not a texture needs its initial data set or not, based on the presence of existing textures and if their memory has been modified. This can improve performance for res scaling, or games that continually create render targets and set the data of other, unrelated ones. (mostly improves res scaling) **It is needed as part of (5)'s performance mitigation.**
7. View compatibility has been refactored a bit so that it returns an enum that indicates if it's only copy compatible. This avoids calling it multiple times.

## Benefits
![image](https://user-images.githubusercontent.com/6294155/87987121-00981380-cad6-11ea-877f-b35b95b225a4.png)

Here are the benefits, with helpful numbers pointing to which change was responsible:

- All random chance course issues (broken shadows, black actor lighting, black screen) in MK8 are fixed. (1, 2)
- In Super Mario Odyssey, you **no longer need to pause the game or fast travel to fix broken graphics in kingdoms.** (1, 2)
- Generally, games with textures are black or garbage after loading will be improved, but that of course does not include all situations (UE4 and catherine don't count) (1, 2)
- **Vertex explosions have been reduced in Unity games**, and their performance has slightly improved. I am not sure if this has affected any other games. (4)
- Write tracking performance will improve with range-tracking, due to less dead overlapping textures within the same spot. In MK8, thousands of 32x32 textures are rendered to in a sequence to generate static lighting for actors. These take up the same space in memory as the _nvdec video_, causing a major performance hit when we return to the menu. With this change, these overlaps are removed before we start tracking the nvdec video, so it can continue being a nice single memory region rather than thousands of tiny ones. (1)

## Downsides
Some existing issues may be eccentuated:

- Luigi's mansion's dynamic resolution will glow with garbage colours more often, due to a ChangeSize bug. (5)
- Some corruption may happen when flushing a texture, though it is infrequent. (see below)

## Overlap + Flushing Rules

(writeup in progress)

## Random corruptions due to flushing?

Yes, I'm PRing something that has a chance to do this. Play 32 courses in Mario Kart and you will notice something that's off in at least one course, or it may even crash. Here's the reason why that is:

The rules for flushing indicate that we should only flush a texture if its memory has not been modified since the last time it was used (and if the memory was unmapped, which is working fine). What happens if two textures share the same page?

Under the _current method_ of tracking texture modification, two or more textures that share a page can face a dilemma. If one texture on the page consumes the dirty flag, it is consumed for _all other textures on the page_. How do we solve this one?

That's right - it's range tracking time again. Literally cannot get away from this. Essentially, it will work better when the memory write tracking is able to signal to each affected texture individually - so that if one's dirty bit is consumed, the other's is still present. The range tracking PR will be rebased on top of this one.

## Call for Testing
Even with the above issue, it would really benefit us to test this PR to check if there have been any regressions. Since every game uses textures, the surface area for potential regressions is huge. If the game is generally improved, good! If textures are corrupt, missing or the game crashes very quickly, then there's probably an issue.

This may change performance on some games, for better or worse. It will be good to know cases where it kills it.

This will be a part of the range tracking PR in future, which may be a better test target when it's up and running due to flushing being more predicatble. I will comment when that is ready.