### PR TITLE
Always set new texture data for textures initialized by a copy.

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -771,7 +771,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 // Any textures that are incompatible will contain garbage data, so they should be removed where possible.
 
                 int viewCompatible = 0;
-                bool setData = isSamplerTexture || overlapsCount == 0;
+                bool setData = isSamplerTexture || overlapsCount == 0 || flags.HasFlag(TextureSearchFlags.ForCopy);
 
                 for (int index = 0; index < overlapsCount; index++)
                 {


### PR DESCRIPTION
This should fix a regression in games that used OpenGL on the guest, where texture copies would fail and cause a single strip of the image to be repeated.

A rule was introduced in https://github.com/Ryujinx/Ryujinx/pull/1408 to skip setting a texture's data if it was a render target, and it had some other overlapping, non-cpu-modified texture in its place. This is because the overlap implies that the data present in memory is part of an incompatible texture, and would just be garbage if read in (and will be overwritten by an imminent clear or draw).

However, this logic was triggering for textures found for MethodCopyTexture, for both the source _and_ destination. Obviously we want the source to prefer data from memory, as copying blank data is useless. Additionally, a copy may be to a _part_ of the destination, so it's more likely that the rest of it in memory is still required than with a draw.

This wouldn't have been a problem if there were no overlapping textures (as this would allow data to be set, or use the existing texture), but with the way MethodCopyTexture works with out of bounds copies, it _generates overlapping source textures intentionally_.

Should help Professor Layton and Snack World, at least to the state they were in before https://github.com/Ryujinx/Ryujinx/pull/1408.