### PR TITLE
Only flush commands when creating sync on Intel/AMD (windows)

### DIFF
--- a/Ryujinx.Graphics.OpenGL/HwCapabilities.cs
+++ b/Ryujinx.Graphics.OpenGL/HwCapabilities.cs
@@ -34,6 +34,7 @@ namespace Ryujinx.Graphics.OpenGL
         public static bool SupportsViewportSwizzle           => _supportsViewportSwizzle.Value;
         public static bool SupportsSeamlessCubemapPerTexture => _supportsSeamlessCubemapPerTexture.Value;
         public static bool SupportsNonConstantTextureOffset  => _gpuVendor.Value == GpuVendor.Nvidia;
+        public static bool RequiresSyncFlush                 => _gpuVendor.Value == GpuVendor.Amd || _gpuVendor.Value == GpuVendor.Intel;
 
         public static int MaximumComputeSharedMemorySize => _maximumComputeSharedMemorySize.Value;
         public static int StorageBufferOffsetAlignment   => _storageBufferOffsetAlignment.Value;


### PR DESCRIPTION
One particular game seemed to slow down due to flushing commands on sync creation, so this PR disables it on the platforms that don't seem to need it, such as NVIDIA's proprietary drivers and Mesa. My guess is that the NVIDIA driver is always flushing commands anyways, and telling it to do so manually slows it down.