### PR TITLE
surfaceflinger: Disable async buffer

### DIFF
--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/BufferQueueCore.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/BufferQueueCore.cs
@@ -50,7 +50,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
             IsAbandoned              = false;
             OverrideMaxBufferCount   = 0;
             DequeueBufferCannotBlock = false;
-            UseAsyncBuffer           = true;
+            UseAsyncBuffer           = false;
             DefaultWidth             = 1;
             DefaultHeight            = 1;
             DefaultMaxBufferCount    = 2;


### PR DESCRIPTION
This fix a mistake I made during my original reimplementation of Surface Flinger by disabling async buffer.

This fix a memory corruption on Super Mario All-Stars 3D (Super Mario Sunshine & Super
Mario Galaxy now go ingame).

This also could fix some crashes on other games.

![image](https://user-images.githubusercontent.com/1760003/95641834-ec482f00-0aa4-11eb-8082-ddb9d79ba7dd.png)

Thanks to @gdkchan for tracing the memory corruption.