### PR TITLE
Fix LOP3 (cbuf) shader instruction encoding

### DIFF
--- a/Ryujinx.Graphics.Shader/Decoders/OpCodeTable.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/OpCodeTable.cs
@@ -185,7 +185,7 @@ namespace Ryujinx.Graphics.Shader.Decoders
             Set("0011100001000x", InstEmit.Lop,     typeof(OpCodeLopImm));
             Set("000001xxxxxxxx", InstEmit.Lop,     typeof(OpCodeLopImm32));
             Set("0101110001000x", InstEmit.Lop,     typeof(OpCodeLopReg));
-            Set("0010000xxxxxxx", InstEmit.Lop3,    typeof(OpCodeLopCbuf));
+            Set("0000001xxxxxxx", InstEmit.Lop3,    typeof(OpCodeLopCbuf));
             Set("001111xxxxxxxx", InstEmit.Lop3,    typeof(OpCodeLopImm));
             Set("0101101111100x", InstEmit.Lop3,    typeof(OpCodeLopReg));
             Set("1110111110011x", InstEmit.Membar,  typeof(OpCodeMemoryBarrier));


### PR DESCRIPTION
Improves rendering on Doom 64.
Before:
![image](https://user-images.githubusercontent.com/5624669/95922469-b4cdd100-0d89-11eb-8a4d-3acdd090410c.png)
After:
![image](https://user-images.githubusercontent.com/5624669/95922484-b8615800-0d89-11eb-8776-74431f0d7940.png)
![image](https://user-images.githubusercontent.com/5624669/95922497-bdbea280-0d89-11eb-9cf9-c21ab9731f97.png)
