### PR TITLE
GUI Update: Enlarge controller input window to fit all images/settings without scrolling

### DIFF
--- a/Ryujinx/Ui/Windows/ControllerWindow.glade
+++ b/Ryujinx/Ui/Windows/ControllerWindow.glade
@@ -48,8 +48,8 @@
     <property name="title" translatable="yes">Ryujinx - Controller Settings</property>
     <property name="modal">True</property>
     <property name="window_position">center</property>
-    <property name="default_width">1100</property>
-    <property name="default_height">600</property>
+    <property name="default_width">1150</property>
+    <property name="default_height">690</property>
     <child type="titlebar">
       <placeholder/>
     </child>


### PR DESCRIPTION
Currently, when configuring controller input with an "Xinput Controller" or "Unmapped Controller", the window does not fit the image for Pro Controller (width limited), the image/settings for Joycon Pair (width and height limited), and the settings for single Joycon options (height limited). This PR proportionally enlarges the window so that no scrolling is ever necessary to fully see the controller image or settings fields.

Before:
![2021-01-25 06_15_30-Ryujinx - Controller Settings - Player1](https://user-images.githubusercontent.com/62343878/105711383-bbfe9200-5ed5-11eb-9e7c-d1d77521d548.png)
![2021-01-25 06_15_47-Ryujinx - Controller Settings - Player1](https://user-images.githubusercontent.com/62343878/105711388-bc972880-5ed5-11eb-86f0-b71659409aee.png)

After:
![2021-01-25 06_17_17-Ryujinx - Controller Settings - Player1](https://user-images.githubusercontent.com/62343878/105711459-d0db2580-5ed5-11eb-8ab9-cac95b5c35c2.png)
![2021-01-25 06_17_20-Ryujinx - Controller Settings - Player1](https://user-images.githubusercontent.com/62343878/105711463-d173bc00-5ed5-11eb-8d44-8ce39fd32596.png)

