### PR TITLE
services: add "apm:p"

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Apm/IManagerPrivileged.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/IManagerPrivileged.cs
@@ -20,14 +20,12 @@ namespace Ryujinx.HLE.HOS.Services.Apm
 
         protected override PerformanceMode GetPerformanceMode()
         {
-            // not implemented
-            return _context.Device.System.PerformanceState.PerformanceMode;
+            return PerformanceMode.Default;
         }
 
         protected override bool IsCpuOverclockEnabled()
         {
-            // not implemented
-            return _context.Device.System.PerformanceState.CpuOverclockEnabled;
+            return false;
         }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Apm/IManagerPrivileged.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/IManagerPrivileged.cs
@@ -1,0 +1,33 @@
+namespace Ryujinx.HLE.HOS.Services.Apm
+{
+    [Service("apm:p")] // 8.0.0-
+    class IManagerPrivileged : IManager
+    {
+        private readonly ServiceCtx _context;
+
+        public IManagerPrivileged(ServiceCtx context) : base(context)
+        {
+            _context = context;
+        }
+
+        [Command(0)]
+        protected override ResultCode OpenSession(out SessionServer sessionServer)
+        {
+            sessionServer = new SessionServer(_context);
+
+            return ResultCode.Success;
+        }
+
+        protected override PerformanceMode GetPerformanceMode()
+        {
+            // not implemented
+            return _context.Device.System.PerformanceState.PerformanceMode;
+        }
+
+        protected override bool IsCpuOverclockEnabled()
+        {
+            // not implemented
+            return _context.Device.System.PerformanceState.CpuOverclockEnabled;
+        }
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Apm/IManagerPrivileged.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/IManagerPrivileged.cs
@@ -1,6 +1,6 @@
 namespace Ryujinx.HLE.HOS.Services.Apm
 {
-    [Service("apm:p")] // 8.0.0-
+    [Service("apm:p")] // 1.0.0-7.0.1
     class IManagerPrivileged : IManager
     {
         private readonly ServiceCtx _context;

--- a/Ryujinx.HLE/HOS/Services/Apm/IManagerPrivileged.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/IManagerPrivileged.cs
@@ -1,31 +1,19 @@
 namespace Ryujinx.HLE.HOS.Services.Apm
 {
-    [Service("apm:p")] // 1.0.0-7.0.1
-    class IManagerPrivileged : IManager
-    {
-        private readonly ServiceCtx _context;
+    // NOTE: This service doesn’t exist anymore after firmware 7.0.1. But some outdated homebrew still uses it.
 
-        public IManagerPrivileged(ServiceCtx context) : base(context)
-        {
-            _context = context;
-        }
+    [Service("apm:p")] // 1.0.0-7.0.1
+    class IManagerPrivileged : IpcService
+    {
+        public IManagerPrivileged(ServiceCtx context) { }
 
         [Command(0)]
-        protected override ResultCode OpenSession(out SessionServer sessionServer)
+        // OpenSession() -> object<nn::apm::ISession>
+        public ResultCode OpenSession(ServiceCtx context)
         {
-            sessionServer = new SessionServer(_context);
+            MakeObject(context, new SessionServer(context));
 
             return ResultCode.Success;
-        }
-
-        protected override PerformanceMode GetPerformanceMode()
-        {
-            return PerformanceMode.Default;
-        }
-
-        protected override bool IsCpuOverclockEnabled()
-        {
-            return false;
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/Ryujinx/Ryujinx/issues/1846

With this PR, there is no more error about missing `apm:p`, but the games that did this error (such as [2048](https://github.com/FlagBrew/2048)) now there is this following error:
```
Exception has occurred: CLR/System.ArgumentOutOfRangeException
An exception of type 'System.ArgumentOutOfRangeException' occurred in Ryujinx.Graphics.Gpu.dll but was not handled in user code: 'Specified argument was out of the range of valid values.'
   at Ryujinx.Graphics.Gpu.Synchronization.SynchronizationManager.RegisterCallbackOnSyncpoint(UInt32 id, UInt32 threshold, Action callback) in C:\Users\macabeus\ApenasMeu\Ryujinx\Ryujinx.Graphics.Gpu\Synchronization\SynchronizationManager.cs:line 80
   at Ryujinx.HLE.HOS.Services.SurfaceFlinger.AndroidFence.RegisterCallback(GpuContext gpuContext, Action callback) in C:\Users\macabeus\ApenasMeu\Ryujinx\Ryujinx.HLE\HOS\Services\SurfaceFlinger\Types\AndroidFence.cs:line 73
   at Ryujinx.HLE.HOS.Services.SurfaceFlinger.SurfaceFlinger.PostFrameBuffer(Layer layer, BufferItem item) in C:\Users\macabeus\ApenasMeu\Ryujinx\Ryujinx.HLE\HOS\Services\SurfaceFlinger\SurfaceFlinger.cs:line 351
   at Ryujinx.HLE.HOS.Services.SurfaceFlinger.SurfaceFlinger.Compose() in C:\Users\macabeus\ApenasMeu\Ryujinx\Ryujinx.HLE\HOS\Services\SurfaceFlinger\SurfaceFlinger.cs:line 290
   at Ryujinx.HLE.HOS.Services.SurfaceFlinger.SurfaceFlinger.HandleComposition() in C:\Users\macabeus\ApenasMeu\Ryujinx\Ryujinx.HLE\HOS\Services\SurfaceFlinger\SurfaceFlinger.cs:line 227
   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
```

I don't know if it's another error, or it's because of the implementation of `apm:p`.