### PR TITLE
[Suggestion] Add base classes to simplify implementing proper disposable patterns.

### DIFF
--- a/Ryujinx.Common/DisposableBase.cs
+++ b/Ryujinx.Common/DisposableBase.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Ryujinx
+namespace Ryujinx.Common
 {
     /// <summary>
     /// A base class to implement IDisposable pattern for classes with only managed resources.

--- a/Ryujinx.Common/DisposableBase.cs
+++ b/Ryujinx.Common/DisposableBase.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace Ryujinx
+{
+    /// <summary>
+    /// A base class to implement IDisposable pattern for classes with only managed resources.
+    /// Use DisposableUnmanagedBase when there are unmanage resources to dispose.
+    /// </summary>
+    public abstract class DisposableBase : IDisposable
+    {
+        /// <summary>
+        /// A flag that indicates whether object has been disposed.
+        /// </summary>
+        public bool Disposed { get; private set; }
+
+        protected void Dispose(bool disposing)
+        {
+            if (Disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                DisposeManaged();
+            }
+
+            Disposed = true;
+        }
+
+        /// <summary>
+        /// Dispose managed resources.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+        }
+
+        protected abstract void DisposeManaged();
+    }
+}

--- a/Ryujinx.Common/DisposableBase.cs
+++ b/Ryujinx.Common/DisposableBase.cs
@@ -4,8 +4,10 @@ namespace Ryujinx
 {
     /// <summary>
     /// A base class to implement IDisposable pattern for classes with only managed resources.
-    /// Use DisposableUnmanagedBase when there are unmanage resources to dispose.
     /// </summary>
+    /// <remarks>
+    /// Use <see cref="DisposableUnmanagedBase"/> when there are unmanaged resources to dispose.
+    /// </remarks>
     public abstract class DisposableBase : IDisposable
     {
         /// <summary>

--- a/Ryujinx.Common/DisposableUnmanagedBase.cs
+++ b/Ryujinx.Common/DisposableUnmanagedBase.cs
@@ -1,0 +1,50 @@
+﻿using System;
+
+namespace Ryujinx
+{
+    /// <summary>
+    /// A base class to implement IDisposable pattern for classes with unmanaged resources.
+    /// Use DisposableBase when there are only manage resources to dispose.
+    /// </summary>
+    public abstract class DisposableUnmanagedBase : IDisposable
+    {
+        /// <summary>
+        /// A flag that indicates whether object has been disposed.
+        /// </summary>
+        public bool Disposed { get; private set; }
+
+        protected void Dispose(bool disposing)
+        {
+            if (Disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                DisposeManaged();
+            }
+
+            DisposeUnmanaged();
+            Disposed = true;
+        }
+
+        ~DisposableUnmanagedBase()
+        {
+            Dispose(disposing: false);
+        }
+
+        /// <summary>
+        /// Dispose managed and unmanaged resources.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void DisposeManaged() { }
+
+        protected abstract void DisposeUnmanaged();
+    }
+}

--- a/Ryujinx.Common/DisposableUnmanagedBase.cs
+++ b/Ryujinx.Common/DisposableUnmanagedBase.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Ryujinx
+namespace Ryujinx.Common
 {
     /// <summary>
     /// A base class to implement IDisposable pattern for classes with unmanaged resources.

--- a/Ryujinx.Common/DisposableUnmanagedBase.cs
+++ b/Ryujinx.Common/DisposableUnmanagedBase.cs
@@ -4,8 +4,10 @@ namespace Ryujinx
 {
     /// <summary>
     /// A base class to implement IDisposable pattern for classes with unmanaged resources.
-    /// Use DisposableBase when there are only manage resources to dispose.
     /// </summary>
+    /// <remarks>
+    /// Use <see cref="DisposableBase"/> when there are only managed resources to dispose.
+    /// </remarks>
     public abstract class DisposableUnmanagedBase : IDisposable
     {
         /// <summary>

--- a/Ryujinx.Cpu/JitMemoryBlock.cs
+++ b/Ryujinx.Cpu/JitMemoryBlock.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace Ryujinx.Cpu
 {
-    class JitMemoryBlock : IJitMemoryBlock
+    class JitMemoryBlock : DisposableBase, IJitMemoryBlock
     {
         private readonly MemoryBlock _impl;
 
@@ -19,6 +19,9 @@ namespace Ryujinx.Cpu
         public void MapAsRx(ulong offset, ulong size) => _impl.Reprotect(offset, size, MemoryPermission.ReadAndExecute);
         public void MapAsRwx(ulong offset, ulong size) => _impl.Reprotect(offset, size, MemoryPermission.ReadWriteExecute);
 
-        public void Dispose() => _impl.Dispose();
+        protected override void DisposeManaged()
+        {
+            _impl.Dispose();
+        }
     }
 }

--- a/Ryujinx.Cpu/JitMemoryBlock.cs
+++ b/Ryujinx.Cpu/JitMemoryBlock.cs
@@ -1,4 +1,5 @@
 ﻿using ARMeilleure.Memory;
+using Ryujinx.Common;
 using Ryujinx.Memory;
 using System;
 

--- a/Ryujinx.Memory/MemoryBlock.cs
+++ b/Ryujinx.Memory/MemoryBlock.cs
@@ -7,7 +7,7 @@ namespace Ryujinx.Memory
     /// <summary>
     /// Represents a block of contiguous physical guest memory.
     /// </summary>
-    public sealed class MemoryBlock : IDisposable
+    public sealed class MemoryBlock : DisposableUnmanagedBase
     {
         private IntPtr _pointer;
 
@@ -263,17 +263,10 @@ namespace Ryujinx.Memory
             return (IntPtr)(pointer.ToInt64() + (long)offset);
         }
 
-        /// <summary>
-        /// Frees the memory allocated for this memory block.
-        /// </summary>
-        /// <remarks>
-        /// It's an error to use the memory block after disposal.
-        /// </remarks>
-        public void Dispose() => FreeMemory();
+        private void ThrowObjectDisposed() => throw new ObjectDisposedException(nameof(MemoryBlock));
+        private void ThrowInvalidMemoryRegionException() => throw new InvalidMemoryRegionException();
 
-        ~MemoryBlock() => FreeMemory();
-
-        private void FreeMemory()
+        protected override void DisposeUnmanaged()
         {
             IntPtr ptr = Interlocked.Exchange(ref _pointer, IntPtr.Zero);
 
@@ -283,8 +276,5 @@ namespace Ryujinx.Memory
                 MemoryManagement.Free(ptr);
             }
         }
-
-        private void ThrowObjectDisposed() => throw new ObjectDisposedException(nameof(MemoryBlock));
-        private void ThrowInvalidMemoryRegionException() => throw new InvalidMemoryRegionException();
     }
 }

--- a/Ryujinx.Memory/MemoryBlock.cs
+++ b/Ryujinx.Memory/MemoryBlock.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Ryujinx.Common;
+using System;
 using System.Runtime.CompilerServices;
 using System.Threading;
 


### PR DESCRIPTION
Disposable pattern is the way MS officially recommends to implement IDisposable interface, and it will give some performance boost in certain cases.

e.g. In current MemoryBlock.cs a finalizer ```~MemoryBlock()``` is implemented, but ```GC.SuppressFinalize(this)``` is not called in ```Dispose()``` which actually leads to perf panelty of GC because GC will put the object in Finalize queue when finalizer is implemented.

> Empty finalizers should not be used. When a class contains a finalizer, an entry is created in the Finalize queue. When the finalizer is called, the garbage collector is invoked to process the queue. An empty finalizer just causes a needless loss of performance.

In this case, resources are manually released by calling ```dispose()```, no need to let GC call finalizer again.

The base classes can be utilized to simpliy the code to implement a proper disposable pattern.

references:
https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose
https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/destructors
http://joeduffyblog.com/2005/04/08/dg-update-dispose-finalization-and-resource-management/