### PR TITLE
Allow copy destination to have a different scale from source

### DIFF
--- a/Ryujinx.Graphics.GAL/Extents2D.cs
+++ b/Ryujinx.Graphics.GAL/Extents2D.cs
@@ -1,3 +1,5 @@
+using Ryujinx.Common;
+
 namespace Ryujinx.Graphics.GAL
 {
     public struct Extents2D
@@ -13,6 +15,17 @@ namespace Ryujinx.Graphics.GAL
             Y1 = y1;
             X2 = x2;
             Y2 = y2;
+        }
+
+        public Extents2D Reduce(int level)
+        {
+            int div = 1 << level;
+            
+            return new Extents2D(
+                X1 >> level, 
+                Y1 >> level,
+                BitUtils.DivRoundUp(X2, div),
+                BitUtils.DivRoundUp(Y2, div));
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Engine/MethodCopyTexture.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodCopyTexture.cs
@@ -71,12 +71,8 @@ namespace Ryujinx.Graphics.Gpu.Engine
                 return;
             }
 
-            if (srcTexture.ScaleFactor != dstTexture.ScaleFactor)
-            {
-                srcTexture.PropagateScale(dstTexture);
-            }
-
-            float scale = srcTexture.ScaleFactor; // src and dest scales are identical now.
+            float scale = srcTexture.ScaleFactor;
+            float dstScale = dstTexture.ScaleFactor;
 
             Extents2D srcRegion = new Extents2D(
                 (int)Math.Ceiling(scale * (srcX1 / srcTexture.Info.SamplesInX)),
@@ -85,10 +81,10 @@ namespace Ryujinx.Graphics.Gpu.Engine
                 (int)Math.Ceiling(scale * (srcY2 / srcTexture.Info.SamplesInY)));
 
             Extents2D dstRegion = new Extents2D(
-                (int)Math.Ceiling(scale * (dstX1 / dstTexture.Info.SamplesInX)),
-                (int)Math.Ceiling(scale * (dstY1 / dstTexture.Info.SamplesInY)),
-                (int)Math.Ceiling(scale * (dstX2 / dstTexture.Info.SamplesInX)),
-                (int)Math.Ceiling(scale * (dstY2 / dstTexture.Info.SamplesInY)));
+                (int)Math.Ceiling(dstScale * (dstX1 / dstTexture.Info.SamplesInX)),
+                (int)Math.Ceiling(dstScale * (dstY1 / dstTexture.Info.SamplesInY)),
+                (int)Math.Ceiling(dstScale * (dstX2 / dstTexture.Info.SamplesInX)),
+                (int)Math.Ceiling(dstScale * (dstY2 / dstTexture.Info.SamplesInY)));
 
             bool linearFilter = control.UnpackLinearFilter();
 
@@ -107,10 +103,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
                 srcCopyTexture.Height++;
 
                 srcTexture = TextureManager.FindOrCreateTexture(srcCopyTexture, srcCopyTextureFormat, srcTexture.ScaleMode == TextureScaleMode.Scaled, srcHint);
-                if (srcTexture.ScaleFactor != dstTexture.ScaleFactor)
-                {
-                    srcTexture.PropagateScale(dstTexture);
-                }
+                scale = srcTexture.ScaleFactor;
 
                 srcRegion = new Extents2D(
                     (int)Math.Ceiling(scale * ((srcX1 / srcTexture.Info.SamplesInX) - srcTexture.Info.Width)),

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -431,48 +431,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Helper method for copying our Texture2DArray texture to the given target, with scaling.
-        /// This creates temporary views for each array layer on both textures, copying each one at a time.
-        /// </summary>
-        /// <param name="target">The texture array to copy to</param>
-        private void CopyArrayScaled(ITexture target)
-        {
-            TextureInfo viewInfo = new TextureInfo(
-                Info.Address,
-                Info.Width,
-                Info.Height,
-                1,
-                Info.Levels,
-                Info.SamplesInX,
-                Info.SamplesInY,
-                Info.Stride,
-                Info.IsLinear,
-                Info.GobBlocksInY,
-                Info.GobBlocksInZ,
-                Info.GobBlocksInTileX,
-                Target.Texture2D,
-                Info.FormatInfo,
-                Info.DepthStencilMode,
-                Info.SwizzleR,
-                Info.SwizzleG,
-                Info.SwizzleB,
-                Info.SwizzleA);
-
-            TextureCreateInfo createInfo = TextureManager.GetCreateInfo(viewInfo, _context.Capabilities, ScaleFactor);
-
-            for (int i = 0; i < Info.DepthOrLayers; i++)
-            {
-                ITexture from = HostTexture.CreateView(createInfo, i, 0);
-                ITexture to = target.CreateView(createInfo, i, 0);
-
-                from.CopyTo(to, new Extents2D(0, 0, from.Width, from.Height), new Extents2D(0, 0, to.Width, to.Height), true);
-
-                from.Release();
-                to.Release();
-            }
-        }
-
-        /// <summary>
         /// Copy the host texture to a scaled one. If a texture is not provided, create it with the given scale.
         /// </summary>
         /// <param name="scale">Scale factor</param>
@@ -486,14 +444,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 storage = _context.Renderer.CreateTexture(createInfo, scale);
             }
 
-            if (Info.Target == Target.Texture2DArray)
-            {
-                CopyArrayScaled(storage);
-            }
-            else
-            {
-                HostTexture.CopyTo(storage, new Extents2D(0, 0, HostTexture.Width, HostTexture.Height), new Extents2D(0, 0, storage.Width, storage.Height), true);
-            }
+            HostTexture.CopyTo(storage, new Extents2D(0, 0, HostTexture.Width, HostTexture.Height), new Extents2D(0, 0, storage.Width, storage.Height), true);
 
             return storage;
         }

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -387,7 +387,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>True if eligible</returns>
         public bool IsUpscaleCompatible(TextureInfo info)
         {
-            return (info.Target == Target.Texture2D || info.Target == Target.Texture2DArray) && info.Levels == 1 && !info.FormatInfo.IsCompressed && UpscaleSafeMode(info);
+            return (info.Target == Target.Texture2D || info.Target == Target.Texture2DArray) && !info.FormatInfo.IsCompressed && UpscaleSafeMode(info);
         }
 
         /// <summary>
@@ -400,6 +400,13 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             // While upscaling works for all targets defined by IsUpscaleCompatible, we additionally blacklist targets here that
             // may have undesirable results (upscaling blur textures) or simply waste GPU resources (upscaling texture atlas).
+
+            if (info.Levels > 3)
+            {
+                // Textures with more than 3 levels are likely to be game textures, rather than render textures.
+                // Small textures with full mips are likely to be removed by the next check.
+                return false;
+            }
 
             if (!(info.FormatInfo.Format.IsDepthOrStencil() || info.FormatInfo.Components == 1))
             {


### PR DESCRIPTION
Will result in more scaled copy destinations, but allows scaling in some games that copy textures to the output framebuffer.

Also, textures with more than one level are no longer blacklisted. This has been changed to more than 3 levels. (indicates a game texture)

- Res scaling now works in Link’s Awakening (causes shadow acne tho)
- Res scaling no longer blacklists in some cutscenes in Super Mario Odyssey.

Needs further testing, so Draft for now.