### PR TITLE
Improve Buffer Textures and flush Image Stores 

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Compute.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Compute.cs
@@ -141,8 +141,8 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
             TextureManager.SetComputeImages(imageBindings);
 
-            BufferManager.CommitComputeBindings();
             TextureManager.CommitComputeBindings();
+            BufferManager.CommitComputeBindings();
 
             _context.Renderer.Pipeline.DispatchCompute(
                 qmd.CtaRasterWidth,

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -304,8 +304,8 @@ namespace Ryujinx.Graphics.Gpu.Engine
         {
             UpdateStorageBuffers();
 
-            BufferManager.CommitGraphicsBindings();
             TextureManager.CommitGraphicsBindings();
+            BufferManager.CommitGraphicsBindings();
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureDescriptor.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureDescriptor.cs
@@ -154,6 +154,15 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Unpack the width of a buffer texture.
+        /// </summary>
+        /// <returns>The texture width</returns>
+        public int UnpackBufferTextureWidth()
+        {
+            return (int)((Word4 & 0xffff) | (Word3 << 16)) + 1;
+        }
+
+        /// <summary>
         /// Unpacks the texture sRGB format flag.
         /// </summary>
         /// <returns>True if the texture is sRGB, false otherwise</returns>

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -172,8 +172,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>The texture information</returns>
         private TextureInfo GetInfo(TextureDescriptor descriptor, out int layerSize)
         {
-            int width         = descriptor.UnpackWidth();
-            int height        = descriptor.UnpackHeight();
             int depthOrLayers = descriptor.UnpackDepth();
             int levels        = descriptor.UnpackLevels();
 
@@ -189,6 +187,9 @@ namespace Ryujinx.Graphics.Gpu.Image
             bool isLinear = descriptorType == TextureDescriptorType.Linear;
 
             Target target = descriptor.UnpackTextureTarget().Convert((samplesInX | samplesInY) != 1);
+
+            int width = target == Target.TextureBuffer ? descriptor.UnpackBufferTextureWidth() : descriptor.UnpackWidth();
+            int height = descriptor.UnpackHeight();
 
             // We use 2D targets for 1D textures as that makes texture cache
             // management easier. We don't know the target for render target

--- a/Ryujinx.Graphics.Gpu/Memory/BufferTextureBinding.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferTextureBinding.cs
@@ -1,0 +1,60 @@
+﻿using Ryujinx.Graphics.GAL;
+using Ryujinx.Graphics.Gpu.Image;
+
+namespace Ryujinx.Graphics.Gpu.Memory
+{
+    /// <summary>
+    /// A buffer binding to apply to a buffer texture.
+    /// </summary>
+    struct BufferTextureBinding
+    {
+        /// <summary>
+        /// The buffer texture.
+        /// </summary>
+        public ITexture Texture { get; }
+
+        /// <summary>
+        /// The base address of the buffer binding.
+        /// </summary>
+        public ulong Address { get; }
+
+        /// <summary>
+        /// The size of the buffer binding in bytes.
+        /// </summary>
+        public ulong Size { get; }
+
+        /// <summary>
+        /// The image or sampler binding info for the buffer texture.
+        /// </summary>
+        public TextureBindingInfo BindingInfo { get; }
+
+        /// <summary>
+        /// The image format for the binding.
+        /// </summary>
+        public Format Format { get; }
+
+        /// <summary>
+        /// Whether the binding is for an image or a sampler.
+        /// </summary>
+        public bool IsImage { get; }
+
+        /// <summary>
+        /// Create a new buffer texture binding.
+        /// </summary>
+        /// <param name="texture">Buffer texture</param>
+        /// <param name="address">Base address</param>
+        /// <param name="size">Size in bytes</param>
+        /// <param name="bindingInfo">Binding info</param>
+        /// <param name="format">Binding format</param>
+        /// <param name="isImage">Whether the binding is for an image or a sampler</param>
+        public BufferTextureBinding(ITexture texture, ulong address, ulong size, TextureBindingInfo bindingInfo, Format format, bool isImage)
+        {
+            Texture = texture;
+            Address = address;
+            Size = size;
+            BindingInfo = bindingInfo;
+            Format = format;
+            IsImage = isImage;
+        }
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -35,7 +35,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 1961;
+        private const ulong ShaderCodeGenVersion = 2088;
 
         // Progress reporting helpers
         private int _shaderCount;

--- a/Ryujinx.Graphics.OpenGL/Image/TextureBuffer.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureBuffer.cs
@@ -6,12 +6,17 @@ namespace Ryujinx.Graphics.OpenGL.Image
 {
     class TextureBuffer : TextureBase, ITexture
     {
+        private Renderer _renderer;
         private int _bufferOffset;
         private int _bufferSize;
+        private int _bufferCount;
 
         private BufferHandle _buffer;
 
-        public TextureBuffer(TextureCreateInfo info) : base(info) {}
+        public TextureBuffer(Renderer renderer, TextureCreateInfo info) : base(info)
+        {
+            _renderer = renderer;
+        }
 
         public void CopyTo(ITexture destination, int firstLayer, int firstLevel)
         {
@@ -50,16 +55,16 @@ namespace Ryujinx.Graphics.OpenGL.Image
 
         public void SetStorage(BufferRange buffer)
         {
-            if (buffer.Handle == _buffer &&
-                buffer.Offset == _bufferOffset &&
-                buffer.Size == _bufferSize)
+            if (_buffer != BufferHandle.Null && _renderer.BufferCount == _bufferCount)
             {
+                // Only rebind the buffer when more have been created.
                 return;
             }
 
             _buffer = buffer.Handle;
             _bufferOffset = buffer.Offset;
             _bufferSize = buffer.Size;
+            _bufferCount = _renderer.BufferCount;
 
             Bind(0);
 

--- a/Ryujinx.Graphics.OpenGL/Image/TextureBuffer.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureBuffer.cs
@@ -55,7 +55,10 @@ namespace Ryujinx.Graphics.OpenGL.Image
 
         public void SetStorage(BufferRange buffer)
         {
-            if (_buffer != BufferHandle.Null && _renderer.BufferCount == _bufferCount)
+            if (_buffer != BufferHandle.Null &&
+                buffer.Offset == _bufferOffset &&
+                buffer.Size == _bufferSize &&
+                _renderer.BufferCount == _bufferCount)
             {
                 // Only rebind the buffer when more have been created.
                 return;

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -30,6 +30,8 @@ namespace Ryujinx.Graphics.OpenGL
 
         internal ResourcePool ResourcePool { get; }
 
+        internal int BufferCount { get; private set; }
+
         public string GpuVendor { get; private set; }
         public string GpuRenderer { get; private set; }
         public string GpuVersion { get; private set; }
@@ -52,6 +54,8 @@ namespace Ryujinx.Graphics.OpenGL
 
         public BufferHandle CreateBuffer(int size)
         {
+            BufferCount++;
+
             return Buffer.Create(size);
         }
 
@@ -69,7 +73,7 @@ namespace Ryujinx.Graphics.OpenGL
         {
             if (info.Target == Target.TextureBuffer)
             {
-                return new TextureBuffer(info);
+                return new TextureBuffer(this, info);
             }
             else
             {

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
@@ -111,6 +111,9 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
 
             if (texOp.Inst == Instruction.ImageStore)
             {
+                int texIndex = context.FindImageDescriptorIndex(texOp);
+                context.ImageDescriptors[texIndex] = context.ImageDescriptors[texIndex].SetFlag(TextureUsageFlags.ImageStore);
+
                 VariableType type = texOp.Format.GetComponentType();
 
                 string[] cElems = new string[4];

--- a/Ryujinx.Graphics.Shader/TextureUsageFlags.cs
+++ b/Ryujinx.Graphics.Shader/TextureUsageFlags.cs
@@ -12,6 +12,7 @@ namespace Ryujinx.Graphics.Shader
 
         // Integer sampled textures must be noted for resolution scaling.
         ResScaleUnsupported = 1 << 0,
-        NeedsScaleValue = 1 << 1
+        NeedsScaleValue = 1 << 1,
+        ImageStore = 1 << 2
     }
 }


### PR DESCRIPTION
Fixes a number of issues with buffer textures:

- Reworked Buffer Textures to create their buffers in the TextureManager, then bind them with the BufferManager later.
  - Fixes an issue where a buffer texture's buffer could be invalidated after it is bound, but before use.
- Fixed width unpacking for large buffer textures. The width is now 32-bit rather than 16.
- Force buffer textures to be rebound whenever any buffer is created, as using the handle id wasn't reliable, and the cost of binding isn't too high.

Fixes vertex explosions and flickering animations in UE4 games. May affect games that use ImageStore, as now those textures are flushed on read/write.

Before:
![image](https://user-images.githubusercontent.com/6294155/110376066-a76ff680-804a-11eb-8587-be1746cb2761.png)
![image](https://user-images.githubusercontent.com/6294155/110376545-3c72ef80-804b-11eb-95e2-8cc06603c9c1.png)
![image](https://user-images.githubusercontent.com/6294155/110376161-c8384c00-804a-11eb-89a8-1eff57dc36a8.png)
(maybe one day I'll open the game on master to get a better comparison shot for this, but you get the gist)

After:
![image](https://user-images.githubusercontent.com/6294155/110376075-ab9c1400-804a-11eb-9c03-30a7416944a0.png)
![image](https://user-images.githubusercontent.com/6294155/110376225-d7b79500-804a-11eb-9fe5-097e9ab07037.png)

