### PR TITLE
Initial Setup: Reload keys before verifying firmware

### DIFF
--- a/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
+++ b/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
@@ -653,6 +653,15 @@ namespace Ryujinx.HLE.FileSystem.Content
 
         public SystemVersion VerifyFirmwarePackage(string firmwarePackage)
         {
+            _virtualFileSystem.Reload();
+
+            // LibHac.NcaHeader's DecryptHeader doesn't check if HeaderKey is empty and throws InvalidDataException instead
+            // So, we check it early for a better user experience.
+            if (_virtualFileSystem.KeySet.HeaderKey.IsEmpty())
+            {
+                throw new MissingKeyException("HeaderKey is empty. Cannot decrypt NCA headers.");
+            }
+
             Dictionary<ulong, List<(NcaContentType type, string path)>> updateNcas = new Dictionary<ulong, List<(NcaContentType, string)>>();
 
             if (Directory.Exists(firmwarePackage))

--- a/Ryujinx/Ui/App/ApplicationLibrary.cs
+++ b/Ryujinx/Ui/App/ApplicationLibrary.cs
@@ -298,8 +298,7 @@ namespace Ryujinx.Ui.App
                             }
                             catch (Exception exception)
                             {
-                                Logger.Warning?.Print(LogClass.Application, $"The file encountered was not of a valid type. Errored File: {applicationPath}");
-                                Logger.Debug?.Print(LogClass.Application, exception.ToString());
+                                Logger.Warning?.Print(LogClass.Application, $"The file encountered was not of a valid type. File: '{applicationPath}' Error: {exception}");
 
                                 numApplicationsFound--;
                                 _loadingError = true;

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -1032,6 +1032,11 @@ namespace Ryujinx.Ui
                         thread.Start();
                     }
                 }
+                catch (LibHac.MissingKeyException ex)
+                {
+                    Logger.Error?.Print(LogClass.Application, ex.ToString());
+                    UserErrorDialog.CreateUserErrorDialog(UserError.NoKeys);
+                }
                 catch (Exception ex)
                 {
                     GtkDialog.CreateErrorDialog(ex.Message);


### PR DESCRIPTION
This PR attempts to improve the initial setup UX. After placing keys, the user no longer needs to restart Ryujinx before installing firmware. Also, if they disregard the `NoKeys` dialog, it'll be shown again when a firmware is selected.

Closes #1843

Slightly unrelated, I noticed the generic exception log in `LoadApplications()` is cryptic unless debug logs are enabled but a dialog pops up asking to check logs. So, moved the exception to the warning itself.