### PR TITLE
Do not perform layout conversion on buffer texture flushes

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -809,33 +809,36 @@ namespace Ryujinx.Graphics.Gpu.Image
                 }
             }
 
-            if (Info.IsLinear)
+            if (Info.Target != Target.TextureBuffer)
             {
-                data = LayoutConverter.ConvertLinearToLinearStrided(
-                    Info.Width,
-                    Info.Height,
-                    Info.FormatInfo.BlockWidth,
-                    Info.FormatInfo.BlockHeight,
-                    Info.Stride,
-                    Info.FormatInfo.BytesPerPixel,
-                    data);
-            }
-            else
-            {
-                data = LayoutConverter.ConvertLinearToBlockLinear(
-                    Info.Width,
-                    Info.Height,
-                    _depth,
-                    Info.Levels,
-                    _layers,
-                    Info.FormatInfo.BlockWidth,
-                    Info.FormatInfo.BlockHeight,
-                    Info.FormatInfo.BytesPerPixel,
-                    Info.GobBlocksInY,
-                    Info.GobBlocksInZ,
-                    Info.GobBlocksInTileX,
-                    _sizeInfo,
-                    data);
+                if (Info.IsLinear)
+                {
+                    data = LayoutConverter.ConvertLinearToLinearStrided(
+                        Info.Width,
+                        Info.Height,
+                        Info.FormatInfo.BlockWidth,
+                        Info.FormatInfo.BlockHeight,
+                        Info.Stride,
+                        Info.FormatInfo.BytesPerPixel,
+                        data);
+                }
+                else
+                {
+                    data = LayoutConverter.ConvertLinearToBlockLinear(
+                        Info.Width,
+                        Info.Height,
+                        _depth,
+                        Info.Levels,
+                        _layers,
+                        Info.FormatInfo.BlockWidth,
+                        Info.FormatInfo.BlockHeight,
+                        Info.FormatInfo.BytesPerPixel,
+                        Info.GobBlocksInY,
+                        Info.GobBlocksInZ,
+                        Info.GobBlocksInTileX,
+                        _sizeInfo,
+                        data);
+                }
             }
 
             return data;


### PR DESCRIPTION
Layout conversion shouldn't be performed on buffer textures because they are effectively just buffers that are accessed as a texture. Attempting to do those conversions could cause memory corruption as the parameters passed to the conversion functions are most invalid (GOB block sizes etc are all supposed to be ignored on buffer textures).

I'm not aware of any specific issue that this fixes, but this might fix memory corruption on UE4 games (that tends to use buffer textures quite frequently).