### PR TITLE
Isolate more services to separate threads

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
@@ -35,7 +35,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         private HidAccelerometerParameters _accelerometerParams;
         private HidVibrationValue          _vibrationValue;
 
-        public IHidServer(ServiceCtx context)
+        public IHidServer(ServiceCtx context) : base(new ServerBase("HidServer"))
         {
             _xpadIdEvent                 = new KEvent(context.Device.System.KernelContext);
             _palmaOperationCompleteEvent = new KEvent(context.Device.System.KernelContext);

--- a/Ryujinx.HLE/HOS/Services/Time/IStaticServiceForGlue.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/IStaticServiceForGlue.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
         private IStaticServiceForPsc _inner;
         private TimePermissions      _permissions;
 
-        public IStaticServiceForGlue(ServiceCtx context, TimePermissions permissions)
+        public IStaticServiceForGlue(ServiceCtx context, TimePermissions permissions) : base(new ServerBase("TimeServer"))
         {
             _permissions = permissions;
             _inner       = new IStaticServiceForPsc(context, permissions);

--- a/Ryujinx.HLE/HOS/Services/Vi/IApplicationRootService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/IApplicationRootService.cs
@@ -5,7 +5,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi
     [Service("vi:u")]
     class IApplicationRootService : IpcService
     {
-        public IApplicationRootService(ServiceCtx context) : base(new ServerBase("ViServer")) { }
+        public IApplicationRootService(ServiceCtx context) : base(new ServerBase("ViServerU")) { }
 
         [Command(0)]
         // GetDisplayService(u32) -> object<nn::visrv::sf::IApplicationDisplayService>

--- a/Ryujinx.HLE/HOS/Services/Vi/IApplicationRootService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/IApplicationRootService.cs
@@ -5,6 +5,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi
     [Service("vi:u")]
     class IApplicationRootService : IpcService
     {
+        // vi:u/m/s aren't on 3 separate threads but we can't put them together with the current ServerBase
         public IApplicationRootService(ServiceCtx context) : base(new ServerBase("ViServerU")) { }
 
         [Command(0)]

--- a/Ryujinx.HLE/HOS/Services/Vi/IManagerRootService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/IManagerRootService.cs
@@ -5,6 +5,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi
     [Service("vi:m")]
     class IManagerRootService : IpcService
     {
+        // vi:u/m/s aren't on 3 separate threads but we can't put them together with the current ServerBase
         public IManagerRootService(ServiceCtx context) : base(new ServerBase("ViServerM")) { }
 
         [Command(2)]

--- a/Ryujinx.HLE/HOS/Services/Vi/IManagerRootService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/IManagerRootService.cs
@@ -5,7 +5,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi
     [Service("vi:m")]
     class IManagerRootService : IpcService
     {
-        public IManagerRootService(ServiceCtx context) { }
+        public IManagerRootService(ServiceCtx context) : base(new ServerBase("ViServerM")) { }
 
         [Command(2)]
         // GetDisplayService(u32) -> object<nn::visrv::sf::IApplicationDisplayService>

--- a/Ryujinx.HLE/HOS/Services/Vi/ISystemRootService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/ISystemRootService.cs
@@ -5,7 +5,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi
     [Service("vi:s")]
     class ISystemRootService : IpcService
     {
-        public ISystemRootService(ServiceCtx context) { }
+        public ISystemRootService(ServiceCtx context) : base(new ServerBase("ViServerS")) { }
 
         [Command(1)]
         // GetDisplayService(u32) -> object<nn::visrv::sf::IApplicationDisplayService>

--- a/Ryujinx.HLE/HOS/Services/Vi/ISystemRootService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/ISystemRootService.cs
@@ -5,6 +5,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi
     [Service("vi:s")]
     class ISystemRootService : IpcService
     {
+        // vi:u/m/s aren't on 3 separate threads but we can't put them together with the current ServerBase
         public ISystemRootService(ServiceCtx context) : base(new ServerBase("ViServerS")) { }
 
         [Command(1)]

--- a/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
@@ -13,7 +13,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
     {
         private IdDictionary _displays;
 
-        public IApplicationDisplayService()
+        public IApplicationDisplayService() : base(new ServerBase("DisplayServer"))
         {
             _displays = new IdDictionary();
         }

--- a/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
@@ -13,7 +13,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
     {
         private IdDictionary _displays;
 
-        public IApplicationDisplayService() : base(new ServerBase("DisplayServer"))
+        public IApplicationDisplayService()
         {
             _displays = new IdDictionary();
         }


### PR DESCRIPTION
This PR isolates the more active services to their own threads.
The ones added here are Surfaceflinger family, HID and Time Services.

I wouldn't be surprised if these services are on separate threads in the native sysmodules as well.

Expands on #1572 