### PR TITLE
Improve BRX target detection heuristics

### DIFF
--- a/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
@@ -311,6 +311,16 @@ namespace Ryujinx.Graphics.Gpu.Memory
         }
 
         /// <summary>
+        /// Checks if a given page is mapped.
+        /// </summary>
+        /// <param name="gpuVa">GPU virtual address of the page to check</param>
+        /// <returns>True if the page is mapped, false otherwise</returns>
+        public bool IsMapped(ulong gpuVa)
+        {
+            return Translate(gpuVa) != PteUnmapped;
+        }
+
+        /// <summary>
         /// Translates a GPU virtual address to a CPU virtual address.
         /// </summary>
         /// <param name="gpuVa">GPU virtual address to be translated</param>

--- a/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
@@ -3,7 +3,6 @@ using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Image;
 using Ryujinx.Graphics.Gpu.State;
 using Ryujinx.Graphics.Shader;
-using System;
 
 namespace Ryujinx.Graphics.Gpu.Shader
 {
@@ -82,6 +81,16 @@ namespace Ryujinx.Graphics.Gpu.Shader
         public T MemoryRead<T>(ulong address) where T : unmanaged
         {
             return _context.MemoryManager.Read<T>(address);
+        }
+
+        /// <summary>
+        /// Checks if a given memory address is mapped.
+        /// </summary>
+        /// <param name="address">GPU virtual address to be checked</param>
+        /// <returns>True if the address is mapped, false otherwise</returns>
+        public bool MemoryMapped(ulong address)
+        {
+            return _context.MemoryManager.IsMapped(address);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Shader/Decoders/Decoder.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/Decoder.cs
@@ -128,7 +128,7 @@ namespace Ryujinx.Graphics.Shader.Decoders
                 }
 
                 // Do we have a block after the current one?
-                if (!IsExit(currBlock.GetLastOp()) && currBlock.BrIndir != null)
+                if (currBlock.BrIndir != null && HasBlockAfter(gpuAccessor, currBlock, startAddress))
                 {
                     bool targetVisited = visited.ContainsKey(currBlock.EndAddress);
 
@@ -152,6 +152,19 @@ namespace Ryujinx.Graphics.Shader.Decoders
             }
 
             return blocks.ToArray();
+        }
+
+        private static bool HasBlockAfter(IGpuAccessor gpuAccessor, Block currBlock, ulong startAdddress)
+        {
+            if (!gpuAccessor.MemoryMapped(startAdddress + currBlock.EndAddress) ||
+                !gpuAccessor.MemoryMapped(startAdddress + currBlock.EndAddress + 7))
+            {
+                return false;
+            }
+
+            ulong inst = gpuAccessor.MemoryRead<ulong>(startAdddress + currBlock.EndAddress);
+
+            return inst != 0UL;
         }
 
         private static bool BinarySearch(List<Block> blocks, ulong address, out int index)

--- a/Ryujinx.Graphics.Shader/IGpuAccessor.cs
+++ b/Ryujinx.Graphics.Shader/IGpuAccessor.cs
@@ -9,6 +9,11 @@
 
         T MemoryRead<T>(ulong address) where T : unmanaged;
 
+        public bool MemoryMapped(ulong address)
+        {
+            return true;
+        }
+
         public int QueryComputeLocalSizeX()
         {
             return 1;


### PR DESCRIPTION
Currently we use a heuristic to find indirect branch targets on shader code. This heuristic was failing to find targets if they were located after a "EXIT" instruction. That was happening because "EXIT" was one of the stop conditions that would make it stop looking. This changes the stop condition to instead stop if the memory is unmapped or if the opcode value is 0 (this disassembles as NOP, but I assume that it's a invalid instruction. It's also what seems to be in the memory after the end of the shader, but I'm not sure if that's 100% reliable).

Maybe theres a better way to solve the problem, I'm not a big fan of this solution to be honest...

This fixes a issue with:
https://github.com/Ryujinx/Ryujinx-Games-List/issues/2538
And the game now renders:
![image](https://user-images.githubusercontent.com/5624669/94756058-d7fd8700-036c-11eb-961d-3b80062a090a.png)
Might affect other games aswell, of course.