### PR TITLE
Fix register read after write on STREX implementation

### DIFF
--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -21,7 +21,7 @@ namespace ARMeilleure.Translation.PTC
     {
         private const string HeaderMagic = "PTChd";
 
-        private const int InternalVersion = 1783; //! To be incremented manually for each change to the ARMeilleure project.
+        private const int InternalVersion = 1801; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";


### PR DESCRIPTION
This fixes a regression introduced on #1413 where the STREX instruction implementation could write the wrong value or write to the wrong address if the register used for Rs (result) was the same register used for either the address or the value. Additionally, this also zeros the upper bits of the exclusive value stored on context, just to be on the safe side, in case there is some application out there mixing LDREX/STREX of different sizes.

This fixes a regression on Sonic Forces, where the game would no longer boot.