### PR TITLE
prepo: Implement GetSystemSessionId and add perms

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Prepo/IPrepoService.cs
+++ b/Ryujinx.HLE/HOS/Services/Prepo/IPrepoService.cs
@@ -5,16 +5,24 @@ using Ryujinx.Common.Logging;
 using Ryujinx.Common.Utilities;
 using Ryujinx.HLE.HOS.Services.Account.Acc;
 using Ryujinx.HLE.Utilities;
+using System;
 using System.Text;
 
 namespace Ryujinx.HLE.HOS.Services.Prepo
 {
-    [Service("prepo:a")]
-    [Service("prepo:a2")]
-    [Service("prepo:u")]
+    [Service("prepo:a",  -1)] // 1.0.0-5.1.0
+    [Service("prepo:a2", -1)] // 6.0.0+
+    [Service("prepo:m",   6)]
+    [Service("prepo:u",   1)]
+    [Service("prepo:s",   2)]
     class IPrepoService : IpcService
     {
-        public IPrepoService(ServiceCtx context) { }
+        private long _permission;
+
+        public IPrepoService(ServiceCtx context, long permission)
+        {
+            _permission = permission;
+        }
 
         [Command(10100)] // 1.0.0-5.1.0
         [Command(10102)] // 6.0.0-9.2.0
@@ -22,6 +30,11 @@ namespace Ryujinx.HLE.HOS.Services.Prepo
         // SaveReport(u64, pid, buffer<u8, 9>, buffer<bytes, 5>)
         public ResultCode SaveReport(ServiceCtx context)
         {
+            if ((_permission & 1) == 0)
+            {
+                return ResultCode.PermissionDenied;
+            }
+
             // We don't care about the differences since we don't use the play report.
             return ProcessReport(context, withUserID: false);
         }
@@ -32,6 +45,11 @@ namespace Ryujinx.HLE.HOS.Services.Prepo
         // SaveReportWithUser(nn::account::Uid, u64, pid, buffer<u8, 9>, buffer<bytes, 5>)
         public ResultCode SaveReportWithUser(ServiceCtx context)
         {
+            if ((_permission & 1) == 0)
+            {
+                return ResultCode.PermissionDenied;
+            }
+
             // We don't care about the differences since we don't use the play report.
             return ProcessReport(context, withUserID: true);
         }
@@ -53,6 +71,26 @@ namespace Ryujinx.HLE.HOS.Services.Prepo
             // It returns the transmission result of nn::prepo::detail::service::core::TransmissionStatusManager.
             // Since we don't use reports it's fine to return ResultCode.Success.
             context.ResponseData.Write((int)ResultCode.Success);
+
+            return ResultCode.Success;
+        }
+
+        [Command(10400)] // 9.0.0+
+        // GetSystemSessionId() -> u64
+        public ResultCode GetSystemSessionId(ServiceCtx context)
+        {
+            if ((_permission & 1) == 0)
+            {
+                return ResultCode.PermissionDenied;
+            }
+
+            byte[] randomBuffer = new byte[8];
+
+            new Random().NextBytes(randomBuffer);
+
+            ulong systemSessionId = BitConverter.ToUInt64(randomBuffer, 0);
+
+            context.ResponseData.Write(systemSessionId);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Prepo/ResultCode.cs
+++ b/Ryujinx.HLE/HOS/Services/Prepo/ResultCode.cs
@@ -7,9 +7,9 @@ namespace Ryujinx.HLE.HOS.Services.Prepo
 
         Success = 0,
 
-        InvalidArgument   = (1 << ErrorCodeShift) | ModuleId,
-        InvalidState      = (5 << ErrorCodeShift) | ModuleId,
-        InvalidBufferSize = (9 << ErrorCodeShift) | ModuleId,
-        Unknown1          = (90 << ErrorCodeShift) | ModuleId
+        InvalidArgument   = (1  << ErrorCodeShift) | ModuleId,
+        InvalidState      = (5  << ErrorCodeShift) | ModuleId,
+        InvalidBufferSize = (9  << ErrorCodeShift) | ModuleId,
+        PermissionDenied  = (90 << ErrorCodeShift) | ModuleId
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Prepo/Types/PrepoServicePermissionLevel.cs
+++ b/Ryujinx.HLE/HOS/Services/Prepo/Types/PrepoServicePermissionLevel.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Ryujinx.HLE.HOS.Services.Prepo
+{
+    enum PrepoServicePermissionLevel
+    {
+        Admin   = -1,
+        User    = 1,
+        System  = 2,
+        Manager = 6
+    }
+}


### PR DESCRIPTION
This PR implement `GetSystemSessionId` of prepo service accordingly to RE.
During my research I've pointed out what the result code `90` is and where it's used in our actual implementation. So I've added it with some missing services too.

This should let "Super Mario 3D World + Bowser's Fury" run without `Ignore Missing Services` enabled. 

Thanks to Ga1act1c from our Discord for let us know the issue.