### PR TITLE
Ensure that the memory manager page table is disposed

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -1047,7 +1047,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="hostTexture">The new host texture</param>
         private void ReplaceStorage(ITexture hostTexture)
         {
-            DisposeTextures();
+            DeleteHostTextures();
 
             HostTexture = hostTexture;
         }
@@ -1129,7 +1129,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <summary>
         /// Performs texture disposal, deleting the texture.
         /// </summary>
-        private void DisposeTextures()
+        public void DeleteHostTextures()
         {
             _currentData = null;
             HostTexture.Release();
@@ -1159,7 +1159,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         public void Dispose()
         {
-            DisposeTextures();
+            DeleteHostTextures();
 
             Disposed?.Invoke(this);
             _memoryTracking?.Dispose();

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -1205,7 +1205,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             {
                 foreach (Texture texture in _textures)
                 {
-                    texture.Dispose();
+                    texture.DeleteHostTextures();
                 }
             }
         }

--- a/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
@@ -397,6 +397,11 @@ namespace Ryujinx.Graphics.Gpu.Memory
             _memoryTrackingGranular?.Dispose();
             _memoryTracking?.Dispose();
 
+            DeleteHostBuffer();
+        }
+
+        public void DeleteHostBuffer()
+        {
             _context.Renderer.DeleteBuffer(Handle);
         }
     }

--- a/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -993,7 +993,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
             {
                 foreach (Buffer buffer in _buffers)
                 {
-                    buffer.Dispose();
+                    buffer.DeleteHostBuffer();
                 }
             }
         }

--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -331,6 +331,7 @@ namespace Ryujinx.HLE.HOS
                         foreach (KProcess process in KernelContext.Processes.Values.Where(x => x.Flags.HasFlag(ProcessCreationFlags.IsApplication)))
                         {
                             process.Terminate();
+                            process.DecrementReferenceCount();
                         }
 
                         // The application existed, now surface flinger can exit too.
@@ -341,7 +342,10 @@ namespace Ryujinx.HLE.HOS
                         foreach (KProcess process in KernelContext.Processes.Values.Where(x => !x.Flags.HasFlag(ProcessCreationFlags.IsApplication)))
                         {
                             process.Terminate();
+                            process.DecrementReferenceCount();
                         }
+
+                        KernelContext.Processes.Clear();
                     }
 
                     // Exit ourself now!


### PR DESCRIPTION
KProcess references needs to be decremented manually when stopping emulation, as it doesn't call the TerminateProcess syscall (that would decrement it), this is required to trigger a call to `Destroy` that will dispose the memory manager and free the page table memory. Fix a memory leak of up to 1GB (commited) when stopping emulation.

Note: I had to change some GPU disposal methods, because they weree calling memory tracking region handles before, that when disposed, would attempt to call the `MemoryManager` and fail, as it has already been disposed at this point (not a problem before as it was not being disposed).

Thanks to @LDj3SNuD for finding the issue.