### PR TITLE
Do not match aligned sizes for buffer texture targets.

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -295,7 +295,9 @@ namespace Ryujinx.Graphics.Gpu.Image
                 return false;
             }
 
-            if (alignSizes)
+            bool isTextureBuffer = lhs.Target == Target.TextureBuffer || rhs.Target == Target.TextureBuffer;
+
+            if (alignSizes && !isTextureBuffer)
             {
                 Size size0 = GetAlignedSize(lhs);
                 Size size1 = GetAlignedSize(rhs);


### PR DESCRIPTION
This should fix a random crash in Hyrule Warriors, and potentially other games that use buffer textures. This crashed before as we don't support copying buffer textures.

Buffer textures don't need to do any size change tricks (they're 1D), and their data should be inherited simply by using the same buffer storage.