### PR TITLE
am: Fix VR enabled by default

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
@@ -12,7 +12,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         private Apm.SystemManagerServer _apmSystemManagerServer;
         private Lbl.LblControllerServer _lblControllerServer;
 
-        private bool _vrModeEnabled = true;
+        private bool _vrModeEnabled = false;
 
         public ICommonStateGetter(ServiceCtx context)
         {


### PR DESCRIPTION
This PR fix an issue I've made in #1688 which is enabled VR as default.
It could cause rendering issues in games when VR mode isn't used, as users have reported in Smash (where VR rendering don't seems to works fine anyway).

Before
![image](https://user-images.githubusercontent.com/4905390/99202046-2ac0c000-27ae-11eb-80f3-621366d22939.png)

After
![image](https://user-images.githubusercontent.com/4905390/99202055-34e2be80-27ae-11eb-96fe-a143fecc4470.png)
