### PR TITLE
Update missing sample timestamp in DebugPad

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Hid/HidDevices/DebugPadDevice.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/HidDevices/DebugPadDevice.cs
@@ -19,6 +19,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             DebugPadEntry previousEntry = debugPad.Entries[previousIndex];
 
             currentEntry.SampleTimestamp = previousEntry.SampleTimestamp + 1;
+            currentEntry.SampleTimestamp2 = previousEntry.SampleTimestamp2 + 1;
         }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMem/DebugPad/DebugPadEntry.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMem/DebugPad/DebugPadEntry.cs
@@ -3,6 +3,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
     unsafe struct DebugPadEntry
     {
         public ulong SampleTimestamp;
-        fixed byte _unknown[0x20];
+        public ulong SampleTimestamp2;
+        fixed byte _unknown[0x18];
     }
 }


### PR DESCRIPTION
Fixes #1872 

Some games seem to be really insistent on a proper DebugPad.
In any case, updating the second sample timestamp (bringing this in line with other devices) fixes the softlock.