### PR TITLE
Fix updater breaking user execute permissions on Unix

### DIFF
--- a/Ryujinx/Modules/Updater/UpdateDialog.cs
+++ b/Ryujinx/Modules/Updater/UpdateDialog.cs
@@ -42,7 +42,7 @@ namespace Ryujinx.Modules
             YesButton.Clicked += YesButton_Clicked;
             NoButton.Clicked  += NoButton_Clicked;
         }
-        
+
         private void YesButton_Clicked(object sender, EventArgs args)
         {
             if (_restartQuery)
@@ -50,12 +50,6 @@ namespace Ryujinx.Modules
                 string ryuName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Ryujinx.exe" : "Ryujinx";
                 string ryuExe  = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ryuName);
                 string ryuArg  = string.Join(" ", Environment.GetCommandLineArgs().AsEnumerable().Skip(1).ToArray());
-
-                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    UnixFileInfo unixFileInfo = new UnixFileInfo(ryuExe);
-                    unixFileInfo.FileAccessPermissions |= FileAccessPermissions.UserExecute;
-                }
 
                 Process.Start(ryuExe, ryuArg);
 

--- a/Ryujinx/Modules/Updater/Updater.cs
+++ b/Ryujinx/Modules/Updater/Updater.cs
@@ -2,6 +2,7 @@ using Gtk;
 using ICSharpCode.SharpZipLib.GZip;
 using ICSharpCode.SharpZipLib.Tar;
 using ICSharpCode.SharpZipLib.Zip;
+using Mono.Unix;
 using Newtonsoft.Json.Linq;
 using Ryujinx.Common.Logging;
 using Ryujinx.Ui;
@@ -325,6 +326,18 @@ namespace Ryujinx.Modules
             }
         }
         
+        private static void SetUnixPermissions()
+        {
+            string ryuBin  = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Ryujinx");
+
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                UnixFileInfo unixFileInfo = new UnixFileInfo(ryuBin);
+                unixFileInfo.FileAccessPermissions |= FileAccessPermissions.UserExecute;
+            }
+
+        }
+
         private static async void InstallUpdate(UpdateDialog updateDialog, string updateFile)
         {
             // Extract Update
@@ -443,6 +456,8 @@ namespace Ryujinx.Modules
             });
 
             Directory.Delete(UpdateDir, true);
+
+            SetUnixPermissions();
 
             updateDialog.MainText.Text      = "Update Complete!";
             updateDialog.SecondaryText.Text = "Do you want to restart Ryujinx now?";

--- a/Ryujinx/Modules/Updater/Updater.cs
+++ b/Ryujinx/Modules/Updater/Updater.cs
@@ -328,14 +328,13 @@ namespace Ryujinx.Modules
         
         private static void SetUnixPermissions()
         {
-            string ryuBin  = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Ryujinx");
+            string ryuBin = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Ryujinx");
 
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 UnixFileInfo unixFileInfo = new UnixFileInfo(ryuBin);
                 unixFileInfo.FileAccessPermissions |= FileAccessPermissions.UserExecute;
             }
-
         }
 
         private static async void InstallUpdate(UpdateDialog updateDialog, string updateFile)


### PR DESCRIPTION
The updater currently sets the binary's (the _"Ryujinx"_ file on Unix) permissions to executable (for the current user) only when the Yes button is clicked on the restart dialog, since the part of the code that performs this task is inside the _YesButton_Clicked_ void in _UpdateDialog.cs_, which means that if you click No, close the updater, kill Ryujinx, etc. you will get a permission denied error the next time you attempt to run it.

This pr moves the part responsible for setting this permission to _Updater.cs_ so it is run after the updater finishes and before the restart dialog.

While when you build Ryujinx the executable has -rwxr-xr-r (any user can execute it), the updater sets the permissions to -rwxr--r-- (only the current user can execute it), this wasn't changed.

_P.S. A white space was also removed._

Fixes https://github.com/Ryujinx/Ryujinx/issues/1676