### PR TITLE
Patch up DNS Blacklist

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsBlacklist.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsBlacklist.cs
@@ -4,12 +4,14 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Proxy
 {
     static class DnsBlacklist
     {
+        const RegexOptions RegexOpts = RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture | RegexOptions.Compiled;
+
         private static readonly Regex[] BlockedHosts = new Regex[]
         {
-            new Regex(@"^g(.*)\-lp1\.s\.n\.srv\.nintendo\.net$"),
-            new Regex(@"^(.*)\-sb\-api\.accounts\.nintendo\.com$"),
-            new Regex(@"^(.*)\-sb\.accounts\.nintendo\.com$"),
-            new Regex(@"^accounts\.nintendo\.com$")
+            new Regex(@"^g(.*)\-lp1\.s\.n\.srv\.nintendo\.net$", RegexOpts),
+            new Regex(@"^(.*)\-sb\-api\.accounts\.nintendo\.com$", RegexOpts),
+            new Regex(@"^(.*)\-sb\.accounts\.nintendo\.com$", RegexOpts),
+            new Regex(@"^accounts\.nintendo\.com$", RegexOpts)
         };
 
         public static bool IsHostBlocked(string host)


### PR DESCRIPTION
Very simple change. Hostname resolution IPC calls don't seem to have any filtering on the input name so, this PR makes the DNS blacklist case-insensitive to catch them properly. Also added a few extra perf-oriented options to them- `ExplicitCapture` as we only use `IsMatch`, `Compiled` as applications can spam it.

A quick test using a single regex with alternation, something like-
```csharp
Regex blockedHosts = new Regex(string.Join('|', patternsArray), options);
```
yielded no clear winner with a small sample of tests I tried (complex state machine or more backtracking?)
As that's more error-prone and confusing anyway, decided not to use it. If you still prefer a single regex, let me know.