### PR TITLE
Support single precision contants for double precision operations

### DIFF
--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/NumberFormatter.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/NumberFormatter.cs
@@ -10,7 +10,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
         public static bool TryFormat(int value, VariableType dstType, out string formatted)
         {
-            if (dstType == VariableType.F32)
+            if (dstType == VariableType.F32 || dstType == VariableType.F64)
             {
                 return TryFormatFloat(BitConverter.Int32BitsToSingle(value), out formatted);
             }


### PR DESCRIPTION
While encoding a float64 on a immediate is not possible on the guest shaders, there are some cases were constants are used with those double precision values, for example, for saturate it uses the constants 0 and 1 with the clamp function. Before trying to use those constants with a float64 type would throw, now it properly inserts the constant on the generated code. The constant is encoded as float32 for the following reasons:
- The IR has no support for 64-bit contants (float or integer).
- Guest shaders do not support 64-bit immediates as mentioned before, for those cases it needs to load from constant buffer.
- A float32 is enough to encode all constants used without any loss of precision.

While the issue did show up on a few UE4 games, they were caused by corrupted/garbage shaders, so this does not actually fix anything on those games (this particular issue is fixed in #1670), however I figured I would fix that too anyway as there may be some game out there using doubles with saturation that would otherwise hit this case.