### PR TITLE
Enable multithreaded VP9 decoding

### DIFF
--- a/Ryujinx.Graphics.Nvdec.Vp9/Decoder.cs
+++ b/Ryujinx.Graphics.Nvdec.Vp9/Decoder.cs
@@ -95,7 +95,9 @@ namespace Ryujinx.Graphics.Nvdec.Vp9
             int tileCols = 1 << pictureInfo.Log2TileCols;
             int tileRows = 1 << pictureInfo.Log2TileRows;
 
-            int maxThreads = 4;
+            // Video usually have only 4 columns, so more threads won't make a difference for those.
+            // Try to not take all CPU cores for video decoding.
+            int maxThreads = Math.Min(4, Environment.ProcessorCount / 2);
 
             cm.AllocTileWorkerData(_allocator, tileCols, tileRows, maxThreads);
             cm.AllocContextBuffers(_allocator, output.Width, output.Height);

--- a/Ryujinx.Graphics.Nvdec.Vp9/Decoder.cs
+++ b/Ryujinx.Graphics.Nvdec.Vp9/Decoder.cs
@@ -92,7 +92,12 @@ namespace Ryujinx.Graphics.Nvdec.Vp9
 
             cm.Mb.SetupBlockPlanes(1, 1);
 
-            cm.AllocTileWorkerData(_allocator, 1 << pictureInfo.Log2TileCols, 1 << pictureInfo.Log2TileRows);
+            int tileCols = 1 << pictureInfo.Log2TileCols;
+            int tileRows = 1 << pictureInfo.Log2TileRows;
+
+            int maxThreads = 4;
+
+            cm.AllocTileWorkerData(_allocator, tileCols, tileRows, maxThreads);
             cm.AllocContextBuffers(_allocator, output.Width, output.Height);
             cm.InitContextBuffers();
             cm.SetupSegmentationDequant();
@@ -104,7 +109,14 @@ namespace Ryujinx.Graphics.Nvdec.Vp9
             {
                 try
                 {
-                    DecodeFrame.DecodeTiles(ref cm, new ArrayPtr<byte>(dataPtr, bitstream.Length));
+                    if (maxThreads > 1 && tileRows == 1 && tileCols > 1)
+                    {
+                        DecodeFrame.DecodeTilesMt(ref cm, new ArrayPtr<byte>(dataPtr, bitstream.Length), maxThreads);
+                    }
+                    else
+                    {
+                        DecodeFrame.DecodeTiles(ref cm, new ArrayPtr<byte>(dataPtr, bitstream.Length));
+                    }
                 }
                 catch (InternalErrorException)
                 {

--- a/Ryujinx.Graphics.Nvdec.Vp9/Dsp/InvTxfm.cs
+++ b/Ryujinx.Graphics.Nvdec.Vp9/Dsp/InvTxfm.cs
@@ -87,6 +87,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             return rv;
         }
 
+        [SkipLocalsInit]
         public static void Iwht4x416Add(ReadOnlySpan<int> input, Span<byte> dest, int stride)
         {
             /* 4-point reversible, orthonormal inverse Walsh-Hadamard in 3.5 adds,
@@ -142,6 +143,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             }
         }
 
+        [SkipLocalsInit]
         public static void Iwht4x41Add(ReadOnlySpan<int> input, Span<byte> dest, int stride)
         {
             int i;
@@ -209,6 +211,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             output[3] = WrapLow(DctConstRoundShift(s0 + s1 - s3));
         }
 
+        [SkipLocalsInit]
         public static void Idct4(ReadOnlySpan<int> input, Span<int> output)
         {
             Span<short> step = stackalloc short[4];
@@ -231,6 +234,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             output[3] = WrapLow(step[0] - step[3]);
         }
 
+        [SkipLocalsInit]
         public static void Idct4x416Add(ReadOnlySpan<int> input, Span<byte> dest, int stride)
         {
             int i, j;
@@ -359,6 +363,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             output[7] = WrapLow(-x1);
         }
 
+        [SkipLocalsInit]
         public static void Idct8(ReadOnlySpan<int> input, Span<int> output)
         {
             Span<short> step1 = stackalloc short[8];
@@ -416,6 +421,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             output[7] = WrapLow(step1[0] - step1[7]);
         }
 
+        [SkipLocalsInit]
         public static void Idct8x864Add(ReadOnlySpan<int> input, Span<byte> dest, int stride)
         {
             int i, j;
@@ -449,6 +455,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             }
         }
 
+        [SkipLocalsInit]
         public static void Idct8x812Add(ReadOnlySpan<int> input, Span<byte> dest, int stride)
         {
             int i, j;
@@ -456,6 +463,8 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             Span<int> outptr = output;
             Span<int> tempIn = stackalloc int[8];
             Span<int> tempOut = stackalloc int[8];
+
+            output.Fill(0);
 
             // First transform rows
             // Only first 4 row has non-zero coefs
@@ -671,6 +680,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             output[15] = WrapLow(-x1);
         }
 
+        [SkipLocalsInit]
         public static void Idct16(ReadOnlySpan<int> input, Span<int> output)
         {
             Span<short> step1 = stackalloc short[16];
@@ -838,6 +848,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             output[15] = WrapLow(step2[0] - step2[15]);
         }
 
+        [SkipLocalsInit]
         public static void Idct16x16256Add(ReadOnlySpan<int> input, Span<byte> dest, int stride)
         {
             int i, j;
@@ -870,6 +881,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             }
         }
 
+        [SkipLocalsInit]
         public static void Idct16x1638Add(ReadOnlySpan<int> input, Span<byte> dest, int stride)
         {
             int i, j;
@@ -877,6 +889,8 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             Span<int> outptr = output;
             Span<int> tempIn = stackalloc int[16];
             Span<int> tempOut = stackalloc int[16];
+
+            output.Fill(0);
 
             // First transform rows. Since all non-zero dct coefficients are in
             // upper-left 8x8 area, we only need to calculate first 8 rows here.
@@ -903,6 +917,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             }
         }
 
+        [SkipLocalsInit]
         public static void Idct16x1610Add(ReadOnlySpan<int> input, Span<byte> dest, int stride)
         {
             int i, j;
@@ -910,6 +925,8 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             Span<int> outptr = output;
             Span<int> tempIn = stackalloc int[16];
             Span<int> tempOut = stackalloc int[16];
+
+            output.Fill(0);
 
             // First transform rows. Since all non-zero dct coefficients are in
             // upper-left 4x4 area, we only need to calculate first 4 rows here.
@@ -955,6 +972,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             }
         }
 
+        [SkipLocalsInit]
         public static void Idct32(ReadOnlySpan<int> input, Span<int> output)
         {
             Span<short> step1 = stackalloc short[32];
@@ -1324,6 +1342,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             output[31] = WrapLow(step1[0] - step1[31]);
         }
 
+        [SkipLocalsInit]
         public static void Idct32x321024Add(ReadOnlySpan<int> input, Span<byte> dest, int stride)
         {
             int i, j;
@@ -1370,6 +1389,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             }
         }
 
+        [SkipLocalsInit]
         public static void Idct32x32135Add(ReadOnlySpan<int> input, Span<byte> dest, int stride)
         {
             int i, j;
@@ -1377,6 +1397,8 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             Span<int> outptr = output;
             Span<int> tempIn = stackalloc int[32];
             Span<int> tempOut = stackalloc int[32];
+
+            output.Fill(0);
 
             // Rows
             // Only upper-left 16x16 has non-zero coeff
@@ -1403,6 +1425,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             }
         }
 
+        [SkipLocalsInit]
         public static void Idct32x3234Add(ReadOnlySpan<int> input, Span<byte> dest, int stride)
         {
             int i, j;
@@ -1410,6 +1433,8 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             Span<int> outptr = output;
             Span<int> tempIn = stackalloc int[32];
             Span<int> tempOut = stackalloc int[32];
+
+            output.Fill(0);
 
             // Rows
             // Only upper-left 8x8 has non-zero coeff
@@ -1456,6 +1481,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             }
         }
 
+        [SkipLocalsInit]
         public static void HighbdIwht4x416Add(ReadOnlySpan<int> input, Span<ushort> dest, int stride, int bd)
         {
             /* 4-point reversible, orthonormal inverse Walsh-Hadamard in 3.5 adds,
@@ -1511,6 +1537,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             }
         }
 
+        [SkipLocalsInit]
         public static void HighbdIwht4x41Add(ReadOnlySpan<int> input, Span<ushort> dest, int stride, int bd)
         {
             int i;
@@ -1584,6 +1611,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             output[3] = HighbdWrapLow(DctConstRoundShift(s0 + s1 - s3), bd);
         }
 
+        [SkipLocalsInit]
         public static void HighbdIdct4(ReadOnlySpan<int> input, Span<int> output, int bd)
         {
             Span<int> step = stackalloc int[4];
@@ -1613,6 +1641,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             output[3] = HighbdWrapLow(step[0] - step[3], bd);
         }
 
+        [SkipLocalsInit]
         public static void HighbdIdct4x416Add(ReadOnlySpan<int> input, Span<ushort> dest, int stride, int bd)
         {
             int i, j;
@@ -1748,6 +1777,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             output[7] = HighbdWrapLow(-x1, bd);
         }
 
+        [SkipLocalsInit]
         public static void HighbdIdct8(ReadOnlySpan<int> input, Span<int> output, int bd)
         {
             Span<int> step1 = stackalloc int[8];
@@ -1803,6 +1833,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             output[7] = HighbdWrapLow(step1[0] - step1[7], bd);
         }
 
+        [SkipLocalsInit]
         public static void HighbdIdct8x864Add(ReadOnlySpan<int> input, Span<ushort> dest, int stride, int bd)
         {
             int i, j;
@@ -1835,6 +1866,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             }
         }
 
+        [SkipLocalsInit]
         public static void HighbdIdct8x812Add(ReadOnlySpan<int> input, Span<ushort> dest, int stride, int bd)
         {
             int i, j;
@@ -1842,6 +1874,8 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             Span<int> outptr = output;
             Span<int> tempIn = stackalloc int[8];
             Span<int> tempOut = stackalloc int[8];
+
+            output.Fill(0);
 
             // First transform rows
             // Only first 4 row has non-zero coefs
@@ -2062,6 +2096,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             output[15] = HighbdWrapLow(-x1, bd);
         }
 
+        [SkipLocalsInit]
         public static void HighbdIdct16(ReadOnlySpan<int> input, Span<int> output, int bd)
         {
             Span<int> step1 = stackalloc int[16];
@@ -2236,6 +2271,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             output[15] = HighbdWrapLow(step2[0] - step2[15], bd);
         }
 
+        [SkipLocalsInit]
         public static void HighbdIdct16x16256Add(ReadOnlySpan<int> input, Span<ushort> dest, int stride, int bd)
         {
             int i, j;
@@ -2268,6 +2304,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             }
         }
 
+        [SkipLocalsInit]
         public static void HighbdIdct16x1638Add(ReadOnlySpan<int> input, Span<ushort> dest, int stride, int bd)
         {
             int i, j;
@@ -2275,6 +2312,8 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             Span<int> outptr = output;
             Span<int> tempIn = stackalloc int[16];
             Span<int> tempOut = stackalloc int[16];
+
+            output.Fill(0);
 
             // First transform rows. Since all non-zero dct coefficients are in
             // upper-left 8x8 area, we only need to calculate first 8 rows here.
@@ -2303,6 +2342,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             }
         }
 
+        [SkipLocalsInit]
         public static void HighbdIdct16x1610Add(ReadOnlySpan<int> input, Span<ushort> dest, int stride, int bd)
         {
             int i, j;
@@ -2310,6 +2350,8 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             Span<int> outptr = output;
             Span<int> tempIn = stackalloc int[16];
             Span<int> tempOut = stackalloc int[16];
+
+            output.Fill(0);
 
             // First transform rows. Since all non-zero dct coefficients are in
             // upper-left 4x4 area, we only need to calculate first 4 rows here.
@@ -2355,6 +2397,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             }
         }
 
+        [SkipLocalsInit]
         public static void HighbdIdct32(ReadOnlySpan<int> input, Span<int> output, int bd)
         {
             Span<int> step1 = stackalloc int[32];
@@ -2539,7 +2582,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             step2[8] = step1[8];
             step2[15] = step1[15];
             temp1 = -step1[9] * (long)CosPi8_64 + step1[14] * (long)CosPi24_64;
-            temp2 =  step1[9] * (long)CosPi24_64 + step1[14] * (long)CosPi8_64;
+            temp2 = step1[9] * (long)CosPi24_64 + step1[14] * (long)CosPi8_64;
             step2[9] = HighbdWrapLow(DctConstRoundShift(temp1), bd);
             step2[14] = HighbdWrapLow(DctConstRoundShift(temp2), bd);
             temp1 = -step1[10] * (long)CosPi24_64 - step1[13] * (long)CosPi8_64;
@@ -2731,6 +2774,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             output[31] = HighbdWrapLow(step1[0] - step1[31], bd);
         }
 
+        [SkipLocalsInit]
         public static void HighbdIdct32x321024Add(ReadOnlySpan<int> input, Span<ushort> dest, int stride, int bd)
         {
             int i, j;
@@ -2777,6 +2821,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             }
         }
 
+        [SkipLocalsInit]
         public static void HighbdIdct32x32135Add(ReadOnlySpan<int> input, Span<ushort> dest, int stride, int bd)
         {
             int i, j;
@@ -2784,6 +2829,8 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             Span<int> outptr = output;
             Span<int> tempIn = stackalloc int[32];
             Span<int> tempOut = stackalloc int[32];
+
+            output.Fill(0);
 
             // Rows
             // Only upper-left 16x16 has non-zero coeff
@@ -2812,6 +2859,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             }
         }
 
+        [SkipLocalsInit]
         public static void HighbdIdct32x3234Add(ReadOnlySpan<int> input, Span<ushort> dest, int stride, int bd)
         {
             int i, j;
@@ -2819,6 +2867,8 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
             Span<int> outptr = output;
             Span<int> tempIn = stackalloc int[32];
             Span<int> tempOut = stackalloc int[32];
+
+            output.Fill(0);
 
             // Rows
             // Only upper-left 8x8 has non-zero coeff

--- a/Ryujinx.Graphics.Nvdec.Vp9/TileBuffer.cs
+++ b/Ryujinx.Graphics.Nvdec.Vp9/TileBuffer.cs
@@ -4,6 +4,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9
 {
     internal struct TileBuffer
     {
+        public int Col;
         public ArrayPtr<byte> Data;
         public int Size;
     }

--- a/Ryujinx.Graphics.Nvdec.Vp9/TileWorkerData.cs
+++ b/Ryujinx.Graphics.Nvdec.Vp9/TileWorkerData.cs
@@ -1,14 +1,20 @@
 ﻿using Ryujinx.Common.Memory;
 using Ryujinx.Graphics.Nvdec.Vp9.Dsp;
 using Ryujinx.Graphics.Nvdec.Vp9.Types;
+using Ryujinx.Graphics.Video;
 
 namespace Ryujinx.Graphics.Nvdec.Vp9
 {
     internal struct TileWorkerData
     {
+        public ArrayPtr<byte> DataEnd;
+        public int BufStart;
+        public int BufEnd;
         public Reader BitReader;
+        public Vp9BackwardUpdates Counts;
         public MacroBlockD Xd;
         /* dqcoeff are shared by all the planes. So planes must be decoded serially */
         public Array32<Array32<int>> Dqcoeff;
+        public InternalErrorInfo ErrorInfo;
     }
 }

--- a/Ryujinx.Graphics.Nvdec.Vp9/Types/Vp9Common.cs
+++ b/Ryujinx.Graphics.Nvdec.Vp9/Types/Vp9Common.cs
@@ -127,9 +127,9 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Types
             MBs = MbRows * MbCols;
         }
 
-        public void AllocTileWorkerData(MemoryAllocator allocator, int tileCols, int tileRows)
+        public void AllocTileWorkerData(MemoryAllocator allocator, int tileCols, int tileRows, int maxThreads)
         {
-            TileWorkerData = allocator.Allocate<TileWorkerData>(tileCols * tileRows);
+            TileWorkerData = allocator.Allocate<TileWorkerData>(tileCols * tileRows + (maxThreads > 1 ? maxThreads : 0));
         }
 
         public void FreeTileWorkerData(MemoryAllocator allocator)


### PR DESCRIPTION
This adds some optimisations to the VP9 decoder:
- Support multithreaded tile decoding. Improves speed by decoding multiple tiles in parallel, on separate CPU cores.
- Add `SkipLocalsInit` attribute to several inverse transform functions with stackallocs. Gives a minor performance improvement by avoiding zeroing the stack.

Most of the benefit comes from the multithreaded decoding. I had an speedup of about 2.5x decoding 1080p videos here (measured with standalone decoding, it is likely lower on the emulator). I would expect similar improvements on other CPUs with more than 6 cores.

**Some technical notes:**

Due to the way how the work is distributed, uneven thread counts does not yield much improvement. For example, a thread count of 2 and a thread count of 3 will give pretty much the same performance, for a video with 4 tile columns, because one thread will need to decode 2 tiles, and the other will need to decode 1. Considering that they all take the same time to decode, then theres no advantage is having 3 threads, because it will still need to way for the one decoding 2 tiles to finish. The code tries to compensate this by sorting the tiles, so that the thread that needs to process 2 tiles only processes the smallest ones (which are assumed to be the fastest to decode).

This is pretty much a port of libvpx multithreaded tile column decoding, but I made it more .NET-like, by using `Parallel.For` rather than manually creating threads and using condition variablles to wait for work completion, etc.

**What to test:**

Any game using VP9 videos. Here's some examples:
- Super Smash Bros Ultimate
- Pokémon Let's Go Eevee/Pikachu
- Zelda Link's Awakening
- Fire Emblem Three Houses
- Tokyo Mirage Session #FE Encore
- Animal Crossing New Horizons
- Mr. Driller no Drillland

One should look for performance improvements, and also possible regressions. For example, Zelda Link's Awakening intro video is very choppy on master right now, it should be better with this change.

[![Download](https://img.shields.io/badge/Download-%232009-black?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAARCAMAAADjcdz2AAAAe1BMVEVHcEyai5T/XFEAyOr/XlQBxeUBxeX9X1YDxOT/X1UBxeX7XlQAyev7X1QCxeX4YVj+X1UBxeRtmqhnnKv+X1UBxOQCxeUBxOT/X1UAzvELwd8Lwd//VUj+X1U2r8fYbmoAx+j/V0r/X1UCxeb/YlcCzO3/Z1wC1vkC0fPqHM+tAAAAInRSTlMACoFJz879AwP89FBlFeA7o5IZLN+tvZPdFRw0WrZsaX1CnD5B2QAAAI1JREFUGNNNz1cOwyAQBNABO2DAVek9ARvn/icMxSD282k0mkUzyWXXwB93B0wrSxAQ0mSgIx0AwxLwi7WzAssJXmsxHxIQQng9C6FhIlT7LxzoBNXnTTsPYoN7+xhITISOW/uiihfgKhQ2CDtwJV0Egd7IvCNA+1vWPoPbgep4OpeJJn/qwY5ACfrZ/QHYMQ4WY6nIhQAAAABJRU5ErkJggg==&style=flat&labelColor=252a2f&color=f2f5f8)](https://w.ryujinx.org/dl/2009)