### PR TITLE
Add support for HLE macros and accelerate MultiDrawElementsIndirectCount

### DIFF
--- a/Ryujinx.Common/Hash128.cs
+++ b/Ryujinx.Common/Hash128.cs
@@ -9,6 +9,12 @@ namespace Ryujinx.Common
         public ulong Low;
         public ulong High;
 
+        public Hash128(ulong low, ulong high)
+        {
+            Low = low;
+            High = high;
+        }
+
         public override string ToString()
         {
             return $"{High:x16}{Low:x16}";

--- a/Ryujinx.Graphics.GAL/IPipeline.cs
+++ b/Ryujinx.Graphics.GAL/IPipeline.cs
@@ -33,6 +33,9 @@ namespace Ryujinx.Graphics.GAL
 
         void EndTransformFeedback();
 
+        void MultiDrawIndirectCount(BufferRange indirectBuffer, BufferRange parameterBuffer, int maxDrawCount, int stride);
+        void MultiDrawIndexedIndirectCount(BufferRange indirectBuffer, BufferRange parameterBuffer, int maxDrawCount, int stride);
+
         void SetAlphaTest(bool enable, float reference, CompareOp op);
 
         void SetBlendState(int index, BlendDescriptor blend);

--- a/Ryujinx.Graphics.GAL/IPipeline.cs
+++ b/Ryujinx.Graphics.GAL/IPipeline.cs
@@ -19,6 +19,8 @@ namespace Ryujinx.Graphics.GAL
             int   stencilValue,
             int   stencilMask);
 
+        void CommandBufferBarrier();
+
         void CopyBuffer(BufferHandle source, BufferHandle destination, int srcOffset, int dstOffset, int size);
 
         void DispatchCompute(int groupsX, int groupsY, int groupsZ);

--- a/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoClass.cs
@@ -197,9 +197,9 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
         /// </summary>
         /// <param name="index">Index of the macro</param>
         /// <param name="argument">Argument to be pushed to the macro</param>
-        public void MmePushArgument(int index, int argument)
+        public void MmePushArgument(int index, ulong gpuVa, int argument)
         {
-            _macros[index].PushArgument(argument);
+            _macros[index].PushArgument(gpuVa, argument);
         }
 
         /// <summary>
@@ -209,7 +209,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
         /// <param name="argument">Initial argument passed to the macro</param>
         public void MmeStart(int index, int argument)
         {
-            _macros[index].StartExecution(argument);
+            _macros[index].StartExecution(_context, _macroCode, argument);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoClass.cs
@@ -162,6 +162,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
         /// <param name="argument">Method call argument</param>
         public void SetReference(int argument)
         {
+            _context.Renderer.Pipeline.CommandBufferBarrier();
+
             _context.CreateHostSyncIfNeeded();
         }
 

--- a/Ryujinx.Graphics.Gpu/Engine/MME/IMacroEE.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MME/IMacroEE.cs
@@ -5,6 +5,33 @@ using System.Collections.Generic;
 namespace Ryujinx.Graphics.Gpu.Engine.MME
 {
     /// <summary>
+    /// FIFO word.
+    /// </summary>
+    struct FifoWord
+    {
+        /// <summary>
+        /// GPU virtual address where the word is located in memory.
+        /// </summary>
+        public ulong GpuVa { get; }
+
+        /// <summary>
+        /// Word value.
+        /// </summary>
+        public int Word { get; }
+
+        /// <summary>
+        /// Creates a new FIFO word.
+        /// </summary>
+        /// <param name="gpuVa">GPU virtual address where the word is located in memory</param>
+        /// <param name="word">Word value</param>
+        public FifoWord(ulong gpuVa, int word)
+        {
+            GpuVa = gpuVa;
+            Word = word;
+        }
+    }
+
+    /// <summary>
     /// Macro Execution Engine interface.
     /// </summary>
     interface IMacroEE
@@ -12,7 +39,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
         /// <summary>
         /// Arguments FIFO.
         /// </summary>
-        public Queue<int> Fifo { get; }
+        Queue<FifoWord> Fifo { get; }
 
         /// <summary>
         /// Should execute the GPU Macro code being passed.

--- a/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLE.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLE.cs
@@ -1,0 +1,141 @@
+using Ryujinx.Common.Logging;
+using Ryujinx.Graphics.GAL;
+using Ryujinx.Graphics.Gpu.State;
+using System;
+using System.Collections.Generic;
+
+namespace Ryujinx.Graphics.Gpu.Engine.MME
+{
+    /// <summary>
+    /// Macro High-level emulation.
+    /// </summary>
+    class MacroHLE : IMacroEE
+    {
+        private readonly GpuContext _context;
+        private readonly MacroHLEFunctionName _functionName;
+
+        /// <summary>
+        /// Arguments FIFO.
+        /// </summary>
+        public Queue<FifoWord> Fifo { get; }
+
+        /// <summary>
+        /// Creates a new instance of the HLE macro handler.
+        /// </summary>
+        /// <param name="context">GPU context the macro is being executed on</param>
+        /// <param name="functionName">Name of the HLE macro function to be called</param>
+        public MacroHLE(GpuContext context, MacroHLEFunctionName functionName)
+        {
+            _context = context;
+            _functionName = functionName;
+
+            Fifo = new Queue<FifoWord>();
+        }
+
+        /// <summary>
+        /// Executes a macro program until it exits.
+        /// </summary>
+        /// <param name="code">Code of the program to execute</param>
+        /// <param name="state">Current GPU state</param>
+        /// <param name="arg0">Optional argument passed to the program, 0 if not used</param>
+        public void Execute(ReadOnlySpan<int> code, GpuState state, int arg0)
+        {
+            switch (_functionName)
+            {
+                case MacroHLEFunctionName.MultiDrawElementsIndirectCount:
+                    MultiDrawElementsIndirectCount(state, arg0);
+                    break;
+                default:
+                    throw new NotImplementedException(_functionName.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Performs a indirect multi-draw, with parameters from a GPU buffer.
+        /// </summary>
+        /// <param name="state">Current GPU state</param>
+        /// <param name="arg0">First argument of the call</param>
+        private void MultiDrawElementsIndirectCount(GpuState state, int arg0)
+        {
+            int arg1 = FetchParam().Word;
+            int arg2 = FetchParam().Word;
+            int arg3 = FetchParam().Word;
+
+            int startOffset = arg0;
+            int endOffset = arg1;
+            var topology = (PrimitiveTopology)arg2;
+            int paddingWords = arg3;
+            int maxDrawCount = endOffset - startOffset;
+            int stride = paddingWords * 4 + 0x14;
+            int indirectBufferSize = maxDrawCount * stride;
+
+            ulong parameterBufferGpuVa = FetchParam().GpuVa;
+            ulong indirectBufferGpuVa = 0;
+
+            int indexCount = 0;
+
+            for (int i = 0; i < maxDrawCount; i++)
+            {
+                var count = FetchParam();
+                var instanceCount = FetchParam();
+                var firstIndex = FetchParam();
+                var baseVertex = FetchParam();
+                var baseInstance = FetchParam();
+
+                if (i == 0)
+                {
+                    indirectBufferGpuVa = count.GpuVa;
+                }
+
+                indexCount = Math.Max(indexCount, count.Word + firstIndex.Word);
+
+                if (i != maxDrawCount - 1)
+                {
+                    for (int j = 0; j < paddingWords; j++)
+                    {
+                        FetchParam();
+                    }
+                }
+            }
+
+            // It should be empty at this point, but clear it just to be safe.
+            Fifo.Clear();
+
+            var parameterBuffer = _context.Methods.BufferManager.GetGpuBufferRange(parameterBufferGpuVa, 4);
+            var indirectBuffer = _context.Methods.BufferManager.GetGpuBufferRange(indirectBufferGpuVa, (ulong)indirectBufferSize);
+
+            Send(state, (int)MethodOffset.IndexBufferCount, indexCount);
+
+            _context.Methods.MultiDrawIndirectCount(state, topology, indirectBuffer, parameterBuffer, maxDrawCount, stride);
+        }
+
+        /// <summary>
+        /// Fetches a arguments from the arguments FIFO.
+        /// </summary>
+        /// <returns>The call argument, or a 0 value with null address if the FIFO is empty</returns>
+        private FifoWord FetchParam()
+        {
+            if (!Fifo.TryDequeue(out var value))
+            {
+                Logger.Warning?.Print(LogClass.Gpu, "Macro attempted to fetch an inexistent argument.");
+
+                return new FifoWord(0UL, 0);
+            }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Performs a GPU method call.
+        /// </summary>
+        /// <param name="state">Current GPU state</param>
+        /// <param name="methAddr">Address, in words, of the method</param>
+        /// <param name="value">Call argument</param>
+        private static void Send(GpuState state, int methAddr, int value)
+        {
+            MethodParams meth = new MethodParams(methAddr, value);
+
+            state.CallMethod(meth);
+        }
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLEFunctionName.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLEFunctionName.cs
@@ -1,0 +1,11 @@
+﻿namespace Ryujinx.Graphics.Gpu.Engine.MME
+{
+    /// <summary>
+    /// Name of the High-level implementation of a Macro function.
+    /// </summary>
+    enum MacroHLEFunctionName
+    {
+        None,
+        MultiDrawElementsIndirectCount
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLETable.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLETable.cs
@@ -1,0 +1,77 @@
+﻿using Ryujinx.Common;
+using System;
+using System.Runtime.InteropServices;
+
+namespace Ryujinx.Graphics.Gpu.Engine.MME
+{
+    /// <summary>
+    /// Table with information about High-level implementations of GPU Macro code.
+    /// </summary>
+    static class MacroHLETable
+    {
+        /// <summary>
+        /// Macroo High-level implementation table entry.
+        /// </summary>
+        struct TableEntry
+        {
+            /// <summary>
+            /// Name of the Macro function.
+            /// </summary>
+            public MacroHLEFunctionName Name { get; }
+
+            /// <summary>
+            /// Hash of the original binary Macro function code.
+            /// </summary>
+            public Hash128 Hash { get; }
+
+            /// <summary>
+            /// Size (in bytes) of the original binary Macro function code.
+            /// </summary>
+            public int Length { get; }
+
+            /// <summary>
+            /// Creates a new table entry.
+            /// </summary>
+            /// <param name="name">Name of the Macro function</param>
+            /// <param name="hash">Hash of the original binary Macro function code</param>
+            /// <param name="length">Size (in bytes) of the original binary Macro function code</param>
+            public TableEntry(MacroHLEFunctionName name, Hash128 hash, int length)
+            {
+                Name = name;
+                Hash = hash;
+                Length = length;
+            }
+        }
+
+        private static readonly TableEntry[] Table = new TableEntry[]
+        {
+            new TableEntry(MacroHLEFunctionName.MultiDrawElementsIndirectCount, new Hash128(0x890AF57ED3FB1C37, 0x35D0C95C61F5386F), 0x19C)
+        };
+
+        /// <summary>
+        /// Checks if there's a fast, High-level implementation of the specified Macro code available.
+        /// </summary>
+        /// <param name="code">Macro code to be checked</param>
+        /// <param name="name">Name of the function if a implementation is available, otherwise <see cref="MacroHLEFunctionName.None"/></param>
+        /// <returns>True if there is a implementation available, false otherwise</returns>
+        public static bool TryGetMacroHLEFunction(ReadOnlySpan<int> code, out MacroHLEFunctionName name)
+        {
+            var mc = MemoryMarshal.Cast<int, byte>(code);
+
+            for (int i = 0; i < Table.Length; i++)
+            {
+                ref var entry = ref Table[i];
+
+                var hash = XXHash128.ComputeHash(mc.Slice(0, entry.Length));
+                if (hash == entry.Hash)
+                {
+                    name = entry.Name;
+                    return true;
+                }
+            }
+
+            name = MacroHLEFunctionName.None;
+            return false;
+        }
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Engine/MME/MacroInterpreter.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MME/MacroInterpreter.cs
@@ -13,7 +13,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
         /// <summary>
         /// Arguments FIFO.
         /// </summary>
-        public Queue<int> Fifo { get; }
+        public Queue<FifoWord> Fifo { get; }
 
         private int[] _gprs;
 
@@ -34,7 +34,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
         /// </summary>
         public MacroInterpreter()
         {
-            Fifo = new Queue<int>();
+            Fifo = new Queue<FifoWord>();
 
             _gprs = new int[8];
         }
@@ -362,14 +362,14 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
         /// <returns>The call argument, or 0 if the FIFO is empty</returns>
         private int FetchParam()
         {
-            if (!Fifo.TryDequeue(out int value))
+            if (!Fifo.TryDequeue(out var value))
             {
                 Logger.Warning?.Print(LogClass.Gpu, "Macro attempted to fetch an inexistent argument.");
 
                 return 0;
             }
 
-            return value;
+            return value.Word;
         }
 
         /// <summary>
@@ -378,7 +378,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
         /// <param name="state">Current GPU state</param>
         /// <param name="reg">Register offset to read</param>
         /// <returns>GPU register value</returns>
-        private int Read(GpuState state, int reg)
+        private static int Read(GpuState state, int reg)
         {
             return state.Read(reg);
         }

--- a/Ryujinx.Graphics.Gpu/Engine/MME/MacroJit.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MME/MacroJit.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
         /// <summary>
         /// Arguments FIFO.
         /// </summary>
-        public Queue<int> Fifo => _context.Fifo;
+        public Queue<FifoWord> Fifo => _context.Fifo;
 
         private MacroJitCompiler.MacroExecute _execute;
 

--- a/Ryujinx.Graphics.Gpu/Engine/MME/MacroJitContext.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MME/MacroJitContext.cs
@@ -12,22 +12,22 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
         /// <summary>
         /// Arguments FIFO.
         /// </summary>
-        public Queue<int> Fifo { get; } = new Queue<int>();
+        public Queue<FifoWord> Fifo { get; } = new Queue<FifoWord>();
 
         /// <summary>
         /// Fetches a arguments from the arguments FIFO.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>The call argument, or 0 if the FIFO is empty</returns>
         public int FetchParam()
         {
-            if (!Fifo.TryDequeue(out int value))
+            if (!Fifo.TryDequeue(out var value))
             {
                 Logger.Warning?.Print(LogClass.Gpu, "Macro attempted to fetch an inexistent argument.");
 
                 return 0;
             }
 
-            return value;
+            return value.Word;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/GraphicsConfig.cs
+++ b/Ryujinx.Graphics.Gpu/GraphicsConfig.cs
@@ -34,6 +34,11 @@ namespace Ryujinx.Graphics.Gpu
         public static bool EnableMacroJit = true;
 
         /// <summary>
+        /// Enables or disables high-level emulation of common GPU Macro code.
+        /// </summary>
+        public static bool EnableMacroHLE = true;
+
+        /// <summary>
         /// Title id of the current running game.
         /// Used by the shader cache.
         /// </summary>

--- a/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
@@ -159,7 +159,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                     {
                         _context.Renderer.SetBufferData(Handle, 0, _context.PhysicalMemory.GetSpan(Address, (int)Size));
                     }
-                    
+
                     _sequenceNumber = _context.SequenceNumber;
                 }
             }

--- a/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -926,6 +926,11 @@ namespace Ryujinx.Graphics.Gpu.Memory
             buffer.SignalModified(address, size);
         }
 
+        public BufferRange GetGpuBufferRange(ulong gpuVa, ulong size)
+        {
+            return GetBufferRange(TranslateAndCreateBuffer(gpuVa, size), size);
+        }
+
         /// <summary>
         /// Gets a buffer sub-range starting at a given memory address.
         /// </summary>

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -535,6 +535,57 @@ namespace Ryujinx.Graphics.OpenGL
             _tfEnabled = false;
         }
 
+        public void MultiDrawIndirectCount(BufferRange indirectBuffer, BufferRange parameterBuffer, int maxDrawCount, int stride)
+        {
+            if (!_program.IsLinked)
+            {
+                Logger.Debug?.Print(LogClass.Gpu, "Draw error, shader not linked.");
+                return;
+            }
+
+            PreDraw();
+
+            GL.BindBuffer((BufferTarget)All.DrawIndirectBuffer, indirectBuffer.Handle.ToInt32());
+            GL.BindBuffer((BufferTarget)All.ParameterBuffer, parameterBuffer.Handle.ToInt32());
+
+            GL.MultiDrawArraysIndirectCount(
+                _primitiveType,
+                (IntPtr)indirectBuffer.Offset,
+                (IntPtr)parameterBuffer.Offset,
+                maxDrawCount,
+                stride);
+
+            PostDraw();
+        }
+
+        public void MultiDrawIndexedIndirectCount(BufferRange indirectBuffer, BufferRange parameterBuffer, int maxDrawCount, int stride)
+        {
+            if (!_program.IsLinked)
+            {
+                Logger.Debug?.Print(LogClass.Gpu, "Draw error, shader not linked.");
+                return;
+            }
+
+            PreDraw();
+
+            _vertexArray.SetRangeOfIndexBuffer();
+
+            GL.BindBuffer((BufferTarget)All.DrawIndirectBuffer, indirectBuffer.Handle.ToInt32());
+            GL.BindBuffer((BufferTarget)All.ParameterBuffer, parameterBuffer.Handle.ToInt32());
+
+            GL.MultiDrawElementsIndirectCount(
+                _primitiveType,
+                (Version46)_elementsType,
+                (IntPtr)indirectBuffer.Offset,
+                (IntPtr)parameterBuffer.Offset,
+                maxDrawCount,
+                stride);
+
+            _vertexArray.RestoreIndexBuffer();
+
+            PostDraw();
+        }
+
         public void SetAlphaTest(bool enable, float reference, CompareOp op)
         {
             if (!enable)
@@ -733,7 +784,7 @@ namespace Ryujinx.Graphics.OpenGL
 
             EnsureVertexArray();
 
-            _vertexArray.SetIndexBuffer(buffer.Handle);
+            _vertexArray.SetIndexBuffer(buffer);
         }
 
         public void SetLogicOpState(bool enable, LogicalOp op)

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -158,6 +158,11 @@ namespace Ryujinx.Graphics.OpenGL
             _framebuffer.SignalModified();
         }
 
+        public void CommandBufferBarrier()
+        {
+            GL.MemoryBarrier(MemoryBarrierFlags.CommandBarrierBit);
+        }
+
         public void CopyBuffer(BufferHandle source, BufferHandle destination, int srcOffset, int dstOffset, int size)
         {
             Buffer.Copy(source, destination, srcOffset, dstOffset, size);

--- a/Ryujinx.Graphics.OpenGL/VertexArray.cs
+++ b/Ryujinx.Graphics.OpenGL/VertexArray.cs
@@ -20,12 +20,17 @@ namespace Ryujinx.Graphics.OpenGL
         private uint _vertexAttribsInUse;
         private uint _vertexBuffersInUse;
 
+        private BufferRange _indexBuffer;
+        private BufferHandle _tempIndexBuffer;
+
         public VertexArray()
         {
             Handle = GL.GenVertexArray();
 
             _vertexAttribs = new VertexAttribDescriptor[Constants.MaxVertexAttribs];
             _vertexBuffers = new VertexBufferDescriptor[Constants.MaxVertexBuffers];
+
+            _tempIndexBuffer = Buffer.Create();
         }
 
         public void Bind()
@@ -120,9 +125,22 @@ namespace Ryujinx.Graphics.OpenGL
             }
         }
 
-        public void SetIndexBuffer(BufferHandle buffer)
+        public void SetIndexBuffer(BufferRange range)
         {
-            GL.BindBuffer(BufferTarget.ElementArrayBuffer, buffer.ToInt32());
+            _indexBuffer = range;
+            GL.BindBuffer(BufferTarget.ElementArrayBuffer, range.Handle.ToInt32());
+        }
+
+        public void SetRangeOfIndexBuffer()
+        {
+            Buffer.Resize(_tempIndexBuffer, _indexBuffer.Size);
+            Buffer.Copy(_indexBuffer.Handle, _tempIndexBuffer, _indexBuffer.Offset, 0, _indexBuffer.Size);
+            GL.BindBuffer(BufferTarget.ElementArrayBuffer, _tempIndexBuffer.ToInt32());
+        }
+
+        public void RestoreIndexBuffer()
+        {
+            GL.BindBuffer(BufferTarget.ElementArrayBuffer, _indexBuffer.Handle.ToInt32());
         }
 
         public void Validate()


### PR DESCRIPTION
This adds support for HLE macros. This is basically an implementation of the macro code in C#, that can take better advantage of the host API and improve performance of some draw operations, like for example multi-draws. With the old implementation, each multi-draw would run the macro code and performs N separate draws. With an HLE macro, it's now possible to just call the host API multi-draw function directly, which not only reduces the number of API calls, but also enables passing the GPU indirect buffers directly, which eliminates the need for buffer flush and greatly improves the performance of games that does indirect draws.

For now, the only HLE macro function implemented is `MultiDrawElementsIndirectCount`, used by Monster Hunter Rise.

While working on this, I had the following problems, I found solutions for them but they are not exactly ideal:
- Unknown index buffer size. Right now, the index count is used to calculate the size, however, on indirect draws, this size is stored on a GPU buffer. Right now the code just assumes those are written from the CPU, which is the case for Monster Hunter Rise, but it could break for other games.
- OpenGL does not allow the index buffer offset to be set. It can only bind from the start of the buffer. Right now I copy the index buffer sub-range to a temporary buffer and bind that before each draw. This is not very efficient. Vulkan should not have this issue.

TODO:
- Find a way to handle `startOffset != 0` on the indirect draw.
- Flush indirect buffer data? This is required for correctness, but right now it takes all the performance benefit of the change, needs further investigation.