### PR TITLE
Improve inline keyboard compatibility

### DIFF
--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineKeyboardRequest.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineKeyboardRequest.cs
@@ -5,7 +5,6 @@
     /// </summary>
     enum InlineKeyboardRequest : uint
     {
-        Unknown0                    = 0x0,
         Finalize                    = 0x4,
         SetUserWordInfo             = 0x6,
         SetCustomizeDic             = 0x7,

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineKeyboardRequest.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineKeyboardRequest.cs
@@ -1,17 +1,48 @@
 ﻿namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
 {
     /// <summary>
-    /// Possible requests to the keyboard when running in inline mode.
+    /// Possible requests to the software keyboard when running in inline mode.
     /// </summary>
     enum InlineKeyboardRequest : uint
     {
-        Finalize                    = 0x4,
-        SetUserWordInfo             = 0x6,
-        SetCustomizeDic             = 0x7,
-        Calc                        = 0xA,
-        SetCustomizedDictionaries   = 0xB,
+        /// <summary>
+        /// Finalize the keyboard applet.
+        /// </summary>
+        Finalize = 0x4,
+
+        /// <summary>
+        /// Set user words for text prediction.
+        /// </summary>
+        SetUserWordInfo = 0x6,
+
+        /// <summary>
+        /// Sets the CustomizeDic data. Can't be used if CustomizedDictionaries is already set.
+        /// </summary>
+        SetCustomizeDic = 0x7,
+
+        /// <summary>
+        /// Configure the keyboard applet and put it in a state where it is processing input.
+        /// </summary>
+        Calc = 0xA,
+
+        /// <summary>
+        /// Set custom dictionaries for text prediction. Can't be used if SetCustomizeDic is already set.
+        /// </summary>
+        SetCustomizedDictionaries = 0xB,
+
+        /// <summary>
+        /// Release custom dictionaries data.
+        /// </summary>
         UnsetCustomizedDictionaries = 0xC,
-        UseChangedStringV2          = 0xD,
-        UseMovedCursorV2            = 0xE
+
+        /// <summary>
+        /// [8.0.0+] Request the keyboard applet to use the ChangedStringV2 response when notifying changes in text data.
+        /// </summary>
+        UseChangedStringV2 = 0xD,
+
+        /// <summary>
+        /// [8.0.0+] Request the keyboard applet to use the MovedCursorV2 response when notifying changes in cursor position.
+        /// </summary>
+        UseMovedCursorV2 = 0xE
     }
 }

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineKeyboardResponse.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineKeyboardResponse.cs
@@ -1,26 +1,93 @@
 ﻿namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
 {
     /// <summary>
-    /// Possible responses from the keyboard when running in inline mode.
+    /// Possible responses from the software keyboard when running in inline mode.
     /// </summary>
     enum InlineKeyboardResponse : uint
     {
-        FinishedInitialize          = 0x0,
-        Default                     = 0x1,
-        ChangedString               = 0x2,
-        MovedCursor                 = 0x3,
-        MovedTab                    = 0x4,
-        DecidedEnter                = 0x5,
-        DecidedCancel               = 0x6,
-        ChangedStringUtf8           = 0x7,
-        MovedCursorUtf8             = 0x8,
-        DecidedEnterUtf8            = 0x9,
-        UnsetCustomizeDic           = 0xA,
-        ReleasedUserWordInfo        = 0xB,
+        /// <summary>
+        /// The software keyboard received a Calc and it is fully initialized. Reply data is ignored by the user-process.
+        /// </summary>
+        FinishedInitialize = 0x0,
+
+        /// <summary>
+        /// Default response. Official sw has no handling for this besides just closing the storage.
+        /// </summary>
+        Default = 0x1,
+
+        /// <summary>
+        /// The text data in the software keyboard changed (UTF-16 encoding).
+        /// </summary>
+        ChangedString = 0x2,
+
+        /// <summary>
+        /// The cursor position in the software keyboard changed (UTF-16 encoding).
+        /// </summary>
+        MovedCursor = 0x3,
+
+        /// <summary>
+        /// A tab in the software keyboard changed.
+        /// </summary>
+        MovedTab = 0x4,
+
+        /// <summary>
+        /// The OK key was pressed in the software keyboard, confirming the input text (UTF-16 encoding).
+        /// </summary>
+        DecidedEnter = 0x5,
+
+        /// <summary>
+        /// The Cancel key was pressed in the software keyboard, cancelling the input.
+        /// </summary>
+        DecidedCancel = 0x6,
+
+        /// <summary>
+        /// Same as ChangedString, but with UTF-8 encoding.
+        /// </summary>
+        ChangedStringUtf8 = 0x7,
+
+        /// <summary>
+        /// Same as MovedCursor, but with UTF-8 encoding.
+        /// </summary>
+        MovedCursorUtf8 = 0x8,
+
+        /// <summary>
+        /// Same as DecidedEnter, but with UTF-8 encoding.
+        /// </summary>
+        DecidedEnterUtf8 = 0x9,
+
+        /// <summary>
+        /// They software keyboard is releasing the data previously set by a SetCustomizeDic request.
+        /// </summary>
+        UnsetCustomizeDic = 0xA,
+
+        /// <summary>
+        /// They software keyboard is releasing the data previously set by a SetUserWordInfo request.
+        /// </summary>
+        ReleasedUserWordInfo = 0xB,
+
+        /// <summary>
+        /// They software keyboard is releasing the data previously set by a SetCustomizedDictionaries request.
+        /// </summary>
         UnsetCustomizedDictionaries = 0xC,
-        ChangedStringV2             = 0xD,
-        MovedCursorV2               = 0xE,
-        ChangedStringUtf8V2         = 0xF,
-        MovedCursorUtf8V2           = 0x10
+
+        /// <summary>
+        /// Same as ChangedString, but with additional fields.
+        /// </summary>
+        ChangedStringV2 = 0xD,
+
+        /// <summary>
+        /// Same as MovedCursor, but with additional fields.
+        /// </summary>
+        MovedCursorV2 = 0xE,
+
+        /// <summary>
+        /// Same as ChangedStringUtf8, but with additional fields.
+        /// </summary>
+        ChangedStringUtf8V2 = 0xF,
+
+        /// <summary>
+        /// Same as MovedCursorUtf8, but with additional fields.
+        /// </summary>
+        MovedCursorUtf8V2 = 0x10
     }
 }

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineKeyboardState.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineKeyboardState.cs
@@ -6,9 +6,9 @@
     enum InlineKeyboardState : uint
     {
         Uninitialized = 0x0,
-        Initializing  = 0x1,
+        Initialized   = 0x1,
         Ready         = 0x2,
         DataAvailable = 0x3,
-        Completed     = 0x4
+        Complete      = 0x4
     }
 }

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineKeyboardState.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineKeyboardState.cs
@@ -1,14 +1,33 @@
 ﻿namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
 {
     /// <summary>
-    /// Possible states for the keyboard when running in inline mode.
+    /// Possible states for the software keyboard when running in inline mode.
     /// </summary>
     enum InlineKeyboardState : uint
     {
+        /// <summary>
+        /// The software keyboard has just been created or finalized and is uninitialized.
+        /// </summary>
         Uninitialized = 0x0,
-        Initialized   = 0x1,
-        Ready         = 0x2,
+
+        /// <summary>
+        /// A Calc was previously received and fulfilled, so the software keyboard is initialized, but is not processing input.
+        /// </summary>
+        Initialized = 0x1,
+
+        /// <summary>
+        /// A Calc was received and the software keyboard is processing input.
+        /// </summary>
+        Ready = 0x2,
+
+        /// <summary>
+        /// New text data or cursor position of the software keyboard are available.
+        /// </summary>
         DataAvailable = 0x3,
-        Complete      = 0x4
+
+        /// <summary>
+        /// The Calc request was fulfilled with either a text input or a cancel.
+        /// </summary>
+        Complete = 0x4
     }
 }

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineResponses.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineResponses.cs
@@ -45,41 +45,41 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             writer.Write(cursor); // Cursor position
         }
 
-        public static byte[] FinishedInitialize()
+        public static byte[] FinishedInitialize(InlineKeyboardState state)
         {
             uint resSize = 2 * sizeof(uint) + 0x1;
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.Ready, InlineKeyboardResponse.FinishedInitialize, writer);
+                BeginResponse(state, InlineKeyboardResponse.FinishedInitialize, writer);
                 writer.Write((byte)1); // Data (ignored by the program)
 
                 return stream.ToArray();
             }
         }
 
-        public static byte[] Default()
+        public static byte[] Default(InlineKeyboardState state)
         {
             uint resSize = 2 * sizeof(uint);
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.Initializing, InlineKeyboardResponse.Default, writer);
+                BeginResponse(state, InlineKeyboardResponse.Default, writer);
 
                 return stream.ToArray();
             }
         }
 
-        public static byte[] ChangedString(string text)
+        public static byte[] ChangedString(string text, InlineKeyboardState state)
         {
             uint resSize = 4 * sizeof(uint) + MaxStrLenUTF16;
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.Initializing, InlineKeyboardResponse.ChangedString, writer);
+                BeginResponse(state, InlineKeyboardResponse.ChangedString, writer);
                 WriteStringWithCursor(text, writer, MaxStrLenUTF16, Encoding.Unicode);
                 writer.Write((int)0); // ?
                 writer.Write((int)0); // ?
@@ -88,21 +88,21 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             }
         }
 
-        public static byte[] MovedCursor(string text)
+        public static byte[] MovedCursor(string text, InlineKeyboardState state)
         {
             uint resSize = 4 * sizeof(uint) + MaxStrLenUTF16;
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.Initializing, InlineKeyboardResponse.MovedCursor, writer);
+                BeginResponse(state, InlineKeyboardResponse.MovedCursor, writer);
                 WriteStringWithCursor(text, writer, MaxStrLenUTF16, Encoding.Unicode);
 
                 return stream.ToArray();
             }
         }
 
-        public static byte[] MovedTab(string text)
+        public static byte[] MovedTab(string text, InlineKeyboardState state)
         {
             // Should be the same as MovedCursor.
 
@@ -111,48 +111,48 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.Initializing, InlineKeyboardResponse.MovedTab, writer);
+                BeginResponse(state, InlineKeyboardResponse.MovedTab, writer);
                 WriteStringWithCursor(text, writer, MaxStrLenUTF16, Encoding.Unicode);
 
                 return stream.ToArray();
             }
         }
 
-        public static byte[] DecidedEnter(string text)
+        public static byte[] DecidedEnter(string text, InlineKeyboardState state)
         {
             uint resSize = 3 * sizeof(uint) + MaxStrLenUTF16;
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.Completed, InlineKeyboardResponse.DecidedEnter, writer);
+                BeginResponse(state, InlineKeyboardResponse.DecidedEnter, writer);
                 WriteString(text, writer, MaxStrLenUTF16, Encoding.Unicode);
 
                 return stream.ToArray();
             }
         }
 
-        public static byte[] DecidedCancel()
+        public static byte[] DecidedCancel(InlineKeyboardState state)
         {
             uint resSize = 2 * sizeof(uint);
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.Completed, InlineKeyboardResponse.DecidedCancel, writer);
+                BeginResponse(state, InlineKeyboardResponse.DecidedCancel, writer);
 
                 return stream.ToArray();
             }
         }
 
-        public static byte[] ChangedStringUtf8(string text)
+        public static byte[] ChangedStringUtf8(string text, InlineKeyboardState state)
         {
             uint resSize = 6 * sizeof(uint) + MaxStrLenUTF8;
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.DataAvailable, InlineKeyboardResponse.ChangedStringUtf8, writer);
+                BeginResponse(state, InlineKeyboardResponse.ChangedStringUtf8, writer);
                 WriteStringWithCursor(text, writer, MaxStrLenUTF8, Encoding.UTF8);
                 writer.Write((int)0); // ?
                 writer.Write((int)0); // ?
@@ -161,81 +161,81 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             }
         }
 
-        public static byte[] MovedCursorUtf8(string text)
+        public static byte[] MovedCursorUtf8(string text, InlineKeyboardState state)
         {
             uint resSize = 4 * sizeof(uint) + MaxStrLenUTF8;
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.DataAvailable, InlineKeyboardResponse.MovedCursorUtf8, writer);
+                BeginResponse(state, InlineKeyboardResponse.MovedCursorUtf8, writer);
                 WriteStringWithCursor(text, writer, MaxStrLenUTF8, Encoding.UTF8);
 
                 return stream.ToArray();
             }
         }
 
-        public static byte[] DecidedEnterUtf8(string text)
+        public static byte[] DecidedEnterUtf8(string text, InlineKeyboardState state)
         {
             uint resSize = 3 * sizeof(uint) + MaxStrLenUTF8;
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.Completed, InlineKeyboardResponse.DecidedEnterUtf8, writer);
+                BeginResponse(state, InlineKeyboardResponse.DecidedEnterUtf8, writer);
                 WriteString(text, writer, MaxStrLenUTF8, Encoding.UTF8);
 
                 return stream.ToArray();
             }
         }
 
-        public static byte[] UnsetCustomizeDic()
+        public static byte[] UnsetCustomizeDic(InlineKeyboardState state)
         {
             uint resSize = 2 * sizeof(uint);
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.Initializing, InlineKeyboardResponse.UnsetCustomizeDic, writer);
+                BeginResponse(state, InlineKeyboardResponse.UnsetCustomizeDic, writer);
 
                 return stream.ToArray();
             }
         }
 
-        public static byte[] ReleasedUserWordInfo()
+        public static byte[] ReleasedUserWordInfo(InlineKeyboardState state)
         {
             uint resSize = 2 * sizeof(uint);
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.Initializing, InlineKeyboardResponse.ReleasedUserWordInfo, writer);
+                BeginResponse(state, InlineKeyboardResponse.ReleasedUserWordInfo, writer);
 
                 return stream.ToArray();
             }
         }
 
-        public static byte[] UnsetCustomizedDictionaries()
+        public static byte[] UnsetCustomizedDictionaries(InlineKeyboardState state)
         {
             uint resSize = 2 * sizeof(uint);
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.Initializing, InlineKeyboardResponse.UnsetCustomizedDictionaries, writer);
+                BeginResponse(state, InlineKeyboardResponse.UnsetCustomizedDictionaries, writer);
 
                 return stream.ToArray();
             }
         }
 
-        public static byte[] ChangedStringV2(string text)
+        public static byte[] ChangedStringV2(string text, InlineKeyboardState state)
         {
             uint resSize = 6 * sizeof(uint) + MaxStrLenUTF16 + 0x1;
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.DataAvailable, InlineKeyboardResponse.ChangedStringV2, writer);
+                BeginResponse(state, InlineKeyboardResponse.ChangedStringV2, writer);
                 WriteStringWithCursor(text, writer, MaxStrLenUTF16, Encoding.Unicode);
                 writer.Write((int)0); // ?
                 writer.Write((int)0); // ?
@@ -245,14 +245,14 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             }
         }
 
-        public static byte[] MovedCursorV2(string text)
+        public static byte[] MovedCursorV2(string text, InlineKeyboardState state)
         {
             uint resSize = 4 * sizeof(uint) + MaxStrLenUTF16 + 0x1;
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.DataAvailable, InlineKeyboardResponse.MovedCursorV2, writer);
+                BeginResponse(state, InlineKeyboardResponse.MovedCursorV2, writer);
                 WriteStringWithCursor(text, writer, MaxStrLenUTF16, Encoding.Unicode);
                 writer.Write((byte)0); // Flag == 0
 
@@ -260,14 +260,14 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             }
         }
 
-        public static byte[] ChangedStringUtf8V2(string text)
+        public static byte[] ChangedStringUtf8V2(string text, InlineKeyboardState state)
         {
             uint resSize = 6 * sizeof(uint) + MaxStrLenUTF8 + 0x1;
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.DataAvailable, InlineKeyboardResponse.ChangedStringUtf8V2, writer);
+                BeginResponse(state, InlineKeyboardResponse.ChangedStringUtf8V2, writer);
                 WriteStringWithCursor(text, writer, MaxStrLenUTF8, Encoding.UTF8);
                 writer.Write((int)0); // ?
                 writer.Write((int)0); // ?
@@ -277,14 +277,14 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             }
         }
 
-        public static byte[] MovedCursorUtf8V2(string text)
+        public static byte[] MovedCursorUtf8V2(string text, InlineKeyboardState state)
         {
             uint resSize = 4 * sizeof(uint) + MaxStrLenUTF8 + 0x1;
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
-                BeginResponse(InlineKeyboardState.DataAvailable, InlineKeyboardResponse.MovedCursorUtf8V2, writer);
+                BeginResponse(state, InlineKeyboardResponse.MovedCursorUtf8V2, writer);
                 WriteStringWithCursor(text, writer, MaxStrLenUTF8, Encoding.UTF8);
                 writer.Write((byte)0); // Flag == 0
 

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineResponses.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineResponses.cs
@@ -74,7 +74,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
 
         public static byte[] ChangedString(string text, InlineKeyboardState state)
         {
-            uint resSize = 4 * sizeof(uint) + MaxStrLenUTF16;
+            uint resSize = 6 * sizeof(uint) + MaxStrLenUTF16;
 
             using (MemoryStream stream = new MemoryStream(new byte[resSize]))
             using (BinaryWriter writer = new BinaryWriter(stream))

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardAppear.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardAppear.cs
@@ -2,33 +2,38 @@
 
 namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
 {
+    /// <summary>
+    /// A structure with appearance configurations for the software keyboard when running in inline mode.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     struct SoftwareKeyboardAppear
     {
         private const int OkTextLength = 8;
 
-        // Some games send a Calc without intention of showing the keyboard, a
-        // common trend observed is that this field will be != 0 in such cases.
+        /// <summary>
+        /// Some games send a Calc without intention of showing the keyboard, a
+        /// common trend observed is that this field will be != 0 in such cases.
+        /// </summary>
         public uint ShouldBeHidden;
 
+        /// <summary>
+        /// The string displayed in the Submit button.
+        /// </summary>
         [MarshalAs(UnmanagedType.ByValTStr, SizeConst = OkTextLength + 1)]
         public string OkText;
 
         /// <summary>
         /// The character displayed in the left button of the numeric keyboard.
-        /// This is ignored when Mode is not set to NumbersOnly.
         /// </summary>
         public char LeftOptionalSymbolKey;
 
         /// <summary>
         /// The character displayed in the right button of the numeric keyboard.
-        /// This is ignored when Mode is not set to NumbersOnly.
         /// </summary>
         public char RightOptionalSymbolKey;
 
         /// <summary>
-        /// When set, predictive typing is enabled making use of the system dictionary,
-        /// and any custom user dictionary.
+        /// When set, predictive typing is enabled making use of the system dictionary, and any custom user dictionary.
         /// </summary>
         [MarshalAs(UnmanagedType.I1)]
         public bool PredictionEnabled;
@@ -43,13 +48,24 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
         public int Padding1;
         public int Padding2;
 
-        public byte EnableReturnButton;
+        /// <summary>
+        /// Indicates the return button is enabled in the keyboard. This allows for input with multiple lines.
+        /// </summary>
+        [MarshalAs(UnmanagedType.I1)]
+        public bool UseNewLine;
 
-        public byte Padding3;
+        /// <summary>
+        /// [10.0.0+] If value is 1 or 2, then keytopAsFloating=0 and footerScalable=1 in Calc.
+        /// </summary>
+        public byte Unknown1;
+
         public byte Padding4;
         public byte Padding5;
 
-        public uint CalcArgFlags;
+        /// <summary>
+        /// Bitmask 0x1000 of the Calc and DirectionalButtonAssignEnabled in bitmask 0x10000000.
+        /// </summary>
+        public uint CalcFlags;
 
         public uint Padding6;
         public uint Padding7;

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardCalc.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardCalc.cs
@@ -3,7 +3,7 @@
 namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
 {
     /// <summary>
-    /// A structure that defines the configuration options of the software keyboard.
+    /// A structure with configuration options of the software keyboard when starting a new input request in inline mode.
     /// </summary>
     [StructLayout(LayoutKind.Sequential, Pack=1, CharSet = CharSet.Unicode)]
     struct SoftwareKeyboardCalc
@@ -12,28 +12,56 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
 
         public uint Unknown;
 
+        /// <summary>
+        /// The size of the Calc struct, as reported by the process communicating with the applet.
+        /// </summary>
         public ushort Size;
 
         public byte Unknown1;
         public byte Unknown2;
 
+        /// <summary>
+        /// Configuration flags. Their purpose is currently unknown.
+        /// </summary>
         public ulong Flags;
 
+        /// <summary>
+        /// The original parameters used when initializing the keyboard applet.
+        /// </summary>
         public SoftwareKeyboardInitialize Initialize;
 
+        /// <summary>
+        /// The audio volume used by the sound effects of the keyboard.
+        /// </summary>
         public float Volume;
 
+        /// <summary>
+        /// The initial position of the text cursor (caret) in the provided input text.
+        /// </summary>
         public int CursorPos;
 
+        /// <summary>
+        /// Appearance configurations for the on-screen keyboard.
+        /// </summary>
         public SoftwareKeyboardAppear Appear;
 
+        /// <summary>
+        /// The initial input text to be used by the software keyboard.
+        /// </summary>
         [MarshalAs(UnmanagedType.ByValTStr, SizeConst = InputTextLength + 1)]
         public string InputText;
 
-        public byte Utf8Mode;
+        /// <summary>
+        /// When set, the strings communicated by software keyboard will be encoded as UTF-8 instead of UTF-16.
+        /// </summary>
+        [MarshalAs(UnmanagedType.I1)]
+        public bool UseUtf8;
 
         public byte Unknown3;
 
+        /// <summary>
+        /// [5.0.0+] Enable the backspace key in the software keyboard.
+        /// </summary>
         [MarshalAs(UnmanagedType.I1)]
         public bool BackspaceEnabled;
 
@@ -41,32 +69,57 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
         public byte Unknown5;
 
         [MarshalAs(UnmanagedType.I1)]
-        public byte KeytopAsFloating;
+        public bool KeytopAsFloating;
 
         [MarshalAs(UnmanagedType.I1)]
-        public byte FooterScalable;
+        public bool FooterScalable;
 
         [MarshalAs(UnmanagedType.I1)]
-        public byte AlphaEnabledInInputMode;
+        public bool AlphaEnabledInInputMode;
 
-        [MarshalAs(UnmanagedType.I1)]
         public byte InputModeFadeType;
 
+        /// <summary>
+        /// When set, the software keyboard ignores touch input.
+        /// </summary>
         [MarshalAs(UnmanagedType.I1)]
-        public byte TouchDisabled;
+        public bool TouchDisabled;
 
+        /// <summary>
+        /// When set, the software keyboard ignores hardware keyboard commands.
+        /// </summary>
         [MarshalAs(UnmanagedType.I1)]
-        public byte HardwareKeyboardDisabled;
+        public bool HardwareKeyboardDisabled;
 
         public uint Unknown6;
         public uint Unknown7;
 
+        /// <summary>
+        /// Default value is 1.0.
+        /// </summary>
         public float KeytopScale0;
+
+        /// <summary>
+        /// Default value is 1.0.
+        /// </summary>
         public float KeytopScale1;
+
         public float KeytopTranslate0;
         public float KeytopTranslate1;
+
+        /// <summary>
+        /// Default value is 1.0.
+        /// </summary>
         public float KeytopBgAlpha;
+
+        /// <summary>
+        /// Default value is 1.0.
+        /// </summary>
         public float FooterBgAlpha;
+
+        /// <summary>
+        /// Default value is 1.0.
+        /// </summary>
         public float BalloonScale;
 
         public float Unknown8;
@@ -74,9 +127,19 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
         public uint Unknown10;
         public uint Unknown11;
 
+        /// <summary>
+        /// [5.0.0+] Enable sound effect.
+        /// </summary>
         public byte SeGroup;
 
+        /// <summary>
+        /// [6.0.0+] Enables the Trigger field when Trigger is non-zero.
+        /// </summary>
         public byte TriggerFlag;
+
+        /// <summary>
+        /// [6.0.0+] Always set to zero.
+        /// </summary>
         public byte Trigger;
 
         public byte Padding;

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardCustomizeDic.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardCustomizeDic.cs
@@ -2,6 +2,9 @@
 
 namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
 {
+    /// <summary>
+    /// A structure used by SetCustomizeDic request to software keyboard.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential, Pack = 4)]
     struct SoftwareKeyboardCustomizeDic
     {

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardCustomizeDic.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardCustomizeDic.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
+{
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    struct SoftwareKeyboardCustomizeDic
+    {
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 112)]
+        public byte[] Unknown;
+    }
+}

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardDictSet.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardDictSet.cs
@@ -2,16 +2,31 @@
 
 namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
 {
+    /// <summary>
+    /// A structure with custom dictionary words for the software keyboard.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential, Pack = 2)]
     struct SoftwareKeyboardDictSet
     {
+        /// <summary>
+        /// A 0x1000-byte aligned buffer position.
+        /// </summary>
         public ulong BufferPosition;
 
+        /// <summary>
+        /// A 0x1000-byte aligned buffer size.
+        /// </summary>
         public uint BufferSize;
 
+        /// <summary>
+        /// Array of word entries in the buffer.
+        /// </summary>
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = 24)]
         public ulong[] Entries;
 
+        /// <summary>
+        /// Number of used entries in the Entries field.
+        /// </summary>
         public ushort TotalEntries;
 
         public ushort Padding1;

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardDictSet.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardDictSet.cs
@@ -2,10 +2,18 @@
 
 namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
 {
-    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    [StructLayout(LayoutKind.Sequential, Pack = 2)]
     struct SoftwareKeyboardDictSet
     {
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 28)]
-        public uint[] Entries;
+        public ulong BufferPosition;
+
+        public uint BufferSize;
+
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 24)]
+        public ulong[] Entries;
+
+        public ushort TotalEntries;
+
+        public ushort Padding1;
     }
 }

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardInitialize.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardInitialize.cs
@@ -3,14 +3,23 @@
 namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
 {
     /// <summary>
-    /// A structure that indicates the initialization the inline software keyboard.
+    /// A structure that mirrors the parameters used to initialize the keyboard applet.
     /// </summary>
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     struct SoftwareKeyboardInitialize
     {
         public uint Unknown;
+
+        /// <summary>
+        /// The applet mode used when launching the swkb. The bits regarding the background vs foreground mode can be wrong.
+        /// </summary>
         public byte LibMode;
+
+        /// <summary>
+        /// [5.0.0+] Set to 0x1 to indicate a firmware version >= 5.0.0.
+        /// </summary>
         public byte FivePlus;
+
         public byte Padding1;
         public byte Padding2;
     }

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardUserWord.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardUserWord.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
+{
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    struct SoftwareKeyboardUserWord
+    {
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 100)]
+        public byte[] Unknown;
+    }
+}

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardUserWord.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardUserWord.cs
@@ -2,6 +2,9 @@
 
 namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
 {
+    /// <summary>
+    /// A structure used by SetUserWordInfo request to the software keyboard.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential, Pack = 4)]
     struct SoftwareKeyboardUserWord
     {


### PR DESCRIPTION
This PR, together with #1945, fixes keyboard soft-locking issues that some players are having in MHGU. It also fixes a bug when creating a character in Dark Souls Remastered, where a second attempt to input the name, if it is smaller than the first one, will crash the game. Finally it implements a new keyboard request used by MHR that otherwise appears as an error in the log.

The particular reason some users have problems in MHGU seems to be related with a save game migrated from Switch or a different version of Monster Hunter, changing the messages exchanged with the applet with some weird ones. A save file kindly provided by a user on Discord happens to manifest the issue, if it ever need to be reproduced again.

A special thanks for Discord user plaisi for the testing and feedback.

Games re-tested:

- Dark Souls Remastered - Character creation screen
- Gnosia - Character creation screen
- Fate / Extella Link - Character creation screen
- Monster Hunter Rise Demo - In-game messaging
- Monster Hunter Generations Ultimate - In-game messaging (standard save)
- Monster Hunter Generations Ultimate - Set / Item renaming (standard save)
- Monster Hunter Generations Ultimate - Guild card renaming (standard save)
- Monster Hunter Generations Ultimate - In-game messaging (imported save)
- Monster Hunter Generations Ultimate - Set / Item renaming (imported save)
- Monster Hunter Generations Ultimate - Guild card renaming (imported save)