### PR TITLE
Fix memory tracking performance regression

### DIFF
--- a/ARMeilleure/Instructions/InstEmitMemoryHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitMemoryHelper.cs
@@ -334,14 +334,14 @@ namespace ARMeilleure.Instructions
             {
                 if (write)
                 {
-                    pte = context.ShiftLeft(pte, Const(1));
                     context.BranchIf(lblSlowPath, pte, Const(0L), Comparison.LessOrEqual);
-                    pte = context.ShiftRightUI(pte, Const(1));
+                    pte = context.BitwiseAnd(pte, Const(0xffffffffffffUL)); // Ignore any software protection bits. (they are still used by C# memory access)
                 }
                 else
                 {
+                    pte = context.ShiftLeft(pte, Const(1));
                     context.BranchIf(lblSlowPath, pte, Const(0L), Comparison.LessOrEqual);
-                    pte = context.BitwiseAnd(pte, Const(0xffffffffffffUL)); // Ignore any software protection bits. (they are still used by C# memory access)
+                    pte = context.ShiftRightUI(pte, Const(1));
                 }
             }
             else

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -22,7 +22,7 @@ namespace ARMeilleure.Translation.PTC
     {
         private const string HeaderMagic = "PTChd";
 
-        private const int InternalVersion = 1987; //! To be incremented manually for each change to the ARMeilleure project.
+        private const int InternalVersion = 1234; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -22,7 +22,7 @@ namespace ARMeilleure.Translation.PTC
     {
         private const string HeaderMagic = "PTChd";
 
-        private const int InternalVersion = 1234; //! To be incremented manually for each change to the ARMeilleure project.
+        private const int InternalVersion = 2026; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";

--- a/Ryujinx.Cpu/MemoryManager.cs
+++ b/Ryujinx.Cpu/MemoryManager.cs
@@ -561,7 +561,7 @@ namespace Ryujinx.Cpu
             long tag = protection switch
             {
                 MemoryPermission.None => 0L,
-                MemoryPermission.Read => 2L << PointerTagBit,
+                MemoryPermission.Write => 2L << PointerTagBit,
                 _ => 3L << PointerTagBit
             };
 
@@ -631,7 +631,7 @@ namespace Ryujinx.Cpu
             // tracking using host guard pages in future, but also supporting platforms where this is not possible.
 
             // Write tag includes read protection, since we don't have any read actions that aren't performed before write too.
-            long tag = (write ? 3L : 2L) << PointerTagBit;
+            long tag = (write ? 3L : 1L) << PointerTagBit;
 
             ulong endVa = (va + size + PageMask) & ~(ulong)PageMask;
 


### PR DESCRIPTION
Fix a regression introduced on #1987 due to the read/write flags being inverted.
It is not possible to track memory writes without also tracking reads, but tracking reads without tracking writes is possible. The previous code assumed the opposite, which lead to it taking the slow path for memory access when it shouldn't.