### PR TITLE
Fix: Issue #1475 Texture Compatibility Check methods need to be centralized

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/MethodCopyTexture.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodCopyTexture.cs
@@ -29,7 +29,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
             // When the source texture that was found has a depth format,
             // we must enforce the target texture also has a depth format,
             // as copies between depth and color formats are not allowed.
-            dstCopyTexture.Format = TextureCompatibility.DeriveDepthFormat(dstCopyTexture, srcTexture);
+            dstCopyTexture.Format = TextureCompatibility.DeriveDepthFormat(dstCopyTexture.Format, srcTexture.Format);
 
             Texture dstTexture = TextureManager.FindOrCreateTexture(dstCopyTexture, srcTexture.ScaleMode == Image.TextureScaleMode.Scaled);
 

--- a/Ryujinx.Graphics.Gpu/Engine/MethodCopyTexture.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodCopyTexture.cs
@@ -1,4 +1,5 @@
 using Ryujinx.Graphics.GAL;
+using Ryujinx.Graphics.Gpu.Image;
 using Ryujinx.Graphics.Gpu.State;
 using System;
 
@@ -28,16 +29,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
             // When the source texture that was found has a depth format,
             // we must enforce the target texture also has a depth format,
             // as copies between depth and color formats are not allowed.
-            dstCopyTexture.Format = srcTexture.Format switch
-            {
-                Format.S8Uint => RtFormat.S8Uint,
-                Format.D16Unorm => RtFormat.D16Unorm,
-                Format.D24X8Unorm => RtFormat.D24Unorm,
-                Format.D32Float => RtFormat.D32Float,
-                Format.D24UnormS8Uint => RtFormat.D24UnormS8Uint,
-                Format.D32FloatS8Uint => RtFormat.D32FloatS8Uint,
-                _ => dstCopyTexture.Format
-            };
+            dstCopyTexture.Format = TextureCompatibility.DeriveDepthFormat(dstCopyTexture, srcTexture);
 
             Texture dstTexture = TextureManager.FindOrCreateTexture(dstCopyTexture, srcTexture.ScaleMode == Image.TextureScaleMode.Scaled);
 

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -47,7 +47,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         private bool _hasData;
 
         private ITexture _arrayViewTexture;
-        private Target _arrayViewTarget;
+        private Target   _arrayViewTarget;
 
         private Texture _viewStorage;
 
@@ -105,12 +105,12 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="scaleFactor">The floating point scale factor to initialize with</param>
         /// <param name="scaleMode">The scale mode to initialize with</param>
         private Texture(
-            GpuContext context,
+            GpuContext  context,
             TextureInfo info,
-            SizeInfo sizeInfo,
-            int firstLayer,
-            int firstLevel,
-            float scaleFactor,
+            SizeInfo    sizeInfo,
+            int         firstLayer,
+            int         firstLevel,
+            float       scaleFactor,
             TextureScaleMode scaleMode)
         {
             InitializeTexture(context, info, sizeInfo);
@@ -159,7 +159,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="sizeInfo">Size information of the texture</param>
         private void InitializeTexture(GpuContext context, TextureInfo info, SizeInfo sizeInfo)
         {
-            _context = context;
+            _context  = context;
             _sizeInfo = sizeInfo;
 
             _modifiedRanges = new (ulong, ulong)[(sizeInfo.TotalSize / PhysicalMemory.PageSize) + 1];
@@ -238,7 +238,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="depthOrLayers">The new texture depth (for 3D textures) or layers (for layered textures)</param>
         public void ChangeSize(int width, int height, int depthOrLayers)
         {
-            width <<= _firstLevel;
+            width  <<= _firstLevel;
             height <<= _firstLevel;
 
             if (Info.Target == Target.Texture3D)
@@ -254,7 +254,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             foreach (Texture view in _viewStorage._views)
             {
-                int viewWidth = Math.Max(1, width >> view._firstLevel);
+                int viewWidth  = Math.Max(1, width >> view._firstLevel);
                 int viewHeight = Math.Max(1, height >> view._firstLevel);
 
                 int viewDepthOrLayers;
@@ -686,10 +686,10 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>True if a view with the given parameters can be created from this texture, false otherwise</returns>
         public bool IsViewCompatible(
             TextureInfo info,
-            ulong size,
-            bool isCopy,
-            out int firstLayer,
-            out int firstLevel)
+            ulong       size,
+            bool        isCopy,
+            out         int firstLayer,
+            out         int firstLevel)
         {
             // Out of range.
             if (info.Address < Address || info.Address + size > EndAddress)
@@ -767,7 +767,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 ITexture viewTexture = HostTexture.CreateView(createInfo, 0, 0);
 
                 _arrayViewTexture = viewTexture;
-                _arrayViewTarget = target;
+                _arrayViewTarget  = target;
 
                 return viewTexture;
             }
@@ -845,7 +845,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             Info = info;
 
-            _depth = info.GetDepth();
+            _depth  = info.GetDepth();
             _layers = info.GetLayers();
         }
 

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -254,7 +254,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             foreach (Texture view in _viewStorage._views)
             {
-                int viewWidth  = Math.Max(1, width >> view._firstLevel);
+                int viewWidth  = Math.Max(1, width  >> view._firstLevel);
                 int viewHeight = Math.Max(1, height >> view._firstLevel);
 
                 int viewDepthOrLayers;

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -658,7 +658,6 @@ namespace Ryujinx.Graphics.Gpu.Image
             return data;
         }
 
-
         /// <summary>
         /// This performs a strict comparison, used to check if this texture is equal to the one supplied.
         /// </summary>
@@ -723,7 +722,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             return IsViewCompatible(info, size, isCopy: false, out firstLayer, out firstLevel);
         }
-
 
         /// <summary>
         /// Check if it's possible to create a view, with the given parameters, from this texture.

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -414,7 +414,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             if (ScaleFactor != scale)
             {
-                Logger.Debug?.Print(LogClass.Gpu, $"Rescaling {Info.Width}x{Info.Height} {Info.FormatInfo.Format} to ({ScaleFactor} to {scale}). ");
+                Logger.Debug?.Print(LogClass.Gpu, $"Rescaling {Info.Width}x{Info.Height} {Info.FormatInfo.Format.ToString()} to ({ScaleFactor} to {scale}). ");
                 TextureCreateInfo createInfo = TextureManager.GetCreateInfo(Info, _context.Capabilities);
 
                 ScaleFactor = scale;
@@ -438,7 +438,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 foreach (var view in _views)
                 {
-                    Logger.Debug?.Print(LogClass.Gpu, $"  Recreating view {Info.Width}x{Info.Height} {Info.FormatInfo.Format}.");
+                    Logger.Debug?.Print(LogClass.Gpu, $"  Recreating view {Info.Width}x{Info.Height} {Info.FormatInfo.Format.ToString()}.");
                     view.ScaleFactor = scale;
 
                     TextureCreateInfo viewCreateInfo = TextureManager.GetCreateInfo(view.Info, _context.Capabilities);

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -47,7 +47,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         private bool _hasData;
 
         private ITexture _arrayViewTexture;
-        private Target   _arrayViewTarget;
+        private Target _arrayViewTarget;
 
         private Texture _viewStorage;
 
@@ -105,12 +105,12 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="scaleFactor">The floating point scale factor to initialize with</param>
         /// <param name="scaleMode">The scale mode to initialize with</param>
         private Texture(
-            GpuContext       context,
-            TextureInfo      info,
-            SizeInfo         sizeInfo,
-            int              firstLayer,
-            int              firstLevel,
-            float            scaleFactor,
+            GpuContext context,
+            TextureInfo info,
+            SizeInfo sizeInfo,
+            int firstLayer,
+            int firstLevel,
+            float scaleFactor,
             TextureScaleMode scaleMode)
         {
             InitializeTexture(context, info, sizeInfo);
@@ -159,7 +159,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="sizeInfo">Size information of the texture</param>
         private void InitializeTexture(GpuContext context, TextureInfo info, SizeInfo sizeInfo)
         {
-            _context  = context;
+            _context = context;
             _sizeInfo = sizeInfo;
 
             _modifiedRanges = new (ulong, ulong)[(sizeInfo.TotalSize / PhysicalMemory.PageSize) + 1];
@@ -238,7 +238,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="depthOrLayers">The new texture depth (for 3D textures) or layers (for layered textures)</param>
         public void ChangeSize(int width, int height, int depthOrLayers)
         {
-            width  <<= _firstLevel;
+            width <<= _firstLevel;
             height <<= _firstLevel;
 
             if (Info.Target == Target.Texture3D)
@@ -254,7 +254,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             foreach (Texture view in _viewStorage._views)
             {
-                int viewWidth  = Math.Max(1, width  >> view._firstLevel);
+                int viewWidth = Math.Max(1, width >> view._firstLevel);
                 int viewHeight = Math.Max(1, height >> view._firstLevel);
 
                 int viewDepthOrLayers;
@@ -414,7 +414,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             if (ScaleFactor != scale)
             {
-                Logger.Debug?.Print(LogClass.Gpu, $"Rescaling {Info.Width}x{Info.Height} {Info.FormatInfo.Format.ToString()} to ({ScaleFactor} to {scale}). ");
+                Logger.Debug?.Print(LogClass.Gpu, $"Rescaling {Info.Width}x{Info.Height} {Info.FormatInfo.Format} to ({ScaleFactor} to {scale}). ");
                 TextureCreateInfo createInfo = TextureManager.GetCreateInfo(Info, _context.Capabilities);
 
                 ScaleFactor = scale;
@@ -438,7 +438,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 foreach (var view in _views)
                 {
-                    Logger.Debug?.Print(LogClass.Gpu, $"  Recreating view {Info.Width}x{Info.Height} {Info.FormatInfo.Format.ToString()}.");
+                    Logger.Debug?.Print(LogClass.Gpu, $"  Recreating view {Info.Width}x{Info.Height} {Info.FormatInfo.Format}.");
                     view.ScaleFactor = scale;
 
                     TextureCreateInfo viewCreateInfo = TextureManager.GetCreateInfo(view.Info, _context.Capabilities);
@@ -659,202 +659,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Performs a comparison of this texture information, with the specified texture information.
-        /// This performs a strict comparison, used to check if two textures are equal.
-        /// </summary>
-        /// <param name="info">Texture information to compare with</param>
-        /// <param name="flags">Comparison flags</param>
-        /// <returns>True if the textures are strictly equal or similar, false otherwise</returns>
-        public bool IsPerfectMatch(TextureInfo info, TextureSearchFlags flags)
-        {
-            if (!FormatMatches(info, (flags & TextureSearchFlags.ForSampler) != 0, (flags & TextureSearchFlags.ForCopy) != 0))
-            {
-                return false;
-            }
-
-            if (!LayoutMatches(info))
-            {
-                return false;
-            }
-
-            if (!SizeMatches(info, (flags & TextureSearchFlags.Strict) == 0))
-            {
-                return false;
-            }
-
-            if ((flags & TextureSearchFlags.ForSampler) != 0 || (flags & TextureSearchFlags.Strict) != 0)
-            {
-                if (!SamplerParamsMatches(info))
-                {
-                    return false;
-                }
-            }
-
-            if ((flags & TextureSearchFlags.ForCopy) != 0)
-            {
-                bool msTargetCompatible = Info.Target == Target.Texture2DMultisample && info.Target == Target.Texture2D;
-
-                if (!msTargetCompatible && !TargetAndSamplesCompatible(info))
-                {
-                    return false;
-                }
-            }
-            else if (!TargetAndSamplesCompatible(info))
-            {
-                return false;
-            }
-
-            return Info.Address == info.Address && Info.Levels == info.Levels;
-        }
-
-        /// <summary>
-        /// Checks if the texture format matches with the specified texture information.
-        /// </summary>
-        /// <param name="info">Texture information to compare with</param>
-        /// <param name="forSampler">Indicates that the texture will be used for shader sampling</param>
-        /// <param name="forCopy">Indicates that the texture will be used as copy source or target</param>
-        /// <returns>True if the format matches, with the given comparison rules</returns>
-        private bool FormatMatches(TextureInfo info, bool forSampler, bool forCopy)
-        {
-            // D32F and R32F texture have the same representation internally,
-            // however the R32F format is used to sample from depth textures.
-            if (Info.FormatInfo.Format == Format.D32Float && info.FormatInfo.Format == Format.R32Float && (forSampler || forCopy))
-            {
-                return true;
-            }
-
-            if (forCopy)
-            {
-                // The 2D engine does not support depth-stencil formats, so it will instead
-                // use equivalent color formats. We must also consider them as compatible.
-                if (Info.FormatInfo.Format == Format.S8Uint && info.FormatInfo.Format == Format.R8Unorm)
-                {
-                    return true;
-                }
-
-                if (Info.FormatInfo.Format == Format.D16Unorm && info.FormatInfo.Format == Format.R16Unorm)
-                {
-                    return true;
-                }
-
-                if ((Info.FormatInfo.Format == Format.D24UnormS8Uint ||
-                     Info.FormatInfo.Format == Format.D24X8Unorm) && info.FormatInfo.Format == Format.B8G8R8A8Unorm)
-                {
-                    return true;
-                }
-            }
-
-            return Info.FormatInfo.Format == info.FormatInfo.Format;
-        }
-
-        /// <summary>
-        /// Checks if the texture layout specified matches with this texture layout.
-        /// The layout information is composed of the Stride for linear textures, or GOB block size
-        /// for block linear textures.
-        /// </summary>
-        /// <param name="info">Texture information to compare with</param>
-        /// <returns>True if the layout matches, false otherwise</returns>
-        private bool LayoutMatches(TextureInfo info)
-        {
-            if (Info.IsLinear != info.IsLinear)
-            {
-                return false;
-            }
-
-            // For linear textures, gob block sizes are ignored.
-            // For block linear textures, the stride is ignored.
-            if (info.IsLinear)
-            {
-                return Info.Stride == info.Stride;
-            }
-            else
-            {
-                return Info.GobBlocksInY == info.GobBlocksInY &&
-                       Info.GobBlocksInZ == info.GobBlocksInZ;
-            }
-        }
-
-        /// <summary>
-        /// Checks if the texture sizes of the supplied texture information matches this texture.
-        /// </summary>
-        /// <param name="info">Texture information to compare with</param>
-        /// <returns>True if the size matches, false otherwise</returns>
-        public bool SizeMatches(TextureInfo info)
-        {
-            return SizeMatches(info, alignSizes: false);
-        }
-
-        /// <summary>
-        /// Checks if the texture sizes of the supplied texture information matches the given level of
-        /// this texture.
-        /// </summary>
-        /// <param name="info">Texture information to compare with</param>
-        /// <param name="level">Mipmap level of this texture to compare with</param>
-        /// <returns>True if the size matches with the level, false otherwise</returns>
-        public bool SizeMatches(TextureInfo info, int level)
-        {
-            return Math.Max(1, Info.Width      >> level) == info.Width  &&
-                   Math.Max(1, Info.Height     >> level) == info.Height &&
-                   Math.Max(1, Info.GetDepth() >> level) == info.GetDepth();
-        }
-
-        /// <summary>
-        /// Checks if the texture sizes of the supplied texture information matches this texture.
-        /// </summary>
-        /// <param name="info">Texture information to compare with</param>
-        /// <param name="alignSizes">True to align the sizes according to the texture layout for comparison</param>
-        /// <returns>True if the sizes matches, false otherwise</returns>
-        private bool SizeMatches(TextureInfo info, bool alignSizes)
-        {
-            if (Info.GetLayers() != info.GetLayers())
-            {
-                return false;
-            }
-
-            if (alignSizes)
-            {
-                Size size0 = GetAlignedSize(Info);
-                Size size1 = GetAlignedSize(info);
-
-                return size0.Width  == size1.Width  &&
-                       size0.Height == size1.Height &&
-                       size0.Depth  == size1.Depth;
-            }
-            else
-            {
-                return Info.Width      == info.Width  &&
-                       Info.Height     == info.Height &&
-                       Info.GetDepth() == info.GetDepth();
-            }
-        }
-
-        /// <summary>
-        /// Checks if the texture shader sampling parameters matches.
-        /// </summary>
-        /// <param name="info">Texture information to compare with</param>
-        /// <returns>True if the texture shader sampling parameters matches, false otherwise</returns>
-        private bool SamplerParamsMatches(TextureInfo info)
-        {
-            return Info.DepthStencilMode == info.DepthStencilMode &&
-                   Info.SwizzleR         == info.SwizzleR         &&
-                   Info.SwizzleG         == info.SwizzleG         &&
-                   Info.SwizzleB         == info.SwizzleB         &&
-                   Info.SwizzleA         == info.SwizzleA;
-        }
-
-        /// <summary>
-        /// Check if the texture target and samples count (for multisampled textures) matches.
-        /// </summary>
-        /// <param name="info">Texture information to compare with</param>
-        /// <returns>True if the texture target and samples count matches, false otherwise</returns>
-        private bool TargetAndSamplesCompatible(TextureInfo info)
-        {
-            return Info.Target     == info.Target     &&
-                   Info.SamplesInX == info.SamplesInX &&
-                   Info.SamplesInY == info.SamplesInY;
-        }
-
-        /// <summary>
         /// Check if it's possible to create a view, with the given parameters, from this texture.
         /// </summary>
         /// <param name="info">Texture view information</param>
@@ -864,9 +668,9 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>True if a view with the given parameters can be created from this texture, false otherwise</returns>
         public bool IsViewCompatible(
             TextureInfo info,
-            ulong       size,
-            out int     firstLayer,
-            out int     firstLevel)
+            ulong size,
+            out int firstLayer,
+            out int firstLevel)
         {
             return IsViewCompatible(info, size, isCopy: false, out firstLayer, out firstLevel);
         }
@@ -882,10 +686,10 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>True if a view with the given parameters can be created from this texture, false otherwise</returns>
         public bool IsViewCompatible(
             TextureInfo info,
-            ulong       size,
-            bool        isCopy,
-            out int     firstLayer,
-            out int     firstLevel)
+            ulong size,
+            bool isCopy,
+            out int firstLayer,
+            out int firstLevel)
         {
             // Out of range.
             if (info.Address < Address || info.Address + size > EndAddress)
@@ -903,189 +707,28 @@ namespace Ryujinx.Graphics.Gpu.Image
                 return false;
             }
 
-            if (!ViewLayoutCompatible(info, firstLevel))
+            if (!TextureCompatibility.ViewLayoutCompatible(Info, info, firstLevel))
             {
                 return false;
             }
 
-            if (!ViewFormatCompatible(info))
+            if (!TextureCompatibility.ViewFormatCompatible(Info, info))
             {
                 return false;
             }
 
-            if (!ViewSizeMatches(info, firstLevel, isCopy))
+            if (!TextureCompatibility.ViewSizeMatches(Info, info, firstLevel, isCopy))
             {
                 return false;
             }
 
-            if (!ViewTargetCompatible(info, isCopy))
+            if (!TextureCompatibility.ViewTargetCompatible(Info, info, isCopy))
             {
                 return false;
             }
 
             return Info.SamplesInX == info.SamplesInX &&
                    Info.SamplesInY == info.SamplesInY;
-        }
-
-        /// <summary>
-        /// Check if it's possible to create a view with the specified layout.
-        /// The layout information is composed of the Stride for linear textures, or GOB block size
-        /// for block linear textures.
-        /// </summary>
-        /// <param name="info">Texture information of the texture view</param>
-        /// <param name="level">Start level of the texture view, in relation with this texture</param>
-        /// <returns>True if the layout is compatible, false otherwise</returns>
-        private bool ViewLayoutCompatible(TextureInfo info, int level)
-        {
-            if (Info.IsLinear != info.IsLinear)
-            {
-                return false;
-            }
-
-            // For linear textures, gob block sizes are ignored.
-            // For block linear textures, the stride is ignored.
-            if (info.IsLinear)
-            {
-                int width = Math.Max(1, Info.Width >> level);
-
-                int stride = width * Info.FormatInfo.BytesPerPixel;
-
-                stride = BitUtils.AlignUp(stride, 32);
-
-                return stride == info.Stride;
-            }
-            else
-            {
-                int height = Math.Max(1, Info.Height     >> level);
-                int depth  = Math.Max(1, Info.GetDepth() >> level);
-
-                (int gobBlocksInY, int gobBlocksInZ) = SizeCalculator.GetMipGobBlockSizes(
-                    height,
-                    depth,
-                    Info.FormatInfo.BlockHeight,
-                    Info.GobBlocksInY,
-                    Info.GobBlocksInZ);
-
-                return gobBlocksInY == info.GobBlocksInY &&
-                       gobBlocksInZ == info.GobBlocksInZ;
-            }
-        }
-
-        /// <summary>
-        /// Checks if the view format is compatible with this texture format.
-        /// In general, the formats are considered compatible if the bytes per pixel values are equal,
-        /// but there are more complex rules for some formats, like compressed or depth-stencil formats.
-        /// This follows the host API copy compatibility rules.
-        /// </summary>
-        /// <param name="info">Texture information of the texture view</param>
-        /// <returns>True if the formats are compatible, false otherwise</returns>
-        private bool ViewFormatCompatible(TextureInfo info)
-        {
-            return TextureCompatibility.FormatCompatible(Info.FormatInfo, info.FormatInfo);
-        }
-
-        /// <summary>
-        /// Checks if the size of a given texture view is compatible with this texture.
-        /// </summary>
-        /// <param name="info">Texture information of the texture view</param>
-        /// <param name="level">Mipmap level of the texture view in relation to this texture</param>
-        /// <param name="isCopy">True to check for copy compatibility rather than view compatibility</param>
-        /// <returns>True if the sizes are compatible, false otherwise</returns>
-        private bool ViewSizeMatches(TextureInfo info, int level, bool isCopy)
-        {
-            Size size = GetAlignedSize(Info, level);
-
-            Size otherSize = GetAlignedSize(info);
-
-            // For copies, we can copy a subset of the 3D texture slices,
-            // so the depth may be different in this case.
-            if (!isCopy && info.Target == Target.Texture3D && size.Depth != otherSize.Depth)
-            {
-                return false;
-            }
-
-            return size.Width  == otherSize.Width &&
-                   size.Height == otherSize.Height;
-        }
-
-        /// <summary>
-        /// Check if the target of the specified texture view information is compatible with this
-        /// texture.
-        /// This follows the host API target compatibility rules.
-        /// </summary>
-        /// <param name="info">Texture information of the texture view</param>
-        /// <param name="isCopy">True to check for copy rather than view compatibility</param>
-        /// <returns>True if the targets are compatible, false otherwise</returns>
-        private bool ViewTargetCompatible(TextureInfo info, bool isCopy)
-        {
-            switch (Info.Target)
-            {
-                case Target.Texture1D:
-                case Target.Texture1DArray:
-                    return info.Target == Target.Texture1D ||
-                           info.Target == Target.Texture1DArray;
-
-                case Target.Texture2D:
-                    return info.Target == Target.Texture2D ||
-                           info.Target == Target.Texture2DArray;
-
-                case Target.Texture2DArray:
-                case Target.Cubemap:
-                case Target.CubemapArray:
-                    return info.Target == Target.Texture2D      ||
-                           info.Target == Target.Texture2DArray ||
-                           info.Target == Target.Cubemap        ||
-                           info.Target == Target.CubemapArray;
-
-                case Target.Texture2DMultisample:
-                case Target.Texture2DMultisampleArray:
-                    return info.Target == Target.Texture2DMultisample ||
-                           info.Target == Target.Texture2DMultisampleArray;
-
-                case Target.Texture3D:
-                    return info.Target == Target.Texture3D ||
-                          (info.Target == Target.Texture2D && isCopy);
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Gets the aligned sizes of the specified texture information.
-        /// The alignment depends on the texture layout and format bytes per pixel.
-        /// </summary>
-        /// <param name="info">Texture information to calculate the aligned size from</param>
-        /// <param name="level">Mipmap level for texture views</param>
-        /// <returns>The aligned texture size</returns>
-        private static Size GetAlignedSize(TextureInfo info, int level = 0)
-        {
-            int width  = Math.Max(1, info.Width  >> level);
-            int height = Math.Max(1, info.Height >> level);
-
-            if (info.IsLinear)
-            {
-                return SizeCalculator.GetLinearAlignedSize(
-                    width,
-                    height,
-                    info.FormatInfo.BlockWidth,
-                    info.FormatInfo.BlockHeight,
-                    info.FormatInfo.BytesPerPixel);
-            }
-            else
-            {
-                int depth = Math.Max(1, info.GetDepth() >> level);
-
-                return SizeCalculator.GetBlockLinearAlignedSize(
-                    width,
-                    height,
-                    depth,
-                    info.FormatInfo.BlockWidth,
-                    info.FormatInfo.BlockHeight,
-                    info.FormatInfo.BytesPerPixel,
-                    info.GobBlocksInY,
-                    info.GobBlocksInZ,
-                    info.GobBlocksInTileX);
-            }
         }
 
         /// <summary>
@@ -1124,7 +767,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 ITexture viewTexture = HostTexture.CreateView(createInfo, 0, 0);
 
                 _arrayViewTexture = viewTexture;
-                _arrayViewTarget  = target;
+                _arrayViewTarget = target;
 
                 return viewTexture;
             }
@@ -1202,7 +845,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             Info = info;
 
-            _depth  = info.GetDepth();
+            _depth = info.GetDepth();
             _layers = info.GetLayers();
         }
 

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -105,12 +105,12 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="scaleFactor">The floating point scale factor to initialize with</param>
         /// <param name="scaleMode">The scale mode to initialize with</param>
         private Texture(
-            GpuContext  context,
-            TextureInfo info,
-            SizeInfo    sizeInfo,
-            int         firstLayer,
-            int         firstLevel,
-            float       scaleFactor,
+            GpuContext       context,
+            TextureInfo      info,
+            SizeInfo         sizeInfo,
+            int              firstLayer,
+            int              firstLevel,
+            float            scaleFactor,
             TextureScaleMode scaleMode)
         {
             InitializeTexture(context, info, sizeInfo);
@@ -717,9 +717,9 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>True if a view with the given parameters can be created from this texture, false otherwise</returns>
         public bool IsViewCompatible(
             TextureInfo info,
-            ulong size,
-            out int firstLayer,
-            out int firstLevel)
+            ulong       size,
+            out int     firstLayer,
+            out int     firstLevel)
         {
             return IsViewCompatible(info, size, isCopy: false, out firstLayer, out firstLevel);
         }
@@ -738,8 +738,8 @@ namespace Ryujinx.Graphics.Gpu.Image
             TextureInfo info,
             ulong       size,
             bool        isCopy,
-            out         int firstLayer,
-            out         int firstLevel)
+            out int     firstLayer,
+            out int     firstLevel)
         {
             // Out of range.
             if (info.Address < Address || info.Address + size > EndAddress)

--- a/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -1,5 +1,6 @@
 using Ryujinx.Common;
 using Ryujinx.Graphics.GAL;
+using Ryujinx.Graphics.Gpu.State;
 using Ryujinx.Graphics.Texture;
 using System;
 
@@ -23,6 +24,26 @@ namespace Ryujinx.Graphics.Gpu.Image
             Bc5,
             Bc6,
             Bc7
+        }
+
+        /// <summary>
+        /// Finds the appropriate depth format for a copy texture if the source texture has a depth format.
+        /// </summary>
+        /// <param name="dstCopyTexture">First comparand</param>
+        /// <param name="srcTexture">Second comparand</param>
+        /// <returns>Dervied RtFormat if the source texture has a depth format, otherwise the format of the destination copy texture.</returns>
+        public static RtFormat DeriveDepthFormat(CopyTexture dstCopyTexture, Texture srcTexture)
+        {
+            return srcTexture.Format switch
+            {
+                Format.S8Uint => RtFormat.S8Uint,
+                Format.D16Unorm => RtFormat.D16Unorm,
+                Format.D24X8Unorm => RtFormat.D24Unorm,
+                Format.D32Float => RtFormat.D32Float,
+                Format.D24UnormS8Uint => RtFormat.D24UnormS8Uint,
+                Format.D32FloatS8Uint => RtFormat.D32FloatS8Uint,
+                _ => dstCopyTexture.Format
+            };
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -1,4 +1,7 @@
+using Ryujinx.Common;
 using Ryujinx.Graphics.GAL;
+using Ryujinx.Graphics.Texture;
+using System;
 
 namespace Ryujinx.Graphics.Gpu.Image
 {
@@ -52,6 +55,377 @@ namespace Ryujinx.Graphics.Gpu.Image
                 return lhs.BytesPerPixel == rhs.BytesPerPixel;
             }
         }
+
+        /// <summary>
+        /// Performs a comparison of two texture informations.
+        /// This performs a strict comparison, used to check if two textures are equal.
+        /// </summary>
+        /// <param name="firstTextureInfo">Texture information to compare</param>
+        /// <param name="secondTextureInfo">Texture information to compare with</param>
+        /// <param name="flags">Comparison flags</param>
+        /// <returns>True if the textures are strictly equal or similar, false otherwise</returns>
+        public static bool IsPerfectMatch(TextureInfo firstTextureInfo, TextureInfo secondTextureInfo, TextureSearchFlags flags)
+        {
+            if (!FormatMatches(firstTextureInfo, secondTextureInfo, (flags & TextureSearchFlags.ForSampler) != 0, (flags & TextureSearchFlags.ForCopy) != 0))
+            {
+                return false;
+            }
+
+            if (!LayoutMatches(firstTextureInfo, secondTextureInfo))
+            {
+                return false;
+            }
+
+            if (!SizeMatches(firstTextureInfo, secondTextureInfo, (flags & TextureSearchFlags.Strict) == 0))
+            {
+                return false;
+            }
+
+            if ((flags & TextureSearchFlags.ForSampler) != 0 || (flags & TextureSearchFlags.Strict) != 0)
+            {
+                if (!SamplerParamsMatches(firstTextureInfo, secondTextureInfo))
+                {
+                    return false;
+                }
+            }
+
+            if ((flags & TextureSearchFlags.ForCopy) != 0)
+            {
+                bool msTargetCompatible = firstTextureInfo.Target == Target.Texture2DMultisample && secondTextureInfo.Target == Target.Texture2D;
+
+                if (!msTargetCompatible && !TargetAndSamplesCompatible(firstTextureInfo, secondTextureInfo))
+                {
+                    return false;
+                }
+            }
+            else if (!TargetAndSamplesCompatible(firstTextureInfo, secondTextureInfo))
+            {
+                return false;
+            }
+
+            return firstTextureInfo.Address == secondTextureInfo.Address && firstTextureInfo.Levels == secondTextureInfo.Levels;
+        }
+
+        /// <summary>
+        /// Checks if the texture format matches with the specified texture information.
+        /// </summary>
+        /// <param name="firstTextureInfo">Texture information to compare</param>
+        /// <param name="secondTextureInfo">Texture information to compare with</param>
+        /// <param name="forSampler">Indicates that the texture will be used for shader sampling</param>
+        /// <param name="forCopy">Indicates that the texture will be used as copy source or target</param>
+        /// <returns>True if the format matches, with the given comparison rules</returns>
+        public static bool FormatMatches(TextureInfo firstTextureInfo, TextureInfo secondTextureInfo, bool forSampler, bool forCopy)
+        {
+            // D32F and R32F texture have the same representation internally,
+            // however the R32F format is used to sample from depth textures.
+            if (firstTextureInfo.FormatInfo.Format == Format.D32Float && secondTextureInfo.FormatInfo.Format == Format.R32Float && (forSampler || forCopy))
+            {
+                return true;
+            }
+
+            if (forCopy)
+            {
+                // The 2D engine does not support depth-stencil formats, so it will instead
+                // use equivalent color formats. We must also consider them as compatible.
+                if (firstTextureInfo.FormatInfo.Format == Format.S8Uint && secondTextureInfo.FormatInfo.Format == Format.R8Unorm)
+                {
+                    return true;
+                }
+
+                if (firstTextureInfo.FormatInfo.Format == Format.D16Unorm && secondTextureInfo.FormatInfo.Format == Format.R16Unorm)
+                {
+                    return true;
+                }
+
+                if ((firstTextureInfo.FormatInfo.Format == Format.D24UnormS8Uint ||
+                     firstTextureInfo.FormatInfo.Format == Format.D24X8Unorm) && secondTextureInfo.FormatInfo.Format == Format.B8G8R8A8Unorm)
+                {
+                    return true;
+                }
+            }
+
+            return firstTextureInfo.FormatInfo.Format == secondTextureInfo.FormatInfo.Format;
+        }
+
+        /// <summary>
+        /// Checks if the texture layout specified matches with this texture layout.
+        /// The layout information is composed of the Stride for linear textures, or GOB block size
+        /// for block linear textures.
+        /// </summary>
+        /// <param name="firstTextureInfo">Texture information to compare</param>
+        /// <param name="secondTextureInfo">Texture information to compare with</param>
+        /// <returns>True if the layout matches, false otherwise</returns>
+        public static bool LayoutMatches(TextureInfo firstTextureInfo, TextureInfo secondTextureInfo)
+        {
+            if (firstTextureInfo.IsLinear != secondTextureInfo.IsLinear)
+            {
+                return false;
+            }
+
+            // For linear textures, gob block sizes are ignored.
+            // For block linear textures, the stride is ignored.
+            if (secondTextureInfo.IsLinear)
+            {
+                return firstTextureInfo.Stride == secondTextureInfo.Stride;
+            }
+            else
+            {
+                return firstTextureInfo.GobBlocksInY == secondTextureInfo.GobBlocksInY &&
+                       firstTextureInfo.GobBlocksInZ == secondTextureInfo.GobBlocksInZ;
+            }
+        }
+
+        /// <summary>
+        /// Checks if the view sizes of a two given texture informations match.
+        /// </summary>
+        /// <param name="firstTextureInfo">Texture information of the texture view</param>
+        /// <param name="secondTextureInfo">Texture information of the texture view to match against</param>
+        /// <param name="level">Mipmap level of the texture view in relation to this texture</param>
+        /// <param name="isCopy">True to check for copy compatibility rather than view compatibility</param>
+        /// <returns>True if the sizes are compatible, false otherwise</returns>
+        public static bool ViewSizeMatches(TextureInfo firstTextureInfo, TextureInfo secondTextureInfo, int level, bool isCopy)
+        {
+            Size size = GetAlignedSize(firstTextureInfo, level);
+
+            Size otherSize = GetAlignedSize(secondTextureInfo);
+
+            // For copies, we can copy a subset of the 3D texture slices,
+            // so the depth may be different in this case.
+            if (!isCopy && secondTextureInfo.Target == Target.Texture3D && size.Depth != otherSize.Depth)
+            {
+                return false;
+            }
+
+            return size.Width == otherSize.Width &&
+                   size.Height == otherSize.Height;
+        }
+
+        /// <summary>
+        /// Checks if the texture sizes of the supplied texture informations match.
+        /// </summary>
+        /// <param name="firstTextureInfo">Texture information to compare</param>
+        /// <param name="secondTextureInfo">Texture information to compare with</param>
+        /// <returns>True if the size matches, false otherwise</returns>
+        public static bool SizeMatches(TextureInfo firstTextureInfo, TextureInfo secondTextureInfo)
+        {
+            return SizeMatches(firstTextureInfo, secondTextureInfo, alignSizes: false);
+        }
+
+        /// <summary>
+        /// Checks if the texture sizes of the supplied texture informations match the given level
+        /// </summary>
+        /// <param name="firstTextureInfo">Texture information to compare</param>
+        /// <param name="secondTextureInfo">Texture information to compare with</param>
+        /// <param name="level">Mipmap level of this texture to compare with</param>
+        /// <returns>True if the size matches with the level, false otherwise</returns>
+        public static bool SizeMatches(TextureInfo firstTextureInfo, TextureInfo secondTextureInfo, int level)
+        {
+            return Math.Max(1, firstTextureInfo.Width >> level) == secondTextureInfo.Width &&
+                   Math.Max(1, firstTextureInfo.Height >> level) == secondTextureInfo.Height &&
+                   Math.Max(1, firstTextureInfo.GetDepth() >> level) == secondTextureInfo.GetDepth();
+        }
+
+        /// <summary>
+        /// Checks if the texture sizes of the supplied texture informations match.
+        /// </summary>
+        /// <param name="firstTextureInfo">Texture information to compare</param>
+        /// <param name="secondTextureInfo">Texture information to compare with</param>
+        /// <param name="alignSizes">True to align the sizes according to the texture layout for comparison</param>
+        /// <returns>True if the sizes matches, false otherwise</returns>
+        private static bool SizeMatches(TextureInfo firstTextureInfo, TextureInfo secondTextureInfo, bool alignSizes)
+        {
+            if (firstTextureInfo.GetLayers() != secondTextureInfo.GetLayers())
+            {
+                return false;
+            }
+
+            if (alignSizes)
+            {
+                Size size0 = GetAlignedSize(firstTextureInfo);
+                Size size1 = GetAlignedSize(secondTextureInfo);
+
+                return size0.Width == size1.Width &&
+                       size0.Height == size1.Height &&
+                       size0.Depth == size1.Depth;
+            }
+            else
+            {
+                return firstTextureInfo.Width == secondTextureInfo.Width &&
+                       firstTextureInfo.Height == secondTextureInfo.Height &&
+                       firstTextureInfo.GetDepth() == secondTextureInfo.GetDepth();
+            }
+        }
+
+
+        /// <summary>
+        /// Gets the aligned sizes of the specified texture information.
+        /// The alignment depends on the texture layout and format bytes per pixel.
+        /// </summary>
+        /// <param name="info">Texture information to calculate the aligned size from</param>
+        /// <param name="level">Mipmap level for texture views</param>
+        /// <returns>The aligned texture size</returns>
+        public static Size GetAlignedSize(TextureInfo info, int level = 0)
+        {
+            int width = Math.Max(1, info.Width >> level);
+            int height = Math.Max(1, info.Height >> level);
+
+            if (info.IsLinear)
+            {
+                return SizeCalculator.GetLinearAlignedSize(
+                    width,
+                    height,
+                    info.FormatInfo.BlockWidth,
+                    info.FormatInfo.BlockHeight,
+                    info.FormatInfo.BytesPerPixel);
+            }
+            else
+            {
+                int depth = Math.Max(1, info.GetDepth() >> level);
+
+                return SizeCalculator.GetBlockLinearAlignedSize(
+                    width,
+                    height,
+                    depth,
+                    info.FormatInfo.BlockWidth,
+                    info.FormatInfo.BlockHeight,
+                    info.FormatInfo.BytesPerPixel,
+                    info.GobBlocksInY,
+                    info.GobBlocksInZ,
+                    info.GobBlocksInTileX);
+            }
+        }
+
+        /// <summary>
+        /// Check if it's possible to create a view with the layout of the second texture information from the first.
+        /// The layout information is composed of the Stride for linear textures, or GOB block size
+        /// for block linear textures.
+        /// </summary>
+        /// <param name="firstTextureInfo">Texture information of the texture view</param>
+        /// <param name="secondTextureInfo">Texture information of the texture view to compare against</param>
+        /// <param name="level">Start level of the texture view, in relation with the first texture</param>
+        /// <returns>True if the layout is compatible, false otherwise</returns>
+        public static bool ViewLayoutCompatible(TextureInfo firstTextureInfo, TextureInfo secondTextureInfo, int level)
+        {
+            if (firstTextureInfo.IsLinear != secondTextureInfo.IsLinear)
+            {
+                return false;
+            }
+
+            // For linear textures, gob block sizes are ignored.
+            // For block linear textures, the stride is ignored.
+            if (secondTextureInfo.IsLinear)
+            {
+                int width = Math.Max(1, firstTextureInfo.Width >> level);
+
+                int stride = width * firstTextureInfo.FormatInfo.BytesPerPixel;
+
+                stride = BitUtils.AlignUp(stride, 32);
+
+                return stride == secondTextureInfo.Stride;
+            }
+            else
+            {
+                int height = Math.Max(1, firstTextureInfo.Height >> level);
+                int depth = Math.Max(1, firstTextureInfo.GetDepth() >> level);
+
+                (int gobBlocksInY, int gobBlocksInZ) = SizeCalculator.GetMipGobBlockSizes(
+                    height,
+                    depth,
+                    firstTextureInfo.FormatInfo.BlockHeight,
+                    firstTextureInfo.GobBlocksInY,
+                    firstTextureInfo.GobBlocksInZ);
+
+                return gobBlocksInY == secondTextureInfo.GobBlocksInY &&
+                       gobBlocksInZ == secondTextureInfo.GobBlocksInZ;
+            }
+        }
+
+
+
+        /// <summary>
+        /// Checks if the view format of the first texture format is compatible with the format of the second.
+        /// In general, the formats are considered compatible if the bytes per pixel values are equal,
+        /// but there are more complex rules for some formats, like compressed or depth-stencil formats.
+        /// This follows the host API copy compatibility rules.
+        /// </summary>
+        /// <param name="firstTextureInfo">Texture information of the texture view</param>
+        /// <param name="secondTextureInfo">Texture information of the texture view</param>
+        /// <returns>True if the formats are compatible, false otherwise</returns>
+        public static bool ViewFormatCompatible(TextureInfo firstTextureInfo, TextureInfo secondTextureInfo)
+        {
+            return FormatCompatible(firstTextureInfo.FormatInfo, secondTextureInfo.FormatInfo);
+        }
+
+        /// <summary>
+        /// Check if the target of the first texture view information is compatible with the target of the second texture view information.
+        /// This follows the host API target compatibility rules.
+        /// </summary>
+        /// <param name="firstTextureInfo">Texture information of the texture view</param
+        /// <param name="secondTextureInfo">Texture information of the texture view</param>
+        /// <param name="isCopy">True to check for copy rather than view compatibility</param>
+        /// <returns>True if the targets are compatible, false otherwise</returns>
+        public static bool ViewTargetCompatible(TextureInfo firstTextureInfo, TextureInfo secondTextureInfo, bool isCopy)
+        {
+            switch (firstTextureInfo.Target)
+            {
+                case Target.Texture1D:
+                case Target.Texture1DArray:
+                    return secondTextureInfo.Target == Target.Texture1D ||
+                           secondTextureInfo.Target == Target.Texture1DArray;
+
+                case Target.Texture2D:
+                    return secondTextureInfo.Target == Target.Texture2D ||
+                           secondTextureInfo.Target == Target.Texture2DArray;
+
+                case Target.Texture2DArray:
+                case Target.Cubemap:
+                case Target.CubemapArray:
+                    return secondTextureInfo.Target == Target.Texture2D ||
+                           secondTextureInfo.Target == Target.Texture2DArray ||
+                           secondTextureInfo.Target == Target.Cubemap ||
+                           secondTextureInfo.Target == Target.CubemapArray;
+
+                case Target.Texture2DMultisample:
+                case Target.Texture2DMultisampleArray:
+                    return secondTextureInfo.Target == Target.Texture2DMultisample ||
+                           secondTextureInfo.Target == Target.Texture2DMultisampleArray;
+
+                case Target.Texture3D:
+                    return secondTextureInfo.Target == Target.Texture3D ||
+                          (secondTextureInfo.Target == Target.Texture2D && isCopy);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks if the texture shader sampling parameters of two texture informations match.
+        /// </summary>
+        /// <param name="firstTextureInfo">Texture information to compare</param>
+        /// <param name="secondTextureInfo">Texture information to compare with</param>
+        /// <returns>True if the texture shader sampling parameters matches, false otherwise</returns>
+        public static bool SamplerParamsMatches(TextureInfo firstTextureInfo, TextureInfo secondTextureInfo)
+        {
+            return firstTextureInfo.DepthStencilMode == secondTextureInfo.DepthStencilMode &&
+                   firstTextureInfo.SwizzleR == secondTextureInfo.SwizzleR &&
+                   firstTextureInfo.SwizzleG == secondTextureInfo.SwizzleG &&
+                   firstTextureInfo.SwizzleB == secondTextureInfo.SwizzleB &&
+                   firstTextureInfo.SwizzleA == secondTextureInfo.SwizzleA;
+        }
+
+        /// <summary>
+        /// Check if the texture target and samples count (for multisampled textures) matches.
+        /// </summary>
+        /// <param name="first">Texture information to compare with</param>
+        /// <param name="secondTextureInfo">Texture information to compare with</param>
+        /// <returns>True if the texture target and samples count matches, false otherwise</returns>
+        public static bool TargetAndSamplesCompatible(TextureInfo firstTextureInfo, TextureInfo secondTextureInfo)
+        {
+            return firstTextureInfo.Target == secondTextureInfo.Target &&
+                   firstTextureInfo.SamplesInX == secondTextureInfo.SamplesInX &&
+                   firstTextureInfo.SamplesInY == secondTextureInfo.SamplesInY;
+        }
+
 
         /// <summary>
         /// Gets the texture format class, for compressed textures, or Unclassified otherwise.

--- a/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -29,12 +29,12 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <summary>
         /// Finds the appropriate depth format for a copy texture if the source texture has a depth format.
         /// </summary>
-        /// <param name="dstCopyTexture">First comparand</param>
-        /// <param name="srcTexture">Second comparand</param>
-        /// <returns>Dervied RtFormat if the source texture has a depth format, otherwise the format of the destination copy texture.</returns>
-        public static RtFormat DeriveDepthFormat(CopyTexture dstCopyTexture, Texture srcTexture)
+        /// <param name="dstTextureFormat">Destination CopyTexture Format</param>
+        /// <param name="srcTextureFormat">Source Texture Format</param>
+        /// <returns>Derived RtFormat if srcTextureFormat is a depth format, otherwise return dstTextureFormat.</returns>
+        public static RtFormat DeriveDepthFormat(RtFormat dstTextureFormat, Format srcTextureFormat)
         {
-            return srcTexture.Format switch
+            return srcTextureFormat switch
             {
                 Format.S8Uint => RtFormat.S8Uint,
                 Format.D16Unorm => RtFormat.D16Unorm,
@@ -42,7 +42,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 Format.D32Float => RtFormat.D32Float,
                 Format.D24UnormS8Uint => RtFormat.D24UnormS8Uint,
                 Format.D32FloatS8Uint => RtFormat.D32FloatS8Uint,
-                _ => dstCopyTexture.Format
+                _ => dstTextureFormat
             };
         }
 
@@ -287,9 +287,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             if (rhs.IsLinear)
             {
                 int width = Math.Max(1, lhs.Width >> level);
-
                 int stride = width * lhs.FormatInfo.BytesPerPixel;
-
                 stride = BitUtils.AlignUp(stride, 32);
 
                 return stride == rhs.Stride;

--- a/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -395,7 +395,6 @@ namespace Ryujinx.Graphics.Gpu.Image
                    lhs.SamplesInY == rhs.SamplesInY;
         }
 
-
         /// <summary>
         /// Gets the texture format class, for compressed textures, or Unclassified otherwise.
         /// </summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -196,7 +196,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 return false;
             }
 
-            return size.Width == otherSize.Width &&
+            return size.Width  == otherSize.Width &&
                    size.Height == otherSize.Height;
         }
 
@@ -220,8 +220,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>True if the size matches with the level, false otherwise</returns>
         public static bool SizeMatches(TextureInfo firstTextureInfo, TextureInfo secondTextureInfo, int level)
         {
-            return Math.Max(1, firstTextureInfo.Width >> level) == secondTextureInfo.Width &&
-                   Math.Max(1, firstTextureInfo.Height >> level) == secondTextureInfo.Height &&
+            return Math.Max(1, firstTextureInfo.Width >> level)      == secondTextureInfo.Width &&
+                   Math.Max(1, firstTextureInfo.Height >> level)     == secondTextureInfo.Height &&
                    Math.Max(1, firstTextureInfo.GetDepth() >> level) == secondTextureInfo.GetDepth();
         }
 
@@ -244,14 +244,14 @@ namespace Ryujinx.Graphics.Gpu.Image
                 Size size0 = GetAlignedSize(firstTextureInfo);
                 Size size1 = GetAlignedSize(secondTextureInfo);
 
-                return size0.Width == size1.Width &&
+                return size0.Width  == size1.Width &&
                        size0.Height == size1.Height &&
-                       size0.Depth == size1.Depth;
+                       size0.Depth  == size1.Depth;
             }
             else
             {
-                return firstTextureInfo.Width == secondTextureInfo.Width &&
-                       firstTextureInfo.Height == secondTextureInfo.Height &&
+                return firstTextureInfo.Width      == secondTextureInfo.Width &&
+                       firstTextureInfo.Height     == secondTextureInfo.Height &&
                        firstTextureInfo.GetDepth() == secondTextureInfo.GetDepth();
             }
         }
@@ -407,10 +407,10 @@ namespace Ryujinx.Graphics.Gpu.Image
         public static bool SamplerParamsMatches(TextureInfo firstTextureInfo, TextureInfo secondTextureInfo)
         {
             return firstTextureInfo.DepthStencilMode == secondTextureInfo.DepthStencilMode &&
-                   firstTextureInfo.SwizzleR == secondTextureInfo.SwizzleR &&
-                   firstTextureInfo.SwizzleG == secondTextureInfo.SwizzleG &&
-                   firstTextureInfo.SwizzleB == secondTextureInfo.SwizzleB &&
-                   firstTextureInfo.SwizzleA == secondTextureInfo.SwizzleA;
+                   firstTextureInfo.SwizzleR         == secondTextureInfo.SwizzleR &&
+                   firstTextureInfo.SwizzleG         == secondTextureInfo.SwizzleG &&
+                   firstTextureInfo.SwizzleB         == secondTextureInfo.SwizzleB &&
+                   firstTextureInfo.SwizzleA         == secondTextureInfo.SwizzleA;
         }
 
         /// <summary>
@@ -421,7 +421,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>True if the texture target and samples count matches, false otherwise</returns>
         public static bool TargetAndSamplesCompatible(TextureInfo firstTextureInfo, TextureInfo secondTextureInfo)
         {
-            return firstTextureInfo.Target == secondTextureInfo.Target &&
+            return firstTextureInfo.Target     == secondTextureInfo.Target &&
                    firstTextureInfo.SamplesInX == secondTextureInfo.SamplesInX &&
                    firstTextureInfo.SamplesInY == secondTextureInfo.SamplesInY;
         }

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -875,12 +875,12 @@ namespace Ryujinx.Graphics.Gpu.Image
             // - If the parent format is not compressed, and the view is, the view
             // size is calculated as described on the first point, but the width and height
             // of the view must be also multiplied by the block width and height.
-            int width  = Math.Max(1, parent.Info.Width >> firstLevel);
+            int width  = Math.Max(1, parent.Info.Width  >> firstLevel);
             int height = Math.Max(1, parent.Info.Height >> firstLevel);
 
             if (parent.Info.FormatInfo.IsCompressed && !info.FormatInfo.IsCompressed)
             {
-                width  = BitUtils.DivRoundUp(width, parent.Info.FormatInfo.BlockWidth);
+                width  = BitUtils.DivRoundUp(width,  parent.Info.FormatInfo.BlockWidth);
                 height = BitUtils.DivRoundUp(height, parent.Info.FormatInfo.BlockHeight);
             }
             else if (!parent.Info.FormatInfo.IsCompressed && info.FormatInfo.IsCompressed)
@@ -953,16 +953,16 @@ namespace Ryujinx.Graphics.Gpu.Image
                 // The shader will need the appropriate conversion code to compensate.
                 switch (formatInfo.Format)
                 {
-                    case Format.R8Snorm: formatInfo           = new FormatInfo(Format.R8Sint, 1, 1, 1); break;
-                    case Format.R16Snorm: formatInfo          = new FormatInfo(Format.R16Sint, 1, 1, 2); break;
-                    case Format.R8G8Snorm: formatInfo         = new FormatInfo(Format.R8G8Sint, 1, 1, 2); break;
-                    case Format.R16G16Snorm: formatInfo       = new FormatInfo(Format.R16G16Sint, 1, 1, 4); break;
-                    case Format.R8G8B8A8Snorm: formatInfo     = new FormatInfo(Format.R8G8B8A8Sint, 1, 1, 4); break;
-                    case Format.R16G16B16A16Snorm: formatInfo = new FormatInfo(Format.R16G16B16A16Sint, 1, 1, 8); break;
+                    case Format.R8Snorm:           formatInfo           = new FormatInfo(Format.R8Sint, 1, 1, 1); break;
+                    case Format.R16Snorm:          formatInfo           = new FormatInfo(Format.R16Sint, 1, 1, 2); break;
+                    case Format.R8G8Snorm:         formatInfo           = new FormatInfo(Format.R8G8Sint, 1, 1, 2); break;
+                    case Format.R16G16Snorm:       formatInfo           = new FormatInfo(Format.R16G16Sint, 1, 1, 4); break;
+                    case Format.R8G8B8A8Snorm:     formatInfo           = new FormatInfo(Format.R8G8B8A8Sint, 1, 1, 4); break;
+                    case Format.R16G16B16A16Snorm: formatInfo           = new FormatInfo(Format.R16G16B16A16Sint, 1, 1, 8); break;
                 }
             }
 
-            int width  = info.Width / info.SamplesInX;
+            int width  = info.Width  / info.SamplesInX;
             int height = info.Height / info.SamplesInY;
 
             int depth = info.GetDepth() * info.GetLayers();

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -625,7 +625,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             {
                 Texture overlap = _textureOverlaps[index];
 
-                if (TextureCompatibility.IsPerfectMatch(overlap.Info, info, flags))
+                if (overlap.IsPerfectMatch(info, flags))
                 {
                     if (!isSamplerTexture)
                     {

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.Graphics.Gpu.Image
     class TextureManager : IDisposable
     {
         private const int OverlapsBufferInitialCapacity = 10;
-        private const int OverlapsBufferMaxCapacity     = 10000;
+        private const int OverlapsBufferMaxCapacity = 10000;
 
         private readonly GpuContext _context;
 
@@ -519,12 +519,12 @@ namespace Ryujinx.Graphics.Gpu.Image
             // so the width we get here is the aligned width.
             if (isLinear)
             {
-                width  = colorState.WidthOrStride / formatInfo.BytesPerPixel;
+                width = colorState.WidthOrStride / formatInfo.BytesPerPixel;
                 stride = colorState.WidthOrStride;
             }
             else
             {
-                width  = colorState.WidthOrStride;
+                width = colorState.WidthOrStride;
                 stride = 0;
             }
 
@@ -625,7 +625,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             {
                 Texture overlap = _textureOverlaps[index];
 
-                if (overlap.IsPerfectMatch(info, flags))
+                if (TextureCompatibility.IsPerfectMatch(overlap.Info, info, flags))
                 {
                     if (!isSamplerTexture)
                     {
@@ -634,7 +634,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                         // deletion.
                         _cache.Lift(overlap);
                     }
-                    else if (!overlap.SizeMatches(info))
+                    else if (!TextureCompatibility.SizeMatches(overlap.Info, info))
                     {
                         // If this is used for sampling, the size must match,
                         // otherwise the shader would sample garbage data.
@@ -707,7 +707,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     // The size only matters (and is only really reliable) when the
                     // texture is used on a sampler, because otherwise the size will be
                     // aligned.
-                    if (!overlap.SizeMatches(info, firstLevel) && isSamplerTexture)
+                    if (!TextureCompatibility.SizeMatches(overlap.Info, info, firstLevel) && isSamplerTexture)
                     {
                         texture.ChangeSize(info.Width, info.Height, info.DepthOrLayers);
                     }
@@ -875,17 +875,17 @@ namespace Ryujinx.Graphics.Gpu.Image
             // - If the parent format is not compressed, and the view is, the view
             // size is calculated as described on the first point, but the width and height
             // of the view must be also multiplied by the block width and height.
-            int width  = Math.Max(1, parent.Info.Width  >> firstLevel);
+            int width = Math.Max(1, parent.Info.Width >> firstLevel);
             int height = Math.Max(1, parent.Info.Height >> firstLevel);
 
             if (parent.Info.FormatInfo.IsCompressed && !info.FormatInfo.IsCompressed)
             {
-                width  = BitUtils.DivRoundUp(width,  parent.Info.FormatInfo.BlockWidth);
+                width = BitUtils.DivRoundUp(width, parent.Info.FormatInfo.BlockWidth);
                 height = BitUtils.DivRoundUp(height, parent.Info.FormatInfo.BlockHeight);
             }
             else if (!parent.Info.FormatInfo.IsCompressed && info.FormatInfo.IsCompressed)
             {
-                width  *= info.FormatInfo.BlockWidth;
+                width *= info.FormatInfo.BlockWidth;
                 height *= info.FormatInfo.BlockHeight;
             }
 
@@ -953,16 +953,16 @@ namespace Ryujinx.Graphics.Gpu.Image
                 // The shader will need the appropriate conversion code to compensate.
                 switch (formatInfo.Format)
                 {
-                    case Format.R8Snorm:           formatInfo = new FormatInfo(Format.R8Sint,           1, 1, 1); break;
-                    case Format.R16Snorm:          formatInfo = new FormatInfo(Format.R16Sint,          1, 1, 2); break;
-                    case Format.R8G8Snorm:         formatInfo = new FormatInfo(Format.R8G8Sint,         1, 1, 2); break;
-                    case Format.R16G16Snorm:       formatInfo = new FormatInfo(Format.R16G16Sint,       1, 1, 4); break;
-                    case Format.R8G8B8A8Snorm:     formatInfo = new FormatInfo(Format.R8G8B8A8Sint,     1, 1, 4); break;
+                    case Format.R8Snorm: formatInfo = new FormatInfo(Format.R8Sint, 1, 1, 1); break;
+                    case Format.R16Snorm: formatInfo = new FormatInfo(Format.R16Sint, 1, 1, 2); break;
+                    case Format.R8G8Snorm: formatInfo = new FormatInfo(Format.R8G8Sint, 1, 1, 2); break;
+                    case Format.R16G16Snorm: formatInfo = new FormatInfo(Format.R16G16Sint, 1, 1, 4); break;
+                    case Format.R8G8B8A8Snorm: formatInfo = new FormatInfo(Format.R8G8B8A8Sint, 1, 1, 4); break;
                     case Format.R16G16B16A16Snorm: formatInfo = new FormatInfo(Format.R16G16B16A16Sint, 1, 1, 8); break;
                 }
             }
 
-            int width  = info.Width  / info.SamplesInX;
+            int width = info.Width / info.SamplesInX;
             int height = info.Height / info.SamplesInY;
 
             int depth = info.GetDepth() * info.GetLayers();

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.Graphics.Gpu.Image
     class TextureManager : IDisposable
     {
         private const int OverlapsBufferInitialCapacity = 10;
-        private const int OverlapsBufferMaxCapacity = 10000;
+        private const int OverlapsBufferMaxCapacity     = 10000;
 
         private readonly GpuContext _context;
 
@@ -519,12 +519,12 @@ namespace Ryujinx.Graphics.Gpu.Image
             // so the width we get here is the aligned width.
             if (isLinear)
             {
-                width = colorState.WidthOrStride / formatInfo.BytesPerPixel;
+                width  = colorState.WidthOrStride / formatInfo.BytesPerPixel;
                 stride = colorState.WidthOrStride;
             }
             else
             {
-                width = colorState.WidthOrStride;
+                width  = colorState.WidthOrStride;
                 stride = 0;
             }
 
@@ -875,17 +875,17 @@ namespace Ryujinx.Graphics.Gpu.Image
             // - If the parent format is not compressed, and the view is, the view
             // size is calculated as described on the first point, but the width and height
             // of the view must be also multiplied by the block width and height.
-            int width = Math.Max(1, parent.Info.Width >> firstLevel);
+            int width  = Math.Max(1, parent.Info.Width >> firstLevel);
             int height = Math.Max(1, parent.Info.Height >> firstLevel);
 
             if (parent.Info.FormatInfo.IsCompressed && !info.FormatInfo.IsCompressed)
             {
-                width = BitUtils.DivRoundUp(width, parent.Info.FormatInfo.BlockWidth);
+                width  = BitUtils.DivRoundUp(width, parent.Info.FormatInfo.BlockWidth);
                 height = BitUtils.DivRoundUp(height, parent.Info.FormatInfo.BlockHeight);
             }
             else if (!parent.Info.FormatInfo.IsCompressed && info.FormatInfo.IsCompressed)
             {
-                width *= info.FormatInfo.BlockWidth;
+                width  *= info.FormatInfo.BlockWidth;
                 height *= info.FormatInfo.BlockHeight;
             }
 
@@ -953,16 +953,16 @@ namespace Ryujinx.Graphics.Gpu.Image
                 // The shader will need the appropriate conversion code to compensate.
                 switch (formatInfo.Format)
                 {
-                    case Format.R8Snorm: formatInfo = new FormatInfo(Format.R8Sint, 1, 1, 1); break;
-                    case Format.R16Snorm: formatInfo = new FormatInfo(Format.R16Sint, 1, 1, 2); break;
-                    case Format.R8G8Snorm: formatInfo = new FormatInfo(Format.R8G8Sint, 1, 1, 2); break;
-                    case Format.R16G16Snorm: formatInfo = new FormatInfo(Format.R16G16Sint, 1, 1, 4); break;
-                    case Format.R8G8B8A8Snorm: formatInfo = new FormatInfo(Format.R8G8B8A8Sint, 1, 1, 4); break;
+                    case Format.R8Snorm: formatInfo           = new FormatInfo(Format.R8Sint, 1, 1, 1); break;
+                    case Format.R16Snorm: formatInfo          = new FormatInfo(Format.R16Sint, 1, 1, 2); break;
+                    case Format.R8G8Snorm: formatInfo         = new FormatInfo(Format.R8G8Sint, 1, 1, 2); break;
+                    case Format.R16G16Snorm: formatInfo       = new FormatInfo(Format.R16G16Sint, 1, 1, 4); break;
+                    case Format.R8G8B8A8Snorm: formatInfo     = new FormatInfo(Format.R8G8B8A8Sint, 1, 1, 4); break;
                     case Format.R16G16B16A16Snorm: formatInfo = new FormatInfo(Format.R16G16B16A16Sint, 1, 1, 8); break;
                 }
             }
 
-            int width = info.Width / info.SamplesInX;
+            int width  = info.Width / info.SamplesInX;
             int height = info.Height / info.SamplesInY;
 
             int depth = info.GetDepth() * info.GetLayers();

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -105,7 +105,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                     // If the descriptors are the same, the texture is the same,
                     // we don't need to remove as it was not modified. Just continue.
-                    if (texture.IsPerfectMatch(GetInfo(descriptor), TextureSearchFlags.Strict))
+                    if (TextureCompatibility.IsPerfectMatch(texture.Info, GetInfo(descriptor), TextureSearchFlags.Strict))
                     {
                         continue;
                     }
@@ -126,10 +126,10 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             ulong address = Context.MemoryManager.Translate(descriptor.UnpackAddress());
 
-            int width         = descriptor.UnpackWidth();
-            int height        = descriptor.UnpackHeight();
+            int width = descriptor.UnpackWidth();
+            int height = descriptor.UnpackHeight();
             int depthOrLayers = descriptor.UnpackDepth();
-            int levels        = descriptor.UnpackLevels();
+            int levels = descriptor.UnpackLevels();
 
             TextureMsaaMode msaaMode = descriptor.UnpackTextureMsaaMode();
 
@@ -145,7 +145,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             Target target = descriptor.UnpackTextureTarget().Convert((samplesInX | samplesInY) != 1);
 
             uint format = descriptor.UnpackFormat();
-            bool srgb   = descriptor.UnpackSrgb();
+            bool srgb = descriptor.UnpackSrgb();
 
             if (!FormatTable.TryGetTextureFormat(format, srgb, out FormatInfo formatInfo))
             {

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -105,7 +105,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                     // If the descriptors are the same, the texture is the same,
                     // we don't need to remove as it was not modified. Just continue.
-                    if (TextureCompatibility.IsPerfectMatch(texture.Info, GetInfo(descriptor), TextureSearchFlags.Strict))
+                    if (texture.IsPerfectMatch(GetInfo(descriptor), TextureSearchFlags.Strict))
                     {
                         continue;
                     }

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -126,10 +126,10 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             ulong address = Context.MemoryManager.Translate(descriptor.UnpackAddress());
 
-            int width = descriptor.UnpackWidth();
-            int height = descriptor.UnpackHeight();
+            int width         = descriptor.UnpackWidth();
+            int height        = descriptor.UnpackHeight();
             int depthOrLayers = descriptor.UnpackDepth();
-            int levels = descriptor.UnpackLevels();
+            int levels        = descriptor.UnpackLevels();
 
             TextureMsaaMode msaaMode = descriptor.UnpackTextureMsaaMode();
 
@@ -145,7 +145,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             Target target = descriptor.UnpackTextureTarget().Convert((samplesInX | samplesInY) != 1);
 
             uint format = descriptor.UnpackFormat();
-            bool srgb = descriptor.UnpackSrgb();
+            bool srgb   = descriptor.UnpackSrgb();
 
             if (!FormatTable.TryGetTextureFormat(format, srgb, out FormatInfo formatInfo))
             {


### PR DESCRIPTION
Closes #1475 

This is a first-time pull request to get acclimated with the project.

Downloaded a code-aligner to undo the spacing changes done by visual studio.