### PR TITLE
Update to LibHac 0.12.0

### DIFF
--- a/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
+++ b/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
@@ -1,6 +1,7 @@
 using LibHac;
 using LibHac.Common;
 using LibHac.Fs;
+using LibHac.Fs.Fsa;
 using LibHac.FsSystem;
 using LibHac.FsSystem.NcaUtils;
 using LibHac.Ncm;
@@ -827,7 +828,7 @@ namespace Ryujinx.HLE.FileSystem.Content
 
                                             LibHac.Crypto.Sha256.GenerateSha256Hash(content, hash);
 
-                                            if (LibHac.Util.ArraysEqual(hash.ToArray(), meta.ContentEntries[0].Hash))
+                                            if (LibHac.Utilities.ArraysEqual(hash.ToArray(), meta.ContentEntries[0].Hash))
                                             {
                                                 updateNcas.Remove(metaEntry.TitleId);
                                             }
@@ -962,7 +963,7 @@ namespace Ryujinx.HLE.FileSystem.Content
 
                                 LibHac.Crypto.Sha256.GenerateSha256Hash(content, hash);
 
-                                if (LibHac.Util.ArraysEqual(hash.ToArray(), meta.ContentEntries[0].Hash))
+                                if (LibHac.Utilities.ArraysEqual(hash.ToArray(), meta.ContentEntries[0].Hash))
                                 {
                                     updateNcas.Remove(metaEntry.TitleId);
                                 }

--- a/Ryujinx.HLE/FileSystem/SaveHelper.cs
+++ b/Ryujinx.HLE/FileSystem/SaveHelper.cs
@@ -1,4 +1,4 @@
-﻿using LibHac.Fs;
+﻿using LibHac.Fs.Fsa;
 using LibHac.FsSystem;
 using Ryujinx.HLE.HOS;
 using System.IO;

--- a/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
+++ b/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
@@ -1,7 +1,8 @@
 using LibHac;
 using LibHac.Common;
 using LibHac.Fs;
-using LibHac.FsService;
+using LibHac.Fs.Fsa;
+using LibHac.FsSrv;
 using LibHac.FsSystem;
 using LibHac.Spl;
 using Ryujinx.HLE.FileSystem.Content;

--- a/Ryujinx.HLE/HOS/ApplicationLoader.cs
+++ b/Ryujinx.HLE/HOS/ApplicationLoader.cs
@@ -3,9 +3,9 @@ using LibHac;
 using LibHac.Account;
 using LibHac.Common;
 using LibHac.Fs;
+using LibHac.Fs.Fsa;
 using LibHac.FsSystem;
 using LibHac.FsSystem.NcaUtils;
-using LibHac.Ncm;
 using LibHac.Ns;
 using Ryujinx.Common.Configuration;
 using Ryujinx.Common.Logging;
@@ -20,6 +20,7 @@ using System.Linq;
 using System.Reflection;
 
 using static LibHac.Fs.ApplicationSaveDataManagement;
+using ApplicationId = LibHac.Ncm.ApplicationId;
 
 namespace Ryujinx.HLE.HOS
 {
@@ -73,7 +74,7 @@ namespace Ryujinx.HLE.HOS
 
             if (TitleId != 0)
             {
-                EnsureSaveData(new TitleId(TitleId));
+                EnsureSaveData(new ApplicationId(TitleId));
             }
 
             LoadExeFs(codeFs, metaData);
@@ -333,7 +334,7 @@ namespace Ryujinx.HLE.HOS
 
             if (TitleId != 0)
             {
-                EnsureSaveData(new TitleId(TitleId));
+                EnsureSaveData(new ApplicationId(TitleId));
             }
 
             LoadExeFs(codeFs, metaData);
@@ -549,7 +550,7 @@ namespace Ryujinx.HLE.HOS
             }
         }
 
-        private Result EnsureSaveData(TitleId titleId)
+        private Result EnsureSaveData(ApplicationId applicationId)
         {
             Logger.Info?.Print(LogClass.Application, "Ensuring required savedata exists.");
 
@@ -557,7 +558,7 @@ namespace Ryujinx.HLE.HOS
 
             ref ApplicationControlProperty control = ref ControlData.Value;
 
-            if (Util.IsEmpty(ControlData.ByteSpan))
+            if (LibHac.Utilities.IsEmpty(ControlData.ByteSpan))
             {
                 // If the current application doesn't have a loaded control property, create a dummy one
                 // and set the savedata sizes so a user savedata will be created.
@@ -573,7 +574,7 @@ namespace Ryujinx.HLE.HOS
 
             FileSystemClient fs = _fileSystem.FsClient;
 
-            Result rc = fs.EnsureApplicationCacheStorage(out _, titleId, ref control);
+            Result rc = fs.EnsureApplicationCacheStorage(out _, applicationId, ref control);
 
             if (rc.IsFailure())
             {
@@ -582,7 +583,7 @@ namespace Ryujinx.HLE.HOS
                 return rc;
             }
 
-            rc = EnsureApplicationSaveData(fs, out _, titleId, ref control, ref user);
+            rc = EnsureApplicationSaveData(fs, out _, applicationId, ref control, ref user);
 
             if (rc.IsFailure())
             {

--- a/Ryujinx.HLE/HOS/Font/SharedFontManager.cs
+++ b/Ryujinx.HLE/HOS/Font/SharedFontManager.cs
@@ -1,8 +1,8 @@
 using LibHac.Common;
 using LibHac.Fs;
+using LibHac.Fs.Fsa;
 using LibHac.FsSystem;
 using LibHac.FsSystem.NcaUtils;
-using Ryujinx.Common.Logging;
 using Ryujinx.HLE.Exceptions;
 using Ryujinx.HLE.FileSystem;
 using Ryujinx.HLE.FileSystem.Content;

--- a/Ryujinx.HLE/HOS/ModLoader.cs
+++ b/Ryujinx.HLE/HOS/ModLoader.cs
@@ -1,5 +1,6 @@
 using LibHac.Common;
 using LibHac.Fs;
+using LibHac.Fs.Fsa;
 using LibHac.FsSystem;
 using LibHac.FsSystem.RomFs;
 using Ryujinx.Common.Logging;

--- a/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
@@ -29,9 +29,9 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
 
         public IApplicationFunctions(Horizon system)
         {
-            _gpuErrorDetectedSystemEvent         = new KEvent(system.KernelContext);
+            _gpuErrorDetectedSystemEvent = new KEvent(system.KernelContext);
             _friendInvitationStorageChannelEvent = new KEvent(system.KernelContext);
-            _notificationStorageChannelEvent     = new KEvent(system.KernelContext);
+            _notificationStorageChannelEvent = new KEvent(system.KernelContext);
         }
 
         [Command(1)]
@@ -48,7 +48,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
         // EnsureSaveData(nn::account::Uid) -> u64
         public ResultCode EnsureSaveData(ServiceCtx context)
         {
-            Uid     userId  = context.RequestData.ReadStruct<AccountUid>().ToLibHacUid();
+            Uid userId = context.RequestData.ReadStruct<AccountUid>().ToLibHacUid();
             ApplicationId applicationId = new ApplicationId(context.Process.TitleId);
 
             BlitStruct<ApplicationControlProperty> controlHolder = context.Device.Application.ControlData;
@@ -62,7 +62,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
                 control = ref new BlitStruct<ApplicationControlProperty>(1).Value;
 
                 // The set sizes don't actually matter as long as they're non-zero because we use directory savedata.
-                control.UserAccountSaveDataSize        = 0x4000;
+                control.UserAccountSaveDataSize = 0x4000;
                 control.UserAccountSaveDataJournalSize = 0x4000;
 
                 Logger.Warning?.Print(LogClass.ServiceAm,
@@ -87,7 +87,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             // TODO: When above calls are implemented, switch to using ns:am
 
             long desiredLanguageCode = context.Device.System.State.DesiredLanguageCode;
-            
+
             int supportedLanguages = (int)context.Device.Application.ControlData.Value.SupportedLanguages;
             int firstSupported = BitOperations.TrailingZeroCount(supportedLanguages);
 
@@ -210,10 +210,10 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
         // InitializeApplicationCopyrightFrameBuffer(s32 width, s32 height, handle<copy, transfer_memory> transfer_memory, u64 transfer_memory_size)
         public ResultCode InitializeApplicationCopyrightFrameBuffer(ServiceCtx context)
         {
-            int   width                 = context.RequestData.ReadInt32();
-            int   height                = context.RequestData.ReadInt32();
-            ulong transferMemorySize    = context.RequestData.ReadUInt64();
-            int   transferMemoryHandle  = context.Request.HandleDesc.ToCopy[0];
+            int width = context.RequestData.ReadInt32();
+            int height = context.RequestData.ReadInt32();
+            ulong transferMemorySize = context.RequestData.ReadUInt64();
+            int transferMemoryHandle = context.Request.HandleDesc.ToCopy[0];
             ulong transferMemoryAddress = context.Process.HandleTable.GetObject<KTransferMemory>(transferMemoryHandle).Address;
 
             ResultCode resultCode = ResultCode.InvalidParameters;
@@ -258,12 +258,12 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
         // SetApplicationCopyrightImage(buffer<bytes, 0x45> frame_buffer, s32 x, s32 y, s32 width, s32 height, s32 window_origin_mode)
         public ResultCode SetApplicationCopyrightImage(ServiceCtx context)
         {
-            long frameBufferPos   = context.Request.SendBuff[0].Position;
-            long frameBufferSize  = context.Request.SendBuff[0].Size;
-            int  x                = context.RequestData.ReadInt32();
-            int  y                = context.RequestData.ReadInt32();
-            int  width            = context.RequestData.ReadInt32();
-            int  height           = context.RequestData.ReadInt32();
+            long frameBufferPos = context.Request.SendBuff[0].Position;
+            long frameBufferSize = context.Request.SendBuff[0].Size;
+            int x = context.RequestData.ReadInt32();
+            int y = context.RequestData.ReadInt32();
+            int width = context.RequestData.ReadInt32();
+            int height = context.RequestData.ReadInt32();
             uint windowOriginMode = context.RequestData.ReadUInt32();
 
             ResultCode resultCode = ResultCode.InvalidParameters;
@@ -272,7 +272,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             {
                 ResultCode result = SetApplicationCopyrightImageImpl(x, y, width, height, frameBufferPos, frameBufferSize, windowOriginMode);
 
-                if (resultCode != ResultCode.Success)
+                if (result != ResultCode.Success)
                 {
                     resultCode = result;
                 }

--- a/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
@@ -2,7 +2,6 @@ using LibHac;
 using LibHac.Account;
 using LibHac.Common;
 using LibHac.Fs;
-using LibHac.Ncm;
 using LibHac.Ns;
 using Ryujinx.Common;
 using Ryujinx.Common.Logging;
@@ -18,6 +17,7 @@ using System.Numerics;
 
 using static LibHac.Fs.ApplicationSaveDataManagement;
 using AccountUid = Ryujinx.HLE.HOS.Services.Account.Acc.UserId;
+using ApplicationId = LibHac.Ncm.ApplicationId;
 
 namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.ApplicationProxy
 {
@@ -49,13 +49,13 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
         public ResultCode EnsureSaveData(ServiceCtx context)
         {
             Uid     userId  = context.RequestData.ReadStruct<AccountUid>().ToLibHacUid();
-            TitleId titleId = new TitleId(context.Process.TitleId);
+            ApplicationId applicationId = new ApplicationId(context.Process.TitleId);
 
             BlitStruct<ApplicationControlProperty> controlHolder = context.Device.Application.ControlData;
 
             ref ApplicationControlProperty control = ref controlHolder.Value;
 
-            if (Util.IsEmpty(controlHolder.ByteSpan))
+            if (LibHac.Utilities.IsEmpty(controlHolder.ByteSpan))
             {
                 // If the current application doesn't have a loaded control property, create a dummy one
                 // and set the savedata sizes so a user savedata will be created.
@@ -69,7 +69,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
                     "No control file was found for this game. Using a dummy one instead. This may cause inaccuracies in some games.");
             }
 
-            Result result = EnsureApplicationSaveData(context.Device.FileSystem.FsClient, out long requiredSize, titleId,
+            Result result = EnsureApplicationSaveData(context.Device.FileSystem.FsClient, out long requiredSize, applicationId,
                 ref control, ref userId);
 
             context.ResponseData.Write(requiredSize);

--- a/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/FileSystemProxyHelper.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/FileSystemProxyHelper.cs
@@ -44,7 +44,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
                     return ResultCode.PartitionNotFound;
                 }
 
-                LibHac.Fs.IFileSystem fileSystem = nca.OpenFileSystem(NcaSectionType.Data, context.Device.System.FsIntegrityCheckLevel);
+                LibHac.Fs.Fsa.IFileSystem fileSystem = nca.OpenFileSystem(NcaSectionType.Data, context.Device.System.FsIntegrityCheckLevel);
 
                 openedFileSystem = new IFileSystem(fileSystem);
             }
@@ -82,7 +82,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
 
                     string filename = fullPath.Replace(archivePath.FullName, string.Empty).TrimStart('\\');
 
-                    Result result = nsp.OpenFile(out LibHac.Fs.IFile ncaFile, filename.ToU8Span(), OpenMode.Read);
+                    Result result = nsp.OpenFile(out LibHac.Fs.Fsa.IFile ncaFile, filename.ToU8Span(), OpenMode.Read);
                     if (result.IsFailure())
                     {
                         return (ResultCode)result.Value;
@@ -99,11 +99,11 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
             return ResultCode.PathDoesNotExist;
         }
 
-        public static void ImportTitleKeysFromNsp(LibHac.Fs.IFileSystem nsp, Keyset keySet)
+        public static void ImportTitleKeysFromNsp(LibHac.Fs.Fsa.IFileSystem nsp, Keyset keySet)
         {
             foreach (DirectoryEntryEx ticketEntry in nsp.EnumerateEntries("/", "*.tik"))
             {
-                Result result = nsp.OpenFile(out LibHac.Fs.IFile ticketFile, ticketEntry.FullPath.ToU8Span(), OpenMode.Read);
+                Result result = nsp.OpenFile(out LibHac.Fs.Fsa.IFile ticketFile, ticketEntry.FullPath.ToU8Span(), OpenMode.Read);
 
                 if (result.IsSuccess())
                 {

--- a/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IDirectory.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IDirectory.cs
@@ -7,9 +7,9 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
 {
     class IDirectory : IpcService
     {
-        private LibHac.Fs.IDirectory _baseDirectory;
+        private LibHac.Fs.Fsa.IDirectory _baseDirectory;
 
-        public IDirectory(LibHac.Fs.IDirectory directory)
+        public IDirectory(LibHac.Fs.Fsa.IDirectory directory)
         {
             _baseDirectory = directory;
         }

--- a/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IFile.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IFile.cs
@@ -6,9 +6,9 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
 {
     class IFile : IpcService, IDisposable
     {
-        private LibHac.Fs.IFile _baseFile;
+        private LibHac.Fs.Fsa.IFile _baseFile;
 
-        public IFile(LibHac.Fs.IFile baseFile)
+        public IFile(LibHac.Fs.Fsa.IFile baseFile)
         {
             _baseFile = baseFile;
         }
@@ -19,7 +19,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
         {
             long position = context.Request.ReceiveBuff[0].Position;
 
-            ReadOption readOption = (ReadOption)context.RequestData.ReadInt32();
+            ReadOption readOption = new ReadOption(context.RequestData.ReadInt32());
             context.RequestData.BaseStream.Position += 4;
 
             long offset = context.RequestData.ReadInt64();
@@ -42,7 +42,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
         {
             long position = context.Request.SendBuff[0].Position;
 
-            WriteOption writeOption = (WriteOption)context.RequestData.ReadInt32();
+            WriteOption writeOption = new WriteOption(context.RequestData.ReadInt32());
             context.RequestData.BaseStream.Position += 4;
 
             long offset = context.RequestData.ReadInt64();

--- a/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IFileSystem.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IFileSystem.cs
@@ -1,21 +1,21 @@
 using LibHac;
 using LibHac.Common;
 using LibHac.Fs;
-
+using LibHac.Fs.Fsa;
 using static Ryujinx.HLE.Utilities.StringUtils;
 
 namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
 {
     class IFileSystem : IpcService
     {
-        private LibHac.Fs.IFileSystem _fileSystem;
+        private LibHac.Fs.Fsa.IFileSystem _fileSystem;
 
-        public IFileSystem(LibHac.Fs.IFileSystem provider)
+        public IFileSystem(LibHac.Fs.Fsa.IFileSystem provider)
         {
             _fileSystem = provider;
         }
 
-        public LibHac.Fs.IFileSystem GetBaseFileSystem()
+        public LibHac.Fs.Fsa.IFileSystem GetBaseFileSystem()
         {
             return _fileSystem;
         }
@@ -111,7 +111,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
 
             U8Span name = ReadUtf8Span(context);
 
-            Result result = _fileSystem.OpenFile(out LibHac.Fs.IFile file, name, mode);
+            Result result = _fileSystem.OpenFile(out LibHac.Fs.Fsa.IFile file, name, mode);
 
             if (result.IsSuccess())
             {
@@ -131,7 +131,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
 
             U8Span name = ReadUtf8Span(context);
 
-            Result result = _fileSystem.OpenDirectory(out LibHac.Fs.IDirectory dir, name, mode);
+            Result result = _fileSystem.OpenDirectory(out LibHac.Fs.Fsa.IDirectory dir, name, mode);
 
             if (result.IsSuccess())
             {

--- a/Ryujinx.HLE/HOS/Services/Fs/IDeviceOperator.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/IDeviceOperator.cs
@@ -1,13 +1,13 @@
 ﻿using LibHac;
-using LibHac.FsService;
+using LibHac.FsSrv;
 
 namespace Ryujinx.HLE.HOS.Services.Fs
 {
     class IDeviceOperator : IpcService
     {
-        private LibHac.FsService.IDeviceOperator _baseOperator;
+        private LibHac.FsSrv.IDeviceOperator _baseOperator;
 
-        public IDeviceOperator(LibHac.FsService.IDeviceOperator baseOperator)
+        public IDeviceOperator(LibHac.FsSrv.IDeviceOperator baseOperator)
         {
             _baseOperator = baseOperator;
         }

--- a/Ryujinx.HLE/HOS/Services/Fs/IMultiCommitManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/IMultiCommitManager.cs
@@ -5,9 +5,9 @@ namespace Ryujinx.HLE.HOS.Services.Fs
 {
     class IMultiCommitManager : IpcService // 6.0.0+
     {
-        private LibHac.FsService.IMultiCommitManager _baseCommitManager;
+        private LibHac.FsSrv.IMultiCommitManager _baseCommitManager;
 
-        public IMultiCommitManager(LibHac.FsService.IMultiCommitManager baseCommitManager)
+        public IMultiCommitManager(LibHac.FsSrv.IMultiCommitManager baseCommitManager)
         {
             _baseCommitManager = baseCommitManager;
         }

--- a/Ryujinx.HLE/HOS/Services/Fs/ISaveDataInfoReader.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/ISaveDataInfoReader.cs
@@ -1,12 +1,13 @@
-﻿using LibHac;
+﻿using System;
+using LibHac;
 
 namespace Ryujinx.HLE.HOS.Services.Fs
 {
-    class ISaveDataInfoReader : IpcService
+    class ISaveDataInfoReader : IpcService, IDisposable
     {
-        private LibHac.FsService.ISaveDataInfoReader _baseReader;
+        private ReferenceCountedDisposable<LibHac.FsSrv.ISaveDataInfoReader> _baseReader;
 
-        public ISaveDataInfoReader(LibHac.FsService.ISaveDataInfoReader baseReader)
+        public ISaveDataInfoReader(ReferenceCountedDisposable<LibHac.FsSrv.ISaveDataInfoReader> baseReader)
         {
             _baseReader = baseReader;
         }
@@ -20,12 +21,17 @@ namespace Ryujinx.HLE.HOS.Services.Fs
 
             byte[] infoBuffer = new byte[bufferLen];
 
-            Result result = _baseReader.ReadSaveDataInfo(out long readCount, infoBuffer);
+            Result result = _baseReader.Target.Read(out long readCount, infoBuffer);
 
             context.Memory.Write((ulong)bufferPosition, infoBuffer);
             context.ResponseData.Write(readCount);
 
             return (ResultCode)result.Value;
+        }
+
+        public void Dispose()
+        {
+            _baseReader.Dispose();
         }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Mii/MiiDatabaseManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Mii/MiiDatabaseManager.cs
@@ -2,7 +2,6 @@
 using LibHac.Common;
 using LibHac.Fs;
 using LibHac.Fs.Shim;
-using LibHac.Ncm;
 using Ryujinx.HLE.HOS.Services.Mii.Types;
 using System.Runtime.CompilerServices;
 
@@ -137,7 +136,8 @@ namespace Ryujinx.HLE.HOS.Services.Mii
                     {
                         // TODO: We're currently always specifying the owner ID because FS doesn't have a way of
                         // knowing which process called it
-                        result = _filesystemClient.CreateSystemSaveData(targetSaveDataId, new TitleId(targetTitleId), 0x10000, 0x10000, SaveDataFlags.KeepAfterResettingSystemSaveDataWithoutUserSaveData);
+                        result = _filesystemClient.CreateSystemSaveData(targetSaveDataId, targetTitleId, 0x10000,
+                            0x10000, SaveDataFlags.KeepAfterResettingSystemSaveDataWithoutUserSaveData);
                         if (result.IsFailure()) return result;
 
                         result = _filesystemClient.MountSystemSaveData(mountName, SaveDataSpaceId.System, targetSaveDataId);

--- a/Ryujinx.HLE/HOS/Services/Mii/Types/StoreData.cs
+++ b/Ryujinx.HLE/HOS/Services/Mii/Types/StoreData.cs
@@ -73,7 +73,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.Types
 
         private ReadOnlySpan<byte> AsSpan()
         {
-            return MemoryMarshal.AsBytes(SpanHelpers.CreateReadOnlySpan(ref this, 1));
+            return MemoryMarshal.AsBytes(SpanHelpers.CreateReadOnlySpan(in this, 1));
         }
 
         private ReadOnlySpan<byte> AsSpanWithoutCrc()

--- a/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
@@ -1,6 +1,7 @@
 using LibHac;
 using LibHac.Common;
 using LibHac.Fs;
+using LibHac.Fs.Fsa;
 using LibHac.FsSystem;
 using LibHac.FsSystem.NcaUtils;
 using Ryujinx.Common.Logging;

--- a/Ryujinx.HLE/HOS/Services/Time/TimeZone/TimeZoneContentManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/TimeZone/TimeZoneContentManager.cs
@@ -1,6 +1,7 @@
 ﻿using LibHac;
 using LibHac.Common;
 using LibHac.Fs;
+using LibHac.Fs.Fsa;
 using LibHac.FsSystem;
 using LibHac.FsSystem.NcaUtils;
 using Ryujinx.Common.Logging;

--- a/Ryujinx.HLE/Loaders/Executables/KipExecutable.cs
+++ b/Ryujinx.HLE/Loaders/Executables/KipExecutable.cs
@@ -1,5 +1,5 @@
 using LibHac.Fs;
-using LibHac.Loader;
+using LibHac.Kernel;
 using System;
 
 namespace Ryujinx.HLE.Loaders.Executables
@@ -31,6 +31,7 @@ namespace Ryujinx.HLE.Loaders.Executables
         public byte IdealCoreId { get; }
         public int Version { get; }
         public string Name { get; }
+
         public KipExecutable(IStorage inStorage)
         {
             KipReader reader = new KipReader();
@@ -70,11 +71,11 @@ namespace Ryujinx.HLE.Loaders.Executables
             DataSize = DecompressSection(reader, KipReader.SegmentType.Data, DataOffset, Program);
         }
 
-        private static int DecompressSection(KipReader reader, KipReader.SegmentType segmentType, int offset, byte[] Program)
+        private static int DecompressSection(KipReader reader, KipReader.SegmentType segmentType, int offset, byte[] program)
         {
             reader.GetSegmentSize(segmentType, out int uncompressedSize).ThrowIfFailure();
 
-            var span = Program.AsSpan().Slice(offset, uncompressedSize);
+            var span = program.AsSpan().Slice(offset, uncompressedSize);
 
             reader.ReadSegment(segmentType, span).ThrowIfFailure();
 

--- a/Ryujinx.HLE/Ryujinx.HLE.csproj
+++ b/Ryujinx.HLE/Ryujinx.HLE.csproj
@@ -59,7 +59,7 @@
 
   <ItemGroup>
     <PackageReference Include="Concentus" Version="1.1.7" />
-    <PackageReference Include="LibHac" Version="0.11.3" />
+    <PackageReference Include="LibHac" Version="0.12.0" />
     <PackageReference Include="MsgPack.Cli" Version="1.0.1" />
   </ItemGroup>
 

--- a/Ryujinx/Ui/ApplicationLibrary.cs
+++ b/Ryujinx/Ui/ApplicationLibrary.cs
@@ -1,12 +1,10 @@
 using LibHac;
 using LibHac.Common;
 using LibHac.Fs;
-using LibHac.Fs.Shim;
+using LibHac.Fs.Fsa;
 using LibHac.FsSystem;
 using LibHac.FsSystem.NcaUtils;
-using LibHac.Ncm;
 using LibHac.Ns;
-using LibHac.Spl;
 using Ryujinx.Common.Logging;
 using Ryujinx.Common.Configuration;
 using Ryujinx.Configuration.System;
@@ -14,13 +12,11 @@ using Ryujinx.HLE.FileSystem;
 using Ryujinx.HLE.Loaders.Npdm;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Reflection;
 using System.Text;
 using System.Text.Json;
 
-using RightsId = LibHac.Fs.RightsId;
 using JsonHelper = Ryujinx.Common.Utilities.JsonHelper;
 
 namespace Ryujinx.Ui
@@ -211,9 +207,6 @@ namespace Ryujinx.Ui
                                     GetControlFsAndTitleId(pfs, out IFileSystem controlFs, out titleId);
 
                                     ReadControlData(controlFs, controlHolder.ByteSpan);
-
-                                    // Creates NACP class from the NACP file
-                                    controlFs.OpenFile(out IFile controlNacpFile, "/control.nacp".ToU8Span(), OpenMode.Read).ThrowIfFailure();
 
                                     // Get the title name, title ID, developer name and version number from the NACP
                                     version = IsUpdateApplied(titleId, out string updateVersion) ? updateVersion : controlHolder.Value.DisplayVersion.ToString();

--- a/Ryujinx/Ui/DlcWindow.cs
+++ b/Ryujinx/Ui/DlcWindow.cs
@@ -1,9 +1,10 @@
 using Gtk;
 using LibHac;
 using LibHac.Common;
-using LibHac.FsSystem.NcaUtils;
 using LibHac.Fs;
+using LibHac.Fs.Fsa;
 using LibHac.FsSystem;
+using LibHac.FsSystem.NcaUtils;
 using Ryujinx.Common.Configuration;
 using Ryujinx.Common.Logging;
 using Ryujinx.HLE.FileSystem;

--- a/Ryujinx/Ui/GameTableContextMenu.cs
+++ b/Ryujinx/Ui/GameTableContextMenu.cs
@@ -3,6 +3,7 @@ using LibHac;
 using LibHac.Account;
 using LibHac.Common;
 using LibHac.Fs;
+using LibHac.Fs.Fsa;
 using LibHac.Fs.Shim;
 using LibHac.FsSystem;
 using LibHac.FsSystem.NcaUtils;
@@ -45,19 +46,19 @@ namespace Ryujinx.Ui
 
             MenuItem openSaveUserDir = new MenuItem("Open User Save Directory")
             {
-                Sensitive   = !Util.IsEmpty(controlData.ByteSpan) && controlData.Value.UserAccountSaveDataSize > 0,
+                Sensitive   = !Utilities.IsEmpty(controlData.ByteSpan) && controlData.Value.UserAccountSaveDataSize > 0,
                 TooltipText = "Open the directory which contains Application's User Saves."
             };
 
             MenuItem openSaveDeviceDir = new MenuItem("Open Device Save Directory")
             {
-                Sensitive   = !Util.IsEmpty(controlData.ByteSpan) && controlData.Value.DeviceSaveDataSize > 0,
+                Sensitive   = !Utilities.IsEmpty(controlData.ByteSpan) && controlData.Value.DeviceSaveDataSize > 0,
                 TooltipText = "Open the directory which contains Application's Device Saves."
             };
 
             MenuItem openSaveBcatDir = new MenuItem("Open BCAT Save Directory")
             {
-                Sensitive   = !Util.IsEmpty(controlData.ByteSpan) && controlData.Value.BcatDeliveryCacheStorageSize > 0,
+                Sensitive   = !Utilities.IsEmpty(controlData.ByteSpan) && controlData.Value.BcatDeliveryCacheStorageSize > 0,
                 TooltipText = "Open the directory which contains Application's BCAT Saves."
             };
 
@@ -175,7 +176,7 @@ namespace Ryujinx.Ui
 
                 ref ApplicationControlProperty control = ref controlHolder.Value;
 
-                if (LibHac.Util.IsEmpty(controlHolder.ByteSpan))
+                if (LibHac.Utilities.IsEmpty(controlHolder.ByteSpan))
                 {
                     // If the current application doesn't have a loaded control property, create a dummy one
                     // and set the savedata sizes so a user savedata will be created.
@@ -191,7 +192,7 @@ namespace Ryujinx.Ui
 
                 Uid user = new Uid(1, 0);
 
-                result = EnsureApplicationSaveData(_virtualFileSystem.FsClient, out _, new TitleId(titleId), ref control, ref user);
+                result = EnsureApplicationSaveData(_virtualFileSystem.FsClient, out _, new LibHac.Ncm.ApplicationId(titleId), ref control, ref user);
 
                 if (result.IsFailure())
                 {
@@ -539,7 +540,7 @@ namespace Ryujinx.Ui
 
         private void OpenSaveDir(string titleName, ulong titleId, SaveDataFilter filter)
         {
-            filter.SetProgramId(new TitleId(titleId));
+            filter.SetProgramId(new ProgramId(titleId));
 
             if (!TryFindSaveData(titleName, titleId, _controlData, filter, out ulong saveDataId))
             {

--- a/Ryujinx/Ui/SaveImporter.cs
+++ b/Ryujinx/Ui/SaveImporter.cs
@@ -11,6 +11,8 @@ using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 
+using ApplicationId = LibHac.Ncm.ApplicationId;
+
 namespace Ryujinx.Ui
 {
     internal class SaveImporter
@@ -57,7 +59,7 @@ namespace Ryujinx.Ui
         {
             SaveDataAttribute key = save.Attribute;
 
-            Result result = fs.CreateSaveData(key.TitleId, key.UserId, key.TitleId, 0, 0, 0);
+            Result result = fs.CreateSaveData(new ApplicationId(key.ProgramId.Value), key.UserId, key.ProgramId.Value, 0, 0, 0);
             if (result.IsFailure()) return result;
 
             bool isOldMounted = false;
@@ -70,7 +72,7 @@ namespace Ryujinx.Ui
 
                 isOldMounted = true;
 
-                result = fs.MountSaveData("NewSave".ToU8Span(), key.TitleId, key.UserId);
+                result = fs.MountSaveData("NewSave".ToU8Span(), new ApplicationId(key.ProgramId.Value), key.UserId);
                 if (result.IsFailure()) return result;
 
                 isNewMounted = true;
@@ -132,7 +134,7 @@ namespace Ryujinx.Ui
                         {
                             Type = SaveDataType.Account,
                             UserId = userId,
-                            TitleId = new TitleId(titleId)
+                            ProgramId = new ProgramId(titleId)
                         };
 
                         SaveToImport save = new SaveToImport(dataPath, attribute);

--- a/Ryujinx/Ui/TitleUpdateWindow.cs
+++ b/Ryujinx/Ui/TitleUpdateWindow.cs
@@ -2,6 +2,7 @@ using Gtk;
 using LibHac;
 using LibHac.Common;
 using LibHac.Fs;
+using LibHac.Fs.Fsa;
 using LibHac.FsSystem;
 using LibHac.FsSystem.NcaUtils;
 using LibHac.Ns;


### PR DESCRIPTION
- Support reading NCA0 files and decrypted NCAs.
- Implement `Kvdb.FlatMapKeyValueStore` and update `SaveDataIndexer` classes to use it. This drastically improves the performance of some save data operations when large numbers of save data exist.
- Change `IFileSystem` interfaces to completely match Nintendo's.
- Add `ReferenceCountedDisposable<T>` to help properly dispose shared objects, and use it when returning an `ISaveDataInfoReader` from `IFileSystemProxy`.
- General system stability improvements to enhance the user's experience.