### PR TITLE
Use a descriptor cache for faster pool invalidation.

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/SamplerDescriptor.cs
+++ b/Ryujinx.Graphics.Gpu/Image/SamplerDescriptor.cs
@@ -1,4 +1,6 @@
 using Ryujinx.Graphics.GAL;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
 
 namespace Ryujinx.Graphics.Gpu.Image
 {
@@ -243,6 +245,16 @@ namespace Ryujinx.Graphics.Gpu.Image
         public float UnpackMaxLod()
         {
             return ((Word2 >> 12) & 0xfff) * Frac8ToF32;
+        }
+
+        /// <summary>
+        /// Check if two descriptors are equal.
+        /// </summary>
+        /// <param name="other">The descriptor to compare against</param>
+        /// <returns>True if they are equal, false otherwise</returns>
+        public bool Equals(ref SamplerDescriptor other)
+        {
+            return Unsafe.As<SamplerDescriptor, Vector256<byte>>(ref this).Equals(Unsafe.As<SamplerDescriptor, Vector256<byte>>(ref other));
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Image/SamplerPool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/SamplerPool.cs
@@ -70,7 +70,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     SamplerDescriptor descriptor = GetDescriptor(id);
 
                     // If the descriptors are the same, the sampler is still valid.
-                    if (descriptor.Equals(DescriptorCache[id]))
+                    if (descriptor.Equals(ref DescriptorCache[id]))
                     {
                         continue;
                     }

--- a/Ryujinx.Graphics.Gpu/Image/SamplerPool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/SamplerPool.cs
@@ -3,7 +3,7 @@ namespace Ryujinx.Graphics.Gpu.Image
     /// <summary>
     /// Sampler pool.
     /// </summary>
-    class SamplerPool : Pool<Sampler>
+    class SamplerPool : Pool<Sampler, SamplerDescriptor>
     {
         private int _sequenceNumber;
 
@@ -38,11 +38,13 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             if (sampler == null)
             {
-                SamplerDescriptor descriptor = Context.PhysicalMemory.Read<SamplerDescriptor>(Address + (ulong)id * DescriptorSize);
+                SamplerDescriptor descriptor = GetDescriptor(id);
 
                 sampler = new Sampler(Context, descriptor);
 
                 Items[id] = sampler;
+
+                DescriptorCache[id] = descriptor;
             }
 
             return sampler;
@@ -65,6 +67,14 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 if (sampler != null)
                 {
+                    SamplerDescriptor descriptor = GetDescriptor(id);
+
+                    // If the descriptors are the same, the sampler is still valid.
+                    if (descriptor.Equals(DescriptorCache[id]))
+                    {
+                        continue;
+                    }
+
                     sampler.Dispose();
 
                     Items[id] = null;

--- a/Ryujinx.Graphics.Gpu/Image/TextureDescriptor.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureDescriptor.cs
@@ -1,4 +1,6 @@
 using Ryujinx.Graphics.Gpu.Shader.Cache.Definition;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
 
 namespace Ryujinx.Graphics.Gpu.Image
 {
@@ -247,6 +249,16 @@ namespace Ryujinx.Graphics.Gpu.Image
             };
 
             return result;
+        }
+
+        /// <summary>
+        /// Check if two descriptors are equal.
+        /// </summary>
+        /// <param name="other">The descriptor to compare against</param>
+        /// <returns>True if they are equal, false otherwise</returns>
+        public bool Equals(ref TextureDescriptor other)
+        {
+            return Unsafe.As<TextureDescriptor, Vector256<byte>>(ref this).Equals(Unsafe.As<TextureDescriptor, Vector256<byte>>(ref other));
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -10,7 +10,7 @@ namespace Ryujinx.Graphics.Gpu.Image
     /// <summary>
     /// Texture pool.
     /// </summary>
-    class TexturePool : Pool<Texture>
+    class TexturePool : Pool<Texture, TextureDescriptor>
     {
         private int _sequenceNumber;
 
@@ -65,6 +65,8 @@ namespace Ryujinx.Graphics.Gpu.Image
                 texture.IncrementReferenceCount();
 
                 Items[id] = texture;
+
+                DescriptorCache[id] = descriptor;
             }
             else
             {
@@ -92,16 +94,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Gets the texture descriptor from a given texture ID.
-        /// </summary>
-        /// <param name="id">ID of the texture. This is effectively a zero-based index</param>
-        /// <returns>The texture descriptor</returns>
-        public TextureDescriptor GetDescriptor(int id)
-        {
-            return Context.PhysicalMemory.Read<TextureDescriptor>(Address + (ulong)id * DescriptorSize);
-        }
-
-        /// <summary>
         /// Implementation of the texture pool range invalidation.
         /// </summary>
         /// <param name="address">Start address of the range of the texture pool</param>
@@ -122,8 +114,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                     // If the descriptors are the same, the texture is the same,
                     // we don't need to remove as it was not modified. Just continue.
-                    if (texture.Info.GpuAddress == descriptor.UnpackAddress() &&
-                        texture.IsExactMatch(GetInfo(descriptor, out _), TextureSearchFlags.Strict) != TextureMatchQuality.NoMatch)
+                    if (descriptor.Equals(DescriptorCache[id]))
                     {
                         continue;
                     }

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -1,6 +1,5 @@
 using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.GAL;
-using Ryujinx.Graphics.Gpu.Memory;
 using Ryujinx.Graphics.Texture;
 using System;
 using System.Collections.Generic;
@@ -114,7 +113,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                     // If the descriptors are the same, the texture is the same,
                     // we don't need to remove as it was not modified. Just continue.
-                    if (descriptor.Equals(DescriptorCache[id]))
+                    if (descriptor.Equals(ref DescriptorCache[id]))
                     {
                         continue;
                     }


### PR DESCRIPTION
Rather than evaluating info for cached textures and checking for a match to the existing pool texture, saves the descriptor used to create that texture and only invalidates textures if it no longer equals the guest memory descriptor. Also does this comparison for samplers, to avoid recreating them (before, all samplers on a page would be invalidated).

This may improve performance in games that have stutters caused by texture pool invalidation. Not sure what games that will be, but at least this is a lot faster now.

This PR also fixes an issue with Mario Kart 8 Deluxe introduced by #1905 where the course's cubemap array and shadow map could be evicted from the pool while playing, which would cause the course to become rainbow soup... and generally really hard to look at:

![image](https://user-images.githubusercontent.com/6294155/106202833-6581a400-61b2-11eb-9491-6d2650d42ed0.png)

A way to reproduce this issue on master is to play Toad Harbor and then Wild Woods back to back. The screenshot above is from going to Yoshi Circuit afterwards.

The problem happened because the GpuAddress in the new descriptor would be compared with the GpuAddress in the texture. But... when the texture was placed in the pool, it was matched by _cpu region_... so any pool invalidation afterwards would erroneously evict the texture. This fixes the issue by comparing against the gpu address in the old descriptor instead.

Any issues that existed before #1905 probably have not been fixed, unless they were performance related.