### PR TITLE
Do not emit StoreToContext before Return

### DIFF
--- a/ARMeilleure/Instructions/InstEmitAluHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitAluHelper.cs
@@ -118,8 +118,12 @@ namespace ARMeilleure.Instructions
 
             if (IsThumb(context.CurrOp))
             {
-                context.StoreToContext();
                 bool isReturn = IsA32Return(context);
+
+                if (!isReturn)
+                {
+                    context.StoreToContext();
+                }
 
                 Operand addr = context.BitwiseOr(value, Const(1));
 

--- a/ARMeilleure/Instructions/InstEmitHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitHelper.cs
@@ -56,7 +56,10 @@ namespace ARMeilleure.Instructions
         {
             if (regIndex == RegisterAlias.Aarch32Pc)
             {
-                context.StoreToContext();
+                if (!IsA32Return(context))
+                {
+                    context.StoreToContext();
+                }
 
                 EmitBxWritePc(context, value);
             }

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -21,7 +21,7 @@ namespace ARMeilleure.Translation.PTC
     {
         private const string HeaderMagic = "PTChd";
 
-        private const int InternalVersion = 1522; //! To be incremented manually for each change to the ARMeilleure project.
+        private const int InternalVersion = 1537; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";


### PR DESCRIPTION
`RegisterUsage` pass considers `Return` as a `StoreToContext`, so we do not need to emit one before a `Return` instruction. Sample [diff](https://www.diffchecker.com/XlZey6rj).