### PR TITLE
Inline software keyboard without input pop up dialog

### DIFF
--- a/Ryujinx.HLE/DynamicTextChangedEvent.cs
+++ b/Ryujinx.HLE/DynamicTextChangedEvent.cs
@@ -1,0 +1,7 @@
+using Ryujinx.HLE.HOS.Applets;
+using Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.ApplicationProxy.Types;
+
+namespace Ryujinx.HLE
+{
+    public delegate void DynamicTextChangedEvent(string text, int cursorBegin, int cursorEnd, bool isAccept, bool isCancel);
+}

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineResponses.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/InlineResponses.cs
@@ -38,9 +38,12 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             return (uint)text.Length; // Return the cursor position at the end of the text
         }
 
-        private static void WriteStringWithCursor(string text, BinaryWriter writer, uint maxSize, Encoding encoding)
+        private static void WriteStringWithCursor(string text, uint cursor, BinaryWriter writer, uint maxSize, Encoding encoding)
         {
-            uint cursor = WriteString(text, writer, maxSize, encoding);
+            uint length = WriteString(text, writer, maxSize, encoding);
+
+            if (cursor > length)
+                cursor = length;
 
             writer.Write(cursor); // Cursor position
         }
@@ -72,7 +75,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             }
         }
 
-        public static byte[] ChangedString(string text, InlineKeyboardState state)
+        public static byte[] ChangedString(string text, uint cursor, InlineKeyboardState state)
         {
             uint resSize = 6 * sizeof(uint) + MaxStrLenUTF16;
 
@@ -80,7 +83,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
                 BeginResponse(state, InlineKeyboardResponse.ChangedString, writer);
-                WriteStringWithCursor(text, writer, MaxStrLenUTF16, Encoding.Unicode);
+                WriteStringWithCursor(text, cursor, writer, MaxStrLenUTF16, Encoding.Unicode);
                 writer.Write((int)0); // ?
                 writer.Write((int)0); // ?
 
@@ -88,7 +91,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             }
         }
 
-        public static byte[] MovedCursor(string text, InlineKeyboardState state)
+        public static byte[] MovedCursor(string text, uint cursor, InlineKeyboardState state)
         {
             uint resSize = 4 * sizeof(uint) + MaxStrLenUTF16;
 
@@ -96,13 +99,13 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
                 BeginResponse(state, InlineKeyboardResponse.MovedCursor, writer);
-                WriteStringWithCursor(text, writer, MaxStrLenUTF16, Encoding.Unicode);
+                WriteStringWithCursor(text, cursor, writer, MaxStrLenUTF16, Encoding.Unicode);
 
                 return stream.ToArray();
             }
         }
 
-        public static byte[] MovedTab(string text, InlineKeyboardState state)
+        public static byte[] MovedTab(string text, uint cursor, InlineKeyboardState state)
         {
             // Should be the same as MovedCursor.
 
@@ -112,7 +115,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
                 BeginResponse(state, InlineKeyboardResponse.MovedTab, writer);
-                WriteStringWithCursor(text, writer, MaxStrLenUTF16, Encoding.Unicode);
+                WriteStringWithCursor(text, cursor, writer, MaxStrLenUTF16, Encoding.Unicode);
 
                 return stream.ToArray();
             }
@@ -145,7 +148,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             }
         }
 
-        public static byte[] ChangedStringUtf8(string text, InlineKeyboardState state)
+        public static byte[] ChangedStringUtf8(string text, uint cursor, InlineKeyboardState state)
         {
             uint resSize = 6 * sizeof(uint) + MaxStrLenUTF8;
 
@@ -153,7 +156,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
                 BeginResponse(state, InlineKeyboardResponse.ChangedStringUtf8, writer);
-                WriteStringWithCursor(text, writer, MaxStrLenUTF8, Encoding.UTF8);
+                WriteStringWithCursor(text, cursor, writer, MaxStrLenUTF8, Encoding.UTF8);
                 writer.Write((int)0); // ?
                 writer.Write((int)0); // ?
 
@@ -161,7 +164,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             }
         }
 
-        public static byte[] MovedCursorUtf8(string text, InlineKeyboardState state)
+        public static byte[] MovedCursorUtf8(string text, uint cursor, InlineKeyboardState state)
         {
             uint resSize = 4 * sizeof(uint) + MaxStrLenUTF8;
 
@@ -169,7 +172,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
                 BeginResponse(state, InlineKeyboardResponse.MovedCursorUtf8, writer);
-                WriteStringWithCursor(text, writer, MaxStrLenUTF8, Encoding.UTF8);
+                WriteStringWithCursor(text, cursor, writer, MaxStrLenUTF8, Encoding.UTF8);
 
                 return stream.ToArray();
             }
@@ -228,7 +231,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             }
         }
 
-        public static byte[] ChangedStringV2(string text, InlineKeyboardState state)
+        public static byte[] ChangedStringV2(string text, uint cursor, InlineKeyboardState state)
         {
             uint resSize = 6 * sizeof(uint) + MaxStrLenUTF16 + 0x1;
 
@@ -236,7 +239,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
                 BeginResponse(state, InlineKeyboardResponse.ChangedStringV2, writer);
-                WriteStringWithCursor(text, writer, MaxStrLenUTF16, Encoding.Unicode);
+                WriteStringWithCursor(text, cursor, writer, MaxStrLenUTF16, Encoding.Unicode);
                 writer.Write((int)0); // ?
                 writer.Write((int)0); // ?
                 writer.Write((byte)0); // Flag == 0
@@ -245,7 +248,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             }
         }
 
-        public static byte[] MovedCursorV2(string text, InlineKeyboardState state)
+        public static byte[] MovedCursorV2(string text, uint cursor, InlineKeyboardState state)
         {
             uint resSize = 4 * sizeof(uint) + MaxStrLenUTF16 + 0x1;
 
@@ -253,14 +256,14 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
                 BeginResponse(state, InlineKeyboardResponse.MovedCursorV2, writer);
-                WriteStringWithCursor(text, writer, MaxStrLenUTF16, Encoding.Unicode);
+                WriteStringWithCursor(text, cursor, writer, MaxStrLenUTF16, Encoding.Unicode);
                 writer.Write((byte)0); // Flag == 0
 
                 return stream.ToArray();
             }
         }
 
-        public static byte[] ChangedStringUtf8V2(string text, InlineKeyboardState state)
+        public static byte[] ChangedStringUtf8V2(string text, uint cursor, InlineKeyboardState state)
         {
             uint resSize = 6 * sizeof(uint) + MaxStrLenUTF8 + 0x1;
 
@@ -268,7 +271,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
                 BeginResponse(state, InlineKeyboardResponse.ChangedStringUtf8V2, writer);
-                WriteStringWithCursor(text, writer, MaxStrLenUTF8, Encoding.UTF8);
+                WriteStringWithCursor(text, cursor, writer, MaxStrLenUTF8, Encoding.UTF8);
                 writer.Write((int)0); // ?
                 writer.Write((int)0); // ?
                 writer.Write((byte)0); // Flag == 0
@@ -277,7 +280,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             }
         }
 
-        public static byte[] MovedCursorUtf8V2(string text, InlineKeyboardState state)
+        public static byte[] MovedCursorUtf8V2(string text, uint cursor, InlineKeyboardState state)
         {
             uint resSize = 4 * sizeof(uint) + MaxStrLenUTF8 + 0x1;
 
@@ -285,7 +288,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
             using (BinaryWriter writer = new BinaryWriter(stream))
             {
                 BeginResponse(state, InlineKeyboardResponse.MovedCursorUtf8V2, writer);
-                WriteStringWithCursor(text, writer, MaxStrLenUTF8, Encoding.UTF8);
+                WriteStringWithCursor(text, cursor, writer, MaxStrLenUTF8, Encoding.UTF8);
                 writer.Write((byte)0); // Flag == 0
 
                 return stream.ToArray();

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardAppear.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardAppear.cs
@@ -10,11 +10,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
     {
         private const int OkTextLength = 8;
 
-        /// <summary>
-        /// Some games send a Calc without intention of showing the keyboard, a
-        /// common trend observed is that this field will be != 0 in such cases.
-        /// </summary>
-        public uint ShouldBeHidden;
+        public uint Unknown1;
 
         /// <summary>
         /// The string displayed in the Submit button.
@@ -57,7 +53,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
         /// <summary>
         /// [10.0.0+] If value is 1 or 2, then keytopAsFloating=0 and footerScalable=1 in Calc.
         /// </summary>
-        public byte Unknown1;
+        public byte Unknown2;
 
         public byte Padding4;
         public byte Padding5;

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardRenderer.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardRenderer.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Diagnostics;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
+{
+    /// <summary>
+    /// Class that generates the graphics for the software keyboard applet during inline mode.
+    /// </summary>
+    internal class SoftwareKeyboardRenderer
+    {
+        private static int _graphicsWidth = 0;
+        private static int _graphicsHeight = 0;
+        private static int _graphicsPitch = 0;
+        private static int _graphicsSize = 0;
+        private static byte[] _graphicsData = null;
+
+        internal static void RedrawGraphicsA8B8G8R8(int width, int height, int pitch, int size)
+        {
+            // Use the whole area of the image to draw, even the alignment, otherwise it will shear the final image.
+            int availableWidth = pitch / 4;
+            int availableHeight = size / pitch;
+
+            Debug.Assert(width <= availableWidth);
+            Debug.Assert(height <= availableHeight);
+            Debug.Assert(pitch * height <= size);
+
+            _graphicsWidth = width;
+            _graphicsHeight = height;
+            _graphicsPitch = pitch;
+            _graphicsSize = size;
+
+            // WARNING: The color format is wrong because the system uses ABGR instead of ARGB, but
+            // this is not a problem for black and white drawings.
+            Bitmap bitmap = new Bitmap(availableWidth, availableHeight, PixelFormat.Format32bppArgb);
+
+            using (var gfx = System.Drawing.Graphics.FromImage(bitmap))
+            {
+                gfx.Clear(Color.Transparent);
+                gfx.SmoothingMode = SmoothingMode.AntiAlias;
+                gfx.InterpolationMode = InterpolationMode.HighQualityBicubic;
+                gfx.PixelOffsetMode = PixelOffsetMode.HighQuality;
+
+                // The keyboard layer does not cover the entire visible area.
+                const float keyboardHeightPercent = 0.625f;
+                int keyboardHeight = (int)(keyboardHeightPercent * height);
+                int keyboardTop = height - keyboardHeight;
+                int keyboardWidth = width;
+                int keyboardLeft = 0;
+
+                RectangleF keyboardRectangle = new RectangleF(keyboardLeft, keyboardTop, keyboardWidth, keyboardHeight);
+
+                // Fill the keyboard area with a transparent black color.
+                SolidBrush backgroundBrush = new SolidBrush(Color.FromArgb(120, 0, 0, 0));
+                gfx.FillRectangle(backgroundBrush, keyboardRectangle);
+
+                string line1Text = "Please use the Keyboard to input text...";
+                string line2Text = "Press Return to accept or Page Up to cancel.";
+
+                // Draw the first line larger then the second.
+                System.Drawing.Font line1Font = new System.Drawing.Font("Tahoma", 40);
+                System.Drawing.Font line2Font = new System.Drawing.Font("Tahoma", 20);
+
+                // Draw the first line in the center of the rectangle area and the second away just below the first.
+                RectangleF line1Rectangle = keyboardRectangle;
+                RectangleF line2Rectangle = line1Rectangle;
+                line2Rectangle.Y += 45;
+
+                StringFormat stringFormat = new StringFormat(StringFormatFlags.NoClip);
+                stringFormat.LineAlignment = StringAlignment.Center;
+                stringFormat.Alignment = StringAlignment.Center;
+
+                gfx.DrawString(line1Text, line1Font, Brushes.White, line1Rectangle, stringFormat);
+                gfx.DrawString(line2Text, line2Font, Brushes.White, line2Rectangle, stringFormat);
+            }
+
+            Rectangle lockRectangle = new Rectangle(0, 0, bitmap.Width, bitmap.Height);
+            BitmapData data = bitmap.LockBits(lockRectangle, ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
+
+            Debug.Assert(data.Stride == pitch);
+
+            byte[] newGraphicsData = new byte[size];
+            Marshal.Copy(data.Scan0, newGraphicsData, 0, size);
+            Volatile.Write(ref _graphicsData, newGraphicsData);
+        }
+
+        internal static Span<byte> GetGraphicsA8B8G8R8(int width, int height, int pitch, int size)
+        {
+            if (_graphicsWidth != width || _graphicsHeight != height ||
+                _graphicsPitch != pitch || _graphicsSize != size)
+            {
+                RedrawGraphicsA8B8G8R8(width, height, pitch, size);
+            }
+
+            return _graphicsData;
+        }
+    }
+}

--- a/Ryujinx.HLE/HostTextInputChangedHandler.cs
+++ b/Ryujinx.HLE/HostTextInputChangedHandler.cs
@@ -1,0 +1,7 @@
+using Ryujinx.HLE.HOS.Applets;
+using Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.ApplicationProxy.Types;
+
+namespace Ryujinx.HLE
+{
+    public delegate void HostTextInputChangedHandler(string text, int cursorPosition, bool isAccept, bool isCancel);
+}

--- a/Ryujinx.HLE/IDynamicTextInputHandler.cs
+++ b/Ryujinx.HLE/IDynamicTextInputHandler.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Ryujinx.HLE
+{
+    public interface IDynamicTextInputHandler : IDisposable
+    {
+        event DynamicTextChangedEvent TextChanged;
+
+        void SetText(string text);
+        void SetMaxLength(int maxLength);
+    }
+}

--- a/Ryujinx.HLE/IHostUiHandler.cs
+++ b/Ryujinx.HLE/IHostUiHandler.cs
@@ -36,5 +36,11 @@ namespace Ryujinx.HLE
         /// </summary>
         /// <returns>False when OK is pressed, True when another button (Details) is pressed.</returns>
         bool DisplayErrorAppletDialog(string title, string message, string[] buttonsText);
+
+        /// <summary>
+        /// Creates a handler to process keyboard inputs into text strings.
+        /// </summary>
+        /// <returns>An instance of the text handler.</returns>
+        IDynamicTextInputHandler CreateDynamicTextInputHandler();
     }
 }

--- a/Ryujinx/Ui/Applet/GtkDynamicTextInputHandler.cs
+++ b/Ryujinx/Ui/Applet/GtkDynamicTextInputHandler.cs
@@ -1,0 +1,70 @@
+using Gtk;
+using Ryujinx.HLE;
+using Ryujinx.Ui.Widgets;
+
+namespace Ryujinx.Ui.Applet
+{
+    internal class GtkDynamicTextInputHandler : IDynamicTextInputHandler
+    {
+        private readonly Window _parent;
+        private readonly RawInputToTextEntry _inputToTextEntry = new RawInputToTextEntry();
+
+        public event DynamicTextChangedEvent TextChanged;
+
+        public GtkDynamicTextInputHandler(Window parent)
+        {
+            _parent = parent;
+            _parent.KeyPressEvent += HandleKeyPressEvent;
+            _parent.KeyReleaseEvent += HandleKeyReleaseEvent;
+        }
+
+        [GLib.ConnectBefore()]
+        private void HandleKeyPressEvent(object o, KeyPressEventArgs args)
+        {
+            if (args.Event.Key == Gdk.Key.Return)
+            {
+                InvokeTextChanged(true, false);
+                _inputToTextEntry.Text = "";
+            }
+            else if (args.Event.Key == Gdk.Key.Page_Up) // TODO other key?
+            {
+                InvokeTextChanged(false, true);
+                _inputToTextEntry.Text = "";
+            }
+            else
+            {
+                _inputToTextEntry.SendKeyPressEvent(o, args);
+                InvokeTextChanged(false, false);
+            }
+        }
+
+        private void InvokeTextChanged(bool isAccept, bool isCancel)
+        {
+            _inputToTextEntry.GetSelectionBounds(out int selectionStart, out int selectionEnd);
+            TextChanged?.Invoke(_inputToTextEntry.Text, selectionStart, selectionEnd, isAccept, isCancel);
+        }
+
+        [GLib.ConnectBefore()]
+        private void HandleKeyReleaseEvent(object o, KeyReleaseEventArgs args)
+        {
+            _inputToTextEntry.SendKeyReleaseEvent(o, args);
+        }
+
+        public void SetText(string text)
+        {
+            _inputToTextEntry.Text = text;
+            _inputToTextEntry.Position = text.Length;
+        }
+
+        public void SetMaxLength(int maxLength)
+        {
+            _inputToTextEntry.MaxLength = maxLength;
+        }
+
+        public void Dispose()
+        {
+            _parent.KeyPressEvent -= HandleKeyPressEvent;
+            _parent.KeyReleaseEvent -= HandleKeyReleaseEvent;
+        }
+    }
+}

--- a/Ryujinx/Ui/Applet/GtkHostUiHandler.cs
+++ b/Ryujinx/Ui/Applet/GtkHostUiHandler.cs
@@ -186,5 +186,10 @@ namespace Ryujinx.Ui.Applet
 
             return showDetails;
         }
+
+        public IDynamicTextInputHandler CreateDynamicTextInputHandler()
+        {
+            return new GtkDynamicTextInputHandler(_parent);
+        }
     }
 }

--- a/Ryujinx/Ui/Widgets/RawInputToTextEntry.cs
+++ b/Ryujinx/Ui/Widgets/RawInputToTextEntry.cs
@@ -1,0 +1,17 @@
+﻿using Gtk;
+
+namespace Ryujinx.Ui.Widgets
+{
+    public class RawInputToTextEntry : Entry
+    {
+        public void SendKeyPressEvent(object o, KeyPressEventArgs args)
+        {
+            base.OnKeyPressEvent(args.Event);
+        }
+
+        public void SendKeyReleaseEvent(object o, KeyReleaseEventArgs args)
+        {
+            base.OnKeyReleaseEvent(args.Event);
+        }
+    }
+}


### PR DESCRIPTION
This is the draft for the proof of concept that I posted on Discord a few days ago. The idea is to use the software keyboard in inline mode without the pop up dialog, since a way to display the text is already provided by the games.

The initial implementation already supports special characters, moving the text cursor with the arrow keys of the keyboard and a custom indirect layer to show the keyboard message:

![specialchars](https://user-images.githubusercontent.com/2220062/113651734-e9e81b80-9668-11eb-8da3-c488394ca7de.PNG)

This PR extends the `IHostUiHandler` interface to allow the creation of a `IDynamicTextInputHandler`, that reads raw data from the keyboard directly and converts it into text. Behind the scenes the key strokes are being forwarded to a custom `Gtk Entry` class.

The keyboard renderer takes advantage of the constant `A8B8G8R8` pixel format of the indirect layer to fill the bytes directly. It currently uses `System.Drawing` as a quick way to render text, but can be improved and refactored to perform more tasks and better integrate with the rendering mechanisms provided by Ryujinx.

The state machine used by the inline keyboard was also simplified, fixing a reported keyboard bug in Monster Hunter XX. This also seems to fix a soft-lock in Monster Hunter Gen U that happens when the player spams the key to show the keyboard.

The following items are still missing from the PR and will be implemented:

- Limit input text size according to Calc message;
- Initial input text according to Calc message;
- Failsafe in case of soft-lock;
- **Bug** Gnosia and Monster Hunter Rise do not update the text while typing (but it is correctly entered);