### PR TITLE
Emulate a circular zone for keyboard analog sticks

### DIFF
--- a/Ryujinx/Ui/KeyboardController.cs
+++ b/Ryujinx/Ui/KeyboardController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using OpenTK;
 using OpenTK.Input;
 using Ryujinx.Common.Configuration.Hid;
 using Ryujinx.Configuration;
@@ -68,13 +69,16 @@ namespace Ryujinx.Ui
 
             short dx = 0;
             short dy = 0;
-            
-            if (keyboard[(Key)_config.LeftJoycon.StickUp])    dy =  short.MaxValue;
-            if (keyboard[(Key)_config.LeftJoycon.StickDown])  dy = -short.MaxValue;
-            if (keyboard[(Key)_config.LeftJoycon.StickLeft])  dx = -short.MaxValue;
-            if (keyboard[(Key)_config.LeftJoycon.StickRight]) dx =  short.MaxValue;
 
-            return (dx, dy);
+            if (keyboard[(Key)_config.LeftJoycon.StickUp])    dy +=  1;
+            if (keyboard[(Key)_config.LeftJoycon.StickDown])  dy += -1;
+            if (keyboard[(Key)_config.LeftJoycon.StickLeft])  dx += -1;
+            if (keyboard[(Key)_config.LeftJoycon.StickRight]) dx +=  1;
+
+            Vector2 stick = new Vector2(dx, dy);
+            stick.NormalizeFast();
+
+            return ((short)(stick.X * short.MaxValue), (short)(stick.Y * short.MaxValue));
         }
 
         public (short, short) GetRightStick()
@@ -84,12 +88,15 @@ namespace Ryujinx.Ui
             short dx = 0;
             short dy = 0;
 
-            if (keyboard[(Key)_config.RightJoycon.StickUp])    dy =  short.MaxValue;
-            if (keyboard[(Key)_config.RightJoycon.StickDown])  dy = -short.MaxValue;
-            if (keyboard[(Key)_config.RightJoycon.StickLeft])  dx = -short.MaxValue;
-            if (keyboard[(Key)_config.RightJoycon.StickRight]) dx =  short.MaxValue;
+            if (keyboard[(Key)_config.RightJoycon.StickUp])    dy +=  1;
+            if (keyboard[(Key)_config.RightJoycon.StickDown])  dy += -1;
+            if (keyboard[(Key)_config.RightJoycon.StickLeft])  dx += -1;
+            if (keyboard[(Key)_config.RightJoycon.StickRight]) dx +=  1;
 
-            return (dx, dy);
+            Vector2 stick = new Vector2(dx, dy);
+            stick.NormalizeFast();
+
+            return ((short)(stick.X * short.MaxValue), (short)(stick.Y * short.MaxValue));
         }
 
         public static HotkeyButtons GetHotkeyButtons(KeyboardState keyboard)


### PR DESCRIPTION
I saw a few user complaints on discord that diagonal inputs are not working with a keyboard controller in certain games. Some games get confused as the current code emulates a square zone whereas they expect a circular one (which is natural). Thought of using a lookup table too but ultimately this seemed cleaner. 

Also previously, the keyboard analog sticks always preferred down-right. So, if say, up & down were pressed together it'd be registered as down. I changed this behavior to be additive so opposite directions cancel out. There's probably other things that could be improved in the area but I'd like to keep this fix simple.