### PR TITLE
Implement ATOM shader instruction

### DIFF
--- a/Ryujinx.Graphics.Shader/Decoders/AtomicOp.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/AtomicOp.cs
@@ -10,6 +10,7 @@ namespace Ryujinx.Graphics.Shader.Decoders
         BitwiseAnd         = 5,
         BitwiseOr          = 6,
         BitwiseExclusiveOr = 7,
-        Swap               = 8
+        Swap               = 8,
+        SafeAdd            = 10 // Only supported by ATOM.
     }
 }

--- a/Ryujinx.Graphics.Shader/Decoders/OpCodeAtom.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/OpCodeAtom.cs
@@ -8,8 +8,6 @@ namespace Ryujinx.Graphics.Shader.Decoders
         public Register Ra { get; }
         public Register Rb { get; }
 
-        public ReductionType Type { get; }
-
         public bool Extended { get; }
 
         public AtomicOp AtomicOp { get; }
@@ -21,13 +19,6 @@ namespace Ryujinx.Graphics.Shader.Decoders
             Rd = new Register(opCode.Extract(0,  8), RegisterType.Gpr);
             Ra = new Register(opCode.Extract(8,  8), RegisterType.Gpr);
             Rb = new Register(opCode.Extract(20, 8), RegisterType.Gpr);
-
-            Type = (ReductionType)opCode.Extract(28, 2);
-
-            if (Type == ReductionType.FP32FtzRn)
-            {
-                Type = ReductionType.S64;
-            }
 
             Extended = opCode.Extract(48);
 

--- a/Ryujinx.Graphics.Shader/Decoders/OpCodeAtom.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/OpCodeAtom.cs
@@ -10,8 +10,6 @@ namespace Ryujinx.Graphics.Shader.Decoders
 
         public ReductionType Type { get; }
 
-        public int Offset { get; }
-
         public bool Extended { get; }
 
         public AtomicOp AtomicOp { get; }
@@ -30,8 +28,6 @@ namespace Ryujinx.Graphics.Shader.Decoders
             {
                 Type = ReductionType.S64;
             }
-
-            Offset = opCode.Extract(30, 22);
 
             Extended = opCode.Extract(48);
 

--- a/Ryujinx.Graphics.Shader/Decoders/OpCodeTable.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/OpCodeTable.cs
@@ -34,6 +34,7 @@ namespace Ryujinx.Graphics.Shader.Decoders
 #region Instructions
             Set("1110111111011x", InstEmit.Ald,     OpCodeAttribute.Create);
             Set("1110111111110x", InstEmit.Ast,     OpCodeAttribute.Create);
+            Set("11101101xxxxxx", InstEmit.Atom,    OpCodeAtom.Create);
             Set("11101100xxxxxx", InstEmit.Atoms,   OpCodeAtom.Create);
             Set("1111000010101x", InstEmit.Bar,     OpCodeBarrier.Create);
             Set("0100110000000x", InstEmit.Bfe,     OpCodeAluCbuf.Create);

--- a/Ryujinx.Graphics.Shader/Decoders/ReductionType.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/ReductionType.cs
@@ -2,11 +2,11 @@ namespace Ryujinx.Graphics.Shader.Decoders
 {
     enum ReductionType
     {
-        U32       = 0,
-        S32       = 1,
-        U64       = 2,
-        FP32FtzRn = 3,
-        U128      = 4,
-        S64       = 5
+        U32         = 0,
+        S32         = 1,
+        U64         = 2,
+        FP32FtzRn   = 3,
+        FP16x2FtzRn = 4,
+        S64         = 5
     }
 }

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitMemory.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitMemory.cs
@@ -61,6 +61,8 @@ namespace Ryujinx.Graphics.Shader.Instructions
         {
             OpCodeAtom op = (OpCodeAtom)context.CurrOp;
 
+            ReductionType type = (ReductionType)op.RawOpCode.Extract(49, 2);
+
             int sOffset = (op.RawOpCode.Extract(28, 20) << 12) >> 12;
 
             (Operand addrLow, Operand addrHigh) = Get40BitsAddress(context, op.Ra, op.Extended, sOffset);
@@ -71,7 +73,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 context,
                 Instruction.MrGlobal,
                 op.AtomicOp,
-                op.Type,
+                type,
                 addrLow,
                 addrHigh,
                 value);
@@ -82,6 +84,14 @@ namespace Ryujinx.Graphics.Shader.Instructions
         public static void Atoms(EmitterContext context)
         {
             OpCodeAtom op = (OpCodeAtom)context.CurrOp;
+
+            ReductionType type = op.RawOpCode.Extract(28, 2) switch
+            {
+                0 => ReductionType.U32,
+                1 => ReductionType.S32,
+                2 => ReductionType.U64,
+                _ => ReductionType.S64
+            };
 
             Operand offset = context.ShiftRightU32(GetSrcA(context), Const(2));
 
@@ -95,7 +105,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 context,
                 Instruction.MrShared,
                 op.AtomicOp,
-                op.Type,
+                type,
                 offset,
                 Const(0),
                 value);

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitMemory.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitMemory.cs
@@ -57,13 +57,37 @@ namespace Ryujinx.Graphics.Shader.Instructions
             }
         }
 
+        public static void Atom(EmitterContext context)
+        {
+            OpCodeAtom op = (OpCodeAtom)context.CurrOp;
+
+            int sOffset = (op.RawOpCode.Extract(28, 20) << 12) >> 12;
+
+            (Operand addrLow, Operand addrHigh) = Get40BitsAddress(context, op.Ra, op.Extended, sOffset);
+
+            Operand value = GetSrcB(context);
+
+            Operand res = EmitAtomicOp(
+                context,
+                Instruction.MrGlobal,
+                op.AtomicOp,
+                op.Type,
+                addrLow,
+                addrHigh,
+                value);
+
+            context.Copy(GetDest(context), res);
+        }
+
         public static void Atoms(EmitterContext context)
         {
             OpCodeAtom op = (OpCodeAtom)context.CurrOp;
 
             Operand offset = context.ShiftRightU32(GetSrcA(context), Const(2));
 
-            offset = context.IAdd(offset, Const(op.Offset));
+            int sOffset = (op.RawOpCode.Extract(30, 22) << 10) >> 10;
+
+            offset = context.IAdd(offset, Const(sOffset));
 
             Operand value = GetSrcB(context);
 


### PR DESCRIPTION
This implements the ATOM shader instruction, and fixes negative offsets on the ATOMS shader instructions (the offset was not being sign-extended).

The ATOM instruction is similar to ATOMS, but operates on global memory. It can be used to do atomic operations on memory, such as GLSL `atomicAdd` and friends.

I know a bunch of games that uses this (Fire Emblem Three Houses is one of them), but I don't know any specific issue that this change fixes.

Note: The compare and swap variant is still not implemented, but it also doesn't seems to be implemented for the other atomic instructions.