### PR TITLE
Use "Screen Scissor" as size hint for render targets

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -355,8 +355,8 @@ namespace Ryujinx.Graphics.Gpu.Engine
             int samplesInX = msaaMode.SamplesInX();
             int samplesInY = msaaMode.SamplesInY();
 
-            var extents = state.Get<ViewportExtents>(MethodOffset.ViewportExtents, 0);
-            Size sizeHint = new Size(extents.X + extents.Width, extents.Y + extents.Height, 1);
+            var scissor = state.Get<ScreenScissorState>(MethodOffset.ScreenScissorState);
+            Size sizeHint = new Size(scissor.X + scissor.Width, scissor.Y + scissor.Height, 1);
 
             bool changedScale = false;
 

--- a/Ryujinx.Graphics.Gpu/State/MethodOffset.cs
+++ b/Ryujinx.Graphics.Gpu/State/MethodOffset.cs
@@ -45,6 +45,7 @@ namespace Ryujinx.Graphics.Gpu.State
         TextureBarrierTiled             = 0x3df,
         RtColorMaskShared               = 0x3e4,
         RtDepthStencilState             = 0x3f8,
+        ScreenScissorState              = 0x3fd,
         VertexAttribState               = 0x458,
         RtControl                       = 0x487,
         RtDepthStencilSize              = 0x48a,

--- a/Ryujinx.Graphics.Gpu/State/ScreenScissorState.cs
+++ b/Ryujinx.Graphics.Gpu/State/ScreenScissorState.cs
@@ -1,0 +1,12 @@
+﻿namespace Ryujinx.Graphics.Gpu.State
+{
+    struct ScreenScissorState
+    {
+#pragma warning disable CS0649
+        public ushort X;
+        public ushort Width;
+        public ushort Y;
+        public ushort Height;
+#pragma warning restore CS0649
+    }
+}


### PR DESCRIPTION
"Screen scissor" is the minimum size of all render targets, and is set when any render target is bound on NVN or OpenGL. Since it works on all render texture's _real_ sizes, it is therefore more reliable than viewport 0's width, and is actually set before clear.

This fixes a regression with Hyrule Warriors: Age Of Calamity's cubemaps, which did not set viewport dimensions before clear, so the hint was inaccurate. This resulted in attempting to create a cubemap with rectangular sides (16x8), which is logically and physically impossible. (also it just fails)

A better solution for size rules regarding cubemap views will likely be done later.