### PR TITLE
Pacify updater

### DIFF
--- a/Ryujinx/Modules/Updater/Updater.cs
+++ b/Ryujinx/Modules/Updater/Updater.cs
@@ -33,6 +33,9 @@ namespace Ryujinx.Modules
         
         private const string AppveyorApiUrl = "https://ci.appveyor.com/api";
 
+        // On Windows, GtkSharp.Dependencies adds these extra dirs that must be cleaned during updates.
+        private static readonly string[] WindowsDependencyDirs = new string[] { "bin", "etc", "lib", "share" };
+
         public static async Task BeginParse(MainWindow mainWindow, bool showVersionUpToDate)
         {
             if (Running) return;
@@ -320,17 +323,14 @@ namespace Ryujinx.Modules
             return true;
         }
 
-        // NOTE: This method should always reflect the latest build layout
+        // NOTE: This method should always reflect the latest build layout.
         private static IEnumerable<string> EnumerateFilesToDelete()
         {
-            var files = Directory.EnumerateFiles(HomeDir); // all files directly in base dir
+            var files = Directory.EnumerateFiles(HomeDir); // All files directly in base dir.
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                // On Windows, GtkSharp.Dependencies adds these extra dirs
-                // the other dependencies are just files in the base dir so they got marked above
-                string[] dependencyDirs = new string[] { "bin", "etc", "lib", "share" };
-                foreach (string dir in dependencyDirs)
+                foreach (string dir in WindowsDependencyDirs)
                 {
                     string dirPath = Path.Combine(HomeDir, dir);
                     if (Directory.Exists(dirPath))

--- a/Ryujinx/Program.cs
+++ b/Ryujinx/Program.cs
@@ -156,7 +156,10 @@ namespace Ryujinx
 
             if (ConfigurationState.Instance.CheckUpdatesOnStart.Value && Updater.CanUpdate(false))
             {
-                _ = Updater.BeginParse(mainWindow, false);
+                Updater.BeginParse(mainWindow, false).ContinueWith(task =>
+                {
+                    Logger.Error?.Print(LogClass.Application, $"Updater Error: {task.Exception}");
+                }, TaskContinuationOptions.OnlyOnFaulted);
             }
 
             Application.Run();

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -1131,7 +1131,10 @@ namespace Ryujinx.Ui
         {
             if (Updater.CanUpdate(true))
             {
-                _ = Updater.BeginParse(this, true);
+                Updater.BeginParse(this, true).ContinueWith(task =>
+                {
+                    Logger.Error?.Print(LogClass.Application, $"Updater Error: {task.Exception}");
+                }, TaskContinuationOptions.OnlyOnFaulted);
             }
         }
 


### PR DESCRIPTION
The current updater marks everything except `.log` files for deletion.
With this PR, it now deletes only select directories (Windows only, Linux and MacOS don't have these) and all top-level files in the base directory. So, if there's other directories (like portable or custom), their contents will be spared.

Also used this opportunity to log errors from the updater (to easily identify future issues).

This PR does not claim to solve #1594 100%. Only to unblock #1885. So, I have not added an auto-close. 
I do think this is enough for most people, but feel free to close this if it isn't the way to go.