### PR TITLE
fs: stub ReadSaveDataFileSystemExtraDataWithMaskBySaveDataAttribute

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
@@ -6,6 +6,7 @@ using LibHac.FsSystem.NcaUtils;
 using LibHac.Ncm;
 using Ryujinx.Common;
 using Ryujinx.Common.Logging;
+using Ryujinx.Cpu;
 using Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy;
 using System.IO;
 
@@ -353,6 +354,16 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             }
 
             return (ResultCode)result.Value;
+        }
+
+        [Command(71)]
+        public ResultCode ReadSaveDataFileSystemExtraDataWithMaskBySaveDataAttribute(ServiceCtx context)
+        {
+            Logger.PrintStub(LogClass.ServiceFs);
+
+            MemoryHelper.FillWithZeros(context.Memory, context.Request.ReceiveBuff[0].Position, (int)context.Request.ReceiveBuff[0].Size);
+
+            return ResultCode.Success;
         }
 
         [Command(200)]


### PR DESCRIPTION
This is required by AC:NH for the new online save features of 1.4.0

NOTE: I haven't bothered to add the IPC comment as most of the FS interface is missing that right now. (will surely do something about that in a next PR)