### PR TITLE
Enable parallel ASTC decoding by default

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -646,7 +646,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             // - BC4/BC5 is not supported on 3D textures.
             if (!_context.Capabilities.SupportsAstcCompression && Info.FormatInfo.Format.IsAstc())
             {
-                if (!AstcDecoder.TryDecodeToRgba8(
+                if (!AstcDecoder.TryDecodeToRgba8P(
                     data.ToArray(),
                     Info.FormatInfo.BlockWidth,
                     Info.FormatInfo.BlockHeight,


### PR DESCRIPTION
This improves the speed of ASTC decoding greatly by using multiple CPU cores for the task. I believe it was not enabled by default due to the concern that it would take away CPU that would be otherwise used by the game and background JIT. This is not as much of a issue now that we have PPTC (enabled by default) that eliminates the JIT cost after a few runs.