### PR TITLE
Fix virtual address overflow near ulong limit

### DIFF
--- a/Ryujinx.Cpu/MemoryManager.cs
+++ b/Ryujinx.Cpu/MemoryManager.cs
@@ -346,12 +346,12 @@ namespace Ryujinx.Cpu
         }
 
         /// <summary>
-        /// Cumputes the number of pages in a virtual address range.
+        /// Computes the number of pages in a virtual address range.
         /// </summary>
         /// <param name="va">Virtual address of the range</param>
         /// <param name="size">Size of the range</param>
         /// <param name="startVa">The virtual address of the beginning of the first page</param>
-        /// <remarks>This function does differentiate between allocated and unallocated pages.</remarks>
+        /// <remarks>This function does not differentiate between allocated and unallocated pages.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private int GetPagesCount(ulong va, ulong size, out ulong startVa)
         {

--- a/Ryujinx.Cpu/MemoryManager.cs
+++ b/Ryujinx.Cpu/MemoryManager.cs
@@ -218,6 +218,8 @@ namespace Ryujinx.Cpu
         {
             try
             {
+                AssertValidAddressAndSize(va, (ulong)data.Length);
+
                 if (IsContiguousAndMapped(va, data.Length))
                 {
                     data.CopyTo(_backingMemory.GetSpan(GetPhysicalAddressInternal(va), data.Length));
@@ -454,6 +456,8 @@ namespace Ryujinx.Cpu
 
             try
             {
+                AssertValidAddressAndSize(va, (ulong)data.Length);
+
                 int offset = 0, size;
 
                 if ((va & PageMask) != 0)

--- a/Ryujinx.Memory/AddressSpaceManager.cs
+++ b/Ryujinx.Memory/AddressSpaceManager.cs
@@ -142,6 +142,8 @@ namespace Ryujinx.Memory
                 return;
             }
 
+            AssertValidAddressAndSize(va, (ulong)data.Length);
+
             if (IsContiguousAndMapped(va, data.Length))
             {
                 data.CopyTo(_backingMemory.GetSpan(GetPhysicalAddressInternal(va), data.Length));
@@ -326,6 +328,8 @@ namespace Ryujinx.Memory
             {
                 return;
             }
+
+            AssertValidAddressAndSize(va, (ulong)data.Length);
 
             int offset = 0, size;
 

--- a/Ryujinx.Memory/AddressSpaceManager.cs
+++ b/Ryujinx.Memory/AddressSpaceManager.cs
@@ -64,6 +64,8 @@ namespace Ryujinx.Memory
         /// <param name="size">Size to be mapped</param>
         public void Map(ulong va, ulong pa, ulong size)
         {
+            AssertValidAddressAndSize(va, size);
+
             while (size != 0)
             {
                 PtMap(va, pa);
@@ -81,6 +83,8 @@ namespace Ryujinx.Memory
         /// <param name="size">Size of the range to be unmapped</param>
         public void Unmap(ulong va, ulong size)
         {
+            AssertValidAddressAndSize(va, size);
+
             while (size != 0)
             {
                 PtUnmap(va);
@@ -254,6 +258,23 @@ namespace Ryujinx.Memory
             return ref _backingMemory.GetRef<T>(GetPhysicalAddressInternal(va));
         }
 
+        /// <summary>
+        /// Computes the number of pages in a virtual address range.
+        /// </summary>
+        /// <param name="va">Virtual address of the range</param>
+        /// <param name="size">Size of the range</param>
+        /// <param name="startVa">The virtual address of the beginning of the first page</param>
+        /// <remarks>This function does not differentiate between allocated and unallocated pages.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private int GetPagesCount(ulong va, uint size, out ulong startVa)
+        {
+            // WARNING: Always check if ulong does not overflow during the operations.
+            startVa = va & ~(ulong)PageMask;
+            ulong vaSpan = (va - startVa + size + PageMask) & ~(ulong)PageMask;
+
+            return (int)(vaSpan / PageSize);
+        }
+
         private void ThrowMemoryNotContiguous() => throw new MemoryNotContiguousException();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -262,16 +283,12 @@ namespace Ryujinx.Memory
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool IsContiguous(ulong va, int size)
         {
-            if (!ValidateAddress(va))
+            if (!ValidateAddress(va) || !ValidateAddressAndSize(va, (ulong)size))
             {
                 return false;
             }
 
-            ulong endVa = (va + (ulong)size + PageMask) & ~(ulong)PageMask;
-
-            va &= ~(ulong)PageMask;
-
-            int pages = (int)((endVa - va) / PageSize);
+            int pages = GetPagesCount(va, (uint)size, out va);
 
             for (int page = 0; page < pages - 1; page++)
             {
@@ -362,11 +379,14 @@ namespace Ryujinx.Memory
                 return true;
             }
 
-            ulong endVa = (va + size + PageMask) & ~(ulong)PageMask;
+            if (!ValidateAddressAndSize(va, size))
+            {
+                return false;
+            }
 
-            va &= ~(ulong)PageMask;
+            int pages = GetPagesCount(va, (uint)size, out va);
 
-            while (va < endVa)
+            for (int page = 0; page < pages; page++)
             {
                 if (!IsMapped(va))
                 {
@@ -382,6 +402,32 @@ namespace Ryujinx.Memory
         private bool ValidateAddress(ulong va)
         {
             return va < _addressSpaceSize;
+        }
+
+        /// <summary>
+        /// Checks if the combination of virtual address and size is part of the addressable space.
+        /// </summary>
+        /// <param name="va">Virtual address of the range</param>
+        /// <param name="size">Size of the range in bytes</param>
+        /// <returns>True if the combination of virtual address and size is part of the addressable space</returns>
+        private bool ValidateAddressAndSize(ulong va, ulong size)
+        {
+            ulong endVa = va + size;
+            return endVa >= va && endVa >= size && endVa <= _addressSpaceSize;
+        }
+
+        /// <summary>
+        /// Ensures the combination of virtual address and size is part of the addressable space.
+        /// </summary>
+        /// <param name="va">Virtual address of the range</param>
+        /// <param name="size">Size of the range in bytes</param>
+        /// <exception cref="InvalidMemoryRegionException">Throw when the memory region specified outside the addressable space</exception>
+        private void AssertValidAddressAndSize(ulong va, ulong size)
+        {
+            if (!ValidateAddressAndSize(va, size))
+            {
+                throw new InvalidMemoryRegionException($"va=0x{va:X16}, size=0x{size:X16}");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Some address arithmetic used in `MemoryManager` are prone to overflow when the virtual address resides in the last page possible of a 64bit address. This causes, for instance, `IsRangeMapped` to return true even though the address is not mapped, which can lead to a bad logic and a crash.

This PR creates an overflow-safe way of counting pages for the affected functions and replaces the address-based loop in `IsRangeMapped` with page-based loop.