### PR TITLE
ErrorApplet: Implement ApplicationErrorArg

### DIFF
--- a/Ryujinx.HLE/HOS/Applets/Error/ApplicationErrorArg.cs
+++ b/Ryujinx.HLE/HOS/Applets/Error/ApplicationErrorArg.cs
@@ -1,0 +1,13 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Applets.Error
+{
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    unsafe struct ApplicationErrorArg
+    {
+        public uint       ErrorNumber;
+        public ulong      LanguageCode;
+        public fixed byte MessageText[0x800];
+        public fixed byte DetailsText[0x800];
+    }
+} 


### PR DESCRIPTION
This PR implement `ApplicationErrorArg` to the Error Applet. It's used by the guest to throw some specific error messages.
The code was done for (and merged) LDN2 build since long time ago and have been tested a bunch of times because of that! In a way to reduce the differences between LDN and master build it's fine to add it to master.