### PR TITLE
Fix Tamper Machine crash and timings

### DIFF
--- a/Ryujinx.HLE/HOS/ModLoader.cs
+++ b/Ryujinx.HLE/HOS/ModLoader.cs
@@ -630,6 +630,8 @@ namespace Ryujinx.HLE.HOS
             if (tamperInfo == null || tamperInfo.BuildIds == null || tamperInfo.CodeAddresses == null)
             {
                 Logger.Error?.Print(LogClass.ModLoader, "Unable to install cheat because the associated process is invalid");
+
+                return;
             }
 
             Logger.Info?.Print(LogClass.ModLoader, $"Build ids found for title {titleId:X16}:\n    {String.Join("\n    ", tamperInfo.BuildIds)}");

--- a/Ryujinx.HLE/HOS/TamperMachine.cs
+++ b/Ryujinx.HLE/HOS/TamperMachine.cs
@@ -13,6 +13,8 @@ namespace Ryujinx.HLE.HOS
 {
     public class TamperMachine
     {
+        private const int TAMPERMACHINE_SLEEP_MS = 1000 / 12;
+
         private Thread _tamperThread = null;
         private ConcurrentQueue<ITamperProgram> _programs = new ConcurrentQueue<ITamperProgram>();
         private long _pressedKeys = 0;
@@ -76,7 +78,7 @@ namespace Ryujinx.HLE.HOS
                 if (sleepCounter == 0)
                 {
                     sleepCounter = _programs.Count;
-                    Thread.Sleep(1);
+                    Thread.Sleep(TAMPERMACHINE_SLEEP_MS);
                 }
                 else
                 {

--- a/Ryujinx.HLE/HOS/TamperMachine.cs
+++ b/Ryujinx.HLE/HOS/TamperMachine.cs
@@ -13,7 +13,9 @@ namespace Ryujinx.HLE.HOS
 {
     public class TamperMachine
     {
-        private const int TAMPERMACHINE_SLEEP_MS = 1000 / 12;
+        // Atmosphere specifies a delay of 83 milliseconds between the execution of the last
+        // cheat and the re-execution of the first one.
+        private const int TamperMachineSleepMs = 1000 / 12;
 
         private Thread _tamperThread = null;
         private ConcurrentQueue<ITamperProgram> _programs = new ConcurrentQueue<ITamperProgram>();
@@ -78,7 +80,7 @@ namespace Ryujinx.HLE.HOS
                 if (sleepCounter == 0)
                 {
                     sleepCounter = _programs.Count;
-                    Thread.Sleep(TAMPERMACHINE_SLEEP_MS);
+                    Thread.Sleep(TamperMachineSleepMs);
                 }
                 else
                 {


### PR DESCRIPTION
Discord user mageven reported two issues with the Tamper Machine that are addressed in this PR:

- The first one is a crash when using unpacked games, caused by a missing `return` statement.
- The second one was an inconsistency between the sleep duration in Tamper Machine (1ms) versus Atmosphere (~83.33ms). Time sensitive cheats (if any) may behave differently.

The first issue was reproduced and tested unpacking a game and running it.

For the second issue, I measured the average time between sleeps in the Tamper Machine and it's around 83.7~83.9ms on Windows/Release, even with multiple cheats running, so the timing is now between spec and no significant drift from the `Sleep` function itself was observed.

I re-tested the cheats from my previous PR #1928, those being:

- 60fps mod in MHGU
- 99 lives / 999 seconds / start as penguin cheats in NSMBD
- 10 coins cheat in MK8D