### PR TITLE
gui: Toggle Docked/Handheld mode and VSync by clicking status bar

### DIFF
--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -117,9 +117,9 @@ namespace Ryujinx.Ui
                 End(null);
             }
 
-            _virtualFileSystem = VirtualFileSystem.CreateInstance();
+            _virtualFileSystem      = VirtualFileSystem.CreateInstance();
             _userChannelPersistence = new UserChannelPersistence();
-            _contentManager    = new ContentManager(_virtualFileSystem);
+            _contentManager         = new ContentManager(_virtualFileSystem);
 
             if (migrationNeeded)
             {
@@ -846,6 +846,12 @@ namespace Ryujinx.Ui
             string path = (string)_tableStore.GetValue(treeIter, 9);
 
             LoadApplication(path);
+        }
+
+        private void DockedMode_Clicked(object sender, ButtonReleaseEventArgs args)
+        {
+            ConfigurationState.Instance.System.EnableDockedMode.Value = !ConfigurationState.Instance.System.EnableDockedMode.Value;
+            ConfigurationState.Instance.ToFileFormat().SaveConfig(Program.ConfigurationPath);
         }
 
         private void Row_Clicked(object sender, ButtonReleaseEventArgs args)

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -848,10 +848,14 @@ namespace Ryujinx.Ui
             LoadApplication(path);
         }
 
+        private void VSyncStatus_Clicked(object sender, ButtonReleaseEventArgs args)
+        {
+            _emulationContext.EnableDeviceVsync = !_emulationContext.EnableDeviceVsync;
+        }
+
         private void DockedMode_Clicked(object sender, ButtonReleaseEventArgs args)
         {
             ConfigurationState.Instance.System.EnableDockedMode.Value = !ConfigurationState.Instance.System.EnableDockedMode.Value;
-            ConfigurationState.Instance.ToFileFormat().SaveConfig(Program.ConfigurationPath);
         }
 
         private void Row_Clicked(object sender, ButtonReleaseEventArgs args)

--- a/Ryujinx/Ui/MainWindow.glade
+++ b/Ryujinx/Ui/MainWindow.glade
@@ -496,21 +496,21 @@
                       </packing>
                     </child>
                     <child>
-				      <object class="GtkEventBox">
-						<property name="visible">True</property>
-						<property name="can_focus">False</property>
-						<property name="margin_left">0</property>
-						<signal name="button-release-event" handler="DockedMode_Clicked" swapped="no"/>
-						<child>
-						  <object class="GtkLabel" id="_dockedMode">
-							<property name="visible">True</property>
-							<property name="can_focus">False</property>
-							<property name="halign">start</property>
-							<property name="margin_left">5</property>
-							<property name="margin_right">5</property>
-						  </object>
-						</child>
-					  </object>
+                      <object class="GtkEventBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_left">0</property>
+                        <signal name="button-release-event" handler="DockedMode_Clicked" swapped="no"/>
+                        <child>
+                          <object class="GtkLabel" id="_dockedMode">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="margin_left">5</property>
+                            <property name="margin_right">5</property>
+                          </object>
+                        </child>
+                      </object>
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>

--- a/Ryujinx/Ui/MainWindow.glade
+++ b/Ryujinx/Ui/MainWindow.glade
@@ -470,13 +470,21 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <child>
-                      <object class="GtkLabel" id="_vSyncStatus">
+                      <object class="GtkEventBox">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">start</property>
-                        <property name="margin_left">5</property>
-                        <property name="margin_right">5</property>
-                        <property name="label" translatable="yes">VSync</property>
+                        <property name="margin_left">0</property>
+                        <signal name="button-release-event" handler="VSyncStatus_Clicked" swapped="no"/>
+                        <child>
+                          <object class="GtkLabel" id="_vSyncStatus">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="margin_left">5</property>
+                            <property name="margin_right">5</property>
+                            <property name="label" translatable="yes">VSync</property>
+                          </object>
+                        </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>

--- a/Ryujinx/Ui/MainWindow.glade
+++ b/Ryujinx/Ui/MainWindow.glade
@@ -496,13 +496,21 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkLabel" id="_dockedMode">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="halign">start</property>
-                        <property name="margin_left">5</property>
-                        <property name="margin_right">5</property>
-                      </object>
+				      <object class="GtkEventBox">
+						<property name="visible">True</property>
+						<property name="can_focus">False</property>
+						<property name="margin_left">0</property>
+						<signal name="button-release-event" handler="DockedMode_Clicked" swapped="no"/>
+						<child>
+						  <object class="GtkLabel" id="_dockedMode">
+							<property name="visible">True</property>
+							<property name="can_focus">False</property>
+							<property name="halign">start</property>
+							<property name="margin_left">5</property>
+							<property name="margin_right">5</property>
+						  </object>
+						</child>
+					  </object>
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>


### PR DESCRIPTION
This PR just add a way to toggle the docked and the handheld mode by clicking the label in the status bar.
Nothing more.

EDIT: Due to some recommandations, I've added the same behavior for the VSync setting, even if we don't recommand to change it when everything works fine.

![docked](https://user-images.githubusercontent.com/4905390/99487890-8bdfc380-2967-11eb-8af2-fff0af5ae153.gif)
