### PR TITLE
surfaceflinger: Fix fences callback registering issue

### DIFF
--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
@@ -345,14 +345,22 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
             TextureCallbackInformation textureCallbackInformation = new TextureCallbackInformation
             {
                 Layer = layer,
-                Item  = item,
+                Item  = item
             };
 
-            item.Fence.RegisterCallback(_device.Gpu, () => 
+            if (item.Fence.FenceCount == 0)
             {
                 _device.Gpu.Window.SignalFrameReady();
                 _device.Gpu.GPFifo.Interrupt();
-            });
+            }
+            else
+            {
+                item.Fence.RegisterCallback(_device.Gpu, () =>
+                {
+                    _device.Gpu.Window.SignalFrameReady();
+                    _device.Gpu.GPFifo.Interrupt();
+                });
+            }
 
             _device.Gpu.Window.EnqueueFrameThreadSafe(
                 frameBufferAddress,


### PR DESCRIPTION
This PR fixes a regression introduced in #1741. The actual implementation do the assumption of fences always exists and then it register the callback.
Homebrews may not use fences, so the code crashes when it try to register the callback.

![image](https://user-images.githubusercontent.com/4905390/103184550-ffef7e80-48b8-11eb-8a81-5c8fde64bf7c.png)
