### PR TITLE
Fix Linux Icon

### DIFF
--- a/Ryujinx/Ui/Applet/ErrorAppletDialog.cs
+++ b/Ryujinx/Ui/Applet/ErrorAppletDialog.cs
@@ -1,4 +1,5 @@
 ﻿using Gtk;
+using System.Reflection;
 
 namespace Ryujinx.Ui.Applet
 {
@@ -6,6 +7,8 @@ namespace Ryujinx.Ui.Applet
     {
         public ErrorAppletDialog(Window parentWindow, DialogFlags dialogFlags, MessageType messageType, string[] buttons) : base(parentWindow, dialogFlags, messageType, ButtonsType.None, null)
         {
+            Icon = new Gdk.Pixbuf(Assembly.GetExecutingAssembly(), "Ryujinx.Ui.Resources.Logo_Ryujinx.png");
+
             int responseId = 0;
 
             if (buttons != null)

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -22,6 +22,7 @@ using Ryujinx.Ui.Windows;
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -110,6 +111,7 @@ namespace Ryujinx.Ui
             DefaultWidth  = monitorWidth  < 1280 ? monitorWidth  : 1280;
             DefaultHeight = monitorHeight < 760  ? monitorHeight : 760;
 
+            Icon  = new Gdk.Pixbuf(Assembly.GetExecutingAssembly(), "Ryujinx.Ui.Resources.Logo_Ryujinx.png");
             Title = $"Ryujinx {Program.Version}";
 
             // Hide emulation context status bar.

--- a/Ryujinx/Ui/Widgets/GameTableContextMenu.cs
+++ b/Ryujinx/Ui/Widgets/GameTableContextMenu.cs
@@ -20,6 +20,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Reflection;
 using System.Threading;
 
 using static LibHac.Fs.ApplicationSaveDataManagement;
@@ -85,6 +86,7 @@ namespace Ryujinx.Ui.Widgets
                 using MessageDialog messageDialog = new MessageDialog(null, DialogFlags.Modal, MessageType.Question, ButtonsType.YesNo, null)
                 {
                     Title          = "Ryujinx",
+                    Icon           = new Gdk.Pixbuf(Assembly.GetExecutingAssembly(), "Ryujinx.Ui.Resources.Logo_Ryujinx.png"),
                     Text           = $"There is no savedata for {titleName} [{titleId:x16}]",
                     SecondaryText  = "Would you like to create savedata for this game?",
                     WindowPosition = WindowPosition.Center
@@ -194,6 +196,7 @@ namespace Ryujinx.Ui.Widgets
                         _dialog = new MessageDialog(null, DialogFlags.DestroyWithParent, MessageType.Info, ButtonsType.Cancel, null)
                         {
                             Title          = "Ryujinx - NCA Section Extractor",
+                            Icon           = new Gdk.Pixbuf(Assembly.GetExecutingAssembly(), "Ryujinx.Ui.Resources.Logo_Ryujinx.png"),
                             SecondaryText  = $"Extracting {ncaSectionType} section from {System.IO.Path.GetFileName(_titleFilePath)}...",
                             WindowPosition = WindowPosition.Center
                         };
@@ -310,6 +313,7 @@ namespace Ryujinx.Ui.Widgets
                                     MessageDialog dialog = new MessageDialog(null, DialogFlags.DestroyWithParent, MessageType.Info, ButtonsType.Ok, null)
                                     {
                                         Title          = "Ryujinx - NCA Section Extractor",
+                                        Icon           = new Gdk.Pixbuf(Assembly.GetExecutingAssembly(), "Ryujinx.Ui.Resources.Logo_Ryujinx.png"),
                                         SecondaryText  = "Extraction has completed successfully.",
                                         WindowPosition = WindowPosition.Center
                                     };

--- a/Ryujinx/Ui/Widgets/GtkDialog.cs
+++ b/Ryujinx/Ui/Widgets/GtkDialog.cs
@@ -1,4 +1,5 @@
 using Gtk;
+using System.Reflection;
 using Ryujinx.Common.Logging;
 
 namespace Ryujinx.Ui.Widgets
@@ -11,6 +12,7 @@ namespace Ryujinx.Ui.Widgets
             : base(null, DialogFlags.Modal, messageType, buttonsType, null)
         {
             Title              = title;
+            Icon               = new Gdk.Pixbuf(Assembly.GetExecutingAssembly(), "Ryujinx.Ui.Resources.Logo_Ryujinx.png");
             Text               = mainText;
             SecondaryText      = secondaryText;
             WindowPosition     = WindowPosition.Center;

--- a/Ryujinx/Ui/Widgets/ProfileDialog.cs
+++ b/Ryujinx/Ui/Widgets/ProfileDialog.cs
@@ -1,5 +1,6 @@
 using Gtk;
 using System;
+using System.Reflection;
 
 using GUI = Gtk.Builder.ObjectAttribute;
 
@@ -19,6 +20,7 @@ namespace Ryujinx.Ui.Widgets
         private ProfileDialog(Builder builder) : base(builder.GetObject("_profileDialog").Handle)
         {
             builder.Autoconnect(this);
+            Icon = new Gdk.Pixbuf(Assembly.GetExecutingAssembly(), "Ryujinx.Ui.Resources.Logo_Ryujinx.png");
         }
 
         private void OkToggle_Activated(object sender, EventArgs args)

--- a/Ryujinx/Ui/Windows/AboutWindow.cs
+++ b/Ryujinx/Ui/Windows/AboutWindow.cs
@@ -3,6 +3,7 @@ using Ryujinx.Common.Utilities;
 using Ryujinx.Ui.Helper;
 using System.Net.Http;
 using System.Net.NetworkInformation;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace Ryujinx.Ui.Windows
@@ -11,6 +12,7 @@ namespace Ryujinx.Ui.Windows
     {
         public AboutWindow() : base($"Ryujinx {Program.Version} - About")
         {
+            Icon = new Gdk.Pixbuf(Assembly.GetExecutingAssembly(), "Ryujinx.Ui.Resources.Logo_Ryujinx.png");
             InitializeComponent();
 
             _ = DownloadPatronsJson();

--- a/Ryujinx/Ui/Windows/ControllerWindow.cs
+++ b/Ryujinx/Ui/Windows/ControllerWindow.cs
@@ -94,6 +94,8 @@ namespace Ryujinx.Ui.Windows
 
         private ControllerWindow(Builder builder, PlayerIndex controllerId) : base(builder.GetObject("_controllerWin").Handle)
         {
+            Icon = new Gdk.Pixbuf(Assembly.GetExecutingAssembly(), "Ryujinx.Ui.Resources.Logo_Ryujinx.png");
+
             builder.Autoconnect(this);
 
             _playerIndex = controllerId;

--- a/Ryujinx/Ui/Windows/SettingsWindow.cs
+++ b/Ryujinx/Ui/Windows/SettingsWindow.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Reflection;
 using System.Threading.Tasks;
 
 using GUI = Gtk.Builder.ObjectAttribute;
@@ -91,6 +92,8 @@ namespace Ryujinx.Ui.Windows
 
         private SettingsWindow(MainWindow parent, Builder builder, VirtualFileSystem virtualFileSystem, HLE.FileSystem.Content.ContentManager contentManager) : base(builder.GetObject("_settingsWin").Handle)
         {
+            Icon = new Gdk.Pixbuf(Assembly.GetExecutingAssembly(), "Ryujinx.Ui.Resources.Logo_Ryujinx.png");
+
             _parent = parent;
 
             builder.Autoconnect(this);


### PR DESCRIPTION
The icon on the Linux build has been broken since #1859 since every mention of Icon was removed.

Current master:
![image](https://user-images.githubusercontent.com/67879877/104912574-1d35db00-5995-11eb-87a7-c6827bb48a96.png)
Generic icon on window and bar

After fix:
![image](https://user-images.githubusercontent.com/67879877/104912140-9254e080-5994-11eb-9728-7e21979c72e9.png)
The icon is back on the window and the bar