### PR TITLE
Add PPTC acronym to settings page for ease of reference

### DIFF
--- a/Ryujinx/Ui/Windows/SettingsWindow.glade
+++ b/Ryujinx/Ui/Windows/SettingsWindow.glade
@@ -1458,7 +1458,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkCheckButton" id="_ptcToggle">
-                                    <property name="label" translatable="yes">Enable Profiled Persistent Translation Cache</property>
+                                    <property name="label" translatable="yes">Enable PPTC (Profiled Persistent Translation Cache)</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">False</property>


### PR DESCRIPTION
We all call it PPTC. The cache management section calls it PPTC. Now the settings page will call it PPTC (but preserve the full term in parentheses). This way, when asking or directing users about their PPTC settings they won't be left wondering what PPTC is and where to find it.

Before:
![image](https://user-images.githubusercontent.com/62343878/106130337-754fa880-611e-11eb-814e-ac7033e90f0c.png)

After:
![image](https://user-images.githubusercontent.com/62343878/106130361-7a145c80-611e-11eb-867a-3ca7f032865f.png)
