### PR TITLE
Implement Force Early Z Test Register

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/Cache/CacheHelper.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/Cache/CacheHelper.cs
@@ -333,6 +333,23 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache
         }
 
         /// <summary>
+        /// Builds gpu state flags using information from the given gpu accessor.
+        /// </summary>
+        /// <param name="gpuAccessor">The gpu accessor</param>
+        /// <returns>The gpu state flags</returns>
+        private static GuestGpuStateFlags GetGpuStateFlags(IGpuAccessor gpuAccessor)
+        {
+            GuestGpuStateFlags flags = 0;
+
+            if (gpuAccessor.QueryEarlyZForce())
+            {
+                flags |= GuestGpuStateFlags.EarlyZForce;
+            }
+
+            return flags;
+        }
+
+        /// <summary>
         /// Create a new instance of <see cref="GuestGpuAccessorHeader"/> from an gpu accessor.
         /// </summary>
         /// <param name="gpuAccessor">The gpu accessor</param>
@@ -347,6 +364,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache
                 ComputeLocalMemorySize = gpuAccessor.QueryComputeLocalMemorySize(),
                 ComputeSharedMemorySize = gpuAccessor.QueryComputeSharedMemorySize(),
                 PrimitiveTopology = gpuAccessor.QueryPrimitiveTopology(),
+                StateFlags = GetGpuStateFlags(gpuAccessor)
             };
         }
 

--- a/Ryujinx.Graphics.Gpu/Shader/Cache/Definition/GuestGpuAccessorHeader.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/Cache/Definition/GuestGpuAccessorHeader.cs
@@ -55,8 +55,8 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache.Definition
         public ushort Reserved2;
 
         /// <summary>
-        /// Unused/reserved.
+        /// GPU boolean state that can influence shader compilation.
         /// </summary>
-        public byte Reserved3;
+        public GuestGpuStateFlags StateFlags;
     }
 }

--- a/Ryujinx.Graphics.Gpu/Shader/Cache/Definition/GuestGpuStateFlags.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/Cache/Definition/GuestGpuStateFlags.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Ryujinx.Graphics.Gpu.Shader.Cache.Definition
+{
+    [Flags]
+    enum GuestGpuStateFlags : byte
+    {
+        EarlyZForce = 1 << 0
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Shader/CachedGpuAccessor.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/CachedGpuAccessor.cs
@@ -150,5 +150,14 @@ namespace Ryujinx.Graphics.Gpu.Shader
 
             return textureDescriptor;
         }
+
+        /// <summary>
+        /// Queries if host state forces early depth testing.
+        /// </summary>
+        /// <returns>True if early depth testing is forced</returns>
+        public bool QueryEarlyZForce()
+        {
+            return (_header.StateFlags & GuestGpuStateFlags.EarlyZForce) != 0;
+        }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
@@ -196,5 +196,14 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 return _context.Methods.TextureManager.GetGraphicsTextureDescriptor(_state, _stageIndex, handle);
             }
         }
+
+        /// <summary>
+        /// Queries if host state forces early depth testing.
+        /// </summary>
+        /// <returns>True if early depth testing is forced</returns>
+        public bool QueryEarlyZForce()
+        {
+            return _state.Get<bool>(MethodOffset.EarlyZForce);
+        }
     }
 }

--- a/Ryujinx.Graphics.Gpu/State/MethodOffset.cs
+++ b/Ryujinx.Graphics.Gpu/State/MethodOffset.cs
@@ -13,6 +13,7 @@ namespace Ryujinx.Graphics.Gpu.State
         LaunchDma                       = 0x6c,
         LoadInlineData                  = 0x6d,
         CopyDstTexture                  = 0x80,
+        EarlyZForce                     = 0x84,
         CopySrcTexture                  = 0x8c,
         DispatchParamsAddress           = 0xad,
         Dispatch                        = 0xaf,

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
@@ -141,6 +141,12 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
             {
                 if (context.Config.Stage == ShaderStage.Fragment)
                 {
+                    if (context.Config.GpuAccessor.QueryEarlyZForce())
+                    {
+                        context.AppendLine("layout(early_fragment_tests) in;");
+                        context.AppendLine();
+                    }
+
                     context.AppendLine($"uniform bool {DefaultNames.IsBgraName}[8];");
                     context.AppendLine();
                 }

--- a/Ryujinx.Graphics.Shader/IGpuAccessor.cs
+++ b/Ryujinx.Graphics.Shader/IGpuAccessor.cs
@@ -78,5 +78,10 @@
         {
             return TextureFormat.R8G8B8A8Unorm;
         }
+
+        bool QueryEarlyZForce()
+        {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
In normal circumstances, the Z test is performed before the fragment test to avoid running it when possible. However, as this is an optimization, cases where it would change the functionality instead perform the _fragment test_ first, as it can do things like set the output depth, or perform incoherent writes.

This register exists to allow shaders to _force_ the Z test to happen early regardless of whether it will cause different behaviour. In the case of Image Load/Store, performing the Z test first can very much be _desired_ behaviour.

Register can be found here:
https://github.com/envytools/envytools/blob/master/rnndb/graph/gf100_3d.xml#L68

This fixes the interior volumes on Xenoblade for good. The issue was actually found by @ReinUsesLisp [over at yuzu,](https://github.com/yuzu-emu/yuzu/pull/5013/) which after reading two sentences I looked up this register as quickly as possible so that Colony 9 wouldn't look like a kaleidoscope.

Essentially a follow-up to https://github.com/Ryujinx/Ryujinx/pull/1380 in terms of Xenoblade. I've been on this mess for a while, and I honestly can't believe that I didn't notice the depth test was essentially meaningless for the image store as it would run the fragment shader first. Khronos even have an explanation with this exact example on their wiki:

> This feature exists to ensure proper behavior when using Image Load Store or other incoherent memory writing. Without turning this on, fragments that fail the depth test would still perform their Image Load/Store operations, since the fragment shader that performed those operations successfully executed.

🥴 

Before:
https://gyazo.com/aae376b1338e835e20c6d64d5b35c0f8

After:
https://gyazo.com/b0c30a18607046588021f21ed778ddfe

![image](https://user-images.githubusercontent.com/6294155/100485205-1c9c6900-30f7-11eb-97e3-007c212ce248.png)
Also fixes Xenoblade 2, if you're into that kind of thing.

## Shader Cache
This register directly affects shader compilation, and therefore the shader cache. Fortunately, the default state for this behaviour is _off_, as it is a _force_ rather than _enable_ register (auto enable is done some other way), so all shaders that don't use this functionality will not change. One of the reserved fields in the Gpu Accessor has been changed to represent GPU state flags, which can be populated with more flags as we discover them.

**HOWEVER**

There is a bug with the shader cache where the cached GpuAccessor state _is not part of the hash_, which will mean that existing broken shaders for xenoblade will still be "valid" for the case that this fixes. This should be fixed by a future PR to the shader cache to fix this and _rehash_ any existing shaders, which will not invalidate any of your precious guest cache but will correctly make them invalid only if the new EarlyZ flag is set.

If you're testing, I'd therefore recommend **doing so with shader cache off for now.** (or rebuilding for xenoblade, you insane people) Go bug @Thog to fix the issue. :P
