### PR TITLE
am: Implement CreateHandleStorage and fixes

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/IStorage.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/IStorage.cs
@@ -2,11 +2,13 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE
 {
     class IStorage : IpcService
     {
-        public byte[] Data { get; private set; }
+        public bool   IsReadOnly { get; private set; }
+        public byte[] Data       { get; private set; }
 
-        public IStorage(byte[] data)
+        public IStorage(byte[] data, bool isReadOnly = false)
         {
-            Data = data;
+            IsReadOnly = isReadOnly;
+            Data       = data;
         }
 
         [Command(0)]

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/IStorageAccessor.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/IStorageAccessor.cs
@@ -24,6 +24,11 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE
         // Write(u64, buffer<bytes, 0x21>)
         public ResultCode Write(ServiceCtx context)
         {
+            if (_storage.IsReadOnly)
+            {
+                return ResultCode.ObjectInvalid;
+            }
+
             long writePosition = context.RequestData.ReadInt64();
 
             if (writePosition > _storage.Data.Length)


### PR DESCRIPTION
This PR implement ILibraryAppletCreator::CreateHandleStorage call (Close #1896), fixes CreateStorage/CreateTransferMemoryStorage results and fixes the am IStorage Write ReadOnly check.

This fix the boot regression of MHGU introduced in #1868.

![image](https://user-images.githubusercontent.com/4905390/104970654-86950880-59ec-11eb-99dc-4ad4852d1724.png)
![image](https://user-images.githubusercontent.com/4905390/104970661-8b59bc80-59ec-11eb-9e2c-190643e2c748.png)
