### PR TITLE
Terminate application before services

### DIFF
--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -32,6 +32,7 @@ using Ryujinx.HLE.Loaders.Executables;
 using Ryujinx.HLE.Utilities;
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading;
 
 namespace Ryujinx.HLE.HOS
@@ -310,8 +311,6 @@ namespace Ryujinx.HLE.HOS
 
                 _isDisposed = true;
 
-                SurfaceFlinger.Dispose();
-
                 KProcess terminationProcess = new KProcess(KernelContext);
                 KThread terminationThread = new KThread(KernelContext);
 
@@ -320,7 +319,18 @@ namespace Ryujinx.HLE.HOS
                     // Force all threads to exit.
                     lock (KernelContext.Processes)
                     {
-                        foreach (KProcess process in KernelContext.Processes.Values)
+                        // Terminate application.
+                        foreach (KProcess process in KernelContext.Processes.Values.Where(x => x.TitleId != 0))
+                        {
+                            process.Terminate();
+                        }
+
+                        // The application existed, now surface flinger can exit too.
+                        SurfaceFlinger.Dispose();
+
+                        // Terminate HLE services (must be done after the application is already terminated,
+                        // otherwise the application will receive errors due to service termination.
+                        foreach (KProcess process in KernelContext.Processes.Values.Where(x => x.TitleId == 0))
                         {
                             process.Terminate();
                         }

--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -320,7 +320,7 @@ namespace Ryujinx.HLE.HOS
                     lock (KernelContext.Processes)
                     {
                         // Terminate application.
-                        foreach (KProcess process in KernelContext.Processes.Values.Where(x => x.TitleId != 0))
+                        foreach (KProcess process in KernelContext.Processes.Values.Where(x => x.Flags.HasFlag(ProcessCreationFlags.IsApplication)))
                         {
                             process.Terminate();
                         }
@@ -330,7 +330,7 @@ namespace Ryujinx.HLE.HOS
 
                         // Terminate HLE services (must be done after the application is already terminated,
                         // otherwise the application will receive errors due to service termination.
-                        foreach (KProcess process in KernelContext.Processes.Values.Where(x => x.TitleId == 0))
+                        foreach (KProcess process in KernelContext.Processes.Values.Where(x => !x.Flags.HasFlag(ProcessCreationFlags.IsApplication)))
                         {
                             process.Terminate();
                         }


### PR DESCRIPTION
This changes the process termination order to terminate the application before services, this way the application doesn't receive errors due to services exiting. This fixes some crashes on exit caused by games asserting or faulting due to service errors.