### PR TITLE
Rewrite size for fixed size buffers

### DIFF
--- a/Ryujinx.Cpu/MemoryHelper.cs
+++ b/Ryujinx.Cpu/MemoryHelper.cs
@@ -37,7 +37,7 @@ namespace Ryujinx.Cpu
             }
         }
 
-        public unsafe static void Write<T>(IVirtualMemoryManager memory, long position, T value) where T : struct
+        public unsafe static long Write<T>(IVirtualMemoryManager memory, long position, T value) where T : struct
         {
             long size = Marshal.SizeOf<T>();
 
@@ -49,6 +49,8 @@ namespace Ryujinx.Cpu
             }
 
             memory.Write((ulong)position, data);
+
+            return size;
         }
 
         public static string ReadAsciiString(IVirtualMemoryManager memory, long position, long maxSize = -1)

--- a/Ryujinx.HLE/HOS/Ipc/IpcPtrBuffDesc.cs
+++ b/Ryujinx.HLE/HOS/Ipc/IpcPtrBuffDesc.cs
@@ -30,6 +30,11 @@ namespace Ryujinx.HLE.HOS.Ipc
             Size = (ushort)(word0 >> 16);
         }
 
+        public IpcPtrBuffDesc WithSize(long size)
+        {
+            return new IpcPtrBuffDesc(Position, Index, size);
+        }
+
         public uint GetWord0()
         {
             uint word0;

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/IManagerForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/IManagerForApplication.cs
@@ -41,7 +41,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
         // GetAccountId() -> nn::account::NetworkServiceAccountId
         public ResultCode GetAccountId(ServiceCtx context)
         {
-            // NOTE: This opens the file at "su/baas/USERID_IN_UUID_STRING.dat" (where USERID_IN_UUID_STRING is formatted 
+            // NOTE: This opens the file at "su/baas/USERID_IN_UUID_STRING.dat" (where USERID_IN_UUID_STRING is formatted
             //       as "%08x-%04x-%04x-%02x%02x-%08x%04x") in the account:/ savedata.
             //       Then it searches the NetworkServiceAccountId related to the UserId in this file and returns it.
 
@@ -121,6 +121,8 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             Logger.Stub?.PrintStub(LogClass.ServiceAcc, new { NetworkServiceAccountId });
 
             context.ResponseData.Write(NetworkServiceAccountId);
+
+            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize(0L);
 
             // TODO: determine and fill the two output IPC buffers.
 

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/IProfile.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/IProfile.cs
@@ -24,6 +24,8 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
         {
             Logger.Stub?.PrintStub(LogClass.ServiceAcc);
 
+            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize(0x80L);
+
             long position = context.Request.ReceiveBuff[0].Position;
 
             MemoryHelper.FillWithZeros(context.Memory, position, 0x80);

--- a/Ryujinx.HLE/HOS/Services/Bcat/ServiceCreator/IDeliveryCacheProgressService.cs
+++ b/Ryujinx.HLE/HOS/Services/Bcat/ServiceCreator/IDeliveryCacheProgressService.cs
@@ -1,5 +1,6 @@
 ﻿using Ryujinx.Common;
 using Ryujinx.Common.Logging;
+using Ryujinx.Cpu;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Kernel.Common;
 using Ryujinx.HLE.HOS.Kernel.Threading;
@@ -48,21 +49,17 @@ namespace Ryujinx.HLE.HOS.Services.Bcat.ServiceCreator
                 Result = 0
             };
 
-            WriteDeliveryCacheProgressImpl(context, context.Request.RecvListBuff[0], deliveryCacheProgress);
+            long dcpSize = WriteDeliveryCacheProgressImpl(context, context.Request.RecvListBuff[0], deliveryCacheProgress);
+            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize(dcpSize);
 
             Logger.Stub?.PrintStub(LogClass.ServiceBcat);
 
             return ResultCode.Success;
         }
 
-        private void WriteDeliveryCacheProgressImpl(ServiceCtx context, IpcRecvListBuffDesc ipcDesc, DeliveryCacheProgressImpl deliveryCacheProgress)
+        private long WriteDeliveryCacheProgressImpl(ServiceCtx context, IpcRecvListBuffDesc ipcDesc, DeliveryCacheProgressImpl deliveryCacheProgress)
         {
-            using (MemoryStream memory = new MemoryStream((int)ipcDesc.Size))
-            using (BinaryWriter bufferWriter = new BinaryWriter(memory))
-            {
-                bufferWriter.WriteStruct(deliveryCacheProgress);
-                context.Memory.Write((ulong)ipcDesc.Position, memory.ToArray());
-            }
+            return MemoryHelper.Write(context.Memory, ipcDesc.Position, deliveryCacheProgress);
         }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Friend/ServiceCreator/IFriendService.cs
+++ b/Ryujinx.HLE/HOS/Services/Friend/ServiceCreator/IFriendService.cs
@@ -221,6 +221,8 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
             bool   unknownBool = context.RequestData.ReadBoolean();
             UserId userId      = context.RequestData.ReadStruct<UserId>();
 
+            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize(0x40L);
+
             long bufferPosition  = context.Request.RecvListBuff[0].Position;
 
             if (userId.IsNull)


### PR DESCRIPTION
#1458 added more accurate IPC handling. After the changes, services no longer have access to the size of fixed size buffers (thats how its done on hardware, they don't need to know the size since the size is fixed). Services were not prepared to handle that, and we were reading them from the client buffer descriptor. So, after the IPC changes the functions using fixed-size output buffers could return data that is too large (that would result in a error being returned by the kernel as copy would fail), or too small (which would cause data to be missing).

This updates the affected function to write the correct sizes on the pointer buffer descriptors.