### PR TITLE
Optimization | Remove unnecessary Emit when ZeroExtend occurs on same register

### DIFF
--- a/ARMeilleure/CodeGen/X86/CodeGenerator.cs
+++ b/ARMeilleure/CodeGen/X86/CodeGenerator.cs
@@ -1556,10 +1556,13 @@ namespace ARMeilleure.CodeGen.X86
 
             Debug.Assert(dest.Type.IsInteger() && source.Type.IsInteger());
 
-            if (!dest.GetRegister().Equals(source.GetRegister()))
+            // Moves to the same register are useless.
+            if (dest.Kind == source.Kind && dest.Value == source.Value)
             {
-                context.Assembler.Mov(dest, source, OperandType.I32);
+                return;
             }
+
+            context.Assembler.Mov(dest, source, OperandType.I32);   
         }
 
         private static void GenerateZeroExtend8(CodeGenContext context, Operation operation)

--- a/ARMeilleure/CodeGen/X86/CodeGenerator.cs
+++ b/ARMeilleure/CodeGen/X86/CodeGenerator.cs
@@ -1599,7 +1599,10 @@ namespace ARMeilleure.CodeGen.X86
 
         private static void GenerateZeroUpper64(CodeGenContext context, Operand dest, Operand source)
         {
-            context.Assembler.Movq(dest, source);
+            if (!dest.GetRegister().Equals(source.GetRegister()))
+            {
+                context.Assembler.Movq(dest, source);
+            }
         }
 
         private static void GenerateZeroUpper96(CodeGenContext context, Operand dest, Operand source)

--- a/ARMeilleure/CodeGen/X86/CodeGenerator.cs
+++ b/ARMeilleure/CodeGen/X86/CodeGenerator.cs
@@ -1556,7 +1556,10 @@ namespace ARMeilleure.CodeGen.X86
 
             Debug.Assert(dest.Type.IsInteger() && source.Type.IsInteger());
 
-            context.Assembler.Mov(dest, source, OperandType.I32);
+            if (!dest.GetRegister().Equals(source.GetRegister()))
+            {
+                context.Assembler.Mov(dest, source, OperandType.I32);
+            }
         }
 
         private static void GenerateZeroExtend8(CodeGenContext context, Operation operation)
@@ -1599,10 +1602,7 @@ namespace ARMeilleure.CodeGen.X86
 
         private static void GenerateZeroUpper64(CodeGenContext context, Operand dest, Operand source)
         {
-            if (!dest.GetRegister().Equals(source.GetRegister()))
-            {
-                context.Assembler.Movq(dest, source);
-            }
+            context.Assembler.Movq(dest, source);
         }
 
         private static void GenerateZeroUpper96(CodeGenContext context, Operand dest, Operand source)

--- a/ARMeilleure/CodeGen/X86/CodeGenerator.cs
+++ b/ARMeilleure/CodeGen/X86/CodeGenerator.cs
@@ -1556,8 +1556,8 @@ namespace ARMeilleure.CodeGen.X86
 
             Debug.Assert(dest.Type.IsInteger() && source.Type.IsInteger());
 
-            // Moves to the same register are useless.
-            if (dest.Kind == source.Kind && dest.Value == source.Value)
+            // Moves to the same register are useless when the SourceType is I32 as the upper bits are already zeroed.
+            if (dest.Kind == source.Kind && dest.Value == source.Value && source.Type == OperandType.I32)
             {
                 return;
             }

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -22,7 +22,7 @@ namespace ARMeilleure.Translation.PTC
     {
         private const string HeaderMagic = "PTChd";
 
-        private const int InternalVersion = 1841; //! To be incremented manually for each change to the ARMeilleure project.
+        private const int InternalVersion = 1897; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -22,7 +22,7 @@ namespace ARMeilleure.Translation.PTC
     {
         private const string HeaderMagic = "PTChd";
 
-        private const int InternalVersion = 1817; //! To be incremented manually for each change to the ARMeilleure project.
+        private const int InternalVersion = 1841; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";


### PR DESCRIPTION
Currently a zero-extend from I32 -> I64 always emits a move, we will only emit a move if the registers of both operands are not the same.