### PR TITLE
GLRenderer: Change between docked and handheld mode using a keybinding

### DIFF
--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -166,7 +166,7 @@ namespace Ryujinx.Ui
 
             bool toggleDockedMode = keyboard.IsKeyDown(OpenTK.Input.Key.F9);
 
-            if(toggleDockedMode != _toggleDockedMode)
+            if (toggleDockedMode != _toggleDockedMode)
             {
                 if (toggleDockedMode)
                 {

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -41,6 +41,7 @@ namespace Ryujinx.Ui
         private bool   _mousePressed;
 
         private bool _toggleFullscreen;
+        private bool _toggleDockedMode;
 
         private readonly long _ticksPerFrame;
 
@@ -162,6 +163,19 @@ namespace Ryujinx.Ui
             }
 
             _toggleFullscreen = toggleFullscreen;
+
+            bool toggleDockedMode = keyboard.IsKeyDown(OpenTK.Input.Key.F9);
+
+            if(toggleDockedMode != _toggleDockedMode)
+            {
+                if (toggleDockedMode)
+                {
+                    ConfigurationState.Instance.System.EnableDockedMode.Value =
+                        !ConfigurationState.Instance.System.EnableDockedMode.Value;
+                }
+            }
+
+            _toggleDockedMode = toggleDockedMode;
         }
 
         private void GLRenderer_Initialized(object sender, EventArgs e)


### PR DESCRIPTION
Made it so you can change between handheld and docked mode with a keybinding, which is set to F9 for now