### PR TITLE
gui/gpu: Implement setting and toggle for Aspect Ratio

### DIFF
--- a/Ryujinx.Common/Configuration/AspectRatioExtensions.cs
+++ b/Ryujinx.Common/Configuration/AspectRatioExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System.Drawing;
+
+namespace Ryujinx.Common.Configuration
+{
+    public enum AspectRatio
+    {
+        To43,
+        To169,
+        To219,
+        To329,
+        Stretched
+    }
+
+    public static class AspectRatioExtensions
+    {
+        public static float ToFloat(this AspectRatio aspectRatio)
+        {
+            return aspectRatio switch
+            {
+                AspectRatio.To43  => 4.0f  / 3.0f,
+                AspectRatio.To169 => 16.0f / 9.0f,
+                AspectRatio.To219 => 21.0f / 9.0f,
+                AspectRatio.To329 => 32.0f / 9.0f,
+                _                 => 16.0f / 9.0f
+            };
+        }
+
+        public static string ToText(this AspectRatio aspectRatio)
+        {
+            return aspectRatio switch
+            {
+                AspectRatio.To43  => "4:3",
+                AspectRatio.To169 => "16:9",
+                AspectRatio.To219 => "21:9",
+                AspectRatio.To329 => "32:9",
+                _                 => "Stretched"
+            };
+        }
+    }
+}

--- a/Ryujinx.Common/Configuration/AspectRatioExtensions.cs
+++ b/Ryujinx.Common/Configuration/AspectRatioExtensions.cs
@@ -1,13 +1,12 @@
-﻿using System.Drawing;
-
-namespace Ryujinx.Common.Configuration
+﻿namespace Ryujinx.Common.Configuration
 {
     public enum AspectRatio
     {
-        To43,
-        To169,
-        To219,
-        To329,
+        To4x3,
+        To16x9,
+        To16x10,
+        To21x9,
+        To32x9,
         Stretched
     }
 
@@ -15,13 +14,32 @@ namespace Ryujinx.Common.Configuration
     {
         public static float ToFloat(this AspectRatio aspectRatio)
         {
+            return aspectRatio.ToFloatX() / aspectRatio.ToFloatY();
+        }
+
+        public static float ToFloatX(this AspectRatio aspectRatio)
+        {
             return aspectRatio switch
             {
-                AspectRatio.To43  => 4.0f  / 3.0f,
-                AspectRatio.To169 => 16.0f / 9.0f,
-                AspectRatio.To219 => 21.0f / 9.0f,
-                AspectRatio.To329 => 32.0f / 9.0f,
-                _                 => 16.0f / 9.0f
+                AspectRatio.To4x3   => 4.0f,
+                AspectRatio.To16x9  => 16.0f,
+                AspectRatio.To16x10 => 16.0f,
+                AspectRatio.To21x9  => 21.0f,
+                AspectRatio.To32x9  => 32.0f,
+                _                   => 16.0f
+            };
+        }
+
+        public static float ToFloatY(this AspectRatio aspectRatio)
+        {
+            return aspectRatio switch
+            {
+                AspectRatio.To4x3   => 3.0f,
+                AspectRatio.To16x9  => 9.0f,
+                AspectRatio.To16x10 => 10.0f,
+                AspectRatio.To21x9  => 9.0f,
+                AspectRatio.To32x9  => 9.0f,
+                _                   => 9.0f
             };
         }
 
@@ -29,11 +47,12 @@ namespace Ryujinx.Common.Configuration
         {
             return aspectRatio switch
             {
-                AspectRatio.To43  => "4:3",
-                AspectRatio.To169 => "16:9",
-                AspectRatio.To219 => "21:9",
-                AspectRatio.To329 => "32:9",
-                _                 => "Stretched"
+                AspectRatio.To4x3   => "4:3",
+                AspectRatio.To16x9  => "16:9",
+                AspectRatio.To16x10 => "16:10",
+                AspectRatio.To21x9  => "21:9",
+                AspectRatio.To32x9  => "32:9",
+                _                   => "Stretched"
             };
         }
     }

--- a/Ryujinx.Common/Configuration/AspectRatioExtensions.cs
+++ b/Ryujinx.Common/Configuration/AspectRatioExtensions.cs
@@ -2,11 +2,11 @@
 {
     public enum AspectRatio
     {
-        To4x3,
-        To16x9,
-        To16x10,
-        To21x9,
-        To32x9,
+        Fixed4x3,
+        Fixed16x9,
+        Fixed16x10,
+        Fixed21x9,
+        Fixed32x9,
         Stretched
     }
 
@@ -21,12 +21,12 @@
         {
             return aspectRatio switch
             {
-                AspectRatio.To4x3   => 4.0f,
-                AspectRatio.To16x9  => 16.0f,
-                AspectRatio.To16x10 => 16.0f,
-                AspectRatio.To21x9  => 21.0f,
-                AspectRatio.To32x9  => 32.0f,
-                _                   => 16.0f
+                AspectRatio.Fixed4x3   => 4.0f,
+                AspectRatio.Fixed16x9  => 16.0f,
+                AspectRatio.Fixed16x10 => 16.0f,
+                AspectRatio.Fixed21x9  => 21.0f,
+                AspectRatio.Fixed32x9  => 32.0f,
+                _                      => 16.0f
             };
         }
 
@@ -34,12 +34,12 @@
         {
             return aspectRatio switch
             {
-                AspectRatio.To4x3   => 3.0f,
-                AspectRatio.To16x9  => 9.0f,
-                AspectRatio.To16x10 => 10.0f,
-                AspectRatio.To21x9  => 9.0f,
-                AspectRatio.To32x9  => 9.0f,
-                _                   => 9.0f
+                AspectRatio.Fixed4x3   => 3.0f,
+                AspectRatio.Fixed16x9  => 9.0f,
+                AspectRatio.Fixed16x10 => 10.0f,
+                AspectRatio.Fixed21x9  => 9.0f,
+                AspectRatio.Fixed32x9  => 9.0f,
+                _                      => 9.0f
             };
         }
 
@@ -47,12 +47,12 @@
         {
             return aspectRatio switch
             {
-                AspectRatio.To4x3   => "4:3",
-                AspectRatio.To16x9  => "16:9",
-                AspectRatio.To16x10 => "16:10",
-                AspectRatio.To21x9  => "21:9",
-                AspectRatio.To32x9  => "32:9",
-                _                   => "Stretched"
+                AspectRatio.Fixed4x3   => "4:3",
+                AspectRatio.Fixed16x9  => "16:9",
+                AspectRatio.Fixed16x10 => "16:10",
+                AspectRatio.Fixed21x9  => "21:9",
+                AspectRatio.Fixed32x9  => "32:9",
+                _                      => "Stretched"
             };
         }
     }

--- a/Ryujinx.Common/Configuration/ConfigurationFileFormat.cs
+++ b/Ryujinx.Common/Configuration/ConfigurationFileFormat.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.Configuration
         /// <summary>
         /// The current version of the file format
         /// </summary>
-        public const int CurrentVersion = 17;
+        public const int CurrentVersion = 18;
 
         public int Version { get; set; }
 
@@ -32,6 +32,11 @@ namespace Ryujinx.Configuration
         /// Max Anisotropy. Values range from 0 - 16. Set to -1 to let the game decide.
         /// </summary>
         public float MaxAnisotropy { get; set; }
+
+        /// <summary>
+        /// Aspect Ratio applied to the renderer window.
+        /// </summary>
+        public AspectRatio AspectRatio { get; set; }
 
         /// <summary>
         /// Dumps shaders in this local directory

--- a/Ryujinx.Common/Configuration/ConfigurationState.cs
+++ b/Ryujinx.Common/Configuration/ConfigurationState.cs
@@ -456,7 +456,7 @@ namespace Ryujinx.Configuration
             Graphics.ResScale.Value                = 1;
             Graphics.ResScaleCustom.Value          = 1.0f;
             Graphics.MaxAnisotropy.Value           = -1.0f;
-            Graphics.AspectRatio.Value             = AspectRatio.To16x9;
+            Graphics.AspectRatio.Value             = AspectRatio.Fixed16x9;
             Graphics.ShadersDumpPath.Value         = "";
             Logger.EnableDebug.Value               = false;
             Logger.EnableStub.Value                = true;
@@ -765,7 +765,7 @@ namespace Ryujinx.Configuration
             {
                 Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 18.");
 
-                configurationFileFormat.AspectRatio = AspectRatio.To16x9;
+                configurationFileFormat.AspectRatio = AspectRatio.Fixed16x9;
 
                 configurationFileUpdated = true;
             }

--- a/Ryujinx.Common/Configuration/ConfigurationState.cs
+++ b/Ryujinx.Common/Configuration/ConfigurationState.cs
@@ -279,6 +279,11 @@ namespace Ryujinx.Configuration
             public ReactiveObject<float> MaxAnisotropy { get; private set; }
 
             /// <summary>
+            /// Aspect Ratio applied to the renderer window.
+            /// </summary>
+            public ReactiveObject<AspectRatio> AspectRatio { get; private set; }
+
+            /// <summary>
             /// Resolution Scale. An integer scale applied to applicable render targets. Values 1-4, or -1 to use a custom floating point scale instead.
             /// </summary>
             public ReactiveObject<int> ResScale { get; private set; }
@@ -308,6 +313,7 @@ namespace Ryujinx.Configuration
                 ResScale          = new ReactiveObject<int>();
                 ResScaleCustom    = new ReactiveObject<float>();
                 MaxAnisotropy     = new ReactiveObject<float>();
+                AspectRatio       = new ReactiveObject<AspectRatio>();
                 ShadersDumpPath   = new ReactiveObject<string>();
                 EnableVsync       = new ReactiveObject<bool>();
                 EnableShaderCache = new ReactiveObject<bool>();
@@ -388,6 +394,7 @@ namespace Ryujinx.Configuration
                 ResScale                  = Graphics.ResScale,
                 ResScaleCustom            = Graphics.ResScaleCustom,
                 MaxAnisotropy             = Graphics.MaxAnisotropy,
+                AspectRatio               = Graphics.AspectRatio,
                 GraphicsShadersDumpPath   = Graphics.ShadersDumpPath,
                 LoggingEnableDebug        = Logger.EnableDebug,
                 LoggingEnableStub         = Logger.EnableStub,
@@ -449,6 +456,7 @@ namespace Ryujinx.Configuration
             Graphics.ResScale.Value                = 1;
             Graphics.ResScaleCustom.Value          = 1.0f;
             Graphics.MaxAnisotropy.Value           = -1.0f;
+            Graphics.AspectRatio.Value             = AspectRatio.To169;
             Graphics.ShadersDumpPath.Value         = "";
             Logger.EnableDebug.Value               = false;
             Logger.EnableStub.Value                = true;
@@ -457,7 +465,7 @@ namespace Ryujinx.Configuration
             Logger.EnableError.Value               = true;
             Logger.EnableGuest.Value               = true;
             Logger.EnableFsAccessLog.Value         = false;
-            Logger.FilteredClasses.Value           = new LogClass[] { };
+            Logger.FilteredClasses.Value           = Array.Empty<LogClass>();
             Logger.GraphicsDebugLevel.Value        = GraphicsDebugLevel.None;
             Logger.EnableFileLog.Value             = true;
             System.Language.Value                  = Language.AmericanEnglish;
@@ -753,6 +761,15 @@ namespace Ryujinx.Configuration
                 configurationFileUpdated = true;
             }
 
+            if (configurationFileFormat.Version < 18)
+            {
+                Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 18.");
+
+                configurationFileFormat.AspectRatio = AspectRatio.To169;
+
+                configurationFileUpdated = true;
+            }
+
             List<InputConfig> inputConfig = new List<InputConfig>();
             inputConfig.AddRange(configurationFileFormat.ControllerConfig);
             inputConfig.AddRange(configurationFileFormat.KeyboardConfig);
@@ -760,6 +777,7 @@ namespace Ryujinx.Configuration
             Graphics.ResScale.Value                = configurationFileFormat.ResScale;
             Graphics.ResScaleCustom.Value          = configurationFileFormat.ResScaleCustom;
             Graphics.MaxAnisotropy.Value           = configurationFileFormat.MaxAnisotropy;
+            Graphics.AspectRatio.Value             = configurationFileFormat.AspectRatio;
             Graphics.ShadersDumpPath.Value         = configurationFileFormat.GraphicsShadersDumpPath;
             Logger.EnableDebug.Value               = configurationFileFormat.LoggingEnableDebug;
             Logger.EnableStub.Value                = configurationFileFormat.LoggingEnableStub;

--- a/Ryujinx.Common/Configuration/ConfigurationState.cs
+++ b/Ryujinx.Common/Configuration/ConfigurationState.cs
@@ -456,7 +456,7 @@ namespace Ryujinx.Configuration
             Graphics.ResScale.Value                = 1;
             Graphics.ResScaleCustom.Value          = 1.0f;
             Graphics.MaxAnisotropy.Value           = -1.0f;
-            Graphics.AspectRatio.Value             = AspectRatio.To169;
+            Graphics.AspectRatio.Value             = AspectRatio.To16x9;
             Graphics.ShadersDumpPath.Value         = "";
             Logger.EnableDebug.Value               = false;
             Logger.EnableStub.Value                = true;
@@ -765,7 +765,7 @@ namespace Ryujinx.Configuration
             {
                 Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 18.");
 
-                configurationFileFormat.AspectRatio = AspectRatio.To169;
+                configurationFileFormat.AspectRatio = AspectRatio.To16x9;
 
                 configurationFileUpdated = true;
             }

--- a/Ryujinx.Graphics.GAL/ImageCrop.cs
+++ b/Ryujinx.Graphics.GAL/ImageCrop.cs
@@ -2,27 +2,37 @@ namespace Ryujinx.Graphics.GAL
 {
     public struct ImageCrop
     {
-        public int  Left   { get; }
-        public int  Right  { get; }
-        public int  Top    { get; }
-        public int  Bottom { get; }
-        public bool FlipX  { get; }
-        public bool FlipY  { get; }
+        public int   Left         { get; }
+        public int   Right        { get; }
+        public int   Top          { get; }
+        public int   Bottom       { get; }
+        public bool  FlipX        { get; }
+        public bool  FlipY        { get; }
+        public bool  IsStretched  { get; }
+        public float AspectRatioX { get; }
+        public float AspectRatioY { get; }
 
         public ImageCrop(
-            int  left,
-            int  right,
-            int  top,
-            int  bottom,
-            bool flipX,
-            bool flipY)
+            int   left,
+            int   right,
+            int   top,
+            int   bottom,
+            bool  flipX,
+            bool  flipY,
+            bool  isStretched,
+            float aspectRatioX,
+            float aspectRatioY
+            )
         {
-            Left   = left;
-            Right  = right;
-            Top    = top;
-            Bottom = bottom;
-            FlipX  = flipX;
-            FlipY  = flipY;
+            Left         = left;
+            Right        = right;
+            Top          = top;
+            Bottom       = bottom;
+            FlipX        = flipX;
+            FlipY        = flipY;
+            IsStretched  = isStretched;
+            AspectRatioX = aspectRatioX;
+            AspectRatioY = aspectRatioY;
         }
     }
 }

--- a/Ryujinx.Graphics.OpenGL/Window.cs
+++ b/Ryujinx.Graphics.OpenGL/Window.cs
@@ -1,7 +1,5 @@
 using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL;
-using Ryujinx.Common.Configuration;
-using Ryujinx.Configuration;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.OpenGL.Image;
 using System;
@@ -98,11 +96,8 @@ namespace Ryujinx.Graphics.OpenGL
                 srcY1 = (int)Math.Ceiling(srcY1 * scale);
             }
 
-            AspectRatio aspectRatio = ConfigurationState.Instance.Graphics.AspectRatio.Value;
-            bool        isStretched = aspectRatio == AspectRatio.Stretched;
-
-            float ratioX = isStretched ? 1.0f : MathF.Min(1.0f, _height * aspectRatio.ToFloatX() / (_width  * aspectRatio.ToFloatY()));
-            float ratioY = isStretched ? 1.0f : MathF.Min(1.0f, _width  * aspectRatio.ToFloatY() / (_height * aspectRatio.ToFloatX()));
+            float ratioX = crop.IsStretched ? 1.0f : MathF.Min(1.0f, _height * crop.AspectRatioX / (_width  * crop.AspectRatioY));
+            float ratioY = crop.IsStretched ? 1.0f : MathF.Min(1.0f, _width  * crop.AspectRatioY / (_height * crop.AspectRatioX));
 
             int dstWidth  = (int)(_width  * ratioX);
             int dstHeight = (int)(_height * ratioY);

--- a/Ryujinx.Graphics.OpenGL/Window.cs
+++ b/Ryujinx.Graphics.OpenGL/Window.cs
@@ -1,7 +1,7 @@
-using OpenTK;
 using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL;
-using OpenTK.Platform;
+using Ryujinx.Common.Configuration;
+using Ryujinx.Configuration;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.OpenGL.Image;
 using System;
@@ -104,8 +104,13 @@ namespace Ryujinx.Graphics.OpenGL
                 srcY1 = (int)Math.Ceiling(srcY1 * scale);
             }
 
-            float ratioX = MathF.Min(1f, (_height * (float)NativeWidth)  / ((float)NativeHeight * _width));
-            float ratioY = MathF.Min(1f, (_width  * (float)NativeHeight) / ((float)NativeWidth  * _height));
+            AspectRatio aspectRatioSetting = ConfigurationState.Instance.Graphics.AspectRatio.Value;
+
+            bool  isStretched = aspectRatioSetting == AspectRatio.Stretched;
+            float aspectRatio = aspectRatioSetting.ToFloat();
+
+            float ratioX = isStretched ? 1.0f : MathF.Min(1f, _height * (float)NativeHeight * aspectRatio / ((float)NativeHeight         * _width));
+            float ratioY = isStretched ? 1.0f : MathF.Min(1f, _width  * (float)NativeHeight                / (NativeHeight * aspectRatio * _height));
 
             int dstWidth  = (int)(_width  * ratioX);
             int dstHeight = (int)(_height * ratioY);

--- a/Ryujinx.Graphics.OpenGL/Window.cs
+++ b/Ryujinx.Graphics.OpenGL/Window.cs
@@ -10,9 +10,6 @@ namespace Ryujinx.Graphics.OpenGL
 {
     class Window : IWindow, IDisposable
     {
-        private const int NativeWidth  = 1280;
-        private const int NativeHeight = 720;
-
         private readonly Renderer _renderer;
 
         private int _width;
@@ -25,9 +22,6 @@ namespace Ryujinx.Graphics.OpenGL
         public Window(Renderer renderer)
         {
             _renderer = renderer;
-
-            _width  = NativeWidth;
-            _height = NativeHeight;
         }
 
         public void Present(ITexture texture, ImageCrop crop)
@@ -104,13 +98,11 @@ namespace Ryujinx.Graphics.OpenGL
                 srcY1 = (int)Math.Ceiling(srcY1 * scale);
             }
 
-            AspectRatio aspectRatioSetting = ConfigurationState.Instance.Graphics.AspectRatio.Value;
+            AspectRatio aspectRatio = ConfigurationState.Instance.Graphics.AspectRatio.Value;
+            bool        isStretched = aspectRatio == AspectRatio.Stretched;
 
-            bool  isStretched = aspectRatioSetting == AspectRatio.Stretched;
-            float aspectRatio = aspectRatioSetting.ToFloat();
-
-            float ratioX = isStretched ? 1.0f : MathF.Min(1f, _height * (float)NativeHeight * aspectRatio / ((float)NativeHeight         * _width));
-            float ratioY = isStretched ? 1.0f : MathF.Min(1f, _width  * (float)NativeHeight                / (NativeHeight * aspectRatio * _height));
+            float ratioX = isStretched ? 1.0f : MathF.Min(1.0f, _height * aspectRatio.ToFloatX() / (_width  * aspectRatio.ToFloatY()));
+            float ratioY = isStretched ? 1.0f : MathF.Min(1.0f, _width  * aspectRatio.ToFloatY() / (_height * aspectRatio.ToFloatX()));
 
             int dstWidth  = (int)(_width  * ratioX);
             int dstHeight = (int)(_height * ratioY);

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
@@ -1,4 +1,6 @@
-﻿using Ryujinx.Common.Logging;
+﻿using Ryujinx.Common.Configuration;
+using Ryujinx.Common.Logging;
+using Ryujinx.Configuration;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu;
 using Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvMap;
@@ -277,13 +279,19 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
             bool flipX = item.Transform.HasFlag(NativeWindowTransform.FlipX);
             bool flipY = item.Transform.HasFlag(NativeWindowTransform.FlipY);
 
+            AspectRatio aspectRatio = ConfigurationState.Instance.Graphics.AspectRatio.Value;
+            bool        isStretched = aspectRatio == AspectRatio.Stretched;
+
             ImageCrop crop = new ImageCrop(
                 cropRect.Left,
                 cropRect.Right,
                 cropRect.Top,
                 cropRect.Bottom,
                 flipX,
-                flipY);
+                flipY,
+                isStretched,
+                aspectRatio.ToFloatX(),
+                aspectRatio.ToFloatY());
 
             TextureCallbackInformation textureCallbackInformation = new TextureCallbackInformation
             {

--- a/Ryujinx/Config.json
+++ b/Ryujinx/Config.json
@@ -1,8 +1,14 @@
+<<<<<<< HEAD
 {
   "version": 17,
+=======
+{ 
+  "version": 18,
+>>>>>>> bf8345e4 (gui/gpu: Implement setting and toggle for Aspect Ratio)
   "res_scale": 1,
   "res_scale_custom": 1,
   "max_anisotropy": -1,
+  "aspect_ratio": "To169",
   "graphics_shaders_dump_path": "",
   "logging_enable_debug": false,
   "logging_enable_stub": true,

--- a/Ryujinx/Config.json
+++ b/Ryujinx/Config.json
@@ -1,14 +1,9 @@
-<<<<<<< HEAD
-{
-  "version": 17,
-=======
 { 
   "version": 18,
->>>>>>> bf8345e4 (gui/gpu: Implement setting and toggle for Aspect Ratio)
   "res_scale": 1,
   "res_scale_custom": 1,
   "max_anisotropy": -1,
-  "aspect_ratio": "To16x9",
+  "aspect_ratio": "To169",
   "graphics_shaders_dump_path": "",
   "logging_enable_debug": false,
   "logging_enable_stub": true,

--- a/Ryujinx/Config.json
+++ b/Ryujinx/Config.json
@@ -8,7 +8,7 @@
   "res_scale": 1,
   "res_scale_custom": 1,
   "max_anisotropy": -1,
-  "aspect_ratio": "To169",
+  "aspect_ratio": "To16x9",
   "graphics_shaders_dump_path": "",
   "logging_enable_debug": false,
   "logging_enable_stub": true,

--- a/Ryujinx/Config.json
+++ b/Ryujinx/Config.json
@@ -1,4 +1,4 @@
-{ 
+{
   "version": 18,
   "res_scale": 1,
   "res_scale_custom": 1,

--- a/Ryujinx/Config.json
+++ b/Ryujinx/Config.json
@@ -3,7 +3,7 @@
   "res_scale": 1,
   "res_scale_custom": 1,
   "max_anisotropy": -1,
-  "aspect_ratio": "To169",
+  "aspect_ratio": "Fixed16x9",
   "graphics_shaders_dump_path": "",
   "logging_enable_debug": false,
   "logging_enable_stub": true,

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -632,18 +632,18 @@ namespace Ryujinx.Ui
             // OpenTK always captures mouse events, even if out of focus, so check if window is focused.
             if (_isFocused && _mousePressed)
             {
-                float aspectRatio = ConfigurationState.Instance.Graphics.AspectRatio.Value.ToFloat();
+                float aspectWidth = SwitchPanelHeight * ConfigurationState.Instance.Graphics.AspectRatio.Value.ToFloat();
 
                 int screenWidth  = AllocatedWidth;
                 int screenHeight = AllocatedHeight;
 
-                if (AllocatedWidth > AllocatedHeight * (SwitchPanelHeight * aspectRatio) / SwitchPanelHeight)
+                if (AllocatedWidth > AllocatedHeight * aspectWidth / SwitchPanelHeight)
                 {
-                    screenWidth = (int)(AllocatedHeight * (SwitchPanelHeight * aspectRatio)) / SwitchPanelHeight;
+                    screenWidth = (int)(AllocatedHeight * aspectWidth) / SwitchPanelHeight;
                 }
                 else
                 {
-                    screenHeight = (AllocatedWidth * SwitchPanelHeight) / (int)(SwitchPanelHeight * aspectRatio);
+                    screenHeight = (AllocatedWidth * SwitchPanelHeight) / (int)aspectWidth;
                 }
 
                 int startX = (AllocatedWidth  - screenWidth)  >> 1;
@@ -661,7 +661,7 @@ namespace Ryujinx.Ui
                     int screenMouseX = (int)_mouseX - startX;
                     int screenMouseY = (int)_mouseY - startY;
 
-                    int mX = (screenMouseX * (int)(SwitchPanelHeight * aspectRatio)) / screenWidth;
+                    int mX = (screenMouseX * (int)aspectWidth)  / screenWidth;
                     int mY = (screenMouseY * SwitchPanelHeight) / screenHeight;
 
                     TouchPoint currentPoint = new TouchPoint

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -632,18 +632,18 @@ namespace Ryujinx.Ui
             // OpenTK always captures mouse events, even if out of focus, so check if window is focused.
             if (_isFocused && _mousePressed)
             {
-                AspectRatio aspectRatio = ConfigurationState.Instance.Graphics.AspectRatio.Value;
+                float aspectRatio = ConfigurationState.Instance.Graphics.AspectRatio.Value.ToFloat();
 
                 int screenWidth  = AllocatedWidth;
                 int screenHeight = AllocatedHeight;
 
-                if (AllocatedWidth > AllocatedHeight * (SwitchPanelHeight * aspectRatio.ToFloat()) / SwitchPanelHeight)
+                if (AllocatedWidth > AllocatedHeight * (SwitchPanelHeight * aspectRatio) / SwitchPanelHeight)
                 {
-                    screenWidth = (int)(AllocatedHeight * (SwitchPanelHeight * aspectRatio.ToFloat())) / SwitchPanelHeight;
+                    screenWidth = (int)(AllocatedHeight * (SwitchPanelHeight * aspectRatio)) / SwitchPanelHeight;
                 }
                 else
                 {
-                    screenHeight = (AllocatedWidth * SwitchPanelHeight) / (int)(SwitchPanelHeight * aspectRatio.ToFloat());
+                    screenHeight = (AllocatedWidth * SwitchPanelHeight) / (int)(SwitchPanelHeight * aspectRatio);
                 }
 
                 int startX = (AllocatedWidth  - screenWidth)  >> 1;
@@ -661,7 +661,7 @@ namespace Ryujinx.Ui
                     int screenMouseX = (int)_mouseX - startX;
                     int screenMouseY = (int)_mouseY - startY;
 
-                    int mX = (screenMouseX * (int)(SwitchPanelHeight * aspectRatio.ToFloat())) / screenWidth;
+                    int mX = (screenMouseX * (int)(SwitchPanelHeight * aspectRatio)) / screenWidth;
                     int mY = (screenMouseY * SwitchPanelHeight) / screenHeight;
 
                     TouchPoint currentPoint = new TouchPoint

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -5,16 +5,16 @@ using OpenTK;
 using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL;
 using OpenTK.Input;
-using Ryujinx.Configuration;
 using Ryujinx.Common.Configuration;
 using Ryujinx.Common.Configuration.Hid;
+using Ryujinx.Configuration;
 using Ryujinx.Graphics.OpenGL;
 using Ryujinx.HLE;
 using Ryujinx.HLE.HOS.Services.Hid;
+using Ryujinx.Motion;
 using System;
 using System.Collections.Generic;
 using System.Threading;
-using Ryujinx.Motion;
 
 namespace Ryujinx.Ui
 {
@@ -219,7 +219,6 @@ namespace Ryujinx.Ui
             {
                 parent.Present();
 
-
                 string titleNameSection = string.IsNullOrWhiteSpace(_device.Application.TitleName) ? string.Empty
                     : $" - {_device.Application.TitleName}";
 
@@ -419,6 +418,7 @@ namespace Ryujinx.Ui
                     StatusUpdatedEvent?.Invoke(this, new StatusUpdatedEventArgs(
                         _device.EnableDeviceVsync,
                         dockedMode,
+                        ConfigurationState.Instance.Graphics.AspectRatio.Value.ToText(),
                         $"Game: {_device.Statistics.GetGameFrameRate():00.00} FPS",
                         $"FIFO: {_device.Statistics.GetFifoPercent():0.00} %",
                         $"GPU:  {_renderer.GpuVendor}"));
@@ -632,16 +632,18 @@ namespace Ryujinx.Ui
             // OpenTK always captures mouse events, even if out of focus, so check if window is focused.
             if (_isFocused && _mousePressed)
             {
+                AspectRatio aspectRatio = ConfigurationState.Instance.Graphics.AspectRatio.Value;
+
                 int screenWidth  = AllocatedWidth;
                 int screenHeight = AllocatedHeight;
 
-                if (AllocatedWidth > (AllocatedHeight * SwitchPanelWidth) / SwitchPanelHeight)
+                if (AllocatedWidth > AllocatedHeight * (SwitchPanelHeight * aspectRatio.ToFloat()) / SwitchPanelHeight)
                 {
-                    screenWidth = (AllocatedHeight * SwitchPanelWidth) / SwitchPanelHeight;
+                    screenWidth = (int)(AllocatedHeight * (SwitchPanelHeight * aspectRatio.ToFloat())) / SwitchPanelHeight;
                 }
                 else
                 {
-                    screenHeight = (AllocatedWidth * SwitchPanelHeight) / SwitchPanelWidth;
+                    screenHeight = (AllocatedWidth * SwitchPanelHeight) / (int)(SwitchPanelHeight * aspectRatio.ToFloat());
                 }
 
                 int startX = (AllocatedWidth  - screenWidth)  >> 1;
@@ -659,7 +661,7 @@ namespace Ryujinx.Ui
                     int screenMouseX = (int)_mouseX - startX;
                     int screenMouseY = (int)_mouseY - startY;
 
-                    int mX = (screenMouseX * SwitchPanelWidth) / screenWidth;
+                    int mX = (screenMouseX * (int)(SwitchPanelHeight * aspectRatio.ToFloat())) / screenWidth;
                     int mY = (screenMouseY * SwitchPanelHeight) / screenHeight;
 
                     TouchPoint currentPoint = new TouchPoint

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -72,6 +72,7 @@ namespace Ryujinx.Ui
         [GUI] CheckMenuItem   _pathToggle;
         [GUI] CheckMenuItem   _fileSizeToggle;
         [GUI] Label           _dockedMode;
+        [GUI] Label           _aspectRatio;
         [GUI] Label           _gameStatus;
         [GUI] TreeView        _gameTable;
         [GUI] TreeSelection   _gameTableSelection;
@@ -666,11 +667,12 @@ namespace Ryujinx.Ui
 
         public static void UpdateGraphicsConfig()
         {
-            int resScale = ConfigurationState.Instance.Graphics.ResScale;
+            int   resScale       = ConfigurationState.Instance.Graphics.ResScale;
             float resScaleCustom = ConfigurationState.Instance.Graphics.ResScaleCustom;
-            Graphics.Gpu.GraphicsConfig.ResScale = (resScale == -1) ? resScaleCustom : resScale;
-            Graphics.Gpu.GraphicsConfig.MaxAnisotropy = ConfigurationState.Instance.Graphics.MaxAnisotropy;
-            Graphics.Gpu.GraphicsConfig.ShadersDumpPath = ConfigurationState.Instance.Graphics.ShadersDumpPath;
+
+            Graphics.Gpu.GraphicsConfig.ResScale          = (resScale == -1) ? resScaleCustom : resScale;
+            Graphics.Gpu.GraphicsConfig.MaxAnisotropy     = ConfigurationState.Instance.Graphics.MaxAnisotropy;
+            Graphics.Gpu.GraphicsConfig.ShadersDumpPath   = ConfigurationState.Instance.Graphics.ShadersDumpPath;
             Graphics.Gpu.GraphicsConfig.EnableShaderCache = ConfigurationState.Instance.Graphics.EnableShaderCache;
         }
 
@@ -806,10 +808,11 @@ namespace Ryujinx.Ui
         {
             Application.Invoke(delegate
             {
-                _gameStatus.Text = args.GameStatus;
-                _fifoStatus.Text = args.FifoStatus;
-                _gpuName.Text    = args.GpuName;
-                _dockedMode.Text = args.DockedMode;
+                _gameStatus.Text  = args.GameStatus;
+                _fifoStatus.Text  = args.FifoStatus;
+                _gpuName.Text     = args.GpuName;
+                _dockedMode.Text  = args.DockedMode;
+                _aspectRatio.Text = args.AspectRatio;
 
                 if (args.VSyncEnabled)
                 {
@@ -866,6 +869,13 @@ namespace Ryujinx.Ui
         private void DockedMode_Clicked(object sender, ButtonReleaseEventArgs args)
         {
             ConfigurationState.Instance.System.EnableDockedMode.Value = !ConfigurationState.Instance.System.EnableDockedMode.Value;
+        }
+
+        private void AspectRatio_Clicked(object sender, ButtonReleaseEventArgs args)
+        {
+            AspectRatio aspectRatio = ConfigurationState.Instance.Graphics.AspectRatio.Value;
+
+            ConfigurationState.Instance.Graphics.AspectRatio.Value = ((int)aspectRatio + 1) > (int)AspectRatio.Stretched ? AspectRatio.To43 : aspectRatio + 1;
         }
 
         private void Row_Clicked(object sender, ButtonReleaseEventArgs args)

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -875,7 +875,7 @@ namespace Ryujinx.Ui
         {
             AspectRatio aspectRatio = ConfigurationState.Instance.Graphics.AspectRatio.Value;
 
-            ConfigurationState.Instance.Graphics.AspectRatio.Value = ((int)aspectRatio + 1) > (int)AspectRatio.Stretched ? AspectRatio.To43 : aspectRatio + 1;
+            ConfigurationState.Instance.Graphics.AspectRatio.Value = ((int)aspectRatio + 1) > Enum.GetNames(typeof(AspectRatio)).Length - 1 ? AspectRatio.To4x3 : aspectRatio + 1;
         }
 
         private void Row_Clicked(object sender, ButtonReleaseEventArgs args)

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -875,7 +875,7 @@ namespace Ryujinx.Ui
         {
             AspectRatio aspectRatio = ConfigurationState.Instance.Graphics.AspectRatio.Value;
 
-            ConfigurationState.Instance.Graphics.AspectRatio.Value = ((int)aspectRatio + 1) > Enum.GetNames(typeof(AspectRatio)).Length - 1 ? AspectRatio.To4x3 : aspectRatio + 1;
+            ConfigurationState.Instance.Graphics.AspectRatio.Value = ((int)aspectRatio + 1) > Enum.GetNames(typeof(AspectRatio)).Length - 1 ? AspectRatio.Fixed4x3 : aspectRatio + 1;
         }
 
         private void Row_Clicked(object sender, ButtonReleaseEventArgs args)

--- a/Ryujinx/Ui/MainWindow.glade
+++ b/Ryujinx/Ui/MainWindow.glade
@@ -552,12 +552,20 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkLabel" id="_gameStatus">
+                      <object class="GtkEventBox">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">start</property>
-                        <property name="margin_left">5</property>
-                        <property name="margin_right">5</property>
+                        <property name="margin_left">0</property>
+                        <signal name="button-release-event" handler="AspectRatio_Clicked" swapped="no"/>
+                        <child>
+                          <object class="GtkLabel" id="_aspectRatio">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="margin_left">5</property>
+                            <property name="margin_right">5</property>
+                          </object>
+                        </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -577,7 +585,7 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkLabel" id="_fifoStatus">
+                      <object class="GtkLabel" id="_gameStatus">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
@@ -602,6 +610,31 @@
                       </packing>
                     </child>
                     <child>
+                      <object class="GtkLabel" id="_fifoStatus">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin_left">5</property>
+                        <property name="margin_right">5</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">8</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSeparator">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">9</property>
+                      </packing>
+                    </child>
+                    <child>
                       <object class="GtkLabel" id="_gpuName">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
@@ -611,7 +644,7 @@
                       <packing>
                         <property name="expand">True</property>
                         <property name="fill">True</property>
-                        <property name="position">8</property>
+                        <property name="position">10</property>
                       </packing>
                     </child>
                   </object>

--- a/Ryujinx/Ui/SettingsWindow.cs
+++ b/Ryujinx/Ui/SettingsWindow.cs
@@ -71,6 +71,7 @@ namespace Ryujinx.Ui
         [GUI] Entry           _addGameDirBox;
         [GUI] Entry           _graphicsShadersDumpPath;
         [GUI] ComboBoxText    _anisotropy;
+        [GUI] ComboBoxText    _aspectRatio;
         [GUI] ComboBoxText    _resScaleCombo;
         [GUI] Entry           _resScaleText;
         [GUI] ToggleButton    _configureController1;
@@ -249,6 +250,7 @@ namespace Ryujinx.Ui
             _systemRegionSelect.SetActiveId(ConfigurationState.Instance.System.Region.Value.ToString());
             _resScaleCombo.SetActiveId(ConfigurationState.Instance.Graphics.ResScale.Value.ToString());
             _anisotropy.SetActiveId(ConfigurationState.Instance.Graphics.MaxAnisotropy.Value.ToString());
+            _aspectRatio.SetActiveId(((int)ConfigurationState.Instance.Graphics.AspectRatio.Value).ToString());
 
             _custThemePath.Buffer.Text           = ConfigurationState.Instance.Ui.CustomThemePath;
             _resScaleText.Buffer.Text            = ConfigurationState.Instance.Graphics.ResScaleCustom.Value.ToString();
@@ -408,6 +410,7 @@ namespace Ryujinx.Ui
             ConfigurationState.Instance.Ui.GameDirs.Value                      = gameDirs;
             ConfigurationState.Instance.System.FsGlobalAccessLogMode.Value     = (int)_fsLogSpinAdjustment.Value;
             ConfigurationState.Instance.Graphics.MaxAnisotropy.Value           = float.Parse(_anisotropy.ActiveId, CultureInfo.InvariantCulture);
+            ConfigurationState.Instance.Graphics.AspectRatio.Value             = Enum.Parse<AspectRatio>(_aspectRatio.ActiveId);
             ConfigurationState.Instance.Graphics.ResScale.Value                = int.Parse(_resScaleCombo.ActiveId);
             ConfigurationState.Instance.Graphics.ResScaleCustom.Value          = resScaleCustom;
 
@@ -422,7 +425,7 @@ namespace Ryujinx.Ui
         }
 
         //Events
-        private void TimeZoneEntry_FocusOut(Object sender, FocusOutEventArgs e)
+        private void TimeZoneEntry_FocusOut(object sender, FocusOutEventArgs e)
         {
             if (!_validTzRegions.Contains(_systemTimeZoneEntry.Text))
             {
@@ -439,7 +442,7 @@ namespace Ryujinx.Ui
                    ((string)compl.Model.GetValue(iter, 0)).Substring(3).StartsWith(key); // offset
         }
 
-        private void SystemTimeSpin_ValueChanged(Object sender, EventArgs e)
+        private void SystemTimeSpin_ValueChanged(object sender, EventArgs e)
         {
             int year   = _systemTimeYearSpin.ValueAsInt;
             int month  = _systemTimeMonthSpin.ValueAsInt;

--- a/Ryujinx/Ui/SettingsWindow.glade
+++ b/Ryujinx/Ui/SettingsWindow.glade
@@ -1811,6 +1811,54 @@
                                     <property name="position">1</property>
                                   </packing>
                                 </child>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Aspect Ratio applied to the renderer window.</property>
+                                        <property name="label" translatable="yes">Aspect Ratio:</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="padding">5</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBoxText" id="_aspectRatio">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Aspect Ratio applied to the renderer window.</property>
+                                        <property name="active-id">1</property>
+                                        <items>
+                                          <item id="0" translatable="yes">4:3</item>
+                                          <item id="1" translatable="yes">16:9</item>
+                                          <item id="2" translatable="yes">21:9</item>
+                                          <item id="3" translatable="yes">32:9</item>
+                                          <item id="4" translatable="yes">Stretch to Fit Window</item>
+                                        </items>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">5</property>
+                                    <property name="position">3</property>
+                                  </packing>
+                                </child>
                               </object>
                               <packing>
                                 <property name="expand">False</property>

--- a/Ryujinx/Ui/SettingsWindow.glade
+++ b/Ryujinx/Ui/SettingsWindow.glade
@@ -1840,9 +1840,10 @@
                                         <items>
                                           <item id="0" translatable="yes">4:3</item>
                                           <item id="1" translatable="yes">16:9</item>
-                                          <item id="2" translatable="yes">21:9</item>
-                                          <item id="3" translatable="yes">32:9</item>
-                                          <item id="4" translatable="yes">Stretch to Fit Window</item>
+                                          <item id="2" translatable="yes">16:10</item>
+                                          <item id="3" translatable="yes">21:9</item>
+                                          <item id="4" translatable="yes">32:9</item>
+                                          <item id="5" translatable="yes">Stretch to Fit Window</item>
                                         </items>
                                       </object>
                                       <packing>

--- a/Ryujinx/Ui/StatusUpdatedEventArgs.cs
+++ b/Ryujinx/Ui/StatusUpdatedEventArgs.cs
@@ -6,14 +6,16 @@ namespace Ryujinx.Ui
     {
         public bool   VSyncEnabled;
         public string DockedMode;
+        public string AspectRatio;
         public string GameStatus;
         public string FifoStatus;
         public string GpuName;
 
-        public StatusUpdatedEventArgs(bool vSyncEnabled, string dockedMode, string gameStatus, string fifoStatus, string gpuName)
+        public StatusUpdatedEventArgs(bool vSyncEnabled, string dockedMode, string aspectRatio, string gameStatus, string fifoStatus, string gpuName)
         {
             VSyncEnabled = vSyncEnabled;
             DockedMode   = dockedMode;
+            AspectRatio  = aspectRatio;
             GameStatus   = gameStatus;
             FifoStatus   = fifoStatus;
             GpuName      = gpuName;

--- a/Ryujinx/_schema.json
+++ b/Ryujinx/_schema.json
@@ -946,12 +946,13 @@
       "type": "string",
       "title": "Aspect Ratio applied to the renderer window.",
       "description": "Aspect Ratio applied to the renderer window.",
-      "default": "To169",
+      "default": "To16x9",
       "examples": [
-        "To43",
-        "To169",
-        "To219",
-        "To329",
+        "To4x3",
+        "To16x9",
+        "To16x10",
+        "To21x9",
+        "To32x9",
         "Stretched"
       ]
     },

--- a/Ryujinx/_schema.json
+++ b/Ryujinx/_schema.json
@@ -946,13 +946,13 @@
       "type": "string",
       "title": "Aspect Ratio applied to the renderer window.",
       "description": "Aspect Ratio applied to the renderer window.",
-      "default": "To16x9",
+      "default": "Fixed16x9",
       "examples": [
-        "To4x3",
-        "To16x9",
-        "To16x10",
-        "To21x9",
-        "To32x9",
+        "Fixed4x3",
+        "Fixed16x9",
+        "Fixed16x10",
+        "Fixed21x9",
+        "Fixed32x9",
         "Stretched"
       ]
     },

--- a/Ryujinx/_schema.json
+++ b/Ryujinx/_schema.json
@@ -941,6 +941,20 @@
         16
       ]
     },
+    "aspect_ratio": {
+      "$id": "#/properties/aspect_ratio",
+      "type": "string",
+      "title": "Aspect Ratio applied to the renderer window.",
+      "description": "Aspect Ratio applied to the renderer window.",
+      "default": "To169",
+      "examples": [
+        "To43",
+        "To169",
+        "To219",
+        "To329",
+        "Stretched"
+      ]
+    },
     "graphics_shaders_dump_path": {
       "$id": "#/properties/graphics_shaders_dump_path",
       "type": "string",


### PR DESCRIPTION
This implement a setting for the aspect ratio to values: 4:3, 16:9 (default value), 21:9, 32:9 and stretched.
You can sets it at runtime using the settings window or using the toggle in the status bar.
It fixes #1597.

MK8 using an ExeFs patch for 21:9 (1080p screen):
![image](https://user-images.githubusercontent.com/4905390/100968770-42c86b80-3532-11eb-8f71-08a0367af5d1.png)
![image](https://user-images.githubusercontent.com/4905390/100968777-46f48900-3532-11eb-90fa-1e218f31a780.png)

ACNH using an ExeFs patch for 21:9 (1080p screen):
![ACNH_219](https://user-images.githubusercontent.com/4905390/100967082-a781c700-352e-11eb-8f3d-b1765f50fec0.PNG)

Some SMO example (without patch):
4:3
![SMO_43](https://user-images.githubusercontent.com/4905390/100967142-caac7680-352e-11eb-9887-83058a957c98.PNG)

16:9
![SMO_169](https://user-images.githubusercontent.com/4905390/100967143-cb450d00-352e-11eb-9c42-941c1bc54e2a.PNG)

21:9
![SMO_219](https://user-images.githubusercontent.com/4905390/100967144-cbdda380-352e-11eb-8b0d-faa7002236ce.PNG)

32:9
![SMO_329](https://user-images.githubusercontent.com/4905390/100967145-cc763a00-352e-11eb-8191-8534101eb4cc.PNG)

Stretched
![SMO_Stretched](https://user-images.githubusercontent.com/4905390/100967140-c97b4980-352e-11eb-8c2c-ac168320ec45.PNG)