### PR TITLE
Texture Cache: "Texture Groups" and "Texture Dependencies"

### DIFF
--- a/Ryujinx.Cpu/Tracking/CpuRegionHandle.cs
+++ b/Ryujinx.Cpu/Tracking/CpuRegionHandle.cs
@@ -1,4 +1,5 @@
 ﻿using Ryujinx.Memory.Tracking;
+using System;
 
 namespace Ryujinx.Cpu.Tracking
 {
@@ -18,6 +19,9 @@ namespace Ryujinx.Cpu.Tracking
 
         public void Dispose() => _impl.Dispose();
         public void RegisterAction(RegionSignal action) => _impl.RegisterAction(action);
-        public void Reprotect() => _impl.Reprotect();
+        public void RegisterDirtyEvent(Action action) => _impl.RegisterDirtyEvent(action);
+        public void Reprotect(bool asDirty = false) => _impl.Reprotect(asDirty);
+
+        public bool OverlapsWith(ulong address, ulong size) => _impl.OverlapsWith(address, size);
     }
 }

--- a/Ryujinx.Graphics.GAL/ITexture.cs
+++ b/Ryujinx.Graphics.GAL/ITexture.cs
@@ -9,6 +9,7 @@ namespace Ryujinx.Graphics.GAL
         float ScaleFactor { get; }
 
         void CopyTo(ITexture destination, int firstLayer, int firstLevel);
+        void CopyTo(ITexture destination, int srcLayer, int dstLayer, int srcLevel, int dstLevel);
         void CopyTo(ITexture destination, Extents2D srcRegion, Extents2D dstRegion, bool linearFilter);
 
         ITexture CreateView(TextureCreateInfo info, int firstLayer, int firstLevel);

--- a/Ryujinx.Graphics.GAL/ITexture.cs
+++ b/Ryujinx.Graphics.GAL/ITexture.cs
@@ -16,6 +16,7 @@ namespace Ryujinx.Graphics.GAL
         byte[] GetData();
 
         void SetData(ReadOnlySpan<byte> data);
+        void SetData(ReadOnlySpan<byte> data, int layer, int level);
         void SetStorage(BufferRange buffer);
         void Release();
     }

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -377,11 +377,6 @@ namespace Ryujinx.Graphics.Gpu.Engine
                 Texture color = TextureManager.FindOrCreateTexture(colorState, samplesInX, samplesInY, sizeHint);
 
                 changedScale |= TextureManager.SetRenderTargetColor(index, color);
-
-                if (color != null)
-                {
-                    color.SignalModified();
-                }
             }
 
             bool dsEnable = state.Get<Boolean32>(MethodOffset.RtDepthStencilEnable);
@@ -405,11 +400,6 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
                 UpdateViewportTransform(state);
                 UpdateScissorState(state);
-            }
-
-            if (depthStencil != null)
-            {
-                depthStencil.SignalModified();
             }
         }
 

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -215,13 +215,13 @@ namespace Ryujinx.Graphics.Gpu.Image
             }
             else
             {
-                // Don't update this texture the next time we synchronize.
-                ConsumeModified();
-
                 _hasData = true;
 
                 if (!isView)
                 {
+                    // Don't update this texture the next time we synchronize.
+                    ConsumeModified();
+
                     if (ScaleMode == TextureScaleMode.Scaled)
                     {
                         // Don't need to start at 1x as there is no data to scale, just go straight to the target scale.
@@ -567,13 +567,10 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Checks if the memory for this texture was modified, and returns true if it was.
         /// The modified flags are consumed as a result.
         /// </summary>
-        /// <remarks>
-        /// If there is no memory tracking for this texture, it will always report as modified.
-        /// </remarks>
         /// <returns>True if the texture was modified, false otherwise.</returns>
         public bool ConsumeModified()
         {
-            return Group?.ConsumeDirty(this) != false;
+            return Group.ConsumeDirty(this);
         }
 
         /// <summary>
@@ -599,10 +596,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             if (_hasData)
             {
-                if (Group != null)
-                {
-                    Group.SynchronizeMemory(this);
-                }
+                Group.SynchronizeMemory(this);
             }
             else
             {

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -336,7 +336,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 return;
             }
 
-            Group.CreateCopyDependency(contained, layer, level, copyTo);
+            Group.CreateCopyDependency(contained, FirstLayer + layer, FirstLevel + level, copyTo);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -236,6 +236,27 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Checks if the potential child texture fits within the level and layer bounds of the parent.
+        /// </summary>
+        /// <param name="parent">Texture information for the parent</param>
+        /// <param name="child">Texture information for the child</param>
+        /// <param name="layer">Base layer of the child texture</param>
+        /// <param name="level">Base level of the child texture</param>
+        /// <returns></returns>
+        public static TextureViewCompatibility ViewSubImagesInBounds(TextureInfo parent, TextureInfo child, int layer, int level)
+        {
+            if (level + child.Levels <= parent.Levels &&
+                layer + child.GetSlices() <= parent.GetSlices())
+            {
+                return TextureViewCompatibility.Full;
+            }
+            else
+            {
+                return TextureViewCompatibility.Incompatible;
+            }
+        }
+
+        /// <summary>
         /// Checks if the texture sizes of the supplied texture informations match.
         /// </summary>
         /// <param name="lhs">Texture information to compare</param>
@@ -382,10 +403,22 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         /// <param name="lhs">Texture information of the texture view</param>
         /// <param name="rhs">Texture information of the texture view</param>
-        /// <returns>True if the formats are compatible, false otherwise</returns>
-        public static bool ViewFormatCompatible(TextureInfo lhs, TextureInfo rhs)
+        /// <returns>How view compatible the formats are</returns>
+        public static TextureViewCompatibility ViewFormatCompatible(TextureInfo lhs, TextureInfo rhs)
         {
-            return FormatCompatible(lhs.FormatInfo, rhs.FormatInfo);
+            if (FormatCompatible(lhs.FormatInfo, rhs.FormatInfo))
+            {
+                if (lhs.FormatInfo.IsCompressed != rhs.FormatInfo.IsCompressed)
+                {
+                    return TextureViewCompatibility.CopyOnly;
+                }
+                else
+                {
+                    return TextureViewCompatibility.Full;
+                }
+            }
+
+            return TextureViewCompatibility.Incompatible;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -215,7 +215,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="lhs">Texture information of the texture view</param>
         /// <param name="rhs">Texture information of the texture view to match against</param>
         /// <param name="level">Mipmap level of the texture view in relation to this texture</param>
-        /// <returns>True if the sizes are compatible, false otherwise</returns>
+        /// <returns>The view compatibility level of the view sizes</returns>
         public static TextureViewCompatibility ViewSizeMatches(TextureInfo lhs, TextureInfo rhs, int level)
         {
             Size size = GetAlignedSize(lhs, level);
@@ -242,7 +242,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="child">Texture information for the child</param>
         /// <param name="layer">Base layer of the child texture</param>
         /// <param name="level">Base level of the child texture</param>
-        /// <returns></returns>
+        /// <returns>Full compatiblity if the child's layer and level count fit within the parent, incompatibile otherwise</returns>
         public static TextureViewCompatibility ViewSubImagesInBounds(TextureInfo parent, TextureInfo child, int layer, int level)
         {
             if (level + child.Levels <= parent.Levels &&
@@ -403,7 +403,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         /// <param name="lhs">Texture information of the texture view</param>
         /// <param name="rhs">Texture information of the texture view</param>
-        /// <returns>How view compatible the formats are</returns>
+        /// <returns>The view compatibility level of the texture formats</returns>
         public static TextureViewCompatibility ViewFormatCompatible(TextureInfo lhs, TextureInfo rhs)
         {
             if (FormatCompatible(lhs.FormatInfo, rhs.FormatInfo))

--- a/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -242,7 +242,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="child">Texture information for the child</param>
         /// <param name="layer">Base layer of the child texture</param>
         /// <param name="level">Base level of the child texture</param>
-        /// <returns>Full compatiblity if the child's layer and level count fit within the parent, incompatibile otherwise</returns>
+        /// <returns>Full compatiblity if the child's layer and level count fit within the parent, incompatible otherwise</returns>
         public static TextureViewCompatibility ViewSubImagesInBounds(TextureInfo parent, TextureInfo child, int layer, int level)
         {
             if (level + child.Levels <= parent.Levels &&

--- a/Ryujinx.Graphics.Gpu/Image/TextureDependency.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureDependency.cs
@@ -1,0 +1,24 @@
+﻿namespace Ryujinx.Graphics.Gpu.Image
+{
+    /// <summary>
+    /// One side of a two-way dependency between one texture view and another.
+    /// Contains a reference to the handle owning the dependency, and the other dependency.
+    /// </summary>
+    class TextureDependency
+    {
+        public TextureGroupHandle Handle;
+        public TextureDependency Other;
+        public bool Dirty;
+
+        public TextureDependency(TextureGroupHandle handle)
+        {
+            Handle = handle;
+        }
+
+        public void SignalModified()
+        {
+            Other.Dirty = true;
+            Other.Handle.DeferCopy(Handle);
+        }
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Image/TextureDependency.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureDependency.cs
@@ -6,14 +6,28 @@
     /// </summary>
     class TextureDependency
     {
+        /// <summary>
+        /// The handle that owns this dependency.
+        /// </summary>
         public TextureGroupHandle Handle;
+        /// <summary>
+        /// The other dependency linked to this one, which belongs to another handle.
+        /// </summary>
         public TextureDependency Other;
 
+        /// <summary>
+        /// Create a new texture dependency.
+        /// </summary>
+        /// <param name="handle">The handle that owns the dependency</param>
         public TextureDependency(TextureGroupHandle handle)
         {
             Handle = handle;
         }
 
+        /// <summary>
+        /// Signal that the owner of this dependency has been modified,
+        /// meaning that the other dependency's handle must defer a copy from it.
+        /// </summary>
         public void SignalModified()
         {
             Other.Handle.DeferCopy(Handle);

--- a/Ryujinx.Graphics.Gpu/Image/TextureDependency.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureDependency.cs
@@ -8,7 +8,6 @@
     {
         public TextureGroupHandle Handle;
         public TextureDependency Other;
-        public bool Dirty;
 
         public TextureDependency(TextureGroupHandle handle)
         {
@@ -17,7 +16,6 @@
 
         public void SignalModified()
         {
-            Other.Dirty = true;
             Other.Handle.DeferCopy(Handle);
         }
     }

--- a/Ryujinx.Graphics.Gpu/Image/TextureDependency.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureDependency.cs
@@ -10,6 +10,7 @@
         /// The handle that owns this dependency.
         /// </summary>
         public TextureGroupHandle Handle;
+
         /// <summary>
         /// The other dependency linked to this one, which belongs to another handle.
         /// </summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -826,7 +826,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             EnsureFullSubdivision();
             otherGroup.EnsureFullSubdivision();
 
-            // The first layer and level for the given texture are already defined in _its_ storage, though they 
+            // Get the location of each texture within its storage, so we can find the handles to apply the dependency to.
 
             int targetIndex = GetOffsetIndex(firstLayer, firstLevel);
             int otherIndex = GetOffsetIndex(other.FirstLayer, other.FirstLevel);
@@ -841,7 +841,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 TextureGroupHandle handle = _handles[targetIndex++];
                 TextureGroupHandle otherHandle = other.Group._handles[otherIndex++];
 
-                handle.CreateCopyDependency(otherHandle);
+                handle.CreateCopyDependency(otherHandle, copyTo);
 
                 // If "copyTo" is true, this texture must copy to the other.
                 // Otherwise, it must copy to this texture.
@@ -854,8 +854,6 @@ namespace Ryujinx.Graphics.Gpu.Image
                 {
                     handle.Copy(otherHandle);
                 }
-
-                if (handle.Handles[0].Dirty || otherHandle.Handles[0].Dirty) { }
             }
         }
 

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -68,6 +68,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <summary>
         /// Initialize a new texture group's dirty regions and offsets.
         /// </summary>
+        /// <param name="size">Size info for the storage texture</param>
         /// <param name="hasLayerViews">True if the storage will have layer views</param>
         /// <param name="hasMipViews">True if the storage will have mip views</param>
         public void Initialize(ref SizeInfo size, bool hasLayerViews, bool hasMipViews)
@@ -272,7 +273,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <summary>
         /// Register a read/write action to flush for a texture group.
         /// </summary>
-        /// <param name="group">The group to register an action for.</param>
+        /// <param name="group">The group to register an action for</param>
         public void RegisterAction(TextureGroupHandle group)
         {
             foreach (CpuRegionHandle handle in group.Handles)
@@ -304,6 +305,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Propagates the mip/layer view flags depending on the texture type.
         /// When the most granular type of subresource has views, the other type of subresource must be segmented granularly too.
         /// </summary>
+        /// <param name="hasLayerViews">True if the storage has layer views</param>
+        /// <param name="hasMipViews">True if the storage has mip views</param>
         /// <returns>The input values after propagation</returns>
         private (bool HasLayerViews, bool HasMipViews) PropagateGranularity(bool hasLayerViews, bool hasMipViews)
         {
@@ -573,7 +576,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         /// <param name="address">The start address of the tracked region</param>
         /// <param name="size">The size of the tracked region</param>
-        /// <returns></returns>
+        /// <returns>A CpuRegionHandle covering the given range</returns>
         private CpuRegionHandle GenerateHandle(ulong address, ulong size)
         {
             return _context.PhysicalMemory.BeginTracking(address, size);

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -1,0 +1,685 @@
+﻿using Ryujinx.Cpu.Tracking;
+using Ryujinx.Graphics.Texture;
+using Ryujinx.Memory.Range;
+using System;
+using System.Collections.Generic;
+
+namespace Ryujinx.Graphics.Gpu.Image
+{
+    /// <summary>
+    /// A tracking handle for a texture group, which represents a range of views in a storage texture.
+    /// Retains a list of overlapping texture views, a modified flag, and tracking for each
+    /// CPU VA range that the views cover.
+    /// </summary>
+    class TextureGroupHandle
+    {
+        /// <summary>
+        /// The byte offset from the start of the storage of this handle.
+        /// </summary>
+        public int Offset { get; }
+
+        /// <summary>
+        /// The size in bytes covered by this handle.
+        /// </summary>
+        public int Size { get; }
+
+        /// <summary>
+        /// The textures which this handle overlaps with.
+        /// </summary>
+        public List<Texture> Overlaps { get; }
+
+        /// <summary>
+        /// The CPU memory tracking handles that cover this handle.
+        /// </summary>
+        public CpuRegionHandle[] Handles { get; }
+
+        /// <summary>
+        /// True if a texture overlapping this handle has been modified. Is set false when the flush action is called.
+        /// </summary>
+        public bool Modified { get; set; }
+
+        /// <summary>
+        /// Create a new texture group handle, representing a range of views in a storage texture.
+        /// </summary>
+        /// <param name="group">The TextureGroup that the handle belongs to</param>
+        /// <param name="offset">The byte offset from the start of the storage of the handle</param>
+        /// <param name="size">The size in bytes covered by the handle</param>
+        /// <param name="views">All views of the storage texture, used to calculate overlaps</param>
+        /// <param name="handles">The memory tracking handles that represent cover the handle</param>
+        public TextureGroupHandle(TextureGroup group, int offset, ulong size, List<Texture> views, CpuRegionHandle[] handles)
+        {
+            Offset = offset;
+            Size = (int)size;
+            Overlaps = new List<Texture>();
+
+            if (views != null)
+            {
+                RecalculateOverlaps(group, views);
+            }
+
+            Handles = handles;
+        }
+
+        /// <summary>
+        /// Calculate a list of which views overlap this handle.
+        /// </summary>
+        /// <param name="group">The parent texture group, used to find a view's base CPU VA offset</param>
+        /// <param name="views">The list of views to search for overlaps</param>
+        public void RecalculateOverlaps(TextureGroup group, List<Texture> views)
+        {
+            // Overlaps can be accessed from the memory tracking signal handler, so access must be atomic.
+            lock (Overlaps)
+            {
+                int endOffset = Offset + Size;
+
+                Overlaps.Clear();
+
+                foreach (Texture view in views)
+                {
+                    int viewOffset = group.FindOffset(view);
+                    if (viewOffset < endOffset && Offset < viewOffset + (int)view.Size)
+                    {
+                        Overlaps.Add(view);
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// A texture group represents a group of textures that belong to the same storage.
+    /// When views are created, this class will track memory accesses for them separately.
+    /// The group iteratively adds more granular tracking as views of different kinds are added.
+    /// Note that a texture group can be absorbed into another when it becomes a view parent.
+    /// </summary>
+    class TextureGroup : IDisposable
+    {
+        /// <summary>
+        /// The storage texture associated with this group.
+        /// </summary>
+        public Texture Storage { get; }
+
+        private GpuContext _context;
+
+        private int[] _allOffsets;
+        private bool _is3D;
+        private bool _hasMipViews;
+        private bool _hasLayerViews;
+        private int _layers;
+        private int _levels;
+
+        private MultiRange _textureRange => Storage.Range;
+
+        /// <summary>
+        /// The views list from the storage texture.
+        /// </summary>
+        private List<Texture> _views;
+        private TextureGroupHandle[] _handles;
+        private bool[] _loadNeeded;
+
+        /// <summary>
+        /// Create a new texture group.
+        /// </summary>
+        /// <param name="context">GPU context that the texture group belongs to</param>
+        /// <param name="storage">The storage texture for this group</param>
+        public TextureGroup(GpuContext context, Texture storage)
+        {
+            Storage = storage;
+            _context = context;
+
+            _is3D = storage.Info.Target == GAL.Target.Texture3D;
+            _layers = storage.Info.GetSlices();
+            _levels = storage.Info.Levels;
+        }
+
+        /// <summary>
+        /// Initialize a new texture group's dirty regions and offsets.
+        /// </summary>
+        /// <param name="hasLayerViews">True if the storage will have layer views</param>
+        /// <param name="hasMipViews">True if the storage will have mip views</param>
+        public void Initialize(ref SizeInfo size, bool hasLayerViews, bool hasMipViews)
+        {
+            _allOffsets = size.AllOffsets;
+            _hasLayerViews = hasLayerViews;
+            _hasMipViews = hasMipViews;
+
+            RecalculateHandleRegions();
+        }
+
+        /// <summary>
+        /// Consume the dirty flags for a given texture. The state is shared between views of the same layers and levels.
+        /// </summary>
+        /// <param name="texture">The texture being used</param>
+        /// <returns>True if a flag was dirty, false otherwise.</returns>
+        public bool ConsumeDirty(Texture texture)
+        {
+            (int baseHandle, int regionCount) = EvaluateRelevantHandles(texture);
+
+            bool dirty = false;
+            for (int i = 0; i < regionCount; i++)
+            {
+                TextureGroupHandle group = _handles[baseHandle + i];
+
+                foreach (CpuRegionHandle handle in group.Handles)
+                {
+                    if (handle.Dirty)
+                    {
+                        handle.Reprotect();
+                        dirty |= true;
+                    }
+                }
+            }
+
+            return dirty;
+        }
+
+        /// <summary>
+        /// Synchronize memory for a given texture. 
+        /// If overlapping tracking handles are dirty, fully or partially synchronize the texture data.
+        /// </summary>
+        /// <param name="texture">The texture being used</param>
+        public void SynchronizeMemory(Texture texture)
+        {
+            (int baseHandle, int regionCount) = EvaluateRelevantHandles(texture);
+
+            // TODO: Partial reload. Right now it will reload the entire texture that was requested.
+            // We want to only reload parts of the texture that have not been modified.
+
+            bool dirty = false;
+            bool anyModified = false;
+            bool notDirty = false;
+            for (int i = 0; i < regionCount; i++)
+            {
+                TextureGroupHandle group = _handles[baseHandle + i];
+
+                bool modified = group.Modified;
+
+                bool handleDirty = false;
+
+                foreach (CpuRegionHandle handle in group.Handles)
+                {
+                    if (handle.Dirty)
+                    {
+                        handle.Reprotect();
+                        dirty |= true;
+                        handleDirty |= true;
+                    }
+                    else
+                    {
+                        anyModified |= modified;
+                        notDirty |= true;
+                    }
+                }
+
+                _loadNeeded[baseHandle + i] = handleDirty;
+            }
+
+            if (dirty)
+            {
+                if (_handles.Length > 1 && anyModified)
+                {
+                    // Partial texture invalidation. Only update the layers/levels with dirty flags of the storage.
+
+                    SynchronizePartial(baseHandle, regionCount);
+                }
+                else
+                {
+                    // Full texture invalidation.
+
+                    texture.SynchronizeFull();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Synchronize part of the storage texture, represented by a given range of handles.
+        /// Only handles marked by the _loadNeeded array will be synchronized.
+        /// </summary>
+        /// <param name="baseRegion"></param>
+        /// <param name="regionCount"></param>
+        private void SynchronizePartial(int baseRegion, int regionCount)
+        {
+            ReadOnlySpan<byte> fullData = _context.PhysicalMemory.GetSpan(Storage.Range);
+
+            for (int i = 0; i < regionCount; i++)
+            {
+                if (_loadNeeded[baseRegion + i])
+                {
+                    var info = GetHandleInformation(baseRegion + i);
+                    int offsetIndex = info.index;
+
+                    // Only one of these will be greater than 1, as partial sync is only called when there are sub-image views.
+                    for (int layer = 0; layer < info.layers; layer++)
+                    {
+                        for (int level = 0; level < info.levels; level++)
+                        {
+                            int offset = _allOffsets[offsetIndex];
+                            int endOffset = (offsetIndex + 1 == _allOffsets.Length) ? (int)Storage.Size : _allOffsets[offsetIndex + 1];
+                            int size = endOffset - offset;
+
+                            ReadOnlySpan<byte> data = fullData.Slice(offset, size);
+
+                            data = Storage.ConvertToHostCompatibleFormat(data, info.baseLevel, true);
+
+                            Storage.SetData(data, info.baseLayer, info.baseLevel);
+
+                            offsetIndex++;
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Signal that a texture in the group has been modified by the GPU.
+        /// </summary>
+        /// <param name="texture">The texture that has been modified.</param>
+        public void SignalModified(Texture texture)
+        {
+            (int baseHandle, int regionCount) = EvaluateRelevantHandles(texture);
+
+            for (int i = 0; i < regionCount; i++)
+            {
+                TextureGroupHandle group = _handles[baseHandle + i];
+
+                group.Modified = true;
+
+                foreach (CpuRegionHandle handle in group.Handles)
+                {
+                    handle.RegisterAction((address, size) => FlushAction(group, address, size));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Evaluate the range of tracking handles which a view texture overlaps with.
+        /// </summary>
+        /// <param name="texture">The texture to get handles for</param>
+        /// <returns></returns>
+        private (int baseHandle, int regionCount) EvaluateRelevantHandles(Texture texture)
+        {
+            if (texture == Storage || !(_hasMipViews || _hasLayerViews))
+            {
+                return (0, _handles.Length);
+            }
+
+            int targetLayerHandles = _hasLayerViews ? texture.Info.GetSlices() : 1;
+            int targetLevelHandles = _hasMipViews ? texture.Info.Levels : 1;
+
+            if (_is3D)
+            {
+                // Mipmaps come after all layers.
+                int layerHandles = _hasLayerViews ? _layers : 1;
+
+                return (texture.FirstLayer + (texture.FirstLevel) * layerHandles, targetLayerHandles + (targetLevelHandles - 1) * layerHandles);
+            }
+            else
+            {
+                // Layers come after all mipmaps.
+                int levelHandles = _hasMipViews ? _levels : 1;
+
+                return (texture.FirstLevel + (texture.FirstLayer) * levelHandles, targetLevelHandles + (targetLayerHandles - 1) * levelHandles);
+            }
+        }
+
+        /// <summary>
+        /// Get view information for a single tracking handle.
+        /// </summary>
+        /// <param name="handleIndex">The index of the handle</param>
+        /// <returns>The layers and levels that the handle covers, and its index in the offsets array</returns>
+        private (int baseLayer, int baseLevel, int levels, int layers, int index) GetHandleInformation(int handleIndex)
+        {
+            int baseLayer;
+            int baseLevel;
+            int levels = _hasMipViews ? 1 : _levels;
+            int layers = _hasLayerViews ? 1 : _layers;
+            int index;
+
+            if (_is3D)
+            {
+                baseLayer = _hasLayerViews ? handleIndex % _layers : 0;
+                baseLevel = _hasLayerViews ? handleIndex / _layers : handleIndex;
+                index = baseLayer + baseLevel * _layers;
+            }
+            else
+            {
+                baseLevel = _hasMipViews ? handleIndex % _levels : 0;
+                baseLayer = _hasMipViews ? handleIndex / _levels : handleIndex;
+                index = baseLevel + baseLayer * _levels;
+            }
+
+            return (baseLayer, baseLevel, levels, layers, index);
+        }
+
+        /// <summary>
+        /// Find the byte offset of a given texture relative to the storage.
+        /// </summary>
+        /// <param name="texture">The texture to locate</param>
+        /// <returns>The offset of the texture in bytes</returns>
+        public int FindOffset(Texture texture)
+        {
+            if (_is3D)
+            {
+                return _allOffsets[texture.FirstLevel + texture.FirstLayer * _levels];
+            }
+            else
+            {
+                return _allOffsets[texture.FirstLayer + texture.FirstLevel * _layers];
+            }
+        }
+
+        /// <summary>
+        /// The action to perform when a memory tracking handle is flipped to dirty.
+        /// This notifies overlapping textures that the memory needs to be synchronized.
+        /// </summary>
+        /// <param name="groupHandle">The handle that a dirty flag was set on</param>
+        private void DirtyAction(TextureGroupHandle groupHandle)
+        {
+            // Notify all textures that belong to this handle.
+
+            Storage.SignalGroupDirty();
+
+            lock (groupHandle.Overlaps)
+            {
+                foreach (Texture overlap in groupHandle.Overlaps)
+                {
+                    overlap.SignalGroupDirty();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Generate a CpuRegionHandle for a given address and size range in CPU VA.
+        /// </summary>
+        /// <param name="address">The start address of the tracked region</param>
+        /// <param name="size">The size of the tracked region</param>
+        /// <returns></returns>
+        private CpuRegionHandle GenerateHandle(ulong address, ulong size)
+        {
+            return _context.PhysicalMemory.BeginTracking(address, size);
+        }
+
+        /// <summary>
+        /// Generate a TextureGroupHandle covering a specified range of views.
+        /// </summary>
+        /// <param name="viewStart">The start view of the handle</param>
+        /// <param name="views">The number of views to cover</param>
+        /// <returns>A TextureGroupHandle covering the given views</returns>
+        private TextureGroupHandle GenerateHandles(int viewStart, int views)
+        {
+            int offset = _allOffsets[viewStart];
+            int endOffset = (viewStart + views == _allOffsets.Length) ? (int)Storage.Size : _allOffsets[viewStart + views];
+            int size = endOffset - offset;
+
+            var result = new List<CpuRegionHandle>();
+
+            for (int i = 0; i < _textureRange.Count; i++)
+            {
+                MemoryRange item = _textureRange.GetSubRange(i);
+                int subRangeSize = (int)item.Size;
+
+                int sliceStart = Math.Clamp(offset, 0, subRangeSize);
+                int sliceEnd = Math.Clamp(endOffset, 0, subRangeSize);
+
+                if (sliceStart != sliceEnd)
+                {
+                    result.Add(GenerateHandle(item.Address + (ulong)sliceStart, (ulong)(sliceEnd - sliceStart)));
+                }
+
+                offset -= subRangeSize;
+                endOffset -= subRangeSize;
+
+                if (endOffset <= 0)
+                {
+                    break;
+                }
+            }
+
+            var groupHandle = new TextureGroupHandle(this, _allOffsets[viewStart], (ulong)size, _views, result.ToArray());
+
+            foreach (CpuRegionHandle handle in result)
+            {
+                handle.RegisterDirtyEvent(() => DirtyAction(groupHandle));
+            }
+
+            return groupHandle;
+        }
+
+        /// <summary>
+        /// Update the views in this texture group, rebuilding the memory tracking if required.
+        /// </summary>
+        /// <param name="views">The views list of the storage texture</param>
+        public void UpdateViews(List<Texture> views)
+        {
+            // This is saved to calculate overlapping views for each handle.
+            _views = views;
+
+            bool layerViews = _hasLayerViews;
+            bool mipViews = _hasMipViews;
+            bool regionsRebuilt = false;
+
+            if (!(layerViews && mipViews))
+            {
+                foreach (Texture view in views)
+                {
+                    if (view.Info.GetSlices() < _layers)
+                    {
+                        layerViews = true;
+                    }
+
+                    if (view.Info.Levels < _levels)
+                    {
+                        mipViews = true;
+                    }
+                }
+
+                if (layerViews != _hasLayerViews || mipViews != _hasMipViews)
+                {
+                    _hasLayerViews = layerViews;
+                    _hasMipViews = mipViews;
+
+                    RecalculateHandleRegions();
+                    regionsRebuilt = true;
+                }
+            }
+
+            if (!regionsRebuilt)
+            {
+                foreach (TextureGroupHandle handle in _handles)
+                {
+                    handle.RecalculateOverlaps(this, views);
+                }
+            }
+
+            Storage.SignalGroupDirty();
+            foreach (Texture texture in views)
+            {
+                texture.SignalGroupDirty();
+            }
+        }
+
+        /// <summary>
+        /// Inherit handle state from an old set of handles, such as modified and dirty flags.
+        /// </summary>
+        /// <param name="oldHandles">The set of handles to inherit state from</param>
+        /// <param name="handles">The set of handles inheriting the state</param>
+        private void InheritHandles(TextureGroupHandle[] oldHandles, TextureGroupHandle[] handles)
+        {
+            foreach (var group in handles)
+            {
+                foreach (var handle in group.Handles)
+                {
+                    bool dirty = false;
+
+                    foreach (var oldGroup in oldHandles)
+                    {
+                        foreach (var oldHandle in oldGroup.Handles)
+                        {
+                            if (handle.OverlapsWith(oldHandle.Address, oldHandle.Size))
+                            {
+                                dirty |= oldHandle.Dirty;
+                                group.Modified |= oldGroup.Modified;
+                            }
+                        }
+                    }
+
+                    if (dirty && !handle.Dirty)
+                    { 
+                        handle.Reprotect(true);
+                    }
+
+                    if (group.Modified)
+                    {
+                        handle.RegisterAction((address, size) => FlushAction(group, address, size));
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Inherit state from another texture group.
+        /// </summary>
+        /// <param name="other">The texture group to inherit from</param>
+        public void Inherit(TextureGroup other)
+        {
+            InheritHandles(other._handles, _handles);
+        }
+
+        /// <summary>
+        /// Replace the current handles with the new handles. It is assumed that the new handles start dirty.
+        /// The dirty flags from the previous handles will be kept.
+        /// </summary>
+        /// <param name="handles">The handles to replace the current handles with</param>
+        private void ReplaceHandles(TextureGroupHandle[] handles)
+        {
+            if (_handles != null)
+            {
+                // When replacing handles, they should start as non-dirty.
+
+                foreach (TextureGroupHandle groupHandle in handles)
+                {
+                    foreach (CpuRegionHandle handle in groupHandle.Handles)
+                    {
+                        handle.Reprotect();
+                    }
+                }
+
+                InheritHandles(_handles, handles);
+
+                foreach (var oldGroup in _handles)
+                {
+                    foreach (var oldHandle in oldGroup.Handles)
+                    {
+                        oldHandle.Dispose();
+                    }
+                }
+            }
+
+            _handles = handles;
+            _loadNeeded = new bool[_handles.Length];
+        }
+
+        /// <summary>
+        /// Recalculate handle regions for this texture group, and inherit existing state into the new handles.
+        /// </summary>
+        private void RecalculateHandleRegions()
+        {
+            TextureGroupHandle[] handles;
+
+            if (!(_hasMipViews || _hasLayerViews))
+            {
+                // Single dirty region.
+                var cpuRegionHandles = new CpuRegionHandle[_textureRange.Count];
+
+                for (int i = 0; i < _textureRange.Count; i++)
+                {
+                    var currentRange = _textureRange.GetSubRange(i);
+                    cpuRegionHandles[i] = GenerateHandle(currentRange.Address, currentRange.Size);
+                }
+
+                var groupHandle = new TextureGroupHandle(this, 0, Storage.Size, _views, cpuRegionHandles);
+
+                foreach (CpuRegionHandle handle in cpuRegionHandles)
+                {
+                    handle.RegisterDirtyEvent(() => DirtyAction(groupHandle));
+                }
+
+                handles = new TextureGroupHandle[] { groupHandle };
+            }
+            else
+            {
+                // Get mips for the host texture.
+
+                int layerHandles = _hasLayerViews ? _layers : 1;
+                int levelHandles = _hasMipViews ? _levels : 1;
+
+                handles = new TextureGroupHandle[layerHandles * levelHandles];
+                int handleIndex = 0;
+
+                if (_is3D)
+                {
+                    for (int i = 0; i < levelHandles; i++)
+                    {
+                        for (int j = 0; j < layerHandles; j++)
+                        {
+                            int viewStart = j + i * _layers;
+                            int views = (_hasLayerViews ? 1 : _layers) * (_hasMipViews ? 1 : _levels);
+
+                            handles[handleIndex++] = GenerateHandles(viewStart, views);
+                        }
+                    }
+                } 
+                else
+                {
+                    for (int i = 0; i < layerHandles; i++)
+                    {
+                        for (int j = 0; j < levelHandles; j++)
+                        {
+                            int viewStart = j + i * _levels;
+                            int views = (_hasLayerViews ? 1 : _layers) * (_hasMipViews ? 1 : _levels);
+
+                            handles[handleIndex++] = GenerateHandles(viewStart, views);
+                        }
+                    }
+                }
+            }
+
+            ReplaceHandles(handles);
+        }
+
+        /// <summary>
+        /// A flush has been requested on a tracked region. Find an appropriate view to flush.
+        /// </summary>
+        /// <param name="handle">The handle this flush action is for</param>
+        /// <param name="address">The address of the flushing memory access</param>
+        /// <param name="address">The size of the flushing memory access</param>
+        public void FlushAction(TextureGroupHandle handle, ulong address, ulong size)
+        {
+            Storage.ExternalFlush(address, size);
+
+            lock (handle.Overlaps)
+            {
+                foreach (Texture overlap in handle.Overlaps)
+                {
+                    overlap.ExternalFlush(address, size);
+                }
+            }
+
+            handle.Modified = false;
+        }
+
+        /// <summary>
+        /// Dispose this texture group, disposing all related memory tracking handles.
+        /// </summary>
+        public void Dispose()
+        {
+            foreach (TextureGroupHandle group in _handles)
+            {
+                foreach (CpuRegionHandle handle in group.Handles)
+                {
+                    handle.Dispose();
+                }
+            }
+        }
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
@@ -1,5 +1,7 @@
 ﻿using Ryujinx.Cpu.Tracking;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Ryujinx.Graphics.Gpu.Image
 {
@@ -7,9 +9,16 @@ namespace Ryujinx.Graphics.Gpu.Image
     /// A tracking handle for a texture group, which represents a range of views in a storage texture.
     /// Retains a list of overlapping texture views, a modified flag, and tracking for each
     /// CPU VA range that the views cover.
+    /// Also tracks copy dependencies for the handle - references to other handles that must be kept 
+    /// in sync with this one before use.
     /// </summary>
-    class TextureGroupHandle
+    class TextureGroupHandle : IDisposable
     {
+        private TextureGroup _group;
+        private int _bindCount;
+        private int _firstLevel;
+        private int _firstLayer;
+
         /// <summary>
         /// The byte offset from the start of the storage of this handle.
         /// </summary>
@@ -36,18 +45,40 @@ namespace Ryujinx.Graphics.Gpu.Image
         public bool Modified { get; set; }
 
         /// <summary>
+        /// Dependencies to handles from other texture groups.
+        /// </summary>
+        public List<TextureDependency> Dependencies { get; }
+
+        /// <summary>
+        /// A flag indicating that a copy is required from one of the dependencies.
+        /// </summary>
+        public bool NeedsCopy => DeferredCopy != null;
+
+        /// <summary>
+        /// A data copy that must be acknowledged the next time this handle is used.
+        /// </summary>
+        public TextureGroupHandle DeferredCopy { get; set; }
+
+        /// <summary>
         /// Create a new texture group handle, representing a range of views in a storage texture.
         /// </summary>
         /// <param name="group">The TextureGroup that the handle belongs to</param>
         /// <param name="offset">The byte offset from the start of the storage of the handle</param>
         /// <param name="size">The size in bytes covered by the handle</param>
         /// <param name="views">All views of the storage texture, used to calculate overlaps</param>
+        /// <param name="firstLayer">The first layer of this handle in the storage texture</param>
+        /// <param name="firstLevel">The first level of this handle in the storage texture</param>
         /// <param name="handles">The memory tracking handles that represent cover the handle</param>
-        public TextureGroupHandle(TextureGroup group, int offset, ulong size, List<Texture> views, CpuRegionHandle[] handles)
+        public TextureGroupHandle(TextureGroup group, int offset, ulong size, List<Texture> views, int firstLayer, int firstLevel, CpuRegionHandle[] handles)
         {
+            _group = group;
+            _firstLayer = firstLayer;
+            _firstLevel = firstLevel;
+
             Offset = offset;
             Size = (int)size;
             Overlaps = new List<Texture>();
+            Dependencies = new List<TextureDependency>();
 
             if (views != null)
             {
@@ -79,6 +110,230 @@ namespace Ryujinx.Graphics.Gpu.Image
                         Overlaps.Add(view);
                     }
                 }
+            }
+        }
+
+        /// <summary>
+        /// Signal that this handle has been modified to any existing dependencies, and set the modified flag.
+        /// </summary>
+        public void SignalModified()
+        {
+            Modified = true;
+
+            // If this handle has any copy dependencies, notify the other handle that a copy needs to be performed.
+
+            foreach (TextureDependency dependency in Dependencies)
+            {
+                dependency.SignalModified();
+            }
+        }
+
+        /// <summary>
+        /// Signal that this handle has either started or ended being modified.
+        /// </summary>
+        /// <param name="bound">True if this handle is being bound, false if unbound</param>
+        public void SignalModifying(bool bound)
+        {
+            SignalModified();
+
+            // Note: Bind count currently resets to 0 on inherit for safety, as the handle <-> view relationship can change.
+            _bindCount = Math.Max(0, _bindCount + (bound ? 1 : -1));
+        }
+
+        /// <summary>
+        /// Signal that a copy dependent texture has been modified, and must have its data copied to this one.
+        /// </summary>
+        /// <param name="copyFrom">The texture handle that must defer a copy to this one.</param>
+        public void DeferCopy(TextureGroupHandle copyFrom)
+        {
+            DeferredCopy = copyFrom;
+
+            _group.Storage.SignalGroupDirty();
+
+            foreach (Texture overlap in Overlaps)
+            {
+                overlap.SignalGroupDirty();
+            }
+        }
+
+        /// <summary>
+        /// Create a copy dependency between this handle, and another.
+        /// </summary>
+        /// <param name="other">The handle to create a copy dependency to</param>
+        /// <param name="copyToThis">True if the dirty flag needs to be set for the dependancy on this side</param>
+        /// <param name="copyToOther">True if the dirty flag needs to be set for the dependancy on the other side</param>
+        public void CreateCopyDependency(TextureGroupHandle other, bool copyToThis = false, bool copyToOther = false)
+        {
+            // Does this dependency already exist?
+            foreach (TextureDependency existing in Dependencies)
+            {
+                if (existing.Other.Handle == other)
+                {
+                    // Do not need to create it again. May need to set the dirty flag.
+                    if (copyToThis)
+                    {
+                        existing.Other.SignalModified();
+                    } 
+                    if (copyToOther)
+                    {
+                        existing.SignalModified();
+                    }
+                    return;
+                }
+            }
+
+            _group.HasCopyDependencies = true;
+            other._group.HasCopyDependencies = true;
+
+            TextureDependency dependency = new TextureDependency(this);
+            TextureDependency otherDependency = new TextureDependency(other);
+
+            dependency.Other = otherDependency;
+            otherDependency.Other = dependency;
+
+            if (copyToThis)
+            {
+                otherDependency.SignalModified();
+            }
+            if (copyToOther)
+            {
+                dependency.SignalModified();
+            }
+
+            Dependencies.Add(dependency);
+            other.Dependencies.Add(otherDependency);
+
+            // Recursively create dependency:
+            // All of this handle's dependencies must depend on the other.
+            foreach (TextureDependency existing in Dependencies.ToArray())
+            {
+                if (existing != dependency && existing.Other.Handle != other)
+                {
+                    existing.Other.Handle.CreateCopyDependency(other, copyToThis, copyToOther);
+                }
+            }
+
+            // All of the other handle's dependencies must depend on the this.
+            foreach (TextureDependency existing in other.Dependencies.ToArray())
+            {
+                if (existing != otherDependency && existing.Other.Handle != this)
+                {
+                    existing.Other.Handle.CreateCopyDependency(this, copyToOther, copyToThis);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Remove a dependency from this handle's dependency list.
+        /// </summary>
+        /// <param name="dependency">The dependency to remove</param>
+        public void RemoveDependency(TextureDependency dependency)
+        {
+            Dependencies.Remove(dependency);
+        }
+
+        /// <summary>
+        /// Check if any of this handle's memory tracking handles are dirty.
+        /// </summary>
+        /// <returns>True if at least one of the handles is dirty</returns>
+        private bool CheckDirty()
+        {
+            return Handles.Any(handle => handle.Dirty);
+        }
+
+        /// <summary>
+        /// Perform a copy from the provided handle to this one, or perform a deferred copy if none is provided.
+        /// </summary>
+        /// <param name="fromHandle">The handle to copy from. If not provided, this method will copy from and clear the deferred copy instead</param>
+        /// <returns>True if the copy was performed, false otherwise</returns>
+        public bool Copy(TextureGroupHandle fromHandle = null)
+        {
+            bool result = false;
+
+            if (fromHandle == null)
+            {
+                fromHandle = DeferredCopy;
+
+                if (fromHandle != null && fromHandle._bindCount == 0)
+                {
+                    // Repeat the copy in future if the bind count is greater than 0.
+                    DeferredCopy = null;
+                }
+            }
+
+            if (fromHandle != null)
+            {
+                // If the copy texture is dirty, do not copy. Its data no longer matters, and this handle should also be dirty.
+                if (!fromHandle.CheckDirty())
+                {
+                    Texture from = fromHandle._group.Storage;
+                    Texture to = _group.Storage;
+
+                    if (from.ScaleFactor != to.ScaleFactor)
+                    {
+                        to.PropagateScale(from);
+                    }
+
+                    from.HostTexture.CopyTo(
+                        to.HostTexture,
+                        fromHandle._firstLayer,
+                        _firstLayer,
+                        fromHandle._firstLevel,
+                        _firstLevel);
+
+                    Modified = true;
+
+                    _group.RegisterAction(this);
+
+                    result = true;
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Inherit modified flags and dependencies from another texture handle.
+        /// </summary>
+        /// <param name="old">The texture handle to inherit from</param>
+        public void Inherit(TextureGroupHandle old)
+        {
+            Modified |= old.Modified;
+
+            foreach (TextureDependency dependency in old.Dependencies.ToArray())
+            {
+                CreateCopyDependency(dependency.Other.Handle, dependency.Dirty, dependency.Other.Dirty);
+
+                if (dependency.Other.Handle.DeferredCopy == old)
+                {
+                    dependency.Other.Handle.DeferredCopy = this;
+                }
+            }
+
+            DeferredCopy = old.DeferredCopy;
+        }
+
+        /// <summary>
+        /// Check if this region overlaps with another.
+        /// </summary>
+        /// <param name="address">Base address</param>
+        /// <param name="size">Size of the region</param>
+        /// <returns>True if overlapping, false otherwise</returns>
+        public bool OverlapsWith(int offset, int size)
+        {
+            return Offset < offset + size && offset < Offset + Size;
+        }
+
+        public void Dispose()
+        {
+            foreach (CpuRegionHandle handle in Handles)
+            {
+                handle.Dispose();
+            }
+
+            foreach (TextureDependency dependency in Dependencies)
+            {
+                dependency.Other.Handle.RemoveDependency(dependency.Other);
             }
         }
     }

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
@@ -1,0 +1,85 @@
+﻿using Ryujinx.Cpu.Tracking;
+using System.Collections.Generic;
+
+namespace Ryujinx.Graphics.Gpu.Image
+{
+    /// <summary>
+    /// A tracking handle for a texture group, which represents a range of views in a storage texture.
+    /// Retains a list of overlapping texture views, a modified flag, and tracking for each
+    /// CPU VA range that the views cover.
+    /// </summary>
+    class TextureGroupHandle
+    {
+        /// <summary>
+        /// The byte offset from the start of the storage of this handle.
+        /// </summary>
+        public int Offset { get; }
+
+        /// <summary>
+        /// The size in bytes covered by this handle.
+        /// </summary>
+        public int Size { get; }
+
+        /// <summary>
+        /// The textures which this handle overlaps with.
+        /// </summary>
+        public List<Texture> Overlaps { get; }
+
+        /// <summary>
+        /// The CPU memory tracking handles that cover this handle.
+        /// </summary>
+        public CpuRegionHandle[] Handles { get; }
+
+        /// <summary>
+        /// True if a texture overlapping this handle has been modified. Is set false when the flush action is called.
+        /// </summary>
+        public bool Modified { get; set; }
+
+        /// <summary>
+        /// Create a new texture group handle, representing a range of views in a storage texture.
+        /// </summary>
+        /// <param name="group">The TextureGroup that the handle belongs to</param>
+        /// <param name="offset">The byte offset from the start of the storage of the handle</param>
+        /// <param name="size">The size in bytes covered by the handle</param>
+        /// <param name="views">All views of the storage texture, used to calculate overlaps</param>
+        /// <param name="handles">The memory tracking handles that represent cover the handle</param>
+        public TextureGroupHandle(TextureGroup group, int offset, ulong size, List<Texture> views, CpuRegionHandle[] handles)
+        {
+            Offset = offset;
+            Size = (int)size;
+            Overlaps = new List<Texture>();
+
+            if (views != null)
+            {
+                RecalculateOverlaps(group, views);
+            }
+
+            Handles = handles;
+        }
+
+        /// <summary>
+        /// Calculate a list of which views overlap this handle.
+        /// </summary>
+        /// <param name="group">The parent texture group, used to find a view's base CPU VA offset</param>
+        /// <param name="views">The list of views to search for overlaps</param>
+        public void RecalculateOverlaps(TextureGroup group, List<Texture> views)
+        {
+            // Overlaps can be accessed from the memory tracking signal handler, so access must be atomic.
+            lock (Overlaps)
+            {
+                int endOffset = Offset + Size;
+
+                Overlaps.Clear();
+
+                foreach (Texture view in views)
+                {
+                    int viewOffset = group.FindOffset(view);
+                    if (viewOffset < endOffset && Offset < viewOffset + (int)view.Size)
+                    {
+                        Overlaps.Add(view);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
@@ -68,7 +68,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="views">All views of the storage texture, used to calculate overlaps</param>
         /// <param name="firstLayer">The first layer of this handle in the storage texture</param>
         /// <param name="firstLevel">The first level of this handle in the storage texture</param>
-        /// <param name="handles">The memory tracking handles that represent cover the handle</param>
+        /// <param name="handles">The memory tracking handles that cover this handle</param>
         public TextureGroupHandle(TextureGroup group, int offset, ulong size, List<Texture> views, int firstLayer, int firstLevel, CpuRegionHandle[] handles)
         {
             _group = group;
@@ -160,7 +160,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Create a copy dependency between this handle, and another.
         /// </summary>
         /// <param name="other">The handle to create a copy dependency to</param>
-        /// <param name="copyToOther">True if a copy should be deferred to all of the other handle's dependencies.</param>
+        /// <param name="copyToOther">True if a copy should be deferred to all of the other handle's dependencies</param>
         public void CreateCopyDependency(TextureGroupHandle other, bool copyToOther = false)
         {
             // Does this dependency already exist?

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
@@ -318,7 +318,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 handle.Dispose();
             }
 
-            foreach (TextureDependency dependency in Dependencies)
+            foreach (TextureDependency dependency in Dependencies.ToArray())
             {
                 dependency.Other.Handle.RemoveDependency(dependency.Other);
             }

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
@@ -143,7 +143,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <summary>
         /// Signal that a copy dependent texture has been modified, and must have its data copied to this one.
         /// </summary>
-        /// <param name="copyFrom">The texture handle that must defer a copy to this one.</param>
+        /// <param name="copyFrom">The texture handle that must defer a copy to this one</param>
         public void DeferCopy(TextureGroupHandle copyFrom)
         {
             DeferredCopy = copyFrom;

--- a/Ryujinx.Graphics.Gpu/Image/TextureInfo.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureInfo.cs
@@ -233,7 +233,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Gets the number of 2d slices of the texture.
+        /// Gets the number of 2D slices of the texture.
         /// Returns 6 for cubemap textures, layer faces for cubemap array textures, and DepthOrLayers for everything else.
         /// </summary>
         /// <returns>The number of texture slices</returns>

--- a/Ryujinx.Graphics.Gpu/Image/TextureInfo.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureInfo.cs
@@ -233,6 +233,27 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Gets the number of 2d slices of the texture.
+        /// Returns 6 for cubemap textures, layer faces for cubemap array textures, and DepthOrLayers for everything else.
+        /// </summary>
+        /// <returns>The number of texture slices</returns>
+        public int GetSlices()
+        {
+            if (Target == Target.CubemapArray)
+            {
+                return DepthOrLayers * 6;
+            }
+            else if (Target == Target.Cubemap)
+            {
+                return 6;
+            }
+            else
+            {
+                return DepthOrLayers;
+            }
+        }
+
+        /// <summary>
         /// Calculates the size information from the texture information.
         /// </summary>
         /// <param name="layerSize">Optional size of each texture layer in bytes</param>

--- a/Ryujinx.Graphics.Gpu/Image/TextureInfo.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureInfo.cs
@@ -239,7 +239,11 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>The number of texture slices</returns>
         public int GetSlices()
         {
-            if (Target == Target.CubemapArray)
+            if (Target == Target.Texture3D || Target == Target.Texture2DArray || Target == Target.Texture2DMultisampleArray)
+            {
+                return DepthOrLayers;
+            }
+            else if (Target == Target.CubemapArray)
             {
                 return DepthOrLayers * 6;
             }
@@ -249,7 +253,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             }
             else
             {
-                return DepthOrLayers;
+                return 1;
             }
         }
 

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -185,7 +185,14 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             bool hasValue = color != null;
             bool changesScale = (hasValue != (_rtColors[index] != null)) || (hasValue && RenderTargetScale != color.ScaleFactor);
-            _rtColors[index] = color;
+
+            if (_rtColors[index] != color)
+            {
+                _rtColors[index]?.SignalModifying(false);
+                color?.SignalModifying(true);
+
+                _rtColors[index] = color;
+            }
 
             return changesScale || (hasValue && color.ScaleMode != TextureScaleMode.Blacklisted && color.ScaleFactor != GraphicsConfig.ResScale);
         }
@@ -292,7 +299,14 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             bool hasValue = depthStencil != null;
             bool changesScale = (hasValue != (_rtDepthStencil != null)) || (hasValue && RenderTargetScale != depthStencil.ScaleFactor);
-            _rtDepthStencil = depthStencil;
+
+            if (_rtDepthStencil != depthStencil)
+            {
+                _rtDepthStencil?.SignalModifying(false);
+                depthStencil?.SignalModifying(true);
+
+                _rtDepthStencil = depthStencil;
+            }
 
             return changesScale || (hasValue && depthStencil.ScaleMode != TextureScaleMode.Blacklisted && depthStencil.ScaleFactor != GraphicsConfig.ResScale);
         }
@@ -754,34 +768,96 @@ namespace Ryujinx.Graphics.Gpu.Image
                 overlapsCount = _textures.FindOverlaps(range.Value, ref _textureOverlaps);
             }
 
+            if (_overlapInfo.Length != _textureOverlaps.Length)
+            {
+                Array.Resize(ref _overlapInfo, _textureOverlaps.Length);
+            }
+
+            // =============== Find Texture View of Existing Texture =============== 
+
+            int fullyCompatible = 0;
+
+            // Evaluate compatibility of overlaps
+
             for (int index = 0; index < overlapsCount; index++)
             {
                 Texture overlap = _textureOverlaps[index];
-                TextureViewCompatibility overlapCompatibility = overlap.IsViewCompatible(info, range.Value, out int firstLayer, out int firstLevel);
+                TextureViewCompatibility overlapCompatibility = overlap.IsViewCompatible(info, range.Value, sizeInfo.LayerSize, out int firstLayer, out int firstLevel);
 
                 if (overlapCompatibility == TextureViewCompatibility.Full)
                 {
-                    TextureInfo oInfo = AdjustSizes(overlap, info, firstLevel);
+                    if (overlap.IsView)
+                    {
+                        overlapCompatibility = TextureViewCompatibility.CopyOnly;
+                    }
+                    else
+                    {
+                        fullyCompatible++;
+                    }
+                }
+
+                _overlapInfo[index] = new OverlapInfo(overlapCompatibility, firstLayer, firstLevel);
+            }
+
+            // Search through the overlaps to find a compatible view and establish any copy dependencies.
+
+            for (int index = 0; index < overlapsCount; index++)
+            {
+                Texture overlap = _textureOverlaps[index];
+                OverlapInfo oInfo = _overlapInfo[index];
+
+                if (oInfo.Compatibility == TextureViewCompatibility.Full)
+                {
+                    TextureInfo adjInfo = AdjustSizes(overlap, info, oInfo.FirstLevel);
 
                     if (!isSamplerTexture)
                     {
-                        info = oInfo;
+                        info = adjInfo;
                     }
 
-                    texture = overlap.CreateView(oInfo, sizeInfo, range.Value, firstLayer, firstLevel);
-
-                    texture.SynchronizeMemory();
+                    texture = overlap.CreateView(adjInfo, sizeInfo, range.Value, oInfo.FirstLayer, oInfo.FirstLevel);
 
                     ChangeSizeIfNeeded(info, texture, isSamplerTexture, sizeHint);
 
+                    texture.SynchronizeMemory();
                     break;
                 }
-                else if (overlapCompatibility == TextureViewCompatibility.CopyOnly)
+                else if (oInfo.Compatibility == TextureViewCompatibility.CopyOnly && fullyCompatible == 0)
                 {
-                    // TODO: Copy rules for targets created after the container texture. See below.
-                    overlap.DisableMemoryTracking();
+                    // Only copy compatible. If there's another choice for a FULLY compatible texture, choose that instead.
+
+                    texture = new Texture(_context, info, sizeInfo, range.Value, scaleMode);
+                    texture.InitializeGroup(true, true);
+                    texture.InitializeData(false, false);
+
+                    overlap.SynchronizeMemory();
+                    overlap.CreateCopyDependency(texture, oInfo.FirstLayer, oInfo.FirstLevel, true);
+                    break;
                 }
             }
+
+            if (texture != null)
+            {
+                // This texture could be a view of multiple parent textures with different storages, even if it is a view.
+                // When a texture is created, make sure all possible dependencies to other textures are created as copies. 
+                // (even if it could be fulfilled without a copy)
+
+                for (int index = 0; index < overlapsCount; index++)
+                {
+                    Texture overlap = _textureOverlaps[index];
+                    OverlapInfo oInfo = _overlapInfo[index];
+
+                    if (oInfo.Compatibility != TextureViewCompatibility.Incompatible && overlap.Group != texture.Group)
+                    {
+                        overlap.SynchronizeMemory();
+                        overlap.CreateCopyDependency(texture, oInfo.FirstLayer, oInfo.FirstLevel, true);
+                    }
+                }
+
+                texture.SynchronizeMemory();
+            }
+
+            // =============== Create a New Texture =============== 
 
             // No match, create a new texture.
             if (texture == null)
@@ -792,6 +868,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 // Any textures that are incompatible will contain garbage data, so they should be removed where possible.
 
                 int viewCompatible = 0;
+                fullyCompatible = 0;
                 bool setData = isSamplerTexture || overlapsCount == 0 || flags.HasFlag(TextureSearchFlags.ForCopy);
 
                 bool hasLayerViews = false;
@@ -802,17 +879,39 @@ namespace Ryujinx.Graphics.Gpu.Image
                     Texture overlap = _textureOverlaps[index];
                     bool overlapInCache = overlap.CacheNode != null;
 
-                    TextureViewCompatibility compatibility = texture.IsViewCompatible(overlap.Info, overlap.Range, out int firstLayer, out int firstLevel);
+                    TextureViewCompatibility compatibility = texture.IsViewCompatible(overlap.Info, overlap.Range, overlap.LayerSize, out int firstLayer, out int firstLevel);
+
+                    if (overlap.IsView && compatibility == TextureViewCompatibility.Full)
+                    {
+                        compatibility = TextureViewCompatibility.CopyOnly;
+                    }
 
                     if (compatibility != TextureViewCompatibility.Incompatible)
                     {
-                        if (_overlapInfo.Length != _textureOverlaps.Length)
+                        if (compatibility == TextureViewCompatibility.Full)
                         {
-                            Array.Resize(ref _overlapInfo, _textureOverlaps.Length);
-                        }
+                            if (viewCompatible == fullyCompatible)
+                            {
+                                _overlapInfo[viewCompatible] = new OverlapInfo(compatibility, firstLayer, firstLevel);
+                                _textureOverlaps[viewCompatible++] = overlap;
+                            }
+                            else
+                            {
+                                // Swap overlaps so that the fully compatible views have priority.
 
-                        _overlapInfo[viewCompatible] = new OverlapInfo(compatibility, firstLayer, firstLevel);
-                        _textureOverlaps[viewCompatible++] = overlap;
+                                _overlapInfo[viewCompatible] = _overlapInfo[fullyCompatible];
+                                _textureOverlaps[viewCompatible++] = _textureOverlaps[fullyCompatible];
+
+                                _overlapInfo[fullyCompatible] = new OverlapInfo(compatibility, firstLayer, firstLevel);
+                                _textureOverlaps[fullyCompatible] = overlap;
+                            }
+                            fullyCompatible++;
+                        }
+                        else
+                        {
+                            _overlapInfo[viewCompatible] = new OverlapInfo(compatibility, firstLayer, firstLevel);
+                            _textureOverlaps[viewCompatible++] = overlap;
+                        }
 
                         hasLayerViews |= overlap.Info.GetSlices() < texture.Info.GetSlices();
                         hasMipViews |= overlap.Info.Levels < texture.Info.Levels;
@@ -853,16 +952,17 @@ namespace Ryujinx.Graphics.Gpu.Image
                 for (int index = 0; index < viewCompatible; index++)
                 {
                     Texture overlap = _textureOverlaps[index];
+
+                    if (overlap.Info.Target == Target.Cubemap && texture.Info.Target == Target.CubemapArray) { }
                     OverlapInfo oInfo = _overlapInfo[index];
 
-                    if (oInfo.Compatibility != TextureViewCompatibility.Full)
+                    if (overlap.Group == texture.Group)
                     {
-                        continue; // Copy only compatibilty.
+                        // If the texture group is equal, then this texture (or its parent) is already a view.
+                        continue;
                     }
 
                     TextureInfo overlapInfo = AdjustSizes(texture, overlap.Info, oInfo.FirstLevel);
-
-                    TextureCreateInfo createInfo = GetCreateInfo(overlapInfo, _context.Capabilities, overlap.ScaleFactor);
 
                     if (texture.ScaleFactor != overlap.ScaleFactor)
                     {
@@ -872,37 +972,30 @@ namespace Ryujinx.Graphics.Gpu.Image
                         texture.PropagateScale(overlap);
                     }
 
-                    ITexture newView = texture.HostTexture.CreateView(createInfo, oInfo.FirstLayer, oInfo.FirstLevel);
-
-                    overlap.HostTexture.CopyTo(newView, 0, 0);
-
-                    overlap.ReplaceView(texture, overlapInfo, newView, oInfo.FirstLayer, oInfo.FirstLevel);
-                }
-
-                texture.SynchronizeMemory();
-
-                // If the texture is a 3D texture, we need to additionally copy any slice
-                // of the 3D texture to the newly created 3D texture.
-                if (info.Target == Target.Texture3D && viewCompatible > 0)
-                {
-                    // TODO: This copy can currently only happen when the 3D texture is created.
-                    // If a game clears and redraws the slices, we won't be able to copy the new data to the 3D texture.
-                    // Disable tracking to try keep at least the original data in there for as long as possible.
-                    texture.DisableMemoryTracking();
-
-                    for (int index = 0; index < viewCompatible; index++)
+                    if (oInfo.Compatibility != TextureViewCompatibility.Full)
                     {
-                        Texture overlap = _textureOverlaps[index];
-                        OverlapInfo oInfo = _overlapInfo[index];
+                        // Copy only compatibility, or target texture is already a view.
 
-                        if (oInfo.Compatibility != TextureViewCompatibility.Incompatible)
-                        {
-                            overlap.BlacklistScale();
+                        ChangeSizeIfNeeded(overlapInfo, overlap, false, sizeHint); // Force a size match for copy
 
-                            overlap.HostTexture.CopyTo(texture.HostTexture, oInfo.FirstLayer, oInfo.FirstLevel);
-                        }
+                        overlap.SynchronizeMemory();
+                        texture.CreateCopyDependency(overlap, oInfo.FirstLayer, oInfo.FirstLevel, false);
+                    }
+                    else
+                    {
+                        TextureCreateInfo createInfo = GetCreateInfo(overlapInfo, _context.Capabilities, overlap.ScaleFactor);
+
+                        ITexture newView = texture.HostTexture.CreateView(createInfo, oInfo.FirstLayer, oInfo.FirstLevel);
+
+                        overlap.SynchronizeMemory();
+
+                        overlap.HostTexture.CopyTo(newView, 0, 0);
+
+                        overlap.ReplaceView(texture, overlapInfo, newView, oInfo.FirstLayer, oInfo.FirstLevel);
                     }
                 }
+                
+                texture.SynchronizeMemory();
             }
 
             // Sampler textures are managed by the texture pool, all other textures

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -953,7 +953,6 @@ namespace Ryujinx.Graphics.Gpu.Image
                 {
                     Texture overlap = _textureOverlaps[index];
 
-                    if (overlap.Info.Target == Target.Cubemap && texture.Info.Target == Target.CubemapArray) { }
                     OverlapInfo oInfo = _overlapInfo[index];
 
                     if (overlap.Group == texture.Group)

--- a/Ryujinx.Graphics.Gpu/Memory/GpuRegionHandle.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/GpuRegionHandle.cs
@@ -49,11 +49,11 @@ namespace Ryujinx.Graphics.Gpu.Memory
             }
         }
 
-        public void Reprotect()
+        public void Reprotect(bool asDirty = false)
         {
             foreach (var regionHandle in _cpuRegionHandles)
             {
-                regionHandle.Reprotect();
+                regionHandle.Reprotect(asDirty);
             }
         }
     }

--- a/Ryujinx.Graphics.OpenGL/Image/TextureBuffer.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureBuffer.cs
@@ -18,6 +18,11 @@ namespace Ryujinx.Graphics.OpenGL.Image
             throw new NotSupportedException();
         }
 
+        public void CopyTo(ITexture destination, int srcLayer, int dstLayer, int srcLevel, int dstLevel)
+        {
+            throw new NotSupportedException();
+        }
+
         public void CopyTo(ITexture destination, Extents2D srcRegion, Extents2D dstRegion, bool linearFilter)
         {
             throw new NotSupportedException();

--- a/Ryujinx.Graphics.OpenGL/Image/TextureBuffer.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureBuffer.cs
@@ -38,6 +38,11 @@ namespace Ryujinx.Graphics.OpenGL.Image
             Buffer.SetData(_buffer, _bufferOffset, data.Slice(0, Math.Min(data.Length, _bufferSize)));
         }
 
+        public void SetData(ReadOnlySpan<byte> data, int layer, int level)
+        {
+            throw new NotSupportedException();
+        }
+
         public void SetStorage(BufferRange buffer)
         {
             if (buffer.Handle == _buffer &&

--- a/Ryujinx.Graphics.OpenGL/Image/TextureCopy.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureCopy.cs
@@ -115,29 +115,50 @@ namespace Ryujinx.Graphics.OpenGL.Image
             TextureCreateInfo srcInfo = src.Info;
             TextureCreateInfo dstInfo = dst.Info;
 
+            int srcDepth = srcInfo.GetDepthOrLayers();
+            int srcLevels = srcInfo.Levels;
+
+            int dstDepth = dstInfo.GetDepthOrLayers();
+            int dstLevels = dstInfo.Levels;
+
+            if (dstInfo.Target == Target.Texture3D)
+            {
+                dstDepth = Math.Max(1, dstDepth >> dstLevel);
+            }
+
+            int depth = Math.Min(srcDepth, dstDepth);
+            int levels = Math.Min(srcLevels, dstLevels);
+
+            CopyUnscaled(src, dst, srcLayer, dstLayer, srcLevel, dstLevel, depth, levels);
+        }
+
+        public void CopyUnscaled(
+            ITextureInfo src,
+            ITextureInfo dst,
+            int srcLayer,
+            int dstLayer,
+            int srcLevel,
+            int dstLevel,
+            int depth,
+            int levels)
+        {
+            TextureCreateInfo srcInfo = src.Info;
+            TextureCreateInfo dstInfo = dst.Info;
+
             int srcHandle = src.Handle;
             int dstHandle = dst.Handle;
 
             int srcWidth = srcInfo.Width;
             int srcHeight = srcInfo.Height;
-            int srcDepth = srcInfo.GetDepthOrLayers();
-            int srcLevels = srcInfo.Levels;
 
             int dstWidth = dstInfo.Width;
             int dstHeight = dstInfo.Height;
-            int dstDepth = dstInfo.GetDepthOrLayers();
-            int dstLevels = dstInfo.Levels;
 
             srcWidth = Math.Max(1, srcWidth >> srcLevel);
             srcHeight = Math.Max(1, srcHeight >> srcLevel);
 
             dstWidth = Math.Max(1, dstWidth >> dstLevel);
             dstHeight = Math.Max(1, dstHeight >> dstLevel);
-
-            if (dstInfo.Target == Target.Texture3D)
-            {
-                dstDepth = Math.Max(1, dstDepth >> dstLevel);
-            }
 
             int blockWidth = 1;
             int blockHeight = 1;
@@ -166,8 +187,6 @@ namespace Ryujinx.Graphics.OpenGL.Image
 
             int width = Math.Min(srcWidth, dstWidth);
             int height = Math.Min(srcHeight, dstHeight);
-            int depth = Math.Min(srcDepth, dstDepth);
-            int levels = Math.Min(srcLevels, dstLevels);
 
             for (int level = 0; level < levels; level++)
             {

--- a/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
@@ -308,6 +308,20 @@ namespace Ryujinx.Graphics.OpenGL.Image
             }
         }
 
+        public void SetData(ReadOnlySpan<byte> data, int layer, int level)
+        {
+            unsafe
+            {
+                fixed (byte* ptr = data)
+                {
+                    int width = Math.Max(Info.Width >> level, 1);
+                    int height = Math.Max(Info.Height >> level, 1);
+
+                    ReadFrom2D((IntPtr)ptr, layer, level, width, height);
+                }
+            }
+        }
+
         public void ReadFromPbo(int offset, int size)
         {
             ReadFrom(IntPtr.Zero + offset, size);

--- a/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
@@ -10,8 +10,6 @@ namespace Ryujinx.Graphics.OpenGL.Image
 
         private readonly TextureStorage _parent;
 
-        private TextureView _emulatedViewParent;
-
         private TextureView _incompatibleFormatView;
 
         public int FirstLayer { get; private set; }
@@ -96,37 +94,10 @@ namespace Ryujinx.Graphics.OpenGL.Image
 
         public ITexture CreateView(TextureCreateInfo info, int firstLayer, int firstLevel)
         {
-            if (Info.IsCompressed == info.IsCompressed)
-            {
-                firstLayer += FirstLayer;
-                firstLevel += FirstLevel;
+            firstLayer += FirstLayer;
+            firstLevel += FirstLevel;
 
-                return _parent.CreateView(info, firstLayer, firstLevel);
-            }
-            else
-            {
-                // TODO: Most graphics APIs doesn't support creating a texture view from a compressed format
-                // with a non-compressed format (or vice-versa), however NVN seems to support it.
-                // So we emulate that here with a texture copy (see the first CopyTo overload).
-                // However right now it only does a single copy right after the view is created,
-                // so it doesn't work for all cases.
-                TextureView emulatedView = (TextureView)_renderer.CreateTexture(info, ScaleFactor);
-
-                _renderer.TextureCopy.CopyUnscaled(
-                    this,
-                    emulatedView,
-                    0,
-                    firstLayer,
-                    0,
-                    firstLevel);
-
-                emulatedView._emulatedViewParent = this;
-
-                emulatedView.FirstLayer = firstLayer;
-                emulatedView.FirstLevel = firstLevel;
-
-                return emulatedView;
-            }
+            return _parent.CreateView(info, firstLayer, firstLevel);
         }
 
         public int GetIncompatibleFormatViewHandle()
@@ -163,17 +134,13 @@ namespace Ryujinx.Graphics.OpenGL.Image
             TextureView destinationView = (TextureView)destination;
 
             _renderer.TextureCopy.CopyUnscaled(this, destinationView, 0, firstLayer, 0, firstLevel);
+        }
 
-            if (destinationView._emulatedViewParent != null)
-            {
-                _renderer.TextureCopy.CopyUnscaled(
-                    this,
-                    destinationView._emulatedViewParent,
-                    0,
-                    destinationView.FirstLayer,
-                    0,
-                    destinationView.FirstLevel);
-            }
+        public void CopyTo(ITexture destination, int srcLayer, int dstLayer, int srcLevel, int dstLevel)
+        {
+             TextureView destinationView = (TextureView)destination;
+
+            _renderer.TextureCopy.CopyUnscaled(this, destinationView, srcLayer, dstLayer, srcLevel, dstLevel, 1, 1);
         }
 
         public void CopyTo(ITexture destination, Extents2D srcRegion, Extents2D dstRegion, bool linearFilter)

--- a/Ryujinx.Graphics.Texture/SizeCalculator.cs
+++ b/Ryujinx.Graphics.Texture/SizeCalculator.cs
@@ -42,6 +42,7 @@ namespace Ryujinx.Graphics.Texture
 
             int[] allOffsets = new int[is3D ? Calculate3DOffsetCount(levels, depth) : levels * layers * depth];
             int[] mipOffsets = new int[levels];
+            int[] sliceSizes = new int[levels];
 
             int mipGobBlocksInY = gobBlocksInY;
             int mipGobBlocksInZ = gobBlocksInZ;
@@ -106,8 +107,9 @@ namespace Ryujinx.Graphics.Texture
                 }
 
                 mipOffsets[level] = layerSize;
+                sliceSizes[level] = totalBlocksOfGobsInY * robSize;
 
-                layerSize += totalBlocksOfGobsInZ * totalBlocksOfGobsInY * robSize;
+                layerSize += totalBlocksOfGobsInZ * sliceSizes[level];
 
                 depthLevelOffset += d;
             }
@@ -150,7 +152,7 @@ namespace Ryujinx.Graphics.Texture
                 }
             }
 
-            return new SizeInfo(mipOffsets, allOffsets, depth, levels, layerSize, totalSize, is3D);
+            return new SizeInfo(mipOffsets, allOffsets, sliceSizes, depth, levels, layerSize, totalSize, is3D);
         }
 
         public static SizeInfo GetLinearTextureSize(int stride, int height, int blockHeight)
@@ -159,7 +161,7 @@ namespace Ryujinx.Graphics.Texture
             // so we only need to handle a single case (2D textures without mipmaps).
             int totalSize = stride * BitUtils.DivRoundUp(height, blockHeight);
 
-            return new SizeInfo(new int[] { 0 }, new int[] { 0 }, 1, 1, totalSize, totalSize, false);
+            return new SizeInfo(totalSize);
         }
 
         private static int AlignLayerSize(

--- a/Ryujinx.Graphics.Texture/SizeInfo.cs
+++ b/Ryujinx.Graphics.Texture/SizeInfo.cs
@@ -7,6 +7,8 @@ namespace Ryujinx.Graphics.Texture
         private readonly int[] _mipOffsets;
 
         private readonly int _levels;
+        private readonly int _depth;
+        private readonly bool _is3D;
 
         public readonly int[] AllOffsets;
         public int LayerSize { get; }
@@ -15,24 +17,30 @@ namespace Ryujinx.Graphics.Texture
         public SizeInfo(int size)
         {
             _mipOffsets = new int[] { 0 };
-            AllOffsets = new int[] { 0 };
+            AllOffsets  = new int[] { 0 };
+            _depth      = 1;
             _levels     = 1;
             LayerSize   = size;
             TotalSize   = size;
+            _is3D       = false;
         }
 
         internal SizeInfo(
             int[] mipOffsets,
             int[] allOffsets,
+            int   depth,
             int   levels,
             int   layerSize,
-            int   totalSize)
+            int   totalSize,
+            bool  is3D)
         {
             _mipOffsets = mipOffsets;
-            AllOffsets = allOffsets;
+            AllOffsets  = allOffsets;
+            _depth      = depth;
             _levels     = levels;
             LayerSize   = layerSize;
             TotalSize   = totalSize;
+            _is3D       = is3D;
         }
 
         public int GetMipOffset(int level)
@@ -57,8 +65,25 @@ namespace Ryujinx.Graphics.Texture
                 return false;
             }
 
-            firstLayer = index / _levels;
-            firstLevel = index - (firstLayer * _levels);
+            if (_is3D)
+            {
+                firstLayer = index;
+                firstLevel = 0;
+
+                int levelDepth = _depth;
+
+                while (firstLayer >= levelDepth)
+                {
+                    firstLayer -= levelDepth;
+                    firstLevel++;
+                    levelDepth = Math.Max(levelDepth >> 1, 1);
+                }
+            }
+            else
+            {
+                firstLayer = index / _levels;
+                firstLevel = index - (firstLayer * _levels);
+            }
 
             return true;
         }

--- a/Ryujinx.Graphics.Texture/SizeInfo.cs
+++ b/Ryujinx.Graphics.Texture/SizeInfo.cs
@@ -11,6 +11,7 @@ namespace Ryujinx.Graphics.Texture
         private readonly bool _is3D;
 
         public readonly int[] AllOffsets;
+        public readonly int[] SliceSizes;
         public int LayerSize { get; }
         public int TotalSize { get; }
 
@@ -18,6 +19,7 @@ namespace Ryujinx.Graphics.Texture
         {
             _mipOffsets = new int[] { 0 };
             AllOffsets  = new int[] { 0 };
+            SliceSizes  = new int[] { size };
             _depth      = 1;
             _levels     = 1;
             LayerSize   = size;
@@ -28,6 +30,7 @@ namespace Ryujinx.Graphics.Texture
         internal SizeInfo(
             int[] mipOffsets,
             int[] allOffsets,
+            int[] sliceSizes,
             int   depth,
             int   levels,
             int   layerSize,
@@ -36,6 +39,7 @@ namespace Ryujinx.Graphics.Texture
         {
             _mipOffsets = mipOffsets;
             AllOffsets  = allOffsets;
+            SliceSizes  = sliceSizes;
             _depth      = depth;
             _levels     = levels;
             LayerSize   = layerSize;

--- a/Ryujinx.Graphics.Texture/SizeInfo.cs
+++ b/Ryujinx.Graphics.Texture/SizeInfo.cs
@@ -5,17 +5,17 @@ namespace Ryujinx.Graphics.Texture
     public struct SizeInfo
     {
         private readonly int[] _mipOffsets;
-        private readonly int[] _allOffsets;
 
         private readonly int _levels;
 
+        public readonly int[] AllOffsets;
         public int LayerSize { get; }
         public int TotalSize { get; }
 
         public SizeInfo(int size)
         {
             _mipOffsets = new int[] { 0 };
-            _allOffsets = new int[] { 0 };
+            AllOffsets = new int[] { 0 };
             _levels     = 1;
             LayerSize   = size;
             TotalSize   = size;
@@ -29,7 +29,7 @@ namespace Ryujinx.Graphics.Texture
             int   totalSize)
         {
             _mipOffsets = mipOffsets;
-            _allOffsets = allOffsets;
+            AllOffsets = allOffsets;
             _levels     = levels;
             LayerSize   = layerSize;
             TotalSize   = totalSize;
@@ -47,7 +47,7 @@ namespace Ryujinx.Graphics.Texture
 
         public bool FindView(int offset, out int firstLayer, out int firstLevel)
         {
-            int index = Array.BinarySearch(_allOffsets, offset);
+            int index = Array.BinarySearch(AllOffsets, offset);
 
             if (index < 0)
             {

--- a/Ryujinx.Memory/Tracking/IRegionHandle.cs
+++ b/Ryujinx.Memory/Tracking/IRegionHandle.cs
@@ -10,7 +10,7 @@ namespace Ryujinx.Memory.Tracking
         ulong Size { get; }
         ulong EndAddress { get; }
 
-        void Reprotect();
+        void Reprotect(bool asDirty = false);
         void RegisterAction(RegionSignal action);
     }
 }

--- a/Ryujinx.Memory/Tracking/RegionHandle.cs
+++ b/Ryujinx.Memory/Tracking/RegionHandle.cs
@@ -25,6 +25,7 @@ namespace Ryujinx.Memory.Tracking
         private RegionSignal _preAction; // Action to perform before a read or write. This will block the memory access.
         private readonly List<VirtualRegion> _regions;
         private readonly MemoryTracking _tracking;
+        private bool _disposed;
 
         internal MemoryPermission RequiredPermission => _preAction != null ? MemoryPermission.None : (Dirty ? MemoryPermission.ReadAndWrite : MemoryPermission.Read);
         internal RegionSignal PreAction => _preAction;
@@ -138,21 +139,17 @@ namespace Ryujinx.Memory.Tracking
             return Address < address + size && address < EndAddress;
         }
 
-        bool disposed;
-
         /// <summary>
         /// Dispose the handle. Within the tracking lock, this removes references from virtual and physical regions.
         /// </summary>
         public void Dispose()
         {
-            if (disposed)
+            if (_disposed)
             {
-                throw new Exception("Double Dispose!");
+                throw new ObjectDisposedException(GetType().FullName);
             }
-            else
-            {
-                disposed = true;
-            }
+
+            _disposed = true;
 
             lock (_tracking.TrackingLock)
             {


### PR DESCRIPTION
## Intro

[![Download](https://img.shields.io/badge/Download-%232001-black?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAARCAMAAADjcdz2AAAAe1BMVEVHcEyai5T/XFEAyOr/XlQBxeUBxeX9X1YDxOT/X1UBxeX7XlQAyev7X1QCxeX4YVj+X1UBxeRtmqhnnKv+X1UBxOQCxeUBxOT/X1UAzvELwd8Lwd//VUj+X1U2r8fYbmoAx+j/V0r/X1UCxeb/YlcCzO3/Z1wC1vkC0fPqHM+tAAAAInRSTlMACoFJz879AwP89FBlFeA7o5IZLN+tvZPdFRw0WrZsaX1CnD5B2QAAAI1JREFUGNNNz1cOwyAQBNABO2DAVek9ARvn/icMxSD282k0mkUzyWXXwB93B0wrSxAQ0mSgIx0AwxLwi7WzAssJXmsxHxIQQng9C6FhIlT7LxzoBNXnTTsPYoN7+xhITISOW/uiihfgKhQ2CDtwJV0Egd7IvCNA+1vWPoPbgep4OpeJJn/qwY5ACfrZ/QHYMQ4WY6nIhQAAAABJRU5ErkJggg==&style=flat&labelColor=252a2f&color=f2f5f8)](https://w.ryujinx.org/dl/2001)

Our texture cache tries to make sense of a low level collection of textures iteratively as draws and copies come in and attempt to use them. When _part_ of an existing texture is used, or an existing texture is used in another format, a _view_ of the existing texture is created, with the existing texture being the "storage". Existing textures can also _become_ views when a new texture creates them, with that new texture becoming storage. This enables a ton of fun things like writing to mip levels, texture arrays and cubemaps, as drawing to these views will draw to the original texture.

The key fact is, all of these textures _share their data_ through the storage texture. When the data for one view is set, all overlapping views will also see that change - they are linked at their core. Before now, views tracked their memory as if they were completely _separate_:
 - Before range-tracking, they would check for modified flags in a page table shared between all textures. This meant that a dirty flag could be cleared by another overlapping texture, and a different storage texture (or even views on the same page) wouldn't see that modified flag.
 - After range tracking, each view had its _own_ tracked handle, which covered its entire memory range. However, this meant that a dirty flag could be consumed on one view, but still present on another. Because synchronizing texture data for one view affects all overlapping ones, this is wrong too. Due to this aggressively setting texture data to its original state, there are a few workarounds to disable memory tracking for views, which cause problems for games that stream in or replace a lot of overlapping textures.
 
## Texture Groups

The real solution to these problems is to acknowledge the link between views of the same storage, and share all memory tracking between them. The structure used to represent a storage texture and its views is called a **Texture Group**, and acknowledges that a storage texture is made up of a number of sub-images, where each view into the storage will cover one or more of them.

So for each sub-image, we want to know if it has been "dirtied" by a guest memory write, and needs to be reloaded. We also want to know whether a sub-image has been modified, and flush out or preserve that data when possible. We don't want to consume dirty flags that we don't use, and we don't want to miss any from partial texture writes or that were not consumed by a previous view, so each view needs to work on a _range_ of these sub image handles, shared between all views of the storage texture.

However, creating tracking handles for every sub-image of every image would be very wasteful. Most textures will never have views of their mips/layers at all - they just contain static texture data that doesn't overlap with anything. So, textures have three separate levels of subdivision: 
 - One where the whole texture is covered by one handle,
 - One where one subdivision of the texture has a view (handle for each layer/face for 2d, and a handle for each mip level for 3d)
 - One where all layers and mip levels are tracked individually - there is a 1:1 mapping between view offsets and handles.
 
Because the layer/face view ordering changes when a texture is 3d, the presence of mip and layer views are tracked separately, and the difference in calculation happens when calculating tracking handles, and converting back to view indexes for the storage.

When additional views are created, the tracking will be subdivided further if needed, and the existing dirty/modified flags will be migrated onto the new handles.

#### Partial Synchronization
Since a view can cover multiple sub-images within the storage, and we have tracking (or potential modification) for each of these sub-images, it's possible that only a selection of them still have dirty flags. In most cases, we can still synchronize the full view, as it is faster to do than individual sub-images if the data on CPU is indeed the data we want. That is - in most cases.

Say that you have a texture array of 6 2d textures, and the first texture in the array is bound as a render target and rendered to. It consumes a dirty flag and synchronizes that first 2d array item from CPU memory - memory that the game cleared for us before use - then renders to it and flags it as GPU modified. So far so good, we have data in the first and no data in the other 5. But what if we suddenly bind the full texture array? When we check the dirty flags for the 6 overlapping faces of the storage, the first is consumed, but the other 5 are not. Synchronizing the full texture would clear out the data we just rendered into the first 2d item. We know that one of the 6 textures has been modified and not flushed out, so we'll need to _partially sync texture data_ from the CPU to honor the 5 other dirty flags.

To do this, we keep track of which of the overlapping handles had a dirty flag. If _at least one, but not all of them_ had a dirty flag, AND at least one of the non-dirty textures is gpu modified, then we need to selectively sync _only_ the textures with the dirty flags to avoid losing the data for the texture we just wrote.

A few changes were made to achieve this. There is an additional method to set a single 2D slice of a texture on the backend, and the `ConvertToHostCompatibleFormat` function has been updated to take a `level` and optionally convert layout for just a single level/layer, rather than all of them. And finally, this is the reason that `Texture.SynchronizeMemory` doesn't do any synchronizing itself, it calls the `TextureGroup` to decide what to do _first_. This will also help in future for other things, and is made just as fast as before by the per texture `_dirty` flag.

### Additional Changes:
A few changes were made so that the assumptions made by the Texture Group were correctly held:
- RegionHandles now let you register an event that is fired when "Dirty" becomes true. This cannot be unregistered, it's assumed that this callback will be relevant until the handle is disposed.
- RegionHandles can now be reprotected as dirty. This is used for inheriting dirty flags from another handle.
- When a texture with views is converted into a view itself, its views will be migrated to the new storage texture first.
  - This may be responsible for improving gpu memory usage in HW:AOC
  - This may fix some other unusual errors, though the process of "stealing" views is still a little flawed without a copy dependency.

### Fixes:
- Texture swaps in Xenoblade Chronicles: Definitive Edition, and Xenoblade 2
  - May fix texture swaps in other games
- Texture memory leak in Hyrule Warriors: Age Of Calamity (possibly additional change 1)
- Small improvements in A Hat in Time and Mario Kart 8, fixed further by what you see further down in the comments.
- Greatly reduced number of texture tracking handles (and frequency of their creation) when views are created. This will spend less time creating the handles, which locks the tracking structure.

## TODO: Future Texture Changes
None of these issues have anything to do with this PR, I just wanted to mention them to manage expectations (these things are not yet fixed), and to plan out a roadmap for future changes of this kind.

- Texture eviction strategy that keeps textures alive (after falling off the pool) in case they were simply moved to another location in the pool, or temporarily removed.
  - Stutters and performance in Hyrule Warriors: Age Of Calamity
- Texture eviction strategy that evicts textures when an overlapping texture is created that is not compatible in any way (its data will be garbage)
  - VRAM usage in Xenoblade Chronicles: Definitive Edition (it's also a bit slower cos of buffer flush, but that's not related at all)
- Keep textures _in the cache_ when a view is still alive.
 - Textures are still kept _alive_ when any view is still alive, but they are not findable via the texture cache. This can lead to situations where we end up recreating a storage texture that already exists, or creating a recursive view train between formats, and doing a bunch of unnecessary work over time, and adding a bunch of confusion when finding overlaps which could impact changes.

#### Texture Dependencies (actually done, see below)
Texture views only perfectly represent the guest state if a texture can only have one storage. In some cases, a texture may end up having separate potential "storages", due to the following:
 - View texture compatible with two or more disjoint storage layouts (mario kart - offset overlapping texture arrays + cubemaps)
 - View cannot be created due to host incompatibility, such as compressed views of uint textures (mario kart, a hat in time, splatoon 2)
 
This change is made a lot more possible by the changes in this PR. Dependencies would be _between groups_, as they are at their core an attempt to keep two overlapping storage textures in sync.

## Testing requests
You can download a build of this PR here: https://w.ryujinx.org/dl/2001

Please test everything. I wish I was kidding. Particular attention to:

- Resolution Scaling. This will definitely affect texture blacklist rules, so make sure all your fave games still work.
- Games which load and stream a lot of textures. (UE4)

[![Download](https://img.shields.io/badge/Download-%232001-black?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAARCAMAAADjcdz2AAAAe1BMVEVHcEyai5T/XFEAyOr/XlQBxeUBxeX9X1YDxOT/X1UBxeX7XlQAyev7X1QCxeX4YVj+X1UBxeRtmqhnnKv+X1UBxOQCxeUBxOT/X1UAzvELwd8Lwd//VUj+X1U2r8fYbmoAx+j/V0r/X1UCxeb/YlcCzO3/Z1wC1vkC0fPqHM+tAAAAInRSTlMACoFJz879AwP89FBlFeA7o5IZLN+tvZPdFRw0WrZsaX1CnD5B2QAAAI1JREFUGNNNz1cOwyAQBNABO2DAVek9ARvn/icMxSD282k0mkUzyWXXwB93B0wrSxAQ0mSgIx0AwxLwi7WzAssJXmsxHxIQQng9C6FhIlT7LxzoBNXnTTsPYoN7+xhITISOW/uiihfgKhQ2CDtwJV0Egd7IvCNA+1vWPoPbgep4OpeJJn/qwY5ACfrZ/QHYMQ4WY6nIhQAAAABJRU5ErkJggg==&style=flat&labelColor=252a2f&color=f2f5f8)](https://w.ryujinx.org/dl/2001)