### PR TITLE
Correct the threshold for control stick buttons

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Hid/Hid.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Hid.cs
@@ -67,17 +67,18 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
         public ControllerKeys UpdateStickButtons(JoystickPosition leftStick, JoystickPosition rightStick)
         {
+            const int stickButtonThreshold = short.MaxValue / 2;
             ControllerKeys result = 0;
 
-            result |= (leftStick.Dx < 0) ? ControllerKeys.LStickLeft  : result;
-            result |= (leftStick.Dx > 0) ? ControllerKeys.LStickRight : result;
-            result |= (leftStick.Dy < 0) ? ControllerKeys.LStickDown  : result;
-            result |= (leftStick.Dy > 0) ? ControllerKeys.LStickUp    : result;
+            result |= (leftStick.Dx < -stickButtonThreshold) ? ControllerKeys.LStickLeft  : result;
+            result |= (leftStick.Dx > stickButtonThreshold)  ? ControllerKeys.LStickRight : result;
+            result |= (leftStick.Dy < -stickButtonThreshold) ? ControllerKeys.LStickDown  : result;
+            result |= (leftStick.Dy > stickButtonThreshold)  ? ControllerKeys.LStickUp    : result;
 
-            result |= (rightStick.Dx < 0) ? ControllerKeys.RStickLeft  : result;
-            result |= (rightStick.Dx > 0) ? ControllerKeys.RStickRight : result;
-            result |= (rightStick.Dy < 0) ? ControllerKeys.RStickDown  : result;
-            result |= (rightStick.Dy > 0) ? ControllerKeys.RStickUp    : result;
+            result |= (rightStick.Dx < -stickButtonThreshold) ? ControllerKeys.RStickLeft  : result;
+            result |= (rightStick.Dx > stickButtonThreshold)  ? ControllerKeys.RStickRight : result;
+            result |= (rightStick.Dy < -stickButtonThreshold) ? ControllerKeys.RStickDown  : result;
+            result |= (rightStick.Dy > stickButtonThreshold)  ? ControllerKeys.RStickUp    : result;
 
             return result;
         }


### PR DESCRIPTION
This was tested against HW with https://github.com/Xpl0itR/Input-Test/tree/master/Input-Test and a few changes to record the minimum value axis value when the stick buttons were marked as pressed.