### PR TITLE
Simplify handling of shader vertex A

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/Cache/CacheHelper.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/Cache/CacheHelper.cs
@@ -280,7 +280,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache
                     }
                 }
 
-                // Transformation feedback
+                // Transform feedback
                 if (tfd != null)
                 {
                     foreach (TransformFeedbackDescriptor transform in tfd)
@@ -311,7 +311,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache
         /// <param name="data">The raw guest transform feedback descriptors</param>
         /// <param name="header">The guest shader program header</param>
         /// <returns>The transform feedback descriptors read from guest</returns>
-        public static TransformFeedbackDescriptor[] ReadTransformationFeedbackInformations(ref ReadOnlySpan<byte> data, GuestShaderCacheHeader header)
+        public static TransformFeedbackDescriptor[] ReadTransformFeedbackInformation(ref ReadOnlySpan<byte> data, GuestShaderCacheHeader header)
         {
             if (header.TransformFeedbackCount != 0)
             {

--- a/Ryujinx.Graphics.Gpu/Shader/Cache/CacheMigration.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/Cache/CacheMigration.cs
@@ -103,7 +103,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache
 
                         ReadOnlySpan<GuestShaderCacheEntry> cachedShaderEntries = GuestShaderCacheEntry.Parse(ref guestProgramReadOnlySpan, out GuestShaderCacheHeader fileHeader);
 
-                        TransformFeedbackDescriptor[] tfd = CacheHelper.ReadTransformationFeedbackInformations(ref guestProgramReadOnlySpan, fileHeader);
+                        TransformFeedbackDescriptor[] tfd = CacheHelper.ReadTransformFeedbackInformation(ref guestProgramReadOnlySpan, fileHeader);
 
                         Hash128 newHash = CacheHelper.ComputeGuestHashFromCache(cachedShaderEntries, tfd);
 

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -128,7 +128,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
                         // Reconstruct code holder.
                         if (isHostProgramValid)
                         {
-                            program = new ShaderProgram(entry.Header.Stage, "", entry.Header.Size, entry.Header.SizeA);
+                            program = new ShaderProgram(entry.Header.Stage, "");
                             shaderProgramInfo = hostShaderEntries[0].ToShaderProgramInfo();
                         }
                         else
@@ -217,14 +217,17 @@ namespace Ryujinx.Graphics.Gpu.Shader
 
                                 if (isHostProgramValid)
                                 {
-                                    program = new ShaderProgram(entry.Header.Stage, "", entry.Header.Size, entry.Header.SizeA);
+                                    program = new ShaderProgram(entry.Header.Stage, "");
                                     shaderProgramInfo = hostShaderEntries[i].ToShaderProgramInfo();
                                 }
                                 else
                                 {
                                     IGpuAccessor gpuAccessor = new CachedGpuAccessor(_context, entry.Code, entry.Header.GpuAccessorHeader, entry.TextureDescriptors);
 
-                                    program = Translator.CreateContext((ulong)entry.Header.Size, 0, gpuAccessor, flags, counts).Translate(out shaderProgramInfo);
+                                    TranslatorContext translatorContext = Translator.CreateContext(0, gpuAccessor, flags, counts);
+                                    TranslatorContext translatorContext2 = Translator.CreateContext((ulong)entry.Header.Size, gpuAccessor, flags | TranslationFlags.VertexA, counts);
+
+                                    program = translatorContext.Translate(out shaderProgramInfo, translatorContext2);
                                 }
 
                                 // NOTE: Vertex B comes first in the shader cache.
@@ -239,7 +242,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
 
                                 if (isHostProgramValid)
                                 {
-                                    program = new ShaderProgram(entry.Header.Stage, "", entry.Header.Size, entry.Header.SizeA);
+                                    program = new ShaderProgram(entry.Header.Stage, "");
                                     shaderProgramInfo = hostShaderEntries[i].ToShaderProgramInfo();
                                 }
                                 else
@@ -446,7 +449,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 }
             }
 
-            TranslatorContext[] shaderContexts = new TranslatorContext[Constants.ShaderStages];
+            TranslatorContext[] shaderContexts = new TranslatorContext[Constants.ShaderStages + 1];
 
             TransformFeedbackDescriptor[] tfd = GetTransformFeedbackDescriptors(state);
 
@@ -461,17 +464,14 @@ namespace Ryujinx.Graphics.Gpu.Shader
 
             if (addresses.VertexA != 0)
             {
-                shaderContexts[0] = DecodeGraphicsShader(state, counts, flags, ShaderStage.Vertex, addresses.Vertex, addresses.VertexA);
-            }
-            else
-            {
-                shaderContexts[0] = DecodeGraphicsShader(state, counts, flags, ShaderStage.Vertex, addresses.Vertex);
+                shaderContexts[0] = DecodeGraphicsShader(state, counts, flags | TranslationFlags.VertexA, ShaderStage.Vertex, addresses.VertexA);
             }
 
-            shaderContexts[1] = DecodeGraphicsShader(state, counts, flags, ShaderStage.TessellationControl, addresses.TessControl);
-            shaderContexts[2] = DecodeGraphicsShader(state, counts, flags, ShaderStage.TessellationEvaluation, addresses.TessEvaluation);
-            shaderContexts[3] = DecodeGraphicsShader(state, counts, flags, ShaderStage.Geometry, addresses.Geometry);
-            shaderContexts[4] = DecodeGraphicsShader(state, counts, flags, ShaderStage.Fragment, addresses.Fragment);
+            shaderContexts[1] = DecodeGraphicsShader(state, counts, flags, ShaderStage.Vertex, addresses.Vertex);
+            shaderContexts[2] = DecodeGraphicsShader(state, counts, flags, ShaderStage.TessellationControl, addresses.TessControl);
+            shaderContexts[3] = DecodeGraphicsShader(state, counts, flags, ShaderStage.TessellationEvaluation, addresses.TessEvaluation);
+            shaderContexts[4] = DecodeGraphicsShader(state, counts, flags, ShaderStage.Geometry, addresses.Geometry);
+            shaderContexts[5] = DecodeGraphicsShader(state, counts, flags, ShaderStage.Fragment, addresses.Fragment);
 
             bool isShaderCacheEnabled = _cacheManager != null;
             bool isShaderCacheReadOnly = false;
@@ -501,11 +501,11 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 // The shader isn't currently cached, translate it and compile it.
                 ShaderCodeHolder[] shaders = new ShaderCodeHolder[Constants.ShaderStages];
 
-                shaders[0] = TranslateShader(shaderContexts[0]);
-                shaders[1] = TranslateShader(shaderContexts[1]);
-                shaders[2] = TranslateShader(shaderContexts[2]);
-                shaders[3] = TranslateShader(shaderContexts[3]);
-                shaders[4] = TranslateShader(shaderContexts[4]);
+                shaders[0] = TranslateShader(shaderContexts[1], shaderContexts[0]);
+                shaders[1] = TranslateShader(shaderContexts[2]);
+                shaders[2] = TranslateShader(shaderContexts[3]);
+                shaders[3] = TranslateShader(shaderContexts[4]);
+                shaders[4] = TranslateShader(shaderContexts[5]);
 
                 List<IShader> hostShaders = new List<IShader>();
 
@@ -696,15 +696,13 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <param name="flags">Flags that controls shader translation</param>
         /// <param name="stage">Shader stage</param>
         /// <param name="gpuVa">GPU virtual address of the shader code</param>
-        /// <param name="gpuVaA">Optional GPU virtual address of the "Vertex A" shader code</param>
         /// <returns>The generated translator context</returns>
         private TranslatorContext DecodeGraphicsShader(
             GpuState state,
             TranslationCounts counts,
             TranslationFlags flags,
             ShaderStage stage,
-            ulong gpuVa,
-            ulong gpuVaA = 0)
+            ulong gpuVa)
         {
             if (gpuVa == 0)
             {
@@ -713,37 +711,31 @@ namespace Ryujinx.Graphics.Gpu.Shader
 
             GpuAccessor gpuAccessor = new GpuAccessor(_context, state, (int)stage - 1);
 
-            if (gpuVaA != 0)
-            {
-                return Translator.CreateContext(gpuVaA, gpuVa, gpuAccessor, flags, counts);
-            }
-            else
-            {
-                return Translator.CreateContext(gpuVa, gpuAccessor, flags, counts);
-            }
+            return Translator.CreateContext(gpuVa, gpuAccessor, flags, counts);
         }
 
         /// <summary>
         /// Translates a previously generated translator context to something that the host API accepts.
         /// </summary>
         /// <param name="translatorContext">Current translator context to translate</param>
+        /// <param name="translatorContext2">Optional translator context of the shader that should be combined</param>
         /// <returns>Compiled graphics shader code</returns>
-        private ShaderCodeHolder TranslateShader(TranslatorContext translatorContext)
+        private ShaderCodeHolder TranslateShader(TranslatorContext translatorContext, TranslatorContext translatorContext2 = null)
         {
             if (translatorContext == null)
             {
                 return null;
             }
 
-            if (translatorContext.AddressA != 0)
+            if (translatorContext2 != null)
             {
-                byte[] codeA = _context.MemoryManager.GetSpan(translatorContext.AddressA, translatorContext.SizeA).ToArray();
+                byte[] codeA = _context.MemoryManager.GetSpan(translatorContext2.Address, translatorContext2.Size).ToArray();
                 byte[] codeB = _context.MemoryManager.GetSpan(translatorContext.Address, translatorContext.Size).ToArray();
 
                 _dumper.Dump(codeA, compute: false, out string fullPathA, out string codePathA);
                 _dumper.Dump(codeB, compute: false, out string fullPathB, out string codePathB);
 
-                ShaderProgram program = translatorContext.Translate(out ShaderProgramInfo shaderProgramInfo);
+                ShaderProgram program = translatorContext.Translate(out ShaderProgramInfo shaderProgramInfo, translatorContext2);
 
                 if (fullPathA != null && fullPathB != null && codePathA != null && codePathB != null)
                 {

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -176,7 +176,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
                         ShaderCodeHolder[] shaders = new ShaderCodeHolder[cachedShaderEntries.Length];
                         List<ShaderProgram> shaderPrograms = new List<ShaderProgram>();
 
-                        TransformFeedbackDescriptor[] tfd = CacheHelper.ReadTransformationFeedbackInformations(ref guestProgramReadOnlySpan, fileHeader);
+                        TransformFeedbackDescriptor[] tfd = CacheHelper.ReadTransformFeedbackInformation(ref guestProgramReadOnlySpan, fileHeader);
 
                         TranslationFlags flags = DefaultFlags;
 

--- a/Ryujinx.Graphics.Shader/ShaderProgram.cs
+++ b/Ryujinx.Graphics.Shader/ShaderProgram.cs
@@ -8,15 +8,10 @@ namespace Ryujinx.Graphics.Shader
 
         public string Code { get; private set; }
 
-        public int SizeA { get; }
-        public int Size { get; }
-
-        public ShaderProgram(ShaderStage stage, string code, int size, int sizeA)
+        public ShaderProgram(ShaderStage stage, string code)
         {
             Stage = stage;
             Code  = code;
-            SizeA = sizeA;
-            Size  = size;
         }
 
         public void Prepend(string line)

--- a/Ryujinx.Graphics.Shader/Translation/Translator.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Translator.cs
@@ -36,22 +36,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             return new TranslatorContext(address, cfg, config);
         }
 
-        public static TranslatorContext CreateContext(
-            ulong addressA,
-            ulong addressB,
-            IGpuAccessor gpuAccessor,
-            TranslationFlags flags,
-            TranslationCounts counts = null)
-        {
-            counts ??= new TranslationCounts();
-
-            Block[][] cfgA = DecodeShader(addressA, gpuAccessor, flags | TranslationFlags.VertexA, counts, out ShaderConfig configA);
-            Block[][] cfgB = DecodeShader(addressB, gpuAccessor, flags, counts, out ShaderConfig configB);
-
-            return new TranslatorContext(addressA, addressB, cfgA, cfgB, configA, configB);
-        }
-
-        internal static ShaderProgram Translate(FunctionCode[] functions, ShaderConfig config, out ShaderProgramInfo shaderProgramInfo, int sizeA = 0)
+        internal static ShaderProgram Translate(FunctionCode[] functions, ShaderConfig config, out ShaderProgramInfo shaderProgramInfo)
         {
             var cfgs = new ControlFlowGraph[functions.Length];
             var frus = new RegisterUsage.FunctionRegisterUsage[functions.Length];
@@ -113,7 +98,7 @@ namespace Ryujinx.Graphics.Shader.Translation
 
             string glslCode = program.Code;
 
-            return new ShaderProgram(config.Stage, glslCode, config.Size, sizeA);
+            return new ShaderProgram(config.Stage, glslCode);
         }
 
         private static Block[][] DecodeShader(

--- a/Ryujinx.Graphics.Shader/Translation/TranslatorContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/TranslatorContext.cs
@@ -10,16 +10,12 @@ namespace Ryujinx.Graphics.Shader.Translation
     public class TranslatorContext
     {
         private readonly Block[][] _cfg;
-        private readonly Block[][] _cfgA;
         private ShaderConfig _config;
-        private ShaderConfig _configA;
 
         public ulong Address { get; }
-        public ulong AddressA { get; }
 
         public ShaderStage Stage => _config.Stage;
         public int Size => _config.Size;
-        public int SizeA => _configA != null ? _configA.Size : 0;
 
         public HashSet<int> TextureHandlesForCache => _config.TextureHandlesForCache;
 
@@ -27,22 +23,9 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         internal TranslatorContext(ulong address, Block[][] cfg, ShaderConfig config)
         {
-            Address    = address;
-            AddressA   = 0;
-            _config    = config;
-            _configA   = null;
-            _cfg       = cfg;
-            _cfgA      = null;
-        }
-
-        internal TranslatorContext(ulong addressA, ulong addressB, Block[][] cfgA, Block[][] cfgB, ShaderConfig configA, ShaderConfig configB)
-        {
-            Address  = addressB;
-            AddressA = addressA;
-            _config  = configB;
-            _configA = configA;
-            _cfg     = cfgB;
-            _cfgA    = cfgA;
+            Address = address;
+            _config = config;
+            _cfg    = cfg;
         }
 
         private static bool IsUserAttribute(Operand operand)
@@ -141,20 +124,18 @@ namespace Ryujinx.Graphics.Shader.Translation
             return output;
         }
 
-        public ShaderProgram Translate(out ShaderProgramInfo shaderProgramInfo)
+        public ShaderProgram Translate(out ShaderProgramInfo shaderProgramInfo, TranslatorContext other = null)
         {
             FunctionCode[] code = EmitShader(_cfg, _config);
 
-            if (_configA != null)
+            if (other != null)
             {
-                FunctionCode[] codeA = EmitShader(_cfgA, _configA);
+                _config.SetUsedFeature(other._config.UsedFeatures);
 
-                _config.SetUsedFeature(_configA.UsedFeatures);
-
-                code = Combine(codeA, code);
+                code = Combine(EmitShader(other._cfg, other._config), code);
             }
 
-            return Translator.Translate(code, _config, out shaderProgramInfo, SizeA);
+            return Translator.Translate(code, _config, out shaderProgramInfo);
         }
     }
 }

--- a/Ryujinx.Graphics.Shader/Translation/TranslatorContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/TranslatorContext.cs
@@ -131,6 +131,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             if (other != null)
             {
                 _config.SetUsedFeature(other._config.UsedFeatures);
+                TextureHandlesForCache.UnionWith(other.TextureHandlesForCache);
 
                 code = Combine(EmitShader(other._cfg, other._config), code);
             }


### PR DESCRIPTION
This is just some refactoring that simplifies how the "Vertex A" shaders (that needs to be combined with "Vertex B" shaders) are handled. The shader translator no longer has an additional overload to create a translator context for "Vertex A". Instead, the caller will call `CreateContext` twice, once for "Vertex B" and then for "Vertex A", and pass "Vertex A" as argument to the `Translate` method, allowing the two to be combined.

Also renamed some instances of "transformation feedback" to "transform feedback", since thats how it is called everywhere else.

Should not change behavior.