### PR TITLE
Align register index between output targets on pixel shaders

### DIFF
--- a/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -1,3 +1,4 @@
+using Ryujinx.Common;
 using Ryujinx.Graphics.Shader.Decoders;
 using Ryujinx.Graphics.Shader.IntermediateRepresentation;
 using System.Collections.Generic;
@@ -154,6 +155,8 @@ namespace Ryujinx.Graphics.Shader.Translation
 
                         regIndex++;
                     }
+
+                    regIndex = BitUtils.AlignUp(regIndex, 4);
                 }
             }
         }


### PR DESCRIPTION
This fixes a issue I observed on Turok 2 where the color components were written to the wrong render target components. Aligning the register index to 4 (the number of components/RGBA) fixes the issue.

Tested with #1558:
Before:
![image](https://user-images.githubusercontent.com/5624669/93657295-1f4c5500-fa08-11ea-9369-35e41d3d7314.png)
After:
![image](https://user-images.githubusercontent.com/5624669/93657277-fa57e200-fa07-11ea-8c26-97d22c83badf.png)
![image](https://user-images.githubusercontent.com/5624669/93657288-0c398500-fa08-11ea-9f64-622b139bf9ea.png)
