### PR TITLE
Fix LiveInterval.Split

### DIFF
--- a/ARMeilleure/CodeGen/RegisterAllocators/LiveInterval.cs
+++ b/ARMeilleure/CodeGen/RegisterAllocators/LiveInterval.cs
@@ -287,7 +287,7 @@ namespace ARMeilleure.CodeGen.RegisterAllocators
             {
                 LiveRange range = _ranges[splitIndex];
 
-                if (position > range.Start && position <= range.End)
+                if (position > range.Start && position < range.End)
                 {
                     right._ranges.Add(new LiveRange(position, range.End));
 


### PR DESCRIPTION
Before when splitting intervals, the end of the range would be included in the split check, this can produce empty ranges in the child split.

This in turn can affect spilling decisions since the child split will have a different start position. This empty range will cause the interval get a register earlier than needed and move to the active set for a brief moment.

For example:
```
  A = [153, 172[; [1899, 1916[; [1991, 2010[; [2397, 2414[; ...

  Split(A, 1916)

  A.0 = [153, 172[; [1899, 1916[
  A.1 = [1916, 1916[; [1991, 2010[; [2397, 2414[; ...
```

Not sure if this caused spooky stuff to happen.