### PR TITLE
Better viewport flipping and depth mode detection method

### DIFF
--- a/Ryujinx.Graphics.GAL/IPipeline.cs
+++ b/Ryujinx.Graphics.GAL/IPipeline.cs
@@ -50,8 +50,6 @@ namespace Ryujinx.Graphics.GAL
 
         void SetLogicOpState(bool enable, LogicalOp op);
 
-        void SetOrigin(Origin origin);
-
         void SetPointParameters(float size, bool isProgramPointSize, bool enablePointSprite, Origin origin);
 
         void SetPrimitiveRestart(bool enable, int index);

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -522,10 +522,10 @@ namespace Ryujinx.Graphics.Gpu.Engine
                     // It is setup like so by said APIs:
                     // If depth mode is ZeroToOne:
                     //  TranslateZ = Near
-                    //  ScaleZ =  Far - Near
+                    //  ScaleZ = Far - Near
                     // If depth mode is MinusOneToOne:
                     //  TranslateZ = (Near + Far) / 2
-                    //  ScaleZ =  (Far - Near) / 2
+                    //  ScaleZ = (Far - Near) / 2
                     // DepthNear/Far are sorted such as that Near is always less than Far.
                     DepthMode depthMode = extents.DepthNear != transform.TranslateZ &&
                                           extents.DepthFar  != transform.TranslateZ ? DepthMode.MinusOneToOne : DepthMode.ZeroToOne;

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -555,14 +555,17 @@ namespace Ryujinx.Graphics.Gpu.Engine
                 ViewportSwizzle swizzleZ = transform.UnpackSwizzleZ();
                 ViewportSwizzle swizzleW = transform.UnpackSwizzleW();
 
-                viewports[index] = new Viewport(
-                    region,
-                    swizzleX,
-                    swizzleY,
-                    swizzleZ,
-                    swizzleW,
-                    extents.DepthNear,
-                    extents.DepthFar);
+                float depthNear = extents.DepthNear;
+                float depthFar  = extents.DepthFar;
+
+                if (transform.ScaleZ < 0)
+                {
+                    float temp = depthNear;
+                    depthNear  = depthFar;
+                    depthFar   = temp;
+                }
+
+                viewports[index] = new Viewport(region, swizzleX, swizzleY, swizzleZ, swizzleW, depthNear, depthFar);
             }
 
             _context.Renderer.Pipeline.SetViewports(0, viewports);

--- a/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
@@ -189,12 +189,6 @@ namespace Ryujinx.Graphics.Gpu.Shader
         public bool QuerySupportsNonConstantTextureOffset() => _context.Capabilities.SupportsNonConstantTextureOffset;
 
         /// <summary>
-        /// Queries host GPU viewport swizzle support.
-        /// </summary>
-        /// <returns>True if the GPU and driver supports viewport swizzle, false otherwise</returns>
-        public bool QuerySupportsViewportSwizzle() => _context.Capabilities.SupportsViewportSwizzle;
-
-        /// <summary>
         /// Queries texture format information, for shaders using image load or store.
         /// </summary>
         /// <remarks>
@@ -254,24 +248,6 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 Format.R10G10B10A2Uint   => TextureFormat.R10G10B10A2Uint,
                 Format.R11G11B10Float    => TextureFormat.R11G11B10Float,
                 _                        => TextureFormat.Unknown
-            };
-        }
-
-        public int QueryViewportSwizzle(int component)
-        {
-            YControl yControl = _state.Get<YControl>(MethodOffset.YControl);
-
-            bool flipY = yControl.HasFlag(YControl.NegateY) ^ !yControl.HasFlag(YControl.TriangleRastFlip);
-
-            ViewportTransform transform = _state.Get<ViewportTransform>(MethodOffset.ViewportTransform, 0);
-
-            return component switch
-            {
-                0 => (int)(transform.UnpackSwizzleX() ^ (transform.ScaleX < 0 ? ViewportSwizzle.NegativeFlag : 0)),
-                1 => (int)(transform.UnpackSwizzleY() ^ (transform.ScaleY < 0 ? ViewportSwizzle.NegativeFlag : 0) ^ (flipY ? ViewportSwizzle.NegativeFlag : 0)),
-                2 => (int)(transform.UnpackSwizzleZ() ^ (transform.ScaleZ < 0 ? ViewportSwizzle.NegativeFlag : 0)),
-                3 => (int)transform.UnpackSwizzleW(),
-                _ => throw new ArgumentOutOfRangeException(nameof(component))
             };
         }
 

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -571,20 +571,6 @@ namespace Ryujinx.Graphics.OpenGL
             GL.Enable(IndexedEnableCap.Blend, index);
         }
 
-        public void SetLogicOpState(bool enable, LogicalOp op)
-        {
-            if (enable)
-            {
-                GL.Enable(EnableCap.ColorLogicOp);
-
-                GL.LogicOp((LogicOp)op.Convert());
-            }
-            else
-            {
-                GL.Disable(EnableCap.ColorLogicOp);
-            }
-        }
-
         public void SetDepthBias(PolygonModeMask enables, float factor, float units, float clamp)
         {
             if ((enables & PolygonModeMask.Point) != 0)
@@ -705,6 +691,20 @@ namespace Ryujinx.Graphics.OpenGL
             EnsureVertexArray();
 
             _vertexArray.SetIndexBuffer(buffer.Handle);
+        }
+
+        public void SetLogicOpState(bool enable, LogicalOp op)
+        {
+            if (enable)
+            {
+                GL.Enable(EnableCap.ColorLogicOp);
+
+                GL.LogicOp((LogicOp)op.Convert());
+            }
+            else
+            {
+                GL.Disable(EnableCap.ColorLogicOp);
+            }
         }
 
         public void SetPointParameters(float size, bool isProgramPointSize, bool enablePointSprite, Origin origin)

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -39,6 +39,7 @@ namespace Ryujinx.Graphics.OpenGL
         private TextureBase _rtColor0Texture;
         private TextureBase _rtDepthTexture;
 
+        private FrontFaceDirection _frontFace;
         private ClipOrigin _clipOrigin;
         private ClipDepthMode _clipDepthMode;
 
@@ -48,7 +49,7 @@ namespace Ryujinx.Graphics.OpenGL
 
         private bool _tfEnabled;
 
-        ColorF _blendConstant = new ColorF(0, 0, 0, 0);
+        private ColorF _blendConstant;
 
         internal Pipeline()
         {
@@ -676,7 +677,7 @@ namespace Ryujinx.Graphics.OpenGL
 
         public void SetFrontFace(FrontFace frontFace)
         {
-            GL.FrontFace(frontFace.Convert());
+            SetFrontFace(_frontFace = frontFace.Convert());
         }
 
         public void SetImage(int index, ShaderStage stage, ITexture texture)
@@ -704,13 +705,6 @@ namespace Ryujinx.Graphics.OpenGL
             EnsureVertexArray();
 
             _vertexArray.SetIndexBuffer(buffer.Handle);
-        }
-
-        public void SetOrigin(Origin origin)
-        {
-            ClipOrigin clipOrigin = origin == Origin.UpperLeft ? ClipOrigin.UpperLeft : ClipOrigin.LowerLeft;
-
-            SetOrigin(clipOrigin);
         }
 
         public void SetPointParameters(float size, bool isProgramPointSize, bool enablePointSprite, Origin origin)
@@ -1030,7 +1024,9 @@ namespace Ryujinx.Graphics.OpenGL
                 Viewport viewport = viewports[index];
 
                 viewportArray[viewportElemIndex + 0] = viewport.Region.X;
-                viewportArray[viewportElemIndex + 1] = viewport.Region.Y;
+                viewportArray[viewportElemIndex + 1] = viewport.Region.Y + (viewport.Region.Height < 0 ? viewport.Region.Height : 0);
+                viewportArray[viewportElemIndex + 2] = viewport.Region.Width;
+                viewportArray[viewportElemIndex + 3] = MathF.Abs(viewport.Region.Height);
 
                 if (HwCapabilities.SupportsViewportSwizzle)
                 {
@@ -1042,12 +1038,13 @@ namespace Ryujinx.Graphics.OpenGL
                         viewport.SwizzleW.Convert());
                 }
 
-                viewportArray[viewportElemIndex + 2] = MathF.Abs(viewport.Region.Width);
-                viewportArray[viewportElemIndex + 3] = MathF.Abs(viewport.Region.Height);
-
                 depthRangeArray[index * 2 + 0] = viewport.DepthNear;
                 depthRangeArray[index * 2 + 1] = viewport.DepthFar;
             }
+
+            bool flipY = viewports.Length != 0 && viewports[0].Region.Height < 0;
+
+            SetOrigin(flipY ? ClipOrigin.UpperLeft : ClipOrigin.LowerLeft);
 
             GL.ViewportArray(first, viewports.Length, viewportArray);
 
@@ -1097,7 +1094,22 @@ namespace Ryujinx.Graphics.OpenGL
                 _clipOrigin = origin;
 
                 GL.ClipControl(origin, _clipDepthMode);
+
+                SetFrontFace(_frontFace);
             }
+        }
+
+        private void SetFrontFace(FrontFaceDirection frontFace)
+        {
+            // Changing clip origin will also change the front face to compensate
+            // for the flipped viewport, we flip it again here to compensate as
+            // this effect is undesirable for us.
+            if (_clipOrigin == ClipOrigin.UpperLeft)
+            {
+                frontFace = frontFace == FrontFaceDirection.Ccw ? FrontFaceDirection.Cw : FrontFaceDirection.Ccw;
+            }
+
+            GL.FrontFace(frontFace);
         }
 
         private void EnsureVertexArray()

--- a/Ryujinx.Graphics.Shader/IGpuAccessor.cs
+++ b/Ryujinx.Graphics.Shader/IGpuAccessor.cs
@@ -64,22 +64,9 @@
             return true;
         }
 
-        public bool QuerySupportsViewportSwizzle()
-        {
-            return true;
-        }
-
         public TextureFormat QueryTextureFormat(int handle)
         {
             return TextureFormat.R8G8B8A8Unorm;
-        }
-
-        public int QueryViewportSwizzle(int component)
-        {
-            // Bit 0: Negate flag.
-            // Bits 2-1: Component.
-            // Example: 0b110 = W, 0b111 = -W, 0b000 = X, 0b010 = Y etc.
-            return component << 1;
         }
     }
 }

--- a/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -73,34 +73,7 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public void PrepareForReturn()
         {
-            if (Config.Stage == ShaderStage.Vertex && (Config.Flags & TranslationFlags.VertexA) == 0)
-            {
-                // Here we attempt to implement viewport swizzle on the vertex shader.
-                // Perform permutation and negation of the output gl_Position components.
-                // Note that per-viewport swizzling can't be supported using this approach.
-                int swizzleX = Config.GpuAccessor.QueryViewportSwizzle(0);
-                int swizzleY = Config.GpuAccessor.QueryViewportSwizzle(1);
-                int swizzleZ = Config.GpuAccessor.QueryViewportSwizzle(2);
-                int swizzleW = Config.GpuAccessor.QueryViewportSwizzle(3);
-
-                bool nonStandardSwizzle = swizzleX != 0 || swizzleY != 2 || swizzleZ != 4 || swizzleW != 6;
-
-                if (!Config.GpuAccessor.QuerySupportsViewportSwizzle() && nonStandardSwizzle)
-                {
-                    Operand[] temp = new Operand[4];
-
-                    temp[0] = this.Copy(Attribute(AttributeConsts.PositionX));
-                    temp[1] = this.Copy(Attribute(AttributeConsts.PositionY));
-                    temp[2] = this.Copy(Attribute(AttributeConsts.PositionZ));
-                    temp[3] = this.Copy(Attribute(AttributeConsts.PositionW));
-
-                    this.Copy(Attribute(AttributeConsts.PositionX), this.FPNegate(temp[(swizzleX >> 1) & 3], (swizzleX & 1) != 0));
-                    this.Copy(Attribute(AttributeConsts.PositionY), this.FPNegate(temp[(swizzleY >> 1) & 3], (swizzleY & 1) != 0));
-                    this.Copy(Attribute(AttributeConsts.PositionZ), this.FPNegate(temp[(swizzleZ >> 1) & 3], (swizzleZ & 1) != 0));
-                    this.Copy(Attribute(AttributeConsts.PositionW), this.FPNegate(temp[(swizzleW >> 1) & 3], (swizzleW & 1) != 0));
-                }
-            }
-            else if (Config.Stage == ShaderStage.Fragment)
+            if (Config.Stage == ShaderStage.Fragment)
             {
                 if (Config.OmapDepth)
                 {


### PR DESCRIPTION
This does two change, the first one changes the method used to flip viewport, this should fix a bug that causes the screen to be flipped on some games on GPUs without viewport swizzle support (old NVIDIA GPUs, AMD and Intel). It would flip on the shader when the extension was not supported, but due to the lack of proper shader specialization, this didn't work very well.

The new approach uses `glClipControl` again to flip the viewport, this time also flipping front face to negate the effects of the viewport flipping.

---

The second one changes the method used to detect the depth mode that the game is using. Just checking the depth mode register is not very reliable as a issue similar to the one that could happen with the origin could happen here aswell. Basically, the game changing the depth mode after queue initialization would leave this register untouched, but it would still affect the viewport transform. The register only seems to control clamping, what actually defines the range is the viewport transform, so it uses that now to detect the correct depth mode.

This fixes some lighting issues on Zelda Link's Awakening, and maybe other games:
![image](https://user-images.githubusercontent.com/5624669/93543956-3a00ca00-f933-11ea-9fb9-ca35914f14aa.png)

Special thanks to Rodrigo for hinting that ZLA could have depth range related issues, and riperiperi for finding the issue and providing a possible fix.

---

Bonus: Swap Near and Far parameters when ScaleZ is negative. The high level APIs sort them such as Near is always less than Far, so this undoes this step. This allows the cases where Near > Far to work properly, although I don't know any game that uses that to test.

I recommend testing this with a few games to be sure there are no regressions related to lighting or viewport flip and culling.