### PR TITLE
Improve handling for unmapped GPU resources

### DIFF
--- a/Ryujinx.Cpu/MemoryManager.cs
+++ b/Ryujinx.Cpu/MemoryManager.cs
@@ -627,7 +627,7 @@ namespace Ryujinx.Cpu
                 {
                     pte = Volatile.Read(ref pageRef);
                 }
-                while (Interlocked.CompareExchange(ref pageRef, (pte & invTagMask) | tag, pte) != pte);
+                while (pte != 0 && Interlocked.CompareExchange(ref pageRef, (pte & invTagMask) | tag, pte) != pte);
 
                 pageStart++;
             }

--- a/Ryujinx.Cpu/Tracking/CpuRegionHandle.cs
+++ b/Ryujinx.Cpu/Tracking/CpuRegionHandle.cs
@@ -8,6 +8,7 @@ namespace Ryujinx.Cpu.Tracking
         private readonly RegionHandle _impl;
 
         public bool Dirty => _impl.Dirty;
+        public bool Unmapped => _impl.Unmapped;
         public ulong Address => _impl.Address;
         public ulong Size => _impl.Size;
         public ulong EndAddress => _impl.EndAddress;

--- a/Ryujinx.Graphics.Gpu/Image/Pool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Pool.cs
@@ -117,7 +117,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Performs the disposal of all resources stored on the pool.
         /// It's an error to try using the pool after disposal.
         /// </summary>
-        public void Dispose()
+        public virtual void Dispose()
         {
             if (Items != null)
             {

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -715,7 +715,9 @@ namespace Ryujinx.Graphics.Gpu.Image
                     // we know the textures are located at the same memory region.
                     // If they don't, it may still be mapped to the same physical region, so we
                     // do a more expensive check to tell if they are mapped into the same physical regions.
-                    if (overlap.Info.GpuAddress != info.GpuAddress && !_context.MemoryManager.CompareRange(overlap.Range, info.GpuAddress))
+                    // If the GPU VA for the texture has ever been unmapped, then the range must be checked regardless.
+                    if ((overlap.Info.GpuAddress != info.GpuAddress || overlap.ChangedMapping) && 
+                        !_context.MemoryManager.CompareRange(overlap.Range, info.GpuAddress))
                     {
                         continue;
                     }

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -13,7 +13,7 @@ namespace Ryujinx.Graphics.Gpu.Image
     class TexturePool : Pool<Texture, TextureDescriptor>
     {
         private int _sequenceNumber;
-        ConcurrentQueue<Texture> _dereferenceQueue = new ConcurrentQueue<Texture>();
+        private readonly ConcurrentQueue<Texture> _dereferenceQueue = new ConcurrentQueue<Texture>();
 
         /// <summary>
         /// Intrusive linked list node used on the texture pool cache.

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -2,6 +2,7 @@ using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Texture;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 namespace Ryujinx.Graphics.Gpu.Image
@@ -12,6 +13,7 @@ namespace Ryujinx.Graphics.Gpu.Image
     class TexturePool : Pool<Texture, TextureDescriptor>
     {
         private int _sequenceNumber;
+        ConcurrentQueue<Texture> _dereferenceQueue = new ConcurrentQueue<Texture>();
 
         /// <summary>
         /// Intrusive linked list node used on the texture pool cache.
@@ -53,6 +55,8 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 TextureInfo info = GetInfo(descriptor, out int layerSize);
 
+                ProcessDereferenceQueue();
+
                 texture = Context.Methods.TextureManager.FindOrCreateTexture(TextureSearchFlags.ForSampler, info, layerSize);
 
                 // If this happens, then the texture address is invalid, we can't add it to the cache.
@@ -61,7 +65,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     return null;
                 }
 
-                texture.IncrementReferenceCount();
+                texture.IncrementReferenceCount(this, id);
 
                 Items[id] = texture;
 
@@ -93,12 +97,47 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Forcibly remove a texture from this pool's items.
+        /// If deferred, the dereference will be queued to occur on the render thread.
+        /// </summary>
+        /// <param name="texture">The texture being removed</param>
+        /// <param name="id">The ID of the texture in this pool</param>
+        /// <param name="deferred">If true, queue the dereference to happen on the render thread, otherwise dereference immediately</param>
+        public void ForceRemove(Texture texture, int id, bool deferred)
+        {
+            Items[id] = null;
+
+            if (deferred)
+            {
+                _dereferenceQueue.Enqueue(texture);
+            }
+            else
+            {
+                texture.DecrementReferenceCount();
+            }
+        }
+
+        /// <summary>
+        /// Process the dereference queue, decrementing the reference count for each texture in it.
+        /// This is used to ensure that texture disposal happens on the render thread.
+        /// </summary>
+        private void ProcessDereferenceQueue()
+        {
+            while (_dereferenceQueue.TryDequeue(out Texture toRemove))
+            {
+                toRemove.DecrementReferenceCount();
+            }
+        }
+
+        /// <summary>
         /// Implementation of the texture pool range invalidation.
         /// </summary>
         /// <param name="address">Start address of the range of the texture pool</param>
         /// <param name="size">Size of the range being invalidated</param>
         protected override void InvalidateRangeImpl(ulong address, ulong size)
         {
+            ProcessDereferenceQueue();
+
             ulong endAddress = address + size;
 
             for (; address < endAddress; address += DescriptorSize)
@@ -118,7 +157,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                         continue;
                     }
 
-                    texture.DecrementReferenceCount();
+                    texture.DecrementReferenceCount(this, id);
 
                     Items[id] = null;
                 }
@@ -342,7 +381,14 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="item">The texture to be deleted</param>
         protected override void Delete(Texture item)
         {
-            item?.DecrementReferenceCount();
+            item?.DecrementReferenceCount(this);
+        }
+
+        public override void Dispose()
+        {
+            ProcessDereferenceQueue();
+
+            base.Dispose();
         }
     }
 }

--- a/Ryujinx.Memory/Range/MultiRange.cs
+++ b/Ryujinx.Memory/Range/MultiRange.cs
@@ -96,6 +96,7 @@ namespace Ryujinx.Memory.Range
             else
             {
                 var ranges = new List<MemoryRange>();
+
                 foreach (MemoryRange range in _ranges)
                 {
                     if ((long)offset <= 0)

--- a/Ryujinx.Memory/Range/MultiRange.cs
+++ b/Ryujinx.Memory/Range/MultiRange.cs
@@ -81,7 +81,7 @@ namespace Ryujinx.Memory.Range
         /// </summary>
         /// <param name="offset">Offset of the slice into the multi-range in bytes</param>
         /// <param name="size">Size of the slice in bytes</param>
-        /// <returns>A new multirange representing the given slice of this one</returns>
+        /// <returns>A new multi-range representing the given slice of this one</returns>
         public MultiRange GetSlice(ulong offset, ulong size)
         {
             if (HasSingleRange)
@@ -105,11 +105,12 @@ namespace Ryujinx.Memory.Range
                     }
                     else if (offset < range.Size)
                     {
-                        ranges.Add(new MemoryRange(range.Address + offset, Math.Min(size, range.Size - offset)));
-                        size -= range.Size;
+                        ulong sliceSize = Math.Min(size, range.Size - offset);
+                        ranges.Add(new MemoryRange(range.Address + offset, sliceSize));
+                        size -= sliceSize;
                     }
 
-                    if (size <= 0)
+                    if ((long)size <= 0)
                     {
                         break;
                     }

--- a/Ryujinx.Memory/Range/MultiRange.cs
+++ b/Ryujinx.Memory/Range/MultiRange.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Ryujinx.Memory.Range
 {
@@ -72,6 +73,51 @@ namespace Ryujinx.Memory.Range
             {
                 MinAddress = 0UL;
                 MaxAddress = 0UL;
+            }
+        }
+
+        /// <summary>
+        /// Gets a slice of the multi-range.
+        /// </summary>
+        /// <param name="offset">Offset of the slice into the multi-range in bytes</param>
+        /// <param name="size">Size of the slice in bytes</param>
+        /// <returns>A new multirange representing the given slice of this one</returns>
+        public MultiRange GetSlice(ulong offset, ulong size)
+        {
+            if (HasSingleRange)
+            {
+                if (_singleRange.Size - offset < size)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(size));
+                }
+
+                return new MultiRange(_singleRange.Address + offset, size);
+            }
+            else
+            {
+                var ranges = new List<MemoryRange>();
+                foreach (MemoryRange range in _ranges)
+                {
+                    if ((long)offset <= 0)
+                    {
+                        ranges.Add(new MemoryRange(range.Address, Math.Min(size, range.Size)));
+                        size -= range.Size;
+                    }
+                    else if (offset < range.Size)
+                    {
+                        ranges.Add(new MemoryRange(range.Address + offset, Math.Min(size, range.Size - offset)));
+                        size -= range.Size;
+                    }
+
+                    if (size <= 0)
+                    {
+                        break;
+                    }
+
+                    offset -= range.Size;
+                }
+
+                return new MultiRange(ranges.ToArray());
             }
         }
 

--- a/Ryujinx.Memory/Tracking/MemoryTracking.cs
+++ b/Ryujinx.Memory/Tracking/MemoryTracking.cs
@@ -74,6 +74,14 @@ namespace Ryujinx.Memory.Tracking
                 for (int i = 0; i < count; i++)
                 {
                     VirtualRegion region = results[i];
+
+                    // If the region has been fully remapped, signal that it has been mapped again.
+                    bool remapped = _memoryManager.IsRangeMapped(region.Address, region.Size);
+                    if (remapped)
+                    {
+                        region.SignalMappingChanged(true);
+                    }
+
                     region.RecalculatePhysicalChildren();
                     region.UpdateProtection();
                 }
@@ -99,6 +107,7 @@ namespace Ryujinx.Memory.Tracking
                 for (int i = 0; i < count; i++)
                 {
                     VirtualRegion region = results[i];
+                    region.SignalMappingChanged(false);
                     region.RecalculatePhysicalChildren();
                 }
             }

--- a/Ryujinx.Memory/Tracking/RegionHandle.cs
+++ b/Ryujinx.Memory/Tracking/RegionHandle.cs
@@ -12,6 +12,7 @@ namespace Ryujinx.Memory.Tracking
     public class RegionHandle : IRegionHandle, IRange
     {
         public bool Dirty { get; private set; }
+        public bool Unmapped { get; private set; }
 
         public ulong Address { get; }
         public ulong Size { get; }
@@ -37,10 +38,11 @@ namespace Ryujinx.Memory.Tracking
         /// <param name="tracking">Tracking object for the target memory block</param>
         /// <param name="address">Virtual address of the region to track</param>
         /// <param name="size">Size of the region to track</param>
-        /// <param name="dirty">Initial value of the dirty flag</param>
-        internal RegionHandle(MemoryTracking tracking, ulong address, ulong size, bool dirty = true)
+        /// <param name="mapped">True if the region handle starts mapped</param>
+        internal RegionHandle(MemoryTracking tracking, ulong address, ulong size, bool mapped = true)
         {
-            Dirty = dirty;
+            Dirty = mapped;
+            Unmapped = !mapped;
             Address = address;
             Size = size;
             EndAddress = address + size;
@@ -126,6 +128,23 @@ namespace Ryujinx.Memory.Tracking
         internal void AddChild(VirtualRegion region)
         {
             _regions.Add(region);
+        }
+
+        /// <summary>
+        /// Signal that this handle has been mapped or unmapped.
+        /// </summary>
+        /// <param name="mapped">True if the handle has been mapped, false if unmapped</param>
+        internal void SignalMappingChanged(bool mapped)
+        {
+            if (Unmapped == mapped)
+            {
+                Unmapped = !mapped;
+
+                if (Unmapped)
+                {
+                    Dirty = false;
+                }
+            }
         }
 
         /// <summary>

--- a/Ryujinx.Memory/Tracking/VirtualRegion.cs
+++ b/Ryujinx.Memory/Tracking/VirtualRegion.cs
@@ -67,6 +67,18 @@ namespace Ryujinx.Memory.Tracking
         }
 
         /// <summary>
+        /// Signal that this region has been mapped or unmapped.
+        /// </summary>
+        /// <param name="mapped">True if the region has been mapped, false if unmapped</param>
+        public void SignalMappingChanged(bool mapped)
+        {
+            foreach (RegionHandle handle in Handles)
+            {
+                handle.SignalMappingChanged(mapped);
+            }
+        }
+
+        /// <summary>
         /// Gets the strictest permission that the child handles demand. Assumes that the tracking lock has been obtained.
         /// </summary>
         /// <returns>Protection level that this region demands</returns>


### PR DESCRIPTION
- Fixed a memory tracking bug that would set protection on empty PTEs. (causes some buffer tracking crashes)
- When a texture's memory is (partially) unmapped, all pool references are forcibly removed and the texture must be rediscovered to draw with it. This will also force the texture discovery to always compare the texture's range for a match.
- RegionHandles now know if they are unmapped, and automatically unset their dirty flag when unmapped.
- Partial texture sync now loads only the region of texture that has been modified. Unmapped memory tracking handles cause dirty flags for a texture group handle to be ignored.

Buffers can try to sync memory that's unmapped if the size is too large, which it usually is for UE4 games, as it seems to pass in a large uniform buffer size no matter what is actually in the slot. These fixes prevent that from happening.

Textures can try to sync memory that's unmapped if a smaller view is created within a larger texture, but part of that larger texture has been unmapped. This can also happen due to GPU VA for a texture being mapped to something else, but its pool entry remaining unchanged. It's important that we do partial sync only with the data that we know is available to avoid an invalid memory access.

This greatly improves the emulator's stability for newer UE4 games, such as Bravely Default II. Does not fix _all_ crashes, and in BD2 there are still a number of graphical issues such as vertex explosions, missing facial animations and missing shadows.

Fixes texture swaps in Bravely Default II. This is specifically due to the change that removes textures from pools on unmap, and forcing compare range on textures where the gpu va has been remapped.

May improve the situation for other games that crash due to buffer sync. Not animal crossing.