### PR TITLE
Hold reference for render targets in use

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -73,7 +73,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         public bool ChangedSize { get; private set; }
 
         /// <summary>
-        /// Set when a texture's GPU VA has ever been partially or fully unmapped. 
+        /// Set when a texture's GPU VA has ever been partially or fully unmapped.
         /// This indicates that the range must be fully checked when matching the texture.
         /// </summary>
         public bool ChangedMapping { get; private set; }
@@ -628,7 +628,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Fully synchronizes guest and host memory. 
+        /// Fully synchronizes guest and host memory.
         /// This will replace the entire texture with the data present in guest memory.
         /// </summary>
         public void SynchronizeFull()
@@ -1127,7 +1127,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 {
                     TextureCreateInfo createInfo = TextureManager.GetCreateInfo(view.Info, _context.Capabilities, ScaleFactor);
 
-                    ITexture newView = parent.HostTexture.CreateView(createInfo, view.FirstLayer + firstLayer, view.FirstLevel + firstLevel); 
+                    ITexture newView = parent.HostTexture.CreateView(createInfo, view.FirstLayer + firstLayer, view.FirstLevel + firstLevel);
 
                     view.ReplaceView(parent, view.Info, newView, view.FirstLayer + firstLayer, view.FirstLevel + firstLevel);
                 }
@@ -1187,6 +1187,15 @@ namespace Ryujinx.Graphics.Gpu.Image
             {
                 IsModified = true;
                 Group.SignalModifying(this, bound, !wasModified);
+            }
+
+            if (bound)
+            {
+                IncrementReferenceCount();
+            }
+            else
+            {
+                DecrementReferenceCount();
             }
         }
 


### PR DESCRIPTION
`SetRenderTargets` might be called on the backend with a texture that was already "released". This happens because the active render targets are stored on the `TextureManager`, but this never increments/decrements the reference count, so those textures might be deleted if they fall out of the auto delete cache. This changes increments and decrements the reference count to prevent that from happening.

Found this while working on Vulkan (using a freed texture would cause a crash), not sure if its causing anything spooky on the OpenGL backend (I guess its less likely to crash there since textures are reused).

Also moved `SetRenderTargetDepthStencil` close to the color one, as the 2 are related and puting them together makes the code easier to read imo.