### PR TITLE
Fix progress reporting

### DIFF
--- a/ARMeilleure/Translation/PTC/PtcLoadingState.cs
+++ b/ARMeilleure/Translation/PTC/PtcLoadingState.cs
@@ -1,0 +1,9 @@
+namespace ARMeilleure.Translation.PTC
+{
+    public enum PtcLoadingState
+    {
+        Start,
+        Loading,
+        Loaded
+    }
+}

--- a/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -80,23 +80,12 @@ namespace Ryujinx.Graphics.Gpu
         internal Capabilities Capabilities => _caps.Value;
 
         /// <summary>
-        /// Signaled when shader cache begins and ends loading.
-        /// Signals true when loading has started, false when ended.
+        /// Event for signalling shader cache loading progress.
         /// </summary>
-        public event Action<bool> ShaderCacheStateChanged
+        public event Action<Shader.ShaderCacheState, int, int> ShaderCacheStateChanged
         {
             add => Methods.ShaderCache.ShaderCacheStateChanged += value;
             remove => Methods.ShaderCache.ShaderCacheStateChanged -= value;
-        }
-
-        /// <summary>
-        /// Signaled while shader cache is loading to indicate current progress.
-        /// Provides current and total number of shaders loaded.
-        /// </summary>
-        public event Action<int, int> ShaderCacheProgressChanged
-        {
-            add => Methods.ShaderCache.ShaderCacheProgressChanged += value;
-            remove => Methods.ShaderCache.ShaderCacheProgressChanged -= value;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCacheState.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCacheState.cs
@@ -1,0 +1,13 @@
+namespace Ryujinx.Graphics.Gpu.Shader
+{
+    /// <summary>Shader cache loading states</summary>
+    public enum ShaderCacheState
+    {
+        /// <summary>Shader cache started loading</summary>
+        Start,
+        /// <summary>Shader cache is loading</summary>
+        Loading,
+        /// <summary>Shader cache finished loading</summary>
+        Loaded
+    }
+}


### PR DESCRIPTION
There were quite a few issues (non-critical or mostly invisible) in my previous code which this PR fixes. My apologies for having to redesign this.

- Reduced the scope of `AutoResetEvent`s used for progress logging threads. It was wasteful to maintain an active `WaitHandle` throughout the emulation session.

- Removed uses of `ThreadPool.QueueUserWorkItem()`. While their placement is calculated, loading is long sometimes and `ThreadPool` might be used internally in other places. So, opted for an explicit low priority `Thread` with a descriptive name. With this and other fixes (below), updates are now twice as frequent with no impact.

- Changed progress reporting to a single event. This removes the awkward boilerplate code on handler side.

- Inconsistencies fixed- NaN/infs, off-by-1 reporting, redundant invokes, possibly stale counts, rare out-of-order state events, and other silliness.

No visible changes (other than smoothness).