### PR TITLE
Remove old, unused CPU optimization

### DIFF
--- a/ARMeilleure/Optimizations.cs
+++ b/ARMeilleure/Optimizations.cs
@@ -4,8 +4,6 @@ namespace ARMeilleure
 {
     public static class Optimizations
     {
-        public static bool AssumeStrictAbiCompliance { get; set; } = true;
-
         public static bool FastFP { get; set; } = true;
 
         public static bool UseSseIfAvailable       { get; set; } = true;

--- a/ARMeilleure/Translation/Translator.cs
+++ b/ARMeilleure/Translation/Translator.cs
@@ -202,7 +202,7 @@ namespace ARMeilleure.Translation
 
             Logger.StartPass(PassName.RegisterUsage);
 
-            RegisterUsage.RunPass(cfg, mode, isCompleteFunction: false);
+            RegisterUsage.RunPass(cfg, mode);
 
             Logger.EndPass(PassName.RegisterUsage);
 


### PR DESCRIPTION
This is an optimization from the old CPU that could eliminate context save of several CPU register by assuming that the function follows the ARM64 ABI. Registers that are caller saved does not need to be saved to the context as the expectation is that the  callee will not use them, and instead just overwrite their values. This optimization has been inactive since the new JIT was implemented (`isCompleteFunction` is always false, so it can never kick in).

Other than the fact that it is unused, I also don't think it's worth re-implementing that as it's a rather dangerous optimizations (as it make assumptions about the code) and the benefits are not even that large anyway.

This should not change anything, it's just removing unused code.