### PR TITLE
salieri: Fix missing guest GPU accessor missing on hashes

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/Cache/CacheHelper.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/Cache/CacheHelper.cs
@@ -1,0 +1,282 @@
+﻿using Ryujinx.Common;
+using Ryujinx.Common.Configuration;
+using Ryujinx.Common.Logging;
+using Ryujinx.Graphics.GAL;
+using Ryujinx.Graphics.Gpu.Shader.Cache.Definition;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Ryujinx.Graphics.Gpu.Shader.Cache
+{
+    /// <summary>
+    /// Helper to manipulate the disk shader cache.
+    /// </summary>
+    static class CacheHelper
+    {
+        public static bool TryReadManifestHeader(string manifestPath, out CacheManifestHeader header)
+        {
+            header = default;
+
+            if (File.Exists(manifestPath))
+            {
+                Memory<byte> rawManifest = File.ReadAllBytes(manifestPath);
+
+                if (MemoryMarshal.TryRead(rawManifest.Span, out header))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public static bool TryReadManifestFile(string manifestPath, CacheGraphicsApi graphicsApi, CacheHashType hashType, out CacheManifestHeader header, out HashSet<Hash128> entries)
+        {
+            header = default;
+            entries = new HashSet<Hash128>();
+
+            if (File.Exists(manifestPath))
+            {
+                Memory<byte> rawManifest = File.ReadAllBytes(manifestPath);
+
+                if (MemoryMarshal.TryRead(rawManifest.Span, out header))
+                {
+                    Memory<byte> hashTableRaw = rawManifest.Slice(Unsafe.SizeOf<CacheManifestHeader>());
+
+                    bool isValid = header.IsValid(graphicsApi, hashType, hashTableRaw.Span);
+
+                    if (isValid)
+                    {
+                        ReadOnlySpan<Hash128> hashTable = MemoryMarshal.Cast<byte, Hash128>(hashTableRaw.Span);
+
+                        foreach (Hash128 hash in hashTable)
+                        {
+                            entries.Add(hash);
+                        }
+                    }
+
+                    return isValid;
+                }
+            }
+
+            return false;
+        }
+
+        public static byte[] ComputeManifest(ulong version, CacheGraphicsApi graphicsApi, CacheHashType hashType, HashSet<Hash128> entries)
+        {
+            CacheManifestHeader manifestHeader = new CacheManifestHeader(version, graphicsApi, hashType);
+
+            byte[] data = new byte[Unsafe.SizeOf<CacheManifestHeader>() + entries.Count * Unsafe.SizeOf<Hash128>()];
+
+            // CacheManifestHeader has the same size as a Hash128.
+            Span<Hash128> dataSpan = MemoryMarshal.Cast<byte, Hash128>(data.AsSpan()).Slice(1);
+
+            int i = 0;
+
+            foreach (Hash128 hash in entries)
+            {
+                dataSpan[i++] = hash;
+            }
+
+            manifestHeader.UpdateChecksum(data.AsSpan().Slice(Unsafe.SizeOf<CacheManifestHeader>()));
+
+            MemoryMarshal.Write(data, ref manifestHeader);
+
+            return data;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string GetBaseCacheDirectory(string titleId) => Path.Combine(AppDataManager.GamesDirPath, titleId, "cache", "shader");
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string GetCacheTempDataPath(string cacheDirectory) => Path.Combine(cacheDirectory, "temp");
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string GetArchivePath(string cacheDirectory) => Path.Combine(cacheDirectory, "cache.zip");
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string GetManifestPath(string cacheDirectory) => Path.Combine(cacheDirectory, "cache.info");
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string GenCacheTempFilePath(string cacheDirectory, Hash128 key) => Path.Combine(GetCacheTempDataPath(cacheDirectory), key.ToString());
+
+        /// <summary>
+        /// Generate the path to the cache directory.
+        /// </summary>
+        /// <param name="baseCacheDirectory">The base of the cache directory</param>
+        /// <param name="graphicsApi">The graphics api in use</param>
+        /// <param name="shaderProvider">The name of the shader provider in use</param>
+        /// <param name="cacheName">The name of the cache</param>
+        /// <returns>The path to the cache directory</returns>
+        public static string GenerateCachePath(string baseCacheDirectory, CacheGraphicsApi graphicsApi, string shaderProvider, string cacheName)
+        {
+            string graphicsApiName = graphicsApi switch
+            {
+                CacheGraphicsApi.OpenGL => "opengl",
+                CacheGraphicsApi.OpenGLES => "opengles",
+                CacheGraphicsApi.Vulkan => "vulkan",
+                CacheGraphicsApi.DirectX => "directx",
+                CacheGraphicsApi.Metal => "metal",
+                CacheGraphicsApi.Guest => "guest",
+                _ => throw new NotImplementedException(graphicsApi.ToString()),
+            };
+
+            return Path.Combine(baseCacheDirectory, graphicsApiName, shaderProvider, cacheName);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static byte[] ReadFromArchive(ZipArchive archive, Hash128 entry)
+        {
+            if (archive != null)
+            {
+                ZipArchiveEntry archiveEntry = archive.GetEntry($"{entry}");
+
+                if (archiveEntry != null)
+                {
+                    try
+                    {
+                        byte[] result = new byte[archiveEntry.Length];
+
+                        using (Stream archiveStream = archiveEntry.Open())
+                        {
+                            archiveStream.Read(result);
+
+                            return result;
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.Error?.Print(LogClass.Gpu, $"Cannot load cache file {entry} from archive");
+                        Logger.Error?.Print(LogClass.Gpu, e.ToString());
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static byte[] ReadFromFile(string tempPath, Hash128 entry)
+        {
+            string cacheTempFilePath = GenCacheTempFilePath(tempPath, entry);
+
+            try
+            {
+                return File.ReadAllBytes(cacheTempFilePath);
+            }
+            catch (Exception e)
+            {
+                Logger.Error?.Print(LogClass.Gpu, $"Cannot load cache file at {cacheTempFilePath}");
+                Logger.Error?.Print(LogClass.Gpu, e.ToString());
+            }
+
+            return null;
+        }
+
+        public static Hash128 ComputeGuestHashFromCache(ReadOnlySpan<GuestShaderCacheEntry> cachedShaderEntries, TransformFeedbackDescriptor[] tfd)
+        {
+            byte[] data;
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                BinaryWriter writer = new BinaryWriter(stream);
+                foreach (GuestShaderCacheEntry cachedShaderEntry in cachedShaderEntries)
+                {
+                    if (cachedShaderEntry != null)
+                    {
+                        // Code (and Code A if present)
+                        stream.Write(cachedShaderEntry.Code);
+
+                        // Guest GPU accessor header
+                        writer.WriteStruct(cachedShaderEntry.Header.GpuAccessorHeader);
+
+                        // Texture descriptors
+                        foreach (GuestTextureDescriptor textureDescriptor in cachedShaderEntry.TextureDescriptors.Values)
+                        {
+                            writer.WriteStruct(textureDescriptor);
+                        }
+                    }
+                }
+
+                // Transformation feedback
+                WriteTransformationFeedbackInformation(stream, tfd);
+
+                data = stream.ToArray();
+            }
+
+            return XXHash128.ComputeHash(data);
+        }
+
+        /// <summary>
+        /// Read transform feedback descriptors from guest.
+        /// </summary>
+        /// <param name="data">The raw guest transform feedback descriptors</param>
+        /// <param name="header">The guest shader program header</param>
+        /// <returns>The transform feedback descriptors read from guest</returns>
+        public static TransformFeedbackDescriptor[] ReadTransformationFeedbackInformations(ref ReadOnlySpan<byte> data, GuestShaderCacheHeader header)
+        {
+            if (header.TransformFeedbackCount != 0)
+            {
+                TransformFeedbackDescriptor[] result = new TransformFeedbackDescriptor[header.TransformFeedbackCount];
+
+                for (int i = 0; i < result.Length; i++)
+                {
+                    GuestShaderCacheTransformFeedbackHeader feedbackHeader = MemoryMarshal.Read<GuestShaderCacheTransformFeedbackHeader>(data);
+
+                    result[i] = new TransformFeedbackDescriptor(feedbackHeader.BufferIndex, feedbackHeader.Stride, data.Slice(Unsafe.SizeOf<GuestShaderCacheTransformFeedbackHeader>(), feedbackHeader.VaryingLocationsLength).ToArray());
+
+                    data = data.Slice(Unsafe.SizeOf<GuestShaderCacheTransformFeedbackHeader>() + feedbackHeader.VaryingLocationsLength);
+                }
+
+                return result;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Write transform feedback guest information to the given stream.
+        /// </summary>
+        /// <param name="stream">The stream to write data to</param>
+        /// <param name="tfd">The current transform feedback descriptors used</param>
+        public static void WriteTransformationFeedbackInformation(Stream stream, TransformFeedbackDescriptor[] tfd)
+        {
+            if (tfd != null)
+            {
+                BinaryWriter writer = new BinaryWriter(stream);
+
+                foreach (TransformFeedbackDescriptor transform in tfd)
+                {
+                    writer.WriteStruct(new GuestShaderCacheTransformFeedbackHeader(transform.BufferIndex, transform.Stride, transform.VaryingLocations.Length));
+                    writer.Write(transform.VaryingLocations);
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void EnsureArchiveUpToDate(string baseCacheDirectory, ZipArchive archive, HashSet<Hash128> entries)
+        {
+            foreach (Hash128 hash in entries)
+            {
+                string cacheTempFilePath = GenCacheTempFilePath(baseCacheDirectory, hash);
+
+                if (File.Exists(cacheTempFilePath))
+                {
+                    string cacheHash = $"{hash}";
+
+                    ZipArchiveEntry entry = archive.GetEntry(cacheHash);
+
+                    entry?.Delete();
+
+                    archive.CreateEntryFromFile(cacheTempFilePath, cacheHash);
+
+                    File.Delete(cacheTempFilePath);
+                }
+            }
+        }
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Shader/Cache/CacheManager.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/Cache/CacheManager.cs
@@ -83,16 +83,6 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache
         }
 
         /// <summary>
-        /// Computes the hash of some data using the current cache hashing algorithm.
-        /// </summary>
-        /// <param name="data">Some data to generate a hash for.</param>
-        /// <returns>The hash of some data using the current hashing algorithm of the cache</returns>
-        public Hash128 ComputeHash(ReadOnlySpan<byte> data)
-        {
-            return XXHash128.ComputeHash(data);
-        }
-
-        /// <summary>
         /// Save a shader program not present in the program cache.
         /// </summary>
         /// <param name="programCodeHash">Target program code hash</param>

--- a/Ryujinx.Graphics.Gpu/Shader/Cache/CacheManager.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/Cache/CacheManager.cs
@@ -29,7 +29,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache
         /// <summary>
         /// Version of the guest cache shader (to increment when guest cache structure change).
         /// </summary>
-        private const ulong GuestCacheVersion = 1717;
+        private const ulong GuestCacheVersion = 1759;
 
         /// <summary>
         /// Create a new cache manager instance
@@ -45,7 +45,9 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache
             _hashType = hashType;
             _shaderProvider = shaderProvider;
 
-            string baseCacheDirectory = Path.Combine(AppDataManager.GamesDirPath, titleId, "cache", "shader");
+            string baseCacheDirectory = CacheHelper.GetBaseCacheDirectory(titleId);
+
+            CacheMigration.Run(baseCacheDirectory, graphicsApi, hashType, shaderProvider);
 
             _guestProgramCache = new CacheCollection(baseCacheDirectory, _hashType, CacheGraphicsApi.Guest, "", "program", GuestCacheVersion);
             _hostProgramCache = new CacheCollection(baseCacheDirectory, _hashType, _graphicsApi, _shaderProvider, "host", shaderCodeGenVersion);

--- a/Ryujinx.Graphics.Gpu/Shader/Cache/CacheMigration.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/Cache/CacheMigration.cs
@@ -1,0 +1,128 @@
+﻿using Ryujinx.Common;
+using Ryujinx.Common.Logging;
+using Ryujinx.Graphics.GAL;
+using Ryujinx.Graphics.Gpu.Shader.Cache.Definition;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+
+namespace Ryujinx.Graphics.Gpu.Shader.Cache
+{
+    static class CacheMigration
+    {
+        public static bool NeedHashRecompute(ulong version, out ulong newVersion)
+        {
+            const ulong TargetBrokenVersion = 1717;
+            const ulong TargetFixedVersion = 1759;
+
+            newVersion = TargetFixedVersion;
+
+            if (version == TargetBrokenVersion)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static void MoveEntry(ZipArchive archive, Hash128 oldKey, Hash128 newKey)
+        {
+            ZipArchiveEntry oldGuestEntry = archive.GetEntry($"{oldKey}");
+
+            if (oldGuestEntry != null)
+            {
+                ZipArchiveEntry newGuestEntry = archive.CreateEntry($"{newKey}");
+
+                using (Stream oldStream = oldGuestEntry.Open())
+                using (Stream newStream = newGuestEntry.Open())
+                {
+                    oldStream.CopyTo(newStream);
+                }
+
+                oldGuestEntry.Delete();
+            }
+        }
+
+        private static void RecomputeHashes(string guestBaseCacheDirectory, string hostBaseCacheDirectory, CacheGraphicsApi graphicsApi, CacheHashType hashType, ulong newVersion)
+        {
+            string guestManifestPath = CacheHelper.GetManifestPath(guestBaseCacheDirectory);
+            string hostManifestPath = CacheHelper.GetManifestPath(hostBaseCacheDirectory);
+
+            if (CacheHelper.TryReadManifestFile(guestManifestPath, CacheGraphicsApi.Guest, hashType, out _, out HashSet<Hash128> guestEntries))
+            {
+                CacheHelper.TryReadManifestFile(hostManifestPath, graphicsApi, hashType, out _, out HashSet<Hash128> hostEntries);
+
+                Logger.Info?.Print(LogClass.Gpu, "Shader cache hashes need to be recomputed, performing migration...");
+
+                string guestArchivePath = CacheHelper.GetArchivePath(guestBaseCacheDirectory);
+                string hostArchivePath = CacheHelper.GetArchivePath(hostBaseCacheDirectory);
+
+                ZipArchive guestArchive = ZipFile.Open(guestArchivePath, ZipArchiveMode.Update);
+                ZipArchive hostArchive = ZipFile.Open(hostArchivePath, ZipArchiveMode.Update);
+
+                CacheHelper.EnsureArchiveUpToDate(guestBaseCacheDirectory, guestArchive, guestEntries);
+                CacheHelper.EnsureArchiveUpToDate(hostBaseCacheDirectory, hostArchive, hostEntries);
+
+                int programIndex = 0;
+
+                HashSet<Hash128> newEntries = new HashSet<Hash128>();
+
+                foreach (Hash128 oldHash in guestEntries)
+                {
+                    byte[] guestProgram = CacheHelper.ReadFromArchive(guestArchive, oldHash);
+
+                    Logger.Info?.Print(LogClass.Gpu, $"Migrating shader {oldHash} ({programIndex + 1} / {guestEntries.Count})");
+
+                    if (guestProgram != null)
+                    {
+                        ReadOnlySpan<byte> guestProgramReadOnlySpan = guestProgram;
+
+                        ReadOnlySpan<GuestShaderCacheEntry> cachedShaderEntries = GuestShaderCacheEntry.Parse(ref guestProgramReadOnlySpan, out GuestShaderCacheHeader fileHeader);
+
+                        TransformFeedbackDescriptor[] tfd = CacheHelper.ReadTransformationFeedbackInformations(ref guestProgramReadOnlySpan, fileHeader);
+
+                        Hash128 newHash = CacheHelper.ComputeGuestHashFromCache(cachedShaderEntries, tfd);
+
+                        if (newHash != oldHash)
+                        {
+                            MoveEntry(guestArchive, oldHash, newHash);
+                            MoveEntry(hostArchive, oldHash, newHash);
+                        }
+                        else
+                        {
+                            Logger.Warning?.Print(LogClass.Gpu, $"Same hashes for shader {oldHash}");
+                        }
+
+                        newEntries.Add(newHash);
+                    }
+
+                    programIndex++;
+                }
+
+                byte[] newGuestManifestContent = CacheHelper.ComputeManifest(newVersion, CacheGraphicsApi.Guest, hashType, newEntries);
+                byte[] newHostManifestContent = CacheHelper.ComputeManifest(newVersion, graphicsApi, hashType, newEntries);
+
+                File.WriteAllBytes(guestManifestPath, newGuestManifestContent);
+                File.WriteAllBytes(hostManifestPath, newHostManifestContent);
+
+                guestArchive.Dispose();
+                hostArchive.Dispose();
+            }
+        }
+
+        public static void Run(string baseCacheDirectory, CacheGraphicsApi graphicsApi, CacheHashType hashType, string shaderProvider)
+        {
+            string guestBaseCacheDirectory = CacheHelper.GenerateCachePath(baseCacheDirectory, CacheGraphicsApi.Guest, "", "program");
+            string hostBaseCacheDirectory = CacheHelper.GenerateCachePath(baseCacheDirectory, graphicsApi, shaderProvider, "host");
+
+            if (CacheHelper.TryReadManifestHeader(CacheHelper.GetManifestPath(guestBaseCacheDirectory), out CacheManifestHeader header))
+            {
+                if (NeedHashRecompute(header.Version, out ulong newVersion))
+                {
+                    RecomputeHashes(guestBaseCacheDirectory, hostBaseCacheDirectory, graphicsApi, hashType, newVersion);
+                }
+            }
+        }
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Shader/Cache/CacheMigration.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/Cache/CacheMigration.cs
@@ -39,8 +39,8 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache
         /// Move a file with the name of a given hash to another in the cache archive.
         /// </summary>
         /// <param name="archive">The archive in use</param>
-        /// <param name="oldKey">The source file name</param>
-        /// <param name="newKey">The destination file name</param>
+        /// <param name="oldKey">The old key</param>
+        /// <param name="newKey">The new key</param>
         private static void MoveEntry(ZipArchive archive, Hash128 oldKey, Hash128 newKey)
         {
             ZipArchiveEntry oldGuestEntry = archive.GetEntry($"{oldKey}");

--- a/Ryujinx.Graphics.Gpu/Shader/Cache/CacheMigration.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/Cache/CacheMigration.cs
@@ -9,8 +9,17 @@ using System.IO.Compression;
 
 namespace Ryujinx.Graphics.Gpu.Shader.Cache
 {
+    /// <summary>
+    /// Class handling shader cache migrations.
+    /// </summary>
     static class CacheMigration
     {
+        /// <summary>
+        /// Check if the given cache version need to recompute its hash.
+        /// </summary>
+        /// <param name="version">The version in use</param>
+        /// <param name="newVersion">The new version after migration</param>
+        /// <returns>True if a hash recompute is needed</returns>
         public static bool NeedHashRecompute(ulong version, out ulong newVersion)
         {
             const ulong TargetBrokenVersion = 1717;
@@ -26,6 +35,12 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache
             return false;
         }
 
+        /// <summary>
+        /// Move a file with the name of a given hash to another in the cache archive.
+        /// </summary>
+        /// <param name="archive">The archive in use</param>
+        /// <param name="oldKey">The source file name</param>
+        /// <param name="newKey">The destination file name</param>
         private static void MoveEntry(ZipArchive archive, Hash128 oldKey, Hash128 newKey)
         {
             ZipArchiveEntry oldGuestEntry = archive.GetEntry($"{oldKey}");
@@ -44,6 +59,14 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache
             }
         }
 
+        /// <summary>
+        /// Recompute all the hashes of a given cache.
+        /// </summary>
+        /// <param name="guestBaseCacheDirectory">The guest cache directory path</param>
+        /// <param name="hostBaseCacheDirectory">The host cache directory path</param>
+        /// <param name="graphicsApi">The graphics api in use</param>
+        /// <param name="hashType">The hash type in use</param>
+        /// <param name="newVersion">The version to write in the host and guest manifest after migration</param>
         private static void RecomputeHashes(string guestBaseCacheDirectory, string hostBaseCacheDirectory, CacheGraphicsApi graphicsApi, CacheHashType hashType, ulong newVersion)
         {
             string guestManifestPath = CacheHelper.GetManifestPath(guestBaseCacheDirectory);
@@ -111,6 +134,13 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache
             }
         }
 
+        /// <summary>
+        /// Check and run cache migration if needed.
+        /// </summary>
+        /// <param name="baseCacheDirectory">The base path of the cache</param>
+        /// <param name="graphicsApi">The graphics api in use</param>
+        /// <param name="hashType">The hash type in use</param>
+        /// <param name="shaderProvider">The shader provider name of the cache</param>
         public static void Run(string baseCacheDirectory, CacheGraphicsApi graphicsApi, CacheHashType hashType, string shaderProvider)
         {
             string guestBaseCacheDirectory = CacheHelper.GenerateCachePath(baseCacheDirectory, CacheGraphicsApi.Guest, "", "program");

--- a/Ryujinx.Graphics.Gpu/Shader/Cache/Definition/CacheManifestHeader.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/Cache/Definition/CacheManifestHeader.cs
@@ -87,11 +87,11 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache.Definition
         /// <param name="graphicsApi">The target graphics api in use</param>
         /// <param name="hashType">The target hash type in use</param>
         /// <param name="data">The data after this header</param>
-        /// <remarks>This doesn't check that version match</remarks>
         /// <returns>True if the header is valid</returns>
+        /// <remarks>This doesn't check that versions match</remarks>
         public bool IsValid(CacheGraphicsApi graphicsApi, CacheHashType hashType, ReadOnlySpan<byte> data)
         {
-            return  GraphicsApi == graphicsApi && HashType == hashType && TableChecksum == CalculateCrc16(data);
+            return GraphicsApi == graphicsApi && HashType == hashType && TableChecksum == CalculateCrc16(data);
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Shader/Cache/Definition/CacheManifestHeader.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/Cache/Definition/CacheManifestHeader.cs
@@ -84,14 +84,14 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache.Definition
         /// <summary>
         /// Check the validity of the header.
         /// </summary>
-        /// <param name="version">The target version in use</param>
         /// <param name="graphicsApi">The target graphics api in use</param>
         /// <param name="hashType">The target hash type in use</param>
         /// <param name="data">The data after this header</param>
+        /// <remarks>This doesn't check that version match</remarks>
         /// <returns>True if the header is valid</returns>
-        public bool IsValid(ulong version, CacheGraphicsApi graphicsApi, CacheHashType hashType, ReadOnlySpan<byte> data)
+        public bool IsValid(CacheGraphicsApi graphicsApi, CacheHashType hashType, ReadOnlySpan<byte> data)
         {
-            return Version == version && GraphicsApi == graphicsApi && HashType == hashType && TableChecksum == CalculateCrc16(data);
+            return  GraphicsApi == graphicsApi && HashType == hashType && TableChecksum == CalculateCrc16(data);
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Shader/Cache/Definition/GuestShaderCacheEntry.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/Cache/Definition/GuestShaderCacheEntry.cs
@@ -31,7 +31,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache.Definition
         /// </summary>
         /// <param name="header">The header of the cached shader entry</param>
         /// <param name="code">The code of this shader</param>
-        private GuestShaderCacheEntry(GuestShaderCacheEntryHeader header, byte[] code)
+        public GuestShaderCacheEntry(GuestShaderCacheEntryHeader header, byte[] code)
         {
             Header = header;
             Code = code;

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -9,9 +9,6 @@ using Ryujinx.Graphics.Shader.Translation;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 namespace Ryujinx.Graphics.Gpu.Shader
 {
@@ -765,40 +762,6 @@ namespace Ryujinx.Graphics.Gpu.Shader
             }
 
             _cacheManager?.Dispose();
-        }
-
-        /// <summary>
-        /// Write the guest GpuAccessor informations to the given stream.
-        /// </summary>
-        /// <param name="stream">The stream to write the guest GpuAcessor</param>
-        /// <param name="shaderContext">The shader tranlator context in use</param>
-        /// <returns>The guest gpu accessor header</returns>
-        private static GuestGpuAccessorHeader WriteGuestGpuAccessorCache(Stream stream, TranslatorContext shaderContext)
-        {
-            BinaryWriter writer = new BinaryWriter(stream);
-
-            GuestGpuAccessorHeader header = CacheHelper.CreateGuestGpuAccessorCache(shaderContext.GpuAccessor);
-
-            // If we have a full gpu accessor, cache textures descriptors
-            if (shaderContext.GpuAccessor is GpuAccessor gpuAccessor)
-            {
-                HashSet<int> textureHandlesInUse = shaderContext.TextureHandlesForCache;
-
-                header.TextureDescriptorCount = textureHandlesInUse.Count;
-
-                writer.WriteStruct(header);
-
-                foreach (int textureHandle in textureHandlesInUse)
-                {
-                    GuestTextureDescriptor textureDescriptor = ((Image.TextureDescriptor)gpuAccessor.GetTextureDescriptor(textureHandle)).ToCache();
-
-                    textureDescriptor.Handle = (uint)textureHandle;
-
-                    writer.WriteStruct(textureDescriptor);
-                }
-            }
-
-            return header;
         }
     }
 }


### PR DESCRIPTION
This adds the guest GPU accessor to hashes computation.
As this change all the hashes from the cache, I added some migration
logic.

This is required for #1755.