### PR TITLE
Fix regression on shader atomic SSBO operations

### DIFF
--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGen.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGen.cs
@@ -44,7 +44,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
                 {
                     // For shared memory access, the second argument is unused and should be ignored.
                     // It is there to make both storage and shared access have the same number of arguments.
-                    if (argIndex == 1 && (inst & Instruction.MrMask) == Instruction.MrShared)
+                    if (argIndex == 1 && (atomic || (inst & Instruction.MrMask) == Instruction.MrShared))
                     {
                         continue;
                     }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGen.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGen.cs
@@ -44,6 +44,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
                 {
                     // For shared memory access, the second argument is unused and should be ignored.
                     // It is there to make both storage and shared access have the same number of arguments.
+                    // For storage, both inputs are consumed when the argument index is 0, so we should skip it here.
                     if (argIndex == 1 && (atomic || (inst & Instruction.MrMask) == Instruction.MrShared))
                     {
                         continue;


### PR DESCRIPTION
Fix a regression introduced on #1948 that would generate invalid code for atomic SSBO operations.
Fixes regression on Persona 5 Scramble where it would crash before the title screen.