### PR TITLE
Fix some GLXBadDrawable crashes on linux

### DIFF
--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -591,7 +591,6 @@ namespace Ryujinx.Ui
                     ToggleExtraWidgets(true);
                 }
 
-                _viewBox.Remove(GlRendererWidget);
                 GlRendererWidget.Exit();
 
                 if(GlRendererWidget.Window != Window && GlRendererWidget.Window != null)
@@ -604,6 +603,7 @@ namespace Ryujinx.Ui
                 _windowsMultimediaTimerResolution?.Dispose();
                 _windowsMultimediaTimerResolution = null;
 
+                _viewBox.Remove(GlRendererWidget);
                 _viewBox.Add(_gameTableWindow);
 
                 _gameTableWindow.Expand = true;
@@ -711,6 +711,7 @@ namespace Ryujinx.Ui
 
                     // Wait for the other thread to dispose the HLE context before exiting.
                     _deviceExitStatus.WaitOne();
+                    GlRendererWidget.Dispose();
                 }
             }
 


### PR DESCRIPTION
fixes the crashes on linux when you stop emulation, and when you try to
exit the emulator while a game is running
tested on windows too, and didn't come up to any problems on my side

Fixes #1810