### PR TITLE
Applets: Explicitly yield kthread when waiting on GUI dialogs

### DIFF
--- a/Ryujinx.HLE/HOS/Applets/Controller/ControllerApplet.cs
+++ b/Ryujinx.HLE/HOS/Applets/Controller/ControllerApplet.cs
@@ -1,10 +1,11 @@
+using Ryujinx.Common.Logging;
+using Ryujinx.HLE.HOS.Services.Hid;
+using Ryujinx.HLE.HOS.Services.Am.AppletAE;
+using Ryujinx.HLE.HOS.Kernel;
 using System;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using Ryujinx.Common.Logging;
-using Ryujinx.HLE.HOS.Services.Hid;
-using Ryujinx.HLE.HOS.Services.Am.AppletAE;
 
 using static Ryujinx.HLE.HOS.Services.Hid.HidServer.HidUtils;
 
@@ -88,7 +89,14 @@ namespace Ryujinx.HLE.HOS.Applets
                     IsDocked = _system.State.DockedMode
                 };
 
-                if (!_system.Device.UiHandler.DisplayMessageDialog(uiArgs))
+                bool okPressed = false;
+
+                KernelStatic.YieldUntilCompletion(() =>
+                {
+                    okPressed = _system.Device.UiHandler.DisplayMessageDialog(uiArgs);
+                });
+
+                if (!okPressed)
                 {
                     break;
                 }

--- a/Ryujinx.HLE/HOS/Applets/Error/ErrorApplet.cs
+++ b/Ryujinx.HLE/HOS/Applets/Error/ErrorApplet.cs
@@ -7,6 +7,7 @@ using Ryujinx.Common.Logging;
 using Ryujinx.HLE.FileSystem;
 using Ryujinx.HLE.HOS.Services.Am.AppletAE;
 using Ryujinx.HLE.HOS.SystemState;
+using Ryujinx.HLE.HOS.Kernel;
 using System;
 using System.IO;
 using System.Linq;
@@ -153,13 +154,22 @@ namespace Ryujinx.HLE.HOS.Applets.Error
 
             string[] buttons = GetButtonsText(module, description, "DlgBtn");
 
-            bool showDetails = _horizon.Device.UiHandler.DisplayErrorAppletDialog($"Error Code: {module}-{description:0000}", "\n" + message, buttons);
+            bool showDetails = false;
+
+            KernelStatic.YieldUntilCompletion(() =>
+            {
+                showDetails = _horizon.Device.UiHandler.DisplayErrorAppletDialog($"Error Code: {module}-{description:0000}", "\n" + message, buttons);
+            });
+
             if (showDetails)
             {
                 message = GetMessageText(module, description, "FlvMsg");
                 buttons = GetButtonsText(module, description, "FlvBtn");
 
-                _horizon.Device.UiHandler.DisplayErrorAppletDialog($"Details: {module}-{description:0000}", "\n" + message, buttons);
+                KernelStatic.YieldUntilCompletion(() =>
+                {
+                    _horizon.Device.UiHandler.DisplayErrorAppletDialog($"Details: {module}-{description:0000}", "\n" + message, buttons);
+                });
             }
         }
 

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardApplet.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardApplet.cs
@@ -1,6 +1,7 @@
 ﻿using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Applets.SoftwareKeyboard;
 using Ryujinx.HLE.HOS.Services.Am.AppletAE;
+using Ryujinx.HLE.HOS.Kernel;
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -115,7 +116,10 @@ namespace Ryujinx.HLE.HOS.Applets
             }
             else
             {
-                _okPressed = _device.UiHandler.DisplayInputDialog(args, out _textValue);
+                KernelStatic.YieldUntilCompletion(() =>
+                {
+                    _okPressed = _device.UiHandler.DisplayInputDialog(args, out _textValue);
+                });
             }
 
             _textValue ??= initialText ?? DefaultText;

--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -59,6 +59,7 @@ namespace Ryujinx.HLE.HOS
 
         internal AppletStateMgr AppletState { get; private set; }
 
+        internal ServerBase AppletServer { get; private set; }
         internal ServerBase BsdServer { get; private set; }
         internal ServerBase AudRenServer { get; private set; }
         internal ServerBase AudOutServer { get; private set; }
@@ -242,6 +243,7 @@ namespace Ryujinx.HLE.HOS
             sm.Server.InitDone.WaitOne();
             sm.Server.InitDone.Dispose();
 
+            AppletServer = new ServerBase(KernelContext, "AppletServer");
             BsdServer = new ServerBase(KernelContext, "BsdServer");
             AudRenServer = new ServerBase(KernelContext, "AudioRendererServer");
             AudOutServer = new ServerBase(KernelContext, "AudioOutServer");

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/IAllSystemAppletProxiesService.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/IAllSystemAppletProxiesService.cs
@@ -5,7 +5,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE
     [Service("appletAE")]
     class IAllSystemAppletProxiesService : IpcService
     {
-        public IAllSystemAppletProxiesService(ServiceCtx context) { }
+        public IAllSystemAppletProxiesService(ServiceCtx context) : base(context.Device.System.AppletServer) { }
 
         [Command(100)]
         // OpenSystemAppletProxy(u64, pid, handle<copy>) -> object<nn::am::service::ISystemAppletProxy>

--- a/Ryujinx.HLE/HOS/Services/Am/AppletOE/IApplicationProxyService.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletOE/IApplicationProxyService.cs
@@ -5,7 +5,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
     [Service("appletOE")]
     class IApplicationProxyService : IpcService
     {
-        public IApplicationProxyService(ServiceCtx context) { }
+        public IApplicationProxyService(ServiceCtx context) : base(context.Device.System.AppletServer) { }
 
         [Command(0)]
         // OpenApplicationProxy(u64, pid, handle<copy>) -> object<nn::am::service::IApplicationProxy>


### PR DESCRIPTION
Following IPC Refactor Pt 2, blocking host calls (such as applet GUI dialogs) cause the entire core to lock as the service processes use cooperative scheduling prio. This PR uses a helper to yield the waiting applet thread.

Also applets now have their own Server; otherwise it'll yield the common server process instead.

Fixes the glitchy audio during FE3H swkbd invoke and similar issues with other applets (post IPC Pt 2).

I'm not sure this is the best solution in the long-term. Will leave the merge decision to gdkchan as I don't know the full scope of upcoming changes.