### PR TITLE
Implement geometry shader passthrough

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -34,7 +34,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 1964;
+        private const ulong ShaderCodeGenVersion = 1961;
 
         /// <summary>
         /// Creates a new instance of the shader cache.

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
@@ -26,26 +26,17 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
                 context.AppendLine("#extension GL_ARB_compute_shader : enable");
             }
 
+            if (context.Config.GpPassthrough)
+            {
+                context.AppendLine("#extension GL_NV_geometry_shader_passthrough : enable");
+            }
+
             context.AppendLine("#pragma optionNV(fastmath off)");
 
             context.AppendLine();
 
             context.AppendLine($"const int {DefaultNames.UndefinedName} = 0;");
             context.AppendLine();
-
-            if (context.Config.Stage == ShaderStage.Geometry)
-            {
-                string inPrimitive = context.Config.GpuAccessor.QueryPrimitiveTopology().ToGlslString();
-
-                context.AppendLine($"layout ({inPrimitive}) in;");
-
-                string outPrimitive = context.Config.OutputTopology.ToGlslString();
-
-                int maxOutputVertices = context.Config.MaxOutputVertices;
-
-                context.AppendLine($"layout ({outPrimitive}, max_vertices = {maxOutputVertices}) out;");
-                context.AppendLine();
-            }
 
             if (context.Config.Stage == ShaderStage.Compute)
             {
@@ -109,6 +100,33 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
             if (context.Config.Stage != ShaderStage.Compute)
             {
+                if (context.Config.Stage == ShaderStage.Geometry)
+                {
+                    string inPrimitive = context.Config.GpuAccessor.QueryPrimitiveTopology().ToGlslString();
+
+                    context.AppendLine($"layout ({inPrimitive}) in;");
+
+                    if (context.Config.GpPassthrough)
+                    {
+                        context.AppendLine($"layout (passthrough) in gl_PerVertex");
+                        context.EnterScope();
+                        context.AppendLine("vec4 gl_Position;");
+                        context.AppendLine("float gl_PointSize;");
+                        context.AppendLine("float gl_ClipDistance[];");
+                        context.LeaveScope(";");
+                    }
+                    else
+                    {
+                        string outPrimitive = context.Config.OutputTopology.ToGlslString();
+
+                        int maxOutputVertices = context.Config.MaxOutputVertices;
+
+                        context.AppendLine($"layout ({outPrimitive}, max_vertices = {maxOutputVertices}) out;");
+                    }
+
+                    context.AppendLine();
+                }
+
                 if (info.IAttributes.Count != 0)
                 {
                     DeclareInputAttributes(context, info);
@@ -432,6 +450,8 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
                     };
                 }
 
+                string pass = context.Config.GpPassthrough ? "passthrough, " : string.Empty;
+
                 string name = $"{DefaultNames.IAttributePrefix}{attr}";
 
                 if ((context.Config.Flags & TranslationFlags.Feedback) != 0)
@@ -440,12 +460,12 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
                     {
                         char swzMask = "xyzw"[c];
 
-                        context.AppendLine($"layout (location = {attr}, component = {c}) {iq}in float {name}_{swzMask}{suffix};");
+                        context.AppendLine($"layout ({pass}location = {attr}, component = {c}) {iq}in float {name}_{swzMask}{suffix};");
                     }
                 }
                 else
                 {
-                    context.AppendLine($"layout (location = {attr}) {iq}in vec4 {name}{suffix};");
+                    context.AppendLine($"layout ({pass}location = {attr}) {iq}in vec4 {name}{suffix};");
                 }
             }
         }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/GlslGenerator.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/GlslGenerator.cs
@@ -69,7 +69,8 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
                 // compiler may eliminate them.
                 // (Not needed for fragment shader as it is the last stage).
                 if (context.Config.Stage != ShaderStage.Compute &&
-                    context.Config.Stage != ShaderStage.Fragment)
+                    context.Config.Stage != ShaderStage.Fragment &&
+                    !context.Config.GpPassthrough)
                 {
                     for (int attr = 0; attr < Declarations.MaxAttributes; attr++)
                     {

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -6,6 +6,8 @@ namespace Ryujinx.Graphics.Shader.Translation
     {
         public ShaderStage Stage { get; }
 
+        public bool GpPassthrough { get; }
+
         public OutputTopology OutputTopology { get; }
 
         public int MaxOutputVertices { get; }
@@ -33,6 +35,7 @@ namespace Ryujinx.Graphics.Shader.Translation
         public ShaderConfig(IGpuAccessor gpuAccessor, TranslationFlags flags, TranslationCounts counts)
         {
             Stage                  = ShaderStage.Compute;
+            GpPassthrough          = false;
             OutputTopology         = OutputTopology.PointList;
             MaxOutputVertices      = 0;
             LocalMemorySize        = 0;
@@ -51,6 +54,7 @@ namespace Ryujinx.Graphics.Shader.Translation
         public ShaderConfig(ShaderHeader header, IGpuAccessor gpuAccessor, TranslationFlags flags, TranslationCounts counts)
         {
             Stage                  = header.Stage;
+            GpPassthrough          = header.Stage == ShaderStage.Geometry && header.GpPassthrough;
             OutputTopology         = header.OutputTopology;
             MaxOutputVertices      = header.MaxOutputVertexCount;
             LocalMemorySize        = header.ShaderLocalMemoryLowSize + header.ShaderLocalMemoryHighSize;

--- a/Ryujinx.Graphics.Shader/Translation/ShaderHeader.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderHeader.cs
@@ -81,6 +81,8 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public int SassVersion { get; }
 
+        public bool GpPassthrough { get; }
+
         public bool DoesLoadOrStore { get; }
         public bool DoesFp64        { get; }
 
@@ -135,6 +137,8 @@ namespace Ryujinx.Graphics.Shader.Translation
             DoesGlobalStore = commonWord0.Extract(16);
 
             SassVersion = commonWord0.Extract(17, 4);
+
+            GpPassthrough = commonWord0.Extract(24);
 
             DoesLoadOrStore = commonWord0.Extract(26);
             DoesFp64        = commonWord0.Extract(27);


### PR DESCRIPTION
This implements the geometry shader passthrough functionality, which allows passing the geometry inputs directly to the output without any modification. This feature is exclusive to NVIDIA, but should be possible to support on other vendors eventually by generating the code to copy all inputs to the output on the geometry shader.

This improves rendering on Marvel Ultimate Alliance 3 a little bit.
Before (screenshot not mine):
![image](https://user-images.githubusercontent.com/5624669/105672817-d6c80b00-5ec3-11eb-9083-d7dc6982ee4e.png)
After:
![image](https://user-images.githubusercontent.com/5624669/105672790-c9ab1c00-5ec3-11eb-8c85-b30eba4f81a3.png)