### PR TITLE
Add support for shader constant buffer slot indexing

### DIFF
--- a/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -272,7 +272,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         }
 
         /// <summary>
-        /// Gets a bit mask indicating which coompute uniform buffers are currently bound.
+        /// Gets a bit mask indicating which compute uniform buffers are currently bound.
         /// </summary>
         /// <returns>Mask where each bit set indicates a bound constant buffer</returns>
         public uint GetComputeUniformBufferUseMask()

--- a/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -147,6 +147,13 @@ namespace Ryujinx.Graphics.Gpu.Memory
             }
         }
 
+        /// <summary>
+        /// Sets a transform feedback buffer on the graphics pipeline.
+        /// The output from the vertex transformation stages are written into the feedback buffer.
+        /// </summary>
+        /// <param name="index">Index of the transform feedback buffer</param>
+        /// <param name="gpuVa">Start GPU virtual address of the buffer</param>
+        /// <param name="size">Size in bytes of the transform feedback buffer</param>
         public void SetTransformFeedbackBuffer(int index, ulong gpuVa, ulong size)
         {
             ulong address = TranslateAndCreateBuffer(gpuVa, size);
@@ -265,6 +272,25 @@ namespace Ryujinx.Graphics.Gpu.Memory
         }
 
         /// <summary>
+        /// Gets a bit mask indicating which coompute uniform buffers are currently bound.
+        /// </summary>
+        /// <returns>Mask where each bit set indicates a bound constant buffer</returns>
+        public uint GetComputeUniformBufferUseMask()
+        {
+            uint mask = 0;
+
+            for (int i = 0; i < _cpUniformBuffers.Buffers.Length; i++)
+            {
+                if (_cpUniformBuffers.Buffers[i].Address != 0)
+                {
+                    mask |= 1u << i;
+                }
+            }
+
+            return mask;
+        }
+
+        /// <summary>
         /// Sets the enabled uniform buffers mask on the graphics pipeline.
         /// Each bit set on the mask indicates that the respective buffer index is enabled.
         /// </summary>
@@ -275,6 +301,26 @@ namespace Ryujinx.Graphics.Gpu.Memory
             _gpUniformBuffers[stage].EnableMask = mask;
 
             _gpUniformBuffersDirty = true;
+        }
+
+        /// <summary>
+        /// Gets a bit mask indicating which graphics uniform buffers are currently bound.
+        /// </summary>
+        /// <param name="stage">Index of the shader stage</param>
+        /// <returns>Mask where each bit set indicates a bound constant buffer</returns>
+        public uint GetGraphicsUniformBufferUseMask(int stage)
+        {
+            uint mask = 0;
+
+            for (int i = 0; i < _gpUniformBuffers[stage].Buffers.Length; i++)
+            {
+                if (_gpUniformBuffers[stage].Buffers[i].Address != 0)
+                {
+                    mask |= 1u << i;
+                }
+            }
+
+            return mask;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
@@ -124,6 +124,17 @@ namespace Ryujinx.Graphics.Gpu.Shader
         public int QueryComputeSharedMemorySize() => _sharedMemorySize;
 
         /// <summary>
+        /// Queries Constant Buffer usage information.
+        /// </summary>
+        /// <returns>A mask where each bit set indicates a bound constant buffer</returns>
+        public uint QueryConstantBufferUse()
+        {
+            return _compute
+                ? _context.Methods.BufferManager.GetComputeUniformBufferUseMask()
+                : _context.Methods.BufferManager.GetGraphicsUniformBufferUseMask(_stageIndex);
+        }
+
+        /// <summary>
         /// Queries texture target information.
         /// </summary>
         /// <param name="handle">Texture handle</param>

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/CodeGenContext.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/CodeGenContext.cs
@@ -12,6 +12,8 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
         public ShaderConfig Config { get; }
 
+        public bool CbIndexable { get; }
+
         public List<BufferDescriptor>  CBufferDescriptors { get; }
         public List<BufferDescriptor>  SBufferDescriptors { get; }
         public List<TextureDescriptor> TextureDescriptors { get; }
@@ -25,9 +27,10 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
         private string _indentation;
 
-        public CodeGenContext(ShaderConfig config)
+        public CodeGenContext(ShaderConfig config, bool cbIndexable)
         {
             Config = config;
+            CbIndexable = cbIndexable;
 
             CBufferDescriptors = new List<BufferDescriptor>();
             SBufferDescriptors = new List<BufferDescriptor>();
@@ -85,9 +88,9 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
             int cBufSlot = bindless ? operand.CbufSlot : 0;
             int cBufOffset = bindless ? operand.CbufOffset : 0;
 
-            return TextureDescriptors.FindIndex(descriptor => 
-                descriptor.Type == texOp.Type && 
-                descriptor.HandleIndex == texOp.Handle && 
+            return TextureDescriptors.FindIndex(descriptor =>
+                descriptor.Type == texOp.Type &&
+                descriptor.HandleIndex == texOp.Handle &&
                 descriptor.CbufSlot == cBufSlot &&
                 descriptor.CbufOffset == cBufOffset);
         }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/GlslGenerator.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/GlslGenerator.cs
@@ -12,7 +12,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
     {
         public static GlslProgram Generate(StructuredProgramInfo info, ShaderConfig config)
         {
-            CodeGenContext context = new CodeGenContext(config);
+            CodeGenContext context = new CodeGenContext(config, info.UsesCbIndexing);
 
             Declarations.Declare(context, info);
 

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGen.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGen.cs
@@ -19,7 +19,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
             }
             else if (node is AstOperand operand)
             {
-                return context.OperandManager.GetExpression(operand, context.Config);
+                return context.OperandManager.GetExpression(operand, context.Config, context.CbIndexable);
             }
 
             throw new ArgumentException($"Invalid node type \"{node?.GetType().Name ?? "null"}\".");

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
@@ -125,7 +125,16 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
 
             offsetExpr = Enclose(offsetExpr, src2, Instruction.ShiftRightS32, isLhs: true);
 
-            return OperandManager.GetConstantBufferName(src1, offsetExpr, context.Config.Stage);
+            if (src1 is AstOperand oper && oper.Type == OperandType.Constant)
+            {
+                return OperandManager.GetConstantBufferName(oper.Value, offsetExpr, context.Config.Stage, context.CbIndexable);
+            }
+            else
+            {
+                string slotExpr = GetSoureExpr(context, src1, GetSrcVarType(operation.Inst, 0));
+
+                return OperandManager.GetConstantBufferName(slotExpr, offsetExpr, context.Config.Stage);
+            }
         }
 
         public static string LoadLocal(CodeGenContext context, AstOperation operation)

--- a/Ryujinx.Graphics.Shader/Decoders/CbIndexMode.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/CbIndexMode.cs
@@ -1,0 +1,10 @@
+namespace Ryujinx.Graphics.Shader.Decoders
+{
+    enum CbIndexMode
+    {
+        Default = 0,
+        Il      = 1,
+        Is      = 2,
+        Isl     = 3
+    }
+}

--- a/Ryujinx.Graphics.Shader/Decoders/OpCodeLdc.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/OpCodeLdc.cs
@@ -10,6 +10,7 @@ namespace Ryujinx.Graphics.Shader.Decoders
         public int Offset { get; }
         public int Slot   { get; }
 
+        public CbIndexMode IndexMode { get; }
         public IntegerSize Size { get; }
 
         public OpCodeLdc(InstEmitter emitter, ulong address, long opCode) : base(emitter, address, opCode)
@@ -20,7 +21,8 @@ namespace Ryujinx.Graphics.Shader.Decoders
             Offset = (opCode.Extract(20, 16) << 16) >> 16;
             Slot   = opCode.Extract(36, 5);
 
-            Size = (IntegerSize)opCode.Extract(48, 3);
+            IndexMode = (CbIndexMode)opCode.Extract(44, 2);
+            Size      = (IntegerSize)opCode.Extract(48, 3);
         }
     }
 }

--- a/Ryujinx.Graphics.Shader/IGpuAccessor.cs
+++ b/Ryujinx.Graphics.Shader/IGpuAccessor.cs
@@ -39,6 +39,11 @@
             return 0xc000;
         }
 
+        public uint QueryConstantBufferUse()
+        {
+            return 0xffff;
+        }
+
         public bool QueryIsTextureBuffer(int handle)
         {
             return false;

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitMemory.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitMemory.cs
@@ -112,7 +112,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
                     res = context.FPMultiply(res, Attribute(AttributeConsts.PositionW));
                 }
             }
- 
+
             if (op.Mode == InterpolationMode.Default)
             {
                 Operand srcB = GetSrcB(context);
@@ -152,7 +152,17 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
             int count = op.Size == IntegerSize.B64 ? 2 : 1;
 
-            Operand addr = context.IAdd(GetSrcA(context), Const(op.Offset));
+            Operand slot = Const(op.Slot);
+            Operand srcA = GetSrcA(context);
+
+            if (op.IndexMode == CbIndexMode.Is ||
+                op.IndexMode == CbIndexMode.Isl)
+            {
+                slot = context.IAdd(slot, context.BitfieldExtractU32(srcA, Const(16), Const(16)));
+                srcA = context.BitwiseAnd(srcA, Const(0xffff));
+            }
+
+            Operand addr = context.IAdd(srcA, Const(op.Offset));
 
             Operand wordOffset = context.ShiftRightU32(addr, Const(2));
 
@@ -169,7 +179,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
                 Operand offset = context.IAdd(wordOffset, Const(index));
 
-                Operand value = context.LoadConstant(Const(op.Slot), offset);
+                Operand value = context.LoadConstant(slot, offset);
 
                 if (isSmallInt)
                 {

--- a/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgramInfo.cs
+++ b/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgramInfo.cs
@@ -15,6 +15,7 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
         public HashSet<int> OAttributes { get; }
 
         public bool UsesInstanceId { get; set; }
+        public bool UsesCbIndexing { get; set; }
 
         public HelperFunctionsMask HelperFunctionsMask { get; set; }
 


### PR DESCRIPTION
The LDC shader instructions has different indexing modes, and one of them allows selecting from which constant buffer the value will be loaded by using a bitfield from a register. This mode was not supported, and it was assuming that the constant buffer slot number was always constant. This change allows it to be indexed.

Indexing of constant buffers is supported by creating a array of uniform buffers on the shader with all the constant buffers, instead of separating them. This is only done when the special LDC indexing modes are actually used on the shader, so the code should remain the same on shaders that do not make use of it.

This fixes skinned meshes not rendering on Super Mario 3D All-Stars.
Before:
![image](https://user-images.githubusercontent.com/5624669/95688464-c162f580-0be0-11eb-864d-f45203465792.png)
After:
![image](https://user-images.githubusercontent.com/5624669/95688455-b6a86080-0be0-11eb-82f9-16ad996d1af5.png)
Before:
![image](https://user-images.githubusercontent.com/5624669/95688478-cfb11180-0be0-11eb-8825-a5574fe79738.png)
After:
![image](https://user-images.githubusercontent.com/5624669/95688483-e0618780-0be0-11eb-8f78-986aada8b47f.png)
![image](https://user-images.githubusercontent.com/5624669/95688486-e5bed200-0be0-11eb-9cd7-cf437e34a889.png)
![image](https://user-images.githubusercontent.com/5624669/95688488-e9525900-0be0-11eb-8236-ed2e0fceccfb.png)