### PR TITLE
Prevent Windows Display Sleep

### DIFF
--- a/Ryujinx.Common/System/DisplaySleep.cs
+++ b/Ryujinx.Common/System/DisplaySleep.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Ryujinx.Common.System
+{
+    public class DisplaySleep
+    {
+        [Flags]
+        enum EXECUTION_STATE : uint
+        {
+            ES_CONTINUOUS = 0x80000000,
+            ES_DISPLAY_REQUIRED = 0x00000002,
+            ES_SYSTEM_REQUIRED = 0x00000001
+        }
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        static extern EXECUTION_STATE SetThreadExecutionState(EXECUTION_STATE esFlags);
+
+        static public void Prevent()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                SetThreadExecutionState(EXECUTION_STATE.ES_CONTINUOUS | EXECUTION_STATE.ES_SYSTEM_REQUIRED | EXECUTION_STATE.ES_DISPLAY_REQUIRED);
+            }
+        }
+        
+        static public void Restore()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                SetThreadExecutionState(EXECUTION_STATE.ES_CONTINUOUS);  
+            }
+        }
+    }
+}

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -549,6 +549,8 @@ namespace Ryujinx.Ui
                 _windowsMultimediaTimerResolution = new WindowsMultimediaTimerResolution(1);
             }
 
+            DisplaySleep.Prevent();
+
             GlRendererWidget = new GlRenderer(_emulationContext, ConfigurationState.Instance.Logger.GraphicsDebugLevel);
 
             Application.Invoke(delegate
@@ -600,6 +602,7 @@ namespace Ryujinx.Ui
 
                 _windowsMultimediaTimerResolution?.Dispose();
                 _windowsMultimediaTimerResolution = null;
+                DisplaySleep.Restore();
 
                 _viewBox.Add(_gameTableWindow);
 

--- a/Ryujinx/Ui/Windows/SettingsWindow.glade
+++ b/Ryujinx/Ui/Windows/SettingsWindow.glade
@@ -1283,6 +1283,7 @@
                                       <object class="GtkLabel">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Change System Time</property>
                                         <property name="halign">end</property>
                                         <property name="label" translatable="yes">System Time:</property>
                                       </object>
@@ -1493,7 +1494,7 @@
                                   <object class="GtkLabel">
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
-                                    <property name="tooltip-text" translatable="yes">Change System Region</property>
+                                    <property name="tooltip-text" translatable="yes">Change Audio Backend</property>
                                     <property name="halign">end</property>
                                     <property name="margin-right">5</property>
                                     <property name="label" translatable="yes">Audio Backend: </property>


### PR DESCRIPTION
This PR prevents Windows from turning off the display while a game is running. 

I also looked into implementing this for Linux but determined it to be too complex, as it requires D-Bus communication, and it would have been hard for me to test since I don't currently have any Linux test environment setup.

The placement and use of the class is based on the WindowsMultimediaTimerResolution class, as that is also a Windows exclusive feature that calls native code. Windows itself keeps tracks of threads that are preventing the display from sleeping and resumes normal behavior when they exit, so it was not necessary to create a method to manually enable the display sleep.

I happened to noticed some minor errors in the GTK Glade file while I was looking at it (One wrong and one missing tooltip) which I decided I might as well fix.

I am pretty new to Git and code contributions in general so I apologize if I have made any mistakes, and I welcome any feedback.

This PR partially fixes issue #1829, I say partially because it only implements it for Windows, and not for Linux And macOS.