### PR TITLE
Use movd,movq for i32/64 VectorExtract %x, 0x0

### DIFF
--- a/ARMeilleure/CodeGen/X86/CodeGenerator.cs
+++ b/ARMeilleure/CodeGen/X86/CodeGenerator.cs
@@ -1146,10 +1146,9 @@ namespace ARMeilleure.CodeGen.X86
             Debug.Assert(src1.Type == OperandType.V128);
             Debug.Assert(src2.Kind == OperandKind.Constant);
 
-            int  count = OperandType.V128.GetSizeInBytes() / dest.Type.GetSizeInBytes();
             byte index = src2.AsByte();
 
-            Debug.Assert(index < count);
+            Debug.Assert(index < OperandType.V128.GetSizeInBytes() / dest.Type.GetSizeInBytes());
 
             if (dest.Type == OperandType.I32)
             {

--- a/ARMeilleure/CodeGen/X86/CodeGenerator.cs
+++ b/ARMeilleure/CodeGen/X86/CodeGenerator.cs
@@ -1152,27 +1152,27 @@ namespace ARMeilleure.CodeGen.X86
             {
                 Debug.Assert(index < 4);
 
-                if (HardwareCapabilities.SupportsSse41)
+                if (index == 0)
                 {
-                    context.Assembler.Pextrd(dest, src1, index);
+                    context.Assembler.Movd(dest, src1);
                 }
                 else
                 {
-                    if (index != 0)
+                    if (HardwareCapabilities.SupportsSse41)
+                    {
+                        context.Assembler.Pextrd(dest, src1, index);
+                    }
+                    else
                     {
                         int mask0 = 0b11_10_01_00;
                         int mask1 = 0b11_10_01_00;
 
-                        mask0 = BitUtils.RotateRight(mask0,     index * 2, 8);
+                        mask0 = BitUtils.RotateRight(mask0, index * 2, 8);
                         mask1 = BitUtils.RotateRight(mask1, 8 - index * 2, 8);
 
                         context.Assembler.Pshufd(src1, src1, (byte)mask0);
                         context.Assembler.Movd  (dest, src1);
                         context.Assembler.Pshufd(src1, src1, (byte)mask1);
-                    }
-                    else
-                    {
-                        context.Assembler.Movd(dest, src1);
                     }
                 }
             }
@@ -1180,23 +1180,23 @@ namespace ARMeilleure.CodeGen.X86
             {
                 Debug.Assert(index < 2);
 
-                if (HardwareCapabilities.SupportsSse41)
+                if (index == 0)
                 {
-                    context.Assembler.Pextrq(dest, src1, index);
+                    context.Assembler.Movq(dest, src1);
                 }
                 else
                 {
-                    if (index != 0)
+                    if (HardwareCapabilities.SupportsSse41)
+                    {
+                        context.Assembler.Pextrq(dest, src1, index);
+                    }
+                    else
                     {
                         const byte mask = 0b01_00_11_10;
 
                         context.Assembler.Pshufd(src1, src1, mask);
                         context.Assembler.Movq  (dest, src1);
                         context.Assembler.Pshufd(src1, src1, mask);
-                    }
-                    else
-                    {
-                        context.Assembler.Movq(dest, src1);
                     }
                 }
             }

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -20,7 +20,7 @@ namespace ARMeilleure.Translation.PTC
     {
         private const string HeaderMagic = "PTChd";
 
-        private const int InternalVersion = 14; //! To be incremented manually for each change to the ARMeilleure project.
+        private const int InternalVersion = 17; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string BaseDir = "Ryujinx";
 


### PR DESCRIPTION
Prefer `movd`/`movq` over `pextrd`/`pextrq` when extracting element 0 of a vector for i32/i64.

```patch
@@ -84,7 +84,7 @@
   jz .L7
 .L5:
   movdqu xmm0,[rsp+0xa0]
-  pextrq rbx,xmm0,0x0
+  movq rbx,xmm0
   mov rbp,WriteUInt64
   mov rax,[rsp+0xbc]
   mov rcx,rax
@@ -1012,7 +1012,7 @@
   movdqu xmm0,xmm4
   movdqu [rsp+0x124],xmm0
   movdqu xmm0,[rsp+0x124]
-  pextrd ebp,xmm0,0x0
+  movd ebp,xmm0
   mov ebp,ebp
   mov rax,rbp
   mov [rsp+0x8c],rax
```

This makes `Instrinsic.X86Cvtsi2si %x` unnecessary since these operations can now be replaced by a `i32/i64 VectorExtract %x, 0x0` instead.