### PR TITLE
Amadeus: Fix multi-channel PCM sources on REV8

### DIFF
--- a/Ryujinx.Audio.Renderer/Dsp/Command/DataSourceVersion2Command.cs
+++ b/Ryujinx.Audio.Renderer/Dsp/Command/DataSourceVersion2Command.cs
@@ -63,7 +63,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
             SrcQuality = serverState.SrcQuality;
             CommandType = GetCommandTypeBySampleFormat(SampleFormat);
 
-            OutputBufferIndex = outputBufferIndex;
+            OutputBufferIndex = (ushort)(channelIndex + outputBufferIndex);
             SampleRate = serverState.SampleRate;
             Pitch = serverState.Pitch;
 

--- a/Ryujinx.Audio.Renderer/Server/CommandGenerator.cs
+++ b/Ryujinx.Audio.Renderer/Server/CommandGenerator.cs
@@ -107,6 +107,8 @@ namespace Ryujinx.Audio.Renderer.Server
 
             if (!voiceState.WasPlaying)
             {
+                Debug.Assert(voiceState.SampleFormat != SampleFormat.Adpcm || channelIndex == 0);
+
                 if (_rendererContext.BehaviourContext.IsWaveBufferVersion2Supported())
                 {
                     _commandBuffer.GenerateDataSourceVersion2(ref voiceState,


### PR DESCRIPTION
This adds a missing offset on the output buffer of the DataSourceVersion2Command.

This fix music only playing on the left channel on Fairy Tail, Family Mysteries: Poisonous Promises, SEGA AGES Sonic the Hedgehog 2, Harukanaru Toki no Naka de７, and probably more.

NOTE: this also add an assert in debug mode to check for the channel index being always 0 for ADPCM. (as this source only support mono)