### PR TITLE
Allow out of bounds storage buffer access by aligning their sizes

### DIFF
--- a/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
@@ -89,6 +89,21 @@ namespace Ryujinx.Graphics.Gpu.Memory
         }
 
         /// <summary>
+        /// Gets a sub-range from the buffer, from a start address till the end of the buffer.
+        /// </summary>
+        /// <remarks>
+        /// This can be used to bind and use sub-ranges of the buffer on the host API.
+        /// </remarks>
+        /// <param name="address">Start address of the sub-range, must be greater than or equal to the buffer address</param>
+        /// <returns>The buffer sub-range</returns>
+        public BufferRange GetRange(ulong address)
+        {
+            ulong offset = address - Address;
+
+            return new BufferRange(Handle, (int)offset, (int)(Size - offset));
+        }
+
+        /// <summary>
         /// Gets a sub-range from the buffer.
         /// </summary>
         /// <remarks>

--- a/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -591,7 +591,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
                 if (bounds.Address != 0)
                 {
-                    sRanges[bindingInfo.Binding] = GetBufferRange(bounds.Address, bounds.Size, bounds.Flags.HasFlag(BufferUsageFlags.Write));
+                    sRanges[bindingInfo.Binding] = GetBufferRange(bounds.Address, bounds.Flags.HasFlag(BufferUsageFlags.Write));
                 }
             }
 
@@ -764,7 +764,9 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
                     if (bounds.Address != 0)
                     {
-                        ranges[bindingInfo.Binding] = GetBufferRange(bounds.Address, bounds.Size, bounds.Flags.HasFlag(BufferUsageFlags.Write));
+                        ranges[bindingInfo.Binding] = isStorage
+                            ? GetBufferRange(bounds.Address, bounds.Flags.HasFlag(BufferUsageFlags.Write))
+                            : GetBufferRange(bounds.Address, bounds.Size, bounds.Flags.HasFlag(BufferUsageFlags.Write));
                     }
                 }
             }
@@ -893,6 +895,17 @@ namespace Ryujinx.Graphics.Gpu.Memory
             _context.Renderer.Pipeline.ClearBuffer(buffer.Handle, offset, (int)size, value);
 
             buffer.SignalModified(address, size);
+        }
+
+        /// <summary>
+        /// Gets a buffer sub-range starting at a given memory address.
+        /// </summary>
+        /// <param name="address">Start address of the memory range</param>
+        /// <param name="write">Whether the buffer will be written to by this use</param>
+        /// <returns>The buffer sub-range starting at rhe given memory address</returns>
+        private BufferRange GetBufferRange(ulong address, bool write = false)
+        {
+            return GetBuffer(address, 1, write).GetRange(address);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -591,6 +591,8 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
                 if (bounds.Address != 0)
                 {
+                    // The storage buffer size is not reliable (it might be lower than the actual size),
+                    // so we bind the entire buffer to allow otherwise out of range accesses to work.
                     sRanges[bindingInfo.Binding] = GetBufferRangeTillEnd(
                         bounds.Address,
                         bounds.Size,
@@ -906,7 +908,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="address">Start address of the memory range</param>
         /// <param name="size">Size in bytes of the memory range</param>
         /// <param name="write">Whether the buffer will be written to by this use</param>
-        /// <returns>The buffer sub-range starting at rhe given memory address</returns>
+        /// <returns>The buffer sub-range starting at the given memory address</returns>
         private BufferRange GetBufferRangeTillEnd(ulong address, ulong size, bool write = false)
         {
             return GetBuffer(address, size, write).GetRange(address);

--- a/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -591,7 +591,10 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
                 if (bounds.Address != 0)
                 {
-                    sRanges[bindingInfo.Binding] = GetBufferRange(bounds.Address, bounds.Flags.HasFlag(BufferUsageFlags.Write));
+                    sRanges[bindingInfo.Binding] = GetBufferRangeTillEnd(
+                        bounds.Address,
+                        bounds.Size,
+                        bounds.Flags.HasFlag(BufferUsageFlags.Write));
                 }
             }
 
@@ -765,7 +768,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                     if (bounds.Address != 0)
                     {
                         ranges[bindingInfo.Binding] = isStorage
-                            ? GetBufferRange(bounds.Address, bounds.Flags.HasFlag(BufferUsageFlags.Write))
+                            ? GetBufferRangeTillEnd(bounds.Address, bounds.Size, bounds.Flags.HasFlag(BufferUsageFlags.Write))
                             : GetBufferRange(bounds.Address, bounds.Size, bounds.Flags.HasFlag(BufferUsageFlags.Write));
                     }
                 }
@@ -901,11 +904,12 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// Gets a buffer sub-range starting at a given memory address.
         /// </summary>
         /// <param name="address">Start address of the memory range</param>
+        /// <param name="size">Size in bytes of the memory range</param>
         /// <param name="write">Whether the buffer will be written to by this use</param>
         /// <returns>The buffer sub-range starting at rhe given memory address</returns>
-        private BufferRange GetBufferRange(ulong address, bool write = false)
+        private BufferRange GetBufferRangeTillEnd(ulong address, ulong size, bool write = false)
         {
-            return GetBuffer(address, 1, write).GetRange(address);
+            return GetBuffer(address, size, write).GetRange(address);
         }
 
         /// <summary>


### PR DESCRIPTION
Some games such as Yo-kai watch performs a out of bounds storage buffer access. It says that the size is 4 bytes, but accesses (reads and writes) 256 bytes on a compute shader. In fact the game allocates enough memory for that (the buffers are 256 bytes apart), its just the size that is wrong on this particular call. The shader does not use this size for anything, so this is not a problem on the Switch, but on OpenGL, looks like theres some bounds checking going on preventing values after the first 4 bytes from being read/written.

This fixes this particular issue by binding the entire buffer rather than just the range that the game says its using. Unfortunately there is no way to guess the real size of the buffer, so this will just effectively page align the size, which works in this case as the real buffer size is way smaller than a page (256 bytes vs 4096 bytes that is the page size).

This solution is not perfect, it won't work for all possible cases where the size is incorrect, but it should work in all cases observed on this particular game. The only way I can think to get it working in all cases is mirroring the guest memory map on the host, which would require a full rewrite of the buffer management code, and I'm not sure if its even feasible.

Closes #1689

I recommend testing on games that makes use of SSBOs. This should not have any performance impact. I only tested Yo-kai watch 4, but the other Yo-kai watch games with a similar issue might be fixed aswell.