### PR TITLE
Fix incorrect GPU GL blend func values

### DIFF
--- a/Ryujinx.Graphics.GAL/BlendOp.cs
+++ b/Ryujinx.Graphics.GAL/BlendOp.cs
@@ -9,9 +9,9 @@ namespace Ryujinx.Graphics.GAL
         Maximum,
 
         AddGl             = 0x8006,
-        SubtractGl        = 0x8007,
-        ReverseSubtractGl = 0x8008,
-        MinimumGl         = 0x800a,
-        MaximumGl         = 0x800b
+        MinimumGl         = 0x8007,
+        MaximumGl         = 0x8008,
+        SubtractGl        = 0x800a,
+        ReverseSubtractGl = 0x800b
     }
 }

--- a/Ryujinx.Graphics.OpenGL/EnumConversion.cs
+++ b/Ryujinx.Graphics.OpenGL/EnumConversion.cs
@@ -104,18 +104,18 @@ namespace Ryujinx.Graphics.OpenGL
                 case BlendOp.Add:
                 case BlendOp.AddGl:
                     return BlendEquationMode.FuncAdd;
-                case BlendOp.Subtract:
-                case BlendOp.SubtractGl:
-                    return BlendEquationMode.FuncSubtract;
-                case BlendOp.ReverseSubtract:
-                case BlendOp.ReverseSubtractGl:
-                    return BlendEquationMode.FuncReverseSubtract;
                 case BlendOp.Minimum:
                 case BlendOp.MinimumGl:
                     return BlendEquationMode.Min;
                 case BlendOp.Maximum:
                 case BlendOp.MaximumGl:
                     return BlendEquationMode.Max;
+                case BlendOp.Subtract:
+                case BlendOp.SubtractGl:
+                    return BlendEquationMode.FuncSubtract;
+                case BlendOp.ReverseSubtract:
+                case BlendOp.ReverseSubtractGl:
+                    return BlendEquationMode.FuncReverseSubtract;
             }
 
             Logger.Debug?.Print(LogClass.Gpu, $"Invalid {nameof(BlendOp)} enum value: {op}.");


### PR DESCRIPTION
Fixes the broken shadows on Super Mario Galaxy. Thanks for riperiperi for the help diagnosing this issue.
Before:
![image](https://user-images.githubusercontent.com/5624669/95800103-05332900-0ccd-11eb-8b81-27d041e7d730.png)
After:
![image](https://user-images.githubusercontent.com/5624669/95800119-0c5a3700-0ccd-11eb-9f5f-162a7fa2a31b.png)
Note: This only affects games using the OpenGL and Vulkan APIs.