### PR TITLE
Only attempt to import common tickets.

### DIFF
--- a/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
+++ b/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
@@ -269,7 +269,10 @@ namespace Ryujinx.HLE.FileSystem
                 {
                     Ticket ticket = new Ticket(ticketFile.AsStream());
 
-                    KeySet.ExternalKeySet.Add(new RightsId(ticket.RightsId), new AccessKey(ticket.GetTitleKey(KeySet)));
+                    if (ticket.TitleKeyType == TitleKeyType.Common)
+                    {
+                        KeySet.ExternalKeySet.Add(new RightsId(ticket.RightsId), new AccessKey(ticket.GetTitleKey(KeySet)));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Loading NSPs with personalized tickets results in the following error, and the game does not load:
```
00:00:00.332 |E| Loader LoadNsp: Unable to load NSP: System.Security.Cryptography.CryptographicException: The specified RSA parameters are not valid. Exponent and Modulus are required. If D is present, it must have the same leng
th as Modulus. If D is present, P, Q, DP, DQ, and InverseQ are required and must have half the length of Modulus, rounded up, otherwise they must be omitted.
   at System.Security.Cryptography.RSAImplementation.RSACng.ImportParameters(RSAParameters parameters)
   at LibHac.Ticket.GetTitleKey(Keyset keyset)
   at Ryujinx.HLE.FileSystem.VirtualFileSystem.ImportTickets(IFileSystem fs) in ...\Ryujinx\Ryujinx.HLE\FileSystem\VirtualFileSystem.cs:line 265
   at Ryujinx.HLE.HOS.ApplicationLoader.GetGameData(VirtualFileSystem fileSystem, PartitionFileSystem pfs, Int32 programIndex) in ...\Ryujinx\Ryujinx.HLE\HOS\ApplicationLoader.cs:line 107
   at Ryujinx.HLE.HOS.ApplicationLoader.LoadNsp(String nspFile) in ...\Ryujinx\Ryujinx.HLE\HOS\ApplicationLoader.cs:line 265
```

After doing some digging, it seems that this is caused by Ryujinx not having EticketExtKeyRsa set. Since keys can be specified through title.keys instead, non-common tickets can just be ignored to prevent this error and let the game load.

Note that these NSPs work fine in Yuzu with just prod.keys and title.keys put in place.