### PR TITLE
Support res scale on images, correctly blacklist for SUST, move logic out of backend.

### DIFF
--- a/Ryujinx.Graphics.GAL/IPipeline.cs
+++ b/Ryujinx.Graphics.GAL/IPipeline.cs
@@ -92,6 +92,6 @@ namespace Ryujinx.Graphics.GAL
         bool TryHostConditionalRendering(ICounterEvent value, ICounterEvent compare, bool isEqual);
         void EndHostConditionalRendering();
 
-        void UpdateRenderScale(ShaderStage stage, int textureCount);
+        void UpdateRenderScale(ShaderStage stage, float[] scales, int textureCount, int imageCount);
     }
 }

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -195,6 +195,15 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Gets the first available bound colour target, or the depth stencil target if not present.
+        /// </summary>
+        /// <returns>The first bound colour target, otherwise the depth stencil target</returns>
+        public Texture GetAnyRenderTarget()
+        {
+            return _rtColors[0] ?? _rtDepthStencil;
+        }
+
+        /// <summary>
         /// Updates the Render Target scale, given the currently bound render targets.
         /// This will update scale to match the configured scale, scale textures that are eligible but not scaled,
         /// and propagate blacklisted status from one texture to the ones bound with it.

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/CodeGenContext.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/CodeGenContext.cs
@@ -84,7 +84,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
             AppendLine("}" + suffix);
         }
 
-        public int FindTextureDescriptorIndex(AstTextureOperation texOp)
+        private int FindDescriptorIndex(List<TextureDescriptor> list, AstTextureOperation texOp)
         {
             AstOperand operand = texOp.GetSource(0) as AstOperand;
             bool bindless = (texOp.Flags & TextureFlags.Bindless) > 0;
@@ -92,11 +92,22 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
             int cBufSlot = bindless ? operand.CbufSlot : 0;
             int cBufOffset = bindless ? operand.CbufOffset : 0;
 
-            return TextureDescriptors.FindIndex(descriptor =>
+            return list.FindIndex(descriptor =>
                 descriptor.Type == texOp.Type &&
                 descriptor.HandleIndex == texOp.Handle &&
+                descriptor.Format == texOp.Format &&
                 descriptor.CbufSlot == cBufSlot &&
                 descriptor.CbufOffset == cBufOffset);
+        }
+
+        public int FindTextureDescriptorIndex(AstTextureOperation texOp)
+        {
+            return FindDescriptorIndex(TextureDescriptors, texOp);
+        }
+
+        public int FindImageDescriptorIndex(AstTextureOperation texOp)
+        {
+            return FindDescriptorIndex(ImageDescriptors, texOp);
         }
 
         public StructuredFunction GetFunction(int id)

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
@@ -509,7 +509,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
             {
                 string stage = OperandManager.GetShaderStagePrefix(context.Config.Stage);
 
-                int scaleElements = context.TextureDescriptors.Count;
+                int scaleElements = context.TextureDescriptors.Count + context.ImageDescriptors.Count;
 
                 if (context.Config.Stage == ShaderStage.Fragment)
                 {

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
@@ -52,7 +52,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
                 int index = context.FindImageDescriptorIndex(texOp);
                 TextureUsageFlags flags = TextureUsageFlags.NeedsScaleValue;
 
-                if ((context.Config.Stage == ShaderStage.Fragment || (context.Config.Stage == ShaderStage.Compute) &&
+                if ((context.Config.Stage == ShaderStage.Fragment || context.Config.Stage == ShaderStage.Compute) &&
                     texOp.Inst == Instruction.ImageLoad &&
                     !isBindless &&
                     !isIndexed)

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
@@ -47,6 +47,43 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
                 texCall += ", " + str;
             }
 
+            string ApplyScaling(string vector)
+            {
+                int index = context.FindImageDescriptorIndex(texOp);
+                TextureUsageFlags flags = TextureUsageFlags.NeedsScaleValue;
+
+                if ((context.Config.Stage == ShaderStage.Fragment || (context.Config.Stage == ShaderStage.Compute) &&
+                    texOp.Inst == Instruction.ImageLoad &&
+                    !isBindless &&
+                    !isIndexed)
+                {
+                    // Image scales start after texture ones.
+                    int scaleIndex = context.TextureDescriptors.Count + index;
+
+                    if (pCount == 3 && isArray)
+                    {
+                        // The array index is not scaled, just x and y.
+                        vector = "ivec3(Helper_TexelFetchScale((" + vector + ").xy, " + scaleIndex + "), (" + vector + ").z)";
+                    }
+                    else if (pCount == 2 && !isArray)
+                    {
+                        vector = "Helper_TexelFetchScale(" + vector + ", " + scaleIndex + ")";
+                    }
+                    else
+                    {
+                        flags |= TextureUsageFlags.ResScaleUnsupported;
+                    }
+                }
+                else
+                {
+                    flags |= TextureUsageFlags.ResScaleUnsupported;
+                }
+
+                context.ImageDescriptors[index] = context.ImageDescriptors[index].SetFlag(flags);
+
+                return vector;
+            }
+
             if (pCount > 1)
             {
                 string[] elems = new string[pCount];
@@ -56,7 +93,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
                     elems[index] = Src(VariableType.S32);
                 }
 
-                Append("ivec" + pCount + "(" + string.Join(", ", elems) + ")");
+                Append(ApplyScaling("ivec" + pCount + "(" + string.Join(", ", elems) + ")"));
             }
             else
             {
@@ -404,28 +441,35 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
                 if (intCoords)
                 {
                     int index = context.FindTextureDescriptorIndex(texOp);
+                    TextureUsageFlags flags = TextureUsageFlags.NeedsScaleValue;
 
                     if ((context.Config.Stage == ShaderStage.Fragment || context.Config.Stage == ShaderStage.Compute) &&
-                        (texOp.Flags & TextureFlags.Bindless) == 0 &&
-                        texOp.Type != SamplerType.Indexed)
+                        !isBindless &&
+                        !isIndexed)
                     {
                         if (pCount == 3 && isArray)
                         {
                             // The array index is not scaled, just x and y.
-                            return "ivec3(Helper_TexelFetchScale((" + vector + ").xy, " + index + "), (" + vector + ").z)";
+                            vector = "ivec3(Helper_TexelFetchScale((" + vector + ").xy, " + index + "), (" + vector + ").z)";
                         }
                         else if (pCount == 2 && !isArray)
                         {
-                            return "Helper_TexelFetchScale(" + vector + ", " + index + ")";
+                            vector = "Helper_TexelFetchScale(" + vector + ", " + index + ")";
                         }
+                        else
+                        {
+                            flags |= TextureUsageFlags.ResScaleUnsupported;
+                        }
+                    } 
+                    else
+                    {
+                        // Resolution scaling cannot be applied to this texture right now.
+                        // Flag so that we know to blacklist scaling on related textures when binding them.
+
+                        flags |= TextureUsageFlags.ResScaleUnsupported;
                     }
 
-                    // Resolution scaling cannot be applied to this texture right now.
-                    // Flag so that we know to blacklist scaling on related textures when binding them.
-
-                    TextureDescriptor descriptor = context.TextureDescriptors[index];
-                    descriptor.Flags |= TextureUsageFlags.ResScaleUnsupported;
-                    context.TextureDescriptors[index] = descriptor;
+                    context.TextureDescriptors[index] = context.TextureDescriptors[index].SetFlag(flags);
                 }
 
                 return vector;

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
@@ -15,6 +15,8 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
         public static void Suld(EmitterContext context)
         {
+            context.Config.SetUsedFeature(FeatureFlags.IntegerSampling);
+
             OpCodeImage op = (OpCodeImage)context.CurrOp;
 
             SamplerType type = ConvertSamplerType(op.Dimensions);

--- a/Ryujinx.Graphics.Shader/TextureDescriptor.cs
+++ b/Ryujinx.Graphics.Shader/TextureDescriptor.cs
@@ -46,5 +46,12 @@ namespace Ryujinx.Graphics.Shader
 
             Flags = TextureUsageFlags.None;
         }
+
+        public TextureDescriptor SetFlag(TextureUsageFlags flag)
+        {
+            Flags |= flag;
+
+            return this;
+        }
     }
 }

--- a/Ryujinx.Graphics.Shader/TextureUsageFlags.cs
+++ b/Ryujinx.Graphics.Shader/TextureUsageFlags.cs
@@ -11,6 +11,7 @@ namespace Ryujinx.Graphics.Shader
         None = 0,
 
         // Integer sampled textures must be noted for resolution scaling.
-        ResScaleUnsupported = 1 << 0
+        ResScaleUnsupported = 1 << 0,
+        NeedsScaleValue = 1 << 1
     }
 }


### PR DESCRIPTION
Resolution scaling is now possible for bound images using SULD, and using SUST will force a blacklist. Additionally, scale calculation logic for texture/images has been moved out of the backend into the GPU, as it should be backend agnostic.

When res scaled:
- Fixes normal-map decals in Xenoblade Chronicles: DE.
- Should cause Paper Mario and Dead or Alive to force to 1x resolution instead of just breaking.
- May fix some other weird issues.

Before (2x):
![image](https://user-images.githubusercontent.com/6294155/97817411-3d0e0a80-1c94-11eb-9874-23036105d5fd.png)

After (2x):
![image](https://user-images.githubusercontent.com/6294155/97817511-d2a99a00-1c94-11eb-98e2-685144775ffb.png)


Should have no effect when res scale is disabled. May do less work when res scale is not needed in the shader, as a result of some restructuring.