### PR TITLE
Disable partial JIT invalidation on unmap

### DIFF
--- a/ARMeilleure/Translation/TranslatedFunction.cs
+++ b/ARMeilleure/Translation/TranslatedFunction.cs
@@ -33,5 +33,10 @@ namespace ARMeilleure.Translation
         {
             return !HighCq && Interlocked.Increment(ref _callCount) == MinCallsForRejit;
         }
+
+        public void ResetCallCount()
+        {
+            Interlocked.Exchange(ref _callCount, 0);
+        }
     }
 }


### PR DESCRIPTION
One of the changes on #1518 caused a large performance regression (mainly during load) on games that unmap memory frequently. This happens because it checks if the JIT cache has a function overlapping the unmapped range on each unmap, which right now is very slow as the data structure used is not really suitable for quick match of overlapping ranges.

This changes fixes the performance regression by completely removing the invalidation on unmap. The reason for this is because it was already largely incomplete anyway, as it does not actually remove the host code from the cache (possibly causing it to use all the memory reserved for the JIT cache, if the game is generating or loading code at runtime), and because the functions being removed from the cache does not become complete unreachable by just removing it from the dictionary, since that, due to the direct call optimization, they can be still reachable from calls that load the function address from the jump/dynamic call tables.

Meanwhile this keeps the bits that actually fixes the issue I noticed and motived me to make the original changes anyway, which was rejiting trying to translate a function that was already unmapped. It does this by just clearing the rejit queue on each unmap. This also fixes a bug on that part where a function could be stuck in LowCq forever, if it was added to the rejit queue, and a overlap was found on unmap, causing the rejit queue to be cleared. Now it resets the call count of all functions removed from the rejit queue, giving them another chance to be rejited.

The affected games are mainly those that makes heavy use on Map/UnmapPhysicalMemory, like a few UE4 games. The boot times seems now close to what it was before the aforementioned PR.