### PR TITLE
Support conditional on BRK and SYNC shader instructions

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -34,7 +34,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 1759;
+        private const ulong ShaderCodeGenVersion = 1878;
 
         /// <summary>
         /// Creates a new instance of the shader cache.

--- a/Ryujinx.Graphics.Shader/Decoders/OpCodeBranch.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/OpCodeBranch.cs
@@ -2,10 +2,8 @@ using Ryujinx.Graphics.Shader.Instructions;
 
 namespace Ryujinx.Graphics.Shader.Decoders
 {
-    class OpCodeBranch : OpCode
+    class OpCodeBranch : OpCodeConditional
     {
-        public Condition Condition { get; }
-
         public int Offset { get; }
 
         public bool PushTarget { get; protected set; }
@@ -14,8 +12,6 @@ namespace Ryujinx.Graphics.Shader.Decoders
 
         public OpCodeBranch(InstEmitter emitter, ulong address, long opCode) : base(emitter, address, opCode)
         {
-            Condition = (Condition)(opCode & 0x1f);
-
             Offset = ((int)(opCode >> 20) << 8) >> 8;
 
             PushTarget = false;

--- a/Ryujinx.Graphics.Shader/Decoders/OpCodeBranchPop.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/OpCodeBranchPop.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Ryujinx.Graphics.Shader.Decoders
 {
-    class OpCodeBranchPop : OpCode
+    class OpCodeBranchPop : OpCodeConditional
     {
         public Dictionary<OpCodePush, int> Targets { get; }
 

--- a/Ryujinx.Graphics.Shader/Decoders/OpCodeConditional.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/OpCodeConditional.cs
@@ -1,0 +1,16 @@
+﻿using Ryujinx.Graphics.Shader.Instructions;
+
+namespace Ryujinx.Graphics.Shader.Decoders
+{
+    class OpCodeConditional : OpCode
+    {
+        public Condition Condition { get; }
+
+        public new static OpCode Create(InstEmitter emitter, ulong address, long opCode) => new OpCodeExit(emitter, address, opCode);
+
+        public OpCodeConditional(InstEmitter emitter, ulong address, long opCode) : base(emitter, address, opCode)
+        {
+            Condition = (Condition)opCode.Extract(0, 5);
+        }
+    }
+}

--- a/Ryujinx.Graphics.Shader/Decoders/OpCodeExit.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/OpCodeExit.cs
@@ -2,15 +2,12 @@ using Ryujinx.Graphics.Shader.Instructions;
 
 namespace Ryujinx.Graphics.Shader.Decoders
 {
-    class OpCodeExit : OpCode
+    class OpCodeExit : OpCodeConditional
     {
-        public Condition Condition { get; }
-
         public new static OpCode Create(InstEmitter emitter, ulong address, long opCode) => new OpCodeExit(emitter, address, opCode);
 
         public OpCodeExit(InstEmitter emitter, ulong address, long opCode) : base(emitter, address, opCode)
         {
-            Condition = (Condition)opCode.Extract(0, 5);
         }
     }
 }

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitFlow.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitFlow.cs
@@ -146,6 +146,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
             }
             else
             {
+                // TODO: Support CC here aswell (condition).
                 foreach (KeyValuePair<OpCodePush, int> kv in op.Targets)
                 {
                     OpCodePush pushOp = kv.Key;

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitFlow.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitFlow.cs
@@ -176,9 +176,9 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
             Operand pred = Register(op.Predicate);
 
-            if (op is OpCodeBranch opBranch && opBranch.Condition != Condition.Always)
+            if (op is OpCodeConditional opCond && opCond.Condition != Condition.Always)
             {
-                Operand cond = GetCondition(context, opBranch.Condition);
+                Operand cond = GetCondition(context, opCond.Condition);
 
                 if (op.Predicate.IsPT)
                 {


### PR DESCRIPTION
Like the BRAnch instruction, BRK and SYNC also support a conditonal, in addition to the predicate, which allows compound predication of the jump. The CC register is set by previous instruction based on the result, setting the NZCV flags. Example:
```
@P0 BRK CC.NEU
```
In this case, the branch is taken if P0 is true *and* the Z flag is clear, as the zero flag should be set if the result is zero, and cleared otherwise. This is usually used with ISET/FSET with `RZ.CC` as destination that will set the zero and negative flags based on the result, which can be -1 (if comparison is true) or 0 (if its false).

This improves rendering on Monster Hunter Rise, but there are still other bugs preventing most objects from being draw.