### PR TITLE
Close audio WorkBuffer transfer memory handle

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Audio/AudioRendererManagerServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioRendererManagerServer.cs
@@ -30,7 +30,8 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             ulong workBufferSize = context.RequestData.ReadUInt64();
             ulong appletResourceUserId = context.RequestData.ReadUInt64();
 
-            KTransferMemory workBufferTransferMemory = context.Process.HandleTable.GetObject<KTransferMemory>(context.Request.HandleDesc.ToCopy[0]);
+            int transferMemoryHandle = context.Request.HandleDesc.ToCopy[0];
+            KTransferMemory workBufferTransferMemory = context.Process.HandleTable.GetObject<KTransferMemory>(transferMemoryHandle);
             uint processHandle = (uint)context.Request.HandleDesc.ToCopy[1];
 
             ResultCode result = _impl.OpenAudioRenderer(context, out IAudioRenderer renderer, ref parameter, workBufferSize, appletResourceUserId, workBufferTransferMemory, processHandle);
@@ -40,6 +41,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
                 MakeObject(context, new AudioRendererServer(renderer));
             }
 
+            context.Device.System.KernelContext.Syscall.CloseHandle(transferMemoryHandle);
             context.Device.System.KernelContext.Syscall.CloseHandle((int)processHandle);
 
             return result;


### PR DESCRIPTION
Fix regression introduced on #1458 causing a error on Rune Factory 4 Special, the transfer memory handle was not being closed on the audio renderer service, this prevented the memory region from being reused as the transfer memory was still in use by the service. Didn't matter before because we didn't have separate guest process per service, so the kernel was not copying the handle and so the service had no ownership of the memory.