### PR TITLE
Support shader F32 to Bool reinterpretation

### DIFF
--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/TypeConversion.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/TypeConversion.cs
@@ -37,8 +37,9 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
             {
                 switch (dstType)
                 {
-                    case VariableType.S32: return $"floatBitsToInt({expr})";
-                    case VariableType.U32: return $"floatBitsToUint({expr})";
+                    case VariableType.Bool: return $"(floatBitsToInt({expr}) != 0)";
+                    case VariableType.S32:  return $"floatBitsToInt({expr})";
+                    case VariableType.U32:  return $"floatBitsToUint({expr})";
                 }
             }
             else if (dstType == VariableType.F32)


### PR DESCRIPTION
Fixes crashes with the exception:
```
System.ArgumentException: Invalid reinterpret cast from "F32" to "Bool".
```
This happens on shaders with the `PSET` instruction when the shader translator decides to use a F32 type for the variable that will hold the value. It does that because `PSET` allows moving a predicate to a register, and it may decide to use the float type to avoid casts (obviously, its not the most appropriate type for that, but it should still work regardless).