### PR TITLE
Replace Host FPS with GPU command queue load ("Fifo %")

### DIFF
--- a/Ryujinx.HLE/PerformanceStatistics.cs
+++ b/Ryujinx.HLE/PerformanceStatistics.cs
@@ -8,7 +8,6 @@ namespace Ryujinx.HLE
         private const double FrameRateWeight = 0.5;
 
         private const int FrameTypeGame   = 0;
-
         private const int PercentTypeFifo = 0;
 
         private double[] _averageFrameRate;

--- a/Ryujinx.HLE/PerformanceStatistics.cs
+++ b/Ryujinx.HLE/PerformanceStatistics.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using Ryujinx.Common;
+using System.Diagnostics;
 using System.Timers;
 
 namespace Ryujinx.HLE
@@ -27,8 +28,6 @@ namespace Ryujinx.HLE
 
         private double _ticksToSeconds;
 
-        private Stopwatch _executionTime;
-
         private Timer _resetTimer;
 
         public PerformanceStatistics()
@@ -48,10 +47,6 @@ namespace Ryujinx.HLE
             _frameLock   = new object[] { new object() };
             _percentLock = new object[] { new object() };
 
-            _executionTime = new Stopwatch();
-
-            _executionTime.Start();
-
             _resetTimer = new Timer(1000);
 
             _resetTimer.Elapsed += ResetTimerElapsed;
@@ -60,7 +55,7 @@ namespace Ryujinx.HLE
 
             _resetTimer.Start();
 
-            _ticksToSeconds = 1.0 / Stopwatch.Frequency;
+            _ticksToSeconds = 1.0 / PerformanceCounter.TicksPerSecond;
         }
 
         private void ResetTimerElapsed(object sender, ElapsedEventArgs e)
@@ -131,14 +126,14 @@ namespace Ryujinx.HLE
 
         private void StartPercentTime(int percentType)
         {
-            double currentTime = _executionTime.ElapsedTicks * _ticksToSeconds;
+            double currentTime = PerformanceCounter.ElapsedTicks * _ticksToSeconds;
 
             _percentStartTime[percentType] = currentTime;
         }
 
         private void EndPercentTime(int percentType)
         {
-            double currentTime = _executionTime.ElapsedTicks * _ticksToSeconds;
+            double currentTime = PerformanceCounter.ElapsedTicks * _ticksToSeconds;
 
             double elapsedTime = currentTime - _percentLastEndTime[percentType];
             double elapsedActiveTime = currentTime - _percentStartTime[percentType];
@@ -158,7 +153,7 @@ namespace Ryujinx.HLE
 
         private void RecordFrameTime(int frameType)
         {
-            double currentFrameTime = _executionTime.ElapsedTicks * _ticksToSeconds;
+            double currentFrameTime = PerformanceCounter.ElapsedTicks * _ticksToSeconds;
 
             double elapsedFrameTime = currentFrameTime - _previousFrameTime[frameType];
 

--- a/Ryujinx.HLE/PerformanceStatistics.cs
+++ b/Ryujinx.HLE/PerformanceStatistics.cs
@@ -93,21 +93,18 @@ namespace Ryujinx.HLE
 
         private void CalculateAveragePercent(int percentType)
         {
-            double percent = 0;
+            // If start time is non-zero, a percent reading is still being measured.
+            // If there aren't any readings, the default should be 100% if still being measured, or 0% if not.
+            double percent = (_percentStartTime[percentType] == 0) ? 0 : 100;
 
-            if (_accumulatedPercent[percentType] > 0)
+            if (_percentCount[percentType] > 0)
             {
                 percent = _accumulatedPercent[percentType] / _percentCount[percentType];
-
-                if (double.IsNaN(percent))
-                {
-                    percent = 0;
-                }
             }
 
             lock (_percentLock[percentType])
             {
-                _averagePercent[percentType] = percent;
+                _averagePercent[percentType] = double.IsNaN(percent) ? 0 : percent;
 
                 _percentCount[percentType] = 0;
 
@@ -164,6 +161,7 @@ namespace Ryujinx.HLE
             }
 
             _percentLastEndTime[percentType] = currentTime;
+            _percentStartTime[percentType] = 0;
         }
 
         private void RecordFrameTime(int frameType)

--- a/Ryujinx.HLE/PerformanceStatistics.cs
+++ b/Ryujinx.HLE/PerformanceStatistics.cs
@@ -7,8 +7,7 @@ namespace Ryujinx.HLE
     {
         private const double FrameRateWeight = 0.5;
 
-        private const int FrameTypeSystem = 0;
-        private const int FrameTypeGame   = 1;
+        private const int FrameTypeGame   = 0;
 
         private const int PercentTypeFifo = 0;
 
@@ -35,19 +34,19 @@ namespace Ryujinx.HLE
 
         public PerformanceStatistics()
         {
-            _averageFrameRate     = new double[2];
-            _accumulatedFrameTime = new double[2];
-            _previousFrameTime    = new double[2];
+            _averageFrameRate     = new double[1];
+            _accumulatedFrameTime = new double[1];
+            _previousFrameTime    = new double[1];
 
             _averagePercent     = new double[1];
             _accumulatedPercent = new double[1];
             _percentLastEndTime = new double[1];
             _percentStartTime   = new double[1];
 
-            _framesRendered = new long[2];
+            _framesRendered = new long[1];
             _percentCount   = new long[1];
 
-            _frameLock   = new object[] { new object(), new object() };
+            _frameLock   = new object[] { new object() };
             _percentLock = new object[] { new object() };
 
             _executionTime = new Stopwatch();
@@ -67,7 +66,6 @@ namespace Ryujinx.HLE
 
         private void ResetTimerElapsed(object sender, ElapsedEventArgs e)
         {
-            CalculateAverageFrameRate(FrameTypeSystem);
             CalculateAverageFrameRate(FrameTypeGame);
             CalculateAveragePercent(PercentTypeFifo);
         }
@@ -104,7 +102,7 @@ namespace Ryujinx.HLE
                     percent = _accumulatedPercent[percentType] / _percentCount[percentType];
                 }
 
-                _averagePercent[percentType] = double.IsNaN(percent) ? 0 : percent;
+                _averagePercent[percentType] = percent;
 
                 _percentCount[percentType] = 0;
 
@@ -115,11 +113,6 @@ namespace Ryujinx.HLE
         private double LinearInterpolate(double lhs, double rhs)
         {
             return lhs * (1.0 - FrameRateWeight) + rhs * FrameRateWeight;
-        }
-
-        public void RecordSystemFrameTime()
-        {
-            RecordFrameTime(FrameTypeSystem);
         }
 
         public void RecordGameFrameTime()
@@ -178,11 +171,6 @@ namespace Ryujinx.HLE
 
                 _framesRendered[frameType]++;
             }
-        }
-
-        public double GetSystemFrameRate()
-        {
-            return _averageFrameRate[FrameTypeSystem];
         }
 
         public double GetGameFrameRate()

--- a/Ryujinx.HLE/PerformanceStatistics.cs
+++ b/Ryujinx.HLE/PerformanceStatistics.cs
@@ -76,13 +76,13 @@ namespace Ryujinx.HLE
         {
             double frameRate = 0;
 
-            if (_accumulatedFrameTime[frameType] > 0)
-            {
-                frameRate = _framesRendered[frameType] / _accumulatedFrameTime[frameType];
-            }
-
             lock (_frameLock[frameType])
             {
+                if (_accumulatedFrameTime[frameType] > 0)
+                {
+                    frameRate = _framesRendered[frameType] / _accumulatedFrameTime[frameType];
+                }
+
                 _averageFrameRate[frameType] = LinearInterpolate(_averageFrameRate[frameType], frameRate);
 
                 _framesRendered[frameType] = 0;
@@ -97,13 +97,13 @@ namespace Ryujinx.HLE
             // If there aren't any readings, the default should be 100% if still being measured, or 0% if not.
             double percent = (_percentStartTime[percentType] == 0) ? 0 : 100;
 
-            if (_percentCount[percentType] > 0)
-            {
-                percent = _accumulatedPercent[percentType] / _percentCount[percentType];
-            }
-
             lock (_percentLock[percentType])
             {
+                if (_percentCount[percentType] > 0)
+                {
+                    percent = _accumulatedPercent[percentType] / _percentCount[percentType];
+                }
+
                 _averagePercent[percentType] = double.IsNaN(percent) ? 0 : percent;
 
                 _percentCount[percentType] = 0;
@@ -112,9 +112,9 @@ namespace Ryujinx.HLE
             }
         }
 
-        private double LinearInterpolate(double old, double New)
+        private double LinearInterpolate(double lhs, double rhs)
         {
-            return old * (1.0 - FrameRateWeight) + New * FrameRateWeight;
+            return lhs * (1.0 - FrameRateWeight) + rhs * FrameRateWeight;
         }
 
         public void RecordSystemFrameTime()

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -355,8 +355,6 @@ namespace Ryujinx.Ui
                 {
                     _device.PresentFrame(SwapBuffers);
 
-                    _device.Statistics.RecordSystemFrameTime();
-
                     StatusUpdatedEvent?.Invoke(this, new StatusUpdatedEventArgs(
                         _device.EnableDeviceVsync,
                         dockedMode,

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -359,7 +359,7 @@ namespace Ryujinx.Ui
                         _device.EnableDeviceVsync,
                         dockedMode,
                         $"Game: {_device.Statistics.GetGameFrameRate():00.00} FPS",
-                        $"Fifo: {_device.Statistics.GetFifoPercent():0.00} %",
+                        $"FIFO: {_device.Statistics.GetFifoPercent():0.00} %",
                         $"GPU:  {_renderer.GpuVendor}"));
 
                     _ticks = Math.Min(_ticks - _ticksPerFrame, _ticksPerFrame);

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -360,8 +360,8 @@ namespace Ryujinx.Ui
                     StatusUpdatedEvent?.Invoke(this, new StatusUpdatedEventArgs(
                         _device.EnableDeviceVsync,
                         dockedMode,
-                        $"Fifo: {_device.Statistics.GetFifoPercent():0.00} %",
                         $"Game: {_device.Statistics.GetGameFrameRate():00.00} FPS",
+                        $"Fifo: {_device.Statistics.GetFifoPercent():0.00} %",
                         $"GPU:  {_renderer.GpuVendor}"));
 
                     _ticks = Math.Min(_ticks - _ticksPerFrame, _ticksPerFrame);

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -339,7 +339,9 @@ namespace Ryujinx.Ui
 
                 if (_device.WaitFifo())
                 {
+                    _device.Statistics.RecordFifoStart();
                     _device.ProcessFrame();
+                    _device.Statistics.RecordFifoEnd();
                 }
 
                 string dockedMode = ConfigurationState.Instance.System.EnableDockedMode ? "Docked" : "Handheld";
@@ -358,7 +360,7 @@ namespace Ryujinx.Ui
                     StatusUpdatedEvent?.Invoke(this, new StatusUpdatedEventArgs(
                         _device.EnableDeviceVsync,
                         dockedMode,
-                        $"Host: {_device.Statistics.GetSystemFrameRate():00.00} FPS",
+                        $"Fifo: {_device.Statistics.GetFifoPercent():0.00} %",
                         $"Game: {_device.Statistics.GetGameFrameRate():00.00} FPS",
                         $"GPU:  {_renderer.GpuVendor}"));
 

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -792,7 +792,7 @@ namespace Ryujinx.Ui
         {
             Application.Invoke(delegate
             {
-                _hostStatus.Text = args.HostStatus;
+                _hostStatus.Text = args.FifoStatus;
                 _gameStatus.Text = args.GameStatus;
                 _gpuName.Text    = args.GpuName;
                 _dockedMode.Text = args.DockedMode;

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -59,7 +59,7 @@ namespace Ryujinx.Ui
         [GUI] CheckMenuItem   _favToggle;
         [GUI] MenuItem        _firmwareInstallDirectory;
         [GUI] MenuItem        _firmwareInstallFile;
-        [GUI] Label           _hostStatus;
+        [GUI] Label           _fifoStatus;
         [GUI] CheckMenuItem   _iconToggle;
         [GUI] CheckMenuItem   _developerToggle;
         [GUI] CheckMenuItem   _appToggle;
@@ -792,8 +792,8 @@ namespace Ryujinx.Ui
         {
             Application.Invoke(delegate
             {
-                _hostStatus.Text = args.FifoStatus;
                 _gameStatus.Text = args.GameStatus;
+                _fifoStatus.Text = args.FifoStatus;
                 _gpuName.Text    = args.GpuName;
                 _dockedMode.Text = args.DockedMode;
 

--- a/Ryujinx/Ui/MainWindow.glade
+++ b/Ryujinx/Ui/MainWindow.glade
@@ -521,7 +521,7 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkLabel" id="_hostStatus">
+                      <object class="GtkLabel" id="_gameStatus">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
@@ -546,7 +546,7 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkLabel" id="_gameStatus">
+                      <object class="GtkLabel" id="_fifoStatus">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>

--- a/Ryujinx/Ui/StatusUpdatedEventArgs.cs
+++ b/Ryujinx/Ui/StatusUpdatedEventArgs.cs
@@ -6,16 +6,16 @@ namespace Ryujinx.Ui
     {
         public bool   VSyncEnabled;
         public string DockedMode;
-        public string HostStatus;
         public string GameStatus;
+        public string FifoStatus;
         public string GpuName;
 
-        public StatusUpdatedEventArgs(bool vSyncEnabled, string dockedMode, string hostStatus, string gameStatus, string gpuName)
+        public StatusUpdatedEventArgs(bool vSyncEnabled, string dockedMode, string gameStatus, string fifoStatus, string gpuName)
         {
             VSyncEnabled = vSyncEnabled;
             DockedMode   = dockedMode;
-            HostStatus   = hostStatus;
             GameStatus   = gameStatus;
+            FifoStatus   = fifoStatus;
             GpuName      = gpuName;
         }
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6294155/94595253-7eb92900-0282-11eb-8bd0-bf30263cfb14.png)
![image](https://user-images.githubusercontent.com/6294155/94595721-1a4a9980-0283-11eb-9d56-5bb4babe2bd2.png)

Host FPS is rather confusing for users as they can easily confuse it with Game FPS, thinking that it represents how many frames the game is putting out. However, it is a useful metric for determining if it's our GPU emulation causing the framerate bottleneck, as the host has time to generate more duplicate frames while waiting for more commands. It is also useful to see in screenshots, as it can indicate games with GPU related framerate issues.

This PR introduces a replacement "Fifo %" which indicates the percentage of time spent executing processing the FIFO queue over a period of time. This is essentially how _saturated_ the graphics processing thread is. A new mechanism for measuring percentage time has been added to the PerformanceStatistics class.

It's calculated by getting the percentage of the time since the last measurement between the start and end marker. This is then averaged similar to FPS, though there's no interpolation from previous values.

The name "Fifo" is very deliberately chosen:

- Anything with GPU in the name would lead people to believe the metric is related to their host GPU, and that they could reduce their load by getting a 3090 or something.
- The real name should be "Graphics Command Queue Load" or something, but that would be too long to fit in the bottom bar.

### Notes:
- **With a low Game FPS:**
  - A high Fifo % (> 75%) indicates that the game is being held back by the graphics processing thread.
  - A low Fifo % indicates that the game is spending a lot of time waiting for commands to be sent to the FIFO, possibly due to jitted code or HLE slowdown.
- **When at full speed:**
  - A low Fifo % indicates a lot of headroom on the graphics processing thread.
  - A high Fifo % indicates that the game is close to slowing down due to the graphics processing thread.
  - Host FPS could not give feedback like this!
- This measurement will still work if we use a separate context for the emulated GPU, unlike Host FPS which would likely just report the output refresh rate.
- Different games have different points where Fifo % indicates a "GPU bottleneck", as commands are not delivered to the GPU instantly.
- Fifo % can also be high if the Host GPU is slow, or the driver is excessively blocking on OpenGL calls. This is important to remember.