### PR TITLE
Avoid sampler conflicts on bindless samplers with the same name

### DIFF
--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
@@ -317,7 +317,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
                     continue;
                 }
 
-                string samplerTypeName = GetSamplerTypeName(texOp.Type);
+                string samplerTypeName = texOp.Type.ToGlslSamplerType();
 
                 context.AppendLine("uniform " + samplerTypeName + " " + samplerName + ";");
             }
@@ -382,7 +382,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
                     layout = "layout(" + layout + ") ";
                 }
 
-                string imageTypeName = GetImageTypeName(texOp.Type, texOp.Format.GetComponentType());
+                string imageTypeName = texOp.Type.ToGlslImageType(texOp.Format.GetComponentType());
 
                 context.AppendLine("uniform " + layout + imageTypeName + " " + imageName + ";");
             }
@@ -536,73 +536,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
             context.AppendLine(code.Replace("\t", CodeGenContext.Tab));
             context.AppendLine();
-        }
-
-        private static string GetSamplerTypeName(SamplerType type)
-        {
-            string typeName;
-
-            switch (type & SamplerType.Mask)
-            {
-                case SamplerType.Texture1D:     typeName = "sampler1D";     break;
-                case SamplerType.TextureBuffer: typeName = "samplerBuffer"; break;
-                case SamplerType.Texture2D:     typeName = "sampler2D";     break;
-                case SamplerType.Texture3D:     typeName = "sampler3D";     break;
-                case SamplerType.TextureCube:   typeName = "samplerCube";   break;
-
-                default: throw new ArgumentException($"Invalid sampler type \"{type}\".");
-            }
-
-            if ((type & SamplerType.Multisample) != 0)
-            {
-                typeName += "MS";
-            }
-
-            if ((type & SamplerType.Array) != 0)
-            {
-                typeName += "Array";
-            }
-
-            if ((type & SamplerType.Shadow) != 0)
-            {
-                typeName += "Shadow";
-            }
-
-            return typeName;
-        }
-
-        private static string GetImageTypeName(SamplerType type, VariableType componentType)
-        {
-            string typeName;
-
-            switch (type & SamplerType.Mask)
-            {
-                case SamplerType.Texture1D:     typeName = "image1D";     break;
-                case SamplerType.TextureBuffer: typeName = "imageBuffer"; break;
-                case SamplerType.Texture2D:     typeName = "image2D";     break;
-                case SamplerType.Texture3D:     typeName = "image3D";     break;
-                case SamplerType.TextureCube:   typeName = "imageCube";   break;
-
-                default: throw new ArgumentException($"Invalid sampler type \"{type}\".");
-            }
-
-            if ((type & SamplerType.Multisample) != 0)
-            {
-                typeName += "MS";
-            }
-
-            if ((type & SamplerType.Array) != 0)
-            {
-                typeName += "Array";
-            }
-
-            switch (componentType)
-            {
-                case VariableType.U32: typeName = 'u' + typeName; break;
-                case VariableType.S32: typeName = 'i' + typeName; break;
-            }
-
-            return typeName;
         }
     }
 }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
@@ -247,7 +247,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
             {
                 AstOperand operand = texOp.GetSource(0) as AstOperand;
 
-                suffix = "_cb" + operand.CbufSlot + "_" + operand.CbufOffset;
+                suffix = $"_{texOp.Type.ToGlslSamplerType()}_cb{operand.CbufSlot}_{operand.CbufOffset}";
             }
             else
             {

--- a/Ryujinx.Graphics.Shader/SamplerType.cs
+++ b/Ryujinx.Graphics.Shader/SamplerType.cs
@@ -1,3 +1,4 @@
+using Ryujinx.Graphics.Shader.StructuredIr;
 using System;
 
 namespace Ryujinx.Graphics.Shader
@@ -34,6 +35,73 @@ namespace Ryujinx.Graphics.Shader
             }
 
             throw new ArgumentException($"Invalid sampler type \"{type}\".");
+        }
+
+        public static string ToGlslSamplerType(this SamplerType type)
+        {
+            string typeName;
+
+            switch (type & SamplerType.Mask)
+            {
+                case SamplerType.Texture1D:     typeName = "sampler1D";     break;
+                case SamplerType.TextureBuffer: typeName = "samplerBuffer"; break;
+                case SamplerType.Texture2D:     typeName = "sampler2D";     break;
+                case SamplerType.Texture3D:     typeName = "sampler3D";     break;
+                case SamplerType.TextureCube:   typeName = "samplerCube";   break;
+
+                default: throw new ArgumentException($"Invalid sampler type \"{type}\".");
+            }
+
+            if ((type & SamplerType.Multisample) != 0)
+            {
+                typeName += "MS";
+            }
+
+            if ((type & SamplerType.Array) != 0)
+            {
+                typeName += "Array";
+            }
+
+            if ((type & SamplerType.Shadow) != 0)
+            {
+                typeName += "Shadow";
+            }
+
+            return typeName;
+        }
+
+        public static string ToGlslImageType(this SamplerType type, VariableType componentType)
+        {
+            string typeName;
+
+            switch (type & SamplerType.Mask)
+            {
+                case SamplerType.Texture1D:     typeName = "image1D";     break;
+                case SamplerType.TextureBuffer: typeName = "imageBuffer"; break;
+                case SamplerType.Texture2D:     typeName = "image2D";     break;
+                case SamplerType.Texture3D:     typeName = "image3D";     break;
+                case SamplerType.TextureCube:   typeName = "imageCube";   break;
+
+                default: throw new ArgumentException($"Invalid sampler type \"{type}\".");
+            }
+
+            if ((type & SamplerType.Multisample) != 0)
+            {
+                typeName += "MS";
+            }
+
+            if ((type & SamplerType.Array) != 0)
+            {
+                typeName += "Array";
+            }
+
+            switch (componentType)
+            {
+                case VariableType.U32: typeName = 'u' + typeName; break;
+                case VariableType.S32: typeName = 'i' + typeName; break;
+            }
+
+            return typeName;
         }
     }
 }


### PR DESCRIPTION
The shader decompiler currently tries to find the source of the handles for bindless texture accesses. If it's a constant buffer, it turns it into a regular texture access, and instructs the GPU emulator to read the handle from the respective constant buffer, and bind it properly. If said analysis fails however, it will create a sampler for a handle at constant buffer 0 at offset 0 (those values comes from the fact that the values are not changed from their defaults).

Anyway, the problem is that when the analysis fails for multiple texture accesses, it's possible that multiple texture sampling operations with different sampler types will share the sampler/name. This is invalid and causes the shader compilation to fail. This adds the sampler type to the name of the sampler itself to disambiguate.

This is intended to be a stop-gap solution until we get proper bindless texture support.
This improves rendering on Super Mario Party.
Before:
![image](https://user-images.githubusercontent.com/5624669/97240195-629aa000-17cc-11eb-84b5-49703658ebe1.png)
After:
![image](https://user-images.githubusercontent.com/5624669/97240215-71815280-17cc-11eb-97a3-9918396894fd.png)
Obviously some bindless accesses are still broken, but with this change the shader at least compiles and the characters render.