### PR TITLE
Relax block ordering constraints

### DIFF
--- a/ARMeilleure/CodeGen/RegisterAllocators/HybridAllocator.cs
+++ b/ARMeilleure/CodeGen/RegisterAllocators/HybridAllocator.cs
@@ -427,18 +427,5 @@ namespace ARMeilleure.CodeGen.RegisterAllocators
         {
             return local.Assignments.Count + local.Uses.Count;
         }
-
-        private static IEnumerable<BasicBlock> Successors(BasicBlock block)
-        {
-            if (block.Next != null)
-            {
-                yield return block.Next;
-            }
-
-            if (block.Branch != null)
-            {
-                yield return block.Branch;
-            }
-        }
     }
 }

--- a/ARMeilleure/CodeGen/RegisterAllocators/LinearScanAllocator.cs
+++ b/ARMeilleure/CodeGen/RegisterAllocators/LinearScanAllocator.cs
@@ -626,16 +626,11 @@ namespace ARMeilleure.CodeGen.RegisterAllocators
                     continue;
                 }
 
-                bool hasSingleOrNoSuccessor = block.Next == null || block.Branch == null;
+                bool hasSingleOrNoSuccessor = block.SuccessorCount <= 1;
 
-                for (int i = 0; i < 2; i++)
+                for (int i = 0; i < block.SuccessorCount; i++)
                 {
-                    // This used to use an enumerable, but it ended up generating a lot of garbage, so now it is a loop.
-                    BasicBlock successor = (i == 0) ? block.Next : block.Branch;
-                    if (successor == null)
-                    {
-                        continue;
-                    }
+                    BasicBlock successor = block.GetSuccessor(i);
 
                     int succIndex = successor.Index;
 
@@ -643,7 +638,7 @@ namespace ARMeilleure.CodeGen.RegisterAllocators
                     // (the successor before the split) should be right after it.
                     if (IsSplitEdgeBlock(successor))
                     {
-                        succIndex = FirstSuccessor(successor).Index;
+                        succIndex = successor.GetSuccessor(0).Index;
                     }
 
                     CopyResolver copyResolver = new CopyResolver();
@@ -883,10 +878,11 @@ namespace ARMeilleure.CodeGen.RegisterAllocators
 
                     BitMap liveOut = blkLiveOut[block.Index];
 
-                    if ((block.Next != null && liveOut.Set(blkLiveIn[block.Next.Index])) || 
-                        (block.Branch != null && liveOut.Set(blkLiveIn[block.Branch.Index])))
+                    for (int i = 0; i < block.SuccessorCount; i++)
                     {
-                        modified = true;
+                        BasicBlock succ = block.GetSuccessor(i);
+
+                        modified |= liveOut.Set(blkLiveIn[succ.Index]);
                     }
 
                     BitMap liveIn = blkLiveIn[block.Index];
@@ -1000,11 +996,6 @@ namespace ARMeilleure.CodeGen.RegisterAllocators
         private static int GetRegisterId(Register register)
         {
             return (register.Index << 1) | (register.Type == RegisterType.Vector ? 1 : 0);
-        }
-
-        private static BasicBlock FirstSuccessor(BasicBlock block)
-        {
-            return block.Next ?? block.Branch;
         }
 
         private static IEnumerable<Node> BottomOperations(BasicBlock block)

--- a/ARMeilleure/CodeGen/X86/CodeGenerator.cs
+++ b/ARMeilleure/CodeGen/X86/CodeGenerator.cs
@@ -32,7 +32,6 @@ namespace ARMeilleure.CodeGen.X86
             Add(Instruction.BitwiseExclusiveOr,      GenerateBitwiseExclusiveOr);
             Add(Instruction.BitwiseNot,              GenerateBitwiseNot);
             Add(Instruction.BitwiseOr,               GenerateBitwiseOr);
-            Add(Instruction.Branch,                  GenerateBranch);
             Add(Instruction.BranchIf,                GenerateBranchIf);
             Add(Instruction.ByteSwap,                GenerateByteSwap);
             Add(Instruction.Call,                    GenerateCall);
@@ -166,6 +165,23 @@ namespace ARMeilleure.CodeGen.X86
                         if (node is Operation operation)
                         {
                             GenerateOperation(context, operation);
+                        }
+                    }
+
+                    if (block.SuccessorCount == 0)
+                    {
+                        // The only blocks which can have 0 successors are exit blocks.
+                        Debug.Assert(block.Operations.Last is Operation operation &&
+                                     (operation.Instruction == Instruction.Tailcall ||
+                                      operation.Instruction == Instruction.Return));
+                    }
+                    else
+                    {
+                        BasicBlock succ = block.GetSuccessor(0);
+
+                        if (succ != block.ListNext)
+                        {
+                            context.JumpTo(succ);
                         }
                     }
                 }
@@ -512,11 +528,6 @@ namespace ARMeilleure.CodeGen.X86
             context.Assembler.Or(dest, src2, dest.Type);
         }
 
-        private static void GenerateBranch(CodeGenContext context, Operation operation)
-        {
-            context.JumpTo(context.CurrBlock.Branch);
-        }
-
         private static void GenerateBranchIf(CodeGenContext context, Operation operation)
         {
             Operand comp = operation.GetSource(2);
@@ -527,7 +538,7 @@ namespace ARMeilleure.CodeGen.X86
 
             GenerateCompareCommon(context, operation);
 
-            context.JumpTo(cond, context.CurrBlock.Branch);
+            context.JumpTo(cond, context.CurrBlock.GetSuccessor(1));
         }
 
         private static void GenerateByteSwap(CodeGenContext context, Operation operation)

--- a/ARMeilleure/Diagnostics/IRDumper.cs
+++ b/ARMeilleure/Diagnostics/IRDumper.cs
@@ -57,17 +57,20 @@ namespace ARMeilleure.Diagnostics
         {
             DumpBlockName(block);
 
-            if (block.Next != null)
+            if (block.SuccessorCount > 0)
             {
-                _builder.Append(" (next ");
-                DumpBlockName(block.Next);
-                _builder.Append(')');
-            }
+                _builder.Append(" (");
 
-            if (block.Branch != null)
-            {
-                _builder.Append(" (branch ");
-                DumpBlockName(block.Branch);
+                for (int i = 0; i < block.SuccessorCount; i++)
+                {
+                    DumpBlockName(block.GetSuccessor(i));
+
+                    if (i < block.SuccessorCount - 1)
+                    {
+                        _builder.Append(", ");
+                    }
+                }
+
                 _builder.Append(')');
             }
 

--- a/ARMeilleure/IntermediateRepresentation/Instruction.cs
+++ b/ARMeilleure/IntermediateRepresentation/Instruction.cs
@@ -7,7 +7,6 @@ namespace ARMeilleure.IntermediateRepresentation
         BitwiseExclusiveOr,
         BitwiseNot,
         BitwiseOr,
-        Branch,
         BranchIf,
         ByteSwap,
         Call,

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -21,7 +21,7 @@ namespace ARMeilleure.Translation.PTC
     {
         private const string HeaderMagic = "PTChd";
 
-        private const int InternalVersion = 1537; //! To be incremented manually for each change to the ARMeilleure project.
+        private const int InternalVersion = 1535; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";

--- a/ARMeilleure/Translation/RegisterUsage.cs
+++ b/ARMeilleure/Translation/RegisterUsage.cs
@@ -171,14 +171,9 @@ namespace ARMeilleure.Translation
 
                     RegisterMask inputs = localInputs[block.Index];
 
-                    if (block.Next != null)
+                    for (int i = 0; i < block.SuccessorCount; i++)
                     {
-                        inputs |= globalInputs[block.Next.Index];
-                    }
-
-                    if (block.Branch != null)
-                    {
-                        inputs |= globalInputs[block.Branch.Index];
+                        inputs |= globalInputs[block.GetSuccessor(i).Index];
                     }
 
                     inputs &= ~globalCmnOutputs[block.Index];

--- a/ARMeilleure/Translation/Translator.cs
+++ b/ARMeilleure/Translation/Translator.cs
@@ -309,8 +309,6 @@ namespace ARMeilleure.Translation
 
             context.Return(Const(0L));
 
-            context.Branch(lblExit);
-
             context.MarkLabel(lblNonZero);
 
             count = context.Subtract(count, Const(1));


### PR DESCRIPTION
Before `block.Next` had to follow `block.ListNext`, now it does not. `block.Next` and `block.Branch` could also be a bit ambiguous when there was a single successor, now they are not.

Instead `CodeGenerator` will now emit the jump instructions when necessary to ensure control flow. This makes control flow and block order modifications easier (see `ControlFlowGraph.SplitEdge(pred, succ)` & `LinearScanAllocator.FirstSuccessor(bb)` for examples). It also eliminates some simple case of redundant unconditional branches.

```patch
@@ -30,8 +30,6 @@
   sub ecx,byte +0x1
   mov [rax+0x400],ecx
 .L4:
-  jmp short .L5
-.L5:
   test rbp,rbp
   setl cl
   movzx ecx,cl
@@ -46,8 +44,8 @@
```

This PR removes the `Branch` instruction. An alternative approach would be to canonicalize flow by using the `Branch` instruction. but I figure its one less operation to traverse, so I removed it. Let me know if you think the alternative solution is better or if there are other better alternatives.

This also improves the liveness analysis done in the LSRA a little bit, when visiting the successors, it was short circuiting early so the result set took a couple of more iterations than usual to stabilize.