### PR TITLE
Reduce temporary copy/fill buffer size

### DIFF
--- a/Ryujinx.Memory/IVirtualMemoryManager.cs
+++ b/Ryujinx.Memory/IVirtualMemoryManager.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.Memory
 
         void Fill(ulong va, ulong size, byte value)
         {
-            const int MaxChunkSize = 1 << 30;
+            const int MaxChunkSize = 1 << 24;
 
             for (ulong subOffset = 0; subOffset < size; subOffset += MaxChunkSize)
             {

--- a/Ryujinx.Memory/MemoryBlock.cs
+++ b/Ryujinx.Memory/MemoryBlock.cs
@@ -136,7 +136,7 @@ namespace Ryujinx.Memory
         /// <exception cref="InvalidMemoryRegionException">Throw when <paramref name="srcOffset"/>, <paramref name="dstOffset"/> or <paramref name="size"/> is out of range</exception>
         public void Copy(ulong dstOffset, ulong srcOffset, ulong size)
         {
-            const int MaxChunkSize = 1 << 30;
+            const int MaxChunkSize = 1 << 24;
 
             for (ulong offset = 0; offset < size; offset += MaxChunkSize)
             {
@@ -155,7 +155,7 @@ namespace Ryujinx.Memory
         /// <exception cref="InvalidMemoryRegionException">Throw when either <paramref name="offset"/> or <paramref name="size"/> are out of range</exception>
         public void ZeroFill(ulong offset, ulong size)
         {
-            const int MaxChunkSize = 1 << 30;
+            const int MaxChunkSize = 1 << 24;
 
             for (ulong subOffset = 0; subOffset < size; subOffset += MaxChunkSize)
             {


### PR DESCRIPTION
This reduces the size of the temporary buffer used for copy and fill operations. This should fix a possible out of memory exception, if the user is already low on ram during game load/startup. Does not have any significant impact other than that.

The size was reduced from 1GB to 16MB.