### PR TITLE
Improve static branch prediction along fast path for memory accesses

### DIFF
--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -20,7 +20,7 @@ namespace ARMeilleure.Translation.PTC
     {
         private const string HeaderMagic = "PTChd";
 
-        private const int InternalVersion = 1471; //! To be incremented manually for each change to the ARMeilleure project.
+        private const int InternalVersion = 1484; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string BaseDir = "Ryujinx";
 


### PR DESCRIPTION
According to the Intel Optimization Reference Manual, forward conditional branches are predicted to be not taken and backward conditional branches are predicated to be taken, when they are not in the branch target buffer (See section 3.4.1.2 Static Branch Prediction). This PR changes the order of the blocks to take advantage of this.

Before
```asm
.L4:
  add rbx,byte -0x30
  mov rax,0xffffff8000000007
  mov rcx,rbx
  and rcx,rax
  jz .L7
.L5:
  mov rax,WriteUInt64
  mov rcx,rbx
  mov rdx,r13
  call rax
  jmp short .L9
.L7:
  mov rax,rbx
  shr rax,byte 0xc
  mov rcx,PAGE_TABLE_0
  mov rax,[rcx+rax*8]
  test rax,rax
  jng .L5
.L8:
  mov rcx,rbx
  and rcx,0xfff
  mov [rax+rcx],r13
.L9:
```

After
```asm
.L4:
  add rbx,byte -0x30
  mov rax,0xffffff8000000007
  mov rcx,rbx
  and rcx,rax
  jnz .L8
.L5:
  mov rax,rbx
  shr rax,byte 0xc
  mov rcx,PAGE_TABLE_0
  mov rax,[rcx+rax*8]
  test rax,rax
  jng .L8
.L6:
  mov rcx,rbx
  and rcx,0xfff
  mov [rax+rcx],r13
  jmp short .L9
.L8:
  mov rax,WriteUInt64
  mov rcx,rbx
  mov rdx,r13
  call rax
.L9:
```
Ideally this would be improved by some kind of scheduling, but it is good do this early anyways for throughput reasons. Also, scheduling could order the slow path at the end of the list of blocks so that we can omit the jump to `.L9` in `.L6`.

Took the opportunity to change vector stores to extract as I32/64 instead of F32/64 for vector stores as well.