### PR TITLE
Optimization | Modify Add (Integer) Instruction to use LEA instead.

### DIFF
--- a/ARMeilleure/CodeGen/X86/CodeGenerator.cs
+++ b/ARMeilleure/CodeGen/X86/CodeGenerator.cs
@@ -518,14 +518,26 @@ namespace ARMeilleure.CodeGen.X86
 
             if (dest.Type.IsInteger())
             {
-                if (dest.GetRegister().Equals(src1.GetRegister()))
+                // Moves to the same register are useless.
+                if (dest.Kind == src1.Kind && dest.Value == src1.Value)
                 {
                     context.Assembler.Add(dest, src2, dest.Type);
                 }
                 else
                 {
-                    int offset = src2.Kind == OperandKind.Constant ? src2.AsInt32() : 0;
-                    Operand index = src2.Kind != OperandKind.Constant ? src2 : null;
+                    int offset;
+                    Operand index;
+
+                    if (src2.Kind == OperandKind.Constant)
+                    {
+                        offset = src2.AsInt32();
+                        index = null;
+                    }
+                    else
+                    {
+                        offset = 0;
+                        index = src2;
+                    }
 
                     MemoryOperand memOp = MemoryOp(dest.Type, src1, index, Multiplier.x1, offset);
 

--- a/ARMeilleure/CodeGen/X86/CodeGenerator.cs
+++ b/ARMeilleure/CodeGen/X86/CodeGenerator.cs
@@ -514,13 +514,13 @@ namespace ARMeilleure.CodeGen.X86
             Operand src1 = operation.GetSource(0);
             Operand src2 = operation.GetSource(1);
 
-            ValidateBinOp(dest, src1, src2);
-
             if (dest.Type.IsInteger())
             {
                 // Moves to the same register are useless.
                 if (dest.Kind == src1.Kind && dest.Value == src1.Value)
                 {
+                    ValidateBinOp(dest, src1, src2);
+
                     context.Assembler.Add(dest, src2, dest.Type);
                 }
                 else
@@ -544,13 +544,17 @@ namespace ARMeilleure.CodeGen.X86
                     context.Assembler.Lea(dest, memOp, dest.Type);
                 }
             }
-            else if (dest.Type == OperandType.FP32)
-            {
-                context.Assembler.Addss(dest, src1, src2);
-            }
-            else /* if (dest.Type == OperandType.FP64) */
-            {
-                context.Assembler.Addsd(dest, src1, src2);
+            else {
+                ValidateBinOp(dest, src1, src2);
+
+                if (dest.Type == OperandType.FP32)
+                {
+                    context.Assembler.Addss(dest, src1, src2);
+                }
+                else /* if (dest.Type == OperandType.FP64) */
+                {
+                    context.Assembler.Addsd(dest, src1, src2);
+                }
             }
         }
 

--- a/ARMeilleure/CodeGen/X86/CodeGenerator.cs
+++ b/ARMeilleure/CodeGen/X86/CodeGenerator.cs
@@ -518,7 +518,7 @@ namespace ARMeilleure.CodeGen.X86
 
             if (dest.Type.IsInteger())
             {
-                if (dest == src1)
+                if (dest.GetRegister().Equals(src1.GetRegister()))
                 {
                     context.Assembler.Add(dest, src2, dest.Type);
                 }

--- a/ARMeilleure/CodeGen/X86/CodeGenerator.cs
+++ b/ARMeilleure/CodeGen/X86/CodeGenerator.cs
@@ -518,12 +518,19 @@ namespace ARMeilleure.CodeGen.X86
 
             if (dest.Type.IsInteger())
             {
-                int offset    = src2.Kind == OperandKind.Constant ? src2.AsInt32() : 0;
-                Operand index = src2.Kind != OperandKind.Constant ? src2           : null;
+                if (dest == src1)
+                {
+                    context.Assembler.Add(dest, src2, dest.Type);
+                }
+                else
+                {
+                    int offset = src2.Kind == OperandKind.Constant ? src2.AsInt32() : 0;
+                    Operand index = src2.Kind != OperandKind.Constant ? src2 : null;
 
-                MemoryOperand memOp = MemoryOp(dest.Type, src1, index, Multiplier.x1, offset);
+                    MemoryOperand memOp = MemoryOp(dest.Type, src1, index, Multiplier.x1, offset);
 
-                context.Assembler.Lea(dest, memOp, dest.Type);
+                    context.Assembler.Lea(dest, memOp, dest.Type);
+                }
             }
             else if (dest.Type == OperandType.FP32)
             {

--- a/ARMeilleure/CodeGen/X86/CodeGenerator.cs
+++ b/ARMeilleure/CodeGen/X86/CodeGenerator.cs
@@ -516,7 +516,7 @@ namespace ARMeilleure.CodeGen.X86
 
             if (dest.Type.IsInteger())
             {
-                // Moves to the same register are useless.
+                // If Destination and Source 1 Operands are the same, perform a standard add as there are no benefits to using LEA.
                 if (dest.Kind == src1.Kind && dest.Value == src1.Value)
                 {
                     ValidateBinOp(dest, src1, src2);

--- a/ARMeilleure/CodeGen/X86/CodeGenerator.cs
+++ b/ARMeilleure/CodeGen/X86/CodeGenerator.cs
@@ -525,6 +525,8 @@ namespace ARMeilleure.CodeGen.X86
                 }
                 else
                 {
+                    EnsureSameType(dest, src1, src2);
+
                     int offset;
                     Operand index;
 
@@ -544,7 +546,8 @@ namespace ARMeilleure.CodeGen.X86
                     context.Assembler.Lea(dest, memOp, dest.Type);
                 }
             }
-            else {
+            else 
+            {
                 ValidateBinOp(dest, src1, src2);
 
                 if (dest.Type == OperandType.FP32)

--- a/ARMeilleure/CodeGen/X86/CodeGenerator.cs
+++ b/ARMeilleure/CodeGen/X86/CodeGenerator.cs
@@ -518,7 +518,12 @@ namespace ARMeilleure.CodeGen.X86
 
             if (dest.Type.IsInteger())
             {
-                context.Assembler.Add(dest, src2, dest.Type);
+                int offset    = src2.Kind == OperandKind.Constant ? src2.AsInt32() : 0;
+                Operand index = src2.Kind != OperandKind.Constant ? src2           : null;
+
+                MemoryOperand memOp = MemoryOp(dest.Type, src1, index, Multiplier.x1, offset);
+
+                context.Assembler.Lea(dest, memOp, dest.Type);
             }
             else if (dest.Type == OperandType.FP32)
             {

--- a/ARMeilleure/CodeGen/X86/PreAllocator.cs
+++ b/ARMeilleure/CodeGen/X86/PreAllocator.cs
@@ -1273,7 +1273,7 @@ namespace ARMeilleure.CodeGen.X86
             switch (operation.Instruction)
             {
                 case Instruction.Add:
-                    return !HardwareCapabilities.SupportsVexEncoding || operation.Destination.Type.IsInteger() && operation.SourcesCount < 2;
+                    return !HardwareCapabilities.SupportsVexEncoding || (operation.Destination.Type.IsInteger() && operation.SourcesCount < 2);
                 case Instruction.Multiply:
                 case Instruction.Subtract:
                     return !HardwareCapabilities.SupportsVexEncoding || operation.Destination.Type.IsInteger();

--- a/ARMeilleure/CodeGen/X86/PreAllocator.cs
+++ b/ARMeilleure/CodeGen/X86/PreAllocator.cs
@@ -1273,6 +1273,7 @@ namespace ARMeilleure.CodeGen.X86
             switch (operation.Instruction)
             {
                 case Instruction.Add:
+                    return !operation.Destination.Type.IsInteger();
                 case Instruction.Multiply:
                 case Instruction.Subtract:
                     return !HardwareCapabilities.SupportsVexEncoding || operation.Destination.Type.IsInteger();

--- a/ARMeilleure/CodeGen/X86/PreAllocator.cs
+++ b/ARMeilleure/CodeGen/X86/PreAllocator.cs
@@ -1273,7 +1273,7 @@ namespace ARMeilleure.CodeGen.X86
             switch (operation.Instruction)
             {
                 case Instruction.Add:
-                    return !HardwareCapabilities.SupportsVexEncoding || operation.Destination.Type.IsInteger() && operation.SourcesCount < 2);
+                    return !HardwareCapabilities.SupportsVexEncoding || operation.Destination.Type.IsInteger() && operation.SourcesCount < 2;
                 case Instruction.Multiply:
                 case Instruction.Subtract:
                     return !HardwareCapabilities.SupportsVexEncoding || operation.Destination.Type.IsInteger();

--- a/ARMeilleure/CodeGen/X86/PreAllocator.cs
+++ b/ARMeilleure/CodeGen/X86/PreAllocator.cs
@@ -1273,7 +1273,7 @@ namespace ARMeilleure.CodeGen.X86
             switch (operation.Instruction)
             {
                 case Instruction.Add:
-                    return !HardwareCapabilities.SupportsVexEncoding || !operation.Destination.Type.IsInteger() || (operation.Destination.Type.IsInteger() && operation.SourcesCount < 2);
+                    return !HardwareCapabilities.SupportsVexEncoding || operation.Destination.Type.IsInteger() && operation.SourcesCount < 2);
                 case Instruction.Multiply:
                 case Instruction.Subtract:
                     return !HardwareCapabilities.SupportsVexEncoding || operation.Destination.Type.IsInteger();

--- a/ARMeilleure/CodeGen/X86/PreAllocator.cs
+++ b/ARMeilleure/CodeGen/X86/PreAllocator.cs
@@ -1273,7 +1273,7 @@ namespace ARMeilleure.CodeGen.X86
             switch (operation.Instruction)
             {
                 case Instruction.Add:
-                    return !HardwareCapabilities.SupportsVexEncoding || (operation.Destination.Type.IsInteger() && operation.SourcesCount < 2);
+                    return !HardwareCapabilities.SupportsVexEncoding && !operation.Destination.Type.IsInteger();
                 case Instruction.Multiply:
                 case Instruction.Subtract:
                     return !HardwareCapabilities.SupportsVexEncoding || operation.Destination.Type.IsInteger();

--- a/ARMeilleure/CodeGen/X86/PreAllocator.cs
+++ b/ARMeilleure/CodeGen/X86/PreAllocator.cs
@@ -1273,7 +1273,7 @@ namespace ARMeilleure.CodeGen.X86
             switch (operation.Instruction)
             {
                 case Instruction.Add:
-                    return !HardwareCapabilities.SupportsVexEncoding && !operation.Destination.Type.IsInteger();
+                    return !HardwareCapabilities.SupportsVexEncoding || !operation.Destination.Type.IsInteger() || (operation.Destination.Type.IsInteger() && operation.SourcesCount < 2);
                 case Instruction.Multiply:
                 case Instruction.Subtract:
                     return !HardwareCapabilities.SupportsVexEncoding || operation.Destination.Type.IsInteger();

--- a/ARMeilleure/CodeGen/X86/PreAllocator.cs
+++ b/ARMeilleure/CodeGen/X86/PreAllocator.cs
@@ -1273,7 +1273,7 @@ namespace ARMeilleure.CodeGen.X86
             switch (operation.Instruction)
             {
                 case Instruction.Add:
-                    return !operation.Destination.Type.IsInteger();
+                    return !HardwareCapabilities.SupportsVexEncoding && !operation.Destination.Type.IsInteger();
                 case Instruction.Multiply:
                 case Instruction.Subtract:
                     return !HardwareCapabilities.SupportsVexEncoding || operation.Destination.Type.IsInteger();

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -22,7 +22,7 @@ namespace ARMeilleure.Translation.PTC
     {
         private const string HeaderMagic = "PTChd";
 
-        private const int InternalVersion = 1956; //! To be incremented manually for each change to the ARMeilleure project.
+        private const int InternalVersion = 1971; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";


### PR DESCRIPTION
Currently, the integer add instruction requires 4 registers to take place. By using LEA, we can effectively perform the same working using 3 registers, reducing memory spills and improving translation efficiency.
