### PR TITLE
nifm: Fix returned buffer size of GetClientId

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Nifm/StaticService/IGeneralService.cs
+++ b/Ryujinx.HLE/HOS/Services/Nifm/StaticService/IGeneralService.cs
@@ -27,7 +27,8 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
         public ResultCode GetClientId(ServiceCtx context)
         {
             long position = context.Request.RecvListBuff[0].Position;
-            long size     = context.Request.RecvListBuff[0].Size;
+
+            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize(4);
 
             context.Memory.Write((ulong)position, _generalServiceDetail.ClientId);
 


### PR DESCRIPTION
This PR fix an issue introduced on last IPC rewrite PRs where some returned buffer size have to be explicit now.
`GetClientId` without an explicit buffer size returns some garbage data to the guest and then `nifm` service crashes because of a wrong ClientId.

Horizon Chase Turbo and Doom regression are fixed.  (Probably some other games too)
![image](https://user-images.githubusercontent.com/4905390/108548752-92763200-72ec-11eb-9fff-acad76ef64af.png)
