### PR TITLE
Fix error when dual source blend is used

### DIFF
--- a/Ryujinx.Graphics.OpenGL/Framebuffer.cs
+++ b/Ryujinx.Graphics.OpenGL/Framebuffer.cs
@@ -13,6 +13,9 @@ namespace Ryujinx.Graphics.OpenGL
 
         private readonly TextureView[] _colors;
 
+        private int _colorsCount;
+        private bool _dualSourceBlend;
+
         public Framebuffer()
         {
             Handle = GL.GenFramebuffer();
@@ -97,7 +100,35 @@ namespace Ryujinx.Graphics.OpenGL
             }
         }
 
+        public void SetDualSourceBlend(bool enable)
+        {
+            bool oldEnable = _dualSourceBlend;
+
+            _dualSourceBlend = enable;
+
+            // When dual source blend is used,
+            // we can only have one draw buffer.
+            if (enable)
+            {
+                GL.DrawBuffer(DrawBufferMode.ColorAttachment0);
+            }
+            else if (oldEnable)
+            {
+                SetDrawBuffersImpl(_colorsCount);
+            }
+        }
+
         public void SetDrawBuffers(int colorsCount)
+        {
+            if (_colorsCount != colorsCount && !_dualSourceBlend)
+            {
+                SetDrawBuffersImpl(colorsCount);
+            }
+
+            _colorsCount = colorsCount;
+        }
+
+        private void SetDrawBuffersImpl(int colorsCount)
         {
             DrawBuffersEnum[] drawBuffers = new DrawBuffersEnum[colorsCount];
 

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -557,6 +557,30 @@ namespace Ryujinx.Graphics.OpenGL
                 (BlendingFactorSrc)blend.AlphaSrcFactor.Convert(),
                 (BlendingFactorDest)blend.AlphaDstFactor.Convert());
 
+            static bool IsDualSource(BlendFactor factor)
+            {
+                switch (factor)
+                {
+                    case BlendFactor.Src1Color:
+                    case BlendFactor.Src1ColorGl:
+                    case BlendFactor.Src1Alpha:
+                    case BlendFactor.Src1AlphaGl:
+                    case BlendFactor.OneMinusSrc1Color:
+                    case BlendFactor.OneMinusSrc1ColorGl:
+                    case BlendFactor.OneMinusSrc1Alpha:
+                    case BlendFactor.OneMinusSrc1AlphaGl:
+                        return true;
+                }
+
+                return false;
+            }
+
+            _framebuffer.SetDualSourceBlend(
+                IsDualSource(blend.ColorSrcFactor) ||
+                IsDualSource(blend.ColorDstFactor) ||
+                IsDualSource(blend.AlphaSrcFactor) ||
+                IsDualSource(blend.AlphaDstFactor));
+
             if (_blendConstant != blend.BlendConstant)
             {
                 _blendConstant = blend.BlendConstant;

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -575,6 +575,8 @@ namespace Ryujinx.Graphics.OpenGL
                 return false;
             }
 
+            EnsureFramebuffer();
+
             _framebuffer.SetDualSourceBlend(
                 IsDualSource(blend.ColorSrcFactor) ||
                 IsDualSource(blend.ColorDstFactor) ||


### PR DESCRIPTION
Dual source blend is a feature that allows two color outputs from the pixel shader to be combined using the GPU blending functions. When one of the dual source blending sources is used, it is only valid to have a single draw buffer set, as on this mode you can only output to a single color buffer. So, this change forces a single draw buffer to be set if dual source blending is in use.

This adds a bunch of checks to the set blend mode function which could potentially slow it down, so if someone has a better suggestion on how to do it without all the checks on a potentially how function, let me know.

This fixes black floor among other things on Super Mario Galaxy observatory.
Before:
![image](https://user-images.githubusercontent.com/5624669/95709982-2d237d80-0c36-11eb-98a0-c5e361304dad.png)
After:
![image](https://user-images.githubusercontent.com/5624669/95709996-33195e80-0c36-11eb-9685-3347931e87f9.png)