### PR TITLE
Support for resources on non-contiguous GPU memory regions

### DIFF
--- a/Ryujinx.Cpu/MemoryManager.cs
+++ b/Ryujinx.Cpu/MemoryManager.cs
@@ -13,7 +13,7 @@ namespace Ryujinx.Cpu
     /// <summary>
     /// Represents a CPU memory manager.
     /// </summary>
-    public sealed class MemoryManager : IMemoryManager, IVirtualMemoryManager, IDisposable
+    public sealed class MemoryManager : IMemoryManager, IVirtualMemoryManager, IWritableBlock, IDisposable
     {
         public const int PageBits = 12;
         public const int PageSize = 1 << PageBits;
@@ -202,12 +202,12 @@ namespace Ryujinx.Cpu
             WriteImpl(va, data);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         /// <summary>
         /// Writes data to CPU mapped memory.
         /// </summary>
         /// <param name="va">Virtual address to write the data into</param>
         /// <param name="data">Data to be written</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void WriteImpl(ulong va, ReadOnlySpan<byte> data)
         {
             try

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -368,6 +368,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             SetInfo(new TextureInfo(
                 Info.Address,
+                Info.GpuAddress,
                 width,
                 height,
                 depthOrLayers,
@@ -554,7 +555,9 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             _memoryTracking?.Reprotect();
 
-            ReadOnlySpan<byte> data = _context.PhysicalMemory.GetSpan(Address, (int)Size);
+            ReadOnlySpan<byte> data = Info.GpuAddress == 0UL
+                ? _context.PhysicalMemory.GetSpan(Address, (int)Size)
+                : _context.MemoryManager.GetSpan(Info.GpuAddress, (int)Size);
 
             IsModified = false;
 
@@ -689,11 +692,11 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             if (tracked)
             {
-                _context.PhysicalMemory.Write(Address, GetTextureDataFromGpu(tracked));
+                _context.MemoryManager.Write(Info.GpuAddress, GetTextureDataFromGpu(tracked));
             }
             else
             {
-                _context.PhysicalMemory.WriteUntracked(Address, GetTextureDataFromGpu(tracked));
+                _context.MemoryManager.WriteUntracked(Info.GpuAddress, GetTextureDataFromGpu(tracked));
             }
         }
 
@@ -725,7 +728,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     texture = _flushHostTexture = GetScaledHostTexture(1f, _flushHostTexture);
                 }
 
-                _context.PhysicalMemory.WriteUntracked(Address, GetTextureDataFromGpu(false, texture));
+                _context.MemoryManager.WriteUntracked(Info.GpuAddress, GetTextureDataFromGpu(false, texture));
             });
         }
 

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -369,7 +369,6 @@ namespace Ryujinx.Graphics.Gpu.Image
             ChangedSize = true;
 
             SetInfo(new TextureInfo(
-                Info.Address,
                 Info.GpuAddress,
                 width,
                 height,
@@ -660,7 +659,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 {
                     string texInfo = $"{Info.Target} {Info.FormatInfo.Format} {Info.Width}x{Info.Height}x{Info.DepthOrLayers} levels {Info.Levels}";
 
-                    Logger.Debug?.Print(LogClass.Gpu, $"Invalid ASTC texture at 0x{Info.Address:X} ({texInfo}).");
+                    Logger.Debug?.Print(LogClass.Gpu, $"Invalid ASTC texture at 0x{Info.GpuAddress:X} ({texInfo}).");
                 }
 
                 data = decoded;
@@ -853,7 +852,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 return TextureMatchQuality.NoMatch;
             }
 
-            return Info.Address == info.Address && Info.Levels == info.Levels ? matchQuality : TextureMatchQuality.NoMatch;
+            return Info.Levels == info.Levels ? matchQuality : TextureMatchQuality.NoMatch;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.Graphics.Gpu.Image
     /// <summary>
     /// Represents a cached GPU texture.
     /// </summary>
-    class Texture : IRange, IDisposable
+    class Texture : IMultiRangeItem, IDisposable
     {
         // How many updates we need before switching to the byte-by-byte comparison
         // modification check method.
@@ -95,14 +95,9 @@ namespace Ryujinx.Graphics.Gpu.Image
         public event Action<Texture> Disposed;
 
         /// <summary>
-        /// Start address of the texture in guest memory.
+        /// Physical memory ranges where the texture data is located.
         /// </summary>
-        public ulong Address => Info.Address;
-
-        /// <summary>
-        /// End address of the texture in guest memory.
-        /// </summary>
-        public ulong EndAddress => Info.Address + Size;
+        public MultiRange Range { get; private set; }
 
         /// <summary>
         /// Texture size in bytes.
@@ -119,6 +114,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="context">GPU context that the texture belongs to</param>
         /// <param name="info">Texture information</param>
         /// <param name="sizeInfo">Size information of the texture</param>
+        /// <param name="range">Physical memory ranges where the texture data is located</param>
         /// <param name="firstLayer">The first layer of the texture, or 0 if the texture has no parent</param>
         /// <param name="firstLevel">The first mipmap level of the texture, or 0 if the texture has no parent</param>
         /// <param name="scaleFactor">The floating point scale factor to initialize with</param>
@@ -127,12 +123,13 @@ namespace Ryujinx.Graphics.Gpu.Image
             GpuContext       context,
             TextureInfo      info,
             SizeInfo         sizeInfo,
+            MultiRange       range,
             int              firstLayer,
             int              firstLevel,
             float            scaleFactor,
             TextureScaleMode scaleMode)
         {
-            InitializeTexture(context, info, sizeInfo);
+            InitializeTexture(context, info, sizeInfo, range);
 
             _firstLayer = firstLayer;
             _firstLevel = firstLevel;
@@ -149,13 +146,14 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="context">GPU context that the texture belongs to</param>
         /// <param name="info">Texture information</param>
         /// <param name="sizeInfo">Size information of the texture</param>
+        /// <param name="range">Physical memory ranges where the texture data is located</param>
         /// <param name="scaleMode">The scale mode to initialize with. If scaled, the texture's data is loaded immediately and scaled up</param>
-        public Texture(GpuContext context, TextureInfo info, SizeInfo sizeInfo, TextureScaleMode scaleMode)
+        public Texture(GpuContext context, TextureInfo info, SizeInfo sizeInfo, MultiRange range, TextureScaleMode scaleMode)
         {
             ScaleFactor = 1f; // Texture is first loaded at scale 1x.
             ScaleMode = scaleMode;
 
-            InitializeTexture(context, info, sizeInfo);
+            InitializeTexture(context, info, sizeInfo, range);
         }
 
         /// <summary>
@@ -166,10 +164,12 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="context">GPU context that the texture belongs to</param>
         /// <param name="info">Texture information</param>
         /// <param name="sizeInfo">Size information of the texture</param>
-        private void InitializeTexture(GpuContext context, TextureInfo info, SizeInfo sizeInfo)
+        /// <param name="range">Physical memory ranges where the texture data is located</param>
+        private void InitializeTexture(GpuContext context, TextureInfo info, SizeInfo sizeInfo, MultiRange range)
         {
             _context  = context;
             _sizeInfo = sizeInfo;
+            Range     = range;
 
             SetInfo(info);
 
@@ -186,7 +186,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="withData">True if the texture is to be initialized with data</param>
         public void InitializeData(bool isView, bool withData = false)
         {
-            _memoryTracking = _context.PhysicalMemory.BeginTracking(Address, Size);
+            // TODO: Proper tracking.
+            _memoryTracking = _context.PhysicalMemory.BeginTracking(Range.GetRange(0).Address, Size);
 
             if (withData)
             {
@@ -229,15 +230,17 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         /// <param name="info">Child texture information</param>
         /// <param name="sizeInfo">Child texture size information</param>
+        /// <param name="range">Physical memory ranges where the texture data is located</param>
         /// <param name="firstLayer">Start layer of the child texture on the parent texture</param>
         /// <param name="firstLevel">Start mipmap level of the child texture on the parent texture</param>
         /// <returns>The child texture</returns>
-        public Texture CreateView(TextureInfo info, SizeInfo sizeInfo, int firstLayer, int firstLevel)
+        public Texture CreateView(TextureInfo info, SizeInfo sizeInfo, MultiRange range, int firstLayer, int firstLevel)
         {
             Texture texture = new Texture(
                 _context,
                 info,
                 sizeInfo,
+                range,
                 _firstLayer + firstLayer,
                 _firstLevel + firstLevel,
                 ScaleFactor,
@@ -555,9 +558,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             _memoryTracking?.Reprotect();
 
-            ReadOnlySpan<byte> data = Info.GpuAddress == 0UL
-                ? _context.PhysicalMemory.GetSpan(Address, (int)Size)
-                : _context.MemoryManager.GetSpan(Info.GpuAddress, (int)Size);
+            ReadOnlySpan<byte> data = _context.PhysicalMemory.GetSpan(Range);
 
             IsModified = false;
 
@@ -857,18 +858,16 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Check if it's possible to create a view, with the given parameters, from this texture.
         /// </summary>
         /// <param name="info">Texture view information</param>
-        /// <param name="size">Texture view size</param>
+        /// <param name="range">Texture view physical memory ranges</param>
         /// <param name="firstLayer">Texture view initial layer on this texture</param>
         /// <param name="firstLevel">Texture view first mipmap level on this texture</param>
         /// <returns>The level of compatiblilty a view with the given parameters created from this texture has</returns>
-        public TextureViewCompatibility IsViewCompatible(
-            TextureInfo info,
-            ulong       size,
-            out int     firstLayer,
-            out int     firstLevel)
+        public TextureViewCompatibility IsViewCompatible(TextureInfo info, MultiRange range, out int firstLayer, out int firstLevel)
         {
+            int offset = Range.FindOffset(range);
+
             // Out of range.
-            if (info.Address < Address || info.Address + size > EndAddress)
+            if (offset < 0)
             {
                 firstLayer = 0;
                 firstLevel = 0;
@@ -876,9 +875,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 return TextureViewCompatibility.Incompatible;
             }
 
-            int offset = (int)(info.Address - Address);
-
-            if (!_sizeInfo.FindView(offset, (int)size, out firstLayer, out firstLevel))
+            if (!_sizeInfo.FindView(offset, out firstLayer, out firstLevel))
             {
                 return TextureViewCompatibility.Incompatible;
             }
@@ -1049,17 +1046,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Checks if the texture overlaps with a memory range.
-        /// </summary>
-        /// <param name="address">Start address of the range</param>
-        /// <param name="size">Size of the range</param>
-        /// <returns>True if the texture overlaps with the range, false otherwise</returns>
-        public bool OverlapsWith(ulong address, ulong size)
-        {
-            return Address < address + size && address < EndAddress;
-        }
-
-        /// <summary>
         /// Determine if any of our child textures are compaible as views of the given texture.
         /// </summary>
         /// <param name="texture">The texture to check against</param>
@@ -1073,7 +1059,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             foreach (Texture view in _views)
             {
-                if (texture.IsViewCompatible(view.Info, view.Size, out int _, out int _) != TextureViewCompatibility.Incompatible)
+                if (texture.IsViewCompatible(view.Info, view.Range, out _, out _) != TextureViewCompatibility.Incompatible)
                 {
                     return true;
                 }

--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -303,7 +303,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     // Ensure that the buffer texture is using the correct buffer as storage.
                     // Buffers are frequently re-created to accomodate larger data, so we need to re-bind
                     // to ensure we're not using a old buffer that was already deleted.
-                    _context.Methods.BufferManager.SetBufferTextureStorage(hostTexture, texture.Address, texture.Size, _isCompute);
+                    _context.Methods.BufferManager.SetBufferTextureStorage(hostTexture, texture.Range.GetRange(0).Address, texture.Size, _isCompute);
                 }
 
                 Sampler sampler = _samplerPool.Get(samplerId);
@@ -354,7 +354,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     // Ensure that the buffer texture is using the correct buffer as storage.
                     // Buffers are frequently re-created to accomodate larger data, so we need to re-bind
                     // to ensure we're not using a old buffer that was already deleted.
-                    _context.Methods.BufferManager.SetBufferTextureStorage(hostTexture, texture.Address, texture.Size, _isCompute);
+                    _context.Methods.BufferManager.SetBufferTextureStorage(hostTexture, texture.Range.GetRange(0).Address, texture.Size, _isCompute);
                 }
 
                 if (_imageState[stageIndex][index].Texture != hostTexture || _rebind)

--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -303,7 +303,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     // Ensure that the buffer texture is using the correct buffer as storage.
                     // Buffers are frequently re-created to accomodate larger data, so we need to re-bind
                     // to ensure we're not using a old buffer that was already deleted.
-                    _context.Methods.BufferManager.SetBufferTextureStorage(hostTexture, texture.Range.GetRange(0).Address, texture.Size, _isCompute);
+                    _context.Methods.BufferManager.SetBufferTextureStorage(hostTexture, texture.Range.GetSubRange(0).Address, texture.Size, _isCompute);
                 }
 
                 Sampler sampler = _samplerPool.Get(samplerId);
@@ -354,7 +354,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     // Ensure that the buffer texture is using the correct buffer as storage.
                     // Buffers are frequently re-created to accomodate larger data, so we need to re-bind
                     // to ensure we're not using a old buffer that was already deleted.
-                    _context.Methods.BufferManager.SetBufferTextureStorage(hostTexture, texture.Range.GetRange(0).Address, texture.Size, _isCompute);
+                    _context.Methods.BufferManager.SetBufferTextureStorage(hostTexture, texture.Range.GetSubRange(0).Address, texture.Size, _isCompute);
                 }
 
                 if (_imageState[stageIndex][index].Texture != hostTexture || _rebind)

--- a/Ryujinx.Graphics.Gpu/Image/TextureInfo.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureInfo.cs
@@ -9,11 +9,6 @@ namespace Ryujinx.Graphics.Gpu.Image
     struct TextureInfo
     {
         /// <summary>
-        /// Address of the texture in guest memory.
-        /// </summary>
-        public ulong Address { get; }
-
-        /// <summary>
         /// Address of the texture in GPU mapped memory.
         /// </summary>
         public ulong GpuAddress { get; }
@@ -117,7 +112,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <summary>
         /// Constructs the texture information structure.
         /// </summary>
-        /// <param name="cpuAddress">The CPU address of the texture</param>
         /// <param name="gpuAddress">The GPU address of the texture</param>
         /// <param name="width">The width of the texture</param>
         /// <param name="height">The height or the texture</param>
@@ -138,7 +132,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="swizzleB">Swizzle for the blue color channel</param>
         /// <param name="swizzleA">Swizzle for the alpha color channel</param>
         public TextureInfo(
-            ulong            cpuAddress,
             ulong            gpuAddress,
             int              width,
             int              height,
@@ -159,7 +152,6 @@ namespace Ryujinx.Graphics.Gpu.Image
             SwizzleComponent swizzleB         = SwizzleComponent.Blue,
             SwizzleComponent swizzleA         = SwizzleComponent.Alpha)
         {
-            Address          = cpuAddress;
             GpuAddress       = gpuAddress;
             Width            = width;
             Height           = height;

--- a/Ryujinx.Graphics.Gpu/Image/TextureInfo.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureInfo.cs
@@ -14,6 +14,11 @@ namespace Ryujinx.Graphics.Gpu.Image
         public ulong Address { get; }
 
         /// <summary>
+        /// Address of the texture in GPU mapped memory.
+        /// </summary>
+        public ulong GpuAddress { get; }
+
+        /// <summary>
         /// The width of the texture.
         /// </summary>
         public int Width { get; }
@@ -112,7 +117,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <summary>
         /// Constructs the texture information structure.
         /// </summary>
-        /// <param name="address">The address of the texture</param>
+        /// <param name="cpuAddress">The CPU address of the texture</param>
+        /// <param name="gpuAddress">The GPU address of the texture</param>
         /// <param name="width">The width of the texture</param>
         /// <param name="height">The height or the texture</param>
         /// <param name="depthOrLayers">The depth or layers count of the texture</param>
@@ -132,7 +138,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="swizzleB">Swizzle for the blue color channel</param>
         /// <param name="swizzleA">Swizzle for the alpha color channel</param>
         public TextureInfo(
-            ulong            address,
+            ulong            cpuAddress,
+            ulong            gpuAddress,
             int              width,
             int              height,
             int              depthOrLayers,
@@ -152,7 +159,8 @@ namespace Ryujinx.Graphics.Gpu.Image
             SwizzleComponent swizzleB         = SwizzleComponent.Blue,
             SwizzleComponent swizzleA         = SwizzleComponent.Alpha)
         {
-            Address          = address;
+            Address          = cpuAddress;
+            GpuAddress       = gpuAddress;
             Width            = width;
             Height           = height;
             DepthOrLayers    = depthOrLayers;

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -470,7 +470,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>The texture</returns>
         public Texture FindOrCreateTexture(CopyTexture copyTexture, FormatInfo formatInfo, bool preferScaling = true, Size? sizeHint = null)
         {
-            ulong address = _context.MemoryManager.Translate(copyTexture.Address.Pack());
+            ulong gpuVa = copyTexture.Address.Pack();
+            ulong address = _context.MemoryManager.Translate(gpuVa);
 
             if (address == MemoryManager.PteUnmapped)
             {
@@ -493,6 +494,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             TextureInfo info = new TextureInfo(
                 address,
+                gpuVa,
                 width,
                 copyTexture.Height,
                 copyTexture.Depth,
@@ -531,7 +533,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>The texture</returns>
         public Texture FindOrCreateTexture(RtColorState colorState, int samplesInX, int samplesInY, Size sizeHint)
         {
-            ulong address = _context.MemoryManager.Translate(colorState.Address.Pack());
+            ulong gpuVa = colorState.Address.Pack();
+            ulong address = _context.MemoryManager.Translate(gpuVa);
 
             if (address == MemoryManager.PteUnmapped)
             {
@@ -584,6 +587,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             TextureInfo info = new TextureInfo(
                 address,
+                gpuVa,
                 width,
                 colorState.Height,
                 colorState.Depth,
@@ -618,7 +622,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>The texture</returns>
         public Texture FindOrCreateTexture(RtDepthStencilState dsState, Size3D size, int samplesInX, int samplesInY, Size sizeHint)
         {
-            ulong address = _context.MemoryManager.Translate(dsState.Address.Pack());
+            ulong gpuVa = dsState.Address.Pack();
+            ulong address = _context.MemoryManager.Translate(gpuVa);
 
             if (address == MemoryManager.PteUnmapped)
             {
@@ -636,6 +641,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             TextureInfo info = new TextureInfo(
                 address,
+                gpuVa,
                 size.Width,
                 size.Height,
                 size.Depth,
@@ -1071,6 +1077,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             return new TextureInfo(
                 info.Address,
+                info.GpuAddress,
                 width,
                 height,
                 depthOrLayers,

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -731,7 +731,16 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             ulong size = (ulong)sizeInfo.TotalSize;
 
-            MultiRange range = new MultiRange(info.Address, size);
+            MultiRange range;
+            
+            if (info.GpuAddress != 0UL)
+            {
+                range = _context.MemoryManager.GetPhysicalRegions(info.GpuAddress, size);
+            }
+            else
+            {
+                range = new MultiRange(info.Address, size);
+            }
 
             // Find view compatible matches.
             int overlapsCount;
@@ -817,7 +826,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                         // If the data has been modified by the CPU, then it also shouldn't be flushed.
                         bool modified = overlap.ConsumeModified();
 
-                        bool flush = overlapInCache && !modified && !texture.Range.CanContain(overlap.Range) && overlap.HasViewCompatibleChild(texture);
+                        bool flush = overlapInCache && !modified && !texture.Range.Contains(overlap.Range) && overlap.HasViewCompatibleChild(texture);
 
                         setData |= modified || flush;
 

--- a/Ryujinx.Graphics.Gpu/Memory/GpuRegionHandle.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/GpuRegionHandle.cs
@@ -1,0 +1,60 @@
+﻿using Ryujinx.Cpu.Tracking;
+using Ryujinx.Memory.Tracking;
+using System;
+
+namespace Ryujinx.Graphics.Gpu.Memory
+{
+    class GpuRegionHandle : IRegionHandle
+    {
+        private readonly CpuRegionHandle[] _cpuRegionHandles;
+
+        public bool Dirty
+        {
+            get
+            {
+                foreach (var regionHandle in _cpuRegionHandles)
+                {
+                    if (regionHandle.Dirty)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        }
+
+        public ulong Address => throw new NotSupportedException();
+        public ulong Size => throw new NotSupportedException();
+        public ulong EndAddress => throw new NotSupportedException();
+
+        public GpuRegionHandle(CpuRegionHandle[] cpuRegionHandles)
+        {
+            _cpuRegionHandles = cpuRegionHandles;
+        }
+
+        public void Dispose()
+        {
+            foreach (var regionHandle in _cpuRegionHandles)
+            {
+                regionHandle.Dispose();
+            }
+        }
+
+        public void RegisterAction(RegionSignal action)
+        {
+            foreach (var regionHandle in _cpuRegionHandles)
+            {
+                regionHandle.RegisterAction(action);
+            }
+        }
+
+        public void Reprotect()
+        {
+            foreach (var regionHandle in _cpuRegionHandles)
+            {
+                regionHandle.Reprotect();
+            }
+        }
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
@@ -98,11 +98,6 @@ namespace Ryujinx.Graphics.Gpu.Memory
             {
                 ulong pa = Translate(va);
 
-                if (pa == PteUnmapped)
-                {
-                    return;
-                }
-
                 size = Math.Min(data.Length, (int)PageSize - (int)(va & PageMask));
 
                 _context.PhysicalMemory.GetSpan(pa, size, tracked).CopyTo(data.Slice(0, size));
@@ -113,11 +108,6 @@ namespace Ryujinx.Graphics.Gpu.Memory
             for (; offset < data.Length; offset += size)
             {
                 ulong pa = Translate(va + (ulong)offset);
-
-                if (pa == PteUnmapped)
-                {
-                    break;
-                }
 
                 size = Math.Min(data.Length - offset, (int)PageSize);
 
@@ -200,11 +190,6 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 {
                     ulong pa = Translate(va);
 
-                    if (pa == PteUnmapped)
-                    {
-                        return;
-                    }
-
                     size = Math.Min(data.Length, (int)PageSize - (int)(va & PageMask));
 
                     writeCallback(pa, data.Slice(0, size));
@@ -215,11 +200,6 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 for (; offset < data.Length; offset += size)
                 {
                     ulong pa = Translate(va + (ulong)offset);
-
-                    if (pa == PteUnmapped)
-                    {
-                        break;
-                    }
 
                     size = Math.Min(data.Length - offset, (int)PageSize);
 
@@ -326,6 +306,9 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 return default;
             }
 
+            ulong regionStart = Translate(va);
+            ulong regionSize = Math.Min(size, PageSize - (va & PageMask));
+
             ulong endVa = va + size;
             ulong endVaRounded = (endVa + PageMask) & ~PageMask;
 
@@ -333,10 +316,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
             int pages = (int)((endVaRounded - va) / PageSize);
 
-            var regions = new List<Ryujinx.Memory.Range.Range>();
-
-            ulong regionStart = Translate(va);
-            ulong regionSize = Math.Min(size, PageSize);
+            var regions = new List<Ryujinx.Memory.Range.Range>();            
 
             for (int page = 0; page < pages - 1; page++)
             {

--- a/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
@@ -10,7 +10,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
     /// <summary>
     /// GPU memory manager.
     /// </summary>
-    public class MemoryManager
+    public class MemoryManager : IWritableBlock
     {
         private const int PtLvl0Bits = 14;
         private const int PtLvl1Bits = 14;
@@ -128,7 +128,11 @@ namespace Ryujinx.Graphics.Gpu.Memory
             }
             else
             {
-                throw new NotImplementedException();
+                Memory<byte> memory = new byte[size];
+
+                GetSpan(va, size).CopyTo(memory.Span);
+
+                return new WritableRegion(this, va, memory);
             }
         }
 

--- a/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
@@ -292,7 +292,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="va">Virtual address of the range</param>
         /// <param name="size">Size of the range</param>
         /// <returns>Multi-range with the physical regions</returns>
-        /// <exception cref="InvalidMemoryRegionException">The memory region specifieed by <paramref name="va"/> and <paramref name="size"/> is not fully mapped</exception>
+        /// <exception cref="InvalidMemoryRegionException">The memory region specified by <paramref name="va"/> and <paramref name="size"/> is not fully mapped</exception>
         public MultiRange GetPhysicalRegions(ulong va, ulong size)
         {
             if (IsContiguous(va, (int)size))
@@ -315,7 +315,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
             int pages = (int)((endVaRounded - va) / PageSize);
 
-            var regions = new List<MemoryRange>();            
+            var regions = new List<MemoryRange>();
 
             for (int page = 0; page < pages - 1; page++)
             {

--- a/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
@@ -49,7 +49,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         {
             if (range.Count == 1)
             {
-                var singleRange = range.GetRange(0);
+                var singleRange = range.GetSubRange(0);
                 return _cpuMemory.GetSpan(singleRange.Address, (int)singleRange.Size, tracked);
             }
             else
@@ -60,7 +60,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
                 for (int i = 0; i < range.Count; i++)
                 {
-                    var currentRange = range.GetRange(i);
+                    var currentRange = range.GetSubRange(i);
                     int size = (int)currentRange.Size;
                     _cpuMemory.GetSpan(currentRange.Address, size, tracked).CopyTo(data.Slice(offset, size));
                     offset += size;
@@ -103,6 +103,16 @@ namespace Ryujinx.Graphics.Gpu.Memory
         }
 
         /// <summary>
+        /// Writes data to the application process.
+        /// </summary>
+        /// <param name="range">Ranges of physical memory where the data is located</param>
+        /// <param name="data">Data to be written</param>
+        public void Write(MultiRange range, ReadOnlySpan<byte> data)
+        {
+            WriteImpl(range, data, _cpuMemory.Write);
+        }
+
+        /// <summary>
         /// Writes data to the application process, without any tracking.
         /// </summary>
         /// <param name="address">Address to write into</param>
@@ -110,6 +120,45 @@ namespace Ryujinx.Graphics.Gpu.Memory
         public void WriteUntracked(ulong address, ReadOnlySpan<byte> data)
         {
             _cpuMemory.WriteUntracked(address, data);
+        }
+
+        /// <summary>
+        /// Writes data to the application process, without any tracking.
+        /// </summary>
+        /// <param name="range">Ranges of physical memory where the data is located</param>
+        /// <param name="data">Data to be written</param>
+        public void WriteUntracked(MultiRange range, ReadOnlySpan<byte> data)
+        {
+            WriteImpl(range, data, _cpuMemory.WriteUntracked);
+        }
+
+        private delegate void WriteCallback(ulong address, ReadOnlySpan<byte> data);
+
+        /// <summary>
+        /// Writes data to the application process, using the supplied callback method.
+        /// </summary>
+        /// <param name="range">Ranges of physical memory where the data is located</param>
+        /// <param name="data">Data to be written</param>
+        /// <param name="writeCallback">Callback method that will perform the write</param>
+        private void WriteImpl(MultiRange range, ReadOnlySpan<byte> data, WriteCallback writeCallback)
+        {
+            if (range.Count == 1)
+            {
+                var singleRange = range.GetSubRange(0);
+                writeCallback(singleRange.Address, data);
+            }
+            else
+            {
+                int offset = 0;
+
+                for (int i = 0; i < range.Count; i++)
+                {
+                    var currentRange = range.GetSubRange(i);
+                    int size = (int)currentRange.Size;
+                    writeCallback(currentRange.Address, data.Slice(offset, size));
+                    offset += size;
+                }
+            }
         }
 
         /// <summary>
@@ -121,6 +170,24 @@ namespace Ryujinx.Graphics.Gpu.Memory
         public CpuRegionHandle BeginTracking(ulong address, ulong size)
         {
             return _cpuMemory.BeginTracking(address, size);
+        }
+
+        /// <summary>
+        /// Obtains a memory tracking handle for the given virtual region. This should be disposed when finished with.
+        /// </summary>
+        /// <param name="range">Ranges of physical memory where the data is located</param>
+        /// <returns>The memory tracking handle</returns>
+        public GpuRegionHandle BeginTracking(MultiRange range)
+        {
+            var cpuRegionHandles = new CpuRegionHandle[range.Count];
+
+            for (int i = 0; i < range.Count; i++)
+            {
+                var currentRange = range.GetSubRange(i);
+                cpuRegionHandles[i] = _cpuMemory.BeginTracking(currentRange.Address, currentRange.Size);
+            }
+
+            return new GpuRegionHandle(cpuRegionHandles);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
@@ -54,7 +54,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
             }
             else
             {
-                Span<byte> data = new byte[range.GetTotalSize()];
+                Span<byte> data = new byte[range.GetSize()];
 
                 int offset = 0;
 

--- a/Ryujinx.Graphics.Gpu/Window.cs
+++ b/Ryujinx.Graphics.Gpu/Window.cs
@@ -119,6 +119,7 @@ namespace Ryujinx.Graphics.Gpu
 
             TextureInfo info = new TextureInfo(
                 address,
+                0UL,
                 width,
                 height,
                 1,

--- a/Ryujinx.Graphics.Gpu/Window.cs
+++ b/Ryujinx.Graphics.Gpu/Window.cs
@@ -1,5 +1,7 @@
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Image;
+using Ryujinx.Graphics.Texture;
+using Ryujinx.Memory.Range;
 using System;
 using System.Collections.Concurrent;
 using System.Threading;
@@ -26,6 +28,11 @@ namespace Ryujinx.Graphics.Gpu
             public TextureInfo Info { get; }
 
             /// <summary>
+            /// Physical memory locations where the texture data is located.
+            /// </summary>
+            public MultiRange Range { get; }
+
+            /// <summary>
             /// Texture crop region.
             /// </summary>
             public ImageCrop Crop { get; }
@@ -49,18 +56,21 @@ namespace Ryujinx.Graphics.Gpu
             /// Creates a new instance of the presentation texture.
             /// </summary>
             /// <param name="info">Information of the texture to be presented</param>
+            /// <param name="range">Physical memory locations where the texture data is located</param>
             /// <param name="crop">Texture crop region</param>
             /// <param name="acquireCallback">Texture acquire callback</param>
             /// <param name="releaseCallback">Texture release callback</param>
             /// <param name="userObj">User defined object passed to the release callback, can be used to identify the texture</param>
             public PresentationTexture(
                 TextureInfo                info,
+                MultiRange                 range,
                 ImageCrop                  crop,
                 Action<GpuContext, object> acquireCallback,
                 Action<object>             releaseCallback,
                 object                     userObj)
             {
                 Info            = info;
+                Range           = range;
                 Crop            = crop;
                 AcquireCallback = acquireCallback;
                 ReleaseCallback = releaseCallback;
@@ -118,7 +128,6 @@ namespace Ryujinx.Graphics.Gpu
             FormatInfo formatInfo = new FormatInfo(format, 1, 1, bytesPerPixel, 4);
 
             TextureInfo info = new TextureInfo(
-                address,
                 0UL,
                 width,
                 height,
@@ -134,7 +143,22 @@ namespace Ryujinx.Graphics.Gpu
                 Target.Texture2D,
                 formatInfo);
 
-            _frameQueue.Enqueue(new PresentationTexture(info, crop, acquireCallback, releaseCallback, userObj));
+            int size = SizeCalculator.GetBlockLinearTextureSize(
+                width,
+                height,
+                1,
+                1,
+                1,
+                1,
+                1,
+                bytesPerPixel,
+                gobBlocksInY,
+                1,
+                1).TotalSize;
+
+            MultiRange range = new MultiRange(address, (ulong)size);
+
+            _frameQueue.Enqueue(new PresentationTexture(info, range, crop, acquireCallback, releaseCallback, userObj));
         }
 
         /// <summary>
@@ -150,7 +174,7 @@ namespace Ryujinx.Graphics.Gpu
             {
                 pt.AcquireCallback(_context, pt.UserObj);
 
-                Texture texture = _context.Methods.TextureManager.FindOrCreateTexture(pt.Info, TextureSearchFlags.WithUpscale);
+                Texture texture = _context.Methods.TextureManager.FindOrCreateTexture(TextureSearchFlags.WithUpscale, pt.Info, 0, null, pt.Range);
 
                 texture.SynchronizeMemory();
 

--- a/Ryujinx.Graphics.Texture/SizeInfo.cs
+++ b/Ryujinx.Graphics.Texture/SizeInfo.cs
@@ -45,7 +45,7 @@ namespace Ryujinx.Graphics.Texture
             return _mipOffsets[level];
         }
 
-        public bool FindView(int offset, int size, out int firstLayer, out int firstLevel)
+        public bool FindView(int offset, out int firstLayer, out int firstLevel)
         {
             int index = Array.BinarySearch(_allOffsets, offset);
 

--- a/Ryujinx.Memory/AddressSpaceManager.cs
+++ b/Ryujinx.Memory/AddressSpaceManager.cs
@@ -1,5 +1,4 @@
-﻿using Ryujinx.Common;
-using System;
+﻿using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -9,7 +8,7 @@ namespace Ryujinx.Memory
     /// Represents a address space manager.
     /// Supports virtual memory region mapping, address translation and read/write access to mapped regions.
     /// </summary>
-    public sealed class AddressSpaceManager : IVirtualMemoryManager
+    public sealed class AddressSpaceManager : IVirtualMemoryManager, IWritableBlock
     {
         public const int PageBits = 12;
         public const int PageSize = 1 << PageBits;

--- a/Ryujinx.Memory/IWritableBlock.cs
+++ b/Ryujinx.Memory/IWritableBlock.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Ryujinx.Memory
+{
+    public interface IWritableBlock
+    {
+        void Write(ulong va, ReadOnlySpan<byte> data);
+    }
+}

--- a/Ryujinx.Memory/Range/IMultiRangeItem.cs
+++ b/Ryujinx.Memory/Range/IMultiRangeItem.cs
@@ -1,0 +1,9 @@
+﻿namespace Ryujinx.Memory.Range
+{
+    public interface IMultiRangeItem
+    {
+        MultiRange Range { get; }
+
+        ulong BaseAddress => Range.GetRange(0).Address;
+    }
+}

--- a/Ryujinx.Memory/Range/IMultiRangeItem.cs
+++ b/Ryujinx.Memory/Range/IMultiRangeItem.cs
@@ -4,6 +4,6 @@
     {
         MultiRange Range { get; }
 
-        ulong BaseAddress => Range.GetRange(0).Address;
+        ulong BaseAddress => Range.GetSubRange(0).Address;
     }
 }

--- a/Ryujinx.Memory/Range/MemoryRange.cs
+++ b/Ryujinx.Memory/Range/MemoryRange.cs
@@ -1,0 +1,71 @@
+﻿using System;
+
+namespace Ryujinx.Memory.Range
+{
+    /// <summary>
+    /// Range of memory composed of an address and size.
+    /// </summary>
+    public struct MemoryRange : IEquatable<MemoryRange>
+    {
+        /// <summary>
+        /// An empty memory range, with a null address and zero size.
+        /// </summary>
+        public static MemoryRange Empty => new MemoryRange(0UL, 0);
+
+        /// <summary>
+        /// Start address of the range.
+        /// </summary>
+        public ulong Address { get; }
+
+        /// <summary>
+        /// Size of the range in bytes.
+        /// </summary>
+        public ulong Size { get; }
+
+        /// <summary>
+        /// Address where the range ends (exclusive).
+        /// </summary>
+        public ulong EndAddress => Address + Size;
+
+        /// <summary>
+        /// Creates a new memory range with the specified address and size.
+        /// </summary>
+        /// <param name="address">Start address</param>
+        /// <param name="size">Size in bytes</param>
+        public MemoryRange(ulong address, ulong size)
+        {
+            Address = address;
+            Size = size;
+        }
+
+        /// <summary>
+        /// Checks if the range overlaps with another.
+        /// </summary>
+        /// <param name="other">The other range to check for overlap</param>
+        /// <returns>True if the ranges overlap, false otherwise</returns>
+        public bool OverlapsWith(MemoryRange other)
+        {
+            ulong thisAddress = Address;
+            ulong thisEndAddress = EndAddress;
+            ulong otherAddress = other.Address;
+            ulong otherEndAddress = other.EndAddress;
+
+            return thisAddress < otherEndAddress && otherAddress < thisEndAddress;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is MemoryRange other && Equals(other);
+        }
+
+        public bool Equals(MemoryRange other)
+        {
+            return Address == other.Address && Size == other.Size;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Address, Size);
+        }
+    }
+}

--- a/Ryujinx.Memory/Range/MultiRange.cs
+++ b/Ryujinx.Memory/Range/MultiRange.cs
@@ -1,0 +1,204 @@
+﻿using System;
+
+namespace Ryujinx.Memory.Range
+{
+    public struct Range : IEquatable<Range>
+    {
+        public static Range Empty => new Range(0UL, 0);
+
+        public ulong Address { get; }
+        public ulong Size { get; }
+        public ulong EndAddress => Address + Size;
+
+        public Range(ulong address, ulong size)
+        {
+            Address = address;
+            Size = size;
+        }
+
+        public bool OverlapsWith(Range other)
+        {
+            ulong thisAddress = Address;
+            ulong thisEndAddress = EndAddress;
+            ulong otherAddress = other.Address;
+            ulong otherEndAddress = other.EndAddress;
+
+            return thisAddress < otherEndAddress && otherAddress < thisEndAddress;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is Range other && Equals(other);
+        }
+
+        public bool Equals(Range other)
+        {
+            return Address == other.Address && Size == other.Size;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Address, Size);
+        }
+    }
+
+    public struct MultiRange
+    {
+        private readonly Range _singleRange;
+        private readonly Range[] _ranges;
+
+        private bool HasSingleRange => _ranges == null;
+        public int Count => HasSingleRange ? 1 : _ranges.Length;
+
+        public MultiRange(ulong address, ulong size)
+        {
+            _singleRange = new Range(address, size);
+            _ranges = null;
+        }
+
+        public MultiRange(Range[] ranges)
+        {
+            _singleRange = Range.Empty;
+            _ranges = ranges ?? throw new ArgumentNullException(nameof(ranges));
+        }
+
+        public Range GetRange(int index)
+        {
+            if (HasSingleRange)
+            {
+                if (index != 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(index));
+                }
+
+                return _singleRange;
+            }
+            else
+            {
+                if ((uint)index >= _ranges.Length)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(index));
+                }
+
+                return _ranges[index];
+            }
+        }
+
+        private Range GetRangeUnchecked(int index)
+        {
+            return HasSingleRange ? _singleRange : _ranges[index];
+        }
+
+        public bool OverlapsWith(MultiRange other)
+        {
+            if (HasSingleRange && other.HasSingleRange)
+            {
+                return _singleRange.OverlapsWith(other._singleRange);
+            }
+            else
+            {
+                for (int i = 0; i < Count; i++)
+                {
+                    Range currentRange = GetRangeUnchecked(i);
+
+                    for (int j = 0; j < other.Count; j++)
+                    {
+                        if (currentRange.OverlapsWith(other.GetRangeUnchecked(j)))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        public bool CanContain(MultiRange other)
+        {
+            return FindOffset(other) >= 0;
+        }
+
+        public int FindOffset(MultiRange other)
+        {
+            if (Count == other.Count)
+            {
+                Range otherFirstRange = other.GetRangeUnchecked(0);
+                Range currentFirstRange = GetRangeUnchecked(0);
+
+                if (otherFirstRange.Address >= currentFirstRange.Address &&
+                    otherFirstRange.EndAddress <= currentFirstRange.EndAddress)
+                {
+                    return (int)(otherFirstRange.Address - currentFirstRange.Address);
+                }
+            }
+            else if (Count > other.Count)
+            {
+                int thisCount = Count;
+                int otherCount = other.Count;
+                ulong baseOffset = 0;
+
+                Range otherFirstRange = other.GetRangeUnchecked(0);
+                Range otherLastRange = other.GetRangeUnchecked(otherCount - 1);
+
+                for (int i = 0; i < (thisCount - otherCount) + 1; baseOffset += GetRangeUnchecked(i).Size, i++)
+                {
+                    Range currentFirstRange = GetRangeUnchecked(i);
+                    Range currentLastRange = GetRangeUnchecked(i + otherCount - 1);
+
+                    if (otherCount > 1)
+                    {
+                        if (otherFirstRange.Address < currentFirstRange.Address ||
+                            otherFirstRange.EndAddress != currentFirstRange.EndAddress)
+                        {
+                            continue;
+                        }
+
+                        if (otherLastRange.Address != currentLastRange.Address ||
+                            otherLastRange.EndAddress > currentLastRange.EndAddress)
+                        {
+                            continue;
+                        }
+
+                        bool fullMatch = true;
+
+                        for (int j = 1; j < otherCount - 1; j++)
+                        {
+                            if (!GetRangeUnchecked(i + j).Equals(other.GetRangeUnchecked(j)))
+                            {
+                                fullMatch = false;
+                                break;
+                            }
+                        }
+
+                        if (!fullMatch)
+                        {
+                            continue;
+                        }
+                    }
+                    else if (currentFirstRange.Address > otherFirstRange.Address ||
+                             currentFirstRange.EndAddress < otherFirstRange.EndAddress)
+                    {
+                        continue;
+                    }
+
+                    return (int)(baseOffset + (otherFirstRange.Address - currentFirstRange.Address));
+                }
+            }
+
+            return -1;
+        }
+
+        public ulong GetTotalSize()
+        {
+            ulong sum = 0;
+
+            foreach (Range range in _ranges)
+            {
+                sum += range.Size;
+            }
+
+            return sum;
+        }
+    }
+}

--- a/Ryujinx.Memory/Range/MultiRange.cs
+++ b/Ryujinx.Memory/Range/MultiRange.cs
@@ -2,67 +2,86 @@
 
 namespace Ryujinx.Memory.Range
 {
-    public struct Range : IEquatable<Range>
+    /// <summary>
+    /// Sequence of physical memory regions that a single non-contiguous virtual memory region maps to.
+    /// </summary>
+    public struct MultiRange : IEquatable<MultiRange>
     {
-        public static Range Empty => new Range(0UL, 0);
-
-        public ulong Address { get; }
-        public ulong Size { get; }
-        public ulong EndAddress => Address + Size;
-
-        public Range(ulong address, ulong size)
-        {
-            Address = address;
-            Size = size;
-        }
-
-        public bool OverlapsWith(Range other)
-        {
-            ulong thisAddress = Address;
-            ulong thisEndAddress = EndAddress;
-            ulong otherAddress = other.Address;
-            ulong otherEndAddress = other.EndAddress;
-
-            return thisAddress < otherEndAddress && otherAddress < thisEndAddress;
-        }
-
-        public override bool Equals(object obj)
-        {
-            return obj is Range other && Equals(other);
-        }
-
-        public bool Equals(Range other)
-        {
-            return Address == other.Address && Size == other.Size;
-        }
-
-        public override int GetHashCode()
-        {
-            return HashCode.Combine(Address, Size);
-        }
-    }
-
-    public struct MultiRange
-    {
-        private readonly Range _singleRange;
-        private readonly Range[] _ranges;
+        private readonly MemoryRange _singleRange;
+        private readonly MemoryRange[] _ranges;
 
         private bool HasSingleRange => _ranges == null;
+
+        /// <summary>
+        /// Total of physical sub-ranges on the virtual memory region.
+        /// </summary>
         public int Count => HasSingleRange ? 1 : _ranges.Length;
 
+        /// <summary>
+        /// Minimum start address of all sub-ranges.
+        /// </summary>
+        public ulong MinAddress { get; }
+
+        /// <summary>
+        /// Maximum end address of all sub-ranges.
+        /// </summary>
+        public ulong MaxAddress { get; }
+
+        /// <summary>
+        /// Creates a new multi-range with a single physical region.
+        /// </summary>
+        /// <param name="address">Start address of the region</param>
+        /// <param name="size">Size of the region in bytes</param>
         public MultiRange(ulong address, ulong size)
         {
-            _singleRange = new Range(address, size);
+            _singleRange = new MemoryRange(address, size);
             _ranges = null;
+            MinAddress = address;
+            MaxAddress = address + size;
         }
 
-        public MultiRange(Range[] ranges)
+        /// <summary>
+        /// Creates a new multi-range with multiple physical regions.
+        /// </summary>
+        /// <param name="ranges">Array of physical regions</param>
+        /// <exception cref="ArgumentNullException"><paramref name="ranges"/> is null</exception>
+        public MultiRange(MemoryRange[] ranges)
         {
-            _singleRange = Range.Empty;
+            _singleRange = MemoryRange.Empty;
             _ranges = ranges ?? throw new ArgumentNullException(nameof(ranges));
+
+            if (ranges.Length != 0)
+            {
+                MinAddress = ulong.MaxValue;
+                MaxAddress = 0UL;
+
+                foreach (MemoryRange range in ranges)
+                {
+                    if (MinAddress > range.Address)
+                    {
+                        MinAddress = range.Address;
+                    }
+
+                    if (MaxAddress < range.EndAddress)
+                    {
+                        MaxAddress = range.EndAddress;
+                    }
+                }
+            }
+            else
+            {
+                MinAddress = 0UL;
+                MaxAddress = 0UL;
+            }
         }
 
-        public Range GetSubRange(int index)
+        /// <summary>
+        /// Gets the physical region at the specified index.
+        /// </summary>
+        /// <param name="index">Index of the physical region</param>
+        /// <returns>Region at the index specified</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is invalid</exception>
+        public MemoryRange GetSubRange(int index)
         {
             if (HasSingleRange)
             {
@@ -84,11 +103,21 @@ namespace Ryujinx.Memory.Range
             }
         }
 
-        private Range GetSubRangeUnchecked(int index)
+        /// <summary>
+        /// Gets the physical region at the specified index, without explicit bounds checking.
+        /// </summary>
+        /// <param name="index">Index of the physical region</param>
+        /// <returns>Region at the index specified</returns>
+        private MemoryRange GetSubRangeUnchecked(int index)
         {
             return HasSingleRange ? _singleRange : _ranges[index];
         }
 
+        /// <summary>
+        /// Check if two multi-ranges overlap with each other.
+        /// </summary>
+        /// <param name="other">Other multi-range to check for overlap</param>
+        /// <returns>True if any sub-range overlaps, false otherwise</returns>
         public bool OverlapsWith(MultiRange other)
         {
             if (HasSingleRange && other.HasSingleRange)
@@ -99,7 +128,7 @@ namespace Ryujinx.Memory.Range
             {
                 for (int i = 0; i < Count; i++)
                 {
-                    Range currentRange = GetSubRangeUnchecked(i);
+                    MemoryRange currentRange = GetSubRangeUnchecked(i);
 
                     for (int j = 0; j < other.Count; j++)
                     {
@@ -114,11 +143,22 @@ namespace Ryujinx.Memory.Range
             return false;
         }
 
+        /// <summary>
+        /// Checks if a given multi-range is fully contained inside another.
+        /// </summary>
+        /// <param name="other">Multi-range to be checked</param>
+        /// <returns>True if all the sub-ranges on <paramref name="other"/> are contained inside the multi-range, with the same order, false otherwise</returns>
         public bool Contains(MultiRange other)
         {
             return FindOffset(other) >= 0;
         }
 
+        /// <summary>
+        /// Calculates the offset of a given multi-range inside another, when the multi-range is fully contained
+        /// inside the other multi-range, otherwise returns -1.
+        /// </summary>
+        /// <param name="other">Multi-range that should be fully contained inside this one</param>
+        /// <returns>Offset in bytes if fully contained, otherwise -1</returns>
         public int FindOffset(MultiRange other)
         {
             int thisCount = Count;
@@ -126,8 +166,8 @@ namespace Ryujinx.Memory.Range
 
             if (thisCount == 1 && otherCount == 1)
             {
-                Range otherFirstRange = other.GetSubRangeUnchecked(0);
-                Range currentFirstRange = GetSubRangeUnchecked(0);
+                MemoryRange otherFirstRange = other.GetSubRangeUnchecked(0);
+                MemoryRange currentFirstRange = GetSubRangeUnchecked(0);
 
                 if (otherFirstRange.Address >= currentFirstRange.Address &&
                     otherFirstRange.EndAddress <= currentFirstRange.EndAddress)
@@ -139,13 +179,13 @@ namespace Ryujinx.Memory.Range
             {
                 ulong baseOffset = 0;
 
-                Range otherFirstRange = other.GetSubRangeUnchecked(0);
-                Range otherLastRange = other.GetSubRangeUnchecked(otherCount - 1);
+                MemoryRange otherFirstRange = other.GetSubRangeUnchecked(0);
+                MemoryRange otherLastRange = other.GetSubRangeUnchecked(otherCount - 1);
 
                 for (int i = 0; i < (thisCount - otherCount) + 1; baseOffset += GetSubRangeUnchecked(i).Size, i++)
                 {
-                    Range currentFirstRange = GetSubRangeUnchecked(i);
-                    Range currentLastRange = GetSubRangeUnchecked(i + otherCount - 1);
+                    MemoryRange currentFirstRange = GetSubRangeUnchecked(i);
+                    MemoryRange currentLastRange = GetSubRangeUnchecked(i + otherCount - 1);
 
                     if (otherCount > 1)
                     {
@@ -190,16 +230,66 @@ namespace Ryujinx.Memory.Range
             return -1;
         }
 
-        public ulong GetTotalSize()
+        /// <summary>
+        /// Gets the total size of all sub-ranges in bytes.
+        /// </summary>
+        /// <returns>Total size in bytes</returns>
+        public ulong GetSize()
         {
             ulong sum = 0;
 
-            foreach (Range range in _ranges)
+            foreach (MemoryRange range in _ranges)
             {
                 sum += range.Size;
             }
 
             return sum;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is MultiRange other && Equals(other);
+        }
+
+        public bool Equals(MultiRange other)
+        {
+            if (HasSingleRange && other.HasSingleRange)
+            {
+                return _singleRange.Equals(other._singleRange);
+            }
+
+            int thisCount = Count;
+            if (thisCount != other.Count)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < thisCount; i++)
+            {
+                if (!GetSubRangeUnchecked(i).Equals(other.GetSubRangeUnchecked(i)))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            if (HasSingleRange)
+            {
+                return _singleRange.GetHashCode();
+            }
+
+            HashCode hash = new HashCode();
+
+            foreach (MemoryRange range in _ranges)
+            {
+                hash.Add(range);
+            }
+
+            return hash.ToHashCode();
         }
     }
 }

--- a/Ryujinx.Memory/Range/MultiRangeList.cs
+++ b/Ryujinx.Memory/Range/MultiRangeList.cs
@@ -1,0 +1,204 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Ryujinx.Memory.Range
+{
+    /// <summary>
+    /// Sorted list of ranges that supports binary search.
+    /// </summary>
+    /// <typeparam name="T">Type of the range.</typeparam>
+    public class MultiRangeList<T> : IEnumerable<T> where T : IMultiRangeItem
+    {
+        private const int ArrayGrowthSize = 32;
+
+        private readonly List<T> _items;
+
+        public int Count => _items.Count;
+
+        /// <summary>
+        /// Creates a new range list.
+        /// </summary>
+        public MultiRangeList()
+        {
+            _items = new List<T>();
+        }
+
+        /// <summary>
+        /// Adds a new item to the list.
+        /// </summary>
+        /// <param name="item">The item to be added</param>
+        public void Add(T item)
+        {
+            int index = BinarySearch(item.BaseAddress);
+
+            if (index < 0)
+            {
+                index = ~index;
+            }
+
+            _items.Insert(index, item);
+        }
+
+        /// <summary>
+        /// Removes an item from the list.
+        /// </summary>
+        /// <param name="item">The item to be removed</param>
+        /// <returns>True if the item was removed, or false if it was not found</returns>
+        public bool Remove(T item)
+        {
+            int index = BinarySearch(item.BaseAddress);
+
+            if (index >= 0)
+            {
+                while (index > 0 && _items[index - 1].BaseAddress == item.BaseAddress)
+                {
+                    index--;
+                }
+
+                while (index < _items.Count)
+                {
+                    if (_items[index].Equals(item))
+                    {
+                        _items.RemoveAt(index);
+
+                        return true;
+                    }
+
+                    if (_items[index].BaseAddress > item.BaseAddress)
+                    {
+                        break;
+                    }
+
+                    index++;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Gets all items on the list overlapping the specified memory range.
+        /// </summary>
+        /// <param name="address">Start address of the range</param>
+        /// <param name="size">Size in bytes of the range</param>
+        /// <param name="output">Output array where matches will be written. It is automatically resized to fit the results</param>
+        /// <returns>The number of overlapping items found</returns>
+        public int FindOverlaps(ulong address, ulong size, ref T[] output)
+        {
+            return FindOverlaps(new MultiRange(address, size), ref output);
+        }
+
+        /// <summary>
+        /// Gets all items on the list overlapping the specified memory ranges.
+        /// </summary>
+        /// <param name="range">Ranges of memory being searched</param>
+        /// <param name="output">Output array where matches will be written. It is automatically resized to fit the results</param>
+        /// <returns>The number of overlapping items found</returns>
+        public int FindOverlaps(MultiRange range, ref T[] output)
+        {
+            int outputIndex = 0;
+
+            foreach (T item in _items)
+            {
+                if (item.Range.OverlapsWith(range))
+                {
+                    if (outputIndex == output.Length)
+                    {
+                        Array.Resize(ref output, outputIndex + ArrayGrowthSize);
+                    }
+
+                    output[outputIndex++] = item;
+                }
+            }
+
+            return outputIndex;
+        }
+
+        /// <summary>
+        /// Gets all items on the list starting at the specified memory address.
+        /// </summary>
+        /// <param name="baseAddress">Base address to find</param>
+        /// <param name="output">Output array where matches will be written. It is automatically resized to fit the results</param>
+        /// <returns>The number of matches found</returns>
+        public int FindOverlaps(ulong baseAddress, ref T[] output)
+        {
+            int index = BinarySearch(baseAddress);
+
+            int outputIndex = 0;
+
+            if (index >= 0)
+            {
+                while (index > 0 && _items[index - 1].BaseAddress == baseAddress)
+                {
+                    index--;
+                }
+
+                while (index < _items.Count)
+                {
+                    T overlap = _items[index++];
+
+                    if (overlap.BaseAddress != baseAddress)
+                    {
+                        break;
+                    }
+
+                    if (outputIndex == output.Length)
+                    {
+                        Array.Resize(ref output, outputIndex + ArrayGrowthSize);
+                    }
+
+                    output[outputIndex++] = overlap;
+                }
+            }
+
+            return outputIndex;
+        }
+
+        /// <summary>
+        /// Performs binary search on the internal list of items.
+        /// </summary>
+        /// <param name="address">Address to find</param>
+        /// <returns>List index of the item, or complement index of nearest item with lower value on the list</returns>
+        private int BinarySearch(ulong address)
+        {
+            int left = 0;
+            int right = _items.Count - 1;
+
+            while (left <= right)
+            {
+                int range = right - left;
+
+                int middle = left + (range >> 1);
+
+                T item = _items[middle];
+
+                if (item.BaseAddress == address)
+                {
+                    return middle;
+                }
+
+                if (address < item.BaseAddress)
+                {
+                    right = middle - 1;
+                }
+                else
+                {
+                    left = middle + 1;
+                }
+            }
+
+            return ~left;
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return _items.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _items.GetEnumerator();
+        }
+    }
+}

--- a/Ryujinx.Memory/WritableRegion.cs
+++ b/Ryujinx.Memory/WritableRegion.cs
@@ -4,16 +4,16 @@ namespace Ryujinx.Memory
 {
     public sealed class WritableRegion : IDisposable
     {
-        private readonly IVirtualMemoryManager _mm;
+        private readonly IWritableBlock _block;
         private readonly ulong _va;
 
-        private bool NeedsWriteback => _mm != null;
+        private bool NeedsWriteback => _block != null;
 
         public Memory<byte> Memory { get; }
 
-        public WritableRegion(IVirtualMemoryManager mm, ulong va, Memory<byte> memory)
+        public WritableRegion(IWritableBlock block, ulong va, Memory<byte> memory)
         {
-            _mm = mm;
+            _block = block;
             _va = va;
             Memory = memory;
         }
@@ -22,7 +22,7 @@ namespace Ryujinx.Memory
         {
             if (NeedsWriteback)
             {
-                _mm.Write(_va, Memory.Span);
+                _block.Write(_va, Memory.Span);
             }
         }
     }


### PR DESCRIPTION
This aims to support GPU textures mapped at non-contiguous CPU regions, as some games requires it (such as the Monster Hunter Rise Demo and possibly some UE4 games).

**Problem:**

Games can map GPU virtual memory regions to non-contiguous physical regions using the remap ioctl. For example, we may have a GPU region, from 0 to 0x2000, where the range from 0..0x1000 is mapped to physical address 0x8000, and the range 0x1000..0x2000 is mapped to physical address 0x15000 (the values are made up and are supposed to be just an example). Right now the texture data would be read from the physical range 0x8000..0x10000, which is wrong because only half of the data is mapped there. The correct behavior would be reading the first half of the data from 0x8000..0x9000, and the second half from 0x15000..0x16000.

**Solution:**

The solution here was changing the way how texture addresses (or rather, regions) are represented. Instead of having a single address and size, a new structure was added, called `MultiRange`, that can store multiple ranges of memory (composed of a address and size pair) pointing to where the texture data is located. A new method was added to the GPU memory manager called `GetPhysicalRegions` that can get such ranges from a single GPU virtual memory range. New overloads of the read, write and tracking functions were added that takes a `MultiRange` instead of a single address and size pair.

One thing that it does right now is calculating the offset of a texture view from its address, and the parent texture address. On master, this is as simple as doing `viewOffset = viewTextureAddress - parentTextureAddress`. With `MultiRange`, this is not so simple because there are now multiple, possibly disjoint addresses. So now, what it does is trying to find the view range sequence inside the parent texture range sequence.

Another possible solution would be always using the GPU virtual address and read the data from that address, doing address translation as needed and reading the data from the correct region. However this has some issues. First, memory aliasing (basically, different GPU virtual memory region mapped to the same physical one) wouldn't work properly, as it would create separate textures for the different GPU regions. Meanwhile if we use physical address (in our case this is a CPU virtual address right now), the memory aliasing work because after address translation, the address will be the same, and it will pull the same texture from the cache. The second problem is texture flushing. When reading from CPU, it only has a CPU virtual address to be used for flushing, finding the correct texture on the cache would require some sort of inverse address translation. Furthermore, it would also need a way to handle the possibility of multiple textures mapped into the same address.

The GPU memory manager was updated, now all methods there should correctly support reading or writing data at non-contiguous ranges. Before it just assumed this could never happen.

**Future work:**

Right now this is only supported for textures. It should be extended to buffers aswell.

**Testing:**

While testing, I recommend looking for the following:
- Games that worked properly before, but regressed in some way with those changes.
- Decrease in performance (it is not expected to have any noticeable performance hit).