### PR TITLE
Do not report unmapped pages as dirty

### DIFF
--- a/Ryujinx.Cpu/MemoryManager.cs
+++ b/Ryujinx.Cpu/MemoryManager.cs
@@ -1,4 +1,4 @@
-using ARMeilleure.Memory;
+﻿using ARMeilleure.Memory;
 using Ryujinx.Cpu.Tracking;
 using Ryujinx.Memory;
 using Ryujinx.Memory.Tracking;
@@ -461,7 +461,32 @@ namespace Ryujinx.Cpu
         }
 
         /// <summary>
-        /// Checks if the page at a given CPU virtual address.
+        /// Checks if a memory range is mapped.
+        /// </summary>
+        /// <param name="va">Virtual address of the range</param>
+        /// <param name="size">Size of the range in bytes</param>
+        /// <returns>True if the entire range is mapped, false otherwise</returns>
+        public bool IsRangeMapped(ulong va, ulong size)
+        {
+            ulong endVa = (va + size + PageMask) & ~(ulong)PageMask;
+
+            va &= ~(ulong)PageMask;
+
+            while (va < endVa)
+            {
+                if (!IsMapped(va))
+                {
+                    return false;
+                }
+
+                va += PageSize;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Checks if the page at a given CPU virtual address is mapped.
         /// </summary>
         /// <param name="va">Virtual address to check</param>
         /// <returns>True if the address is mapped, false otherwise</returns>

--- a/Ryujinx.Memory.Tests/MockVirtualMemoryManager.cs
+++ b/Ryujinx.Memory.Tests/MockVirtualMemoryManager.cs
@@ -15,6 +15,11 @@ namespace Ryujinx.Memory.Tests
             return NoMappings ? new (ulong address, ulong size)[0] : new (ulong address, ulong size)[] { (va, size) };
         }
 
+        public bool IsRangeMapped(ulong va, ulong size)
+        {
+            return true;
+        }
+
         public void TrackingReprotect(ulong va, ulong size, MemoryPermission protection)
         {
             

--- a/Ryujinx.Memory/Tracking/IVirtualMemoryManager.cs
+++ b/Ryujinx.Memory/Tracking/IVirtualMemoryManager.cs
@@ -4,6 +4,7 @@
     {
         (ulong address, ulong size)[] GetPhysicalRegions(ulong va, ulong size);
 
+        bool IsRangeMapped(ulong va, ulong size);
         void TrackingReprotect(ulong va, ulong size, MemoryPermission protection);
     }
 }

--- a/Ryujinx.Memory/Tracking/MemoryTracking.cs
+++ b/Ryujinx.Memory/Tracking/MemoryTracking.cs
@@ -75,6 +75,7 @@ namespace Ryujinx.Memory.Tracking
                 {
                     VirtualRegion region = results[i];
                     region.RecalculatePhysicalChildren();
+                    region.UpdateProtection();
                 }
             }
         }

--- a/Ryujinx.Memory/Tracking/MemoryTracking.cs
+++ b/Ryujinx.Memory/Tracking/MemoryTracking.cs
@@ -200,7 +200,7 @@ namespace Ryujinx.Memory.Tracking
 
             lock (TrackingLock)
             {
-                RegionHandle handle = new RegionHandle(this, address, size);
+                RegionHandle handle = new RegionHandle(this, address, size, _memoryManager.IsRangeMapped(address, size));
 
                 return handle;
             }

--- a/Ryujinx.Memory/Tracking/RegionHandle.cs
+++ b/Ryujinx.Memory/Tracking/RegionHandle.cs
@@ -10,7 +10,7 @@ namespace Ryujinx.Memory.Tracking
     /// </summary>
     public class RegionHandle : IRegionHandle, IRange
     {
-        public bool Dirty { get; private set; } = true;
+        public bool Dirty { get; private set; }
 
         public ulong Address { get; }
         public ulong Size { get; }
@@ -32,8 +32,10 @@ namespace Ryujinx.Memory.Tracking
         /// <param name="tracking">Tracking object for the target memory block</param>
         /// <param name="address">Virtual address of the region to track</param>
         /// <param name="size">Size of the region to track</param>
-        internal RegionHandle(MemoryTracking tracking, ulong address, ulong size)
+        /// <param name="dirty">Initial value of the dirty flag</param>
+        internal RegionHandle(MemoryTracking tracking, ulong address, ulong size, bool dirty = true)
         {
+            Dirty = dirty;
             Address = address;
             Size = size;
             EndAddress = address + size;


### PR DESCRIPTION
Some games uses ranges that are partially unmapped for buffers (I don't know if this is normal or a bug to be honest). This change makes it not report unmapped regions as dirty, as attempting to read from those regions will throw. This fixes a regression in Higurashi no Naku Koro ni Hou after range tracking.