### PR TITLE
Remove some warnings and cleaning code

### DIFF
--- a/Ryujinx.Common/SystemInfo/LinuxSystemInfo.cs
+++ b/Ryujinx.Common/SystemInfo/LinuxSystemInfo.cs
@@ -1,8 +1,10 @@
 using System.IO;
 using System.Linq;
+using System.Runtime.Versioning;
 
 namespace Ryujinx.Common.SystemInfo
 {
+    [SupportedOSPlatform("linux")]
     internal class LinuxSysteminfo : SystemInfo
     {
         public override string CpuName { get; }

--- a/Ryujinx.Common/SystemInfo/MacOSSysteminfo.cs
+++ b/Ryujinx.Common/SystemInfo/MacOSSysteminfo.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Text;
 using Ryujinx.Common.Logging;
 
 namespace Ryujinx.Common.SystemInfo
 {
+    [SupportedOSPlatform("macos")]
     internal class MacOSSysteminfo : SystemInfo
     {
         public override string CpuName { get; }

--- a/Ryujinx.Common/SystemInfo/WindowsSystemInfo.cs
+++ b/Ryujinx.Common/SystemInfo/WindowsSystemInfo.cs
@@ -2,9 +2,11 @@ using Ryujinx.Common.Logging;
 using System;
 using System.Management;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace Ryujinx.Common.SystemInfo
 {
+    [SupportedOSPlatform("windows")]
     internal class WindowsSysteminfo : SystemInfo
     {
         public override string CpuName { get; }

--- a/Ryujinx.Graphics.Nvdec.Vp9/DecodeMv.cs
+++ b/Ryujinx.Graphics.Nvdec.Vp9/DecodeMv.cs
@@ -918,9 +918,10 @@ namespace Ryujinx.Graphics.Nvdec.Vp9
 
                 if (mi.Mode != PredictionMode.ZeroMv)
                 {
+                    Span<Mv> tmpMvs = stackalloc Mv[Constants.MaxMvRefCandidates];
+
                     for (refr = 0; refr < 1 + isCompound; ++refr)
                     {
-                        Span<Mv> tmpMvs = stackalloc Mv[Constants.MaxMvRefCandidates];
                         sbyte frame = mi.RefFrame[refr];
                         int refmvCount;
 

--- a/Ryujinx/Program.cs
+++ b/Ryujinx/Program.cs
@@ -128,7 +128,7 @@ namespace Ryujinx
 
             if (ConfigurationState.Instance.CheckUpdatesOnStart.Value && Updater.CanUpdate(false))
             {
-                Updater.BeginParse(mainWindow, false);
+                _ = Updater.BeginParse(mainWindow, false);
             }
 
             Application.Run();

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -1192,7 +1192,7 @@ namespace Ryujinx.Ui
         {
             if (Updater.CanUpdate(true))
             {
-                Updater.BeginParse(this, true);
+                _ = Updater.BeginParse(this, true);
             }
         }
 

--- a/Ryujinx/Updater/UpdateDialog.cs
+++ b/Ryujinx/Updater/UpdateDialog.cs
@@ -70,7 +70,7 @@ namespace Ryujinx.Ui
                 SecondaryText.Text = "";
                 _restartQuery      = true;
 
-                Updater.UpdateRyujinx(this, _buildUrl);
+                _ = Updater.UpdateRyujinx(this, _buildUrl);
             }
         }
 

--- a/Ryujinx/Updater/Updater.cs
+++ b/Ryujinx/Updater/Updater.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace Ryujinx
@@ -163,7 +164,7 @@ namespace Ryujinx
             {
                 using (Stream         inStream   = File.OpenRead(updateFile))
                 using (Stream         gzipStream = new GZipInputStream(inStream))
-                using (TarInputStream tarStream  = new TarInputStream(gzipStream))
+                using (TarInputStream tarStream  = new TarInputStream(gzipStream, Encoding.ASCII))
                 {
                     updateDialog.ProgressBar.MaxValue = inStream.Length;
 


### PR DESCRIPTION
This PR fix some warnings:
- SystemInfo which are platform specific, since .NET 5 we have to use `SupportedOSPlatform` attribute.
- `stackalloc` used in a loop could cause a potential stack overflow.
- All not used exceptions have their var removed in Motion client.
- Updater async tasks are currently run synchronously, so I've discarded the await warning by an empty assign.
- `TarInputStream` in the Updater is obsolete now and needs the filename Encoding.

Additionnally to that, I've cleaned up a bit Motion Client code.
BinaryFormatter warnings are still here, I'll let LDj3SNuD handle that.