### PR TITLE
updater: Ignore first commandline argument when passing commandline to updated binary

### DIFF
--- a/Ryujinx/Updater/UpdateDialog.cs
+++ b/Ryujinx/Updater/UpdateDialog.cs
@@ -3,6 +3,7 @@ using Gtk;
 using Mono.Unix;
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace Ryujinx.Ui
@@ -45,7 +46,7 @@ namespace Ryujinx.Ui
             {
                 string ryuName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Ryujinx.exe" : "Ryujinx";
                 string ryuExe  = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ryuName);
-                string ryuArg = String.Join(" ", Environment.GetCommandLineArgs());
+                string ryuArg = String.Join(" ", Environment.GetCommandLineArgs().AsEnumerable().Skip(1).ToArray());
 
                 if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {


### PR DESCRIPTION
Fix a regression caused by #1643 causing the updated emulator to try to run itself as a game.