### PR TITLE
Implement block placement

### DIFF
--- a/ARMeilleure/CodeGen/Optimizations/BlockPlacement.cs
+++ b/ARMeilleure/CodeGen/Optimizations/BlockPlacement.cs
@@ -1,0 +1,66 @@
+﻿using ARMeilleure.IntermediateRepresentation;
+using ARMeilleure.Translation;
+using System.Diagnostics;
+
+using static ARMeilleure.IntermediateRepresentation.OperandHelper;
+
+namespace ARMeilleure.CodeGen.Optimizations
+{
+    static class BlockPlacement
+    {
+        public static void RunPass(ControlFlowGraph cfg)
+        {
+            bool update = false;
+
+            BasicBlock block;
+            BasicBlock nextBlock;
+
+            BasicBlock lastBlock = cfg.Blocks.Last;
+
+            // Move cold blocks at the end of the list, so that they are emitted away from hot code.
+            for (block = cfg.Blocks.First; block != lastBlock; block = nextBlock)
+            {
+                nextBlock = block.ListNext;
+
+                if (block.Frequency == BasicBlockFrequency.Cold)
+                {
+                    cfg.Blocks.Remove(block);
+                    cfg.Blocks.AddLast(block);
+                }
+            }
+
+            for (block = cfg.Blocks.First; block != null; block = nextBlock)
+            {
+                nextBlock = block.ListNext;
+
+                if (block.SuccessorCount == 2 && block.Operations.Last is Operation branchOp)
+                {
+                    Debug.Assert(branchOp.Instruction == Instruction.BranchIf);
+
+                    BasicBlock falseSucc = block.GetSuccessor(0);
+                    BasicBlock trueSucc = block.GetSuccessor(1);
+
+                    // If true successor is next block in list, invert the condition. We avoid extra branching by
+                    // making the true side the fallthrough (i.e, convert it to the false side).
+                    if (trueSucc == block.ListNext)
+                    {
+                        Comparison comp = (Comparison)branchOp.GetSource(2).AsInt32();
+                        Comparison compInv = comp.Invert();
+
+                        branchOp.SetSource(2, Const((int)compInv));
+
+                        block.SetSuccessor(0, trueSucc);
+                        block.SetSuccessor(1, falseSucc);
+
+                        update = true;
+                    }
+                }
+            }
+
+            if (update)
+            {
+                cfg.Update(removeUnreachableBlocks: false);
+            }
+        }
+    }
+}

--- a/ARMeilleure/CodeGen/X86/CodeGenerator.cs
+++ b/ARMeilleure/CodeGen/X86/CodeGenerator.cs
@@ -106,6 +106,8 @@ namespace ARMeilleure.CodeGen.X86
 
             X86Optimizer.RunPass(cfg);
 
+            BlockPlacement.RunPass(cfg);
+
             Logger.EndPass(PassName.Optimization, cfg);
 
             Logger.StartPass(PassName.PreAllocation);
@@ -186,9 +188,11 @@ namespace ARMeilleure.CodeGen.X86
                     }
                 }
 
+                byte[] code = context.GetCode();
+
                 Logger.EndPass(PassName.CodeGeneration);
 
-                return new CompiledFunction(context.GetCode(), unwindInfo);
+                return new CompiledFunction(code, unwindInfo);
             }
         }
 

--- a/ARMeilleure/Diagnostics/IRDumper.cs
+++ b/ARMeilleure/Diagnostics/IRDumper.cs
@@ -57,6 +57,11 @@ namespace ARMeilleure.Diagnostics
         {
             DumpBlockName(block);
 
+            if (block.Frequency == BasicBlockFrequency.Cold)
+            {
+                _builder.Append(" cold");
+            }
+
             if (block.SuccessorCount > 0)
             {
                 _builder.Append(" (");

--- a/ARMeilleure/Instructions/InstEmitFlowHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitFlowHelper.cs
@@ -174,7 +174,7 @@ namespace ARMeilleure.Instructions
                 Operand lblContinue = context.GetLabel(nextAddr.Value);
 
                 // We need to clear out the call flag for the return address before comparing it.
-                context.BranchIf(lblContinue, context.BitwiseAnd(returnAddress, Const(~CallFlag)), nextAddr, Comparison.Equal);
+                context.BranchIf(lblContinue, context.BitwiseAnd(returnAddress, Const(~CallFlag)), nextAddr, Comparison.Equal, BasicBlockFrequency.Cold);
 
                 context.Return(returnAddress);
             }

--- a/ARMeilleure/Instructions/InstEmitMemoryHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitMemoryHelper.cs
@@ -147,7 +147,7 @@ namespace ARMeilleure.Instructions
 
             context.Branch(lblEnd);
 
-            context.MarkLabel(lblSlowPath);
+            context.MarkLabel(lblSlowPath, BasicBlockFrequency.Cold);
 
             EmitReadIntFallback(context, address, rt, size);
 
@@ -165,7 +165,7 @@ namespace ARMeilleure.Instructions
 
             Operand lblFastPath = Label();
 
-            context.BranchIfFalse(lblFastPath, isUnalignedAddr);
+            context.BranchIfFalse(lblFastPath, isUnalignedAddr, BasicBlockFrequency.Cold);
 
             // The call is not expected to return (it should throw).
             context.Call(typeof(NativeInterface).GetMethod(nameof(NativeInterface.ThrowInvalidMemoryAccess)), address);
@@ -216,7 +216,7 @@ namespace ARMeilleure.Instructions
 
             context.Branch(lblEnd);
 
-            context.MarkLabel(lblSlowPath);
+            context.MarkLabel(lblSlowPath, BasicBlockFrequency.Cold);
 
             EmitReadVectorFallback(context, address, vector, rt, elem, size);
 
@@ -256,7 +256,7 @@ namespace ARMeilleure.Instructions
 
             context.Branch(lblEnd);
 
-            context.MarkLabel(lblSlowPath);
+            context.MarkLabel(lblSlowPath, BasicBlockFrequency.Cold);
 
             EmitWriteIntFallback(context, address, rt, size);
 
@@ -274,7 +274,7 @@ namespace ARMeilleure.Instructions
 
             Operand lblFastPath = Label();
 
-            context.BranchIfFalse(lblFastPath, isUnalignedAddr);
+            context.BranchIfFalse(lblFastPath, isUnalignedAddr, BasicBlockFrequency.Cold);
 
             // The call is not expected to return (it should throw).
             context.Call(typeof(NativeInterface).GetMethod(nameof(NativeInterface.ThrowInvalidMemoryAccess)), address);
@@ -331,7 +331,7 @@ namespace ARMeilleure.Instructions
 
             context.Branch(lblEnd);
 
-            context.MarkLabel(lblSlowPath);
+            context.MarkLabel(lblSlowPath, BasicBlockFrequency.Cold);
 
             EmitWriteVectorFallback(context, address, rt, elem, size);
 
@@ -402,7 +402,7 @@ namespace ARMeilleure.Instructions
                     Operand lblNotWatched = Label();
 
                     // Is the page currently being monitored for modifications? If so we need to call MarkRegionAsModified.
-                    context.BranchIf(lblNotWatched, pte, Const(0L), Comparison.GreaterOrEqual);
+                    context.BranchIf(lblNotWatched, pte, Const(0L), Comparison.GreaterOrEqual, BasicBlockFrequency.Cold);
 
                     // Mark the region as modified. Size here doesn't matter as address is assumed to be size aligned here.
                     context.Call(typeof(NativeInterface).GetMethod(nameof(NativeInterface.MarkRegionAsModified)), address, Const(1UL));
@@ -412,7 +412,7 @@ namespace ARMeilleure.Instructions
                 Operand lblNonNull = Label();
 
                 // Skip exception if the PTE address is non-null (not zero).
-                context.BranchIfTrue(lblNonNull, pte);
+                context.BranchIfTrue(lblNonNull, pte, BasicBlockFrequency.Cold);
 
                 // The call is not expected to return (it should throw).
                 context.Call(typeof(NativeInterface).GetMethod(nameof(NativeInterface.ThrowInvalidMemoryAccess)), address);

--- a/ARMeilleure/IntermediateRepresentation/BasicBlock.cs
+++ b/ARMeilleure/IntermediateRepresentation/BasicBlock.cs
@@ -5,9 +5,11 @@ namespace ARMeilleure.IntermediateRepresentation
 {
     class BasicBlock : IIntrusiveListNode<BasicBlock>
     {
-        private readonly List<BasicBlock> _successors = new List<BasicBlock>();
+        private readonly List<BasicBlock> _successors;
 
         public int Index { get; set; }
+
+        public BasicBlockFrequency Frequency { get; set; }
 
         public BasicBlock ListPrevious { get; set; }
         public BasicBlock ListNext { get; set; }
@@ -25,6 +27,8 @@ namespace ARMeilleure.IntermediateRepresentation
 
         public BasicBlock(int index)
         {
+            _successors = new List<BasicBlock>();
+
             Operations = new IntrusiveList<Node>();
             Predecessors = new List<BasicBlock>();
             DominanceFrontiers = new HashSet<BasicBlock>();

--- a/ARMeilleure/IntermediateRepresentation/BasicBlockFrequency.cs
+++ b/ARMeilleure/IntermediateRepresentation/BasicBlockFrequency.cs
@@ -1,0 +1,8 @@
+﻿namespace ARMeilleure.IntermediateRepresentation
+{
+    enum BasicBlockFrequency
+    {
+        Default,
+        Cold
+    }
+}

--- a/ARMeilleure/Translation/ControlFlowGraph.cs
+++ b/ARMeilleure/Translation/ControlFlowGraph.cs
@@ -9,24 +9,43 @@ namespace ARMeilleure.Translation
     {
         public BasicBlock Entry { get; }
         public IntrusiveList<BasicBlock> Blocks { get; }
-        public BasicBlock[] PostOrderBlocks { get; }
-        public int[] PostOrderMap { get; }
+        public BasicBlock[] PostOrderBlocks { get; private set; }
+        public int[] PostOrderMap { get; private set; }
 
         public ControlFlowGraph(BasicBlock entry, IntrusiveList<BasicBlock> blocks)
         {
             Entry = entry;
             Blocks = blocks;
 
-            RemoveUnreachableBlocks(blocks);
+            Update(removeUnreachableBlocks: true);
+        }
+
+        public void Update(bool removeUnreachableBlocks)
+        {
+            if (removeUnreachableBlocks)
+            {
+                RemoveUnreachableBlocks(Blocks);
+            }
 
             var visited = new HashSet<BasicBlock>();
             var blockStack = new Stack<BasicBlock>();
 
-            PostOrderBlocks = new BasicBlock[blocks.Count];
-            PostOrderMap = new int[blocks.Count];
+            static T[] Initialize<T>(T[] array, int length)
+            {
+                if (array == null || array.Length != length)
+                {
+                    array = new T[length];
+                }
+                
+                // No need to clear the array because all its elements will be written to anyways.
+                return array;
+            }
 
-            visited.Add(entry);
-            blockStack.Push(entry);
+            PostOrderBlocks = Initialize(PostOrderBlocks, Blocks.Count);
+            PostOrderMap = Initialize(PostOrderMap, Blocks.Count);
+
+            visited.Add(Entry);
+            blockStack.Push(Entry);
 
             int index = 0;
 

--- a/ARMeilleure/Translation/ControlFlowGraph.cs
+++ b/ARMeilleure/Translation/ControlFlowGraph.cs
@@ -7,10 +7,13 @@ namespace ARMeilleure.Translation
 {
     class ControlFlowGraph
     {
+        private BasicBlock[] _postOrderBlocks;
+        private int[] _postOrderMap;
+
         public BasicBlock Entry { get; }
         public IntrusiveList<BasicBlock> Blocks { get; }
-        public BasicBlock[] PostOrderBlocks { get; private set; }
-        public int[] PostOrderMap { get; private set; }
+        public BasicBlock[] PostOrderBlocks => _postOrderBlocks;
+        public int[] PostOrderMap => _postOrderMap; 
 
         public ControlFlowGraph(BasicBlock entry, IntrusiveList<BasicBlock> blocks)
         {
@@ -30,19 +33,8 @@ namespace ARMeilleure.Translation
             var visited = new HashSet<BasicBlock>();
             var blockStack = new Stack<BasicBlock>();
 
-            static T[] Initialize<T>(T[] array, int length)
-            {
-                if (array == null || array.Length != length)
-                {
-                    array = new T[length];
-                }
-                
-                // No need to clear the array because all its elements will be written to anyways.
-                return array;
-            }
-
-            PostOrderBlocks = Initialize(PostOrderBlocks, Blocks.Count);
-            PostOrderMap = Initialize(PostOrderMap, Blocks.Count);
+            Array.Resize(ref _postOrderBlocks, Blocks.Count);
+            Array.Resize(ref _postOrderMap, Blocks.Count);
 
             visited.Add(Entry);
             blockStack.Push(Entry);

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -21,7 +21,7 @@ namespace ARMeilleure.Translation.PTC
     {
         private const string HeaderMagic = "PTChd";
 
-        private const int InternalVersion = 1535; //! To be incremented manually for each change to the ARMeilleure project.
+        private const int InternalVersion = 1549; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";

--- a/ARMeilleure/Translation/Translator.cs
+++ b/ARMeilleure/Translation/Translator.cs
@@ -301,11 +301,11 @@ namespace ARMeilleure.Translation
             Operand lblNonZero = Label();
             Operand lblExit    = Label();
 
-            context.BranchIfTrue(lblNonZero, count);
+            context.BranchIfTrue(lblNonZero, count, BasicBlockFrequency.Cold);
 
             Operand running = context.Call(typeof(NativeInterface).GetMethod(nameof(NativeInterface.CheckSynchronization)));
 
-            context.BranchIfTrue(lblExit, running);
+            context.BranchIfTrue(lblExit, running, BasicBlockFrequency.Cold);
 
             context.Return(Const(0L));
 


### PR DESCRIPTION
Implement a simple pass which re-orders cold blocks at the end of the list of blocks in the CFG. Sample [diff](https://www.diffchecker.com/tPgkKPTd).

This removes some branching along the fast path for memory accesses and moves `CheckSynchronization` away from loops. It is not clear if we should attempt to re-order the decoded stuff, since presumably the guest compiler should already have placed it in an "optimal" order. 