### PR TITLE
IPSwitch: Quick fix to patch sets toggling

### DIFF
--- a/Ryujinx.HLE/Loaders/Mods/IPSwitchPatcher.cs
+++ b/Ryujinx.HLE/Loaders/Mods/IPSwitchPatcher.cs
@@ -147,7 +147,7 @@ namespace Ryujinx.HLE.Loaders.Mods
 
             MemPatch patches = new MemPatch();
 
-            bool enabled = true;
+            bool enabled = false;
             bool printValues = false;
             int offset_shift = 0;
 
@@ -160,6 +160,12 @@ namespace Ryujinx.HLE.Loaders.Mods
 
             while ((line = _reader.ReadLine()) != null)
             {
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    enabled = false;
+                    continue;
+                }
+
                 line = PreprocessLine(line);
                 lineNum += 1;
 

--- a/Ryujinx.HLE/Loaders/Mods/IPSwitchPatcher.cs
+++ b/Ryujinx.HLE/Loaders/Mods/IPSwitchPatcher.cs
@@ -18,6 +18,7 @@ namespace Ryujinx.HLE.Loaders.Mods
             if (header == null || !header.StartsWith(BidHeader))
             {
                 Logger.Error?.Print(LogClass.ModLoader, "IPSwitch:    Malformed PCHTXT file. Skipping...");
+
                 return;
             }
 
@@ -163,6 +164,7 @@ namespace Ryujinx.HLE.Loaders.Mods
                 if (string.IsNullOrWhiteSpace(line))
                 {
                     enabled = false;
+
                     continue;
                 }
 
@@ -196,6 +198,7 @@ namespace Ryujinx.HLE.Loaders.Mods
                     if (tokens.Length < 2)
                     {
                         ParseWarn();
+
                         continue;
                     }
 
@@ -204,6 +207,7 @@ namespace Ryujinx.HLE.Loaders.Mods
                         if (tokens.Length != 3 || !ParseInt(tokens[2], out offset_shift))
                         {
                             ParseWarn();
+
                             continue;
                         }
                     }
@@ -228,12 +232,14 @@ namespace Ryujinx.HLE.Loaders.Mods
                     if (tokens.Length < 2)
                     {
                         ParseWarn();
+
                         continue;
                     }
 
                     if (!Int32.TryParse(tokens[0], System.Globalization.NumberStyles.HexNumber, null, out int offset))
                     {
                         ParseWarn();
+
                         continue;
                     }
 


### PR DESCRIPTION
Just a quick change to `@enabled` functionality in pchtxt. Previous behavior considered `@enabled` and `@disabled` as state flags, but apparently that's not the case.

```
                      | Before   | Now

@enabled              |          |
00ABCD0 1F2003D5      | enabled  | enabled
// comment            |          |
00ABCD4 1F2003D5      | enabled  | enabled
                      |          | 
00ABCD8 1F2003D5      | enabled  | disabled
                      |          | 
@disabled             |          | 
00ABCDC 1F2003D5      | disabled | disabled
```
Simply put, you now have to add `@enabled` to every block of patches explicitly.
For extensive changes, it's probably best to rewrite to the new spec. I can't right now, if anyone wants to, feel free.