### PR TITLE
Implement friendlier portable mode

### DIFF
--- a/Ryujinx.Common/Configuration/AppDataManager.cs
+++ b/Ryujinx.Common/Configuration/AppDataManager.cs
@@ -47,19 +47,7 @@ namespace Ryujinx.Common.Configuration
             string userProfilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), DefaultBaseDir);
             string portablePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, DefaultPortableDir);
 
-            if (baseDirPath != null && baseDirPath != userProfilePath)
-            {
-                if (!Directory.Exists(baseDirPath))
-                {
-                    Logger.Error?.Print(LogClass.Application, $"Custom Data Directory '{baseDirPath}' does not exist. Using defaults...");
-                }
-                else
-                {
-                    BaseDirPath = baseDirPath;
-                    Mode = LaunchMode.Custom;
-                }
-            }
-            else if (Directory.Exists(portablePath))
+            if (Directory.Exists(portablePath))
             {
                 BaseDirPath = portablePath;
                 Mode = LaunchMode.Portable;
@@ -69,6 +57,21 @@ namespace Ryujinx.Common.Configuration
                 BaseDirPath = userProfilePath;
                 Mode = LaunchMode.UserProfile;
             }
+
+            if (baseDirPath != null && baseDirPath != userProfilePath)
+            {
+                if (!Directory.Exists(baseDirPath))
+                {
+                    Logger.Error?.Print(LogClass.Application, $"Custom Data Directory '{baseDirPath}' does not exist. Falling back to {Mode}...");
+                }
+                else
+                {
+                    BaseDirPath = baseDirPath;
+                    Mode = LaunchMode.Custom;
+                }
+            }
+
+            BaseDirPath = Path.GetFullPath(BaseDirPath); // convert relative paths
 
             SetupBasePaths();
         }

--- a/Ryujinx.Common/Configuration/AppDataManager.cs
+++ b/Ryujinx.Common/Configuration/AppDataManager.cs
@@ -42,7 +42,7 @@ namespace Ryujinx.Common.Configuration
             KeysDirPathUser = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".switch");
         }
 
-        public static void Initialize(string baseDirPath, Func<bool> FirstRunPortableChoice)
+        public static void Initialize(string baseDirPath)
         {
             string userProfilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), DefaultBaseDir);
             string portablePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, DefaultPortableDir);
@@ -68,20 +68,6 @@ namespace Ryujinx.Common.Configuration
             {
                 BaseDirPath = userProfilePath;
                 Mode = LaunchMode.UserProfile;
-            }
-
-            if (!Directory.Exists(BaseDirPath)) // First run
-            {
-                if (FirstRunPortableChoice())
-                {
-                    BaseDirPath = portablePath;
-                    Mode = LaunchMode.Portable;
-                }
-                else
-                {
-                    BaseDirPath = userProfilePath;
-                    Mode = LaunchMode.UserProfile;
-                }
             }
 
             SetupBasePaths();

--- a/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
+++ b/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
@@ -227,9 +227,9 @@ namespace Ryujinx.HLE.FileSystem
             string titleKeyFile   = null;
             string consoleKeyFile = null;
 
-            if (!AppDataManager.IsCustomBasePath)
+            if (AppDataManager.Mode == AppDataManager.LaunchMode.UserProfile)
             {
-                LoadSetAtPath(AppDataManager.KeysDirPathAlt);
+                LoadSetAtPath(AppDataManager.KeysDirPathUser);
             }
 
             LoadSetAtPath(AppDataManager.KeysDirPath);

--- a/Ryujinx/Modules/Updater/Updater.cs
+++ b/Ryujinx/Modules/Updater/Updater.cs
@@ -4,6 +4,7 @@ using ICSharpCode.SharpZipLib.Tar;
 using ICSharpCode.SharpZipLib.Zip;
 using Mono.Unix;
 using Newtonsoft.Json.Linq;
+using Ryujinx.Common.Configuration;
 using Ryujinx.Common.Logging;
 using Ryujinx.Ui;
 using Ryujinx.Ui.Widgets;
@@ -484,6 +485,16 @@ namespace Ryujinx.Modules
                 if (showWarnings)
                 {
                     GtkDialog.CreateWarningDialog("You are not connected to the Internet!", "Please verify that you have a working Internet connection!");
+                }
+
+                return false;
+            }
+
+            if (AppDataManager.Mode == AppDataManager.LaunchMode.Portable)
+            {
+                if (showWarnings)
+                {
+                    GtkDialog.CreateWarningDialog("You cannot update a portable version of Ryujinx!", "Please use a non-portable configuration to enable updates.");
                 }
 
                 return false;

--- a/Ryujinx/Program.cs
+++ b/Ryujinx/Program.cs
@@ -80,15 +80,8 @@ namespace Ryujinx
             AppDomain.CurrentDomain.UnhandledException += (object sender, UnhandledExceptionEventArgs e) => ProcessUnhandledException(e.ExceptionObject as Exception, e.IsTerminating);
             AppDomain.CurrentDomain.ProcessExit        += (object sender, EventArgs e)                   => Exit();
 
-            // Initialize Gtk.
-            Application.Init();
-
             // Setup base data directory.
-            AppDataManager.Initialize(baseDirPathArg, () => GtkDialog.CreateChoiceDialog(
-                "Ryujinx - First Run",
-                "Do you want to enable portable mode?",
-                $"In portable mode, all Ryujinx-specific data is stored within your Ryujinx program folder.\n\nIf No (default) is chosen, data will be stored in your user profile directory."
-            ));
+            AppDataManager.Initialize(baseDirPathArg);
 
             // Initialize the configuration.
             ConfigurationState.Initialize();
@@ -137,6 +130,9 @@ namespace Ryujinx
 
             // Logging system information.
             PrintSystemInfo();
+
+            // Initialize Gtk.
+            Application.Init();
 
             // Check if keys exists.
             bool hasSystemProdKeys = File.Exists(Path.Combine(AppDataManager.KeysDirPath, "prod.keys"));


### PR DESCRIPTION
Users seem to have trouble using the "custom data directory" feature for portability. This implements an extra (arguably redundant) way to achieve it. Creating a `portable` dir in the exe base directory now activates portable mode.

This code prioritizes Custom Data argument -> Portable dir -> User Profile.

**EDIT:** Removed first run dialog.

**NOTE1:** I was unable to figure out a way to stop GTK from creating a 'recently-used.xbel' file in user profiles used for Recent items in file dialogs. Besides that, the application should be fully portable.

**NOTE2:** It's still a bit jarring to find the portable directory among the plethora of files and folders. This would have to be resolved in the future.

Closes #1879

Tested on Windows. Should work on others but please do test.

~__I highly recommend blocking this from merge until #1594 is resolved.__~
To unblock this PR, using portable mode blocks updates for now.