### PR TITLE
Dummy out occlusion queries with 0 draws, remove glFlush call

### DIFF
--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -10,6 +10,8 @@ namespace Ryujinx.Graphics.OpenGL
 {
     class Pipeline : IPipeline, IDisposable
     {
+        internal ulong DrawCount { get; private set; }
+
         private Program _program;
 
         private bool _rasterizerDiscard;
@@ -1196,6 +1198,8 @@ namespace Ryujinx.Graphics.OpenGL
 
         private void PreDraw()
         {
+            DrawCount++;
+
             _vertexArray.Validate();
 
             if (_unit0Texture != null)

--- a/Ryujinx.Graphics.OpenGL/Queries/BufferedQuery.cs
+++ b/Ryujinx.Graphics.OpenGL/Queries/BufferedQuery.cs
@@ -46,7 +46,6 @@ namespace Ryujinx.Graphics.OpenGL.Queries
 
         public unsafe void End()
         {
-            GL.Flush();
             GL.EndQuery(_type);
 
             GL.BindBuffer(BufferTarget.QueryBuffer, _buffer);

--- a/Ryujinx.Graphics.OpenGL/Queries/CounterQueueEvent.cs
+++ b/Ryujinx.Graphics.OpenGL/Queries/CounterQueueEvent.cs
@@ -16,17 +16,21 @@ namespace Ryujinx.Graphics.OpenGL.Queries
         public bool Disposed { get; private set; }
         public bool Invalid { get; set; }
 
+        public ulong DrawIndex { get; }
+
         private CounterQueue _queue;
         private BufferedQuery _counter;
 
         private object _lock = new object();
 
-        public CounterQueueEvent(CounterQueue queue, QueryTarget type)
+        public CounterQueueEvent(CounterQueue queue, QueryTarget type, ulong drawIndex)
         {
             _queue = queue;
 
             _counter = queue.GetQueryObject();
             Type = type;
+
+            DrawIndex = drawIndex;
 
             _counter.Begin();
         }

--- a/Ryujinx.Graphics.OpenGL/Queries/Counters.cs
+++ b/Ryujinx.Graphics.OpenGL/Queries/Counters.cs
@@ -23,9 +23,9 @@ namespace Ryujinx.Graphics.OpenGL.Queries
             }
         }
 
-        public CounterQueueEvent QueueReport(CounterType type, EventHandler<ulong> resultHandler)
+        public CounterQueueEvent QueueReport(CounterType type, EventHandler<ulong> resultHandler, ulong lastDrawIndex)
         {
-            return _counterQueues[(int)type].QueueReport(resultHandler);
+            return _counterQueues[(int)type].QueueReport(resultHandler, lastDrawIndex);
         }
 
         public void QueueReset(CounterType type)

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -113,7 +113,7 @@ namespace Ryujinx.Graphics.OpenGL
 
         public ICounterEvent ReportCounter(CounterType type, EventHandler<ulong> resultHandler)
         {
-            return _counters.QueueReport(type, resultHandler);
+            return _counters.QueueReport(type, resultHandler, _pipeline.DrawCount);
         }
 
         public void Initialize(GraphicsDebugLevel glLogLevel)


### PR DESCRIPTION
A glFlush was placed before query end to mitigate some potential issues when ending a query after 0 draw calls were made. However, glFlush has a substantial cost that can greatly slow down OpenGL if you're not careful.

This PR adds a draw count, which can be snapshotted when a query begins and compared when it ends. If 0 draws have occurred since we began, simply return the result immediately (0) and don't add it to the queue.

Affected games:
- Super Mario Odyssey (primarily metro kingdom, or when res scaling is active)
  - Specifically, the nvoglv64.dll thread's load is now ~65% of the FIFO processing thread's load in the metro kingdom initial view, rather than being neck and neck with it. This means that perf improvements elsewhere are now visible.
- Splatoon 2
- Mario Kart 8 (many racers, extreme circumstances. in vs race translated cpu code is now always the bottleneck)

Best friends with https://github.com/Ryujinx/Ryujinx/pull/1771

This does not affect games that do not use occlusion queries. There don't seem to be any regressions, can still swim thru ink in splat2 etc. May fix some weird driver bugs with drawless queries. (query timed out?)