### PR TITLE
Ensure storage is set for Buffer Textures when binding an Image.

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -290,6 +290,14 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 ITexture hostTexture = texture?.GetTargetTexture(binding.Target);
 
+                if (hostTexture != null && texture.Info.Target == Target.TextureBuffer)
+                {
+                    // Ensure that the buffer texture is using the correct buffer as storage.
+                    // Buffers are frequently re-created to accomodate larger data, so we need to re-bind
+                    // to ensure we're not using a old buffer that was already deleted.
+                    _context.Methods.BufferManager.SetBufferTextureStorage(hostTexture, texture.Address, texture.Size, _isCompute);
+                }
+
                 if (_imageState[stageIndex][index].Texture != hostTexture || _rebind)
                 {
                     _imageState[stageIndex][index].Texture = hostTexture;


### PR DESCRIPTION
This was causing OpenGL errors in UE4 games, and a driver crash on NVIDIA Pascal GPUs (GeForce 1070 etc). With this fixed, you can now get ingame on UE4 games with a Pascal GPU. (does not appear to fix any other issues)

![image](https://user-images.githubusercontent.com/6294155/96319591-ff5c8100-1007-11eb-8d4a-f49b077b654e.png)