### PR TITLE
shader cache: Fix possible race causing crashes on manifest at startup

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/Cache/CacheCollection.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/Cache/CacheCollection.cs
@@ -34,6 +34,11 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache
             SaveManifest,
 
             /// <summary>
+            /// Remove entries from the hash manifest and save it.
+            /// </summary>
+            RemoveManifestEntries,
+
+            /// <summary>
             /// Flush temporary cache to archive.
             /// </summary>
             FlushToArchive,
@@ -228,10 +233,23 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache
         }
 
         /// <summary>
+        /// Queue a task to remove entries from the hash manifest.
+        /// </summary>
+        /// <param name="entries">Entries to remove from the manifest</param>
+        public void RemoveManifestEntriesAsync(HashSet<Hash128> entries)
+        {
+            _fileWriterWorkerQueue.Add(new CacheFileOperationTask
+            {
+                Type = CacheFileOperation.RemoveManifestEntries,
+                Data = entries
+            });
+        }
+
+        /// <summary>
         /// Remove given entries from the manifest.
         /// </summary>
         /// <param name="entries">Entries to remove from the manifest</param>
-        public void RemoveManifestEntries(HashSet<Hash128> entries)
+        private void RemoveManifestEntries(HashSet<Hash128> entries)
         {
             lock (_hashTable)
             {
@@ -487,6 +505,9 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache
                     break;
                 case CacheFileOperation.SaveManifest:
                     SaveManifest();
+                    break;
+                case CacheFileOperation.RemoveManifestEntries:
+                    RemoveManifestEntries((HashSet<Hash128>)task.Data);
                     break;
                 case CacheFileOperation.FlushToArchive:
                     FlushToArchive();

--- a/Ryujinx.Graphics.Gpu/Shader/Cache/CacheManager.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/Cache/CacheManager.cs
@@ -58,8 +58,8 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache
         /// <param name="entries">Entries to remove from the manifest of all caches</param>
         public void RemoveManifestEntries(HashSet<Hash128> entries)
         {
-            _guestProgramCache.RemoveManifestEntries(entries);
-            _hostProgramCache.RemoveManifestEntries(entries);
+            _guestProgramCache.RemoveManifestEntriesAsync(entries);
+            _hostProgramCache.RemoveManifestEntriesAsync(entries);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -290,9 +290,9 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 }
 
                 // Remove entries that are broken in the cache
-                _cacheManager.Synchronize();
                 _cacheManager.RemoveManifestEntries(invalidEntries);
                 _cacheManager.FlushToArchive();
+                _cacheManager.Synchronize();
 
                 Logger.Info?.Print(LogClass.Gpu, "Shader cache loaded.");
             }

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -290,9 +290,9 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 }
 
                 // Remove entries that are broken in the cache
+                _cacheManager.Synchronize();
                 _cacheManager.RemoveManifestEntries(invalidEntries);
                 _cacheManager.FlushToArchive();
-                _cacheManager.Synchronize();
 
                 Logger.Info?.Print(LogClass.Gpu, "Shader cache loaded.");
             }


### PR DESCRIPTION
This fix a misplace function call ending up causing possibly two write
on the cache.info at the same time.