### PR TITLE
Fix out of range exception when a invalid base lod is used

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -223,7 +223,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 layerSize = sizeInfo.LayerSize;
 
-                if (minLod != 0)
+                if (minLod != 0 && minLod < levels)
                 {
                     // If the base level is not zero, we additionally add the mip level offset
                     // to the address, this allows the texture manager to find the base level from the


### PR DESCRIPTION
Fix a regression introduced by #1911 on Kirby Star Allies, where the game would crash on startup. The game was trying to use a invalid min lod value, where min and max lod where set to 15, and levels was 8, leading to a out of range exception. Now it does not take the base level into account if its value is invalid.

It might be worth doing something similar for min lod and max lod, just in case min lod > max lod (which is also invalid and would result in a negative levels count).