### PR TITLE
Only report that GPU commands are available when the queue is not empty.

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoDevice.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoDevice.cs
@@ -163,7 +163,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
         /// <returns>True if commands were received, false if wait timed out</returns>
         public bool WaitForCommands()
         {
-            return _event.WaitOne(8) && _commandBufferQueue.Count > 0;
+            return _event.WaitOne(8) && !_commandBufferQueue.IsEmpty;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoDevice.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoDevice.cs
@@ -163,7 +163,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
         /// <returns>True if commands were received, false if wait timed out</returns>
         public bool WaitForCommands()
         {
-            return _event.WaitOne(8);
+            return _event.WaitOne(8) && _commandBufferQueue.Count > 0;
         }
 
         /// <summary>


### PR DESCRIPTION
When certain games are running slowly (or at all), they submit commands to the queue while we are still executing commands from a previous submission. This can lead to the event for commands being present being set, but there being no commands on the queue. 

This PR adds an additional check to make sure commands are in the queue before continuing.

- Fixes Fifo% reading in a few games. (capped at 50% sometimes)

(this might indicate a larger problem where we are consuming 2 frames at once without presenting both)