### PR TITLE
Blacklist textures with a very small width or height from scaling

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -408,6 +408,12 @@ namespace Ryujinx.Graphics.Gpu.Image
                 return false;
             }
 
+            if (info.Width < 8 || info.Height < 8)
+            {
+                // Discount textures with small dimensions.
+                return false;
+            }
+
             if (!(info.FormatInfo.Format.IsDepthOrStencil() || info.FormatInfo.Components == 1))
             {
                 // Discount square textures that aren't depth-stencil like. (excludes game textures, cubemap faces, most 3D texture LUT, texture atlas)


### PR DESCRIPTION
This PR disables resolution scaling on textures smaller than 8px on either width or height. It's very unlikely that textures this small (or thin) contain data that the end user really wants to scale.

The existing rules assumed that small textures would be covered by the square texture rule (which works on aligned sizes), this just solidifies it.

A very specific case that this fixes is when a game uses 1-dimensional-like textures, such as the HDR in:
- Splatoon 2
- Pikmin 3 Deluxe
- Captain Toad: Treasure Tracker
These games no longer dramatically increase ingame exposure when res scaling is enabled.

Before:
https://gyazo.com/e857b305b03b93105b4289dfa239658e

After:
![image](https://user-images.githubusercontent.com/6294155/100383309-382f4300-3015-11eb-9836-5a88496ba859.png)

This may also fix the blue colour ramp for strong attacks in Hyrule Warriors sometimes becoming trashed, though this game also has its own problems with VRAM usage that might be responsible instead.

