### PR TITLE
Signal memory tracking before/after mapping into another process

### DIFF
--- a/Ryujinx.HLE/HOS/Kernel/Memory/KMemoryManager.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Memory/KMemoryManager.cs
@@ -1656,6 +1656,9 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
                 }
             }
 
+            // Signal a read for any resources tracking reads in the region, as the other process is likely to use their data.
+            _cpuMemory.SignalMemoryTracking(addressTruncated, endAddrRounded - addressTruncated, false);
+
             lock (_blocks)
             {
                 KernelResult result;
@@ -2036,6 +2039,8 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
             ulong endAddr = address + size;
 
             ulong addressRounded   = BitUtils.AlignUp  (address, PageSize);
+            ulong addressTruncated = BitUtils.AlignDown(address, PageSize);
+            ulong endAddrRounded   = BitUtils.AlignUp  (endAddr, PageSize);
             ulong endAddrTruncated = BitUtils.AlignDown(endAddr, PageSize);
 
             ulong pagesCount = addressRounded < endAddrTruncated ? (endAddrTruncated - addressRounded) / PageSize : 0;
@@ -2070,6 +2075,9 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
             {
                 return KernelResult.OutOfResource;
             }
+
+            // Anything on the CPU side should see this memory as modified.
+            _cpuMemory.SignalMemoryTracking(addressTruncated, endAddrRounded - addressTruncated, true);
 
             lock (_blocks)
             {

--- a/Ryujinx.HLE/HOS/Kernel/Memory/KMemoryManager.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Memory/KMemoryManager.cs
@@ -2076,7 +2076,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
                 return KernelResult.OutOfResource;
             }
 
-            // Anything on the CPU side should see this memory as modified.
+            // Anything on the client side should see this memory as modified.
             _cpuMemory.SignalMemoryTracking(addressTruncated, endAddrRounded - addressTruncated, true);
 
             lock (_blocks)

--- a/Ryujinx.Memory.Tests/MockVirtualMemoryManager.cs
+++ b/Ryujinx.Memory.Tests/MockVirtualMemoryManager.cs
@@ -75,6 +75,11 @@ namespace Ryujinx.Memory.Tests
             throw new NotImplementedException();
         }
 
+        public void SignalMemoryTracking(ulong va, ulong size, bool write)
+        {
+            throw new NotImplementedException();
+        }
+
         public void TrackingReprotect(ulong va, ulong size, MemoryPermission protection)
         {
         }

--- a/Ryujinx.Memory/AddressSpaceManager.cs
+++ b/Ryujinx.Memory/AddressSpaceManager.cs
@@ -545,5 +545,10 @@ namespace Ryujinx.Memory
                 _pageTable[l0] = null;
             }
         }
+
+        public void SignalMemoryTracking(ulong va, ulong size, bool write)
+        {
+            // Only the ARM Memory Manager has tracking for now.
+        }
     }
 }

--- a/Ryujinx.Memory/IVirtualMemoryManager.cs
+++ b/Ryujinx.Memory/IVirtualMemoryManager.cs
@@ -23,6 +23,7 @@ namespace Ryujinx.Memory
         bool IsRangeMapped(ulong va, ulong size);
         ulong GetPhysicalAddress(ulong va);
 
+        void SignalMemoryTracking(ulong va, ulong size, bool write);
         void TrackingReprotect(ulong va, ulong size, MemoryPermission protection);
     }
 }


### PR DESCRIPTION
Fixes a regression from #1458 , where data written by a service would not mark regions as dirty, and reads from the service would not trigger flushes from textures.

This fixes vertex explosions after one race in Mario Kart 8 Deluxe, and may fix some other games with graphical errors introduced in #1458 . The game appears to write buffer data directly from a service.

Easy repro:
VS Race: Hyrule Circuit -> Sunshine Airport -> Yoshi Circuit

Broken example:
https://gyazo.com/a6ce0d7219ebe086dbb48c0324c43e16

You don't need a fixed example, you've all seen Mario Kart 8 before.