### PR TITLE
Preserve command line arguments when updater restarts Ryujinx

### DIFF
--- a/Ryujinx/Updater/UpdateDialog.cs
+++ b/Ryujinx/Updater/UpdateDialog.cs
@@ -45,6 +45,7 @@ namespace Ryujinx.Ui
             {
                 string ryuName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Ryujinx.exe" : "Ryujinx";
                 string ryuExe  = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ryuName);
+                string ryuArg = String.Join(" ", Environment.GetCommandLineArgs());
 
                 if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
@@ -52,7 +53,7 @@ namespace Ryujinx.Ui
                     unixFileInfo.FileAccessPermissions |= FileAccessPermissions.UserExecute;
                 }
 
-                Process.Start(ryuExe);
+                Process.Start(ryuExe, ryuArg);
 
                 Environment.Exit(0);
             }


### PR DESCRIPTION
Command line arguments are not preserved by the updater, and this causes an issue when the updater restarts Ryujinx in portable mode as it will create/use/modify its default directory instead.

This simple pull addresses the first part of #1594 

As far as the second part of the issue, where the updater perhaps overzealously deletes everything but log files and leaving a graveyard of empty folders, which causes problems in portable installs with a Ryujinx\user subfolder or something else the user places inside the Ryujinx folder is unexpectedly deleted, the idea of doing what fuller installers do comes to mind.

Perhaps an UpdateList.txt containing a list of files that the updater deletes is included in the ryujinx.zip/tar.gz/etc and placed in the unpacked directory for the updater to use upon the next upgrade.

The build system can run something like `forfiles /s /m *.txt /c "cmd /c echo @relpath"` or the correct command for the OS and include it in the distribution, or it could be generated by the updater itself after it unpacks the files in the temporary directory.