### PR TITLE
Amadeus: Fix inverted downmixing of center and lfe

### DIFF
--- a/Ryujinx.Audio.Renderer/Dsp/Command/DownMixSurroundToStereoCommand.cs
+++ b/Ryujinx.Audio.Renderer/Dsp/Command/DownMixSurroundToStereoCommand.cs
@@ -62,8 +62,8 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
         {
             ReadOnlySpan<float> frontLeft = context.GetBuffer(InputBufferIndices[0]);
             ReadOnlySpan<float> frontRight = context.GetBuffer(InputBufferIndices[1]);
-            ReadOnlySpan<float> lowFrequency = context.GetBuffer(InputBufferIndices[2]);
-            ReadOnlySpan<float> frontCenter = context.GetBuffer(InputBufferIndices[3]);
+            ReadOnlySpan<float> frontCenter = context.GetBuffer(InputBufferIndices[2]);
+            ReadOnlySpan<float> lowFrequency = context.GetBuffer(InputBufferIndices[3]);
             ReadOnlySpan<float> backLeft = context.GetBuffer(InputBufferIndices[4]);
             ReadOnlySpan<float> backRight = context.GetBuffer(InputBufferIndices[5]);
 


### PR DESCRIPTION
This fix front center and lfe being inverted in input of the DownMixSurroundToStereo command.

This fix:
- Voices being missing on FE3H videos.
- Mario Tennis Aces missing background.
- Probably all missing sound issues that anyone could have.