### PR TITLE
Improve `StoreToContext` emission

### DIFF
--- a/ARMeilleure/Instructions/InstEmitFlowHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitFlowHelper.cs
@@ -147,10 +147,8 @@ namespace ARMeilleure.Instructions
             EmitJumpTableBranch(context, Const(immediate), isRecursive);
         }
 
-        private static void EmitNativeCall(ArmEmitterContext context, Operand nativeContextPtr, Operand funcAddr, bool isJump = false)
+        private static void EmitNativeCall(ArmEmitterContext context, Operand nativeContextPtr, Operand funcAddr, bool isJump)
         {
-            context.StoreToContext();
-
             if (isJump)
             {
                 context.Tailcall(funcAddr, nativeContextPtr);
@@ -180,22 +178,17 @@ namespace ARMeilleure.Instructions
             }
         }
 
-        private static void EmitNativeCall(ArmEmitterContext context, Operand funcAddr, bool isJump = false)
+        private static void EmitNativeCall(ArmEmitterContext context, Operand funcAddr, bool isJump)
         {
             EmitNativeCall(context, context.LoadArgument(OperandType.I64, 0), funcAddr, isJump);
         }
 
         public static void EmitVirtualCall(ArmEmitterContext context, Operand target)
         {
-            EmitVirtualCallOrJump(context, target, isJump: false);
+            EmitJumpTableBranch(context, target, isJump: false);
         }
 
         public static void EmitVirtualJump(ArmEmitterContext context, Operand target, bool isReturn)
-        {
-            EmitVirtualCallOrJump(context, target, isJump: true, isReturn: isReturn);
-        }
-
-        private static void EmitVirtualCallOrJump(ArmEmitterContext context, Operand target, bool isJump, bool isReturn = false)
         {
             if (isReturn)
             {
@@ -203,7 +196,7 @@ namespace ARMeilleure.Instructions
             }
             else
             {
-                EmitJumpTableBranch(context, target, isJump);
+                EmitJumpTableBranch(context, target, isJump: true);
             }
         }
 
@@ -219,15 +212,17 @@ namespace ARMeilleure.Instructions
                 {
                     // If we're doing a tail continue in HighCq, reserve a space in the jump table to avoid calling back
                     // to the translator. This will always try to get a HighCq version of our continue target as well.
-                    EmitJumpTableBranch(context, address, true);
+                    EmitJumpTableBranch(context, address, isJump: true);
                 }
                 else
                 {
+                    context.StoreToContext();
+
                     Operand fallbackAddr = context.Call(typeof(NativeInterface).GetMethod(allowRejit
                         ? nameof(NativeInterface.GetFunctionAddress)
                         : nameof(NativeInterface.GetFunctionAddressWithoutRejit)), address);
 
-                    EmitNativeCall(context, fallbackAddr, true);
+                    EmitNativeCall(context, fallbackAddr, isJump: true);
                 }
             }
             else
@@ -310,12 +305,14 @@ namespace ARMeilleure.Instructions
             context.MarkLabel(endLabel);
         }
 
-        public static void EmitJumpTableBranch(ArmEmitterContext context, Operand address, bool isJump = false)
+        private static void EmitJumpTableBranch(ArmEmitterContext context, Operand address, bool isJump)
         {
             if (address.Type == OperandType.I32)
             {
                 address = context.ZeroExtend32(OperandType.I64, address);
             }
+
+            context.StoreToContext();
 
             // TODO: Constant folding. Indirect calls are slower in the best case and emit more code so we want to
             // avoid them when possible.

--- a/ARMeilleure/Instructions/InstEmitFlowHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitFlowHelper.cs
@@ -246,7 +246,7 @@ namespace ARMeilleure.Instructions
             EmitNativeCall(context, fallbackAddr, isJump);
         }
 
-        public static void EmitDynamicTableCall(ArmEmitterContext context, Operand tableAddress, Operand address, bool isJump)
+        private static void EmitDynamicTableCall(ArmEmitterContext context, Operand tableAddress, Operand address, bool isJump)
         {
             // Loop over elements of the dynamic table. Unrolled loop.
 

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -26,7 +26,7 @@ namespace ARMeilleure.Translation.PTC
     {
         private const string HeaderMagicString = "PTChd\0\0\0";
 
-        private const uint InternalVersion = 1990; //! To be incremented manually for each change to the ARMeilleure project.
+        private const uint InternalVersion = 2155; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";


### PR DESCRIPTION
Hoist `StoreToContext` in dynamic branch fast & slow paths out into their predecessor. Reduces register pressure, code size and compile time a little bit because we're throwing less stuff down the pipeline. Sample [diff](https://www.diffchecker.com/17Or5Uog).

Some thing similar can be done with `LoadFromContext` emitted for dynamic calls, by sinking them into the successor. We need to store the return address of the calls (fast & slow paths) into a single variable and apply the call guard check on it. This is essentially tail merging and could be applied to tail continues as well. However we get limited by the `EmitterContext` and `SsaConstruction` because local variables are assumed to be in SSA early on, so they cannot participate in phi nodes.