### PR TITLE
Match texture if the physical range is the same

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -689,11 +689,18 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 if (matchQuality != TextureMatchQuality.NoMatch)
                 {
+                    // If the parameters match, we need to make sure the texture is mapped to the same memory regions.
+
+                    // If a range of memory was supplied, just check if the ranges match.
                     if (range != null && !overlap.Range.Equals(range.Value))
                     {
                         continue;
                     }
 
+                    // If no range was supplied, we can check if the GPU virtual address match. If they do,
+                    // we know the textures are located at the same memory region.
+                    // If they don't, it may still be mapped to the same physical region, so we
+                    // do a more expensive check to tell if they are mapped into the same physical regions.
                     if (overlap.Info.GpuAddress != info.GpuAddress && !_context.MemoryManager.CompareRange(overlap.Range, info.GpuAddress))
                     {
                         continue;

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -685,13 +685,20 @@ namespace Ryujinx.Graphics.Gpu.Image
             {
                 Texture overlap = _textureOverlaps[index];
 
-                bool rangeMatches = range != null ? overlap.Range.Equals(range.Value) : overlap.Info.GpuAddress == info.GpuAddress;
-                if (!rangeMatches)
-                {
-                    continue;
-                }
-
                 TextureMatchQuality matchQuality = overlap.IsExactMatch(info, flags);
+
+                if (matchQuality != TextureMatchQuality.NoMatch)
+                {
+                    if (range != null && !overlap.Range.Equals(range.Value))
+                    {
+                        continue;
+                    }
+
+                    if (overlap.Info.GpuAddress != info.GpuAddress && !_context.MemoryManager.CompareRange(overlap.Range, info.GpuAddress))
+                    {
+                        continue;
+                    }
+                }
 
                 if (matchQuality == TextureMatchQuality.Perfect)
                 {

--- a/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
@@ -343,6 +343,13 @@ namespace Ryujinx.Graphics.Gpu.Memory
             return new MultiRange(regions.ToArray());
         }
 
+        /// <summary>
+        /// Checks if a given GPU virtual memory range is mapped to the same physical regions
+        /// as the specified physical memory multi-range.
+        /// </summary>
+        /// <param name="range">Physical memory multi-range</param>
+        /// <param name="va">GPU virtual memory address</param>
+        /// <returns>True if the virtual memory region is mapped into the specified physical one, false otherwise</returns>
         public bool CompareRange(MultiRange range, ulong va)
         {
             va &= ~PageMask;

--- a/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
@@ -343,6 +343,32 @@ namespace Ryujinx.Graphics.Gpu.Memory
             return new MultiRange(regions.ToArray());
         }
 
+        public bool CompareRange(MultiRange range, ulong va)
+        {
+            va &= ~PageMask;
+
+            for (int i = 0; i < range.Count; i++)
+            {
+                MemoryRange currentRange = range.GetSubRange(i);
+
+                ulong address = currentRange.Address & ~PageMask;
+                ulong endAddress = (currentRange.EndAddress + PageMask) & ~PageMask;
+
+                while (address < endAddress)
+                {
+                    if (Translate(va) != address)
+                    {
+                        return false;
+                    }
+
+                    va += PageSize;
+                    address += PageSize;
+                }
+            }
+
+            return true;
+        }
+
         /// <summary>
         /// Validates a GPU virtual address.
         /// </summary>


### PR DESCRIPTION
#1905 changed the behavior of exact texture matches a little bit. Instead of comparing the physical address (CPU VA) and assuming it is contiguous, it was changed to compare the GPU VA instead (as physical regions might not be contiguous). This change makes it closer to the previous behavior, it now compares the physical regions if the virtual address is not the same (see the new `CompareRange` method), and allows a match if the virtual addresses are different, but mapped to the same physical region.

This seems to fix (or at least greatly improve) a regression on Rune Factory 4 Special caused by the aforementioned PR.

NOTE: This has the potential to slow things down if the slow path that calls `CompareRange` is hit frequently, which is the reason I was only compared the GPU virtual addresses.