### PR TITLE
Convert 1D texture targets to 2D

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -144,6 +144,22 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             Target target = descriptor.UnpackTextureTarget().Convert((samplesInX | samplesInY) != 1);
 
+            // We use 2D targets for 1D textures as that makes texture cache
+            // management easier. We don't know the target for render target
+            // and copies, so those would normally use 2D targets, which are
+            // not compatible with 1D targets. By doing that we also allow those
+            // to match when looking for compatible textures on the cache.
+            if (target == Target.Texture1D)
+            {
+                target = Target.Texture2D;
+                height = 1;
+            }
+            else if (target == Target.Texture1DArray)
+            {
+                target = Target.Texture2DArray;
+                height = 1;
+            }
+
             uint format = descriptor.UnpackFormat();
             bool srgb   = descriptor.UnpackSrgb();
 

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
@@ -11,6 +11,8 @@ namespace Ryujinx.Graphics.Shader.Instructions
 {
     static partial class InstEmit
     {
+        private const bool Sample1DAs2D = true;
+
         public static void Suld(EmitterContext context)
         {
             OpCodeImage op = (OpCodeImage)context.CurrOp;
@@ -55,6 +57,13 @@ namespace Ryujinx.Graphics.Shader.Instructions
             for (int index = 0; index < coordsCount; index++)
             {
                 sourcesList.Add(Ra());
+            }
+
+            if (Sample1DAs2D && type == SamplerType.Texture1D)
+            {
+                sourcesList.Add(Const(0));
+
+                type = SamplerType.Texture2D;
             }
 
             if (isArray)
@@ -203,6 +212,13 @@ namespace Ryujinx.Graphics.Shader.Instructions
             for (int index = 0; index < coordsCount; index++)
             {
                 sourcesList.Add(Ra());
+            }
+
+            if (Sample1DAs2D && type == SamplerType.Texture1D)
+            {
+                sourcesList.Add(Const(0));
+
+                type = SamplerType.Texture2D;
             }
 
             if (isArray)
@@ -355,6 +371,12 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
                 flags = ConvertTextureFlags(texsOp.Target);
 
+                if (texsOp.Target == TextureTarget.Texture1DLodZero && context.Config.GpuAccessor.QueryIsTextureBuffer(texsOp.Immediate))
+                {
+                    type = SamplerType.TextureBuffer;
+                    flags &= ~TextureFlags.LodLevel;
+                }
+
                 if ((type & SamplerType.Array) != 0)
                 {
                     Operand arrayIndex = Ra();
@@ -380,7 +402,18 @@ namespace Ryujinx.Graphics.Shader.Instructions
                     {
                         case TextureTarget.Texture1DLodZero:
                             sourcesList.Add(Ra());
-                            sourcesList.Add(ConstF(0));
+
+                            if (type != SamplerType.TextureBuffer)
+                            {
+                                if (Sample1DAs2D)
+                                {
+                                    sourcesList.Add(ConstF(0));
+                                    type &= ~SamplerType.Mask;
+                                    type |= SamplerType.Texture2D;
+                                }
+
+                                sourcesList.Add(ConstF(0));
+                            }
                             break;
 
                         case TextureTarget.Texture2D:
@@ -423,7 +456,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
             }
             else if (op is OpCodeTlds tldsOp)
             {
-                type = ConvertSamplerType (tldsOp.Target);
+                type = ConvertSamplerType(tldsOp.Target);
 
                 if (type == SamplerType.None)
                 {
@@ -449,12 +482,27 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
                         if (type != SamplerType.TextureBuffer)
                         {
-                            sourcesList.Add(Const(0));
+                            if (Sample1DAs2D)
+                            {
+                                sourcesList.Add(ConstF(0));
+                                type &= ~SamplerType.Mask;
+                                type |= SamplerType.Texture2D;
+                            }
+
+                            sourcesList.Add(ConstF(0));
                         }
                         break;
 
                     case TexelLoadTarget.Texture1DLodLevel:
                         sourcesList.Add(Ra());
+
+                        if (Sample1DAs2D)
+                        {
+                            sourcesList.Add(ConstF(0));
+                            type &= ~SamplerType.Mask;
+                            type |= SamplerType.Texture2D;
+                        }
+
                         sourcesList.Add(Rb());
                         break;
 
@@ -649,6 +697,15 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 sourcesList.Add(Ra());
             }
 
+            bool is1DTo2D = Sample1DAs2D && type == SamplerType.Texture1D;
+
+            if (is1DTo2D)
+            {
+                sourcesList.Add(ConstF(0));
+
+                type = SamplerType.Texture2D;
+            }
+
             if (op.IsArray)
             {
                 sourcesList.Add(arrayIndex);
@@ -677,6 +734,14 @@ namespace Ryujinx.Graphics.Shader.Instructions
                     Operand packed = packedOffs[(index >> 2) & 1];
 
                     sourcesList.Add(context.BitfieldExtractS32(packed, Const((index & 3) * 8), Const(6)));
+                }
+
+                if (is1DTo2D)
+                {
+                    for (int index = 0; index < offsetTexelsCount; index++)
+                    {
+                        sourcesList.Add(Const(0));
+                    }
                 }
 
                 flags |= op.Offset == TextureGatherOffset.Offsets
@@ -784,6 +849,13 @@ namespace Ryujinx.Graphics.Shader.Instructions
             for (int index = 0; index < coordsCount; index++)
             {
                 sourcesList.Add(Ra());
+            }
+
+            if (Sample1DAs2D && type == SamplerType.Texture1D)
+            {
+                sourcesList.Add(ConstF(0));
+
+                type = SamplerType.Texture2D;
             }
 
             if (op.IsArray)
@@ -898,6 +970,15 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 sourcesList.Add(Ra());
             }
 
+            bool is1DTo2D = Sample1DAs2D && type == SamplerType.Texture1D;
+
+            if (is1DTo2D)
+            {
+                sourcesList.Add(ConstF(0));
+
+                type = SamplerType.Texture2D;
+            }
+
             Operand packedParams = Ra();
 
             if (op.IsArray)
@@ -911,6 +992,11 @@ namespace Ryujinx.Graphics.Shader.Instructions
             for (int dIndex = 0; dIndex < 2 * coordsCount; dIndex++)
             {
                 sourcesList.Add(Rb());
+
+                if (is1DTo2D)
+                {
+                    sourcesList.Add(ConstF(0));
+                }
             }
 
             if (op.HasOffset)
@@ -918,6 +1004,11 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 for (int index = 0; index < coordsCount; index++)
                 {
                     sourcesList.Add(context.BitfieldExtractS32(packedParams, Const(16 + index * 4), Const(4)));
+                }
+
+                if (is1DTo2D)
+                {
+                    sourcesList.Add(Const(0));
                 }
 
                 flags |= TextureFlags.Offset;
@@ -1114,6 +1205,13 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 sourcesList.Add(Ra());
             }
 
+            if (Sample1DAs2D && type == SamplerType.Texture1D)
+            {
+                sourcesList.Add(ConstF(0));
+
+                type = SamplerType.Texture2D;
+            }
+
             if (op.IsArray)
             {
                 sourcesList.Add(arrayIndex);
@@ -1247,13 +1345,15 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
         private static SamplerType ConvertSamplerType(ImageDimensions target)
         {
+            // Note: The caller sets the array flag is necessary,
+            // it expects the value returned to be without it.
             return target switch
             {
                 ImageDimensions.Image1D      => SamplerType.Texture1D,
                 ImageDimensions.ImageBuffer  => SamplerType.TextureBuffer,
-                ImageDimensions.Image1DArray => SamplerType.Texture1D | SamplerType.Array,
+                ImageDimensions.Image1DArray => SamplerType.Texture1D,
                 ImageDimensions.Image2D      => SamplerType.Texture2D,
-                ImageDimensions.Image2DArray => SamplerType.Texture2D | SamplerType.Array,
+                ImageDimensions.Image2DArray => SamplerType.Texture2D,
                 ImageDimensions.Image3D      => SamplerType.Texture3D,
                 _                            => SamplerType.None
             };

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
@@ -56,7 +56,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 sourcesList.Add(Ra());
             }
 
-            if (Sample1DAs2D && type == SamplerType.Texture1D)
+            if (Sample1DAs2D && (type & SamplerType.Mask) == SamplerType.Texture1D)
             {
                 sourcesList.Add(Const(0));
 
@@ -209,7 +209,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 sourcesList.Add(Ra());
             }
 
-            if (Sample1DAs2D && type == SamplerType.Texture1D)
+            if (Sample1DAs2D && (type & SamplerType.Mask) == SamplerType.Texture1D)
             {
                 sourcesList.Add(Const(0));
 

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
@@ -1345,7 +1345,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
         private static SamplerType ConvertSamplerType(ImageDimensions target)
         {
-            // Note: The caller sets the array flag is necessary,
+            // Note: The caller sets the array flag as necessary,
             // it expects the value returned to be without it.
             return target switch
             {

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
@@ -399,6 +399,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
                             if (Sample1DAs2D)
                             {
                                 sourcesList.Add(ConstF(0));
+
                                 type &= ~SamplerType.Mask;
                                 type |= SamplerType.Texture2D;
                             }
@@ -475,6 +476,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
                             if (Sample1DAs2D)
                             {
                                 sourcesList.Add(ConstF(0));
+
                                 type &= ~SamplerType.Mask;
                                 type |= SamplerType.Texture2D;
                             }
@@ -489,6 +491,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
                         if (Sample1DAs2D)
                         {
                             sourcesList.Add(ConstF(0));
+
                             type &= ~SamplerType.Mask;
                             type |= SamplerType.Texture2D;
                         }


### PR DESCRIPTION
Some games render to 1D textures. For the GPU, there's no difference between a 1D texture and a 2D texture with a height of 1, when it is being rendered. For this reason we can't determine if the texture is 1D or 2D when it is used as render target or copy texture. That means that if a game renders to a 2D texture, and later tries to sample it as a 1D texture, it will read garbage as 2D and 1D targets are not considered compatible (the host API does not allow that).

To fix this issue I just converted all 1D textures to 2D textures with a height of 1. The generated shader code was also adjusted to expect 2D textures instead of 1D ones. I added a constant that controls whenever it does that for the shader or not, later the constant can be replaced by a flag somewhere to make the behavior easily configurable.

This fixes the fog (?) on Monster Hunter Generations Ultimate.
Before:
![image](https://user-images.githubusercontent.com/5624669/94525243-2cd4bc80-020a-11eb-9674-50d84d89072d.png)
After:
![image](https://user-images.githubusercontent.com/5624669/94525268-352cf780-020a-11eb-8480-099e1ce5bf75.png)