### PR TITLE
Fix shader LOP3 predicate write condition

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -34,7 +34,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 1901;
+        private const ulong ShaderCodeGenVersion = 1910;
 
         /// <summary>
         /// Creates a new instance of the shader cache.

--- a/Ryujinx.Graphics.Shader/Decoders/OpCodeLop.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/OpCodeLop.cs
@@ -9,8 +9,6 @@ namespace Ryujinx.Graphics.Shader.Decoders
 
         public LogicalOperation LogicalOp { get; }
 
-        public ConditionalOperation CondOp { get; }
-
         public Register Predicate48 { get; }
 
         public new static OpCode Create(InstEmitter emitter, ulong address, long opCode) => new OpCodeLop(emitter, address, opCode);
@@ -21,8 +19,6 @@ namespace Ryujinx.Graphics.Shader.Decoders
             InvertB = opCode.Extract(40);
 
             LogicalOp = (LogicalOperation)opCode.Extract(41, 2);
-
-            CondOp = (ConditionalOperation)opCode.Extract(44, 2);
 
             Predicate48 = new Register(opCode.Extract(48, 3), RegisterType.Predicate);
         }

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitAlu.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitAlu.cs
@@ -459,7 +459,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 case LogicalOperation.ExclusiveOr: res = context.BitwiseExclusiveOr(srcA, srcB); break;
             }
 
-            EmitLopPredWrite(context, op, res);
+            EmitLopPredWrite(context, op, res, (ConditionalOperation)context.CurrOp.RawOpCode.Extract(44, 2));
 
             Operand dest = GetDest(context);
 
@@ -486,7 +486,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
             if (regVariant)
             {
-                EmitLopPredWrite(context, op, res);
+                EmitLopPredWrite(context, op, res, (ConditionalOperation)context.CurrOp.RawOpCode.Extract(36, 2));
             }
 
             Operand dest = GetDest(context);
@@ -917,21 +917,21 @@ namespace Ryujinx.Graphics.Shader.Instructions
             return res;
         }
 
-        private static void EmitLopPredWrite(EmitterContext context, IOpCodeLop op, Operand result)
+        private static void EmitLopPredWrite(EmitterContext context, IOpCodeLop op, Operand result, ConditionalOperation condOp)
         {
             if (op is OpCodeLop opLop && !opLop.Predicate48.IsPT)
             {
                 Operand pRes;
 
-                if (opLop.CondOp == ConditionalOperation.False)
+                if (condOp == ConditionalOperation.False)
                 {
                     pRes = Const(IrConsts.False);
                 }
-                else if (opLop.CondOp == ConditionalOperation.True)
+                else if (condOp == ConditionalOperation.True)
                 {
                     pRes = Const(IrConsts.True);
                 }
-                else if (opLop.CondOp == ConditionalOperation.Zero)
+                else if (condOp == ConditionalOperation.Zero)
                 {
                     pRes = context.ICompareEqual(result, Const(0));
                 }


### PR DESCRIPTION
The condition was being read from the wrong bits on the LOP3 instruction.
Note: The shader cache version was updated, shaders will be invalidated (again, sorry about that).