### PR TITLE
settings: Fix returned buffer size of GetFirmwareVersion

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
@@ -30,7 +30,8 @@ namespace Ryujinx.HLE.HOS.Services.Settings
         public ResultCode GetFirmwareVersion2(ServiceCtx context)
         {
             long replyPos  = context.Request.RecvListBuff[0].Position;
-            long replySize = context.Request.RecvListBuff[0].Size;
+
+            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize(0x100L);
 
             byte[] firmwareData = GetFirmwareData(context.Device);
 


### PR DESCRIPTION
This PR fix an issue introduced on last IPC rewrite PRs where some returned buffer size have to be explicit now.
GetFirmwareVersion/GetFirmwareVersion2 missed this and could crashes some homebrew because libnx have to check the firmware version to allow some call usage (with `hosversionBefore()`).