### PR TITLE
UI: Multithreaded Updater

### DIFF
--- a/Ryujinx/Modules/Updater/UpdateDialog.cs
+++ b/Ryujinx/Modules/Updater/UpdateDialog.cs
@@ -22,16 +22,18 @@ namespace Ryujinx.Modules
 
         private readonly MainWindow _mainWindow;
         private readonly string     _buildUrl;
+        private readonly long       _buildSize;
         private          bool       _restartQuery;
 
-        public UpdateDialog(MainWindow mainWindow, Version newVersion, string buildUrl) : this(new Builder("Ryujinx.Modules.Updater.UpdateDialog.glade"), mainWindow, newVersion, buildUrl) { }
+        public UpdateDialog(MainWindow mainWindow, Version newVersion, string buildUrl, long buildSize) : this(new Builder("Ryujinx.Modules.Updater.UpdateDialog.glade"), mainWindow, newVersion, buildUrl, buildSize) { }
 
-        private UpdateDialog(Builder builder, MainWindow mainWindow, Version newVersion, string buildUrl) : base(builder.GetObject("UpdateDialog").Handle)
+        private UpdateDialog(Builder builder, MainWindow mainWindow, Version newVersion, string buildUrl, long buildSize) : base(builder.GetObject("UpdateDialog").Handle)
         {
             builder.Autoconnect(this);
 
             _mainWindow = mainWindow;
             _buildUrl   = buildUrl;
+            _buildSize = buildSize;
 
             Icon = new Gdk.Pixbuf(Assembly.GetExecutingAssembly(), "Ryujinx.Ui.Resources.Logo_Ryujinx.png");
             MainText.Text      = "Do you want to update Ryujinx to the latest version?";
@@ -73,7 +75,8 @@ namespace Ryujinx.Modules
                 SecondaryText.Text = "";
                 _restartQuery      = true;
 
-                _ = Updater.UpdateRyujinx(this, _buildUrl);
+                //_ = 
+                    Updater.UpdateRyujinx(this, _buildUrl, _buildSize);
             }
         }
 

--- a/Ryujinx/Modules/Updater/UpdateDialog.cs
+++ b/Ryujinx/Modules/Updater/UpdateDialog.cs
@@ -22,18 +22,16 @@ namespace Ryujinx.Modules
 
         private readonly MainWindow _mainWindow;
         private readonly string     _buildUrl;
-        private readonly long       _buildSize;
         private          bool       _restartQuery;
 
-        public UpdateDialog(MainWindow mainWindow, Version newVersion, string buildUrl, long buildSize) : this(new Builder("Ryujinx.Modules.Updater.UpdateDialog.glade"), mainWindow, newVersion, buildUrl, buildSize) { }
+        public UpdateDialog(MainWindow mainWindow, Version newVersion, string buildUrl) : this(new Builder("Ryujinx.Modules.Updater.UpdateDialog.glade"), mainWindow, newVersion, buildUrl) { }
 
-        private UpdateDialog(Builder builder, MainWindow mainWindow, Version newVersion, string buildUrl, long buildSize) : base(builder.GetObject("UpdateDialog").Handle)
+        private UpdateDialog(Builder builder, MainWindow mainWindow, Version newVersion, string buildUrl) : base(builder.GetObject("UpdateDialog").Handle)
         {
             builder.Autoconnect(this);
 
             _mainWindow = mainWindow;
             _buildUrl   = buildUrl;
-            _buildSize = buildSize;
 
             Icon = new Gdk.Pixbuf(Assembly.GetExecutingAssembly(), "Ryujinx.Ui.Resources.Logo_Ryujinx.png");
             MainText.Text      = "Do you want to update Ryujinx to the latest version?";
@@ -75,8 +73,7 @@ namespace Ryujinx.Modules
                 SecondaryText.Text = "";
                 _restartQuery      = true;
 
-                //_ = 
-                    Updater.UpdateRyujinx(this, _buildUrl, _buildSize);
+                Updater.UpdateRyujinx(this, _buildUrl);
             }
         }
 

--- a/Ryujinx/Modules/Updater/Updater.cs
+++ b/Ryujinx/Modules/Updater/Updater.cs
@@ -255,9 +255,10 @@ namespace Ryujinx.Modules
                         if (Interlocked.Equals(completedRequests, ConnectionCount))
                         {
                             byte[] mergedFileBytes = new byte[_buildSize];
-                            for (int connectionIndex = 0, destinationOffset = 0; connectionIndex < ConnectionCount; connectionIndex++, destinationOffset += list[connectionIndex].Length)
+                            for (int connectionIndex = 0, destinationOffset = 0; connectionIndex < ConnectionCount; connectionIndex++)
                             {
                                 Array.Copy(list[connectionIndex], 0, mergedFileBytes, destinationOffset, list[connectionIndex].Length);
+                                destinationOffset += list[connectionIndex].Length
                             }
 
                             File.WriteAllBytes(updateFile, mergedFileBytes);

--- a/Ryujinx/Modules/Updater/Updater.cs
+++ b/Ryujinx/Modules/Updater/Updater.cs
@@ -255,13 +255,9 @@ namespace Ryujinx.Modules
                         if (Interlocked.Equals(completedRequests, ConnectionCount))
                         {
                             byte[] finalFile = new byte[_buildSize];
-                            int j = 0;
-                            for (int connectionIndex = 0; connectionIndex < ConnectionCount; connectionIndex++)
+                            for (int connectionIndex = 0, j = 0; connectionIndex < ConnectionCount; connectionIndex++, j += list[connectionIndex].Length)
                             {
-                                for (int k = 0; k < list[connectionIndex].Length; k++)
-                                {
-                                    finalFile[j++] = list[connectionIndex][k];
-                                }
+                                Array.Copy(list[connectionIndex], 0, finalFile, j, list[connectionIndex].Length);
                             }
 
                             File.WriteAllBytes(updateFile, finalFile);

--- a/Ryujinx/Modules/Updater/Updater.cs
+++ b/Ryujinx/Modules/Updater/Updater.cs
@@ -331,7 +331,7 @@ namespace Ryujinx.Modules
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                using (Stream          inStream  = File.OpenRead(updateFile))
+                using (Stream         inStream   = File.OpenRead(updateFile))
                 using (Stream         gzipStream = new GZipInputStream(inStream))
                 using (TarInputStream tarStream  = new TarInputStream(gzipStream, Encoding.ASCII))
                 {

--- a/Ryujinx/Modules/Updater/Updater.cs
+++ b/Ryujinx/Modules/Updater/Updater.cs
@@ -315,8 +315,8 @@ namespace Ryujinx.Modules
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                using (Stream inStream          = File.OpenRead(updateFile))
-                using (Stream gzipStream        = new GZipInputStream(inStream))
+                using (Stream          inStream = File.OpenRead(updateFile))
+                using (Stream        gzipStream = new GZipInputStream(inStream))
                 using (TarInputStream tarStream = new TarInputStream(gzipStream, Encoding.ASCII))
                 {
                     updateDialog.ProgressBar.MaxValue = inStream.Length;
@@ -354,7 +354,7 @@ namespace Ryujinx.Modules
             else
             {
                 using (Stream  inStream = File.OpenRead(updateFile))
-                using (ZipFile zipFile  = new ZipFile(inStream))
+                using (ZipFile  zipFile = new ZipFile(inStream))
                 {
                     updateDialog.ProgressBar.MaxValue = zipFile.Count;
 
@@ -368,7 +368,7 @@ namespace Ryujinx.Modules
 
                             Directory.CreateDirectory(Path.GetDirectoryName(outPath));
 
-                            using (Stream zipStream     = zipFile.GetInputStream(zipEntry))
+                            using (Stream     zipStream = zipFile.GetInputStream(zipEntry))
                             using (FileStream outStream = File.OpenWrite(outPath))
                             {
                                 zipStream.CopyTo(outStream);

--- a/Ryujinx/Modules/Updater/Updater.cs
+++ b/Ryujinx/Modules/Updater/Updater.cs
@@ -141,13 +141,14 @@ namespace Ryujinx.Modules
             }
 
             // Fetch build size information to learn chunk sizes.
-            using (WebClient jsonClient = new WebClient()) { 
+            using (WebClient buildSizeClient = new WebClient()) { 
                 try
                 {
-                    string fetchedArtifactJson = await jsonClient.DownloadStringTaskAsync($"{AppveyorApiUrl}/buildjobs/{_jobId}/artifacts");
-                    JArray artifactRoot = JArray.Parse(fetchedArtifactJson);
+                    buildSizeClient.Headers.Add("Range", "bytes=0-0");
+                    await buildSizeClient.DownloadDataTaskAsync(new Uri(_buildUrl));
 
-                    _buildSize = long.Parse((string)artifactRoot[artifactIndex]["size"]);
+                    string contentRange = buildSizeClient.ResponseHeaders["Content-Range"];
+                    _buildSize          = long.Parse(contentRange.Substring(contentRange.IndexOf('/') + 1));
                 }
                 catch (Exception e)
                 {

--- a/Ryujinx/Modules/Updater/Updater.cs
+++ b/Ryujinx/Modules/Updater/Updater.cs
@@ -331,9 +331,9 @@ namespace Ryujinx.Modules
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                using (Stream          inStream = File.OpenRead(updateFile))
-                using (Stream        gzipStream = new GZipInputStream(inStream))
-                using (TarInputStream tarStream = new TarInputStream(gzipStream, Encoding.ASCII))
+                using (Stream          inStream  = File.OpenRead(updateFile))
+                using (Stream         gzipStream = new GZipInputStream(inStream))
+                using (TarInputStream tarStream  = new TarInputStream(gzipStream, Encoding.ASCII))
                 {
                     updateDialog.ProgressBar.MaxValue = inStream.Length;
 
@@ -369,8 +369,8 @@ namespace Ryujinx.Modules
             }
             else
             {
-                using (Stream inStream = File.OpenRead(updateFile))
-                using (ZipFile zipFile = new ZipFile(inStream))
+                using (Stream  inStream = File.OpenRead(updateFile))
+                using (ZipFile zipFile  = new ZipFile(inStream))
                 {
                     updateDialog.ProgressBar.MaxValue = zipFile.Count;
 

--- a/Ryujinx/Modules/Updater/Updater.cs
+++ b/Ryujinx/Modules/Updater/Updater.cs
@@ -25,7 +25,7 @@ namespace Ryujinx.Modules
         private static readonly string HomeDir          = AppDomain.CurrentDomain.BaseDirectory;
         private static readonly string UpdateDir        = Path.Combine(Path.GetTempPath(), "Ryujinx", "update");
         private static readonly string UpdatePublishDir = Path.Combine(UpdateDir, "publish");
-        private static readonly int    ConnectionCount  = 8;
+        private static readonly int    ConnectionCount  = 4;
 
         private static string _jobId;
         private static string _buildVer;

--- a/Ryujinx/Modules/Updater/Updater.cs
+++ b/Ryujinx/Modules/Updater/Updater.cs
@@ -254,13 +254,13 @@ namespace Ryujinx.Modules
 
                         if (Interlocked.Equals(completedRequests, ConnectionCount))
                         {
-                            byte[] finalFile = new byte[_buildSize];
-                            for (int connectionIndex = 0, j = 0; connectionIndex < ConnectionCount; connectionIndex++, j += list[connectionIndex].Length)
+                            byte[] mergedFileBytes = new byte[_buildSize];
+                            for (int connectionIndex = 0, destinationOffset = 0; connectionIndex < ConnectionCount; connectionIndex++, destinationOffset += list[connectionIndex].Length)
                             {
-                                Array.Copy(list[connectionIndex], 0, finalFile, j, list[connectionIndex].Length);
+                                Array.Copy(list[connectionIndex], 0, mergedFileBytes, destinationOffset, list[connectionIndex].Length);
                             }
 
-                            File.WriteAllBytes(updateFile, finalFile);
+                            File.WriteAllBytes(updateFile, mergedFileBytes);
 
                             try
                             {

--- a/Ryujinx/Modules/Updater/Updater.cs
+++ b/Ryujinx/Modules/Updater/Updater.cs
@@ -43,6 +43,7 @@ namespace Ryujinx.Modules
             mainWindow.UpdateMenuItem.Sensitive = false;
 
             int artifactIndex = -1;
+
             // Detect current platform
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
@@ -63,6 +64,7 @@ namespace Ryujinx.Modules
             if (artifactIndex == -1)
             {
                 GtkDialog.CreateErrorDialog("Your platform is not supported!");
+
                 return;
             }
 
@@ -141,18 +143,19 @@ namespace Ryujinx.Modules
             }
 
             // Fetch build size information to learn chunk sizes.
-            using (WebClient buildSizeClient = new WebClient()) { 
+            using (WebClient buildSizeClient = new WebClient()) 
+            { 
                 try
                 {
                     buildSizeClient.Headers.Add("Range", "bytes=0-0");
                     await buildSizeClient.DownloadDataTaskAsync(new Uri(_buildUrl));
 
                     string contentRange = buildSizeClient.ResponseHeaders["Content-Range"];
-                    _buildSize          = long.Parse(contentRange.Substring(contentRange.IndexOf('/') + 1));
+                    _buildSize = long.Parse(contentRange.Substring(contentRange.IndexOf('/') + 1));
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    Logger.Warning?.Print(LogClass.Application, e.Message);
+                    Logger.Warning?.Print(LogClass.Application, ex.Message);
                     Logger.Warning?.Print(LogClass.Application, "Couldn't determine build size for update, will use single-threaded updater");
                     _buildSize = -1;
                 }
@@ -274,10 +277,11 @@ namespace Ryujinx.Modules
                     {
                         client.DownloadDataAsync(new Uri(downloadUrl), i);
                     }
-                    catch (WebException e)
+                    catch (WebException ex)
                     {
-                        Logger.Warning?.Print(LogClass.Application, e.Message);
+                        Logger.Warning?.Print(LogClass.Application, ex.Message);
                         Logger.Warning?.Print(LogClass.Application, $"Multi-Threaded update failed, falling back to single-threaded updater.");
+                        
                         for(int j = 0; j < webClients.Count; j++)
                         {
                             webClients[j].CancelAsync();
@@ -316,8 +320,8 @@ namespace Ryujinx.Modules
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                using (Stream          inStream = File.OpenRead(updateFile))
-                using (Stream        gzipStream = new GZipInputStream(inStream))
+                using (Stream inStream          = File.OpenRead(updateFile))
+                using (Stream gzipStream        = new GZipInputStream(inStream))
                 using (TarInputStream tarStream = new TarInputStream(gzipStream, Encoding.ASCII))
                 {
                     updateDialog.ProgressBar.MaxValue = inStream.Length;
@@ -354,8 +358,8 @@ namespace Ryujinx.Modules
             }
             else
             {
-                using (Stream  inStream = File.OpenRead(updateFile))
-                using (ZipFile  zipFile = new ZipFile(inStream))
+                using (Stream inStream = File.OpenRead(updateFile))
+                using (ZipFile zipFile = new ZipFile(inStream))
                 {
                     updateDialog.ProgressBar.MaxValue = zipFile.Count;
 
@@ -369,7 +373,7 @@ namespace Ryujinx.Modules
 
                             Directory.CreateDirectory(Path.GetDirectoryName(outPath));
 
-                            using (Stream     zipStream = zipFile.GetInputStream(zipEntry))
+                            using (Stream zipStream     = zipFile.GetInputStream(zipEntry))
                             using (FileStream outStream = File.OpenWrite(outPath))
                             {
                                 zipStream.CopyTo(outStream);

--- a/Ryujinx/Modules/Updater/Updater.cs
+++ b/Ryujinx/Modules/Updater/Updater.cs
@@ -263,6 +263,7 @@ namespace Ryujinx.Modules
                                 Logger.Warning?.Print(LogClass.Application, e.Message);
                                 Logger.Warning?.Print(LogClass.Application, $"Multi-Threaded update failed, falling back to single-threaded updater.");
                                 DoUpdateWithSingleThread(updateDialog, downloadUrl, updateFile);
+                                return;
                             }
                         }
                     };
@@ -279,7 +280,6 @@ namespace Ryujinx.Modules
                         {
                             webClients[j].CancelAsync();
                         }
-
                         DoUpdateWithSingleThread(updateDialog, downloadUrl, updateFile);
                         return;
                     }

--- a/Ryujinx/Modules/Updater/Updater.cs
+++ b/Ryujinx/Modules/Updater/Updater.cs
@@ -71,7 +71,7 @@ namespace Ryujinx.Modules
 
             try
             {
-                currentVersion = Version.Parse("1.0");//Program.Version);
+                currentVersion = Version.Parse(Program.Version);
             }
             catch
             {
@@ -461,15 +461,15 @@ namespace Ryujinx.Modules
                 return false;
             }
 
-            //if (Program.Version.Contains("dirty"))
-            //{
-            //    if (showWarnings)
-            //    {
-            //        GtkDialog.CreateWarningDialog("You Cannot update a Dirty build of Ryujinx!", "Please download Ryujinx at https://ryujinx.org/ if you are looking for a supported version.");
-            //    }
+            if (Program.Version.Contains("dirty"))
+            {
+                if (showWarnings)
+                {
+                    GtkDialog.CreateWarningDialog("You Cannot update a Dirty build of Ryujinx!", "Please download Ryujinx at https://ryujinx.org/ if you are looking for a supported version.");
+                }
 
-            //    return false;
-            //}
+                return false;
+            }
 
             return true;
         }

--- a/Ryujinx/Modules/Updater/Updater.cs
+++ b/Ryujinx/Modules/Updater/Updater.cs
@@ -184,7 +184,7 @@ namespace Ryujinx.Modules
             updateDialog.ProgressBar.Value    = 0;
             updateDialog.ProgressBar.MaxValue = 100;
 
-            if(_buildSize >= 0)
+            if (_buildSize >= 0)
             {
                 DoUpdateWithMultipleThreads(updateDialog, downloadUrl, updateFile);
             }
@@ -270,7 +270,7 @@ namespace Ryujinx.Modules
                             {
                                 InstallUpdate(updateDialog, updateFile);
                             }
-                            catch(Exception e)
+                            catch (Exception e)
                             {
                                 Logger.Warning?.Print(LogClass.Application, e.Message);
                                 Logger.Warning?.Print(LogClass.Application, $"Multi-Threaded update failed, falling back to single-threaded updater.");

--- a/Ryujinx/Modules/Updater/Updater.cs
+++ b/Ryujinx/Modules/Updater/Updater.cs
@@ -303,6 +303,7 @@ namespace Ryujinx.Modules
                 }
             }
         }
+
         private static void DoUpdateWithSingleThread(UpdateDialog updateDialog, string downloadUrl, string updateFile)
         {
             // Single-Threaded Updater

--- a/Ryujinx/Modules/Updater/Updater.cs
+++ b/Ryujinx/Modules/Updater/Updater.cs
@@ -41,21 +41,22 @@ namespace Ryujinx.Modules
 
             Running = true;
             mainWindow.UpdateMenuItem.Sensitive = false;
+
             int artifactIndex = -1;
             // Detect current platform
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                _platformExt = "osx_x64.zip";
+                _platformExt  = "osx_x64.zip";
                 artifactIndex = 1;
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                _platformExt = "win_x64.zip";
+                _platformExt  = "win_x64.zip";
                 artifactIndex = 2;
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                _platformExt = "linux_x64.tar.gz";
+                _platformExt  = "linux_x64.tar.gz";
                 artifactIndex = 0;
             }
 
@@ -86,11 +87,11 @@ namespace Ryujinx.Modules
                 using (WebClient jsonClient = new WebClient())
                 {
                     // Fetch latest build information
-                    string fetchedJson = await jsonClient.DownloadStringTaskAsync($"{AppveyorApiUrl}/projects/gdkchan/ryujinx/branch/master");
-                    JObject jsonRoot = JObject.Parse(fetchedJson);
-                    JToken buildToken = jsonRoot["build"];
+                    string  fetchedJson = await jsonClient.DownloadStringTaskAsync($"{AppveyorApiUrl}/projects/gdkchan/ryujinx/branch/master");
+                    JObject jsonRoot    = JObject.Parse(fetchedJson);
+                    JToken  buildToken  = jsonRoot["build"];
 
-                    _jobId = (string)buildToken["jobs"][0]["jobId"];
+                    _jobId    = (string)buildToken["jobs"][0]["jobId"];
                     _buildVer = (string)buildToken["version"];
                     _buildUrl = $"{AppveyorApiUrl}/buildjobs/{_jobId}/artifacts/ryujinx-{_buildVer}-{_platformExt}";
 

--- a/Ryujinx/Modules/Updater/Updater.cs
+++ b/Ryujinx/Modules/Updater/Updater.cs
@@ -310,13 +310,13 @@ namespace Ryujinx.Modules
         private static async void InstallUpdate(UpdateDialog updateDialog, string updateFile)
         {
             // Extract Update
-            updateDialog.MainText.Text = "Extracting Update...";
+            updateDialog.MainText.Text     = "Extracting Update...";
             updateDialog.ProgressBar.Value = 0;
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                using (Stream inStream = File.OpenRead(updateFile))
-                using (Stream gzipStream = new GZipInputStream(inStream))
+                using (Stream inStream          = File.OpenRead(updateFile))
+                using (Stream gzipStream        = new GZipInputStream(inStream))
                 using (TarInputStream tarStream = new TarInputStream(gzipStream, Encoding.ASCII))
                 {
                     updateDialog.ProgressBar.MaxValue = inStream.Length;
@@ -353,8 +353,8 @@ namespace Ryujinx.Modules
             }
             else
             {
-                using (Stream inStream = File.OpenRead(updateFile))
-                using (ZipFile zipFile = new ZipFile(inStream))
+                using (Stream  inStream = File.OpenRead(updateFile))
+                using (ZipFile zipFile  = new ZipFile(inStream))
                 {
                     updateDialog.ProgressBar.MaxValue = zipFile.Count;
 
@@ -368,7 +368,7 @@ namespace Ryujinx.Modules
 
                             Directory.CreateDirectory(Path.GetDirectoryName(outPath));
 
-                            using (Stream zipStream = zipFile.GetInputStream(zipEntry))
+                            using (Stream zipStream     = zipFile.GetInputStream(zipEntry))
                             using (FileStream outStream = File.OpenWrite(outPath))
                             {
                                 zipStream.CopyTo(outStream);
@@ -390,8 +390,8 @@ namespace Ryujinx.Modules
 
             string[] allFiles = Directory.GetFiles(HomeDir, "*", SearchOption.AllDirectories);
 
-            updateDialog.MainText.Text = "Renaming Old Files...";
-            updateDialog.ProgressBar.Value = 0;
+            updateDialog.MainText.Text        = "Renaming Old Files...";
+            updateDialog.ProgressBar.Value    = 0;
             updateDialog.ProgressBar.MaxValue = allFiles.Length;
 
             // Replace old files
@@ -419,8 +419,8 @@ namespace Ryujinx.Modules
 
                 Application.Invoke(delegate
                 {
-                    updateDialog.MainText.Text = "Adding New Files...";
-                    updateDialog.ProgressBar.Value = 0;
+                    updateDialog.MainText.Text        = "Adding New Files...";
+                    updateDialog.ProgressBar.Value    = 0;
                     updateDialog.ProgressBar.MaxValue = Directory.GetFiles(UpdatePublishDir, "*", SearchOption.AllDirectories).Length;
                 });
 
@@ -429,14 +429,15 @@ namespace Ryujinx.Modules
 
             Directory.Delete(UpdateDir, true);
 
-            updateDialog.MainText.Text = "Update Complete!";
+            updateDialog.MainText.Text      = "Update Complete!";
             updateDialog.SecondaryText.Text = "Do you want to restart Ryujinx now?";
-            updateDialog.Modal = true;
+            updateDialog.Modal              = true;
 
             updateDialog.ProgressBar.Hide();
             updateDialog.YesButton.Show();
             updateDialog.NoButton.Show();
         }
+
         public static bool CanUpdate(bool showWarnings)
         {
             if (RuntimeInformation.OSArchitecture != Architecture.X64)

--- a/Ryujinx/Modules/Updater/Updater.cs
+++ b/Ryujinx/Modules/Updater/Updater.cs
@@ -276,6 +276,7 @@ namespace Ryujinx.Modules
                                 Logger.Warning?.Print(LogClass.Application, $"Multi-Threaded update failed, falling back to single-threaded updater.");
 
                                 DoUpdateWithSingleThread(updateDialog, downloadUrl, updateFile);
+
                                 return;
                             }
                         }
@@ -290,7 +291,7 @@ namespace Ryujinx.Modules
                         Logger.Warning?.Print(LogClass.Application, ex.Message);
                         Logger.Warning?.Print(LogClass.Application, $"Multi-Threaded update failed, falling back to single-threaded updater.");
                         
-                        for(int j = 0; j < webClients.Count; j++)
+                        for (int j = 0; j < webClients.Count; j++)
                         {
                             webClients[j].CancelAsync();
                         }
@@ -330,8 +331,8 @@ namespace Ryujinx.Modules
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
-                using (Stream inStream          = File.OpenRead(updateFile))
-                using (Stream gzipStream        = new GZipInputStream(inStream))
+                using (Stream          inStream = File.OpenRead(updateFile))
+                using (Stream        gzipStream = new GZipInputStream(inStream))
                 using (TarInputStream tarStream = new TarInputStream(gzipStream, Encoding.ASCII))
                 {
                     updateDialog.ProgressBar.MaxValue = inStream.Length;
@@ -383,7 +384,7 @@ namespace Ryujinx.Modules
 
                             Directory.CreateDirectory(Path.GetDirectoryName(outPath));
 
-                            using (Stream zipStream     = zipFile.GetInputStream(zipEntry))
+                            using (Stream     zipStream = zipFile.GetInputStream(zipEntry))
                             using (FileStream outStream = File.OpenWrite(outPath))
                             {
                                 zipStream.CopyTo(outStream);

--- a/Ryujinx/Modules/Updater/Updater.cs
+++ b/Ryujinx/Modules/Updater/Updater.cs
@@ -258,7 +258,7 @@ namespace Ryujinx.Modules
                             for (int connectionIndex = 0, destinationOffset = 0; connectionIndex < ConnectionCount; connectionIndex++)
                             {
                                 Array.Copy(list[connectionIndex], 0, mergedFileBytes, destinationOffset, list[connectionIndex].Length);
-                                destinationOffset += list[connectionIndex].Length
+                                destinationOffset += list[connectionIndex].Length;
                             }
 
                             File.WriteAllBytes(updateFile, mergedFileBytes);


### PR DESCRIPTION
Use multiple threads to download different chunks of an update simultaneously. This may reduce download times significantly (depending on your connection / bandwidth limitations).

For example: on my 50mbps connection, download times (windows build) have been reduced from 20s to 10s. Your results will vary.