### PR TITLE
Support multiple destination operands on shader IR and shuffle predicates

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -34,7 +34,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 1790;
+        private const ulong ShaderCodeGenVersion = 1964;
 
         /// <summary>
         /// Creates a new instance of the shader cache.

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/Shuffle.glsl
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/Shuffle.glsl
@@ -1,9 +1,10 @@
-float Helper_Shuffle(float x, uint index, uint mask)
+float Helper_Shuffle(float x, uint index, uint mask, out bool valid)
 {
     uint clamp = mask & 0x1fu;
     uint segMask = (mask >> 8) & 0x1fu;
     uint minThreadId = gl_SubGroupInvocationARB & segMask;
     uint maxThreadId = minThreadId | (clamp & ~segMask);
     uint srcThreadId = (index & ~segMask) | minThreadId;
-    return (srcThreadId <= maxThreadId) ? readInvocationARB(x, srcThreadId) : x;
+    valid = srcThreadId <= maxThreadId;
+    return valid ? readInvocationARB(x, srcThreadId) : x;
 }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/ShuffleDown.glsl
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/ShuffleDown.glsl
@@ -1,9 +1,10 @@
-float Helper_ShuffleDown(float x, uint index, uint mask)
+float Helper_ShuffleDown(float x, uint index, uint mask, out bool valid)
 {
     uint clamp = mask & 0x1fu;
     uint segMask = (mask >> 8) & 0x1fu;
     uint minThreadId = gl_SubGroupInvocationARB & segMask;
     uint maxThreadId = minThreadId | (clamp & ~segMask);
     uint srcThreadId = gl_SubGroupInvocationARB + index;
-    return (srcThreadId <= maxThreadId) ? readInvocationARB(x, srcThreadId) : x;
+    valid = srcThreadId <= maxThreadId;
+    return valid ? readInvocationARB(x, srcThreadId) : x;
 }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/ShuffleUp.glsl
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/ShuffleUp.glsl
@@ -1,8 +1,9 @@
-float Helper_ShuffleUp(float x, uint index, uint mask)
+float Helper_ShuffleUp(float x, uint index, uint mask, out bool valid)
 {
     uint clamp = mask & 0x1fu;
     uint segMask = (mask >> 8) & 0x1fu;
     uint minThreadId = gl_SubGroupInvocationARB & segMask;
     uint srcThreadId = gl_SubGroupInvocationARB - index;
-    return (srcThreadId >= minThreadId) ? readInvocationARB(x, srcThreadId) : x;
+    valid = srcThreadId >= minThreadId;
+    return valid ? readInvocationARB(x, srcThreadId) : x;
 }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/ShuffleXor.glsl
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/ShuffleXor.glsl
@@ -1,9 +1,10 @@
-float Helper_ShuffleXor(float x, uint index, uint mask)
+float Helper_ShuffleXor(float x, uint index, uint mask, out bool valid)
 {
     uint clamp = mask & 0x1fu;
     uint segMask = (mask >> 8) & 0x1fu;
     uint minThreadId = gl_SubGroupInvocationARB & segMask;
     uint maxThreadId = minThreadId | (clamp & ~segMask);
     uint srcThreadId = gl_SubGroupInvocationARB ^ index;
-    return (srcThreadId <= maxThreadId) ? readInvocationARB(x, srcThreadId) : x;
+    valid = srcThreadId <= maxThreadId;
+    return valid ? readInvocationARB(x, srcThreadId) : x;
 }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenHelper.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenHelper.cs
@@ -88,13 +88,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
             Add(Instruction.LoopContinue,             InstType.OpNullary,      "continue");
             Add(Instruction.PackDouble2x32,           InstType.Special);
             Add(Instruction.PackHalf2x16,             InstType.Special);
-            Add(Instruction.ShiftLeft,                InstType.OpBinary,       "<<",              3);
-            Add(Instruction.ShiftRightS32,            InstType.OpBinary,       ">>",              3);
-            Add(Instruction.ShiftRightU32,            InstType.OpBinary,       ">>",              3);
-            Add(Instruction.Shuffle,                  InstType.CallTernary,    HelperFunctionNames.Shuffle);
-            Add(Instruction.ShuffleDown,              InstType.CallTernary,    HelperFunctionNames.ShuffleDown);
-            Add(Instruction.ShuffleUp,                InstType.CallTernary,    HelperFunctionNames.ShuffleUp);
-            Add(Instruction.ShuffleXor,               InstType.CallTernary,    HelperFunctionNames.ShuffleXor);
             Add(Instruction.Maximum,                  InstType.CallBinary,     "max");
             Add(Instruction.MaximumU32,               InstType.CallBinary,     "max");
             Add(Instruction.MemoryBarrier,            InstType.CallNullary,    "memoryBarrier");
@@ -107,6 +100,13 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
             Add(Instruction.ReciprocalSquareRoot,     InstType.CallUnary,      "inversesqrt");
             Add(Instruction.Return,                   InstType.OpNullary,      "return");
             Add(Instruction.Round,                    InstType.CallUnary,      "roundEven");
+            Add(Instruction.ShiftLeft,                InstType.OpBinary,       "<<",              3);
+            Add(Instruction.ShiftRightS32,            InstType.OpBinary,       ">>",              3);
+            Add(Instruction.ShiftRightU32,            InstType.OpBinary,       ">>",              3);
+            Add(Instruction.Shuffle,                  InstType.CallQuaternary, HelperFunctionNames.Shuffle);
+            Add(Instruction.ShuffleDown,              InstType.CallQuaternary, HelperFunctionNames.ShuffleDown);
+            Add(Instruction.ShuffleUp,                InstType.CallQuaternary, HelperFunctionNames.ShuffleUp);
+            Add(Instruction.ShuffleXor,               InstType.CallQuaternary, HelperFunctionNames.ShuffleXor);
             Add(Instruction.Sine,                     InstType.CallUnary,      "sin");
             Add(Instruction.SquareRoot,               InstType.CallUnary,      "sqrt");
             Add(Instruction.StoreLocal,               InstType.Special);

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitMove.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitMove.cs
@@ -118,25 +118,17 @@ namespace Ryujinx.Graphics.Shader.Instructions
             Operand srcB = op.IsBImmediate ? Const(op.ImmediateB) : Register(op.Rb);
             Operand srcC = op.IsCImmediate ? Const(op.ImmediateC) : Register(op.Rc);
 
-            Operand res = null;
-
-            switch (op.ShuffleType)
+            (Operand res, Operand valid) = op.ShuffleType switch
             {
-                case ShuffleType.Indexed:
-                    res = context.Shuffle(srcA, srcB, srcC);
-                    break;
-                case ShuffleType.Up:
-                    res = context.ShuffleUp(srcA, srcB, srcC);
-                    break;
-                case ShuffleType.Down:
-                    res = context.ShuffleDown(srcA, srcB, srcC);
-                    break;
-                case ShuffleType.Butterfly:
-                    res = context.ShuffleXor(srcA, srcB, srcC);
-                    break;
-            }
+                ShuffleType.Indexed   => context.Shuffle(srcA, srcB, srcC),
+                ShuffleType.Up        => context.ShuffleUp(srcA, srcB, srcC),
+                ShuffleType.Down      => context.ShuffleDown(srcA, srcB, srcC),
+                ShuffleType.Butterfly => context.ShuffleXor(srcA, srcB, srcC),
+                _                     => (null, null)
+            };
 
             context.Copy(GetDest(context), res);
+            context.Copy(pred, valid);
         }
     }
 }

--- a/Ryujinx.Graphics.Shader/IntermediateRepresentation/INode.cs
+++ b/Ryujinx.Graphics.Shader/IntermediateRepresentation/INode.cs
@@ -4,8 +4,10 @@ namespace Ryujinx.Graphics.Shader.IntermediateRepresentation
     {
         Operand Dest { get; set; }
 
+        int DestsCount { get; }
         int SourcesCount { get; }
 
+        Operand GetDest(int index);
         Operand GetSource(int index);
 
         void SetSource(int index, Operand operand);

--- a/Ryujinx.Graphics.Shader/IntermediateRepresentation/PhiNode.cs
+++ b/Ryujinx.Graphics.Shader/IntermediateRepresentation/PhiNode.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Ryujinx.Graphics.Shader.IntermediateRepresentation
@@ -11,6 +12,8 @@ namespace Ryujinx.Graphics.Shader.IntermediateRepresentation
             get => _dest;
             set => _dest = AssignDest(value);
         }
+
+        public int DestsCount => _dest != null ? 1 : 0;
 
         private HashSet<BasicBlock> _blocks;
 
@@ -62,6 +65,16 @@ namespace Ryujinx.Graphics.Shader.IntermediateRepresentation
 
                 _sources.Add(new PhiSource(block, operand));
             }
+        }
+
+        public Operand GetDest(int index)
+        {
+            if (index != 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+
+            return _dest;
         }
 
         public Operand GetSource(int index)

--- a/Ryujinx.Graphics.Shader/StructuredIr/InstructionInfo.cs
+++ b/Ryujinx.Graphics.Shader/StructuredIr/InstructionInfo.cs
@@ -94,13 +94,6 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
             Add(Instruction.LogicalExclusiveOr,       VariableType.Bool,   VariableType.Bool,   VariableType.Bool);
             Add(Instruction.LogicalNot,               VariableType.Bool,   VariableType.Bool);
             Add(Instruction.LogicalOr,                VariableType.Bool,   VariableType.Bool,   VariableType.Bool);
-            Add(Instruction.ShiftLeft,                VariableType.Int,    VariableType.Int,    VariableType.Int);
-            Add(Instruction.ShiftRightS32,            VariableType.S32,    VariableType.S32,    VariableType.Int);
-            Add(Instruction.ShiftRightU32,            VariableType.U32,    VariableType.U32,    VariableType.Int);
-            Add(Instruction.Shuffle,                  VariableType.F32,    VariableType.F32,    VariableType.U32,    VariableType.U32);
-            Add(Instruction.ShuffleDown,              VariableType.F32,    VariableType.F32,    VariableType.U32,    VariableType.U32);
-            Add(Instruction.ShuffleUp,                VariableType.F32,    VariableType.F32,    VariableType.U32,    VariableType.U32);
-            Add(Instruction.ShuffleXor,               VariableType.F32,    VariableType.F32,    VariableType.U32,    VariableType.U32);
             Add(Instruction.Maximum,                  VariableType.Scalar, VariableType.Scalar, VariableType.Scalar);
             Add(Instruction.MaximumU32,               VariableType.U32,    VariableType.U32,    VariableType.U32);
             Add(Instruction.Minimum,                  VariableType.Scalar, VariableType.Scalar, VariableType.Scalar);
@@ -113,6 +106,13 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
             Add(Instruction.PackHalf2x16,             VariableType.U32,    VariableType.F32,    VariableType.F32);
             Add(Instruction.ReciprocalSquareRoot,     VariableType.Scalar, VariableType.Scalar);
             Add(Instruction.Round,                    VariableType.Scalar, VariableType.Scalar);
+            Add(Instruction.ShiftLeft,                VariableType.Int,    VariableType.Int,    VariableType.Int);
+            Add(Instruction.ShiftRightS32,            VariableType.S32,    VariableType.S32,    VariableType.Int);
+            Add(Instruction.ShiftRightU32,            VariableType.U32,    VariableType.U32,    VariableType.Int);
+            Add(Instruction.Shuffle,                  VariableType.F32,    VariableType.F32,    VariableType.U32,    VariableType.U32,    VariableType.Bool);
+            Add(Instruction.ShuffleDown,              VariableType.F32,    VariableType.F32,    VariableType.U32,    VariableType.U32,    VariableType.Bool);
+            Add(Instruction.ShuffleUp,                VariableType.F32,    VariableType.F32,    VariableType.U32,    VariableType.U32,    VariableType.Bool);
+            Add(Instruction.ShuffleXor,               VariableType.F32,    VariableType.F32,    VariableType.U32,    VariableType.U32,    VariableType.Bool);
             Add(Instruction.Sine,                     VariableType.Scalar, VariableType.Scalar);
             Add(Instruction.SquareRoot,               VariableType.Scalar, VariableType.Scalar);
             Add(Instruction.StoreGlobal,              VariableType.None,   VariableType.S32,    VariableType.S32,    VariableType.U32);

--- a/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgram.cs
+++ b/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgram.cs
@@ -77,6 +77,7 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
             bool isCall = inst == Instruction.Call;
 
             int sourcesCount = operation.SourcesCount;
+            int outDestsCount = operation.DestsCount != 0 ? operation.DestsCount - 1 : 0;
 
             List<Operand> callOutOperands = new List<Operand>();
 
@@ -93,7 +94,7 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
                 sourcesCount += callOutOperands.Count;
             }
 
-            IAstNode[] sources = new IAstNode[sourcesCount];
+            IAstNode[] sources = new IAstNode[sourcesCount + outDestsCount];
 
             for (int index = 0; index < operation.SourcesCount; index++)
             {
@@ -108,6 +109,15 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
                 }
 
                 callOutOperands.Clear();
+            }
+
+            for (int index = 0; index < outDestsCount; index++)
+            {
+                AstOperand oper = context.GetOperandDef(operation.GetDest(1 + index));
+
+                oper.VarType = InstructionInfo.GetSrcVarType(inst, sourcesCount + index);
+
+                sources[sourcesCount + index] = oper;
             }
 
             AstTextureOperation GetAstTextureOperation(TextureOperation texOp)

--- a/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -37,6 +37,17 @@ namespace Ryujinx.Graphics.Shader.Translation
             return dest;
         }
 
+        public (Operand, Operand) Add(Instruction inst, (Operand, Operand) dest, params Operand[] sources)
+        {
+            Operand[] dests = new[] { dest.Item1, dest.Item2 };
+
+            Operation operation = new Operation(inst, 0, dests, sources);
+
+            Add(operation);
+
+            return dest;
+        }
+
         public void Add(Operation operation)
         {
             _operations.Add(operation);

--- a/Ryujinx.Graphics.Shader/Translation/EmitterContextInsts.cs
+++ b/Ryujinx.Graphics.Shader/Translation/EmitterContextInsts.cs
@@ -588,24 +588,24 @@ namespace Ryujinx.Graphics.Shader.Translation
             return context.Add(Instruction.ShiftRightU32, Local(), a, b);
         }
 
-        public static Operand Shuffle(this EmitterContext context, Operand a, Operand b, Operand c)
+        public static (Operand, Operand) Shuffle(this EmitterContext context, Operand a, Operand b, Operand c)
         {
-            return context.Add(Instruction.Shuffle, Local(), a, b, c);
+            return context.Add(Instruction.Shuffle, (Local(), Local()), a, b, c);
         }
 
-        public static Operand ShuffleDown(this EmitterContext context, Operand a, Operand b, Operand c)
+        public static (Operand, Operand) ShuffleDown(this EmitterContext context, Operand a, Operand b, Operand c)
         {
-            return context.Add(Instruction.ShuffleDown, Local(), a, b, c);
+            return context.Add(Instruction.ShuffleDown, (Local(), Local()), a, b, c);
         }
 
-        public static Operand ShuffleUp(this EmitterContext context, Operand a, Operand b, Operand c)
+        public static (Operand, Operand) ShuffleUp(this EmitterContext context, Operand a, Operand b, Operand c)
         {
-            return context.Add(Instruction.ShuffleUp, Local(), a, b, c);
+            return context.Add(Instruction.ShuffleUp, (Local(), Local()), a, b, c);
         }
 
-        public static Operand ShuffleXor(this EmitterContext context, Operand a, Operand b, Operand c)
+        public static (Operand, Operand) ShuffleXor(this EmitterContext context, Operand a, Operand b, Operand c)
         {
-            return context.Add(Instruction.ShuffleXor, Local(), a, b, c);
+            return context.Add(Instruction.ShuffleXor, (Local(), Local()), a, b, c);
         }
 
         public static Operand StoreGlobal(this EmitterContext context, Operand a, Operand b, Operand c)

--- a/Ryujinx.Graphics.Shader/Translation/Ssa.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Ssa.cs
@@ -116,13 +116,18 @@ namespace Ryujinx.Graphics.Shader.Translation
                             operation.SetSource(index, RenameLocal(operation.GetSource(index)));
                         }
 
-                        if (operation.Dest != null && operation.Dest.Type == OperandType.Register)
+                        for (int index = 0; index < operation.DestsCount; index++)
                         {
-                            Operand local = Local();
+                            Operand dest = operation.GetDest(index);
 
-                            localDefs[GetKeyFromRegister(operation.Dest.GetRegister())] = local;
+                            if (dest.Type == OperandType.Register)
+                            {
+                                Operand local = Local();
 
-                            operation.Dest = local;
+                                localDefs[GetKeyFromRegister(dest.GetRegister())] = local;
+
+                                operation.SetDest(index, local);
+                            }
                         }
                     }
 
@@ -185,9 +190,7 @@ namespace Ryujinx.Graphics.Shader.Translation
                     return operand;
                 }
 
-                LinkedListNode<INode> node = block.Operations.First;
-
-                while (node != null)
+                for (LinkedListNode<INode> node = block.Operations.First; node != null; node = node.Next)
                 {
                     if (node.Value is Operation operation)
                     {
@@ -196,8 +199,6 @@ namespace Ryujinx.Graphics.Shader.Translation
                             operation.SetSource(index, RenameGlobal(operation.GetSource(index)));
                         }
                     }
-
-                    node = node.Next;
                 }
             }
         }


### PR DESCRIPTION
This support multiple destination operands on the IR rather than just one.
This is required for supporting the predicate writes for the shuffle instruction. Without this change it would either need to calculate the value inline, or add a separate function just to return the bool result. With the change, now the same function can return both values.
As a follow-up I plan to change the call instruciton implementation and 64-bit multiply to also use it, which will simplify some code.