### PR TITLE
disable fastfp on faddp_v

### DIFF
--- a/ARMeilleure/Instructions/InstEmitSimdArithmetic.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdArithmetic.cs
@@ -380,7 +380,7 @@ namespace ARMeilleure.Instructions
 
         public static void Faddp_V(ArmEmitterContext context)
         {
-            if (Optimizations.FastFP && Optimizations.UseSse2)
+            if (false && Optimizations.UseSse2)
             {
                 EmitSse2VectorPairwiseOpF(context, (op1, op2) =>
                 {


### PR DESCRIPTION
Fixes a hang in LM3 going to B2 floor or loading saved state before that point.

Probably solution should be more quirorgic, but I know nothing about this part of code. Just follow suggestions of @kakasita user.

fix #1611 

relates to https://github.com/Ryujinx/Ryujinx-Games-List/issues/207