### PR TITLE
Fix compressed to non-compressed texture copy size

### DIFF
--- a/Ryujinx.Graphics.OpenGL/Image/TextureCopyUnscaled.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureCopyUnscaled.cs
@@ -46,8 +46,8 @@ namespace Ryujinx.Graphics.OpenGL.Image
             }
             else if (srcInfo.IsCompressed && !dstInfo.IsCompressed)
             {
-                dstWidth  *= dstInfo.BlockWidth;
-                dstHeight *= dstInfo.BlockHeight;
+                dstWidth  *= srcInfo.BlockWidth;
+                dstHeight *= srcInfo.BlockHeight;
             }
 
             int width  = Math.Min(srcWidth,  dstWidth);


### PR DESCRIPTION
Current code was a no-op, if the format is not a compressed format, block width and height will be 1, it should multiply by the compressed format block size. I'm not aware of any specific game or graphical glitch that this fixes (probably none as I don't think it even does compressed -> uncompressed copies right now), but I noticed this long ago and figured it was probably worth to get it fixed anyway.