### PR TITLE
Fix mipmap base level being ignored for sampled textures and images

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -139,6 +139,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Gets texture information from a texture descriptor.
         /// </summary>
         /// <param name="descriptor">The texture descriptor</param>
+        /// <param name="layerSize">Layer size for textures using a sub-range of mipmap levels, otherwise 0</param>
         /// <returns>The texture information</returns>
         private TextureInfo GetInfo(TextureDescriptor descriptor, out int layerSize)
         {
@@ -199,13 +200,10 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             layerSize = 0;
 
-            // If the base level is not zero, we additionally add the mip level offset
-            // to the address, this allows the texture manager to find the base level from the
-            // address if there is a overlapping texture on the cache that can contain the new texture.
-            // Linear textures don't support mipmaps, so we don't handle this case here.
             int minLod = descriptor.UnpackBaseLevel();
             int maxLod = descriptor.UnpackMaxLevelInclusive();
 
+            // Linear textures don't support mipmaps, so we don't handle this case here.
             if ((minLod != 0 || maxLod + 1 != levels) && target != Target.TextureBuffer && !isLinear && addressIsValid)
             {
                 int depth  = TextureInfo.GetDepth(target, depthOrLayers);
@@ -228,6 +226,9 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 if (minLod != 0)
                 {
+                    // If the base level is not zero, we additionally add the mip level offset
+                    // to the address, this allows the texture manager to find the base level from the
+                    // address if there is a overlapping texture on the cache that can contain the new texture.
                     address += (ulong)sizeInfo.GetMipOffset(minLod);
 
                     width  = Math.Max(1, width  >> minLod);

--- a/Ryujinx.Graphics.Texture/SizeCalculator.cs
+++ b/Ryujinx.Graphics.Texture/SizeCalculator.cs
@@ -20,7 +20,8 @@ namespace Ryujinx.Graphics.Texture
             int bytesPerPixel,
             int gobBlocksInY,
             int gobBlocksInZ,
-            int gobBlocksInTileX)
+            int gobBlocksInTileX,
+            int gpuLayerSize = 0)
         {
             bool is3D = depth > 1;
 
@@ -94,14 +95,29 @@ namespace Ryujinx.Graphics.Texture
                 layerSize += totalBlocksOfGobsInZ * totalBlocksOfGobsInY * robSize;
             }
 
-            layerSize = AlignLayerSize(
-                layerSize,
-                height,
-                depth,
-                blockHeight,
-                gobBlocksInY,
-                gobBlocksInZ,
-                gobBlocksInTileX);
+            if (layers > 1)
+            {
+                layerSize = AlignLayerSize(
+                    layerSize,
+                    height,
+                    depth,
+                    blockHeight,
+                    gobBlocksInY,
+                    gobBlocksInZ,
+                    gobBlocksInTileX);
+            }
+
+            int totalSize;
+
+            if (layerSize < gpuLayerSize)
+            {
+                totalSize = (layers - 1) * gpuLayerSize + layerSize;
+                layerSize = gpuLayerSize;
+            }
+            else
+            {
+                totalSize = layerSize * layers;
+            }
 
             if (!is3D)
             {
@@ -116,8 +132,6 @@ namespace Ryujinx.Graphics.Texture
                     }
                 }
             }
-
-            int totalSize = layerSize * layers;
 
             return new SizeInfo(mipOffsets, allOffsets, levels, layerSize, totalSize);
         }


### PR DESCRIPTION
The base level was being ignored, which meant that it would bind level 0 only, ignoring the level that was specified. This change allows the correct mipmap level to be accessed from the shader.

Summary of the changes:
- Use base level and max level values from the texture descriptor on the texture pool. They were previously ignored, which means it would always bind all the levels of the texture regardless of what the game actually wants.
- Use layer size provided by the game for render targets. Before the layer size was calculated from the texture dimensions. However, for textures were not all levels are used, we can't calculate the layer size as we don't know the real amount of levels, and we don't know the current base level. So instead of calculating it, it uses the value provided by the game. Should fix array textures using a sub-range of levels.

It is worth noting that flush can't currently handle flushing multiple layers with a sub-range of levels correctly, because there are gaps between the layers (for the unused levels) that it will blank out, instead of leaving untouched, due to the fact that it allocates a array and writes it back to memory. A solution to this is passing a span to the linear -> block linear conversion method that would just write the new data to guest memory directly, and this is also more efficient than the current method. I plan to do that in a future PR. It is worth noting that this was already wrong before, but in a different way, since it was simply ignoring the base level and max level completely.

I recommend testing this in a number of games to ensure that nothing regressed, in special those know to do texture flushes. 

Together with #1910, this improves shadows on Monster Hunter Rise Demo.
Before:
![image](https://user-images.githubusercontent.com/5624669/104526467-3d564a80-55e1-11eb-8212-bed61e8007ff.png)
After:
![image](https://user-images.githubusercontent.com/5624669/104526479-4515ef00-55e1-11eb-946c-feeb2337bb22.png)
![image](https://user-images.githubusercontent.com/5624669/104526493-4b0bd000-55e1-11eb-9b8d-7a05cc0a4efd.png)
![image](https://user-images.githubusercontent.com/5624669/104526527-6080fa00-55e1-11eb-8530-e247e574a578.png)
(also includes ssbo-flush and the other texture fix for those tests).
