### PR TITLE
Use copy dependencies for the Intel/AMD view format workaround

### DIFF
--- a/Ryujinx.Graphics.GAL/Capabilities.cs
+++ b/Ryujinx.Graphics.GAL/Capabilities.cs
@@ -5,6 +5,7 @@ namespace Ryujinx.Graphics.GAL
         public bool SupportsAstcCompression          { get; }
         public bool SupportsImageLoadFormatted       { get; }
         public bool SupportsNonConstantTextureOffset { get; }
+        public bool SupportsMismatchingViewFormat    { get; }
         public bool SupportsViewportSwizzle          { get; }
 
         public int   MaximumComputeSharedMemorySize { get; }
@@ -15,6 +16,7 @@ namespace Ryujinx.Graphics.GAL
             bool  supportsAstcCompression,
             bool  supportsImageLoadFormatted,
             bool  supportsNonConstantTextureOffset,
+            bool  supportsMismatchingViewFormat,
             bool  supportsViewportSwizzle,
             int   maximumComputeSharedMemorySize,
             float maximumSupportedAnisotropy,
@@ -23,6 +25,7 @@ namespace Ryujinx.Graphics.GAL
             SupportsAstcCompression          = supportsAstcCompression;
             SupportsImageLoadFormatted       = supportsImageLoadFormatted;
             SupportsNonConstantTextureOffset = supportsNonConstantTextureOffset;
+            SupportsMismatchingViewFormat     = supportsMismatchingViewFormat;
             SupportsViewportSwizzle          = supportsViewportSwizzle;
             MaximumComputeSharedMemorySize   = maximumComputeSharedMemorySize;
             MaximumSupportedAnisotropy       = maximumSupportedAnisotropy;

--- a/Ryujinx.Graphics.GAL/Capabilities.cs
+++ b/Ryujinx.Graphics.GAL/Capabilities.cs
@@ -25,7 +25,7 @@ namespace Ryujinx.Graphics.GAL
             SupportsAstcCompression          = supportsAstcCompression;
             SupportsImageLoadFormatted       = supportsImageLoadFormatted;
             SupportsNonConstantTextureOffset = supportsNonConstantTextureOffset;
-            SupportsMismatchingViewFormat     = supportsMismatchingViewFormat;
+            SupportsMismatchingViewFormat    = supportsMismatchingViewFormat;
             SupportsViewportSwizzle          = supportsViewportSwizzle;
             MaximumComputeSharedMemorySize   = maximumComputeSharedMemorySize;
             MaximumSupportedAnisotropy       = maximumSupportedAnisotropy;

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -1014,6 +1014,11 @@ namespace Ryujinx.Graphics.Gpu.Image
             result = TextureCompatibility.PropagateViewCompatibility(result, TextureCompatibility.ViewTargetCompatible(Info, info));
             result = TextureCompatibility.PropagateViewCompatibility(result, TextureCompatibility.ViewSubImagesInBounds(Info, info, firstLayer, firstLevel));
 
+            if (result == TextureViewCompatibility.Full && Info.FormatInfo.Format != info.FormatInfo.Format && !_context.Capabilities.SupportsMismatchingViewFormat)
+            {
+                result = TextureViewCompatibility.CopyOnly;
+            }
+
             return (Info.SamplesInX == info.SamplesInX &&
                     Info.SamplesInY == info.SamplesInY) ? result : TextureViewCompatibility.Incompatible;
         }

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -1016,6 +1016,10 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             if (result == TextureViewCompatibility.Full && Info.FormatInfo.Format != info.FormatInfo.Format && !_context.Capabilities.SupportsMismatchingViewFormat)
             {
+                // AMD and Intel have a bug where the view format is always ignored;
+                // they use the parent format instead.
+                // Create a copy dependency to avoid this issue.
+
                 result = TextureViewCompatibility.CopyOnly;
             }
 

--- a/Ryujinx.Graphics.OpenGL/Framebuffer.cs
+++ b/Ryujinx.Graphics.OpenGL/Framebuffer.cs
@@ -40,15 +40,7 @@ namespace Ryujinx.Graphics.OpenGL
 
             FramebufferAttachment attachment = FramebufferAttachment.ColorAttachment0 + index;
 
-            if (HwCapabilities.Vendor == HwCapabilities.GpuVendor.Amd ||
-                HwCapabilities.Vendor == HwCapabilities.GpuVendor.IntelWindows)
-            {
-                GL.FramebufferTexture(FramebufferTarget.Framebuffer, attachment, color?.GetIncompatibleFormatViewHandle() ?? 0, 0);
-            }
-            else
-            {
-                GL.FramebufferTexture(FramebufferTarget.Framebuffer, attachment, color?.Handle ?? 0, 0);
-            }
+            GL.FramebufferTexture(FramebufferTarget.Framebuffer, attachment, color?.Handle ?? 0, 0);
 
             _colors[index] = color;
         }
@@ -89,21 +81,6 @@ namespace Ryujinx.Graphics.OpenGL
             else
             {
                 _lastDsAttachment = 0;
-            }
-        }
-
-        public void SignalModified()
-        {
-            if (HwCapabilities.Vendor == HwCapabilities.GpuVendor.Amd ||
-                HwCapabilities.Vendor == HwCapabilities.GpuVendor.IntelWindows)
-            {
-                for (int i = 0; i < 8; i++)
-                {
-                    if (_colors[i] != null)
-                    {
-                        _colors[i].SignalModified();
-                    }
-                }
             }
         }
 

--- a/Ryujinx.Graphics.OpenGL/HwCapabilities.cs
+++ b/Ryujinx.Graphics.OpenGL/HwCapabilities.cs
@@ -36,6 +36,7 @@ namespace Ryujinx.Graphics.OpenGL
         public static bool SupportsSeamlessCubemapPerTexture => _supportsSeamlessCubemapPerTexture.Value;
         public static bool SupportsNonConstantTextureOffset  => _gpuVendor.Value == GpuVendor.Nvidia;
         public static bool RequiresSyncFlush                 => _gpuVendor.Value == GpuVendor.Amd || _gpuVendor.Value == GpuVendor.IntelWindows || _gpuVendor.Value == GpuVendor.IntelUnix;
+        public static bool SupportsMismatchingViewFormat     => _gpuVendor.Value != GpuVendor.Amd && _gpuVendor.Value != GpuVendor.IntelWindows;
 
         public static int MaximumComputeSharedMemorySize => _maximumComputeSharedMemorySize.Value;
         public static int StorageBufferOffsetAlignment   => _storageBufferOffsetAlignment.Value;

--- a/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
@@ -10,8 +10,6 @@ namespace Ryujinx.Graphics.OpenGL.Image
 
         private readonly TextureStorage _parent;
 
-        private TextureView _incompatibleFormatView;
-
         public ITextureInfo Storage => _parent;
 
         public int FirstLayer { get; private set; }
@@ -100,35 +98,6 @@ namespace Ryujinx.Graphics.OpenGL.Image
             firstLevel += FirstLevel;
 
             return _parent.CreateView(info, firstLayer, firstLevel);
-        }
-
-        public int GetIncompatibleFormatViewHandle()
-        {
-            // AMD and Intel have a bug where the view format is always ignored;
-            // they use the parent format instead.
-            // As a workaround we create a new texture with the correct
-            // format, and then do a copy after the draw.
-            if (_parent.Info.Format != Format)
-            {
-                if (_incompatibleFormatView == null)
-                {
-                    _incompatibleFormatView = (TextureView)_renderer.CreateTexture(Info, ScaleFactor);
-                }
-
-                _renderer.TextureCopy.CopyUnscaled(_parent, _incompatibleFormatView, FirstLayer, 0, FirstLevel, 0);
-
-                return _incompatibleFormatView.Handle;
-            }
-
-            return Handle;
-        }
-
-        public void SignalModified()
-        {
-            if (_incompatibleFormatView != null)
-            {
-                _renderer.TextureCopy.CopyUnscaled(_incompatibleFormatView, _parent, 0, FirstLayer, 0, FirstLevel);
-            }
         }
 
         public void CopyTo(ITexture destination, int firstLayer, int firstLevel)
@@ -634,13 +603,6 @@ namespace Ryujinx.Graphics.OpenGL.Image
 
         private void DisposeHandles()
         {
-            if (_incompatibleFormatView != null)
-            {
-                _incompatibleFormatView.Dispose();
-
-                _incompatibleFormatView = null;
-            }
-
             if (Handle != 0)
             {
                 GL.DeleteTexture(Handle);

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -110,8 +110,6 @@ namespace Ryujinx.Graphics.OpenGL
             GL.ClearBuffer(OpenTK.Graphics.OpenGL.ClearBuffer.Color, index, colors);
 
             RestoreComponentMask(index);
-
-            _framebuffer.SignalModified();
         }
 
         public void ClearRenderTargetDepthStencil(float depthValue, bool depthMask, int stencilValue, int stencilMask)
@@ -154,8 +152,6 @@ namespace Ryujinx.Graphics.OpenGL
             {
                 GL.DepthMask(_depthMask);
             }
-
-            _framebuffer.SignalModified();
         }
 
         public void CopyBuffer(BufferHandle source, BufferHandle destination, int srcOffset, int dstOffset, int size)
@@ -1224,8 +1220,6 @@ namespace Ryujinx.Graphics.OpenGL
 
         private void PostDraw()
         {
-            _framebuffer?.SignalModified();
-
             if (_tfEnabled)
             {
                 for (int i = 0; i < Constants.MaxTransformFeedbackBuffers; i++)

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -97,6 +97,7 @@ namespace Ryujinx.Graphics.OpenGL
                 HwCapabilities.SupportsAstcCompression,
                 HwCapabilities.SupportsImageLoadFormatted,
                 HwCapabilities.SupportsNonConstantTextureOffset,
+                HwCapabilities.SupportsMismatchingViewFormat,
                 HwCapabilities.SupportsViewportSwizzle,
                 HwCapabilities.MaximumComputeSharedMemorySize,
                 HwCapabilities.MaximumSupportedAnisotropy,


### PR DESCRIPTION
Currently, on Intel/AMD (windows, not mesa) we must perform a copy whenever rendering to a view with a different format from its storage. This is rather slow because it happens after every draw. This change moves this behaviour out of the backend, so that it can be covered by Copy Dependencies, which are much faster as they only copy on read, rather than after every write.

Upsides:
- Greatly speeds up drawing to views with a different format for AMD/Intel, as the copy is only performed when the texture with the other format is read, rather than after every draw.
- Removes the SignalModified calls and checks from GAL, which may speed up drawing a little on NVIDIA where it did not matter.
  - Removing this makes the code in the gl backend a little nicer too.
- This may avoid other weird issues relating to view format mismatches, for example if there is an issue with image store. 

Downsides:
- Have to check capabilities within texture view compatibility check, which is a tad messy.
- May create copy dependencies when they are not needed, for example between the format matching storage that is rendered to, and a different format view which is only read from.

I'd recommend testing on a few games on AMD/Intel and Windows. Mario Kart 8 definitely has a boost, but other games may get worse (captain toad treasure tracker?).