### PR TITLE
Add seamless cubemap flag in sampler parameters.

### DIFF
--- a/Ryujinx.Graphics.GAL/SamplerCreateInfo.cs
+++ b/Ryujinx.Graphics.GAL/SamplerCreateInfo.cs
@@ -5,6 +5,8 @@ namespace Ryujinx.Graphics.GAL
         public MinFilter MinFilter { get; }
         public MagFilter MagFilter { get; }
 
+        public bool SeamlessCubemap { get; }
+
         public AddressMode AddressU { get; }
         public AddressMode AddressV { get; }
         public AddressMode AddressP { get; }
@@ -22,6 +24,7 @@ namespace Ryujinx.Graphics.GAL
         public SamplerCreateInfo(
             MinFilter   minFilter,
             MagFilter   magFilter,
+            bool        seamlessCubemap,
             AddressMode addressU,
             AddressMode addressV,
             AddressMode addressP,
@@ -33,18 +36,19 @@ namespace Ryujinx.Graphics.GAL
             float       mipLodBias,
             float       maxAnisotropy)
         {
-            MinFilter     = minFilter;
-            MagFilter     = magFilter;
-            AddressU      = addressU;
-            AddressV      = addressV;
-            AddressP      = addressP;
-            CompareMode   = compareMode;
-            CompareOp     = compareOp;
-            BorderColor   = borderColor;
-            MinLod        = minLod;
-            MaxLod        = maxLod;
-            MipLodBias    = mipLodBias;
-            MaxAnisotropy = maxAnisotropy;
+            MinFilter       = minFilter;
+            MagFilter       = magFilter;
+            SeamlessCubemap = seamlessCubemap;
+            AddressU        = addressU;
+            AddressV        = addressV;
+            AddressP        = addressP;
+            CompareMode     = compareMode;
+            CompareOp       = compareOp;
+            BorderColor     = borderColor;
+            MinLod          = minLod;
+            MaxLod          = maxLod;
+            MipLodBias      = mipLodBias;
+            MaxAnisotropy   = maxAnisotropy;
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Image/Sampler.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Sampler.cs
@@ -23,6 +23,8 @@ namespace Ryujinx.Graphics.Gpu.Image
             MinFilter minFilter = descriptor.UnpackMinFilter();
             MagFilter magFilter = descriptor.UnpackMagFilter();
 
+            bool seamlessCubemap = descriptor.UnpackSeamlessCubemap();
+
             AddressMode addressU = descriptor.UnpackAddressU();
             AddressMode addressV = descriptor.UnpackAddressV();
             AddressMode addressP = descriptor.UnpackAddressP();
@@ -49,6 +51,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             HostSampler = context.Renderer.CreateSampler(new SamplerCreateInfo(
                 minFilter,
                 magFilter,
+                seamlessCubemap,
                 addressU,
                 addressV,
                 addressP,

--- a/Ryujinx.Graphics.Gpu/Image/SamplerDescriptor.cs
+++ b/Ryujinx.Graphics.Gpu/Image/SamplerDescriptor.cs
@@ -185,6 +185,15 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Unpacks the seamless cubemap flag.
+        /// </summary>
+        /// <returns>The seamless cubemap flag</returns>
+        public bool UnpackSeamlessCubemap()
+        {
+            return (Word1 & (1 << 9)) != 0;
+        }
+
+        /// <summary>
         /// Unpacks the reduction filter, used with texture minification linear filtering.
         /// This describes how the final value will be computed from neighbouring pixels.
         /// </summary>

--- a/Ryujinx.Graphics.OpenGL/HwCapabilities.cs
+++ b/Ryujinx.Graphics.OpenGL/HwCapabilities.cs
@@ -5,10 +5,11 @@ namespace Ryujinx.Graphics.OpenGL
 {
     static class HwCapabilities
     {
-        private static readonly Lazy<bool> _supportsAstcCompression    = new Lazy<bool>(() => HasExtension("GL_KHR_texture_compression_astc_ldr"));
-        private static readonly Lazy<bool> _supportsImageLoadFormatted = new Lazy<bool>(() => HasExtension("GL_EXT_shader_image_load_formatted"));
-        private static readonly Lazy<bool> _supportsPolygonOffsetClamp = new Lazy<bool>(() => HasExtension("GL_EXT_polygon_offset_clamp"));
-        private static readonly Lazy<bool> _supportsViewportSwizzle    = new Lazy<bool>(() => HasExtension("GL_NV_viewport_swizzle"));
+        private static readonly Lazy<bool> _supportsAstcCompression           = new Lazy<bool>(() => HasExtension("GL_KHR_texture_compression_astc_ldr"));
+        private static readonly Lazy<bool> _supportsImageLoadFormatted        = new Lazy<bool>(() => HasExtension("GL_EXT_shader_image_load_formatted"));
+        private static readonly Lazy<bool> _supportsPolygonOffsetClamp        = new Lazy<bool>(() => HasExtension("GL_EXT_polygon_offset_clamp"));
+        private static readonly Lazy<bool> _supportsViewportSwizzle           = new Lazy<bool>(() => HasExtension("GL_NV_viewport_swizzle"));
+        private static readonly Lazy<bool> _supportsSeamlessCubemapPerTexture = new Lazy<bool>(() => HasExtension("GL_ARB_seamless_cubemap_per_texture"));
 
         private static readonly Lazy<int> _maximumComputeSharedMemorySize = new Lazy<int>(() => GetLimit(All.MaxComputeSharedMemorySize));
         private static readonly Lazy<int> _storageBufferOffsetAlignment   = new Lazy<int>(() => GetLimit(All.ShaderStorageBufferOffsetAlignment));
@@ -27,11 +28,12 @@ namespace Ryujinx.Graphics.OpenGL
 
         private static Lazy<float> _maxSupportedAnisotropy = new Lazy<float>(GL.GetFloat((GetPName)All.MaxTextureMaxAnisotropy));
 
-        public static bool SupportsAstcCompression          => _supportsAstcCompression.Value;
-        public static bool SupportsImageLoadFormatted       => _supportsImageLoadFormatted.Value;
-        public static bool SupportsPolygonOffsetClamp       => _supportsPolygonOffsetClamp.Value;
-        public static bool SupportsViewportSwizzle          => _supportsViewportSwizzle.Value;
-        public static bool SupportsNonConstantTextureOffset => _gpuVendor.Value == GpuVendor.Nvidia;
+        public static bool SupportsAstcCompression           => _supportsAstcCompression.Value;
+        public static bool SupportsImageLoadFormatted        => _supportsImageLoadFormatted.Value;
+        public static bool SupportsPolygonOffsetClamp        => _supportsPolygonOffsetClamp.Value;
+        public static bool SupportsViewportSwizzle           => _supportsViewportSwizzle.Value;
+        public static bool SupportsSeamlessCubemapPerTexture => _supportsSeamlessCubemapPerTexture.Value;
+        public static bool SupportsNonConstantTextureOffset  => _gpuVendor.Value == GpuVendor.Nvidia;
 
         public static int MaximumComputeSharedMemorySize => _maximumComputeSharedMemorySize.Value;
         public static int StorageBufferOffsetAlignment   => _storageBufferOffsetAlignment.Value;

--- a/Ryujinx.Graphics.OpenGL/Image/Sampler.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/Sampler.cs
@@ -14,7 +14,10 @@ namespace Ryujinx.Graphics.OpenGL.Image
             GL.SamplerParameter(Handle, SamplerParameterName.TextureMinFilter, (int)info.MinFilter.Convert());
             GL.SamplerParameter(Handle, SamplerParameterName.TextureMagFilter, (int)info.MagFilter.Convert());
 
-            GL.SamplerParameter(Handle, (SamplerParameterName)ArbSeamlessCubemapPerTexture.TextureCubeMapSeamless, info.SeamlessCubemap ? 1 : 0);
+            if (HwCapabilities.SupportsSeamlessCubemapPerTexture)
+            {
+                GL.SamplerParameter(Handle, (SamplerParameterName)ArbSeamlessCubemapPerTexture.TextureCubeMapSeamless, info.SeamlessCubemap ? 1 : 0);
+            }
 
             GL.SamplerParameter(Handle, SamplerParameterName.TextureWrapS, (int)info.AddressU.Convert());
             GL.SamplerParameter(Handle, SamplerParameterName.TextureWrapT, (int)info.AddressV.Convert());

--- a/Ryujinx.Graphics.OpenGL/Image/Sampler.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/Sampler.cs
@@ -14,6 +14,8 @@ namespace Ryujinx.Graphics.OpenGL.Image
             GL.SamplerParameter(Handle, SamplerParameterName.TextureMinFilter, (int)info.MinFilter.Convert());
             GL.SamplerParameter(Handle, SamplerParameterName.TextureMagFilter, (int)info.MagFilter.Convert());
 
+            GL.SamplerParameter(Handle, (SamplerParameterName)ArbSeamlessCubemapPerTexture.TextureCubeMapSeamless, info.SeamlessCubemap ? 1 : 0);
+
             GL.SamplerParameter(Handle, SamplerParameterName.TextureWrapS, (int)info.AddressU.Convert());
             GL.SamplerParameter(Handle, SamplerParameterName.TextureWrapT, (int)info.AddressV.Convert());
             GL.SamplerParameter(Handle, SamplerParameterName.TextureWrapR, (int)info.AddressP.Convert());


### PR DESCRIPTION
Adds the seamless cubemap flag for samplers, which allows linear blending over cubemap edges. This removes hard edges from cubemaps, and specifically improves really low res cubemaps (used for glossy surfaces).

As seen on nouveau, and supposedly set on every texture by NVN.
https://github.com/envytools/envytools/blob/master/rnndb/graph/g80_texture.xml#L389

There is also a global setting for this, but since the per-texture one is set by NVN I just used that instead. Other guest apis may expect the global setting, which should be added separately.

Before:
![image](https://user-images.githubusercontent.com/6294155/97818321-b8be8600-1c99-11eb-9886-c4c0ba41a06d.png)

After:
![image](https://user-images.githubusercontent.com/6294155/97818347-d986db80-1c99-11eb-8031-41fe960ccdf3.png)

(this does not fix missing cubemaps in mario kart 8)

