### PR TITLE
Use multiple dest operands for shader call instructions

### DIFF
--- a/Ryujinx.Graphics.Shader/IntermediateRepresentation/Instruction.cs
+++ b/Ryujinx.Graphics.Shader/IntermediateRepresentation/Instruction.cs
@@ -32,7 +32,6 @@ namespace Ryujinx.Graphics.Shader.IntermediateRepresentation
         BranchIfFalse,
         BranchIfTrue,
         Call,
-        CallOutArgument,
         Ceiling,
         Clamp,
         ClampU32,

--- a/Ryujinx.Graphics.Shader/IntermediateRepresentation/Operation.cs
+++ b/Ryujinx.Graphics.Shader/IntermediateRepresentation/Operation.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 
 namespace Ryujinx.Graphics.Shader.IntermediateRepresentation
 {
@@ -96,7 +97,27 @@ namespace Ryujinx.Graphics.Shader.IntermediateRepresentation
             Index = index;
         }
 
-        public void AppendOperands(params Operand[] operands)
+        public void AppendDests(Operand[] operands)
+        {
+            int startIndex = _dests.Length;
+
+            Array.Resize(ref _dests, startIndex + operands.Length);
+
+            for (int index = 0; index < operands.Length; index++)
+            {
+                Operand dest = operands[index];
+
+                if (dest != null && dest.Type == OperandType.LocalVariable)
+                {
+                    Debug.Assert(dest.AsgOp == null);
+                    dest.AsgOp = this;
+                }
+
+                _dests[startIndex + index] = dest;
+            }
+        }
+
+        public void AppendSources(Operand[] operands)
         {
             int startIndex = _sources.Length;
 

--- a/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgram.cs
+++ b/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgram.cs
@@ -51,7 +51,7 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
                         {
                             context.LeaveBlock(block, operation);
                         }
-                        else if (operation.Inst != Instruction.CallOutArgument)
+                        else
                         {
                             AddOperation(context, opNode);
                         }
@@ -74,41 +74,14 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
 
             Instruction inst = operation.Inst;
 
-            bool isCall = inst == Instruction.Call;
-
             int sourcesCount = operation.SourcesCount;
             int outDestsCount = operation.DestsCount != 0 ? operation.DestsCount - 1 : 0;
-
-            List<Operand> callOutOperands = new List<Operand>();
-
-            if (isCall)
-            {
-                LinkedListNode<INode> scan = opNode.Next;
-
-                while (scan != null && scan.Value is Operation nextOp && nextOp.Inst == Instruction.CallOutArgument)
-                {
-                    callOutOperands.Add(nextOp.Dest);
-                    scan = scan.Next;
-                }
-
-                sourcesCount += callOutOperands.Count;
-            }
 
             IAstNode[] sources = new IAstNode[sourcesCount + outDestsCount];
 
             for (int index = 0; index < operation.SourcesCount; index++)
             {
                 sources[index] = context.GetOperandUse(operation.GetSource(index));
-            }
-
-            if (isCall)
-            {
-                for (int index = 0; index < callOutOperands.Count; index++)
-                {
-                    sources[operation.SourcesCount + index] = context.GetOperandDef(callOutOperands[index]);
-                }
-
-                callOutOperands.Clear();
             }
 
             for (int index = 0; index < outDestsCount; index++)

--- a/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgram.cs
+++ b/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgram.cs
@@ -53,7 +53,7 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
                         }
                         else
                         {
-                            AddOperation(context, opNode);
+                            AddOperation(context, operation);
                         }
                     }
                 }
@@ -68,10 +68,8 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
             return context.Info;
         }
 
-        private static void AddOperation(StructuredProgramContext context, LinkedListNode<INode> opNode)
+        private static void AddOperation(StructuredProgramContext context, Operation operation)
         {
-            Operation operation = (Operation)opNode.Value;
-
             Instruction inst = operation.Inst;
 
             int sourcesCount = operation.SourcesCount;

--- a/Ryujinx.Graphics.Shader/Translation/Optimizations/Optimizer.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Optimizations/Optimizer.cs
@@ -289,7 +289,6 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
                     case Instruction.AtomicSwap:
                     case Instruction.AtomicXor:
                     case Instruction.Call:
-                    case Instruction.CallOutArgument:
                         return true;
                 }
             }
@@ -306,7 +305,9 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
 
             for (int index = 0; index < node.DestsCount; index++)
             {
-                if (node.GetDest(index).Type != OperandType.LocalVariable)
+                Operand dest = node.GetDest(index);
+
+                if (dest != null && dest.Type != OperandType.LocalVariable)
                 {
                     return false;
                 }
@@ -319,7 +320,9 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
         {
             for (int index = 0; index < node.DestsCount; index++)
             {
-                if (node.GetDest(index).UseOps.Count != 0)
+                Operand dest = node.GetDest(index);
+
+                if (dest != null && dest.UseOps.Count != 0)
                 {
                     return false;
                 }

--- a/Ryujinx.Graphics.Shader/Translation/RegisterUsage.cs
+++ b/Ryujinx.Graphics.Shader/Translation/RegisterUsage.cs
@@ -299,21 +299,23 @@ namespace Ryujinx.Graphics.Shader.Translation
 
                         var fru = frus[funcId.Value];
 
-                        Operand[] regs = new Operand[fru.InArguments.Length];
+                        Operand[] inRegs = new Operand[fru.InArguments.Length];
 
                         for (int i = 0; i < fru.InArguments.Length; i++)
                         {
-                            regs[i] = OperandHelper.Register(fru.InArguments[i]);
+                            inRegs[i] = OperandHelper.Register(fru.InArguments[i]);
                         }
 
-                        operation.AppendOperands(regs);
+                        operation.AppendSources(inRegs);
+
+                        Operand[] outRegs = new Operand[1 + fru.OutArguments.Length];
 
                         for (int i = 0; i < fru.OutArguments.Length; i++)
                         {
-                            Operation callOutArgOp = new Operation(Instruction.CallOutArgument, OperandHelper.Register(fru.OutArguments[i]));
-
-                            node = block.Operations.AddAfter(node, callOutArgOp);
+                            outRegs[1 + i] = OperandHelper.Register(fru.OutArguments[i]);
                         }
+
+                        operation.AppendDests(outRegs);
                     }
                 }
             }

--- a/Ryujinx.Graphics.Shader/Translation/Ssa.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Ssa.cs
@@ -120,7 +120,7 @@ namespace Ryujinx.Graphics.Shader.Translation
                         {
                             Operand dest = operation.GetDest(index);
 
-                            if (dest.Type == OperandType.Register)
+                            if (dest != null && dest.Type == OperandType.Register)
                             {
                                 Operand local = Local();
 

--- a/Ryujinx.Graphics.Shader/Translation/Translator.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Translator.cs
@@ -88,7 +88,6 @@ namespace Ryujinx.Graphics.Shader.Translation
                     RegisterUsage.FixupCalls(cfg.Blocks, frus);
 
                     Dominance.FindDominators(cfg);
-
                     Dominance.FindDominanceFrontiers(cfg.Blocks);
 
                     Ssa.Rename(cfg.Blocks);


### PR DESCRIPTION
Simplifies handling of shader call instructions, now that multiple operands are supported, the `CallOutArgument` IR instruction is no longer needed, and has been removed. It now stores the out arguments as operands on the call operation itself.

This should not cause any change to the generated code and should also not have any effect, its just refactoring.