### PR TITLE
Extend info printed when guest crashes/breaks execution

### DIFF
--- a/Ryujinx.HLE/HOS/Kernel/Process/HleProcessDebugger.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/HleProcessDebugger.cs
@@ -27,7 +27,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
             public Image(ulong baseAddress, ulong size, ElfSymbol[] symbols)
             {
                 BaseAddress = baseAddress;
-                Size = size;
+                Size        = size;
                 Symbols     = symbols;
             }
         }
@@ -58,7 +58,8 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
                 if(AnalyzePointer(out PointerInfo info, address, thread))
                 {
                     trace.AppendLine($"   {address:x16}\t{info.ImageDisplay}\t{info.SubDisplay}");
-                } else
+                }
+                else
                 {
                     trace.AppendLine($"   {address:x16}");
                 }
@@ -116,13 +117,19 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
             {
                 var v = x == 32 ? (ulong)thread.LastPc : context.GetX(x);
                 if (!AnalyzePointer(out PointerInfo info, v, thread))
+                {
                     return $"{v:x16}";
+                }
                 else
                 {
                     if (!string.IsNullOrEmpty(info.ImageName))
+                    {
                         return $"{v:x16} ({info.ImageDisplay})\t=> {info.SubDisplay}";
+                    }
                     else
+                    {
                         return $"{v:x16} ({info.SpDisplay})";
+                    }
                 }
             }
 
@@ -203,9 +210,15 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
         private bool AnalyzePointer(out PointerInfo info, ulong address, KThread thread)
         {
             if (AnalyzePointerFromImages(out info, address))
+            {
                 return true;
+            }
+
             if (AnalyzePointerFromStack(out info, address, thread))
+            {
                 return true;
+            }
+
             return false;
         }
 
@@ -252,6 +265,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
             ulong sp = thread.Context.GetX(31);
             var meminfo = _owner.MemoryManager.QueryMemory(address);
             uint type = (uint)meminfo.State;
+
             type &= 0xff; // take lower 8 bits
 
             if(type != 0x0B) // is this pointer within the stack?

--- a/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
@@ -1082,6 +1082,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
         private void UndefinedInstructionHandler(object sender, InstUndefinedEventArgs e)
         {
             KernelStatic.GetCurrentThread().PrintGuestStackTrace();
+            KernelStatic.GetCurrentThread().PrintGuestRegisterPrintout();
 
             throw new UndefinedInstructionException(e.Address, e.OpCode);
         }

--- a/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
@@ -1073,6 +1073,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
         private bool InvalidAccessHandler(ulong va)
         {
             KernelStatic.GetCurrentThread()?.PrintGuestStackTrace();
+            KernelStatic.GetCurrentThread()?.PrintGuestRegisterPrintout();
 
             Logger.Error?.Print(LogClass.Cpu, $"Invalid memory access at virtual address 0x{va:X16}.");
 
@@ -1082,7 +1083,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
         private void UndefinedInstructionHandler(object sender, InstUndefinedEventArgs e)
         {
             KernelStatic.GetCurrentThread().PrintGuestStackTrace();
-            KernelStatic.GetCurrentThread().PrintGuestRegisterPrintout();
+            KernelStatic.GetCurrentThread()?.PrintGuestRegisterPrintout();
 
             throw new UndefinedInstructionException(e.Address, e.OpCode);
         }

--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
@@ -1409,6 +1409,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             if ((reason & (1UL << 31)) == 0)
             {
                 currentThread.PrintGuestStackTrace();
+                currentThread.PrintGuestRegisterPrintout();
 
                 // As the process is exiting, this is probably caused by emulation termination.
                 if (currentThread.Owner.State == ProcessState.Exiting)

--- a/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
@@ -991,12 +991,22 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
 
         public string GetGuestStackTrace()
         {
-            return Owner.Debugger.GetGuestStackTrace(Context);
+            return Owner.Debugger.GetGuestStackTrace(this);
+        }
+
+        public string GetGuestRegisterPrintout()
+        {
+            return Owner.Debugger.GetCpuRegisterPrintout(this);
         }
 
         public void PrintGuestStackTrace()
         {
             Logger.Info?.Print(LogClass.Cpu, $"Guest stack trace:\n{GetGuestStackTrace()}\n");
+        }
+
+        public void PrintGuestRegisterPrintout()
+        {
+            Logger.Info?.Print(LogClass.Cpu, $"Guest CPU registers:\n{GetGuestRegisterPrintout()}\n");
         }
 
         public void AddCpuTime(long ticks)


### PR DESCRIPTION
HleProcessDebugger was changed quite a bit to facilitate code reuse between the stack trace and register print code.