### PR TITLE
Fix OpenGL debug's allure

### DIFF
--- a/Ryujinx.Common/Configuration/GraphicsDebugLevel.cs
+++ b/Ryujinx.Common/Configuration/GraphicsDebugLevel.cs
@@ -4,7 +4,7 @@ namespace Ryujinx.Common.Configuration
     {
         None,
         Error,
-        Performance,
+        Slowdowns,
         All
     }
 }

--- a/Ryujinx.Graphics.OpenGL/Debugger.cs
+++ b/Ryujinx.Graphics.OpenGL/Debugger.cs
@@ -32,7 +32,7 @@ namespace Ryujinx.Graphics.OpenGL
             {
                 GL.DebugMessageControl(DebugSourceControl.DontCare, DebugTypeControl.DebugTypeError, DebugSeverityControl.DontCare, 0, (int[])null, true);
             }
-            else if (logLevel == GraphicsDebugLevel.Performance)
+            else if (logLevel == GraphicsDebugLevel.Slowdowns)
             {
                 GL.DebugMessageControl(DebugSourceControl.DontCare, DebugTypeControl.DebugTypeError, DebugSeverityControl.DontCare, 0, (int[])null, true);
                 GL.DebugMessageControl(DebugSourceControl.DontCare, DebugTypeControl.DebugTypePerformance, DebugSeverityControl.DontCare, 0, (int[])null, true);

--- a/Ryujinx/Ui/SettingsWindow.glade
+++ b/Ryujinx/Ui/SettingsWindow.glade
@@ -2185,7 +2185,7 @@
                                 <property name="halign">start</property>
                                 <property name="margin_bottom">5</property>
                                 <property name="tooltip_text" translatable="yes">Use with care</property>
-                                <property name="label" translatable="yes">Developer Options</property>
+                                <property name="label" translatable="yes">Developer Options (WARNING: Will reduce performance)</property>
                                 <attributes>
                                   <attribute name="weight" value="bold"/>
                                 </attributes>
@@ -2231,7 +2231,7 @@
                                     <object class="GtkLabel">
                                       <property name="visible">True</property>
                                       <property name="can_focus">False</property>
-                                      <property name="tooltip_text" translatable="yes">Requires appropriate log levels enabled. Not persistent across restarts.</property>
+                                      <property name="tooltip_text" translatable="yes">Requires appropriate log levels enabled.</property>
                                       <property name="label" translatable="yes">OpenGL Log Level</property>
                                     </object>
                                     <packing>
@@ -2245,7 +2245,7 @@
                                     <object class="GtkComboBoxText" id="_graphicsDebugLevel">
                                       <property name="visible">True</property>
                                       <property name="can_focus">False</property>
-                                      <property name="tooltip_text" translatable="yes">Requires appropriate log levels enabled. Not persistent across restarts.</property>
+                                      <property name="tooltip_text" translatable="yes">Requires appropriate log levels enabled.</property>
                                       <property name="margin_left">5</property>
                                     </object>
                                     <packing>


### PR DESCRIPTION
Users seem to be infatuated with the new OpenGL debug log option even when placed under Developer options.
This PR tries to dissuade them from fake love.