### PR TITLE
Fix compute shader code dumping

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -759,7 +759,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
             {
                 byte[] code = _context.MemoryManager.GetSpan(translatorContext.Address, translatorContext.Size).ToArray();
 
-                _dumper.Dump(code, compute: false, out string fullPath, out string codePath);
+                _dumper.Dump(code, translatorContext.Stage == ShaderStage.Compute, out string fullPath, out string codePath);
 
                 ShaderProgram program = translatorContext.Translate(out ShaderProgramInfo shaderProgramInfo);
 


### PR DESCRIPTION
Fix a regression when dumping compute shader code since #1701, where it would pretend that the shader has a 0x50 bytes header when it doesn't, so the "code" dump was missing the first 0x50 bytes of code.