### PR TITLE
Refactor shader translator ShaderConfig and reduce the number of out args

### DIFF
--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
@@ -283,14 +283,14 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
         public static void Tld(EmitterContext context)
         {
-            context.UsedFeatures |= FeatureFlags.IntegerSampling;
+            context.Config.SetUsedFeature(FeatureFlags.IntegerSampling);
 
             EmitTextureSample(context, TextureFlags.IntCoords);
         }
 
         public static void TldB(EmitterContext context)
         {
-            context.UsedFeatures |= FeatureFlags.IntegerSampling;
+            context.Config.SetUsedFeature(FeatureFlags.IntegerSampling);
 
             EmitTextureSample(context, TextureFlags.IntCoords | TextureFlags.Bindless);
         }
@@ -432,7 +432,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
                     return;
                 }
 
-                context.UsedFeatures |= FeatureFlags.IntegerSampling;
+                context.Config.SetUsedFeature(FeatureFlags.IntegerSampling);
 
                 flags = ConvertTextureFlags(tldsOp.Target) | TextureFlags.IntCoords;
 

--- a/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -11,8 +11,6 @@ namespace Ryujinx.Graphics.Shader.Translation
         public Block  CurrBlock { get; set; }
         public OpCode CurrOp    { get; set; }
 
-        public FeatureFlags UsedFeatures { get; set; }
-
         public ShaderConfig Config { get; }
 
         private List<Operation> _operations;
@@ -50,7 +48,7 @@ namespace Ryujinx.Graphics.Shader.Translation
                 {
                     case AttributeConsts.PositionX:
                     case AttributeConsts.PositionY:
-                        UsedFeatures |= FeatureFlags.FragCoordXY;
+                        Config.SetUsedFeature(FeatureFlags.FragCoordXY);
                         break;
                 }
             }

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -1,8 +1,6 @@
-using System;
-
 namespace Ryujinx.Graphics.Shader.Translation
 {
-    struct ShaderConfig
+    class ShaderConfig
     {
         public ShaderStage Stage { get; }
 
@@ -22,7 +20,9 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public TranslationFlags Flags { get; }
 
-        public FeatureFlags UsedFeatures { get; set; }
+        public int Size { get; private set; }
+
+        public FeatureFlags UsedFeatures { get; private set; }
 
         public ShaderConfig(IGpuAccessor gpuAccessor, TranslationFlags flags)
         {
@@ -36,6 +36,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             OmapDepth         = false;
             GpuAccessor       = gpuAccessor;
             Flags             = flags;
+            Size              = 0;
             UsedFeatures      = FeatureFlags.None;
         }
 
@@ -51,6 +52,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             OmapDepth         = header.OmapDepth;
             GpuAccessor       = gpuAccessor;
             Flags             = flags;
+            Size              = 0;
             UsedFeatures      = FeatureFlags.None;
         }
 
@@ -92,6 +94,16 @@ namespace Ryujinx.Graphics.Shader.Translation
             }
 
             return format;
+        }
+
+        public void SizeAdd(int size)
+        {
+            Size += size;
+        }
+
+        public void SetUsedFeature(FeatureFlags flags)
+        {
+            UsedFeatures |= flags;
         }
     }
 }


### PR DESCRIPTION
The main goal here is reducing the number of out arguments on the `Decode` function (from 3 to 1). The other out args were moved to the `ShaderConfig` struct. Said struct was also changed to a class as there was no advantage in keeping it a struct, plus it was necessary for those changes to work. as otherwise it would have copy semantics and the new methods added wouldn't change what it should.

The intention of those changes is just improving the code without any changes on functionality.