### PR TITLE
am/ectx: Implement SetRequestExitToLibraryAppletAtExecuteNextProgramEnabled and add service placeholder

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
@@ -13,8 +13,10 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         private Lbl.LblControllerServer _lblControllerServer;
 
         private bool _vrModeEnabled;
+#pragma warning disable CS0169
         private bool _lcdBacklighOffEnabled;
         private bool _requestExitToLibraryAppletAtExecuteNextProgramEnabled;
+#pragma warning restore CS0169
         private int  _messageEventHandle;
         private int  _displayResolutionChangedEventHandle;
 

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
@@ -14,6 +14,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
 
         private bool _vrModeEnabled;
         private bool _lcdBacklighOffEnabled;
+        private bool _requestExitToLibraryAppletAtExecuteNextProgramEnabled;
         private int  _messageEventHandle;
         private int  _displayResolutionChangedEventHandle;
 
@@ -236,6 +237,16 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         public ResultCode GetCurrentPerformanceConfiguration(ServiceCtx context)
         {
             return (ResultCode)_apmSystemManagerServer.GetCurrentPerformanceConfiguration(context);
+        }
+
+        [Command(900)] // 11.0.0+
+        // SetRequestExitToLibraryAppletAtExecuteNextProgramEnabled()
+        public ResultCode SetRequestExitToLibraryAppletAtExecuteNextProgramEnabled(ServiceCtx context)
+        {
+            // TODO : Find where the field is used.
+            _requestExitToLibraryAppletAtExecuteNextProgramEnabled = true;
+
+            return ResultCode.Success;
         }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Ectx/IReaderForSystem.cs
+++ b/Ryujinx.HLE/HOS/Services/Ectx/IReaderForSystem.cs
@@ -1,0 +1,8 @@
+﻿namespace Ryujinx.HLE.HOS.Services.Ectx
+{
+    [Service("ectx:r")] // 11.0.0+
+    class IReaderForSystem : IpcService
+    {
+        public IReaderForSystem(ServiceCtx context) { }
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Ectx/IWriterForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Ectx/IWriterForApplication.cs
@@ -1,0 +1,8 @@
+﻿namespace Ryujinx.HLE.HOS.Services.Ectx
+{
+    [Service("ectx:aw")] // 11.0.0+
+    class IWriterForApplication : IpcService
+    {
+        public IWriterForApplication(ServiceCtx context) { }
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Ectx/IWriterForSystem.cs
+++ b/Ryujinx.HLE/HOS/Services/Ectx/IWriterForSystem.cs
@@ -1,0 +1,8 @@
+﻿namespace Ryujinx.HLE.HOS.Services.Ectx
+{
+    [Service("ectx:w")] // 11.0.0+
+    class IWriterForSystem : IpcService
+    {
+        public IWriterForSystem(ServiceCtx context) { }
+    }
+}


### PR DESCRIPTION
This PR implements `am` service call `SetRequestExitToLibraryAppletAtExecuteNextProgramEnabled` (closes #2028) accordingly to RE and adds placeholder for the `ectx` services. All were added in 11.0.0+ firmware and are needed to boots games (or updated games) which needs this version.

Some games are now playable/bootable:
![image](https://user-images.githubusercontent.com/4905390/112370202-62e88a00-8cdd-11eb-9e54-5b2a1181fc88.png)
![image](https://user-images.githubusercontent.com/4905390/112370210-654ae400-8cdd-11eb-9b42-b901a7a6b5b3.png)
![image](https://user-images.githubusercontent.com/4905390/112370221-6845d480-8cdd-11eb-9f4d-564718d67b32.png)
