### PR TITLE
Fix conditional rendering without queries

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/MethodConditionalRendering.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodConditionalRendering.cs
@@ -71,11 +71,6 @@ namespace Ryujinx.Graphics.Gpu.Engine
             ICounterEvent evt = FindEvent(gpuVa);
             ICounterEvent evt2 = FindEvent(gpuVa + 16);
 
-            if (evt == null && evt2 == null)
-            {
-                return ConditionalRenderEnabled.False;
-            }
-
             bool useHost;
 
             if (evt != null && evt2 == null)
@@ -86,9 +81,13 @@ namespace Ryujinx.Graphics.Gpu.Engine
             {
                 useHost = _context.Renderer.Pipeline.TryHostConditionalRendering(evt2, _context.MemoryManager.Read<ulong>(gpuVa), isEqual);
             }
-            else
+            else if (evt != null && evt2 != null)
             {
                 useHost = _context.Renderer.Pipeline.TryHostConditionalRendering(evt, evt2, isEqual);
+            }
+            else
+            {
+                useHost = false;
             }
 
             if (useHost)


### PR DESCRIPTION
This changes the implementation of conditional rendering to actually compare the values on memory even if they don't come from queries, instead of just returning false.

I beleive it was done this way because Super Mario Maker 2 and Animal Crossing New Horizons had some issues otherwise, but I tested both games and they seem fine now with this change.

This is required to make Marvel Ultimate Alliance 3 render. The game now shows vertex explosions with this change, but it was probably already broken, but not visible as it was not rendering most models.

Games that should be tested with the change (they use conditional rendering without queries):
- Animal Crossing New Horizons
- Super Mario Maker 2
Doesn't hurt to also test other games using conditional rendering (from queries), such as SMO and Splatoon 2.