### PR TITLE
Fix TZName parsing in TZIF footer

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Time/TimeZone/TimeZone.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/TimeZone/TimeZone.cs
@@ -183,11 +183,10 @@ namespace Ryujinx.HLE.HOS.Services.Time.TimeZone
         {
             int i = namePosition;
 
-            char c = name[i];
+            char c;
 
-            while (c != '\0' && !char.IsDigit(c) && c != ',' && c != '-' && c != '+')
+            while ((c = name[i]) != '\0' && !char.IsDigit(c) && c != ',' && c != '-' && c != '+')
             {
-                c = name[i];
                 i++;
             }
 


### PR DESCRIPTION
An unfortunate optimization resulted in `ParsePosixTime` returning false early, making the TZIF footer info go unused for all timezones.
Closes #1949
![tzfix](https://user-images.githubusercontent.com/62494521/105578000-32e73e00-5da3-11eb-8adb-c41a322989fd.png)
