### PR TITLE
am/gui: Implement Wake-up message

### DIFF
--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -278,13 +278,21 @@ namespace Ryujinx.HLE.HOS
                 State.DockedMode = e.NewValue;
                 PerformanceState.PerformanceMode = State.DockedMode ? PerformanceMode.Boost : PerformanceMode.Default;
 
-                AppletState.EnqueueMessage(MessageInfo.OperationModeChanged);
-                AppletState.EnqueueMessage(MessageInfo.PerformanceModeChanged);
+                AppletState.Messages.Enqueue(MessageInfo.OperationModeChanged);
+                AppletState.Messages.Enqueue(MessageInfo.PerformanceModeChanged);
+                AppletState.MessageEvent.ReadableEvent.Signal();
+
                 SignalDisplayResolutionChange();
 
                 // Reconfigure controllers
                 Device.Hid.RefreshInputConfig(ConfigurationState.Instance.Hid.InputConfig.Value);
             }
+        }
+
+        public void SimulateWakeUpMessage()
+        {
+            AppletState.Messages.Enqueue(MessageInfo.Resume);
+            AppletState.MessageEvent.ReadableEvent.Signal();
         }
 
         public void SignalDisplayResolutionChange()

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
@@ -51,18 +51,18 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
                 return ResultCode.NoMessages;
             }
 
-            KEvent Event = context.Device.System.AppletState.MessageEvent;
+            KEvent messageEvent = context.Device.System.AppletState.MessageEvent;
 
             // NOTE: Service checks if current states are different than the stored ones.
             //       Since we don't support any states for now, it's fine to check if there is still messages available.
 
-            if (context.Device.System.AppletState.Messages.Count == 0)
+            if (context.Device.System.AppletState.Messages.IsEmpty)
             {
-                Event.ReadableEvent.Clear();
+                messageEvent.ReadableEvent.Clear();
             }
             else
             {
-                Event.ReadableEvent.Signal();
+                messageEvent.ReadableEvent.Signal();
             }
 
             context.ResponseData.Write((int)message);

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
@@ -29,7 +29,11 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         {
             KEvent messageEvent = context.Device.System.AppletState.MessageEvent;
 
+<<<<<<< HEAD
             if (_messageEventHandle == 0)
+=======
+            if (context.Process.HandleTable.GenerateHandle(messageEvent.ReadableEvent, out int messageEventHandle) != KernelResult.Success)
+>>>>>>> dc0a846f (Address gdkchan feedback)
             {
                 if (context.Process.HandleTable.GenerateHandle(messageEvent.ReadableEvent, out _messageEventHandle) != KernelResult.Success)
                 {
@@ -37,7 +41,11 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
                 }
             }
 
+<<<<<<< HEAD
             context.Response.HandleDesc = IpcHandleDesc.MakeCopy(_messageEventHandle);
+=======
+            context.Response.HandleDesc = IpcHandleDesc.MakeCopy(messageEventHandle);
+>>>>>>> dc0a846f (Address gdkchan feedback)
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
@@ -46,9 +46,23 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // ReceiveMessage() -> nn::am::AppletMessage
         public ResultCode ReceiveMessage(ServiceCtx context)
         {
-            if (!context.Device.System.AppletState.TryDequeueMessage(out MessageInfo message))
+            if (!context.Device.System.AppletState.Messages.TryDequeue(out MessageInfo message))
             {
                 return ResultCode.NoMessages;
+            }
+
+            KEvent Event = context.Device.System.AppletState.MessageEvent;
+
+            // NOTE: Service checks if current states are different than the stored ones.
+            //       Since we don't support any states for now, it's fine to check if there is still messages available.
+
+            if (context.Device.System.AppletState.Messages.Count == 0)
+            {
+                Event.ReadableEvent.Clear();
+            }
+            else
+            {
+                Event.ReadableEvent.Signal();
             }
 
             context.ResponseData.Write((int)message);

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
@@ -29,11 +29,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         {
             KEvent messageEvent = context.Device.System.AppletState.MessageEvent;
 
-<<<<<<< HEAD
             if (_messageEventHandle == 0)
-=======
-            if (context.Process.HandleTable.GenerateHandle(messageEvent.ReadableEvent, out int messageEventHandle) != KernelResult.Success)
->>>>>>> dc0a846f (Address gdkchan feedback)
             {
                 if (context.Process.HandleTable.GenerateHandle(messageEvent.ReadableEvent, out _messageEventHandle) != KernelResult.Success)
                 {
@@ -41,11 +37,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
                 }
             }
 
-<<<<<<< HEAD
             context.Response.HandleDesc = IpcHandleDesc.MakeCopy(_messageEventHandle);
-=======
-            context.Response.HandleDesc = IpcHandleDesc.MakeCopy(messageEventHandle);
->>>>>>> dc0a846f (Address gdkchan feedback)
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/Types/MessageInfo.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/Types/MessageInfo.cs
@@ -3,6 +3,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
     enum MessageInfo
     {
         FocusStateChanged      = 0xf,
+        Resume                 = 0x10,
         OperationModeChanged   = 0x1e,
         PerformanceModeChanged = 0x1f
     }

--- a/Ryujinx.HLE/HOS/SystemState/AppletStateMgr.cs
+++ b/Ryujinx.HLE/HOS/SystemState/AppletStateMgr.cs
@@ -6,7 +6,7 @@ namespace Ryujinx.HLE.HOS.SystemState
 {
     class AppletStateMgr
     {
-        private ConcurrentQueue<MessageInfo> _messages;
+        public ConcurrentQueue<MessageInfo> Messages { get; private set; }
 
         public FocusState FocusState { get; private set; }
 
@@ -16,8 +16,7 @@ namespace Ryujinx.HLE.HOS.SystemState
 
         public AppletStateMgr(Horizon system)
         {
-            _messages = new ConcurrentQueue<MessageInfo>();
-
+            Messages     = new ConcurrentQueue<MessageInfo>();
             MessageEvent = new KEvent(system.KernelContext);
 
             AppletResourceUserIds = new IdDictionary();
@@ -25,28 +24,10 @@ namespace Ryujinx.HLE.HOS.SystemState
 
         public void SetFocus(bool isFocused)
         {
-            FocusState = isFocused
-                ? FocusState.InFocus
-                : FocusState.OutOfFocus;
+            FocusState = isFocused ? FocusState.InFocus : FocusState.OutOfFocus;
 
-            EnqueueMessage(MessageInfo.FocusStateChanged);
-        }
-
-        public void EnqueueMessage(MessageInfo message)
-        {
-            _messages.Enqueue(message);
-
+            Messages.Enqueue(MessageInfo.FocusStateChanged);
             MessageEvent.ReadableEvent.Signal();
-        }
-
-        public bool TryDequeueMessage(out MessageInfo message)
-        {
-            if (_messages.Count < 2)
-            {
-                MessageEvent.ReadableEvent.Clear();
-            }
-
-            return _messages.TryDequeue(out message);
         }
     }
 }

--- a/Ryujinx.HLE/HOS/SystemState/AppletStateMgr.cs
+++ b/Ryujinx.HLE/HOS/SystemState/AppletStateMgr.cs
@@ -6,7 +6,7 @@ namespace Ryujinx.HLE.HOS.SystemState
 {
     class AppletStateMgr
     {
-        public ConcurrentQueue<MessageInfo> Messages { get; private set; }
+        public ConcurrentQueue<MessageInfo> Messages { get; }
 
         public FocusState FocusState { get; private set; }
 

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -1205,6 +1205,11 @@ namespace Ryujinx.Ui
             settingsWin.Show();
         }
 
+        private void Simulate_WakeUp_Message_Pressed(object sender, EventArgs args)
+        {
+            _emulationContext.System.SimulateWakeUpMessage();
+        }
+
         private void Update_Pressed(object sender, EventArgs args)
         {
             if (Updater.CanUpdate(true))

--- a/Ryujinx/Ui/MainWindow.glade
+++ b/Ryujinx/Ui/MainWindow.glade
@@ -138,6 +138,16 @@
                       </object>
                     </child>
                     <child>
+                      <object class="GtkMenuItem" id="SimulateWakeUpMessage">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="tooltip_text" translatable="yes">Simulate a Wake-up Message</property>
+                        <property name="label" translatable="yes">Simulate Wake-up Message</property>
+                        <property name="use_underline">True</property>
+                        <signal name="activate" handler="Simulate_WakeUp_Message_Pressed" swapped="no"/>
+                      </object>
+                    </child>
+                    <child>
                       <object class="GtkSeparatorMenuItem">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>


### PR DESCRIPTION
This implement the ability to send a Wake-up (Resume) message to the guest.
Some games needs to sleep and wake-up the switch to unlock some ingame features, we now supports that.
I've cleaned up the `AppletState` class and `ICommonStateGetter::ReceiveMessage` call is implemented accordingly to RE.

(Thanks to Ryushu on Discord for helping me to reproduce the issue)

![Oa3VOPXLj4](https://user-images.githubusercontent.com/4905390/100139206-67b44300-2e8f-11eb-94a6-7ebd8200127d.gif)
