### PR TITLE
Use backup when PTC compression is corrupt

### DIFF
--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -196,7 +196,16 @@ namespace ARMeilleure.Translation.PTC
             {
                 int hashSize = md5.HashSize / 8;
 
-                deflateStream.CopyTo(stream);
+                try 
+                {
+                    deflateStream.CopyTo(stream);
+                } 
+                catch
+                {
+                    InvalidateCompressedStream(compressedStream);
+
+                    return false;
+                }
 
                 stream.Seek(0L, SeekOrigin.Begin);
 

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -196,10 +196,10 @@ namespace ARMeilleure.Translation.PTC
             {
                 int hashSize = md5.HashSize / 8;
 
-                try 
+                try
                 {
                     deflateStream.CopyTo(stream);
-                } 
+                }
                 catch
                 {
                     InvalidateCompressedStream(compressedStream);

--- a/ARMeilleure/Translation/PTC/PtcProfiler.cs
+++ b/ARMeilleure/Translation/PTC/PtcProfiler.cs
@@ -123,7 +123,7 @@ namespace ARMeilleure.Translation.PTC
                 try
                 {
                     deflateStream.CopyTo(stream);
-                } 
+                }
                 catch
                 {
                     InvalidateCompressedStream(compressedStream);

--- a/ARMeilleure/Translation/PTC/PtcProfiler.cs
+++ b/ARMeilleure/Translation/PTC/PtcProfiler.cs
@@ -120,7 +120,16 @@ namespace ARMeilleure.Translation.PTC
             {
                 int hashSize = md5.HashSize / 8;
 
-                deflateStream.CopyTo(stream);
+                try
+                {
+                    deflateStream.CopyTo(stream);
+                } 
+                catch
+                {
+                    InvalidateCompressedStream(compressedStream);
+
+                    return false;
+                }
 
                 stream.Seek(0L, SeekOrigin.Begin);
 


### PR DESCRIPTION
We have some nice checks for PTC to make sure the data is valid before we load and use it, and a backup to try in case it isn't.

Unfortunately, none of that is used right now because most of the time it throws attempting to decompress an incomplete stream.

This PR catches decompression errors and treats it as a loading failure, which lets it fall back to the backup instead of crashing. The change has been made for both the cache and the info.