### PR TITLE
Flip component mask if target is BGRA.

### DIFF
--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -862,7 +862,14 @@ namespace Ryujinx.Graphics.OpenGL
 
                 _framebuffer.AttachColor(index, color);
 
-                _fpIsBgra[index] = color != null && color.Format.IsBgra8() ? 1 : 0;
+                int isBgra = color != null && color.Format.IsBgra8() ? 1 : 0;
+
+                if (_fpIsBgra[index] != isBgra)
+                {
+                    _fpIsBgra[index] = isBgra;
+
+                    RestoreComponentMask(index);
+                }
             }
 
             UpdateFpIsBgra();
@@ -1233,11 +1240,15 @@ namespace Ryujinx.Graphics.OpenGL
 
         private void RestoreComponentMask(int index)
         {
+            // If the bound render target is bgra, swap the red and blue masks.
+            bool redMask = _fpIsBgra[index] == 0 ? (_componentMasks[index] & 1u) != 0 : (_componentMasks[index] & 4u) != 0;
+            bool blueMask = _fpIsBgra[index] == 0 ? (_componentMasks[index] & 4u) != 0 : (_componentMasks[index] & 1u) != 0;
+
             GL.ColorMask(
                 index,
-                (_componentMasks[index] & 1u) != 0,
+                redMask,
                 (_componentMasks[index] & 2u) != 0,
-                (_componentMasks[index] & 4u) != 0,
+                blueMask,
                 (_componentMasks[index] & 8u) != 0);
         }
 

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -1241,14 +1241,14 @@ namespace Ryujinx.Graphics.OpenGL
         private void RestoreComponentMask(int index)
         {
             // If the bound render target is bgra, swap the red and blue masks.
-            bool redMask = _fpIsBgra[index] == 0 ? (_componentMasks[index] & 1u) != 0 : (_componentMasks[index] & 4u) != 0;
-            bool blueMask = _fpIsBgra[index] == 0 ? (_componentMasks[index] & 4u) != 0 : (_componentMasks[index] & 1u) != 0;
+            uint redMask = _fpIsBgra[index] == 0 ? 1u : 4u;
+            uint blueMask = _fpIsBgra[index] == 0 ? 4u : 1u;
 
             GL.ColorMask(
                 index,
-                redMask,
+                (_componentMasks[index] & redMask) != 0,
                 (_componentMasks[index] & 2u) != 0,
-                blueMask,
+                (_componentMasks[index] & blueMask) != 0,
                 (_componentMasks[index] & 8u) != 0);
         }
 


### PR DESCRIPTION
For OpenGL, we use RGBA textures as BGRA and swap the components on draw, write, copy etc. However, we forgot to swap the component mask, so when a texture meant to draw to only "blue", it ended up drawing to only "red" and vice versa.

On its own, this doesn't do much as far as I know. Combined with better bindless texture handling, it will lead to fixing shadows in BD2's battles.