### PR TITLE
Fix off-by-one error in pages count calculation on GPU pool

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/Pool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Pool.cs
@@ -1,3 +1,4 @@
+using Ryujinx.Common;
 using Ryujinx.Graphics.Gpu.Memory;
 using System;
 
@@ -49,7 +50,11 @@ namespace Ryujinx.Graphics.Gpu.Image
             Address = address;
             Size    = size;
 
-            _modifiedRanges = new (ulong, ulong)[size / PhysicalMemory.PageSize];
+            ulong endAddress = BitUtils.AlignUp(Address + Size, PhysicalMemory.PageSize);
+
+            ulong pagesCount = (endAddress - BitUtils.AlignDown(Address, PhysicalMemory.PageSize)) / PhysicalMemory.PageSize;
+
+            _modifiedRanges = new (ulong, ulong)[pagesCount];
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes a regression introduced in #856 where the pages count would not be calculated properly for the GPU pools, leading to a `ArgumentOutOfRangeException` when `SynchronizeMemory` was called because the array was not large enough to hold all the modified pages.

To my knowledge, the bug is only manifested on deko3d homebrew, I'm not aware of any other application that triggers the bug.