### PR TITLE
End empty gl queries before returning them to the pool.

### DIFF
--- a/Ryujinx.Graphics.OpenGL/Queries/BufferedQuery.cs
+++ b/Ryujinx.Graphics.OpenGL/Queries/BufferedQuery.cs
@@ -44,14 +44,17 @@ namespace Ryujinx.Graphics.OpenGL.Queries
             GL.BeginQuery(_type, Query);
         }
 
-        public unsafe void End()
+        public unsafe void End(bool withResult)
         {
             GL.EndQuery(_type);
 
-            GL.BindBuffer(BufferTarget.QueryBuffer, _buffer);
+            if (withResult)
+            {
+                GL.BindBuffer(BufferTarget.QueryBuffer, _buffer);
 
-            Marshal.WriteInt64(_bufferMap, -1L);
-            GL.GetQueryObject(Query, GetQueryObjectParam.QueryResult, (long*)0);
+                Marshal.WriteInt64(_bufferMap, -1L);
+                GL.GetQueryObject(Query, GetQueryObjectParam.QueryResult, (long*)0);
+            }
         }
 
         public bool TryGetResult(out long result)

--- a/Ryujinx.Graphics.OpenGL/Queries/CounterQueue.cs
+++ b/Ryujinx.Graphics.OpenGL/Queries/CounterQueue.cs
@@ -107,13 +107,14 @@ namespace Ryujinx.Graphics.OpenGL.Queries
 
                 if (draws > 0)
                 {
-                    _current.Complete();
+                    _current.Complete(true);
                     _events.Enqueue(_current);
 
                     _current.OnResult += resultHandler;
                 }
                 else
                 {
+                    _current.Complete(false);
                     _current.Dispose();
                     resultHandler(_current, 0);
                 }

--- a/Ryujinx.Graphics.OpenGL/Queries/CounterQueueEvent.cs
+++ b/Ryujinx.Graphics.OpenGL/Queries/CounterQueueEvent.cs
@@ -41,9 +41,9 @@ namespace Ryujinx.Graphics.OpenGL.Queries
             ClearCounter = true;
         }
 
-        internal void Complete()
+        internal void Complete(bool withResult)
         {
-            _counter.End();
+            _counter.End(withResult);
         }
 
         internal bool TryConsume(ref ulong result, bool block, AutoResetEvent wakeSignal = null)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6294155/101943240-aa418380-3be2-11eb-9340-2f7c9f4c31b9.png)

Fixes an issue where GL queries could end up never returning a value after a previous 0-draw query (Luigi's Mansion 3). Ending the empty query before returning it to the pool seems to fix the issue.