### PR TITLE
Hide Cursor On Idle

### DIFF
--- a/Ryujinx.Common/Configuration/ConfigurationFileFormat.cs
+++ b/Ryujinx.Common/Configuration/ConfigurationFileFormat.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.Configuration
         /// <summary>
         /// The current version of the file format
         /// </summary>
-        public const int CurrentVersion = 21;
+        public const int CurrentVersion = 22;
 
         public int Version { get; set; }
 

--- a/Ryujinx.Common/Configuration/ConfigurationFileFormat.cs
+++ b/Ryujinx.Common/Configuration/ConfigurationFileFormat.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.Configuration
         /// <summary>
         /// The current version of the file format
         /// </summary>
-        public const int CurrentVersion = 20;
+        public const int CurrentVersion = 21;
 
         public int Version { get; set; }
 
@@ -132,6 +132,11 @@ namespace Ryujinx.Configuration
         /// Show "Confirm Exit" Dialog
         /// </summary>
         public bool ShowConfirmExit { get; set; }
+
+        /// <summary>
+        /// Hide Cursor on Idle
+        /// </summary>
+        public bool HideCursorOnIdle { get; set; }
 
         /// <summary>
         /// Enables or disables Vertical Sync

--- a/Ryujinx.Common/Configuration/ConfigurationState.cs
+++ b/Ryujinx.Common/Configuration/ConfigurationState.cs
@@ -795,9 +795,9 @@ namespace Ryujinx.Configuration
                 configurationFileUpdated = true;
             }
 
-            if (configurationFileFormat.Version < 21)
+            if (configurationFileFormat.Version < 22)
             {
-                Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 21.");
+                Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 22.");
 
                 configurationFileFormat.HideCursorOnIdle = true;
 

--- a/Ryujinx.Common/Configuration/ConfigurationState.cs
+++ b/Ryujinx.Common/Configuration/ConfigurationState.cs
@@ -365,6 +365,11 @@ namespace Ryujinx.Configuration
         /// </summary>
         public ReactiveObject<bool> ShowConfirmExit { get; private set; }
 
+        /// <summary>
+        /// Hide Cursor on Idle
+        /// </summary>
+        public ReactiveObject<bool> HideCursorOnIdle { get; private set; }
+
         private ConfigurationState()
         {
             Ui                       = new UiSection();
@@ -375,6 +380,7 @@ namespace Ryujinx.Configuration
             EnableDiscordIntegration = new ReactiveObject<bool>();
             CheckUpdatesOnStart      = new ReactiveObject<bool>();
             ShowConfirmExit          = new ReactiveObject<bool>();
+            HideCursorOnIdle         = new ReactiveObject<bool>();
         }
 
         public ConfigurationFileFormat ToFileFormat()
@@ -420,6 +426,7 @@ namespace Ryujinx.Configuration
                 EnableDiscordIntegration  = EnableDiscordIntegration,
                 CheckUpdatesOnStart       = CheckUpdatesOnStart,
                 ShowConfirmExit           = ShowConfirmExit,
+                HideCursorOnIdle          = HideCursorOnIdle,
                 EnableVsync               = Graphics.EnableVsync,
                 EnableShaderCache         = Graphics.EnableShaderCache,
                 EnablePtc                 = System.EnablePtc,
@@ -483,6 +490,7 @@ namespace Ryujinx.Configuration
             EnableDiscordIntegration.Value         = true;
             CheckUpdatesOnStart.Value              = true;
             ShowConfirmExit.Value                  = true;
+            HideCursorOnIdle.Value                 = true;
             Graphics.EnableVsync.Value             = true;
             Graphics.EnableShaderCache.Value       = true;
             System.EnablePtc.Value                 = true;
@@ -787,6 +795,15 @@ namespace Ryujinx.Configuration
                 configurationFileUpdated = true;
             }
 
+            if (configurationFileFormat.Version < 21)
+            {
+                Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 21.");
+
+                configurationFileFormat.HideCursorOnIdle = true;
+
+                configurationFileUpdated = true;
+            }
+
             List<InputConfig> inputConfig = new List<InputConfig>();
             inputConfig.AddRange(configurationFileFormat.ControllerConfig);
             inputConfig.AddRange(configurationFileFormat.KeyboardConfig);
@@ -814,6 +831,7 @@ namespace Ryujinx.Configuration
             EnableDiscordIntegration.Value         = configurationFileFormat.EnableDiscordIntegration;
             CheckUpdatesOnStart.Value              = configurationFileFormat.CheckUpdatesOnStart;
             ShowConfirmExit.Value                  = configurationFileFormat.ShowConfirmExit;
+            HideCursorOnIdle.Value                 = configurationFileFormat.HideCursorOnIdle;
             Graphics.EnableVsync.Value             = configurationFileFormat.EnableVsync;
             Graphics.EnableShaderCache.Value       = configurationFileFormat.EnableShaderCache;
             System.EnablePtc.Value                 = configurationFileFormat.EnablePtc;

--- a/Ryujinx.Common/Configuration/ConfigurationState.cs
+++ b/Ryujinx.Common/Configuration/ConfigurationState.cs
@@ -490,7 +490,7 @@ namespace Ryujinx.Configuration
             EnableDiscordIntegration.Value         = true;
             CheckUpdatesOnStart.Value              = true;
             ShowConfirmExit.Value                  = true;
-            HideCursorOnIdle.Value                 = true;
+            HideCursorOnIdle.Value                 = false;
             Graphics.EnableVsync.Value             = true;
             Graphics.EnableShaderCache.Value       = true;
             System.EnablePtc.Value                 = true;
@@ -799,7 +799,7 @@ namespace Ryujinx.Configuration
             {
                 Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 22.");
 
-                configurationFileFormat.HideCursorOnIdle = true;
+                configurationFileFormat.HideCursorOnIdle = false;
 
                 configurationFileUpdated = true;
             }

--- a/Ryujinx/Config.json
+++ b/Ryujinx/Config.json
@@ -22,7 +22,7 @@
   "enable_discord_integration": true,
   "check_updates_on_start": true,
   "show_confirm_exit": true,
-  "hide_cursor_on_idle": true,
+  "hide_cursor_on_idle": false,
   "enable_vsync": true,
   "enable_shader_cache": true,
   "enable_ptc": true,

--- a/Ryujinx/Config.json
+++ b/Ryujinx/Config.json
@@ -1,5 +1,5 @@
 {
-  "version": 21,
+  "version": 22,
   "res_scale": 1,
   "res_scale_custom": 1,
   "max_anisotropy": -1,

--- a/Ryujinx/Config.json
+++ b/Ryujinx/Config.json
@@ -1,5 +1,5 @@
 {
-  "version": 20,
+  "version": 21,
   "res_scale": 1,
   "res_scale_custom": 1,
   "max_anisotropy": -1,
@@ -22,6 +22,7 @@
   "enable_discord_integration": true,
   "check_updates_on_start": true,
   "show_confirm_exit": true,
+  "hide_cursor_on_idle": true,
   "enable_vsync": true,
   "enable_shader_cache": true,
   "enable_ptc": true,

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -328,11 +328,14 @@ namespace Ryujinx.Ui
 
         private void HideCursorIdle()
         {
-           TimeSpan elapsedTime = DateTime.Now.Subtract(_lastCursorMoveTime);
-
-           if (elapsedTime.TotalSeconds > 8)
+           if (ConfigurationState.Instance.HideCursorOnIdle)
            {
-               Gtk.Application.Invoke(delegate { Window.Cursor = _invisibleCursor; });
+               TimeSpan elapsedTime = DateTime.Now.Subtract(_lastCursorMoveTime);
+
+               if (elapsedTime.TotalSeconds > 8)
+               {
+                   Gtk.Application.Invoke(delegate { Window.Cursor = _invisibleCursor; });
+               }
            }
         }
 
@@ -514,10 +517,7 @@ namespace Ryujinx.Ui
 
             MotionDevice motionDevice = new MotionDevice(_dsuClient);
 
-            if (ConfigurationState.Instance.HideCursorOnIdle)
-            {
-                HideCursorIdle();
-            }
+            HideCursorIdle();
 
             foreach (InputConfig inputConfig in ConfigurationState.Instance.Hid.InputConfig.Value)
             {

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -66,7 +66,7 @@ namespace Ryujinx.Ui
 
         private static System.Timers.Timer _idleTimer = new System.Timers.Timer();
         
-        private Gdk.Cursor _invisibleCursor = new Gdk.Cursor (Gdk.CursorType.BlankCursor);
+        private Gdk.Cursor _invisibleCursor = new Gdk.Cursor (Gdk.Display.Default, Gdk.CursorType.BlankCursor);
 
         public GlRenderer(Switch device, GraphicsDebugLevel glLogLevel)
             : base (GetGraphicsMode(),

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -42,7 +42,7 @@ namespace Ryujinx.Ui
         private double _mouseY;
         private bool   _mousePressed;
 
-        private TimeSpan _lastCursorMove = (DateTime.UtcNow - new DateTime(1970, 1, 1));
+        private DateTime _lastCursorMoveTime = DateTime.Now;
 
         private bool _toggleFullscreen;
         private bool _toggleDockedMode;
@@ -101,7 +101,6 @@ namespace Ryujinx.Ui
             _glLogLevel = glLogLevel;
 
             _exitEvent = new ManualResetEvent(false);
-
         }
 
         private static GraphicsMode GetGraphicsMode()
@@ -309,15 +308,16 @@ namespace Ryujinx.Ui
                 _mouseY = evnt.Y;
             }
 
-            ResetCursor();
+            ResetCursorIdle();
+
             return false;
         }
 
-        private void ResetCursor()
+        private void ResetCursorIdle()
         {
            if (ConfigurationState.Instance.HideCursorOnIdle)
            {
-               _lastCursorMove=(DateTime.UtcNow - new DateTime(1970, 1, 1));
+               _lastCursorMoveTime = DateTime.Now;
            }
 
            if (Window.Cursor != null)
@@ -326,11 +326,11 @@ namespace Ryujinx.Ui
            }
         }
 
-        private void HideCursorOnIdle()
+        private void HideCursorIdle()
         {
-           TimeSpan _currentTime=(DateTime.UtcNow - new DateTime(1970, 1, 1));
-           TimeSpan difference = _currentTime.Subtract(_lastCursorMove);
-           if (ConfigurationState.Instance.HideCursorOnIdle && difference.TotalSeconds > 8)
+           TimeSpan elapsedTime = DateTime.Now.Subtract(_lastCursorMoveTime);
+
+           if (ConfigurationState.Instance.HideCursorOnIdle && elapsedTime.TotalSeconds > 8)
            {
                Gtk.Application.Invoke(delegate { Window.Cursor = _invisibleCursor; });
            }
@@ -481,7 +481,6 @@ namespace Ryujinx.Ui
 
         private bool UpdateFrame()
         {
-            
             if (!_isActive)
             {
                 return true;
@@ -515,7 +514,7 @@ namespace Ryujinx.Ui
 
             MotionDevice motionDevice = new MotionDevice(_dsuClient);
 
-            HideCursorOnIdle();
+            HideCursorIdle();
 
             foreach (InputConfig inputConfig in ConfigurationState.Instance.Hid.InputConfig.Value)
             {

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -128,7 +128,8 @@ namespace Ryujinx.Ui
            if (_cursorHidden)
            {
                _cursorHidden = false;
-               Window.Cursor = new Gdk.Cursor(Gdk.Display.Default, Gdk.CursorType.LeftPtr);
+               Window.Cursor.Dispose();
+               Window.Cursor = null;
            }
         }
 
@@ -345,7 +346,7 @@ namespace Ryujinx.Ui
         {
            if (ConfigurationState.Instance.HideCursorOnIdle)
            {
-               Window.Cursor = new Gdk.Cursor(Gdk.Display.Default, Gdk.CursorType.BlankCursor);
+               Gtk.Application.Invoke(delegate { Window.Cursor = new Gdk.Cursor(Gdk.CursorType.BlankCursor); });
                _cursorHidden = true;
            }
         }

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -64,7 +64,9 @@ namespace Ryujinx.Ui
 
         private readonly ManualResetEvent _exitEvent;
 
-        public static System.Timers.Timer idleTimer = new System.Timers.Timer();
+        private static System.Timers.Timer _idleTimer = new System.Timers.Timer();
+        
+        private Gdk.Cursor _invisibleCursor = new Gdk.Cursor (Gdk.CursorType.BlankCursor);
 
         public GlRenderer(Switch device, GraphicsDebugLevel glLogLevel)
             : base (GetGraphicsMode(),
@@ -106,29 +108,28 @@ namespace Ryujinx.Ui
 
         public void TimingIdle()
         {
-            idleTimer = new System.Timers.Timer();
-            idleTimer.Interval = 8000;
-            idleTimer.Elapsed += OnTimedEvent;
-            idleTimer.AutoReset = false;
-            idleTimer.Enabled = true;
+            _idleTimer = new System.Timers.Timer();
+            _idleTimer.Interval = 8000;
+            _idleTimer.Elapsed += OnTimedEvent;
+            _idleTimer.AutoReset = false;
+            _idleTimer.Enabled = true;
         }
 
         private void ResetPtr()
         {
            if (ConfigurationState.Instance.HideCursorOnIdle)
            {
-               idleTimer.Stop();
-               idleTimer.Start();
+               _idleTimer.Stop();
+               _idleTimer.Start();
            }
            else
            {
-               idleTimer.Stop();
+               _idleTimer.Stop();
            }
 
            if (_cursorHidden)
            {
                _cursorHidden = false;
-               Window.Cursor.Dispose();
                Window.Cursor = null;
            }
         }
@@ -346,7 +347,7 @@ namespace Ryujinx.Ui
         {
            if (ConfigurationState.Instance.HideCursorOnIdle)
            {
-               Gtk.Application.Invoke(delegate { Window.Cursor = new Gdk.Cursor(Gdk.CursorType.BlankCursor); });
+               Gtk.Application.Invoke(delegate { Window.Cursor = _invisibleCursor; });
                _cursorHidden = true;
            }
         }

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -330,7 +330,7 @@ namespace Ryujinx.Ui
         {
            TimeSpan elapsedTime = DateTime.Now.Subtract(_lastCursorMoveTime);
 
-           if (ConfigurationState.Instance.HideCursorOnIdle && elapsedTime.TotalSeconds > 8)
+           if (elapsedTime.TotalSeconds > 8)
            {
                Gtk.Application.Invoke(delegate { Window.Cursor = _invisibleCursor; });
            }
@@ -514,7 +514,10 @@ namespace Ryujinx.Ui
 
             MotionDevice motionDevice = new MotionDevice(_dsuClient);
 
-            HideCursorIdle();
+            if (ConfigurationState.Instance.HideCursorOnIdle)
+            {
+                HideCursorIdle();
+            }
 
             foreach (InputConfig inputConfig in ConfigurationState.Instance.Hid.InputConfig.Value)
             {

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -64,7 +64,7 @@ namespace Ryujinx.Ui
 
         private readonly ManualResetEvent _exitEvent;
 
-        private static System.Timers.Timer _idleTimer = new System.Timers.Timer();
+        private System.Timers.Timer _idleCursorTimer = new System.Timers.Timer();
         
         private Gdk.Cursor _invisibleCursor = new Gdk.Cursor (Gdk.Display.Default, Gdk.CursorType.BlankCursor);
 
@@ -108,23 +108,22 @@ namespace Ryujinx.Ui
 
         public void TimingIdle()
         {
-            _idleTimer = new System.Timers.Timer();
-            _idleTimer.Interval = 8000;
-            _idleTimer.Elapsed += OnTimedEvent;
-            _idleTimer.AutoReset = false;
-            _idleTimer.Enabled = true;
+            _idleCursorTimer.Interval = 8000;
+            _idleCursorTimer.Elapsed += OnTimedEvent;
+            _idleCursorTimer.AutoReset = false;
+            _idleCursorTimer.Enabled = true;
         }
 
-        private void ResetPtr()
+        private void ResetCursor()
         {
            if (ConfigurationState.Instance.HideCursorOnIdle)
            {
-               _idleTimer.Stop();
-               _idleTimer.Start();
+               _idleCursorTimer.Stop();
+               _idleCursorTimer.Start();
            }
            else
            {
-               _idleTimer.Stop();
+               _idleCursorTimer.Stop();
            }
 
            if (_cursorHidden)
@@ -339,7 +338,7 @@ namespace Ryujinx.Ui
                 _mouseY = evnt.Y;
             }
 
-            ResetPtr();
+            ResetCursor();
             return false;
         }
 

--- a/Ryujinx/Ui/Windows/SettingsWindow.cs
+++ b/Ryujinx/Ui/Windows/SettingsWindow.cs
@@ -43,6 +43,7 @@ namespace Ryujinx.Ui.Windows
         [GUI] CheckButton     _discordToggle;
         [GUI] CheckButton     _checkUpdatesToggle;
         [GUI] CheckButton     _showConfirmExitToggle;
+        [GUI] CheckButton     _hideCursorOnIdleToggle;
         [GUI] CheckButton     _vSyncToggle;
         [GUI] CheckButton     _shaderCacheToggle;
         [GUI] CheckButton     _ptcToggle;
@@ -184,6 +185,12 @@ namespace Ryujinx.Ui.Windows
             {
                 _showConfirmExitToggle.Click();
             }
+
+            if (ConfigurationState.Instance.HideCursorOnIdle)
+            {
+                _hideCursorOnIdleToggle.Click();
+            }
+
 
             if (ConfigurationState.Instance.Graphics.EnableVsync)
             {
@@ -403,6 +410,7 @@ namespace Ryujinx.Ui.Windows
             ConfigurationState.Instance.EnableDiscordIntegration.Value         = _discordToggle.Active;
             ConfigurationState.Instance.CheckUpdatesOnStart.Value              = _checkUpdatesToggle.Active;
             ConfigurationState.Instance.ShowConfirmExit.Value                  = _showConfirmExitToggle.Active;
+            ConfigurationState.Instance.HideCursorOnIdle.Value                 = _hideCursorOnIdleToggle.Active;
             ConfigurationState.Instance.Graphics.EnableVsync.Value             = _vSyncToggle.Active;
             ConfigurationState.Instance.Graphics.EnableShaderCache.Value       = _shaderCacheToggle.Active;
             ConfigurationState.Instance.System.EnablePtc.Value                 = _ptcToggle.Active;

--- a/Ryujinx/Ui/Windows/SettingsWindow.cs
+++ b/Ryujinx/Ui/Windows/SettingsWindow.cs
@@ -191,7 +191,6 @@ namespace Ryujinx.Ui.Windows
                 _hideCursorOnIdleToggle.Click();
             }
 
-
             if (ConfigurationState.Instance.Graphics.EnableVsync)
             {
                 _vSyncToggle.Click();

--- a/Ryujinx/Ui/Windows/SettingsWindow.glade
+++ b/Ryujinx/Ui/Windows/SettingsWindow.glade
@@ -150,7 +150,23 @@
                                     <property name="expand">False</property>
                                     <property name="fill">True</property>
                                     <property name="padding">5</property>
-                                    <property name="position">1</property>
+                                    <property name="position">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="_hideCursorOnIdleToggle">
+                                    <property name="label" translatable="yes">Hide Cursor On Idle</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">5</property>
+                                    <property name="position">3</property>
                                   </packing>
                                 </child>
                               </object>

--- a/Ryujinx/_schema.json
+++ b/Ryujinx/_schema.json
@@ -1215,7 +1215,7 @@
       "type": "boolean",
       "title": "Hide Cursor On Idle",
       "description": "Hides the cursor after being idle for 5 seconds",
-      "default": true,
+      "default": false,
       "examples": [
         true,
         false

--- a/Ryujinx/_schema.json
+++ b/Ryujinx/_schema.json
@@ -1210,6 +1210,17 @@
         false
       ]
     },
+        "hide_cursor_on_idle": {
+      "$id": "#/properties/hide_cursor_on_idle",
+      "type": "boolean",
+      "title": "Hide Cursor On Idle",
+      "description": "Hides the cursor after being idle for 5 seconds",
+      "default": true,
+      "examples": [
+        true,
+        false
+      ]
+    },
     "enable_vsync": {
       "$id": "#/properties/enable_vsync",
       "type": "boolean",

--- a/Ryujinx/_schema.json
+++ b/Ryujinx/_schema.json
@@ -1210,7 +1210,7 @@
         false
       ]
     },
-        "hide_cursor_on_idle": {
+      "hide_cursor_on_idle": {
       "$id": "#/properties/hide_cursor_on_idle",
       "type": "boolean",
       "title": "Hide Cursor On Idle",


### PR DESCRIPTION
Closes #1508 

This adds an option on General Settings,  on by default, that when enabled the mouse cursor will automatically hide if it's idle on the game space (windowed or full screen) for more than 8 seconds and recover it once it's moved again.

Before:
![image](https://user-images.githubusercontent.com/67879877/106794788-f8fb1f00-6661-11eb-8b7d-d503a4e06c02.png)

After:
![image](https://user-images.githubusercontent.com/67879877/106794857-0b755880-6662-11eb-823d-85b2c86a862b.png)

Note: Show "Confirm Exit" Dialog is moved on the second screenshot because it should have had position 2 on the SettingsWindow.glade file but it had 1 instead (which belongs to Check for Updates on Launch)

The way this works is pretty simple:

- A timer runs for 8 seconds (8000 msec)
- When it ticks an event fires and the cursor is changed to Gdk's BlankCursor
- Every time the mouse is moved the event that checks that fires, the timer is reset and the cursor gets unset

P.S. The first iteration of the code set the cursor used 
`Window.Cursor = new Gdk.Cursor(Gdk.Display.Default, Gdk.CursorType.BlankCursor);`
to hide the cursor and while this worked on Linux it didn't on Windows. The correct way was to set
`Gtk.Application.Invoke(delegate { Window.Cursor = new Gdk.Cursor(Gdk.Display.Default, Gdk.CursorType.BlankCursor); });`