### PR TITLE
Fix "Failed to make context current" error

### DIFF
--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -190,6 +190,8 @@ namespace Ryujinx.Ui
             GraphicsContext.MakeCurrent(null);
 
             WaitEvent.Set();
+            
+            Thread.Sleep(1);
         }
 
         protected override bool OnConfigureEvent(EventConfigure evnt)


### PR DESCRIPTION
Fixes the `Unhandled exception. OpenTK.Graphics.GraphicsContextException: Failed to make context current.` crash. Perhaps a Linux specific error.

Full error:
`00:00:03.735 |E| GUI.RenderLoop Application : Unhandled exception caught: OpenTK.Graphics.GraphicsContextException: Failed to make context current.
   at OpenTK.Platform.X11.X11GLContext.MakeCurrent(IWindowInfo window)
   at Ryujinx.Ui.GlRenderer.Render() in C:\projects\ryujinx\Ryujinx\Ui\GLRenderer.cs:line 375
   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.ThreadHelper.ThreadStart()
Unhandled exception. OpenTK.Graphics.GraphicsContextException: Failed to make context current.
   at OpenTK.Platform.X11.X11GLContext.MakeCurrent(IWindowInfo window)
   at Ryujinx.Ui.GlRenderer.Render() in C:\projects\ryujinx\Ryujinx\Ui\GLRenderer.cs:line 375
   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.ThreadHelper.ThreadStart()
`