### PR TITLE
audio: Fix wrong buffer size check

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/AudioDeviceServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/AudioDeviceServer.cs
@@ -28,15 +28,13 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             long position = context.Request.ReceiveBuff[0].Position;
             long size = context.Request.ReceiveBuff[0].Size;
 
-            long basePosition = position;
-
             int count = 0;
 
             foreach (string name in deviceNames)
             {
                 byte[] buffer = Encoding.ASCII.GetBytes(name);
 
-                if ((position - basePosition) + buffer.Length > size)
+                if (count + 1 * AudioDeviceNameSize > size)
                 {
                     Logger.Error?.Print(LogClass.ServiceAudio, $"Output buffer size {size} too small!");
 
@@ -148,15 +146,13 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
 
             (long position, long size) = context.Request.GetBufferType0x22();
 
-            long basePosition = position;
-
             int count = 0;
 
             foreach (string name in deviceNames)
             {
                 byte[] buffer = Encoding.ASCII.GetBytes(name);
 
-                if ((position - basePosition) + buffer.Length > size)
+                if (count + 1 * AudioDeviceNameSize > size)
                 {
                     Logger.Error?.Print(LogClass.ServiceAudio, $"Output buffer size {size} too small!");
 


### PR DESCRIPTION
This PR fix a wrong buffer size check in `ListAudioDeviceName` and `ListAudioDeviceNameAuto`.
Now the error isn't reached anymore and the device name is written in the buffer.