### PR TITLE
Implement a Macro JIT

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoClass.cs
@@ -13,6 +13,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
     class GPFifoClass : IDeviceState
     {
         private readonly GpuContext _context;
+        private readonly GPFifoProcessor _parent;
         private readonly DeviceState<GPFifoClassState> _state;
 
         private const int MacrosCount = 0x80;
@@ -25,17 +26,14 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
         private readonly int[] _macroCode;
 
         /// <summary>
-        /// MME Shadow RAM Control.
-        /// </summary>
-        public ShadowRamControl ShadowCtrl { get; private set; }
-
-        /// <summary>
         /// Creates a new instance of the GPU General Purpose FIFO class.
         /// </summary>
         /// <param name="context">GPU context</param>
-        public GPFifoClass(GpuContext context)
+        /// <param name="parent">Parent GPU General Purpose FIFO processor</param>
+        public GPFifoClass(GpuContext context, GPFifoProcessor parent)
         {
             _context = context;
+            _parent = parent;
             _state = new DeviceState<GPFifoClassState>(new Dictionary<string, RwCallback>
             {
                 { nameof(GPFifoClassState.Semaphored), new RwCallback(Semaphored, null) },
@@ -155,7 +153,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
         }
 
         /// <summary>
-        /// Send macro code/data to the MME
+        /// Sends macro code/data to the MME.
         /// </summary>
         /// <param name="argument">Method call argument</param>
         public void LoadMmeInstructionRam(int argument)
@@ -164,7 +162,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
         }
 
         /// <summary>
-        /// Bind a macro index to a position for the MME
+        /// Binds a macro index to a position for the MME
         /// </summary>
         /// <param name="argument">Method call argument</param>
         public void LoadMmeStartAddressRam(int argument)
@@ -173,12 +171,12 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
         }
 
         /// <summary>
-        /// Change the shadow RAM setting
+        /// Changes the shadow RAM control.
         /// </summary>
         /// <param name="argument">Method call argument</param>
         public void SetMmeShadowRamControl(int argument)
         {
-            ShadowCtrl = (ShadowRamControl)argument;
+            _parent.SetShadowRamControl((ShadowRamControl)argument);
         }
 
         /// <summary>
@@ -208,7 +206,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
         /// <param name="state">Current GPU state</param>
         public void CallMme(int index, GpuState state)
         {
-            _macros[index].Execute(_macroCode, ShadowCtrl, state);
+            _macros[index].Execute(_macroCode, state);
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoProcessor.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoProcessor.cs
@@ -39,8 +39,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
         {
             _context = context;
 
-            _fifoClass = new GPFifoClass(context);
-
+            _fifoClass = new GPFifoClass(context, this);
             _subChannels = new GpuState[8];
 
             for (int index = 0; index < _subChannels.Length; index++)
@@ -152,7 +151,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
             }
             else if (meth.Method < 0xe00)
             {
-                _subChannels[meth.SubChannel].CallMethod(meth, _fifoClass.ShadowCtrl);
+                _subChannels[meth.SubChannel].CallMethod(meth);
             }
             else
             {
@@ -173,6 +172,18 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
 
                     _context.Methods.PerformDeferredDraws();
                 }
+            }
+        }
+
+        /// <summary>
+        /// Sets the shadow ram control value of all sub-channels.
+        /// </summary>
+        /// <param name="control">New shadow ram control value</param>
+        public void SetShadowRamControl(ShadowRamControl control)
+        {
+            for (int i = 0; i < _subChannels.Length; i++)
+            {
+                _subChannels[i].ShadowRamControl = control;
             }
         }
     }

--- a/Ryujinx.Graphics.Gpu/Engine/MME/AluOperation.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MME/AluOperation.cs
@@ -1,0 +1,15 @@
+﻿namespace Ryujinx.Graphics.Gpu.Engine.MME
+{
+    /// <summary>
+    /// GPU Macro Arithmetic and Logic unit operation.
+    /// </summary>
+    enum AluOperation
+    {
+        AluReg = 0,
+        AddImmediate = 1,
+        BitfieldReplace = 2,
+        BitfieldExtractLslImm = 3,
+        BitfieldExtractLslReg = 4,
+        ReadImmediate = 5
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Engine/MME/AluRegOperation.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MME/AluRegOperation.cs
@@ -1,0 +1,18 @@
+﻿namespace Ryujinx.Graphics.Gpu.Engine.MME
+{
+    /// <summary>
+    /// GPU Macro Arithmetic and Logic unit binary register-to-register operation.
+    /// </summary>
+    enum AluRegOperation
+    {
+        Add = 0,
+        AddWithCarry = 1,
+        Subtract = 2,
+        SubtractWithBorrow = 3,
+        BitwiseExclusiveOr = 8,
+        BitwiseOr = 9,
+        BitwiseAnd = 10,
+        BitwiseAndNot = 11,
+        BitwiseNotAnd = 12
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Engine/MME/AssignmentOperation.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MME/AssignmentOperation.cs
@@ -1,0 +1,17 @@
+﻿namespace Ryujinx.Graphics.Gpu.Engine.MME
+{
+    /// <summary>
+    /// GPU Macro assignment operation.
+    /// </summary>
+    enum AssignmentOperation
+    {
+        IgnoreAndFetch = 0,
+        Move = 1,
+        MoveAndSetMaddr = 2,
+        FetchAndSend = 3,
+        MoveAndSend = 4,
+        FetchAndSetMaddr = 5,
+        MoveAndSetMaddrThenFetchAndSend = 6,
+        MoveAndSetMaddrThenSendHigh = 7
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Engine/MME/IMacroEE.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MME/IMacroEE.cs
@@ -1,0 +1,25 @@
+﻿using Ryujinx.Graphics.Gpu.State;
+using System;
+using System.Collections.Generic;
+
+namespace Ryujinx.Graphics.Gpu.Engine.MME
+{
+    /// <summary>
+    /// Macro Execution Engine interface.
+    /// </summary>
+    interface IMacroEE
+    {
+        /// <summary>
+        /// Arguments FIFO.
+        /// </summary>
+        public Queue<int> Fifo { get; }
+
+        /// <summary>
+        /// Should execute the GPU Macro code being passed.
+        /// </summary>
+        /// <param name="code">Code to be executed</param>
+        /// <param name="state">GPU state at the time of the call</param>
+        /// <param name="arg0">First argument to be passed to the GPU Macro</param>
+        void Execute(ReadOnlySpan<int> code, GpuState state, int arg0);
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Engine/MME/MacroJit.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MME/MacroJit.cs
@@ -1,0 +1,39 @@
+﻿using Ryujinx.Graphics.Gpu.State;
+using System;
+using System.Collections.Generic;
+
+namespace Ryujinx.Graphics.Gpu.Engine.MME
+{
+    /// <summary>
+    /// Represents a execution engine that uses a Just-in-Time compiler for fast execution.
+    /// </summary>
+    class MacroJit : IMacroEE
+    {
+        private readonly MacroJitContext _context = new MacroJitContext();
+
+        /// <summary>
+        /// Arguments FIFO.
+        /// </summary>
+        public Queue<int> Fifo => _context.Fifo;
+
+        private MacroJitCompiler.MacroExecute _execute;
+
+        /// <summary>
+        /// Executes a macro program until it exits.
+        /// </summary>
+        /// <param name="code">Code of the program to execute</param>
+        /// <param name="state">Current GPU state</param>
+        /// <param name="arg0">Optional argument passed to the program, 0 if not used</param>
+        public void Execute(ReadOnlySpan<int> code, GpuState state, int arg0)
+        {
+            if (_execute == null)
+            {
+                MacroJitCompiler compiler = new MacroJitCompiler();
+
+                _execute = compiler.Compile(code);
+            }
+
+            _execute(_context, state, arg0);
+        }
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Engine/MME/MacroJitCompiler.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MME/MacroJitCompiler.cs
@@ -1,0 +1,516 @@
+﻿using Ryujinx.Graphics.Gpu.State;
+using System;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+
+namespace Ryujinx.Graphics.Gpu.Engine.MME
+{
+    /// <summary>
+    /// Represents a Macro Just-in-Time compiler.
+    /// </summary>R
+    class MacroJitCompiler
+    {
+        private readonly DynamicMethod _meth;
+        private readonly ILGenerator _ilGen;
+        private readonly LocalBuilder[] _gprs;
+        private readonly LocalBuilder _carry;
+        private readonly LocalBuilder _methAddr;
+        private readonly LocalBuilder _methIncr;
+
+        /// <summary>
+        /// Creates a new instance of the Macro Just-in-Time compiler.
+        /// </summary>
+        public MacroJitCompiler()
+        {
+            _meth = new DynamicMethod("Macro", typeof(void), new Type[] { typeof(MacroJitContext), typeof(GpuState), typeof(int) });
+            _ilGen = _meth.GetILGenerator();
+            _gprs = new LocalBuilder[8];
+
+            for (int i = 1; i < 8; i++)
+            {
+                _gprs[i] = _ilGen.DeclareLocal(typeof(int));
+            }
+
+            _carry = _ilGen.DeclareLocal(typeof(int));
+            _methAddr = _ilGen.DeclareLocal(typeof(int));
+            _methIncr = _ilGen.DeclareLocal(typeof(int));
+
+            _ilGen.Emit(OpCodes.Ldarg_2);
+            _ilGen.Emit(OpCodes.Stloc, _gprs[1]);
+        }
+
+        public delegate void MacroExecute(MacroJitContext context, GpuState state, int arg0);
+
+        /// <summary>
+        /// Translates a new piece of GPU Macro code into host executable code.
+        /// </summary>
+        /// <param name="code">Code to be translated</param>
+        /// <returns>Delegate of the host compiled code</returns>
+        public MacroExecute Compile(ReadOnlySpan<int> code)
+        {
+            Dictionary<int, Label> labels = new Dictionary<int, Label>();
+
+            int lastTarget = 0;
+            int i;
+
+            // Collect all branch targets.
+            for (i = 0; i < code.Length; i++)
+            {
+                int opCode = code[i];
+
+                if ((opCode & 7) == 7)
+                {
+                    int target = i + (opCode >> 14);
+
+                    if (!labels.ContainsKey(target))
+                    {
+                        labels.Add(target, _ilGen.DefineLabel());
+                    }
+
+                    if (lastTarget < target)
+                    {
+                        lastTarget = target;
+                    }
+                }
+
+                bool exit = (opCode & 0x80) != 0;
+
+                if (exit && i >= lastTarget)
+                {
+                    break;
+                }
+            }
+
+            // Code generation.
+            for (i = 0; i < code.Length; i++)
+            {
+                if (labels.TryGetValue(i, out Label label))
+                {
+                    _ilGen.MarkLabel(label);
+                }
+
+                Emit(code, i, labels);
+
+                int opCode = code[i];
+
+                bool exit = (opCode & 0x80) != 0;
+
+                if (exit)
+                {
+                    Emit(code, i + 1, labels);
+                    _ilGen.Emit(OpCodes.Ret);
+
+                    if (i >= lastTarget)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            if (i == code.Length)
+            {
+                _ilGen.Emit(OpCodes.Ret);
+            }
+
+            return (MacroExecute)_meth.CreateDelegate(typeof(MacroExecute));
+        }
+
+        /// <summary>
+        /// Emits IL equivalent to the Macro instruction at a given offset.
+        /// </summary>
+        /// <param name="code">GPU Macro code</param>
+        /// <param name="offset">Offset, in words, where the instruction is located</param>
+        /// <param name="labels">Labels for Macro branch targets, used by branch instructions</param>
+        private void Emit(ReadOnlySpan<int> code, int offset, Dictionary<int, Label> labels)
+        {
+            int opCode = code[offset];
+
+            if ((opCode & 7) < 7)
+            {
+                // Operation produces a value.
+                AssignmentOperation asgOp = (AssignmentOperation)((opCode >> 4) & 7);
+
+                EmitAluOp(opCode);
+
+                switch (asgOp)
+                {
+                    // Fetch parameter and ignore result.
+                    case AssignmentOperation.IgnoreAndFetch:
+                        _ilGen.Emit(OpCodes.Pop);
+                        EmitFetchParam();
+                        EmitStoreDstGpr(opCode);
+                        break;
+                    // Move result.
+                    case AssignmentOperation.Move:
+                        EmitStoreDstGpr(opCode);
+                        break;
+                    // Move result and use as Method Address.
+                    case AssignmentOperation.MoveAndSetMaddr:
+                        _ilGen.Emit(OpCodes.Dup);
+                        EmitStoreDstGpr(opCode);
+                        EmitStoreMethAddr();
+                        break;
+                    // Fetch parameter and send result.
+                    case AssignmentOperation.FetchAndSend:
+                        EmitFetchParam();
+                        EmitStoreDstGpr(opCode);
+                        EmitSend();
+                        break;
+                    // Move and send result.
+                    case AssignmentOperation.MoveAndSend:
+                        _ilGen.Emit(OpCodes.Dup);
+                        EmitStoreDstGpr(opCode);
+                        EmitSend();
+                        break;
+                    // Fetch parameter and use result as Method Address.
+                    case AssignmentOperation.FetchAndSetMaddr:
+                        EmitFetchParam();
+                        EmitStoreDstGpr(opCode);
+                        EmitStoreMethAddr();
+                        break;
+                    // Move result and use as Method Address, then fetch and send parameter.
+                    case AssignmentOperation.MoveAndSetMaddrThenFetchAndSend:
+                        _ilGen.Emit(OpCodes.Dup);
+                        EmitStoreDstGpr(opCode);
+                        EmitStoreMethAddr();
+                        EmitFetchParam();
+                        EmitSend();
+                        break;
+                    // Move result and use as Method Address, then send bits 17:12 of result.
+                    case AssignmentOperation.MoveAndSetMaddrThenSendHigh:
+                        _ilGen.Emit(OpCodes.Dup);
+                        _ilGen.Emit(OpCodes.Dup);
+                        EmitStoreDstGpr(opCode);
+                        EmitStoreMethAddr();
+                        _ilGen.Emit(OpCodes.Ldc_I4, 12);
+                        _ilGen.Emit(OpCodes.Shr_Un);
+                        _ilGen.Emit(OpCodes.Ldc_I4, 0x3f);
+                        _ilGen.Emit(OpCodes.And);
+                        EmitSend();
+                        break;
+                }
+            }
+            else
+            {
+                // Branch.
+                bool onNotZero = ((opCode >> 4) & 1) != 0;
+
+                EmitLoadGprA(opCode);
+
+                Label lblSkip = _ilGen.DefineLabel();
+
+                if (onNotZero)
+                {
+                    _ilGen.Emit(OpCodes.Brfalse, lblSkip);
+                }
+                else
+                {
+                    _ilGen.Emit(OpCodes.Brtrue, lblSkip);
+                }
+
+                bool noDelays = (opCode & 0x20) != 0;
+
+                if (!noDelays)
+                {
+                    Emit(code, offset + 1, labels);
+                }
+
+                int target = offset + (opCode >> 14);
+
+                _ilGen.Emit(OpCodes.Br, labels[target]);
+
+                _ilGen.MarkLabel(lblSkip);
+            }
+        }
+
+        /// <summary>
+        /// Emits IL for a Arithmetic and Logic Unit instruction.
+        /// </summary>
+        /// <param name="opCode">Instruction to be translated</param>
+        /// <exception cref="InvalidOperationException">Throw when the instruction encoding is invalid</exception>
+        private void EmitAluOp(int opCode)
+        {
+            AluOperation op = (AluOperation)(opCode & 7);
+
+            switch (op)
+            {
+                case AluOperation.AluReg:
+                    EmitAluOp((AluRegOperation)((opCode >> 17) & 0x1f), opCode);
+                    break;
+
+                case AluOperation.AddImmediate:
+                    EmitLoadGprA(opCode);
+                    EmitLoadImm(opCode);
+                    _ilGen.Emit(OpCodes.Add);
+                    break;
+
+                case AluOperation.BitfieldReplace:
+                case AluOperation.BitfieldExtractLslImm:
+                case AluOperation.BitfieldExtractLslReg:
+                    int bfSrcBit = (opCode >> 17) & 0x1f;
+                    int bfSize = (opCode >> 22) & 0x1f;
+                    int bfDstBit = (opCode >> 27) & 0x1f;
+
+                    int bfMask = (1 << bfSize) - 1;
+
+                    switch (op)
+                    {
+                        case AluOperation.BitfieldReplace:
+                            EmitLoadGprB(opCode);
+                            _ilGen.Emit(OpCodes.Ldc_I4, bfSrcBit);
+                            _ilGen.Emit(OpCodes.Shr_Un);
+                            _ilGen.Emit(OpCodes.Ldc_I4, bfMask);
+                            _ilGen.Emit(OpCodes.And);
+                            _ilGen.Emit(OpCodes.Ldc_I4, bfDstBit);
+                            _ilGen.Emit(OpCodes.Shl);
+                            EmitLoadGprA(opCode);
+                            _ilGen.Emit(OpCodes.Ldc_I4, ~(bfMask << bfDstBit));
+                            _ilGen.Emit(OpCodes.And);
+                            _ilGen.Emit(OpCodes.Or);
+                            break;
+
+                        case AluOperation.BitfieldExtractLslImm:
+                            EmitLoadGprB(opCode);
+                            EmitLoadGprA(opCode);
+                            _ilGen.Emit(OpCodes.Shr_Un);
+                            _ilGen.Emit(OpCodes.Ldc_I4, bfMask);
+                            _ilGen.Emit(OpCodes.And);
+                            _ilGen.Emit(OpCodes.Ldc_I4, bfDstBit);
+                            _ilGen.Emit(OpCodes.Shl);
+                            break;
+
+                        case AluOperation.BitfieldExtractLslReg:
+                            EmitLoadGprB(opCode);
+                            _ilGen.Emit(OpCodes.Ldc_I4, bfSrcBit);
+                            _ilGen.Emit(OpCodes.Shr_Un);
+                            _ilGen.Emit(OpCodes.Ldc_I4, bfMask);
+                            _ilGen.Emit(OpCodes.And);
+                            EmitLoadGprA(opCode);
+                            _ilGen.Emit(OpCodes.Shl);
+                            break;
+                    }
+                    break;
+
+                case AluOperation.ReadImmediate:
+                    _ilGen.Emit(OpCodes.Ldarg_1);
+                    EmitLoadGprA(opCode);
+                    EmitLoadImm(opCode);
+                    _ilGen.Emit(OpCodes.Add);
+                    _ilGen.Emit(OpCodes.Call, typeof(MacroJitContext).GetMethod(nameof(MacroJitContext.Read)));
+                    break;
+
+                default:
+                    throw new InvalidOperationException($"Invalid operation \"{op}\" on instruction 0x{opCode:X8}.");
+            }
+        }
+
+        /// <summary>
+        /// Emits IL for a binary Arithmetic and Logic Unit instruction.
+        /// </summary>
+        /// <param name="aluOp">Arithmetic and Logic Unit instruction</param>
+        /// <param name="opCode">Raw instruction</param>
+        /// <exception cref="InvalidOperationException">Throw when the instruction encoding is invalid</exception>
+        private void EmitAluOp(AluRegOperation aluOp, int opCode)
+        {
+            switch (aluOp)
+            {
+                case AluRegOperation.Add:
+                    EmitLoadGprA(opCode);
+                    _ilGen.Emit(OpCodes.Conv_U8);
+                    EmitLoadGprB(opCode);
+                    _ilGen.Emit(OpCodes.Conv_U8);
+                    _ilGen.Emit(OpCodes.Add);
+                    _ilGen.Emit(OpCodes.Dup);
+                    _ilGen.Emit(OpCodes.Ldc_I8, 0xffffffffL);
+                    _ilGen.Emit(OpCodes.Cgt_Un);
+                    _ilGen.Emit(OpCodes.Stloc, _carry);
+                    _ilGen.Emit(OpCodes.Conv_U4);
+                    break;
+                case AluRegOperation.AddWithCarry:
+                    EmitLoadGprA(opCode);
+                    _ilGen.Emit(OpCodes.Conv_U8);
+                    EmitLoadGprB(opCode);
+                    _ilGen.Emit(OpCodes.Conv_U8);
+                    _ilGen.Emit(OpCodes.Ldloc_S, _carry);
+                    _ilGen.Emit(OpCodes.Conv_U8);
+                    _ilGen.Emit(OpCodes.Add);
+                    _ilGen.Emit(OpCodes.Add);
+                    _ilGen.Emit(OpCodes.Dup);
+                    _ilGen.Emit(OpCodes.Ldc_I8, 0xffffffffL);
+                    _ilGen.Emit(OpCodes.Cgt_Un);
+                    _ilGen.Emit(OpCodes.Stloc, _carry);
+                    _ilGen.Emit(OpCodes.Conv_U4);
+                    break;
+                case AluRegOperation.Subtract:
+                    EmitLoadGprA(opCode);
+                    _ilGen.Emit(OpCodes.Conv_U8);
+                    EmitLoadGprB(opCode);
+                    _ilGen.Emit(OpCodes.Conv_U8);
+                    _ilGen.Emit(OpCodes.Sub);
+                    _ilGen.Emit(OpCodes.Dup);
+                    _ilGen.Emit(OpCodes.Ldc_I8, 0x100000000L);
+                    _ilGen.Emit(OpCodes.Clt_Un);
+                    _ilGen.Emit(OpCodes.Stloc, _carry);
+                    _ilGen.Emit(OpCodes.Conv_U4);
+                    break;
+                case AluRegOperation.SubtractWithBorrow:
+                    EmitLoadGprA(opCode);
+                    _ilGen.Emit(OpCodes.Conv_U8);
+                    EmitLoadGprB(opCode);
+                    _ilGen.Emit(OpCodes.Conv_U8);
+                    _ilGen.Emit(OpCodes.Ldloc_S, _carry);
+                    _ilGen.Emit(OpCodes.Conv_U8);
+                    _ilGen.Emit(OpCodes.Neg);
+                    _ilGen.Emit(OpCodes.Sub);
+                    _ilGen.Emit(OpCodes.Add);
+                    _ilGen.Emit(OpCodes.Dup);
+                    _ilGen.Emit(OpCodes.Ldc_I8, 0x100000000L);
+                    _ilGen.Emit(OpCodes.Clt_Un);
+                    _ilGen.Emit(OpCodes.Stloc, _carry);
+                    _ilGen.Emit(OpCodes.Conv_U4);
+                    break;
+                case AluRegOperation.BitwiseExclusiveOr:
+                    EmitLoadGprA(opCode);
+                    EmitLoadGprB(opCode);
+                    _ilGen.Emit(OpCodes.Xor);
+                    break;
+                case AluRegOperation.BitwiseOr:
+                    EmitLoadGprA(opCode);
+                    EmitLoadGprB(opCode);
+                    _ilGen.Emit(OpCodes.Or);
+                    break;
+                case AluRegOperation.BitwiseAnd:
+                    EmitLoadGprA(opCode);
+                    EmitLoadGprB(opCode);
+                    _ilGen.Emit(OpCodes.And);
+                    break;
+                case AluRegOperation.BitwiseAndNot:
+                    EmitLoadGprA(opCode);
+                    EmitLoadGprB(opCode);
+                    _ilGen.Emit(OpCodes.Not);
+                    _ilGen.Emit(OpCodes.And);
+                    break;
+                case AluRegOperation.BitwiseNotAnd:
+                    EmitLoadGprA(opCode);
+                    EmitLoadGprB(opCode);
+                    _ilGen.Emit(OpCodes.And);
+                    _ilGen.Emit(OpCodes.Not);
+                    break;
+                default:
+                    throw new InvalidOperationException($"Invalid operation \"{aluOp}\" on instruction 0x{opCode:X8}.");
+            }
+        }
+
+        /// <summary>
+        /// Loads a immediate value on the IL evaluation stack.
+        /// </summary>
+        /// <param name="opCode">Instruction from where the immediate should be extracted</param>
+        private void EmitLoadImm(int opCode)
+        {
+            // Note: The immediate is signed, the sign-extension is intended here.
+            _ilGen.Emit(OpCodes.Ldc_I4, opCode >> 14);
+        }
+
+        /// <summary>
+        /// Loads a value from the General Purpose register specified as first operand on the IL evaluation stack.
+        /// </summary>
+        /// <param name="opCode">Instruction from where the register number should be extracted</param>
+        private void EmitLoadGprA(int opCode)
+        {
+            EmitLoadGpr((opCode >> 11) & 7);
+        }
+
+        /// <summary>
+        /// Loads a value from the General Purpose register specified as second operand on the IL evaluation stack.
+        /// </summary>
+        /// <param name="opCode">Instruction from where the register number should be extracted</param>
+        private void EmitLoadGprB(int opCode)
+        {
+            EmitLoadGpr((opCode >> 14) & 7);
+        }
+
+        /// <summary>
+        /// Loads a value a General Purpose register on the IL evaluation stack.
+        /// </summary>
+        /// <remarks>
+        /// Register number 0 has a hardcoded value of 0.
+        /// </remarks>
+        /// <param name="index">Register number</param>
+        private void EmitLoadGpr(int index)
+        {
+            if (index == 0)
+            {
+                _ilGen.Emit(OpCodes.Ldc_I4_0);
+            }
+            else
+            {
+                _ilGen.Emit(OpCodes.Ldloc_S, _gprs[index]);
+            }
+        }
+
+        /// <summary>
+        /// Emits a call to the method that fetches an argument from the arguments FIFO.
+        /// The argument is pushed into the IL evaluation stack.
+        /// </summary>
+        private void EmitFetchParam()
+        {
+            _ilGen.Emit(OpCodes.Ldarg_0);
+            _ilGen.Emit(OpCodes.Call, typeof(MacroJitContext).GetMethod(nameof(MacroJitContext.FetchParam)));
+        }
+
+        /// <summary>
+        /// Stores the value on the top of the IL evaluation stack into a General Purpose register.
+        /// </summary>
+        /// <remarks>
+        /// Register number 0 does not exist, reads are hardcoded to 0, and writes are simply discarded.
+        /// </remarks>
+        /// <param name="opCode">Instruction from where the register number should be extracted</param>
+        private void EmitStoreDstGpr(int opCode)
+        {
+            int index = (opCode >> 8) & 7;
+
+            if (index == 0)
+            {
+                _ilGen.Emit(OpCodes.Pop);
+            }
+            else
+            {
+                _ilGen.Emit(OpCodes.Stloc_S, _gprs[index]);
+            }
+        }
+
+        /// <summary>
+        /// Stores the value on the top of the IL evaluation stack as method address.
+        /// This will be used on subsequent send calls as the destination method address.
+        /// Additionally, the 6 bits starting at bit 12 will be used as increment value,
+        /// added to the method address after each sent value.
+        /// </summary>
+        private void EmitStoreMethAddr()
+        {
+            _ilGen.Emit(OpCodes.Dup);
+            _ilGen.Emit(OpCodes.Ldc_I4, 0xfff);
+            _ilGen.Emit(OpCodes.And);
+            _ilGen.Emit(OpCodes.Stloc_S, _methAddr);
+            _ilGen.Emit(OpCodes.Ldc_I4, 12);
+            _ilGen.Emit(OpCodes.Shr_Un);
+            _ilGen.Emit(OpCodes.Ldc_I4, 0x3f);
+            _ilGen.Emit(OpCodes.And);
+            _ilGen.Emit(OpCodes.Stloc_S, _methIncr);
+        }
+
+        /// <summary>
+        /// Sends the value on the top of the IL evaluation stack to the GPU,
+        /// using the current method address.
+        /// </summary>
+        private void EmitSend()
+        {
+            _ilGen.Emit(OpCodes.Ldarg_1);
+            _ilGen.Emit(OpCodes.Ldloc_S, _methAddr);
+            _ilGen.Emit(OpCodes.Call, typeof(MacroJitContext).GetMethod(nameof(MacroJitContext.Send)));
+            _ilGen.Emit(OpCodes.Ldloc_S, _methAddr);
+            _ilGen.Emit(OpCodes.Ldloc_S, _methIncr);
+            _ilGen.Emit(OpCodes.Add);
+            _ilGen.Emit(OpCodes.Stloc_S, _methAddr);
+        }
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Engine/MME/MacroJitContext.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MME/MacroJitContext.cs
@@ -1,0 +1,57 @@
+﻿using Ryujinx.Common.Logging;
+using Ryujinx.Graphics.Gpu.State;
+using System.Collections.Generic;
+
+namespace Ryujinx.Graphics.Gpu.Engine.MME
+{
+    /// <summary>
+    /// Represents a Macro Just-in-Time compiler execution context.
+    /// </summary>
+    class MacroJitContext
+    {
+        /// <summary>
+        /// Arguments FIFO.
+        /// </summary>
+        public Queue<int> Fifo { get; } = new Queue<int>();
+
+        /// <summary>
+        /// Fetches a arguments from the arguments FIFO.
+        /// </summary>
+        /// <returns></returns>
+        public int FetchParam()
+        {
+            if (!Fifo.TryDequeue(out int value))
+            {
+                Logger.PrintWarning(LogClass.Gpu, "Macro attempted to fetch an inexistent argument.");
+
+                return 0;
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Reads data from a GPU register.
+        /// </summary>
+        /// <param name="state">Current GPU state</param>
+        /// <param name="reg">Register offset to read</param>
+        /// <returns>GPU register value</returns>
+        public static int Read(GpuState state, int reg)
+        {
+            return state.Read(reg);
+        }
+
+        /// <summary>
+        /// Performs a GPU method call.
+        /// </summary>
+        /// <param name="value">Call argument</param>
+        /// <param name="state">Current GPU state</param>
+        /// <param name="methAddr">Address, in words, of the method</param>
+        public static void Send(int value, GpuState state, int methAddr)
+        {
+            MethodParams meth = new MethodParams(methAddr, value);
+
+            state.CallMethod(meth);
+        }
+    }
+}

--- a/Ryujinx.Graphics.Gpu/GraphicsConfig.cs
+++ b/Ryujinx.Graphics.Gpu/GraphicsConfig.cs
@@ -27,5 +27,10 @@ namespace Ryujinx.Graphics.Gpu
         /// This can avoid lower resolution on some games when GPU performance is poor.
         /// </summary>
         public static bool FastGpuTime = true;
+
+        /// <summary>
+        /// Enables or disables the Just-in-Time compiler for GPU Macro code.
+        /// </summary>
+        public static bool EnableMacroJit = true;
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/GpuState.cs
+++ b/Ryujinx.Graphics.Gpu/State/GpuState.cs
@@ -33,6 +33,11 @@ namespace Ryujinx.Graphics.Gpu.State
         private readonly Register[] _registers;
 
         /// <summary>
+        /// Gets or sets the shadow ram control used for this sub-channel.
+        /// </summary>
+        public ShadowRamControl ShadowRamControl { get; set; }
+
+        /// <summary>
         /// Creates a new instance of the GPU state.
         /// </summary>
         public GpuState()
@@ -72,14 +77,15 @@ namespace Ryujinx.Graphics.Gpu.State
         /// Calls a GPU method, using this state.
         /// </summary>
         /// <param name="meth">The GPU method to be called</param>
-        /// <param name="shadowCtrl">Shadow RAM control register value</param>
-        public void CallMethod(MethodParams meth, ShadowRamControl shadowCtrl)
+        public void CallMethod(MethodParams meth)
         {
             int value = meth.Argument;
 
             // Methods < 0x80 shouldn't be affected by shadow RAM at all.
             if (meth.Method >= 0x80)
             {
+                ShadowRamControl shadowCtrl = ShadowRamControl;
+
                 // TODO: Figure out what TrackWithFilter does, compared to Track.
                 if (shadowCtrl == ShadowRamControl.Track ||
                     shadowCtrl == ShadowRamControl.TrackWithFilter)
@@ -90,7 +96,7 @@ namespace Ryujinx.Graphics.Gpu.State
                 {
                     value = _shadow[meth.Method];
                 }
-            }
+            } 
 
             Register register = _registers[meth.Method];
 

--- a/Ryujinx.Graphics.Gpu/State/GpuState.cs
+++ b/Ryujinx.Graphics.Gpu/State/GpuState.cs
@@ -96,7 +96,7 @@ namespace Ryujinx.Graphics.Gpu.State
                 {
                     value = _shadow[meth.Method];
                 }
-            } 
+            }
 
             Register register = _registers[meth.Method];
 


### PR DESCRIPTION
This implement a Macro JIT. It improves the speed of GPU Macro execution by recompiling the code to the host architecture on-demand. Macros are small programs that can read/write GPU registers. Macros are usually very small and simple, and for this reason, there's not much benefit in replacing the interpreter by a JIT. When you have < 50 instructions to run, it just doesn't make that much difference.

This could bring a small speed-up for games using instanced draws, since they use a macro with a loop for them.

Sample CodeGen:
Macro:
```
00000000: 00110071     maddrsend 0x44
00000001: 07400451     parm $r4 maddr 0x1d00
00000002: 00000301     parm $r3
00000003: 00000041     send 0x0
00000004: 00002041     send $r4
00000005: 00001841     send $r3
00000006: 02310021     maddr 0x8c4
00000007: 00000841     send $r1
00000008: 03468115     read $r1 0xd1a
00000009: 02004112     mov $r1 (extrinsrt 0x0 $r1 0x0 0x8 0x0)
0000000a: ffff8911     mov $r1 (add $r1 0xfffffffffffffffe)
0000000b: 00024827     braz annul $r1 0x14
0000000c: 03400115     read $r1 0xd00
0000000d: 00004211     mov $r2 0x1
0000000e: 00048910   B mov $r1 (sub $r1 $r2)
0000000f: 00024827     braz annul $r1 0x18
00000010: 00100071     maddrsend 0x40
00000011: ffff4007     bra 0xe
00000012: 03400195     exit read $r1 0xd00
00000013: 00000011     nop
00000014: 00028211   B mov $r2 0xa
00000015: ffffd211   B mov $r2 (add $r2 0xffffffffffffffff)
00000016: ffffd097     exit branz $r2 0x15
00000017: 00100071     maddrsend 0x40
00000018: 00000091   B exit
00000019: 00000011     nop
```
IL:
https://gist.github.com/gdkchan/f70d71cb2b9f6c6ebc063309ee6fdfbb
C# (decompiled, not optimized):
https://gist.github.com/gdkchan/9e7257f9e1c6fb5695b635b77cc76908
Generated x64 code:
https://gist.github.com/gdkchan/8502e0f254f48680f8158115b2377380
(NOTE: Prologue omitted).

**How it works:**

The Macro JIT works by using `System.Reflection.Emit` to create a `DynamicMethod`. It generates MSIL at runtime, which is then compiled by the .NET JIT to host machine code. The function is generated on the first call to the macro, and then cached. Subsequent executions will use the already compiled code.

A new setting has been added in `GraphicsConfig` that allow enabling or disabling the Macro JIT. When disabled, it will use the old interpreter. This has not been integrated with the GUI however (and I don't plan to do that), so it's always on. It can be used to test if there's a problem with the JIT.

Note about about branch on delay slot: Right now it keeps executing the branches. So one can create a long chain of branches, and it could cause a stack overflow exception. A branch on a delay slot doesn't really make sense, so I don't expect code to actually use it, unless its corrupt or it's intentionally written to do weird stuff.

I recommend testing this on a number of games, to ensure the JIT is working properly. I didn't have time to test it much yet.