### PR TITLE
logger: Add build version to the log file names

### DIFF
--- a/Ryujinx.Common/Logging/Targets/FileLogTarget.cs
+++ b/Ryujinx.Common/Logging/Targets/FileLogTarget.cs
@@ -1,14 +1,12 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
-using System.Text;
+using System.Reflection;
 
 namespace Ryujinx.Common.Logging
 {
     public class FileLogTarget : ILogTarget
     {
-        private static readonly ObjectPool<StringBuilder> _stringBuilderPool = SharedPools.Default<StringBuilder>();
-
         private readonly StreamWriter  _logWriter;
         private readonly ILogFormatter _formatter;
         private readonly string        _name;
@@ -32,8 +30,10 @@ namespace Ryujinx.Common.Logging
                 files[i].Delete();
             }
 
+            string version = Assembly.GetEntryAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+
             // Get path for the current time
-            path = Path.Combine(logDir.FullName, $"Ryujinx_{DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss")}.log");
+            path = Path.Combine(logDir.FullName, $"Ryujinx_{version}_{DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss")}.log");
 
             _name      = name;
             _logWriter = new StreamWriter(File.Open(path, fileMode, FileAccess.Write, fileShare));

--- a/Ryujinx/Ui/AboutWindow.cs
+++ b/Ryujinx/Ui/AboutWindow.cs
@@ -1,8 +1,6 @@
 ﻿using Gtk;
 using System;
-using System.Diagnostics;
 using System.Reflection;
-using System.Runtime.InteropServices;
 
 using GUI = Gtk.Builder.ObjectAttribute;
 


### PR DESCRIPTION
This change add the build version to the log file names, as example: `Ryujinx_1.0.0-dirty_yyyy-MM-dd_HH-mm-ss.log`
Fixes https://github.com/Ryujinx/Ryujinx/issues/1527 but log file names can't contains the game names since they aren't game specific.

I've cleaned up the class and the About window a bit.