### PR TITLE
[Perf] KTimeManager.UnscheduleFutureInvocation

### DIFF
--- a/Ryujinx.HLE/HOS/Kernel/Common/IKFutureSchedulerObject.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Common/IKFutureSchedulerObject.cs
@@ -2,6 +2,8 @@ namespace Ryujinx.HLE.HOS.Kernel.Common
 {
     interface IKFutureSchedulerObject
     {
+        long TimePoint { get; set; }
+
         void TimeUp();
     }
 }

--- a/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
@@ -23,6 +23,8 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
 
         public KThreadContext ThreadContext { get; private set; }
 
+        public long TimePoint { get; set; }
+
         public int DynamicPriority { get; set; }
         public long AffinityMask { get; set; }
 


### PR DESCRIPTION
Profiling shows that linq in KTimeManager.UnscheduleFutureInvocation is doing a lot of unnecessary allocations, this PR is an attempt to make some improvement.  Ideally, a PrioriyQueue seems to be the best fix but a hashmap would make an easy improvement without introducing 3rd packages or own PQ implementation.

Before:
![3](https://user-images.githubusercontent.com/6546635/111443658-8e4f0000-8744-11eb-8116-d0ea92808e0b.jpg)

After:
![2](https://user-images.githubusercontent.com/6546635/111443694-9870fe80-8744-11eb-9383-e4874f1b3262.jpg)
