### PR TITLE
Improves logging to console.

### DIFF
--- a/Ryujinx.Common/Configuration/ConfigurationState.cs
+++ b/Ryujinx.Common/Configuration/ConfigurationState.cs
@@ -91,10 +91,10 @@ namespace Ryujinx.Configuration
             {
                 GuiColumns        = new Columns();
                 ColumnSort        = new ColumnSortSettings();
-                GameDirs          = new ReactiveObject<List<string>>();
-                EnableCustomTheme = new ReactiveObject<bool>();
-                CustomThemePath   = new ReactiveObject<string>();
-                StartFullscreen   = new ReactiveObject<bool>();
+                GameDirs          = new ReactiveObject<List<string>>(); //{ Name = "Game dir", Category = "UI" };
+                EnableCustomTheme = new ReactiveObject<bool>(); //{ Name = "Custom Theme", Category = "UI" };
+                CustomThemePath   = new ReactiveObject<string>(); //{ Name = "Custom Theme", Category = "UI" };
+                StartFullscreen   = new ReactiveObject<bool>(); //{ Name = "Fullscreen", Category = "UI" };
             }
         }
 
@@ -163,8 +163,8 @@ namespace Ryujinx.Configuration
                 EnableGuest        = new ReactiveObject<bool>();
                 EnableFsAccessLog  = new ReactiveObject<bool>();
                 FilteredClasses    = new ReactiveObject<LogClass[]>();
-                EnableFileLog      = new ReactiveObject<bool>();
-                GraphicsDebugLevel = new ReactiveObject<GraphicsDebugLevel>();
+                EnableFileLog      = new ReactiveObject<bool>(); //{ Name = "File Log", Category = "Logger" };
+                GraphicsDebugLevel = new ReactiveObject<GraphicsDebugLevel>() { Name = "Graphics level", Category = "Logger" };
             }
         }
 
@@ -268,7 +268,7 @@ namespace Ryujinx.Configuration
 
             public HidSection()
             {
-                EnableKeyboard = new ReactiveObject<bool>();
+                EnableKeyboard = new ReactiveObject<bool>() { Name = "Keyboard", Category = "Input" };
                 Hotkeys        = new ReactiveObject<KeyboardHotkeys>();
                 InputConfig    = new ReactiveObject<List<InputConfig>>();
             }
@@ -316,13 +316,13 @@ namespace Ryujinx.Configuration
 
             public GraphicsSection()
             {
-                ResScale          = new ReactiveObject<int>();
-                ResScaleCustom    = new ReactiveObject<float>();
-                MaxAnisotropy     = new ReactiveObject<float>();
-                AspectRatio       = new ReactiveObject<AspectRatio>();
-                ShadersDumpPath   = new ReactiveObject<string>();
-                EnableVsync       = new ReactiveObject<bool>();
-                EnableShaderCache = new ReactiveObject<bool>();
+                ResScale          = new ReactiveObject<int>() { Name = "Res Scale", Category = "Graphics" };
+                ResScaleCustom    = new ReactiveObject<float>() { Name = "Custom Scale", Category = "Graphics" };
+                MaxAnisotropy     = new ReactiveObject<float>() { Name = "Anisotrophy", Category = "Graphics" };
+                AspectRatio       = new ReactiveObject<AspectRatio>() { Name = "Aspect", Category = "Graphics" };
+                ShadersDumpPath   = new ReactiveObject<string>(); //{ Name = "Dump Path", Category = "Graphics" };
+                EnableVsync       = new ReactiveObject<bool>() { Name = "VSync" , Category = "Graphics"};
+                EnableShaderCache = new ReactiveObject<bool>() { Name = "Shader Cache", Category = "Graphics" };
             }
         }
 
@@ -383,10 +383,10 @@ namespace Ryujinx.Configuration
             System                   = new SystemSection();
             Graphics                 = new GraphicsSection();
             Hid                      = new HidSection();
-            EnableDiscordIntegration = new ReactiveObject<bool>();
-            CheckUpdatesOnStart      = new ReactiveObject<bool>();
-            ShowConfirmExit          = new ReactiveObject<bool>();
-            HideCursorOnIdle         = new ReactiveObject<bool>();
+            EnableDiscordIntegration = new ReactiveObject<bool>(); //{ Name = "Discord Integration", Category = "ConfigState" };
+            CheckUpdatesOnStart      = new ReactiveObject<bool>(); //{ Name = "Update on start", Category = "ConfigState" };
+            ShowConfirmExit          = new ReactiveObject<bool>(); //{ Name = "Confirm on Exit", Category = "ConfigState" };
+            HideCursorOnIdle         = new ReactiveObject<bool>(); //{ Name = "Hide Cursor on Idle", Category = "ConfigState" };
         }
 
         public ConfigurationFileFormat ToFileFormat()

--- a/Ryujinx.Common/Configuration/ConfigurationState.cs
+++ b/Ryujinx.Common/Configuration/ConfigurationState.cs
@@ -91,10 +91,10 @@ namespace Ryujinx.Configuration
             {
                 GuiColumns        = new Columns();
                 ColumnSort        = new ColumnSortSettings();
-                GameDirs          = new ReactiveObject<List<string>>(); //{ Name = "Game dir", Category = "UI" };
-                EnableCustomTheme = new ReactiveObject<bool>(); //{ Name = "Custom Theme", Category = "UI" };
-                CustomThemePath   = new ReactiveObject<string>(); //{ Name = "Custom Theme", Category = "UI" };
-                StartFullscreen   = new ReactiveObject<bool>(); //{ Name = "Fullscreen", Category = "UI" };
+                GameDirs          = new ReactiveObject<List<string>>();
+                EnableCustomTheme = new ReactiveObject<bool>();
+                CustomThemePath   = new ReactiveObject<string>();
+                StartFullscreen   = new ReactiveObject<bool>();
             }
         }
 
@@ -163,8 +163,8 @@ namespace Ryujinx.Configuration
                 EnableGuest        = new ReactiveObject<bool>();
                 EnableFsAccessLog  = new ReactiveObject<bool>();
                 FilteredClasses    = new ReactiveObject<LogClass[]>();
-                EnableFileLog      = new ReactiveObject<bool>(); //{ Name = "File Log", Category = "Logger" };
-                GraphicsDebugLevel = new ReactiveObject<GraphicsDebugLevel>() { Name = "Graphics level", Category = "Logger" };
+                EnableFileLog      = new ReactiveObject<bool>(loggedName: nameof(EnableFileLog));
+                GraphicsDebugLevel = new ReactiveObject<GraphicsDebugLevel>();
             }
         }
 
@@ -268,7 +268,7 @@ namespace Ryujinx.Configuration
 
             public HidSection()
             {
-                EnableKeyboard = new ReactiveObject<bool>() { Name = "Keyboard", Category = "Input" };
+                EnableKeyboard = new ReactiveObject<bool>();
                 Hotkeys        = new ReactiveObject<KeyboardHotkeys>();
                 InputConfig    = new ReactiveObject<List<InputConfig>>();
             }
@@ -316,13 +316,13 @@ namespace Ryujinx.Configuration
 
             public GraphicsSection()
             {
-                ResScale          = new ReactiveObject<int>() { Name = "Res Scale", Category = "Graphics" };
-                ResScaleCustom    = new ReactiveObject<float>() { Name = "Custom Scale", Category = "Graphics" };
-                MaxAnisotropy     = new ReactiveObject<float>() { Name = "Anisotrophy", Category = "Graphics" };
-                AspectRatio       = new ReactiveObject<AspectRatio>() { Name = "Aspect", Category = "Graphics" };
-                ShadersDumpPath   = new ReactiveObject<string>(); //{ Name = "Dump Path", Category = "Graphics" };
-                EnableVsync       = new ReactiveObject<bool>() { Name = "VSync" , Category = "Graphics"};
-                EnableShaderCache = new ReactiveObject<bool>() { Name = "Shader Cache", Category = "Graphics" };
+                ResScale          = new ReactiveObject<int>(loggedName: nameof(ResScale));
+                ResScaleCustom    = new ReactiveObject<float>(loggedName: nameof(ResScaleCustom));
+                MaxAnisotropy     = new ReactiveObject<float>(loggedName: nameof(MaxAnisotropy));
+                AspectRatio       = new ReactiveObject<AspectRatio>(loggedName: nameof(AspectRatio));
+                ShadersDumpPath   = new ReactiveObject<string>();
+                EnableVsync       = new ReactiveObject<bool>(loggedName: nameof(EnableVsync));
+                EnableShaderCache = new ReactiveObject<bool>(loggedName: nameof(EnableShaderCache));
             }
         }
 
@@ -383,10 +383,10 @@ namespace Ryujinx.Configuration
             System                   = new SystemSection();
             Graphics                 = new GraphicsSection();
             Hid                      = new HidSection();
-            EnableDiscordIntegration = new ReactiveObject<bool>(); //{ Name = "Discord Integration", Category = "ConfigState" };
-            CheckUpdatesOnStart      = new ReactiveObject<bool>(); //{ Name = "Update on start", Category = "ConfigState" };
-            ShowConfirmExit          = new ReactiveObject<bool>(); //{ Name = "Confirm on Exit", Category = "ConfigState" };
-            HideCursorOnIdle         = new ReactiveObject<bool>(); //{ Name = "Hide Cursor on Idle", Category = "ConfigState" };
+            EnableDiscordIntegration = new ReactiveObject<bool>();
+            CheckUpdatesOnStart      = new ReactiveObject<bool>();
+            ShowConfirmExit          = new ReactiveObject<bool>();
+            HideCursorOnIdle         = new ReactiveObject<bool>();
         }
 
         public ConfigurationFileFormat ToFileFormat()

--- a/Ryujinx.Common/Configuration/ConfigurationState.cs
+++ b/Ryujinx.Common/Configuration/ConfigurationState.cs
@@ -155,16 +155,17 @@ namespace Ryujinx.Configuration
 
             public LoggerSection()
             {
-                EnableDebug        = new ReactiveObject<bool>();
-                EnableStub         = new ReactiveObject<bool>();
-                EnableInfo         = new ReactiveObject<bool>();
-                EnableWarn         = new ReactiveObject<bool>();
-                EnableError        = new ReactiveObject<bool>();
-                EnableGuest        = new ReactiveObject<bool>();
-                EnableFsAccessLog  = new ReactiveObject<bool>();
-                FilteredClasses    = new ReactiveObject<LogClass[]>();
-                EnableFileLog      = new ReactiveObject<bool>(loggedName: nameof(EnableFileLog));
-                GraphicsDebugLevel = new ReactiveObject<GraphicsDebugLevel>();
+                EnableDebug         = new ReactiveObject<bool>();
+                EnableStub          = new ReactiveObject<bool>();
+                EnableInfo          = new ReactiveObject<bool>();
+                EnableWarn          = new ReactiveObject<bool>();
+                EnableError         = new ReactiveObject<bool>();
+                EnableGuest         = new ReactiveObject<bool>();
+                EnableFsAccessLog   = new ReactiveObject<bool>();
+                FilteredClasses     = new ReactiveObject<LogClass[]>();
+                EnableFileLog       = new ReactiveObject<bool>();
+                EnableFileLog.Event += static (sender, e) => LogValueChange(sender, e, nameof(EnableFileLog));
+                GraphicsDebugLevel  = new ReactiveObject<GraphicsDebugLevel>();
             }
         }
 
@@ -230,17 +231,24 @@ namespace Ryujinx.Configuration
 
             public SystemSection()
             {
-                Language                = new ReactiveObject<Language>();
-                Region                  = new ReactiveObject<Region>();
-                TimeZone                = new ReactiveObject<string>();
-                SystemTimeOffset        = new ReactiveObject<long>();
-                EnableDockedMode        = new ReactiveObject<bool>();
-                EnablePtc               = new ReactiveObject<bool>();
-                EnableFsIntegrityChecks = new ReactiveObject<bool>();
-                FsGlobalAccessLogMode   = new ReactiveObject<int>();
-                AudioBackend            = new ReactiveObject<AudioBackend>();
-                ExpandRam               = new ReactiveObject<bool>();
-                IgnoreMissingServices   = new ReactiveObject<bool>();
+                Language                      = new ReactiveObject<Language>();
+                Region                        = new ReactiveObject<Region>();
+                TimeZone                      = new ReactiveObject<string>();
+                SystemTimeOffset              = new ReactiveObject<long>();
+                EnableDockedMode              = new ReactiveObject<bool>();
+                EnableDockedMode.Event        += static (sender, e) => LogValueChange(sender, e, nameof(EnableDockedMode));
+                EnablePtc                     = new ReactiveObject<bool>();
+                EnablePtc.Event               += static (sender, e) => LogValueChange(sender, e, nameof(EnablePtc));
+                EnableFsIntegrityChecks       = new ReactiveObject<bool>();
+                EnableFsIntegrityChecks.Event += static (sender, e) => LogValueChange(sender, e, nameof(EnableFsIntegrityChecks));
+                FsGlobalAccessLogMode         = new ReactiveObject<int>();
+                FsGlobalAccessLogMode.Event   += static (sender, e) => LogValueChange(sender, e, nameof(FsGlobalAccessLogMode));
+                AudioBackend                  = new ReactiveObject<AudioBackend>();
+                AudioBackend.Event            += static (sender, e) => LogValueChange(sender, e, nameof(AudioBackend));
+                ExpandRam                     = new ReactiveObject<bool>();
+                ExpandRam.Event               += static (sender, e) => LogValueChange(sender, e, nameof(ExpandRam));
+                IgnoreMissingServices         = new ReactiveObject<bool>();
+                IgnoreMissingServices.Event   += static (sender, e) => LogValueChange(sender, e, nameof(IgnoreMissingServices));
             }
         }
 
@@ -316,13 +324,19 @@ namespace Ryujinx.Configuration
 
             public GraphicsSection()
             {
-                ResScale          = new ReactiveObject<int>(loggedName: nameof(ResScale));
-                ResScaleCustom    = new ReactiveObject<float>(loggedName: nameof(ResScaleCustom));
-                MaxAnisotropy     = new ReactiveObject<float>(loggedName: nameof(MaxAnisotropy));
-                AspectRatio       = new ReactiveObject<AspectRatio>(loggedName: nameof(AspectRatio));
-                ShadersDumpPath   = new ReactiveObject<string>();
-                EnableVsync       = new ReactiveObject<bool>(loggedName: nameof(EnableVsync));
-                EnableShaderCache = new ReactiveObject<bool>(loggedName: nameof(EnableShaderCache));
+                ResScale                = new ReactiveObject<int>();
+                ResScale.Event          += static (sender, e) => LogValueChange(sender, e, nameof(ResScale));
+                ResScaleCustom          = new ReactiveObject<float>();
+                ResScaleCustom.Event    += static (sender, e) => LogValueChange(sender, e, nameof(ResScaleCustom));
+                MaxAnisotropy           = new ReactiveObject<float>();
+                MaxAnisotropy.Event     += static (sender, e) => LogValueChange(sender, e, nameof(MaxAnisotropy));
+                AspectRatio             = new ReactiveObject<AspectRatio>();
+                AspectRatio.Event       += static (sender, e) => LogValueChange(sender, e, nameof(AspectRatio));
+                ShadersDumpPath         = new ReactiveObject<string>();
+                EnableVsync             = new ReactiveObject<bool>();
+                EnableVsync.Event       += static (sender, e) => LogValueChange(sender, e, nameof(EnableVsync));
+                EnableShaderCache       = new ReactiveObject<bool>();
+                EnableShaderCache.Event += static (sender, e) => LogValueChange(sender, e, nameof(EnableShaderCache));
             }
         }
 
@@ -874,6 +888,11 @@ namespace Ryujinx.Configuration
 
                 Common.Logging.Logger.Notice.Print(LogClass.Application, $"Configuration file updated to version {ConfigurationFileFormat.CurrentVersion}");
             }
+        }
+
+        private static void LogValueChange<T>(object sender, ReactiveEventArgs<T> eventArgs, string valueName)
+        {
+            Common.Logging.Logger.Info?.Print(LogClass.Configuration, $"{valueName} set to: {eventArgs.NewValue}");
         }
 
         public static void Initialize()

--- a/Ryujinx.Common/Logging/LogClass.cs
+++ b/Ryujinx.Common/Logging/LogClass.cs
@@ -5,6 +5,7 @@ namespace Ryujinx.Common.Logging
         Application,
         Audio,
         AudioRenderer,
+        Configuration,
         Cpu,
         Font,
         Emulation,

--- a/Ryujinx.Common/ReactiveObject.cs
+++ b/Ryujinx.Common/ReactiveObject.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using Ryujinx.Common.Logging;
 
 namespace Ryujinx.Common
 {
@@ -8,6 +9,10 @@ namespace Ryujinx.Common
         private ReaderWriterLock _readerWriterLock = new ReaderWriterLock();
         private bool _isInitialized = false;
         private T _value;
+        public string _name { get; private set; }
+        public string Name { get { return _name; } set { _name = value; } }
+        public string _category { get; private set; }
+        public string Category { get { return _category; } set { _category = value; } }
 
         public event EventHandler<ReactiveEventArgs<T>> Event;
 
@@ -30,12 +35,17 @@ namespace Ryujinx.Common
                 bool oldIsInitialized = _isInitialized;
 
                 _isInitialized = true;
-                _value         = value;
+                _value = value;
 
                 _readerWriterLock.ReleaseWriterLock();
 
                 if (!oldIsInitialized || !oldValue.Equals(_value))
                 {
+                    if (!string.IsNullOrEmpty(Name))
+                        //When values are changed, logged to console. If value does not have a Name, no log is printed
+                        //Some reactive object names are left commented out here, since they don't need to be exposed to the end user but the option is there for devs
+                        Logger.Info?.Print(LogClass.Application, $"({Category}) {Name} set to: {_value}");
+
                     Event?.Invoke(this, new ReactiveEventArgs<T>(oldValue, value));
                 }
             }

--- a/Ryujinx.Common/ReactiveObject.cs
+++ b/Ryujinx.Common/ReactiveObject.cs
@@ -9,10 +9,13 @@ namespace Ryujinx.Common
         private ReaderWriterLock _readerWriterLock = new ReaderWriterLock();
         private bool _isInitialized = false;
         private T _value;
-        public string _name { get; private set; }
-        public string Name { get { return _name; } set { _name = value; } }
-        public string _category { get; private set; }
-        public string Category { get { return _category; } set { _category = value; } }
+
+        private string _loggedName;
+
+        public ReactiveObject(string loggedName = "")
+        {
+            _loggedName = loggedName;
+        }
 
         public event EventHandler<ReactiveEventArgs<T>> Event;
 
@@ -35,16 +38,16 @@ namespace Ryujinx.Common
                 bool oldIsInitialized = _isInitialized;
 
                 _isInitialized = true;
-                _value = value;
+                _value         = value;
 
                 _readerWriterLock.ReleaseWriterLock();
 
                 if (!oldIsInitialized || !oldValue.Equals(_value))
                 {
-                    if (!string.IsNullOrEmpty(Name))
-                        //When values are changed, logged to console. If value does not have a Name, no log is printed
-                        //Some reactive object names are left commented out here, since they don't need to be exposed to the end user but the option is there for devs
-                        Logger.Info?.Print(LogClass.Application, $"({Category}) {Name} set to: {_value}");
+                    if (!string.IsNullOrEmpty(_loggedName))
+                    {
+                        Logger.Info?.Print(LogClass.Configuration, $"{_loggedName} set to: {_value}");
+                    }
 
                     Event?.Invoke(this, new ReactiveEventArgs<T>(oldValue, value));
                 }

--- a/Ryujinx.Common/ReactiveObject.cs
+++ b/Ryujinx.Common/ReactiveObject.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Threading;
-using Ryujinx.Common.Logging;
 
 namespace Ryujinx.Common
 {
@@ -9,13 +8,6 @@ namespace Ryujinx.Common
         private ReaderWriterLock _readerWriterLock = new ReaderWriterLock();
         private bool _isInitialized = false;
         private T _value;
-
-        private string _loggedName;
-
-        public ReactiveObject(string loggedName = "")
-        {
-            _loggedName = loggedName;
-        }
 
         public event EventHandler<ReactiveEventArgs<T>> Event;
 
@@ -44,11 +36,6 @@ namespace Ryujinx.Common
 
                 if (!oldIsInitialized || !oldValue.Equals(_value))
                 {
-                    if (!string.IsNullOrEmpty(_loggedName))
-                    {
-                        Logger.Info?.Print(LogClass.Configuration, $"{_loggedName} set to: {_value}");
-                    }
-
                     Event?.Invoke(this, new ReactiveEventArgs<T>(oldValue, value));
                 }
             }

--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -9,7 +9,6 @@ using Ryujinx.Audio.Output;
 using Ryujinx.Audio.Renderer.Device;
 using Ryujinx.Audio.Renderer.Server;
 using Ryujinx.Common;
-using Ryujinx.Common.Logging;
 using Ryujinx.Configuration;
 using Ryujinx.HLE.FileSystem.Content;
 using Ryujinx.HLE.HOS.Font;

--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -325,8 +325,6 @@ namespace Ryujinx.HLE.HOS
 
                 // Reconfigure controllers
                 Device.Hid.RefreshInputConfig(ConfigurationState.Instance.Hid.InputConfig.Value);
-
-                Logger.Info?.Print(LogClass.Application, $"IsDocked toggled to: {State.DockedMode}");
             }
         }
 

--- a/Ryujinx.HLE/Switch.cs
+++ b/Ryujinx.HLE/Switch.cs
@@ -2,7 +2,6 @@ using LibHac.FsSystem;
 using Ryujinx.Audio.Backends.CompatLayer;
 using Ryujinx.Audio.Integration;
 using Ryujinx.Common;
-using Ryujinx.Common.Logging;
 using Ryujinx.Configuration;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu;
@@ -152,11 +151,6 @@ namespace Ryujinx.HLE
             // Configure controllers
             Hid.RefreshInputConfig(ConfigurationState.Instance.Hid.InputConfig.Value);
             ConfigurationState.Instance.Hid.InputConfig.Event += Hid.RefreshInputConfigEvent;
-
-            Logger.Info?.Print(LogClass.Application, $"AudioBackend: {ConfigurationState.Instance.System.AudioBackend.Value}");
-            Logger.Info?.Print(LogClass.Application, $"IsDocked: {ConfigurationState.Instance.System.EnableDockedMode.Value}");
-            Logger.Info?.Print(LogClass.Application, $"Vsync: {ConfigurationState.Instance.Graphics.EnableVsync.Value}");
-            Logger.Info?.Print(LogClass.Application, $"MemoryConfiguration: {_memoryConfiguration}");
         }
 
         public static IntegrityCheckLevel GetIntegrityCheckLevel()

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -8,7 +8,6 @@ using OpenTK.Input;
 using Ryujinx.Common;
 using Ryujinx.Common.Configuration;
 using Ryujinx.Common.Configuration.Hid;
-using Ryujinx.Common.Logging;
 using Ryujinx.Configuration;
 using Ryujinx.Graphics.OpenGL;
 using Ryujinx.HLE.HOS.Services.Hid;
@@ -670,8 +669,6 @@ namespace Ryujinx.Ui
                     !_prevHotkeyButtons.HasFlag(HotkeyButtons.ToggleVSync))
                 {
                     _device.EnableDeviceVsync = !_device.EnableDeviceVsync;
-
-                    Logger.Info?.Print(LogClass.Application, $"Vsync toggled to: {_device.EnableDeviceVsync}");
                 }
 
                 _prevHotkeyButtons = currentHotkeyButtons;

--- a/Ryujinx/Ui/Windows/SettingsWindow.cs
+++ b/Ryujinx/Ui/Windows/SettingsWindow.cs
@@ -1,10 +1,8 @@
 using Gtk;
-using Ryujinx.Audio;
 using Ryujinx.Audio.Backends.OpenAL;
 using Ryujinx.Audio.Backends.SoundIo;
 using Ryujinx.Common.Configuration;
 using Ryujinx.Common.Configuration.Hid;
-using Ryujinx.Common.Logging;
 using Ryujinx.Configuration;
 using Ryujinx.Configuration.System;
 using Ryujinx.HLE.FileSystem;
@@ -442,12 +440,6 @@ namespace Ryujinx.Ui.Windows
             if (_audioBackendSelect.GetActiveIter(out TreeIter activeIter))
             {
                 AudioBackend audioBackend = (AudioBackend)_audioBackendStore.GetValue(activeIter, 1);
-                if (audioBackend != ConfigurationState.Instance.System.AudioBackend.Value)
-                {
-                    ConfigurationState.Instance.System.AudioBackend.Value = audioBackend;
-
-                    Logger.Info?.Print(LogClass.Application, $"AudioBackend toggled to: {audioBackend}");
-                }
             }
 
             ConfigurationState.Instance.ToFileFormat().SaveConfig(Program.ConfigurationPath);

--- a/Ryujinx/Ui/Windows/SettingsWindow.cs
+++ b/Ryujinx/Ui/Windows/SettingsWindow.cs
@@ -439,7 +439,7 @@ namespace Ryujinx.Ui.Windows
 
             if (_audioBackendSelect.GetActiveIter(out TreeIter activeIter))
             {
-                AudioBackend audioBackend = (AudioBackend)_audioBackendStore.GetValue(activeIter, 1);
+                ConfigurationState.Instance.System.AudioBackend.Value = (AudioBackend)_audioBackendStore.GetValue(activeIter, 1);
             }
 
             ConfigurationState.Instance.ToFileFormat().SaveConfig(Program.ConfigurationPath);


### PR DESCRIPTION
This PR aims to expose more user changeable information in the logs, mainly so that the upcoming Discord bot (https://github.com/Ryujinx/ryuko-ng/pull/3) can use this information for analysis.

This also simplifies the hotkey states logging from #1942 (which I have now removed), as it uses the already recorded configuration states and leverages the already existing `ReactiveObject.cs` change state.

Both UI menu item changes and hotkey changes are logged in real time once settings are saved.

New information includes:

- File Logging Enabled
- File Integrity Checks Enabled
- File Global Access Log Mode
- Resolution scale
- Resolution scale custom
- Aspect Ratio
- Anisotrophic Filtering
- Docked/Undocked
- PPTC enabled/disabled
- Shader Cache enabled/disabled
- V-Sync enabled/disabled
- Audio Backend
- Ignore Missing Services enabled/disabled