### PR TITLE
Standardize to camel-case: option to check for updates on launch

### DIFF
--- a/Ryujinx/Ui/SettingsWindow.glade
+++ b/Ryujinx/Ui/SettingsWindow.glade
@@ -126,7 +126,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkCheckButton" id="_checkUpdatesToggle">
-                                    <property name="label" translatable="yes">Check For Updates On Launch</property>
+                                    <property name="label" translatable="yes">Check for Updates on Launch</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>

--- a/Ryujinx/Ui/SettingsWindow.glade
+++ b/Ryujinx/Ui/SettingsWindow.glade
@@ -126,7 +126,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkCheckButton" id="_checkUpdatesToggle">
-                                    <property name="label" translatable="yes">Check for updates on launch</property>
+                                    <property name="label" translatable="yes">Check For Updates On Launch</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>


### PR DESCRIPTION
Updates the "Check for updates on launch" to read instead "Check for Updates on Launch" to be consistent with camel-case options elsewhere in the UI. This time done with manual editing instead of with the Glade app.