### PR TITLE
Return "NotAvailable" when no UserChannel data is present.

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
@@ -57,6 +57,11 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
                     throw new NotImplementedException($"Unknown LaunchParameterKind {kind}");
             }
 
+            if (storageData == null)
+            {
+                return ResultCode.NotAvailable;
+            }
+
             MakeObject(context, new AppletAE.IStorage(storageData));
 
             return ResultCode.Success;

--- a/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
@@ -53,8 +53,11 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
                     // Only the first 0x18 bytes of the Data seems to be actually used.
                     storageData = StorageHelper.MakeLaunchParams(context.Device.System.State.Account.LastOpenedUser);
                     break;
-                default:
+                case LaunchParameterKind.Unknown:
                     throw new NotImplementedException($"Unknown LaunchParameterKind {kind}");
+
+                default:
+                    return ResultCode.ObjectInvalid;
             }
 
             if (storageData == null)

--- a/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
@@ -54,7 +54,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
                     storageData = StorageHelper.MakeLaunchParams(context.Device.System.State.Account.LastOpenedUser);
                     break;
                 case LaunchParameterKind.Unknown:
-                    throw new NotImplementedException($"Unknown LaunchParameterKind {kind}");
+                    throw new NotImplementedException($"Unknown LaunchParameterKind.");
 
                 default:
                     return ResultCode.ObjectInvalid;

--- a/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
@@ -54,7 +54,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
                     storageData = StorageHelper.MakeLaunchParams(context.Device.System.State.Account.LastOpenedUser);
                     break;
                 case LaunchParameterKind.Unknown:
-                    throw new NotImplementedException($"Unknown LaunchParameterKind.");
+                    throw new NotImplementedException("Unknown LaunchParameterKind.");
 
                 default:
                     return ResultCode.ObjectInvalid;

--- a/Ryujinx.HLE/HOS/UserChannelPersistence.cs
+++ b/Ryujinx.HLE/HOS/UserChannelPersistence.cs
@@ -31,7 +31,9 @@ namespace Ryujinx.HLE.HOS
 
         public byte[] Pop()
         {
-            return _userChannelStorages.Pop();
+            _userChannelStorages.TryPop(out byte[] result);
+
+            return result;
         }
 
         public bool IsEmpty => _userChannelStorages.Count == 0;


### PR DESCRIPTION
Now when no data is available, it returns NotAvailable like the other `Pop` functions. Fixes crashing regressions caused by https://github.com/Ryujinx/Ryujinx/pull/1560 .

Examples of games that call this when no data is present: Splatoon, Super Kirby Clash