### PR TITLE
Implement lazy flush-on-read for Buffers (SSBO/Copy)

### DIFF
--- a/Ryujinx.Cpu/MemoryManager.cs
+++ b/Ryujinx.Cpu/MemoryManager.cs
@@ -131,7 +131,7 @@ namespace Ryujinx.Cpu
         /// <exception cref="InvalidMemoryRegionException">Throw for unhandled invalid or unmapped memory accesses</exception>
         public T Read<T>(ulong va) where T : unmanaged
         {
-            return MemoryMarshal.Cast<byte, T>(GetSpan(va, Unsafe.SizeOf<T>()))[0];
+            return MemoryMarshal.Cast<byte, T>(GetSpan(va, Unsafe.SizeOf<T>(), true))[0];
         }
 
         /// <summary>

--- a/Ryujinx.Cpu/Tracking/CpuMultiRegionHandle.cs
+++ b/Ryujinx.Cpu/Tracking/CpuMultiRegionHandle.cs
@@ -18,6 +18,7 @@ namespace Ryujinx.Cpu.Tracking
         public void QueryModified(Action<ulong, ulong> modifiedAction) => _impl.QueryModified(modifiedAction);
         public void QueryModified(ulong address, ulong size, Action<ulong, ulong> modifiedAction) => _impl.QueryModified(address, size, modifiedAction);
         public void QueryModified(ulong address, ulong size, Action<ulong, ulong> modifiedAction, int sequenceNumber) => _impl.QueryModified(address, size, modifiedAction, sequenceNumber);
+        public void RegisterAction(ulong address, ulong size, RegionSignal action) => _impl.RegisterAction(address, size, action);
         public void SignalWrite() => _impl.SignalWrite();
     }
 }

--- a/Ryujinx.Cpu/Tracking/CpuSmartMultiRegionHandle.cs
+++ b/Ryujinx.Cpu/Tracking/CpuSmartMultiRegionHandle.cs
@@ -15,6 +15,7 @@ namespace Ryujinx.Cpu.Tracking
         }
 
         public void Dispose() => _impl.Dispose();
+        public void RegisterAction(RegionSignal action) => _impl.RegisterAction(action);
         public void QueryModified(Action<ulong, ulong> modifiedAction) => _impl.QueryModified(modifiedAction);
         public void QueryModified(ulong address, ulong size, Action<ulong, ulong> modifiedAction) => _impl.QueryModified(address, size, modifiedAction);
         public void QueryModified(ulong address, ulong size, Action<ulong, ulong> modifiedAction, int sequenceNumber) => _impl.QueryModified(address, size, modifiedAction, sequenceNumber);

--- a/Ryujinx.Graphics.GAL/IRenderer.cs
+++ b/Ryujinx.Graphics.GAL/IRenderer.cs
@@ -21,6 +21,8 @@ namespace Ryujinx.Graphics.GAL
         ISampler CreateSampler(SamplerCreateInfo info);
         ITexture CreateTexture(TextureCreateInfo info, float scale);
 
+        void CreateSync(ulong id);
+
         void DeleteBuffer(BufferHandle buffer);
 
         byte[] GetBufferData(BufferHandle buffer, int offset, int size);
@@ -38,6 +40,8 @@ namespace Ryujinx.Graphics.GAL
         ICounterEvent ReportCounter(CounterType type, EventHandler<ulong> resultHandler);
 
         void ResetCounter(CounterType type);
+
+        void WaitSync(ulong id);
 
         void Initialize(GraphicsDebugLevel logLevel);
     }

--- a/Ryujinx.Graphics.Gpu/Engine/Compute.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Compute.cs
@@ -97,7 +97,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
                 SbDescriptor sbDescriptor = _context.PhysicalMemory.Read<SbDescriptor>(sbDescAddress);
 
-                BufferManager.SetComputeStorageBuffer(sb.Slot, sbDescriptor.PackAddress(), (uint)sbDescriptor.Size);
+                BufferManager.SetComputeStorageBuffer(sb.Slot, sbDescriptor.PackAddress(), (uint)sbDescriptor.Size, sb.Flags);
             }
 
             BufferManager.SetComputeStorageBufferBindings(info.SBuffers);

--- a/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoClass.cs
@@ -136,6 +136,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
             }
             else if (operation == SyncpointbOperation.Incr)
             {
+                _context.CreateHostSyncIfNeeded();
                 _context.Synchronization.IncrementSyncpoint(syncpointId);
             }
 

--- a/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoClass.cs
@@ -151,6 +151,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
         {
             _context.Methods.PerformDeferredDraws();
             _context.Renderer.Pipeline.Barrier();
+
+            _context.CreateHostSyncIfNeeded();
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoClass.cs
@@ -39,6 +39,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
                 { nameof(GPFifoClassState.Semaphored), new RwCallback(Semaphored, null) },
                 { nameof(GPFifoClassState.Syncpointb), new RwCallback(Syncpointb, null) },
                 { nameof(GPFifoClassState.WaitForIdle), new RwCallback(WaitForIdle, null) },
+                { nameof(GPFifoClassState.SetReference), new RwCallback(SetReference, null) },
                 { nameof(GPFifoClassState.LoadMmeInstructionRam), new RwCallback(LoadMmeInstructionRam, null) },
                 { nameof(GPFifoClassState.LoadMmeStartAddressRam), new RwCallback(LoadMmeStartAddressRam, null) },
                 { nameof(GPFifoClassState.SetMmeShadowRamControl), new RwCallback(SetMmeShadowRamControl, null) }
@@ -152,6 +153,15 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
             _context.Methods.PerformDeferredDraws();
             _context.Renderer.Pipeline.Barrier();
 
+            _context.CreateHostSyncIfNeeded();
+        }
+
+        /// <summary>
+        /// Used as an indirect data barrier on NVN. When used, access to previously written data must be coherent.
+        /// </summary>
+        /// <param name="argument">Method call argument</param>
+        public void SetReference(int argument)
+        {
             _context.CreateHostSyncIfNeeded();
         }
 

--- a/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoDevice.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoDevice.cs
@@ -52,7 +52,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
             {
                 if (Words == null)
                 {
-                    Words = MemoryMarshal.Cast<byte, int>(context.MemoryManager.GetSpan(EntryAddress, (int)EntryCount * 4)).ToArray();
+                    Words = MemoryMarshal.Cast<byte, int>(context.MemoryManager.GetSpan(EntryAddress, (int)EntryCount * 4, true)).ToArray();
                 }
             }
         }

--- a/Ryujinx.Graphics.Gpu/Engine/MethodIncrementSyncpoint.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodIncrementSyncpoint.cs
@@ -13,6 +13,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
         {
             uint syncpointId = (uint)(argument) & 0xFFFF;
 
+            _context.CreateHostSyncIfNeeded();
             _context.Renderer.UpdateCounters(); // Poll the query counters, the game may want an updated result.
             _context.Synchronization.IncrementSyncpoint(syncpointId);
         }

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -333,7 +333,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
                     SbDescriptor sbDescriptor = _context.PhysicalMemory.Read<SbDescriptor>(sbDescAddress);
 
-                    BufferManager.SetGraphicsStorageBuffer(stage, sb.Slot, sbDescriptor.PackAddress(), (uint)sbDescriptor.Size);
+                    BufferManager.SetGraphicsStorageBuffer(stage, sb.Slot, sbDescriptor.PackAddress(), (uint)sbDescriptor.Size, sb.Flags);
                 }
             }
         }

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -61,6 +61,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
             context.MemoryManager.MemoryUnmapped += _counterCache.MemoryUnmappedHandler;
             context.MemoryManager.MemoryUnmapped += TextureManager.MemoryUnmappedHandler;
+            context.MemoryManager.MemoryUnmapped += BufferManager.MemoryUnmappedHandler;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -4,6 +4,7 @@ using Ryujinx.Graphics.Gpu.Engine.GPFifo;
 using Ryujinx.Graphics.Gpu.Memory;
 using Ryujinx.Graphics.Gpu.Synchronization;
 using System;
+using System.Collections.Generic;
 using System.Threading;
 
 namespace Ryujinx.Graphics.Gpu
@@ -59,6 +60,18 @@ namespace Ryujinx.Graphics.Gpu
         /// </summary>
         internal int SequenceNumber { get; private set; }
 
+        /// <summary>
+        /// Internal sync number, used to denote points at which host synchronization can be requested.
+        /// </summary>
+        internal ulong SyncNumber { get; private set; }
+
+        /// <summary>
+        /// Actions to be performed when a CPU waiting sync point is triggered.
+        /// If there are more than 0 items when this happens, a host sync object will be generated for the given SyncNumber,
+        /// and the SyncNumber will be incremented.
+        /// </summary>
+        internal List<Action> SyncActions { get; }
+
         private readonly Lazy<Capabilities> _caps;
 
         /// <summary>
@@ -87,6 +100,8 @@ namespace Ryujinx.Graphics.Gpu
             _caps = new Lazy<Capabilities>(Renderer.GetCapabilities);
 
             HostInitalized = new ManualResetEvent(false);
+
+            SyncActions = new List<Action>();
         }
 
         /// <summary>
@@ -116,6 +131,37 @@ namespace Ryujinx.Graphics.Gpu
         public void SetVmm(Cpu.MemoryManager cpuMemory)
         {
             PhysicalMemory = new PhysicalMemory(cpuMemory);
+        }
+
+        /// <summary>
+        /// Registers an action to be performed the next time a syncpoint is incremented.
+        /// This will also ensure a host sync object is created, and SyncNumber is incremented.
+        /// </summary>
+        /// <param name="action"></param>
+        public void RegisterSyncAction(Action action)
+        {
+            SyncActions.Add(action);
+        }
+
+        /// <summary>
+        /// Creates a host sync object if there are any pending sync actions. The actions will then be called.
+        /// If no actions are present, a host sync object is not created.
+        /// </summary>
+        public void CreateHostSyncIfNeeded()
+        {
+            if (SyncActions.Count > 0)
+            {
+                Renderer.CreateSync(SyncNumber);
+
+                SyncNumber++;
+
+                foreach (Action action in SyncActions)
+                {
+                    action();
+                }
+
+                SyncActions.Clear();
+            }
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -137,7 +137,7 @@ namespace Ryujinx.Graphics.Gpu
         /// Registers an action to be performed the next time a syncpoint is incremented.
         /// This will also ensure a host sync object is created, and SyncNumber is incremented.
         /// </summary>
-        /// <param name="action"></param>
+        /// <param name="action">The action to be performed on sync object creation</param>
         public void RegisterSyncAction(Action action)
         {
             SyncActions.Add(action);

--- a/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -67,7 +67,7 @@ namespace Ryujinx.Graphics.Gpu
 
         /// <summary>
         /// Actions to be performed when a CPU waiting sync point is triggered.
-        /// If there are more than 0 items when this happens, a host sync object will be generated for the given SyncNumber,
+        /// If there are more than 0 items when this happens, a host sync object will be generated for the given <see cref="SyncNumber"/>,
         /// and the SyncNumber will be incremented.
         /// </summary>
         internal List<Action> SyncActions { get; }
@@ -135,7 +135,7 @@ namespace Ryujinx.Graphics.Gpu
 
         /// <summary>
         /// Registers an action to be performed the next time a syncpoint is incremented.
-        /// This will also ensure a host sync object is created, and SyncNumber is incremented.
+        /// This will also ensure a host sync object is created, and <see cref="SyncNumber"/> is incremented.
         /// </summary>
         /// <param name="action">The action to be performed on sync object creation</param>
         public void RegisterSyncAction(Action action)

--- a/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
@@ -289,16 +289,14 @@ namespace Ryujinx.Graphics.Gpu.Memory
         }
 
         /// <summary>
-        /// Called when the memory for this buffer has been unmapped.
+        /// Called when part of the memory for this buffer has been unmapped.
         /// Calls are from non-gpu threads.
         /// </summary>
-        public void Unmapped()
+        /// <param name="address">Start address of the unmapped region</param>
+        /// <param name="size">Size of the unmapped region</param>
+        public void Unmapped(ulong address, ulong size)
         {
-            _memoryTracking?.Reprotect();
-            _memoryTracking?.RegisterAction(null);
-
-            _memoryTrackingGranular?.QueryModified((address, size) => { });
-            _memoryTrackingGranular?.RegisterAction(Address, Size, null);
+            _modifiedRanges?.Clear(address, size);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
@@ -289,19 +289,6 @@ namespace Ryujinx.Graphics.Gpu.Memory
         }
 
         /// <summary>
-        /// Called when the memory for this buffer has been unmapped.
-        /// Calls are from non-gpu threads.
-        /// </summary>
-        public void Unmapped()
-        {
-            _memoryTracking?.Reprotect();
-            _memoryTracking?.RegisterAction(null);
-
-            _memoryTrackingGranular?.QueryModified((address, size) => { });
-            _memoryTrackingGranular?.RegisterAction(Address, Size, null);
-        }
-
-        /// <summary>
         /// Disposes the host buffer.
         /// </summary>
         public void Dispose()

--- a/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
@@ -328,6 +328,20 @@ namespace Ryujinx.Graphics.Gpu.Memory
         }
 
         /// <summary>
+        /// Align a given address and size region to page boundaries.
+        /// </summary>
+        /// <param name="address">The start address of the region</param>
+        /// <param name="size">The size of the region</param>
+        /// <returns>The page aligned address and size</returns>
+        private (ulong address, ulong size) PageAlign(ulong address, ulong size)
+        {
+            ulong pageMask = (ulong)MemoryManager.PageSize - 1;
+            ulong rA = address & ~pageMask;
+            ulong rS = ((address + size + pageMask) & ~pageMask) - rA;
+            return (rA, rS);
+        }
+
+        /// <summary>
         /// Flush modified ranges of the buffer from another thread.
         /// This will flush all modifications made before the active SyncNumber was set, and may block to wait for GPU sync.
         /// </summary>
@@ -341,7 +355,8 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
                 if (ranges != null)
                 {
-                    ranges.WaitForAndGetRanges(Address, Size, Flush);
+                    (address, size) = PageAlign(address, size);
+                    ranges.WaitForAndGetRanges(address, size, Flush);
                 }
             });
         }

--- a/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
@@ -289,6 +289,19 @@ namespace Ryujinx.Graphics.Gpu.Memory
         }
 
         /// <summary>
+        /// Called when the memory for this buffer has been unmapped.
+        /// Calls are from non-gpu threads.
+        /// </summary>
+        public void Unmapped()
+        {
+            _memoryTracking?.Reprotect();
+            _memoryTracking?.RegisterAction(null);
+
+            _memoryTrackingGranular?.QueryModified((address, size) => { });
+            _memoryTrackingGranular?.RegisterAction(Address, Size, null);
+        }
+
+        /// <summary>
         /// Disposes the host buffer.
         /// </summary>
         public void Dispose()

--- a/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
@@ -333,7 +333,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="address">The start address of the region</param>
         /// <param name="size">The size of the region</param>
         /// <returns>The page aligned address and size</returns>
-        private (ulong address, ulong size) PageAlign(ulong address, ulong size)
+        private static (ulong address, ulong size) PageAlign(ulong address, ulong size)
         {
             ulong pageMask = MemoryManager.PageMask;
             ulong rA = address & ~pageMask;

--- a/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
@@ -335,7 +335,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <returns>The page aligned address and size</returns>
         private (ulong address, ulong size) PageAlign(ulong address, ulong size)
         {
-            ulong pageMask = (ulong)MemoryManager.PageSize - 1;
+            ulong pageMask = MemoryManager.PageMask;
             ulong rA = address & ~pageMask;
             ulong rS = ((address + size + pageMask) & ~pageMask) - rA;
             return (rA, rS);

--- a/Ryujinx.Graphics.Gpu/Memory/BufferBounds.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferBounds.cs
@@ -1,3 +1,5 @@
+using Ryujinx.Graphics.Shader;
+
 namespace Ryujinx.Graphics.Gpu.Memory
 {
     /// <summary>
@@ -16,14 +18,20 @@ namespace Ryujinx.Graphics.Gpu.Memory
         public ulong Size { get; }
 
         /// <summary>
+        /// Buffer usage flags.
+        /// </summary>
+        public BufferUsageFlags Flags { get; }
+
+        /// <summary>
         /// Creates a new buffer region.
         /// </summary>
         /// <param name="address">Region address</param>
         /// <param name="size">Region size</param>
-        public BufferBounds(ulong address, ulong size)
+        public BufferBounds(ulong address, ulong size, BufferUsageFlags flags = BufferUsageFlags.None)
         {
             Address = address;
             Size = size;
+            Flags = flags;
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Memory/BufferBounds.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferBounds.cs
@@ -27,6 +27,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// </summary>
         /// <param name="address">Region address</param>
         /// <param name="size">Region size</param>
+        /// <param name="flags">Buffer usage flags</param>
         public BufferBounds(ulong address, ulong size, BufferUsageFlags flags = BufferUsageFlags.None)
         {
             Address = address;

--- a/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -889,7 +889,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
             _context.Renderer.Pipeline.ClearBuffer(buffer.Handle, offset, (int)size, value);
 
-            buffer.Flush(address, size);
+            buffer.SignalModified(address, size);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -512,6 +512,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                         int dstOffset = (int)(buffer.Address - newBuffer.Address);
 
                         buffer.CopyTo(newBuffer, dstOffset);
+                        newBuffer.InheritModifiedRanges(buffer);
 
                         buffer.Dispose();
                     }

--- a/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -489,8 +489,6 @@ namespace Ryujinx.Graphics.Gpu.Memory
                         address    = Math.Min(address,    buffer.Address);
                         endAddress = Math.Max(endAddress, buffer.EndAddress);
 
-                        buffer.SynchronizeMemory(buffer.Address, buffer.Size);
-
                         lock (_buffers)
                         {
                             _buffers.Remove(buffer);
@@ -510,6 +508,8 @@ namespace Ryujinx.Graphics.Gpu.Memory
                         Buffer buffer = _bufferOverlaps[index];
 
                         int dstOffset = (int)(buffer.Address - newBuffer.Address);
+
+                        buffer.SynchronizeMemory(buffer.Address, buffer.Size);
 
                         buffer.CopyTo(newBuffer, dstOffset);
                         newBuffer.InheritModifiedRanges(buffer);
@@ -854,13 +854,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 dstOffset,
                 (int)size);
 
-            if (srcBuffer.IsModified)
-            {
-                srcBuffer.Flush(srcBuffer.Address, srcBuffer.Size);
-            }
-
-            // Copy the memory directly, so that we don't need to dirty the target buffer.
-            _context.PhysicalMemory.WriteUntracked(dstAddress, _context.PhysicalMemory.GetSpan(srcAddress, (int)size));
+            dstBuffer.SignalModified(dstAddress, size);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -386,27 +386,6 @@ namespace Ryujinx.Graphics.Gpu.Memory
         }
 
         /// <summary>
-        /// Handles removal of bufferss written to a memory region being unmapped.
-        /// </summary>
-        /// <param name="sender">Sender object</param>
-        /// <param name="e">Event arguments</param>
-        public void MemoryUnmappedHandler(object sender, UnmapEventArgs e)
-        {
-            Buffer[] overlaps = new Buffer[10];
-            int overlapCount;
-
-            lock (_buffers)
-            {
-                overlapCount = _buffers.FindOverlaps(_context.MemoryManager.Translate(e.Address), e.Size, ref overlaps);
-            }
-
-            for (int i = 0; i < overlapCount; i++)
-            {
-                overlaps[i].Unmapped();
-            }
-        }
-
-        /// <summary>
         /// Performs address translation of the GPU virtual address, and creates a
         /// new buffer, if needed, for the specified range.
         /// </summary>
@@ -464,12 +443,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="size">Size in bytes of the buffer</param>
         private void CreateBufferAligned(ulong address, ulong size)
         {
-            int overlapsCount;
-
-            lock (_buffers)
-            {
-                overlapsCount = _buffers.FindOverlapsNonOverlapping(address, size, ref _bufferOverlaps);
-            }
+            int overlapsCount = _buffers.FindOverlapsNonOverlapping(address, size, ref _bufferOverlaps);
 
             if (overlapsCount != 0)
             {
@@ -489,19 +463,13 @@ namespace Ryujinx.Graphics.Gpu.Memory
                         address    = Math.Min(address,    buffer.Address);
                         endAddress = Math.Max(endAddress, buffer.EndAddress);
 
-                        lock (_buffers)
-                        {
-                            _buffers.Remove(buffer);
-                        }
+                        _buffers.Remove(buffer);
                     }
 
                     Buffer newBuffer = new Buffer(_context, address, endAddress - address);
                     newBuffer.SynchronizeMemory(address, endAddress - address);
 
-                    lock (_buffers)
-                    {
-                        _buffers.Add(newBuffer);
-                    }
+                    _buffers.Add(newBuffer);
 
                     for (int index = 0; index < overlapsCount; index++)
                     {
@@ -526,10 +494,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 // No overlap, just create a new buffer.
                 Buffer buffer = new Buffer(_context, address, size);
 
-                lock (_buffers)
-                {
-                    _buffers.Add(buffer);
-                }
+                _buffers.Add(buffer);
             }
 
             ShrinkOverlapsBufferIfNeeded();
@@ -903,10 +868,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
             if (size != 0)
             {
-                lock (_buffers)
-                {
-                    buffer = _buffers.FindFirstOverlap(address, size);
-                }
+                buffer = _buffers.FindFirstOverlap(address, size);
 
                 buffer.SynchronizeMemory(address, size);
 
@@ -917,10 +879,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
             }
             else
             {
-                lock (_buffers)
-                {
-                    buffer = _buffers.FindFirstOverlap(address, 1);
-                }
+                buffer = _buffers.FindFirstOverlap(address, 1);
             }
 
             return buffer;
@@ -935,12 +894,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         {
             if (size != 0)
             {
-                Buffer buffer;
-
-                lock (_buffers)
-                {
-                    buffer = _buffers.FindFirstOverlap(address, size);
-                }
+                Buffer buffer = _buffers.FindFirstOverlap(address, size);
 
                 buffer.SynchronizeMemory(address, size);
             }
@@ -952,12 +906,9 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// </summary>
         public void Dispose()
         {
-            lock (_buffers)
+            foreach (Buffer buffer in _buffers)
             {
-                foreach (Buffer buffer in _buffers)
-                {
-                    buffer.Dispose();
-                }
+                buffer.Dispose();
             }
         }
     }

--- a/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -395,14 +395,17 @@ namespace Ryujinx.Graphics.Gpu.Memory
             Buffer[] overlaps = new Buffer[10];
             int overlapCount;
 
+            ulong address = _context.MemoryManager.Translate(e.Address);
+            ulong size = e.Size;
+
             lock (_buffers)
             {
-                overlapCount = _buffers.FindOverlaps(_context.MemoryManager.Translate(e.Address), e.Size, ref overlaps);
+                overlapCount = _buffers.FindOverlaps(address, size, ref overlaps);
             }
 
             for (int i = 0; i < overlapCount; i++)
             {
-                overlaps[i].Unmapped();
+                overlaps[i].Unmapped(address, size);
             }
         }
 

--- a/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -857,7 +857,17 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 dstOffset,
                 (int)size);
 
-            dstBuffer.SignalModified(dstAddress, size);
+            if (srcBuffer.IsModified(srcAddress, size))
+            {
+                dstBuffer.SignalModified(dstAddress, size);
+            }
+            else
+            {
+                // Optimization: If the data being copied is already in memory, then copy it directly instead of flushing from GPU.
+
+                dstBuffer.ClearModified(dstAddress, size);
+                _context.PhysicalMemory.WriteUntracked(dstAddress, _context.PhysicalMemory.GetSpan(srcAddress, (int)size));
+            }
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -68,6 +68,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
             /// <param name="index">Buffer slot</param>
             /// <param name="address">Region virtual address</param>
             /// <param name="size">Region size in bytes</param>
+            /// <param name="flags">Buffer usage flags</param>
             public void SetBounds(int index, ulong address, ulong size, BufferUsageFlags flags = BufferUsageFlags.None)
             {
                 Buffers[index] = new BufferBounds(address, size, flags);
@@ -219,6 +220,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="index">Index of the storage buffer</param>
         /// <param name="gpuVa">Start GPU virtual address of the buffer</param>
         /// <param name="size">Size in bytes of the storage buffer</param>
+        /// <param name="flags">Buffer usage flags</param>
         public void SetComputeStorageBuffer(int index, ulong gpuVa, ulong size, BufferUsageFlags flags)
         {
             size += gpuVa & ((ulong)_context.Capabilities.StorageBufferOffsetAlignment - 1);
@@ -238,6 +240,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="index">Index of the storage buffer</param>
         /// <param name="gpuVa">Start GPU virtual address of the buffer</param>
         /// <param name="size">Size in bytes of the storage buffer</param>
+        /// <param name="flags">Buffer usage flags</param>
         public void SetGraphicsStorageBuffer(int stage, int index, ulong gpuVa, ulong size, BufferUsageFlags flags)
         {
             size += gpuVa & ((ulong)_context.Capabilities.StorageBufferOffsetAlignment - 1);
@@ -386,7 +389,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         }
 
         /// <summary>
-        /// Handles removal of bufferss written to a memory region being unmapped.
+        /// Handles removal of buffers written to a memory region being unmapped.
         /// </summary>
         /// <param name="sender">Sender object</param>
         /// <param name="e">Event arguments</param>
@@ -897,6 +900,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// </summary>
         /// <param name="address">Start address of the memory range</param>
         /// <param name="size">Size in bytes of the memory range</param>
+        /// <param name="write">Whether the buffer will be written to by this use</param>
         /// <returns>The buffer sub-range for the given range</returns>
         private BufferRange GetBufferRange(ulong address, ulong size, bool write = false)
         {
@@ -909,6 +913,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// </summary>
         /// <param name="address">Start address of the memory range</param>
         /// <param name="size">Size in bytes of the memory range</param>
+        /// <param name="write">Whether the buffer will be written to by this use</param>
         /// <returns>The buffer where the range is fully contained</returns>
         private Buffer GetBuffer(ulong address, ulong size, bool write = false)
         {

--- a/Ryujinx.Graphics.Gpu/Memory/BufferModifiedRangeList.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferModifiedRangeList.cs
@@ -173,6 +173,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         public void GetRanges(ulong address, ulong size, Action<ulong, ulong> rangeAction)
         {
             int count = 0;
+
             // Range list must be consistent for this operation.
             lock (_lock)
             {
@@ -219,6 +220,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
             ulong currentSync = _context.SyncNumber;
 
             int rangeCount = 0;
+
             // Range list must be consistent for this operation
             lock (_lock)
             {

--- a/Ryujinx.Graphics.Gpu/Memory/BufferModifiedRangeList.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferModifiedRangeList.cs
@@ -173,7 +173,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         public void GetRanges(ulong address, ulong size, Action<ulong, ulong> rangeAction)
         {
             int count = 0;
-            // Range list must be consistent for this operation
+            // Range list must be consistent for this operation.
             lock (_lock)
             {
                 count = FindOverlapsNonOverlapping(address, size, ref _foregroundOverlaps);
@@ -183,6 +183,21 @@ namespace Ryujinx.Graphics.Gpu.Memory
             {
                 BufferModifiedRange overlap = _foregroundOverlaps[i];
                 rangeAction(overlap.Address, overlap.Size);
+            }
+        }
+
+        /// <summary>
+        /// Queries if a range exists within the specified region.
+        /// </summary>
+        /// <param name="address">Start address to query</param>
+        /// <param name="size">Size to query</param>
+        /// <returns>True if a range exists in the specified region, false otherwise</returns>
+        public bool HasRange(ulong address, ulong size)
+        {
+            // Range list must be consistent for this operation.
+            lock (_lock)
+            {
+                return FindOverlapsNonOverlapping(address, size, ref _foregroundOverlaps) > 0;
             }
         }
 

--- a/Ryujinx.Graphics.Gpu/Memory/BufferModifiedRangeList.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferModifiedRangeList.cs
@@ -1,0 +1,277 @@
+﻿using Ryujinx.Memory.Range;
+using System;
+
+namespace Ryujinx.Graphics.Gpu.Memory
+{
+    /// <summary>
+    /// A range within a buffer that has been modified by the GPU.
+    /// </summary>
+    class BufferModifiedRange : IRange
+    {
+        /// <summary>
+        /// Start address of the range in guest memory.
+        /// </summary>
+        public ulong Address { get; }
+
+        /// <summary>
+        /// Size of the range in bytes.
+        /// </summary>
+        public ulong Size { get; }
+
+        /// <summary>
+        /// End address of the range in guest memory.
+        /// </summary>
+        public ulong EndAddress => Address + Size;
+
+        /// <summary>
+        /// The GPU sync number at the time of the last modification.
+        /// </summary>
+        public ulong SyncNumber { get; internal set; }
+
+        /// <summary>
+        /// Creates a new instance of a modified range.
+        /// </summary>
+        /// <param name="address">Start address of the range</param>
+        /// <param name="size">Size of the range in bytes</param>
+        /// <param name="syncNumber">The GPU sync number at the time of creation</param>
+        public BufferModifiedRange(ulong address, ulong size, ulong syncNumber)
+        {
+            Address = address;
+            Size = size;
+            SyncNumber = syncNumber;
+        }
+
+        /// <summary>
+        /// Checks if a given range overlaps with the modified range.
+        /// </summary>
+        /// <param name="address">Start address of the range</param>
+        /// <param name="size">Size in bytes of the range</param>
+        /// <returns>True if the range overlaps, false otherwise</returns>
+        public bool OverlapsWith(ulong address, ulong size)
+        {
+            return Address < address + size && address < EndAddress;
+        }
+    }
+
+    /// <summary>
+    /// A structure used to track GPU modified ranges within a buffer.
+    /// </summary>
+    class BufferModifiedRangeList : RangeList<BufferModifiedRange>
+    {
+        private GpuContext _context;
+
+        private object _lock = new object();
+
+        // The list can be accessed from both the GPU thread, and a background thread.
+        private BufferModifiedRange[] _foregroundOverlaps = new BufferModifiedRange[1];
+        private BufferModifiedRange[] _backgroundOverlaps = new BufferModifiedRange[1];
+
+        /// <summary>
+        /// Creates a new instance of a modified range list.
+        /// </summary>
+        /// <param name="context">GPU context that the buffer range list belongs to</param>
+        public BufferModifiedRangeList(GpuContext context)
+        {
+            _context = context;
+        }
+
+        /// <summary>
+        /// Given an input range, calls the given action with sub-ranges which exclude any of the modified regions.
+        /// </summary>
+        /// <param name="address">Start address of the query range</param>
+        /// <param name="size">Size of the query range in bytes</param>
+        /// <param name="action">Action to perform for each remaining sub-range of the input range</param>
+        public void ExcludeModifiedRegions(ulong address, ulong size, Action<ulong, ulong> action)
+        {
+            lock (_lock)
+            {
+                // Slices a given region using the modified regions in the list. Calls the action for the new slices.
+                int count = FindOverlapsNonOverlapping(address, size, ref _foregroundOverlaps);
+
+                for (int i = 0; i < count; i++)
+                {
+                    BufferModifiedRange overlap = _foregroundOverlaps[i];
+                    
+                    if (overlap.Address > address)
+                    {
+                        // The start of the remaining region is uncovered by this overlap. Call the action for it.
+                        action(address, overlap.Address - address);
+                    }
+
+                    // Remaining region is after this overlap.
+                    size -= overlap.EndAddress - address;
+                    address = overlap.EndAddress;
+                }
+
+                if ((long)size > 0)
+                {
+                    // If there is any region left after removing the overlaps, signal it.
+                    action(address, size);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Signal that a region of the buffer has been modified, and add the new region to the range list.
+        /// Any overlapping ranges will be (partially) removed.
+        /// </summary>
+        /// <param name="address">Start address of the modified region</param>
+        /// <param name="size">Size of the modified region in bytes</param>
+        public void SignalModified(ulong address, ulong size)
+        {
+            // Must lock, as this can affect flushes from the background thread.
+            lock (_lock)
+            {
+                // We may overlap with some existing modified regions. They must be cut into by the new entry.
+                int count = FindOverlapsNonOverlapping(address, size, ref _foregroundOverlaps);
+
+                ulong endAddress = address + size;
+                ulong syncNumber = _context.SyncNumber;
+
+                for (int i = 0; i < count; i++)
+                {
+                    // The overlaps must be removed or split.
+
+                    BufferModifiedRange overlap = _foregroundOverlaps[i];
+
+                    if (overlap.Address == address && overlap.Size == size)
+                    {
+                        // Region already exists. Just update the existing sync number.
+                        overlap.SyncNumber = syncNumber;
+
+                        return;
+                    }
+
+                    Remove(overlap);
+
+                    if (overlap.Address < address && overlap.EndAddress > address)
+                    {
+                        // A split item must be created behind this overlap.
+
+                        Add(new BufferModifiedRange(overlap.Address, address - overlap.Address, overlap.SyncNumber));
+                    }
+
+                    if (overlap.Address < endAddress && overlap.EndAddress > endAddress)
+                    {
+                        // A split item must be created after this overlap.
+
+                        Add(new BufferModifiedRange(endAddress, overlap.EndAddress - endAddress, overlap.SyncNumber));
+                    }
+                }
+
+                Add(new BufferModifiedRange(address, size, syncNumber));
+            }
+        }
+
+        /// <summary>
+        /// Gets modified ranges within the specified region, and then fires the given action for each range individually.
+        /// </summary>
+        /// <param name="address">Start address to query</param>
+        /// <param name="size">Size to query</param>
+        /// <param name="rangeAction">The action to call for each modified range</param>
+        public void GetRanges(ulong address, ulong size, Action<ulong, ulong> rangeAction)
+        {
+            int count = 0;
+            // Range list must be consistent for this operation
+            lock (_lock)
+            {
+                count = FindOverlapsNonOverlapping(address, size, ref _foregroundOverlaps);
+            }
+
+            for (int i = 0; i < count; i++)
+            {
+                BufferModifiedRange overlap = _foregroundOverlaps[i];
+                rangeAction(overlap.Address, overlap.Size);
+            }
+        }
+
+        /// <summary>
+        /// Gets modified ranges within the specified region, waits on ones from a previous sync number,
+        /// and then fires the given action for each range individually.
+        /// </summary>
+        /// <remarks>
+        /// This function assumes it is called from the background thread.
+        /// Modifications from the current sync number are ignored because the guest should not expect them to be available yet.
+        /// They will remain reserved, so that any data sync prioritizes the data in the GPU.
+        /// </remarks>
+        /// <param name="address">Start address to query</param>
+        /// <param name="size">Size to query</param>
+        /// <param name="rangeAction">The action to call for each modified range</param>
+        public void WaitForAndGetRanges(ulong address, ulong size, Action<ulong, ulong> rangeAction)
+        {
+            ulong currentSync = _context.SyncNumber;
+
+            int rangeCount = 0;
+            // Range list must be consistent for this operation
+            lock (_lock)
+            {
+                rangeCount = FindOverlapsNonOverlapping(address, size, ref _backgroundOverlaps);
+            }
+
+            if (rangeCount == 0)
+            {
+                return;
+            }
+
+            // First, determine which syncpoint to wait on.
+            // This is the latest syncpoint that is not equal to the current sync.
+
+            long highestDiff = long.MinValue;
+
+            for (int i = 0; i < rangeCount; i++)
+            {
+                BufferModifiedRange overlap = _backgroundOverlaps[i];
+
+                long diff = (long)(overlap.SyncNumber - currentSync);
+
+                if (diff < 0 && diff > highestDiff)
+                {
+                    highestDiff = diff;
+                }
+            }
+
+            if (highestDiff == long.MinValue)
+            {
+                return;
+            }
+
+            // Wait for the syncpoint.
+            _context.Renderer.WaitSync(currentSync + (ulong)highestDiff);
+
+            // Flush and remove all regions with the older syncpoint.
+            lock (_lock)
+            {
+                for (int i = 0; i < rangeCount; i++)
+                {
+                    BufferModifiedRange overlap = _backgroundOverlaps[i];
+
+                    long diff = (long)(overlap.SyncNumber - currentSync);
+
+                    if (diff <= highestDiff)
+                    {
+                        Remove(overlap);
+                        rangeAction(overlap.Address, overlap.Size);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Inherit ranges from another modified range list.
+        /// </summary>
+        /// <param name="ranges">The range list to inherit from</param>
+        public void InheritRanges(BufferModifiedRangeList ranges)
+        {
+            lock (ranges._lock)
+            {
+                lock (_lock)
+                {
+                    foreach (var range in ranges)
+                    {
+                        Add(range);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Memory/BufferModifiedRangeList.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferModifiedRangeList.cs
@@ -360,7 +360,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         {
             lock (_lock)
             {
-                _items.Clear();
+                Items.Clear();
             }
         }
     }

--- a/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
@@ -61,6 +61,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// </summary>
         /// <param name="va">GPU virtual address where the data is located</param>
         /// <param name="size">Size of the data</param>
+        /// <param name="tracked">True if read tracking is triggered on the span</param>
         /// <returns>The span of the data at the specified memory location</returns>
         public ReadOnlySpan<byte> GetSpan(ulong va, int size, bool tracked = false)
         {

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -34,7 +34,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 1910;
+        private const ulong ShaderCodeGenVersion = 1790;
 
         /// <summary>
         /// Creates a new instance of the shader cache.

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -26,6 +26,8 @@ namespace Ryujinx.Graphics.OpenGL
         private TextureCopy _backgroundTextureCopy;
         internal TextureCopy TextureCopy => BackgroundContextWorker.InBackground ? _backgroundTextureCopy : _textureCopy;
 
+        private Sync _sync;
+
         internal ResourcePool ResourcePool { get; }
 
         public string GpuVendor { get; private set; }
@@ -39,6 +41,7 @@ namespace Ryujinx.Graphics.OpenGL
             _window = new Window(this);
             _textureCopy = new TextureCopy(this);
             _backgroundTextureCopy = new TextureCopy(this);
+            _sync = new Sync();
             ResourcePool = new ResourcePool();
         }
 
@@ -108,6 +111,7 @@ namespace Ryujinx.Graphics.OpenGL
 
         public void PreFrame()
         {
+            _sync.Cleanup();
             ResourcePool.Tick();
         }
 
@@ -178,6 +182,16 @@ namespace Ryujinx.Graphics.OpenGL
             program.Dispose();
 
             return null;
+        }
+
+        public void CreateSync(ulong id)
+        {
+            _sync.Create(id);
+        }
+
+        public void WaitSync(ulong id)
+        {
+            _sync.Wait(id);
         }
     }
 }

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -168,6 +168,7 @@ namespace Ryujinx.Graphics.OpenGL
             _pipeline.Dispose();
             _window.Dispose();
             _counters.Dispose();
+            _sync.Dispose();
         }
 
         public IProgram LoadProgramBinary(byte[] programBinary)

--- a/Ryujinx.Graphics.OpenGL/Sync.cs
+++ b/Ryujinx.Graphics.OpenGL/Sync.cs
@@ -1,4 +1,5 @@
 ﻿using OpenTK.Graphics.OpenGL;
+using Ryujinx.Common.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -61,7 +62,12 @@ namespace Ryujinx.Graphics.OpenGL
                         return;
                     }
 
-                    WaitSyncStatus syncResult = GL.ClientWaitSync(result.Handle, ClientWaitSyncFlags.SyncFlushCommandsBit, 1000);
+                    WaitSyncStatus syncResult = GL.ClientWaitSync(result.Handle, ClientWaitSyncFlags.SyncFlushCommandsBit, 1000000000);
+                    
+                    if (syncResult == WaitSyncStatus.TimeoutExpired)
+                    {
+                        Logger.Error?.PrintMsg(LogClass.Gpu, $"GL Sync Object {result.ID} failed to signal within 1000ms. Continuing...");
+                    }
                 }
             }
         }

--- a/Ryujinx.Graphics.OpenGL/Sync.cs
+++ b/Ryujinx.Graphics.OpenGL/Sync.cs
@@ -91,12 +91,15 @@ namespace Ryujinx.Graphics.OpenGL
                 if (syncResult == WaitSyncStatus.AlreadySignaled)
                 {
                     // Delete the sync object.
-                    lock (first)
+                    lock (Handles)
                     {
-                        _firstHandle = first.ID + 1;
-                        Handles.RemoveAt(0);
-                        GL.DeleteSync(first.Handle);
-                        first.Handle = IntPtr.Zero;
+                        lock (first)
+                        {
+                            _firstHandle = first.ID + 1;
+                            Handles.RemoveAt(0);
+                            GL.DeleteSync(first.Handle);
+                            first.Handle = IntPtr.Zero;
+                        }
                     }
                 } else
                 {

--- a/Ryujinx.Graphics.OpenGL/Sync.cs
+++ b/Ryujinx.Graphics.OpenGL/Sync.cs
@@ -1,0 +1,103 @@
+﻿using OpenTK.Graphics.OpenGL;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Ryujinx.Graphics.OpenGL
+{
+    class Sync
+    {
+        private class SyncHandle
+        {
+            public ulong ID;
+            public IntPtr Handle;
+        }
+
+        private ulong _firstHandle = 0;
+
+        private List<SyncHandle> Handles = new List<SyncHandle>();
+
+        public void Create(ulong id)
+        {
+            SyncHandle handle = new SyncHandle
+            {
+                ID = id,
+                Handle = GL.FenceSync(SyncCondition.SyncGpuCommandsComplete, WaitSyncFlags.None)
+            };
+
+            lock (Handles)
+            {
+                Handles.Add(handle);
+            }
+        }
+
+        public void Wait(ulong id)
+        {
+            SyncHandle result = null;
+
+            lock (Handles)
+            {
+                if ((long)(_firstHandle - id) > 0)
+                {
+                    return; // The handle has already been signalled or deleted.
+                }
+
+                foreach (SyncHandle handle in Handles)
+                {
+                    if (handle.ID == id)
+                    {
+                        result = handle;
+                        break;
+                    }
+                }
+            }
+
+            if (result != null)
+            {
+                lock (result)
+                {
+                    if (result.Handle == IntPtr.Zero)
+                    {
+                        return;
+                    }
+
+                    WaitSyncStatus syncResult = GL.ClientWaitSync(result.Handle, ClientWaitSyncFlags.SyncFlushCommandsBit, 1000);
+                }
+            }
+        }
+
+        public void Cleanup()
+        {
+            // Iterate through handles and remove any that have already been signalled.
+
+            while (true)
+            {
+                SyncHandle first = null;
+                lock (Handles)
+                {
+                    first = Handles.FirstOrDefault();
+                }
+
+                if (first == null) break;
+
+                WaitSyncStatus syncResult = GL.ClientWaitSync(first.Handle, ClientWaitSyncFlags.SyncFlushCommandsBit, 0);
+
+                if (syncResult == WaitSyncStatus.AlreadySignaled)
+                {
+                    // Delete the sync object.
+                    lock (first)
+                    {
+                        _firstHandle = first.ID + 1;
+                        Handles.RemoveAt(0);
+                        GL.DeleteSync(first.Handle);
+                        first.Handle = IntPtr.Zero;
+                    }
+                } else
+                {
+                    // This sync handle and any following have not been reached yet.
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/Ryujinx.Graphics.OpenGL/Sync.cs
+++ b/Ryujinx.Graphics.OpenGL/Sync.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace Ryujinx.Graphics.OpenGL
 {
-    class Sync
+    class Sync : IDisposable
     {
         private class SyncHandle
         {
@@ -103,6 +103,23 @@ namespace Ryujinx.Graphics.OpenGL
                     // This sync handle and any following have not been reached yet.
                     break;
                 }
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (Handles)
+            {
+                foreach (SyncHandle handle in Handles)
+                {
+                    lock (handle)
+                    {
+                        GL.DeleteSync(handle.Handle);
+                        handle.Handle = IntPtr.Zero;
+                    }
+                }
+
+                Handles.Clear();
             }
         }
     }

--- a/Ryujinx.Graphics.Shader/BufferDescriptor.cs
+++ b/Ryujinx.Graphics.Shader/BufferDescriptor.cs
@@ -4,11 +4,21 @@ namespace Ryujinx.Graphics.Shader
     {
         public readonly int Binding;
         public readonly int Slot;
+        public BufferUsageFlags Flags;
 
         public BufferDescriptor(int binding, int slot)
         {
             Binding = binding;
             Slot = slot;
+
+            Flags = BufferUsageFlags.None;
+        }
+
+        public BufferDescriptor SetFlag(BufferUsageFlags flag)
+        {
+            Flags |= flag;
+
+            return this;
         }
     }
 }

--- a/Ryujinx.Graphics.Shader/BufferUsageFlags.cs
+++ b/Ryujinx.Graphics.Shader/BufferUsageFlags.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Ryujinx.Graphics.Shader
+{
+    /// <summary>
+    /// Flags that indicate how a buffer will be used in a shader.
+    /// </summary>
+    [Flags]
+    public enum BufferUsageFlags
+    {
+        None = 0,
+
+        // Buffer is written to.
+        Write = 1 << 0
+    }
+}

--- a/Ryujinx.Graphics.Shader/BufferUsageFlags.cs
+++ b/Ryujinx.Graphics.Shader/BufferUsageFlags.cs
@@ -10,7 +10,9 @@ namespace Ryujinx.Graphics.Shader
     {
         None = 0,
 
-        // Buffer is written to.
+        /// <summary>
+        /// Buffer is written to.
+        /// </summary>
         Write = 1 << 0
     }
 }

--- a/Ryujinx.Memory.Tests/MockVirtualMemoryManager.cs
+++ b/Ryujinx.Memory.Tests/MockVirtualMemoryManager.cs
@@ -6,6 +6,8 @@ namespace Ryujinx.Memory.Tests
     {
         public bool NoMappings;
 
+        public event Action<ulong, ulong, MemoryPermission> OnProtect;
+
         public MockVirtualMemoryManager(ulong size, int pageSize)
         {
         }
@@ -82,6 +84,7 @@ namespace Ryujinx.Memory.Tests
 
         public void TrackingReprotect(ulong va, ulong size, MemoryPermission protection)
         {
+            OnProtect?.Invoke(va, size, protection);
         }
     }
 }

--- a/Ryujinx.Memory/Range/RangeList.cs
+++ b/Ryujinx.Memory/Range/RangeList.cs
@@ -12,7 +12,7 @@ namespace Ryujinx.Memory.Range
     {
         private const int ArrayGrowthSize = 32;
 
-        private readonly List<T> _items;
+        protected readonly List<T> _items;
 
         public int Count => _items.Count;
 

--- a/Ryujinx.Memory/Range/RangeList.cs
+++ b/Ryujinx.Memory/Range/RangeList.cs
@@ -12,16 +12,16 @@ namespace Ryujinx.Memory.Range
     {
         private const int ArrayGrowthSize = 32;
 
-        protected readonly List<T> _items;
+        protected readonly List<T> Items;
 
-        public int Count => _items.Count;
+        public int Count => Items.Count;
 
         /// <summary>
         /// Creates a new range list.
         /// </summary>
         public RangeList()
         {
-            _items = new List<T>();
+            Items = new List<T>();
         }
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace Ryujinx.Memory.Range
                 index = ~index;
             }
 
-            _items.Insert(index, item);
+            Items.Insert(index, item);
         }
 
         /// <summary>
@@ -51,21 +51,21 @@ namespace Ryujinx.Memory.Range
 
             if (index >= 0)
             {
-                while (index > 0 && _items[index - 1].Address == item.Address)
+                while (index > 0 && Items[index - 1].Address == item.Address)
                 {
                     index--;
                 }
 
-                while (index < _items.Count)
+                while (index < Items.Count)
                 {
-                    if (_items[index].Equals(item))
+                    if (Items[index].Equals(item))
                     {
-                        _items.RemoveAt(index);
+                        Items.RemoveAt(index);
 
                         return true;
                     }
 
-                    if (_items[index].Address > item.Address)
+                    if (Items[index].Address > item.Address)
                     {
                         break;
                     }
@@ -110,7 +110,7 @@ namespace Ryujinx.Memory.Range
                 return default(T);
             }
 
-            return _items[index];
+            return Items[index];
         }
 
         /// <summary>
@@ -137,7 +137,7 @@ namespace Ryujinx.Memory.Range
 
             ulong endAddress = address + size;
 
-            foreach (T item in _items)
+            foreach (T item in Items)
             {
                 if (item.Address >= endAddress)
                 {
@@ -196,7 +196,7 @@ namespace Ryujinx.Memory.Range
 
             if (index >= 0)
             {
-                while (index > 0 && _items[index - 1].OverlapsWith(address, size))
+                while (index > 0 && Items[index - 1].OverlapsWith(address, size))
                 {
                     index--;
                 }
@@ -208,9 +208,9 @@ namespace Ryujinx.Memory.Range
                         Array.Resize(ref output, outputIndex + ArrayGrowthSize);
                     }
 
-                    output[outputIndex++] = _items[index++];
+                    output[outputIndex++] = Items[index++];
                 }
-                while (index < _items.Count && _items[index].OverlapsWith(address, size));
+                while (index < Items.Count && Items[index].OverlapsWith(address, size));
             }
 
             return outputIndex;
@@ -230,14 +230,14 @@ namespace Ryujinx.Memory.Range
 
             if (index >= 0)
             {
-                while (index > 0 && _items[index - 1].Address == address)
+                while (index > 0 && Items[index - 1].Address == address)
                 {
                     index--;
                 }
 
-                while (index < _items.Count)
+                while (index < Items.Count)
                 {
-                    T overlap = _items[index++];
+                    T overlap = Items[index++];
 
                     if (overlap.Address != address)
                     {
@@ -264,7 +264,7 @@ namespace Ryujinx.Memory.Range
         private int BinarySearch(ulong address)
         {
             int left  = 0;
-            int right = _items.Count - 1;
+            int right = Items.Count - 1;
 
             while (left <= right)
             {
@@ -272,7 +272,7 @@ namespace Ryujinx.Memory.Range
 
                 int middle = left + (range >> 1);
 
-                T item = _items[middle];
+                T item = Items[middle];
 
                 if (item.Address == address)
                 {
@@ -301,7 +301,7 @@ namespace Ryujinx.Memory.Range
         private int BinarySearch(ulong address, ulong size)
         {
             int left  = 0;
-            int right = _items.Count - 1;
+            int right = Items.Count - 1;
 
             while (left <= right)
             {
@@ -309,7 +309,7 @@ namespace Ryujinx.Memory.Range
 
                 int middle = left + (range >> 1);
 
-                T item = _items[middle];
+                T item = Items[middle];
 
                 if (item.OverlapsWith(address, size))
                 {
@@ -331,12 +331,12 @@ namespace Ryujinx.Memory.Range
 
         public IEnumerator<T> GetEnumerator()
         {
-            return _items.GetEnumerator();
+            return Items.GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return _items.GetEnumerator();
+            return Items.GetEnumerator();
         }
     }
 }

--- a/Ryujinx.Memory/Tracking/MultiRegionHandle.cs
+++ b/Ryujinx.Memory/Tracking/MultiRegionHandle.cs
@@ -123,6 +123,17 @@ namespace Ryujinx.Memory.Tracking
             }
         }
 
+        public void RegisterAction(ulong address, ulong size, RegionSignal action)
+        {
+            int startHandle = (int)((address - Address) / Granularity);
+            int lastHandle = (int)((address + (size - 1) - Address) / Granularity);
+
+            for (int i = startHandle; i <= lastHandle; i++)
+            {
+                _handles[i].RegisterAction(action);
+            }
+        }
+
         public void Dispose()
         {
             foreach (var handle in _handles)

--- a/Ryujinx.Memory/Tracking/RegionHandle.cs
+++ b/Ryujinx.Memory/Tracking/RegionHandle.cs
@@ -24,6 +24,7 @@ namespace Ryujinx.Memory.Tracking
         private readonly MemoryTracking _tracking;
 
         internal MemoryPermission RequiredPermission => _preAction != null ? MemoryPermission.None : (Dirty ? MemoryPermission.ReadAndWrite : MemoryPermission.Read);
+        internal RegionSignal PreAction => _preAction;
 
         /// <summary>
         /// Create a new region handle. The handle is registered with the given tracking object,

--- a/Ryujinx.Memory/Tracking/VirtualRegion.cs
+++ b/Ryujinx.Memory/Tracking/VirtualRegion.cs
@@ -22,12 +22,12 @@ namespace Ryujinx.Memory.Tracking
 
         public override void Signal(ulong address, ulong size, bool write)
         {
-            _tracking.ProtectVirtualRegion(this, MemoryPermission.ReadAndWrite); // Remove our protection immedately.
-
             foreach (var handle in Handles)
             {
                 handle.Signal(address, size, write);
             }
+
+            UpdateProtection();
         }
 
         /// <summary>


### PR DESCRIPTION
This PR makes it possible for SSBO writes to be read from CPU, and ensures they are not accidentally overwritten. The performance impact should be minimal due to the approach, but more extreme cases could have an impact.

The primary goal is fixing restarting particles that appear in many Nintendo games, caused by CPU writes to the same page that an SSBO write happens to (which causes the whole page to be read in, and replace the SSBO written data with its initial value). I was also hoping it might fix some vertex explosions. Flushing data to be read by CPU is hilariously just a second goal, but it works now too.

Simply adding read/write protection to a region of a buffer every time there is a modification would be a recipe for disaster - a tracked write could happen to the same page of the data immediately after it is written, which would require us to wait on a draw that just happened. This could happen multiple times in a row, which could reduce framerate dramatically. Ideally, we only want to flush the data when the guest _expects_ it to be there and is actually reading/overwriting, rather than whenever it is writing to the same page for an unrelated draw.

So, instead I took an approach that takes advantage of guest syncpoints. The assumption is that data written from a shader will _never_ be tampered with by the guest before the GPU tells it that the command has executed, so during this time it should never be read/overwritten. This way, our syncpoints are finally actually waiting on the GPU (hooray), but only for flushing buffers right now. This functionality can be extended to ensure better sync for other things.

Essentially, the order of operations is:
- Shader or Copy sets a region of the buffer as modified.
- The region is added to the modified range list, with the current "SyncNumber" stored with the region.
  - If the region already exists, its SyncNumber will be updated.
  - When a region slices into another, it will split the existing region into multiple parts.
  - A "SyncAction" is registered, which will add the flush action for this buffer when the next syncpoint is reached.
- When a buffer has queried as modified, any existing modified ranges are excluded from the data load.
  - It is not possible to overwrite GPU modified data until the GPU increments a syncpoint.
- When the GPU increments a syncpoint, it is telling the CPU that the data in the buffers is ready to either be read or replaced.
  - A GL sync object is created. This is waited on before flushing data, to ensure that it is up to date before the flush.
  - All modified ranges will add a read action to their pages that attempts to flush the buffer data, and remove the modified range.
- When the CPU reads/writes to a page containing one of the ranges, it will find all ranges that have sync objects (not == current SyncNumber), and wait on them. Then, it will flush all of their data to memory.
  - When data is flushed, the range is removed from the modified range list. This allows a following write from CPU to overwrite the data (and avoids flushing it again)

In the background, we are lazily deleting sync objects as they are reached in `PreFrame`. Deleting sync objects mid draw is costly, especially if they have not been reached yet, so this is crucial for performance.

## Other Changes
- Buffer copies now set buffer regions as modified and flush lazily. Unity games do this a lot, and so does Pokemon.
- Order of operations when expanding buffers has been changed for more robustness.
- Fixed a bug with Memory Tracking where write tracking (dirty flags) could be lost after read tracking (flush) was triggered.
- GPU MemoryManager reads can now trigger memory tracking (shader data).

## Examples

_**Mario Kart 8**_
**(before):**
- Explosion & snow particles: https://gyazo.com/6a02ef6468ff1208a8120e1823a5a498
- Drift particles: https://gyazo.com/69c80073f6949ab6187f05fc631a0129

**(after):**
- Explosion & snow particles: https://gyazo.com/18e77b5be3ce0f22c65f23ab43e96880
- Drift particles: https://gyazo.com/bc454bdeca06939f7f2886c1fe39e258

_**Super Mario Odyssey**_
**(before):**
- Birds: https://gyazo.com/a610cf477f6897c20adff54634e6540b
- Flagpole: https://gyazo.com/e0c845e8373ca7a7d6300201075e72ef

**(after)**
- Birds: https://gyazo.com/c0eb8fa3953bb8147e65e12b90a7471a
- Flagpole: https://gyazo.com/638476d00221e719552fa6fcaf3e1131

**Link's Awakening Flashing (before):** https://gyazo.com/7c10a670ab62ba9eaed137564c3f246c
**(after):** https://gyazo.com/b4113dab7728ce7076f6141bbacf2b44

**Also fixed:**
- Animal Crossing particles no longer reset.
- Any other nintendo game with resetting particles.
- Vertex explosions in any Unity games that had them.
- A bug was fixed where modified textures could flush over buffer or other texture data and cause corruption/crashes (Mario Kart mostly)
- Hyrule Warriors vertex explosions are somewhat reduced (but still occur rarely)
- Any game that expects buffer data to be available to the CPU will now do better at that. I have no idea what games that could mean.

## Special Section for Ruining your Hopes and Dreams
### Super Smash Bros Ultimate is not affected
### Despite fixing flashing in Link's Awakening, Bow-Wow and friends are still just a polygonal mess.

## Future
- Two resources with tracked regions cannot interact. Ideally, adding a read action would immediately set any handles on the same page as dirty, therefore allowing for buffer to texture flushes. This is not yet possible, but it wasn't possible before anyways.
- We can potentially flush textures directly to buffers now, for MethodCopyBuffer, and have the data readable from CPU. I'm specifically thinking of pokemon here. To do this, the above bullet needs to be completed.