### PR TITLE
olsc: Add service olsc:u and stub some calls

### DIFF
--- a/Ryujinx.Common/Logging/LogClass.cs
+++ b/Ryujinx.Common/Logging/LogClass.cs
@@ -42,6 +42,7 @@ namespace Ryujinx.Common.Logging
         ServiceNs,
         ServiceNsd,
         ServiceNv,
+        ServiceOlsc,
         ServicePctl,
         ServicePl,
         ServicePrepo,

--- a/Ryujinx.HLE/HOS/Services/Olsc/IOlscServiceForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Olsc/IOlscServiceForApplication.cs
@@ -1,0 +1,53 @@
+﻿using Ryujinx.Common;
+using Ryujinx.Common.Logging;
+using Ryujinx.HLE.HOS.Services.Account.Acc;
+
+namespace Ryujinx.HLE.HOS.Services.Olsc
+{
+    [Service("olsc:u")] // 10.0.0+
+    class IOlscServiceForApplication : IpcService
+    {
+        private bool _initialized;
+
+        public IOlscServiceForApplication(ServiceCtx context) { }
+
+        [Command(0)]
+        // Initialize(pid)
+        public ResultCode Initialize(ServiceCtx context)
+        {
+            // NOTE: Service call arp:r GetApplicationInstanceUnregistrationNotifier with the pid and initialize some internal struct.
+            //       Since we will not support online savedata backup. It's fine to stub it for now.
+
+            _initialized = true;
+
+            Logger.Stub?.PrintStub(LogClass.ServiceOlsc);
+
+            return ResultCode.Success;
+        }
+
+        [Command(14)]
+        // SetSaveDataBackupSettingEnabled(nn::account::Uid, bool)
+        public ResultCode SetSaveDataBackupSettingEnabled(ServiceCtx context)
+        {
+            UserId userId                       = context.RequestData.ReadStruct<UserId>();
+            ulong  saveDataBackupSettingEnabled = context.RequestData.ReadUInt64();
+
+            if (!_initialized)
+            {
+                return ResultCode.NotInitialized;
+            }
+
+            if (userId.IsNull)
+            {
+                return ResultCode.NullArgument;
+            }
+
+            // NOTE: Service store the UserId and the boolean in an internal SaveDataBackupSettingDatabase object.
+            //       Since we will not support online savedata backup. It's fine to stub it for now.
+
+            Logger.Stub?.PrintStub(LogClass.ServiceOlsc, new { userId, saveDataBackupSettingEnabled });
+
+            return ResultCode.Success;
+        }
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Olsc/ResultCode.cs
+++ b/Ryujinx.HLE/HOS/Services/Olsc/ResultCode.cs
@@ -1,0 +1,13 @@
+namespace Ryujinx.HLE.HOS.Services.Olsc
+{
+    enum ResultCode
+    {
+        ModuleId       = 179,
+        ErrorCodeShift = 9,
+
+        Success = 0,
+
+        NullArgument   = (100 << ErrorCodeShift) | ModuleId,
+        NotInitialized = (101 << ErrorCodeShift) | ModuleId
+    }
+}


### PR DESCRIPTION
This PR fix an issue of missing service `olsc:u` added in firmware 10.0.
ACNH 1.6.0 update needs it and some other service calls:

- Initialize
- SetSaveDataBackupSettingEnabled

Both are stubbed since we will not support online savedata backup. 
Checked with RE to return the right result.

ACNH can still be playable now:
![image](https://user-images.githubusercontent.com/4905390/99700761-df4f3000-2a93-11eb-8b5c-d516a19dee98.png)
