### PR TITLE
Propagate zeta format properly

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/MethodCopyTexture.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodCopyTexture.cs
@@ -57,7 +57,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
             if (srcTexture.Format.IsDepthOrStencil())
             {
-                dstCopyTextureFormat = srcCopyTextureFormat;
+                dstCopyTextureFormat = srcTexture.Info.FormatInfo;
             }
             else
             {


### PR DESCRIPTION
Fix a regression introduced on #1647 where the wrong format would be propagated to the destination texture. Should fix performance regression on Zelda Links Awakening.