### PR TITLE
Interrupt GPU command processing when a frame's fence is reached.

### DIFF
--- a/Ryujinx.Graphics.Gpu/Window.cs
+++ b/Ryujinx.Graphics.Gpu/Window.cs
@@ -175,7 +175,7 @@ namespace Ryujinx.Graphics.Gpu
         /// <returns>True if a frame is available, false otherwise</returns>
         public bool ConsumeFrameAvailable()
         {
-            if (_framesAvailable > 0)
+            if (Interlocked.CompareExchange(ref _framesAvailable, 0, 0) != 0)
             {
                 Interlocked.Decrement(ref _framesAvailable);
 

--- a/Ryujinx.Graphics.Gpu/Window.cs
+++ b/Ryujinx.Graphics.Gpu/Window.cs
@@ -2,6 +2,7 @@ using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Image;
 using System;
 using System.Collections.Concurrent;
+using System.Threading;
 
 namespace Ryujinx.Graphics.Gpu
 {
@@ -68,6 +69,8 @@ namespace Ryujinx.Graphics.Gpu
         }
 
         private readonly ConcurrentQueue<PresentationTexture> _frameQueue;
+
+        private int _framesAvailable;
 
         /// <summary>
         /// Creates a new instance of the GPU presentation window.
@@ -156,6 +159,30 @@ namespace Ryujinx.Graphics.Gpu
 
                 pt.ReleaseCallback(pt.UserObj);
             }
+        }
+
+        /// <summary>
+        /// Indicate that a frame on the queue is ready to be acquired.
+        /// </summary>
+        public void SignalFrameReady()
+        {
+            Interlocked.Increment(ref _framesAvailable);
+        }
+
+        /// <summary>
+        /// Determine if any frames are available, and decrement the available count if there are.
+        /// </summary>
+        /// <returns>True if a frame is available, false otherwise</returns>
+        public bool ConsumeFrameAvailable()
+        {
+            if (_framesAvailable > 0)
+            {
+                Interlocked.Decrement(ref _framesAvailable);
+
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/BufferQueueCore.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/BufferQueueCore.cs
@@ -46,6 +46,8 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
         public const int BufferHistoryArraySize = 8;
 
+        public event Action BufferQueued;
+
         public BufferQueueCore(Switch device, long pid)
         {
             Slots                    = new BufferSlotArray();
@@ -195,6 +197,11 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
         public void WaitIsAllocatingEvent()
         {
             WaitForLock();
+        }
+
+        public void SignalQueueEvent()
+        {
+            BufferQueued?.Invoke();
         }
 
         private void WaitForLock()

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/BufferQueueProducer.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/BufferQueueProducer.cs
@@ -486,6 +486,8 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
                 Monitor.PulseAll(_callbackLock);
             }
 
+            Core.SignalQueueEvent();
+
             return Status.Success;
         }
 

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
@@ -27,6 +27,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
         private long _ticks;
         private long _ticksPerFrame;
         private long _spinTicks;
+        private long _1msTicks;
 
         private int _swapInterval;
 
@@ -65,6 +66,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
             _ticks = 0;
             _spinTicks = Stopwatch.Frequency / 500;
+            _1msTicks = Stopwatch.Frequency / 1000;
 
             UpdateSwapInterval(1);
 
@@ -224,7 +226,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
                     }
                     else
                     {
-                        _event.WaitOne(1);
+                        _event.WaitOne((int)(diff / _1msTicks));
                     }
                 }
             }

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
@@ -229,7 +229,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
                         _ticks = Math.Min(_ticks - _ticksPerFrame, _ticksPerFrame * 3);
                     }
 
-                    // Sleep the minimal amount of time to avoid being too expensive.
+                    // Sleep if possible. If the time til the next frame is too low, spin wait instead.
                     long diff = _ticksPerFrame - (_ticks + _chrono.ElapsedTicks - ticks);
                     if (diff > 0)
                     {

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
@@ -226,6 +226,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
                         _device.System?.SignalVsync();
 
+                        // Apply a maximum bound of 3 frames to the tick remainder, in case some event causes Ryujinx to pause for a long time or messes with the timer.
                         _ticks = Math.Min(_ticks - _ticksPerFrame, _ticksPerFrame * 3);
                     }
 
@@ -237,7 +238,10 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
                         {
                             do
                             {
+                                // SpinWait is a little more HT/SMT friendly than aggressively updating/checking ticks.
+                                // The value of 5 still gives us quite a bit of precision (~0.0003ms variance at worst) while waiting a reasonable amount of time.
                                 Thread.SpinWait(5);
+
                                 ticks = _chrono.ElapsedTicks;
                                 _ticks += ticks - lastTicks;
                                 lastTicks = ticks;

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
@@ -64,7 +64,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
             _chrono.Start();
 
             _ticks = 0;
-            _spinTicks = Stopwatch.Frequency / 1000;
+            _spinTicks = Stopwatch.Frequency / 500;
 
             UpdateSwapInterval(1);
 
@@ -209,14 +209,14 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
                 }
 
                 // Sleep the minimal amount of time to avoid being too expensive.
-                long diff = _ticksPerFrame - _chrono.ElapsedTicks;
+                long diff = _ticksPerFrame - (_ticks + _chrono.ElapsedTicks - ticks);
                 if (diff > 0)
                 {
                     if (diff < _spinTicks)
                     {
                         do
                         {
-                            Thread.SpinWait(50000);
+                            Thread.SpinWait(5);
                             ticks = _chrono.ElapsedTicks;
                             _ticks += ticks - lastTicks;
                             lastTicks = ticks;

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
@@ -291,6 +291,12 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
                 Item  = item,
             };
 
+            item.Fence.RegisterCallback(_device.Gpu, () => 
+            {
+                _device.Gpu.Window.SignalFrameReady();
+                _device.Gpu.GPFifo.Interrupt();
+            });
+
             _device.Gpu.Window.EnqueueFrameThreadSafe(
                 frameBufferAddress,
                 frameBufferWidth,

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/Types/AndroidFence.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/Types/AndroidFence.cs
@@ -66,6 +66,13 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
             return false;
         }
 
+        public void RegisterCallback(GpuContext gpuContext, Action callback)
+        {
+            ref NvFence fence = ref NvFences[FenceCount - 1];
+
+            gpuContext.Synchronization.RegisterCallbackOnSyncpoint(fence.Id, fence.Value, callback);
+        }
+
         public uint GetFlattenedSize()
         {
             return (uint)Unsafe.SizeOf<AndroidFence>();

--- a/Ryujinx.HLE/PerformanceStatistics.cs
+++ b/Ryujinx.HLE/PerformanceStatistics.cs
@@ -16,12 +16,12 @@ namespace Ryujinx.HLE
         private double[] _previousFrameTime;
 
         private double[] _averagePercent;
-        private double[] _accumulatedPercent;
+        private double[] _accumulatedActiveTime;
         private double[] _percentLastEndTime;
         private double[] _percentStartTime;
 
-        private long[] _framesRendered;
-        private long[] _percentCount;
+        private long[]   _framesRendered;
+        private double[] _percentTime;
 
         private object[] _frameLock;
         private object[] _percentLock;
@@ -36,13 +36,13 @@ namespace Ryujinx.HLE
             _accumulatedFrameTime = new double[1];
             _previousFrameTime    = new double[1];
 
-            _averagePercent     = new double[1];
-            _accumulatedPercent = new double[1];
-            _percentLastEndTime = new double[1];
-            _percentStartTime   = new double[1];
+            _averagePercent        = new double[1];
+            _accumulatedActiveTime = new double[1];
+            _percentLastEndTime    = new double[1];
+            _percentStartTime      = new double[1];
 
             _framesRendered = new long[1];
-            _percentCount   = new long[1];
+            _percentTime    = new double[1];
 
             _frameLock   = new object[] { new object() };
             _percentLock = new object[] { new object() };
@@ -91,16 +91,16 @@ namespace Ryujinx.HLE
 
             lock (_percentLock[percentType])
             {
-                if (_percentCount[percentType] > 0)
+                if (_percentTime[percentType] > 0)
                 {
-                    percent = _accumulatedPercent[percentType] / _percentCount[percentType];
+                    percent = (_accumulatedActiveTime[percentType] / _percentTime[percentType]) * 100;
                 }
 
                 _averagePercent[percentType] = percent;
 
-                _percentCount[percentType] = 0;
+                _percentTime[percentType] = 0;
 
-                _accumulatedPercent[percentType] = 0;
+                _accumulatedActiveTime[percentType] = 0;
             }
         }
 
@@ -138,13 +138,11 @@ namespace Ryujinx.HLE
             double elapsedTime = currentTime - _percentLastEndTime[percentType];
             double elapsedActiveTime = currentTime - _percentStartTime[percentType];
 
-            double percentActive = (elapsedActiveTime / elapsedTime) * 100;
-
             lock (_percentLock[percentType])
             {
-                _accumulatedPercent[percentType] += percentActive;
+                _accumulatedActiveTime[percentType] += elapsedActiveTime;
 
-                _percentCount[percentType]++;
+                _percentTime[percentType] += elapsedTime;
             }
 
             _percentLastEndTime[percentType] = currentTime;

--- a/Ryujinx.HLE/Switch.cs
+++ b/Ryujinx.HLE/Switch.cs
@@ -177,6 +177,11 @@ namespace Ryujinx.HLE
             Gpu.GPFifo.DispatchCalls();
         }
 
+        public bool ConsumeFrameAvailable()
+        {
+            return Gpu.Window.ConsumeFrameAvailable();
+        }
+
         public void PresentFrame(Action swapBuffersCallback)
         {
             Gpu.Window.Present(swapBuffersCallback);

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -405,16 +405,19 @@ namespace Ryujinx.Ui
                     _device.Statistics.RecordFifoEnd();
                 }
 
-                string dockedMode = ConfigurationState.Instance.System.EnableDockedMode ? "Docked" : "Handheld";
-                float scale = Graphics.Gpu.GraphicsConfig.ResScale;
-                if (scale != 1)
+                while (_device.ConsumeFrameAvailable())
                 {
-                    dockedMode += $" ({scale}x)";
+                    _device.PresentFrame(SwapBuffers);
                 }
 
                 if (_ticks >= _ticksPerFrame)
                 {
-                    _device.PresentFrame(SwapBuffers);
+                    string dockedMode = ConfigurationState.Instance.System.EnableDockedMode ? "Docked" : "Handheld";
+                    float scale = Graphics.Gpu.GraphicsConfig.ResScale;
+                    if (scale != 1)
+                    {
+                        dockedMode += $" ({scale}x)";
+                    }
 
                     StatusUpdatedEvent?.Invoke(this, new StatusUpdatedEventArgs(
                         _device.EnableDeviceVsync,


### PR DESCRIPTION
Experimental (needs testing and approach review). This PR removes the frame timer in GLRenderer and replaces it with a "frame ready" signal that's sent whenever a frame's AndroidFence is completed. When this happens, GPU command processing is interrupted and we present a frame immediately.

- "interrupts" the GPFifo processing, allowing it to check for frames to present
- Window keeps track of # frames with their fences reached. Present only occurs when at least one frame is ready.

This is an alternative to processing and presenting on separate threads. In future this should be rethought since we will have multiple SurfaceFlinger layers to consider, though it might still be useful if we decide to single thread GPU processing between these layers for whatever reason (easier debug?)

### Improvements
Generally improves framerate when the emulator below the game's framerate target due to GPU processing. Will not improve bad framerates to full speed, but may move them _towards_ it.

- Xenoblade DE and 2 have much better utilization and framepacing when they go below 30 fps. Duplicate frames at 25 fps look like 10, so the games are a _lot_ smoother even when they aren't at fullspeed.

Before:
![image](https://user-images.githubusercontent.com/6294155/99880875-ffa2fa00-2c0d-11eb-8f5a-728cb1bf1833.png)
After (note FIFO% - higher utilization):
![image](https://user-images.githubusercontent.com/6294155/99880885-11849d00-2c0e-11eb-9b79-95823cc66915.png)

- Game speed in Link's Awakening much more stable. It is not perfect - may improve with a sharper vsync clock.
- Frame pacing in windowed mode or when using a high refresh rate (144hz) seems somewhat improved.
- Disabling guest vsync now allows the game to reach your monitor refresh rate, as there is no artificial 60fps limit.
![image](https://user-images.githubusercontent.com/6294155/99881384-7097e100-2c11-11eb-818e-5fe5f6b0561c.png)

### Drawbacks
This changes the render loop, so will affect every game differently. I'd recommend testing a few games to make sure they don't start deadlocking.

- I encountered an issue in Link's Awakening where the game was stuck at 15 fps with vsync enabled. I could not replicate it after the fact, but the `_framesAvailable` count may have got out of sync with the actual frame queue.
- **Does not fix Zelda BOTW**

### TODO
I'm looking into some other frame time behaviours. Also, need to figure out what cause the weird bug in LA I described above.