### PR TITLE
Fix inverted read only flag in transfer memory creation

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ILibraryAppletCreator.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ILibraryAppletCreator.cs
@@ -42,7 +42,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // CreateTransferMemoryStorage(b8, u64, handle<copy>) -> object<nn::am::service::IStorage>
         public ResultCode CreateTransferMemoryStorage(ServiceCtx context)
         {
-            bool isReadOnly = (context.RequestData.ReadInt64() & 1) != 0;
+            bool isReadOnly = (context.RequestData.ReadInt64() & 1) == 0;
             long size       = context.RequestData.ReadInt64();
             int  handle     = context.Request.HandleDesc.ToCopy[0];
 


### PR DESCRIPTION
From https://switchbrew.org/wiki/Applet_Manager_services#CreateTransferMemoryStorage :

```
The input bool controls whether writing to the storage is allowed: #Write will throw an error if this flag is not set.
```

So the state of `isReadOnly` must be inverted.