### PR TITLE
Fix H264 output frame size when decoding videos of different sizes

### DIFF
--- a/Ryujinx.Graphics.Nvdec.H264/Surface.cs
+++ b/Ryujinx.Graphics.Nvdec.H264/Surface.cs
@@ -8,6 +8,9 @@ namespace Ryujinx.Graphics.Nvdec.H264
     {
         public AVFrame* Frame { get; }
 
+        public int RequestedWidth { get; }
+        public int RequestedHeight { get; }
+
         public Plane YPlane => new Plane((IntPtr)Frame->data[0], Stride * Height);
         public Plane UPlane => new Plane((IntPtr)Frame->data[1], UvStride * UvHeight);
         public Plane VPlane => new Plane((IntPtr)Frame->data[2], UvStride * UvHeight);
@@ -19,8 +22,11 @@ namespace Ryujinx.Graphics.Nvdec.H264
         public int UvHeight => (Frame->height + 1) >> 1;
         public int UvStride => Frame->linesize[1];
 
-        public Surface()
+        public Surface(int width, int height)
         {
+            RequestedWidth = width;
+            RequestedHeight = height;
+
             Frame = ffmpeg.av_frame_alloc();
         }
 


### PR DESCRIPTION
Currently, NVDEC uses the size of the surface returned by FFMPEG when writing data back to memory. The problem is that this size is not always correct, afterall FFMPEG does not know when a video ends and another begins. Using the wrong frame size will cause memory corruption, as it will overwrite unrelated data in memory.

I fixed that by forcing the re-creation of the FFMPEG context when the frame size changes. After doing that, FFMPEG is returning the correct frame sizes for the subsequent videos (according to my tests).

This fixes a memory corruption that could occur after switching between different H264 videos with different frame sizes. This fixes random crashes on Super Mario 3D All-Stars main menu/launcher.