### PR TITLE
Support 2D array ASTC compressed texture formats decoding

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -657,6 +657,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     Info.Height,
                     _depth,
                     Info.Levels,
+                    _layers,
                     out Span<byte> decoded))
                 {
                     string texInfo = $"{Info.Target} {Info.FormatInfo.Format} {Info.Width}x{Info.Height}x{Info.DepthOrLayers} levels {Info.Levels}";


### PR DESCRIPTION
Decoding 2D array ASTC texture was not supported, which means that layers other than the base layer would be completely blank. This adds support for decompression for 2D array textures aswell.

Fixes missing textures in Donkey Kong Country Tropical Freeze.
Before:
![image](https://user-images.githubusercontent.com/5624669/94876354-d0ea7d80-042d-11eb-8525-9255a327422c.png)
After:
![image](https://user-images.githubusercontent.com/5624669/94876342-c3cd8e80-042d-11eb-9582-fc8ec12dfad8.png)