### PR TITLE
Fix lineSize for LinearStrided -> Linear conversion

### DIFF
--- a/Ryujinx.Graphics.Texture/LayoutConverter.cs
+++ b/Ryujinx.Graphics.Texture/LayoutConverter.cs
@@ -256,7 +256,7 @@ namespace Ryujinx.Graphics.Texture
             int h = BitUtils.DivRoundUp(height, blockHeight);
 
             int outStride = BitUtils.AlignUp(w * bytesPerPixel, HostStrideAlignment);
-            int lineSize = w * bytesPerPixel;
+            int lineSize = Math.Min(stride, outStride);
 
             Span<byte> output = new byte[h * outStride];
 


### PR DESCRIPTION
Fixes a possible crash when width is greater than stride, which can happen due to alignment when copying textures with the copy buffer method.

Fixes `System.ArgumentOutOfRangeException` in `ConvertLinearStridedToLinear` called from `CopyBuffer`. May fix another issue when outStride < stride.