### PR TITLE
Edit the global.json to allow the use of dotnet sdk 5.0.XXX

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.100"
+    "version": "5.0.100",
+	"rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
This life changing feature allows the use of dotnet sdk 5.0.XXX rather than locking it to 5.0.100