### PR TITLE
Add missing depth-color conversions in CopyTexture

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/MethodCopyTexture.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodCopyTexture.cs
@@ -28,9 +28,14 @@ namespace Ryujinx.Graphics.Gpu.Engine
             // When the source texture that was found has a depth format,
             // we must enforce the target texture also has a depth format,
             // as copies between depth and color formats are not allowed.
-            if (srcTexture.Format == Format.D32Float)
+            switch (srcTexture.Format)
             {
-                dstCopyTexture.Format = RtFormat.D32Float;
+                case Format.S8Uint         : dstCopyTexture.Format = RtFormat.S8Uint; break;
+                case Format.D16Unorm       : dstCopyTexture.Format = RtFormat.D16Unorm; break;
+                case Format.D24X8Unorm     : dstCopyTexture.Format = RtFormat.D24Unorm; break;
+                case Format.D32Float       : dstCopyTexture.Format = RtFormat.D32Float; break;
+                case Format.D24UnormS8Uint : dstCopyTexture.Format = RtFormat.D24UnormS8Uint; break;
+                case Format.D32FloatS8Uint : dstCopyTexture.Format = RtFormat.D32FloatS8Uint; break;
             }
 
             Texture dstTexture = TextureManager.FindOrCreateTexture(dstCopyTexture, srcTexture.ScaleMode == Image.TextureScaleMode.Scaled);

--- a/Ryujinx.Graphics.Gpu/Engine/MethodCopyTexture.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodCopyTexture.cs
@@ -30,12 +30,12 @@ namespace Ryujinx.Graphics.Gpu.Engine
             // as copies between depth and color formats are not allowed.
             switch (srcTexture.Format)
             {
-                case Format.S8Uint         : dstCopyTexture.Format = RtFormat.S8Uint; break;
-                case Format.D16Unorm       : dstCopyTexture.Format = RtFormat.D16Unorm; break;
-                case Format.D24X8Unorm     : dstCopyTexture.Format = RtFormat.D24Unorm; break;
-                case Format.D32Float       : dstCopyTexture.Format = RtFormat.D32Float; break;
-                case Format.D24UnormS8Uint : dstCopyTexture.Format = RtFormat.D24UnormS8Uint; break;
-                case Format.D32FloatS8Uint : dstCopyTexture.Format = RtFormat.D32FloatS8Uint; break;
+                case Format.S8Uint: dstCopyTexture.Format = RtFormat.S8Uint; break;
+                case Format.D16Unorm: dstCopyTexture.Format = RtFormat.D16Unorm; break;
+                case Format.D24X8Unorm: dstCopyTexture.Format = RtFormat.D24Unorm; break;
+                case Format.D32Float: dstCopyTexture.Format = RtFormat.D32Float; break;
+                case Format.D24UnormS8Uint: dstCopyTexture.Format = RtFormat.D24UnormS8Uint; break;
+                case Format.D32FloatS8Uint: dstCopyTexture.Format = RtFormat.D32FloatS8Uint; break;
             }
 
             Texture dstTexture = TextureManager.FindOrCreateTexture(dstCopyTexture, srcTexture.ScaleMode == Image.TextureScaleMode.Scaled);

--- a/Ryujinx.Graphics.Gpu/Engine/MethodCopyTexture.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodCopyTexture.cs
@@ -28,15 +28,16 @@ namespace Ryujinx.Graphics.Gpu.Engine
             // When the source texture that was found has a depth format,
             // we must enforce the target texture also has a depth format,
             // as copies between depth and color formats are not allowed.
-            switch (srcTexture.Format)
+            dstCopyTexture.Format = srcTexture.Format switch
             {
-                case Format.S8Uint: dstCopyTexture.Format = RtFormat.S8Uint; break;
-                case Format.D16Unorm: dstCopyTexture.Format = RtFormat.D16Unorm; break;
-                case Format.D24X8Unorm: dstCopyTexture.Format = RtFormat.D24Unorm; break;
-                case Format.D32Float: dstCopyTexture.Format = RtFormat.D32Float; break;
-                case Format.D24UnormS8Uint: dstCopyTexture.Format = RtFormat.D24UnormS8Uint; break;
-                case Format.D32FloatS8Uint: dstCopyTexture.Format = RtFormat.D32FloatS8Uint; break;
-            }
+                Format.S8Uint => RtFormat.S8Uint,
+                Format.D16Unorm => RtFormat.D16Unorm,
+                Format.D24X8Unorm => RtFormat.D24Unorm,
+                Format.D32Float => RtFormat.D32Float,
+                Format.D24UnormS8Uint => RtFormat.D24UnormS8Uint,
+                Format.D32FloatS8Uint => RtFormat.D32FloatS8Uint,
+                _ => dstCopyTexture.Format
+            };
 
             Texture dstTexture = TextureManager.FindOrCreateTexture(dstCopyTexture, srcTexture.ScaleMode == Image.TextureScaleMode.Scaled);
 


### PR DESCRIPTION
Texture copies between depth and color formats aren't allowed in OGL.

Bgra Support (https://github.com/Ryujinx/Ryujinx/pull/1418) exposed an existing bug in texture copies with a new OGL error-
```
GL_INVALID_OPERATION error generated. The <type> and <format> pair is not suppported
```

The root cause for the error was https://github.com/Ryujinx/Ryujinx/pull/1198, which relaxed format matching rules.
But this wasn't reflected in `Methods.CopyTexture()`. This PR updates that check.

Resolves the above OGL error SPAM, removes blur flicker and fixes performance regression after Bgra support in ZLA.

**Note:** Does not fix all graphical glitches in ZLA.