### PR TITLE
Override openal-soft configuration

### DIFF
--- a/Ryujinx/Ryujinx.csproj
+++ b/Ryujinx/Ryujinx.csproj
@@ -34,6 +34,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="alsoft.ini">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Config.json" Condition="'$(Configuration)' == 'Debug' OR '$(Configuration)' == 'Profile Debug'">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Ryujinx/alsoft.ini
+++ b/Ryujinx/alsoft.ini
@@ -1,0 +1,2 @@
+[General]
+stereo-mode=speakers


### PR DESCRIPTION
This enforce speaker mode to avoid weird audio quality reduction with
output considered as headphones by Windows (It applies a HRTF or crossfeed filter supposed to improve audio quality, might be a bug on their end)