### PR TITLE
Report active audio device as TV, rather than internal speakers.

### DIFF
--- a/Ryujinx.Audio/Renderer/Device/VirtualDeviceSessionRegistry.cs
+++ b/Ryujinx.Audio/Renderer/Device/VirtualDeviceSessionRegistry.cs
@@ -39,7 +39,7 @@ namespace Ryujinx.Audio.Renderer.Device
         /// The current active <see cref="VirtualDevice"/>.
         /// </summary>
         // TODO: make this configurable
-        public VirtualDevice ActiveDevice = VirtualDevice.Devices[1];
+        public VirtualDevice ActiveDevice = VirtualDevice.Devices[2];
 
         /// <summary>
         /// Get the associated <see cref="T:VirtualDeviceSession[]"/> from an AppletResourceId.


### PR DESCRIPTION
Some games read the active device name, and decide to ruin the audio if it's the internal speakers. This PR changes it to always report the TV output device. This may also get 5.1 out of a few more games.

Should be tested across a variety of engines in handheld mode, in case they don't appreciate reporting a TV output when in handheld mode.

Fixes awful tinny audio in Pokemon Sword.