### PR TITLE
Fix ZN flags set for shader instructions using RZ.CC dest

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -35,7 +35,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2088;
+        private const ulong ShaderCodeGenVersion = 2147;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitAlu.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitAlu.cs
@@ -278,9 +278,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
             Operand pred = GetPredicate39(context);
             Operand res = context.ConditionalSelect(pred, resMin, resMax);
 
-            Operand dest = GetDest(context);
-
-            context.Copy(dest, res);
+            context.Copy(GetDest(context), res);
 
             SetZnFlags(context, res, op.SetCondCode);
 

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitAlu.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitAlu.cs
@@ -276,12 +276,13 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 : context.IMaximumU32(srcA, srcB);
 
             Operand pred = GetPredicate39(context);
+            Operand res = context.ConditionalSelect(pred, resMin, resMax);
 
             Operand dest = GetDest(context);
 
-            context.Copy(dest, context.ConditionalSelect(pred, resMin, resMax));
+            context.Copy(dest, res);
 
-            SetZnFlags(context, dest, op.SetCondCode);
+            SetZnFlags(context, res, op.SetCondCode);
 
             // TODO: X flags.
         }
@@ -461,11 +462,9 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
             EmitLopPredWrite(context, op, res, (ConditionalOperation)context.CurrOp.RawOpCode.Extract(44, 2));
 
-            Operand dest = GetDest(context);
+            context.Copy(GetDest(context), res);
 
-            context.Copy(dest, res);
-
-            SetZnFlags(context, dest, op.SetCondCode, op.Extended);
+            SetZnFlags(context, res, op.SetCondCode, op.Extended);
         }
 
         public static void Lop3(EmitterContext context)
@@ -489,11 +488,9 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 EmitLopPredWrite(context, op, res, (ConditionalOperation)context.CurrOp.RawOpCode.Extract(36, 2));
             }
 
-            Operand dest = GetDest(context);
+            context.Copy(GetDest(context), res);
 
-            context.Copy(dest, res);
-
-            SetZnFlags(context, dest, op.SetCondCode, op.Extended);
+            SetZnFlags(context, res, op.SetCondCode, op.Extended);
         }
 
         public static void Popc(EmitterContext context)

--- a/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -91,7 +91,7 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public void PrepareForReturn()
         {
-            if (Config.Stage == ShaderStage.Fragment)
+            if (!IsNonMain && Config.Stage == ShaderStage.Fragment)
             {
                 if (Config.OmapDepth)
                 {


### PR DESCRIPTION
This fixes a bug where the Z/N flags would be set to a incorrect value if the destination register of some shader instructions are RZ. This was happening because it was comparing the RZ register value, rather than the actual operation result.

While I was at it, I also fixed a bug on pixel shaders with calls where it would set the output pixel values before every return, rather than just on the main function.

I found the first bug while looking at one of the Monster Hunter Rise compute shaders, but I did not notice any improvement after fixing this.