### PR TITLE
Allow parallel shader compilation when loading a shader cache

### DIFF
--- a/Ryujinx.Graphics.GAL/IProgram.cs
+++ b/Ryujinx.Graphics.GAL/IProgram.cs
@@ -4,6 +4,8 @@ namespace Ryujinx.Graphics.GAL
 {
     public interface IProgram : IDisposable
     {
+        ProgramLinkStatus CheckProgramLink(bool blocking);
+
         byte[] GetBinary();
     }
 }

--- a/Ryujinx.Graphics.GAL/ProgramLinkStatus.cs
+++ b/Ryujinx.Graphics.GAL/ProgramLinkStatus.cs
@@ -1,0 +1,9 @@
+﻿namespace Ryujinx.Graphics.GAL
+{
+    public enum ProgramLinkStatus
+    {
+        Incomplete,
+        Success,
+        Failure
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -197,11 +197,6 @@ namespace Ryujinx.Graphics.Gpu.Shader
 
                                         task.OnCompiled(hostProgram, (bool isNewProgramValid, ShaderCompileTask task) =>
                                         {
-                                            if (!isNewProgramValid)
-                                            {
-                                                return true;
-                                            }
-
                                             // As the host program was invalidated, save the new entry in the cache.
                                             hostProgramBinary = HostShaderCacheEntry.Create(hostProgram.GetBinary(), new ShaderCodeHolder[] { shader });
 
@@ -365,11 +360,6 @@ namespace Ryujinx.Graphics.Gpu.Shader
 
                                         task.OnCompiled(hostProgram, (bool isNewProgramValid, ShaderCompileTask task) =>
                                         {
-                                            if (!isNewProgramValid)
-                                            {
-                                                return true;
-                                            }
-
                                             // As the host program was invalidated, save the new entry in the cache.
                                             hostProgramBinary = HostShaderCacheEntry.Create(hostProgram.GetBinary(), shaders);
 

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Ryujinx.Graphics.Gpu.Shader
 {
@@ -102,234 +103,327 @@ namespace Ryujinx.Graphics.Gpu.Shader
                     progressReportThread.Start(progressReportEvent);
                 }
 
-                for (int programIndex = 0; programIndex < guestProgramList.Length; programIndex++)
+                // Make sure these are initialized before doing compilation.
+                Capabilities caps = _context.Capabilities;
+
+                int maxTaskCount = Math.Min(Environment.ProcessorCount, 8);
+                int programIndex = 0;
+                List<ShaderCompileTask> activeTasks = new List<ShaderCompileTask>();
+
+                // This thread dispatches tasks to do shader translation, and creates programs that OpenGL will link in the background.
+                // The program link status is checked in a non-blocking manner so that multiple shaders can be compiled at once.
+                
+                while (programIndex < guestProgramList.Length || activeTasks.Count > 0)
                 {
-                    Hash128 key = guestProgramList[programIndex];
-
-                    byte[] hostProgramBinary = _cacheManager.GetHostProgramByHash(ref key);
-                    bool hasHostCache = hostProgramBinary != null;
-
-                    IProgram hostProgram = null;
-
-                    // If the program sources aren't in the cache, compile from saved guest program.
-                    byte[] guestProgram = _cacheManager.GetGuestProgramByHash(ref key);
-
-                    if (guestProgram == null)
+                    if (activeTasks.Count < maxTaskCount && programIndex < guestProgramList.Length)
                     {
-                        Logger.Error?.Print(LogClass.Gpu, $"Ignoring orphan shader hash {key} in cache (is the cache incomplete?)");
+                        // Begin a new shader compilation.
+                        Hash128 key = guestProgramList[programIndex];
 
-                        // Should not happen, but if someone messed with the cache it's better to catch it.
-                        invalidEntries?.Add(key);
+                        byte[] hostProgramBinary = _cacheManager.GetHostProgramByHash(ref key);
+                        bool hasHostCache = hostProgramBinary != null;
 
-                        continue;
-                    }
+                        IProgram hostProgram = null;
 
-                    ReadOnlySpan<byte> guestProgramReadOnlySpan = guestProgram;
+                        // If the program sources aren't in the cache, compile from saved guest program.
+                        byte[] guestProgram = _cacheManager.GetGuestProgramByHash(ref key);
 
-                    ReadOnlySpan<GuestShaderCacheEntry> cachedShaderEntries = GuestShaderCacheEntry.Parse(ref guestProgramReadOnlySpan, out GuestShaderCacheHeader fileHeader);
-
-                    if (cachedShaderEntries[0].Header.Stage == ShaderStage.Compute)
-                    {
-                        Debug.Assert(cachedShaderEntries.Length == 1);
-
-                        GuestShaderCacheEntry entry = cachedShaderEntries[0];
-
-                        HostShaderCacheEntry[] hostShaderEntries = null;
-
-                        // Try loading host shader binary.
-                        if (hasHostCache)
+                        if (guestProgram == null)
                         {
-                            hostShaderEntries = HostShaderCacheEntry.Parse(hostProgramBinary, out ReadOnlySpan<byte> hostProgramBinarySpan);
-                            hostProgramBinary = hostProgramBinarySpan.ToArray();
-                            hostProgram = _context.Renderer.LoadProgramBinary(hostProgramBinary);
+                            Logger.Error?.Print(LogClass.Gpu, $"Ignoring orphan shader hash {key} in cache (is the cache incomplete?)");
+
+                            // Should not happen, but if someone messed with the cache it's better to catch it.
+                            invalidEntries?.Add(key);
+
+                            continue;
                         }
 
-                        bool isHostProgramValid = hostProgram != null;
+                        ReadOnlySpan<byte> guestProgramReadOnlySpan = guestProgram;
 
-                        ShaderProgram program;
-                        ShaderProgramInfo shaderProgramInfo;
+                        ReadOnlySpan<GuestShaderCacheEntry> cachedShaderEntries = GuestShaderCacheEntry.Parse(ref guestProgramReadOnlySpan, out GuestShaderCacheHeader fileHeader);
 
-                        // Reconstruct code holder.
-                        if (isHostProgramValid)
+                        if (cachedShaderEntries[0].Header.Stage == ShaderStage.Compute)
                         {
-                            program = new ShaderProgram(entry.Header.Stage, "");
-                            shaderProgramInfo = hostShaderEntries[0].ToShaderProgramInfo();
+                            Debug.Assert(cachedShaderEntries.Length == 1);
+
+                            GuestShaderCacheEntry entry = cachedShaderEntries[0];
+
+                            HostShaderCacheEntry[] hostShaderEntries = null;
+
+                            // Try loading host shader binary.
+                            if (hasHostCache)
+                            {
+                                hostShaderEntries = HostShaderCacheEntry.Parse(hostProgramBinary, out ReadOnlySpan<byte> hostProgramBinarySpan);
+                                hostProgramBinary = hostProgramBinarySpan.ToArray();
+                                hostProgram = _context.Renderer.LoadProgramBinary(hostProgramBinary);
+                            }
+
+                            ShaderCompileTask task = new ShaderCompileTask();
+                            activeTasks.Add(task);
+
+                            task.OnCompiled(hostProgram, (bool isHostProgramValid, ShaderCompileTask task) =>
+                            {
+                                ShaderProgram program = null;
+                                ShaderProgramInfo shaderProgramInfo = null;
+
+                                Task compileTask = Task.Run(() =>
+                                {
+                                    // Reconstruct code holder.
+                                    if (isHostProgramValid)
+                                    {
+                                        program = new ShaderProgram(entry.Header.Stage, "");
+                                        shaderProgramInfo = hostShaderEntries[0].ToShaderProgramInfo();
+                                    }
+                                    else
+                                    {
+                                        IGpuAccessor gpuAccessor = new CachedGpuAccessor(_context, entry.Code, entry.Header.GpuAccessorHeader, entry.TextureDescriptors);
+
+                                        program = Translator.CreateContext(0, gpuAccessor, DefaultFlags | TranslationFlags.Compute).Translate(out shaderProgramInfo);
+                                    }
+                                });
+
+                                task.OnTask(compileTask, (bool _, ShaderCompileTask task) =>
+                                {
+                                    ShaderCodeHolder shader = new ShaderCodeHolder(program, shaderProgramInfo, entry.Code);
+
+                                    // If the host program was rejected by the gpu driver or isn't in cache, try to build from program sources again.
+                                    if (!isHostProgramValid)
+                                    {
+                                        Logger.Info?.Print(LogClass.Gpu, $"Host shader {key} got invalidated, rebuilding from guest...");
+
+                                        // Compile shader and create program as the shader program binary got invalidated.
+                                        shader.HostShader = _context.Renderer.CompileShader(ShaderStage.Compute, shader.Program.Code);
+                                        hostProgram = _context.Renderer.CreateProgram(new IShader[] { shader.HostShader }, null);
+
+                                        task.OnCompiled(hostProgram, (bool isNewProgramValid, ShaderCompileTask task) =>
+                                        {
+                                            if (!isNewProgramValid)
+                                            {
+                                                return true;
+                                            }
+
+                                            // As the host program was invalidated, save the new entry in the cache.
+                                            hostProgramBinary = HostShaderCacheEntry.Create(hostProgram.GetBinary(), new ShaderCodeHolder[] { shader });
+
+                                            if (!isReadOnly)
+                                            {
+                                                if (hasHostCache)
+                                                {
+                                                    _cacheManager.ReplaceHostProgram(ref key, hostProgramBinary);
+                                                }
+                                                else
+                                                {
+                                                    Logger.Warning?.Print(LogClass.Gpu, $"Add missing host shader {key} in cache (is the cache incomplete?)");
+
+                                                    _cacheManager.AddHostProgram(ref key, hostProgramBinary);
+                                                }
+                                            }
+
+                                            _cpProgramsDiskCache.Add(key, new ShaderBundle(hostProgram, shader));
+
+                                            return true;
+                                        });
+
+                                        return false; // Not finished: still need to compile the host program.
+                                    }
+                                    else
+                                    {
+                                        _cpProgramsDiskCache.Add(key, new ShaderBundle(hostProgram, shader));
+
+                                        return true;
+                                    }
+                                });
+
+                                return false; // Not finished: translating the shaders.
+                            });
+                            
                         }
                         else
                         {
-                            IGpuAccessor gpuAccessor = new CachedGpuAccessor(_context, entry.Code, entry.Header.GpuAccessorHeader, entry.TextureDescriptors);
+                            Debug.Assert(cachedShaderEntries.Length == Constants.ShaderStages);
 
-                            program = Translator.CreateContext(0, gpuAccessor, DefaultFlags | TranslationFlags.Compute).Translate(out shaderProgramInfo);
-                        }
+                            ShaderCodeHolder[] shaders = new ShaderCodeHolder[cachedShaderEntries.Length];
+                            List<ShaderProgram> shaderPrograms = new List<ShaderProgram>();
 
-                        ShaderCodeHolder shader = new ShaderCodeHolder(program, shaderProgramInfo, entry.Code);
+                            TransformFeedbackDescriptor[] tfd = CacheHelper.ReadTransformFeedbackInformation(ref guestProgramReadOnlySpan, fileHeader);
 
-                        // If the host program was rejected by the gpu driver or isn't in cache, try to build from program sources again.
-                        if (hostProgram == null)
-                        {
-                            Logger.Info?.Print(LogClass.Gpu, $"Host shader {key} got invalidated, rebuilding from guest...");
+                            TranslationFlags flags = DefaultFlags;
 
-                            // Compile shader and create program as the shader program binary got invalidated.
-                            shader.HostShader = _context.Renderer.CompileShader(ShaderStage.Compute, shader.Program.Code);
-                            hostProgram = _context.Renderer.CreateProgram(new IShader[] { shader.HostShader }, null);
-
-                            // As the host program was invalidated, save the new entry in the cache.
-                            hostProgramBinary = HostShaderCacheEntry.Create(hostProgram.GetBinary(), new ShaderCodeHolder[] { shader });
-
-                            if (!isReadOnly)
+                            if (tfd != null)
                             {
-                                if (hasHostCache)
-                                {
-                                    _cacheManager.ReplaceHostProgram(ref key, hostProgramBinary);
-                                }
-                                else
-                                {
-                                    Logger.Warning?.Print(LogClass.Gpu, $"Add missing host shader {key} in cache (is the cache incomplete?)");
-
-                                    _cacheManager.AddHostProgram(ref key, hostProgramBinary);
-                                }
+                                flags |= TranslationFlags.Feedback;
                             }
+
+                            TranslationCounts counts = new TranslationCounts();
+
+                            HostShaderCacheEntry[] hostShaderEntries = null;
+
+                            // Try loading host shader binary.
+                            if (hasHostCache)
+                            {
+                                hostShaderEntries = HostShaderCacheEntry.Parse(hostProgramBinary, out ReadOnlySpan<byte> hostProgramBinarySpan);
+                                hostProgramBinary = hostProgramBinarySpan.ToArray();
+                                hostProgram = _context.Renderer.LoadProgramBinary(hostProgramBinary);
+                            }
+
+                            ShaderCompileTask task = new ShaderCompileTask();
+                            activeTasks.Add(task);
+
+                            GuestShaderCacheEntry[] entries = cachedShaderEntries.ToArray();
+
+                            task.OnCompiled(hostProgram, (bool isHostProgramValid, ShaderCompileTask task) =>
+                            {
+                                Task compileTask = Task.Run(() =>
+                                {
+                                    // Reconstruct code holder.
+                                    for (int i = 0; i < entries.Length; i++)
+                                    {
+                                        GuestShaderCacheEntry entry = entries[i];
+
+                                        if (entry == null)
+                                        {
+                                            continue;
+                                        }
+
+                                        ShaderProgram program;
+
+                                        if (entry.Header.SizeA != 0)
+                                        {
+                                            ShaderProgramInfo shaderProgramInfo;
+
+                                            if (isHostProgramValid)
+                                            {
+                                                program = new ShaderProgram(entry.Header.Stage, "");
+                                                shaderProgramInfo = hostShaderEntries[i].ToShaderProgramInfo();
+                                            }
+                                            else
+                                            {
+                                                IGpuAccessor gpuAccessor = new CachedGpuAccessor(_context, entry.Code, entry.Header.GpuAccessorHeader, entry.TextureDescriptors);
+
+                                                TranslatorContext translatorContext = Translator.CreateContext(0, gpuAccessor, flags, counts);
+                                                TranslatorContext translatorContext2 = Translator.CreateContext((ulong)entry.Header.Size, gpuAccessor, flags | TranslationFlags.VertexA, counts);
+
+                                                program = translatorContext.Translate(out shaderProgramInfo, translatorContext2);
+                                            }
+
+                                            // NOTE: Vertex B comes first in the shader cache.
+                                            byte[] code = entry.Code.AsSpan().Slice(0, entry.Header.Size).ToArray();
+                                            byte[] code2 = entry.Code.AsSpan().Slice(entry.Header.Size, entry.Header.SizeA).ToArray();
+
+                                            shaders[i] = new ShaderCodeHolder(program, shaderProgramInfo, code, code2);
+                                        }
+                                        else
+                                        {
+                                            ShaderProgramInfo shaderProgramInfo;
+
+                                            if (isHostProgramValid)
+                                            {
+                                                program = new ShaderProgram(entry.Header.Stage, "");
+                                                shaderProgramInfo = hostShaderEntries[i].ToShaderProgramInfo();
+                                            }
+                                            else
+                                            {
+                                                IGpuAccessor gpuAccessor = new CachedGpuAccessor(_context, entry.Code, entry.Header.GpuAccessorHeader, entry.TextureDescriptors);
+
+                                                program = Translator.CreateContext(0, gpuAccessor, flags, counts).Translate(out shaderProgramInfo);
+                                            }
+
+                                            shaders[i] = new ShaderCodeHolder(program, shaderProgramInfo, entry.Code);
+                                        }
+
+                                        shaderPrograms.Add(program);
+                                    }
+                                });
+
+                                task.OnTask(compileTask, (bool _, ShaderCompileTask task) =>
+                                {
+                                    // If the host program was rejected by the gpu driver or isn't in cache, try to build from program sources again.
+                                    if (!isHostProgramValid)
+                                    {
+                                        Logger.Info?.Print(LogClass.Gpu, $"Host shader {key} got invalidated, rebuilding from guest...");
+
+                                        List<IShader> hostShaders = new List<IShader>();
+
+                                        // Compile shaders and create program as the shader program binary got invalidated.
+                                        for (int stage = 0; stage < Constants.ShaderStages; stage++)
+                                        {
+                                            ShaderProgram program = shaders[stage]?.Program;
+
+                                            if (program == null)
+                                            {
+                                                continue;
+                                            }
+
+                                            IShader hostShader = _context.Renderer.CompileShader(program.Stage, program.Code);
+
+                                            shaders[stage].HostShader = hostShader;
+
+                                            hostShaders.Add(hostShader);
+                                        }
+
+                                        hostProgram = _context.Renderer.CreateProgram(hostShaders.ToArray(), tfd);
+
+                                        task.OnCompiled(hostProgram, (bool isNewProgramValid, ShaderCompileTask task) =>
+                                        {
+                                            if (!isNewProgramValid)
+                                            {
+                                                return true;
+                                            }
+
+                                            // As the host program was invalidated, save the new entry in the cache.
+                                            hostProgramBinary = HostShaderCacheEntry.Create(hostProgram.GetBinary(), shaders);
+
+                                            if (!isReadOnly)
+                                            {
+                                                if (hasHostCache)
+                                                {
+                                                    _cacheManager.ReplaceHostProgram(ref key, hostProgramBinary);
+                                                }
+                                                else
+                                                {
+                                                    Logger.Warning?.Print(LogClass.Gpu, $"Add missing host shader {key} in cache (is the cache incomplete?)");
+
+                                                    _cacheManager.AddHostProgram(ref key, hostProgramBinary);
+                                                }
+                                            }
+
+                                            _gpProgramsDiskCache.Add(key, new ShaderBundle(hostProgram, shaders));
+
+                                            return true;
+                                        });
+
+                                        return false; // Not finished: still need to compile the host program.
+                                    }
+                                    else
+                                    {
+                                        _gpProgramsDiskCache.Add(key, new ShaderBundle(hostProgram, shaders));
+
+                                        return true;
+                                    }
+                                });
+
+                                return false; // Not finished: translating the shaders.
+                            });
                         }
 
-                        _cpProgramsDiskCache.Add(key, new ShaderBundle(hostProgram, shader));
+                        _shaderCount = ++programIndex;
                     }
-                    else
+
+                    // Process the queue.
+                    for (int i = 0; i < activeTasks.Count; i++)
                     {
-                        Debug.Assert(cachedShaderEntries.Length == Constants.ShaderStages);
+                        ShaderCompileTask task = activeTasks[i];
 
-                        ShaderCodeHolder[] shaders = new ShaderCodeHolder[cachedShaderEntries.Length];
-                        List<ShaderProgram> shaderPrograms = new List<ShaderProgram>();
-
-                        TransformFeedbackDescriptor[] tfd = CacheHelper.ReadTransformFeedbackInformation(ref guestProgramReadOnlySpan, fileHeader);
-
-                        TranslationFlags flags = DefaultFlags;
-
-                        if (tfd != null)
+                        if (task.IsDone())
                         {
-                            flags |= TranslationFlags.Feedback;
+                            activeTasks.RemoveAt(i--);
                         }
-
-                        TranslationCounts counts = new TranslationCounts();
-
-                        HostShaderCacheEntry[] hostShaderEntries = null;
-
-                        // Try loading host shader binary.
-                        if (hasHostCache)
-                        {
-                            hostShaderEntries = HostShaderCacheEntry.Parse(hostProgramBinary, out ReadOnlySpan<byte> hostProgramBinarySpan);
-                            hostProgramBinary = hostProgramBinarySpan.ToArray();
-                            hostProgram = _context.Renderer.LoadProgramBinary(hostProgramBinary);
-                        }
-
-                        bool isHostProgramValid = hostProgram != null;
-
-                        // Reconstruct code holder.
-                        for (int i = 0; i < cachedShaderEntries.Length; i++)
-                        {
-                            GuestShaderCacheEntry entry = cachedShaderEntries[i];
-
-                            if (entry == null)
-                            {
-                                continue;
-                            }
-
-                            ShaderProgram program;
-
-                            if (entry.Header.SizeA != 0)
-                            {
-                                ShaderProgramInfo shaderProgramInfo;
-
-                                if (isHostProgramValid)
-                                {
-                                    program = new ShaderProgram(entry.Header.Stage, "");
-                                    shaderProgramInfo = hostShaderEntries[i].ToShaderProgramInfo();
-                                }
-                                else
-                                {
-                                    IGpuAccessor gpuAccessor = new CachedGpuAccessor(_context, entry.Code, entry.Header.GpuAccessorHeader, entry.TextureDescriptors);
-
-                                    TranslatorContext translatorContext = Translator.CreateContext(0, gpuAccessor, flags, counts);
-                                    TranslatorContext translatorContext2 = Translator.CreateContext((ulong)entry.Header.Size, gpuAccessor, flags | TranslationFlags.VertexA, counts);
-
-                                    program = translatorContext.Translate(out shaderProgramInfo, translatorContext2);
-                                }
-
-                                // NOTE: Vertex B comes first in the shader cache.
-                                byte[] code = entry.Code.AsSpan().Slice(0, entry.Header.Size).ToArray();
-                                byte[] code2 = entry.Code.AsSpan().Slice(entry.Header.Size, entry.Header.SizeA).ToArray();
-
-                                shaders[i] = new ShaderCodeHolder(program, shaderProgramInfo, code, code2);
-                            }
-                            else
-                            {
-                                ShaderProgramInfo shaderProgramInfo;
-
-                                if (isHostProgramValid)
-                                {
-                                    program = new ShaderProgram(entry.Header.Stage, "");
-                                    shaderProgramInfo = hostShaderEntries[i].ToShaderProgramInfo();
-                                }
-                                else
-                                {
-                                    IGpuAccessor gpuAccessor = new CachedGpuAccessor(_context, entry.Code, entry.Header.GpuAccessorHeader, entry.TextureDescriptors);
-
-                                    program = Translator.CreateContext(0, gpuAccessor, flags, counts).Translate(out shaderProgramInfo);
-                                }
-
-                                shaders[i] = new ShaderCodeHolder(program, shaderProgramInfo, entry.Code);
-                            }
-
-                            shaderPrograms.Add(program);
-                        }
-
-                        // If the host program was rejected by the gpu driver or isn't in cache, try to build from program sources again.
-                        if (!isHostProgramValid)
-                        {
-                            Logger.Info?.Print(LogClass.Gpu, $"Host shader {key} got invalidated, rebuilding from guest...");
-
-                            List<IShader> hostShaders = new List<IShader>();
-
-                            // Compile shaders and create program as the shader program binary got invalidated.
-                            for (int stage = 0; stage < Constants.ShaderStages; stage++)
-                            {
-                                ShaderProgram program = shaders[stage]?.Program;
-
-                                if (program == null)
-                                {
-                                    continue;
-                                }
-
-                                IShader hostShader = _context.Renderer.CompileShader(program.Stage, program.Code);
-
-                                shaders[stage].HostShader = hostShader;
-
-                                hostShaders.Add(hostShader);
-                            }
-
-                            hostProgram = _context.Renderer.CreateProgram(hostShaders.ToArray(), tfd);
-
-                            // As the host program was invalidated, save the new entry in the cache.
-                            hostProgramBinary = HostShaderCacheEntry.Create(hostProgram.GetBinary(), shaders);
-
-                            if (!isReadOnly)
-                            {
-                                if (hasHostCache)
-                                {
-                                    _cacheManager.ReplaceHostProgram(ref key, hostProgramBinary);
-                                }
-                                else
-                                {
-                                    Logger.Warning?.Print(LogClass.Gpu, $"Add missing host shader {key} in cache (is the cache incomplete?)");
-
-                                    _cacheManager.AddHostProgram(ref key, hostProgramBinary);
-                                }
-                            }
-                        }
-
-                        _gpProgramsDiskCache.Add(key, new ShaderBundle(hostProgram, shaders));
                     }
 
-                    _shaderCount = programIndex + 1;
+                    if (activeTasks.Count == maxTaskCount)
+                    {
+                        Thread.Sleep(1);
+                    }
                 }
 
                 if (!isReadOnly)
@@ -457,6 +551,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 shader.HostShader = _context.Renderer.CompileShader(ShaderStage.Compute, shader.Program.Code);
 
                 IProgram hostProgram = _context.Renderer.CreateProgram(new IShader[] { shader.HostShader }, null);
+
+                hostProgram.CheckProgramLink(true);
 
                 byte[] hostProgramBinary = HostShaderCacheEntry.Create(hostProgram.GetBinary(), new ShaderCodeHolder[] { shader });
 
@@ -597,6 +693,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 }
 
                 IProgram hostProgram = _context.Renderer.CreateProgram(hostShaders.ToArray(), tfd);
+
+                hostProgram.CheckProgramLink(true);
 
                 byte[] hostProgramBinary = HostShaderCacheEntry.Create(hostProgram.GetBinary(), shaders);
 

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCompileTask.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCompileTask.cs
@@ -1,0 +1,81 @@
+﻿using Ryujinx.Graphics.GAL;
+using System;
+using System.Threading.Tasks;
+
+namespace Ryujinx.Graphics.Gpu.Shader
+{
+    delegate bool ShaderCompileTaskCallback(bool success, ShaderCompileTask task);
+
+    /// <summary>
+    /// A class that represents a shader compilation.
+    /// </summary>
+    class ShaderCompileTask
+    {
+        private bool _compiling;
+
+        private Task _programsTask;
+        private IProgram _program;
+
+        private ShaderCompileTaskCallback _action;
+
+        /// <summary>
+        /// Check the completion status of the shader compile task, and run callbacks on step completion.
+        /// Calling this periodically is required to progress through steps of the compilation.
+        /// </summary>
+        /// <returns>True if the task is complete, false if it is in progress</returns>
+        public bool IsDone()
+        {
+            if (_compiling)
+            {
+                ProgramLinkStatus status = _program.CheckProgramLink(false);
+
+                if (status != ProgramLinkStatus.Incomplete)
+                {
+                    return _action(status == ProgramLinkStatus.Success, this);
+                }
+            }
+            else
+            {
+                // Waiting on the task.
+
+                if (_programsTask.IsCompleted)
+                {
+                    return _action(true, this);
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Run a callback when the specified task has completed.
+        /// </summary>
+        /// <param name="task">The task object that needs to complete</param>
+        /// <param name="action">The action to perform when it is complete</param>
+        public void OnTask(Task task, ShaderCompileTaskCallback action)
+        {
+            _compiling = false;
+
+            _programsTask = task;
+            _action = action;
+        }
+
+        /// <summary>
+        /// Run a callback when the specified program has been linked.
+        /// </summary>
+        /// <param name="task">The program that needs to be linked</param>
+        /// <param name="action">The action to perform when linking is complete</param>
+        public void OnCompiled(IProgram program, ShaderCompileTaskCallback action)
+        {
+            _compiling = true;
+
+            _program = program;
+            _action = action;
+
+            if (program == null)
+            {
+                action(false, this);
+            }
+        }
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCompileTask.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCompileTask.cs
@@ -1,5 +1,6 @@
 ﻿using Ryujinx.Graphics.GAL;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Ryujinx.Graphics.Gpu.Shader
@@ -17,6 +18,16 @@ namespace Ryujinx.Graphics.Gpu.Shader
         private IProgram _program;
 
         private ShaderCompileTaskCallback _action;
+        private AutoResetEvent _taskDoneEvent;
+
+        /// <summary>
+        /// Create a new shader compile task, with an event to signal whenever a subtask completes.
+        /// </summary>
+        /// <param name="taskDoneEvent">Event to signal when a subtask completes</param>
+        public ShaderCompileTask(AutoResetEvent taskDoneEvent)
+        {
+            _taskDoneEvent = taskDoneEvent;
+        }
 
         /// <summary>
         /// Check the completion status of the shader compile task, and run callbacks on step completion.
@@ -58,6 +69,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
 
             _programsTask = task;
             _action = action;
+
+            task.ContinueWith(task => _taskDoneEvent.Set());
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.OpenGL/HwCapabilities.cs
+++ b/Ryujinx.Graphics.OpenGL/HwCapabilities.cs
@@ -10,6 +10,7 @@ namespace Ryujinx.Graphics.OpenGL
         private static readonly Lazy<bool> _supportsPolygonOffsetClamp        = new Lazy<bool>(() => HasExtension("GL_EXT_polygon_offset_clamp"));
         private static readonly Lazy<bool> _supportsViewportSwizzle           = new Lazy<bool>(() => HasExtension("GL_NV_viewport_swizzle"));
         private static readonly Lazy<bool> _supportsSeamlessCubemapPerTexture = new Lazy<bool>(() => HasExtension("GL_ARB_seamless_cubemap_per_texture"));
+        private static readonly Lazy<bool> _supportsParallelShaderCompile     = new Lazy<bool>(() => HasExtension("GL_ARB_parallel_shader_compile"));
 
         private static readonly Lazy<int> _maximumComputeSharedMemorySize = new Lazy<int>(() => GetLimit(All.MaxComputeSharedMemorySize));
         private static readonly Lazy<int> _storageBufferOffsetAlignment   = new Lazy<int>(() => GetLimit(All.ShaderStorageBufferOffsetAlignment));
@@ -33,6 +34,7 @@ namespace Ryujinx.Graphics.OpenGL
         public static bool SupportsPolygonOffsetClamp        => _supportsPolygonOffsetClamp.Value;
         public static bool SupportsViewportSwizzle           => _supportsViewportSwizzle.Value;
         public static bool SupportsSeamlessCubemapPerTexture => _supportsSeamlessCubemapPerTexture.Value;
+        public static bool SupportsParallelShaderCompile     => _supportsParallelShaderCompile.Value;
         public static bool SupportsNonConstantTextureOffset  => _gpuVendor.Value == GpuVendor.Nvidia;
 
         public static int MaximumComputeSharedMemorySize => _maximumComputeSharedMemorySize.Value;

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -130,6 +130,11 @@ namespace Ryujinx.Graphics.OpenGL
 
             PrintGpuInformation();
 
+            if (HwCapabilities.SupportsParallelShaderCompile)
+            {
+                GL.Arb.MaxShaderCompilerThreads(Math.Min(Environment.ProcessorCount, 8));
+            }
+
             _counters.Initialize();
         }
 
@@ -177,16 +182,7 @@ namespace Ryujinx.Graphics.OpenGL
 
         public IProgram LoadProgramBinary(byte[] programBinary)
         {
-            Program program = new Program(programBinary);
-
-            if (program.IsLinked)
-            {
-                return program;
-            }
-
-            program.Dispose();
-
-            return null;
+            return new Program(programBinary);
         }
 
         public void CreateSync(ulong id)


### PR DESCRIPTION
When your shader cache version is out of date, or your host shader cache is no longer valid for your GPU, you're subjected to the slow process of compiling all of the saved guest shaders. This PR allows programs to report their compilation process without blocking, and use the OpenGL's capability for multithreading shader compilation with `ARB_parallel_shader_compile`.

**This PR does not affect runtime shader compilation time.**

- ShaderCache Initialize now dispatches up to 8 concurrent tasks and shader compilations, and periodically checks them for completion to start the next step or add the compiled shader to the cache.
  - 8 seems to be the max level of multithreading that NVIDIA allows. We choose the minimum of 8 and the # of logical cores.
- Programs no longer check their link status on compilation.
- Uniform locations are now initialized on the first bind of a program, rather than on creation.
  - These two changes allow programs to start compilation without blocking.
- There is a new IProgram method for checking link status of a shader, optionally blocking. This is used internally when attempting to use a program.
  - If `ARB_parallel_shader_compile` is not supported, the link check will always block.

### Numbers
When rebuilding from guest with no driver cache, NVIDIA compilation is 4-5x faster on capable hardware.
AMD windows compilation is about 2x faster.
Unknown on Intel.

**Mario Kart 8:**
- No Host Cache, no Driver Cache
  - **Parallel:** 1:43.130
  - **Master:** 7:58.810
- No Host Cache, but Driver Cached
  - **Parallel:** 18.590
  - **Master:** 26.918
- Host Cache
  - **Parallel:** 8.697
  - **Master:** 9.051
  
**Splatoon 2:**
- No Host Cache, no Driver Cache
  - **Parallel:** 5:39.208
  - **Master:** 23:09.293

### Note on ShaderCache.cs
I don't like the current Initialize function, but I don't know how to fix it. I'd split it into individual steps, but there's so much shared state that capturing variables with lambdas seems like it works better than moving all the state variables to the task class, as that would be very arbitrary and weird.