### PR TITLE
Add Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug Report
+about: Something doesn't work correctly in Ryujinx.
+#assignees:
+---
+
+## Bug Report
+
+[ If any section does not apply, replace its contents with "N/A". ]</br>
+[ Lines between [ ] (square brackets) should be removed before posting. ]
+
+### What's the issue you encountered?
+
+[ Describe the issue in detail and what you were doing beforehand. ]</br>
+[ Did you make any changes related to Ryujinx itself? ]</br>
+[ If so, make sure to include details relating to what exactly you changed. ]
+
+### How can the issue be reproduced?
+
+[ Include a detailed step by step process for recreating your issue. ]
+
+### Log file
+
+[ Logs files can be found under ``Logs`` folder in Ryujinx program folder. ]</br>
+[ If you don't include a crash report in instances of crash related issues, we will ask you one to provide one. ]
+
+### Environment?
+
+- Ryujinx version: 1.0.X</br>
+[ Replace X's with the Ryujinx version at time of crash. ]
+- Game version: X.X.X</br>
+[ Replace X's with the game version at time of crash. ]
+- System Specs:
+  - OS: *(e.g. Windows 10)*
+  - CPU: *(e.g. i7-6700)*
+  - GPU: *(e.g. NVIDIA RTX 2070)*
+  - RAM: *(e.g. 16GB)*
+- Applied Mods : [ Yes (Which ones) / No ]
+
+### Additional context?
+
+Additional info about your environment:</br>
+[ Any other information relevant to your issue. ]

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ryujinx Discord
+    url: https://discord.gg/N2FmfVc
+    about: This is for development related issues. For support and technical issues, please come to our Discord server.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,34 @@
+---
+name: Feature Request
+about: Suggest a new feature for Ryujinx.
+#assignees:
+---
+
+## Feature Request
+
+[ If any section does not apply, replace its contents with "N/A". ]</br>
+[ If you do not have the information needed for a section, replace its contents with "Unknown". ]</br>
+[ Lines between [ ] (square brackets) are to be removed before posting. ]</br>
+
+[ Please search for existing [feature requests](https://github.com/Ryujinx/Ryujinx/issues) before you make your own request. ]</br>
+[ Duplicate requests will be marked as such and you will be referred to the original request. ]
+
+### What feature are you suggesting?
+#### Overview:
+- [ Include the basic, high-level concepts for this feature here. ]
+
+#### Smaller Details: 
+- [ These may include specific methods of implementation etc. ]
+
+#### Nature of Request:  
+[ Remove all that do not apply to your request. ]
+- Addition
+  - [ Ex: Addition of certain original features or features from other community projects. ]
+  - [ If you are suggesting porting features or including features from other projects, include what license they are distributed under and what, if any libraries those project use. ]
+- Change
+- Removal
+  - [Ex: Removal of certain features or implementation due to a specific issue/bug or because of low quality code, etc.]
+
+### Why would this feature be useful?
+[ If this is a feature for an end-user, how does it benefit the end-user? ]</br>
+[ If this feature is for developers, what does it add to Ryujinx that did not already exist? ]

--- a/.github/ISSUE_TEMPLATE/missing_cpu_instruction.md
+++ b/.github/ISSUE_TEMPLATE/missing_cpu_instruction.md
@@ -10,7 +10,7 @@ about: CPU Instruction is missing in Ryujinx.
 [ If you do not have the information needed for a section, replace its contents with "Unknown". ]</br>
 [ Lines between [ ] (square brackets) are to be removed before posting. ]
 
-[ Please search for existing [missing service call](https://github.com/Ryujinx/Ryujinx/issues) before you make your own issue. ]</br>
+[ Please search for existing [missing CPU instruction](https://github.com/Ryujinx/Ryujinx/issues) before you make your own issue. ]</br>
 [ See the following [issue](https://github.com/Ryujinx/Ryujinx/issues/1405) as an example ]</br>
 [ Duplicate issue will be marked as such and you will be referred to the original request. ]
 

--- a/.github/ISSUE_TEMPLATE/missing_cpu_instruction.md
+++ b/.github/ISSUE_TEMPLATE/missing_cpu_instruction.md
@@ -24,11 +24,11 @@ Requires the *INSTRUCTION* instruction.</br>
 ```
 [ Add the undefined instruction error message in the above code block ]
 
-### Instruction description
+### Instruction name
 ```
 *
 ```
-[ Include the description from [armconverter.com](https://armconverter.com/?disasm) or [shell-storm.org](http://shell-storm.org/online/Online-Assembler-and-Disassembler/?arch=arm64&endianness=big&dis_with_raw=True&dis_with_ins=True) in the above code block ]
+[ Include the name from [armconverter.com](https://armconverter.com/?disasm) or [shell-storm.org](http://shell-storm.org/online/Online-Assembler-and-Disassembler/?arch=arm64&endianness=big&dis_with_raw=True&dis_with_ins=True) in the above code block ]
 
 ### Required by: 
 [ Add our (games list database)[https://github.com/Ryujinx/Ryujinx-Games-List/issues] links of games who require this instruction ]

--- a/.github/ISSUE_TEMPLATE/missing_cpu_instruction.md
+++ b/.github/ISSUE_TEMPLATE/missing_cpu_instruction.md
@@ -1,0 +1,34 @@
+---
+name: Missing CPU Instruction
+about: CPU Instruction is missing in Ryujinx.
+#assignees:
+---
+
+## Missing CPU Instruction
+
+[ If any section does not apply, replace its contents with "N/A". ]</br>
+[ If you do not have the information needed for a section, replace its contents with "Unknown". ]</br>
+[ Lines between [ ] (square brackets) are to be removed before posting. ]
+
+[ Please search for existing [missing service call](https://github.com/Ryujinx/Ryujinx/issues) before you make your own issue. ]</br>
+[ See the following [issue](https://github.com/Ryujinx/Ryujinx/issues/1405) as an example ]</br>
+[ Duplicate issue will be marked as such and you will be referred to the original request. ]
+
+### What CPU instruction is missing?
+
+Requires the *INSTRUCTION* instruction.</br>
+[ Replace *INSTRUCTION* by the instruction name, e.g. VADDL.U16 ]
+
+```
+*
+```
+[ Add the undefined instruction error message in the above code block ]
+
+### Instruction description
+```
+*
+```
+[ Include the description from [armconverter.com](https://armconverter.com/?disasm) or [shell-storm.org](http://shell-storm.org/online/Online-Assembler-and-Disassembler/?arch=arm64&endianness=big&dis_with_raw=True&dis_with_ins=True) in the above code block ]
+
+### Required by: 
+[ Add our (games list database)[https://github.com/Ryujinx/Ryujinx-Games-List/issues] links of games who require this instruction ]

--- a/.github/ISSUE_TEMPLATE/missing_service_call.md
+++ b/.github/ISSUE_TEMPLATE/missing_service_call.md
@@ -1,0 +1,35 @@
+---
+name: Missing Service Call
+about: Service call is missing in Ryujinx.
+#assignees:
+---
+
+## Missing Service Call
+
+[ If any section does not apply, replace its contents with "N/A". ]</br>
+[ If you do not have the information needed for a section, replace its contents with "Unknown". ]</br>
+[ Lines between [ ] (square brackets) are to be removed before posting. ]
+
+[ Please search for existing [missing service call](https://github.com/Ryujinx/Ryujinx/issues) before you make your own issue. ]</br>
+[ See the following [issue](https://github.com/Ryujinx/Ryujinx/issues/1431) as an example ]</br>
+[ Duplicate issue will be marked as such and you will be referred to the original request. ]
+
+### What service call is missing?
+
+*SERVICE* *INTERFACE*: *NUMBER* (*NAME*) is not implemented.</br>
+[ Replace *SERVICE* by the service name, e.g. appletAE ]</br>
+[ Replace *INTERFACE* by the interface name, e.g. IAllSystemAppletProxiesService ]</br>
+[ Replace *NUMBER* by the call number, e.g. 100 ]</br>
+[ Replace *NAME* by the call name, e.g. OpenSystemAppletProxy ]</br>
+[ e.g. appletAE IAllSystemAppletProxiesService: 100 (OpenSystemAppletProxy) ]
+
+[ Add related links to the specific call from [Switchbrew](https://switchbrew.org/w/index.php?title=Services_API) and/or [SwIPC](https://reswitched.github.io/SwIPC/) ]
+
+### Service description
+```
+*
+```
+[ Include the description/explanation from [Switchbrew](https://switchbrew.org/w/index.php?title=Services_API) and/or [SwIPC](https://reswitched.github.io/SwIPC/) in the above code block ]
+
+### Required by: 
+[ Add our (games list database)[https://github.com/Ryujinx/Ryujinx-Games-List/issues] links of games who require this call ]


### PR DESCRIPTION
This disable the creation of empty issues and adds some templates when one is opened.
A link to our discord is directly added to the issue templates list.

Thanks EmulationFanatic for the proof reading.