### PR TITLE
amadeus: Fix a typo in TapFrame logic

### DIFF
--- a/Ryujinx.Audio.Renderer/Server/Performance/PerformanceManagerGeneric.cs
+++ b/Ryujinx.Audio.Renderer/Server/Performance/PerformanceManagerGeneric.cs
@@ -277,7 +277,7 @@ namespace Ryujinx.Audio.Renderer.Server.Performance
 
         public override void TapFrame(bool dspRunningBehind, uint voiceDropCount, ulong startRenderingTicks)
         {
-            if (_availableFrameCount > 1)
+            if (_availableFrameCount > 0)
             {
                 int targetIndexForHistory = _indexHistoryWrite;
 


### PR DESCRIPTION
This fix a crash at boot in Pang Adventures.