### PR TITLE
common: Fix WMI exception

### DIFF
--- a/Ryujinx.Common/SystemInfo/WindowsSystemInfo.cs
+++ b/Ryujinx.Common/SystemInfo/WindowsSystemInfo.cs
@@ -1,3 +1,5 @@
+using Ryujinx.Common.Logging;
+using System;
 using System.Management;
 
 namespace Ryujinx.Common.SystemInfo
@@ -9,14 +11,24 @@ namespace Ryujinx.Common.SystemInfo
 
         public WindowsSysteminfo()
         {
-            foreach (ManagementBaseObject mObject in new ManagementObjectSearcher("root\\CIMV2", "SELECT * FROM Win32_Processor").Get())
+            try
             {
-                CpuName = mObject["Name"].ToString();
-            }
+                foreach (ManagementBaseObject mObject in new ManagementObjectSearcher("root\\CIMV2", "SELECT * FROM Win32_Processor").Get())
+                {
+                    CpuName = mObject["Name"].ToString();
+                }
 
-            foreach (ManagementBaseObject mObject in new ManagementObjectSearcher("root\\CIMV2", "SELECT * FROM Win32_OperatingSystem").Get())
+                foreach (ManagementBaseObject mObject in new ManagementObjectSearcher("root\\CIMV2", "SELECT * FROM Win32_OperatingSystem").Get())
+                {
+                    RamSize = ulong.Parse(mObject["TotalVisibleMemorySize"].ToString()) * 1024;
+                }
+            }
+            catch (Exception)
             {
-                RamSize = ulong.Parse(mObject["TotalVisibleMemorySize"].ToString()) * 1024;
+                Logger.PrintError(LogClass.Application, "WMI isn't available, system informations will use default values.");
+
+                CpuName = "Unknown";
+                RamSize = 0;
             }
         }
     }

--- a/Ryujinx.Common/SystemInfo/WindowsSystemInfo.cs
+++ b/Ryujinx.Common/SystemInfo/WindowsSystemInfo.cs
@@ -1,4 +1,5 @@
 using Ryujinx.Common.Logging;
+using System;
 using System.Management;
 using System.Runtime.InteropServices;
 
@@ -11,6 +12,8 @@ namespace Ryujinx.Common.SystemInfo
 
         public WindowsSysteminfo()
         {
+            bool wmiNotAvailable = false;
+
             try
             {
                 foreach (ManagementBaseObject mObject in new ManagementObjectSearcher("root\\CIMV2", "SELECT * FROM Win32_Processor").Get())
@@ -23,7 +26,16 @@ namespace Ryujinx.Common.SystemInfo
                     RamSize = ulong.Parse(mObject["TotalVisibleMemorySize"].ToString()) * 1024;
                 }
             }
+            catch (PlatformNotSupportedException)
+            {
+                wmiNotAvailable = true;
+            }
             catch (COMException)
+            {
+                wmiNotAvailable = true;
+            }
+
+            if (wmiNotAvailable)
             {
                 Logger.PrintError(LogClass.Application, "WMI isn't available, system informations will use default values.");
 

--- a/Ryujinx.Common/SystemInfo/WindowsSystemInfo.cs
+++ b/Ryujinx.Common/SystemInfo/WindowsSystemInfo.cs
@@ -28,7 +28,6 @@ namespace Ryujinx.Common.SystemInfo
                 Logger.PrintError(LogClass.Application, "WMI isn't available, system informations will use default values.");
 
                 CpuName = "Unknown";
-                RamSize = 0;
             }
         }
     }

--- a/Ryujinx.Common/SystemInfo/WindowsSystemInfo.cs
+++ b/Ryujinx.Common/SystemInfo/WindowsSystemInfo.cs
@@ -1,6 +1,6 @@
 using Ryujinx.Common.Logging;
-using System;
 using System.Management;
+using System.Runtime.InteropServices;
 
 namespace Ryujinx.Common.SystemInfo
 {
@@ -23,7 +23,7 @@ namespace Ryujinx.Common.SystemInfo
                     RamSize = ulong.Parse(mObject["TotalVisibleMemorySize"].ToString()) * 1024;
                 }
             }
-            catch (Exception)
+            catch (COMException)
             {
                 Logger.PrintError(LogClass.Application, "WMI isn't available, system informations will use default values.");
 


### PR DESCRIPTION
We currently don't check if WMI service is available when we get the CPU name and the RAM size.
This fix the issue by catching all exceptions and set default values instead.

Close #1353