### PR TITLE
Create a single guest process per IPC message processor

### DIFF
--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -14,6 +14,7 @@ using Ryujinx.HLE.HOS.Kernel;
 using Ryujinx.HLE.HOS.Kernel.Memory;
 using Ryujinx.HLE.HOS.Kernel.Process;
 using Ryujinx.HLE.HOS.Kernel.Threading;
+using Ryujinx.HLE.HOS.Services;
 using Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.SystemAppletProxy;
 using Ryujinx.HLE.HOS.Services.Apm;
 using Ryujinx.HLE.HOS.Services.Arp;
@@ -57,6 +58,16 @@ namespace Ryujinx.HLE.HOS
         internal PerformanceState PerformanceState { get; private set; }
 
         internal AppletStateMgr AppletState { get; private set; }
+
+        internal ServerBase BsdServer { get; private set; }
+        internal ServerBase AudRenServer { get; private set; }
+        internal ServerBase AudOutServer { get; private set; }
+        internal ServerBase HidServer { get; private set; }
+        internal ServerBase NvDrvServer { get; private set; }
+        internal ServerBase TimeServer { get; private set; }
+        internal ServerBase ViServer { get; private set; }
+        internal ServerBase ViServerM { get; private set; }
+        internal ServerBase ViServerS { get; private set; }
 
         internal KSharedMemory HidSharedMem  { get; private set; }
         internal KSharedMemory FontSharedMem { get; private set; }
@@ -230,6 +241,16 @@ namespace Ryujinx.HLE.HOS
             // only then doing connections to SM is safe.
             sm.Server.InitDone.WaitOne();
             sm.Server.InitDone.Dispose();
+
+            BsdServer = new ServerBase(KernelContext, "BsdServer");
+            AudRenServer = new ServerBase(KernelContext, "AudioRendererServer");
+            AudOutServer = new ServerBase(KernelContext, "AudioOutServer");
+            HidServer = new ServerBase(KernelContext, "HidServer");
+            NvDrvServer = new ServerBase(KernelContext, "NvservicesServer");
+            TimeServer = new ServerBase(KernelContext, "TimeServer");
+            ViServer = new ServerBase(KernelContext, "ViServerU");
+            ViServerM = new ServerBase(KernelContext, "ViServerM");
+            ViServerS = new ServerBase(KernelContext, "ViServerS");
         }
 
         public void LoadKip(string kipPath)

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioRendererManagerServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioRendererManagerServer.cs
@@ -16,7 +16,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
 
         public AudioRendererManagerServer(ServiceCtx context) : this(context, new AudioRendererManager(context.Device.System.AudioRendererManager, context.Device.System.AudioDeviceSessionRegistry)) { }
 
-        public AudioRendererManagerServer(ServiceCtx context, IAudioRendererManager impl) : base(new ServerBase(context.Device.System.KernelContext, "AudioRendererServer"))
+        public AudioRendererManagerServer(ServiceCtx context, IAudioRendererManager impl) : base(context.Device.System.AudRenServer)
         {
             _impl = impl;
         }

--- a/Ryujinx.HLE/HOS/Services/Audio/IAudioOutManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/IAudioOutManager.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
         private const int    DefaultSampleRate    = 48000;
         private const int    DefaultChannelsCount = 2;
 
-        public IAudioOutManager(ServiceCtx context) : base(new ServerBase(context.Device.System.KernelContext, "AudioOutServer")) { }
+        public IAudioOutManager(ServiceCtx context) : base(context.Device.System.AudOutServer) { }
 
         [Command(0)]
         // ListAudioOuts() -> (u32 count, buffer<bytes, 6>)

--- a/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
@@ -35,7 +35,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         private HidAccelerometerParameters _accelerometerParams;
         private HidVibrationValue          _vibrationValue;
 
-        public IHidServer(ServiceCtx context) : base(new ServerBase(context.Device.System.KernelContext, "HidServer"))
+        public IHidServer(ServiceCtx context) : base(context.Device.System.HidServer)
         {
             _xpadIdEvent                 = new KEvent(context.Device.System.KernelContext);
             _palmaOperationCompleteEvent = new KEvent(context.Device.System.KernelContext);

--- a/Ryujinx.HLE/HOS/Services/Nv/INvDrvServices.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/INvDrvServices.cs
@@ -46,7 +46,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
 
         private bool _transferMemInitialized = false;
 
-        public INvDrvServices(ServiceCtx context) : base(new ServerBase(context.Device.System.KernelContext, "NvservicesServer"))
+        public INvDrvServices(ServiceCtx context) : base(context.Device.System.NvDrvServer)
         {
             _owner = 0;
         }

--- a/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
@@ -102,7 +102,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
 
         private List<BsdSocket> _sockets = new List<BsdSocket>();
 
-        public IClient(ServiceCtx context, bool isPrivileged) : base(new ServerBase(context.Device.System.KernelContext, "BsdServer"))
+        public IClient(ServiceCtx context, bool isPrivileged) : base(context.Device.System.BsdServer)
         {
             _isPrivileged = isPrivileged;
         }

--- a/Ryujinx.HLE/HOS/Services/Time/IStaticServiceForGlue.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/IStaticServiceForGlue.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
         private IStaticServiceForPsc _inner;
         private TimePermissions      _permissions;
 
-        public IStaticServiceForGlue(ServiceCtx context, TimePermissions permissions) : base(new ServerBase(context.Device.System.KernelContext, "TimeServer"))
+        public IStaticServiceForGlue(ServiceCtx context, TimePermissions permissions) : base(context.Device.System.TimeServer)
         {
             _permissions = permissions;
             _inner       = new IStaticServiceForPsc(context, permissions);

--- a/Ryujinx.HLE/HOS/Services/Vi/IApplicationRootService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/IApplicationRootService.cs
@@ -5,7 +5,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi
     [Service("vi:u")]
     class IApplicationRootService : IpcService
     {
-        public IApplicationRootService(ServiceCtx context) : base(new ServerBase(context.Device.System.KernelContext, "ViServerU")) { }
+        public IApplicationRootService(ServiceCtx context) : base(context.Device.System.ViServer) { }
 
         [Command(0)]
         // GetDisplayService(u32) -> object<nn::visrv::sf::IApplicationDisplayService>

--- a/Ryujinx.HLE/HOS/Services/Vi/IManagerRootService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/IManagerRootService.cs
@@ -6,7 +6,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi
     class IManagerRootService : IpcService
     {
         // vi:u/m/s aren't on 3 separate threads but we can't put them together with the current ServerBase
-        public IManagerRootService(ServiceCtx context) : base(new ServerBase(context.Device.System.KernelContext, "ViServerM")) { }
+        public IManagerRootService(ServiceCtx context) : base(context.Device.System.ViServerM) { }
 
         [Command(2)]
         // GetDisplayService(u32) -> object<nn::visrv::sf::IApplicationDisplayService>

--- a/Ryujinx.HLE/HOS/Services/Vi/ISystemRootService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/ISystemRootService.cs
@@ -6,7 +6,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi
     class ISystemRootService : IpcService
     {
         // vi:u/m/s aren't on 3 separate threads but we can't put them together with the current ServerBase
-        public ISystemRootService(ServiceCtx context) : base(new ServerBase(context.Device.System.KernelContext, "ViServerS")) { }
+        public ISystemRootService(ServiceCtx context) : base(context.Device.System.ViServerS) { }
 
         [Command(1)]
         // GetDisplayService(u32) -> object<nn::visrv::sf::IApplicationDisplayService>


### PR DESCRIPTION
Should fix a regression introduced on #1458 that caused some games like Pokémon to crash due to a OutOfMemory error being returned from SendSyncRequest. It was getting out of memory because multiple guest processes were being creased for the Bsd service, and the memory used by them was never freed. This change creates just a single process for Bsd and fixes the issue. It's worth noting that #1504 does something similar, so it should fix the issue aswell in theory, but I didn't test yet.