### PR TITLE
Fix SetStandardSteadyClockInternalOffset permission check

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Time/IStaticServiceForGlue.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/IStaticServiceForGlue.cs
@@ -78,7 +78,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
         // SetStandardSteadyClockInternalOffset(nn::TimeSpanType internal_offset)
         public ResultCode SetStandardSteadyClockInternalOffset(ServiceCtx context)
         {
-            if ((_permissions & TimePermissions.BypassUninitialized) == 0)
+            if ((_permissions & TimePermissions.SteadyClockWritableMask) == 0)
             {
                 return ResultCode.PermissionDenied;
             }


### PR DESCRIPTION
I happened to notice this when checking Ryu's IPC structures. After double checking with RE it seems the current check is incorrect so use the correct member to fix that.