### PR TITLE
amadeus: Fix reverb 3d mono wrong delay line offset

### DIFF
--- a/Ryujinx.Audio.Renderer/Dsp/Command/Reverb3dCommand.cs
+++ b/Ryujinx.Audio.Renderer/Dsp/Command/Reverb3dCommand.cs
@@ -83,34 +83,28 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         private void ProcessReverb3dMono(Memory<float>[] outputBuffers, ReadOnlyMemory<float>[] inputBuffers, uint sampleCount)
         {
-            const int delayLineSampleIndexOffset = -1;
-
-            ProcessReverb3dGeneric(outputBuffers, inputBuffers, sampleCount, OutputEarlyIndicesTableMono, TargetEarlyDelayLineIndicesTableMono, TargetOutputFeedbackIndicesTableMono, delayLineSampleIndexOffset);
+            ProcessReverb3dGeneric(outputBuffers, inputBuffers, sampleCount, OutputEarlyIndicesTableMono, TargetEarlyDelayLineIndicesTableMono, TargetOutputFeedbackIndicesTableMono);
         }
 
         private void ProcessReverb3dStereo(Memory<float>[] outputBuffers, ReadOnlyMemory<float>[] inputBuffers, uint sampleCount)
         {
-            const int delayLineSampleIndexOffset = 1;
-
-            ProcessReverb3dGeneric(outputBuffers, inputBuffers, sampleCount, OutputEarlyIndicesTableStereo, TargetEarlyDelayLineIndicesTableStereo, TargetOutputFeedbackIndicesTableStereo, delayLineSampleIndexOffset);
+            ProcessReverb3dGeneric(outputBuffers, inputBuffers, sampleCount, OutputEarlyIndicesTableStereo, TargetEarlyDelayLineIndicesTableStereo, TargetOutputFeedbackIndicesTableStereo);
         }
 
         private void ProcessReverb3dQuadraphonic(Memory<float>[] outputBuffers, ReadOnlyMemory<float>[] inputBuffers, uint sampleCount)
         {
-            const int delayLineSampleIndexOffset = 1;
-
-            ProcessReverb3dGeneric(outputBuffers, inputBuffers, sampleCount, OutputEarlyIndicesTableQuadraphonic, TargetEarlyDelayLineIndicesTableQuadraphonic, TargetOutputFeedbackIndicesTableQuadraphonic, delayLineSampleIndexOffset);
+            ProcessReverb3dGeneric(outputBuffers, inputBuffers, sampleCount, OutputEarlyIndicesTableQuadraphonic, TargetEarlyDelayLineIndicesTableQuadraphonic, TargetOutputFeedbackIndicesTableQuadraphonic);
         }
 
         private void ProcessReverb3dSurround(Memory<float>[] outputBuffers, ReadOnlyMemory<float>[] inputBuffers, uint sampleCount)
         {
-            const int delayLineSampleIndexOffset = 1;
-
-            ProcessReverb3dGeneric(outputBuffers, inputBuffers, sampleCount, OutputEarlyIndicesTableSurround, TargetEarlyDelayLineIndicesTableSurround, TargetOutputFeedbackIndicesTableSurround, delayLineSampleIndexOffset);
+            ProcessReverb3dGeneric(outputBuffers, inputBuffers, sampleCount, OutputEarlyIndicesTableSurround, TargetEarlyDelayLineIndicesTableSurround, TargetOutputFeedbackIndicesTableSurround);
         }
 
-        private void ProcessReverb3dGeneric(Memory<float>[] outputBuffers, ReadOnlyMemory<float>[] inputBuffers, uint sampleCount, ReadOnlySpan<int> outputEarlyIndicesTable, ReadOnlySpan<int> targetEarlyDelayLineIndicesTable, ReadOnlySpan<int> targetOutputFeedbackIndicesTable, int delayLineSampleIndexOffset)
+        private void ProcessReverb3dGeneric(Memory<float>[] outputBuffers, ReadOnlyMemory<float>[] inputBuffers, uint sampleCount, ReadOnlySpan<int> outputEarlyIndicesTable, ReadOnlySpan<int> targetEarlyDelayLineIndicesTable, ReadOnlySpan<int> targetOutputFeedbackIndicesTable)
         {
+            const int delayLineSampleIndexOffset = 1;
+
             ref Reverb3dState state = ref State.Span[0];
 
             bool isMono = Parameter.ChannelCount == 1;


### PR DESCRIPTION
This fix reverb 3d mono rendering that was using -1 instead of 1 for delay line
offset.

I also did some clean up as this value is now used by all channels
variants.

Now Resident Evil 6 goes in-gane.

![image](https://user-images.githubusercontent.com/1760003/99882249-582ec300-2c1f-11eb-9403-f8de03c24cf3.png)
![image](https://user-images.githubusercontent.com/1760003/99882258-62e95800-2c1f-11eb-9d9b-24818a5f5874.png)

