### PR TITLE
Fix transform feedback errors caused by host pause/resume and multiple uses

### DIFF
--- a/Ryujinx.Graphics.GAL/BufferRange.cs
+++ b/Ryujinx.Graphics.GAL/BufferRange.cs
@@ -4,7 +4,7 @@ namespace Ryujinx.Graphics.GAL
     {
         private static readonly BufferRange _empty = new BufferRange(BufferHandle.Null, 0, 0);
 
-        public BufferRange Empty => _empty;
+        public static BufferRange Empty => _empty;
 
         public BufferHandle Handle { get; }
 

--- a/Ryujinx.Graphics.GAL/IPipeline.cs
+++ b/Ryujinx.Graphics.GAL/IPipeline.cs
@@ -75,7 +75,7 @@ namespace Ryujinx.Graphics.GAL
 
         void SetTexture(int index, ShaderStage stage, ITexture texture);
 
-        void SetTransformFeedbackBuffer(int index, BufferRange buffer);
+        void SetTransformFeedbackBuffers(ReadOnlySpan<BufferRange> buffers);
         void SetUniformBuffer(int index, ShaderStage stage, BufferRange buffer);
 
         void SetUserClipDistance(int index, bool enableClip);

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -545,7 +545,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Checks if the memory for this texture was modified, and returns true if it was. 
+        /// Checks if the memory for this texture was modified, and returns true if it was.
         /// The modified flags are consumed as a result.
         /// </summary>
         /// <remarks>

--- a/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -587,21 +587,22 @@ namespace Ryujinx.Graphics.Gpu.Memory
             {
                 _transformFeedbackBuffersDirty = false;
 
+                Span<BufferRange> tfbs = stackalloc BufferRange[Constants.TotalTransformFeedbackBuffers];
+
                 for (int index = 0; index < Constants.TotalTransformFeedbackBuffers; index++)
                 {
                     BufferBounds tfb = _transformFeedbackBuffers[index];
 
                     if (tfb.Address == 0)
                     {
-                        _context.Renderer.Pipeline.SetTransformFeedbackBuffer(index, new BufferRange(BufferHandle.Null, 0, 0));
-
+                        tfbs[index] = BufferRange.Empty;
                         continue;
                     }
 
-                    BufferRange buffer = GetBufferRange(tfb.Address, tfb.Size);
-
-                    _context.Renderer.Pipeline.SetTransformFeedbackBuffer(index, buffer);
+                    tfbs[index] = GetBufferRange(tfb.Address, tfb.Size);
                 }
+
+                _context.Renderer.Pipeline.SetTransformFeedbackBuffers(tfbs);
             }
             else
             {

--- a/Ryujinx.Graphics.OpenGL/Buffer.cs
+++ b/Ryujinx.Graphics.OpenGL/Buffer.cs
@@ -6,6 +6,11 @@ namespace Ryujinx.Graphics.OpenGL
 {
     static class Buffer
     {
+        public static BufferHandle Create()
+        {
+            return Handle.FromInt32<BufferHandle>(GL.GenBuffer());
+        }
+
         public static BufferHandle Create(int size)
         {
             int handle = GL.GenBuffer();
@@ -38,6 +43,12 @@ namespace Ryujinx.Graphics.OpenGL
             GL.GetBufferSubData(BufferTarget.CopyReadBuffer, (IntPtr)offset, size, data);
 
             return data;
+        }
+
+        public static void Resize(BufferHandle handle, int size)
+        {
+            GL.BindBuffer(BufferTarget.CopyWriteBuffer, handle.ToInt32());
+            GL.BufferData(BufferTarget.CopyWriteBuffer, size, IntPtr.Zero, BufferUsageHint.StaticCopy);
         }
 
         public static void SetData(BufferHandle buffer, int offset, ReadOnlySpan<byte> data)

--- a/Ryujinx.Graphics.OpenGL/Buffer.cs
+++ b/Ryujinx.Graphics.OpenGL/Buffer.cs
@@ -48,7 +48,7 @@ namespace Ryujinx.Graphics.OpenGL
         public static void Resize(BufferHandle handle, int size)
         {
             GL.BindBuffer(BufferTarget.CopyWriteBuffer, handle.ToInt32());
-            GL.BufferData(BufferTarget.CopyWriteBuffer, size, IntPtr.Zero, BufferUsageHint.StaticCopy);
+            GL.BufferData(BufferTarget.CopyWriteBuffer, size, IntPtr.Zero, BufferUsageHint.StreamCopy);
         }
 
         public static void SetData(BufferHandle buffer, int offset, ReadOnlySpan<byte> data)

--- a/Ryujinx.Graphics.OpenGL/Constants.cs
+++ b/Ryujinx.Graphics.OpenGL/Constants.cs
@@ -6,5 +6,6 @@
         public const int MaxViewports = 16;
         public const int MaxVertexAttribs = 16;
         public const int MaxVertexBuffers = 16;
+        public const int MaxTransformFeedbackBuffers = 4;
     }
 }

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -50,6 +50,9 @@ namespace Ryujinx.Graphics.OpenGL
         private bool _tfEnabled;
         private TransformFeedbackPrimitiveType _tfTopology;
 
+        private readonly BufferHandle[] _tfbs;
+        private readonly BufferRange[] _tfbTargets;
+
         private ColorF _blendConstant;
 
         internal Pipeline()
@@ -74,6 +77,9 @@ namespace Ryujinx.Graphics.OpenGL
             {
                 _cpRenderScale[index] = 1f;
             }
+
+            _tfbs = new BufferHandle[Constants.MaxTransformFeedbackBuffers];
+            _tfbTargets = new BufferRange[Constants.MaxTransformFeedbackBuffers];
         }
 
         public void Barrier()
@@ -175,7 +181,7 @@ namespace Ryujinx.Graphics.OpenGL
                 return;
             }
 
-            PrepareForDraw();
+            PreDraw();
 
             if (_primitiveType == PrimitiveType.Quads)
             {
@@ -190,7 +196,7 @@ namespace Ryujinx.Graphics.OpenGL
                 DrawImpl(vertexCount, instanceCount, firstVertex, firstInstance);
             }
 
-            _framebuffer.SignalModified();
+            PostDraw();
         }
 
         private void DrawQuadsImpl(
@@ -293,7 +299,7 @@ namespace Ryujinx.Graphics.OpenGL
                 return;
             }
 
-            PrepareForDraw();
+            PreDraw();
 
             int indexElemSize = 1;
 
@@ -335,7 +341,7 @@ namespace Ryujinx.Graphics.OpenGL
                     firstInstance);
             }
 
-            _framebuffer.SignalModified();
+            PostDraw();
         }
 
         private void DrawQuadsIndexedImpl(
@@ -993,19 +999,39 @@ namespace Ryujinx.Graphics.OpenGL
             }
         }
 
-        public void SetTransformFeedbackBuffer(int index, BufferRange buffer)
+        public void SetTransformFeedbackBuffers(ReadOnlySpan<BufferRange> buffers)
         {
-            const BufferRangeTarget target = BufferRangeTarget.TransformFeedbackBuffer;
-
             if (_tfEnabled)
             {
                 GL.EndTransformFeedback();
-                GL.BindBufferRange(target, index, buffer.Handle.ToInt32(), (IntPtr)buffer.Offset, buffer.Size);
-                GL.BeginTransformFeedback(_tfTopology);
             }
-            else
+
+            int count = Math.Min(buffers.Length, Constants.MaxTransformFeedbackBuffers);
+
+            for (int i = 0; i < count; i++)
             {
-                GL.BindBufferRange(target, index, buffer.Handle.ToInt32(), (IntPtr)buffer.Offset, buffer.Size);
+                BufferRange buffer = buffers[i];
+                _tfbTargets[i] = buffer;
+
+                if (buffer.Handle == BufferHandle.Null)
+                {
+                    GL.BindBufferBase(BufferRangeTarget.TransformFeedbackBuffer, i, 0);
+                    continue;
+                }
+
+                if (_tfbs[i] == BufferHandle.Null)
+                {
+                    _tfbs[i] = Buffer.Create();
+                }
+
+                Buffer.Resize(_tfbs[i], buffer.Size);
+                Buffer.Copy(buffer.Handle, _tfbs[i], buffer.Offset, 0, buffer.Size);
+                GL.BindBufferBase(BufferRangeTarget.TransformFeedbackBuffer, i, _tfbs[i].ToInt32());
+            }
+
+            if (_tfEnabled)
+            {
+                GL.BeginTransformFeedback(_tfTopology);
             }
         }
 
@@ -1104,7 +1130,7 @@ namespace Ryujinx.Graphics.OpenGL
                 ? BufferRangeTarget.ShaderStorageBuffer
                 : BufferRangeTarget.UniformBuffer;
 
-            if (buffer.Handle == null)
+            if (buffer.Handle == BufferHandle.Null)
             {
                 GL.BindBufferRange(target, bindingPoint, 0, IntPtr.Zero, 0);
                 return;
@@ -1237,13 +1263,29 @@ namespace Ryujinx.Graphics.OpenGL
             }
         }
 
-        private void PrepareForDraw()
+        private void PreDraw()
         {
             _vertexArray.Validate();
 
             if (_unit0Texture != null)
             {
                 _unit0Texture.Bind(0);
+            }
+        }
+
+        private void PostDraw()
+        {
+            _framebuffer?.SignalModified();
+
+            if (_tfEnabled)
+            {
+                for (int i = 0; i < Constants.MaxTransformFeedbackBuffers; i++)
+                {
+                    if (_tfbTargets[i].Handle != BufferHandle.Null)
+                    {
+                        Buffer.Copy(_tfbs[i], _tfbTargets[i].Handle, 0, _tfbTargets[i].Offset, _tfbTargets[i].Size);
+                    }
+                }
             }
         }
 
@@ -1319,6 +1361,15 @@ namespace Ryujinx.Graphics.OpenGL
 
         public void Dispose()
         {
+            for (int i = 0; i < Constants.MaxTransformFeedbackBuffers; i++)
+            {
+                if (_tfbs[i] != BufferHandle.Null)
+                {
+                    Buffer.Delete(_tfbs[i]);
+                    _tfbs[i] = BufferHandle.Null;
+                }
+            }
+
             _framebuffer?.Dispose();
             _vertexArray?.Dispose();
         }

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -5,7 +5,6 @@ using Ryujinx.Graphics.OpenGL.Image;
 using Ryujinx.Graphics.OpenGL.Queries;
 using Ryujinx.Graphics.Shader;
 using System;
-using System.Threading;
 
 namespace Ryujinx.Graphics.OpenGL
 {
@@ -49,6 +48,7 @@ namespace Ryujinx.Graphics.OpenGL
         private bool _scissor0Enable = false;
 
         private bool _tfEnabled;
+        private TransformFeedbackPrimitiveType _tfTopology;
 
         private ColorF _blendConstant;
 
@@ -83,7 +83,7 @@ namespace Ryujinx.Graphics.OpenGL
 
         public void BeginTransformFeedback(PrimitiveTopology topology)
         {
-            GL.BeginTransformFeedback(topology.ConvertToTfType());
+            GL.BeginTransformFeedback(_tfTopology = topology.ConvertToTfType());
             _tfEnabled = true;
         }
 
@@ -790,9 +790,9 @@ namespace Ryujinx.Graphics.OpenGL
 
             if (_tfEnabled)
             {
-                GL.PauseTransformFeedback();
+                GL.EndTransformFeedback();
                 _program.Bind();
-                GL.ResumeTransformFeedback();
+                GL.BeginTransformFeedback(_tfTopology);
             }
             else
             {
@@ -999,9 +999,9 @@ namespace Ryujinx.Graphics.OpenGL
 
             if (_tfEnabled)
             {
-                GL.PauseTransformFeedback();
+                GL.EndTransformFeedback();
                 GL.BindBufferRange(target, index, buffer.Handle.ToInt32(), (IntPtr)buffer.Offset, buffer.Size);
-                GL.ResumeTransformFeedback();
+                GL.BeginTransformFeedback(_tfTopology);
             }
             else
             {

--- a/Ryujinx.Graphics.OpenGL/Program.cs
+++ b/Ryujinx.Graphics.OpenGL/Program.cs
@@ -131,8 +131,6 @@ namespace Ryujinx.Graphics.OpenGL
 
             CheckProgramLink();
 
-            Bind();
-
             int ubBindingPoint = 0;
             int sbBindingPoint = 0;
             int textureUnit    = 0;
@@ -189,7 +187,7 @@ namespace Ryujinx.Graphics.OpenGL
                         continue;
                     }
 
-                    GL.Uniform1(location, textureUnit);
+                    GL.ProgramUniform1(Handle, location, textureUnit);
 
                     int uIndex = (int)shader.Stage << TexStageShift | samplerIndex++;
 
@@ -209,7 +207,7 @@ namespace Ryujinx.Graphics.OpenGL
                         continue;
                     }
 
-                    GL.Uniform1(location, imageUnit);
+                    GL.ProgramUniform1(Handle, location, imageUnit);
 
                     int uIndex = (int)shader.Stage << ImgStageShift | imageIndex++;
 


### PR DESCRIPTION
The NVIDIA driver is returning an error if an attempt is made to resume transform feedback after changing the shader program. I couldn't find anything on the spec that forbids that, it just says:

> An INVALID_OPERATION error is generated by UseProgram if the current transform feedback object is active and not paused;

`glBindBufferRange` with the target set to transform feedback was also returning an error, which also seems to be caused by a transform feedback being currently active. So as a solution for both errors, it now ends and restarts the feedback instead of pausing and resuming it.

The last issue is that having transform feedback buffers used for anything else while the transform feedback is active is not valid and will cause the draw to fail. This is what blocked #1607. This is fixed here by first doing a copy from the TFB to a temporary internal TFB when it is bound, and then doing a copy from the temporary TFB back to the actual TFB after draw.

Special thanks to Rodrigo for the hint on how to do fast buffer re-allocations.

The shader `Program` constructor was also changed to use `glProgramUniform1` rather than `glUniform1`, because the latter requires a program to be currently bound (using `glUseProgram`), which is undesirable (because it changes the current shader program) and fails if the transform feedback is active. The former allows the program handle to be passed so nothing needs to be bound.

Other minor things that were fixed:
- Comparison of `BufferHandle` with null was being done, but `BufferHandle` is a struct. It now compares with `BufferHandle.Null` which is zero. Note that this will change behavior.
- `BufferHandle` has a `Empty` property that was supposed to be static, but wasn't. Fixed that and used it. Does not change behavior.

`SetTransformFeedbackBuffers` was also changed to take multiple buffers instead of just one at a time. This reduces the number of calls, but otherwise should not change behavior.

This fixes T-Posed models on SNK Heroines: Tag Team Frenzy:
Before (image from gamedb, not mine):
![image](https://user-images.githubusercontent.com/5624669/97065746-1eb65980-1586-11eb-9474-7039db096369.png)
After:
![image](https://user-images.githubusercontent.com/5624669/97085974-177b6400-15f7-11eb-8b34-faf8c20b4c45.png)
Should also fix the black grass issue on #1620.