### PR TITLE
apm/am: Refactoring/Unstub services

### DIFF
--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -15,6 +15,7 @@ using Ryujinx.HLE.HOS.Kernel.Memory;
 using Ryujinx.HLE.HOS.Kernel.Process;
 using Ryujinx.HLE.HOS.Kernel.Threading;
 using Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.SystemAppletProxy;
+using Ryujinx.HLE.HOS.Services.Apm;
 using Ryujinx.HLE.HOS.Services.Arp;
 using Ryujinx.HLE.HOS.Services.Audio.AudioRenderer;
 using Ryujinx.HLE.HOS.Services.Mii;
@@ -52,6 +53,8 @@ namespace Ryujinx.HLE.HOS
         internal VirtualDeviceSessionRegistry AudioDeviceSessionRegistry { get; private set; }
 
         public SystemStateMgr State { get; private set; }
+
+        public PerformanceState PerformanceState { get; private set; }
 
         internal AppletStateMgr AppletState { get; private set; }
 
@@ -93,6 +96,8 @@ namespace Ryujinx.HLE.HOS
             Device = device;
 
             State = new SystemStateMgr();
+
+            PerformanceState = new PerformanceState();
 
             // Note: This is not really correct, but with HLE of services, the only memory
             // region used that is used is Application, so we can use the other ones for anything.

--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -54,7 +54,7 @@ namespace Ryujinx.HLE.HOS
 
         public SystemStateMgr State { get; private set; }
 
-        public PerformanceState PerformanceState { get; private set; }
+        internal PerformanceState PerformanceState { get; private set; }
 
         internal AppletStateMgr AppletState { get; private set; }
 

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/ISystemAppletProxy.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/ISystemAppletProxy.cs
@@ -10,7 +10,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService
         // GetCommonStateGetter() -> object<nn::am::service::ICommonStateGetter>
         public ResultCode GetCommonStateGetter(ServiceCtx context)
         {
-            MakeObject(context, new ICommonStateGetter());
+            MakeObject(context, new ICommonStateGetter(context));
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
@@ -135,9 +135,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
                 return ResultCode.InvalidParameters;
             }
 
-            context.RequestData.BaseStream.Position = 0;
-
-            apmSystemManagerServer.SetCpuBoostMode(context);
+            apmSystemManagerServer.SetCpuBoostMode((Apm.CpuBoostMode)cpuBoostMode);
 
             // TODO: It signals an internal event of ICommonStateGetter. We have to determine where this event is used. 
 

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
@@ -8,9 +8,16 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
 {
     class ICommonStateGetter : IpcService
     {
-        private bool         _vrModeEnabled = false;
+        private Apm.ManagerServer       apmManagerServer;
+        private Apm.SystemManagerServer apmSystemManagerServer;
 
-        public ICommonStateGetter() { }
+        private bool _vrModeEnabled = false;
+
+        public ICommonStateGetter(ServiceCtx context)
+        {
+            apmManagerServer       = new Apm.ManagerServer(context);
+            apmSystemManagerServer = new Apm.SystemManagerServer(context);
+        }
 
         [Command(0)]
         // GetEventHandle() -> handle<copy>
@@ -59,7 +66,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // GetPerformanceMode() -> nn::apm::PerformanceMode
         public ResultCode GetPerformanceMode(ServiceCtx context)
         {
-            return (ResultCode)Apm.IManager.GetPerformanceModeImpl(context);
+            return (ResultCode)apmManagerServer.GetPerformanceMode(context);
         }
 
         [Command(8)]
@@ -128,7 +135,9 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
                 return ResultCode.InvalidParameters;
             }
 
-            Apm.ISystemManager.SetCpuBoostModeImpl(cpuBoostMode);
+            context.RequestData.BaseStream.Position = 0;
+
+            apmSystemManagerServer.SetCpuBoostMode(context);
 
             // TODO: It signals an internal event of ICommonStateGetter. We have to determine where this event is used. 
 
@@ -139,7 +148,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // GetCurrentPerformanceConfiguration() -> nn::apm::PerformanceConfiguration
         public ResultCode GetCurrentPerformanceConfiguration(ServiceCtx context)
         {
-            return (ResultCode)Apm.ISystemManager.GetCurrentPerformanceConfigurationImpl(context);
+            return (ResultCode)apmSystemManagerServer.GetCurrentPerformanceConfiguration(context);
         }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/IApplicationProxy.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/IApplicationProxy.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService
         // GetCommonStateGetter() -> object<nn::am::service::ICommonStateGetter>
         public ResultCode GetCommonStateGetter(ServiceCtx context)
         {
-            MakeObject(context, new ICommonStateGetter());
+            MakeObject(context, new ICommonStateGetter(context));
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Apm/IManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/IManager.cs
@@ -1,8 +1,6 @@
 namespace Ryujinx.HLE.HOS.Services.Apm
 {
-    [Service("apm")]
-    [Service("apm:am")] // 8.0.0+
-    class IManager : IpcService
+    abstract class IManager : IpcService
     {
         public IManager(ServiceCtx context) { }
 
@@ -10,21 +8,21 @@ namespace Ryujinx.HLE.HOS.Services.Apm
         // OpenSession() -> object<nn::apm::ISession>
         public ResultCode OpenSession(ServiceCtx context)
         {
-            MakeObject(context, new ISession());
+            ResultCode resultCode = OpenSession(out ISession sessionObj);
 
-            return ResultCode.Success;
+            if (resultCode == ResultCode.Success)
+            {
+                MakeObject(context, sessionObj);
+            }
+
+            return resultCode;
         }
 
         [Command(1)]
         // GetPerformanceMode() -> nn::apm::PerformanceMode
         public ResultCode GetPerformanceMode(ServiceCtx context)
         {
-            return GetPerformanceModeImpl(context);
-        }
-
-        public static ResultCode GetPerformanceModeImpl(ServiceCtx context)
-        {
-            context.ResponseData.Write((uint)PerformanceState.PerformanceMode);
+            context.ResponseData.Write((uint)GetPerformanceMode());
 
             return ResultCode.Success;
         }
@@ -33,9 +31,15 @@ namespace Ryujinx.HLE.HOS.Services.Apm
         // IsCpuOverclockEnabled() -> bool
         public ResultCode IsCpuOverclockEnabled(ServiceCtx context)
         {
-            context.ResponseData.Write(PerformanceState.CpuOverclockEnabled);
+            context.ResponseData.Write(IsCpuOverclockEnabled());
 
             return ResultCode.Success;
         }
+
+        protected abstract ResultCode OpenSession(out ISession sessionObj);
+
+        protected abstract PerformanceMode GetPerformanceMode();
+
+        protected abstract bool IsCpuOverclockEnabled();
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Apm/IManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/IManager.cs
@@ -4,15 +4,19 @@ namespace Ryujinx.HLE.HOS.Services.Apm
     {
         public IManager(ServiceCtx context) { }
 
+        protected abstract ResultCode OpenSession(out SessionServer sessionServer);
+        protected abstract PerformanceMode GetPerformanceMode();
+        protected abstract bool IsCpuOverclockEnabled();
+
         [Command(0)]
         // OpenSession() -> object<nn::apm::ISession>
         public ResultCode OpenSession(ServiceCtx context)
         {
-            ResultCode resultCode = OpenSession(out ISession sessionObj);
+            ResultCode resultCode = OpenSession(out SessionServer sessionServer);
 
             if (resultCode == ResultCode.Success)
             {
-                MakeObject(context, sessionObj);
+                MakeObject(context, sessionServer);
             }
 
             return resultCode;
@@ -35,11 +39,5 @@ namespace Ryujinx.HLE.HOS.Services.Apm
 
             return ResultCode.Success;
         }
-
-        protected abstract ResultCode OpenSession(out ISession sessionObj);
-
-        protected abstract PerformanceMode GetPerformanceMode();
-
-        protected abstract bool IsCpuOverclockEnabled();
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Apm/IManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/IManager.cs
@@ -1,6 +1,7 @@
 namespace Ryujinx.HLE.HOS.Services.Apm
 {
-    [Service("apm")] // 8.0.0+
+    [Service("apm")]
+    [Service("apm:am")] // 8.0.0+
     class IManager : IpcService
     {
         public IManager(ServiceCtx context) { }
@@ -10,6 +11,29 @@ namespace Ryujinx.HLE.HOS.Services.Apm
         public ResultCode OpenSession(ServiceCtx context)
         {
             MakeObject(context, new ISession());
+
+            return ResultCode.Success;
+        }
+
+        [Command(1)]
+        // GetPerformanceMode() -> nn::apm::PerformanceMode
+        public ResultCode GetPerformanceMode(ServiceCtx context)
+        {
+            return GetPerformanceModeImpl(context);
+        }
+
+        public static ResultCode GetPerformanceModeImpl(ServiceCtx context)
+        {
+            context.ResponseData.Write((uint)PerformanceState.PerformanceMode);
+
+            return ResultCode.Success;
+        }
+
+        [Command(6)] // 7.0.0+
+        // IsCpuOverclockEnabled() -> bool
+        public ResultCode IsCpuOverclockEnabled(ServiceCtx context)
+        {
+            context.ResponseData.Write(PerformanceState.CpuOverclockEnabled);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Apm/ISession.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/ISession.cs
@@ -10,8 +10,26 @@ namespace Ryujinx.HLE.HOS.Services.Apm
         // SetPerformanceConfiguration(nn::apm::PerformanceMode, nn::apm::PerformanceConfiguration)
         public ResultCode SetPerformanceConfiguration(ServiceCtx context)
         {
-            PerformanceMode          perfMode   = (PerformanceMode)context.RequestData.ReadInt32();
-            PerformanceConfiguration perfConfig = (PerformanceConfiguration)context.RequestData.ReadInt32();
+            PerformanceMode          performanceMode          = (PerformanceMode)context.RequestData.ReadInt32();
+            PerformanceConfiguration performanceConfiguration = (PerformanceConfiguration)context.RequestData.ReadInt32();
+
+            if (performanceMode > PerformanceMode.Boost)
+            {
+                return ResultCode.InvalidParameters;
+            }
+
+            switch (performanceMode)
+            {
+                case PerformanceMode.Default: 
+                    PerformanceState.DefaultPerformanceConfiguration = performanceConfiguration; 
+                    break;
+                case PerformanceMode.Boost:   
+                    PerformanceState.BoostPerformanceConfiguration = performanceConfiguration; 
+                    break;
+                default:
+                    Logger.Error?.PrintMsg(LogClass.ServiceApm, $"PerformanceMode isn't supported: {performanceMode}");
+                    break;
+            }
 
             return ResultCode.Success;
         }
@@ -20,11 +38,25 @@ namespace Ryujinx.HLE.HOS.Services.Apm
         // GetPerformanceConfiguration(nn::apm::PerformanceMode) -> nn::apm::PerformanceConfiguration
         public ResultCode GetPerformanceConfiguration(ServiceCtx context)
         {
-            PerformanceMode perfMode = (PerformanceMode)context.RequestData.ReadInt32();
+            PerformanceMode performanceMode = (PerformanceMode)context.RequestData.ReadInt32();
 
-            context.ResponseData.Write((uint)PerformanceConfiguration.PerformanceConfiguration1);
+            if (performanceMode > PerformanceMode.Boost)
+            {
+                return ResultCode.InvalidParameters;
+            }
 
-            Logger.Stub?.PrintStub(LogClass.ServiceApm);
+            context.ResponseData.Write((uint)PerformanceState.GetCurrentPerformanceConfiguration(performanceMode));
+
+            return ResultCode.Success;
+        }
+
+        [Command(2)] // 8.0.0+
+        // SetCpuOverclockEnabled(bool)
+        public ResultCode SetCpuOverclockEnabled(ServiceCtx context)
+        {
+            PerformanceState.CpuOverclockEnabled = context.RequestData.ReadBoolean();
+
+            // NOTE: This call seems to overclock the system, since we emulate it, it's fine to do nothing instead.
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Apm/ISession.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/ISession.cs
@@ -2,7 +2,7 @@ namespace Ryujinx.HLE.HOS.Services.Apm
 {
     abstract class ISession : IpcService
     {
-        public ISession() { }
+        public ISession(ServiceCtx context) { }
 
         protected abstract ResultCode SetPerformanceConfiguration(PerformanceMode performanceMode, PerformanceConfiguration performanceConfiguration);
         protected abstract ResultCode GetPerformanceConfiguration(PerformanceMode performanceMode, out PerformanceConfiguration performanceConfiguration);

--- a/Ryujinx.HLE/HOS/Services/Apm/ISystemManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/ISystemManager.cs
@@ -1,7 +1,6 @@
 namespace Ryujinx.HLE.HOS.Services.Apm
 {
-    [Service("apm:sys")]
-    class ISystemManager : IpcService
+    abstract class ISystemManager : IpcService
     {
         public ISystemManager(ServiceCtx context) { }
 
@@ -9,7 +8,7 @@ namespace Ryujinx.HLE.HOS.Services.Apm
         // RequestPerformanceMode(nn::apm::PerformanceMode)
         public ResultCode RequestPerformanceMode(ServiceCtx context)
         {
-            PerformanceState.PerformanceMode = (PerformanceMode)context.RequestData.ReadInt32();
+            RequestPerformanceMode((PerformanceMode)context.RequestData.ReadInt32());
 
             // NOTE: This call seems to overclock the system related to the PerformanceMode, since we emulate it, it's fine to do nothing instead.
 
@@ -20,12 +19,7 @@ namespace Ryujinx.HLE.HOS.Services.Apm
         // SetCpuBoostMode(nn::apm::CpuBootMode)
         public ResultCode SetCpuBoostMode(ServiceCtx context)
         {
-            return SetCpuBoostModeImpl(context.RequestData.ReadUInt32());
-        }
-
-        public static ResultCode SetCpuBoostModeImpl(uint cpuBoostMode)
-        {
-            PerformanceState.CpuBoostMode = (CpuBoostMode)cpuBoostMode;
+            SetCpuBoostMode((CpuBoostMode)context.RequestData.ReadUInt32());
 
             // NOTE: This call seems to overclock the system related to the CpuBoostMode, since we emulate it, it's fine to do nothing instead.
 
@@ -36,14 +30,15 @@ namespace Ryujinx.HLE.HOS.Services.Apm
         // GetCurrentPerformanceConfiguration() -> nn::apm::PerformanceConfiguration
         public ResultCode GetCurrentPerformanceConfiguration(ServiceCtx context)
         {
-            return GetCurrentPerformanceConfigurationImpl(context);
-        }
-
-        public static ResultCode GetCurrentPerformanceConfigurationImpl(ServiceCtx context)
-        {
-            context.ResponseData.Write((uint)PerformanceState.GetCurrentPerformanceConfiguration(PerformanceState.PerformanceMode));
+            context.ResponseData.Write((uint)GetCurrentPerformanceConfiguration());
 
             return ResultCode.Success;
         }
+
+        protected abstract void RequestPerformanceMode(PerformanceMode performanceMode);
+
+        protected abstract void SetCpuBoostMode(CpuBoostMode cpuBoostMode);
+
+        protected abstract PerformanceConfiguration GetCurrentPerformanceConfiguration();
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Apm/ISystemManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/ISystemManager.cs
@@ -1,0 +1,49 @@
+namespace Ryujinx.HLE.HOS.Services.Apm
+{
+    [Service("apm:sys")]
+    class ISystemManager : IpcService
+    {
+        public ISystemManager(ServiceCtx context) { }
+
+        [Command(0)]
+        // RequestPerformanceMode(nn::apm::PerformanceMode)
+        public ResultCode RequestPerformanceMode(ServiceCtx context)
+        {
+            PerformanceState.PerformanceMode = (PerformanceMode)context.RequestData.ReadInt32();
+
+            // NOTE: This call seems to overclock the system related to the PerformanceMode, since we emulate it, it's fine to do nothing instead.
+
+            return ResultCode.Success;
+        }
+
+        [Command(6)] // 7.0.0+
+        // SetCpuBoostMode(nn::apm::CpuBootMode)
+        public ResultCode SetCpuBoostMode(ServiceCtx context)
+        {
+            return SetCpuBoostModeImpl(context.RequestData.ReadUInt32());
+        }
+
+        public static ResultCode SetCpuBoostModeImpl(uint cpuBoostMode)
+        {
+            PerformanceState.CpuBoostMode = (CpuBoostMode)cpuBoostMode;
+
+            // NOTE: This call seems to overclock the system related to the CpuBoostMode, since we emulate it, it's fine to do nothing instead.
+
+            return ResultCode.Success;
+        }
+
+        [Command(7)] // 7.0.0+
+        // GetCurrentPerformanceConfiguration() -> nn::apm::PerformanceConfiguration
+        public ResultCode GetCurrentPerformanceConfiguration(ServiceCtx context)
+        {
+            return GetCurrentPerformanceConfigurationImpl(context);
+        }
+
+        public static ResultCode GetCurrentPerformanceConfigurationImpl(ServiceCtx context)
+        {
+            context.ResponseData.Write((uint)PerformanceState.GetCurrentPerformanceConfiguration(PerformanceState.PerformanceMode));
+
+            return ResultCode.Success;
+        }
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Apm/ISystemManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/ISystemManager.cs
@@ -4,6 +4,10 @@ namespace Ryujinx.HLE.HOS.Services.Apm
     {
         public ISystemManager(ServiceCtx context) { }
 
+        protected abstract void RequestPerformanceMode(PerformanceMode performanceMode);
+        internal abstract void SetCpuBoostMode(CpuBoostMode cpuBoostMode);
+        protected abstract PerformanceConfiguration GetCurrentPerformanceConfiguration();
+
         [Command(0)]
         // RequestPerformanceMode(nn::apm::PerformanceMode)
         public ResultCode RequestPerformanceMode(ServiceCtx context)
@@ -34,11 +38,5 @@ namespace Ryujinx.HLE.HOS.Services.Apm
 
             return ResultCode.Success;
         }
-
-        protected abstract void RequestPerformanceMode(PerformanceMode performanceMode);
-
-        protected abstract void SetCpuBoostMode(CpuBoostMode cpuBoostMode);
-
-        protected abstract PerformanceConfiguration GetCurrentPerformanceConfiguration();
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Apm/ManagerServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/ManagerServer.cs
@@ -6,9 +6,9 @@
     {
         public ManagerServer(ServiceCtx context) : base(context) { }
 
-        protected override ResultCode OpenSession(out ISession sessionObj)
+        protected override ResultCode OpenSession(out SessionServer sessionServer)
         {
-            sessionObj = new ISession();
+            sessionServer = new SessionServer();
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Apm/ManagerServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/ManagerServer.cs
@@ -4,23 +4,28 @@
     [Service("apm:am")] // 8.0.0+
     class ManagerServer : IManager
     {
-        public ManagerServer(ServiceCtx context) : base(context) { }
+        private readonly ServiceCtx _context;
+
+        public ManagerServer(ServiceCtx context) : base(context)
+        {
+            _context = context;
+        }
 
         protected override ResultCode OpenSession(out SessionServer sessionServer)
         {
-            sessionServer = new SessionServer();
+            sessionServer = new SessionServer(_context);
 
             return ResultCode.Success;
         }
 
         protected override PerformanceMode GetPerformanceMode()
         {
-            return PerformanceState.PerformanceMode;
+            return _context.Device.System.PerformanceState.PerformanceMode;
         }
 
         protected override bool IsCpuOverclockEnabled()
         {
-            return PerformanceState.CpuOverclockEnabled;
+            return _context.Device.System.PerformanceState.CpuOverclockEnabled;
         }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Apm/ManagerServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/ManagerServer.cs
@@ -1,0 +1,26 @@
+﻿namespace Ryujinx.HLE.HOS.Services.Apm
+{
+    [Service("apm")]
+    [Service("apm:am")] // 8.0.0+
+    class ManagerServer : IManager
+    {
+        public ManagerServer(ServiceCtx context) : base(context) { }
+
+        protected override ResultCode OpenSession(out ISession sessionObj)
+        {
+            sessionObj = new ISession();
+
+            return ResultCode.Success;
+        }
+
+        protected override PerformanceMode GetPerformanceMode()
+        {
+            return PerformanceState.PerformanceMode;
+        }
+
+        protected override bool IsCpuOverclockEnabled()
+        {
+            return PerformanceState.CpuOverclockEnabled;
+        }
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Apm/PerformanceState.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/PerformanceState.cs
@@ -1,16 +1,18 @@
 ﻿namespace Ryujinx.HLE.HOS.Services.Apm
 {
-    static class PerformanceState
+    public sealed class PerformanceState
     {
-        public static bool CpuOverclockEnabled = false;
+        public PerformanceState() { }
 
-        public static PerformanceMode PerformanceMode = PerformanceMode.Default;
-        public static CpuBoostMode    CpuBoostMode    = CpuBoostMode.Disabled;
+        public bool CpuOverclockEnabled = false;
 
-        public static PerformanceConfiguration DefaultPerformanceConfiguration = PerformanceConfiguration.PerformanceConfiguration7;
-        public static PerformanceConfiguration BoostPerformanceConfiguration   = PerformanceConfiguration.PerformanceConfiguration8;
+        public PerformanceMode PerformanceMode = PerformanceMode.Default;
+        public CpuBoostMode    CpuBoostMode    = CpuBoostMode.Disabled;
 
-        public static PerformanceConfiguration GetCurrentPerformanceConfiguration(PerformanceMode performanceMode)
+        public PerformanceConfiguration DefaultPerformanceConfiguration = PerformanceConfiguration.PerformanceConfiguration7;
+        public PerformanceConfiguration BoostPerformanceConfiguration   = PerformanceConfiguration.PerformanceConfiguration8;
+
+        public PerformanceConfiguration GetCurrentPerformanceConfiguration(PerformanceMode performanceMode)
         {
             return performanceMode switch
             {

--- a/Ryujinx.HLE/HOS/Services/Apm/PerformanceState.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/PerformanceState.cs
@@ -1,0 +1,23 @@
+﻿namespace Ryujinx.HLE.HOS.Services.Apm
+{
+    static class PerformanceState
+    {
+        public static bool CpuOverclockEnabled = false;
+
+        public static PerformanceMode PerformanceMode = PerformanceMode.Default;
+        public static CpuBoostMode    CpuBoostMode    = CpuBoostMode.Disabled;
+
+        public static PerformanceConfiguration DefaultPerformanceConfiguration = PerformanceConfiguration.PerformanceConfiguration7;
+        public static PerformanceConfiguration BoostPerformanceConfiguration   = PerformanceConfiguration.PerformanceConfiguration8;
+
+        public static PerformanceConfiguration GetCurrentPerformanceConfiguration(PerformanceMode performanceMode)
+        {
+            return performanceMode switch
+            {
+                PerformanceMode.Default => DefaultPerformanceConfiguration,
+                PerformanceMode.Boost   => BoostPerformanceConfiguration,
+                _                       => PerformanceConfiguration.PerformanceConfiguration7
+            };
+        }
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Apm/PerformanceState.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/PerformanceState.cs
@@ -1,6 +1,6 @@
 ﻿namespace Ryujinx.HLE.HOS.Services.Apm
 {
-    public sealed class PerformanceState
+    class PerformanceState
     {
         public PerformanceState() { }
 

--- a/Ryujinx.HLE/HOS/Services/Apm/ResultCode.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/ResultCode.cs
@@ -1,0 +1,12 @@
+namespace Ryujinx.HLE.HOS.Services.Apm
+{
+    enum ResultCode
+    {
+        ModuleId       = 148,
+        ErrorCodeShift = 9,
+
+        Success = 0,
+
+        InvalidParameters = (1 << ErrorCodeShift) | ModuleId
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Apm/SessionServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/SessionServer.cs
@@ -4,6 +4,13 @@ namespace Ryujinx.HLE.HOS.Services.Apm
 {
     class SessionServer : ISession
     {
+        private readonly ServiceCtx _context;
+
+        public SessionServer(ServiceCtx context) : base(context) 
+        {
+            _context = context;
+        }
+
         protected override ResultCode SetPerformanceConfiguration(PerformanceMode performanceMode, PerformanceConfiguration performanceConfiguration)
         {
             if (performanceMode > PerformanceMode.Boost)
@@ -14,10 +21,10 @@ namespace Ryujinx.HLE.HOS.Services.Apm
             switch (performanceMode)
             {
                 case PerformanceMode.Default:
-                    PerformanceState.DefaultPerformanceConfiguration = performanceConfiguration;
+                    _context.Device.System.PerformanceState.DefaultPerformanceConfiguration = performanceConfiguration;
                     break;
                 case PerformanceMode.Boost:
-                    PerformanceState.BoostPerformanceConfiguration = performanceConfiguration;
+                    _context.Device.System.PerformanceState.BoostPerformanceConfiguration = performanceConfiguration;
                     break;
                 default:
                     Logger.Error?.PrintMsg(LogClass.ServiceApm, $"PerformanceMode isn't supported: {performanceMode}");
@@ -36,14 +43,14 @@ namespace Ryujinx.HLE.HOS.Services.Apm
                 return ResultCode.InvalidParameters;
             }
 
-            performanceConfiguration = PerformanceState.GetCurrentPerformanceConfiguration(performanceMode);
+            performanceConfiguration = _context.Device.System.PerformanceState.GetCurrentPerformanceConfiguration(performanceMode);
 
             return ResultCode.Success;
         }
 
         protected override void SetCpuOverclockEnabled(bool enabled)
         {
-            PerformanceState.CpuOverclockEnabled = enabled;
+            _context.Device.System.PerformanceState.CpuOverclockEnabled = enabled;
 
             // NOTE: This call seems to overclock the system, since we emulate it, it's fine to do nothing instead.
         }

--- a/Ryujinx.HLE/HOS/Services/Apm/SessionServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/SessionServer.cs
@@ -1,0 +1,51 @@
+﻿using Ryujinx.Common.Logging;
+
+namespace Ryujinx.HLE.HOS.Services.Apm
+{
+    class SessionServer : ISession
+    {
+        protected override ResultCode SetPerformanceConfiguration(PerformanceMode performanceMode, PerformanceConfiguration performanceConfiguration)
+        {
+            if (performanceMode > PerformanceMode.Boost)
+            {
+                return ResultCode.InvalidParameters;
+            }
+
+            switch (performanceMode)
+            {
+                case PerformanceMode.Default:
+                    PerformanceState.DefaultPerformanceConfiguration = performanceConfiguration;
+                    break;
+                case PerformanceMode.Boost:
+                    PerformanceState.BoostPerformanceConfiguration = performanceConfiguration;
+                    break;
+                default:
+                    Logger.Error?.PrintMsg(LogClass.ServiceApm, $"PerformanceMode isn't supported: {performanceMode}");
+                    break;
+            }
+
+            return ResultCode.Success;
+        }
+
+        protected override ResultCode GetPerformanceConfiguration(PerformanceMode performanceMode, out PerformanceConfiguration performanceConfiguration)
+        {
+            if (performanceMode > PerformanceMode.Boost)
+            {
+                performanceConfiguration = 0;
+
+                return ResultCode.InvalidParameters;
+            }
+
+            performanceConfiguration = PerformanceState.GetCurrentPerformanceConfiguration(performanceMode);
+
+            return ResultCode.Success;
+        }
+
+        protected override void SetCpuOverclockEnabled(bool enabled)
+        {
+            PerformanceState.CpuOverclockEnabled = enabled;
+
+            // NOTE: This call seems to overclock the system, since we emulate it, it's fine to do nothing instead.
+        }
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Apm/SessionServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/SessionServer.cs
@@ -27,7 +27,7 @@ namespace Ryujinx.HLE.HOS.Services.Apm
                     _context.Device.System.PerformanceState.BoostPerformanceConfiguration = performanceConfiguration;
                     break;
                 default:
-                    Logger.Error?.PrintMsg(LogClass.ServiceApm, $"PerformanceMode isn't supported: {performanceMode}");
+                    Logger.Error?.Print(LogClass.ServiceApm, $"PerformanceMode isn't supported: {performanceMode}");
                     break;
             }
 

--- a/Ryujinx.HLE/HOS/Services/Apm/SystemManagerServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/SystemManagerServer.cs
@@ -1,0 +1,23 @@
+﻿namespace Ryujinx.HLE.HOS.Services.Apm
+{
+    [Service("apm:sys")]
+    class SystemManagerServer : ISystemManager
+    {
+        public SystemManagerServer(ServiceCtx context) : base(context) { }
+
+        protected override void RequestPerformanceMode(PerformanceMode performanceMode)
+        {
+            PerformanceState.PerformanceMode = performanceMode;
+        }
+
+        protected override void SetCpuBoostMode(CpuBoostMode cpuBoostMode)
+        {
+            PerformanceState.CpuBoostMode = cpuBoostMode;
+        }
+
+        protected override PerformanceConfiguration GetCurrentPerformanceConfiguration()
+        {
+            return PerformanceState.GetCurrentPerformanceConfiguration(PerformanceState.PerformanceMode);
+        }
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Apm/SystemManagerServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/SystemManagerServer.cs
@@ -3,21 +3,26 @@
     [Service("apm:sys")]
     class SystemManagerServer : ISystemManager
     {
-        public SystemManagerServer(ServiceCtx context) : base(context) { }
+        private readonly ServiceCtx _context;
+
+        public SystemManagerServer(ServiceCtx context) : base(context)
+        {
+            _context = context;
+        }
 
         protected override void RequestPerformanceMode(PerformanceMode performanceMode)
         {
-            PerformanceState.PerformanceMode = performanceMode;
+            _context.Device.System.PerformanceState.PerformanceMode = performanceMode;
         }
 
         internal override void SetCpuBoostMode(CpuBoostMode cpuBoostMode)
         {
-            PerformanceState.CpuBoostMode = cpuBoostMode;
+            _context.Device.System.PerformanceState.CpuBoostMode = cpuBoostMode;
         }
 
         protected override PerformanceConfiguration GetCurrentPerformanceConfiguration()
         {
-            return PerformanceState.GetCurrentPerformanceConfiguration(PerformanceState.PerformanceMode);
+            return _context.Device.System.PerformanceState.GetCurrentPerformanceConfiguration(_context.Device.System.PerformanceState.PerformanceMode);
         }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Apm/SystemManagerServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/SystemManagerServer.cs
@@ -10,7 +10,7 @@
             PerformanceState.PerformanceMode = performanceMode;
         }
 
-        protected override void SetCpuBoostMode(CpuBoostMode cpuBoostMode)
+        internal override void SetCpuBoostMode(CpuBoostMode cpuBoostMode)
         {
             PerformanceState.CpuBoostMode = cpuBoostMode;
         }

--- a/Ryujinx.HLE/HOS/Services/Apm/Types/CpuBoostMode.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/Types/CpuBoostMode.cs
@@ -1,6 +1,6 @@
 ﻿namespace Ryujinx.HLE.HOS.Services.Apm
 {
-    public enum CpuBoostMode
+    enum CpuBoostMode
     {
         Disabled      = 0,
         BoostCPU      = 1, // Uses PerformanceConfiguration13 and PerformanceConfiguration14, or PerformanceConfiguration15 and PerformanceConfiguration16

--- a/Ryujinx.HLE/HOS/Services/Apm/Types/CpuBoostMode.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/Types/CpuBoostMode.cs
@@ -2,8 +2,8 @@
 {
     enum CpuBoostMode
     {
-        Disabled = 0,
-        Mode1    = 1, // Use PerformanceConfiguration13 and PerformanceConfiguration14, or PerformanceConfiguration15 and PerformanceConfiguration16
-        Mode2    = 2  // Use PerformanceConfiguration15 and PerformanceConfiguration16.
+        Disabled      = 0,
+        BoostCPU      = 1, // Use PerformanceConfiguration13 and PerformanceConfiguration14, or PerformanceConfiguration15 and PerformanceConfiguration16
+        ConservePower = 2  // Use PerformanceConfiguration15 and PerformanceConfiguration16.
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Apm/Types/CpuBoostMode.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/Types/CpuBoostMode.cs
@@ -1,9 +1,9 @@
 ﻿namespace Ryujinx.HLE.HOS.Services.Apm
 {
-    enum CpuBoostMode
+    public enum CpuBoostMode
     {
         Disabled      = 0,
-        BoostCPU      = 1, // Use PerformanceConfiguration13 and PerformanceConfiguration14, or PerformanceConfiguration15 and PerformanceConfiguration16
-        ConservePower = 2  // Use PerformanceConfiguration15 and PerformanceConfiguration16.
+        BoostCPU      = 1, // Uses PerformanceConfiguration13 and PerformanceConfiguration14, or PerformanceConfiguration15 and PerformanceConfiguration16
+        ConservePower = 2  // Uses PerformanceConfiguration15 and PerformanceConfiguration16.
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Apm/Types/PerformanceConfiguration.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/Types/PerformanceConfiguration.cs
@@ -1,6 +1,6 @@
 ﻿namespace Ryujinx.HLE.HOS.Services.Apm
 {
-    public enum PerformanceConfiguration : uint  // Clocks are all in MHz.
+    enum PerformanceConfiguration : uint  // Clocks are all in MHz.
     {                                            // CPU  | GPU   | RAM    | NOTE
         PerformanceConfiguration1  = 0x00010000, // 1020 | 384   | 1600   | Only available while docked.
         PerformanceConfiguration2  = 0x00010001, // 1020 | 768   | 1600   | Only available while docked.

--- a/Ryujinx.HLE/HOS/Services/Apm/Types/PerformanceConfiguration.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/Types/PerformanceConfiguration.cs
@@ -1,6 +1,6 @@
 ﻿namespace Ryujinx.HLE.HOS.Services.Apm
 {
-    enum PerformanceConfiguration : uint         // Clocks are all in MHz.
+    public enum PerformanceConfiguration : uint  // Clocks are all in MHz.
     {                                            // CPU  | GPU   | RAM    | NOTE
         PerformanceConfiguration1  = 0x00010000, // 1020 | 384   | 1600   | Only available while docked.
         PerformanceConfiguration2  = 0x00010001, // 1020 | 768   | 1600   | Only available while docked.

--- a/Ryujinx.HLE/HOS/Services/Apm/Types/PerformanceMode.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/Types/PerformanceMode.cs
@@ -2,7 +2,7 @@
 {
     enum PerformanceMode
     {
-        Handheld = 0,
-        Docked   = 1
+        Default = 0,
+        Boost   = 1
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Apm/Types/PerformanceMode.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/Types/PerformanceMode.cs
@@ -1,6 +1,6 @@
 ﻿namespace Ryujinx.HLE.HOS.Services.Apm
 {
-    public enum PerformanceMode : uint
+    enum PerformanceMode : uint
     {
         Default = 0,
         Boost   = 1

--- a/Ryujinx.HLE/HOS/Services/Apm/Types/PerformanceMode.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/Types/PerformanceMode.cs
@@ -1,6 +1,6 @@
 ﻿namespace Ryujinx.HLE.HOS.Services.Apm
 {
-    enum PerformanceMode
+    public enum PerformanceMode : uint
     {
         Default = 0,
         Boost   = 1


### PR DESCRIPTION
This PR implement some IPC calls of apm service:
- `nn::apm::IManager` is fully implemented.
- `nn::apm::ISession` is fully implemented (close #1633).
- `nn::apm::ISystemManager` is partially implemented.

`nn::appletAE::ICommonStateGetter` have some calls which are just a layer of apm IPC calls. What we currently do in some calls is wrong, it's fixed now!

Everything is checked with RE.