### PR TITLE
Add scaling for Texture2DArray when using TexelFetch.

### DIFF
--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
@@ -412,7 +412,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
                         if (pCount == 3 && isArray)
                         {
                             // The array index is not scaled, just x and y.
-                            return "ivec3(Helper_TexelFetchScale((" + vector + ").xy, " + index + "),(" + vector + ").z)";
+                            return "ivec3(Helper_TexelFetchScale((" + vector + ").xy, " + index + "), (" + vector + ").z)";
                         }
                         else if (pCount == 2 && !isArray)
                         {

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
@@ -414,7 +414,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
                             // The array index is not scaled, just x and y.
                             return "ivec3(Helper_TexelFetchScale((" + vector + ").xy, " + index + "),(" + vector + ").z)";
                         }
-                        else if (pCount == 2)
+                        else if (pCount == 2 && !isArray)
                         {
                             return "Helper_TexelFetchScale(" + vector + ", " + index + ")";
                         }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
@@ -407,20 +407,25 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
 
                     if ((context.Config.Stage == ShaderStage.Fragment || context.Config.Stage == ShaderStage.Compute) &&
                         (texOp.Flags & TextureFlags.Bindless) == 0 &&
-                        texOp.Type != SamplerType.Indexed &&
-                        pCount == 2)
+                        texOp.Type != SamplerType.Indexed)
                     {
-                        return "Helper_TexelFetchScale(" + vector + ", " + index + ")";
+                        if (pCount == 3 && isArray)
+                        {
+                            // The array index is not scaled, just x and y.
+                            return "ivec3(Helper_TexelFetchScale((" + vector + ").xy, " + index + "),(" + vector + ").z)";
+                        }
+                        else if (pCount == 2)
+                        {
+                            return "Helper_TexelFetchScale(" + vector + ", " + index + ")";
+                        }
                     }
-                    else
-                    {
-                        // Resolution scaling cannot be applied to this texture right now.
-                        // Flag so that we know to blacklist scaling on related textures when binding them.
 
-                        TextureDescriptor descriptor = context.TextureDescriptors[index];
-                        descriptor.Flags |= TextureUsageFlags.ResScaleUnsupported;
-                        context.TextureDescriptors[index] = descriptor;
-                    }
+                    // Resolution scaling cannot be applied to this texture right now.
+                    // Flag so that we know to blacklist scaling on related textures when binding them.
+
+                    TextureDescriptor descriptor = context.TextureDescriptors[index];
+                    descriptor.Flags |= TextureUsageFlags.ResScaleUnsupported;
+                    context.TextureDescriptors[index] = descriptor;
                 }
 
                 return vector;


### PR DESCRIPTION
Texture2DArray can be scaled without issue, so allow TexelFetch to apply for it.

- Scales x and y, does not scale layer.
- Does not allow Texture3D, Texture1D arrays to be scaled.

Fixes Res Scale in HW:AoC demo:

https://cdn.knightlab.com/libs/juxtapose/latest/embed/index.html?uid=0d23fa36-1952-11eb-83c8-ebb5d6f907df