### PR TITLE
Traverse PhiNodes for Bindless Elimination

### DIFF
--- a/Ryujinx.Graphics.Shader/Translation/Optimizations/BindlessElimination.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Optimizations/BindlessElimination.cs
@@ -5,6 +5,66 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
 {
     class BindlessElimination
     {
+        private static Operation FindBranchSource(BasicBlock block)
+        {
+            foreach (BasicBlock sourceBlock in block.Predecessors)
+            {
+                if (sourceBlock.Operations.Count > 0)
+                {
+                    Operation lastOp = sourceBlock.Operations.Last.Value as Operation;
+
+                    if (lastOp != null &&
+                        ((sourceBlock.Next == block && lastOp.Inst == Instruction.BranchIfFalse) ||
+                        (sourceBlock.Branch == block && lastOp.Inst == Instruction.BranchIfTrue)))
+                    {
+                        return lastOp;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static bool BlockConditionsMatch(BasicBlock currentBlock, BasicBlock queryBlock)
+        {
+            // Check if all the conditions for the query block are satisfied by the current block.
+            // Just checks the top-most conditional for now.
+
+            Operation currentBranch = FindBranchSource(currentBlock);
+            Operation queryBranch = FindBranchSource(queryBlock);
+
+            Operand currentCondition = currentBranch?.GetSource(0);
+            Operand queryCondition = queryBranch?.GetSource(0);
+
+            // The condition should be the same operand instance.
+
+            return currentBranch != null && queryBranch != null &&
+                   currentBranch.Inst == queryBranch.Inst &&
+                   currentCondition == queryCondition;
+        }
+
+        private static Operand FindLastOperation(Operand source, BasicBlock block)
+        {
+            if (source.AsgOp is PhiNode phiNode)
+            {
+                // This source can have a different value depending on a previous branch.
+                // Ensure that conditions met for that branch are also met for the current one.
+                // Prefer the latest sources for the phi node.
+
+                for (int i = phiNode.SourcesCount - 1; i >= 0; i--)
+                {
+                    BasicBlock phiBlock = phiNode.GetBlock(i);
+
+                    if (BlockConditionsMatch(block, phiBlock))
+                    {
+                        return phiNode.GetSource(i);
+                    }
+                }
+            }
+
+            return source;
+        }
+
         public static void RunPass(BasicBlock block, ShaderConfig config)
         {
             // We can turn a bindless into regular access by recognizing the pattern
@@ -29,7 +89,7 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
                     texOp.Inst == Instruction.TextureSample ||
                     texOp.Inst == Instruction.TextureSize)
                 {
-                    Operand bindlessHandle = texOp.GetSource(0);
+                    Operand bindlessHandle = FindLastOperation(texOp.GetSource(0), block);
 
                     if (bindlessHandle.Type == OperandType.ConstantBuffer)
                     {
@@ -47,8 +107,8 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
                         continue;
                     }
 
-                    Operand src0 = handleCombineOp.GetSource(0);
-                    Operand src1 = handleCombineOp.GetSource(1);
+                    Operand src0 = FindLastOperation(handleCombineOp.GetSource(0), block);
+                    Operand src1 = FindLastOperation(handleCombineOp.GetSource(1), block);
 
                     if (src0.Type != OperandType.ConstantBuffer ||
                         src1.Type != OperandType.ConstantBuffer || src0.GetCbufSlot() != src1.GetCbufSlot())
@@ -60,7 +120,7 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
                 }
                 else if (texOp.Inst == Instruction.ImageLoad || texOp.Inst == Instruction.ImageStore)
                 {
-                    Operand src0 = texOp.GetSource(0);
+                    Operand src0 = FindLastOperation(texOp.GetSource(0), block);
 
                     if (src0.Type == OperandType.ConstantBuffer)
                     {


### PR DESCRIPTION
This allows bindless handles to be found for image/texture instructions with predicates, when the assignment of the texture handle is within the same predicate. This is a little rough, since it's made to target a specific pattern.

If the handle source is a PhiNode rather than an Operation, we try to find which phi source is relevant to the instruction. This source is the latest source block that has a branching condition matching the texture access block.

This seems to cover the remaining bindless handles that compilers seem to be creating as an optimization. Note that this is more likely to make a shader create too many samplers, and fail to link.

The only way to solve the issue with creating too many samplers, is either to play bindless textures straight and support bindless on them, or to emulate more then 32 samplers with host bindless texture access of our own design. This isn't in the scope of this PR.

Will affect newer UE4 games, and games by NdCube (Super Mario Party, Clubhouse Games)

## Before:
![image](https://user-images.githubusercontent.com/6294155/110379530-d6886700-804e-11eb-90e4-5ca10ee985c6.png)
(note, shadows and eyes. this screenshot is at night, so the overall brightness shouldn't be compared)

## After:
![image](https://user-images.githubusercontent.com/6294155/110379748-1ea78980-804f-11eb-8248-63346e29287c.png)
