### PR TITLE
Fix regression in SignalMemoryTracking

### DIFF
--- a/Ryujinx.Cpu/MemoryManager.cs
+++ b/Ryujinx.Cpu/MemoryManager.cs
@@ -684,7 +684,7 @@ namespace Ryujinx.Cpu
             // Write tag includes read protection, since we don't have any read actions that aren't performed before write too.
             long tag = (write ? 3L : 1L) << PointerTagBit;
 
-            int pages = GetPagesCount(va, (uint)size, out va);
+            int pages = GetPagesCount(va, (uint)size, out ulong _);
             ulong pageStart = va >> PageBits;
 
             for (int page = 0; page < pages; page++)

--- a/Ryujinx.Cpu/MemoryManager.cs
+++ b/Ryujinx.Cpu/MemoryManager.cs
@@ -684,7 +684,7 @@ namespace Ryujinx.Cpu
             // Write tag includes read protection, since we don't have any read actions that aren't performed before write too.
             long tag = (write ? 3L : 1L) << PointerTagBit;
 
-            int pages = GetPagesCount(va, (uint)size, out ulong _);
+            int pages = GetPagesCount(va, (uint)size, out _);
             ulong pageStart = va >> PageBits;
 
             for (int page = 0; page < pages; page++)


### PR DESCRIPTION
This PR solves the regression introduced by #2044. As mentioned in the PR, altering the value of `va` breaks the `Tracking.VirtualMemoryEvent` call.

This PR was tested with Monster Hunter Rise DEMO as it is known to manifest the regression.

I also looked for similar regressions in `MemoryTracking` and `AddressSpaceManager`.