### PR TITLE
Integration with kodi

### DIFF
--- a/Ryujinx.Common/Combo/ComboPressedEventArgs.cs
+++ b/Ryujinx.Common/Combo/ComboPressedEventArgs.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Ryujinx.Common.Combo
+{
+    public enum ComboType : uint
+    {
+        SpecialOne,
+        SpecialTwo
+    }
+
+    public class ComboPressedEventArgs : EventArgs
+    {
+        public ComboType Combo;
+
+        public ComboPressedEventArgs(ComboType combo)
+        {
+            Combo = combo;
+        }
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Hid/HidDevices/NpadDevices.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/HidDevices/NpadDevices.cs
@@ -110,7 +110,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
                 }
             }
 
-            if (configuredCount < playerMin || configuredCount > playerMax || primaryIndex == PlayerIndex.Unknown)
+            if (configuredCount < playerMin  || primaryIndex == PlayerIndex.Unknown)
             {
                 Logger.Info?.Print(LogClass.Hid, $"min{playerMin} count {configuredCount} max {playerMax} index unknown {primaryIndex == PlayerIndex.Unknown}");
                 return false;

--- a/Ryujinx.HLE/HOS/Services/Hid/HidDevices/NpadDevices.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/HidDevices/NpadDevices.cs
@@ -112,6 +112,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             if (configuredCount < playerMin || configuredCount > playerMax || primaryIndex == PlayerIndex.Unknown)
             {
+                Logger.Info?.Print(LogClass.Hid, $"min{playerMin} count {configuredCount} max {playerMax} index unknown {primaryIndex == PlayerIndex.Unknown}");
                 return false;
             }
 

--- a/Ryujinx.Input/HLE/NpadManager.cs
+++ b/Ryujinx.Input/HLE/NpadManager.cs
@@ -1,3 +1,4 @@
+using Ryujinx.Common.Combo;
 using Ryujinx.Common.Configuration.Hid;
 using Ryujinx.Common.Configuration.Hid.Controller;
 using Ryujinx.Common.Configuration.Hid.Controller.Motion;
@@ -34,6 +35,7 @@ namespace Ryujinx.Input.HLE
         private bool _enableKeyboard;
         private bool _enableMouse;
         private Switch _device;
+        public event EventHandler<ComboPressedEventArgs> ComboPressed;
 
         public NpadManager(IGamepadDriver keyboardDriver, IGamepadDriver gamepadDriver, IGamepadDriver mouseDriver)
         {
@@ -185,6 +187,16 @@ namespace Ryujinx.Input.HLE
 
                         inputState.Buttons |= _device.Hid.UpdateStickButtons(inputState.LStick, inputState.RStick);
 
+                        ControllerKeys specialCombo1 = ControllerKeys.Minus|ControllerKeys.L|ControllerKeys.Plus|ControllerKeys.R;
+                        ControllerKeys specialCombo2 = ControllerKeys.Minus|ControllerKeys.Plus;
+
+                        if ((inputState.Buttons & specialCombo1) == specialCombo1) {
+                            OnComboPressed(new ComboPressedEventArgs(ComboType.SpecialOne));
+                        }
+                        else if ((inputState.Buttons & specialCombo2) == specialCombo2) {
+                            OnComboPressed(new ComboPressedEventArgs(ComboType.SpecialTwo));
+                        }
+
                         isJoyconPair = inputConfig.ControllerType == Common.Configuration.Hid.ControllerType.JoyconPair;
 
                         var altMotionState = isJoyconPair ? controller.GetHLEMotionState(true) : default;
@@ -268,6 +280,11 @@ namespace Ryujinx.Input.HLE
 
                 _device.TamperMachine.UpdateInput(hleInputStates);
             }
+        }
+
+        protected void OnComboPressed(ComboPressedEventArgs args)
+        {
+            ComboPressed?.Invoke(null, args);
         }
 
         internal InputConfig GetPlayerInputConfigByIndex(int index)

--- a/Ryujinx/Program.cs
+++ b/Ryujinx/Program.cs
@@ -57,6 +57,7 @@ namespace Ryujinx
             // Parse Arguments.
             string launchPathArg      = null;
             string baseDirPathArg     = null;
+            List<string> dirGames     = null;
             bool   startFullscreenArg = false;
             bool   listGames = false;
             bool   showVersion = false;
@@ -84,10 +85,10 @@ namespace Ryujinx
                 {
                     Console.Write(@"Ryujinx [options] [file]
 
--h, --help         Show this help
--v, --version      Show Ryujinx version
--f, --fullscreen   Run in fullscreen
-    --list-games   List Available games in json format
+-h, --help              Show this help
+-v, --version           Show Ryujinx version
+-f, --fullscreen        Run in fullscreen
+    --list-games [dir]  List Available games in json format
 
 ");
                     return;
@@ -110,6 +111,13 @@ namespace Ryujinx
                 else if (arg == "--list-games")
                 {
                     listGames = true;
+                    if (i + 1 >= args.Length || args[i + 1].StartsWith('-') )
+                    {
+                        continue;
+                    }
+
+                    dirGames = new List<string>();
+                    dirGames.Add(args[++i]);
                 }
                 else if (launchPathArg == null)
                 {
@@ -199,6 +207,10 @@ namespace Ryujinx
 
             if (listGames)
             {
+                if (dirGames == null)
+                {
+                    dirGames = ConfigurationState.Instance.Ui.GameDirs;
+                }
                 ArrayList gameMetadataArray           = new ArrayList();
                 VirtualFileSystem virtualFileSystem   = VirtualFileSystem.CreateInstance();
                 ContentManager contentManager         = new ContentManager(virtualFileSystem);
@@ -213,7 +225,7 @@ namespace Ryujinx
                     };
                     gameMetadataArray.Add(data);
                 };
-                applicationLibrary.LoadApplications(ConfigurationState.Instance.Ui.GameDirs, ConfigurationState.Instance.System.Language);
+                applicationLibrary.LoadApplications(dirGames, ConfigurationState.Instance.System.Language);
                 Console.Write(JsonHelper.Serialize(gameMetadataArray, true));
                 return;
             }

--- a/Ryujinx/Program.cs
+++ b/Ryujinx/Program.cs
@@ -59,6 +59,7 @@ namespace Ryujinx
             string baseDirPathArg     = null;
             bool   startFullscreenArg = false;
             bool   listGames = false;
+            bool   showVersion = false;
 
             for (int i = 0; i < args.Length; ++i)
             {
@@ -74,6 +75,22 @@ namespace Ryujinx
                     }
 
                     baseDirPathArg = args[++i];
+                }
+                else if (arg == "-v" || arg == "--version")
+                {
+                    showVersion = true;
+                }
+                else if (arg == "-h" || arg == "--help")
+                {
+                    Console.Write(@"Ryujinx [options] [file]
+
+-h, --help         Show this help
+-v, --version      Show Ryujinx version
+-f, --fullscreen   Run in fullscreen
+    --list-games   List Available games in json format
+
+");
+                    return;
                 }
                 else if (arg == "-p" || arg == "--profile")
                 {
@@ -106,6 +123,13 @@ namespace Ryujinx
 
             // Delete backup files after updating.
             Task.Run(Updater.CleanupUpdate);
+
+            Version = Assembly.GetEntryAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+            if (showVersion)
+            {
+                Console.Write(Version);
+                return;
+            }
 
             Console.Title = $"Ryujinx Console {Version}";
 
@@ -190,7 +214,7 @@ namespace Ryujinx
                     gameMetadataArray.Add(data);
                 };
                 applicationLibrary.LoadApplications(ConfigurationState.Instance.Ui.GameDirs, ConfigurationState.Instance.System.Language);
-                System.Console.Write(JsonHelper.Serialize(gameMetadataArray, true));
+                Console.Write(JsonHelper.Serialize(gameMetadataArray, true));
                 return;
             }
 

--- a/Ryujinx/Program.cs
+++ b/Ryujinx/Program.cs
@@ -60,6 +60,7 @@ namespace Ryujinx
             List<string> dirGames     = null;
             bool   startFullscreenArg = false;
             bool   listGames = false;
+            bool   runOnce = false;
             bool   showVersion = false;
 
             for (int i = 0; i < args.Length; ++i)
@@ -89,6 +90,7 @@ namespace Ryujinx
 -v, --version           Show Ryujinx version
 -f, --fullscreen        Run in fullscreen
     --list-games [dir]  List Available games in json format
+    --run-once     Don't return to game list after emulation
 
 ");
                     return;
@@ -118,6 +120,10 @@ namespace Ryujinx
 
                     dirGames = new List<string>();
                     dirGames.Add(args[++i]);
+                }
+                else if (arg == "--run-once")
+                {
+                    runOnce = true;
                 }
                 else if (launchPathArg == null)
                 {
@@ -254,7 +260,7 @@ namespace Ryujinx
 
             if (launchPathArg != null)
             {
-                mainWindow.LoadApplication(launchPathArg, startFullscreenArg);
+                mainWindow.LoadApplication(launchPathArg, startFullscreenArg, runOnce);
             }
 
             if (ConfigurationState.Instance.CheckUpdatesOnStart.Value && Updater.CanUpdate(false))

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -13,6 +13,7 @@ using Ryujinx.Audio.Backends.SDL2;
 using Ryujinx.Audio.Backends.SoundIo;
 using Ryujinx.Audio.Integration;
 using Ryujinx.Common;
+using Ryujinx.Common.Combo;
 using Ryujinx.Common.Configuration;
 using Ryujinx.Common.Logging;
 using Ryujinx.Common.System;
@@ -963,6 +964,11 @@ namespace Ryujinx.Ui
 
             DisplaySleep.Prevent();
 
+            if (runOnce)
+            {
+                RendererWidget.ComboPressed += Combo_Pressed;
+            }
+
             RendererWidget.Initialize(_emulationContext);
 
             RendererWidget.WaitEvent.WaitOne();
@@ -985,6 +991,26 @@ namespace Ryujinx.Ui
             {
                 SwitchToGameTable();
             });
+        }
+
+        private void Combo_Pressed(object sender, ComboPressedEventArgs args)
+        {
+            if (args.Combo == ComboType.SpecialOne)
+            {
+                Logger.Info?.Print(LogClass.Application, "Exit from game");
+                Thread applicationLibraryThread = new Thread(() =>
+                {
+                    End();
+                });
+                applicationLibraryThread.Name         = "GUI.ApplicationLibraryThread";
+                applicationLibraryThread.IsBackground = true;
+                applicationLibraryThread.Start();
+            }
+            else if (args.Combo == ComboType.SpecialTwo)
+            {
+                Logger.Info?.Print(LogClass.Application, "WakeupCombo");
+                Simulate_WakeUp_Message_Pressed(null, null);
+            }
         }
 
         private void RecreateFooterForMenu()

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -678,7 +678,7 @@ namespace Ryujinx.Ui
             }
         }
 
-        public void LoadApplication(string path, bool startFullscreen = false)
+        public void LoadApplication(string path, bool startFullscreen = false, bool runOnce = false)
         {
             if (_gameLoaded)
             {
@@ -843,11 +843,11 @@ namespace Ryujinx.Ui
 
                 Translator.IsReadyForTranslation.Reset();
 #if MACOS_BUILD
-                CreateGameWindow();
+                CreateGameWindow(runOnce);
 #else
                 Thread windowThread = new Thread(() =>
                 {
-                    CreateGameWindow();
+                    CreateGameWindow(runOnce);
                 })
                 {
                     Name = "GUI.WindowThread"
@@ -954,7 +954,7 @@ namespace Ryujinx.Ui
             _firmwareInstallDirectory.Sensitive = true;
         }
 
-        private void CreateGameWindow()
+        private void CreateGameWindow(bool runOnce)
         {
             if (OperatingSystem.IsWindows())
             {
@@ -974,6 +974,11 @@ namespace Ryujinx.Ui
 
             _emulationContext.Dispose();
             _deviceExitStatus.Set();
+
+            if (runOnce)
+            {
+                End();
+            }
 
             // NOTE: Everything that is here will not be executed when you close the UI.
             Application.Invoke(delegate

--- a/Ryujinx/Ui/RendererWidgetBase.cs
+++ b/Ryujinx/Ui/RendererWidgetBase.cs
@@ -3,6 +3,7 @@ using ARMeilleure.Translation.PTC;
 using Gdk;
 using Gtk;
 using Ryujinx.Common;
+using Ryujinx.Common.Combo;
 using Ryujinx.Common.Configuration;
 using Ryujinx.Common.Logging;
 using Ryujinx.Ui.Common.Configuration;
@@ -47,6 +48,7 @@ namespace Ryujinx.Ui
         protected int WindowHeight { get; private set; }
 
         public static event EventHandler<StatusUpdatedEventArgs> StatusUpdatedEvent;
+        public event EventHandler<ComboPressedEventArgs>         ComboPressed;
 
         private bool _isActive;
         private bool _isStopped;
@@ -84,6 +86,7 @@ namespace Ryujinx.Ui
             _inputManager = inputManager;
             _inputManager.SetMouseDriver(mouseDriver);
             NpadManager = _inputManager.CreateNpadManager();
+            NpadManager.ComboPressed += Combo_Pressed;
             TouchScreenManager = _inputManager.CreateTouchScreenManager();
             _keyboardInterface = (IKeyboard)_inputManager.KeyboardDriver.GetGamepad("0");
 
@@ -708,6 +711,11 @@ namespace Ryujinx.Ui
             }
 
             return state;
+        }
+
+        private void Combo_Pressed(object sender, ComboPressedEventArgs args)
+        {
+            ComboPressed?.Invoke(null, args);
         }
     }
 }


### PR DESCRIPTION
Kodi is a media center manager, to integrate with Ryujinx kodi needs:

- List of games available
- Interact without keyboard or mouse

This PR adds needed functionality, extending or modifying a bit Ryujinx internals:

- To list game list metadata, a `--list-games` option is added
- 
This will output a json array of metadata for games:

```
[
  {
    "path": "/home/user/games/foo.nsp",
    "title_name": "Foo game",
    "icon": "/9j/4QD9RXhpZgAATU0AKgAAAAg..."
  },
  {
    "path": "/home/user/games/bar.nsp",
    "title_name": "Bar game",
    "icon": "/9j/4QD9RXhpZgAATU0AKgAAAAgACAEPAAIAAAASAAAAbgESAAMAAAABAA..."
  }
]
```

that will be consumed by kodi game addon.

I'm not expert on .NET so a review is highly appreciated.

Good to have:
- Refactor of packages so this CLI function do not relay on Ryujinx.UI packages

To interact with emulation without keyboard or mouse a trick used in retroarch is added. Detect special combos on joycons to execute actions. Actions needed are:

- Wake up message (`Plus` + `Minus`)
- Exit emulation (`Plus` + `Minus` + `L` + `R`)

Modified behaviour of ryujinx is to exit Ryujinx if you stop emulation launching it with a nsp file as argument (like just run emulation and avoid to go to game list after that)

This PR is fully functional with this Ryujinx kodi addon: xbmc/repo-plugins#3510