### PR TITLE
Fix exiting emulator with multi programs

### DIFF
--- a/Ryujinx.HLE/HOS/UserChannelPersistence.cs
+++ b/Ryujinx.HLE/HOS/UserChannelPersistence.cs
@@ -10,6 +10,7 @@ namespace Ryujinx.HLE.HOS
         public int PreviousIndex { get; private set; }
         public int Index { get; private set; }
         public ProgramSpecifyKind Kind { get; private set; }
+        public bool ShouldRestart { get; set; }
 
         public UserChannelPersistence()
         {
@@ -42,6 +43,7 @@ namespace Ryujinx.HLE.HOS
         {
             Kind = kind;
             PreviousIndex = Index;
+            ShouldRestart = true;
 
             switch (kind)
             {

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -975,9 +975,10 @@ namespace Ryujinx.Ui
 
         private void HandleRelaunch()
         {
-            // If the previous index isn't -1, that mean we are relaunching.
-            if (_userChannelPersistence.PreviousIndex != -1)
+            if (_userChannelPersistence.PreviousIndex != -1 && _userChannelPersistence.ShouldRestart)
             {
+                _userChannelPersistence.ShouldRestart = false;
+
                 LoadApplication(_gamePath);
             }
             else


### PR DESCRIPTION
This fix a bug introduced in #1560 that would cause "Stop emulation" to actually restart the game all the time if it was restarted on another program.