### PR TITLE
Fix gl_in being used with built-in variables that are not per-vertex

### DIFF
--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
@@ -206,7 +206,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
                     string name = builtInAttr.Name;
 
-                    if (config.Stage == ShaderStage.Geometry && !isOutAttr)
+                    if (config.Stage == ShaderStage.Geometry && (value & AttributeConsts.SpecialMask) == 0 && !isOutAttr)
                     {
                         name = $"gl_in[{indexExpr}].{name}";
                     }

--- a/Ryujinx.Graphics.Shader/Translation/AttributeConsts.cs
+++ b/Ryujinx.Graphics.Shader/Translation/AttributeConsts.cs
@@ -31,6 +31,7 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         // Note: Those attributes are used internally by the translator
         // only, they don't exist on Maxwell.
+        public const int SpecialMask             = 0xff << 24;
         public const int FragmentOutputDepth     = 0x1000000;
         public const int FragmentOutputColorBase = 0x1000010;
         public const int FragmentOutputColorEnd  = FragmentOutputColorBase + 8 * 16;


### PR DESCRIPTION
This could cause geometry shaders to fail to compile if those built-ins were used. I'm not aware of any game having a visible improvement with those changes however.