### PR TITLE
Fix shader image load/store array index register

### DIFF
--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
@@ -40,8 +40,6 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 return context.Copy(Register(raIndex++, RegisterType.Gpr));
             }
 
-            Operand arrayIndex = type.HasFlag(SamplerType.Array) ? Ra() : null;
-
             List<Operand> sourcesList = new List<Operand>();
 
             if (op.IsBindless)
@@ -56,19 +54,19 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 sourcesList.Add(Ra());
             }
 
+            if (type.HasFlag(SamplerType.Array))
+            {
+                sourcesList.Add(Ra());
+
+                type |= SamplerType.Array;
+            }
+
             if (Sample1DAs2D && (type & SamplerType.Mask) == SamplerType.Texture1D)
             {
                 sourcesList.Add(Const(0));
 
                 type &= ~SamplerType.Mask;
                 type |= SamplerType.Texture2D;
-            }
-
-            if (type.HasFlag(SamplerType.Array))
-            {
-                sourcesList.Add(arrayIndex);
-
-                type |= SamplerType.Array;
             }
 
             Operand[] sources = sourcesList.ToArray();
@@ -193,8 +191,6 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 return context.Copy(Register(rbIndex++, RegisterType.Gpr));
             }
 
-            Operand arrayIndex = type.HasFlag(SamplerType.Array) ? Ra() : null;
-
             List<Operand> sourcesList = new List<Operand>();
 
             if (op.IsBindless)
@@ -209,19 +205,19 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 sourcesList.Add(Ra());
             }
 
+            if (type.HasFlag(SamplerType.Array))
+            {
+                sourcesList.Add(Ra());
+
+                type |= SamplerType.Array;
+            }
+
             if (Sample1DAs2D && (type & SamplerType.Mask) == SamplerType.Texture1D)
             {
                 sourcesList.Add(Const(0));
 
                 type &= ~SamplerType.Mask;
                 type |= SamplerType.Texture2D;
-            }
-
-            if (type.HasFlag(SamplerType.Array))
-            {
-                sourcesList.Add(arrayIndex);
-
-                type |= SamplerType.Array;
             }
 
             TextureFormat format = TextureFormat.Unknown;

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
@@ -54,19 +54,19 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 sourcesList.Add(Ra());
             }
 
-            if (type.HasFlag(SamplerType.Array))
-            {
-                sourcesList.Add(Ra());
-
-                type |= SamplerType.Array;
-            }
-
             if (Sample1DAs2D && (type & SamplerType.Mask) == SamplerType.Texture1D)
             {
                 sourcesList.Add(Const(0));
 
                 type &= ~SamplerType.Mask;
                 type |= SamplerType.Texture2D;
+            }
+
+            if (type.HasFlag(SamplerType.Array))
+            {
+                sourcesList.Add(Ra());
+
+                type |= SamplerType.Array;
             }
 
             Operand[] sources = sourcesList.ToArray();
@@ -205,19 +205,19 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 sourcesList.Add(Ra());
             }
 
-            if (type.HasFlag(SamplerType.Array))
-            {
-                sourcesList.Add(Ra());
-
-                type |= SamplerType.Array;
-            }
-
             if (Sample1DAs2D && (type & SamplerType.Mask) == SamplerType.Texture1D)
             {
                 sourcesList.Add(Const(0));
 
                 type &= ~SamplerType.Mask;
                 type |= SamplerType.Texture2D;
+            }
+
+            if (type.HasFlag(SamplerType.Array))
+            {
+                sourcesList.Add(Ra());
+
+                type |= SamplerType.Array;
             }
 
             TextureFormat format = TextureFormat.Unknown;


### PR DESCRIPTION
The coords were read from the wrong register for array image load/store.
This fixes the "screen too dark" in Yomi wo Saku Hana.
Before:
![image](https://user-images.githubusercontent.com/5624669/97109677-51aa3b80-16b3-11eb-9fe7-244365031779.png)
After:
![image](https://user-images.githubusercontent.com/5624669/97109667-46571000-16b3-11eb-8ea2-7ae61d0a8414.png)
Fixes #1635.