### PR TITLE
Implement Shader Instructions SUATOM and SURED

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -40,7 +40,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2605;
+        private const ulong ShaderCodeGenVersion = 2092;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGen.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGen.cs
@@ -132,9 +132,9 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
                         return Call(context, operation);
 
                     case Instruction.ImageLoad:
-                        return ImageLoadOrStore(context, operation);
-
                     case Instruction.ImageStore:
+                    case Instruction.ImageAtomic:
+                    case Instruction.ImageReduce:
                         return ImageLoadOrStore(context, operation);
 
                     case Instruction.LoadAttribute:

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGen.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGen.cs
@@ -134,7 +134,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
                     case Instruction.ImageLoad:
                     case Instruction.ImageStore:
                     case Instruction.ImageAtomic:
-                    case Instruction.ImageReduce:
                         return ImageLoadOrStore(context, operation);
 
                     case Instruction.LoadAttribute:

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenHelper.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenHelper.cs
@@ -73,7 +73,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
             Add(Instruction.ImageLoad,                InstType.Special);
             Add(Instruction.ImageStore,               InstType.Special);
             Add(Instruction.ImageAtomic,              InstType.Special);
-            Add(Instruction.ImageReduce,              InstType.Special);
             Add(Instruction.IsNan,                    InstType.CallUnary,      "isnan");
             Add(Instruction.LoadAttribute,            InstType.Special);
             Add(Instruction.LoadConstant,             InstType.Special);

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenHelper.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenHelper.cs
@@ -72,6 +72,8 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
             Add(Instruction.GroupMemoryBarrier,       InstType.CallNullary,    "groupMemoryBarrier");
             Add(Instruction.ImageLoad,                InstType.Special);
             Add(Instruction.ImageStore,               InstType.Special);
+            Add(Instruction.ImageAtomic,              InstType.Special);
+            Add(Instruction.ImageReduce,              InstType.Special);
             Add(Instruction.IsNan,                    InstType.CallUnary,      "isnan");
             Add(Instruction.LoadAttribute,            InstType.Special);
             Add(Instruction.LoadConstant,             InstType.Special);

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
@@ -117,8 +117,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
 
             if (texOp.Inst == Instruction.ImageStore)
             {
-                int texIndex = context.FindImageDescriptorIndex(texOp);
-
                 VariableType type = texOp.Format.GetComponentType();
 
                 string[] cElems = new string[4];

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
@@ -152,9 +152,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
 
             if (texOp.Inst == Instruction.ImageAtomic)
             {
-                int texIndex = context.FindImageDescriptorIndex(texOp);
-                context.ImageDescriptors[texIndex] = context.ImageDescriptors[texIndex].SetFlag(TextureUsageFlags.ImageStore);
-
                 VariableType type = texOp.Format.GetComponentType();
 
                 if ((texOp.Flags & TextureFlags.AtomicMask) == TextureFlags.CAS)

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
@@ -26,7 +26,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
 
             string texCall;
 
-            if (texOp.Inst == Instruction.ImageAtomic || texOp.Inst == Instruction.ImageReduce)
+            if (texOp.Inst == Instruction.ImageAtomic)
             {
                 texCall = (texOp.Flags & TextureFlags.AtomicMask) switch {
                     TextureFlags.Add        => "imageAtomicAdd",
@@ -150,7 +150,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
                 Append(prefix + "vec4(" + string.Join(", ", cElems) + ")");
             }
 
-            if (texOp.Inst == Instruction.ImageAtomic || texOp.Inst == Instruction.ImageReduce)
+            if (texOp.Inst == Instruction.ImageAtomic)
             {
                 int texIndex = context.FindImageDescriptorIndex(texOp);
                 context.ImageDescriptors[texIndex] = context.ImageDescriptors[texIndex].SetFlag(TextureUsageFlags.ImageStore);

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
@@ -51,7 +51,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
             {
                 texCall = texOp.Inst == Instruction.ImageLoad ? "imageLoad" : "imageStore";
             }
-             
 
             int srcIndex = isBindless ? 1 : 0;
 

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
@@ -363,8 +363,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
                 else if (operation is AstTextureOperation texOp &&
                          (texOp.Inst == Instruction.ImageLoad ||
                           texOp.Inst == Instruction.ImageStore ||
-                          texOp.Inst == Instruction.ImageAtomic ||
-                          texOp.Inst == Instruction.ImageReduce))
+                          texOp.Inst == Instruction.ImageAtomic))
                 {
                     return texOp.Format.GetComponentType();
                 }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
@@ -362,7 +362,9 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
                 }
                 else if (operation is AstTextureOperation texOp &&
                          (texOp.Inst == Instruction.ImageLoad ||
-                          texOp.Inst == Instruction.ImageStore))
+                          texOp.Inst == Instruction.ImageStore ||
+                          texOp.Inst == Instruction.ImageAtomic ||
+                          texOp.Inst == Instruction.ImageReduce))
                 {
                     return texOp.Format.GetComponentType();
                 }

--- a/Ryujinx.Graphics.Shader/Decoders/OpCodeSuatom.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/OpCodeSuatom.cs
@@ -1,0 +1,38 @@
+﻿using Ryujinx.Graphics.Shader.Instructions;
+
+namespace Ryujinx.Graphics.Shader.Decoders
+{
+    class OpCodeSuatom : OpCodeTextureBase
+    {
+        public Register Rd { get; }
+        public Register Ra { get; }
+        public Register Rb { get; }
+
+        public AtomicOp AtomicOp { get; }
+
+        public ImageDimensions Dimensions { get; }
+
+        public ClampMode ClampMode { get; }
+
+        public bool ByteAddress { get; }
+        public bool UseComponents { get; }
+        public bool IsBindless { get; }
+
+        public new static OpCode Create(InstEmitter emitter, ulong address, long opCode) => new OpCodeSuatom(emitter, address, opCode);
+
+        public OpCodeSuatom(InstEmitter emitter, ulong address, long opCode) : base(emitter, address, opCode)
+        {
+            Rd = new Register(opCode.Extract(0,  8), RegisterType.Gpr);
+            Ra = new Register(opCode.Extract(8,  8), RegisterType.Gpr);
+            Rb = new Register(opCode.Extract(20, 8), RegisterType.Gpr);
+
+            ByteAddress = opCode.Extract(23);
+            AtomicOp = (AtomicOp)opCode.Extract(29, 4); // only in 0xea6 and 0xea0
+            Dimensions = (ImageDimensions)opCode.Extract(33, 3);
+            ClampMode = (ClampMode)opCode.Extract(49, 2);
+
+            IsBindless = !opCode.Extract(51); // only in 0xea6 and 0xeac
+            UseComponents = !opCode.Extract(52);
+        }
+    }
+}

--- a/Ryujinx.Graphics.Shader/Decoders/OpCodeSuatom.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/OpCodeSuatom.cs
@@ -7,16 +7,18 @@ namespace Ryujinx.Graphics.Shader.Decoders
         public Register Rd { get; }
         public Register Ra { get; }
         public Register Rb { get; }
+        public Register Rc { get; }
 
+        public ReductionType Type { get; }
         public AtomicOp AtomicOp { get; }
-
         public ImageDimensions Dimensions { get; }
-
         public ClampMode ClampMode { get; }
 
         public bool ByteAddress { get; }
-        public bool UseComponents { get; }
+        public bool UseType { get; }
         public bool IsBindless { get; }
+
+        public bool CompareAndSwap { get; }
 
         public new static OpCode Create(InstEmitter emitter, ulong address, long opCode) => new OpCodeSuatom(emitter, address, opCode);
 
@@ -25,14 +27,20 @@ namespace Ryujinx.Graphics.Shader.Decoders
             Rd = new Register(opCode.Extract(0,  8), RegisterType.Gpr);
             Ra = new Register(opCode.Extract(8,  8), RegisterType.Gpr);
             Rb = new Register(opCode.Extract(20, 8), RegisterType.Gpr);
+            Rc = new Register(opCode.Extract(39, 8), RegisterType.Gpr);
 
-            ByteAddress = opCode.Extract(23);
-            AtomicOp = (AtomicOp)opCode.Extract(29, 4); // only in 0xea6 and 0xea0
+            bool supportsBindless = opCode.Extract(54);
+
+            Type = (ReductionType)opCode.Extract(supportsBindless ? 36 : 51, 3);
+            ByteAddress = opCode.Extract(28);
+            AtomicOp = (AtomicOp)opCode.Extract(29, 4); // Only useful if CAS is not true.
             Dimensions = (ImageDimensions)opCode.Extract(33, 3);
             ClampMode = (ClampMode)opCode.Extract(49, 2);
 
-            IsBindless = !opCode.Extract(51); // only in 0xea6 and 0xeac
-            UseComponents = !opCode.Extract(52);
+            IsBindless = supportsBindless && !opCode.Extract(51);
+            UseType = !supportsBindless || opCode.Extract(52);
+
+            CompareAndSwap = opCode.Extract(55);
         }
     }
 }

--- a/Ryujinx.Graphics.Shader/Decoders/OpCodeSured.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/OpCodeSured.cs
@@ -1,0 +1,42 @@
+﻿using Ryujinx.Graphics.Shader.Instructions;
+
+namespace Ryujinx.Graphics.Shader.Decoders
+{
+    enum ClampMode
+    {
+        Ignore = 0,
+        Trap = 2
+    }
+
+    class OpCodeSured : OpCodeTextureBase
+    {
+        public Register Ra { get; }
+        public Register Rb { get; }
+        public Register Rc { get; }
+
+        public AtomicOp AtomicOp { get; }
+
+        public ImageDimensions Dimensions { get; }
+
+        public ClampMode ClampMode { get; }
+
+        public bool UseComponents { get; }
+        public bool IsBindless { get; }
+
+        public new static OpCode Create(InstEmitter emitter, ulong address, long opCode) => new OpCodeSured(emitter, address, opCode);
+
+        public OpCodeSured(InstEmitter emitter, ulong address, long opCode) : base(emitter, address, opCode)
+        {
+            Ra = new Register(opCode.Extract(8, 8), RegisterType.Gpr);
+            Rb = new Register(opCode.Extract(0, 8), RegisterType.Gpr);
+            Rc = new Register(opCode.Extract(39, 8), RegisterType.Gpr);
+
+            AtomicOp = (AtomicOp)opCode.Extract(24, 3);
+            Dimensions = (ImageDimensions)opCode.Extract(33, 3);
+            ClampMode = (ClampMode)opCode.Extract(49, 2);
+
+            IsBindless = !opCode.Extract(51);
+            UseComponents = !opCode.Extract(52);
+        }
+    }
+}

--- a/Ryujinx.Graphics.Shader/Decoders/OpCodeSured.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/OpCodeSured.cs
@@ -14,14 +14,14 @@ namespace Ryujinx.Graphics.Shader.Decoders
         public Register Rb { get; }
         public Register Rc { get; }
 
+        public ReductionType Type { get; }
         public AtomicOp AtomicOp { get; }
-
         public ImageDimensions Dimensions { get; }
-
         public ClampMode ClampMode { get; }
 
-        public bool UseComponents { get; }
+        public bool UseType { get; }
         public bool IsBindless { get; }
+        public bool ByteAddress { get; }
 
         public new static OpCode Create(InstEmitter emitter, ulong address, long opCode) => new OpCodeSured(emitter, address, opCode);
 
@@ -31,12 +31,14 @@ namespace Ryujinx.Graphics.Shader.Decoders
             Rb = new Register(opCode.Extract(0, 8), RegisterType.Gpr);
             Rc = new Register(opCode.Extract(39, 8), RegisterType.Gpr);
 
+            Type = (ReductionType)opCode.Extract(20, 3);
+            ByteAddress = opCode.Extract(23);
             AtomicOp = (AtomicOp)opCode.Extract(24, 3);
             Dimensions = (ImageDimensions)opCode.Extract(33, 3);
             ClampMode = (ClampMode)opCode.Extract(49, 2);
 
             IsBindless = !opCode.Extract(51);
-            UseComponents = !opCode.Extract(52);
+            UseType = opCode.Extract(52);
         }
     }
 }

--- a/Ryujinx.Graphics.Shader/Decoders/OpCodeTable.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/OpCodeTable.cs
@@ -209,6 +209,8 @@ namespace Ryujinx.Graphics.Shader.Decoders
             Set("1110111101011x", InstEmit.Sts,     OpCodeMemory.Create);
             Set("11101011000xxx", InstEmit.Suld,    OpCodeImage.Create);
             Set("11101011001xxx", InstEmit.Sust,    OpCodeImage.Create);
+            Set("11101011010xxx", InstEmit.Sured,   OpCodeSured.Create);
+            Set("1110101000xxxx", InstEmit.Suatom,  OpCodeSuatom.Create);
             Set("1111000011111x", InstEmit.Sync,    OpCodeBranchPop.Create);
             Set("110000xxxx111x", InstEmit.Tex,     OpCodeTex.Create);
             Set("1101111010111x", InstEmit.TexB,    OpCodeTexB.Create);

--- a/Ryujinx.Graphics.Shader/Decoders/OpCodeTable.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/OpCodeTable.cs
@@ -210,6 +210,9 @@ namespace Ryujinx.Graphics.Shader.Decoders
             Set("11101011000xxx", InstEmit.Suld,    OpCodeImage.Create);
             Set("11101011001xxx", InstEmit.Sust,    OpCodeImage.Create);
             Set("11101011010xxx", InstEmit.Sured,   OpCodeSured.Create);
+            Set("11101010110xxx", InstEmit.Suatom,  OpCodeSuatom.Create);
+            Set("1110101010xxxx", InstEmit.Suatom,  OpCodeSuatom.Create);
+            Set("11101010011xxx", InstEmit.Suatom,  OpCodeSuatom.Create);
             Set("1110101000xxxx", InstEmit.Suatom,  OpCodeSuatom.Create);
             Set("1111000011111x", InstEmit.Sync,    OpCodeBranchPop.Create);
             Set("110000xxxx111x", InstEmit.Tex,     OpCodeTex.Create);

--- a/Ryujinx.Graphics.Shader/Decoders/ReductionType.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/ReductionType.cs
@@ -7,6 +7,8 @@ namespace Ryujinx.Graphics.Shader.Decoders
         U64         = 2,
         FP32FtzRn   = 3,
         FP16x2FtzRn = 4,
-        S64         = 5
+        S64         = 5,
+        SD32        = 6,
+        SD64        = 7
     }
 }

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
@@ -377,7 +377,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
             }
 
             TextureOperation operation = new TextureOperation(
-                Instruction.ImageReduce,
+                Instruction.ImageAtomic,
                 type,
                 flags,
                 handle,

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
@@ -376,17 +376,15 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 flags |= TextureFlags.Bindless;
             }
 
-            TextureOperation operation = new TextureOperation(
+            TextureOperation operation = context.CreateTextureOperation(
                 Instruction.ImageAtomic,
                 type,
+                format,
                 flags,
                 handle,
                 0,
                 null,
-                sources)
-            {
-                Format = format
-            };
+                sources);
 
             context.Add(operation);
         }
@@ -507,17 +505,15 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 flags |= TextureFlags.Bindless;
             }
 
-            TextureOperation operation = new TextureOperation(
+            TextureOperation operation = context.CreateTextureOperation(
                 Instruction.ImageAtomic,
                 type,
+                format,
                 flags,
                 handle,
                 0,
                 GetDest(),
-                sources)
-            {
-                Format = format
-            };
+                sources);
 
             context.Add(operation);
         }

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
@@ -353,6 +353,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
                     sourcesList[xIndex] = context.ShiftRightS32(sourcesList[xIndex], Const(GetComponentSizeInBytesLog2(op.Type)));
                 }
 
+                // TODO: FP and 64-bit formats.
                 format = (op.Type == ReductionType.SD32 || op.Type == ReductionType.SD64) ?
                     context.Config.GetTextureFormatAtomic(op.HandleOffset) :
                     GetTextureFormat(op.Type);
@@ -477,6 +478,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
                     sourcesList[xIndex] = context.ShiftRightS32(sourcesList[xIndex], Const(GetComponentSizeInBytesLog2(op.Type)));
                 }
 
+                // TODO: FP and 64-bit formats.
                 format = (op.Type == ReductionType.SD32 || op.Type == ReductionType.SD64) ?
                     context.Config.GetTextureFormatAtomic(op.HandleOffset) :
                     GetTextureFormat(op.Type);

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
@@ -1587,7 +1587,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 ReductionType.S64         => 3,
                 ReductionType.SD32        => 2,
                 ReductionType.SD64        => 3,
-                _ => 2
+                _                         => 2
             };
         }
 

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
@@ -769,8 +769,6 @@ namespace Ryujinx.Graphics.Shader.Instructions
                         sourcesList.Add(Ra());
                         sourcesList.Add(Const(0));
                         break;
-                    default:
-                        break;
                 }
 
                 if ((flags & TextureFlags.Offset) != 0)

--- a/Ryujinx.Graphics.Shader/IntermediateRepresentation/Instruction.cs
+++ b/Ryujinx.Graphics.Shader/IntermediateRepresentation/Instruction.cs
@@ -70,7 +70,6 @@ namespace Ryujinx.Graphics.Shader.IntermediateRepresentation
         ImageLoad,
         ImageStore,
         ImageAtomic,
-        ImageReduce,
         IsNan,
         LoadAttribute,
         LoadConstant,

--- a/Ryujinx.Graphics.Shader/IntermediateRepresentation/Instruction.cs
+++ b/Ryujinx.Graphics.Shader/IntermediateRepresentation/Instruction.cs
@@ -69,6 +69,8 @@ namespace Ryujinx.Graphics.Shader.IntermediateRepresentation
         GroupMemoryBarrier,
         ImageLoad,
         ImageStore,
+        ImageAtomic,
+        ImageReduce,
         IsNan,
         LoadAttribute,
         LoadConstant,

--- a/Ryujinx.Graphics.Shader/IntermediateRepresentation/TextureFlags.cs
+++ b/Ryujinx.Graphics.Shader/IntermediateRepresentation/TextureFlags.cs
@@ -13,6 +13,18 @@ namespace Ryujinx.Graphics.Shader.IntermediateRepresentation
         LodBias     = 1 << 4,
         LodLevel    = 1 << 5,
         Offset      = 1 << 6,
-        Offsets     = 1 << 7
+        Offsets     = 1 << 7,
+
+        AtomicMask  = 15 << 16,
+
+        Add         = 0 << 16,
+        Minimum     = 1 << 16,
+        Maximum     = 2 << 16,
+        Increment   = 3 << 16,
+        Decrement   = 4 << 16,
+        BitwiseAnd  = 5 << 16,
+        BitwiseOr   = 6 << 16,
+        BitwiseXor  = 7 << 16,
+        Swap        = 8 << 16
     }
 }

--- a/Ryujinx.Graphics.Shader/IntermediateRepresentation/TextureFlags.cs
+++ b/Ryujinx.Graphics.Shader/IntermediateRepresentation/TextureFlags.cs
@@ -25,6 +25,7 @@ namespace Ryujinx.Graphics.Shader.IntermediateRepresentation
         BitwiseAnd  = 5 << 16,
         BitwiseOr   = 6 << 16,
         BitwiseXor  = 7 << 16,
-        Swap        = 8 << 16
+        Swap        = 8 << 16,
+        CAS         = 9 << 16
     }
 }

--- a/Ryujinx.Graphics.Shader/StructuredIr/InstructionInfo.cs
+++ b/Ryujinx.Graphics.Shader/StructuredIr/InstructionInfo.cs
@@ -82,7 +82,6 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
             Add(Instruction.ImageLoad,                VariableType.F32);
             Add(Instruction.ImageStore,               VariableType.None);
             Add(Instruction.ImageAtomic,              VariableType.S32);
-            Add(Instruction.ImageReduce,              VariableType.None);
             Add(Instruction.IsNan,                    VariableType.Bool,   VariableType.F32);
             Add(Instruction.LoadAttribute,            VariableType.F32,    VariableType.S32,    VariableType.S32,    VariableType.S32);
             Add(Instruction.LoadConstant,             VariableType.F32,    VariableType.S32,    VariableType.S32);
@@ -151,7 +150,6 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
             if (inst == Instruction.ImageLoad   ||
                 inst == Instruction.ImageStore  ||
                 inst == Instruction.ImageAtomic ||
-                inst == Instruction.ImageReduce ||
                 inst == Instruction.Lod         ||
                 inst == Instruction.TextureSample)
             {

--- a/Ryujinx.Graphics.Shader/StructuredIr/InstructionInfo.cs
+++ b/Ryujinx.Graphics.Shader/StructuredIr/InstructionInfo.cs
@@ -81,6 +81,8 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
             Add(Instruction.FusedMultiplyAdd,         VariableType.Scalar, VariableType.Scalar, VariableType.Scalar, VariableType.Scalar);
             Add(Instruction.ImageLoad,                VariableType.F32);
             Add(Instruction.ImageStore,               VariableType.None);
+            Add(Instruction.ImageAtomic,              VariableType.S32);
+            Add(Instruction.ImageReduce,              VariableType.None);
             Add(Instruction.IsNan,                    VariableType.Bool,   VariableType.F32);
             Add(Instruction.LoadAttribute,            VariableType.F32,    VariableType.S32,    VariableType.S32,    VariableType.S32);
             Add(Instruction.LoadConstant,             VariableType.F32,    VariableType.S32,    VariableType.S32);
@@ -146,9 +148,11 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
         {
             // TODO: Return correct type depending on source index,
             // that can improve the decompiler output.
-            if (inst == Instruction.ImageLoad  ||
-                inst == Instruction.ImageStore ||
-                inst == Instruction.Lod        ||
+            if (inst == Instruction.ImageLoad   ||
+                inst == Instruction.ImageStore  ||
+                inst == Instruction.ImageAtomic ||
+                inst == Instruction.ImageReduce ||
+                inst == Instruction.Lod         ||
                 inst == Instruction.TextureSample)
             {
                 return VariableType.F32;

--- a/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgram.cs
+++ b/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgram.cs
@@ -98,7 +98,7 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
                     texOp.Format,
                     texOp.Flags,
                     texOp.CbufSlot,
-                    texOp.  Handle,
+                    texOp.Handle,
                     texOp.Index,
                     sources);
             }

--- a/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgram.cs
+++ b/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgram.cs
@@ -98,7 +98,7 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
                     texOp.Format,
                     texOp.Flags,
                     texOp.CbufSlot,
-                    texOp.Handle,
+                    texOp.  Handle,
                     texOp.Index,
                     sources);
             }

--- a/Ryujinx.Graphics.Shader/Translation/Optimizations/BindlessElimination.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Optimizations/BindlessElimination.cs
@@ -61,8 +61,9 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
                         src0.GetCbufOffset() | ((src1.GetCbufOffset() + 1) << 16),
                         src0.GetCbufSlot() | ((src1.GetCbufSlot() + 1) << 16));
                 }
-                else if (texOp.Inst == Instruction.ImageLoad || texOp.Inst == Instruction.ImageStore ||
-                         texOp.Inst == Instruction.ImageAtomic || texOp.Inst == Instruction.ImageReduce)
+                else if (texOp.Inst == Instruction.ImageLoad ||
+                         texOp.Inst == Instruction.ImageStore ||
+                         texOp.Inst == Instruction.ImageAtomic)
                 {
                     Operand src0 = Utils.FindLastOperation(texOp.GetSource(0), block);
 
@@ -71,7 +72,11 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
                         int cbufOffset = src0.GetCbufOffset();
                         int cbufSlot = src0.GetCbufSlot();
 
-                        if (!(texOp.Inst == Instruction.ImageAtomic || texOp.Inst == Instruction.ImageReduce))
+                        if (texOp.Inst == Instruction.ImageAtomic)
+                        {
+                            texOp.Format = config.GetTextureFormatAtomic(texOp.Handle);
+                        }
+                        else
                         {
                             texOp.Format = config.GetTextureFormat(cbufOffset, cbufSlot);
                         }

--- a/Ryujinx.Graphics.Shader/Translation/Optimizations/BindlessElimination.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Optimizations/BindlessElimination.cs
@@ -74,7 +74,7 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
 
                         if (texOp.Inst == Instruction.ImageAtomic)
                         {
-                            texOp.Format = config.GetTextureFormatAtomic(texOp.Handle);
+                            texOp.Format = config.GetTextureFormatAtomic(cbufOffset, cbufSlot);
                         }
                         else
                         {

--- a/Ryujinx.Graphics.Shader/Translation/Optimizations/BindlessElimination.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Optimizations/BindlessElimination.cs
@@ -61,7 +61,8 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
                         src0.GetCbufOffset() | ((src1.GetCbufOffset() + 1) << 16),
                         src0.GetCbufSlot() | ((src1.GetCbufSlot() + 1) << 16));
                 }
-                else if (texOp.Inst == Instruction.ImageLoad || texOp.Inst == Instruction.ImageStore)
+                else if (texOp.Inst == Instruction.ImageLoad || texOp.Inst == Instruction.ImageStore ||
+                         texOp.Inst == Instruction.ImageAtomic || texOp.Inst == Instruction.ImageReduce)
                 {
                     Operand src0 = Utils.FindLastOperation(texOp.GetSource(0), block);
 
@@ -69,7 +70,12 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
                     {
                         int cbufOffset = src0.GetCbufOffset();
                         int cbufSlot = src0.GetCbufSlot();
-                        texOp.Format = config.GetTextureFormat(cbufOffset, cbufSlot);
+
+                        if (!(texOp.Inst == Instruction.ImageAtomic || texOp.Inst == Instruction.ImageReduce))
+                        {
+                            texOp.Format = config.GetTextureFormat(cbufOffset, cbufSlot);
+                        }
+
                         SetHandle(config, texOp, cbufOffset, cbufSlot);
                     }
                 }

--- a/Ryujinx.Graphics.Shader/Translation/Optimizations/Optimizer.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Optimizations/Optimizer.cs
@@ -278,6 +278,7 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
                     case Instruction.AtomicSwap:
                     case Instruction.AtomicXor:
                     case Instruction.Call:
+                    case Instruction.ImageAtomic:
                         return true;
                 }
             }

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -167,12 +167,12 @@ namespace Ryujinx.Graphics.Shader.Translation
             return format == TextureFormat.R32Sint || format == TextureFormat.R32Uint;
         }
 
-        public TextureFormat GetTextureFormatAtomic(int handle)
+        public TextureFormat GetTextureFormatAtomic(int handle, int cbufSlot = -1)
         {
             // Atomic image instructions do not support GL_EXT_shader_image_load_formatted, 
             // and must have a type specified. Default to R32Sint if not available.
 
-            var format = GpuAccessor.QueryTextureFormat(handle);
+            var format = GpuAccessor.QueryTextureFormat(handle, cbufSlot);
 
             if (!FormatSupportedAtomic(format))
             {
@@ -293,7 +293,7 @@ namespace Ryujinx.Graphics.Shader.Translation
         {
             inst &= Instruction.Mask;
             bool isImage = inst == Instruction.ImageLoad || inst == Instruction.ImageStore;
-            bool isWrite = inst == Instruction.ImageStore;
+            bool isWrite = inst == Instruction.ImageStore || inst == Instruction.ImageAtomic;
             bool accurateType = inst != Instruction.TextureSize && inst != Instruction.Lod;
 
             if (isImage)

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -292,7 +292,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             int handle)
         {
             inst &= Instruction.Mask;
-            bool isImage = inst == Instruction.ImageLoad || inst == Instruction.ImageStore;
+            bool isImage = inst == Instruction.ImageLoad || inst == Instruction.ImageStore || inst == Instruction.ImageAtomic;
             bool isWrite = inst == Instruction.ImageStore || inst == Instruction.ImageAtomic;
             bool accurateType = inst != Instruction.TextureSize && inst != Instruction.Lod;
 

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -162,6 +162,28 @@ namespace Ryujinx.Graphics.Shader.Translation
             return format;
         }
 
+        private bool FormatSupportedAtomic(TextureFormat format)
+        {
+            return format == TextureFormat.R32Sint || format == TextureFormat.R32Uint;
+        }
+
+        public TextureFormat GetTextureFormatAtomic(int handle)
+        {
+            // Atomic image instructions do not support GL_EXT_shader_image_load_formatted, 
+            // and must have a type specified. Default to R32Sint if not available.
+
+            var format = GpuAccessor.QueryTextureFormat(handle);
+
+            if (!FormatSupportedAtomic(format))
+            {
+                GpuAccessor.Log($"Unsupported format for texture {handle}: {format}.");
+
+                format = TextureFormat.R32Sint;
+            }
+
+            return format;
+        }
+
         public void SizeAdd(int size)
         {
             Size += size;

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -162,7 +162,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             return format;
         }
 
-        private bool FormatSupportedAtomic(TextureFormat format)
+        private bool FormatSupportsAtomic(TextureFormat format)
         {
             return format == TextureFormat.R32Sint || format == TextureFormat.R32Uint;
         }
@@ -174,7 +174,7 @@ namespace Ryujinx.Graphics.Shader.Translation
 
             var format = GpuAccessor.QueryTextureFormat(handle, cbufSlot);
 
-            if (!FormatSupportedAtomic(format))
+            if (!FormatSupportsAtomic(format))
             {
                 GpuAccessor.Log($"Unsupported format for texture {handle}: {format}.");
 


### PR DESCRIPTION
Fixes morph target animation (used for facial animations, eyes) and anything else using atomic image store (probably on buffer textures) in UE4 games. Should affect BD2 and I think Trials of Mana. Yoshi's Crafted World uses these, but I'm not sure what for. May affect other games.

envytools and nvdisasm were used to determine the opcode formats. 

BD2 example:

https://user-images.githubusercontent.com/6294155/110537362-81b22280-811a-11eb-845b-bd67aba491f3.mp4

https://user-images.githubusercontent.com/6294155/110537430-91316b80-811a-11eb-91cf-aa62db561999.mp4

Note: Currently does not support FP or 64-bit types (which may not even exist for textures). Not sure if we should, but that's why the PR is currently draft.