### PR TITLE
Implement VCNT instruction

### DIFF
--- a/ARMeilleure/Decoders/OpCodeTable.cs
+++ b/ARMeilleure/Decoders/OpCodeTable.cs
@@ -814,6 +814,7 @@ namespace ARMeilleure.Decoders
             SetA32("111100111x11xx01xxxx0x100xx0xxxx", InstName.Vclt,     InstEmit32.Vclt_Z,   OpCode32SimdCmpZ.Create);
             SetA32("<<<<11101x11010xxxxx101x01x0xxxx", InstName.Vcmp,     InstEmit32.Vcmp,     OpCode32SimdS.Create);
             SetA32("<<<<11101x11010xxxxx101x11x0xxxx", InstName.Vcmpe,    InstEmit32.Vcmpe,    OpCode32SimdS.Create);
+            SetA32("111100111x11xx00xxxx01010xx0xxxx", InstName.Vcnt,     InstEmit32.Vcnt,     OpCode32SimdCmpZ.Create);
             SetA32("<<<<11101x110111xxxx101x11x0xxxx", InstName.Vcvt,     InstEmit32.Vcvt_FD,  OpCode32SimdS.Create); // FP 32 and 64, scalar.
             SetA32("<<<<11101x11110xxxxx101x11x0xxxx", InstName.Vcvt,     InstEmit32.Vcvt_FI,  OpCode32SimdCvtFI.Create); // FP32 to int.
             SetA32("<<<<11101x111000xxxx101xx1x0xxxx", InstName.Vcvt,     InstEmit32.Vcvt_FI,  OpCode32SimdCvtFI.Create); // Int to FP32.

--- a/ARMeilleure/Decoders/OpCodeTable.cs
+++ b/ARMeilleure/Decoders/OpCodeTable.cs
@@ -814,7 +814,7 @@ namespace ARMeilleure.Decoders
             SetA32("111100111x11xx01xxxx0x100xx0xxxx", InstName.Vclt,     InstEmit32.Vclt_Z,   OpCode32SimdCmpZ.Create);
             SetA32("<<<<11101x11010xxxxx101x01x0xxxx", InstName.Vcmp,     InstEmit32.Vcmp,     OpCode32SimdS.Create);
             SetA32("<<<<11101x11010xxxxx101x11x0xxxx", InstName.Vcmpe,    InstEmit32.Vcmpe,    OpCode32SimdS.Create);
-            SetA32("111100111x11xx00xxxx01010xx0xxxx", InstName.Vcnt,     InstEmit32.Vcnt,     OpCode32SimdCmpZ.Create);
+            SetA32("111100111x110000xxxx01010xx0xxxx", InstName.Vcnt,     InstEmit32.Vcnt,     OpCode32SimdCmpZ.Create);
             SetA32("<<<<11101x110111xxxx101x11x0xxxx", InstName.Vcvt,     InstEmit32.Vcvt_FD,  OpCode32SimdS.Create); // FP 32 and 64, scalar.
             SetA32("<<<<11101x11110xxxxx101x11x0xxxx", InstName.Vcvt,     InstEmit32.Vcvt_FI,  OpCode32SimdCvtFI.Create); // FP32 to int.
             SetA32("<<<<11101x111000xxxx101xx1x0xxxx", InstName.Vcvt,     InstEmit32.Vcvt_FI,  OpCode32SimdCvtFI.Create); // Int to FP32.

--- a/ARMeilleure/Instructions/InstEmitSimdArithmetic.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdArithmetic.cs
@@ -289,7 +289,7 @@ namespace ARMeilleure.Instructions
                 }
                 else
                 {
-                    de = context.Call(typeof(SoftFallback).GetMethod(nameof(SoftFallback.CountSetBits8)), ne);
+                    de = EmitCountSetBits8(context, ne);
                 }
 
                 res = EmitVectorInsert(context, res, de, index, 0);

--- a/ARMeilleure/Instructions/InstEmitSimdArithmetic32.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdArithmetic32.cs
@@ -139,11 +139,6 @@ namespace ARMeilleure.Instructions
         {
             OpCode32SimdCmpZ op = (OpCode32SimdCmpZ)context.CurrOp;
 
-            if (op.Size != 0)
-            {
-                throw new InvalidOperationException($"Invalid Vcnt size {op.Size}. Elements must be bytes.");
-            }
-
             Operand res = GetVecA32(op.Qd);
 
             int elems = op.GetBytesCount();
@@ -159,7 +154,7 @@ namespace ARMeilleure.Instructions
                 }
                 else
                 {
-                    de = context.Call(typeof(SoftFallback).GetMethod(nameof(SoftFallback.CountSetBits8)), me);
+                    de = EmitCountSetBits8(context, me);
                 }
 
                 res = EmitVectorInsert(context, res, de, op.Id + index, op.Size);

--- a/ARMeilleure/Instructions/InstEmitSimdHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdHelper.cs
@@ -234,6 +234,23 @@ namespace ARMeilleure.Instructions
             throw new ArgumentException($"Invalid rounding mode \"{roundMode}\".");
         }
 
+        public static Operand EmitCountSetBits8(ArmEmitterContext context, Operand me) // "size" is 8 (SIMD&FP Inst.).
+        {
+            Operand me0 = context.Add
+            (
+                context.BitwiseAnd(context.ShiftRightUI(me, Const(1)), Const(me.Type, 0x55L)),
+                context.BitwiseAnd(me, Const(me.Type, 0x55L))
+            );
+
+            Operand me1 = context.Add
+            (
+                context.BitwiseAnd(context.ShiftRightUI(me0, Const(2)), Const(me.Type, 0x33L)),
+                context.BitwiseAnd(me0, Const(me.Type, 0x33L))
+            );
+
+            return context.Add(context.ShiftRightUI(me1, Const(4)), context.BitwiseAnd(me1, Const(me.Type, 0x0fL)));
+        }
+
         public static void EmitScalarUnaryOpF(ArmEmitterContext context, Intrinsic inst32, Intrinsic inst64)
         {
             OpCodeSimd op = (OpCodeSimd)context.CurrOp;

--- a/ARMeilleure/Instructions/InstEmitSimdHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdHelper.cs
@@ -234,18 +234,16 @@ namespace ARMeilleure.Instructions
             throw new ArgumentException($"Invalid rounding mode \"{roundMode}\".");
         }
 
-        public static Operand EmitCountSetBits8(ArmEmitterContext context, Operand me) // "size" is 8 (SIMD&FP Inst.).
+        public static Operand EmitCountSetBits8(ArmEmitterContext context, Operand op) // "size" is 8 (SIMD&FP Inst.).
         {
-            Operand me0 = context.Subtract(me, context.BitwiseAnd(context.ShiftRightUI(me, Const(1)), Const(me.Type, 0x55L)));
+            Debug.Assert(op.Type == OperandType.I32 || op.Type == OperandType.I64);
 
-            Operand c1 = Const(me.Type, 0x33L);
-            Operand me1 = context.Add
-            (
-                context.BitwiseAnd(context.ShiftRightUI(me0, Const(2)), c1),
-                context.BitwiseAnd(me0, c1)
-            );
+            Operand op0 = context.Subtract(op, context.BitwiseAnd(context.ShiftRightUI(op, Const(1)), Const(op.Type, 0x55L)));
 
-            return context.BitwiseAnd(context.Add(me1, context.ShiftRightUI(me1, Const(4))), Const(me.Type, 0x0fL));
+            Operand c1 = Const(op.Type, 0x33L);
+            Operand op1 = context.Add(context.BitwiseAnd(context.ShiftRightUI(op0, Const(2)), c1), context.BitwiseAnd(op0, c1));
+
+            return context.BitwiseAnd(context.Add(op1, context.ShiftRightUI(op1, Const(4))), Const(op.Type, 0x0fL));
         }
 
         public static void EmitScalarUnaryOpF(ArmEmitterContext context, Intrinsic inst32, Intrinsic inst64)

--- a/ARMeilleure/Instructions/InstEmitSimdHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdHelper.cs
@@ -236,19 +236,16 @@ namespace ARMeilleure.Instructions
 
         public static Operand EmitCountSetBits8(ArmEmitterContext context, Operand me) // "size" is 8 (SIMD&FP Inst.).
         {
-            Operand me0 = context.Add
-            (
-                context.BitwiseAnd(context.ShiftRightUI(me, Const(1)), Const(me.Type, 0x55L)),
-                context.BitwiseAnd(me, Const(me.Type, 0x55L))
-            );
+            Operand me0 = context.Subtract(me, context.BitwiseAnd(context.ShiftRightUI(me, Const(1)), Const(me.Type, 0x55L)));
 
+            Operand c1 = Const(me.Type, 0x33L);
             Operand me1 = context.Add
             (
-                context.BitwiseAnd(context.ShiftRightUI(me0, Const(2)), Const(me.Type, 0x33L)),
-                context.BitwiseAnd(me0, Const(me.Type, 0x33L))
+                context.BitwiseAnd(context.ShiftRightUI(me0, Const(2)), c1),
+                context.BitwiseAnd(me0, c1)
             );
 
-            return context.Add(context.ShiftRightUI(me1, Const(4)), context.BitwiseAnd(me1, Const(me.Type, 0x0fL)));
+            return context.BitwiseAnd(context.Add(me1, context.ShiftRightUI(me1, Const(4))), Const(me.Type, 0x0fL));
         }
 
         public static void EmitScalarUnaryOpF(ArmEmitterContext context, Intrinsic inst32, Intrinsic inst64)

--- a/ARMeilleure/Instructions/InstName.cs
+++ b/ARMeilleure/Instructions/InstName.cs
@@ -567,6 +567,7 @@ namespace ARMeilleure.Instructions
         Vclt,
         Vcmp,
         Vcmpe,
+        Vcnt,
         Vcvt,
         Vdiv,
         Vdup,

--- a/ARMeilleure/Instructions/SoftFallback.cs
+++ b/ARMeilleure/Instructions/SoftFallback.cs
@@ -846,14 +846,6 @@ namespace ARMeilleure.Instructions
 
             return (ulong)count;
         }
-
-        public static ulong CountSetBits8(ulong value) // "size" is 8 (SIMD&FP Inst.).
-        {
-            value = ((value >> 1) & 0x55ul) + (value & 0x55ul);
-            value = ((value >> 2) & 0x33ul) + (value & 0x33ul);
-
-            return (value >> 4) + (value & 0x0ful);
-        }
 #endregion
 
 #region "Table"

--- a/ARMeilleure/Translation/Delegates.cs
+++ b/ARMeilleure/Translation/Delegates.cs
@@ -148,7 +148,6 @@ namespace ARMeilleure.Translation
             SetDelegateInfo(typeof(SoftFallback).GetMethod(nameof(SoftFallback.BinaryUnsignedSatQSub)));
             SetDelegateInfo(typeof(SoftFallback).GetMethod(nameof(SoftFallback.CountLeadingSigns)));
             SetDelegateInfo(typeof(SoftFallback).GetMethod(nameof(SoftFallback.CountLeadingZeros)));
-            SetDelegateInfo(typeof(SoftFallback).GetMethod(nameof(SoftFallback.CountSetBits8)));
             SetDelegateInfo(typeof(SoftFallback).GetMethod(nameof(SoftFallback.Crc32b)));
             SetDelegateInfo(typeof(SoftFallback).GetMethod(nameof(SoftFallback.Crc32cb)));
             SetDelegateInfo(typeof(SoftFallback).GetMethod(nameof(SoftFallback.Crc32ch)));

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -26,7 +26,7 @@ namespace ARMeilleure.Translation.PTC
     {
         private const string HeaderMagicString = "PTChd\0\0\0";
 
-        private const uint InternalVersion = 1968; //! To be incremented manually for each change to the ARMeilleure project.
+        private const int InternalVersion = 1963; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";


### PR DESCRIPTION
Implement `VCNT.8` from the existing `CNT` impl (`Cnt_V` in code).

Tests were also adapted from `Cnt_V`. Both intrinsic and soft-fallback paths succeeded locally.

Closes #1825 

~Will increment PTC version once github tests are successful.~