### PR TITLE
Size hints for copy regions and viewport dimensions to avoid data loss

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -5,6 +5,7 @@ using Ryujinx.Graphics.Gpu.Memory;
 using Ryujinx.Graphics.Gpu.Shader;
 using Ryujinx.Graphics.Gpu.State;
 using Ryujinx.Graphics.Shader;
+using Ryujinx.Graphics.Texture;
 using System;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -354,6 +355,9 @@ namespace Ryujinx.Graphics.Gpu.Engine
             int samplesInX = msaaMode.SamplesInX();
             int samplesInY = msaaMode.SamplesInY();
 
+            var extents = state.Get<ViewportExtents>(MethodOffset.ViewportExtents, 0);
+            Size sizeHint = new Size(extents.X + extents.Width, extents.Y + extents.Height, 1);
+
             bool changedScale = false;
 
             for (int index = 0; index < Constants.TotalRenderTargets; index++)
@@ -369,7 +373,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
                     continue;
                 }
 
-                Texture color = TextureManager.FindOrCreateTexture(colorState, samplesInX, samplesInY);
+                Texture color = TextureManager.FindOrCreateTexture(colorState, samplesInX, samplesInY, sizeHint);
 
                 changedScale |= TextureManager.SetRenderTargetColor(index, color);
 
@@ -388,7 +392,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
                 var dsState = state.Get<RtDepthStencilState>(MethodOffset.RtDepthStencilState);
                 var dsSize  = state.Get<Size3D>(MethodOffset.RtDepthStencilSize);
 
-                depthStencil = TextureManager.FindOrCreateTexture(dsState, dsSize, samplesInX, samplesInY);
+                depthStencil = TextureManager.FindOrCreateTexture(dsState, dsSize, samplesInX, samplesInY, sizeHint);
             }
 
             changedScale |= TextureManager.SetRenderTargetDepthStencil(depthStencil);

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -50,6 +50,12 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         public bool IsModified { get; internal set; }
 
+        /// <summary>
+        /// Set when a texture has been changed size. This indicates that it may need to be
+        /// changed again when obtained as a sampler.
+        /// </summary>
+        public bool ChangedSize { get; internal set; }
+
         private int _depth;
         private int _layers;
         private int _firstLayer;
@@ -353,6 +359,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="depthOrLayers">The new texture depth (for 3D textures) or layers (for layered textures)</param>
         private void RecreateStorageOrView(int width, int height, int depthOrLayers)
         {
+            ChangedSize = true;
+
             SetInfo(new TextureInfo(
                 Info.Address,
                 width,

--- a/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -2,7 +2,6 @@ using Ryujinx.Common;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Texture;
 using System;
-using System.Runtime.CompilerServices;
 
 namespace Ryujinx.Graphics.Gpu.Image
 {
@@ -305,22 +304,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             int width = Math.Max(1, info.Width >> level);
             int height = Math.Max(1, info.Height >> level);
-            int depth = Math.Max(1, info.GetDepth() >> level);
-
-            return GetAlignedSize(info, width, height, depth);
-        }
-
-        /// <summary>
-        /// Gets the aligned sizes of the specified texture information and dimensions.
-        /// The alignment depends on the texture layout and format bytes per pixel.
-        /// </summary>
-        /// <param name="info">Texture information to calculate the aligned size from</param>
-        /// <param name="width">Texture width</param>
-        /// <param name="height">Texture height</param>
-        /// <param name="depth">Texture depth</param>
-        /// <returns>The aligned texture size</returns>
-        public static Size GetAlignedSize(TextureInfo info, int width, int height, int depth)
-        {
+            
             if (info.IsLinear)
             {
                 return SizeCalculator.GetLinearAlignedSize(
@@ -332,6 +316,8 @@ namespace Ryujinx.Graphics.Gpu.Image
             }
             else
             {
+                int depth = Math.Max(1, info.GetDepth() >> level);
+
                 return SizeCalculator.GetBlockLinearAlignedSize(
                     width,
                     height,

--- a/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -304,7 +304,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             int width = Math.Max(1, info.Width >> level);
             int height = Math.Max(1, info.Height >> level);
-            
+
             if (info.IsLinear)
             {
                 return SizeCalculator.GetLinearAlignedSize(

--- a/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -2,6 +2,7 @@ using Ryujinx.Common;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Texture;
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Ryujinx.Graphics.Gpu.Image
 {
@@ -304,7 +305,22 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             int width = Math.Max(1, info.Width >> level);
             int height = Math.Max(1, info.Height >> level);
+            int depth = Math.Max(1, info.GetDepth() >> level);
 
+            return GetAlignedSize(info, width, height, depth);
+        }
+
+        /// <summary>
+        /// Gets the aligned sizes of the specified texture information and dimensions.
+        /// The alignment depends on the texture layout and format bytes per pixel.
+        /// </summary>
+        /// <param name="info">Texture information to calculate the aligned size from</param>
+        /// <param name="width">Texture width</param>
+        /// <param name="height">Texture height</param>
+        /// <param name="depth">Texture depth</param>
+        /// <returns>The aligned texture size</returns>
+        public static Size GetAlignedSize(TextureInfo info, int width, int height, int depth)
+        {
             if (info.IsLinear)
             {
                 return SizeCalculator.GetLinearAlignedSize(
@@ -316,8 +332,6 @@ namespace Ryujinx.Graphics.Gpu.Image
             }
             else
             {
-                int depth = Math.Max(1, info.GetDepth() >> level);
-
                 return SizeCalculator.GetBlockLinearAlignedSize(
                     width,
                     height,

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -937,7 +937,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 if (texture.Info.Width != width || texture.Info.Height != height)
                 {
-                    // Only attempt to resize if the new width and height are within alignment constraints.
+                    // Only attempt to resize if the new width and height match within alignment constraints.
 
                     if (TextureCompatibility.GetAlignedSize(texture.Info).Equals(TextureCompatibility.GetAlignedSize(texture.Info, width, height, texture.Info.GetDepth())))
                     {

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -930,19 +930,15 @@ namespace Ryujinx.Graphics.Gpu.Image
             else if (sizeHint != null)
             {
                 // A size hint indicates that data will be used within that range, at least.
-                // If the texture is smaller than the size hint, it must be resized to meet it.
+                // If the texture is smaller than the size hint, it must be enlarged to meet it.
+                // The maximum size is provided by the requested info, which generally has an aligned size.
 
-                int width = Math.Max(sizeHint.Value.Width, texture.Info.Width);
-                int height = Math.Max(sizeHint.Value.Height, texture.Info.Height);
+                int width = Math.Min(Math.Max(sizeHint.Value.Width, texture.Info.Width), info.Width);
+                int height = Math.Min(Math.Max(sizeHint.Value.Height, texture.Info.Height), info.Height);
 
                 if (texture.Info.Width != width || texture.Info.Height != height)
                 {
-                    // Only attempt to resize if the new width and height match within alignment constraints.
-
-                    if (TextureCompatibility.GetAlignedSize(texture.Info).Equals(TextureCompatibility.GetAlignedSize(texture.Info, width, height, texture.Info.GetDepth())))
-                    {
-                        texture.ChangeSize(width, height, info.DepthOrLayers);
-                    }
+                    texture.ChangeSize(width, height, info.DepthOrLayers);
                 }
             }
         }

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -933,8 +933,8 @@ namespace Ryujinx.Graphics.Gpu.Image
                 // If the texture is smaller than the size hint, it must be enlarged to meet it.
                 // The maximum size is provided by the requested info, which generally has an aligned size.
 
-                int width = Math.Min(Math.Max(sizeHint.Value.Width, texture.Info.Width), info.Width);
-                int height = Math.Min(Math.Max(sizeHint.Value.Height, texture.Info.Height), info.Height);
+                int width = Math.Max(texture.Info.Width, Math.Min(sizeHint.Value.Width, info.Width));
+                int height = Math.Max(texture.Info.Height, Math.Min(sizeHint.Value.Height, info.Height));
 
                 if (texture.Info.Width != width || texture.Info.Height != height)
                 {

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -453,8 +453,9 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="copyTexture">Copy texture to find or create</param>
         /// <param name="formatInfo">Format information of the copy texture</param>
         /// <param name="preferScaling">Indicates if the texture should be scaled from the start</param>
+        /// <param name="sizeHint">A hint indicating the minimum used size for the texture</param>
         /// <returns>The texture</returns>
-        public Texture FindOrCreateTexture(CopyTexture copyTexture, FormatInfo formatInfo, bool preferScaling = true)
+        public Texture FindOrCreateTexture(CopyTexture copyTexture, FormatInfo formatInfo, bool preferScaling = true, Size? sizeHint = null)
         {
             ulong address = _context.MemoryManager.Translate(copyTexture.Address.Pack());
 
@@ -500,7 +501,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 flags |= TextureSearchFlags.WithUpscale;
             }
 
-            Texture texture = FindOrCreateTexture(info, flags);
+            Texture texture = FindOrCreateTexture(info, flags, sizeHint);
 
             texture.SynchronizeMemory();
 
@@ -513,8 +514,9 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="colorState">Color buffer texture to find or create</param>
         /// <param name="samplesInX">Number of samples in the X direction, for MSAA</param>
         /// <param name="samplesInY">Number of samples in the Y direction, for MSAA</param>
+        /// <param name="sizeHint">A hint indicating the minimum used size for the texture</param>
         /// <returns>The texture</returns>
-        public Texture FindOrCreateTexture(RtColorState colorState, int samplesInX, int samplesInY)
+        public Texture FindOrCreateTexture(RtColorState colorState, int samplesInX, int samplesInY, Size sizeHint)
         {
             ulong address = _context.MemoryManager.Translate(colorState.Address.Pack());
 
@@ -583,7 +585,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 target,
                 formatInfo);
 
-            Texture texture = FindOrCreateTexture(info, TextureSearchFlags.WithUpscale);
+            Texture texture = FindOrCreateTexture(info, TextureSearchFlags.WithUpscale, sizeHint);
 
             texture.SynchronizeMemory();
 
@@ -597,8 +599,9 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="size">Size of the depth-stencil texture</param>
         /// <param name="samplesInX">Number of samples in the X direction, for MSAA</param>
         /// <param name="samplesInY">Number of samples in the Y direction, for MSAA</param>
+        /// <param name="sizeHint">A hint indicating the minimum used size for the texture</param>
         /// <returns>The texture</returns>
-        public Texture FindOrCreateTexture(RtDepthStencilState dsState, Size3D size, int samplesInX, int samplesInY)
+        public Texture FindOrCreateTexture(RtDepthStencilState dsState, Size3D size, int samplesInX, int samplesInY, Size sizeHint)
         {
             ulong address = _context.MemoryManager.Translate(dsState.Address.Pack());
 
@@ -632,7 +635,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 target,
                 formatInfo);
 
-            Texture texture = FindOrCreateTexture(info, TextureSearchFlags.WithUpscale);
+            Texture texture = FindOrCreateTexture(info, TextureSearchFlags.WithUpscale, sizeHint);
 
             texture.SynchronizeMemory();
 
@@ -644,8 +647,9 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         /// <param name="info">Texture information of the texture to be found or created</param>
         /// <param name="flags">The texture search flags, defines texture comparison rules</param>
+        /// <param name="sizeHint">A hint indicating the minimum used size for the texture</param>
         /// <returns>The texture</returns>
-        public Texture FindOrCreateTexture(TextureInfo info, TextureSearchFlags flags = TextureSearchFlags.None)
+        public Texture FindOrCreateTexture(TextureInfo info, TextureSearchFlags flags = TextureSearchFlags.None, Size? sizeHint = null)
         {
             bool isSamplerTexture = (flags & TextureSearchFlags.ForSampler) != 0;
 
@@ -678,14 +682,8 @@ namespace Ryujinx.Graphics.Gpu.Image
                         // deletion.
                         _cache.Lift(overlap);
                     }
-                    else if (!TextureCompatibility.SizeMatches(overlap.Info, info))
-                    {
-                        // If this is used for sampling, the size must match,
-                        // otherwise the shader would sample garbage data.
-                        // To fix that, we create a new texture with the correct
-                        // size, and copy the data from the old one to the new one.
-                        overlap.ChangeSize(info.Width, info.Height, info.DepthOrLayers);
-                    }
+
+                    ChangeSizeIfNeeded(info, overlap, isSamplerTexture, sizeHint);
 
                     overlap.SynchronizeMemory();
 
@@ -741,25 +739,21 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 if (overlapCompatibility == TextureViewCompatibility.Full)
                 {
+                    TextureInfo oInfo = AdjustSizes(overlap, info, firstLevel);
+
                     if (!isSamplerTexture)
                     {
-                        info = AdjustSizes(overlap, info, firstLevel);
+                        info = oInfo;
                     }
 
-                    texture = overlap.CreateView(info, sizeInfo, firstLayer, firstLevel);
+                    texture = overlap.CreateView(oInfo, sizeInfo, firstLayer, firstLevel);
 
                     if (overlap.IsModified)
                     {
                         texture.SignalModified();
                     }
 
-                    // The size only matters (and is only really reliable) when the
-                    // texture is used on a sampler, because otherwise the size will be
-                    // aligned.
-                    if (!TextureCompatibility.SizeMatches(overlap.Info, info, firstLevel) && isSamplerTexture)
-                    {
-                        texture.ChangeSize(info.Width, info.Height, info.DepthOrLayers);
-                    }
+                    ChangeSizeIfNeeded(info, texture, isSamplerTexture, sizeHint);
 
                     break;
                 }
@@ -909,6 +903,48 @@ namespace Ryujinx.Graphics.Gpu.Image
             ShrinkOverlapsBufferIfNeeded();
 
             return texture;
+        }
+
+        /// <summary>
+        /// Changes a texture's size to match the desired size for samplers,
+        /// or increases a texture's size to fit the region indicated by a size hint.
+        /// </summary>
+        /// <param name="info">The desired texture info</param>
+        /// <param name="texture">The texture to resize</param>
+        /// <param name="isSamplerTexture">True if the texture will be used for a sampler, false otherwise</param>
+        /// <param name="sizeHint">A hint indicating the minimum used size for the texture</param>
+        private void ChangeSizeIfNeeded(TextureInfo info, Texture texture, bool isSamplerTexture, Size? sizeHint)
+        {
+            if (isSamplerTexture)
+            {
+                // If this is used for sampling, the size must match,
+                // otherwise the shader would sample garbage data.
+                // To fix that, we create a new texture with the correct
+                // size, and copy the data from the old one to the new one.
+
+                if (!TextureCompatibility.SizeMatches(texture.Info, info))
+                {
+                    texture.ChangeSize(info.Width, info.Height, info.DepthOrLayers);
+                }
+            }
+            else if (sizeHint != null)
+            {
+                // A size hint indicates that data will be used within that range, at least.
+                // If the texture is smaller than the size hint, it must be resized to meet it.
+
+                int width = Math.Max(sizeHint.Value.Width, texture.Info.Width);
+                int height = Math.Max(sizeHint.Value.Height, texture.Info.Height);
+
+                if (texture.Info.Width != width || texture.Info.Height != height)
+                {
+                    // Only attempt to resize if the new width and height are within alignment constraints.
+
+                    if (TextureCompatibility.GetAlignedSize(texture.Info).Equals(TextureCompatibility.GetAlignedSize(texture.Info, width, height, texture.Info.GetDepth())))
+                    {
+                        texture.ChangeSize(width, height, info.DepthOrLayers);
+                    }
+                }
+            }
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -67,6 +67,22 @@ namespace Ryujinx.Graphics.Gpu.Image
             }
             else
             {
+                if (texture.ChangedSize)
+                {
+                    // Texture changed size at one point - it may be a different size than the sampler expects.
+                    // This can be triggered when the size is changed by a size hint on copy or draw, but the texture has been sampled before.
+
+                    TextureDescriptor descriptor = GetDescriptor(id);
+
+                    int width = descriptor.UnpackWidth();
+                    int height = descriptor.UnpackHeight();
+
+                    if (texture.Info.Width != width || texture.Info.Height != height)
+                    {
+                        texture.ChangeSize(width, height, texture.Info.DepthOrLayers);
+                    }
+                }
+
                 // Memory is automatically synchronized on texture creation.
                 texture.SynchronizeMemory();
             }


### PR DESCRIPTION
Data can be lost if the last sampled size for a texture is smaller than the region it wants to render to, due to the texture being changed to the smaller size. This manifests in games with dynamic resolution as garbage at the bottom right edge, cropping, the image shifting every frame etc. It can also cause data to be lost when copying between textures. This PR attempts to solve this issue by passing in usage hints that indicate the minimum size that the requester would _prefer_, and increase the size to meet it when possible.

Size Hints currently come from two places:
- Textures used as color or depth targets use Viewport 0's dimensions.
- Source and destination textures for copies use the copy region.
  - Source is included because generally the texture needs to be synchronized before copy. Synchronizing with the wrong size could lose data.

Both these hints fit the pattern `Position + Size`, which should result in a size that fully covers the desired region.

The rules for using the size hints are as follows:
- If the texture requested is for a sampler, trust and resize to the dimensions in the given texture info, as we did before.
- If this is not a case and a size hint is not provided, do nothing.
- If it is, grow the existing texture's size to contain the size hint, but with dimensions in the given info as an upper bound.
  - If neither dimension is affected, do nothing.
  - Otherwise resize the texture.

Additionally, when a texture is resized at least once, an additional check will be done when retrieving it from a texture pool to check if its size doesn't match the texture descriptor. This fixes an issue where multiple entries on the pool could point to the same texture at different sizes, without changing to the correct size on use.

The most visible improvements will be in Luigi's Mansion 3 and Kingdom Hearts: Melody of Memory. This also helps texture streaming in unreal engine 3/4 games, and cubemap generation in MK8, though the improvements will be hard to spot through everything else being broken. This PR does not speed up uses of dynamic resolution, it just fixes graphics in games that use it.

I'd recommend testing in a few other games to make sure nothing weird happens.

Before:
https://gyazo.com/387bdbefacad6fb56768eddbe85613a3

After:
https://gyazo.com/ee8dff8573d34883d1d126a98497fb90
