### PR TITLE
Use explicit buffer and texture bindings on shaders

### DIFF
--- a/Ryujinx.Graphics.GAL/IPipeline.cs
+++ b/Ryujinx.Graphics.GAL/IPipeline.cs
@@ -46,7 +46,7 @@ namespace Ryujinx.Graphics.GAL
 
         void SetIndexBuffer(BufferRange buffer, IndexType type);
 
-        void SetImage(int index, ShaderStage stage, ITexture texture, Format imageFormat);
+        void SetImage(int binding, ITexture texture, Format imageFormat);
 
         void SetLogicOpState(bool enable, LogicalOp op);
 
@@ -64,19 +64,19 @@ namespace Ryujinx.Graphics.GAL
         void SetRenderTargetColorMasks(ReadOnlySpan<uint> componentMask);
         void SetRenderTargets(ITexture[] colors, ITexture depthStencil);
 
-        void SetSampler(int index, ShaderStage stage, ISampler sampler);
+        void SetSampler(int binding, ISampler sampler);
 
         void SetScissorEnable(int index, bool enable);
         void SetScissor(int index, int x, int y, int width, int height);
 
         void SetStencilTest(StencilTestDescriptor stencilTest);
 
-        void SetStorageBuffer(int index, ShaderStage stage, BufferRange buffer);
+        void SetStorageBuffers(ReadOnlySpan<BufferRange> buffers);
 
-        void SetTexture(int index, ShaderStage stage, ITexture texture);
+        void SetTexture(int binding, ITexture texture);
 
         void SetTransformFeedbackBuffers(ReadOnlySpan<BufferRange> buffers);
-        void SetUniformBuffer(int index, ShaderStage stage, BufferRange buffer);
+        void SetUniformBuffers(ReadOnlySpan<BufferRange> buffers);
 
         void SetUserClipDistance(int index, bool enableClip);
 

--- a/Ryujinx.Graphics.GAL/IRenderer.cs
+++ b/Ryujinx.Graphics.GAL/IRenderer.cs
@@ -12,7 +12,7 @@ namespace Ryujinx.Graphics.GAL
 
         void BackgroundContextAction(Action action);
 
-        IShader CompileShader(ShaderProgram shader);
+        IShader CompileShader(ShaderStage stage, string code);
 
         BufferHandle CreateBuffer(int size);
 

--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingInfo.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingInfo.cs
@@ -20,6 +20,11 @@ namespace Ryujinx.Graphics.Gpu.Image
         public Format Format { get; }
 
         /// <summary>
+        /// Shader texture host binding point.
+        /// </summary>
+        public int Binding { get; }
+
+        /// <summary>
         /// Shader texture handle.
         /// This is an index into the texture constant buffer.
         /// </summary>
@@ -53,13 +58,15 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         /// <param name="target">The shader sampler target type</param>
         /// <param name="format">Format of the image as declared on the shader</param>
+        /// <param name="binding">The shader texture binding point</param>
         /// <param name="handle">The shader texture handle (read index into the texture constant buffer)</param>
         /// <param name="flags">The texture's usage flags, indicating how it is used in the shader</param>
-        public TextureBindingInfo(Target target, Format format, int handle, TextureUsageFlags flags)
+        public TextureBindingInfo(Target target, Format format, int binding, int handle, TextureUsageFlags flags)
         {
-            Target = target;
-            Format = format;
-            Handle = handle;
+            Target  = target;
+            Format  = format;
+            Binding = binding;
+            Handle  = handle;
 
             IsBindless = false;
 
@@ -73,9 +80,10 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Constructs the texture binding information structure.
         /// </summary>
         /// <param name="target">The shader sampler target type</param>
+        /// <param name="binding">The shader texture binding point</param>
         /// <param name="handle">The shader texture handle (read index into the texture constant buffer)</param>
         /// <param name="flags">The texture's usage flags, indicating how it is used in the shader</param>
-        public TextureBindingInfo(Target target, int handle, TextureUsageFlags flags) : this(target, (Format)0, handle, flags)
+        public TextureBindingInfo(Target target, int binding, int handle, TextureUsageFlags flags) : this(target, (Format)0, binding, handle, flags)
         {
         }
 
@@ -83,14 +91,16 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Constructs the bindless texture binding information structure.
         /// </summary>
         /// <param name="target">The shader sampler target type</param>
+        /// <param name="binding">The shader texture binding point</param>
         /// <param name="cbufSlot">Constant buffer slot where the bindless texture handle is located</param>
         /// <param name="cbufOffset">Constant buffer offset of the bindless texture handle</param>
         /// <param name="flags">The texture's usage flags, indicating how it is used in the shader</param>
-        public TextureBindingInfo(Target target, int cbufSlot, int cbufOffset, TextureUsageFlags flags)
+        public TextureBindingInfo(Target target, int binding, int cbufSlot, int cbufOffset, TextureUsageFlags flags)
         {
-            Target = target;
-            Format = 0;
-            Handle = 0;
+            Target  = target;
+            Format  = 0;
+            Binding = binding;
+            Handle  = 0;
 
             IsBindless = true;
 

--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -265,11 +265,11 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             for (int index = 0; index < _textureBindings[stageIndex].Length; index++)
             {
-                TextureBindingInfo binding = _textureBindings[stageIndex][index];
+                TextureBindingInfo bindingInfo = _textureBindings[stageIndex][index];
 
                 int packedId;
 
-                if (binding.IsBindless)
+                if (bindingInfo.IsBindless)
                 {
                     ulong address;
 
@@ -277,18 +277,18 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                     if (_isCompute)
                     {
-                        address = bufferManager.GetComputeUniformBufferAddress(binding.CbufSlot);
+                        address = bufferManager.GetComputeUniformBufferAddress(bindingInfo.CbufSlot);
                     }
                     else
                     {
-                        address = bufferManager.GetGraphicsUniformBufferAddress(stageIndex, binding.CbufSlot);
+                        address = bufferManager.GetGraphicsUniformBufferAddress(stageIndex, bindingInfo.CbufSlot);
                     }
 
-                    packedId = _context.PhysicalMemory.Read<int>(address + (ulong)binding.CbufOffset * 4);
+                    packedId = _context.PhysicalMemory.Read<int>(address + (ulong)bindingInfo.CbufOffset * 4);
                 }
                 else
                 {
-                    packedId = ReadPackedId(stageIndex, binding.Handle, _textureBufferIndex);
+                    packedId = ReadPackedId(stageIndex, bindingInfo.Handle, _textureBufferIndex);
                 }
 
                 int textureId = UnpackTextureId(packedId);
@@ -305,18 +305,18 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 Texture texture = pool.Get(textureId);
 
-                ITexture hostTexture = texture?.GetTargetTexture(binding.Target);
+                ITexture hostTexture = texture?.GetTargetTexture(bindingInfo.Target);
 
                 if (_textureState[stageIndex][index].Texture != hostTexture || _rebind)
                 {
-                    if (UpdateScale(texture, binding, index, stage))
+                    if (UpdateScale(texture, bindingInfo, index, stage))
                     {
-                        hostTexture = texture?.GetTargetTexture(binding.Target);
+                        hostTexture = texture?.GetTargetTexture(bindingInfo.Target);
                     }
 
                     _textureState[stageIndex][index].Texture = hostTexture;
 
-                    _context.Renderer.Pipeline.SetTexture(index, stage, hostTexture);
+                    _context.Renderer.Pipeline.SetTexture(bindingInfo.Binding, hostTexture);
                 }
 
                 if (hostTexture != null && texture.Info.Target == Target.TextureBuffer)
@@ -335,7 +335,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 {
                     _textureState[stageIndex][index].Sampler = hostSampler;
 
-                    _context.Renderer.Pipeline.SetSampler(index, stage, hostSampler);
+                    _context.Renderer.Pipeline.SetSampler(bindingInfo.Binding, hostSampler);
                 }
             }
         }
@@ -359,14 +359,14 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             for (int index = 0; index < _imageBindings[stageIndex].Length; index++)
             {
-                TextureBindingInfo binding = _imageBindings[stageIndex][index];
+                TextureBindingInfo bindingInfo = _imageBindings[stageIndex][index];
 
-                int packedId = ReadPackedId(stageIndex, binding.Handle, _textureBufferIndex);
+                int packedId = ReadPackedId(stageIndex, bindingInfo.Handle, _textureBufferIndex);
                 int textureId = UnpackTextureId(packedId);
 
                 Texture texture = pool.Get(textureId);
 
-                ITexture hostTexture = texture?.GetTargetTexture(binding.Target);
+                ITexture hostTexture = texture?.GetTargetTexture(bindingInfo.Target);
 
                 if (hostTexture != null && texture.Info.Target == Target.TextureBuffer)
                 {
@@ -378,21 +378,21 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 if (_imageState[stageIndex][index].Texture != hostTexture || _rebind)
                 {
-                    if (UpdateScale(texture, binding, baseScaleIndex + index, stage))
+                    if (UpdateScale(texture, bindingInfo, baseScaleIndex + index, stage))
                     {
-                        hostTexture = texture?.GetTargetTexture(binding.Target);
+                        hostTexture = texture?.GetTargetTexture(bindingInfo.Target);
                     }
 
                     _imageState[stageIndex][index].Texture = hostTexture;
 
-                    Format format = binding.Format;
+                    Format format = bindingInfo.Format;
 
                     if (format == 0 && texture != null)
                     {
                         format = texture.Format;
                     }
 
-                    _context.Renderer.Pipeline.SetImage(index, stage, hostTexture, format);
+                    _context.Renderer.Pipeline.SetImage(bindingInfo.Binding, hostTexture, format);
                 }
             }
         }

--- a/Ryujinx.Graphics.Gpu/Memory/BufferBounds.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferBounds.cs
@@ -5,9 +5,21 @@ namespace Ryujinx.Graphics.Gpu.Memory
     /// </summary>
     struct BufferBounds
     {
+        /// <summary>
+        /// Region virtual address.
+        /// </summary>
         public ulong Address { get; }
+
+        /// <summary>
+        /// Region size in bytes.
+        /// </summary>
         public ulong Size { get; }
 
+        /// <summary>
+        /// Creates a new buffer region.
+        /// </summary>
+        /// <param name="address">Region address</param>
+        /// <param name="size">Region size</param>
         public BufferBounds(ulong address, ulong size)
         {
             Address = address;

--- a/Ryujinx.Graphics.Gpu/Memory/BufferBounds.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferBounds.cs
@@ -5,7 +5,13 @@ namespace Ryujinx.Graphics.Gpu.Memory
     /// </summary>
     struct BufferBounds
     {
-        public ulong Address;
-        public ulong Size;
+        public ulong Address { get; }
+        public ulong Size { get; }
+
+        public BufferBounds(ulong address, ulong size)
+        {
+            Address = address;
+            Size = size;
+        }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -32,24 +32,51 @@ namespace Ryujinx.Graphics.Gpu.Memory
         private VertexBuffer[] _vertexBuffers;
         private BufferBounds[] _transformFeedbackBuffers;
 
+        /// <summary>
+        /// Holds shader stage buffer state and binding information.
+        /// </summary>
         private class BuffersPerStage
         {
+            /// <summary>
+            /// Shader buffer binding information.
+            /// </summary>
             public BufferDescriptor[] Bindings { get; }
+
+            /// <summary>
+            /// Buffer regions.
+            /// </summary>
             public BufferBounds[] Buffers { get; }
 
+            /// <summary>
+            /// Total amount of buffers used on the shader.
+            /// </summary>
             public int Count { get; private set; }
 
+            /// <summary>
+            /// Creates a new instance of the shader stage buffer information.
+            /// </summary>
+            /// <param name="count">Maximum amount of buffers that the shader stage can use</param>
             public BuffersPerStage(int count)
             {
                 Bindings = new BufferDescriptor[count];
                 Buffers = new BufferBounds[count];
             }
 
+            /// <summary>
+            /// Sets the region of a buffer at a given slot.
+            /// </summary>
+            /// <param name="index">Buffer slot</param>
+            /// <param name="address">Region virtual address</param>
+            /// <param name="size">Region size in bytes</param>
             public void SetBounds(int index, ulong address, ulong size)
             {
                 Buffers[index] = new BufferBounds(address, size);
             }
 
+            /// <summary>
+            /// Sets shader buffer binding information.
+            /// </summary>
+            /// <param name="descriptors">Buffer binding information</param>
             public void SetBindings(ReadOnlyCollection<BufferDescriptor> descriptors)
             {
                 if (descriptors == null)

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -80,7 +80,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 localMemorySize,
                 sharedMemorySize);
 
-            shader.HostShader = _context.Renderer.CompileShader(shader.Program);
+            shader.HostShader = _context.Renderer.CompileShader(ShaderStage.Compute, shader.Program.Code);
 
             IProgram hostProgram = _context.Renderer.CreateProgram(new IShader[] { shader.HostShader }, null);
 
@@ -161,7 +161,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
                     continue;
                 }
 
-                IShader hostShader = _context.Renderer.CompileShader(program);
+                IShader hostShader = _context.Renderer.CompileShader(program.Stage, program.Code);
 
                 shaders[stage].HostShader = hostShader;
 

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -134,19 +134,21 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 flags |= TranslationFlags.Feedback;
             }
 
+            TranslationCounts counts = new TranslationCounts();
+
             if (addresses.VertexA != 0)
             {
-                shaders[0] = TranslateGraphicsShader(state, flags, ShaderStage.Vertex, addresses.Vertex, addresses.VertexA);
+                shaders[0] = TranslateGraphicsShader(state, counts, flags, ShaderStage.Vertex, addresses.Vertex, addresses.VertexA);
             }
             else
             {
-                shaders[0] = TranslateGraphicsShader(state, flags, ShaderStage.Vertex, addresses.Vertex);
+                shaders[0] = TranslateGraphicsShader(state, counts, flags, ShaderStage.Vertex, addresses.Vertex);
             }
 
-            shaders[1] = TranslateGraphicsShader(state, flags, ShaderStage.TessellationControl,    addresses.TessControl);
-            shaders[2] = TranslateGraphicsShader(state, flags, ShaderStage.TessellationEvaluation, addresses.TessEvaluation);
-            shaders[3] = TranslateGraphicsShader(state, flags, ShaderStage.Geometry,               addresses.Geometry);
-            shaders[4] = TranslateGraphicsShader(state, flags, ShaderStage.Fragment,               addresses.Fragment);
+            shaders[1] = TranslateGraphicsShader(state, counts, flags, ShaderStage.TessellationControl,    addresses.TessControl);
+            shaders[2] = TranslateGraphicsShader(state, counts, flags, ShaderStage.TessellationEvaluation, addresses.TessEvaluation);
+            shaders[3] = TranslateGraphicsShader(state, counts, flags, ShaderStage.Geometry,               addresses.Geometry);
+            shaders[4] = TranslateGraphicsShader(state, counts, flags, ShaderStage.Fragment,               addresses.Fragment);
 
             List<IShader> hostShaders = new List<IShader>();
 
@@ -334,12 +336,19 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// This will combine the "Vertex A" and "Vertex B" shader stages, if specified, into one shader.
         /// </remarks>
         /// <param name="state">Current GPU state</param>
+        /// <param name="counts">Cumulative shader resource counts</param>
         /// <param name="flags">Flags that controls shader translation</param>
         /// <param name="stage">Shader stage</param>
         /// <param name="gpuVa">GPU virtual address of the shader code</param>
         /// <param name="gpuVaA">Optional GPU virtual address of the "Vertex A" shader code</param>
         /// <returns>Compiled graphics shader code</returns>
-        private ShaderCodeHolder TranslateGraphicsShader(GpuState state, TranslationFlags flags, ShaderStage stage, ulong gpuVa, ulong gpuVaA = 0)
+        private ShaderCodeHolder TranslateGraphicsShader(
+            GpuState state,
+            TranslationCounts counts,
+            TranslationFlags flags,
+            ShaderStage stage,
+            ulong gpuVa,
+            ulong gpuVaA = 0)
         {
             if (gpuVa == 0)
             {
@@ -350,7 +359,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
 
             if (gpuVaA != 0)
             {
-                ShaderProgram program = Translator.Translate(gpuVaA, gpuVa, gpuAccessor, flags);
+                ShaderProgram program = Translator.Translate(gpuVaA, gpuVa, gpuAccessor, flags, counts);
 
                 byte[] codeA = _context.MemoryManager.GetSpan(gpuVaA, program.SizeA).ToArray();
                 byte[] codeB = _context.MemoryManager.GetSpan(gpuVa,  program.Size).ToArray();
@@ -370,7 +379,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
             }
             else
             {
-                ShaderProgram program = Translator.Translate(gpuVa, gpuAccessor, flags);
+                ShaderProgram program = Translator.Translate(gpuVa, gpuAccessor, flags, counts);
 
                 byte[] code = _context.MemoryManager.GetSpan(gpuVa, program.Size).ToArray();
 

--- a/Ryujinx.Graphics.OpenGL/Program.cs
+++ b/Ryujinx.Graphics.OpenGL/Program.cs
@@ -1,7 +1,6 @@
 using OpenTK.Graphics.OpenGL;
 using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.GAL;
-using Ryujinx.Graphics.Shader;
 using Ryujinx.Graphics.Shader.CodeGen.Glsl;
 using System;
 using System.Collections.Generic;
@@ -11,18 +10,6 @@ namespace Ryujinx.Graphics.OpenGL
 {
     class Program : IProgram
     {
-        private const int ShaderStages = 6;
-
-        private const int UbStageShift  = 5;
-        private const int SbStageShift  = 4;
-        private const int TexStageShift = 5;
-        private const int ImgStageShift = 3;
-
-        private const int UbsPerStage  = 1 << UbStageShift;
-        private const int SbsPerStage  = 1 << SbStageShift;
-        private const int TexsPerStage = 1 << TexStageShift;
-        private const int ImgsPerStage = 1 << ImgStageShift;
-
         public int Handle { get; private set; }
 
         public int FragmentIsBgraUniform { get; }
@@ -31,38 +18,8 @@ namespace Ryujinx.Graphics.OpenGL
 
         public bool IsLinked { get; private set; }
 
-        private int[] _ubBindingPoints;
-        private int[] _sbBindingPoints;
-        private int[] _textureUnits;
-        private int[] _imageUnits;
-
         public Program(IShader[] shaders, TransformFeedbackDescriptor[] transformFeedbackDescriptors)
         {
-            _ubBindingPoints = new int[UbsPerStage  * ShaderStages];
-            _sbBindingPoints = new int[SbsPerStage  * ShaderStages];
-            _textureUnits    = new int[TexsPerStage * ShaderStages];
-            _imageUnits      = new int[ImgsPerStage * ShaderStages];
-
-            for (int index = 0; index < _ubBindingPoints.Length; index++)
-            {
-                _ubBindingPoints[index] = -1;
-            }
-
-            for (int index = 0; index < _sbBindingPoints.Length; index++)
-            {
-                _sbBindingPoints[index] = -1;
-            }
-
-            for (int index = 0; index < _textureUnits.Length; index++)
-            {
-                _textureUnits[index] = -1;
-            }
-
-            for (int index = 0; index < _imageUnits.Length; index++)
-            {
-                _imageUnits[index] = -1;
-            }
-
             Handle = GL.CreateProgram();
 
             for (int index = 0; index < shaders.Length; index++)
@@ -131,92 +88,6 @@ namespace Ryujinx.Graphics.OpenGL
 
             CheckProgramLink();
 
-            int ubBindingPoint = 0;
-            int sbBindingPoint = 0;
-            int textureUnit    = 0;
-            int imageUnit      = 0;
-
-            for (int index = 0; index < shaders.Length; index++)
-            {
-                Shader shader = (Shader)shaders[index];
-
-                foreach (BufferDescriptor descriptor in shader.Info.CBuffers)
-                {
-                    int location = GL.GetUniformBlockIndex(Handle, descriptor.Name);
-
-                    if (location < 0)
-                    {
-                        continue;
-                    }
-
-                    GL.UniformBlockBinding(Handle, location, ubBindingPoint);
-
-                    int bpIndex = (int)shader.Stage << UbStageShift | descriptor.Slot;
-
-                    _ubBindingPoints[bpIndex] = ubBindingPoint;
-
-                    ubBindingPoint++;
-                }
-
-                foreach (BufferDescriptor descriptor in shader.Info.SBuffers)
-                {
-                    int location = GL.GetProgramResourceIndex(Handle, ProgramInterface.ShaderStorageBlock, descriptor.Name);
-
-                    if (location < 0)
-                    {
-                        continue;
-                    }
-
-                    GL.ShaderStorageBlockBinding(Handle, location, sbBindingPoint);
-
-                    int bpIndex = (int)shader.Stage << SbStageShift | descriptor.Slot;
-
-                    _sbBindingPoints[bpIndex] = sbBindingPoint;
-
-                    sbBindingPoint++;
-                }
-
-                int samplerIndex = 0;
-
-                foreach (TextureDescriptor descriptor in shader.Info.Textures)
-                {
-                    int location = GL.GetUniformLocation(Handle, descriptor.Name);
-
-                    if (location < 0)
-                    {
-                        continue;
-                    }
-
-                    GL.ProgramUniform1(Handle, location, textureUnit);
-
-                    int uIndex = (int)shader.Stage << TexStageShift | samplerIndex++;
-
-                    _textureUnits[uIndex] = textureUnit;
-
-                    textureUnit++;
-                }
-
-                int imageIndex = 0;
-
-                foreach (TextureDescriptor descriptor in shader.Info.Images)
-                {
-                    int location = GL.GetUniformLocation(Handle, descriptor.Name);
-
-                    if (location < 0)
-                    {
-                        continue;
-                    }
-
-                    GL.ProgramUniform1(Handle, location, imageUnit);
-
-                    int uIndex = (int)shader.Stage << ImgStageShift | imageIndex++;
-
-                    _imageUnits[uIndex] = imageUnit;
-
-                    imageUnit++;
-                }
-            }
-
             FragmentIsBgraUniform = GL.GetUniformLocation(Handle, "is_bgra");
             FragmentRenderScaleUniform = GL.GetUniformLocation(Handle, "fp_renderScale");
             ComputeRenderScaleUniform = GL.GetUniformLocation(Handle, "cp_renderScale");
@@ -225,26 +96,6 @@ namespace Ryujinx.Graphics.OpenGL
         public void Bind()
         {
             GL.UseProgram(Handle);
-        }
-
-        public int GetUniformBufferBindingPoint(ShaderStage stage, int index)
-        {
-            return _ubBindingPoints[(int)stage << UbStageShift | index];
-        }
-
-        public int GetStorageBufferBindingPoint(ShaderStage stage, int index)
-        {
-            return _sbBindingPoints[(int)stage << SbStageShift | index];
-        }
-
-        public int GetTextureUnit(ShaderStage stage, int index)
-        {
-            return _textureUnits[(int)stage << TexStageShift | index];
-        }
-
-        public int GetImageUnit(ShaderStage stage, int index)
-        {
-            return _imageUnits[(int)stage << ImgStageShift | index];
         }
 
         private void CheckProgramLink()

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -42,9 +42,9 @@ namespace Ryujinx.Graphics.OpenGL
             ResourcePool = new ResourcePool();
         }
 
-        public IShader CompileShader(ShaderProgram shader)
+        public IShader CompileShader(ShaderStage stage, string code)
         {
-            return new Shader(shader);
+            return new Shader(stage, code);
         }
 
         public BufferHandle CreateBuffer(int size)

--- a/Ryujinx.Graphics.OpenGL/Shader.cs
+++ b/Ryujinx.Graphics.OpenGL/Shader.cs
@@ -8,31 +8,22 @@ namespace Ryujinx.Graphics.OpenGL
     {
         public int Handle { get; private set; }
 
-        private ShaderProgram _program;
-
-        public ShaderProgramInfo Info => _program.Info;
-
-        public ShaderStage Stage => _program.Stage;
-
-        public Shader(ShaderProgram program)
+        public Shader(ShaderStage stage, string code)
         {
-            _program = program;
-
-            ShaderType type = ShaderType.VertexShader;
-
-            switch (program.Stage)
+            ShaderType type = stage switch
             {
-                case ShaderStage.Compute:                type = ShaderType.ComputeShader;        break;
-                case ShaderStage.Vertex:                 type = ShaderType.VertexShader;         break;
-                case ShaderStage.TessellationControl:    type = ShaderType.TessControlShader;    break;
-                case ShaderStage.TessellationEvaluation: type = ShaderType.TessEvaluationShader; break;
-                case ShaderStage.Geometry:               type = ShaderType.GeometryShader;       break;
-                case ShaderStage.Fragment:               type = ShaderType.FragmentShader;       break;
-            }
+                ShaderStage.Compute => ShaderType.ComputeShader,
+                ShaderStage.Vertex => ShaderType.VertexShader,
+                ShaderStage.TessellationControl => ShaderType.TessControlShader,
+                ShaderStage.TessellationEvaluation => ShaderType.TessEvaluationShader,
+                ShaderStage.Geometry => ShaderType.GeometryShader,
+                ShaderStage.Fragment => ShaderType.FragmentShader,
+                _ => ShaderType.VertexShader
+            };
 
             Handle = GL.CreateShader(type);
 
-            GL.ShaderSource(Handle, program.Code);
+            GL.ShaderSource(Handle, code);
             GL.CompileShader(Handle);
         }
 

--- a/Ryujinx.Graphics.Shader/BufferDescriptor.cs
+++ b/Ryujinx.Graphics.Shader/BufferDescriptor.cs
@@ -2,13 +2,12 @@ namespace Ryujinx.Graphics.Shader
 {
     public struct BufferDescriptor
     {
-        public string Name { get; }
-
+        public int Binding { get; }
         public int Slot { get; }
 
-        public BufferDescriptor(string name, int slot)
+        public BufferDescriptor(int binding, int slot)
         {
-            Name = name;
+            Binding = binding;
             Slot = slot;
         }
     }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
@@ -218,50 +218,46 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
             if (info.UsesCbIndexing)
             {
+                int count = info.CBuffers.Max() + 1;
+
+                int[] bindings = new int[count];
+
+                for (int i = 0; i < count; i++)
+                {
+                    bindings[i] = context.Config.Counts.IncrementUniformBuffersCount();
+                }
+
+                foreach (int cbufSlot in info.CBuffers.OrderBy(x => x))
+                {
+                    context.CBufferDescriptors.Add(new BufferDescriptor(bindings[cbufSlot], cbufSlot));
+                }
+
                 string ubName = OperandManager.GetShaderStagePrefix(context.Config.Stage);
 
                 ubName += "_" + DefaultNames.UniformNamePrefix;
 
                 string blockName = $"{ubName}_{DefaultNames.BlockSuffix}";
 
-                int maxSlot = 0;
-
-                foreach (int cbufSlot in info.CBuffers.OrderBy(x => x))
-                {
-                    context.CBufferDescriptors.Add(new BufferDescriptor($"{blockName}[{cbufSlot}]", cbufSlot));
-
-                    if (maxSlot < cbufSlot)
-                    {
-                        maxSlot = cbufSlot;
-                    }
-                }
-
-                context.AppendLine("layout (std140) uniform " + blockName);
-
+                context.AppendLine($"layout (binding = {bindings[0]}, std140) uniform {blockName}");
                 context.EnterScope();
-
                 context.AppendLine("vec4 " + DefaultNames.DataName + ubSize + ";");
-
-                string arraySize = NumberFormatter.FormatInt(maxSlot + 1);
-
-                context.LeaveScope($" {ubName}[{arraySize}];");
+                context.LeaveScope($" {ubName}[{NumberFormatter.FormatInt(count)}];");
             }
             else
             {
                 foreach (int cbufSlot in info.CBuffers.OrderBy(x => x))
                 {
+                    int binding = context.Config.Counts.IncrementUniformBuffersCount();
+
+                    context.CBufferDescriptors.Add(new BufferDescriptor(binding, cbufSlot));
+
                     string ubName = OperandManager.GetShaderStagePrefix(context.Config.Stage);
 
                     ubName += "_" + DefaultNames.UniformNamePrefix + cbufSlot;
 
-                    context.CBufferDescriptors.Add(new BufferDescriptor(ubName, cbufSlot));
-
-                    context.AppendLine("layout (std140) uniform " + ubName);
-
+                    context.AppendLine($"layout (binding = {binding}, std140) uniform {ubName}");
                     context.EnterScope();
-
                     context.AppendLine("vec4 " + OperandManager.GetUbName(context.Config.Stage, cbufSlot, false) + ubSize + ";");
-
                     context.LeaveScope(";");
                 }
             }
@@ -275,32 +271,29 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
             string blockName = $"{sbName}_{DefaultNames.BlockSuffix}";
 
-            int maxSlot = 0;
+            int count = info.SBuffers.Max() + 1;
+
+            int[] bindings = new int[count];
+
+            for (int i = 0; i < count; i++)
+            {
+                bindings[i] = context.Config.Counts.IncrementStorageBuffersCount();
+            }
 
             foreach (int sbufSlot in info.SBuffers)
             {
-                context.SBufferDescriptors.Add(new BufferDescriptor($"{blockName}[{sbufSlot}]", sbufSlot));
-
-                if (maxSlot < sbufSlot)
-                {
-                    maxSlot = sbufSlot;
-                }
+                context.SBufferDescriptors.Add(new BufferDescriptor(bindings[sbufSlot], sbufSlot));
             }
 
-            context.AppendLine("layout (std430) buffer " + blockName);
-
+            context.AppendLine($"layout (binding = {bindings[0]}, std430) buffer {blockName}");
             context.EnterScope();
-
             context.AppendLine("uint " + DefaultNames.DataName + "[];");
-
-            string arraySize = NumberFormatter.FormatInt(maxSlot + 1);
-
-            context.LeaveScope($" {sbName}[{arraySize}];");
+            context.LeaveScope($" {sbName}[{NumberFormatter.FormatInt(count)}];");
         }
 
         private static void DeclareSamplers(CodeGenContext context, StructuredProgramInfo info)
         {
-            Dictionary<string, AstTextureOperation> samplers = new Dictionary<string, AstTextureOperation>();
+            HashSet<string> samplers = new HashSet<string>();
 
             // Texture instructions other than TextureSample (like TextureSize)
             // may have incomplete sampler type information. In those cases,
@@ -312,29 +305,20 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
                 string samplerName = OperandManager.GetSamplerName(context.Config.Stage, texOp, indexExpr);
 
-                if (!samplers.TryAdd(samplerName, texOp))
+                if (!samplers.Add(samplerName))
                 {
                     continue;
                 }
 
-                string samplerTypeName = texOp.Type.ToGlslSamplerType();
-
-                context.AppendLine("uniform " + samplerTypeName + " " + samplerName + ";");
-            }
-
-            foreach (KeyValuePair<string, AstTextureOperation> kv in samplers)
-            {
-                string samplerName = kv.Key;
-
-                AstTextureOperation texOp = kv.Value;
-
-                TextureDescriptor desc;
+                int firstBinding = -1;
 
                 if ((texOp.Flags & TextureFlags.Bindless) != 0)
                 {
                     AstOperand operand = texOp.GetSource(0) as AstOperand;
 
-                    desc = new TextureDescriptor(samplerName, texOp.Type, operand.CbufSlot, operand.CbufOffset);
+                    firstBinding = context.Config.Counts.IncrementTexturesCount();
+
+                    var desc = new TextureDescriptor(firstBinding, texOp.Type, operand.CbufSlot, operand.CbufOffset);
 
                     context.TextureDescriptors.Add(desc);
                 }
@@ -342,27 +326,36 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
                 {
                     for (int index = 0; index < texOp.ArraySize; index++)
                     {
-                        string indexExpr = NumberFormatter.FormatInt(index);
+                        int binding = context.Config.Counts.IncrementTexturesCount();
 
-                        string indexedSamplerName = OperandManager.GetSamplerName(context.Config.Stage, texOp, indexExpr);
+                        if (firstBinding < 0)
+                        {
+                            firstBinding = binding;
+                        }
 
-                        desc = new TextureDescriptor(indexedSamplerName, texOp.Type, texOp.Format, texOp.Handle + index * 2);
+                        var desc = new TextureDescriptor(binding, texOp.Type, texOp.Format, texOp.Handle + index * 2);
 
                         context.TextureDescriptors.Add(desc);
                     }
                 }
                 else
                 {
-                    desc = new TextureDescriptor(samplerName, texOp.Type, texOp.Format, texOp.Handle);
+                    firstBinding = context.Config.Counts.IncrementTexturesCount();
+
+                    var desc = new TextureDescriptor(firstBinding, texOp.Type, texOp.Format, texOp.Handle);
 
                     context.TextureDescriptors.Add(desc);
                 }
+
+                string samplerTypeName = texOp.Type.ToGlslSamplerType();
+
+                context.AppendLine($"layout (binding = {firstBinding}) uniform {samplerTypeName} {samplerName};");
             }
         }
 
         private static void DeclareImages(CodeGenContext context, StructuredProgramInfo info)
         {
-            Dictionary<string, AstTextureOperation> images = new Dictionary<string, AstTextureOperation>();
+            HashSet<string> images = new HashSet<string>();
 
             foreach (AstTextureOperation texOp in info.Images.OrderBy(x => x.Handle))
             {
@@ -370,48 +363,48 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
                 string imageName = OperandManager.GetImageName(context.Config.Stage, texOp, indexExpr);
 
-                if (!images.TryAdd(imageName, texOp))
+                if (!images.Add(imageName))
                 {
                     continue;
+                }
+
+                int firstBinding = -1;
+
+                if ((texOp.Type & SamplerType.Indexed) != 0)
+                {
+                    for (int index = 0; index < texOp.ArraySize; index++)
+                    {
+                        int binding = context.Config.Counts.IncrementImagesCount();
+
+                        if (firstBinding < 0)
+                        {
+                            firstBinding = binding;
+                        }
+
+                        var desc = new TextureDescriptor(binding, texOp.Type, texOp.Format, texOp.Handle + index * 2);
+
+                        context.ImageDescriptors.Add(desc);
+                    }
+                }
+                else
+                {
+                    firstBinding = context.Config.Counts.IncrementImagesCount();
+
+                    var desc = new TextureDescriptor(firstBinding, texOp.Type, texOp.Format, texOp.Handle);
+
+                    context.ImageDescriptors.Add(desc);
                 }
 
                 string layout = texOp.Format.ToGlslFormat();
 
                 if (!string.IsNullOrEmpty(layout))
                 {
-                    layout = "layout(" + layout + ") ";
+                    layout = ", " + layout;
                 }
 
                 string imageTypeName = texOp.Type.ToGlslImageType(texOp.Format.GetComponentType());
 
-                context.AppendLine("uniform " + layout + imageTypeName + " " + imageName + ";");
-            }
-
-            foreach (KeyValuePair<string, AstTextureOperation> kv in images)
-            {
-                string imageName = kv.Key;
-
-                AstTextureOperation texOp = kv.Value;
-
-                if ((texOp.Type & SamplerType.Indexed) != 0)
-                {
-                    for (int index = 0; index < texOp.ArraySize; index++)
-                    {
-                        string indexExpr = NumberFormatter.FormatInt(index);
-
-                        string indexedSamplerName = OperandManager.GetSamplerName(context.Config.Stage, texOp, indexExpr);
-
-                        var desc = new TextureDescriptor(indexedSamplerName, texOp.Type, texOp.Format, texOp.Handle + index * 2);
-
-                        context.TextureDescriptors.Add(desc);
-                    }
-                }
-                else
-                {
-                    var desc = new TextureDescriptor(imageName, texOp.Type, texOp.Format, texOp.Handle);
-
-                    context.ImageDescriptors.Add(desc);
-                }
+                context.AppendLine($"layout (binding = {firstBinding}{layout}) uniform {imageTypeName} {imageName};");
             }
         }
 

--- a/Ryujinx.Graphics.Shader/IGpuAccessor.cs
+++ b/Ryujinx.Graphics.Shader/IGpuAccessor.cs
@@ -2,79 +2,79 @@
 {
     public interface IGpuAccessor
     {
-        public void Log(string message)
+        void Log(string message)
         {
             // No default log output.
         }
 
         T MemoryRead<T>(ulong address) where T : unmanaged;
 
-        public bool MemoryMapped(ulong address)
+        bool MemoryMapped(ulong address)
         {
             return true;
         }
 
-        public int QueryComputeLocalSizeX()
+        int QueryComputeLocalSizeX()
         {
             return 1;
         }
 
-        public int QueryComputeLocalSizeY()
+        int QueryComputeLocalSizeY()
         {
             return 1;
         }
 
-        public int QueryComputeLocalSizeZ()
+        int QueryComputeLocalSizeZ()
         {
             return 1;
         }
 
-        public int QueryComputeLocalMemorySize()
+        int QueryComputeLocalMemorySize()
         {
             return 0x1000;
         }
 
-        public int QueryComputeSharedMemorySize()
+        int QueryComputeSharedMemorySize()
         {
             return 0xc000;
         }
 
-        public uint QueryConstantBufferUse()
+        uint QueryConstantBufferUse()
         {
             return 0xffff;
         }
 
-        public bool QueryIsTextureBuffer(int handle)
+        bool QueryIsTextureBuffer(int handle)
         {
             return false;
         }
 
-        public bool QueryIsTextureRectangle(int handle)
+        bool QueryIsTextureRectangle(int handle)
         {
             return false;
         }
 
-        public InputTopology QueryPrimitiveTopology()
+        InputTopology QueryPrimitiveTopology()
         {
             return InputTopology.Points;
         }
 
-        public int QueryStorageBufferOffsetAlignment()
+        int QueryStorageBufferOffsetAlignment()
         {
             return 16;
         }
 
-        public bool QuerySupportsImageLoadFormatted()
+        bool QuerySupportsImageLoadFormatted()
         {
             return true;
         }
 
-        public bool QuerySupportsNonConstantTextureOffset()
+        bool QuerySupportsNonConstantTextureOffset()
         {
             return true;
         }
 
-        public TextureFormat QueryTextureFormat(int handle)
+        TextureFormat QueryTextureFormat(int handle)
         {
             return TextureFormat.R8G8B8A8Unorm;
         }

--- a/Ryujinx.Graphics.Shader/TextureDescriptor.cs
+++ b/Ryujinx.Graphics.Shader/TextureDescriptor.cs
@@ -2,7 +2,7 @@ namespace Ryujinx.Graphics.Shader
 {
     public struct TextureDescriptor
     {
-        public string Name { get; }
+        public int Binding { get; }
 
         public SamplerType Type { get; }
 
@@ -17,9 +17,9 @@ namespace Ryujinx.Graphics.Shader
 
         public TextureUsageFlags Flags { get; set; }
 
-        public TextureDescriptor(string name, SamplerType type, TextureFormat format, int handleIndex)
+        public TextureDescriptor(int binding, SamplerType type, TextureFormat format, int handleIndex)
         {
-            Name        = name;
+            Binding     = binding;
             Type        = type;
             Format      = format;
             HandleIndex = handleIndex;
@@ -32,9 +32,9 @@ namespace Ryujinx.Graphics.Shader
             Flags = TextureUsageFlags.None;
         }
 
-        public TextureDescriptor(string name, SamplerType type, int cbufSlot, int cbufOffset)
+        public TextureDescriptor(int binding, SamplerType type, int cbufSlot, int cbufOffset)
         {
-            Name        = name;
+            Binding     = binding;
             Type        = type;
             Format      = TextureFormat.Unknown;
             HandleIndex = 0;

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -20,11 +20,13 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public TranslationFlags Flags { get; }
 
+        public TranslationCounts Counts { get; }
+
         public int Size { get; private set; }
 
         public FeatureFlags UsedFeatures { get; private set; }
 
-        public ShaderConfig(IGpuAccessor gpuAccessor, TranslationFlags flags)
+        public ShaderConfig(IGpuAccessor gpuAccessor, TranslationFlags flags, TranslationCounts counts)
         {
             Stage             = ShaderStage.Compute;
             OutputTopology    = OutputTopology.PointList;
@@ -38,9 +40,10 @@ namespace Ryujinx.Graphics.Shader.Translation
             Flags             = flags;
             Size              = 0;
             UsedFeatures      = FeatureFlags.None;
+            Counts            = counts;
         }
 
-        public ShaderConfig(ShaderHeader header, IGpuAccessor gpuAccessor, TranslationFlags flags)
+        public ShaderConfig(ShaderHeader header, IGpuAccessor gpuAccessor, TranslationFlags flags, TranslationCounts counts)
         {
             Stage             = header.Stage;
             OutputTopology    = header.OutputTopology;
@@ -54,6 +57,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             Flags             = flags;
             Size              = 0;
             UsedFeatures      = FeatureFlags.None;
+            Counts            = counts;
         }
 
         public int GetDepthRegister()

--- a/Ryujinx.Graphics.Shader/Translation/TranslationCounts.cs
+++ b/Ryujinx.Graphics.Shader/Translation/TranslationCounts.cs
@@ -1,0 +1,30 @@
+namespace Ryujinx.Graphics.Shader.Translation
+{
+    public class TranslationCounts
+    {
+        public int UniformBuffersCount { get; private set; }
+        public int StorageBuffersCount { get; private set; }
+        public int TexturesCount { get; private set; }
+        public int ImagesCount { get; private set; }
+
+        internal int IncrementUniformBuffersCount()
+        {
+            return UniformBuffersCount++;
+        }
+
+        internal int IncrementStorageBuffersCount()
+        {
+            return StorageBuffersCount++;
+        }
+
+        internal int IncrementTexturesCount()
+        {
+            return TexturesCount++;
+        }
+
+        internal int IncrementImagesCount()
+        {
+            return ImagesCount++;
+        }
+    }
+}


### PR DESCRIPTION
This change uses explicit binding points on the shader code, rather than calling the OpenGL `glGet*Location` functions with the texture/image/buffer name and assigning a binding point on the backend. The main advantage here is making the backend cleaner and more flexible.

Advantages:
- Code is simpler/smaller.
- Binding should be a little bit faster, as it no longer needs to get the binding point from index/stage, the binding point is passed directly. A few other things were optimized aswell (for example, it passes all buffers to be bound at once instead of one at a time).

Other changes:
- Buffers are properly unbound instead of just keeping the last binding.

I recommend testing on a few games just to be sure nothing regressed.