### PR TITLE
Fix IDeliveryCacheProgressService GetEvent

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Bcat/ServiceCreator/IDeliveryCacheProgressService.cs
+++ b/Ryujinx.HLE/HOS/Services/Bcat/ServiceCreator/IDeliveryCacheProgressService.cs
@@ -27,7 +27,7 @@ namespace Ryujinx.HLE.HOS.Services.Bcat.ServiceCreator
                 throw new InvalidOperationException("Out of handles!");
             }
 
-            context.Response.HandleDesc = IpcHandleDesc.MakeMove(handle);
+            context.Response.HandleDesc = IpcHandleDesc.MakeCopy(handle);
 
             Logger.PrintStub(LogClass.ServiceBcat);
 


### PR DESCRIPTION
The function should copy, not move the handle to the client (the comment on top of the function says so aswell). Before it was returning the handle at the wrong place. This fixes a issue that was uncovered after #1362 that improved the WaitSynchronization implementation. Fixes a regression in SSBU.