### PR TITLE
Update InvalidMemoryRegionException.cs to abide by English rules.

### DIFF
--- a/Ryujinx.Memory/InvalidMemoryRegionException.cs
+++ b/Ryujinx.Memory/InvalidMemoryRegionException.cs
@@ -4,7 +4,7 @@ namespace Ryujinx.Memory
 {
     public class InvalidMemoryRegionException : Exception
     {
-        public InvalidMemoryRegionException() : base("Attempted to access a invalid memory region.")
+        public InvalidMemoryRegionException() : base("Attempted to access an invalid memory region.")
         {
         }
 


### PR DESCRIPTION
Changes "a" to "an" since the next word begins with a vowel.