### PR TITLE
audin: fix wrong id ListAudioInsAuto call

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Audio/IAudioInManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/IAudioInManager.cs
@@ -27,7 +27,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             return ResultCode.Success;
         }
 
-        [Command(3)] // 3.0.0+
+        [Command(2)] // 3.0.0+
         // ListAudioInsAuto() -> (u32 count, buffer<bytes, 0x22> names)
         public ResultCode ListAudioInsAuto(ServiceCtx context)
         {


### PR DESCRIPTION
This PR fix a wrong id for call `ListAudioInsAuto` in `IAudioInManager`.