### PR TITLE
account: Implement IManagerForApplication calls and IAsyncContext

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Account/Acc/AsyncContext/AsyncExecution.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/AsyncContext/AsyncExecution.cs
@@ -1,0 +1,56 @@
+﻿﻿using Ryujinx.Common.Logging;
+using Ryujinx.HLE.HOS.Kernel.Threading;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ryujinx.HLE.HOS.Services.Account.Acc.AsyncContext
+{
+    class AsyncExecution
+    {
+        CancellationTokenSource _tokenSource;
+        CancellationToken       _token;
+
+        public KEvent SystemEvent   { get; private set; }
+        public bool   IsInitialized { get; private set; }
+        public bool   IsRunning     { get; private set; }
+
+        public AsyncExecution(KEvent asyncEvent)
+        {
+            SystemEvent = asyncEvent;
+
+            _tokenSource = new CancellationTokenSource();
+            _token       = _tokenSource.Token;
+        }
+
+        public void Initialize(int timeout, Func<CancellationToken, Task> taskAsync)
+        {
+            Task.Run(async () =>
+            {
+                IsRunning = true;
+
+                _tokenSource.CancelAfter(timeout);
+
+                try
+                {
+                    await taskAsync(_token);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Warning?.Print(LogClass.ServiceAcc, $"Exception: {ex.Message}");
+                }
+
+                SystemEvent.ReadableEvent.Signal();
+
+                IsRunning = false;
+            }, _token);
+
+            IsInitialized = true;
+        }
+
+        public void Cancel()
+        {
+            _tokenSource.Cancel();
+        }
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/AsyncContext/AsyncExecution.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/AsyncContext/AsyncExecution.cs
@@ -8,10 +8,10 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc.AsyncContext
 {
     class AsyncExecution
     {
-        CancellationTokenSource _tokenSource;
-        CancellationToken       _token;
+        private readonly CancellationTokenSource _tokenSource;
+        private readonly CancellationToken       _token;
 
-        public KEvent SystemEvent   { get; private set; }
+        public KEvent SystemEvent   { get; }
         public bool   IsInitialized { get; private set; }
         public bool   IsRunning     { get; private set; }
 

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
@@ -160,7 +160,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
         {
             if (_applicationLaunchProperty != null)
             {
-                return ResultCode.ApplicationLaunchPropertyAlreadyInit;
+                return ResultCode.Unknown41;
             }
 
             // The u64 argument seems to be unused by account.
@@ -282,7 +282,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             /*
             if (_applicationLaunchProperty != null)
             {
-                return ResultCode.ApplicationLaunchPropertyAlreadyInit;
+                return ResultCode.Unknown41;
             }
             */
 

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/IAsyncContext.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/IAsyncContext.cs
@@ -1,0 +1,79 @@
+﻿﻿using Ryujinx.HLE.HOS.Ipc;
+using Ryujinx.HLE.HOS.Kernel.Common;
+using Ryujinx.HLE.HOS.Services.Account.Acc.AsyncContext;
+using System;
+
+namespace Ryujinx.HLE.HOS.Services.Account.Acc
+{
+    class IAsyncContext : IpcService
+    {
+        AsyncExecution _asyncExecution;
+
+        public IAsyncContext(AsyncExecution asyncExecution)
+        {
+            _asyncExecution = asyncExecution;
+        }
+
+        [Command(0)]
+        // GetSystemEvent() -> handle<copy>
+        public ResultCode GetSystemEvent(ServiceCtx context)
+        {
+            if (context.Process.HandleTable.GenerateHandle(_asyncExecution.SystemEvent.ReadableEvent, out int _systemEventHandle) != KernelResult.Success)
+            {
+                throw new InvalidOperationException("Out of handles!");
+            }
+
+            context.Response.HandleDesc = IpcHandleDesc.MakeCopy(_systemEventHandle);
+
+            return ResultCode.Success;
+        }
+
+        [Command(1)]
+        // Cancel()
+        public ResultCode Cancel(ServiceCtx context)
+        {
+            if (!_asyncExecution.IsInitialized)
+            {
+                return ResultCode.AsyncExecutionNotInitialized;
+            }
+
+            if (_asyncExecution.IsRunning)
+            {
+                _asyncExecution.Cancel();
+            }
+
+            return ResultCode.Success;
+        }
+
+        [Command(2)]
+        // HasDone() -> b8
+        public ResultCode HasDone(ServiceCtx context)
+        {
+            if (!_asyncExecution.IsInitialized)
+            {
+                return ResultCode.AsyncExecutionNotInitialized;
+            }
+
+            context.ResponseData.Write(_asyncExecution.SystemEvent.ReadableEvent.IsSignaled());
+
+            return ResultCode.Success;
+        }
+
+        [Command(3)]
+        // GetResult()
+        public ResultCode GetResult(ServiceCtx context)
+        {
+            if (!_asyncExecution.IsInitialized)
+            {
+                return ResultCode.AsyncExecutionNotInitialized;
+            }
+
+            if (!_asyncExecution.SystemEvent.ReadableEvent.IsSignaled())
+            {
+                return ResultCode.Unknown41;
+            }
+
+            return ResultCode.Success;
+        }
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/IManagerForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/IManagerForApplication.cs
@@ -28,8 +28,8 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
         // CheckAvailability()
         public ResultCode CheckAvailability(ServiceCtx context)
         {
-            // NOTE: This open the file at "su/baas/USERID_IN_UUID_STRING.dat" where USERID_IN_UUID_STRING is formatted as "%08x-%04x-%04x-%02x%02x-%08x%04x".
-            //       Then its search the Availability of Online Service related to the UserId in this file and return it.
+            // NOTE: This opens the file at "su/baas/USERID_IN_UUID_STRING.dat" where USERID_IN_UUID_STRING is formatted as "%08x-%04x-%04x-%02x%02x-%08x%04x".
+            //       Then it searches the Availability of Online Services related to the UserId in this file and returns it.
 
             Logger.Stub?.PrintStub(LogClass.ServiceAcc);
 
@@ -41,9 +41,9 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
         // GetAccountId() -> nn::account::NetworkServiceAccountId
         public ResultCode GetAccountId(ServiceCtx context)
         {
-            // NOTE: This open the file at "su/baas/USERID_IN_UUID_STRING.dat" (where USERID_IN_UUID_STRING is formatted 
+            // NOTE: This opens the file at "su/baas/USERID_IN_UUID_STRING.dat" (where USERID_IN_UUID_STRING is formatted 
             //       as "%08x-%04x-%04x-%02x%02x-%08x%04x") in the account:/ savedata.
-            //       Then its search the NetworkServiceAccountId related to the UserId in this file and return it.
+            //       Then it searches the NetworkServiceAccountId related to the UserId in this file and returns it.
 
             Logger.Stub?.PrintStub(LogClass.ServiceAcc, new { NetworkServiceAccountId });
 
@@ -56,8 +56,6 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
         // EnsureIdTokenCacheAsync() -> object<nn::account::detail::IAsyncContext>
         public ResultCode EnsureIdTokenCacheAsync(ServiceCtx context)
         {
-            // if (!(this + 0x48)) return ResultCode.Unknown1;
-
             KEvent         asyncEvent     = new KEvent(context.Device.System.KernelContext);
             AsyncExecution asyncExecution = new AsyncExecution(asyncEvent);
 
@@ -65,8 +63,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
 
             MakeObject(context, new IAsyncContext(asyncExecution));
 
-            // Doesn't occur in our case.
-            // if (IAsyncContext == null) return ResultCode.NullObject;
+            // return ResultCode.NullObject if the IAsyncContext pointer is null. Doesn't occur in our case.
 
             return ResultCode.Success;
         }
@@ -81,8 +78,8 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
 
             Logger.Stub?.PrintStub(LogClass.ServiceAcc);
 
-            // TODO: Use a real function instead of this little async delay.
-            await Task.Delay(10, token);
+            // TODO: Use a real function instead of the empty Task.
+            await Task.Run(() => { }, token);
         }
 
         [Command(3)]
@@ -92,8 +89,8 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             long bufferPosition = context.Request.ReceiveBuff[0].Position;
             long bufferSize     = context.Request.ReceiveBuff[0].Size;
 
-            // NOTE: This open the file at "su/cache/USERID_IN_UUID_STRING.dat" (where USERID_IN_UUID_STRING is formatted as "%08x-%04x-%04x-%02x%02x-%08x%04x")
-            //       in the "account:/" savedata and write some data in the buffer.
+            // NOTE: This opens the file at "su/cache/USERID_IN_UUID_STRING.dat" (where USERID_IN_UUID_STRING is formatted as "%08x-%04x-%04x-%02x%02x-%08x%04x")
+            //       in the "account:/" savedata and writes some data in the buffer.
             //       Since we don't support online services, we can stub it.
 
             Logger.Stub?.PrintStub(LogClass.ServiceAcc);

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/IManagerForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/IManagerForApplication.cs
@@ -78,8 +78,8 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
 
             Logger.Stub?.PrintStub(LogClass.ServiceAcc);
 
-            // TODO: Use a real function instead of the empty Task.
-            await Task.Run(() => { }, token);
+            // TODO: Use a real function instead, with the CancellationToken.
+            await Task.CompletedTask;
         }
 
         [Command(3)]

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/IManagerForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/IManagerForApplication.cs
@@ -1,5 +1,12 @@
 using Ryujinx.Common.Logging;
+using Ryujinx.Cpu;
+using Ryujinx.HLE.HOS.Kernel.Threading;
+using Ryujinx.HLE.HOS.Services.Account.Acc.AsyncContext;
 using Ryujinx.HLE.HOS.Services.Arp;
+using System;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Ryujinx.HLE.HOS.Services.Account.Acc
 {
@@ -7,21 +14,27 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
     {
         private UserId                    _userId;
         private ApplicationLaunchProperty _applicationLaunchProperty;
-
-        private const long NetworkServiceAccountId = 0xcafe;
+        private long                      _networkServiceAccountId;
 
         public IManagerForApplication(UserId userId, ApplicationLaunchProperty applicationLaunchProperty)
         {
             _userId                    = userId;
             _applicationLaunchProperty = applicationLaunchProperty;
+
+            // TODO: Determine where and how NetworkServiceAccountId is set.
+            _networkServiceAccountId = new Random().Next();
         }
 
         [Command(0)]
         // CheckAvailability()
         public ResultCode CheckAvailability(ServiceCtx context)
         {
+            // NOTE: This open the file at "su/baas/USERID_IN_UUID_STRING.dat" where USERID_IN_UUID_STRING is formatted as "%08x-%04x-%04x-%02x%02x-%08x%04x".
+            //       Then its search the Availability of Online Service related to the UserId in this file and return it.
+
             Logger.Stub?.PrintStub(LogClass.ServiceAcc);
 
+            // NOTE: Even if we try to return different error codes here, the guest still needs other calls.
             return ResultCode.Success;
         }
 
@@ -29,9 +42,78 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
         // GetAccountId() -> nn::account::NetworkServiceAccountId
         public ResultCode GetAccountId(ServiceCtx context)
         {
-            Logger.Stub?.PrintStub(LogClass.ServiceAcc, new { NetworkServiceAccountId });
+            // NOTE: This open the file at "su/baas/USERID_IN_UUID_STRING.dat" (where USERID_IN_UUID_STRING is formatted 
+            //       as "%08x-%04x-%04x-%02x%02x-%08x%04x") in the account:/ savedata.
+            //       Then its search the NetworkServiceAccountId related to the UserId in this file and return it.
 
-            context.ResponseData.Write(NetworkServiceAccountId);
+            Logger.Stub?.PrintStub(LogClass.ServiceAcc, new { _networkServiceAccountId });
+
+            context.ResponseData.Write(_networkServiceAccountId);
+
+            return ResultCode.Success;
+        }
+
+        [Command(2)]
+        // EnsureIdTokenCacheAsync() -> object<nn::account::detail::IAsyncContext>
+        public ResultCode EnsureIdTokenCacheAsync(ServiceCtx context)
+        {
+            // if (!(this + 0x48)) return ResultCode.Unknown1;
+
+            KEvent         asyncEvent     = new KEvent(context.Device.System.KernelContext);
+            AsyncExecution asyncExecution = new AsyncExecution(asyncEvent);
+
+            asyncExecution.Initialize(1000, EnsureIdTokenCacheAsyncImpl);
+
+            MakeObject(context, new IAsyncContext(asyncExecution));
+
+            // Doesn't occur in our case.
+            // if (IAsyncContext == null) return ResultCode.NullObject;
+
+            return ResultCode.Success;
+        }
+
+        private async Task EnsureIdTokenCacheAsyncImpl(CancellationToken token)
+        {
+            // NOTE: This open the file at "su/baas/USERID_IN_UUID_STRING.dat" (where USERID_IN_UUID_STRING is formatted as "%08x-%04x-%04x-%02x%02x-%08x%04x")
+            //       in the "account:/" savedata.
+            //       Then its read data, use dauth API with this data to get the Token Id and probably store the dauth response
+            //       in "su/cache/USERID_IN_UUID_STRING.dat" (where USERID_IN_UUID_STRING is formatted as "%08x-%04x-%04x-%02x%02x-%08x%04x") in the "account:/" savedata.
+            //       Since we don't support online services, we can stub it.
+
+            Logger.Stub?.PrintStub(LogClass.ServiceAcc);
+
+            // TODO: Use a real function instead of this little async delay.
+            await Task.Delay(10, token);
+        }
+
+        [Command(3)]
+        // LoadIdTokenCache() -> (u32 id_token_cache_size, buffer<bytes, 6>)
+        public ResultCode LoadIdTokenCache(ServiceCtx context)
+        {
+            long bufferPosition = context.Request.ReceiveBuff[0].Position;
+            long bufferSize     = context.Request.ReceiveBuff[0].Size;
+
+            // NOTE: This open the file at "su/cache/USERID_IN_UUID_STRING.dat" (where USERID_IN_UUID_STRING is formatted as "%08x-%04x-%04x-%02x%02x-%08x%04x")
+            //       in the "account:/" savedata and write some data in the buffer.
+            //       Since we don't support online services, we can stub it.
+
+            Logger.Stub?.PrintStub(LogClass.ServiceAcc);
+
+            /*
+            if (internal_object != null)
+            {
+                if (bufferSize > 0xC00)
+                {
+                    return ResultCode.InvalidIdTokenCacheBufferSize;
+                }
+            }
+            */
+
+            int idTokenCacheSize = 0;
+
+            MemoryHelper.FillWithZeros(context.Memory, bufferPosition, (int)bufferSize);
+
+            context.ResponseData.Write(idTokenCacheSize);
 
             return ResultCode.Success;
         }
@@ -40,9 +122,9 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
         // GetNintendoAccountUserResourceCacheForApplication() -> (nn::account::NintendoAccountId, buffer<nn::account::nas::NasUserBaseForApplication, 0x1a>, buffer<bytes, 6>)
         public ResultCode GetNintendoAccountUserResourceCacheForApplication(ServiceCtx context)
         {
-            Logger.Stub?.PrintStub(LogClass.ServiceAcc, new { NetworkServiceAccountId });
+            Logger.Stub?.PrintStub(LogClass.ServiceAcc, new { _networkServiceAccountId });
 
-            context.ResponseData.Write(NetworkServiceAccountId);
+            context.ResponseData.Write(_networkServiceAccountId);
 
             // TODO: determine and fill the two output IPC buffers.
 

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/IManagerForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/IManagerForApplication.cs
@@ -12,17 +12,16 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
 {
     class IManagerForApplication : IpcService
     {
+        // TODO: Determine where and how NetworkServiceAccountId is set.
+        private const long NetworkServiceAccountId = 0xcafe;
+
         private UserId                    _userId;
         private ApplicationLaunchProperty _applicationLaunchProperty;
-        private long                      _networkServiceAccountId;
 
         public IManagerForApplication(UserId userId, ApplicationLaunchProperty applicationLaunchProperty)
         {
             _userId                    = userId;
             _applicationLaunchProperty = applicationLaunchProperty;
-
-            // TODO: Determine where and how NetworkServiceAccountId is set.
-            _networkServiceAccountId = new Random().Next();
         }
 
         [Command(0)]
@@ -46,9 +45,9 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             //       as "%08x-%04x-%04x-%02x%02x-%08x%04x") in the account:/ savedata.
             //       Then its search the NetworkServiceAccountId related to the UserId in this file and return it.
 
-            Logger.Stub?.PrintStub(LogClass.ServiceAcc, new { _networkServiceAccountId });
+            Logger.Stub?.PrintStub(LogClass.ServiceAcc, new { NetworkServiceAccountId });
 
-            context.ResponseData.Write(_networkServiceAccountId);
+            context.ResponseData.Write(NetworkServiceAccountId);
 
             return ResultCode.Success;
         }
@@ -122,9 +121,9 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
         // GetNintendoAccountUserResourceCacheForApplication() -> (nn::account::NintendoAccountId, buffer<nn::account::nas::NasUserBaseForApplication, 0x1a>, buffer<bytes, 6>)
         public ResultCode GetNintendoAccountUserResourceCacheForApplication(ServiceCtx context)
         {
-            Logger.Stub?.PrintStub(LogClass.ServiceAcc, new { _networkServiceAccountId });
+            Logger.Stub?.PrintStub(LogClass.ServiceAcc, new { NetworkServiceAccountId });
 
-            context.ResponseData.Write(_networkServiceAccountId);
+            context.ResponseData.Write(NetworkServiceAccountId);
 
             // TODO: determine and fill the two output IPC buffers.
 

--- a/Ryujinx.HLE/HOS/Services/Account/ResultCode.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/ResultCode.cs
@@ -12,10 +12,12 @@ namespace Ryujinx.HLE.HOS.Services.Account
         NullInputBuffer                      = (30  << ErrorCodeShift) | ModuleId,
         InvalidInputBufferSize               = (31  << ErrorCodeShift) | ModuleId,
         InvalidInputBuffer                   = (32  << ErrorCodeShift) | ModuleId,
-        ApplicationLaunchPropertyAlreadyInit = (41  << ErrorCodeShift) | ModuleId,
+        AsyncExecutionNotInitialized         = (40  << ErrorCodeShift) | ModuleId,
+        Unknown41                            = (41  << ErrorCodeShift) | ModuleId,
         InternetRequestDenied                = (59  << ErrorCodeShift) | ModuleId,
         UserNotFound                         = (100 << ErrorCodeShift) | ModuleId,
         NullObject                           = (302 << ErrorCodeShift) | ModuleId,
-        UnknownError1                        = (341 << ErrorCodeShift) | ModuleId
+        Unknown341                           = (341 << ErrorCodeShift) | ModuleId,
+        InvalidIdTokenCacheBufferSize        = (451 << ErrorCodeShift) | ModuleId
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Nifm/StaticService/IGeneralService.cs
+++ b/Ryujinx.HLE/HOS/Services/Nifm/StaticService/IGeneralService.cs
@@ -3,12 +3,7 @@ using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Services.Nifm.StaticService.GeneralService;
 using Ryujinx.HLE.HOS.Services.Nifm.StaticService.Types;
 using System;
-using System.Diagnostics;
-using System.Linq;
-using System.Net;
 using System.Net.NetworkInformation;
-using System.Net.Sockets;
-using System.Runtime.CompilerServices;
 
 namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
 {


### PR DESCRIPTION
This implement:
- IManagerForApplication::EnsureIdTokenCacheAsync (accordingly to RE) but the Async task is stubbed.
- IAsyncContext interface (accordingly to RE).
- IManagerForApplication::LoadIdTokenCache (checked with RE, and stubbed).

I've tried some games but now they needs some `sfdnsres` calls, some other boots and crashes with other issues.
Maybe we should disable the connection somewhere to lets the game think we are offline. I have done many attempts, without success, but since the code is here now, it's better than nothing.

(I've cleaned up `using` of IGeneralService too)

Closes #629 and closes #630