### PR TITLE
Fix asserts on VP9 decoder in debug mode and build warnings

### DIFF
--- a/Ryujinx.Graphics.Nvdec.H264/Decoder.cs
+++ b/Ryujinx.Graphics.Nvdec.H264/Decoder.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Ryujinx.Graphics.Nvdec.H264
 {
-    public class Decoder : IH264Decoder
+    public sealed class Decoder : IH264Decoder
     {
         public bool IsHardwareAccelerated => false;
 

--- a/Ryujinx.Graphics.Nvdec.Vp9/DecodeFrame.cs
+++ b/Ryujinx.Graphics.Nvdec.Vp9/DecodeFrame.cs
@@ -1149,7 +1149,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9
                     ref TileWorkerData tileData = ref cm.TileWorkerData[tileCols * tileRow + tileCol];
                     tileData.Xd = cm.Mb;
                     tileData.Xd.Corrupted = false;
-                    tileData.Xd.Counts = cm.FrameParallelDecodingMode ? Ptr<Vp9BackwardUpdates>.Null : cm.Counts;
+                    tileData.Xd.Counts = cm.Counts;
                     tileData.Dqcoeff = new Array32<Array32<int>>();
                     tileData.Xd.Tile.Init(ref cm, tileRow, tileCol);
                     SetupTokenDecoder(buf.Data, buf.Size, ref cm.Error, ref tileData.BitReader);

--- a/Ryujinx.Graphics.Nvdec.Vp9/Decoder.cs
+++ b/Ryujinx.Graphics.Nvdec.Vp9/Decoder.cs
@@ -7,7 +7,7 @@ using Vp9MvRef = Ryujinx.Graphics.Video.Vp9MvRef;
 
 namespace Ryujinx.Graphics.Nvdec.Vp9
 {
-    public class Decoder : IVp9Decoder
+    public sealed class Decoder : IVp9Decoder
     {
         public bool IsHardwareAccelerated => false;
 
@@ -37,6 +37,8 @@ namespace Ryujinx.Graphics.Nvdec.Vp9
 
             cm.Width = output.Width;
             cm.Height = output.Height;
+            cm.SubsamplingX = 1;
+            cm.SubsamplingY = 1;
 
             cm.UsePrevFrameMvs = pictureInfo.UsePrevInFindMvRefs;
 
@@ -48,6 +50,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9
             cm.UvDcDeltaQ = pictureInfo.UvDcDeltaQ;
 
             cm.Mb.Lossless = pictureInfo.Lossless;
+            cm.Mb.Bd = 8;
 
             cm.TxMode = (TxMode)pictureInfo.TransformMode;
 

--- a/Ryujinx.Graphics.Nvdec.Vp9/Types/Vp9Common.cs
+++ b/Ryujinx.Graphics.Nvdec.Vp9/Types/Vp9Common.cs
@@ -83,8 +83,6 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Types
         public Ptr<Vp9EntropyProbs> Fc;
         public Ptr<Vp9BackwardUpdates> Counts;
 
-        public bool FrameParallelDecodingMode;
-
         public int Log2TileCols, Log2TileRows;
 
         public ArrayPtr<sbyte> AboveSegContext;


### PR DESCRIPTION
This fixes some build warnings and debug asserts caused by uninitialized fields on the VP9 decoder.