### PR TITLE
Prefer truly perfect texture matches over format aliased ones

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -800,29 +800,31 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         /// <param name="info">Texture information to compare against</param>
         /// <param name="flags">Comparison flags</param>
-        /// <returns>True if the textures are strictly equal or similar, false otherwise</returns>
-        public bool IsPerfectMatch(TextureInfo info, TextureSearchFlags flags)
+        /// <returns>A value indicating how well this texture matches the given info</returns>
+        public TextureMatchQuality IsExactMatch(TextureInfo info, TextureSearchFlags flags)
         {
-            if (!TextureCompatibility.FormatMatches(Info, info, (flags & TextureSearchFlags.ForSampler) != 0, (flags & TextureSearchFlags.ForCopy) != 0))
+            TextureMatchQuality matchQuality = TextureCompatibility.FormatMatches(Info, info, (flags & TextureSearchFlags.ForSampler) != 0, (flags & TextureSearchFlags.ForCopy) != 0);
+
+            if (matchQuality == TextureMatchQuality.NoMatch)
             {
-                return false;
+                return matchQuality;
             }
 
             if (!TextureCompatibility.LayoutMatches(Info, info))
             {
-                return false;
+                return TextureMatchQuality.NoMatch;
             }
 
             if (!TextureCompatibility.SizeMatches(Info, info, (flags & TextureSearchFlags.Strict) == 0))
             {
-                return false;
+                return TextureMatchQuality.NoMatch;
             }
 
             if ((flags & TextureSearchFlags.ForSampler) != 0 || (flags & TextureSearchFlags.Strict) != 0)
             {
                 if (!TextureCompatibility.SamplerParamsMatches(Info, info))
                 {
-                    return false;
+                    return TextureMatchQuality.NoMatch;
                 }
             }
 
@@ -832,15 +834,15 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 if (!msTargetCompatible && !TextureCompatibility.TargetAndSamplesCompatible(Info, info))
                 {
-                    return false;
+                    return TextureMatchQuality.NoMatch;
                 }
             }
             else if (!TextureCompatibility.TargetAndSamplesCompatible(Info, info))
             {
-                return false;
+                return TextureMatchQuality.NoMatch;
             }
 
-            return Info.Address == info.Address && Info.Levels == info.Levels;
+            return Info.Address == info.Address && Info.Levels == info.Levels ? matchQuality : TextureMatchQuality.NoMatch;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -125,14 +125,14 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="rhs">Texture information to compare with</param>
         /// <param name="forSampler">Indicates that the texture will be used for shader sampling</param>
         /// <param name="forCopy">Indicates that the texture will be used as copy source or target</param>
-        /// <returns>True if the format matches, with the given comparison rules</returns>
-        public static bool FormatMatches(TextureInfo lhs, TextureInfo rhs, bool forSampler, bool forCopy)
+        /// <returns>A value indicating how well the formats match</returns>
+        public static TextureMatchQuality FormatMatches(TextureInfo lhs, TextureInfo rhs, bool forSampler, bool forCopy)
         {
             // D32F and R32F texture have the same representation internally,
             // however the R32F format is used to sample from depth textures.
             if (lhs.FormatInfo.Format == Format.D32Float && rhs.FormatInfo.Format == Format.R32Float && (forSampler || forCopy))
             {
-                return true;
+                return TextureMatchQuality.FormatAlias;
             }
 
             if (forCopy)
@@ -141,22 +141,22 @@ namespace Ryujinx.Graphics.Gpu.Image
                 // use equivalent color formats. We must also consider them as compatible.
                 if (lhs.FormatInfo.Format == Format.S8Uint && rhs.FormatInfo.Format == Format.R8Unorm)
                 {
-                    return true;
+                    return TextureMatchQuality.FormatAlias;
                 }
 
                 if (lhs.FormatInfo.Format == Format.D16Unorm && rhs.FormatInfo.Format == Format.R16Unorm)
                 {
-                    return true;
+                    return TextureMatchQuality.FormatAlias;
                 }
 
                 if ((lhs.FormatInfo.Format == Format.D24UnormS8Uint ||
                      lhs.FormatInfo.Format == Format.D24X8Unorm) && rhs.FormatInfo.Format == Format.B8G8R8A8Unorm)
                 {
-                    return true;
+                    return TextureMatchQuality.FormatAlias;
                 }
             }
 
-            return lhs.FormatInfo.Format == rhs.FormatInfo.Format;
+            return lhs.FormatInfo.Format == rhs.FormatInfo.Format ? TextureMatchQuality.Perfect : TextureMatchQuality.NoMatch;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -676,26 +676,43 @@ namespace Ryujinx.Graphics.Gpu.Image
                 sameAddressOverlapsCount = _textures.FindOverlaps(info.Address, ref _textureOverlaps);
             }
 
+            Texture texture = null;
+
+            TextureMatchQuality bestQuality = TextureMatchQuality.NoMatch;
+
             for (int index = 0; index < sameAddressOverlapsCount; index++)
             {
                 Texture overlap = _textureOverlaps[index];
 
-                if (overlap.IsPerfectMatch(info, flags))
+                TextureMatchQuality matchQuality = overlap.IsExactMatch(info, flags);
+
+                if (matchQuality == TextureMatchQuality.Perfect)
                 {
-                    if (!isSamplerTexture)
-                    {
-                        // If not a sampler texture, it is managed by the auto delete
-                        // cache, ensure that it is on the "top" of the list to avoid
-                        // deletion.
-                        _cache.Lift(overlap);
-                    }
-
-                    ChangeSizeIfNeeded(info, overlap, isSamplerTexture, sizeHint);
-
-                    overlap.SynchronizeMemory();
-
-                    return overlap;
+                    texture = overlap;
+                    break;
                 }
+                else if (matchQuality > bestQuality)
+                {
+                    texture = overlap;
+                    bestQuality = matchQuality;
+                }
+            }
+
+            if (texture != null)
+            {
+                if (!isSamplerTexture)
+                {
+                    // If not a sampler texture, it is managed by the auto delete
+                    // cache, ensure that it is on the "top" of the list to avoid
+                    // deletion.
+                    _cache.Lift(texture);
+                }
+
+                ChangeSizeIfNeeded(info, texture, isSamplerTexture, sizeHint);
+
+                texture.SynchronizeMemory();
+
+                return texture;
             }
 
             // Calculate texture sizes, used to find all overlapping textures.
@@ -736,8 +753,6 @@ namespace Ryujinx.Graphics.Gpu.Image
             {
                 overlapsCount = _textures.FindOverlaps(info.Address, size, ref _textureOverlaps);
             }
-
-            Texture texture = null;
 
             for (int index = 0; index < overlapsCount; index++)
             {

--- a/Ryujinx.Graphics.Gpu/Image/TextureMatchQuality.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureMatchQuality.cs
@@ -1,0 +1,9 @@
+﻿namespace Ryujinx.Graphics.Gpu.Image
+{
+    enum TextureMatchQuality
+    {
+        NoMatch,
+        FormatAlias,
+        Perfect
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -121,7 +121,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                     // If the descriptors are the same, the texture is the same,
                     // we don't need to remove as it was not modified. Just continue.
-                    if (texture.IsPerfectMatch(GetInfo(descriptor), TextureSearchFlags.Strict))
+                    if (texture.IsExactMatch(GetInfo(descriptor), TextureSearchFlags.Strict) != TextureMatchQuality.NoMatch)
                     {
                         continue;
                     }


### PR DESCRIPTION
When attempting to find "perfectly matching" textures, we actually have a few gives that allow matches that are not exactly perfect. However, this means that multiple textures that are "perfect" can exist, and some might be more preferable to others.

This PR adds a preference system to selection of matching textures, where it will pick the "most perfect" match available in the texture cache. If a match is deemed truly perfect, then it is returned immediately as before. However, if some matches are not perfect, it will return the one with the highest "quality" defined in an enum.

Currently, only format aliasing for sampler/copy is considered an imperfect match. This could be expanded in future to choose better texture matches for texture sizes that match by alignment vs perfectly. I didn't include it here as it'll only be clear if it's needed when doing larger scale changes.

### Example

For the specific case in Zelda, imagine there are 2 textures with the same address and size, (1) and (2), that are half the game resolution.

- The game reduces the main depth buffer into (1) as a D32F depth buffer.
- The game draws (1): D32F into (2): R32F using a fragment shader, rescaling the depth values from [0.5,10] to [0.0,1.0]
- The game samples (2): R32F when doing the final draw, using it for the fog
- **Next frame...**
- The game reduces the main depth buffer into (2) as a D32F depth buffer. 
  - If the (1->2) step happened first, this will create a second texture with the same address and size. 
- The game draws (2): D32F into (1): R32F using a fragment shader, rescaling the depth values from [0.5,10] to [0.0,1.0]
  - Binding (1) as R32F will create a new texture for (1) that is R32F.

We now have 2 distinct versions of (1) and (2), a R32F and D32F version. Currently in master, the last sample for R32F gets the D32F texture _from the last frame_, so not only is it in the incorrect interval/format, it's also in the past. Ideally, the sample should choose the R32F version over the D32F one as it is already in the desired format, but if the D32F one exists in the list first, it will be chosen instead.

For this specific case (where the depth and red textures are used for distinct purposes), recognising these are different textures and picking the best match fixes the issue, and does not need any pesky copies. In future, this should probably create a copy dependency (once those exist) between the D32F and R32F textures, so that the data is not lost between uses of the texture. At least in this specific example, the data is overwritten every time, so it is not needed.

Fixed screenshot, immediately after loading in:
![image](https://user-images.githubusercontent.com/6294155/100400212-9d068f80-304d-11eb-83fa-971a010e6627.png)

Would recommend testing games that use the depth format aliasing functionality. It looks fine in Burnout Paradise and Link's Awakening.