### PR TITLE
Add support for inline software keyboard

### DIFF
--- a/Ryujinx.Common/Logging/LogClass.cs
+++ b/Ryujinx.Common/Logging/LogClass.cs
@@ -28,7 +28,6 @@ namespace Ryujinx.Common.Logging
         ServiceBsd,
         ServiceBtm,
         ServiceCaps,
-        ServiceDisplay,
         ServiceFriend,
         ServiceFs,
         ServiceHid,

--- a/Ryujinx.Common/Logging/LogClass.cs
+++ b/Ryujinx.Common/Logging/LogClass.cs
@@ -28,6 +28,7 @@ namespace Ryujinx.Common.Logging
         ServiceBsd,
         ServiceBtm,
         ServiceCaps,
+        ServiceDisplay,
         ServiceFriend,
         ServiceFs,
         ServiceHid,

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineKeyboardRequest.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineKeyboardRequest.cs
@@ -1,0 +1,18 @@
+﻿namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
+{
+    /// <summary>
+    /// Possible requests to the keyboard when running in inline mode.
+    /// </summary>
+    enum InlineKeyboardRequest : uint
+    {
+
+        Finalize                    = 0x4,
+        SetUserWordInfo             = 0x6,
+        SetCustomizeDic             = 0x7,
+        Calc                        = 0xA,
+        SetCustomizedDictionaries   = 0xB,
+        UnsetCustomizedDictionaries = 0xC,
+        UseChangedStringV2          = 0xD,
+        UseMovedCursorV2            = 0xE
+    }
+}

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineKeyboardRequest.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineKeyboardRequest.cs
@@ -5,7 +5,7 @@
     /// </summary>
     enum InlineKeyboardRequest : uint
     {
-
+        Unknown0                    = 0x0,
         Finalize                    = 0x4,
         SetUserWordInfo             = 0x6,
         SetCustomizeDic             = 0x7,

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineKeyboardResponse.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineKeyboardResponse.cs
@@ -1,0 +1,26 @@
+﻿namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
+{
+    /// <summary>
+    /// Possible responses from the keyboard when running in inline mode.
+    /// </summary>
+    enum InlineKeyboardResponse : uint
+    {
+        FinishedInitialize          = 0x0,
+        Default                     = 0x1,
+        ChangedString               = 0x2,
+        MovedCursor                 = 0x3,
+        MovedTab                    = 0x4,
+        DecidedEnter                = 0x5,
+        DecidedCancel               = 0x6,
+        ChangedStringUtf8           = 0x7,
+        MovedCursorUtf8             = 0x8,
+        DecidedEnterUtf8            = 0x9,
+        UnsetCustomizeDic           = 0xA,
+        ReleasedUserWordInfo        = 0xB,
+        UnsetCustomizedDictionaries = 0xC,
+        ChangedStringV2             = 0xD,
+        MovedCursorV2               = 0xE,
+        ChangedStringUtf8V2         = 0xF,
+        MovedCursorUtf8V2           = 0x10
+    }
+}

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineKeyboardState.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineKeyboardState.cs
@@ -1,0 +1,14 @@
+﻿namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
+{
+    /// <summary>
+    /// Possible states for the keyboard when running in inline mode.
+    /// </summary>
+    enum InlineKeyboardState : uint
+    {
+        Uninitialized = 0x0,
+        Initializing  = 0x1,
+        Ready         = 0x2,
+        DataAvailable = 0x3,
+        Completed     = 0x4
+    }
+}

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineResponses.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineResponses.cs
@@ -26,7 +26,9 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
                 // This loop will probably will run only once.
                 bytes = encoding.GetBytes(text.Substring(0, maxStr));
                 if (bytes.Length <= maxSize)
+                {
                     break;
+                }
             }
 
             writer.Write(bytes);

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineResponses.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineResponses.cs
@@ -91,7 +91,7 @@ namespace Ryujinx.HLE.HOS.Applets
             }
         }
 
-        public static byte[] DecidedCancel(uint state = 1)
+        public static byte[] DecidedCancel(uint state = 4)
         {
             using (MemoryStream stream = new MemoryStream(new byte[2*sizeof(uint) + 0x0]))
             using (BinaryWriter writer = new BinaryWriter(stream))

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineResponses.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineResponses.cs
@@ -39,6 +39,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
         private static void WriteStringWithCursor(string text, BinaryWriter writer, uint maxSize, Encoding encoding)
         {
             uint cursor = WriteString(text, writer, maxSize, encoding);
+
             writer.Write(cursor); // Cursor position
         }
 
@@ -49,9 +50,9 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.Ready,
-                              InlineKeyboardResponse.FinishedInitialize, writer);
+                BeginResponse(InlineKeyboardState.Ready, InlineKeyboardResponse.FinishedInitialize, writer);
                 writer.Write((byte)1); // Data (ignored by the program)
+
                 return stream.ToArray();
             }
         }
@@ -63,8 +64,8 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.Initializing,
-                              InlineKeyboardResponse.Default, writer);
+                BeginResponse(InlineKeyboardState.Initializing, InlineKeyboardResponse.Default, writer);
+
                 return stream.ToArray();
             }
         }
@@ -76,11 +77,11 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.Initializing,
-                              InlineKeyboardResponse.ChangedString, writer);
+                BeginResponse(InlineKeyboardState.Initializing, InlineKeyboardResponse.ChangedString, writer);
                 WriteStringWithCursor(text, writer, MaxStrLenUTF16, Encoding.Unicode);
                 writer.Write((int)0); // ?
                 writer.Write((int)0); // ?
+
                 return stream.ToArray();
             }
         }
@@ -92,9 +93,9 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.Initializing,
-                              InlineKeyboardResponse.MovedCursor, writer);
+                BeginResponse(InlineKeyboardState.Initializing, InlineKeyboardResponse.MovedCursor, writer);
                 WriteStringWithCursor(text, writer, MaxStrLenUTF16, Encoding.Unicode);
+
                 return stream.ToArray();
             }
         }
@@ -108,9 +109,9 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.Initializing,
-                              InlineKeyboardResponse.MovedTab, writer);
+                BeginResponse(InlineKeyboardState.Initializing, InlineKeyboardResponse.MovedTab, writer);
                 WriteStringWithCursor(text, writer, MaxStrLenUTF16, Encoding.Unicode);
+
                 return stream.ToArray();
             }
         }
@@ -122,9 +123,9 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.Completed,
-                              InlineKeyboardResponse.DecidedEnter, writer);
+                BeginResponse(InlineKeyboardState.Completed, InlineKeyboardResponse.DecidedEnter, writer);
                 WriteString(text, writer, MaxStrLenUTF16, Encoding.Unicode);
+
                 return stream.ToArray();
             }
         }
@@ -136,8 +137,8 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.Completed,
-                              InlineKeyboardResponse.DecidedCancel, writer);
+                BeginResponse(InlineKeyboardState.Completed, InlineKeyboardResponse.DecidedCancel, writer);
+
                 return stream.ToArray();
             }
         }
@@ -149,11 +150,11 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.DataAvailable,
-                              InlineKeyboardResponse.ChangedStringUtf8, writer);
+                BeginResponse(InlineKeyboardState.DataAvailable, InlineKeyboardResponse.ChangedStringUtf8, writer);
                 WriteStringWithCursor(text, writer, MaxStrLenUTF8, Encoding.UTF8);
                 writer.Write((int)0); // ?
                 writer.Write((int)0); // ?
+
                 return stream.ToArray();
             }
         }
@@ -165,9 +166,9 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.DataAvailable,
-                              InlineKeyboardResponse.MovedCursorUtf8, writer);
+                BeginResponse(InlineKeyboardState.DataAvailable, InlineKeyboardResponse.MovedCursorUtf8, writer);
                 WriteStringWithCursor(text, writer, MaxStrLenUTF8, Encoding.UTF8);
+
                 return stream.ToArray();
             }
         }
@@ -179,9 +180,9 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.Completed,
-                              InlineKeyboardResponse.DecidedEnterUtf8, writer);
+                BeginResponse(InlineKeyboardState.Completed, InlineKeyboardResponse.DecidedEnterUtf8, writer);
                 WriteString(text, writer, MaxStrLenUTF8, Encoding.UTF8);
+
                 return stream.ToArray();
             }
         }
@@ -193,8 +194,8 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.Initializing,
-                              InlineKeyboardResponse.UnsetCustomizeDic, writer);
+                BeginResponse(InlineKeyboardState.Initializing, InlineKeyboardResponse.UnsetCustomizeDic, writer);
+
                 return stream.ToArray();
             }
         }
@@ -206,8 +207,8 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.Initializing,
-                              InlineKeyboardResponse.ReleasedUserWordInfo, writer);
+                BeginResponse(InlineKeyboardState.Initializing, InlineKeyboardResponse.ReleasedUserWordInfo, writer);
+
                 return stream.ToArray();
             }
         }
@@ -219,8 +220,8 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.Initializing,
-                              InlineKeyboardResponse.UnsetCustomizedDictionaries, writer);
+                BeginResponse(InlineKeyboardState.Initializing, InlineKeyboardResponse.UnsetCustomizedDictionaries, writer);
+
                 return stream.ToArray();
             }
         }
@@ -232,12 +233,12 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.DataAvailable,
-                              InlineKeyboardResponse.ChangedStringV2, writer);
+                BeginResponse(InlineKeyboardState.DataAvailable, InlineKeyboardResponse.ChangedStringV2, writer);
                 WriteStringWithCursor(text, writer, MaxStrLenUTF16, Encoding.Unicode);
                 writer.Write((int)0); // ?
                 writer.Write((int)0); // ?
                 writer.Write((byte)0); // Flag == 0
+
                 return stream.ToArray();
             }
         }
@@ -249,10 +250,10 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.DataAvailable,
-                              InlineKeyboardResponse.MovedCursorV2, writer);
+                BeginResponse(InlineKeyboardState.DataAvailable, InlineKeyboardResponse.MovedCursorV2, writer);
                 WriteStringWithCursor(text, writer, MaxStrLenUTF16, Encoding.Unicode);
                 writer.Write((byte)0); // Flag == 0
+
                 return stream.ToArray();
             }
         }
@@ -264,12 +265,12 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.DataAvailable,
-                              InlineKeyboardResponse.ChangedStringUtf8V2, writer);
+                BeginResponse(InlineKeyboardState.DataAvailable, InlineKeyboardResponse.ChangedStringUtf8V2, writer);
                 WriteStringWithCursor(text, writer, MaxStrLenUTF8, Encoding.UTF8);
                 writer.Write((int)0); // ?
                 writer.Write((int)0); // ?
                 writer.Write((byte)0); // Flag == 0
+
                 return stream.ToArray();
             }
         }
@@ -281,10 +282,10 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.DataAvailable,
-                              InlineKeyboardResponse.MovedCursorUtf8V2, writer);
+                BeginResponse(InlineKeyboardState.DataAvailable, InlineKeyboardResponse.MovedCursorUtf8V2, writer);
                 WriteStringWithCursor(text, writer, MaxStrLenUTF8, Encoding.UTF8);
                 writer.Write((byte)0); // Flag == 0
+
                 return stream.ToArray();
             }
         }

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineResponses.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineResponses.cs
@@ -5,8 +5,8 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
 {
     internal class InlineResponses
     {
-        private const uint maxStrLenUTF8 = 0x7D4;
-        private const uint maxStrLenUTF16 = 0x3EC;
+        private const uint MaxStrLenUTF8 = 0x7D4;
+        private const uint MaxStrLenUTF16 = 0x3EC;
 
         private static void BeginResponse(InlineKeyboardState state, InlineKeyboardResponse resCode, BinaryWriter writer)
         {
@@ -71,14 +71,14 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
 
         public static byte[] ChangedString(string text)
         {
-            uint resSize = 4 * sizeof(uint) + maxStrLenUTF16;
+            uint resSize = 4 * sizeof(uint) + MaxStrLenUTF16;
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
                 BeginResponse(InlineKeyboardState.Initializing,
                               InlineKeyboardResponse.ChangedString, writer);
-                WriteStringWithCursor(text, writer, maxStrLenUTF16, Encoding.Unicode);
+                WriteStringWithCursor(text, writer, MaxStrLenUTF16, Encoding.Unicode);
                 writer.Write((int)0); // ?
                 writer.Write((int)0); // ?
                 return stream.ToArray();
@@ -87,14 +87,14 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
 
         public static byte[] MovedCursor(string text)
         {
-            uint resSize = 4 * sizeof(uint) + maxStrLenUTF16;
+            uint resSize = 4 * sizeof(uint) + MaxStrLenUTF16;
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
                 BeginResponse(InlineKeyboardState.Initializing,
                               InlineKeyboardResponse.MovedCursor, writer);
-                WriteStringWithCursor(text, writer, maxStrLenUTF16, Encoding.Unicode);
+                WriteStringWithCursor(text, writer, MaxStrLenUTF16, Encoding.Unicode);
                 return stream.ToArray();
             }
         }
@@ -103,28 +103,28 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
         {
             // Should be the same as MovedCursor.
 
-            uint resSize = 4 * sizeof(uint) + maxStrLenUTF16;
+            uint resSize = 4 * sizeof(uint) + MaxStrLenUTF16;
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
                 BeginResponse(InlineKeyboardState.Initializing,
                               InlineKeyboardResponse.MovedTab, writer);
-                WriteStringWithCursor(text, writer, maxStrLenUTF16, Encoding.Unicode);
+                WriteStringWithCursor(text, writer, MaxStrLenUTF16, Encoding.Unicode);
                 return stream.ToArray();
             }
         }
 
         public static byte[] DecidedEnter(string text)
         {
-            uint resSize = 3 * sizeof(uint) + maxStrLenUTF16;
+            uint resSize = 3 * sizeof(uint) + MaxStrLenUTF16;
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
                 BeginResponse(InlineKeyboardState.Completed,
                               InlineKeyboardResponse.DecidedEnter, writer);
-                WriteString(text, writer, maxStrLenUTF16, Encoding.Unicode);
+                WriteString(text, writer, MaxStrLenUTF16, Encoding.Unicode);
                 return stream.ToArray();
             }
         }
@@ -144,14 +144,14 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
 
         public static byte[] ChangedStringUtf8(string text)
         {
-            uint resSize = 6 * sizeof(uint) + maxStrLenUTF8;
+            uint resSize = 6 * sizeof(uint) + MaxStrLenUTF8;
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
                 BeginResponse(InlineKeyboardState.DataAvailable,
                               InlineKeyboardResponse.ChangedStringUtf8, writer);
-                WriteStringWithCursor(text, writer, maxStrLenUTF8, Encoding.UTF8);
+                WriteStringWithCursor(text, writer, MaxStrLenUTF8, Encoding.UTF8);
                 writer.Write((int)0); // ?
                 writer.Write((int)0); // ?
                 return stream.ToArray();
@@ -160,28 +160,28 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
 
         public static byte[] MovedCursorUtf8(string text)
         {
-            uint resSize = 4 * sizeof(uint) + maxStrLenUTF8;
+            uint resSize = 4 * sizeof(uint) + MaxStrLenUTF8;
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
                 BeginResponse(InlineKeyboardState.DataAvailable,
                               InlineKeyboardResponse.MovedCursorUtf8, writer);
-                WriteStringWithCursor(text, writer, maxStrLenUTF8, Encoding.UTF8);
+                WriteStringWithCursor(text, writer, MaxStrLenUTF8, Encoding.UTF8);
                 return stream.ToArray();
             }
         }
 
         public static byte[] DecidedEnterUtf8(string text)
         {
-            uint resSize = 3 * sizeof(uint) + maxStrLenUTF8;
+            uint resSize = 3 * sizeof(uint) + MaxStrLenUTF8;
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
                 BeginResponse(InlineKeyboardState.Completed,
                               InlineKeyboardResponse.DecidedEnterUtf8, writer);
-                WriteString(text, writer, maxStrLenUTF8, Encoding.UTF8);
+                WriteString(text, writer, MaxStrLenUTF8, Encoding.UTF8);
                 return stream.ToArray();
             }
         }
@@ -227,14 +227,14 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
 
         public static byte[] ChangedStringV2(string text)
         {
-            uint resSize = 6 * sizeof(uint) + maxStrLenUTF16 + 0x1;
+            uint resSize = 6 * sizeof(uint) + MaxStrLenUTF16 + 0x1;
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
                 BeginResponse(InlineKeyboardState.DataAvailable,
                               InlineKeyboardResponse.ChangedStringV2, writer);
-                WriteStringWithCursor(text, writer, maxStrLenUTF16, Encoding.Unicode);
+                WriteStringWithCursor(text, writer, MaxStrLenUTF16, Encoding.Unicode);
                 writer.Write((int)0); // ?
                 writer.Write((int)0); // ?
                 writer.Write((byte)0); // Flag == 0
@@ -244,14 +244,14 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
 
         public static byte[] MovedCursorV2(string text)
         {
-            uint resSize = 4 * sizeof(uint) + maxStrLenUTF16 + 0x1;
+            uint resSize = 4 * sizeof(uint) + MaxStrLenUTF16 + 0x1;
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
                 BeginResponse(InlineKeyboardState.DataAvailable,
                               InlineKeyboardResponse.MovedCursorV2, writer);
-                WriteStringWithCursor(text, writer, maxStrLenUTF16, Encoding.Unicode);
+                WriteStringWithCursor(text, writer, MaxStrLenUTF16, Encoding.Unicode);
                 writer.Write((byte)0); // Flag == 0
                 return stream.ToArray();
             }
@@ -259,14 +259,14 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
 
         public static byte[] ChangedStringUtf8V2(string text)
         {
-            uint resSize = 6 * sizeof(uint) + maxStrLenUTF8 + 0x1;
+            uint resSize = 6 * sizeof(uint) + MaxStrLenUTF8 + 0x1;
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
                 BeginResponse(InlineKeyboardState.DataAvailable,
                               InlineKeyboardResponse.ChangedStringUtf8V2, writer);
-                WriteStringWithCursor(text, writer, maxStrLenUTF8, Encoding.UTF8);
+                WriteStringWithCursor(text, writer, MaxStrLenUTF8, Encoding.UTF8);
                 writer.Write((int)0); // ?
                 writer.Write((int)0); // ?
                 writer.Write((byte)0); // Flag == 0
@@ -276,14 +276,14 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
 
         public static byte[] MovedCursorUtf8V2(string text)
         {
-            uint resSize = 4 * sizeof(uint) + maxStrLenUTF8 + 0x1;
+            uint resSize = 4 * sizeof(uint) + MaxStrLenUTF8 + 0x1;
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
                 BeginResponse(InlineKeyboardState.DataAvailable,
                               InlineKeyboardResponse.MovedCursorUtf8V2, writer);
-                WriteStringWithCursor(text, writer, maxStrLenUTF8, Encoding.UTF8);
+                WriteStringWithCursor(text, writer, MaxStrLenUTF8, Encoding.UTF8);
                 writer.Write((byte)0); // Flag == 0
                 return stream.ToArray();
             }

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineResponses.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineResponses.cs
@@ -1,0 +1,230 @@
+﻿using System.IO;
+using System.Text;
+
+namespace Ryujinx.HLE.HOS.Applets
+{
+    internal class InlineResponses
+    {
+        private static uint WriteString(string text, BinaryWriter writer, int maxSize, Encoding encoding)
+        {
+            var bytes = encoding.GetBytes(text);
+            writer.Write(bytes);
+            writer.Seek(maxSize - bytes.Length, SeekOrigin.Current);
+            writer.Write((uint)text.Length); // String size
+            return (uint)bytes.Length;
+        }
+
+        private static void WriteStringWithCursor(string text, BinaryWriter writer, int maxSize, Encoding encoding)
+        {
+            uint cursor = WriteString(text, writer, maxSize, encoding);
+            writer.Write(cursor); // Cursor position
+        }
+
+        public static byte[] FinishedInitialize(uint state = 2)
+        {
+            using (MemoryStream stream = new MemoryStream(new byte[2*sizeof(uint) + 0x1]))
+            using (BinaryWriter writer = new BinaryWriter(stream))
+            {
+                writer.Write((uint)state); // State
+                writer.Write((uint)0x0); // Reply code
+                writer.Write((byte)1); // Data
+                return stream.ToArray();
+            }
+        }
+
+        public static byte[] Default(uint state = 1)
+        {
+            using (MemoryStream stream = new MemoryStream(new byte[2*sizeof(uint) + 0x0]))
+            using (BinaryWriter writer = new BinaryWriter(stream))
+            {
+                writer.Write((uint)state); // State
+                writer.Write((uint)0x1); // Reply code
+                return stream.ToArray();
+            }
+        }
+
+        public static byte[] ChangedString(string text, uint state = 1)
+        {
+            using (MemoryStream stream = new MemoryStream(new byte[2*sizeof(uint) + 0x3FC]))
+            using (BinaryWriter writer = new BinaryWriter(stream))
+            {
+                writer.Write((uint)state); // State
+                writer.Write((uint)0x2); // Reply code
+                writer.Write((byte)1); // Data
+                return stream.ToArray();
+            }
+        }
+
+        public static byte[] MovedCursor(string text, uint state = 1)
+        {
+            using (MemoryStream stream = new MemoryStream(new byte[2*sizeof(uint) + 0x3F4]))
+            using (BinaryWriter writer = new BinaryWriter(stream))
+            {
+                writer.Write((uint)state); // State
+                writer.Write((uint)0x3); // Reply code
+                WriteStringWithCursor(text, writer, 0x3EC, Encoding.Unicode);
+                return stream.ToArray();
+            }
+        }
+
+        public static byte[] MovedTab(uint state = 1)
+        {
+            using (MemoryStream stream = new MemoryStream(new byte[2*sizeof(uint) + 0x3F4]))
+            using (BinaryWriter writer = new BinaryWriter(stream))
+            {
+                writer.Write((uint)state); // State
+                writer.Write((uint)0x4); // Reply code
+                writer.Write((byte)1); // Data
+                return stream.ToArray();
+            }
+        }
+
+        public static byte[] DecidedEnter(string text, uint state = 4)
+        {
+            using (MemoryStream stream = new MemoryStream(new byte[2*sizeof(uint) + 0x3F0]))
+            using (BinaryWriter writer = new BinaryWriter(stream))
+            {
+                writer.Write((uint)state); // State
+                writer.Write((uint)0x5); // Reply code
+                WriteString(text, writer, 0x3EC, Encoding.Unicode);
+                return stream.ToArray();
+            }
+        }
+
+        public static byte[] DecidedCancel(uint state = 1)
+        {
+            using (MemoryStream stream = new MemoryStream(new byte[2*sizeof(uint) + 0x0]))
+            using (BinaryWriter writer = new BinaryWriter(stream))
+            {
+                writer.Write((uint)state); // State
+                writer.Write((uint)0x6); // Reply code
+                return stream.ToArray();
+            }
+        }
+
+        public static byte[] ChangedStringUtf8(string text, uint state = 3)
+        {
+            using (MemoryStream stream = new MemoryStream(new byte[2*sizeof(uint) + 0x7E4]))
+            using (BinaryWriter writer = new BinaryWriter(stream))
+            {
+                writer.Write((uint)state); // State
+                writer.Write((uint)0x7); // Reply code
+                writer.Write((byte)1); // Data
+                return stream.ToArray();
+            }
+        }
+
+        public static byte[] MovedCursorUtf8(string text, uint state = 3)
+        {
+            using (MemoryStream stream = new MemoryStream(new byte[2*sizeof(uint) + 0x7DC]))
+            using (BinaryWriter writer = new BinaryWriter(stream))
+            {
+                writer.Write((uint)state); // State
+                writer.Write((uint)0x8); // Reply code
+                WriteStringWithCursor(text, writer, 0x7D4, Encoding.UTF8);
+                return stream.ToArray();
+            }
+        }
+
+        public static byte[] DecidedEnterUtf8(string text, uint state = 4)
+        {
+            using (MemoryStream stream = new MemoryStream(new byte[2*sizeof(uint) + 0x7D8]))
+            using (BinaryWriter writer = new BinaryWriter(stream))
+            {
+                writer.Write((uint)state); // State
+                writer.Write((uint)0x9); // Reply code
+                WriteString(text, writer, 0x7D4, Encoding.UTF8);
+                return stream.ToArray();
+            }
+        }
+
+        public static byte[] UnsetCustomizeDic(uint state = 1)
+        {
+            using (MemoryStream stream = new MemoryStream(new byte[2*sizeof(uint) + 0x0]))
+            using (BinaryWriter writer = new BinaryWriter(stream))
+            {
+                writer.Write((uint)state); // State
+                writer.Write((uint)0xA); // Reply code
+                return stream.ToArray();
+            }
+        }
+
+        public static byte[] ReleasedUserWordInfo(uint state = 1)
+        {
+            using (MemoryStream stream = new MemoryStream(new byte[2*sizeof(uint) + 0x0]))
+            using (BinaryWriter writer = new BinaryWriter(stream))
+            {
+                writer.Write((uint)state); // State
+                writer.Write((uint)0xB); // Reply code
+                return stream.ToArray();
+            }
+        }
+
+        public static byte[] UnsetCustomizedDictionaries(uint state = 1)
+        {
+            using (MemoryStream stream = new MemoryStream(new byte[2*sizeof(uint) + 0x0]))
+            using (BinaryWriter writer = new BinaryWriter(stream))
+            {
+                writer.Write((uint)state); // State
+                writer.Write((uint)0xC); // Reply code
+                return stream.ToArray();
+            }
+        }
+
+        public static byte[] ChangedStringV2(string text, uint state = 3)
+        {
+            using (MemoryStream stream = new MemoryStream(new byte[2*sizeof(uint) + 0x3FD]))
+            using (BinaryWriter writer = new BinaryWriter(stream))
+            {
+                writer.Write((uint)state); // State: Data available
+                writer.Write((uint)0xD); // Reply code
+                WriteStringWithCursor(text, writer, 0x3EC, Encoding.Unicode);
+                writer.Write((int)0); // ?
+                writer.Write((int)0); // ?
+                writer.Write((byte)0); // Flag == 0
+                return stream.ToArray();
+            }
+        }
+
+        public static byte[] MovedCursorV2(string text, uint state = 3)
+        {
+            using (MemoryStream stream = new MemoryStream(new byte[2*sizeof(uint) + 0x3F5]))
+            using (BinaryWriter writer = new BinaryWriter(stream))
+            {
+                writer.Write((uint)state); // State: Data available
+                writer.Write((uint)0xE); // Reply code
+                WriteStringWithCursor(text, writer, 0x3EC, Encoding.Unicode);
+                writer.Write((byte)0); // Flag == 0
+                return stream.ToArray();
+            }
+        }
+
+        public static byte[] ChangedStringUtf8V2(string text, uint state = 3)
+        {
+            using (MemoryStream stream = new MemoryStream(new byte[2*sizeof(uint) + 0x7E5]))
+            using (BinaryWriter writer = new BinaryWriter(stream))
+            {
+                writer.Write((uint)state); // State
+                writer.Write((uint)0xF); // Reply code
+                WriteStringWithCursor(text, writer, 0x7D4, Encoding.UTF8);
+                writer.Write((int)0); // ?
+                writer.Write((int)0); // ?
+                writer.Write((byte)0); // Flag == 0
+                return stream.ToArray();
+            }
+        }
+
+        public static byte[] MovedCursorUtf8V2(string text, uint state = 3)
+        {
+            using (MemoryStream stream = new MemoryStream(new byte[2*sizeof(uint) + 0x7DD]))
+            using (BinaryWriter writer = new BinaryWriter(stream))
+            {
+                writer.Write((uint)state); // State
+                writer.Write((uint)0x10); // Reply code
+                WriteStringWithCursor(text, writer, 0x7D4, Encoding.UTF8);
+                writer.Write((byte)0); // Flag == 0
+                return stream.ToArray();
+            }
+        }
+    }
+}

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineResponses.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineResponses.cs
@@ -5,8 +5,8 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
 {
     internal class InlineResponses
     {
-        private static readonly uint maxStrLenUTF8 = 0x7D4;
-        private static readonly uint maxStrLenUTF16 = 0x3EC;
+        private const uint maxStrLenUTF8 = 0x7D4;
+        private const uint maxStrLenUTF16 = 0x3EC;
 
         private static void BeginResponse(InlineKeyboardState state, InlineKeyboardResponse resCode, BinaryWriter writer)
         {

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardAppear.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardAppear.cs
@@ -1,0 +1,59 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
+{
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    struct SoftwareKeyboardAppear
+    {
+        private const int OkTextLength = 8;
+
+        public uint Unknown;
+
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = OkTextLength + 1)]
+        public string OkText;
+
+        /// <summary>
+        /// The character displayed in the left button of the numeric keyboard.
+        /// This is ignored when Mode is not set to NumbersOnly.
+        /// </summary>
+        public char LeftOptionalSymbolKey;
+
+        /// <summary>
+        /// The character displayed in the right button of the numeric keyboard.
+        /// This is ignored when Mode is not set to NumbersOnly.
+        /// </summary>
+        public char RightOptionalSymbolKey;
+
+        /// <summary>
+        /// When set, predictive typing is enabled making use of the system dictionary,
+        /// and any custom user dictionary.
+        /// </summary>
+        [MarshalAs(UnmanagedType.I1)]
+        public bool PredictionEnabled;
+
+        public byte Empty;
+
+        /// <summary>
+        /// Specifies prohibited characters that cannot be input into the text entry area.
+        /// </summary>
+        public InvalidCharFlags InvalidCharFlag;
+
+        public int Padding1;
+        public int Padding2;
+
+        public byte EnableReturnButton;
+
+        public byte Padding3;
+        public byte Padding4;
+        public byte Padding5;
+
+        public uint CalcArgFlags;
+
+        public uint Padding6;
+        public uint Padding7;
+        public uint Padding8;
+        public uint Padding9;
+        public uint Padding10;
+        public uint Padding11;
+    }
+}

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardAppear.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardAppear.cs
@@ -7,7 +7,9 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
     {
         private const int OkTextLength = 8;
 
-        public uint Unknown;
+        // Some games send a Calc without intention of showing the keyboard, a
+        // common trend observed is that this field will be != 0 in such cases.
+        public uint ShouldBeHidden;
 
         [MarshalAs(UnmanagedType.ByValTStr, SizeConst = OkTextLength + 1)]
         public string OkText;

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardApplet.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardApplet.cs
@@ -272,7 +272,6 @@ namespace Ryujinx.HLE.HOS.Applets
                         {
                             var keyboardDictData = reader.ReadBytes((int)remaining);
                             _keyboardDict = ReadStruct<SoftwareKeyboardDictSet>(keyboardDictData);
-
                         }
                         _interactiveSession.Push(InlineResponses.Default());
                         break;
@@ -290,12 +289,16 @@ namespace Ryujinx.HLE.HOS.Applets
                             _keyboardCalc = ReadStruct<SoftwareKeyboardCalc>(keyboardCalcData);
 
                             if (_keyboardCalc.Utf8Mode == 0x1)
+                            {
                                 _encoding = Encoding.UTF8;
+                            }
 
                             // Force showing the keyboard regardless of the state, an unwanted
                             // input dialog may show, but it is better than a soft lock.
                             if (_keyboardCalc.Appear.ShouldBeHidden == 0)
+                            {
                                 showKeyboard = true;
+                            }
                         }
                         // Send an initialization finished signal.
                         _interactiveSession.Push(InlineResponses.FinishedInitialize());
@@ -303,9 +306,7 @@ namespace Ryujinx.HLE.HOS.Applets
                         new Task(() =>
                         {
                             bool submit = true;
-                            string inputText = (!string.IsNullOrWhiteSpace(
-                                _keyboardCalc.InputText) ?
-                                _keyboardCalc.InputText : DefaultText);
+                            string inputText = (!string.IsNullOrWhiteSpace(_keyboardCalc.InputText) ? _keyboardCalc.InputText : DefaultText);
 
                             // Call the configured GUI handler to get user's input.
                             if (!showKeyboard)
@@ -328,9 +329,7 @@ namespace Ryujinx.HLE.HOS.Applets
                                     HeaderText = "", // The inline keyboard lacks these texts
                                     SubtitleText = "",
                                     GuideText = "",
-                                    SubmitText = (!string.IsNullOrWhiteSpace(
-                                        _keyboardCalc.Appear.OkText) ?
-                                        _keyboardCalc.Appear.OkText : "OK"),
+                                    SubmitText = (!string.IsNullOrWhiteSpace(_keyboardCalc.Appear.OkText) ? _keyboardCalc.Appear.OkText : "OK"),
                                     StringLengthMin = 0,
                                     StringLengthMax = 100,
                                     InitialText = inputText
@@ -344,9 +343,13 @@ namespace Ryujinx.HLE.HOS.Applets
                                 Logger.Debug?.Print(LogClass.ServiceAm, "Sending keyboard OK...");
 
                                 if (_encoding == Encoding.UTF8)
+                                {
                                     _interactiveSession.Push(InlineResponses.DecidedEnterUtf8(inputText));
+                                }
                                 else
+                                {
                                     _interactiveSession.Push(InlineResponses.DecidedEnter(inputText));
+                                }
                             }
                             else
                             {
@@ -372,7 +375,6 @@ namespace Ryujinx.HLE.HOS.Applets
                         _interactiveSession.Push(InlineResponses.Default());
                         break;
                 }
-
             }
         }
 

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardApplet.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardApplet.cs
@@ -58,7 +58,7 @@ namespace Ryujinx.HLE.HOS.Applets
             var launchParams   = _normalSession.Pop();
             var keyboardConfig = _normalSession.Pop();
 
-            // TODO: a better way would be handling the background creation properly
+            // TODO: A better way would be handling the background creation properly
             // in LibraryAppleCreator / Acessor instead of guessing by size.
             if (keyboardConfig.Length == Marshal.SizeOf<SoftwareKeyboardInitialize>())
             {
@@ -354,7 +354,7 @@ namespace Ryujinx.HLE.HOS.Applets
                                 _interactiveSession.Push(InlineResponses.DecidedCancel());
                             }
 
-                            // TODO: why is this necessary? Does the software expect a constant stream of responses?
+                            // TODO: Why is this necessary? Does the software expect a constant stream of responses?
                             Thread.Sleep(500);
 
                             Logger.Debug?.Print(LogClass.ServiceAm, "Resetting state of the keyboard...");

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardApplet.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardApplet.cs
@@ -33,8 +33,6 @@ namespace Ryujinx.HLE.HOS.Applets
 
         // Configuration for background mode
         private SoftwareKeyboardInitialize _keyboardBgInitialize;
-        private bool                       _useChangedStringV2 = false;
-        private bool                       _useMovedCursorV2 = false;
 
         private byte[] _transferMemory;
 
@@ -60,8 +58,8 @@ namespace Ryujinx.HLE.HOS.Applets
             var launchParams   = _normalSession.Pop();
             var keyboardConfig = _normalSession.Pop();
 
-            // TODO a better way would be handling the background creation properly
-            // in LibraryAppleCreator / Acessor instead of guessing by size
+            // TODO: a better way would be handling the background creation properly
+            // in LibraryAppleCreator / Acessor instead of guessing by size.
             if (keyboardConfig.Length == Marshal.SizeOf<SoftwareKeyboardInitialize>())
             {
                 _isBackground = true;
@@ -139,7 +137,7 @@ namespace Ryujinx.HLE.HOS.Applets
             // Call the configured GUI handler to get user's input
             if (_device.UiHandler == null)
             {
-                Logger.Warning?.Print(LogClass.Application, $"GUI Handler is not set. Falling back to default");
+                Logger.Warning?.Print(LogClass.Application, "GUI Handler is not set. Falling back to default");
                 _okPressed = true;
             }
             else
@@ -191,7 +189,7 @@ namespace Ryujinx.HLE.HOS.Applets
 
         private void OnInteractiveData(object sender, EventArgs e)
         {
-            // Obtain the validation status response,
+            // Obtain the validation status response.
             var data = _interactiveSession.Pop();
 
             if (_isBackground)
@@ -237,8 +235,8 @@ namespace Ryujinx.HLE.HOS.Applets
 
         private void OnBackgroundInteractiveData(byte[] data)
         {
-            // WARNING Do not invoke applet state changes because the inline keyboard
-            // is expected to be always running once it is initialized
+            // WARNING: Do not invoke applet state changes because the inline keyboard
+            // is expected to be always running once it is initialized.
 
             using (MemoryStream stream = new MemoryStream(data))
             using (BinaryReader reader = new BinaryReader(stream))
@@ -250,11 +248,11 @@ namespace Ryujinx.HLE.HOS.Applets
                     switch (request)
                     {
                         case InlineKeyboardRequest.UseChangedStringV2:
-                            _useChangedStringV2 = true;
+                            // Not used because we only send the entire string after confirmation.
                             _interactiveSession.Push(InlineResponses.Default());
                             return;
                         case InlineKeyboardRequest.UseMovedCursorV2:
-                            _useMovedCursorV2 = true;
+                            // Not used because we only send the entire string after confirmation.
                             _interactiveSession.Push(InlineResponses.Default());
                             return;
                         case InlineKeyboardRequest.Calc:
@@ -270,14 +268,14 @@ namespace Ryujinx.HLE.HOS.Applets
 
                     switch (request)
                     {
-                        case (InlineKeyboardRequest)0: // Unknown request sent by some games after calc
+                        case InlineKeyboardRequest.Unknown0: // Unknown request sent by some games after calc
                             _interactiveSession.Push(InlineResponses.Default());
                             return;
                         case InlineKeyboardRequest.SetCustomizeDic:
                             remaining = stream.Length - stream.Position;
                             if (remaining != Marshal.SizeOf<SoftwareKeyboardDictSet>())
                             {
-                                Logger.Error?.PrintStub(LogClass.ServiceAm, $"Received invalid Software Keyboard DictSet of {remaining} bytes!");
+                                Logger.Error?.Print(LogClass.ServiceAm, $"Received invalid Software Keyboard DictSet of {remaining} bytes!");
                             }
                             else
                             {
@@ -291,7 +289,7 @@ namespace Ryujinx.HLE.HOS.Applets
                             remaining = stream.Length - stream.Position;
                             if (remaining != Marshal.SizeOf<SoftwareKeyboardCalc>())
                             {
-                                Logger.Error?.PrintStub(LogClass.ServiceAm, $"Received invalid Software Keyboard Calc of {remaining} bytes!");
+                                Logger.Error?.Print(LogClass.ServiceAm, $"Received invalid Software Keyboard Calc of {remaining} bytes!");
                             }
                             else
                             {
@@ -312,7 +310,7 @@ namespace Ryujinx.HLE.HOS.Applets
                                 // Call the configured GUI handler to get user's input
                                 if (_device.UiHandler == null)
                                 {
-                                    Logger.Warning?.Print(LogClass.Application, $"GUI Handler is not set. Falling back to default");
+                                    Logger.Warning?.Print(LogClass.Application, "GUI Handler is not set. Falling back to default");
                                 }
                                 else
                                 {
@@ -347,7 +345,7 @@ namespace Ryujinx.HLE.HOS.Applets
                                     _interactiveSession.Push(InlineResponses.DecidedCancel());
                                 }
 
-                                // TODO why is this necessary? Does the software expect a constant stream of responses?
+                                // TODO: why is this necessary? Does the software expect a constant stream of responses?
                                 Thread.Sleep(500);
 
                                 Logger.Debug?.Print(LogClass.ServiceAm, "Resetting state of the keyboard...");
@@ -358,7 +356,7 @@ namespace Ryujinx.HLE.HOS.Applets
                 }
 
                 // We shouldn't be able to get here through standard swkbd execution.
-                Logger.Error?.PrintStub(LogClass.ServiceAm, $"Invalid Software Keyboard request {request} during state {_state}!");
+                Logger.Error?.Print(LogClass.ServiceAm, $"Invalid Software Keyboard request {request} during state {_state}!");
                 _interactiveSession.Push(InlineResponses.Default());
             }
         }

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardCalc.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardCalc.cs
@@ -1,0 +1,84 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
+{
+    /// <summary>
+    /// A structure that defines the configuration options of the software keyboard.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, Pack=1, CharSet = CharSet.Unicode)]
+    struct SoftwareKeyboardCalc
+    {
+        private const int InputTextLength = 505;
+
+        public uint Unknown;
+
+        public ushort Size;
+
+        public byte Unknown1;
+        public byte Unknown2;
+
+        public ulong Flags;
+
+        public SoftwareKeyboardInitialize Initialize;
+
+        public float Volume;
+
+        public int CursorPos;
+
+        public SoftwareKeyboardAppear Appear;
+
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = InputTextLength + 1)]
+        public string InputText;
+
+        public byte Utf8Mode;
+
+        public byte Unknown3;
+
+        [MarshalAs(UnmanagedType.I1)]
+        public bool BackspaceEnabled;
+
+        public short Unknown4;
+        public byte Unknown5;
+
+        [MarshalAs(UnmanagedType.I1)]
+        public byte KeytopAsFloating;
+
+        [MarshalAs(UnmanagedType.I1)]
+        public byte FooterScalable;
+
+        [MarshalAs(UnmanagedType.I1)]
+        public byte AlphaEnabledInInputMode;
+
+        [MarshalAs(UnmanagedType.I1)]
+        public byte InputModeFadeType;
+
+        [MarshalAs(UnmanagedType.I1)]
+        public byte TouchDisabled;
+
+        [MarshalAs(UnmanagedType.I1)]
+        public byte HardwareKeyboardDisabled;
+
+        public uint Unknown6;
+        public uint Unknown7;
+
+        public float KeytopScale0;
+        public float KeytopScale1;
+        public float KeytopTranslate0;
+        public float KeytopTranslate1;
+        public float KeytopBgAlpha;
+        public float FooterBgAlpha;
+        public float BalloonScale;
+
+        public float Unknown8;
+        public uint Unknown9;
+        public uint Unknown10;
+        public uint Unknown11;
+
+        public byte SeGroup;
+
+        public byte TriggerFlag;
+        public byte Trigger;
+
+        public byte Padding;
+    }
+}

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardDictSet.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardDictSet.cs
@@ -2,7 +2,7 @@
 
 namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
 {
-    [StructLayout(LayoutKind.Sequential, Pack=4)]
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
     struct SoftwareKeyboardDictSet
     {
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = 28)]

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardDictSet.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardDictSet.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
+{
+    [StructLayout(LayoutKind.Sequential, Pack=4)]
+    struct SoftwareKeyboardDictSet
+    {
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 28)]
+        public uint[] Entries;
+    }
+}

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardInitialize.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardInitialize.cs
@@ -1,0 +1,17 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
+{
+    /// <summary>
+    /// A structure that indicates the initialization the inline software keyboard.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    struct SoftwareKeyboardInitialize
+    {
+        public uint Unknown;
+        public byte LibMode;
+        public byte FivePlus;
+        public byte Padding1;
+        public byte Padding2;
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
@@ -241,15 +241,6 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
         // GetIndirectLayerImageMap(s64 width, s64 height, u64 handle, nn::applet::AppletResourceUserId, pid) -> (s64, s64, buffer<bytes, 0x46>)
         public ResultCode GetIndirectLayerImageMap(ServiceCtx context)
         {
-            int buffersCount = context.Request.ReceiveBuff.Count;
-
-            if (buffersCount != 1)
-            {
-                Logger.Warning?.Print(LogClass.ServiceVi, $"GetIndirectLayerImageMap expects just 1 receive buffer instead of {buffersCount}!");
-
-                return ResultCode.Success;
-            }
-
             // The size of the layer buffer should be an aligned multiple of width * height
             // because it was created using GetIndirectLayerImageRequiredMemoryInfo as a guide.
 
@@ -296,8 +287,8 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
                 const ulong defaultAlignment = 0x1000;
                 const ulong defaultSize      = 0x20000;
 
-                // NOTE: The official service setup a A8B8G8R8 texture with a linear layout and then query its size. 
-                //       As we don't need this texture on the emulator, we can just simplify this logic and directly 
+                // NOTE: The official service setup a A8B8G8R8 texture with a linear layout and then query its size.
+                //       As we don't need this texture on the emulator, we can just simplify this logic and directly
                 //       do a linear layout size calculation. (stride * height * bytePerPixel)
                 int   pitch              = BitUtils.AlignUp(BitUtils.DivRoundUp(width * 32, 8), 64);
                 int   memorySize         = pitch * BitUtils.AlignUp(height, 64);

--- a/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
@@ -238,28 +238,28 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
         }
 
         [Command(2450)]
-        // GetIndirectLayerImageMap(u64 width, u64 height, u64 handle, u64 ??, u64 ??, u64 ??) -> nothing??
+        // GetIndirectLayerImageMap(s64 width, s64 height, u64 handle, nn::applet::AppletResourceUserId, pid) -> (s64, s64, buffer<bytes, 0x46>)
         public ResultCode GetIndirectLayerImageMap(ServiceCtx context)
         {
-            Logger.Stub?.PrintStub(LogClass.ServiceVi);
+            int buffersCount = context.Request.ReceiveBuff.Count;
 
-            var numBuffs = context.Request.ReceiveBuff.Count;
-
-            if (numBuffs != 1)
+            if (buffersCount != 1)
             {
-                Logger.Warning?.Print(LogClass.ServiceVi, $"GetIndirectLayerImageMap expects just 1 receive buffer instead of {numBuffs}!");
+                Logger.Warning?.Print(LogClass.ServiceVi, $"GetIndirectLayerImageMap expects just 1 receive buffer instead of {buffersCount}!");
+
                 return ResultCode.Success;
             }
 
             // The size of the layer buffer should be an aligned multiple of width * height
-            // because it was created using GetIndirectLayerImageRequiredMemoryInfo as a guide
+            // because it was created using GetIndirectLayerImageRequiredMemoryInfo as a guide.
 
-            var layerBuff = context.Request.ReceiveBuff[0];
-            var layerBuffPtr = layerBuff.Position;
-            var layerBuffSz = layerBuff.Size;
+            long layerBuffPosition = context.Request.ReceiveBuff[0].Position;
+            long layerBuffSize     = context.Request.ReceiveBuff[0].Size;
 
-            // Fill the layer with zeros
-            context.Memory.Fill((ulong)layerBuffPtr, (ulong)layerBuffSz, 0x00);
+            // Fill the layer with zeros.
+            context.Memory.Fill((ulong)layerBuffPosition, (ulong)layerBuffSize, 0x00);
+
+            Logger.Stub?.PrintStub(LogClass.ServiceVi);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
@@ -238,16 +238,28 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
         }
 
         [Command(2450)]
-        // GetIndirectLayerImageMap(u64 width, u64 height, u64 handle, u64 ??, u64 ??, u64 ??) -> (u64 size, u64 alignment)
+        // GetIndirectLayerImageMap(u64 width, u64 height, u64 handle, u64 ??, u64 ??, u64 ??) -> nothing??
         public ResultCode GetIndirectLayerImageMap(ServiceCtx context)
         {
             Logger.Stub?.PrintStub(LogClass.ServiceDisplay, $"GetIndirectLayerImageMap");
 
-            ulong width = context.RequestData.ReadUInt64();
-            ulong height = context.RequestData.ReadUInt64();
+            var numBuffs = context.Request.ReceiveBuff.Count;
 
-            context.ResponseData.Write(width);
-            context.ResponseData.Write(height);
+            if (numBuffs != 1)
+            {
+                Logger.Stub?.PrintStub(LogClass.ServiceDisplay, $"GetIndirectLayerImageMap expects just 1 receive buffer instead of {numBuffs}!");
+                return ResultCode.Success;
+            }
+
+            // The size of the layer buffer should be an aligned multiple of width * height
+            // because it was created using GetIndirectLayerImageRequiredMemoryInfo as a guide
+
+            var layerBuff = context.Request.ReceiveBuff[0];
+            var layerBuffPtr = layerBuff.Position;
+            var layerBuffSz = layerBuff.Size;
+
+            // Fill the layer with zeros
+            context.Memory.Fill((ulong)layerBuffPtr, (ulong)layerBuffSz, 0x00);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
@@ -241,13 +241,13 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
         // GetIndirectLayerImageMap(u64 width, u64 height, u64 handle, u64 ??, u64 ??, u64 ??) -> nothing??
         public ResultCode GetIndirectLayerImageMap(ServiceCtx context)
         {
-            Logger.Stub?.PrintStub(LogClass.ServiceDisplay);
+            Logger.Stub?.PrintStub(LogClass.ServiceVi);
 
             var numBuffs = context.Request.ReceiveBuff.Count;
 
             if (numBuffs != 1)
             {
-                Logger.Warning?.Print(LogClass.ServiceDisplay, $"GetIndirectLayerImageMap expects just 1 receive buffer instead of {numBuffs}!");
+                Logger.Warning?.Print(LogClass.ServiceVi, $"GetIndirectLayerImageMap expects just 1 receive buffer instead of {numBuffs}!");
                 return ResultCode.Success;
             }
 

--- a/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
@@ -241,13 +241,13 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
         // GetIndirectLayerImageMap(u64 width, u64 height, u64 handle, u64 ??, u64 ??, u64 ??) -> nothing??
         public ResultCode GetIndirectLayerImageMap(ServiceCtx context)
         {
-            Logger.Stub?.PrintStub(LogClass.ServiceDisplay, $"GetIndirectLayerImageMap");
+            Logger.Stub?.PrintStub(LogClass.ServiceDisplay);
 
             var numBuffs = context.Request.ReceiveBuff.Count;
 
             if (numBuffs != 1)
             {
-                Logger.Stub?.PrintStub(LogClass.ServiceDisplay, $"GetIndirectLayerImageMap expects just 1 receive buffer instead of {numBuffs}!");
+                Logger.Warning?.Print(LogClass.ServiceDisplay, $"GetIndirectLayerImageMap expects just 1 receive buffer instead of {numBuffs}!");
                 return ResultCode.Success;
             }
 

--- a/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
@@ -1,4 +1,5 @@
 using Ryujinx.Common;
+using Ryujinx.Common.Logging;
 using Ryujinx.Cpu;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Kernel.Common;
@@ -234,6 +235,21 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
             }
 
             return null;
+        }
+
+        [Command(2450)]
+        // GetIndirectLayerImageMap(u64 width, u64 height, u64 handle, u64 ??, u64 ??, u64 ??) -> (u64 size, u64 alignment)
+        public ResultCode GetIndirectLayerImageMap(ServiceCtx context)
+        {
+            Logger.Stub?.PrintStub(LogClass.ServiceDisplay, $"GetIndirectLayerImageMap");
+
+            ulong width = context.RequestData.ReadUInt64();
+            ulong height = context.RequestData.ReadUInt64();
+
+            context.ResponseData.Write(width);
+            context.ResponseData.Write(height);
+
+            return ResultCode.Success;
         }
 
         [Command(2460)]


### PR DESCRIPTION
This PR implements the inline protocol used by the `SoftwareKeyboardApplet` to talk to games like Gnosia (Ryujinx/Ryujinx-Games-List#2563) and Monster Hunter Gen U (#1640). The lack of this protocol results in bad initialization of the software keyboard applet and, very likely, a hard lock inside the game.

This implementation of the Inline keyboard has support for Ok and Cancel operations and relies on the input GUI to acquire user input while the game runs in the background:

![s1](https://user-images.githubusercontent.com/2220062/103680194-90d2f380-4f64-11eb-826e-d7085855a1fd.PNG)

Therefore it does not draw a virtual keyboard on top of the game ~~, which (for now) can lead to minor graphical glitches~~

**OLD version:**

![s2](https://user-images.githubusercontent.com/2220062/103680511-09d24b00-4f65-11eb-9a7d-a9128e35f2c4.PNG)

~~These glitches do not break the game and may only appear when the input is requested. They may be fixed by implementing the `IApplicationDisplayService.GetIndirectLayerImageMap` method that I stubbed.~~

**Updated:**

![s6](https://user-images.githubusercontent.com/2220062/103763347-7185a600-4ff8-11eb-92e5-09ebaec43496.PNG)
