### PR TITLE
Do not flush multisample textures

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -723,6 +723,12 @@ namespace Ryujinx.Graphics.Gpu.Image
                     return; // Flushing this format is not supported, as it may have been converted to another host format.
                 }
 
+                if (Info.Target == Target.Texture2DMultisample ||
+                    Info.Target == Target.Texture2DMultisampleArray)
+                {
+                    return; // Flushing multisample textures is not supported, the host does not allow getting their data.
+                }
+
                 ITexture texture = HostTexture;
                 if (ScaleFactor != 1f)
                 {


### PR DESCRIPTION
On the guest, multisample textures have their width/height multiplied by the amount of samples in each axis. When the texture is passed to the host, the actual size of the texture is calculated by dividing the width and height by the amount of samples in X and Y. And then the total amount of samples (samples in X * samples in Y) is also passed to the host. This creates a mismatch during flush where the texture that it gets back from the host is smaller than what is is trying to write in memory, this causes an access violation on Linear -> Block Linear conversion as it attempts to do a out of bounds access. Another problem is that the host simple does not support getting data from a multisample texture.

For the reasons listed above, this simply disables flushing for those multisample textures. There is no reason for reading them from the CPU, and most games don't use multisampling anyway, so I don't expect them to need that data.

This fixes the following crash on Super Bomberman R (and most likely a few other games):
```
Fatal error. System.AccessViolationException: Attempted to read or write protected memory. This is often an indication that other memory is corrupt.
   at Ryujinx.Graphics.Texture.LayoutConverter.<ConvertLinearToBlockLinear>g__Convert|5_0[
```