### PR TITLE
am: Stub ILibraryAppletAccessor RequestExit

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/LibraryAppletCreator/ILibraryAppletAccessor.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/LibraryAppletCreator/ILibraryAppletAccessor.cs
@@ -84,6 +84,18 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Lib
             return (ResultCode)_applet.Start(_normalSession.GetConsumer(), _interactiveSession.GetConsumer());
         }
 
+        [Command(20)]
+        // RequestExit()
+        public ResultCode RequestExit(ServiceCtx context)
+        {
+            // TODO: Since we don't support software Applet for now, we can just signals the changed state of the applet.
+            _stateChangedEvent.ReadableEvent.Signal();
+
+            Logger.Stub?.PrintStub(LogClass.ServiceAm);
+
+            return ResultCode.Success;
+        }
+
         [Command(30)]
         // GetResult()
         public ResultCode GetResult(ServiceCtx context)


### PR DESCRIPTION
This PR stub `ILibraryAppletAccessor (20) RequestExit` call which is needed by Monster Hunter Rise when you press "Private Policy" at the beginning.
The game try to run the `WebApplet` which is already partially stubbed, then call `RequestExit` to know when the applet exits. If the call does nothing, the game just hang forever. If you signals the event, you can interracts with the menu again.

Closes #2016

![image](https://user-images.githubusercontent.com/4905390/112572891-7bdf6100-8deb-11eb-8073-8067cb684f2f.png)
