### PR TITLE
Fix button press issue

### DIFF
--- a/Ryujinx/Updater/UpdateDialog.cs
+++ b/Ryujinx/Updater/UpdateDialog.cs
@@ -36,8 +36,8 @@ namespace Ryujinx.Ui
 
             ProgressBar.Hide();
 
-            YesButton.Pressed += YesButton_Pressed;
-            NoButton.Pressed  += NoButton_Pressed;
+            YesButton.Clicked += YesButton_Pressed;
+            NoButton.Clicked  += NoButton_Pressed;
         }
         
         private void YesButton_Pressed(object sender, EventArgs args)


### PR DESCRIPTION
A small code change to fix the issue that was forcing the user to press the "Yes" button twice to restart Ryujinx after it had been updated, instead of only once.
Fixes recently opened issue #1800 