### PR TITLE
Fix vote and shuffle shader instructions on AMD GPUs

### DIFF
--- a/Ryujinx.Graphics.GAL/Capabilities.cs
+++ b/Ryujinx.Graphics.GAL/Capabilities.cs
@@ -9,6 +9,7 @@ namespace Ryujinx.Graphics.GAL
 
         public int   MaximumComputeSharedMemorySize { get; }
         public float MaximumSupportedAnisotropy     { get; }
+        public bool  ShaderMaxThreads32             { get; }
         public int   StorageBufferOffsetAlignment   { get; }
 
         public Capabilities(
@@ -18,6 +19,7 @@ namespace Ryujinx.Graphics.GAL
             bool  supportsViewportSwizzle,
             int   maximumComputeSharedMemorySize,
             float maximumSupportedAnisotropy,
+            bool  shaderMaxThreads32,
             int   storageBufferOffsetAlignment)
         {
             SupportsAstcCompression          = supportsAstcCompression;
@@ -26,6 +28,7 @@ namespace Ryujinx.Graphics.GAL
             SupportsViewportSwizzle          = supportsViewportSwizzle;
             MaximumComputeSharedMemorySize   = maximumComputeSharedMemorySize;
             MaximumSupportedAnisotropy       = maximumSupportedAnisotropy;
+            ShaderMaxThreads32               = shaderMaxThreads32;
             StorageBufferOffsetAlignment     = storageBufferOffsetAlignment;
         }
     }

--- a/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
@@ -163,6 +163,12 @@ namespace Ryujinx.Graphics.Gpu.Shader
         }
 
         /// <summary>
+        /// Queries if the host GPU uses 32 threads per warp.
+        /// </summary>
+        /// <returns>True if 32 threads are used, false if not or unknown</returns>
+        public bool QueryShaderMaxThreads32() => _context.Capabilities.ShaderMaxThreads32;
+
+        /// <summary>
         /// Queries host storage buffer alignment required.
         /// </summary>
         /// <returns>Host storage buffer alignment in bytes</returns>

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -35,7 +35,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2163;
+        private const ulong ShaderCodeGenVersion = 1234;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -35,7 +35,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 1234;
+        private const ulong ShaderCodeGenVersion = 2178;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -100,6 +100,7 @@ namespace Ryujinx.Graphics.OpenGL
                 HwCapabilities.SupportsViewportSwizzle,
                 HwCapabilities.MaximumComputeSharedMemorySize,
                 HwCapabilities.MaximumSupportedAnisotropy,
+                HwCapabilities.Vendor == HwCapabilities.GpuVendor.Nvidia,
                 HwCapabilities.StorageBufferOffsetAlignment);
         }
 

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/Shuffle.glsl
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/Shuffle.glsl
@@ -2,9 +2,10 @@ float Helper_Shuffle(float x, uint index, uint mask, out bool valid)
 {
     uint clamp = mask & 0x1fu;
     uint segMask = (mask >> 8) & 0x1fu;
-    uint minThreadId = gl_SubGroupInvocationARB & segMask;
+    uint threadId = gl_SubGroupInvocationARB;
+    uint minThreadId = threadId & segMask;
     uint maxThreadId = minThreadId | (clamp & ~segMask);
     uint srcThreadId = (index & ~segMask) | minThreadId;
     valid = srcThreadId <= maxThreadId;
-    return valid ? readInvocationARB(x, srcThreadId) : x;
+    return valid ? readInvocationARB(x, (threadId & 32u) | srcThreadId) : x;
 }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/ShuffleDown.glsl
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/ShuffleDown.glsl
@@ -2,9 +2,10 @@ float Helper_ShuffleDown(float x, uint index, uint mask, out bool valid)
 {
     uint clamp = mask & 0x1fu;
     uint segMask = (mask >> 8) & 0x1fu;
-    uint minThreadId = gl_SubGroupInvocationARB & segMask;
+    uint threadId = gl_SubGroupInvocationARB;
+    uint minThreadId = threadId & segMask;
     uint maxThreadId = minThreadId | (clamp & ~segMask);
-    uint srcThreadId = gl_SubGroupInvocationARB + index;
+    uint srcThreadId = (threadId & 0x1fu) + index;
     valid = srcThreadId <= maxThreadId;
-    return valid ? readInvocationARB(x, srcThreadId) : x;
+    return valid ? readInvocationARB(x, (threadId & 32u) | srcThreadId) : x;
 }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/ShuffleUp.glsl
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/ShuffleUp.glsl
@@ -2,8 +2,9 @@ float Helper_ShuffleUp(float x, uint index, uint mask, out bool valid)
 {
     uint clamp = mask & 0x1fu;
     uint segMask = (mask >> 8) & 0x1fu;
-    uint minThreadId = gl_SubGroupInvocationARB & segMask;
-    uint srcThreadId = gl_SubGroupInvocationARB - index;
+    uint threadId = gl_SubGroupInvocationARB;
+    uint minThreadId = threadId & segMask;
+    uint srcThreadId = (threadId & 0x1fu) - index;
     valid = srcThreadId >= minThreadId;
-    return valid ? readInvocationARB(x, srcThreadId) : x;
+    return valid ? readInvocationARB(x, (threadId & 32u) | srcThreadId) : x;
 }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/ShuffleXor.glsl
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/ShuffleXor.glsl
@@ -2,9 +2,10 @@ float Helper_ShuffleXor(float x, uint index, uint mask, out bool valid)
 {
     uint clamp = mask & 0x1fu;
     uint segMask = (mask >> 8) & 0x1fu;
-    uint minThreadId = gl_SubGroupInvocationARB & segMask;
+    uint threadId = gl_SubGroupInvocationARB;
+    uint minThreadId = threadId & segMask;
     uint maxThreadId = minThreadId | (clamp & ~segMask);
-    uint srcThreadId = gl_SubGroupInvocationARB ^ index;
+    uint srcThreadId = (threadId & 0x1fu) ^ index;
     valid = srcThreadId <= maxThreadId;
-    return valid ? readInvocationARB(x, srcThreadId) : x;
+    return valid ? readInvocationARB(x, (threadId & 32u) | srcThreadId) : x;
 }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGen.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGen.cs
@@ -77,7 +77,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
 
                 if (inst == Instruction.Ballot)
                 {
-                    return ThreadCommon.GenerateUnpackMask($"{info.OpName}({args})");
+                    return ThreadCommon.GenerateUnpackMask(context.Config, $"{info.OpName}({args})");
                 }
                 else
                 {

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGen.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGen.cs
@@ -77,7 +77,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
 
                 if (inst == Instruction.Ballot)
                 {
-                    return $"unpackUint2x32({info.OpName}({args})).x";
+                    return ThreadCommon.GenerateUnpackMask($"{info.OpName}({args})");
                 }
                 else
                 {

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
+using static Ryujinx.Graphics.Shader.CodeGen.Glsl.ThreadCommon;
 using static Ryujinx.Graphics.Shader.StructuredIr.InstructionInfo;
 
 namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
@@ -52,20 +53,20 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
             { AttributeConsts.FrontFacing,         new BuiltInAttribute("gl_FrontFacing",     VariableType.Bool) },
 
             // Special.
-            { AttributeConsts.FragmentOutputDepth, new BuiltInAttribute("gl_FragDepth",                           VariableType.F32)  },
-            { AttributeConsts.ThreadKill,          new BuiltInAttribute("gl_HelperInvocation",                    VariableType.Bool) },
-            { AttributeConsts.ThreadIdX,           new BuiltInAttribute("gl_LocalInvocationID.x",                 VariableType.U32)  },
-            { AttributeConsts.ThreadIdY,           new BuiltInAttribute("gl_LocalInvocationID.y",                 VariableType.U32)  },
-            { AttributeConsts.ThreadIdZ,           new BuiltInAttribute("gl_LocalInvocationID.z",                 VariableType.U32)  },
-            { AttributeConsts.CtaIdX,              new BuiltInAttribute("gl_WorkGroupID.x",                       VariableType.U32)  },
-            { AttributeConsts.CtaIdY,              new BuiltInAttribute("gl_WorkGroupID.y",                       VariableType.U32)  },
-            { AttributeConsts.CtaIdZ,              new BuiltInAttribute("gl_WorkGroupID.z",                       VariableType.U32)  },
-            { AttributeConsts.LaneId,              new BuiltInAttribute("gl_SubGroupInvocationARB",               VariableType.U32)  },
-            { AttributeConsts.EqMask,              new BuiltInAttribute("unpackUint2x32(gl_SubGroupEqMaskARB).x", VariableType.U32)  },
-            { AttributeConsts.GeMask,              new BuiltInAttribute("unpackUint2x32(gl_SubGroupGeMaskARB).x", VariableType.U32)  },
-            { AttributeConsts.GtMask,              new BuiltInAttribute("unpackUint2x32(gl_SubGroupGtMaskARB).x", VariableType.U32)  },
-            { AttributeConsts.LeMask,              new BuiltInAttribute("unpackUint2x32(gl_SubGroupLeMaskARB).x", VariableType.U32)  },
-            { AttributeConsts.LtMask,              new BuiltInAttribute("unpackUint2x32(gl_SubGroupLtMaskARB).x", VariableType.U32)  },
+            { AttributeConsts.FragmentOutputDepth, new BuiltInAttribute("gl_FragDepth",                             VariableType.F32)  },
+            { AttributeConsts.ThreadKill,          new BuiltInAttribute("gl_HelperInvocation",                      VariableType.Bool) },
+            { AttributeConsts.ThreadIdX,           new BuiltInAttribute("gl_LocalInvocationID.x",                   VariableType.U32)  },
+            { AttributeConsts.ThreadIdY,           new BuiltInAttribute("gl_LocalInvocationID.y",                   VariableType.U32)  },
+            { AttributeConsts.ThreadIdZ,           new BuiltInAttribute("gl_LocalInvocationID.z",                   VariableType.U32)  },
+            { AttributeConsts.CtaIdX,              new BuiltInAttribute("gl_WorkGroupID.x",                         VariableType.U32)  },
+            { AttributeConsts.CtaIdY,              new BuiltInAttribute("gl_WorkGroupID.y",                         VariableType.U32)  },
+            { AttributeConsts.CtaIdZ,              new BuiltInAttribute("gl_WorkGroupID.z",                         VariableType.U32)  },
+            { AttributeConsts.LaneId,              new BuiltInAttribute("(gl_SubGroupInvocationARB & 31)",          VariableType.U32)  },
+            { AttributeConsts.EqMask,              new BuiltInAttribute(GenerateUnpackMask("gl_SubGroupEqMaskARB"), VariableType.U32)  },
+            { AttributeConsts.GeMask,              new BuiltInAttribute(GenerateUnpackMask("gl_SubGroupGeMaskARB"), VariableType.U32)  },
+            { AttributeConsts.GtMask,              new BuiltInAttribute(GenerateUnpackMask("gl_SubGroupGtMaskARB"), VariableType.U32)  },
+            { AttributeConsts.LeMask,              new BuiltInAttribute(GenerateUnpackMask("gl_SubGroupLeMaskARB"), VariableType.U32)  },
+            { AttributeConsts.LtMask,              new BuiltInAttribute(GenerateUnpackMask("gl_SubGroupLtMaskARB"), VariableType.U32)  },
 
             // Support uniforms.
             { AttributeConsts.FragmentOutputIsBgraBase + 0,  new BuiltInAttribute($"{DefaultNames.IsBgraName}[0]",  VariableType.Bool) },

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/ThreadCommon.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/ThreadCommon.cs
@@ -6,14 +6,14 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
     {
         public static string GenerateMaskInvocation(ShaderConfig config, string invocation)
         {
-            return config.GpuAccessor.QueryShaderMaxThreads32() ? invocation : $"({invocation} & 31)";
+            return config.GpuAccessor.QueryShaderMaxThreads32() ? invocation : $"({invocation} & 0x1fu)";
         }
 
         public static string GenerateUnpackMask(ShaderConfig config, string u64mask)
         {
             return config.GpuAccessor.QueryShaderMaxThreads32()
                 ? $"unpackUint2x32({u64mask}).x"
-                : $"(gl_SubGroupInvocationARB < 32 ? unpackUint2x32({u64mask}).x : unpackUint2x32({u64mask}).y)";
+                : $"(gl_SubGroupInvocationARB < 32u ? unpackUint2x32({u64mask}).x : unpackUint2x32({u64mask}).y)";
         }
     }
 }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/ThreadCommon.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/ThreadCommon.cs
@@ -1,0 +1,10 @@
+﻿namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
+{
+    static class ThreadCommon
+    {
+        public static string GenerateUnpackMask(string u64mask)
+        {
+            return $"(gl_SubGroupInvocationARB < 32 ? unpackUint2x32({u64mask}).x : unpackUint2x32({u64mask}).y)";
+        }
+    }
+}

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/ThreadCommon.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/ThreadCommon.cs
@@ -1,10 +1,19 @@
-﻿namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
+﻿using Ryujinx.Graphics.Shader.Translation;
+
+namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 {
     static class ThreadCommon
     {
-        public static string GenerateUnpackMask(string u64mask)
+        public static string GenerateMaskInvocation(ShaderConfig config, string invocation)
         {
-            return $"(gl_SubGroupInvocationARB < 32 ? unpackUint2x32({u64mask}).x : unpackUint2x32({u64mask}).y)";
+            return config.GpuAccessor.QueryShaderMaxThreads32() ? invocation : $"({invocation} & 31)";
+        }
+
+        public static string GenerateUnpackMask(ShaderConfig config, string u64mask)
+        {
+            return config.GpuAccessor.QueryShaderMaxThreads32()
+                ? $"unpackUint2x32({u64mask}).x"
+                : $"(gl_SubGroupInvocationARB < 32 ? unpackUint2x32({u64mask}).x : unpackUint2x32({u64mask}).y)";
         }
     }
 }

--- a/Ryujinx.Graphics.Shader/IGpuAccessor.cs
+++ b/Ryujinx.Graphics.Shader/IGpuAccessor.cs
@@ -59,6 +59,11 @@
             return InputTopology.Points;
         }
 
+        bool QueryShaderMaxThreads32()
+        {
+            return true;
+        }
+
         int QueryStorageBufferOffsetAlignment()
         {
             return 16;


### PR DESCRIPTION
AMD GPUs have a maximum of 64 threads per warp (or invocations per subgroup, in Khronos terms), unlike NVIDIA that has 32. Since the Switch has a NVIDIA GPU, the shaders are expecting 32 threads. In order to make them work on AMD, we need to sub-divide the 64 threads into 2 groups of 32. This change takes the extra threads into account, before this change, it just assumed that the GPU only had 32, and the other 32 were ignored, which can cause bugs.

This can fix artifacts on screen, flickering and other bugs on AMD for games that makes use of those operations.
**Note:** NVIDIA GPUs should not be affected by this change.
**Note 2:** Does NOT fix Monster Hunter Rise crash on Windows + AMD GPU.