### PR TITLE
acc/hid: Implement ListQualifiedUsers and SetTouchScreenConfiguration

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
@@ -41,14 +41,14 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
         }
 
         [Command(2)]
-        // ListAllUsers() -> array<nn::account::Uid, 0xa>
+        // ListAllUsers() -> buffer<nn::account::Uid, 0xa>
         public ResultCode ListAllUsers(ServiceCtx context)
         {
             return WriteUserList(context, context.Device.System.State.Account.GetAllUsers());
         }
 
         [Command(3)]
-        // ListOpenUsers() -> array<nn::account::Uid, 0xa>
+        // ListOpenUsers() -> buffer<nn::account::Uid, 0xa>
         public ResultCode ListOpenUsers(ServiceCtx context)
         {
             return WriteUserList(context, context.Device.System.State.Account.GetOpenedUsers());
@@ -272,6 +272,31 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             Logger.Stub?.PrintStub(LogClass.ServiceAcc);
 
             return ResultCode.Success;
+        }
+
+        [Command(131)] // 6.0.0+
+        // ListOpenContextStoredUsers() -> buffer<nn::account::Uid, 0xa>
+        public ResultCode ListOpenContextStoredUsers(ServiceCtx context)
+        {
+            long outputPosition = context.Request.RecvListBuff[0].Position;
+            long outputSize     = context.Request.RecvListBuff[0].Size;
+
+            MemoryHelper.FillWithZeros(context.Memory, outputPosition, (int)outputSize);
+
+            // TODO: This seems to write stored userids of the OpenContext in the buffer. We needs to determine them.
+            
+            Logger.Stub?.PrintStub(LogClass.ServiceAcc);
+
+            return ResultCode.Success;
+        }
+
+        [Command(141)] // 6.0.0+
+        // ListQualifiedUsers() -> buffer<nn::account::Uid, 0xa>
+        public ResultCode ListQualifiedUsers(ServiceCtx context)
+        {
+            // TODO: Determine how users are "qualified". We assume all users are "qualified" for now.
+
+            return WriteUserList(context, context.Device.System.State.Account.GetAllUsers());
         }
 
         [Command(150)] // 6.0.0+

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
@@ -41,14 +41,14 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
         }
 
         [Command(2)]
-        // ListAllUsers() -> buffer<nn::account::Uid, 0xa>
+        // ListAllUsers() -> array<nn::account::Uid, 0xa>
         public ResultCode ListAllUsers(ServiceCtx context)
         {
             return WriteUserList(context, context.Device.System.State.Account.GetAllUsers());
         }
 
         [Command(3)]
-        // ListOpenUsers() -> buffer<nn::account::Uid, 0xa>
+        // ListOpenUsers() -> array<nn::account::Uid, 0xa>
         public ResultCode ListOpenUsers(ServiceCtx context)
         {
             return WriteUserList(context, context.Device.System.State.Account.GetOpenedUsers());
@@ -275,7 +275,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
         }
 
         [Command(131)] // 6.0.0+
-        // ListOpenContextStoredUsers() -> buffer<nn::account::Uid, 0xa>
+        // ListOpenContextStoredUsers() -> array<nn::account::Uid, 0xa>
         public ResultCode ListOpenContextStoredUsers(ServiceCtx context)
         {
             long outputPosition = context.Request.RecvListBuff[0].Position;
@@ -291,7 +291,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
         }
 
         [Command(141)] // 6.0.0+
-        // ListQualifiedUsers() -> buffer<nn::account::Uid, 0xa>
+        // ListQualifiedUsers() -> array<nn::account::Uid, 0xa>
         public ResultCode ListQualifiedUsers(ServiceCtx context)
         {
             // TODO: Determine how users are "qualified". We assume all users are "qualified" for now.

--- a/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
@@ -1501,5 +1501,17 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             return ResultCode.Success;
         }
+
+        [Command(1002)]
+        // SetTouchScreenConfiguration(nn::hid::TouchScreenConfigurationForNx, nn::applet::AppletResourceUserId)
+        public ResultCode SetTouchScreenConfiguration(ServiceCtx context)
+        {
+            long touchScreenConfigurationForNx = context.RequestData.ReadInt64();
+            long appletResourceUserId          = context.RequestData.ReadInt64();
+
+            Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, touchScreenConfigurationForNx });
+
+            return ResultCode.Success;
+        }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
@@ -1502,7 +1502,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(1002)]
+        [Command(1002)] // 9.0.0+
         // SetTouchScreenConfiguration(nn::hid::TouchScreenConfigurationForNx, nn::applet::AppletResourceUserId)
         public ResultCode SetTouchScreenConfiguration(ServiceCtx context)
         {


### PR DESCRIPTION
This implement/stub:
- IAccountServiceForApplication ListOpenContextStoredUsers
- IAccountServiceForApplication ListQualifiedUsers
- IHidServer SetTouchScreenConfiguration

All checked by RE.

Closes #1306, Closes #1267 

Make some games goes ingame: 

![Capture1](https://user-images.githubusercontent.com/4905390/93406708-a080dc00-f890-11ea-8461-da5794da7025.PNG)
![image](https://user-images.githubusercontent.com/4905390/93406677-8ba44880-f890-11ea-8c24-e3144ef7130f.png)
![image](https://user-images.githubusercontent.com/4905390/93406683-919a2980-f890-11ea-829f-d1151154d19f.png)
![image](https://user-images.githubusercontent.com/4905390/93406694-97900a80-f890-11ea-8a39-a2e10772891b.png)
