### PR TITLE
Use polygon offset clamp if supported

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -568,7 +568,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
             enables |= (depthBias.LineEnable  ? PolygonModeMask.Line  : 0);
             enables |= (depthBias.FillEnable  ? PolygonModeMask.Fill  : 0);
 
-            _context.Renderer.Pipeline.SetDepthBias(enables, factor, units, clamp);
+            _context.Renderer.Pipeline.SetDepthBias(enables, factor, units / 2f, clamp);
         }
 
         /// <summary>
@@ -697,7 +697,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
             float size = state.Get<float>(MethodOffset.PointSize);
             bool isProgramPointSize = state.Get<Boolean32>(MethodOffset.VertexProgramPointSize);
             bool enablePointSprite = state.Get<Boolean32>(MethodOffset.PointSpriteEnable);
-            
+
             // TODO: Need to figure out a way to map PointCoordReplace enable bit.
             Origin origin = (state.Get<int>(MethodOffset.PointCoordReplace) & 4) == 0 ? Origin.LowerLeft : Origin.UpperLeft;
 

--- a/Ryujinx.Graphics.OpenGL/HwCapabilities.cs
+++ b/Ryujinx.Graphics.OpenGL/HwCapabilities.cs
@@ -7,6 +7,7 @@ namespace Ryujinx.Graphics.OpenGL
     {
         private static readonly Lazy<bool> _supportsAstcCompression    = new Lazy<bool>(() => HasExtension("GL_KHR_texture_compression_astc_ldr"));
         private static readonly Lazy<bool> _supportsImageLoadFormatted = new Lazy<bool>(() => HasExtension("GL_EXT_shader_image_load_formatted"));
+        private static readonly Lazy<bool> _supportsPolygonOffsetClamp = new Lazy<bool>(() => HasExtension("GL_EXT_polygon_offset_clamp"));
         private static readonly Lazy<bool> _supportsViewportSwizzle    = new Lazy<bool>(() => HasExtension("GL_NV_viewport_swizzle"));
 
         private static readonly Lazy<int> _maximumComputeSharedMemorySize = new Lazy<int>(() => GetLimit(All.MaxComputeSharedMemorySize));
@@ -28,6 +29,7 @@ namespace Ryujinx.Graphics.OpenGL
 
         public static bool SupportsAstcCompression          => _supportsAstcCompression.Value;
         public static bool SupportsImageLoadFormatted       => _supportsImageLoadFormatted.Value;
+        public static bool SupportsPolygonOffsetClamp       => _supportsPolygonOffsetClamp.Value;
         public static bool SupportsViewportSwizzle          => _supportsViewportSwizzle.Value;
         public static bool SupportsNonConstantTextureOffset => _gpuVendor.Value == GpuVendor.Nvidia;
 

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -609,9 +609,14 @@ namespace Ryujinx.Graphics.OpenGL
                 return;
             }
 
-            GL.PolygonOffset(factor, units / 2f);
-            // TODO: Enable when GL_EXT_polygon_offset_clamp is supported.
-            // GL.PolygonOffsetClamp(factor, units, clamp);
+            if (HwCapabilities.SupportsPolygonOffsetClamp)
+            {
+                GL.PolygonOffsetClamp(factor, units, clamp);
+            }
+            else
+            {
+                GL.PolygonOffset(factor, units);
+            }
         }
 
         public void SetDepthClamp(bool clamp)
@@ -722,12 +727,12 @@ namespace Ryujinx.Graphics.OpenGL
                 GL.Disable(EnableCap.ProgramPointSize);
             }
 
-            GL.PointParameter(origin == Origin.LowerLeft 
-                ? PointSpriteCoordOriginParameter.LowerLeft 
+            GL.PointParameter(origin == Origin.LowerLeft
+                ? PointSpriteCoordOriginParameter.LowerLeft
                 : PointSpriteCoordOriginParameter.UpperLeft);
 
             // Games seem to set point size to 0 which generates a GL_INVALID_VALUE
-            // From the spec, GL_INVALID_VALUE is generated if size is less than or equal to 0. 
+            // From the spec, GL_INVALID_VALUE is generated if size is less than or equal to 0.
             GL.PointSize(Math.Max(float.Epsilon, size));
         }
 


### PR DESCRIPTION
This uses the polygon offset clamp value set by the game if the host supports it. I don't know any game that uses a non-zero value for the clamp, so I'm not aware of any game that would be affected by this change.