### PR TITLE
amadeus: Fix possible underflow in delay time parameter in delay effect

### DIFF
--- a/Ryujinx.Audio.Renderer/Dsp/Effect/DelayLine.cs
+++ b/Ryujinx.Audio.Renderer/Dsp/Effect/DelayLine.cs
@@ -42,7 +42,15 @@ namespace Ryujinx.Audio.Renderer.Dsp.Effect
         {
             CurrentSampleCount = Math.Min(SampleCountMax, targetSampleCount);
             _currentSampleIndex = 0;
-            _lastSampleIndex = CurrentSampleCount - 1;
+
+            if (CurrentSampleCount == 0)
+            {
+                _lastSampleIndex = 0;
+            }
+            else
+            {
+                _lastSampleIndex = CurrentSampleCount - 1;
+            }
         }
 
         public void SetDelay(float delayTime)


### PR DESCRIPTION
This fix an underflow in the setup of delay time in the delay effect.
This fix a regression caused by Amadeus on Shovel Knight: Treasure Trove.

![image](https://user-images.githubusercontent.com/1760003/99882305-b196f200-2c1f-11eb-9b7d-aee3d0362e03.png)
