### PR TITLE
Implement BGRA texture support

### DIFF
--- a/Ryujinx.Graphics.GAL/Format.cs
+++ b/Ryujinx.Graphics.GAL/Format.cs
@@ -231,6 +231,25 @@ namespace Ryujinx.Graphics.GAL
         }
 
         /// <summary>
+        /// Checks if the texture format is a BGRA format with 8-bit components.
+        /// </summary>
+        /// <param name="format">Texture format</param>
+        /// <returns>True if the texture format is a BGRA format with 8-bit components, false otherwise</returns>
+        public static bool IsBgra8(this Format format)
+        {
+            switch (format)
+            {
+                case Format.B8G8R8X8Unorm:
+                case Format.B8G8R8A8Unorm:
+                case Format.B8G8R8X8Srgb:
+                case Format.B8G8R8A8Srgb:
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Checks if the texture format is a depth, stencil or depth-stencil format.
         /// </summary>
         /// <param name="format">Texture format</param>

--- a/Ryujinx.Graphics.OpenGL/FormatTable.cs
+++ b/Ryujinx.Graphics.OpenGL/FormatTable.cs
@@ -164,10 +164,10 @@ namespace Ryujinx.Graphics.OpenGL
             Add(Format.B5G5R5X1Unorm,       new FormatInfo(4, true,  false, All.Rgb5,              PixelFormat.Bgra,           PixelType.UnsignedShort5551));
             Add(Format.B5G5R5A1Unorm,       new FormatInfo(4, true,  false, All.Rgb5A1,            PixelFormat.Bgra,           PixelType.UnsignedShort5551));
             Add(Format.A1B5G5R5Unorm,       new FormatInfo(4, true,  false, All.Rgb5A1,            PixelFormat.Bgra,           PixelType.UnsignedShort1555Reversed));
-            Add(Format.B8G8R8X8Unorm,       new FormatInfo(4, true,  false, All.Rgba8,             PixelFormat.Bgra,           PixelType.UnsignedByte));
-            Add(Format.B8G8R8A8Unorm,       new FormatInfo(4, true,  false, All.Rgba8,             PixelFormat.Bgra,           PixelType.UnsignedByte));
-            Add(Format.B8G8R8X8Srgb,        new FormatInfo(4, false, false, All.Srgb8,             PixelFormat.BgraInteger,    PixelType.UnsignedByte));
-            Add(Format.B8G8R8A8Srgb,        new FormatInfo(4, false, false, All.Srgb8Alpha8,       PixelFormat.BgraInteger,    PixelType.UnsignedByte));
+            Add(Format.B8G8R8X8Unorm,       new FormatInfo(4, true,  false, All.Rgba8,             PixelFormat.Rgba,           PixelType.UnsignedByte));
+            Add(Format.B8G8R8A8Unorm,       new FormatInfo(4, true,  false, All.Rgba8,             PixelFormat.Rgba,           PixelType.UnsignedByte));
+            Add(Format.B8G8R8X8Srgb,        new FormatInfo(4, false, false, All.Srgb8,             PixelFormat.Rgba,           PixelType.UnsignedByte));
+            Add(Format.B8G8R8A8Srgb,        new FormatInfo(4, false, false, All.Srgb8Alpha8,       PixelFormat.Rgba,           PixelType.UnsignedByte));
         }
 
         private static void Add(Format format, FormatInfo info)

--- a/Ryujinx.Graphics.OpenGL/Image/TextureBase.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureBase.cs
@@ -8,7 +8,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
     {
         public int Handle { get; protected set; }
 
-        protected TextureCreateInfo Info { get; }
+        public TextureCreateInfo Info { get; }
 
         public int Width { get; }
         public int Height { get; }

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -31,7 +31,7 @@ namespace Ryujinx.Graphics.OpenGL
         private int _boundDrawFramebuffer;
         private int _boundReadFramebuffer;
 
-        private bool[] _fpIsBgra = new bool[8];
+        private int[] _fpIsBgra = new int[8];
         private float[] _fpRenderScale = new float[33];
         private float[] _cpRenderScale = new float[32];
 
@@ -817,7 +817,7 @@ namespace Ryujinx.Graphics.OpenGL
 
                 _framebuffer.AttachColor(index, color);
 
-                _fpIsBgra[index] = color != null ? color.Format.IsBgra8() : false;
+                _fpIsBgra[index] = color != null && color.Format.IsBgra8() ? 1 : 0;
             }
 
             UpdateFpIsBgra();
@@ -1123,10 +1123,7 @@ namespace Ryujinx.Graphics.OpenGL
         {
             if (_program != null)
             {
-                for (int index = 0; index < _fpIsBgra.Length; index++)
-                {
-                    GL.Uniform1(_program.FragmentIsBgraUniform[index], _fpIsBgra[index] ? 1 : 0);
-                }
+                GL.Uniform1(_program.FragmentIsBgraUniform, 8, _fpIsBgra);
             }
         }
 

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -31,6 +31,7 @@ namespace Ryujinx.Graphics.OpenGL
         private int _boundDrawFramebuffer;
         private int _boundReadFramebuffer;
 
+        private bool[] _fpIsBgra = new bool[8];
         private float[] _fpRenderScale = new float[33];
         private float[] _cpRenderScale = new float[32];
 
@@ -722,12 +723,12 @@ namespace Ryujinx.Graphics.OpenGL
                 GL.Disable(EnableCap.ProgramPointSize);
             }
 
-            GL.PointParameter(origin == Origin.LowerLeft 
-                ? PointSpriteCoordOriginParameter.LowerLeft 
+            GL.PointParameter(origin == Origin.LowerLeft
+                ? PointSpriteCoordOriginParameter.LowerLeft
                 : PointSpriteCoordOriginParameter.UpperLeft);
 
             // Games seem to set point size to 0 which generates a GL_INVALID_VALUE
-            // From the spec, GL_INVALID_VALUE is generated if size is less than or equal to 0. 
+            // From the spec, GL_INVALID_VALUE is generated if size is less than or equal to 0.
             GL.PointSize(Math.Max(float.Epsilon, size));
         }
 
@@ -765,6 +766,7 @@ namespace Ryujinx.Graphics.OpenGL
                 _program.Bind();
             }
 
+            UpdateFpIsBgra();
             SetRenderTargetScale(_fpRenderScale[0]);
         }
 
@@ -814,12 +816,15 @@ namespace Ryujinx.Graphics.OpenGL
                 TextureView color = (TextureView)colors[index];
 
                 _framebuffer.AttachColor(index, color);
+
+                _fpIsBgra[index] = color != null ? color.Format.IsBgra8() : false;
             }
+
+            UpdateFpIsBgra();
 
             TextureView depthStencilView = (TextureView)depthStencil;
 
             _framebuffer.AttachDepthStencil(depthStencilView);
-
             _framebuffer.SetDrawBuffers(colors.Length);
 
             _hasDepthBuffer = depthStencil != null && depthStencilView.Format != Format.S8Uint;
@@ -938,7 +943,9 @@ namespace Ryujinx.Graphics.OpenGL
 
                                 if (activeTarget != null && activeTarget.Width / (float)texture.Width == activeTarget.Height / (float)texture.Height)
                                 {
-                                    // If the texture's size is a multiple of the sampler size, enable interpolation using gl_FragCoord. (helps "invent" new integer values between scaled pixels)
+                                    // If the texture's size is a multiple of the sampler size,
+                                    // enable interpolation using gl_FragCoord.
+                                    // (helps "invent" new integer values between scaled pixels)
                                     interpolate = true;
                                 }
                             }
@@ -1112,6 +1119,17 @@ namespace Ryujinx.Graphics.OpenGL
             return (_boundDrawFramebuffer, _boundReadFramebuffer);
         }
 
+        private void UpdateFpIsBgra()
+        {
+            if (_program != null)
+            {
+                for (int index = 0; index < _fpIsBgra.Length; index++)
+                {
+                    GL.Uniform1(_program.FragmentIsBgraUniform[index], _fpIsBgra[index] ? 1 : 0);
+                }
+            }
+        }
+
         private void UpdateDepthTest()
         {
             // Enabling depth operations is only valid when we have
@@ -1134,6 +1152,29 @@ namespace Ryujinx.Graphics.OpenGL
                 GL.Disable(EnableCap.DepthTest);
 
                 GL.DepthMask(false);
+            }
+        }
+
+        public void UpdateRenderScale(ShaderStage stage, int textureCount)
+        {
+            if (_program != null)
+            {
+                switch (stage)
+                {
+                    case ShaderStage.Fragment:
+                        if (_program.FragmentRenderScaleUniform != -1)
+                        {
+                            GL.Uniform1(_program.FragmentRenderScaleUniform, textureCount + 1, _fpRenderScale);
+                        }
+                        break;
+
+                    case ShaderStage.Compute:
+                        if (_program.ComputeRenderScaleUniform != -1)
+                        {
+                            GL.Uniform1(_program.ComputeRenderScaleUniform, textureCount, _cpRenderScale);
+                        }
+                        break;
+                }
             }
         }
 
@@ -1229,29 +1270,6 @@ namespace Ryujinx.Graphics.OpenGL
         {
             _framebuffer?.Dispose();
             _vertexArray?.Dispose();
-        }
-
-        public void UpdateRenderScale(ShaderStage stage, int textureCount)
-        {
-            if (_program != null)
-            {
-                switch (stage)
-                {
-                    case ShaderStage.Fragment:
-                        if (_program.FragmentRenderScaleUniform != -1)
-                        {
-                            GL.Uniform1(_program.FragmentRenderScaleUniform, textureCount + 1, _fpRenderScale);
-                        }
-                        break;
-
-                    case ShaderStage.Compute:
-                        if (_program.ComputeRenderScaleUniform != -1)
-                        {
-                            GL.Uniform1(_program.ComputeRenderScaleUniform, textureCount, _cpRenderScale);
-                        }
-                        break;
-                }
-            }
         }
     }
 }

--- a/Ryujinx.Graphics.OpenGL/Program.cs
+++ b/Ryujinx.Graphics.OpenGL/Program.cs
@@ -25,6 +25,7 @@ namespace Ryujinx.Graphics.OpenGL
 
         public int Handle { get; private set; }
 
+        public int[] FragmentIsBgraUniform { get; }
         public int FragmentRenderScaleUniform { get; }
         public int ComputeRenderScaleUniform { get; }
 
@@ -216,6 +217,13 @@ namespace Ryujinx.Graphics.OpenGL
 
                     imageUnit++;
                 }
+            }
+
+            FragmentIsBgraUniform = new int[8];
+
+            for (int index = 0; index < FragmentIsBgraUniform.Length; index++)
+            {
+                FragmentIsBgraUniform[index] = GL.GetUniformLocation(Handle, $"is_bgra[{index}]");
             }
 
             FragmentRenderScaleUniform = GL.GetUniformLocation(Handle, "fp_renderScale");

--- a/Ryujinx.Graphics.OpenGL/Program.cs
+++ b/Ryujinx.Graphics.OpenGL/Program.cs
@@ -25,7 +25,7 @@ namespace Ryujinx.Graphics.OpenGL
 
         public int Handle { get; private set; }
 
-        public int[] FragmentIsBgraUniform { get; }
+        public int FragmentIsBgraUniform { get; }
         public int FragmentRenderScaleUniform { get; }
         public int ComputeRenderScaleUniform { get; }
 
@@ -219,13 +219,7 @@ namespace Ryujinx.Graphics.OpenGL
                 }
             }
 
-            FragmentIsBgraUniform = new int[8];
-
-            for (int index = 0; index < FragmentIsBgraUniform.Length; index++)
-            {
-                FragmentIsBgraUniform[index] = GL.GetUniformLocation(Handle, $"is_bgra[{index}]");
-            }
-
+            FragmentIsBgraUniform = GL.GetUniformLocation(Handle, "is_bgra");
             FragmentRenderScaleUniform = GL.GetUniformLocation(Handle, "fp_renderScale");
             ComputeRenderScaleUniform = GL.GetUniformLocation(Handle, "cp_renderScale");
         }

--- a/Ryujinx.Graphics.OpenGL/Window.cs
+++ b/Ryujinx.Graphics.OpenGL/Window.cs
@@ -161,8 +161,6 @@ namespace Ryujinx.Graphics.OpenGL
             return handle;
         }
 
-
-
         public void Dispose()
         {
             if (_copyFramebufferHandle != 0)

--- a/Ryujinx.Graphics.OpenGL/Window.cs
+++ b/Ryujinx.Graphics.OpenGL/Window.cs
@@ -51,10 +51,12 @@ namespace Ryujinx.Graphics.OpenGL
             GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, drawFramebuffer);
             GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, readFramebuffer);
 
+            TextureView viewConverted = view.Format.IsBgra8() ? _renderer.TextureCopy.BgraSwap(view) : view;
+
             GL.FramebufferTexture(
                 FramebufferTarget.ReadFramebuffer,
                 FramebufferAttachment.ColorAttachment0,
-                view.Handle,
+                viewConverted.Handle,
                 0);
 
             GL.ReadBuffer(ReadBufferMode.ColorAttachment0);
@@ -138,6 +140,11 @@ namespace Ryujinx.Graphics.OpenGL
 
             ((Pipeline)_renderer.Pipeline).RestoreScissor0Enable();
             ((Pipeline)_renderer.Pipeline).RestoreRasterizerDiscard();
+
+            if (viewConverted != view)
+            {
+                viewConverted.Dispose();
+            }
         }
 
         private int GetCopyFramebufferHandleLazy()
@@ -153,6 +160,8 @@ namespace Ryujinx.Graphics.OpenGL
 
             return handle;
         }
+
+
 
         public void Dispose()
         {

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
@@ -139,6 +139,11 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
             if (context.Config.Stage == ShaderStage.Fragment || context.Config.Stage == ShaderStage.Compute)
             {
+                if (context.Config.Stage == ShaderStage.Fragment)
+                {
+                    context.AppendLine($"uniform bool {DefaultNames.IsBgraName}[8];");
+                }
+
                 if (DeclareRenderScale(context))
                 {
                     context.AppendLine();

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
@@ -142,6 +142,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
                 if (context.Config.Stage == ShaderStage.Fragment)
                 {
                     context.AppendLine($"uniform bool {DefaultNames.IsBgraName}[8];");
+                    context.AppendLine();
                 }
 
                 if (DeclareRenderScale(context))

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/DefaultNames.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/DefaultNames.cs
@@ -23,5 +23,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
         public const string SharedMemoryName = "shared_mem";
 
         public const string UndefinedName = "undef";
+
+        public const string IsBgraName = "is_bgra";
     }
 }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
@@ -64,6 +64,16 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
             { AttributeConsts.GtMask,              new BuiltInAttribute("unpackUint2x32(gl_SubGroupGtMaskARB).x", VariableType.U32) },
             { AttributeConsts.LeMask,              new BuiltInAttribute("unpackUint2x32(gl_SubGroupLeMaskARB).x", VariableType.U32) },
             { AttributeConsts.LtMask,              new BuiltInAttribute("unpackUint2x32(gl_SubGroupLtMaskARB).x", VariableType.U32) },
+
+            // Support uniforms.
+            { AttributeConsts.FragmentOutputIsBgraBase + 0,  new BuiltInAttribute($"{DefaultNames.IsBgraName}[0]",  VariableType.Bool) },
+            { AttributeConsts.FragmentOutputIsBgraBase + 4,  new BuiltInAttribute($"{DefaultNames.IsBgraName}[1]",  VariableType.Bool) },
+            { AttributeConsts.FragmentOutputIsBgraBase + 8,  new BuiltInAttribute($"{DefaultNames.IsBgraName}[2]",  VariableType.Bool) },
+            { AttributeConsts.FragmentOutputIsBgraBase + 12, new BuiltInAttribute($"{DefaultNames.IsBgraName}[3]",  VariableType.Bool) },
+            { AttributeConsts.FragmentOutputIsBgraBase + 16, new BuiltInAttribute($"{DefaultNames.IsBgraName}[4]",  VariableType.Bool) },
+            { AttributeConsts.FragmentOutputIsBgraBase + 20, new BuiltInAttribute($"{DefaultNames.IsBgraName}[5]",  VariableType.Bool) },
+            { AttributeConsts.FragmentOutputIsBgraBase + 24, new BuiltInAttribute($"{DefaultNames.IsBgraName}[6]",  VariableType.Bool) },
+            { AttributeConsts.FragmentOutputIsBgraBase + 28, new BuiltInAttribute($"{DefaultNames.IsBgraName}[7]",  VariableType.Bool) }
         };
 
         private Dictionary<AstOperand, string> _locals;
@@ -149,8 +159,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
             char swzMask = GetSwizzleMask((value >> 2) & 3);
 
-            if (value >= AttributeConsts.UserAttributeBase &&
-                value <  AttributeConsts.UserAttributeEnd)
+            if (value >= AttributeConsts.UserAttributeBase && value < AttributeConsts.UserAttributeEnd)
             {
                 value -= AttributeConsts.UserAttributeBase;
 
@@ -169,8 +178,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
             }
             else
             {
-                if (value >= AttributeConsts.FragmentOutputColorBase &&
-                    value <  AttributeConsts.FragmentOutputColorEnd)
+                if (value >= AttributeConsts.FragmentOutputColorBase && value < AttributeConsts.FragmentOutputColorEnd)
                 {
                     value -= AttributeConsts.FragmentOutputColorBase;
 

--- a/Ryujinx.Graphics.Shader/Translation/AttributeConsts.cs
+++ b/Ryujinx.Graphics.Shader/Translation/AttributeConsts.cs
@@ -35,6 +35,9 @@ namespace Ryujinx.Graphics.Shader.Translation
         public const int FragmentOutputColorBase = 0x1000010;
         public const int FragmentOutputColorEnd  = FragmentOutputColorBase + 8 * 16;
 
+        public const int FragmentOutputIsBgraBase = 0x1000100;
+        public const int FragmentOutputIsBgraEnd  = FragmentOutputIsBgraBase + 8 * 4;
+
         public const int ThreadIdX = 0x2000000;
         public const int ThreadIdY = 0x2000004;
         public const int ThreadIdZ = 0x2000008;

--- a/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -115,22 +115,46 @@ namespace Ryujinx.Graphics.Shader.Translation
 
                 int regIndex = 0;
 
-                for (int attachment = 0; attachment < 8; attachment++)
+                for (int rtIndex = 0; rtIndex < 8; rtIndex++)
                 {
-                    OmapTarget target = Config.OmapTargets[attachment];
+                    OmapTarget target = Config.OmapTargets[rtIndex];
 
                     for (int component = 0; component < 4; component++)
                     {
-                        if (target.ComponentEnabled(component))
+                        if (!target.ComponentEnabled(component))
                         {
-                            Operand dest = Attribute(AttributeConsts.FragmentOutputColorBase + attachment * 16 + component * 4);
-
-                            Operand src = Register(regIndex, RegisterType.Gpr);
-
-                            this.Copy(dest, src);
-
-                            regIndex++;
+                            continue;
                         }
+
+                        int fragmentOutputColorAttr = AttributeConsts.FragmentOutputColorBase + rtIndex * 16;
+
+                        Operand src = Register(regIndex, RegisterType.Gpr);
+
+                        // Perform B <-> R swap if needed, for BGRA formats (not support on OpenGL).
+                        if (component == 0 || component == 2)
+                        {
+                            Operand isBgra = Attribute(AttributeConsts.FragmentOutputIsBgraBase + rtIndex * 4);
+
+                            Operand lblIsBgra = Label();
+                            Operand lblEnd    = Label();
+
+                            this.BranchIfTrue(lblIsBgra, isBgra);
+
+                            this.Copy(Attribute(fragmentOutputColorAttr + component * 4), src);
+                            this.Branch(lblEnd);
+
+                            MarkLabel(lblIsBgra);
+
+                            this.Copy(Attribute(fragmentOutputColorAttr + (2 - component) * 4), src);
+
+                            MarkLabel(lblEnd);
+                        }
+                        else
+                        {
+                            this.Copy(Attribute(fragmentOutputColorAttr + component * 4), src);
+                        }
+
+                        regIndex++;
                     }
                 }
             }

--- a/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -130,7 +130,7 @@ namespace Ryujinx.Graphics.Shader.Translation
 
                         Operand src = Register(regIndex, RegisterType.Gpr);
 
-                        // Perform B <-> R swap if needed, for BGRA formats (not support on OpenGL).
+                        // Perform B <-> R swap if needed, for BGRA formats (not supported on OpenGL).
                         if (component == 0 || component == 2)
                         {
                             Operand isBgra = Attribute(AttributeConsts.FragmentOutputIsBgraBase + rtIndex * 4);

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
@@ -247,7 +247,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
         }
 
         private void PostFrameBuffer(Layer layer, BufferItem item)
-        { 
+        {
             int frameBufferWidth  = item.GraphicBuffer.Object.Width;
             int frameBufferHeight = item.GraphicBuffer.Object.Height;
 


### PR DESCRIPTION
This adds proper support for BGRA8 textures. OpenGL does not support this format, so before data was just being written as RGBA. This actually emulates BGRA with the following method:
- When the BGRA texture is used as render target, the R and B components are swapped on the pixel shader. New uniforms were added to indicate if the given output N should have their components swapped. Note that this will consume one extra constant buffer, that can't be used for game constant buffers anymore (however this was already the case with resolution scaling enabled).
- When a BGRA texture is bound, the R and B components are swapped on the swizzle parameters.
- When a BGRA texture is copied to another non-BGRA texture (and vice-versa), it first swaps R and B doing a PBO copy to a temporary texture, and then performs the copy as normal, using the temporary texture as source.
- When a BGRA texture is presented to the screen, it does the same as above, but doing a blit to the backbuffer instead of another destination texture.

This fixes all isues I'm aware of games with inverted R and B components. Examples:
Before:
![image](https://user-images.githubusercontent.com/5624669/88340679-a3d56c80-cd12-11ea-878d-9c2724aabca7.png)
After:
![image](https://user-images.githubusercontent.com/5624669/88340730-b8b20000-cd12-11ea-9bc4-8e960e38e156.png)
Before:
![image](https://user-images.githubusercontent.com/5624669/88340805-db441900-cd12-11ea-8c0d-7a87dded5072.png)
After:
![image](https://user-images.githubusercontent.com/5624669/88340824-e26b2700-cd12-11ea-95a3-ab1ecb03ebcf.png)
Before:
![image](https://user-images.githubusercontent.com/5624669/88341005-3118c100-cd13-11ea-88ec-0ef070e95e51.png)
After:
![image](https://user-images.githubusercontent.com/5624669/88341026-383fcf00-cd13-11ea-8e10-1c6fe22bab46.png)
Hatsune Miku Project DIVA MEGA39's also had a similar issue on displays, which is now fixed:
![image](https://user-images.githubusercontent.com/5624669/88341091-51488000-cd13-11ea-98d4-6003b4726c4b.png)

NOTE: Some of the before screenshots were taken from the gamedb, not by me, so credits goes for those that took said screenshots.