### PR TITLE
Fix regression on texture compatibility match checks

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -676,7 +676,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 return false;
             }
 
-            if (!TextureCompatibility.SizeMatches(Info, info))
+            if (!TextureCompatibility.SizeMatches(Info, info, (flags & TextureSearchFlags.Strict) == 0))
             {
                 return false;
             }

--- a/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -203,7 +203,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="rhs">Texture information to compare with</param>
         /// <param name="alignSizes">True to align the sizes according to the texture layout for comparison</param>
         /// <returns>True if the sizes matches, false otherwise</returns>
-        private static bool SizeMatches(TextureInfo lhs, TextureInfo rhs, bool alignSizes)
+        public static bool SizeMatches(TextureInfo lhs, TextureInfo rhs, bool alignSizes)
         {
             if (lhs.GetLayers() != rhs.GetLayers())
             {


### PR DESCRIPTION
Fixes a regression introduced on #1482 that caused height maps to break in SMO after a few steps (and probably affected other games too), the wrong `SizeMatches` overload was being used, compared to the previous code.