### PR TITLE
ui: Check last played datetime validity against current culture

### DIFF
--- a/Ryujinx/Ui/ApplicationLibrary.cs
+++ b/Ryujinx/Ui/ApplicationLibrary.cs
@@ -392,7 +392,7 @@ namespace Ryujinx.Ui
 
                 if (appMetadata.LastPlayed != "Never" && !DateTime.TryParse(appMetadata.LastPlayed, out _))
                 {
-                    Logger.Warning?.Print(LogClass.Application, $"Last played datetime \"{appMetadata.LastPlayed}\" is invalid for current system culture, skipping (did current culture changed?)");
+                    Logger.Warning?.Print(LogClass.Application, $"Last played datetime \"{appMetadata.LastPlayed}\" is invalid for current system culture, skipping (did current culture change?)");
 
                     appMetadata.LastPlayed = "Never";
                 }

--- a/Ryujinx/Ui/ApplicationLibrary.cs
+++ b/Ryujinx/Ui/ApplicationLibrary.cs
@@ -390,6 +390,13 @@ namespace Ryujinx.Ui
 
                 ApplicationMetadata appMetadata = LoadAndSaveMetaData(titleId);
 
+                if (appMetadata.LastPlayed != "Never" && !DateTime.TryParse(appMetadata.LastPlayed, out _))
+                {
+                    Logger.Warning?.Print(LogClass.Application, $"Last played datetime \"{appMetadata.LastPlayed}\" is invalid for current system culture, skipping (did current culture changed?)");
+
+                    appMetadata.LastPlayed = "Never";
+                }
+
                 ApplicationData data = new ApplicationData
                 {
                     Favorite      = appMetadata.Favorite,


### PR DESCRIPTION
This is an issue happening when you change your datetime format on your system and try to sort via last played datetime.
DateTime.Parse use the current thread culture and will not parse date correctly, effectively causing a crash.

As such, I added a check when loading the game list that ensure that the datetime is valid in current culture.

Fix #1727.