### PR TITLE
Add multiple calls to am service

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/LibraryAppletCreator/ILibraryAppletAccessor.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/LibraryAppletCreator/ILibraryAppletAccessor.cs
@@ -161,5 +161,42 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Lib
 
             return ResultCode.Success;
         }
+
+        [Command(110)]
+        // NeedsToExitProcess()
+        public ResultCode NeedsToExitProcess(ServiceCtx context)
+        {
+            return ResultCode.Stubbed;
+        }
+
+        [Command(150)]
+        // RequestForAppletToGetForeground()
+        public ResultCode RequestForAppletToGetForeground(ServiceCtx context)
+        {
+            return ResultCode.Stubbed;
+        }
+
+        [Command(160)] // 2.0.0+
+        // GetIndirectLayerConsumerHandle() -> u64 indirect_layer_consumer_handle
+        public ResultCode GetIndirectLayerConsumerHandle(ServiceCtx context)
+        {
+            /*
+            if (indirectLayerConsumer == null)
+            {
+                return ResultCode.ObjectInvalid;
+            }
+            */
+
+            // TODO: Official sw uses this during LibraryApplet creation when LibraryAppletMode is 0x3.
+            //       Since we don't support IndirectLayer and the handle couldn't be 0, it's fine to return 1.
+
+            ulong indirectLayerConsumerHandle = 1;
+
+            context.ResponseData.Write(indirectLayerConsumerHandle);
+
+            Logger.PrintStub(LogClass.ServiceAm, new { indirectLayerConsumerHandle });
+
+            return ResultCode.Success;
+        }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ISelfController.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ISelfController.cs
@@ -209,7 +209,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // SetIdleTimeDetectionExtension(u32)
         public ResultCode SetIdleTimeDetectionExtension(ServiceCtx context)
         {
-            _idleTimeDetectionExtension = context.RequestData.ReadInt32();
+            _idleTimeDetectionExtension = context.RequestData.ReadUInt32();
 
             Logger.PrintStub(LogClass.ServiceAm, new { _idleTimeDetectionExtension });
 

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ISelfController.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ISelfController.cs
@@ -19,7 +19,18 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // TODO: Set this when the game goes in suspension (go back to home menu ect), we currently don't support that so we can keep it set to 0.
         private ulong _accumulatedSuspendedTickValue = 0;
 
-        private int _idleTimeDetectionExtension;
+        // TODO: Determine where those fields are used.
+        private bool _screenShotPermission               = false;
+        private bool _operationModeChangedNotification   = false;
+        private bool _performanceModeChangedNotification = false;
+        private bool _restartMessageEnabled              = false;
+        private bool _outOfFocusSuspendingEnabled        = false;
+        private bool _handlesRequestToDisplay            = false;
+        private bool _autoSleepDisabled                  = false;
+        private bool _albumImageTakenNotificationEnabled = false;
+
+        private uint _screenShotImageOrientation = 0;
+        private uint _idleTimeDetectionExtension = 0;
 
         public ISelfController(Horizon system)
         {
@@ -108,9 +119,9 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // SetScreenShotPermission(u32)
         public ResultCode SetScreenShotPermission(ServiceCtx context)
         {
-            bool enable = context.RequestData.ReadByte() != 0;
+            _screenShotPermission = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServiceAm);
+            Logger.PrintStub(LogClass.ServiceAm, new { _screenShotPermission });
 
             return ResultCode.Success;
         }
@@ -119,9 +130,9 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // SetOperationModeChangedNotification(b8)
         public ResultCode SetOperationModeChangedNotification(ServiceCtx context)
         {
-            bool enable = context.RequestData.ReadByte() != 0;
+            _operationModeChangedNotification = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServiceAm);
+            Logger.PrintStub(LogClass.ServiceAm, new { _operationModeChangedNotification });
 
             return ResultCode.Success;
         }
@@ -130,9 +141,9 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // SetPerformanceModeChangedNotification(b8)
         public ResultCode SetPerformanceModeChangedNotification(ServiceCtx context)
         {
-            bool enable = context.RequestData.ReadByte() != 0;
+            _performanceModeChangedNotification = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServiceAm);
+            Logger.PrintStub(LogClass.ServiceAm, new { _performanceModeChangedNotification });
 
             return ResultCode.Success;
         }
@@ -141,11 +152,11 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // SetFocusHandlingMode(b8, b8, b8)
         public ResultCode SetFocusHandlingMode(ServiceCtx context)
         {
-            bool flag1 = context.RequestData.ReadByte() != 0;
-            bool flag2 = context.RequestData.ReadByte() != 0;
-            bool flag3 = context.RequestData.ReadByte() != 0;
+            bool unknownFlag1 = context.RequestData.ReadBoolean();
+            bool unknownFlag2 = context.RequestData.ReadBoolean();
+            bool unknownFlag3 = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServiceAm);
+            Logger.PrintStub(LogClass.ServiceAm, new { unknownFlag1, unknownFlag2, unknownFlag3 });
 
             return ResultCode.Success;
         }
@@ -154,9 +165,9 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // SetRestartMessageEnabled(b8)
         public ResultCode SetRestartMessageEnabled(ServiceCtx context)
         {
-            bool enable = context.RequestData.ReadByte() != 0;
+            _restartMessageEnabled = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServiceAm);
+            Logger.PrintStub(LogClass.ServiceAm, new { _restartMessageEnabled });
 
             return ResultCode.Success;
         }
@@ -165,19 +176,20 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // SetOutOfFocusSuspendingEnabled(b8)
         public ResultCode SetOutOfFocusSuspendingEnabled(ServiceCtx context)
         {
-            bool enable = context.RequestData.ReadByte() != 0;
+            _outOfFocusSuspendingEnabled = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServiceAm);
+            Logger.PrintStub(LogClass.ServiceAm, new { _outOfFocusSuspendingEnabled });
 
             return ResultCode.Success;
         }
 
         [Command(19)] // 3.0.0+
+        // SetScreenShotImageOrientation(u32)
         public ResultCode SetScreenShotImageOrientation(ServiceCtx context)
         {
-            int orientation = context.RequestData.ReadInt32();
+            _screenShotImageOrientation = context.RequestData.ReadUInt32();
 
-            Logger.PrintStub(LogClass.ServiceAm);
+            Logger.PrintStub(LogClass.ServiceAm, new { _screenShotImageOrientation });
 
             return ResultCode.Success;
         }
@@ -186,9 +198,9 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // SetHandlesRequestToDisplay(b8)
         public ResultCode SetHandlesRequestToDisplay(ServiceCtx context)
         {
-            bool enable = context.RequestData.ReadByte() != 0;
+            _handlesRequestToDisplay = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServiceAm);
+            Logger.PrintStub(LogClass.ServiceAm, new { _handlesRequestToDisplay });
 
             return ResultCode.Success;
         }
@@ -211,6 +223,24 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             context.ResponseData.Write(_idleTimeDetectionExtension);
 
             Logger.PrintStub(LogClass.ServiceAm, new { _idleTimeDetectionExtension });
+
+            return ResultCode.Success;
+        }
+
+        [Command(68)]
+        // SetAutoSleepDisabled(u8)
+        public ResultCode SetAutoSleepDisabled(ServiceCtx context)
+        {
+            _autoSleepDisabled = context.RequestData.ReadBoolean();
+
+            return ResultCode.Success;
+        }
+
+        [Command(69)]
+        // IsAutoSleepDisabled() -> u8
+        public ResultCode IsAutoSleepDisabled(ServiceCtx context)
+        {
+            context.ResponseData.Write(_autoSleepDisabled);
 
             return ResultCode.Success;
         }
@@ -241,6 +271,15 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             }
 
             context.Response.HandleDesc = IpcHandleDesc.MakeCopy(_accumulatedSuspendedTickChangedEventHandle);
+
+            return ResultCode.Success;
+        }
+
+        [Command(100)] // 7.0.0+
+        // SetAlbumImageTakenNotificationEnabled(u8)
+        public ResultCode SetAlbumImageTakenNotificationEnabled(ServiceCtx context)
+        {
+            _albumImageTakenNotificationEnabled = context.RequestData.ReadBoolean();
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ISelfController.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ISelfController.cs
@@ -119,9 +119,11 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // SetScreenShotPermission(u32)
         public ResultCode SetScreenShotPermission(ServiceCtx context)
         {
-            _screenShotPermission = context.RequestData.ReadBoolean();
+            bool screenShotPermission = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServiceAm, new { _screenShotPermission });
+            Logger.PrintStub(LogClass.ServiceAm, new { screenShotPermission });
+
+            _screenShotPermission = screenShotPermission;
 
             return ResultCode.Success;
         }
@@ -130,9 +132,11 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // SetOperationModeChangedNotification(b8)
         public ResultCode SetOperationModeChangedNotification(ServiceCtx context)
         {
-            _operationModeChangedNotification = context.RequestData.ReadBoolean();
+            bool operationModeChangedNotification = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServiceAm, new { _operationModeChangedNotification });
+            Logger.PrintStub(LogClass.ServiceAm, new { operationModeChangedNotification });
+
+            _operationModeChangedNotification = operationModeChangedNotification;
 
             return ResultCode.Success;
         }
@@ -141,9 +145,11 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // SetPerformanceModeChangedNotification(b8)
         public ResultCode SetPerformanceModeChangedNotification(ServiceCtx context)
         {
-            _performanceModeChangedNotification = context.RequestData.ReadBoolean();
+            bool performanceModeChangedNotification = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServiceAm, new { _performanceModeChangedNotification });
+            Logger.PrintStub(LogClass.ServiceAm, new { performanceModeChangedNotification });
+
+            _performanceModeChangedNotification = performanceModeChangedNotification;
 
             return ResultCode.Success;
         }
@@ -165,9 +171,11 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // SetRestartMessageEnabled(b8)
         public ResultCode SetRestartMessageEnabled(ServiceCtx context)
         {
-            _restartMessageEnabled = context.RequestData.ReadBoolean();
+            bool restartMessageEnabled = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServiceAm, new { _restartMessageEnabled });
+            Logger.PrintStub(LogClass.ServiceAm, new { restartMessageEnabled });
+
+            _restartMessageEnabled = restartMessageEnabled;
 
             return ResultCode.Success;
         }
@@ -176,9 +184,11 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // SetOutOfFocusSuspendingEnabled(b8)
         public ResultCode SetOutOfFocusSuspendingEnabled(ServiceCtx context)
         {
-            _outOfFocusSuspendingEnabled = context.RequestData.ReadBoolean();
+            bool outOfFocusSuspendingEnabled = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServiceAm, new { _outOfFocusSuspendingEnabled });
+            Logger.PrintStub(LogClass.ServiceAm, new { outOfFocusSuspendingEnabled });
+
+            _outOfFocusSuspendingEnabled = outOfFocusSuspendingEnabled;
 
             return ResultCode.Success;
         }
@@ -187,9 +197,11 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // SetScreenShotImageOrientation(u32)
         public ResultCode SetScreenShotImageOrientation(ServiceCtx context)
         {
-            _screenShotImageOrientation = context.RequestData.ReadUInt32();
+            uint screenShotImageOrientation = context.RequestData.ReadUInt32();
 
-            Logger.PrintStub(LogClass.ServiceAm, new { _screenShotImageOrientation });
+            Logger.PrintStub(LogClass.ServiceAm, new { screenShotImageOrientation });
+
+            _screenShotImageOrientation = screenShotImageOrientation;
 
             return ResultCode.Success;
         }
@@ -198,9 +210,11 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // SetHandlesRequestToDisplay(b8)
         public ResultCode SetHandlesRequestToDisplay(ServiceCtx context)
         {
-            _handlesRequestToDisplay = context.RequestData.ReadBoolean();
+            bool handlesRequestToDisplay = context.RequestData.ReadBoolean();
 
-            Logger.PrintStub(LogClass.ServiceAm, new { _handlesRequestToDisplay });
+            Logger.PrintStub(LogClass.ServiceAm, new { handlesRequestToDisplay });
+
+            _handlesRequestToDisplay = handlesRequestToDisplay;
 
             return ResultCode.Success;
         }
@@ -209,9 +223,11 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // SetIdleTimeDetectionExtension(u32)
         public ResultCode SetIdleTimeDetectionExtension(ServiceCtx context)
         {
-            _idleTimeDetectionExtension = context.RequestData.ReadUInt32();
+            uint idleTimeDetectionExtension = context.RequestData.ReadUInt32();
 
-            Logger.PrintStub(LogClass.ServiceAm, new { _idleTimeDetectionExtension });
+            Logger.PrintStub(LogClass.ServiceAm, new { idleTimeDetectionExtension });
+
+            _idleTimeDetectionExtension = idleTimeDetectionExtension;
 
             return ResultCode.Success;
         }
@@ -231,7 +247,9 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // SetAutoSleepDisabled(u8)
         public ResultCode SetAutoSleepDisabled(ServiceCtx context)
         {
-            _autoSleepDisabled = context.RequestData.ReadBoolean();
+            bool autoSleepDisabled = context.RequestData.ReadBoolean();
+
+            _autoSleepDisabled = autoSleepDisabled;
 
             return ResultCode.Success;
         }
@@ -279,7 +297,9 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // SetAlbumImageTakenNotificationEnabled(u8)
         public ResultCode SetAlbumImageTakenNotificationEnabled(ServiceCtx context)
         {
-            _albumImageTakenNotificationEnabled = context.RequestData.ReadBoolean();
+            bool albumImageTakenNotificationEnabled = context.RequestData.ReadBoolean();
+
+            _albumImageTakenNotificationEnabled = albumImageTakenNotificationEnabled;
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
@@ -158,7 +158,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
         // NotifyRunning() -> b8
         public ResultCode NotifyRunning(ServiceCtx context)
         {
-            context.ResponseData.Write(1);
+            context.ResponseData.Write(true);
 
             return ResultCode.Success;
         }
@@ -191,6 +191,17 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             int state = context.RequestData.ReadInt32();
 
             Logger.PrintStub(LogClass.ServiceAm, new { state });
+
+            return ResultCode.Success;
+        }
+
+        [Command(90)] // 4.0.0+
+        // EnableApplicationCrashReport(u8)
+        public ResultCode EnableApplicationCrashReport(ServiceCtx context)
+        {
+            bool applicationCrashReportEnabled = context.RequestData.ReadBoolean();
+
+            Logger.PrintStub(LogClass.ServiceAm, new { applicationCrashReportEnabled });
 
             return ResultCode.Success;
         }
@@ -317,6 +328,22 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
         {
             // TODO: Call pdm:qry cmd 16 when IPC call between services will be implemented.
             return (ResultCode)QueryPlayStatisticsManager.GetPlayStatistics(context, true);
+        }
+
+        [Command(123)] // 5.0.0+
+        // GetPreviousProgramIndex() -> s32 program_index
+        public ResultCode GetPreviousProgramIndex(ServiceCtx context)
+        {
+            // TODO: The output PreviousProgramIndex is -1 when there was no previous title.
+            //       When multi-process will be supported, return the last program index.
+
+            int previousProgramIndex = -1;
+
+            context.ResponseData.Write(previousProgramIndex);
+
+            Logger.PrintStub(LogClass.ServiceAm, new { previousProgramIndex });
+
+            return ResultCode.Success;
         }
 
         [Command(130)] // 8.0.0+

--- a/Ryujinx.HLE/HOS/Services/Am/ResultCode.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/ResultCode.cs
@@ -22,6 +22,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
         StackPoolExhausted     = (712 << ErrorCodeShift) | ModuleId,
         DebugModeNotEnabled    = (974 << ErrorCodeShift) | ModuleId,
         DevFunctionNotEnabled  = (980 << ErrorCodeShift) | ModuleId,
-        NotImplemented         = (998 << ErrorCodeShift) | ModuleId
+        NotImplemented         = (998 << ErrorCodeShift) | ModuleId,
+        Stubbed                = (999 << ErrorCodeShift) | ModuleId
     }
 }


### PR DESCRIPTION
This implement/stub some am calls:

- SetAutoSleepDisabled
- IsAutoSleepDisabled
- SetAlbumImageTakenNotificationEnabled
- EnableApplicationCrashReport
- GetPreviousProgramIndex
- NeedsToExitProcess
- RequestForAppletToGetForeground
- GetIndirectLayerConsumerHandle

All checked by RE.
Additionnaly to that, there is some cleanup here and there.

Fix #1387, #1324, #1165, #1163, #1065