### PR TITLE
SIMD&FP load/store with scale > 4 should be undefined

### DIFF
--- a/ARMeilleure/Decoders/OpCodeSimdMemImm.cs
+++ b/ARMeilleure/Decoders/OpCodeSimdMemImm.cs
@@ -6,7 +6,16 @@ namespace ARMeilleure.Decoders
         {
             Size |= (opCode >> 21) & 4;
 
-            if (!WBack && !Unscaled && Size >= 4)
+            if (Size > 4)
+            {
+                Instruction = InstDescriptor.Undefined;
+
+                return;
+            }
+
+            // Base class already shifts the immediate, we only
+            // need to shift it if size (scale) is 4, since this value is only set here.
+            if (!WBack && !Unscaled && Size == 4)
             {
                 Immediate <<= 4;
             }

--- a/ARMeilleure/Decoders/OpCodeSimdMemReg.cs
+++ b/ARMeilleure/Decoders/OpCodeSimdMemReg.cs
@@ -6,6 +6,13 @@ namespace ARMeilleure.Decoders
         {
             Size |= (opCode >> 21) & 4;
 
+            if (Size > 4)
+            {
+                Instruction = InstDescriptor.Undefined;
+
+                return;
+            }
+
             Extend64 = false;
         }
     }

--- a/ARMeilleure/Decoders/OpCodeTable.cs
+++ b/ARMeilleure/Decoders/OpCodeTable.cs
@@ -412,7 +412,7 @@ namespace ARMeilleure.Decoders
             SetA64("xx111100x10xxxxxxxxx01xxxxxxxxxx", InstName.Ldr,             InstEmit.Ldr,             typeof(OpCodeSimdMemImm));
             SetA64("xx111100x10xxxxxxxxx11xxxxxxxxxx", InstName.Ldr,             InstEmit.Ldr,             typeof(OpCodeSimdMemImm));
             SetA64("xx111101x1xxxxxxxxxxxxxxxxxxxxxx", InstName.Ldr,             InstEmit.Ldr,             typeof(OpCodeSimdMemImm));
-            SetA64("xx111100x11xxxxxxxxx10xxxxxxxxxx", InstName.Ldr,             InstEmit.Ldr,             typeof(OpCodeSimdMemReg));
+            SetA64("xx111100x11xxxxxx1xx10xxxxxxxxxx", InstName.Ldr,             InstEmit.Ldr,             typeof(OpCodeSimdMemReg));
             SetA64("xx011100xxxxxxxxxxxxxxxxxxxxxxxx", InstName.Ldr_Literal,     InstEmit.Ldr_Literal,     typeof(OpCodeSimdMemLit));
             SetA64("0x001110<<1xxxxx100101xxxxxxxxxx", InstName.Mla_V,           InstEmit.Mla_V,           typeof(OpCodeSimdReg));
             SetA64("0x101111xxxxxxxx0000x0xxxxxxxxxx", InstName.Mla_Ve,          InstEmit.Mla_Ve,          typeof(OpCodeSimdRegElem));
@@ -554,7 +554,7 @@ namespace ARMeilleure.Decoders
             SetA64("xx111100x00xxxxxxxxx01xxxxxxxxxx", InstName.Str,             InstEmit.Str,             typeof(OpCodeSimdMemImm));
             SetA64("xx111100x00xxxxxxxxx11xxxxxxxxxx", InstName.Str,             InstEmit.Str,             typeof(OpCodeSimdMemImm));
             SetA64("xx111101x0xxxxxxxxxxxxxxxxxxxxxx", InstName.Str,             InstEmit.Str,             typeof(OpCodeSimdMemImm));
-            SetA64("xx111100x01xxxxxxxxx10xxxxxxxxxx", InstName.Str,             InstEmit.Str,             typeof(OpCodeSimdMemReg));
+            SetA64("xx111100x01xxxxxx1xx10xxxxxxxxxx", InstName.Str,             InstEmit.Str,             typeof(OpCodeSimdMemReg));
             SetA64("01111110111xxxxx100001xxxxxxxxxx", InstName.Sub_S,           InstEmit.Sub_S,           typeof(OpCodeSimdReg));
             SetA64("0>101110<<1xxxxx100001xxxxxxxxxx", InstName.Sub_V,           InstEmit.Sub_V,           typeof(OpCodeSimdReg));
             SetA64("0x001110<<1xxxxx011000xxxxxxxxxx", InstName.Subhn_V,         InstEmit.Subhn_V,         typeof(OpCodeSimdReg));

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -21,7 +21,7 @@ namespace ARMeilleure.Translation.PTC
     {
         private const string HeaderMagic = "PTChd";
 
-        private const int InternalVersion = 1484; //! To be incremented manually for each change to the ARMeilleure project.
+        private const int InternalVersion = 1522; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";


### PR DESCRIPTION
Per the manual:
```
if scale > 4 then UNDEFINED; 
```
This was not being enforced, which lead to a exception later on, during emit stage since the size could be invalid. Now it should produce a "undefined" instruction instead for those invalid cases.

~~PPTC increment is not required, since when the invalid encoding is encountered, it throws a exception later on and no code is generated (before this change).~~ Nevermind that, incremented it since I found another case of undefined encoding that was also not being matched:
```
if option<1> == '0' then UNDEFINED;    // sub-word index
```
This one is also fixed now.