### PR TITLE
ci: Use Github artifacts for PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,22 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         configuration: [Debug, Release]
+        include:
+        - os: ubuntu-latest
+          OS_NAME: Linux x64
+          DOTNET_RUNTIME_IDENTIFIER: linux-x64
+          RELEASE_ZIP_OS_NAME: linux_x64.tar.gz
+
+        - os: macOS-latest
+          OS_NAME: MacOS x64
+          DOTNET_RUNTIME_IDENTIFIER: osx-x64
+          RELEASE_ZIP_OS_NAME: osx_x64
+
+        - os: windows-latest
+          OS_NAME: Windows x64
+          DOTNET_RUNTIME_IDENTIFIER: win-x64
+          RELEASE_ZIP_OS_NAME: win_x64
+
       fail-fast: false
     env:
       POWERSHELL_TELEMETRY_OPTOUT: 1
@@ -33,9 +49,32 @@ jobs:
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 5.0.x
+      - name: Get git short hash
+        id: git_short_hash
+        run: echo "::set-output name=result::$(git rev-parse --short HEAD)"
       - name: Clear
         run: dotnet clean && dotnet nuget locals all --clear
       - name: Build
-        run: dotnet build -c "${{ matrix.configuration }}"
+        run: dotnet build -c "${{ matrix.configuration }}" /p:Version="1.0.0" /p:SourceRevisionId="${{ steps.git_short_hash.outputs.result }}" /p:ExtraDefineConstants=DISABLE_UPDATER
       - name: Test
         run: dotnet test -c "${{ matrix.configuration }}"
+      - name: Publish
+        run: dotnet publish -c "${{ matrix.configuration }}" -r "${{ matrix.DOTNET_RUNTIME_IDENTIFIER }}" -o ./publish /p:Version="1.0.0" /p:SourceRevisionId="${{ steps.git_short_hash.outputs.result }}" /p:ExtraDefineConstants=DISABLE_UPDATER
+        if: github.event_name == 'pull_request'
+      - name: Packing artifacts (Normal)
+        run: |
+          mkdir output
+          7z a "./output/ryujinx-${{ matrix.configuration }}-1.0.0+${{ steps.git_short_hash.outputs.result }}-${{ matrix.RELEASE_ZIP_OS_NAME }}.zip" ./publish
+        if: github.event_name == 'pull_request' && matrix.os != 'ubuntu-latest'
+      - name: Packing artifacts (Linux only)
+        run: |
+          mkdir output
+          7z a "ryujinx-${{ matrix.configuration }}-1.0.0+${{ steps.git_short_hash.outputs.result }}-${{ matrix.RELEASE_ZIP_OS_NAME }}.tar" ./publish
+          7z a "./output/ryujinx-${{ matrix.configuration }}-1.0.0+${{ steps.git_short_hash.outputs.result }}-${{ matrix.RELEASE_ZIP_OS_NAME }}.tar.gz" "ryujinx-${{ matrix.configuration }}-1.0.0+${{ steps.git_short_hash.outputs.result }}-${{ matrix.RELEASE_ZIP_OS_NAME }}.tar"
+        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest'
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Output ${{ matrix.OS_NAME }} (${{ matrix.configuration }})
+          path: output
+        if: github.event_name == 'pull_request'

--- a/.github/workflows/nightly_pr_comment.yml
+++ b/.github/workflows/nightly_pr_comment.yml
@@ -1,0 +1,52 @@
+name: Comment PR artifacts links
+on:
+  workflow_run:
+    workflows: ['Build job']
+    types: [completed]
+jobs:
+  pr_comment:
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v3
+        with:
+          script: |
+            const {owner, repo} = context.repo;
+            const run_id = ${{github.event.workflow_run.id}};
+            const pull_head_sha = '${{github.event.workflow_run.head_sha}}';
+            const pull_user_id = ${{github.event.sender.id}};
+
+            const issue_number = await (async () => {
+              const pulls = await github.pulls.list({owner, repo});
+              for await (const {data} of github.paginate.iterator(pulls)) {
+                for (const pull of data) {
+                  if (pull.head.sha === pull_head_sha && pull.user.id === pull_user_id) {
+                    return pull.number;
+                  }
+                }
+              }
+            })();
+            if (issue_number) {
+              core.info(`Using pull request ${issue_number}`);
+            } else {
+              return core.error(`No matching pull request found`);
+            }
+
+            const {data: {artifacts}} = await github.actions.listWorkflowRunArtifacts({owner, repo, run_id});
+            if (!artifacts.length) {
+              return core.error(`No artifacts found`);
+            }
+            let body = `Download the artifacts for this pull request:\n`;
+            for (const art of artifacts) {
+              body += `\n* [${art.name}](https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip)`;
+            }
+
+            const {data: comments} = await github.issues.listComments({repo, owner, issue_number});
+            const existing_comment = comments.find((c) => c.user.login === 'github-actions[bot]');
+            if (existing_comment) {
+              core.info(`Updating comment ${existing_comment.id}`);
+              await github.issues.updateComment({repo, owner, comment_id: existing_comment.id, body});
+            } else {
+              core.info(`Creating a comment`);
+              await github.issues.createComment({repo, owner, issue_number, body});
+            }

--- a/Ryujinx/Modules/Updater/Updater.cs
+++ b/Ryujinx/Modules/Updater/Updater.cs
@@ -288,6 +288,7 @@ namespace Ryujinx.Modules
 
         public static bool CanUpdate(bool showWarnings)
         {
+#if !DISABLE_UPDATER
             if (RuntimeInformation.OSArchitecture != Architecture.X64)
             {
                 if (showWarnings)
@@ -312,13 +313,21 @@ namespace Ryujinx.Modules
             {
                 if (showWarnings)
                 {
-                    GtkDialog.CreateWarningDialog("You Cannot update a Dirty build of Ryujinx!", "Please download Ryujinx at https://ryujinx.org/ if you are looking for a supported version.");
+                    GtkDialog.CreateWarningDialog("You cannot update a Dirty build of Ryujinx!", "Please download Ryujinx at https://ryujinx.org/ if you are looking for a supported version.");
                 }
 
                 return false;
             }
 
             return true;
+#else
+            if (showWarnings)
+            {
+                GtkDialog.CreateWarningDialog("Updater Disabled!", "Please download Ryujinx at https://ryujinx.org/ if you are looking for a supported version.");
+            }
+            return false;
+
+#endif
         }
 
         private static void MoveAllFilesOver(string root, string dest, UpdateDialog dialog)

--- a/Ryujinx/Modules/Updater/Updater.cs
+++ b/Ryujinx/Modules/Updater/Updater.cs
@@ -325,8 +325,8 @@ namespace Ryujinx.Modules
             {
                 GtkDialog.CreateWarningDialog("Updater Disabled!", "Please download Ryujinx at https://ryujinx.org/ if you are looking for a supported version.");
             }
-            return false;
 
+            return false;
 #endif
         }
 

--- a/Ryujinx/Ryujinx.csproj
+++ b/Ryujinx/Ryujinx.csproj
@@ -8,6 +8,7 @@
     <Version>1.0.0-dirty</Version>
     <TieredCompilation>false</TieredCompilation>
     <TieredCompilationQuickJit>false</TieredCompilationQuickJit>
+    <DefineConstants Condition=" '$(ExtraDefineConstants)' != '' ">$(DefineConstants);$(ExtraDefineConstants)</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -51,7 +52,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'osx-x64'">
-    <DefineConstants>MACOS_BUILD</DefineConstants>
+    <DefineConstants>$(DefineConstants);MACOS_BUILD</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR extends the build job by uploading artifacts for all PRs.
The version of those builds is set to ``1.0.0-<git_short_hash>`` and those builds have the updater explicitly disabled.

With this in place, we will be able to disable AppVeyor on PRs.