### PR TITLE
NVIDIA Thread create/delete stutter workarounds

### DIFF
--- a/Ryujinx/Ryujinx.csproj
+++ b/Ryujinx/Ryujinx.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
@@ -6,6 +6,7 @@
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Version>1.0.0-dirty</Version>
+    <TieredCompilation>false</TieredCompilation>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Ryujinx/Ryujinx.csproj
+++ b/Ryujinx/Ryujinx.csproj
@@ -7,6 +7,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Version>1.0.0-dirty</Version>
     <TieredCompilation>false</TieredCompilation>
+    <TieredCompilationQuickJit>false</TieredCompilationQuickJit>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -256,7 +256,7 @@ namespace Ryujinx.Ui
 
         private void NVStutterWorkaround()
         {
-            while (IsActive)
+            while (_isActive)
             {
                 // When NVIDIA Threaded Optimization is on, the driver will snapshot all threads in the system whenever the application creates any new ones.
                 // The ThreadPool has something called a "GateThread" which terminates itself after some inactivity.

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -240,11 +240,37 @@ namespace Ryujinx.Ui
             };
             renderLoopThread.Start();
 
+            Thread nvStutterWorkaround = new Thread(NVStutterWorkaround)
+            {
+                Name = "GUI.NVStutterWorkaround"
+            };
+            nvStutterWorkaround.Start();
+
             MainLoop();
 
             renderLoopThread.Join();
+            nvStutterWorkaround.Join();
 
             Exit();
+        }
+
+        private void NVStutterWorkaround()
+        {
+            while (IsActive)
+            {
+                // When NVIDIA Threaded Optimization is on, the driver will snapshot all threads in the system whenever the application creates any new ones.
+                // The ThreadPool has something called a "GateThread" which terminates itself after some inactivity.
+                // However, it immediately starts up again, since the rules regarding when to terminate and when to start differ.
+                // This creates a new thread every second or so.
+                // The main problem with this is that the thread snapshot can take 70ms, is on the OpenGL thread and will delay rendering any graphics.
+                // This is a little over budget on a frame time of 16ms, so creates a large stutter.
+                // The solution is to keep the ThreadPool active so that it never has a reason to terminate the GateThread.
+
+                // TODO: This should be removed when the issue with the GateThread is resolved.
+
+                ThreadPool.QueueUserWorkItem((state) => { });
+                Thread.Sleep(300);
+            }
         }
 
         protected override bool OnButtonPressEvent(EventButton evnt)


### PR DESCRIPTION
When NVIDIA Threaded Optimization is on, the driver will snapshot all threads in the system whenever the application creates or exits any threads. I’m guessing it does this so it knows what all your program’s threads are, but the method it uses to do this snapshots and iterates threads in _the entire system_.

https://docs.microsoft.com/en-us/windows/win32/api/tlhelp32/nf-tlhelp32-createtoolhelp32snapshot

The ThreadPool has something called a "GateThread" which terminates itself after some inactivity. However, it immediately starts up again, since the rules regarding when to terminate and when to start differ. This creates a new thread every second or so.

https://github.com/dotnet/runtime/blob/v5.0.0-rtm.20519.4/src/coreclr/src/vm/win32threadpool.cpp#L1424

The main problem with this is that the thread snapshot can take 70ms, is on the OpenGL thread and will delay rendering any graphics. This is a little over budget on a frame time of 16ms, so creates a large stutter.

The solution is to keep the ThreadPool active so that it never has a reason to terminate the GateThread. I’ve also taken the liberty of disabling tiered compilation, as it appeared to be creating temporary threads.

---

![image](https://user-images.githubusercontent.com/6294155/100528063-55f4d780-31d0-11eb-8c04-467252bd1ad1.png)

For the poor souls plagued with this ailment, your FPS will rise from 57-58 to 60 in games where you can reach it. You should still play in fullscreen to really feel the 60fps, tho

I’d like to also set a minimum on the ThreadPool to stop it from downsizing, but the methods for doing that right now are not a _hard_ minimum, it still slowly kills threads while the pool is inactive. If you have any suggestions on how to improve this, please send your fix to my PO box, or just comment it idk.

![image](https://user-images.githubusercontent.com/6294155/100528411-7888ef80-31d4-11eb-9f11-30f4e0d1c484.png)
