### PR TITLE
Texture: Make viewStorage still valid after view removal.

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -259,7 +259,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             _views.Remove(texture);
 
-            texture._viewStorage = null;
+            texture._viewStorage = texture;
 
             DeleteIfNotUsed();
         }


### PR DESCRIPTION
There's a problem with some games, including `Hatsune Miku: Project DIVA Mega Mix`, where they use a texture after it has been removed as a view. In this state, `viewStorage` should be the texture itself, but it was being set as null. A method for propagating the modified flag used in `SignalModified` requires that this is not null, so it only became a problem after it was added with the texture management PR.

Obviously I don't have this game, so I'll be waiting for testing from someone else to ensure it's fixed. Game issue: https://github.com/Ryujinx/Ryujinx-Games-List/issues/237