### PR TITLE
Remove unused texture and sampler pool invalidation code

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/Pool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Pool.cs
@@ -86,46 +86,6 @@ namespace Ryujinx.Graphics.Gpu.Image
             });
         }
 
-        private void InvalidateRangeInternal(ulong offset, int size)
-        {
-            InvalidateRangeImpl(Address + offset, (ulong)size);
-        }
-
-        /// <summary>
-        /// Invalidates a range of memory of the GPU resource pool.
-        /// Entries that falls inside the speicified range will be invalidated,
-        /// causing all the data to be reloaded from guest memory.
-        /// </summary>
-        /// <param name="address">The start address of the range to invalidate</param>
-        /// <param name="size">The size of the range to invalidate</param>
-        public void InvalidateRange(ulong address, ulong size)
-        {
-            ulong endAddress = address + size;
-
-            ulong texturePoolEndAddress = Address + Size;
-
-            // If the range being invalidated is not overlapping the texture pool range,
-            // then we don't have anything to do, exit early.
-            if (address >= texturePoolEndAddress || endAddress <= Address)
-            {
-                return;
-            }
-
-            if (address < Address)
-            {
-                address = Address;
-            }
-
-            if (endAddress > texturePoolEndAddress)
-            {
-                endAddress = texturePoolEndAddress;
-            }
-
-            size = endAddress - address;
-
-            InvalidateRangeImpl(address, size);
-        }
-
         protected abstract void InvalidateRangeImpl(ulong address, ulong size);
 
         protected abstract void Delete(T item);

--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -395,18 +395,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Invalidates a range of memory on all GPU resource pools (both texture and sampler pools).
-        /// </summary>
-        /// <param name="address">Start address of the range to invalidate</param>
-        /// <param name="size">Size of the range to invalidate</param>
-        public void InvalidatePoolRange(ulong address, ulong size)
-        {
-            _samplerPool?.InvalidateRange(address, size);
-
-            _texturePoolCache.InvalidateRange(address, size);
-        }
-
-        /// <summary>
         /// Force all bound textures and images to be rebound the next time CommitBindings is called.
         /// </summary>
         public void Rebind()

--- a/Ryujinx.Graphics.Gpu/Image/TexturePoolCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePoolCache.cs
@@ -72,20 +72,5 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             return pool;
         }
-
-        /// <summary>
-        /// Invalidates a memory range of all intersecting texture pools on the cache.
-        /// </summary>
-        /// <param name="address">Start address of the range to invalidate</param>
-        /// <param name="size">Size of the range to invalidate</param>
-        public void InvalidateRange(ulong address, ulong size)
-        {
-            for (LinkedListNode<TexturePool> node = _pools.First; node != null; node = node.Next)
-            {
-                TexturePool pool = node.Value;
-
-                pool.InvalidateRange(address, size);
-            }
-        }
     }
 }


### PR DESCRIPTION
This is now unused (I think it was unused for a long time actually, I remember introducing them at one point, but in the end I did not use it, and after range tracking, I don't think it will be necessary), so we can remove it. Or, we can keep it too if anyone thinks it could be useful in the future...