### PR TITLE
Add MotionButton to simulate shaking of controller

### DIFF
--- a/Ryujinx.Common/Configuration/ConfigurationFileFormat.cs
+++ b/Ryujinx.Common/Configuration/ConfigurationFileFormat.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.Configuration
         /// <summary>
         /// The current version of the file format
         /// </summary>
-        public const int CurrentVersion = 22;
+        public const int CurrentVersion = 23;
 
         public int Version { get; set; }
 

--- a/Ryujinx.Common/Configuration/ConfigurationState.cs
+++ b/Ryujinx.Common/Configuration/ConfigurationState.cs
@@ -517,7 +517,8 @@ namespace Ryujinx.Configuration
             Hid.EnableKeyboard.Value               = false;
             Hid.Hotkeys.Value = new KeyboardHotkeys
             {
-                ToggleVsync = Key.Tab
+                ToggleVsync = Key.Tab,
+                MotionButton = Key.Grave
             };
             Hid.InputConfig.Value = new List<InputConfig>
             {
@@ -716,7 +717,7 @@ namespace Ryujinx.Configuration
 
                 configurationFileFormat.Hotkeys = new KeyboardHotkeys
                 {
-                    ToggleVsync = Key.Tab
+                    ToggleVsync = Key.Tab,
                 };
 
                 configurationFileUpdated = true;
@@ -800,6 +801,18 @@ namespace Ryujinx.Configuration
                 Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 22.");
 
                 configurationFileFormat.HideCursorOnIdle = false;
+
+                configurationFileUpdated = true;
+            }
+
+            if (configurationFileFormat.Version < 23)
+            {
+                Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 23.");
+
+                configurationFileFormat.Hotkeys = new KeyboardHotkeys
+                {
+                    MotionButton = Key.Grave,
+                };
 
                 configurationFileUpdated = true;
             }

--- a/Ryujinx.Common/Configuration/ConfigurationState.cs
+++ b/Ryujinx.Common/Configuration/ConfigurationState.cs
@@ -717,7 +717,7 @@ namespace Ryujinx.Configuration
 
                 configurationFileFormat.Hotkeys = new KeyboardHotkeys
                 {
-                    ToggleVsync = Key.Tab,
+                    ToggleVsync = Key.Tab
                 };
 
                 configurationFileUpdated = true;
@@ -811,7 +811,8 @@ namespace Ryujinx.Configuration
 
                 configurationFileFormat.Hotkeys = new KeyboardHotkeys
                 {
-                    MotionButton = Key.Grave,
+                    ToggleVsync = Key.Tab,
+                    MotionButton = Key.Grave
                 };
 
                 configurationFileUpdated = true;

--- a/Ryujinx.Common/Configuration/Hid/KeyboardHotkeys.cs
+++ b/Ryujinx.Common/Configuration/Hid/KeyboardHotkeys.cs
@@ -5,5 +5,6 @@ namespace Ryujinx.Common.Configuration.Hid
     public struct KeyboardHotkeys
     {
         public Key ToggleVsync { get; set; }
+        public Key MotionButton { get; set; }
     }
 }

--- a/Ryujinx/Modules/Motion/MotionDevice.cs
+++ b/Ryujinx/Modules/Motion/MotionDevice.cs
@@ -97,7 +97,6 @@ namespace Ryujinx.Modules.Motion
             value.X = float.IsNegative(value.X) ? MathF.Ceiling(value.X * power) / power : MathF.Floor(value.X * power) / power;
             value.Y = float.IsNegative(value.Y) ? MathF.Ceiling(value.Y * power) / power : MathF.Floor(value.Y * power) / power;
             value.Z = float.IsNegative(value.Z) ? MathF.Ceiling(value.Z * power) / power : MathF.Floor(value.Z * power) / power;
-
             return value;
         }
     }

--- a/Ryujinx/Modules/Motion/MotionDevice.cs
+++ b/Ryujinx/Modules/Motion/MotionDevice.cs
@@ -87,7 +87,6 @@ namespace Ryujinx.Modules.Motion
             Orientation[0] = 1f;
             Orientation[4] = 1f;
             Orientation[8] = 1f;
-
         }
 
         private static Vector3 Truncate(Vector3 value, int decimals)
@@ -97,6 +96,7 @@ namespace Ryujinx.Modules.Motion
             value.X = float.IsNegative(value.X) ? MathF.Ceiling(value.X * power) / power : MathF.Floor(value.X * power) / power;
             value.Y = float.IsNegative(value.Y) ? MathF.Ceiling(value.Y * power) / power : MathF.Floor(value.Y * power) / power;
             value.Z = float.IsNegative(value.Z) ? MathF.Ceiling(value.Z * power) / power : MathF.Floor(value.Z * power) / power;
+
             return value;
         }
     }

--- a/Ryujinx/Modules/Motion/MotionDevice.cs
+++ b/Ryujinx/Modules/Motion/MotionDevice.cs
@@ -67,6 +67,29 @@ namespace Ryujinx.Modules.Motion
             Orientation[8] = Math.Clamp(orientation.M33, -1f, 1f);
         }
 
+        public void PollRandomData(InputConfig config)
+        {
+            var random = new Random();
+            Orientation = new float[9];
+
+            if (!config.EnableMotion)
+            {
+                Accelerometer = new Vector3();
+                Gyroscope = new Vector3();
+
+                return;
+            }
+
+            Gyroscope = new Vector3(random.Next(-2000, 2000) * 0.001f);
+            Accelerometer = new Vector3(random.Next(-2000, 2000) * 0.001f);
+            Rotation = Vector3.Zero;
+
+            Orientation[0] = 1f;
+            Orientation[4] = 1f;
+            Orientation[8] = 1f;
+
+        }
+
         private static Vector3 Truncate(Vector3 value, int decimals)
         {
             float power = MathF.Pow(10, decimals);

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -616,11 +616,13 @@ namespace Ryujinx.Ui
                 currentButton |= _device.Hid.UpdateStickButtons(leftJoystick, rightJoystick);
 
                 HotkeyButtons currentHotkeyButtons = KeyboardController.GetHotkeyButtons(OpenTK.Input.Keyboard.GetState());
+
                 if (currentHotkeyButtons.HasFlag(HotkeyButtons.MotionButton))
                 {
                     motionDevice.PollRandomData(inputConfig);
                 }
-                else {
+                else 
+                {
                     motionDevice.Poll(inputConfig, inputConfig.Slot);
                 }
 

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -615,7 +615,14 @@ namespace Ryujinx.Ui
 
                 currentButton |= _device.Hid.UpdateStickButtons(leftJoystick, rightJoystick);
 
-                motionDevice.Poll(inputConfig, inputConfig.Slot);
+                HotkeyButtons currentHotkeyButtons = KeyboardController.GetHotkeyButtons(OpenTK.Input.Keyboard.GetState());
+                if (currentHotkeyButtons.HasFlag(HotkeyButtons.MotionButton))
+                {
+                    motionDevice.PollRandomData(inputConfig);
+                }
+                else {
+                    motionDevice.Poll(inputConfig, inputConfig.Slot);
+                }
 
                 SixAxisInput sixAxisInput = new SixAxisInput()
                 {
@@ -640,7 +647,14 @@ namespace Ryujinx.Ui
                 {
                     if (!inputConfig.MirrorInput)
                     {
-                        motionDevice.Poll(inputConfig, inputConfig.AltSlot);
+                        if (currentHotkeyButtons.HasFlag(HotkeyButtons.MotionButton))
+                        {
+                            motionDevice.PollRandomData(inputConfig);
+                        }
+                        else
+                        {
+                            motionDevice.Poll(inputConfig, inputConfig.AltSlot);
+                        }
 
                         sixAxisInput = new SixAxisInput()
                         {

--- a/Ryujinx/Ui/KeyboardController.cs
+++ b/Ryujinx/Ui/KeyboardController.cs
@@ -11,6 +11,7 @@ namespace Ryujinx.Ui
     public enum HotkeyButtons
     {
         ToggleVSync = 1 << 0,
+        MotionButton = 1 << 1,
     }
 
     public class KeyboardController
@@ -106,6 +107,11 @@ namespace Ryujinx.Ui
             if (keyboard[(Key)ConfigurationState.Instance.Hid.Hotkeys.Value.ToggleVsync])
             {
                 buttons |= HotkeyButtons.ToggleVSync;
+            }
+
+            if (keyboard[(Key)ConfigurationState.Instance.Hid.Hotkeys.Value.MotionButton])
+            {
+                buttons |= HotkeyButtons.MotionButton;
             }
 
             return buttons;

--- a/Ryujinx/_schema.json
+++ b/Ryujinx/_schema.json
@@ -1431,7 +1431,8 @@
       "type": "object",
       "title": "Hotkey Controls",
       "required": [
-        "toggle_vsync"
+        "toggle_vsync",
+        "motion_button"
       ],
       "properties": {
         "toggle_vsync": {
@@ -1439,6 +1440,12 @@
           "$ref": "#/definitions/key",
           "title": "Toggle VSync",
           "default": "Tab"
+        },
+        "motion_button": {
+          "$id": "#/properties/hotkeys/properties/motion_button",
+          "$ref": "#/definitions/key",
+          "title": "Motion Button",
+          "default": "Grave"
         }
       }
     },


### PR DESCRIPTION
Adds a hotkey(inspired by yuzu feature) that simulates shaking of a motion devices.  It is currently defaults to Grave " ` " .  The ranges are from shaking my phone while running the sixaxis homebrew from https://github.com/switchbrew/switch-examples/tree/master/hid/sixaxis .  A hotkey was chosen because a person might not have a joystick button to assign or may not be using keyboard input as a controller.

It works for my purposes as hitting a key is easier than using my feet to shake my phone, perhaps this will work for others as well.