### PR TITLE
Attempt improvement of Shader Cache (Compute)

### DIFF
--- a/Ryujinx.Graphics.Gpu/Memory/ResourceName.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/ResourceName.cs
@@ -8,6 +8,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         Buffer,
         Texture,
         TexturePool,
-        SamplerPool
+        SamplerPool,
+        Shader
     }
 }

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderBundleWrapper.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderBundleWrapper.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ryujinx.Graphics.Gpu.Shader
+{
+
+
+    class ShaderBundleWrapper
+    {
+        public ShaderBundle shaderBundle { get; set; }
+        public ulong shaderAddress { get; set; }
+        public ShaderAddresses shaderAddresses { get; set; }
+
+        public ShaderBundleWrapper(ShaderBundle bundle, ulong address)
+        {
+            this.shaderBundle = bundle;
+            this.shaderAddress = address;
+        }
+
+        public ShaderBundleWrapper(ShaderBundle bundle, ShaderAddresses addresses)
+        {
+            this.shaderBundle = bundle;
+            this.shaderAddresses = addresses;
+        }
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -289,15 +289,14 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 return true;
             }
 
-            ReadOnlySpan<byte> memoryCode = _context.MemoryManager.GetSpan(gpuVa, shader.Code.Length);
-
-            bool equals = memoryCode.SequenceEqual(shader.Code);
+            int isModified = _context.PhysicalMemory.QueryModified(gpuVa, (ulong) shader.Code.Length, Gpu.Memory.ResourceName.Shader);
+            bool equals = isModified == 0;
 
             if (equals && shader.Code2 != null)
             {
-                memoryCode = _context.MemoryManager.GetSpan(gpuVaA, shader.Code2.Length);
+                isModified = _context.PhysicalMemory.QueryModified(gpuVaA, (ulong)shader.Code2.Length, Gpu.Memory.ResourceName.Shader);
 
-                equals = memoryCode.SequenceEqual(shader.Code2);
+                return isModified == 0;
             }
 
             return equals;

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -20,7 +20,6 @@ namespace Ryujinx.Graphics.Gpu.Shader
 
         private readonly Dictionary<int, ShaderBundleWrapper> _cpProgramsByHash;
         private readonly Dictionary<ulong, Dictionary<int, ShaderBundle>> _cpPrograms;
-        private readonly Dictionary<int, ShaderBundleWrapper> _gpProgramsByHash;
         private readonly Dictionary<ShaderAddresses, List<ShaderBundle>> _gpPrograms;
 
         /// <summary>
@@ -35,7 +34,6 @@ namespace Ryujinx.Graphics.Gpu.Shader
 
             _cpProgramsByHash = new Dictionary<int, ShaderBundleWrapper>();
             _cpPrograms = new Dictionary<ulong, Dictionary<int, ShaderBundle>>();
-            _gpProgramsByHash = new Dictionary<int, ShaderBundleWrapper>();
             _gpPrograms = new Dictionary<ShaderAddresses, List<ShaderBundle>>();
         }
 

--- a/Ryujinx.Graphics.Shader/Translation/Translator.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Translator.cs
@@ -62,42 +62,6 @@ namespace Ryujinx.Graphics.Shader.Translation
             return new ShaderProgram(spInfo, config.Stage, glslCode, config.Size, sizeA);
         }
 
-        public static int DecodeShaderSize(ulong address, IGpuAccessor gpuAccessor, TranslationFlags flags)
-        {
-            Block[] cfg;
-
-            if ((flags & TranslationFlags.Compute) != 0)
-            {
-                cfg = Decoder.Decode(gpuAccessor, address);
-            }
-            else
-            {
-                cfg = Decoder.Decode(gpuAccessor, address + HeaderSize);
-            }
-
-            if (cfg == null)
-            {
-                gpuAccessor.Log("Invalid branch detected, failed to build CFG.");
-
-                return 0;
-            }
-
-            ulong maxEndAddress = 0;
-
-            for (int blkIndex = 0; blkIndex < cfg.Length; blkIndex++)
-            {
-                Block block = cfg[blkIndex];
-
-                if (maxEndAddress < block.EndAddress)
-                {
-                    maxEndAddress = block.EndAddress;
-                }
-            }
-
-            return (int)maxEndAddress + (flags.HasFlag(TranslationFlags.Compute) ? 0 : HeaderSize);
-
-        }
-
         private static Operation[] DecodeShader(ulong address, IGpuAccessor gpuAccessor, TranslationFlags flags, out ShaderConfig config)
         {
             Block[] cfg;


### PR DESCRIPTION
Closes #864 

Convert _cpPrograms to dictionary for O(1) removal of moved shader.

Created _cpProgramsByHash to store all created shaders.

_cpProgramsByHash is a fallback check for shaders who've been compiled before but are written to a new memory address.

ShaderBundleWrapper class is used to keep track of the last address a particular shader was used, to allow us to remove the shader from that address.

Considering two maps are used, memory consumption may be increased depending on the game. (Up to 2 copies of one shader will exist throughout gameplay).

(Graphics Shaders have not been modified, don't understand it yet and experimental implementations have actually reduced performance)