### PR TITLE
Improve Controller Applet UX

### DIFF
--- a/Ryujinx.HLE/HOS/Applets/Controller/ControllerAppletUiArgs.cs
+++ b/Ryujinx.HLE/HOS/Applets/Controller/ControllerAppletUiArgs.cs
@@ -3,12 +3,15 @@ using System.Collections.Generic;
 
 namespace Ryujinx.HLE.HOS.Applets
 {
-    public struct ControllerAppletUiArgs
+    public class ControllerAppletUiArgs
     {
         public int PlayerCountMin;
         public int PlayerCountMax;
         public ControllerType SupportedStyles;
         public IEnumerable<PlayerIndex> SupportedPlayers;
         public bool IsDocked;
+        public bool IsSinglePlayer;
+        public uint[] IdentificationColors;
+        public string[] ExplainTexts;
     }
 }

--- a/Ryujinx.HLE/HOS/Applets/Controller/ControllerAppletUiArgs.cs
+++ b/Ryujinx.HLE/HOS/Applets/Controller/ControllerAppletUiArgs.cs
@@ -8,9 +8,9 @@ namespace Ryujinx.HLE.HOS.Applets
         public int PlayerCountMin;
         public int PlayerCountMax;
         public ControllerType SupportedStyles;
-        public IEnumerable<PlayerIndex> SupportedPlayers;
         public bool IsDocked;
         public bool IsSinglePlayer;
+        public bool PermitJoyDual;
         public uint[] IdentificationColors;
         public string[] ExplainTexts;
     }

--- a/Ryujinx.HLE/HOS/Applets/Controller/ControllerSupportArgHeader.cs
+++ b/Ryujinx.HLE/HOS/Applets/Controller/ControllerSupportArgHeader.cs
@@ -12,7 +12,6 @@ namespace Ryujinx.HLE.HOS.Applets
         public byte EnableLeftJustify;
         public byte EnablePermitJoyDual;
         public byte EnableSingleMode;
-        public byte EnableIdentificationColor;
     }
 #pragma warning restore CS0649
 }

--- a/Ryujinx.HLE/HOS/Applets/Controller/ControllerSupportArgV7.cs
+++ b/Ryujinx.HLE/HOS/Applets/Controller/ControllerSupportArgV7.cs
@@ -1,16 +1,56 @@
+using System;
 using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Applets
 {
 #pragma warning disable CS0649
     // (8.0.0+ version)
-    [StructLayout(LayoutKind.Sequential, Pack=1)]
-    unsafe struct ControllerSupportArgV7
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    unsafe struct ControllerSupportArgV7 : IControllerSupportArg
     {
+        const int MaxPlayers = 8;
+        const int TextSize = 0x81;
+
         public ControllerSupportArgHeader Header;
-        public fixed uint IdentificationColor[8];
+        public byte EnableIdentificationColor;
+        public fixed uint IdentificationColor[MaxPlayers];
         public byte EnableExplainText;
-        public fixed byte ExplainText[8 * 0x81];
+        public fixed byte ExplainText[MaxPlayers * TextSize];
+
+        public string[] GetExplainTexts()
+        {
+            if (EnableExplainText == 0)
+            {
+                return new string[0];
+            }
+
+            string[] texts = new string[MaxPlayers];
+            fixed (byte* textPtr = ExplainText)
+            {
+                for (int i = 0; i < MaxPlayers; ++i)
+                {
+                    texts[i] = Marshal.PtrToStringUTF8((IntPtr)textPtr + i * TextSize);
+                }
+            }
+
+            return texts;
+        }
+
+        public uint[] GetIdentificationColors()
+        {
+            if (EnableIdentificationColor == 0)
+            {
+                return new uint[0];
+            }
+
+            uint[] colors = new uint[MaxPlayers];
+            for (int i=0; i< MaxPlayers; ++i)
+            {
+                colors[i] = IdentificationColor[i];
+            }
+
+            return colors;
+        }
     }
 #pragma warning restore CS0649
 }

--- a/Ryujinx.HLE/HOS/Applets/Controller/ControllerSupportArgVPre7.cs
+++ b/Ryujinx.HLE/HOS/Applets/Controller/ControllerSupportArgVPre7.cs
@@ -5,7 +5,7 @@ namespace Ryujinx.HLE.HOS.Applets
 {
 #pragma warning disable CS0649
     // (1.0.0+ version)
-    [StructLayout(LayoutKind.Sequential, Pack=1)]
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
     unsafe struct ControllerSupportArgVPre7 : IControllerSupportArg
     {
         const int MaxPlayers = 4;
@@ -44,7 +44,7 @@ namespace Ryujinx.HLE.HOS.Applets
             }
 
             uint[] colors = new uint[MaxPlayers];
-            for (int i=0; i< MaxPlayers; ++i)
+            for (int i = 0; i < MaxPlayers; ++i)
             {
                 colors[i] = IdentificationColor[i];
             }

--- a/Ryujinx.HLE/HOS/Applets/Controller/ControllerSupportArgVPre7.cs
+++ b/Ryujinx.HLE/HOS/Applets/Controller/ControllerSupportArgVPre7.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Applets
@@ -5,12 +6,51 @@ namespace Ryujinx.HLE.HOS.Applets
 #pragma warning disable CS0649
     // (1.0.0+ version)
     [StructLayout(LayoutKind.Sequential, Pack=1)]
-    unsafe struct ControllerSupportArgVPre7
+    unsafe struct ControllerSupportArgVPre7 : IControllerSupportArg
     {
+        const int MaxPlayers = 4;
+        const int TextSize = 0x81;
+
         public ControllerSupportArgHeader Header;
-        public fixed uint IdentificationColor[4];
+        public byte EnableIdentificationColor;
+        public fixed uint IdentificationColor[MaxPlayers];
         public byte EnableExplainText;
-        public fixed byte ExplainText[4 * 0x81];
+        public fixed byte ExplainText[MaxPlayers * TextSize];
+
+        public string[] GetExplainTexts()
+        {
+            if (EnableExplainText == 0)
+            {
+                return new string[0];
+            }
+
+            string[] texts = new string[MaxPlayers];
+            fixed (byte* textPtr = ExplainText)
+            {
+                for (int i = 0; i < MaxPlayers; ++i)
+                {
+                    texts[i] = Marshal.PtrToStringUTF8((IntPtr)textPtr + i * TextSize);
+                }
+            }
+
+            return texts;
+        }
+
+        public uint[] GetIdentificationColors()
+        {
+            if (EnableIdentificationColor == 0)
+            {
+                return new uint[0];
+            }
+
+            uint[] colors = new uint[MaxPlayers];
+            for (int i=0; i< MaxPlayers; ++i)
+            {
+                colors[i] = IdentificationColor[i];
+            }
+
+            return colors;
+        }
     }
 #pragma warning restore CS0649
 }

--- a/Ryujinx.HLE/HOS/Applets/Controller/IControllerSupportArg.cs
+++ b/Ryujinx.HLE/HOS/Applets/Controller/IControllerSupportArg.cs
@@ -1,0 +1,8 @@
+namespace Ryujinx.HLE.HOS.Applets
+{
+    interface IControllerSupportArg
+    {
+        string[] GetExplainTexts();
+        uint[] GetIdentificationColors();
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Hid/HidDevices/NpadDevices.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/HidDevices/NpadDevices.cs
@@ -53,14 +53,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ref _styleSetUpdateEvents[(int)player];
         }
 
-        internal void ClearSupportedPlayers()
+        internal void SetSupportedPlayers(ReadOnlySpan<bool> players)
         {
-            _supportedPlayers.AsSpan().Clear();
-        }
-
-        internal void SetSupportedPlayer(PlayerIndex player, bool supported = true)
-        {
-            _supportedPlayers[(int)player] = supported;
+            players.CopyTo(_supportedPlayers.AsSpan());
         }
 
         internal ReadOnlySpan<bool> GetSupportedPlayers()

--- a/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
@@ -592,9 +592,8 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             long appletResourceUserId = context.RequestData.ReadInt64();
             long arraySize = context.Request.PtrBuff[0].Size / 4;
 
-            NpadIdType[] supportedPlayerIds = new NpadIdType[arraySize];
-
-            context.Device.Hid.Npads.ClearSupportedPlayers();
+            Span<bool> supportedPlayers = stackalloc bool[NpadDevices.MaxControllers];
+            Span<NpadIdType> supportedPlayerIds = stackalloc NpadIdType[(int)arraySize];
 
             for (int i = 0; i < arraySize; ++i)
             {
@@ -602,13 +601,15 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
                 if (id >= 0)
                 {
-                    context.Device.Hid.Npads.SetSupportedPlayer(HidUtils.GetIndexFromNpadIdType(id));
+                    supportedPlayers[(int)HidUtils.GetIndexFromNpadIdType(id)] = true;
                 }
 
                 supportedPlayerIds[i] = id;
             }
 
-            Logger.Stub?.PrintStub(LogClass.ServiceHid, $"{arraySize} " + string.Join(",", supportedPlayerIds));
+            context.Device.Hid.Npads.SetSupportedPlayers(supportedPlayers);
+
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, $"{arraySize} " + string.Join(",", supportedPlayerIds.ToArray()));
 
             return ResultCode.Success;
         }
@@ -1005,11 +1006,11 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         {
             long appletResourceUserId = context.RequestData.ReadInt64();
 
-            byte[] vibrationDeviceHandleBuffer = new byte[context.Request.PtrBuff[0].Size];
+            Span<byte> vibrationDeviceHandleBuffer = stackalloc byte[(int)context.Request.PtrBuff[0].Size];
 
             context.Memory.Read((ulong)context.Request.PtrBuff[0].Position, vibrationDeviceHandleBuffer);
 
-            byte[] vibrationValueBuffer = new byte[context.Request.PtrBuff[1].Size];
+            Span<byte> vibrationValueBuffer = stackalloc byte[(int)context.Request.PtrBuff[1].Size];
 
             context.Memory.Read((ulong)context.Request.PtrBuff[1].Position, vibrationValueBuffer);
 

--- a/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
@@ -559,12 +559,15 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             ControllerType type = (ControllerType)context.RequestData.ReadInt32();
             long appletResourceUserId = context.RequestData.ReadInt64();
 
-            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { 
-                    appletResourceUserId, 
-                    type 
-                });
+            if (context.Device.Hid.Npads.SupportedStyleSets != type)
+            {
+                Logger.Stub?.Print(LogClass.ServiceHid, "", new { 
+                        appletResourceUserId, 
+                        type 
+                    });
 
-            context.Device.Hid.Npads.SupportedStyleSets = type;
+                context.Device.Hid.Npads.SupportedStyleSets = type;
+            }
 
             return ResultCode.Success;
         }
@@ -721,7 +724,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             context.ResponseData.Write((long)context.Device.Hid.Npads.JoyHold);
 
-            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { 
+            Logger.Debug?.PrintStub(LogClass.ServiceHid, new { 
                     appletResourceUserId, 
                     context.Device.Hid.Npads.JoyHold 
                 });
@@ -912,7 +915,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             context.ResponseData.Write((int)deviceInfo.DeviceType);
             context.ResponseData.Write((int)deviceInfo.Position);
 
-            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { vibrationDeviceHandle, deviceInfo.DeviceType, deviceInfo.Position });
+            Logger.Debug?.PrintStub(LogClass.ServiceHid, new { vibrationDeviceHandle, deviceInfo.DeviceType, deviceInfo.Position });
 
             return ResultCode.Success;
         }
@@ -957,7 +960,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             context.ResponseData.Write(_vibrationValue.AmplitudeHigh);
             context.ResponseData.Write(_vibrationValue.FrequencyHigh);
 
-            Logger.Stub?.PrintStub(LogClass.ServiceHid, new {
+            Logger.Debug?.PrintStub(LogClass.ServiceHid, new {
                 appletResourceUserId,
                 vibrationDeviceHandle,
                 _vibrationValue.AmplitudeLow,

--- a/Ryujinx.HLE/IHostUiHandler.cs
+++ b/Ryujinx.HLE/IHostUiHandler.cs
@@ -18,9 +18,8 @@ namespace Ryujinx.HLE
         bool DisplayMessageDialog(string title, string message);
 
         /// <summary>
-        /// Displays a Message Dialog box specific to Controller Applet and blocks until it is closed.
+        /// Opens a Dialog to configure controllers when an application requests Controller Applet
         /// </summary>
-        /// <returns>True when OK is pressed, False otherwise.</returns>
-        bool DisplayMessageDialog(ControllerAppletUiArgs args);
+        void DisplayControllerApplet(ControllerAppletUiArgs args);
     }
 }

--- a/Ryujinx/Ui/GtkHostUiHandler.cs
+++ b/Ryujinx/Ui/GtkHostUiHandler.cs
@@ -7,8 +7,6 @@ using Ryujinx.HLE.HOS.Applets;
 using System;
 using System.Threading;
 
-using System.Linq;
-
 namespace Ryujinx.Ui
 {
     internal class GtkHostUiHandler : IHostUiHandler
@@ -24,7 +22,7 @@ namespace Ryujinx.Ui
             _contentManager = contentManager;
         }
 
-        public bool DisplayMessageDialog(ControllerAppletUiArgs args)
+        public void DisplayControllerApplet(ControllerAppletUiArgs args)
         {
             ManualResetEvent closeEvent = new ManualResetEvent(false);
 
@@ -32,7 +30,7 @@ namespace Ryujinx.Ui
             {
                 Logger.Error?.Print(LogClass.Application, "Controller Applet requested Input Settings window but it's already open");
                 Thread.Sleep(1000); // Wait to prevent spam
-                return true;
+                return;
             }
 
             Application.Invoke(delegate
@@ -51,7 +49,7 @@ namespace Ryujinx.Ui
             });
 
             closeEvent.WaitOne();
-            return true;
+            return;
         }
 
         public bool DisplayMessageDialog(string title, string message)

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -179,7 +179,7 @@ namespace Ryujinx.Ui
 
             _statusBar.Hide();
 
-            _uiHandler = new GtkHostUiHandler(this);
+            _uiHandler = new GtkHostUiHandler(this, _virtualFileSystem, _contentManager);
         }
 
         private void MainWindow_WindowStateEvent(object o, WindowStateEventArgs args)

--- a/Ryujinx/Ui/SettingsWindow.glade
+++ b/Ryujinx/Ui/SettingsWindow.glade
@@ -1,16 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.36.0 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="_fsLogSpinAdjustment">
     <property name="upper">3</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
-  </object>
-  <object class="GtkEntryCompletion" id="_systemTimeZoneCompletion">
-    <property name="inline-completion">True</property>
-    <property name="inline-selection">True</property>
-    <property name="minimum-key-length">0</property>
   </object>
   <object class="GtkAdjustment" id="_systemTimeDaySpinAdjustment">
     <property name="lower">1</property>
@@ -40,16 +35,18 @@
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
+  <object class="GtkEntryCompletion" id="_systemTimeZoneCompletion">
+    <property name="minimum_key_length">0</property>
+    <property name="inline_completion">True</property>
+    <property name="inline_selection">True</property>
+  </object>
   <object class="GtkWindow" id="_settingsWin">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Ryujinx - Settings</property>
     <property name="modal">True</property>
     <property name="window_position">center</property>
     <property name="default_width">650</property>
-    <property name="default_height">550</property>
-    <child>
-      <placeholder/>
-    </child>
+    <property name="default_height">620</property>
     <child>
       <object class="GtkBox">
         <property name="visible">True</property>
@@ -65,7 +62,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <child>
-                  <object class="GtkNotebook">
+                  <object class="GtkNotebook" id="_notebook">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <child>
@@ -495,45 +492,112 @@
                           </packing>
                         </child>
                         <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkLabel" id="_inputHelpText">
+                                <property name="can_focus">False</property>
+                                <property name="margin_left">30</property>
+                                <property name="margin_right">30</property>
+                                <property name="margin_top">10</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child>
                           <object class="GtkGrid" id="ControllerGrid">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="halign">center</property>
                             <property name="valign">center</property>
-                            <property name="column_spacing">20</property>
+                            <property name="margin_start">20</property>
+                            <property name="margin_end">20</property>
+                            <property name="margin_top">20</property>
+                            <property name="margin_bottom">20</property>
+                            <property name="column_spacing">40</property>
                             <child>
                               <object class="GtkBox">
+                                <property name="width_request">90</property>
+                                <property name="height_request">130</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="orientation">vertical</property>
                                 <child>
-                                  <object class="GtkLabel">
+                                  <object class="GtkLabel" id="_playerLabel1">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="margin_top">20</property>
-                                    <property name="margin_bottom">20</property>
+                                    <property name="valign">start</property>
+                                    <property name="margin_top">15</property>
                                     <property name="label" translatable="yes">Player 1</property>
+                                    <property name="justify">center</property>
+                                    <property name="yalign">0.5</property>
                                   </object>
                                   <packing>
-                                    <property name="expand">False</property>
+                                    <property name="expand">True</property>
                                     <property name="fill">True</property>
                                     <property name="position">0</property>
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkToggleButton" id="_configureController1">
-                                    <property name="label" translatable="yes">Configure</property>
+                                  <object class="GtkToggleButton" id="_playerButton1">
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">True</property>
-                                    <property name="margin_left">20</property>
-                                    <property name="margin_right">20</property>
-                                    <property name="margin_top">20</property>
-                                    <property name="margin_bottom">20</property>
+                                    <property name="margin_bottom">15</property>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_bottom">5</property>
+                                            <property name="label" translatable="yes">Configure</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="_controllerLabel1">
+                                            <property name="name">5</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label" translatable="yes">Pro Controller</property>
+                                            <attributes>
+                                              <attribute name="style" value="italic"/>
+                                            </attributes>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="pack_type">end</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
-                                    <property name="fill">True</property>
+                                    <property name="fill">False</property>
+                                    <property name="pack_type">end</property>
                                     <property name="position">1</property>
                                   </packing>
                                 </child>
@@ -545,79 +609,155 @@
                             </child>
                             <child>
                               <object class="GtkBox">
+                                <property name="width_request">90</property>
+                                <property name="height_request">130</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="orientation">vertical</property>
                                 <child>
-                                  <object class="GtkLabel">
+                                  <object class="GtkLabel" id="_playerLabel2">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="margin_top">20</property>
-                                    <property name="margin_bottom">20</property>
-                                    <property name="label" translatable="yes">Player 3</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkToggleButton" id="_configureController3">
-                                    <property name="label" translatable="yes">Configure</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">True</property>
-                                    <property name="margin_left">20</property>
-                                    <property name="margin_right">20</property>
-                                    <property name="margin_top">20</property>
-                                    <property name="margin_bottom">20</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="left_attach">4</property>
-                                <property name="top_attach">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="margin_top">20</property>
-                                    <property name="margin_bottom">20</property>
+                                    <property name="valign">start</property>
+                                    <property name="margin_top">15</property>
                                     <property name="label" translatable="yes">Player 2</property>
+                                    <property name="justify">center</property>
+                                    <property name="yalign">0.5</property>
                                   </object>
                                   <packing>
-                                    <property name="expand">False</property>
+                                    <property name="expand">True</property>
                                     <property name="fill">True</property>
                                     <property name="position">0</property>
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkToggleButton" id="_configureController2">
-                                    <property name="label" translatable="yes">Configure</property>
+                                  <object class="GtkToggleButton" id="_playerButton2">
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">True</property>
-                                    <property name="margin_left">20</property>
-                                    <property name="margin_right">20</property>
-                                    <property name="margin_top">20</property>
-                                    <property name="margin_bottom">20</property>
+                                    <property name="margin_bottom">15</property>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_bottom">5</property>
+                                            <property name="label" translatable="yes">Configure</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="_controllerLabel2">
+                                            <property name="name">5</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label" translatable="yes">Pro Controller</property>
+                                            <attributes>
+                                              <attribute name="style" value="italic"/>
+                                            </attributes>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="pack_type">end</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="pack_type">end</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="width_request">90</property>
+                                <property name="height_request">130</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkLabel" id="_playerLabel3">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="valign">start</property>
+                                    <property name="margin_top">15</property>
+                                    <property name="label" translatable="yes">Player 3</property>
+                                    <property name="justify">center</property>
+                                    <property name="yalign">0.5</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
                                     <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkToggleButton" id="_playerButton3">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">True</property>
+                                    <property name="margin_bottom">15</property>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_bottom">5</property>
+                                            <property name="label" translatable="yes">Configure</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="_controllerLabel3">
+                                            <property name="name">5</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label" translatable="yes">Pro Controller</property>
+                                            <attributes>
+                                              <attribute name="style" value="italic"/>
+                                            </attributes>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="pack_type">end</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="pack_type">end</property>
                                     <property name="position">1</property>
                                   </packing>
                                 </child>
@@ -629,205 +769,202 @@
                             </child>
                             <child>
                               <object class="GtkBox">
+                                <property name="width_request">90</property>
+                                <property name="height_request">130</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="orientation">vertical</property>
                                 <child>
-                                  <object class="GtkLabel">
+                                  <object class="GtkLabel" id="_playerLabel4">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="margin_top">20</property>
-                                    <property name="margin_bottom">20</property>
-                                    <property name="label" translatable="yes">Handheld</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkToggleButton" id="_configureControllerH">
-                                    <property name="label" translatable="yes">Configure</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">True</property>
-                                    <property name="margin_left">20</property>
-                                    <property name="margin_right">20</property>
-                                    <property name="margin_top">20</property>
-                                    <property name="margin_bottom">20</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="left_attach">4</property>
-                                <property name="top_attach">4</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="margin_top">20</property>
-                                    <property name="margin_bottom">20</property>
-                                    <property name="label" translatable="yes">Player 6</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkToggleButton" id="_configureController6">
-                                    <property name="label" translatable="yes">Configure</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">True</property>
-                                    <property name="margin_left">20</property>
-                                    <property name="margin_right">20</property>
-                                    <property name="margin_top">20</property>
-                                    <property name="margin_bottom">20</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="left_attach">4</property>
-                                <property name="top_attach">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="margin_top">20</property>
-                                    <property name="margin_bottom">20</property>
-                                    <property name="label" translatable="yes">Player 5</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkToggleButton" id="_configureController5">
-                                    <property name="label" translatable="yes">Configure</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">True</property>
-                                    <property name="margin_left">20</property>
-                                    <property name="margin_right">20</property>
-                                    <property name="margin_top">20</property>
-                                    <property name="margin_bottom">20</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="left_attach">2</property>
-                                <property name="top_attach">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="margin_top">20</property>
-                                    <property name="margin_bottom">20</property>
-                                    <property name="label" translatable="yes">Player 7</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkToggleButton" id="_configureController7">
-                                    <property name="label" translatable="yes">Configure</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">True</property>
-                                    <property name="margin_left">20</property>
-                                    <property name="margin_right">20</property>
-                                    <property name="margin_top">20</property>
-                                    <property name="margin_bottom">20</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="left_attach">0</property>
-                                <property name="top_attach">4</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="margin_top">20</property>
-                                    <property name="margin_bottom">20</property>
+                                    <property name="valign">start</property>
+                                    <property name="margin_top">15</property>
                                     <property name="label" translatable="yes">Player 4</property>
+                                    <property name="justify">center</property>
+                                    <property name="yalign">0.5</property>
                                   </object>
                                   <packing>
-                                    <property name="expand">False</property>
+                                    <property name="expand">True</property>
                                     <property name="fill">True</property>
                                     <property name="position">0</property>
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkToggleButton" id="_configureController4">
+                                  <object class="GtkToggleButton" id="_playerButton4">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">True</property>
+                                    <property name="margin_bottom">15</property>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_bottom">5</property>
+                                            <property name="label" translatable="yes">Configure</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="_controllerLabel4">
+                                            <property name="name">5</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label" translatable="yes">Pro Controller</property>
+                                            <attributes>
+                                              <attribute name="style" value="italic"/>
+                                            </attributes>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="pack_type">end</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="pack_type">end</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left_attach">3</property>
+                                <property name="top_attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="width_request">90</property>
+                                <property name="height_request">130</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkLabel" id="_playerLabelH">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="valign">start</property>
+                                    <property name="margin_top">15</property>
+                                    <property name="label" translatable="yes">Handheld</property>
+                                    <property name="justify">center</property>
+                                    <property name="yalign">0.5</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkToggleButton" id="_playerButtonH">
                                     <property name="label" translatable="yes">Configure</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">True</property>
-                                    <property name="margin_left">20</property>
-                                    <property name="margin_right">20</property>
-                                    <property name="margin_top">20</property>
-                                    <property name="margin_bottom">20</property>
+                                    <property name="margin_start">60</property>
+                                    <property name="margin_end">60</property>
+                                    <property name="margin_bottom">15</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="pack_type">end</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">4</property>
+                                <property name="width">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="width_request">90</property>
+                                <property name="height_request">130</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkLabel" id="_playerLabel5">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="valign">start</property>
+                                    <property name="margin_top">15</property>
+                                    <property name="label" translatable="yes">Player 5</property>
+                                    <property name="justify">center</property>
+                                    <property name="yalign">0.5</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
                                     <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkToggleButton" id="_playerButton5">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">True</property>
+                                    <property name="margin_bottom">15</property>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_bottom">5</property>
+                                            <property name="label" translatable="yes">Configure</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="_controllerLabel5">
+                                            <property name="name">5</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label" translatable="yes">Pro Controller</property>
+                                            <attributes>
+                                              <attribute name="style" value="italic"/>
+                                            </attributes>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="pack_type">end</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="pack_type">end</property>
                                     <property name="position">1</property>
                                   </packing>
                                 </child>
@@ -839,70 +976,238 @@
                             </child>
                             <child>
                               <object class="GtkBox">
+                                <property name="width_request">90</property>
+                                <property name="height_request">130</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="orientation">vertical</property>
                                 <child>
-                                  <object class="GtkLabel">
+                                  <object class="GtkLabel" id="_playerLabel6">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="margin_top">20</property>
-                                    <property name="margin_bottom">20</property>
-                                    <property name="label" translatable="yes">Player 8</property>
+                                    <property name="valign">start</property>
+                                    <property name="margin_top">15</property>
+                                    <property name="label" translatable="yes">Player 6</property>
+                                    <property name="justify">center</property>
+                                    <property name="yalign">0.5</property>
                                   </object>
                                   <packing>
-                                    <property name="expand">False</property>
+                                    <property name="expand">True</property>
                                     <property name="fill">True</property>
                                     <property name="position">0</property>
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkToggleButton" id="_configureController8">
-                                    <property name="label" translatable="yes">Configure</property>
+                                  <object class="GtkToggleButton" id="_playerButton6">
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">True</property>
-                                    <property name="margin_left">20</property>
-                                    <property name="margin_right">20</property>
-                                    <property name="margin_top">20</property>
-                                    <property name="margin_bottom">20</property>
+                                    <property name="margin_bottom">15</property>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_bottom">5</property>
+                                            <property name="label" translatable="yes">Configure</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="_controllerLabel6">
+                                            <property name="name">5</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label" translatable="yes">Pro Controller</property>
+                                            <attributes>
+                                              <attribute name="style" value="italic"/>
+                                            </attributes>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="pack_type">end</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="pack_type">end</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="width_request">90</property>
+                                <property name="height_request">130</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkLabel" id="_playerLabel7">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="valign">start</property>
+                                    <property name="margin_top">15</property>
+                                    <property name="label" translatable="yes">Player 7</property>
+                                    <property name="justify">center</property>
+                                    <property name="yalign">0.5</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
                                     <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkToggleButton" id="_playerButton7">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">True</property>
+                                    <property name="margin_bottom">15</property>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_bottom">5</property>
+                                            <property name="label" translatable="yes">Configure</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="_controllerLabel7">
+                                            <property name="name">5</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label" translatable="yes">Pro Controller</property>
+                                            <attributes>
+                                              <attribute name="style" value="italic"/>
+                                            </attributes>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="pack_type">end</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="pack_type">end</property>
                                     <property name="position">1</property>
                                   </packing>
                                 </child>
                               </object>
                               <packing>
                                 <property name="left_attach">2</property>
-                                <property name="top_attach">4</property>
+                                <property name="top_attach">2</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkSeparator">
+                              <object class="GtkBox">
+                                <property name="width_request">90</property>
+                                <property name="height_request">130</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left_attach">1</property>
-                                <property name="top_attach">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left_attach">3</property>
-                                <property name="top_attach">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkLabel" id="_playerLabel8">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="valign">start</property>
+                                    <property name="margin_top">15</property>
+                                    <property name="label" translatable="yes">Player 8</property>
+                                    <property name="justify">center</property>
+                                    <property name="yalign">0.5</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkToggleButton" id="_playerButton8">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">True</property>
+                                    <property name="margin_bottom">15</property>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_bottom">5</property>
+                                            <property name="label" translatable="yes">Configure</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="_controllerLabel8">
+                                            <property name="name">5</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="label" translatable="yes">Pro Controller</property>
+                                            <attributes>
+                                              <attribute name="style" value="italic"/>
+                                            </attributes>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="pack_type">end</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="pack_type">end</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
                               </object>
                               <packing>
                                 <property name="left_attach">3</property>
@@ -915,98 +1220,9 @@
                                 <property name="can_focus">False</property>
                               </object>
                               <packing>
-                                <property name="left_attach">3</property>
-                                <property name="top_attach">4</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left_attach">1</property>
-                                <property name="top_attach">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left_attach">1</property>
-                                <property name="top_attach">4</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left_attach">1</property>
-                                <property name="top_attach">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left_attach">1</property>
-                                <property name="top_attach">3</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left_attach">3</property>
-                                <property name="top_attach">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left_attach">3</property>
-                                <property name="top_attach">3</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                              </object>
-                              <packing>
                                 <property name="left_attach">0</property>
                                 <property name="top_attach">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left_attach">2</property>
-                                <property name="top_attach">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left_attach">4</property>
-                                <property name="top_attach">1</property>
+                                <property name="width">4</property>
                               </packing>
                             </child>
                             <child>
@@ -1017,33 +1233,20 @@
                               <packing>
                                 <property name="left_attach">0</property>
                                 <property name="top_attach">3</property>
+                                <property name="width">4</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left_attach">2</property>
-                                <property name="top_attach">3</property>
-                              </packing>
+                              <placeholder/>
                             </child>
                             <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left_attach">4</property>
-                                <property name="top_attach">3</property>
-                              </packing>
+                              <placeholder/>
                             </child>
                           </object>
                           <packing>
                             <property name="expand">True</property>
                             <property name="fill">True</property>
-                            <property name="position">2</property>
+                            <property name="position">3</property>
                           </packing>
                         </child>
                       </object>
@@ -1721,8 +1924,8 @@
                                         <property name="tooltip_text" translatable="yes">Floating point resolution scale, such as 1.5. Non-integral scales are more likely to cause issues or crash.</property>
                                         <property name="valign">center</property>
                                         <property name="caps_lock_warning">False</property>
-                                        <property name="placeholder-text">1.0</property>
-                                        <property name="input-purpose">GTK_INPUT_PURPOSE_NUMBER</property>
+                                        <property name="placeholder_text">1.0</property>
+                                        <property name="input_purpose">number</property>
                                       </object>
                                       <packing>
                                         <property name="expand">True</property>
@@ -2169,9 +2372,9 @@
                               <object class="GtkLabel">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
+                                <property name="tooltip_text" translatable="yes">Use with care</property>
                                 <property name="halign">start</property>
                                 <property name="margin_bottom">5</property>
-                                <property name="tooltip_text" translatable="yes">Use with care</property>
                                 <property name="label" translatable="yes">Developer Options (WARNING: Will reduce performance)</property>
                                 <attributes>
                                   <attribute name="weight" value="bold"/>
@@ -2180,7 +2383,7 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">20</property>
+                                <property name="position">0</property>
                               </packing>
                             </child>
                             <child>
@@ -2206,44 +2409,54 @@
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="fill">True</property>
-                                    <property name="position">21</property>
+                                    <property name="position">1</property>
                                   </packing>
                                 </child>
                                 <child>
                                   <object class="GtkBox">
-                                  <property name="visible">True</property>
-                                  <property name="can_focus">False</property>
-                                  <property name="margin_top">5</property>
-                                  <child>
-                                    <object class="GtkLabel">
-                                      <property name="visible">True</property>
-                                      <property name="can_focus">False</property>
-                                      <property name="tooltip_text" translatable="yes">Requires appropriate log levels enabled.</property>
-                                      <property name="label" translatable="yes">OpenGL Log Level</property>
-                                    </object>
-                                    <packing>
-                                      <property name="expand">False</property>
-                                      <property name="fill">True</property>
-                                      <property name="padding">5</property>
-                                      <property name="position">22</property>
-                                    </packing>
-                                  </child>
-                                  <child>
-                                    <object class="GtkComboBoxText" id="_graphicsDebugLevel">
-                                      <property name="visible">True</property>
-                                      <property name="can_focus">False</property>
-                                      <property name="tooltip_text" translatable="yes">Requires appropriate log levels enabled.</property>
-                                      <property name="margin_left">5</property>
-                                    </object>
-                                    <packing>
-                                      <property name="expand">False</property>
-                                      <property name="fill">True</property>
-                                      <property name="position">22</property>
-                                    </packing>
-                                  </child>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_top">5</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="tooltip_text" translatable="yes">Requires appropriate log levels enabled.</property>
+                                        <property name="label" translatable="yes">OpenGL Log Level</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="padding">5</property>
+                                        <property name="position">22</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBoxText" id="_graphicsDebugLevel">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="tooltip_text" translatable="yes">Requires appropriate log levels enabled.</property>
+                                        <property name="margin_left">5</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">22</property>
+                                      </packing>
+                                    </child>
                                   </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">2</property>
+                                  </packing>
                                 </child>
                               </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
                             </child>
                           </object>
                           <packing>
@@ -2326,6 +2539,9 @@
           </packing>
         </child>
       </object>
+    </child>
+    <child type="titlebar">
+      <placeholder/>
     </child>
   </object>
 </interface>

--- a/Ryujinx/Ui/SettingsWindow.glade
+++ b/Ryujinx/Ui/SettingsWindow.glade
@@ -579,7 +579,6 @@
                                             <property name="name">5</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Pro Controller</property>
                                             <attributes>
                                               <attribute name="style" value="italic"/>
                                             </attributes>
@@ -659,7 +658,6 @@
                                             <property name="name">5</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Pro Controller</property>
                                             <attributes>
                                               <attribute name="style" value="italic"/>
                                             </attributes>
@@ -739,7 +737,6 @@
                                             <property name="name">5</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Pro Controller</property>
                                             <attributes>
                                               <attribute name="style" value="italic"/>
                                             </attributes>
@@ -819,7 +816,6 @@
                                             <property name="name">5</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Pro Controller</property>
                                             <attributes>
                                               <attribute name="style" value="italic"/>
                                             </attributes>
@@ -845,53 +841,6 @@
                               <packing>
                                 <property name="left_attach">3</property>
                                 <property name="top_attach">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="width_request">90</property>
-                                <property name="height_request">130</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <object class="GtkLabel" id="_playerLabelH">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="valign">start</property>
-                                    <property name="margin_top">15</property>
-                                    <property name="label" translatable="yes">Handheld</property>
-                                    <property name="justify">center</property>
-                                    <property name="yalign">0.5</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">True</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkToggleButton" id="_playerButtonH">
-                                    <property name="label" translatable="yes">Configure</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">True</property>
-                                    <property name="margin_start">60</property>
-                                    <property name="margin_end">60</property>
-                                    <property name="margin_bottom">15</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="pack_type">end</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="left_attach">1</property>
-                                <property name="top_attach">4</property>
-                                <property name="width">2</property>
                               </packing>
                             </child>
                             <child>
@@ -946,7 +895,6 @@
                                             <property name="name">5</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Pro Controller</property>
                                             <attributes>
                                               <attribute name="style" value="italic"/>
                                             </attributes>
@@ -1026,7 +974,6 @@
                                             <property name="name">5</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Pro Controller</property>
                                             <attributes>
                                               <attribute name="style" value="italic"/>
                                             </attributes>
@@ -1106,7 +1053,6 @@
                                             <property name="name">5</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Pro Controller</property>
                                             <attributes>
                                               <attribute name="style" value="italic"/>
                                             </attributes>
@@ -1186,7 +1132,6 @@
                                             <property name="name">5</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">Pro Controller</property>
                                             <attributes>
                                               <attribute name="style" value="italic"/>
                                             </attributes>
@@ -1234,6 +1179,88 @@
                                 <property name="left_attach">0</property>
                                 <property name="top_attach">3</property>
                                 <property name="width">4</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="width_request">90</property>
+                                <property name="height_request">130</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkLabel" id="_playerLabelH">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="valign">start</property>
+                                    <property name="margin_top">15</property>
+                                    <property name="label" translatable="yes">Handheld</property>
+                                    <property name="justify">center</property>
+                                    <property name="yalign">0.5</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkToggleButton" id="_playerButtonH">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">True</property>
+                                    <property name="margin_start">60</property>
+                                    <property name="margin_end">60</property>
+                                    <property name="margin_bottom">15</property>
+                                    <child>
+                                      <object class="GtkBox">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="orientation">vertical</property>
+                                        <child>
+                                          <object class="GtkLabel">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_bottom">5</property>
+                                            <property name="label" translatable="yes">Configure</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkLabel" id="_controllerLabelH">
+                                            <property name="name">5</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <attributes>
+                                              <attribute name="style" value="italic"/>
+                                            </attributes>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">True</property>
+                                            <property name="pack_type">end</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="pack_type">end</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">4</property>
+                                <property name="width">2</property>
                               </packing>
                             </child>
                             <child>


### PR DESCRIPTION
In my last PR about this (#1453) I said-
> Note: While I'm sure there's going to be plenty of good suggestions and changes that can be made, I'm unable to touch more code (like wrestling with GTK) atm unless there's a bug/regression.

But, alas, I noticed quite a few users are confused about what the message dialog tells them to do. So, in order to improve the user experience, now controller applet directly launches a modified version of Input Settings.

Since there are more UI elements to play with, I added some missing fields and now the whole process is more visual and interactive.

Also, I noticed there was some talk about a crash in Splatoon 2 related to multiple configured controllers while playing with the new local wireless feature. This one crash is because controller applet was being silently spammed. The underlying reason was that the applet didn't consider `EnableSingleMode` and so thought the configuration was valid (it wasn't). This has also been fixed. Added a few more checks too while we're at it.

Controller applet now errs on the side of caution and is _less_ silent now to prevent issues like above cropping up.

I'll wait for testers to post screenshots of the different ways it looks with different games.

Also moved some logs to Debug which closes #1452

SettingsWindow was edited with glade, hence the line count.

**Note:** There are still some invalid configurations related to handheld config (bottom-most), so I suggest using it only when necessary. Docked is superior anyway. I'm not really satisfied with these changes but it'll have to do until a full HID RE.