### PR TITLE
Implement LEA.HI shader instruction

### DIFF
--- a/Ryujinx.Graphics.Shader/Decoders/OpCodeTable.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/OpCodeTable.cs
@@ -179,6 +179,8 @@ namespace Ryujinx.Graphics.Shader.Decoders
             Set("010010111101xx", InstEmit.Lea,     typeof(OpCodeAluCbuf));
             Set("0011011x11010x", InstEmit.Lea,     typeof(OpCodeAluImm));
             Set("0101101111010x", InstEmit.Lea,     typeof(OpCodeAluReg));
+            Set("000110xxxxxxxx", InstEmit.Lea_Hi,  typeof(OpCodeAluCbuf));
+            Set("0101101111011x", InstEmit.Lea_Hi,  typeof(OpCodeAluReg));
             Set("0100110001000x", InstEmit.Lop,     typeof(OpCodeLopCbuf));
             Set("0011100001000x", InstEmit.Lop,     typeof(OpCodeLopImm));
             Set("000001xxxxxxxx", InstEmit.Lop,     typeof(OpCodeLopImm32));

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitAluHelper.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitAluHelper.cs
@@ -100,5 +100,15 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 context.Copy(GetNF(), context.FPCompareLess (dest, zero, fpType));
             }
         }
+
+        public static Operand AddWithCarry(EmitterContext context, Operand lhs, Operand rhs, out Operand carryOut)
+        {
+            Operand result = context.IAdd(lhs, rhs);
+
+            // C = Rd < Rn
+            carryOut = context.INegate(context.ICompareLessUnsigned(result, lhs));
+
+            return result;
+        }
     }
 }


### PR DESCRIPTION
Implements the LEA.HI shader instruction.
This fixes Rosalina rendering on Super Mario Galaxy.
Before:
![image](https://user-images.githubusercontent.com/5624669/95694449-7fe64080-0c08-11eb-9d2d-dbdb0e9b77c8.png)
After:
![image](https://user-images.githubusercontent.com/5624669/95694458-883e7b80-0c08-11eb-89df-b4270875b2fe.png)