### PR TITLE
Avoid some redundant GL calls

### DIFF
--- a/Ryujinx.Graphics.GAL/IPipeline.cs
+++ b/Ryujinx.Graphics.GAL/IPipeline.cs
@@ -68,8 +68,7 @@ namespace Ryujinx.Graphics.GAL
 
         void SetSampler(int binding, ISampler sampler);
 
-        void SetScissorEnable(int index, bool enable);
-        void SetScissor(int index, int x, int y, int width, int height);
+        void SetScissor(int index, bool enable, int x, int y, int width, int height);
 
         void SetStencilTest(StencilTestDescriptor stencilTest);
 

--- a/Ryujinx.Graphics.GAL/VertexAttribDescriptor.cs
+++ b/Ryujinx.Graphics.GAL/VertexAttribDescriptor.cs
@@ -1,6 +1,8 @@
+using System;
+
 namespace Ryujinx.Graphics.GAL
 {
-    public struct VertexAttribDescriptor
+    public struct VertexAttribDescriptor : IEquatable<VertexAttribDescriptor>
     {
         public int BufferIndex { get; }
         public int Offset      { get; }
@@ -15,6 +17,24 @@ namespace Ryujinx.Graphics.GAL
             Offset      = offset;
             IsZero      = isZero;
             Format      = format;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is VertexAttribDescriptor other && Equals(other);
+        }
+
+        public bool Equals(VertexAttribDescriptor other)
+        {
+            return BufferIndex == other.BufferIndex &&
+                   Offset      == other.Offset &&
+                   IsZero      == other.IsZero &&
+                   Format      == other.Format;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(BufferIndex, Offset, IsZero, Format);
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -436,8 +436,6 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
                 bool enable = scissor.Enable && (scissor.X1 != 0 || scissor.Y1 != 0 || scissor.X2 != 0xffff || scissor.Y2 != 0xffff);
 
-                _context.Renderer.Pipeline.SetScissorEnable(index, enable);
-
                 if (enable)
                 {
                     int x = scissor.X1;
@@ -454,7 +452,11 @@ namespace Ryujinx.Graphics.Gpu.Engine
                         height = (int)Math.Ceiling(height * scale);
                     }
 
-                    _context.Renderer.Pipeline.SetScissor(index, x, y, width, height);
+                    _context.Renderer.Pipeline.SetScissor(index, true, x, y, width, height);
+                }
+                else
+                {
+                    _context.Renderer.Pipeline.SetScissor(index, false, 0, 0, 0, 0);
                 }
             }
         }

--- a/Ryujinx.Graphics.OpenGL/Framebuffer.cs
+++ b/Ryujinx.Graphics.OpenGL/Framebuffer.cs
@@ -2,6 +2,7 @@ using OpenTK.Graphics.OpenGL;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.OpenGL.Image;
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Ryujinx.Graphics.OpenGL
 {
@@ -29,21 +30,27 @@ namespace Ryujinx.Graphics.OpenGL
             return Handle;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void AttachColor(int index, TextureView color)
         {
+            if (_colors[index] == color)
+            {
+                return;
+            }
+
             FramebufferAttachment attachment = FramebufferAttachment.ColorAttachment0 + index;
 
             if (HwCapabilities.Vendor == HwCapabilities.GpuVendor.Amd ||
                 HwCapabilities.Vendor == HwCapabilities.GpuVendor.Intel)
             {
                 GL.FramebufferTexture(FramebufferTarget.Framebuffer, attachment, color?.GetIncompatibleFormatViewHandle() ?? 0, 0);
-
-                _colors[index] = color;
             }
             else
             {
                 GL.FramebufferTexture(FramebufferTarget.Framebuffer, attachment, color?.Handle ?? 0, 0);
             }
+
+            _colors[index] = color;
         }
 
         public void AttachDepthStencil(TextureView depthStencil)


### PR DESCRIPTION
This makes some simple changes on the OpenGL backend to reduce the number of redudant calls (that does not change any state). This make navigating debugging captures a little bit easier. It might also have a very small performance improvement since it does less native calls.

As an example, I have attached 2 NSight captures, the top one is master and the bottom one is with this PR. Both taken in Xenoblade Chronicles Definitive Edition, on the very first part of the game (last screenshot shows which part it was captured at).
master:
![image](https://user-images.githubusercontent.com/5624669/105647922-8a5eda00-5e87-11eb-8006-2c550cee59f0.png)
PR:
![image](https://user-images.githubusercontent.com/5624669/105647930-8e8af780-5e87-11eb-88ca-9f64adb15015.png)
As you can see, the event count dropped from 96418 to 35501, thus the number of calls is approximately 37% compare to master, so roughly 1/3 of calls. The improvement depends on the game and on the area, but in general those changes at least halves the number of calls.
![image](https://user-images.githubusercontent.com/5624669/105648197-ff7edf00-5e88-11eb-9f2f-bd0113303374.png)
