### PR TITLE
misc: Add credit to AmiiboAPI properly and fix a wrong warning code

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,6 @@ The Ryujinx.Audio project is licensed under the terms of the LGPLv3 license.
 This project makes use of code authored by the libvpx project, licensed under BSD and the ffmpeg project, licensed under LGPLv3.
 See [LICENSE.txt](LICENSE.txt) and [THIRDPARTY.md](Ryujinx/THIRDPARTY.md) for more details.
  
+## Credits
+
+- [AmiiboAPI](https://www.amiiboapi.com) which is used in our Amiibo scanning implementation.

--- a/README.md
+++ b/README.md
@@ -110,4 +110,4 @@ See [LICENSE.txt](LICENSE.txt) and [THIRDPARTY.md](Ryujinx/THIRDPARTY.md) for mo
  
 ## Credits
 
-- [AmiiboAPI](https://www.amiiboapi.com) which is used in our Amiibo scanning implementation.
+- [AmiiboAPI](https://www.amiiboapi.com) is used in our Amiibo emulation.

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
@@ -13,10 +13,10 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         private Lbl.LblControllerServer _lblControllerServer;
 
         private bool _vrModeEnabled;
-#pragma warning disable CS0169
+#pragma warning disable CS0414
         private bool _lcdBacklighOffEnabled;
         private bool _requestExitToLibraryAppletAtExecuteNextProgramEnabled;
-#pragma warning restore CS0169
+#pragma warning restore CS0414
         private int  _messageEventHandle;
         private int  _displayResolutionChangedEventHandle;
 

--- a/Ryujinx/Ui/Windows/AboutWindow.Designer.cs
+++ b/Ryujinx/Ui/Windows/AboutWindow.Designer.cs
@@ -17,6 +17,8 @@ namespace Ryujinx.Ui.Windows
         private Label          _ryujinxLinkLabel;
         private Label          _versionLabel;
         private Label          _disclaimerLabel;
+        private EventBox       _amiiboApiLink;
+        private Label          _amiiboApiLinkLabel;
         private Box            _socialBox;
         private EventBox       _patreonEventBox;
         private Box            _patreonBox;
@@ -156,6 +158,26 @@ namespace Ryujinx.Ui.Windows
                 Attributes = new AttrList()
             };
             _disclaimerLabel.Attributes.Insert(new Pango.AttrScale(0.8f));
+
+            //
+            // _amiiboApiLink
+            //
+            _amiiboApiLink = new EventBox()
+            {
+                Margin = 5
+            };
+            _amiiboApiLink.ButtonPressEvent += AmiiboApiButton_Pressed;
+
+            //
+            // _amiiboApiLinkLabel
+            //
+            _amiiboApiLinkLabel = new Label("AmiiboAPI (www.amiiboapi.com) is used\nin our Amiibo emulation.")
+            {
+                TooltipText = "Click to open the AmiiboAPI website in your default browser.",
+                Justify = Justification.Center,
+                Attributes = new AttrList()
+            };
+            _amiiboApiLinkLabel.Attributes.Insert(new Pango.AttrScale(0.9f));
 
             //
             // _socialBox
@@ -418,6 +440,8 @@ namespace Ryujinx.Ui.Windows
 
             _logoBox.Add(_logoTextBox);
 
+            _amiiboApiLink.Add(_amiiboApiLinkLabel);
+
             _patreonBox.Add(_patreonLogo);
             _patreonBox.Add(_patreonLabel);
             _patreonEventBox.Add(_patreonBox);
@@ -442,6 +466,7 @@ namespace Ryujinx.Ui.Windows
             _leftBox.Add(_logoBox);
             _leftBox.Add(_versionLabel);
             _leftBox.Add(_disclaimerLabel);
+            _leftBox.Add(_amiiboApiLink);
             _leftBox.Add(_socialBox);
 
             _contributorsEventBox.Add(_contributorsLinkLabel);

--- a/Ryujinx/Ui/Windows/AboutWindow.Designer.cs
+++ b/Ryujinx/Ui/Windows/AboutWindow.Designer.cs
@@ -174,8 +174,8 @@ namespace Ryujinx.Ui.Windows
             _amiiboApiLinkLabel = new Label("AmiiboAPI (www.amiiboapi.com) is used\nin our Amiibo emulation.")
             {
                 TooltipText = "Click to open the AmiiboAPI website in your default browser.",
-                Justify = Justification.Center,
-                Attributes = new AttrList()
+                Justify     = Justification.Center,
+                Attributes  = new AttrList()
             };
             _amiiboApiLinkLabel.Attributes.Insert(new Pango.AttrScale(0.9f));
 

--- a/Ryujinx/Ui/Windows/AboutWindow.cs
+++ b/Ryujinx/Ui/Windows/AboutWindow.cs
@@ -47,6 +47,11 @@ namespace Ryujinx.Ui.Windows
             OpenHelper.OpenUrl("https://ryujinx.org");
         }
 
+        private void AmiiboApiButton_Pressed(object sender, ButtonPressEventArgs args)
+        {
+            OpenHelper.OpenUrl("https://amiiboapi.com");
+        }
+
         private void PatreonButton_Pressed(object sender, ButtonPressEventArgs args)
         {
             OpenHelper.OpenUrl("https://www.patreon.com/ryujinx");


### PR DESCRIPTION
This PR adds a properly credit to AmiiboAPI which is used in our Amiibo emulation in the Readme and in the about window.
I've changed a wrong warning code added in a recent PR too (there is no more warning now).