### PR TITLE
Remove interrupt counting and interrupt CPU immediately

### DIFF
--- a/ARMeilleure/State/ExecutionContext.cs
+++ b/ARMeilleure/State/ExecutionContext.cs
@@ -6,13 +6,9 @@ namespace ARMeilleure.State
 {
     public class ExecutionContext
     {
-        private const int MinCountForCheck = 4000;
-
         private NativeContext _nativeContext;
 
         internal IntPtr NativeContextPtr => _nativeContext.BasePtr;
-
-        private bool _interrupted;
 
         private static Stopwatch _tickCounter;
 
@@ -87,8 +83,7 @@ namespace ARMeilleure.State
             _nativeContext = new NativeContext(allocator);
 
             Running = true;
-
-            _nativeContext.SetCounter(MinCountForCheck);
+            _nativeContext.SetInterruptState(0);
         }
 
         public ulong GetX(int index)              => _nativeContext.GetX(index);
@@ -105,19 +100,13 @@ namespace ARMeilleure.State
 
         internal void CheckInterrupt()
         {
-            if (_interrupted)
-            {
-                _interrupted = false;
-
-                Interrupt?.Invoke(this, EventArgs.Empty);
-            }
-
-            _nativeContext.SetCounter(MinCountForCheck);
+            _nativeContext.SetInterruptState(0);
+            Interrupt?.Invoke(this, EventArgs.Empty);
         }
 
         public void RequestInterrupt()
         {
-            _interrupted = true;
+            _nativeContext.SetInterruptState(1);
         }
 
         internal void OnBreak(ulong address, int imm)
@@ -138,7 +127,7 @@ namespace ARMeilleure.State
         public void StopRunning()
         {
             Running = false;
-            _nativeContext.SetCounter(0);
+            _nativeContext.SetInterruptState(1);
         }
 
         public void Dispose()

--- a/ARMeilleure/State/NativeContext.cs
+++ b/ARMeilleure/State/NativeContext.cs
@@ -13,7 +13,7 @@ namespace ARMeilleure.State
             public fixed ulong V[RegisterConsts.VecRegsCount * 2];
             public fixed uint Flags[RegisterConsts.FlagsCount];
             public fixed uint FpFlags[RegisterConsts.FpFlagsCount];
-            public int Counter;
+            public int InterruptState;
             public ulong CallAddress;
             public ulong ExclusiveAddress;
             public ulong ExclusiveValueLow;
@@ -114,8 +114,8 @@ namespace ARMeilleure.State
             GetStorage().FpFlags[(int)flag] = value ? 1u : 0u;
         }
 
-        public int GetCounter() => GetStorage().Counter;
-        public void SetCounter(int value) => GetStorage().Counter = value;
+        public int GetInterruptState() => GetStorage().InterruptState;
+        public void SetInterruptState(int value) => GetStorage().InterruptState = value;
 
         public unsafe static int GetRegisterOffset(Register reg)
         {
@@ -157,9 +157,9 @@ namespace ARMeilleure.State
             }
         }
 
-        public static int GetCounterOffset()
+        public static int GetInterruptStateOffset()
         {
-            return StorageOffset(ref _dummyStorage, ref _dummyStorage.Counter);
+            return StorageOffset(ref _dummyStorage, ref _dummyStorage.InterruptState);
         }
 
         public static int GetCallAddressOffset()

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -21,7 +21,7 @@ namespace ARMeilleure.Translation.PTC
     {
         private const string HeaderMagic = "PTChd";
 
-        private const int InternalVersion = 1783; //! To be incremented manually for each change to the ARMeilleure project.
+        private const int InternalVersion = 123; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";

--- a/ARMeilleure/Translation/Translator.cs
+++ b/ARMeilleure/Translation/Translator.cs
@@ -297,29 +297,18 @@ namespace ARMeilleure.Translation
 
         internal static void EmitSynchronization(EmitterContext context)
         {
-            long countOffs = NativeContext.GetCounterOffset();
+            long interruptedOffs = NativeContext.GetInterruptStateOffset();
 
-            Operand countAddr = context.Add(context.LoadArgument(OperandType.I64, 0), Const(countOffs));
+            Operand interruptedAddr = context.Add(context.LoadArgument(OperandType.I64, 0), Const(interruptedOffs));
+            Operand interrupted = context.Load(OperandType.I32, interruptedAddr);
+            Operand lblExit = Label();
 
-            Operand count = context.Load(OperandType.I32, countAddr);
-
-            Operand lblNonZero = Label();
-            Operand lblExit    = Label();
-
-            context.BranchIfTrue(lblNonZero, count, BasicBlockFrequency.Cold);
+            context.BranchIfFalse(lblExit, interrupted, BasicBlockFrequency.Cold);
 
             Operand running = context.Call(typeof(NativeInterface).GetMethod(nameof(NativeInterface.CheckSynchronization)));
 
             context.BranchIfTrue(lblExit, running, BasicBlockFrequency.Cold);
-
             context.Return(Const(0L));
-
-            context.MarkLabel(lblNonZero);
-
-            count = context.Subtract(count, Const(1));
-
-            context.Store(countAddr, count);
-
             context.MarkLabel(lblExit);
         }
     }

--- a/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
@@ -1072,7 +1072,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
         private bool InvalidAccessHandler(ulong va)
         {
-            KernelStatic.GetCurrentThread().PrintGuestStackTrace();
+            KernelStatic.GetCurrentThread()?.PrintGuestStackTrace();
 
             Logger.Error?.Print(LogClass.Cpu, $"Invalid memory access at virtual address 0x{va:X16}.");
 


### PR DESCRIPTION
Currently the CPU has a counter that only checks if a interrupt was requested after N blocks were executed. This was done to prevent slow down in some games (like Sonic Mania) caused by context switch overhead. #1786 improved context switch speed, so I think it's worth revisiting it.

With those changes it simply checks if a interrupt was requested, if so it calls the interrupt handler immediately, without any counting. This can improve performance a little bit for the following reasons:
- Less time waiting to switch threads.
- Less code to check if a interrupt was requested.
- No periodic calls to the `CheckInterrupt` function.

However it can also slow down games doing a *lot* of context switches in rapid succession, so it's worth watching out for that.