### PR TITLE
Fix PSL and MRG flags on XMAD cbuf-reg shader instruction

### DIFF
--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitAlu.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitAlu.cs
@@ -674,7 +674,12 @@ namespace Ryujinx.Graphics.Shader.Instructions
             bool productShiftLeft = false;
             bool merge            = false;
 
-            if (!(op is OpCodeAluRegCbuf))
+            if (op is OpCodeAluCbuf)
+            {
+                productShiftLeft = context.CurrOp.RawOpCode.Extract(55);
+                merge            = context.CurrOp.RawOpCode.Extract(56);
+            }
+            else if (!(op is OpCodeAluRegCbuf))
             {
                 productShiftLeft = context.CurrOp.RawOpCode.Extract(36);
                 merge            = context.CurrOp.RawOpCode.Extract(37);


### PR DESCRIPTION
It was reading the flags from the wrong bits for the constant buffer + register variant of this instruction.

Fixes dithering pattern on SMO.
Before:
![image](https://user-images.githubusercontent.com/5624669/91784452-5b468400-ebd9-11ea-85a6-d214a819fed7.png)
After:
![image](https://user-images.githubusercontent.com/5624669/91784460-626d9200-ebd9-11ea-8eeb-c5a6b1c29b86.png)
Might also fix issues on other games, of course.
