### PR TITLE
Add progress reporting to PTC and Shader Cache

### DIFF
--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -776,7 +776,7 @@ namespace ARMeilleure.Translation.PTC
 
             ThreadPool.QueueUserWorkItem(TranslationLogger, profiledFuncsToTranslate.Count);
 
-            PtcTranslationStateChanged(true);
+            PtcTranslationStateChanged?.Invoke(true);
 
             void TranslateFuncs()
             {
@@ -826,7 +826,7 @@ namespace ARMeilleure.Translation.PTC
             threads.Clear();
 
             _loggerEvent.Set();
-            PtcTranslationStateChanged(false);
+            PtcTranslationStateChanged?.Invoke(false);
 
             PtcJumpTable.Initialize(jumpTable);
 
@@ -846,7 +846,7 @@ namespace ARMeilleure.Translation.PTC
 
             do
             {
-                PtcTranslationProgressChanged(_translateCount, profiledFuncsToTranslateCount);
+                PtcTranslationProgressChanged?.Invoke(_translateCount, profiledFuncsToTranslateCount);
             }
             while (!_loggerEvent.WaitOne(refreshRate));
 

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -70,6 +70,10 @@ namespace ARMeilleure.Translation.PTC
 
         internal static PtcState State { get; private set; }
 
+        // Progress update events
+        public static event Action<bool> PtcTranslationStateChanged;
+        public static event Action<int, int> PtcTranslationProgressChanged;
+
         static Ptc()
         {
             InitializeMemoryStreams();
@@ -772,6 +776,8 @@ namespace ARMeilleure.Translation.PTC
 
             ThreadPool.QueueUserWorkItem(TranslationLogger, profiledFuncsToTranslate.Count);
 
+            PtcTranslationStateChanged(true);
+
             void TranslateFuncs()
             {
                 while (profiledFuncsToTranslate.TryDequeue(out var item))
@@ -820,6 +826,7 @@ namespace ARMeilleure.Translation.PTC
             threads.Clear();
 
             _loggerEvent.Set();
+            PtcTranslationStateChanged(false);
 
             PtcJumpTable.Initialize(jumpTable);
 
@@ -833,15 +840,15 @@ namespace ARMeilleure.Translation.PTC
 
         private static void TranslationLogger(object state)
         {
-            const int refreshRate = 1; // Seconds.
+            const int refreshRate = 100; // ms
 
             int profiledFuncsToTranslateCount = (int)state;
 
             do
             {
-                Logger.Info?.Print(LogClass.Ptc, $"{_translateCount} of {profiledFuncsToTranslateCount} functions translated");
+                PtcTranslationProgressChanged(_translateCount, profiledFuncsToTranslateCount);
             }
-            while (!_loggerEvent.WaitOne(refreshRate * 1000));
+            while (!_loggerEvent.WaitOne(refreshRate));
 
             Logger.Info?.Print(LogClass.Ptc, $"{_translateCount} of {profiledFuncsToTranslateCount} functions translated");
         }

--- a/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -80,7 +80,8 @@ namespace Ryujinx.Graphics.Gpu
         internal Capabilities Capabilities => _caps.Value;
 
         /// <summary>
-        /// Passthrough for ShaderCache.ShaderCacheStateChanged event
+        /// Signaled when shader cache begins and ends loading.
+        /// Signals true when loading has started, false when ended.
         /// </summary>
         public event Action<bool> ShaderCacheStateChanged
         {
@@ -89,7 +90,8 @@ namespace Ryujinx.Graphics.Gpu
         }
 
         /// <summary>
-        /// Passthrough for ShaderCache.ShaderCacheProgressChanged event
+        /// Signaled while shader cache is loading to indicate current progress.
+        /// Provides current and total number of shaders loaded.
         /// </summary>
         public event Action<int, int> ShaderCacheProgressChanged
         {

--- a/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -80,6 +80,24 @@ namespace Ryujinx.Graphics.Gpu
         internal Capabilities Capabilities => _caps.Value;
 
         /// <summary>
+        /// Passthrough for ShaderCache.ShaderCacheStateChanged event
+        /// </summary>
+        public event Action<bool> ShaderCacheStateChanged
+        {
+            add => Methods.ShaderCache.ShaderCacheStateChanged += value;
+            remove => Methods.ShaderCache.ShaderCacheStateChanged -= value;
+        }
+
+        /// <summary>
+        /// Passthrough for ShaderCache.ShaderCacheProgressChanged event
+        /// </summary>
+        public event Action<int, int> ShaderCacheProgressChanged
+        {
+            add => Methods.ShaderCache.ShaderCacheProgressChanged += value;
+            remove => Methods.ShaderCache.ShaderCacheProgressChanged -= value;
+        }
+
+        /// <summary>
         /// Creates a new instance of the GPU emulation context.
         /// </summary>
         /// <param name="renderer">Host renderer</param>

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -88,7 +88,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 _progressReportEvent.Reset();
                 _shaderCount = 0;
 
-                ShaderCacheStateChanged(true);
+                ShaderCacheStateChanged?.Invoke(true);
                 ThreadPool.QueueUserWorkItem(ProgressLogger, guestProgramList.Length);
 
                 for (int programIndex = 0; programIndex < guestProgramList.Length; programIndex++)
@@ -330,7 +330,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 }
 
                 _progressReportEvent.Set();
-                ShaderCacheStateChanged(false);
+                ShaderCacheStateChanged?.Invoke(false);
 
                 Logger.Info?.Print(LogClass.Gpu, $"Shader cache loaded {_shaderCount} entries.");
             }
@@ -346,7 +346,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
             int totalCount = (int)state;
             do
             {
-                ShaderCacheProgressChanged(_shaderCount, totalCount);
+                ShaderCacheProgressChanged?.Invoke(_shaderCount, totalCount);
             }
             while (!_progressReportEvent.WaitOne(refreshRate));
         }

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -9,6 +9,7 @@ using Ryujinx.Graphics.Shader.Translation;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 
 namespace Ryujinx.Graphics.Gpu.Shader
 {
@@ -36,6 +37,12 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// </summary>
         private const ulong ShaderCodeGenVersion = 1961;
 
+        // Progress reporting helpers
+        private int _shaderCount;
+        private readonly AutoResetEvent _progressReportEvent;
+        public event Action<bool> ShaderCacheStateChanged;
+        public event Action<int, int> ShaderCacheProgressChanged;
+
         /// <summary>
         /// Creates a new instance of the shader cache.
         /// </summary>
@@ -50,6 +57,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
             _gpPrograms = new Dictionary<ShaderAddresses, List<ShaderBundle>>();
             _gpProgramsDiskCache = new Dictionary<Hash128, ShaderBundle>();
             _cpProgramsDiskCache = new Dictionary<Hash128, ShaderBundle>();
+
+            _progressReportEvent = new AutoResetEvent(false);
         }
 
         /// <summary>
@@ -76,11 +85,15 @@ namespace Ryujinx.Graphics.Gpu.Shader
 
                 ReadOnlySpan<Hash128> guestProgramList = _cacheManager.GetGuestProgramList();
 
+                _progressReportEvent.Reset();
+                _shaderCount = 0;
+
+                ShaderCacheStateChanged(true);
+                ThreadPool.QueueUserWorkItem(ProgressLogger, guestProgramList.Length);
+
                 for (int programIndex = 0; programIndex < guestProgramList.Length; programIndex++)
                 {
                     Hash128 key = guestProgramList[programIndex];
-
-                    Logger.Info?.Print(LogClass.Gpu, $"Compiling shader {key} ({programIndex + 1} / {guestProgramList.Length})");
 
                     byte[] hostProgramBinary = _cacheManager.GetHostProgramByHash(ref key);
                     bool hasHostCache = hostProgramBinary != null;
@@ -304,6 +317,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
 
                         _gpProgramsDiskCache.Add(key, new ShaderBundle(hostProgram, shaders));
                     }
+
+                    _shaderCount = programIndex;
                 }
 
                 if (!isReadOnly)
@@ -314,8 +329,26 @@ namespace Ryujinx.Graphics.Gpu.Shader
                     _cacheManager.Synchronize();
                 }
 
-                Logger.Info?.Print(LogClass.Gpu, "Shader cache loaded.");
+                _progressReportEvent.Set();
+                ShaderCacheStateChanged(false);
+
+                Logger.Info?.Print(LogClass.Gpu, $"Shader cache loaded {_shaderCount} entries.");
             }
+        }
+
+        /// <summary>
+        /// Raises ShaderCacheProgressChanged events periodically.
+        /// </summary>
+        private void ProgressLogger(object state)
+        {
+            const int refreshRate = 100; // ms
+
+            int totalCount = (int)state;
+            do
+            {
+                ShaderCacheProgressChanged(_shaderCount, totalCount);
+            }
+            while (!_progressReportEvent.WaitOne(refreshRate));
         }
 
         /// <summary>
@@ -787,6 +820,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 }
             }
 
+            _progressReportEvent?.Dispose();
             _cacheManager?.Dispose();
         }
     }

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -92,10 +92,12 @@ namespace Ryujinx.Ui
         [GUI] Label           _gpuName;
         [GUI] Label           _progressLabel;
         [GUI] Label           _firmwareVersionLabel;
-        [GUI] LevelBar        _progressBar;
+        [GUI] ProgressBar     _progressBar;
         [GUI] Box             _viewBox;
         [GUI] Label           _vSyncStatus;
         [GUI] Box             _listStatusBox;
+        [GUI] Label           _loadingStatusLabel;
+        [GUI] ProgressBar     _loadingStatusBar;
 
 #pragma warning restore CS0649, IDE0044, CS0169
 
@@ -775,7 +777,7 @@ namespace Ryujinx.Ui
                     barValue = (float)args.NumAppsLoaded / args.NumAppsFound;
                 }
 
-                _progressBar.Value = barValue;
+                _progressBar.Fraction = barValue;
 
                 // Reset the vertical scrollbar to the top when titles finish loading
                 if (args.NumAppsLoaded == args.NumAppsFound)

--- a/Ryujinx/Ui/MainWindow.glade
+++ b/Ryujinx/Ui/MainWindow.glade
@@ -459,13 +459,14 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkLevelBar" id="_progressBar">
+                      <object class="GtkProgressBar" id="_progressBar">
                         <property name="width_request">200</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
                         <property name="margin_left">10</property>
                         <property name="margin_right">5</property>
+                        <property name="margin_bottom">6</property>
                       </object>
                       <packing>
                         <property name="expand">True</property>
@@ -640,6 +641,7 @@
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
                         <property name="margin_left">5</property>
+                        <property name="margin_right">5</property>
                       </object>
                       <packing>
                         <property name="expand">True</property>
@@ -654,16 +656,34 @@
                     <property name="position">1</property>
                   </packing>
                 </child>
-                <child>
-                  <object class="GtkSeparator">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">3</property>
-                  </packing>
+                  <child>
+                    <object class="GtkLabel" id="_loadingStatusLabel">
+                      <property name="can_focus">False</property>
+                      <property name="margin_left">5</property>
+                      <property name="margin_right">5</property>
+                      <property name="label" translatable="yes">0/0 </property>
+                      <property name="visible">False</property>
+                    </object>
+                    <packing>
+                      <property name="expand">False</property>
+                      <property name="fill">True</property>
+                      <property name="position">11</property>
+                    </packing>
+                  </child>
+                  <child>
+                    <object class="GtkProgressBar" id="_loadingStatusBar">
+                      <property name="width_request">200</property>
+                      <property name="can_focus">False</property>
+                      <property name="margin_left">5</property>
+                      <property name="margin_right">5</property>
+                      <property name="margin_bottom">6</property>
+                      <property name="visible">False</property>
+                    </object>
+                    <packing>
+                      <property name="expand">False</property>
+                      <property name="fill">True</property>
+                      <property name="position">12</property>
+                    </packing>
                 </child>
                 <child>
                   <object class="GtkBox">


### PR DESCRIPTION
Both of them expose two events, one for state change and the other for progress which are consumed by `MainWindow`.
Both PTC and Shader Cache report progress events on a timer (currently 100ms).
This is because PTC/ShaderCache has (or eventually will have) parallel processing. So, it's not easy to serialize it per-change.

GUI changes and initial concept courtesy of @Joshi234 (credited changes) from #1946 which this supersedes.