### PR TITLE
Reduce allocation during SSA construction

### DIFF
--- a/ARMeilleure/IntermediateRepresentation/Operand.cs
+++ b/ARMeilleure/IntermediateRepresentation/Operand.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace ARMeilleure.IntermediateRepresentation
 {
@@ -84,6 +85,7 @@ namespace ARMeilleure.IntermediateRepresentation
             return With(OperandKind.Register, type, (ulong)((int)regType << 24 | index));
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Register GetRegister()
         {
             return new Register((int)Value & 0xffffff, (RegisterType)(Value >> 24));


### PR DESCRIPTION
SSA construction was allocating an array for each basic block twice, it re-uses a single array instead now. This also removes `DefMap`'s dependency on `Register` which makes extending SSA construction to handle `LocalVariable` easier.

Also mark `Operand.GetRegister()` as aggressive inlining, because it wasn't getting inlined.