### PR TITLE
Synchronize Rasterizer State before Clear

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/MethodClear.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodClear.cs
@@ -20,10 +20,15 @@ namespace Ryujinx.Graphics.Gpu.Engine
                 return;
             }
 
-            // Scissor affects clears aswell.
+            // Scissor and rasterizer discard also affect clears.
             if (state.QueryModified(MethodOffset.ScissorState))
             {
                 UpdateScissorState(state);
+            }
+
+            if (state.QueryModified(MethodOffset.RasterizeEnable))
+            {
+                UpdateRasterizerState(state);
             }
 
             int index = (argument >> 6) & 0xf;


### PR DESCRIPTION
This fixes shadows sometimes not clearing in Xenoblade 2, as they are usually cleared immediately after a series of commands with Rasterizer Discard enabled.

![image](https://user-images.githubusercontent.com/6294155/98449418-66fb7d00-212b-11eb-8817-d4ca8f72ed4c.png)