### PR TITLE
Fix pre-allocator shift instruction copy on a specific case

### DIFF
--- a/ARMeilleure/CodeGen/X86/Assembler.cs
+++ b/ARMeilleure/CodeGen/X86/Assembler.cs
@@ -899,7 +899,7 @@ namespace ARMeilleure.CodeGen.X86
             }
             else if (source.Kind == OperandKind.Constant)
             {
-                source = source.With((uint)source.Value & (dest.Type == OperandType.I32 ? 0x1f : 0x3f));
+                source = source.With((int)source.Value & (dest.Type == OperandType.I32 ? 0x1f : 0x3f));
             }
 
             WriteInstruction(dest, source, type, inst);

--- a/ARMeilleure/CodeGen/X86/PreAllocator.cs
+++ b/ARMeilleure/CodeGen/X86/PreAllocator.cs
@@ -22,16 +22,20 @@ namespace ARMeilleure.CodeGen.X86
 
             for (BasicBlock block = cctx.Cfg.Blocks.First; block != null; block = block.ListNext)
             {
-                for (Node node = block.Operations.First; node != null; node = node.ListNext)
+                Node nextNode;
+
+                for (Node node = block.Operations.First; node != null; node = nextNode)
                 {
-                    if (!(node is Operation operation))
+                    nextNode = node.ListNext;
+
+                    if (node is not Operation operation)
                     {
                         continue;
                     }
 
                     HandleConstantRegCopy(block.Operations, node, operation);
-                    node = HandleDestructiveRegCopy(block.Operations, node, operation);
-                    node = HandleConstrainedRegCopy(block.Operations, node, operation);
+                    HandleDestructiveRegCopy(block.Operations, node, operation);
+                    HandleConstrainedRegCopy(block.Operations, node, operation);
 
                     switch (operation.Instruction)
                     {
@@ -56,33 +60,33 @@ namespace ARMeilleure.CodeGen.X86
                             // being called, as mandated by the ABI.
                             if (callConv == CallConvName.Windows)
                             {
-                                node = HandleCallWindowsAbi(block.Operations, stackAlloc, node, operation);
+                                HandleCallWindowsAbi(block.Operations, stackAlloc, node, operation);
                             }
                             else /* if (callConv == CallConvName.SystemV) */
                             {
-                                node = HandleCallSystemVAbi(block.Operations, node, operation);
+                                HandleCallSystemVAbi(block.Operations, node, operation);
                             }
                             break;
 
                         case Instruction.ConvertToFPUI:
-                            node = HandleConvertToFPUI(block.Operations, node, operation);
+                            HandleConvertToFPUI(block.Operations, node, operation);
                             break;
 
                         case Instruction.LoadArgument:
                             if (callConv == CallConvName.Windows)
                             {
-                                node = HandleLoadArgumentWindowsAbi(cctx, block.Operations, node, preservedArgs, operation);
+                                nextNode = HandleLoadArgumentWindowsAbi(cctx, block.Operations, node, preservedArgs, operation);
                             }
                             else /* if (callConv == CallConvName.SystemV) */
                             {
-                                node = HandleLoadArgumentSystemVAbi(cctx, block.Operations, node, preservedArgs, operation);
+                                nextNode = HandleLoadArgumentSystemVAbi(cctx, block.Operations, node, preservedArgs, operation);
                             }
                             break;
 
                         case Instruction.Negate:
                             if (!operation.GetSource(0).Type.IsInteger())
                             {
-                                node = HandleNegate(block.Operations, node, operation);
+                                HandleNegate(block.Operations, node, operation);
                             }
                             break;
 
@@ -111,7 +115,7 @@ namespace ARMeilleure.CodeGen.X86
                         case Instruction.VectorInsert8:
                             if (!HardwareCapabilities.SupportsSse41)
                             {
-                                node = HandleVectorInsert8(block.Operations, node, operation);
+                                HandleVectorInsert8(block.Operations, node, operation);
                             }
                             break;
                     }
@@ -200,7 +204,7 @@ namespace ARMeilleure.CodeGen.X86
             }
         }
 
-        private static Node HandleConstrainedRegCopy(IntrusiveList<Node> nodes, Node node, Operation operation)
+        private static void HandleConstrainedRegCopy(IntrusiveList<Node> nodes, Node node, Operation operation)
         {
             Operand dest = operation.Destination;
 
@@ -233,7 +237,7 @@ namespace ARMeilleure.CodeGen.X86
                         SplitOperand(operation.GetSource(2), rbx, rcx);
 
                         node = nodes.AddAfter(node, Operation(Instruction.VectorCreateScalar, dest, rax));
-                        node = nodes.AddAfter(node, Operation(Instruction.VectorInsert,       dest, dest, rdx, Const(1)));
+                        nodes.AddAfter(node, Operation(Instruction.VectorInsert, dest, dest, rdx, Const(1)));
 
                         operation.SetDestinations(new Operand[] { rdx, rax });
 
@@ -259,7 +263,7 @@ namespace ARMeilleure.CodeGen.X86
 
                         operation.SetSources(new Operand[] { operation.GetSource(0), rax, temp });
 
-                        node = nodes.AddAfter(node, Operation(Instruction.Copy, dest, rax));
+                        nodes.AddAfter(node, Operation(Instruction.Copy, dest, rax));
 
                         operation.Destination = rax;
                     }
@@ -284,7 +288,7 @@ namespace ARMeilleure.CodeGen.X86
                         nodes.AddBefore(node, Operation(Instruction.Copy,    rax, src1));
                         nodes.AddBefore(node, Operation(Instruction.Clobber, rdx));
 
-                        node = nodes.AddAfter(node, Operation(Instruction.Copy, dest, rax));
+                        nodes.AddAfter(node, Operation(Instruction.Copy, dest, rax));
 
                         operation.SetDestinations(new Operand[] { rdx, rax });
 
@@ -332,7 +336,7 @@ namespace ARMeilleure.CodeGen.X86
 
                     operation.SetSource(0, rax);
 
-                    node = nodes.AddAfter(node, Operation(Instruction.Copy, dest, rdx));
+                    nodes.AddAfter(node, Operation(Instruction.Copy, dest, rdx));
 
                     operation.SetDestinations(new Operand[] { rdx, rax });
 
@@ -357,15 +361,13 @@ namespace ARMeilleure.CodeGen.X86
                     break;
                 }
             }
-
-            return node;
         }
 
-        private static Node HandleDestructiveRegCopy(IntrusiveList<Node> nodes, Node node, Operation operation)
+        private static void HandleDestructiveRegCopy(IntrusiveList<Node> nodes, Node node, Operation operation)
         {
             if (operation.Destination == null || operation.SourcesCount == 0)
             {
-                return node;
+                return;
             }
 
             Instruction inst = operation.Instruction;
@@ -402,7 +404,7 @@ namespace ARMeilleure.CodeGen.X86
 
                     operation.SetSource(0, temp);
 
-                    node = nodes.AddAfter(node, Operation(Instruction.Copy, dest, temp));
+                    nodes.AddAfter(node, Operation(Instruction.Copy, dest, temp));
 
                     operation.Destination = temp;
                 }
@@ -426,7 +428,7 @@ namespace ARMeilleure.CodeGen.X86
 
                     operation.SetSource(2, temp);
 
-                    node = nodes.AddAfter(node, Operation(Instruction.Copy, dest, temp));
+                    nodes.AddAfter(node, Operation(Instruction.Copy, dest, temp));
 
                     operation.Destination = temp;
                 }
@@ -437,11 +439,9 @@ namespace ARMeilleure.CodeGen.X86
                     operation.SetSource(2, dest);
                 }
             }
-
-            return node;
         }
 
-        private static Node HandleConvertToFPUI(IntrusiveList<Node> nodes, Node node, Operation operation)
+        private static void HandleConvertToFPUI(IntrusiveList<Node> nodes, Node node, Operation operation)
         {
             // Unsigned integer to FP conversions are not supported on X86.
             // We need to turn them into signed integer to FP conversions, and
@@ -489,15 +489,13 @@ namespace ARMeilleure.CodeGen.X86
                 node = nodes.AddAfter(node, Operation(Instruction.ConvertToFP, dest, half));
 
                 node = nodes.AddAfter(node, Operation(Instruction.Add, dest, dest, dest));
-                node = nodes.AddAfter(node, Operation(Instruction.Add, dest, dest, lsbF));
+                nodes.AddAfter(node, Operation(Instruction.Add, dest, dest, lsbF));
             }
 
             Delete(nodes, currentNode, operation);
-
-            return node;
         }
 
-        private static Node HandleNegate(IntrusiveList<Node> nodes, Node node, Operation operation)
+        private static void HandleNegate(IntrusiveList<Node> nodes, Node node, Operation operation)
         {
             // There's no SSE FP negate instruction, so we need to transform that into
             // a XOR of the value to be negated with a mask with the highest bit set.
@@ -525,14 +523,12 @@ namespace ARMeilleure.CodeGen.X86
 
             node = nodes.AddAfter(node, new IntrinsicOperation(Intrinsic.X86Xorps, res, res, source));
 
-            node = nodes.AddAfter(node, Operation(Instruction.Copy, dest, res));
+            nodes.AddAfter(node, Operation(Instruction.Copy, dest, res));
 
             Delete(nodes, currentNode, operation);
-
-            return node;
         }
 
-        private static Node HandleVectorInsert8(IntrusiveList<Node> nodes, Node node, Operation operation)
+        private static void HandleVectorInsert8(IntrusiveList<Node> nodes, Node node, Operation operation)
         {
             // Handle vector insertion, when SSE 4.1 is not supported.
             Operand dest = operation.Destination;
@@ -572,14 +568,12 @@ namespace ARMeilleure.CodeGen.X86
 
             Operation vinsOp = Operation(Instruction.VectorInsert16, dest, src1, temp1, Const(index >> 1));
 
-            node = nodes.AddAfter(node, vinsOp);
+            nodes.AddAfter(node, vinsOp);
 
             Delete(nodes, currentNode, operation);
-
-            return node;
         }
 
-        private static Node HandleCallWindowsAbi(IntrusiveList<Node> nodes, StackAllocator stackAlloc, Node node, Operation operation)
+        private static void HandleCallWindowsAbi(IntrusiveList<Node> nodes, StackAllocator stackAlloc, Node node, Operation operation)
         {
             Operand dest = operation.Destination;
 
@@ -707,7 +701,7 @@ namespace ARMeilleure.CodeGen.X86
 
                     Operation loadOp = Operation(Instruction.Load, dest, retValueAddr);
 
-                    node = nodes.AddAfter(node, loadOp);
+                    nodes.AddAfter(node, loadOp);
 
                     operation.Destination = null;
                 }
@@ -719,18 +713,16 @@ namespace ARMeilleure.CodeGen.X86
 
                     Operation copyOp = Operation(Instruction.Copy, dest, retReg);
 
-                    node = nodes.AddAfter(node, copyOp);
+                    nodes.AddAfter(node, copyOp);
 
                     operation.Destination = retReg;
                 }
             }
 
             operation.SetSources(sources);
-
-            return node;
         }
 
-        private static Node HandleCallSystemVAbi(IntrusiveList<Node> nodes, Node node, Operation operation)
+        private static void HandleCallSystemVAbi(IntrusiveList<Node> nodes, Node node, Operation operation)
         {
             Operand dest = operation.Destination;
 
@@ -812,7 +804,7 @@ namespace ARMeilleure.CodeGen.X86
                     Operand retHReg = Gpr(CallingConvention.GetIntReturnRegisterHigh(), OperandType.I64);
 
                     node = nodes.AddAfter(node, Operation(Instruction.VectorCreateScalar, dest, retLReg));
-                    node = nodes.AddAfter(node, Operation(Instruction.VectorInsert,       dest, dest, retHReg, Const(1)));
+                    nodes.AddAfter(node, Operation(Instruction.VectorInsert, dest, dest, retHReg, Const(1)));
 
                     operation.Destination = null;
                 }
@@ -824,15 +816,13 @@ namespace ARMeilleure.CodeGen.X86
 
                     Operation copyOp = Operation(Instruction.Copy, dest, retReg);
 
-                    node = nodes.AddAfter(node, copyOp);
+                    nodes.AddAfter(node, copyOp);
 
                     operation.Destination = retReg;
                 }
             }
 
             operation.SetSources(sources.ToArray());
-
-            return node;
         }
 
         private static void HandleTailcallSystemVAbi(IntrusiveList<Node> nodes, StackAllocator stackAlloc, Node node, Operation operation)


### PR DESCRIPTION
For shift instructions, the pre-allocator needs to insert a copy to ensure the shift value is on the CL register (and you can only use CL for the shift on x86), and additionally, it needs to insert copies to ensure that the first source operand and the destination are on the same register. Right now there are 2 separate functions that handles this, but the problem is that each one of those functions returns a new node that is the node of the last operation is inserted on the list, and due to this behavior, the shift instruction would be skipped on the next call.

To sum it up, the following was possible:
- `HandleDestructiveRegCopy` inserts a copy before and a copy after the operation to ensure dest == src1, then it returns the node of the last copy.
- `HandleConstrainedRegCopy` is then not able to insert the copy to the CL register as we are at the node of the copy inserted on the previous step, with leads to a assert later on.

To fix it I simply changed it to not return the last inserted node. This ensures that all functions will be able to visit the current instruction node. I also added a temp variable that holds the next node, this allows easily skipping any newly inserted nodes that do not need to be visited.

In partice nothing hits this right now as far I'm aware, because `useNewLocal ` must be true for it to insert a node *after* the operation on `HandleDestructiveRegCopy`. And for it to be true, the destination operand and at least one of the sources must be equal. This does not happen right now because the optimizations are still not able to eliminate all copies. Since I could not find evidence that this is being hit right now, I also did not increment the PPTC version, but can do so just to be on the safe side if desired.

