### PR TITLE
Improve GPU Memory Allocation

### DIFF
--- a/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
@@ -125,7 +125,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         private void Alloc(ulong address, ulong size)
         {
             LinkedListNode<MemoryRange> node = _memory.First;
-            ulong endAddress = address + size;
+            ulong endAddress = address + size - 1UL;
             while(node != null)
             {
                 MemoryRange range = node.Value;
@@ -356,9 +356,8 @@ namespace Ryujinx.Graphics.Gpu.Memory
         private ulong GetFreePosition(ulong size, ulong alignment = 1, ulong start = 1UL << 32)
         {
             stopwatch.Restart();
-            // Note: Address 0 is not considered valid by the driver,
-            // when 0 is returned it's considered a mapping error.
-            foreach(MemoryRange memoryRange in _memory)
+
+            foreach (MemoryRange memoryRange in _memory)
             {
                 if (memoryRange.endAddress - memoryRange.startAddress >= size)
                 {
@@ -366,40 +365,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                     return memoryRange.startAddress;
                 }
             }
-            //ulong address  = start;
-            //ulong freeSize = 0;
 
-            //if (alignment == 0)
-            //{
-            //    alignment = 1;
-            //}
-
-            //alignment = (alignment + PageMask) & ~PageMask;
-
-            //while (address + freeSize < AddressSpaceSize)
-            //{
-            //    if (!IsPageInUse(address + freeSize))
-            //    {
-            //        freeSize += PageSize;
-
-            //        if (freeSize >= size)
-            //        {
-            //            return address;
-            //        }
-            //    }
-            //    else
-            //    {
-            //        address += freeSize + PageSize;
-            //        freeSize = 0;
-
-            //        ulong remainder = address % alignment;
-
-            //        if (remainder != 0)
-            //        {
-            //            address = (address - remainder) + alignment;
-            //        }
-            //    }
-            //}
             Console.WriteLine($"Position Took: {stopwatch.ElapsedMilliseconds}ms");
             return PteUnmapped;
         }

--- a/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
@@ -169,12 +169,32 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
                     LinkedListNode<MemoryRange> prev = node.Previous;
 
-                    if (prev != null)
+                    while (prev != null)
                     {
-                        if(prev.Value.endAddress == start - 1UL)
+                        if (prev.Value.endAddress == start - 1UL)
                         {
                             start = prev.Value.startAddress;
                             _memory.Remove(prev);
+                            prev = prev.Previous;
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+
+                    LinkedListNode<MemoryRange> next = node.Next;
+
+                    while(next != null)
+                    {
+                        if(next.Value.startAddress == end + 1UL)
+                        {
+                            end = next.Value.endAddress;
+                            _memory.Remove(next);
+                            next = next.Next;
+                        }
+                        else {
+                            break;
                         }
                     }
 
@@ -381,9 +401,10 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 while(null != node)
                 {
                     MemoryRange memoryRange = node.Value;
-                    if (address >= memoryRange.startAddress && address + PageSize - 1UL <= memoryRange.endAddress)
+                    if (memoryRange.size >= PageSize && address >= memoryRange.startAddress && address + PageSize - 1UL <= memoryRange.endAddress)
                     {
                         Console.WriteLine($"Position Took: {stopwatch.ElapsedMilliseconds}ms");
+                        Console.WriteLine($"# Ranges: {_memory.Count}");
                         return address;
                     }
                     node = node.Next;

--- a/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
@@ -202,6 +202,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
             {
                 MemoryUnmapped?.Invoke(this, new UnmapEventArgs(va, size));
 
+                Alloc(va, (size / PageSize) + (size % PageSize));
                 for (ulong offset = 0; offset < size; offset += PageSize)
                 {
                     SetPte(va + offset, pa + offset);

--- a/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
@@ -161,6 +161,44 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 }
             }
         }
+
+        /// <summary>
+        /// Marks a range of memory as free.
+        /// </summary>
+        /// <param name="address">The address at which to mark</param>
+        /// <param name="size">Size in bytes of the range</param>
+        private void Dealloc(ulong address, ulong size)
+        {
+            LinkedListNode<MemoryRange> node = _memory.First;
+            while (node != null)
+            {
+                MemoryRange range = node.Value;
+                if (address < range.startAddress)
+                {
+                    ulong start = address, end = range.endAddress;
+
+                    LinkedListNode<MemoryRange> prev = node.Previous;
+
+                    if (prev != null)
+                    {
+                        if(prev.Value.endAddress == start - 1UL)
+                        {
+                            start = prev.Value.startAddress;
+                            _memory.Remove(prev);
+                        }
+                    }
+
+                    _memory.AddBefore(node, new MemoryRange(start, end));
+                    _memory.Remove(node);
+                    return;
+                }
+                else
+                {
+                    node = node.Next;
+                }
+            }
+        }
+
         /// <summary>
         /// Maps a given range of pages to the specified CPU virtual address.
         /// </summary>

--- a/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
@@ -54,7 +54,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
             
             ulong current = PageSize;
             ulong i = 1;
-            while(i <= 128)
+            while(i <= 256)
             {
                 _tree.Add(current, new LinkedList<LinkedListNode<MemoryRange>>());
                 current = PageSize * i;
@@ -510,9 +510,9 @@ namespace Ryujinx.Graphics.Gpu.Memory
             }
 
             Console.WriteLine($"Position Took: {stopwatch.ElapsedMilliseconds}ms");
-            Console.WriteLine($"# Ranges: {_memory.Count}");
-            Console.WriteLine(String.Join(',', _memory));
-            Console.WriteLine($"Desired Address: |{address} -> {address + size}");
+            //Console.WriteLine($"# Ranges: {_memory.Count}");
+            //Console.WriteLine(String.Join(',', _memory));
+            //Console.WriteLine($"Desired Address: |{address} -> {address + size}");
 
             list = new LinkedList<LinkedListNode<MemoryRange>>();
             memoryRange = new LinkedListNode<MemoryRange>(MemoryRange.InvalidRange);

--- a/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
@@ -38,6 +38,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
         private readonly ulong[][] _pageTable;
         private LinkedList<MemoryRange> _memory = new LinkedList<MemoryRange>();
+        private SortedDictionary<ulong, MemoryRange> _tree = new SortedDictionary<ulong, MemoryRange>();
         public event EventHandler<UnmapEventArgs> MemoryUnmapped;
 
         private GpuContext _context;
@@ -50,6 +51,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
             _context = context;
             _pageTable = new ulong[PtLvl0Size][];
             _memory.AddFirst(new MemoryRange(MinAddress, MaxAddress));
+            Tree
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Memory/MemoryRange.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryRange.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+
+namespace Ryujinx.Graphics.Gpu.Memory
+{
+    class MemoryRange : IEquatable<MemoryRange>, IComparable<MemoryRange>
+    {
+        public ulong startAddress { get; }
+
+        public ulong endAddress { get; }
+        public MemoryRange(ulong address, ulong endAddress)
+        {
+            this.startAddress = address;
+            this.endAddress = endAddress;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as MemoryRange);
+        }
+
+        public bool Equals(MemoryRange other)
+        {
+            return other != null &&
+                   startAddress == other.startAddress &&
+                   endAddress == other.endAddress;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(startAddress, endAddress);
+        }
+
+        public int CompareTo(MemoryRange other)
+        {
+            return this.startAddress.CompareTo(other.startAddress);
+        }
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Memory/MemoryRange.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryRange.cs
@@ -19,7 +19,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
             this.size = endAddress - address;
         }
 
-        public override bool Equals([AllowNull] object obj)
+        public override bool Equals(object obj)
         {
             return Equals((MemoryRange)obj);
         }

--- a/Ryujinx.Graphics.Gpu/Memory/MemoryRange.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryRange.cs
@@ -5,25 +5,28 @@ using System.Text;
 
 namespace Ryujinx.Graphics.Gpu.Memory
 {
-    class MemoryRange : IEquatable<MemoryRange>, IComparable<MemoryRange>
+    struct MemoryRange : IEquatable<MemoryRange>, IComparable<MemoryRange>
     {
         public ulong startAddress { get; }
 
         public ulong endAddress { get; }
+        
+        public ulong size { get; }
         public MemoryRange(ulong address, ulong endAddress)
         {
             this.startAddress = address;
             this.endAddress = endAddress;
+            this.size = endAddress - address;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals([AllowNull] object obj)
         {
-            return Equals(obj as MemoryRange);
+            return Equals((MemoryRange)obj);
         }
 
         public bool Equals(MemoryRange other)
         {
-            return other != null &&
+            return 
                    startAddress == other.startAddress &&
                    endAddress == other.endAddress;
         }

--- a/Ryujinx.Graphics.Gpu/Memory/MemoryRange.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryRange.cs
@@ -37,5 +37,10 @@ namespace Ryujinx.Graphics.Gpu.Memory
         {
             return this.startAddress.CompareTo(other.startAddress);
         }
+
+        public override string ToString()
+        {
+            return $" |{startAddress} -> {endAddress}| ";
+        }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Memory/MemoryRange.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryRange.cs
@@ -12,6 +12,9 @@ namespace Ryujinx.Graphics.Gpu.Memory
         public ulong endAddress { get; }
         
         public ulong size { get; }
+
+        public static MemoryRange InvalidRange = new MemoryRange(0, 0);
+
         public MemoryRange(ulong address, ulong endAddress)
         {
             this.startAddress = address;
@@ -43,7 +46,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
         public override string ToString()
         {
-            return $" |{startAddress} -> {endAddress}| ";
+            return $" [{startAddress} -> {endAddress}] ";
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Memory/TreeDictionary.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/TreeDictionary.cs
@@ -7,7 +7,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
     class TreeDictionary<K, V> where K : IComparable<K>
     {
-        private Node root;
+        private TreeNode<K, V> root;
 
         public TreeDictionary()
         {
@@ -16,19 +16,18 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
         public TreeDictionary(K key, V value)
         {
-            this.root = new Node(key, value);
+            this.root = new TreeNode<K, V>(key, value);
         }
 
-
-        public K Floor(K key)
+        public TreeNode<K, V> Floor(K key)
         {
             return Floor(root, key);
         }
 
-        private K Floor(Node node, K key)
+        private TreeNode<K, V> Floor(TreeNode<K, V> node, K key)
         {
             if (node == null) return default;
-            if (node.Key.Equals(key)) return key;
+            if (node.Key.Equals(key)) return node;
             int compare = key.CompareTo(node.Key);
             if(compare > 0)
             {
@@ -38,7 +37,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 }
                 else
                 {
-                    return node.Key;
+                    return node;
                 }
             }
             else
@@ -47,19 +46,19 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 {
                     return Floor(node.Left, key);
                 }
-                return node.Key;
+                return node;
             }
         }
 
-        public K Ceiling(K key)
+        public TreeNode<K, V> Ceiling(K key)
         {
             return Ceiling(root, key);
         }
 
-        private K Ceiling(Node node, K key)
+        private TreeNode<K, V> Ceiling(TreeNode<K, V> node, K key)
         {
             if (node == null) return default;
-            if (node.Key.Equals(key)) return key;
+            if (node.Key.Equals(key)) return node;
             int compare = key.CompareTo(node.Key);
             if (compare < 0)
             {
@@ -69,7 +68,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 }
                 else
                 {
-                    return node.Key;
+                    return node;
                 }
             }
             else
@@ -78,7 +77,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 {
                     return Ceiling(node.Right, key);
                 }
-                return node.Key;
+                return node;
             }
         }
 
@@ -92,17 +91,18 @@ namespace Ryujinx.Graphics.Gpu.Memory
             Remove(root, key);
         }
 
-        public bool Contains(K key)
+        public V Get(K key)
         {
-            return Contains(root, key);
+            return Get(root, key);
         }
 
-        private Node Add(Node node, K key, V value)
+        private TreeNode<K, V> Add(TreeNode<K, V> node, K key, V value)
         {
             {
                 if (node == null)
                 {
-                    return new Node(key, value);
+                    TreeNode<K, V> n = new TreeNode<K, V>(key, value);
+                    return n;
                 }
                 int cmp = key.CompareTo(node.Key);
                 if (cmp < 0)
@@ -122,7 +122,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
             }
         }
 
-        private Node Remove(Node node, K key)
+        private TreeNode<K, V> Remove(TreeNode<K, V> node, K key)
         {
             if (node == null) return null;
             if(key.Equals(node.Key))
@@ -141,7 +141,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 }
                 else
                 {
-                    Node smallestNode = findSmallestKey(node.Right);
+                    TreeNode<K, V> smallestNode = findSmallestKey(node.Right);
                     node.Key = smallestNode.Key;
                     node.Value = smallestNode.Value;
                     node.Right = Remove(node.Right, smallestNode.Key);
@@ -157,32 +157,33 @@ namespace Ryujinx.Graphics.Gpu.Memory
             return node;
         }
 
-        private Node findSmallestKey(Node node)
+        private TreeNode<K, V> findSmallestKey(TreeNode<K, V> node)
         {
             return node.Left == null ? node : findSmallestKey(node.Left);
         }
 
-        private bool Contains(Node node, K key)
+        private V Get(TreeNode<K,V> node, K key)
         {
-            if (node == null) return false;
-            if (key.Equals(node.Key)) return true;
-            return key.CompareTo(node.Key) < 0 ? Contains(node.Left, key) : Contains(node.Right, key);
+            if (node == null) return default;
+            if (key.Equals(node.Key)) return node.Value;
+            return key.CompareTo(node.Key) < 0 ? Get(node.Left, key) : Get(node.Right, key);
         }
 
-        protected class Node
-        {
-            public Node Left;
-            public Node Right;
-            public K Key;
-            public V Value;
+        
+    }
+    public class TreeNode<E, C>
+    {
+        public TreeNode<E, C> Left;
+        public TreeNode<E, C> Right;
+        public E Key;
+        public C Value;
 
-            public Node(K key, V value)
-            {
-                this.Key = key;
-                this.Value = value;
-                this.Left = null;
-                this.Right = null;
-            }
+        public TreeNode(E key, C value)
+        {
+            this.Key = key;
+            this.Value = value;
+            this.Left = null;
+            this.Right = null;
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Memory/TreeDictionary.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/TreeDictionary.cs
@@ -1,0 +1,188 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Ryujinx.Graphics.Gpu.Memory
+{
+
+    class TreeDictionary<K, V> where K : IComparable<K>
+    {
+        private Node root;
+
+        public TreeDictionary()
+        {
+            this.root = null;
+        }
+
+        public TreeDictionary(K key, V value)
+        {
+            this.root = new Node(key, value);
+        }
+
+
+        public K Floor(K key)
+        {
+            return Floor(root, key);
+        }
+
+        private K Floor(Node node, K key)
+        {
+            if (node == null) return default;
+            if (node.Key.Equals(key)) return key;
+            int compare = key.CompareTo(node.Key);
+            if(compare > 0)
+            {
+                if(node.Right != null)
+                {
+                    return Floor(node.Right, key);
+                }
+                else
+                {
+                    return node.Key;
+                }
+            }
+            else
+            {
+                if(node.Left != null)
+                {
+                    return Floor(node.Left, key);
+                }
+                return node.Key;
+            }
+        }
+
+        public K Ceiling(K key)
+        {
+            return Ceiling(root, key);
+        }
+
+        private K Ceiling(Node node, K key)
+        {
+            if (node == null) return default;
+            if (node.Key.Equals(key)) return key;
+            int compare = key.CompareTo(node.Key);
+            if (compare < 0)
+            {
+                if (node.Left != null)
+                {
+                    return Ceiling(node.Left, key);
+                }
+                else
+                {
+                    return node.Key;
+                }
+            }
+            else
+            {
+                if (node.Right != null)
+                {
+                    return Ceiling(node.Right, key);
+                }
+                return node.Key;
+            }
+        }
+
+        public void Add(K key, V value)
+        {
+            root = Add(root, key, value);
+        }
+
+        public void Remove(K key)
+        {
+            Remove(root, key);
+        }
+
+        public bool Contains(K key)
+        {
+            return Contains(root, key);
+        }
+
+        private Node Add(Node node, K key, V value)
+        {
+            {
+                if (node == null)
+                {
+                    return new Node(key, value);
+                }
+                int cmp = key.CompareTo(node.Key);
+                if (cmp < 0)
+                {
+                    node.Left = Add(node.Left, key, value);
+                }
+                else if (cmp > 0)
+                {
+                    node.Right = Add(node.Right, key, value);
+                }
+                else
+                {
+                    return node;
+                }
+
+                return node;
+            }
+        }
+
+        private Node Remove(Node node, K key)
+        {
+            if (node == null) return null;
+            if(key.Equals(node.Key))
+            {
+                if (node.Left == null && node.Right == null)
+                {
+                    return null;
+                }
+                else if(node.Left == null)
+                {
+                    return node.Right;
+                }
+                else if(node.Right == null)
+                {
+                    return node.Left;
+                }
+                else
+                {
+                    Node smallestNode = findSmallestKey(node.Right);
+                    node.Key = smallestNode.Key;
+                    node.Value = smallestNode.Value;
+                    node.Right = Remove(node.Right, smallestNode.Key);
+                    return node;
+                }
+            }
+            if(key.CompareTo(node.Key) < 0)
+            {
+                node.Left = Remove(node.Left, key);
+                return node;
+            }
+            node.Right = Remove(node.Right, key);
+            return node;
+        }
+
+        private Node findSmallestKey(Node node)
+        {
+            return node.Left == null ? node : findSmallestKey(node.Left);
+        }
+
+        private bool Contains(Node node, K key)
+        {
+            if (node == null) return false;
+            if (key.Equals(node.Key)) return true;
+            return key.CompareTo(node.Key) < 0 ? Contains(node.Left, key) : Contains(node.Right, key);
+        }
+
+        protected class Node
+        {
+            public Node Left;
+            public Node Right;
+            public K Key;
+            public V Value;
+
+            public Node(K key, V value)
+            {
+                this.Key = key;
+                this.Value = value;
+                this.Left = null;
+                this.Right = null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1299 

This is a different take on GPU memory allocation improvements, by using a double linked list to keep track of free memory regions.

There is currently an issue that causes invalid operation errors, so additional eyes would be welcome.

@jduncanator Your expertise would be greatly appreciated :)