### PR TITLE
Fix: Update performance mode when docked mode changes.

### DIFF
--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -250,6 +250,7 @@ namespace Ryujinx.HLE.HOS
             if (e.NewValue != State.DockedMode)
             {
                 State.DockedMode = e.NewValue;
+                PerformanceState.PerformanceMode = State.DockedMode ? PerformanceMode.Boost : PerformanceMode.Default;
 
                 AppletState.EnqueueMessage(MessageInfo.OperationModeChanged);
                 AppletState.EnqueueMessage(MessageInfo.PerformanceModeChanged);

--- a/Ryujinx.HLE/Switch.cs
+++ b/Ryujinx.HLE/Switch.cs
@@ -10,6 +10,7 @@ using Ryujinx.HLE.FileSystem;
 using Ryujinx.HLE.FileSystem.Content;
 using Ryujinx.HLE.HOS;
 using Ryujinx.HLE.HOS.Services;
+using Ryujinx.HLE.HOS.Services.Apm;
 using Ryujinx.HLE.HOS.Services.Hid;
 using Ryujinx.HLE.HOS.SystemState;
 using Ryujinx.Memory;
@@ -110,6 +111,8 @@ namespace Ryujinx.HLE
             EnableDeviceVsync = ConfigurationState.Instance.Graphics.EnableVsync;
 
             System.State.DockedMode = ConfigurationState.Instance.System.EnableDockedMode;
+
+            System.PerformanceState.PerformanceMode = System.State.DockedMode ? PerformanceMode.Boost : PerformanceMode.Default;
 
             if (ConfigurationState.Instance.System.EnableMulticoreScheduling)
             {


### PR DESCRIPTION
Performance mode was stuck on "default", which caused SMO to always run as if it were in handheld mode. This fixes the system init and docked mode switch to also update the performance mode.