### PR TITLE
Fix output component register on pixel shaders

### DIFF
--- a/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -1,4 +1,3 @@
-using Ryujinx.Common;
 using Ryujinx.Graphics.Shader.Decoders;
 using Ryujinx.Graphics.Shader.IntermediateRepresentation;
 using System.Collections.Generic;

--- a/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -126,7 +126,10 @@ namespace Ryujinx.Graphics.Shader.Translation
                         }
                     }
 
-                    regIndexBase += 4;
+                    if (target.Enabled)
+                    {
+                        regIndexBase += 4;
+                    }
                 }
             }
         }

--- a/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -85,7 +85,7 @@ namespace Ryujinx.Graphics.Shader.Translation
                     this.Copy(dest, src);
                 }
 
-                int regIndex = 0;
+                int regIndexBase = 0;
 
                 for (int rtIndex = 0; rtIndex < 8; rtIndex++)
                 {
@@ -100,7 +100,7 @@ namespace Ryujinx.Graphics.Shader.Translation
 
                         int fragmentOutputColorAttr = AttributeConsts.FragmentOutputColorBase + rtIndex * 16;
 
-                        Operand src = Register(regIndex, RegisterType.Gpr);
+                        Operand src = Register(regIndexBase + component, RegisterType.Gpr);
 
                         // Perform B <-> R swap if needed, for BGRA formats (not supported on OpenGL).
                         if (component == 0 || component == 2)
@@ -125,11 +125,9 @@ namespace Ryujinx.Graphics.Shader.Translation
                         {
                             this.Copy(Attribute(fragmentOutputColorAttr + component * 4), src);
                         }
-
-                        regIndex++;
                     }
 
-                    regIndex = BitUtils.AlignUp(regIndex, 4);
+                    regIndexBase += 4;
                 }
             }
         }


### PR DESCRIPTION
This fixes an error I noticed on one of Super Mario Galaxy shaders. When the shader does not output to all the components of a color buffer, the register number still corresponds to the component number. So if, for example, only A (alpha) is written to, the output will be still on R3 rather than R0.

I'm not sure about what exactly this fixes on this game, but mario shadow seems better with this fix. I also tested on other games that had similar issues on the past, and they did not regress.