### PR TITLE
Enable Profiled Persistent Translation Cache (PPTC) by default

### DIFF
--- a/Ryujinx.Common/Configuration/ConfigurationState.cs
+++ b/Ryujinx.Common/Configuration/ConfigurationState.cs
@@ -477,7 +477,7 @@ namespace Ryujinx.Configuration
             CheckUpdatesOnStart.Value              = true;
             Graphics.EnableVsync.Value             = true;
             Graphics.EnableShaderCache.Value       = true;
-            System.EnablePtc.Value                 = false;
+            System.EnablePtc.Value                 = true;
             System.EnableFsIntegrityChecks.Value   = true;
             System.FsGlobalAccessLogMode.Value     = 0;
             System.AudioBackend.Value              = AudioBackend.OpenAl;
@@ -683,7 +683,7 @@ namespace Ryujinx.Configuration
             {
                 Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 8.");
 
-                configurationFileFormat.EnablePtc = false;
+                configurationFileFormat.EnablePtc = true;
 
                 configurationFileUpdated = true;
             }

--- a/Ryujinx/Config.json
+++ b/Ryujinx/Config.json
@@ -23,7 +23,7 @@
   "check_updates_on_start": true,
   "enable_vsync": true,
   "enable_shader_cache": true,
-  "enable_ptc": false,
+  "enable_ptc": true,
   "enable_fs_integrity_checks": true,
   "fs_global_access_log_mode": 0,
   "audio_backend": "OpenAl",

--- a/Ryujinx/_schema.json
+++ b/Ryujinx/_schema.json
@@ -1215,7 +1215,7 @@
       "type": "boolean",
       "title": "Enable Profiled Persistent Translation Cache",
       "description": "Enables or disables profiled translation cache persistency",
-      "default": false,
+      "default": true,
       "examples": [
         true,
         false


### PR DESCRIPTION
Enables PPTC by default. Enough time has passed and enough games tested that it should be the preferred setting for 99.9% of games. In case we are worried about PPTC files being put on the user's disk, shader cache already does this by default and generates about the same size files on average, so this should no longer be a concern.