### PR TITLE
Initial support for the new 12.x IPC system

### DIFF
--- a/Ryujinx.HLE/Exceptions/ServiceNotImplementedException.cs
+++ b/Ryujinx.HLE/Exceptions/ServiceNotImplementedException.cs
@@ -18,24 +18,28 @@ namespace Ryujinx.HLE.Exceptions
         public ServiceCtx Context { get; }
         public IpcMessage Request { get; }
 
-        public ServiceNotImplementedException(IpcService service, ServiceCtx context)
-            : this(service, context, "The service call is not implemented.")
+        private bool _isTipcCommand;
+
+        public ServiceNotImplementedException(IpcService service, ServiceCtx context, bool isTipcCommand)
+            : this(service, context, "The service call is not implemented.", isTipcCommand)
         { }
 
-        public ServiceNotImplementedException(IpcService service, ServiceCtx context, string message)
+        public ServiceNotImplementedException(IpcService service, ServiceCtx context, string message, bool isTipcCommand)
             : base(message)
         {
             Service = service;
             Context = context;
             Request = context.Request;
+            _isTipcCommand = isTipcCommand;
         }
 
-        public ServiceNotImplementedException(IpcService service, ServiceCtx context, string message, Exception inner)
+        public ServiceNotImplementedException(IpcService service, ServiceCtx context, string message, Exception inner, bool isTipcCommand)
             : base(message, inner)
         {
             Service = service;
             Context = context;
             Request = context.Request;
+            _isTipcCommand = isTipcCommand;
         }
 
         protected ServiceNotImplementedException(SerializationInfo info, StreamingContext context)
@@ -62,7 +66,7 @@ namespace Ryujinx.HLE.Exceptions
 
             if (callingType != null && callingMethod != null)
             {
-                var ipcCommands = Service.HipcCommands;
+                var ipcCommands = _isTipcCommand ? Service.TipcCommands : Service.HipcCommands;
 
                 // Find the handler for the method called
                 var ipcHandler   = ipcCommands.FirstOrDefault(x => x.Value == callingMethod);

--- a/Ryujinx.HLE/Exceptions/ServiceNotImplementedException.cs
+++ b/Ryujinx.HLE/Exceptions/ServiceNotImplementedException.cs
@@ -62,7 +62,7 @@ namespace Ryujinx.HLE.Exceptions
 
             if (callingType != null && callingMethod != null)
             {
-                var ipcCommands = Service.Commands;
+                var ipcCommands = Service.HIpcCommands;
 
                 // Find the handler for the method called
                 var ipcHandler   = ipcCommands.FirstOrDefault(x => x.Value == callingMethod);

--- a/Ryujinx.HLE/Exceptions/ServiceNotImplementedException.cs
+++ b/Ryujinx.HLE/Exceptions/ServiceNotImplementedException.cs
@@ -62,7 +62,7 @@ namespace Ryujinx.HLE.Exceptions
 
             if (callingType != null && callingMethod != null)
             {
-                var ipcCommands = Service.HIpcCommands;
+                var ipcCommands = Service.HipcCommands;
 
                 // Find the handler for the method called
                 var ipcHandler   = ipcCommands.FirstOrDefault(x => x.Value == callingMethod);

--- a/Ryujinx.HLE/HOS/Ipc/IpcMessage.cs
+++ b/Ryujinx.HLE/HOS/Ipc/IpcMessage.cs
@@ -82,14 +82,18 @@ namespace Ryujinx.HLE.HOS.Ipc
 
             long recvListPos = reader.BaseStream.Position + rawDataSize;
 
-            long pad0 = GetPadSize16(reader.BaseStream.Position + cmdPtr);
-
-            if (rawDataSize != 0)
+            // only HIPC have the padding requirements.
+            if (Type < IpcMessageType.TipcCloseSession)
             {
-                rawDataSize -= (int)pad0;
-            }
+                long pad0 = GetPadSize16(reader.BaseStream.Position + cmdPtr);
 
-            reader.BaseStream.Seek(pad0, SeekOrigin.Current);
+                if (rawDataSize != 0)
+                {
+                    rawDataSize -= (int)pad0;
+                }
+
+                reader.BaseStream.Seek(pad0, SeekOrigin.Current);
+            }
 
             int recvListCount = recvListFlags - 2;
 

--- a/Ryujinx.HLE/HOS/Ipc/IpcMessageType.cs
+++ b/Ryujinx.HLE/HOS/Ipc/IpcMessageType.cs
@@ -8,5 +8,6 @@ namespace Ryujinx.HLE.HOS.Ipc
         HipcControl            = 5,
         HipcRequestWithContext = 6,
         HipcControlWithContext = 7,
+        TipcCloseSession       = 0xF
     }
 }

--- a/Ryujinx.HLE/HOS/Ipc/IpcMessageType.cs
+++ b/Ryujinx.HLE/HOS/Ipc/IpcMessageType.cs
@@ -2,11 +2,11 @@ namespace Ryujinx.HLE.HOS.Ipc
 {
     enum IpcMessageType
     {
-        Response           = 0,
-        CloseSession       = 2,
-        Request            = 4,
-        Control            = 5,
-        RequestWithContext = 6,
-        ControlWithContext = 7
+        HipcResponse           = 0,
+        HipcCloseSession       = 2,
+        HipcRequest            = 4,
+        HipcControl            = 5,
+        HipcRequestWithContext = 6,
+        HipcControlWithContext = 7,
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/AccountService/IManagerForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/AccountService/IManagerForApplication.cs
@@ -9,21 +9,21 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc.AccountService
             _managerServer = new ManagerServer(userId);
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // CheckAvailability()
         public ResultCode CheckAvailability(ServiceCtx context)
         {
             return _managerServer.CheckAvailability(context);
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetAccountId() -> nn::account::NetworkServiceAccountId
         public ResultCode GetAccountId(ServiceCtx context)
         {
             return _managerServer.GetAccountId(context);
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // EnsureIdTokenCacheAsync() -> object<nn::account::detail::IAsyncContext>
         public ResultCode EnsureIdTokenCacheAsync(ServiceCtx context)
         {
@@ -37,21 +37,21 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc.AccountService
             return resultCode;
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // LoadIdTokenCache() -> (u32 id_token_cache_size, buffer<bytes, 6>)
         public ResultCode LoadIdTokenCache(ServiceCtx context)
         {
             return _managerServer.LoadIdTokenCache(context);
         }
 
-        [Command(130)]
+        [CommandHipc(130)]
         // GetNintendoAccountUserResourceCacheForApplication() -> (nn::account::NintendoAccountId, nn::account::nas::NasUserBaseForApplication, buffer<bytes, 6>)
         public ResultCode GetNintendoAccountUserResourceCacheForApplication(ServiceCtx context)
         {
             return _managerServer.GetNintendoAccountUserResourceCacheForApplication(context);
         }
 
-        [Command(160)] // 5.0.0+
+        [CommandHipc(160)] // 5.0.0+
         // StoreOpenContext()
         public ResultCode StoreOpenContext(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/AccountService/IManagerForSystemService.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/AccountService/IManagerForSystemService.cs
@@ -9,21 +9,21 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc.AccountService
             _managerServer = new ManagerServer(userId);
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // CheckAvailability()
         public ResultCode CheckAvailability(ServiceCtx context)
         {
             return _managerServer.CheckAvailability(context);
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetAccountId() -> nn::account::NetworkServiceAccountId
         public ResultCode GetAccountId(ServiceCtx context)
         {
             return _managerServer.GetAccountId(context);
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // EnsureIdTokenCacheAsync() -> object<nn::account::detail::IAsyncContext>
         public ResultCode EnsureIdTokenCacheAsync(ServiceCtx context)
         {
@@ -37,7 +37,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc.AccountService
             return resultCode;
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // LoadIdTokenCache() -> (u32 id_token_cache_size, buffer<bytes, 6>)
         public ResultCode LoadIdTokenCache(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/AccountService/IProfile.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/AccountService/IProfile.cs
@@ -9,28 +9,28 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc.AccountService
             _profileServer = new ProfileServer(profile);
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // Get() -> (nn::account::profile::ProfileBase, buffer<nn::account::profile::UserData, 0x1a>)
         public ResultCode Get(ServiceCtx context)
         {
             return _profileServer.Get(context);
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetBase() -> nn::account::profile::ProfileBase
         public ResultCode GetBase(ServiceCtx context)
         {
             return _profileServer.GetBase(context);
         }
 
-        [Command(10)]
+        [CommandHipc(10)]
         // GetImageSize() -> u32
         public ResultCode GetImageSize(ServiceCtx context)
         {
             return _profileServer.GetImageSize(context);
         }
 
-        [Command(11)]
+        [CommandHipc(11)]
         // LoadImage() -> (u32, buffer<bytes, 6>)
         public ResultCode LoadImage(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/AccountService/IProfileEditor.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/AccountService/IProfileEditor.cs
@@ -9,42 +9,42 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc.AccountService
             _profileServer = new ProfileServer(profile);
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // Get() -> (nn::account::profile::ProfileBase, buffer<nn::account::profile::UserData, 0x1a>)
         public ResultCode Get(ServiceCtx context)
         {
             return _profileServer.Get(context);
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetBase() -> nn::account::profile::ProfileBase
         public ResultCode GetBase(ServiceCtx context)
         {
             return _profileServer.GetBase(context);
         }
 
-        [Command(10)]
+        [CommandHipc(10)]
         // GetImageSize() -> u32
         public ResultCode GetImageSize(ServiceCtx context)
         {
             return _profileServer.GetImageSize(context);
         }
 
-        [Command(11)]
+        [CommandHipc(11)]
         // LoadImage() -> (u32, buffer<bytes, 6>)
         public ResultCode LoadImage(ServiceCtx context)
         {
             return _profileServer.LoadImage(context);
         }
 
-        [Command(100)]
+        [CommandHipc(100)]
         // Store(nn::account::profile::ProfileBase, buffer<nn::account::profile::UserData, 0x19>)
         public ResultCode Store(ServiceCtx context)
         {
             return _profileServer.Store(context);
         }
 
-        [Command(101)]
+        [CommandHipc(101)]
         // StoreWithImage(nn::account::profile::ProfileBase, buffer<nn::account::profile::UserData, 0x19>, buffer<bytes, 5>)
         public ResultCode StoreWithImage(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForAdministrator.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForAdministrator.cs
@@ -14,42 +14,42 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             _applicationServiceServer = new ApplicationServiceServer(serviceFlag);
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetUserCount() -> i32
         public ResultCode GetUserCount(ServiceCtx context)
         {
             return _applicationServiceServer.GetUserCountImpl(context);
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetUserExistence(nn::account::Uid) -> bool
         public ResultCode GetUserExistence(ServiceCtx context)
         {
             return _applicationServiceServer.GetUserExistenceImpl(context);
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // ListAllUsers() -> array<nn::account::Uid, 0xa>
         public ResultCode ListAllUsers(ServiceCtx context)
         {
             return _applicationServiceServer.ListAllUsers(context);
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // ListOpenUsers() -> array<nn::account::Uid, 0xa>
         public ResultCode ListOpenUsers(ServiceCtx context)
         {
             return _applicationServiceServer.ListOpenUsers(context);
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // GetLastOpenedUser() -> nn::account::Uid
         public ResultCode GetLastOpenedUser(ServiceCtx context)
         {
             return _applicationServiceServer.GetLastOpenedUser(context);
         }
 
-        [Command(5)]
+        [CommandHipc(5)]
         // GetProfile(nn::account::Uid) -> object<nn::account::profile::IProfile>
         public ResultCode GetProfile(ServiceCtx context)
         {
@@ -63,7 +63,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             return resultCode;
         }
 
-        [Command(50)]
+        [CommandHipc(50)]
         // IsUserRegistrationRequestPermitted(pid) -> bool
         public ResultCode IsUserRegistrationRequestPermitted(ServiceCtx context)
         {
@@ -72,14 +72,14 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             return _applicationServiceServer.IsUserRegistrationRequestPermitted(context);
         }
 
-        [Command(51)]
+        [CommandHipc(51)]
         // TrySelectUserWithoutInteraction(bool) -> nn::account::Uid
         public ResultCode TrySelectUserWithoutInteraction(ServiceCtx context)
         {
             return _applicationServiceServer.TrySelectUserWithoutInteraction(context);
         }
 
-        [Command(102)]
+        [CommandHipc(102)]
         // GetBaasAccountManagerForSystemService(nn::account::Uid) -> object<nn::account::baas::IManagerForApplication>
         public ResultCode GetBaasAccountManagerForSystemService(ServiceCtx context)
         {
@@ -98,14 +98,14 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             return ResultCode.Success;
         }
 
-        [Command(140)] // 6.0.0+
+        [CommandHipc(140)] // 6.0.0+
         // ListQualifiedUsers() -> array<nn::account::Uid, 0xa>
         public ResultCode ListQualifiedUsers(ServiceCtx context)
         {
             return _applicationServiceServer.ListQualifiedUsers(context);
         }
 
-        [Command(205)]
+        [CommandHipc(205)]
         // GetProfileEditor(nn::account::Uid) -> object<nn::account::profile::IProfileEditor>
         public ResultCode GetProfileEditor(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
@@ -15,42 +15,42 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             _applicationServiceServer = new ApplicationServiceServer(serviceFlag);
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetUserCount() -> i32
         public ResultCode GetUserCount(ServiceCtx context)
         {
             return _applicationServiceServer.GetUserCountImpl(context);
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetUserExistence(nn::account::Uid) -> bool
         public ResultCode GetUserExistence(ServiceCtx context)
         {
             return _applicationServiceServer.GetUserExistenceImpl(context);
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // ListAllUsers() -> array<nn::account::Uid, 0xa>
         public ResultCode ListAllUsers(ServiceCtx context)
         {
             return _applicationServiceServer.ListAllUsers(context);
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // ListOpenUsers() -> array<nn::account::Uid, 0xa>
         public ResultCode ListOpenUsers(ServiceCtx context)
         {
             return _applicationServiceServer.ListOpenUsers(context);
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // GetLastOpenedUser() -> nn::account::Uid
         public ResultCode GetLastOpenedUser(ServiceCtx context)
         {
             return _applicationServiceServer.GetLastOpenedUser(context);
         }
 
-        [Command(5)]
+        [CommandHipc(5)]
         // GetProfile(nn::account::Uid) -> object<nn::account::profile::IProfile>
         public ResultCode GetProfile(ServiceCtx context)
         {
@@ -64,7 +64,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             return resultCode;
         }
 
-        [Command(50)]
+        [CommandHipc(50)]
         // IsUserRegistrationRequestPermitted(pid) -> bool
         public ResultCode IsUserRegistrationRequestPermitted(ServiceCtx context)
         {
@@ -72,15 +72,15 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             return _applicationServiceServer.IsUserRegistrationRequestPermitted(context);
         }
 
-        [Command(51)]
+        [CommandHipc(51)]
         // TrySelectUserWithoutInteraction(bool) -> nn::account::Uid
         public ResultCode TrySelectUserWithoutInteraction(ServiceCtx context)
         {
             return _applicationServiceServer.TrySelectUserWithoutInteraction(context);
         }
 
-        [Command(100)]
-        [Command(140)] // 6.0.0+
+        [CommandHipc(100)]
+        [CommandHipc(140)] // 6.0.0+
         // InitializeApplicationInfo(u64 pid_placeholder, pid)
         public ResultCode InitializeApplicationInfo(ServiceCtx context)
         {
@@ -105,7 +105,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             return ResultCode.Success;
         }
 
-        [Command(101)]
+        [CommandHipc(101)]
         // GetBaasAccountManagerForApplication(nn::account::Uid) -> object<nn::account::baas::IManagerForApplication>
         public ResultCode GetBaasAccountManagerForApplication(ServiceCtx context)
         {
@@ -124,21 +124,21 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             return ResultCode.Success;
         }
 
-        [Command(110)]
+        [CommandHipc(110)]
         // StoreSaveDataThumbnail(nn::account::Uid, buffer<bytes, 5>)
         public ResultCode StoreSaveDataThumbnail(ServiceCtx context)
         {
             return _applicationServiceServer.StoreSaveDataThumbnail(context);
         }
 
-        [Command(111)]
+        [CommandHipc(111)]
         // ClearSaveDataThumbnail(nn::account::Uid)
         public ResultCode ClearSaveDataThumbnail(ServiceCtx context)
         {
             return _applicationServiceServer.ClearSaveDataThumbnail(context);
         }
 
-        [Command(131)] // 6.0.0+
+        [CommandHipc(131)] // 6.0.0+
         // ListOpenContextStoredUsers() -> array<nn::account::Uid, 0xa>
         public ResultCode ListOpenContextStoredUsers(ServiceCtx context)
         {
@@ -154,14 +154,14 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             return ResultCode.Success;
         }
 
-        [Command(141)] // 6.0.0+
+        [CommandHipc(141)] // 6.0.0+
         // ListQualifiedUsers() -> array<nn::account::Uid, 0xa>
         public ResultCode ListQualifiedUsers(ServiceCtx context)
         {
             return _applicationServiceServer.ListQualifiedUsers(context);
         }
 
-        [Command(150)] // 6.0.0+
+        [CommandHipc(150)] // 6.0.0+
         // IsUserAccountSwitchLocked() -> bool
         public ResultCode IsUserAccountSwitchLocked(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForSystemService.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForSystemService.cs
@@ -13,42 +13,42 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             _applicationServiceServer = new ApplicationServiceServer(serviceFlag);
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetUserCount() -> i32
         public ResultCode GetUserCount(ServiceCtx context)
         {
             return _applicationServiceServer.GetUserCountImpl(context);
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetUserExistence(nn::account::Uid) -> bool
         public ResultCode GetUserExistence(ServiceCtx context)
         {
             return _applicationServiceServer.GetUserExistenceImpl(context);
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // ListAllUsers() -> array<nn::account::Uid, 0xa>
         public ResultCode ListAllUsers(ServiceCtx context)
         {
             return _applicationServiceServer.ListAllUsers(context);
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // ListOpenUsers() -> array<nn::account::Uid, 0xa>
         public ResultCode ListOpenUsers(ServiceCtx context)
         {
             return _applicationServiceServer.ListOpenUsers(context);
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // GetLastOpenedUser() -> nn::account::Uid
         public ResultCode GetLastOpenedUser(ServiceCtx context)
         {
             return _applicationServiceServer.GetLastOpenedUser(context);
         }
 
-        [Command(5)]
+        [CommandHipc(5)]
         // GetProfile(nn::account::Uid) -> object<nn::account::profile::IProfile>
         public ResultCode GetProfile(ServiceCtx context)
         {
@@ -62,7 +62,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             return resultCode;
         }
 
-        [Command(50)]
+        [CommandHipc(50)]
         // IsUserRegistrationRequestPermitted(pid) -> bool
         public ResultCode IsUserRegistrationRequestPermitted(ServiceCtx context)
         {
@@ -71,14 +71,14 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             return _applicationServiceServer.IsUserRegistrationRequestPermitted(context);
         }
 
-        [Command(51)]
+        [CommandHipc(51)]
         // TrySelectUserWithoutInteraction(bool) -> nn::account::Uid
         public ResultCode TrySelectUserWithoutInteraction(ServiceCtx context)
         {
             return _applicationServiceServer.TrySelectUserWithoutInteraction(context);
         }
 
-        [Command(102)]
+        [CommandHipc(102)]
         // GetBaasAccountManagerForSystemService(nn::account::Uid) -> object<nn::account::baas::IManagerForApplication>
         public ResultCode GetBaasAccountManagerForSystemService(ServiceCtx context)
         {
@@ -97,7 +97,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             return ResultCode.Success;
         }
 
-        [Command(140)] // 6.0.0+
+        [CommandHipc(140)] // 6.0.0+
         // ListQualifiedUsers() -> array<nn::account::Uid, 0xa>
         public ResultCode ListQualifiedUsers(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/IAsyncContext.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/IAsyncContext.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             _asyncExecution = asyncExecution;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetSystemEvent() -> handle<copy>
         public ResultCode GetSystemEvent(ServiceCtx context)
         {
@@ -28,7 +28,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // Cancel()
         public ResultCode Cancel(ServiceCtx context)
         {
@@ -45,7 +45,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             return ResultCode.Success;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // HasDone() -> b8
         public ResultCode HasDone(ServiceCtx context)
         {
@@ -59,7 +59,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             return ResultCode.Success;
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // GetResult()
         public ResultCode GetResult(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/ISystemAppletProxy.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/ISystemAppletProxy.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService
             _pid = pid;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetCommonStateGetter() -> object<nn::am::service::ICommonStateGetter>
         public ResultCode GetCommonStateGetter(ServiceCtx context)
         {
@@ -20,7 +20,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetSelfController() -> object<nn::am::service::ISelfController>
         public ResultCode GetSelfController(ServiceCtx context)
         {
@@ -29,7 +29,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService
             return ResultCode.Success;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // GetWindowController() -> object<nn::am::service::IWindowController>
         public ResultCode GetWindowController(ServiceCtx context)
         {
@@ -38,7 +38,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService
             return ResultCode.Success;
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // GetAudioController() -> object<nn::am::service::IAudioController>
         public ResultCode GetAudioController(ServiceCtx context)
         {
@@ -47,7 +47,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService
             return ResultCode.Success;
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // GetDisplayController() -> object<nn::am::service::IDisplayController>
         public ResultCode GetDisplayController(ServiceCtx context)
         {
@@ -56,7 +56,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService
             return ResultCode.Success;
         }
 
-        [Command(11)]
+        [CommandHipc(11)]
         // GetLibraryAppletCreator() -> object<nn::am::service::ILibraryAppletCreator>
         public ResultCode GetLibraryAppletCreator(ServiceCtx context)
         {
@@ -65,7 +65,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService
             return ResultCode.Success;
         }
 
-        [Command(20)]
+        [CommandHipc(20)]
         // GetHomeMenuFunctions() -> object<nn::am::service::IHomeMenuFunctions>
         public ResultCode GetHomeMenuFunctions(ServiceCtx context)
         {
@@ -74,7 +74,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService
             return ResultCode.Success;
         }
 
-        [Command(21)]
+        [CommandHipc(21)]
         // GetGlobalStateController() -> object<nn::am::service::IGlobalStateController>
         public ResultCode GetGlobalStateController(ServiceCtx context)
         {
@@ -83,7 +83,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService
             return ResultCode.Success;
         }
 
-        [Command(22)]
+        [CommandHipc(22)]
         // GetApplicationCreator() -> object<nn::am::service::IApplicationCreator>
         public ResultCode GetApplicationCreator(ServiceCtx context)
         {
@@ -92,7 +92,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService
             return ResultCode.Success;
         }
 
-        [Command(1000)]
+        [CommandHipc(1000)]
         // GetDebugFunctions() -> object<nn::am::service::IDebugFunctions>
         public ResultCode GetDebugFunctions(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/LibraryAppletCreator/ILibraryAppletAccessor.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/LibraryAppletCreator/ILibraryAppletAccessor.cs
@@ -60,7 +60,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Lib
             _interactiveOutDataEvent.WritableEvent.Signal();
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetAppletStateChangedEvent() -> handle<copy>
         public ResultCode GetAppletStateChangedEvent(ServiceCtx context)
         {
@@ -77,14 +77,14 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Lib
             return ResultCode.Success;
         }
 
-        [Command(10)]
+        [CommandHipc(10)]
         // Start()
         public ResultCode Start(ServiceCtx context)
         {
             return (ResultCode)_applet.Start(_normalSession.GetConsumer(), _interactiveSession.GetConsumer());
         }
 
-        [Command(20)]
+        [CommandHipc(20)]
         // RequestExit()
         public ResultCode RequestExit(ServiceCtx context)
         {
@@ -96,14 +96,14 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Lib
             return ResultCode.Success;
         }
 
-        [Command(30)]
+        [CommandHipc(30)]
         // GetResult()
         public ResultCode GetResult(ServiceCtx context)
         {
             return (ResultCode)_applet.GetResult();
         }
 
-        [Command(60)]
+        [CommandHipc(60)]
         // PresetLibraryAppletGpuTimeSliceZero()
         public ResultCode PresetLibraryAppletGpuTimeSliceZero(ServiceCtx context)
         {
@@ -116,7 +116,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Lib
             return ResultCode.Success;
         }
 
-        [Command(100)]
+        [CommandHipc(100)]
         // PushInData(object<nn::am::service::IStorage>)
         public ResultCode PushInData(ServiceCtx context)
         {
@@ -127,7 +127,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Lib
             return ResultCode.Success;
         }
 
-        [Command(101)]
+        [CommandHipc(101)]
         // PopOutData() -> object<nn::am::service::IStorage>
         public ResultCode PopOutData(ServiceCtx context)
         {
@@ -143,7 +143,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Lib
             return ResultCode.NotAvailable;
         }
 
-        [Command(103)]
+        [CommandHipc(103)]
         // PushInteractiveInData(object<nn::am::service::IStorage>)
         public ResultCode PushInteractiveInData(ServiceCtx context)
         {
@@ -154,7 +154,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Lib
             return ResultCode.Success;
         }
 
-        [Command(104)]
+        [CommandHipc(104)]
         // PopInteractiveOutData() -> object<nn::am::service::IStorage>
         public ResultCode PopInteractiveOutData(ServiceCtx context)
         {
@@ -170,7 +170,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Lib
             return ResultCode.NotAvailable;
         }
 
-        [Command(105)]
+        [CommandHipc(105)]
         // GetPopOutDataEvent() -> handle<copy>
         public ResultCode GetPopOutDataEvent(ServiceCtx context)
         {
@@ -187,7 +187,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Lib
             return ResultCode.Success;
         }
 
-        [Command(106)]
+        [CommandHipc(106)]
         // GetPopInteractiveOutDataEvent() -> handle<copy>
         public ResultCode GetPopInteractiveOutDataEvent(ServiceCtx context)
         {
@@ -204,21 +204,21 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Lib
             return ResultCode.Success;
         }
 
-        [Command(110)]
+        [CommandHipc(110)]
         // NeedsToExitProcess()
         public ResultCode NeedsToExitProcess(ServiceCtx context)
         {
             return ResultCode.Stubbed;
         }
 
-        [Command(150)]
+        [CommandHipc(150)]
         // RequestForAppletToGetForeground()
         public ResultCode RequestForAppletToGetForeground(ServiceCtx context)
         {
             return ResultCode.Stubbed;
         }
 
-        [Command(160)] // 2.0.0+
+        [CommandHipc(160)] // 2.0.0+
         // GetIndirectLayerConsumerHandle() -> u64 indirect_layer_consumer_handle
         public ResultCode GetIndirectLayerConsumerHandle(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/IAudioController.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/IAudioController.cs
@@ -6,7 +6,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
     {
         public IAudioController() { }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // SetExpectedMasterVolume(f32, f32)
         public ResultCode SetExpectedMasterVolume(ServiceCtx context)
         {
@@ -18,7 +18,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetMainAppletExpectedMasterVolume() -> f32
         public ResultCode GetMainAppletExpectedMasterVolume(ServiceCtx context)
         {
@@ -29,7 +29,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // GetLibraryAppletExpectedMasterVolume() -> f32
         public ResultCode GetLibraryAppletExpectedMasterVolume(ServiceCtx context)
         {
@@ -40,7 +40,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // ChangeMainAppletMasterVolume(f32, u64)
         public ResultCode ChangeMainAppletMasterVolume(ServiceCtx context)
         {
@@ -52,7 +52,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // SetTransparentVolumeRate(f32)
         public ResultCode SetTransparentVolumeRate(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
@@ -27,7 +27,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             _lblControllerServer    = new Lbl.LblControllerServer(context);
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetEventHandle() -> handle<copy>
         public ResultCode GetEventHandle(ServiceCtx context)
         {
@@ -46,7 +46,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // ReceiveMessage() -> nn::am::AppletMessage
         public ResultCode ReceiveMessage(ServiceCtx context)
         {
@@ -74,7 +74,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(5)]
+        [CommandHipc(5)]
         // GetOperationMode() -> u8
         public ResultCode GetOperationMode(ServiceCtx context)
         {
@@ -87,14 +87,14 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(6)]
+        [CommandHipc(6)]
         // GetPerformanceMode() -> nn::apm::PerformanceMode
         public ResultCode GetPerformanceMode(ServiceCtx context)
         {
             return (ResultCode)_apmManagerServer.GetPerformanceMode(context);
         }
 
-        [Command(8)]
+        [CommandHipc(8)]
         // GetBootMode() -> u8
         public ResultCode GetBootMode(ServiceCtx context)
         {
@@ -105,7 +105,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(9)]
+        [CommandHipc(9)]
         // GetCurrentFocusState() -> u8
         public ResultCode GetCurrentFocusState(ServiceCtx context)
         {
@@ -114,7 +114,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(50)] // 3.0.0+
+        [CommandHipc(50)] // 3.0.0+
         // IsVrModeEnabled() -> b8
         public ResultCode IsVrModeEnabled(ServiceCtx context)
         {
@@ -123,7 +123,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(51)] // 3.0.0+
+        [CommandHipc(51)] // 3.0.0+
         // SetVrModeEnabled(b8)
         public ResultCode SetVrModeEnabled(ServiceCtx context)
         {
@@ -134,7 +134,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(52)] // 4.0.0+
+        [CommandHipc(52)] // 4.0.0+
         // SetLcdBacklighOffEnabled(b8)
         public ResultCode SetLcdBacklighOffEnabled(ServiceCtx context)
         {
@@ -148,7 +148,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(53)] // 7.0.0+
+        [CommandHipc(53)] // 7.0.0+
         // BeginVrModeEx()
         public ResultCode BeginVrModeEx(ServiceCtx context)
         {
@@ -157,7 +157,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(54)] // 7.0.0+
+        [CommandHipc(54)] // 7.0.0+
         // EndVrModeEx()
         public ResultCode EndVrModeEx(ServiceCtx context)
         {
@@ -187,7 +187,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             // TODO: It signals an internal event of ICommonStateGetter. We have to determine where this event is used.
         }
 
-        [Command(60)] // 3.0.0+
+        [CommandHipc(60)] // 3.0.0+
         // GetDefaultDisplayResolution() -> (u32, u32)
         public ResultCode GetDefaultDisplayResolution(ServiceCtx context)
         {
@@ -197,7 +197,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(61)] // 3.0.0+
+        [CommandHipc(61)] // 3.0.0+
         // GetDefaultDisplayResolutionChangeEvent() -> handle<copy>
         public ResultCode GetDefaultDisplayResolutionChangeEvent(ServiceCtx context)
         {
@@ -216,7 +216,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(66)] // 6.0.0+
+        [CommandHipc(66)] // 6.0.0+
         // SetCpuBoostMode(u32 cpu_boost_mode)
         public ResultCode SetCpuBoostMode(ServiceCtx context)
         {
@@ -234,14 +234,14 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(91)] // 7.0.0+
+        [CommandHipc(91)] // 7.0.0+
         // GetCurrentPerformanceConfiguration() -> nn::apm::PerformanceConfiguration
         public ResultCode GetCurrentPerformanceConfiguration(ServiceCtx context)
         {
             return (ResultCode)_apmSystemManagerServer.GetCurrentPerformanceConfiguration(context);
         }
 
-        [Command(900)] // 11.0.0+
+        [CommandHipc(900)] // 11.0.0+
         // SetRequestExitToLibraryAppletAtExecuteNextProgramEnabled()
         public ResultCode SetRequestExitToLibraryAppletAtExecuteNextProgramEnabled(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/IHomeMenuFunctions.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/IHomeMenuFunctions.cs
@@ -17,7 +17,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             _channelEvent = new KEvent(system.KernelContext);
         }
 
-        [Command(10)]
+        [CommandHipc(10)]
         // RequestToGetForeground()
         public ResultCode RequestToGetForeground(ServiceCtx context)
         {
@@ -26,7 +26,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(21)]
+        [CommandHipc(21)]
         // GetPopFromGeneralChannelEvent() -> handle<copy>
         public ResultCode GetPopFromGeneralChannelEvent(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ILibraryAppletCreator.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ILibraryAppletCreator.cs
@@ -8,7 +8,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
     {
         public ILibraryAppletCreator() { }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // CreateLibraryApplet(u32, u32) -> object<nn::am::service::ILibraryAppletAccessor>
         public ResultCode CreateLibraryApplet(ServiceCtx context)
         {
@@ -20,7 +20,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(10)]
+        [CommandHipc(10)]
         // CreateStorage(u64) -> object<nn::am::service::IStorage>
         public ResultCode CreateStorage(ServiceCtx context)
         {
@@ -38,7 +38,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(11)]
+        [CommandHipc(11)]
         // CreateTransferMemoryStorage(b8, u64, handle<copy>) -> object<nn::am::service::IStorage>
         public ResultCode CreateTransferMemoryStorage(ServiceCtx context)
         {
@@ -64,7 +64,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(12)] // 2.0.0+
+        [CommandHipc(12)] // 2.0.0+
         // CreateHandleStorage(u64, handle<copy>) -> object<nn::am::service::IStorage>
         public ResultCode CreateHandleStorage(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ISelfController.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ISelfController.cs
@@ -41,7 +41,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             _pid = pid;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // Exit()
         public ResultCode Exit(ServiceCtx context)
         {
@@ -50,7 +50,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // LockExit()
         public ResultCode LockExit(ServiceCtx context)
         {
@@ -59,7 +59,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // UnlockExit()
         public ResultCode UnlockExit(ServiceCtx context)
         {
@@ -68,7 +68,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(3)] // 2.0.0+
+        [CommandHipc(3)] // 2.0.0+
         // EnterFatalSection()
         public ResultCode EnterFatalSection(ServiceCtx context)
         {
@@ -80,7 +80,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(4)] // 2.0.0+
+        [CommandHipc(4)] // 2.0.0+
         // LeaveFatalSection()
         public ResultCode LeaveFatalSection(ServiceCtx context)
         {
@@ -101,7 +101,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return result;
         }
 
-        [Command(9)]
+        [CommandHipc(9)]
         // GetLibraryAppletLaunchableEvent() -> handle<copy>
         public ResultCode GetLibraryAppletLaunchableEvent(ServiceCtx context)
         {
@@ -122,7 +122,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(10)]
+        [CommandHipc(10)]
         // SetScreenShotPermission(u32)
         public ResultCode SetScreenShotPermission(ServiceCtx context)
         {
@@ -135,7 +135,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(11)]
+        [CommandHipc(11)]
         // SetOperationModeChangedNotification(b8)
         public ResultCode SetOperationModeChangedNotification(ServiceCtx context)
         {
@@ -148,7 +148,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(12)]
+        [CommandHipc(12)]
         // SetPerformanceModeChangedNotification(b8)
         public ResultCode SetPerformanceModeChangedNotification(ServiceCtx context)
         {
@@ -161,7 +161,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(13)]
+        [CommandHipc(13)]
         // SetFocusHandlingMode(b8, b8, b8)
         public ResultCode SetFocusHandlingMode(ServiceCtx context)
         {
@@ -174,7 +174,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(14)]
+        [CommandHipc(14)]
         // SetRestartMessageEnabled(b8)
         public ResultCode SetRestartMessageEnabled(ServiceCtx context)
         {
@@ -187,7 +187,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(16)] // 2.0.0+
+        [CommandHipc(16)] // 2.0.0+
         // SetOutOfFocusSuspendingEnabled(b8)
         public ResultCode SetOutOfFocusSuspendingEnabled(ServiceCtx context)
         {
@@ -200,7 +200,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(19)] // 3.0.0+
+        [CommandHipc(19)] // 3.0.0+
         // SetScreenShotImageOrientation(u32)
         public ResultCode SetScreenShotImageOrientation(ServiceCtx context)
         {
@@ -213,7 +213,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(40)]
+        [CommandHipc(40)]
         // CreateManagedDisplayLayer() -> u64
         public ResultCode CreateManagedDisplayLayer(ServiceCtx context)
         {
@@ -225,7 +225,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(44)] // 10.0.0+
+        [CommandHipc(44)] // 10.0.0+
         // CreateManagedDisplaySeparableLayer() -> (u64, u64)
         public ResultCode CreateManagedDisplaySeparableLayer(ServiceCtx context)
         {
@@ -239,7 +239,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(50)]
+        [CommandHipc(50)]
         // SetHandlesRequestToDisplay(b8)
         public ResultCode SetHandlesRequestToDisplay(ServiceCtx context)
         {
@@ -252,7 +252,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(62)]
+        [CommandHipc(62)]
         // SetIdleTimeDetectionExtension(u32)
         public ResultCode SetIdleTimeDetectionExtension(ServiceCtx context)
         {
@@ -265,7 +265,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(63)]
+        [CommandHipc(63)]
         // GetIdleTimeDetectionExtension() -> u32
         public ResultCode GetIdleTimeDetectionExtension(ServiceCtx context)
         {
@@ -276,7 +276,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(68)]
+        [CommandHipc(68)]
         // SetAutoSleepDisabled(u8)
         public ResultCode SetAutoSleepDisabled(ServiceCtx context)
         {
@@ -287,7 +287,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(69)]
+        [CommandHipc(69)]
         // IsAutoSleepDisabled() -> u8
         public ResultCode IsAutoSleepDisabled(ServiceCtx context)
         {
@@ -296,7 +296,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(90)] // 6.0.0+
+        [CommandHipc(90)] // 6.0.0+
         // GetAccumulatedSuspendedTickValue() -> u64
         public ResultCode GetAccumulatedSuspendedTickValue(ServiceCtx context)
         {
@@ -305,7 +305,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(91)] // 6.0.0+
+        [CommandHipc(91)] // 6.0.0+
         // GetAccumulatedSuspendedTickChangedEvent() -> handle<copy>
         public ResultCode GetAccumulatedSuspendedTickChangedEvent(ServiceCtx context)
         {
@@ -326,7 +326,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(100)] // 7.0.0+
+        [CommandHipc(100)] // 7.0.0+
         // SetAlbumImageTakenNotificationEnabled(u8)
         public ResultCode SetAlbumImageTakenNotificationEnabled(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/IWindowController.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/IWindowController.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             _pid = pid;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetAppletResourceUserId() -> nn::applet::AppletResourceUserId
         public ResultCode GetAppletResourceUserId(ServiceCtx context)
         {
@@ -24,7 +24,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return ResultCode.Success;
         }
 
-        [Command(10)]
+        [CommandHipc(10)]
         // AcquireForegroundRights()
         public ResultCode AcquireForegroundRights(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/IAllSystemAppletProxiesService.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/IAllSystemAppletProxiesService.cs
@@ -7,7 +7,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE
     {
         public IAllSystemAppletProxiesService(ServiceCtx context) { }
 
-        [Command(100)]
+        [CommandHipc(100)]
         // OpenSystemAppletProxy(u64, pid, handle<copy>) -> object<nn::am::service::ISystemAppletProxy>
         public ResultCode OpenSystemAppletProxy(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/IStorage.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/IStorage.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE
             Data       = data;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // Open() -> object<nn::am::service::IStorageAccessor>
         public ResultCode Open(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/IStorageAccessor.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/IStorageAccessor.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE
             _storage = storage;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetSize() -> u64
         public ResultCode GetSize(ServiceCtx context)
         {
@@ -20,7 +20,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE
             return ResultCode.Success;
         }
 
-        [Command(10)]
+        [CommandHipc(10)]
         // Write(u64, buffer<bytes, 0x21>)
         public ResultCode Write(ServiceCtx context)
         {
@@ -59,7 +59,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE
             return ResultCode.Success;
         }
 
-        [Command(11)]
+        [CommandHipc(11)]
         // Read(u64) -> buffer<bytes, 0x22>
         public ResultCode Read(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
@@ -43,7 +43,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             _healthWarningDisappearedSystemEvent = new KEvent(system.KernelContext);
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // PopLaunchParameter(LaunchParameterKind kind) -> object<nn::am::service::IStorage>
         public ResultCode PopLaunchParameter(ServiceCtx context)
         {
@@ -76,7 +76,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return ResultCode.Success;
         }
 
-        [Command(20)]
+        [CommandHipc(20)]
         // EnsureSaveData(nn::account::Uid) -> u64
         public ResultCode EnsureSaveData(ServiceCtx context)
         {
@@ -108,7 +108,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return (ResultCode)result.Value;
         }
 
-        [Command(21)]
+        [CommandHipc(21)]
         // GetDesiredLanguage() -> nn::settings::LanguageCode
         public ResultCode GetDesiredLanguage(ServiceCtx context)
         {
@@ -145,7 +145,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return ResultCode.Success;
         }
 
-        [Command(22)]
+        [CommandHipc(22)]
         // SetTerminateResult(u32)
         public ResultCode SetTerminateResult(ServiceCtx context)
         {
@@ -156,7 +156,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return ResultCode.Success;
         }
 
-        [Command(23)]
+        [CommandHipc(23)]
         // GetDisplayVersion() -> nn::oe::DisplayVersion
         public ResultCode GetDisplayVersion(ServiceCtx context)
         {
@@ -167,7 +167,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return ResultCode.Success;
         }
 
-        [Command(26)] // 3.0.0+
+        [CommandHipc(26)] // 3.0.0+
         // GetSaveDataSize(u8 save_data_type, nn::account::Uid) -> (u64 save_size, u64 journal_size)
         public ResultCode GetSaveDataSize(ServiceCtx context)
         {
@@ -186,7 +186,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return ResultCode.Success;
         }
 
-        [Command(30)]
+        [CommandHipc(30)]
         // BeginBlockingHomeButtonShortAndLongPressed()
         public ResultCode BeginBlockingHomeButtonShortAndLongPressed(ServiceCtx context)
         {
@@ -197,7 +197,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return ResultCode.Success;
         }
 
-        [Command(31)]
+        [CommandHipc(31)]
         // EndBlockingHomeButtonShortAndLongPressed()
         public ResultCode EndBlockingHomeButtonShortAndLongPressed(ServiceCtx context)
         {
@@ -208,7 +208,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return ResultCode.Success;
         }
 
-        [Command(32)] // 2.0.0+
+        [CommandHipc(32)] // 2.0.0+
         // BeginBlockingHomeButton(u64 nano_second)
         public ResultCode BeginBlockingHomeButton(ServiceCtx context)
         {
@@ -221,7 +221,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return ResultCode.Success;
         }
 
-        [Command(33)] // 2.0.0+
+        [CommandHipc(33)] // 2.0.0+
         // EndBlockingHomeButton()
         public ResultCode EndBlockingHomeButton(ServiceCtx context)
         {
@@ -232,7 +232,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return ResultCode.Success;
         }
 
-        [Command(40)]
+        [CommandHipc(40)]
         // NotifyRunning() -> b8
         public ResultCode NotifyRunning(ServiceCtx context)
         {
@@ -241,7 +241,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return ResultCode.Success;
         }
 
-        [Command(50)] // 2.0.0+
+        [CommandHipc(50)] // 2.0.0+
         // GetPseudoDeviceId() -> nn::util::Uuid
         public ResultCode GetPseudoDeviceId(ServiceCtx context)
         {
@@ -253,7 +253,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return ResultCode.Success;
         }
 
-        [Command(66)] // 3.0.0+
+        [CommandHipc(66)] // 3.0.0+
         // InitializeGamePlayRecording(u64, handle<copy>)
         public ResultCode InitializeGamePlayRecording(ServiceCtx context)
         {
@@ -262,7 +262,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return ResultCode.Success;
         }
 
-        [Command(67)] // 3.0.0+
+        [CommandHipc(67)] // 3.0.0+
         // SetGamePlayRecordingState(u32)
         public ResultCode SetGamePlayRecordingState(ServiceCtx context)
         {
@@ -273,7 +273,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return ResultCode.Success;
         }
 
-        [Command(90)] // 4.0.0+
+        [CommandHipc(90)] // 4.0.0+
         // EnableApplicationCrashReport(u8)
         public ResultCode EnableApplicationCrashReport(ServiceCtx context)
         {
@@ -284,7 +284,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return ResultCode.Success;
         }
 
-        [Command(100)] // 5.0.0+
+        [CommandHipc(100)] // 5.0.0+
         // InitializeApplicationCopyrightFrameBuffer(s32 width, s32 height, handle<copy, transfer_memory> transfer_memory, u64 transfer_memory_size)
         public ResultCode InitializeApplicationCopyrightFrameBuffer(ServiceCtx context)
         {
@@ -330,7 +330,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return resultCode;
         }
 
-        [Command(101)] // 5.0.0+
+        [CommandHipc(101)] // 5.0.0+
         // SetApplicationCopyrightImage(buffer<bytes, 0x45> frame_buffer, s32 x, s32 y, s32 width, s32 height, s32 window_origin_mode)
         public ResultCode SetApplicationCopyrightImage(ServiceCtx context)
         {
@@ -377,7 +377,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return ResultCode.Success;
         }
 
-        [Command(102)] // 5.0.0+
+        [CommandHipc(102)] // 5.0.0+
         // SetApplicationCopyrightVisibility(bool visible)
         public ResultCode SetApplicationCopyrightVisibility(ServiceCtx context)
         {
@@ -390,7 +390,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return ResultCode.Success;
         }
 
-        [Command(110)] // 5.0.0+
+        [CommandHipc(110)] // 5.0.0+
         // QueryApplicationPlayStatistics(buffer<bytes, 5> title_id_list) -> (buffer<bytes, 6> entries, s32 entries_count)
         public ResultCode QueryApplicationPlayStatistics(ServiceCtx context)
         {
@@ -398,7 +398,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return (ResultCode)QueryPlayStatisticsManager.GetPlayStatistics(context);
         }
 
-        [Command(111)] // 6.0.0+
+        [CommandHipc(111)] // 6.0.0+
         // QueryApplicationPlayStatisticsByUid(nn::account::Uid, buffer<bytes, 5> title_id_list) -> (buffer<bytes, 6> entries, s32 entries_count)
         public ResultCode QueryApplicationPlayStatisticsByUid(ServiceCtx context)
         {
@@ -406,7 +406,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return (ResultCode)QueryPlayStatisticsManager.GetPlayStatistics(context, true);
         }
 
-        [Command(120)] // 5.0.0+
+        [CommandHipc(120)] // 5.0.0+
         // ExecuteProgram(ProgramSpecifyKind kind, u64 value)
         public ResultCode ExecuteProgram(ServiceCtx context)
         {
@@ -424,7 +424,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return ResultCode.Success;
         }
 
-        [Command(121)] // 5.0.0+
+        [CommandHipc(121)] // 5.0.0+
         // ClearUserChannel()
         public ResultCode ClearUserChannel(ServiceCtx context)
         {
@@ -433,7 +433,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return ResultCode.Success;
         }
 
-        [Command(122)] // 5.0.0+
+        [CommandHipc(122)] // 5.0.0+
         // UnpopToUserChannel(object<nn::am::service::IStorage> input_storage)
         public ResultCode UnpopToUserChannel(ServiceCtx context)
         {
@@ -444,7 +444,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return ResultCode.Success;
         }
 
-        [Command(123)] // 5.0.0+
+        [CommandHipc(123)] // 5.0.0+
         // GetPreviousProgramIndex() -> s32 program_index
         public ResultCode GetPreviousProgramIndex(ServiceCtx context)
         {
@@ -457,7 +457,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return ResultCode.Success;
         }
 
-        [Command(130)] // 8.0.0+
+        [CommandHipc(130)] // 8.0.0+
         // GetGpuErrorDetectedSystemEvent() -> handle<copy>
         public ResultCode GetGpuErrorDetectedSystemEvent(ServiceCtx context)
         {
@@ -478,7 +478,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return ResultCode.Success;
         }
 
-        [Command(140)] // 9.0.0+
+        [CommandHipc(140)] // 9.0.0+
         // GetFriendInvitationStorageChannelEvent() -> handle<copy>
         public ResultCode GetFriendInvitationStorageChannelEvent(ServiceCtx context)
         {
@@ -495,7 +495,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return ResultCode.Success;
         }
 
-        [Command(141)] // 9.0.0+
+        [CommandHipc(141)] // 9.0.0+
         // TryPopFromFriendInvitationStorageChannel() -> object<nn::am::service::IStorage>
         public ResultCode TryPopFromFriendInvitationStorageChannel(ServiceCtx context)
         {
@@ -509,7 +509,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return ResultCode.NotAvailable;
         }
 
-        [Command(150)] // 9.0.0+
+        [CommandHipc(150)] // 9.0.0+
         // GetNotificationStorageChannelEvent() -> handle<copy>
         public ResultCode GetNotificationStorageChannelEvent(ServiceCtx context)
         {
@@ -526,7 +526,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return ResultCode.Success;
         }
 
-        [Command(160)] // 9.0.0+
+        [CommandHipc(160)] // 9.0.0+
         // GetHealthWarningDisappearedSystemEvent() -> handle<copy>
         public ResultCode GetHealthWarningDisappearedSystemEvent(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/IApplicationProxy.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/IApplicationProxy.cs
@@ -12,7 +12,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService
             _pid = pid;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetCommonStateGetter() -> object<nn::am::service::ICommonStateGetter>
         public ResultCode GetCommonStateGetter(ServiceCtx context)
         {
@@ -21,7 +21,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetSelfController() -> object<nn::am::service::ISelfController>
         public ResultCode GetSelfController(ServiceCtx context)
         {
@@ -30,7 +30,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService
             return ResultCode.Success;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // GetWindowController() -> object<nn::am::service::IWindowController>
         public ResultCode GetWindowController(ServiceCtx context)
         {
@@ -39,7 +39,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService
             return ResultCode.Success;
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // GetAudioController() -> object<nn::am::service::IAudioController>
         public ResultCode GetAudioController(ServiceCtx context)
         {
@@ -48,7 +48,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService
             return ResultCode.Success;
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // GetDisplayController() -> object<nn::am::service::IDisplayController>
         public ResultCode GetDisplayController(ServiceCtx context)
         {
@@ -57,7 +57,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService
             return ResultCode.Success;
         }
 
-        [Command(11)]
+        [CommandHipc(11)]
         // GetLibraryAppletCreator() -> object<nn::am::service::ILibraryAppletCreator>
         public ResultCode GetLibraryAppletCreator(ServiceCtx context)
         {
@@ -66,7 +66,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService
             return ResultCode.Success;
         }
 
-        [Command(20)]
+        [CommandHipc(20)]
         // GetApplicationFunctions() -> object<nn::am::service::IApplicationFunctions>
         public ResultCode GetApplicationFunctions(ServiceCtx context)
         {
@@ -75,7 +75,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService
             return ResultCode.Success;
         }
 
-        [Command(1000)]
+        [CommandHipc(1000)]
         // GetDebugFunctions() -> object<nn::am::service::IDebugFunctions>
         public ResultCode GetDebugFunctions(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Am/AppletOE/IApplicationProxyService.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletOE/IApplicationProxyService.cs
@@ -7,7 +7,7 @@ namespace Ryujinx.HLE.HOS.Services.Am
     {
         public IApplicationProxyService(ServiceCtx context) { }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // OpenApplicationProxy(u64, pid, handle<copy>) -> object<nn::am::service::IApplicationProxy>
         public ResultCode OpenApplicationProxy(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Apm/IManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/IManager.cs
@@ -8,7 +8,7 @@ namespace Ryujinx.HLE.HOS.Services.Apm
         protected abstract PerformanceMode GetPerformanceMode();
         protected abstract bool IsCpuOverclockEnabled();
 
-        [Command(0)]
+        [CommandHipc(0)]
         // OpenSession() -> object<nn::apm::ISession>
         public ResultCode OpenSession(ServiceCtx context)
         {
@@ -22,7 +22,7 @@ namespace Ryujinx.HLE.HOS.Services.Apm
             return resultCode;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetPerformanceMode() -> nn::apm::PerformanceMode
         public ResultCode GetPerformanceMode(ServiceCtx context)
         {
@@ -31,7 +31,7 @@ namespace Ryujinx.HLE.HOS.Services.Apm
             return ResultCode.Success;
         }
 
-        [Command(6)] // 7.0.0+
+        [CommandHipc(6)] // 7.0.0+
         // IsCpuOverclockEnabled() -> bool
         public ResultCode IsCpuOverclockEnabled(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Apm/IManagerPrivileged.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/IManagerPrivileged.cs
@@ -7,7 +7,7 @@ namespace Ryujinx.HLE.HOS.Services.Apm
     {
         public IManagerPrivileged(ServiceCtx context) { }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // OpenSession() -> object<nn::apm::ISession>
         public ResultCode OpenSession(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Apm/ISession.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/ISession.cs
@@ -8,7 +8,7 @@ namespace Ryujinx.HLE.HOS.Services.Apm
         protected abstract ResultCode GetPerformanceConfiguration(PerformanceMode performanceMode, out PerformanceConfiguration performanceConfiguration);
         protected abstract void SetCpuOverclockEnabled(bool enabled);
 
-        [Command(0)]
+        [CommandHipc(0)]
         // SetPerformanceConfiguration(nn::apm::PerformanceMode, nn::apm::PerformanceConfiguration)
         public ResultCode SetPerformanceConfiguration(ServiceCtx context)
         {
@@ -18,7 +18,7 @@ namespace Ryujinx.HLE.HOS.Services.Apm
             return SetPerformanceConfiguration(performanceMode, performanceConfiguration);
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetPerformanceConfiguration(nn::apm::PerformanceMode) -> nn::apm::PerformanceConfiguration
         public ResultCode GetPerformanceConfiguration(ServiceCtx context)
         {
@@ -31,7 +31,7 @@ namespace Ryujinx.HLE.HOS.Services.Apm
             return resultCode;
         }
 
-        [Command(2)] // 8.0.0+
+        [CommandHipc(2)] // 8.0.0+
         // SetCpuOverclockEnabled(bool)
         public ResultCode SetCpuOverclockEnabled(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Apm/ISystemManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Apm/ISystemManager.cs
@@ -8,7 +8,7 @@ namespace Ryujinx.HLE.HOS.Services.Apm
         internal abstract void SetCpuBoostMode(CpuBoostMode cpuBoostMode);
         protected abstract PerformanceConfiguration GetCurrentPerformanceConfiguration();
 
-        [Command(0)]
+        [CommandHipc(0)]
         // RequestPerformanceMode(nn::apm::PerformanceMode)
         public ResultCode RequestPerformanceMode(ServiceCtx context)
         {
@@ -19,7 +19,7 @@ namespace Ryujinx.HLE.HOS.Services.Apm
             return ResultCode.Success;
         }
 
-        [Command(6)] // 7.0.0+
+        [CommandHipc(6)] // 7.0.0+
         // SetCpuBoostMode(nn::apm::CpuBootMode)
         public ResultCode SetCpuBoostMode(ServiceCtx context)
         {
@@ -30,7 +30,7 @@ namespace Ryujinx.HLE.HOS.Services.Apm
             return ResultCode.Success;
         }
 
-        [Command(7)] // 7.0.0+
+        [CommandHipc(7)] // 7.0.0+
         // GetCurrentPerformanceConfiguration() -> nn::apm::PerformanceConfiguration
         public ResultCode GetCurrentPerformanceConfiguration(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioIn/AudioInServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioIn/AudioInServer.cs
@@ -18,7 +18,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioIn
             _impl = impl;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetAudioInState() -> u32 state
         public ResultCode GetAudioInState(ServiceCtx context)
         {
@@ -27,21 +27,21 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioIn
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // Start()
         public ResultCode Start(ServiceCtx context)
         {
             return _impl.Start();
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // Stop()
         public ResultCode StopAudioIn(ServiceCtx context)
         {
             return _impl.Stop();
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // AppendAudioInBuffer(u64 tag, buffer<nn::audio::AudioInBuffer, 5>)
         public ResultCode AppendAudioInBuffer(ServiceCtx context)
         {
@@ -54,7 +54,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioIn
             return _impl.AppendBuffer(bufferTag, ref data);
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // RegisterBufferEvent() -> handle<copy>
         public ResultCode RegisterBufferEvent(ServiceCtx context)
         {
@@ -70,7 +70,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioIn
             return ResultCode.Success;
         }
 
-        [Command(5)]
+        [CommandHipc(5)]
         // GetReleasedAudioInBuffers() -> (u32 count, buffer<u64, 6> tags)
         public ResultCode GetReleasedAudioInBuffers(ServiceCtx context)
         {
@@ -87,7 +87,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioIn
             }
         }
 
-        [Command(6)]
+        [CommandHipc(6)]
         // ContainsAudioInBuffer(u64 tag) -> b8
         public ResultCode ContainsAudioInBuffer(ServiceCtx context)
         {
@@ -98,7 +98,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioIn
             return ResultCode.Success;
         }
 
-        [Command(7)] // 3.0.0+
+        [CommandHipc(7)] // 3.0.0+
         // AppendUacInBuffer(u64 tag, handle<copy, unknown>, buffer<nn::audio::AudioInBuffer, 5>)
         public ResultCode AppendUacInBuffer(ServiceCtx context)
         {
@@ -112,7 +112,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioIn
             return _impl.AppendUacBuffer(bufferTag, ref data, handle);
         }
 
-        [Command(8)] // 3.0.0+
+        [CommandHipc(8)] // 3.0.0+
         // AppendAudioInBufferAuto(u64 tag, buffer<nn::audio::AudioInBuffer, 0x21>)
         public ResultCode AppendAudioInBufferAuto(ServiceCtx context)
         {
@@ -125,7 +125,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioIn
             return _impl.AppendBuffer(bufferTag, ref data);
         }
 
-        [Command(9)] // 3.0.0+
+        [CommandHipc(9)] // 3.0.0+
         // GetReleasedAudioInBuffersAuto() -> (u32 count, buffer<u64, 0x22> tags)
         public ResultCode GetReleasedAudioInBuffersAuto(ServiceCtx context)
         {
@@ -141,7 +141,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioIn
             }
         }
 
-        [Command(10)] // 3.0.0+
+        [CommandHipc(10)] // 3.0.0+
         // AppendUacInBufferAuto(u64 tag, handle<copy, event>, buffer<nn::audio::AudioInBuffer, 0x21>)
         public ResultCode AppendUacInBufferAuto(ServiceCtx context)
         {
@@ -155,7 +155,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioIn
             return _impl.AppendUacBuffer(bufferTag, ref data, handle);
         }
 
-        [Command(11)] // 4.0.0+
+        [CommandHipc(11)] // 4.0.0+
         // GetAudioInBufferCount() -> u32
         public ResultCode GetAudioInBufferCount(ServiceCtx context)
         {
@@ -164,7 +164,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioIn
             return ResultCode.Success;
         }
 
-        [Command(12)] // 4.0.0+
+        [CommandHipc(12)] // 4.0.0+
         // SetAudioInVolume(s32)
         public ResultCode SetAudioInVolume(ServiceCtx context)
         {
@@ -175,7 +175,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioIn
             return ResultCode.Success;
         }
 
-        [Command(13)] // 4.0.0+
+        [CommandHipc(13)] // 4.0.0+
         // GetAudioInVolume() -> s32
         public ResultCode GetAudioInVolume(ServiceCtx context)
         {
@@ -184,7 +184,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioIn
             return ResultCode.Success;
         }
 
-        [Command(14)] // 6.0.0+
+        [CommandHipc(14)] // 6.0.0+
         // FlushAudioInBuffers() -> b8
         public ResultCode FlushAudioInBuffers(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioInManagerServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioInManagerServer.cs
@@ -21,7 +21,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             _impl = impl;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // ListAudioIns() -> (u32, buffer<bytes, 6>)
         public ResultCode ListAudioIns(ServiceCtx context)
         {
@@ -57,7 +57,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // OpenAudioIn(AudioInInputConfiguration input_config, nn::applet::AppletResourceUserId, pid, handle<copy, process>, buffer<bytes, 5> name)
         // -> (u32 sample_rate, u32 channel_count, u32 pcm_format, u32, object<nn::audio::detail::IAudioIn>, buffer<bytes, 6> name)
         public ResultCode OpenAudioIn(ServiceCtx context)
@@ -92,7 +92,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             return resultCode;
         }
 
-        [Command(2)] // 3.0.0+
+        [CommandHipc(2)] // 3.0.0+
         // ListAudioInsAuto() -> (u32, buffer<bytes, 0x22>)
         public ResultCode ListAudioInsAuto(ServiceCtx context)
         {
@@ -127,7 +127,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             return ResultCode.Success;
         }
 
-        [Command(3)] // 3.0.0+
+        [CommandHipc(3)] // 3.0.0+
         // OpenAudioInAuto(AudioInInputConfiguration input_config, nn::applet::AppletResourceUserId, pid, handle<copy, process>, buffer<bytes, 0x21>)
         // -> (u32 sample_rate, u32 channel_count, u32 pcm_format, u32, object<nn::audio::detail::IAudioIn>, buffer<bytes, 0x22> name)
         public ResultCode OpenAudioInAuto(ServiceCtx context)
@@ -159,7 +159,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             return resultCode;
         }
 
-        [Command(4)] // 3.0.0+
+        [CommandHipc(4)] // 3.0.0+
         // ListAudioInsAutoFiltered() -> (u32, buffer<bytes, 0x22>)
         public ResultCode ListAudioInsAutoFiltered(ServiceCtx context)
         {
@@ -194,7 +194,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             return ResultCode.Success;
         }
 
-        [Command(5)] // 5.0.0+
+        [CommandHipc(5)] // 5.0.0+
         // OpenAudioInProtocolSpecified(b64 protocol_specified_related, AudioInInputConfiguration input_config, nn::applet::AppletResourceUserId, pid, handle<copy, process>, buffer<bytes, 5> name)
         // -> (u32 sample_rate, u32 channel_count, u32 pcm_format, u32, object<nn::audio::detail::IAudioIn>, buffer<bytes, 6> name)
         public ResultCode OpenAudioInProtocolSpecified(ServiceCtx context)

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioOut/AudioOutServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioOut/AudioOutServer.cs
@@ -18,7 +18,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioOut
             _impl = impl;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetAudioOutState() -> u32 state
         public ResultCode GetAudioOutState(ServiceCtx context)
         {
@@ -27,21 +27,21 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioOut
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // Start()
         public ResultCode Start(ServiceCtx context)
         {
             return _impl.Start();
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // Stop()
         public ResultCode Stop(ServiceCtx context)
         {
             return _impl.Stop();
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // AppendAudioOutBuffer(u64 bufferTag, buffer<nn::audio::AudioOutBuffer, 5> buffer)
         public ResultCode AppendAudioOutBuffer(ServiceCtx context)
         {
@@ -54,7 +54,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioOut
             return _impl.AppendBuffer(bufferTag, ref data);
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // RegisterBufferEvent() -> handle<copy>
         public ResultCode RegisterBufferEvent(ServiceCtx context)
         {
@@ -70,7 +70,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioOut
             return ResultCode.Success;
         }
 
-        [Command(5)]
+        [CommandHipc(5)]
         // GetReleasedAudioOutBuffers() -> (u32 count, buffer<u64, 6> tags)
         public ResultCode GetReleasedAudioOutBuffers(ServiceCtx context)
         {
@@ -87,7 +87,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioOut
             }
         }
 
-        [Command(6)]
+        [CommandHipc(6)]
         // ContainsAudioOutBuffer(u64 tag) -> b8
         public ResultCode ContainsAudioOutBuffer(ServiceCtx context)
         {
@@ -98,7 +98,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioOut
             return ResultCode.Success;
         }
 
-        [Command(7)] // 3.0.0+
+        [CommandHipc(7)] // 3.0.0+
         // AppendAudioOutBufferAuto(u64 tag, buffer<nn::audio::AudioOutBuffer, 0x21>)
         public ResultCode AppendAudioOutBufferAuto(ServiceCtx context)
         {
@@ -111,7 +111,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioOut
             return _impl.AppendBuffer(bufferTag, ref data);
         }
 
-        [Command(8)] // 3.0.0+
+        [CommandHipc(8)] // 3.0.0+
         // GetReleasedAudioOutBuffersAuto() -> (u32 count, buffer<u64, 0x22> tags)
         public ResultCode GetReleasedAudioOutBuffersAuto(ServiceCtx context)
         {
@@ -127,7 +127,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioOut
             }
         }
 
-        [Command(9)] // 4.0.0+
+        [CommandHipc(9)] // 4.0.0+
         // GetAudioOutBufferCount() -> u32
         public ResultCode GetAudioOutBufferCount(ServiceCtx context)
         {
@@ -136,7 +136,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioOut
             return ResultCode.Success;
         }
 
-        [Command(10)] // 4.0.0+
+        [CommandHipc(10)] // 4.0.0+
         // GetAudioOutPlayedSampleCount() -> u64
         public ResultCode GetAudioOutPlayedSampleCount(ServiceCtx context)
         {
@@ -145,7 +145,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioOut
             return ResultCode.Success;
         }
 
-        [Command(11)] // 4.0.0+
+        [CommandHipc(11)] // 4.0.0+
         // FlushAudioOutBuffers() -> b8
         public ResultCode FlushAudioOutBuffers(ServiceCtx context)
         {
@@ -154,7 +154,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioOut
             return ResultCode.Success;
         }
 
-        [Command(12)] // 6.0.0+
+        [CommandHipc(12)] // 6.0.0+
         // SetAudioOutVolume(s32)
         public ResultCode SetAudioOutVolume(ServiceCtx context)
         {
@@ -165,7 +165,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioOut
             return ResultCode.Success;
         }
 
-        [Command(13)] // 6.0.0+
+        [CommandHipc(13)] // 6.0.0+
         // GetAudioOutVolume() -> s32
         public ResultCode GetAudioOutVolume(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioOutManagerServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioOutManagerServer.cs
@@ -21,7 +21,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             _impl = impl;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // ListAudioOuts() -> (u32, buffer<bytes, 6>)
         public ResultCode ListAudioOuts(ServiceCtx context)
         {
@@ -57,7 +57,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // OpenAudioOut(AudioOutInputConfiguration input_config, nn::applet::AppletResourceUserId, pid, handle<copy, process> process_handle, buffer<bytes, 5> name_in)
         // -> (AudioOutInputConfiguration output_config, object<nn::audio::detail::IAudioOut>, buffer<bytes, 6> name_out)
         public ResultCode OpenAudioOut(ServiceCtx context)
@@ -92,7 +92,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             return resultCode;
         }
 
-        [Command(2)] // 3.0.0+
+        [CommandHipc(2)] // 3.0.0+
         // ListAudioOutsAuto() -> (u32, buffer<bytes, 0x22>)
         public ResultCode ListAudioOutsAuto(ServiceCtx context)
         {
@@ -127,7 +127,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             return ResultCode.Success;
         }
 
-        [Command(3)] // 3.0.0+
+        [CommandHipc(3)] // 3.0.0+
         // OpenAudioOut(AudioOutInputConfiguration input_config, nn::applet::AppletResourceUserId, pid, handle<copy, process> process_handle, buffer<bytes, 0x21> name_in)
         // -> (AudioOutInputConfiguration output_config, object<nn::audio::detail::IAudioOut>, buffer<bytes, 0x22> name_out)
         public ResultCode OpenAudioOutAuto(ServiceCtx context)

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/AudioDeviceServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/AudioDeviceServer.cs
@@ -19,7 +19,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             _impl = impl;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // ListAudioDeviceName() -> (u32, buffer<bytes, 6>)
         public ResultCode ListAudioDeviceName(ServiceCtx context)
         {
@@ -55,7 +55,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // SetAudioDeviceOutputVolume(f32 volume, buffer<bytes, 5> name)
         public ResultCode SetAudioDeviceOutputVolume(ServiceCtx context)
         {
@@ -69,7 +69,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             return _impl.SetAudioDeviceOutputVolume(deviceName, volume);
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // GetAudioDeviceOutputVolume(buffer<bytes, 5> name) -> f32 volume
         public ResultCode GetAudioDeviceOutputVolume(ServiceCtx context)
         {
@@ -88,7 +88,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             return result;
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // GetActiveAudioDeviceName() -> buffer<bytes, 6>
         public ResultCode GetActiveAudioDeviceName(ServiceCtx context)
         {
@@ -111,7 +111,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             return ResultCode.Success;
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // QueryAudioDeviceSystemEvent() -> handle<copy, event>
         public ResultCode QueryAudioDeviceSystemEvent(ServiceCtx context)
         {
@@ -129,7 +129,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             return ResultCode.Success;
         }
 
-        [Command(5)]
+        [CommandHipc(5)]
         // GetActiveChannelCount() -> u32
         public ResultCode GetActiveChannelCount(ServiceCtx context)
         {
@@ -140,7 +140,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             return ResultCode.Success;
         }
 
-        [Command(6)] // 3.0.0+
+        [CommandHipc(6)] // 3.0.0+
         // ListAudioDeviceNameAuto() -> (u32, buffer<bytes, 0x22>)
         public ResultCode ListAudioDeviceNameAuto(ServiceCtx context)
         {
@@ -175,7 +175,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             return ResultCode.Success;
         }
 
-        [Command(7)] // 3.0.0+
+        [CommandHipc(7)] // 3.0.0+
         // SetAudioDeviceOutputVolumeAuto(f32 volume, buffer<bytes, 0x21> name)
         public ResultCode SetAudioDeviceOutputVolumeAuto(ServiceCtx context)
         {
@@ -188,7 +188,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             return _impl.SetAudioDeviceOutputVolume(deviceName, volume);
         }
 
-        [Command(8)] // 3.0.0+
+        [CommandHipc(8)] // 3.0.0+
         // GetAudioDeviceOutputVolumeAuto(buffer<bytes, 0x21> name) -> f32
         public ResultCode GetAudioDeviceOutputVolumeAuto(ServiceCtx context)
         {
@@ -206,7 +206,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             return ResultCode.Success;
         }
 
-        [Command(10)] // 3.0.0+
+        [CommandHipc(10)] // 3.0.0+
         // GetActiveAudioDeviceNameAuto() -> buffer<bytes, 0x22>
         public ResultCode GetActiveAudioDeviceNameAuto(ServiceCtx context)
         {
@@ -228,7 +228,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             return ResultCode.Success;
         }
 
-        [Command(11)] // 3.0.0+
+        [CommandHipc(11)] // 3.0.0+
         // QueryAudioDeviceInputEvent() -> handle<copy, event>
         public ResultCode QueryAudioDeviceInputEvent(ServiceCtx context)
         {
@@ -246,7 +246,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             return ResultCode.Success;
         }
 
-        [Command(12)] // 3.0.0+
+        [CommandHipc(12)] // 3.0.0+
         // QueryAudioDeviceOutputEvent() -> handle<copy, event>
         public ResultCode QueryAudioDeviceOutputEvent(ServiceCtx context)
         {
@@ -264,7 +264,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             return ResultCode.Success;
         }
 
-        [Command(13)]
+        [CommandHipc(13)]
         // GetAudioSystemMasterVolumeSetting(buffer<bytes, 5> name) -> f32
         public ResultCode GetAudioSystemMasterVolumeSetting(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/AudioRendererServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/AudioRendererServer.cs
@@ -16,7 +16,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             _impl = impl;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetSampleRate() -> u32
         public ResultCode GetSampleRate(ServiceCtx context)
         {
@@ -25,7 +25,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetSampleCount() -> u32
         public ResultCode GetSampleCount(ServiceCtx context)
         {
@@ -34,7 +34,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             return ResultCode.Success;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // GetMixBufferCount() -> u32
         public ResultCode GetMixBufferCount(ServiceCtx context)
         {
@@ -43,7 +43,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             return ResultCode.Success;
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // GetState() -> u32
         public ResultCode GetState(ServiceCtx context)
         {
@@ -52,7 +52,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             return ResultCode.Success;
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // RequestUpdate(buffer<nn::audio::detail::AudioRendererUpdateDataHeader, 5> input)
         // -> (buffer<nn::audio::detail::AudioRendererUpdateDataHeader, 6> output, buffer<nn::audio::detail::AudioRendererUpdateDataHeader, 6> performanceOutput)
         public ResultCode RequestUpdate(ServiceCtx context)
@@ -89,21 +89,21 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             return result;
         }
 
-        [Command(5)]
+        [CommandHipc(5)]
         // Start()
         public ResultCode Start(ServiceCtx context)
         {
             return _impl.Start();
         }
 
-        [Command(6)]
+        [CommandHipc(6)]
         // Stop()
         public ResultCode Stop(ServiceCtx context)
         {
             return _impl.Stop();
         }
 
-        [Command(7)]
+        [CommandHipc(7)]
         // QuerySystemEvent() -> handle<copy, event>
         public ResultCode QuerySystemEvent(ServiceCtx context)
         {
@@ -122,7 +122,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             return result;
         }
 
-        [Command(8)]
+        [CommandHipc(8)]
         // SetAudioRendererRenderingTimeLimit(u32 limit)
         public ResultCode SetAudioRendererRenderingTimeLimit(ServiceCtx context)
         {
@@ -133,7 +133,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             return ResultCode.Success;
         }
 
-        [Command(9)]
+        [CommandHipc(9)]
         // GetAudioRendererRenderingTimeLimit() -> u32 limit
         public ResultCode GetAudioRendererRenderingTimeLimit(ServiceCtx context)
         {
@@ -144,7 +144,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             return ResultCode.Success;
         }
 
-        [Command(10)] // 3.0.0+
+        [CommandHipc(10)] // 3.0.0+
         //  RequestUpdateAuto(buffer<nn::audio::detail::AudioRendererUpdateDataHeader, 0x21> input)
         // -> (buffer<nn::audio::detail::AudioRendererUpdateDataHeader, 0x22> output, buffer<nn::audio::detail::AudioRendererUpdateDataHeader, 0x22> performanceOutput)
         public ResultCode RequestUpdateAuto(ServiceCtx context)

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioRendererManagerServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioRendererManagerServer.cs
@@ -21,7 +21,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             _impl = impl;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // OpenAudioRenderer(nn::audio::detail::AudioRendererParameterInternal parameter, u64 workBufferSize, nn::applet::AppletResourceUserId appletResourceId, pid, handle<copy> workBuffer, handle<copy> processHandle)
         // -> object<nn::audio::detail::IAudioRenderer>
         public ResultCode OpenAudioRenderer(ServiceCtx context)
@@ -47,7 +47,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             return result;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetWorkBufferSize(nn::audio::detail::AudioRendererParameterInternal parameter) -> u64 workBufferSize
         public ResultCode GetAudioRendererWorkBufferSize(ServiceCtx context)
         {
@@ -73,7 +73,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             }
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // GetAudioDeviceService(nn::applet::AppletResourceUserId) -> object<nn::audio::detail::IAudioDevice>
         public ResultCode GetAudioDeviceService(ServiceCtx context)
         {
@@ -89,7 +89,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             return result;
         }
 
-        [Command(4)] // 4.0.0+
+        [CommandHipc(4)] // 4.0.0+
         // GetAudioDeviceServiceWithRevisionInfo(s32 revision, nn::applet::AppletResourceUserId appletResourceId) -> object<nn::audio::detail::IAudioDevice>
         public ResultCode GetAudioDeviceServiceWithRevisionInfo(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Audio/HardwareOpusDecoderManager/IHardwareOpusDecoder.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/HardwareOpusDecoderManager/IHardwareOpusDecoder.cs
@@ -100,7 +100,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.HardwareOpusDecoderManager
             return ResultCode.Success;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // DecodeInterleaved(buffer<unknown, 5>) -> (u32, u32, buffer<unknown, 6>)
         public ResultCode DecodeInterleavedOriginal(ServiceCtx context)
         {
@@ -133,7 +133,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.HardwareOpusDecoderManager
             return result;
         }
 
-        [Command(4)] // 6.0.0+
+        [CommandHipc(4)] // 6.0.0+
         // DecodeInterleavedWithPerfOld(buffer<unknown, 5>) -> (u32, u32, u64, buffer<unknown, 0x46>)
         public ResultCode DecodeInterleavedWithPerfOld(ServiceCtx context)
         {
@@ -169,7 +169,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.HardwareOpusDecoderManager
             return result;
         }
 
-        [Command(6)] // 6.0.0+
+        [CommandHipc(6)] // 6.0.0+
         // DecodeInterleavedOld(bool reset, buffer<unknown, 5>) -> (u32, u32, u64, buffer<unknown, 0x46>)
         public ResultCode DecodeInterleavedOld(ServiceCtx context)
         {
@@ -207,7 +207,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.HardwareOpusDecoderManager
             return result;
         }
 
-        [Command(8)] // 7.0.0+
+        [CommandHipc(8)] // 7.0.0+
         // DecodeInterleaved(bool reset, buffer<unknown, 0x45>) -> (u32, u32, u64, buffer<unknown, 0x46>)
         public ResultCode DecodeInterleaved(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Audio/IHardwareOpusDecoderManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/IHardwareOpusDecoderManager.cs
@@ -7,7 +7,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
     {
         public IHardwareOpusDecoderManager(ServiceCtx context) { }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // Initialize(bytes<8, 4>, u32, handle<copy>) -> object<nn::codec::detail::IHardwareOpusDecoder>
         public ResultCode Initialize(ServiceCtx context)
         {
@@ -22,7 +22,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetWorkBufferSize(bytes<8, 4>) -> u32
         public ResultCode GetWorkBufferSize(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Bcat/IServiceCreator.cs
+++ b/Ryujinx.HLE/HOS/Services/Bcat/IServiceCreator.cs
@@ -18,7 +18,7 @@ namespace Ryujinx.HLE.HOS.Services.Bcat
             context.Device.System.LibHacHorizonClient.Sm.GetService(out _base, serviceName).ThrowIfFailure();
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // CreateBcatService(pid) -> object<nn::bcat::detail::ipc::IBcatService>
         public ResultCode CreateBcatService(ServiceCtx context)
         {
@@ -36,7 +36,7 @@ namespace Ryujinx.HLE.HOS.Services.Bcat
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // CreateDeliveryCacheStorageService(pid) -> object<nn::bcat::detail::ipc::IDeliveryCacheStorageService>
         public ResultCode CreateDeliveryCacheStorageService(ServiceCtx context)
         {
@@ -52,7 +52,7 @@ namespace Ryujinx.HLE.HOS.Services.Bcat
             return (ResultCode)rc.Value;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // CreateDeliveryCacheStorageServiceWithApplicationId(nn::ApplicationId) -> object<nn::bcat::detail::ipc::IDeliveryCacheStorageService>
         public ResultCode CreateDeliveryCacheStorageServiceWithApplicationId(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Bcat/ServiceCreator/IBcatService.cs
+++ b/Ryujinx.HLE/HOS/Services/Bcat/ServiceCreator/IBcatService.cs
@@ -6,7 +6,7 @@ namespace Ryujinx.HLE.HOS.Services.Bcat.ServiceCreator
     {
         public IBcatService(ApplicationLaunchProperty applicationLaunchProperty) { }
 
-        [Command(10100)]
+        [CommandHipc(10100)]
         // RequestSyncDeliveryCache() -> object<nn::bcat::detail::ipc::IDeliveryCacheProgressService>
         public ResultCode RequestSyncDeliveryCache(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Bcat/ServiceCreator/IDeliveryCacheDirectoryService.cs
+++ b/Ryujinx.HLE/HOS/Services/Bcat/ServiceCreator/IDeliveryCacheDirectoryService.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.HLE.HOS.Services.Bcat.ServiceCreator
             _base = baseService;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // Open(nn::bcat::DirectoryName)
         public ResultCode Open(ServiceCtx context)
         {
@@ -26,7 +26,7 @@ namespace Ryujinx.HLE.HOS.Services.Bcat.ServiceCreator
             return (ResultCode)result.Value;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // Read() -> (u32, buffer<nn::bcat::DeliveryCacheDirectoryEntry, 6>)
         public ResultCode Read(ServiceCtx context)
         {
@@ -44,7 +44,7 @@ namespace Ryujinx.HLE.HOS.Services.Bcat.ServiceCreator
             return (ResultCode)result.Value;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // GetCount() -> u32
         public ResultCode GetCount(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Bcat/ServiceCreator/IDeliveryCacheFileService.cs
+++ b/Ryujinx.HLE/HOS/Services/Bcat/ServiceCreator/IDeliveryCacheFileService.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.HLE.HOS.Services.Bcat.ServiceCreator
             _base = baseService;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // Open(nn::bcat::DirectoryName, nn::bcat::FileName)
         public ResultCode Open(ServiceCtx context)
         {
@@ -26,7 +26,7 @@ namespace Ryujinx.HLE.HOS.Services.Bcat.ServiceCreator
             return (ResultCode)result.Value;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // Read(u64) -> (u64, buffer<bytes, 6>)
         public ResultCode Read(ServiceCtx context)
         {
@@ -46,7 +46,7 @@ namespace Ryujinx.HLE.HOS.Services.Bcat.ServiceCreator
             return (ResultCode)result.Value;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // GetSize() -> u64
         public ResultCode GetSize(ServiceCtx context)
         {
@@ -57,7 +57,7 @@ namespace Ryujinx.HLE.HOS.Services.Bcat.ServiceCreator
             return (ResultCode)result.Value;
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // GetDigest() -> nn::bcat::Digest
         public ResultCode GetDigest(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Bcat/ServiceCreator/IDeliveryCacheProgressService.cs
+++ b/Ryujinx.HLE/HOS/Services/Bcat/ServiceCreator/IDeliveryCacheProgressService.cs
@@ -20,7 +20,7 @@ namespace Ryujinx.HLE.HOS.Services.Bcat.ServiceCreator
             _event = new KEvent(context.Device.System.KernelContext);
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetEvent() -> handle<copy>
         public ResultCode GetEvent(ServiceCtx context)
         {
@@ -39,7 +39,7 @@ namespace Ryujinx.HLE.HOS.Services.Bcat.ServiceCreator
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetImpl() -> buffer<nn::bcat::detail::DeliveryCacheProgressImpl, 0x1a>
         public ResultCode GetImpl(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Bcat/ServiceCreator/IDeliveryCacheStorageService.cs
+++ b/Ryujinx.HLE/HOS/Services/Bcat/ServiceCreator/IDeliveryCacheStorageService.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.HLE.HOS.Services.Bcat.ServiceCreator
             _base = baseService;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // CreateFileService() -> object<nn::bcat::detail::ipc::IDeliveryCacheFileService>
         public ResultCode CreateFileService(ServiceCtx context)
         {
@@ -28,7 +28,7 @@ namespace Ryujinx.HLE.HOS.Services.Bcat.ServiceCreator
             return (ResultCode)result.Value;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // CreateDirectoryService() -> object<nn::bcat::detail::ipc::IDeliveryCacheDirectoryService>
         public ResultCode CreateDirectoryService(ServiceCtx context)
         {
@@ -42,7 +42,7 @@ namespace Ryujinx.HLE.HOS.Services.Bcat.ServiceCreator
             return (ResultCode)result.Value;
         }
 
-        [Command(10)]
+        [CommandHipc(10)]
         // EnumerateDeliveryCacheDirectory() -> (u32, buffer<nn::bcat::DirectoryName, 6>)
         public ResultCode EnumerateDeliveryCacheDirectory(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Bluetooth/IBluetoothDriver.cs
+++ b/Ryujinx.HLE/HOS/Services/Bluetooth/IBluetoothDriver.cs
@@ -16,7 +16,7 @@ namespace Ryujinx.HLE.HOS.Services.Bluetooth
 
         public IBluetoothDriver(ServiceCtx context) { }
 
-        [Command(46)]
+        [CommandHipc(46)]
         // InitializeBluetoothLe() -> handle<copy>
         public ResultCode InitializeBluetoothLe(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Bluetooth/IBluetoothUser.cs
+++ b/Ryujinx.HLE/HOS/Services/Bluetooth/IBluetoothUser.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.HLE.HOS.Services.Bluetooth
     {
         public IBluetoothUser(ServiceCtx context) { }
 
-        [Command(9)]
+        [CommandHipc(9)]
         // RegisterBleEvent(pid) -> handle<copy>
         public ResultCode RegisterBleEvent(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/BluetoothManager/BtmUser/IBtmUserCore.cs
+++ b/Ryujinx.HLE/HOS/Services/BluetoothManager/BtmUser/IBtmUserCore.cs
@@ -21,7 +21,7 @@ namespace Ryujinx.HLE.HOS.Services.BluetoothManager.BtmUser
 
         public IBtmUserCore() { }
 
-        [Command(0)] // 5.0.0+
+        [CommandHipc(0)] // 5.0.0+
         // AcquireBleScanEvent() -> (byte<1>, handle<copy>)
         public ResultCode AcquireBleScanEvent(ServiceCtx context)
         {
@@ -47,7 +47,7 @@ namespace Ryujinx.HLE.HOS.Services.BluetoothManager.BtmUser
             return ResultCode.Success;
         }
 
-        [Command(17)] // 5.0.0+
+        [CommandHipc(17)] // 5.0.0+
         // AcquireBleConnectionEvent() -> (byte<1>, handle<copy>)
         public ResultCode AcquireBleConnectionEvent(ServiceCtx context)
         {
@@ -73,7 +73,7 @@ namespace Ryujinx.HLE.HOS.Services.BluetoothManager.BtmUser
             return ResultCode.Success;
         }
 
-        [Command(26)] // 5.0.0+
+        [CommandHipc(26)] // 5.0.0+
         // AcquireBleServiceDiscoveryEvent() -> (byte<1>, handle<copy>)
         public ResultCode AcquireBleServiceDiscoveryEvent(ServiceCtx context)
         {
@@ -99,7 +99,7 @@ namespace Ryujinx.HLE.HOS.Services.BluetoothManager.BtmUser
             return ResultCode.Success;
         }
 
-        [Command(33)] // 5.0.0+
+        [CommandHipc(33)] // 5.0.0+
         // AcquireBleMtuConfigEvent() -> (byte<1>, handle<copy>)
         public ResultCode AcquireBleMtuConfigEvent(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/BluetoothManager/IBtmUser.cs
+++ b/Ryujinx.HLE/HOS/Services/BluetoothManager/IBtmUser.cs
@@ -7,7 +7,7 @@ namespace Ryujinx.HLE.HOS.Services.BluetoothManager
     {
         public IBtmUser(ServiceCtx context) { }
 
-        [Command(0)] // 5.0.0+
+        [CommandHipc(0)] // 5.0.0+
         // GetCore() -> object<nn::btm::IBtmUserCore>
         public ResultCode GetCore(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Caps/IAlbumApplicationService.cs
+++ b/Ryujinx.HLE/HOS/Services/Caps/IAlbumApplicationService.cs
@@ -7,7 +7,7 @@ namespace Ryujinx.HLE.HOS.Services.Caps
     {
         public IAlbumApplicationService(ServiceCtx context) { }
 
-        [Command(32)] // 7.0.0+
+        [CommandHipc(32)] // 7.0.0+
         // SetShimLibraryVersion(pid, u64, nn::applet::AppletResourceUserId)
         public ResultCode SetShimLibraryVersion(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Caps/IAlbumControlService.cs
+++ b/Ryujinx.HLE/HOS/Services/Caps/IAlbumControlService.cs
@@ -5,7 +5,7 @@ namespace Ryujinx.HLE.HOS.Services.Caps
     {
         public IAlbumControlService(ServiceCtx context) { }
 
-        [Command(33)] // 7.0.0+
+        [CommandHipc(33)] // 7.0.0+
         // SetShimLibraryVersion(pid, u64, nn::applet::AppletResourceUserId)
         public ResultCode SetShimLibraryVersion(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Caps/IScreenShotApplicationService.cs
+++ b/Ryujinx.HLE/HOS/Services/Caps/IScreenShotApplicationService.cs
@@ -8,14 +8,14 @@ namespace Ryujinx.HLE.HOS.Services.Caps
     {
         public IScreenShotApplicationService(ServiceCtx context) { }
 
-        [Command(32)] // 7.0.0+
+        [CommandHipc(32)] // 7.0.0+
         // SetShimLibraryVersion(pid, u64, nn::applet::AppletResourceUserId)
         public ResultCode SetShimLibraryVersion(ServiceCtx context)
         {
             return context.Device.System.CaptureManager.SetShimLibraryVersion(context);
         }
 
-        [Command(203)]
+        [CommandHipc(203)]
         // SaveScreenShotEx0(bytes<0x40> ScreenShotAttribute, u32 unknown, u64 AppletResourceUserId, pid, buffer<bytes, 0x45> ScreenshotData) -> bytes<0x20> ApplicationAlbumEntry
         public ResultCode SaveScreenShotEx0(ServiceCtx context)
         {
@@ -38,7 +38,7 @@ namespace Ryujinx.HLE.HOS.Services.Caps
             return resultCode;
         }
 
-        [Command(205)] // 8.0.0+
+        [CommandHipc(205)] // 8.0.0+
         // SaveScreenShotEx1(bytes<0x40> ScreenShotAttribute, u32 unknown, u64 AppletResourceUserId, pid, buffer<bytes, 0x15> ApplicationData, buffer<bytes, 0x45> ScreenshotData) -> bytes<0x20> ApplicationAlbumEntry
         public ResultCode SaveScreenShotEx1(ServiceCtx context)
         {
@@ -67,7 +67,7 @@ namespace Ryujinx.HLE.HOS.Services.Caps
             return resultCode;
         }
 
-        [Command(210)]
+        [CommandHipc(210)]
         // SaveScreenShotEx2(bytes<0x40> ScreenShotAttribute, u32 unknown, u64 AppletResourceUserId, buffer<bytes, 0x15> UserIdList, buffer<bytes, 0x45> ScreenshotData) -> bytes<0x20> ApplicationAlbumEntry
         public ResultCode SaveScreenShotEx2(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/CommandHIpcAttribute.cs
+++ b/Ryujinx.HLE/HOS/Services/CommandHIpcAttribute.cs
@@ -3,10 +3,10 @@
 namespace Ryujinx.HLE.HOS.Services
 {
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    class CommandAttribute : Attribute
+    class CommandHipcAttribute : Attribute
     {
         public readonly int Id;
 
-        public CommandAttribute(int id) => Id = id;
+        public CommandHipcAttribute(int id) => Id = id;
     }
 }

--- a/Ryujinx.HLE/HOS/Services/CommandTIpcAttribute.cs
+++ b/Ryujinx.HLE/HOS/Services/CommandTIpcAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Ryujinx.HLE.HOS.Services
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
+    class CommandTIpcAttribute : Attribute
+    {
+        public readonly int Id;
+
+        public CommandTIpcAttribute(int id) => Id = id;
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/CommandTIpcAttribute.cs
+++ b/Ryujinx.HLE/HOS/Services/CommandTIpcAttribute.cs
@@ -3,10 +3,10 @@
 namespace Ryujinx.HLE.HOS.Services
 {
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
-    class CommandTIpcAttribute : Attribute
+    class CommandTipcAttribute : Attribute
     {
         public readonly int Id;
 
-        public CommandTIpcAttribute(int id) => Id = id;
+        public CommandTipcAttribute(int id) => Id = id;
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Friend/IServiceCreator.cs
+++ b/Ryujinx.HLE/HOS/Services/Friend/IServiceCreator.cs
@@ -18,7 +18,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend
             _permissionLevel = permissionLevel;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // CreateFriendService() -> object<nn::friends::detail::ipc::IFriendService>
         public ResultCode CreateFriendService(ServiceCtx context)
         {
@@ -27,7 +27,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend
             return ResultCode.Success;
         }
 
-        [Command(1)] // 2.0.0+
+        [CommandHipc(1)] // 2.0.0+
         // CreateNotificationService(nn::account::Uid userId) -> object<nn::friends::detail::ipc::INotificationService>
         public ResultCode CreateNotificationService(ServiceCtx context)
         {
@@ -43,7 +43,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend
             return ResultCode.Success;
         }
 
-        [Command(2)] // 4.0.0+
+        [CommandHipc(2)] // 4.0.0+
         // CreateDaemonSuspendSessionService() -> object<nn::friends::detail::ipc::IDaemonSuspendSessionService>
         public ResultCode CreateDaemonSuspendSessionService(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Friend/ServiceCreator/IFriendService.cs
+++ b/Ryujinx.HLE/HOS/Services/Friend/ServiceCreator/IFriendService.cs
@@ -24,7 +24,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
             _permissionLevel = permissionLevel;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetCompletionEvent() -> handle<copy>
         public ResultCode GetCompletionEvent(ServiceCtx context)
         {
@@ -43,7 +43,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
             return ResultCode.Success;
         }
 
-        [Command(10100)]
+        [CommandHipc(10100)]
         // nn::friends::GetFriendListIds(int offset, nn::account::Uid userId, nn::friends::detail::ipc::SizedFriendFilter friendFilter, ulong pidPlaceHolder, pid)
         // -> int outCount, array<nn::account::NetworkServiceAccountId, 0xa>
         public ResultCode GetFriendListIds(ServiceCtx context)
@@ -82,7 +82,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
             return ResultCode.Success;
         }
 
-        [Command(10101)]
+        [CommandHipc(10101)]
         // nn::friends::GetFriendList(int offset, nn::account::Uid userId, nn::friends::detail::ipc::SizedFriendFilter friendFilter, ulong pidPlaceHolder, pid)
         // -> int outCount, array<nn::friends::detail::FriendImpl, 0x6>
         public ResultCode GetFriendList(ServiceCtx context)
@@ -120,7 +120,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
             return ResultCode.Success;
         }
 
-        [Command(10400)]
+        [CommandHipc(10400)]
         // nn::friends::GetBlockedUserListIds(int offset, nn::account::Uid userId) -> (u32, buffer<nn::account::NetworkServiceAccountId, 0xa>)
         public ResultCode GetBlockedUserListIds(ServiceCtx context)
         {
@@ -139,7 +139,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
             return ResultCode.Success;
         }
 
-        [Command(10600)]
+        [CommandHipc(10600)]
         // nn::friends::DeclareOpenOnlinePlaySession(nn::account::Uid userId)
         public ResultCode DeclareOpenOnlinePlaySession(ServiceCtx context)
         {
@@ -160,7 +160,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
             return ResultCode.Success;
         }
 
-        [Command(10601)]
+        [CommandHipc(10601)]
         // nn::friends::DeclareCloseOnlinePlaySession(nn::account::Uid userId)
         public ResultCode DeclareCloseOnlinePlaySession(ServiceCtx context)
         {
@@ -181,7 +181,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
             return ResultCode.Success;
         }
 
-        [Command(10610)]
+        [CommandHipc(10610)]
         // nn::friends::UpdateUserPresence(nn::account::Uid, u64, pid, buffer<nn::friends::detail::UserPresenceImpl, 0x19>)
         public ResultCode UpdateUserPresence(ServiceCtx context)
         {
@@ -214,7 +214,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
             return ResultCode.Success;
         }
 
-        [Command(10700)]
+        [CommandHipc(10700)]
         // nn::friends::GetPlayHistoryRegistrationKey(b8 unknown, nn::account::Uid) -> buffer<nn::friends::PlayHistoryRegistrationKey, 0x1a>
         public ResultCode GetPlayHistoryRegistrationKey(ServiceCtx context)
         {
@@ -277,7 +277,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
             return ResultCode.Success;
         }
 
-        [Command(10702)]
+        [CommandHipc(10702)]
         // nn::friends::AddPlayHistory(nn::account::Uid, u64, pid, buffer<nn::friends::PlayHistoryRegistrationKey, 0x19>, buffer<nn::friends::InAppScreenName, 0x19>, buffer<nn::friends::InAppScreenName, 0x19>)
         public ResultCode AddPlayHistory(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Friend/ServiceCreator/INotificationService.cs
+++ b/Ryujinx.HLE/HOS/Services/Friend/ServiceCreator/INotificationService.cs
@@ -37,7 +37,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
             NotificationEventHandler.Instance.RegisterNotificationService(this);
         }
 
-        [Command(0)] //2.0.0+
+        [CommandHipc(0)] //2.0.0+
         // nn::friends::detail::ipc::INotificationService::GetEvent() -> handle<copy>
         public ResultCode GetEvent(ServiceCtx context)
         {
@@ -54,7 +54,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
             return ResultCode.Success;
         }
 
-        [Command(1)] //2.0.0+
+        [CommandHipc(1)] //2.0.0+
         // nn::friends::detail::ipc::INotificationService::Clear()
         public ResultCode Clear(ServiceCtx context)
         {
@@ -69,7 +69,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
             return ResultCode.Success;
         }
 
-        [Command(2)] // 2.0.0+
+        [CommandHipc(2)] // 2.0.0+
         // nn::friends::detail::ipc::INotificationService::Pop() -> nn::friends::detail::ipc::SizedNotificationInfo
         public ResultCode Pop(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IDirectory.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IDirectory.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
             _baseDirectory = directory;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // Read() -> (u64 count, buffer<nn::fssrv::sf::IDirectoryEntry, 6, 0> entries)
         public ResultCode Read(ServiceCtx context)
         {
@@ -32,7 +32,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
             return (ResultCode)result.Value;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetEntryCount() -> u64
         public ResultCode GetEntryCount(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IFile.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IFile.cs
@@ -13,7 +13,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
             _baseFile = baseFile;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // Read(u32 readOption, u64 offset, u64 size) -> (u64 out_size, buffer<u8, 0x46, 0> out_buf)
         public ResultCode Read(ServiceCtx context)
         {
@@ -36,7 +36,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
             return (ResultCode)result.Value;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // Write(u32 writeOption, u64 offset, u64 size, buffer<u8, 0x45, 0>)
         public ResultCode Write(ServiceCtx context)
         {
@@ -55,14 +55,14 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
             return (ResultCode)_baseFile.Write(offset, data, writeOption).Value;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // Flush()
         public ResultCode Flush(ServiceCtx context)
         {
             return (ResultCode)_baseFile.Flush().Value;
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // SetSize(u64 size)
         public ResultCode SetSize(ServiceCtx context)
         {
@@ -71,7 +71,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
             return (ResultCode)_baseFile.SetSize(size).Value;
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // GetSize() -> u64 fileSize
         public ResultCode GetSize(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IFileSystem.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IFileSystem.cs
@@ -20,7 +20,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
             return _fileSystem;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // CreateFile(u32 createOption, u64 size, buffer<bytes<0x301>, 0x19, 0x301> path)
         public ResultCode CreateFile(ServiceCtx context)
         {
@@ -34,7 +34,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
             return (ResultCode)_fileSystem.CreateFile(name, size, createOption).Value;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // DeleteFile(buffer<bytes<0x301>, 0x19, 0x301> path)
         public ResultCode DeleteFile(ServiceCtx context)
         {
@@ -43,7 +43,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
             return (ResultCode)_fileSystem.DeleteFile(name).Value;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // CreateDirectory(buffer<bytes<0x301>, 0x19, 0x301> path)
         public ResultCode CreateDirectory(ServiceCtx context)
         {
@@ -52,7 +52,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
             return (ResultCode)_fileSystem.CreateDirectory(name).Value;
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // DeleteDirectory(buffer<bytes<0x301>, 0x19, 0x301> path)
         public ResultCode DeleteDirectory(ServiceCtx context)
         {
@@ -61,7 +61,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
             return (ResultCode)_fileSystem.DeleteDirectory(name).Value;
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // DeleteDirectoryRecursively(buffer<bytes<0x301>, 0x19, 0x301> path)
         public ResultCode DeleteDirectoryRecursively(ServiceCtx context)
         {
@@ -70,7 +70,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
             return (ResultCode)_fileSystem.DeleteDirectoryRecursively(name).Value;
         }
 
-        [Command(5)]
+        [CommandHipc(5)]
         // RenameFile(buffer<bytes<0x301>, 0x19, 0x301> oldPath, buffer<bytes<0x301>, 0x19, 0x301> newPath)
         public ResultCode RenameFile(ServiceCtx context)
         {
@@ -80,7 +80,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
             return (ResultCode)_fileSystem.RenameFile(oldName, newName).Value;
         }
 
-        [Command(6)]
+        [CommandHipc(6)]
         // RenameDirectory(buffer<bytes<0x301>, 0x19, 0x301> oldPath, buffer<bytes<0x301>, 0x19, 0x301> newPath)
         public ResultCode RenameDirectory(ServiceCtx context)
         {
@@ -90,7 +90,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
             return (ResultCode)_fileSystem.RenameDirectory(oldName, newName).Value;
         }
 
-        [Command(7)]
+        [CommandHipc(7)]
         // GetEntryType(buffer<bytes<0x301>, 0x19, 0x301> path) -> nn::fssrv::sf::DirectoryEntryType
         public ResultCode GetEntryType(ServiceCtx context)
         {
@@ -103,7 +103,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
             return (ResultCode)result.Value;
         }
 
-        [Command(8)]
+        [CommandHipc(8)]
         // OpenFile(u32 mode, buffer<bytes<0x301>, 0x19, 0x301> path) -> object<nn::fssrv::sf::IFile> file
         public ResultCode OpenFile(ServiceCtx context)
         {
@@ -123,7 +123,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
             return (ResultCode)result.Value;
         }
 
-        [Command(9)]
+        [CommandHipc(9)]
         // OpenDirectory(u32 filter_flags, buffer<bytes<0x301>, 0x19, 0x301> path) -> object<nn::fssrv::sf::IDirectory> directory
         public ResultCode OpenDirectory(ServiceCtx context)
         {
@@ -143,14 +143,14 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
             return (ResultCode)result.Value;
         }
 
-        [Command(10)]
+        [CommandHipc(10)]
         // Commit()
         public ResultCode Commit(ServiceCtx context)
         {
             return (ResultCode)_fileSystem.Commit().Value;
         }
 
-        [Command(11)]
+        [CommandHipc(11)]
         // GetFreeSpaceSize(buffer<bytes<0x301>, 0x19, 0x301> path) -> u64 totalFreeSpace
         public ResultCode GetFreeSpaceSize(ServiceCtx context)
         {
@@ -163,7 +163,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
             return (ResultCode)result.Value;
         }
 
-        [Command(12)]
+        [CommandHipc(12)]
         // GetTotalSpaceSize(buffer<bytes<0x301>, 0x19, 0x301> path) -> u64 totalSize
         public ResultCode GetTotalSpaceSize(ServiceCtx context)
         {
@@ -176,7 +176,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
             return (ResultCode)result.Value;
         }
 
-        [Command(13)]
+        [CommandHipc(13)]
         // CleanDirectoryRecursively(buffer<bytes<0x301>, 0x19, 0x301> path)
         public ResultCode CleanDirectoryRecursively(ServiceCtx context)
         {
@@ -185,7 +185,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
             return (ResultCode)_fileSystem.CleanDirectoryRecursively(name).Value;
         }
 
-        [Command(14)]
+        [CommandHipc(14)]
         // GetFileTimeStampRaw(buffer<bytes<0x301>, 0x19, 0x301> path) -> bytes<0x20> timestamp
         public ResultCode GetFileTimeStampRaw(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IStorage.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IStorage.cs
@@ -13,7 +13,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
             _baseStorage = baseStorage;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // Read(u64 offset, u64 length) -> buffer<u8, 0x46, 0> buffer
         public ResultCode Read(ServiceCtx context)
         {
@@ -42,7 +42,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
             return ResultCode.Success;
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // GetSize() -> u64 size
         public ResultCode GetSize(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Fs/IDeviceOperator.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/IDeviceOperator.cs
@@ -12,7 +12,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             _baseOperator = baseOperator;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // IsSdCardInserted() -> b8 is_inserted
         public ResultCode IsSdCardInserted(ServiceCtx context)
         {
@@ -23,7 +23,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return (ResultCode)result.Value;
         }
 
-        [Command(200)]
+        [CommandHipc(200)]
         // IsGameCardInserted() -> b8 is_inserted
         public ResultCode IsGameCardInserted(ServiceCtx context)
         {
@@ -34,7 +34,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return (ResultCode)result.Value;
         }
 
-        [Command(202)]
+        [CommandHipc(202)]
         // GetGameCardHandle() -> u32 gamecard_handle
         public ResultCode GetGameCardHandle(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
@@ -25,14 +25,14 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             _baseFileSystemProxy = context.Device.FileSystem.FsServer.CreateFileSystemProxyService();
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // Initialize(u64, pid)
         public ResultCode Initialize(ServiceCtx context)
         {
             return ResultCode.Success;
         }
 
-        [Command(8)]
+        [CommandHipc(8)]
         // OpenFileSystemWithId(nn::fssrv::sf::FileSystemType filesystem_type, nn::ApplicationId tid, buffer<bytes<0x301>, 0x19, 0x301> path)
         // -> object<nn::fssrv::sf::IFileSystem> contentFs
         public ResultCode OpenFileSystemWithId(ServiceCtx context)
@@ -88,7 +88,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return ResultCode.InvalidInput;
         }
 
-        [Command(11)]
+        [CommandHipc(11)]
         // OpenBisFileSystem(nn::fssrv::sf::Partition partitionID, buffer<bytes<0x301>, 0x19, 0x301>) -> object<nn::fssrv::sf::IFileSystem> Bis
         public ResultCode OpenBisFileSystem(ServiceCtx context)
         {
@@ -105,7 +105,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return ResultCode.Success;
         }
 
-        [Command(18)]
+        [CommandHipc(18)]
         // OpenSdCardFileSystem() -> object<nn::fssrv::sf::IFileSystem>
         public ResultCode OpenSdCardFileSystem(ServiceCtx context)
         {
@@ -117,7 +117,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return ResultCode.Success;
         }
 
-        [Command(21)]
+        [CommandHipc(21)]
         public ResultCode DeleteSaveDataFileSystem(ServiceCtx context)
         {
             ulong saveDataId = context.RequestData.ReadUInt64();
@@ -127,7 +127,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return (ResultCode)result.Value;
         }
 
-        [Command(22)]
+        [CommandHipc(22)]
         public ResultCode CreateSaveDataFileSystem(ServiceCtx context)
         {
             SaveDataAttribute attribute = context.RequestData.ReadStruct<SaveDataAttribute>();
@@ -148,7 +148,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return (ResultCode)result.Value;
         }
 
-        [Command(23)]
+        [CommandHipc(23)]
         public ResultCode CreateSaveDataFileSystemBySystemSaveDataId(ServiceCtx context)
         {
             SaveDataAttribute attribute = context.RequestData.ReadStruct<SaveDataAttribute>();
@@ -159,7 +159,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return (ResultCode)result.Value;
         }
 
-        [Command(25)]
+        [CommandHipc(25)]
         public ResultCode DeleteSaveDataFileSystemBySaveDataSpaceId(ServiceCtx context)
         {
             SaveDataSpaceId spaceId = (SaveDataSpaceId)context.RequestData.ReadInt64();
@@ -170,7 +170,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return (ResultCode)result.Value;
         }
 
-        [Command(28)]
+        [CommandHipc(28)]
         public ResultCode DeleteSaveDataFileSystemBySaveDataAttribute(ServiceCtx context)
         {
             SaveDataSpaceId spaceId = (SaveDataSpaceId)context.RequestData.ReadInt64();
@@ -181,7 +181,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return (ResultCode)result.Value;
         }
 
-        [Command(30)]
+        [CommandHipc(30)]
         // OpenGameCardStorage(u32, u32) -> object<nn::fssrv::sf::IStorage>
         public ResultCode OpenGameCardStorage(ServiceCtx context)
         {
@@ -198,7 +198,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return (ResultCode)result.Value;
         }
 
-        [Command(35)]
+        [CommandHipc(35)]
         public ResultCode CreateSaveDataFileSystemWithHashSalt(ServiceCtx context)
         {
             SaveDataAttribute attribute = context.RequestData.ReadStruct<SaveDataAttribute>();
@@ -218,7 +218,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return (ResultCode)result.Value;
         }
 
-        [Command(51)]
+        [CommandHipc(51)]
         // OpenSaveDataFileSystem(u8 save_data_space_id, nn::fssrv::sf::SaveStruct saveStruct) -> object<nn::fssrv::sf::IFileSystem> saveDataFs
         public ResultCode OpenSaveDataFileSystem(ServiceCtx context)
         {
@@ -242,7 +242,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return (ResultCode)result.Value;
         }
 
-        [Command(52)]
+        [CommandHipc(52)]
         // OpenSaveDataFileSystemBySystemSaveDataId(u8 save_data_space_id, nn::fssrv::sf::SaveStruct saveStruct) -> object<nn::fssrv::sf::IFileSystem> systemSaveDataFs
         public ResultCode OpenSaveDataFileSystemBySystemSaveDataId(ServiceCtx context)
         {
@@ -259,7 +259,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return (ResultCode)result.Value;
         }
 
-        [Command(53)]
+        [CommandHipc(53)]
         // OpenReadOnlySaveDataFileSystem(u8 save_data_space_id, nn::fssrv::sf::SaveStruct save_struct) -> object<nn::fssrv::sf::IFileSystem>
         public ResultCode OpenReadOnlySaveDataFileSystem(ServiceCtx context)
         {
@@ -283,7 +283,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return (ResultCode)result.Value;
         }
 
-        [Command(60)]
+        [CommandHipc(60)]
         public ResultCode OpenSaveDataInfoReader(ServiceCtx context)
         {
             Result result = _baseFileSystemProxy.OpenSaveDataInfoReader(out ReferenceCountedDisposable<LibHac.FsSrv.ISaveDataInfoReader> infoReader);
@@ -296,7 +296,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return (ResultCode)result.Value;
         }
 
-        [Command(61)]
+        [CommandHipc(61)]
         public ResultCode OpenSaveDataInfoReaderBySaveDataSpaceId(ServiceCtx context)
         {
             SaveDataSpaceId spaceId = (SaveDataSpaceId)context.RequestData.ReadByte();
@@ -311,7 +311,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return (ResultCode)result.Value;
         }
 
-        [Command(62)]
+        [CommandHipc(62)]
         public ResultCode OpenSaveDataInfoReaderOnlyCacheStorage(ServiceCtx context)
         {
             SaveDataFilter filter = new SaveDataFilter();
@@ -331,7 +331,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return (ResultCode)result.Value;
         }
 
-        [Command(67)]
+        [CommandHipc(67)]
         public ResultCode FindSaveDataWithFilter(ServiceCtx context)
         {
             SaveDataSpaceId spaceId = (SaveDataSpaceId)context.RequestData.ReadInt64();
@@ -350,7 +350,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return (ResultCode)result.Value;
         }
 
-        [Command(68)]
+        [CommandHipc(68)]
         public ResultCode OpenSaveDataInfoReaderWithFilter(ServiceCtx context)
         {
             SaveDataSpaceId spaceId = (SaveDataSpaceId)context.RequestData.ReadInt64();
@@ -367,7 +367,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return (ResultCode)result.Value;
         }
 
-        [Command(71)]
+        [CommandHipc(71)]
         public ResultCode ReadSaveDataFileSystemExtraDataWithMaskBySaveDataAttribute(ServiceCtx context)
         {
             Logger.Stub?.PrintStub(LogClass.ServiceFs);
@@ -377,7 +377,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return ResultCode.Success;
         }
 
-        [Command(200)]
+        [CommandHipc(200)]
         // OpenDataStorageByCurrentProcess() -> object<nn::fssrv::sf::IStorage> dataStorage
         public ResultCode OpenDataStorageByCurrentProcess(ServiceCtx context)
         {
@@ -386,7 +386,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return 0;
         }
 
-        [Command(202)]
+        [CommandHipc(202)]
         // OpenDataStorageByDataId(u8 storageId, nn::ApplicationId tid) -> object<nn::fssrv::sf::IStorage> dataStorage
         public ResultCode OpenDataStorageByDataId(ServiceCtx context)
         {
@@ -456,7 +456,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             throw new FileNotFoundException($"System archive with titleid {titleId:x16} was not found on Storage {storageId}. Found in {installedStorage}.");
         }
 
-        [Command(203)]
+        [CommandHipc(203)]
         // OpenPatchDataStorageByCurrentProcess() -> object<nn::fssrv::sf::IStorage>
         public ResultCode OpenPatchDataStorageByCurrentProcess(ServiceCtx context)
         {
@@ -465,7 +465,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return ResultCode.Success;
         }
 
-        [Command(400)]
+        [CommandHipc(400)]
         // OpenDataStorageByCurrentProcess() -> object<nn::fssrv::sf::IStorage> dataStorage
         public ResultCode OpenDeviceOperator(ServiceCtx context)
         {
@@ -479,7 +479,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return (ResultCode)result.Value;
         }
 
-        [Command(630)]
+        [CommandHipc(630)]
         // SetSdCardAccessibility(u8)
         public ResultCode SetSdCardAccessibility(ServiceCtx context)
         {
@@ -488,7 +488,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return (ResultCode)_baseFileSystemProxy.SetSdCardAccessibility(isAccessible).Value;
         }
 
-        [Command(631)]
+        [CommandHipc(631)]
         // IsSdCardAccessible() -> u8
         public ResultCode IsSdCardAccessible(ServiceCtx context)
         {
@@ -499,7 +499,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return (ResultCode)result.Value;
         }
 
-        [Command(1004)]
+        [CommandHipc(1004)]
         // SetGlobalAccessLogMode(u32 mode)
         public ResultCode SetGlobalAccessLogMode(ServiceCtx context)
         {
@@ -510,7 +510,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return ResultCode.Success;
         }
 
-        [Command(1005)]
+        [CommandHipc(1005)]
         // GetGlobalAccessLogMode() -> u32 logMode
         public ResultCode GetGlobalAccessLogMode(ServiceCtx context)
         {
@@ -521,7 +521,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return ResultCode.Success;
         }
 
-        [Command(1006)]
+        [CommandHipc(1006)]
         // OutputAccessLogToSdCard(buffer<bytes, 5> log_text)
         public ResultCode OutputAccessLogToSdCard(ServiceCtx context)
         {
@@ -533,7 +533,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return ResultCode.Success;
         }
 
-        [Command(1011)]
+        [CommandHipc(1011)]
         public ResultCode GetProgramIndexForAccessLog(ServiceCtx context)
         {
             int programIndex = 0;
@@ -545,7 +545,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return ResultCode.Success;
         }
 
-        [Command(1200)] // 6.0.0+
+        [CommandHipc(1200)] // 6.0.0+
         // OpenMultiCommitManager() -> object<nn::fssrv::sf::IMultiCommitManager>
         public ResultCode OpenMultiCommitManager(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Fs/IMultiCommitManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/IMultiCommitManager.cs
@@ -12,7 +12,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             _baseCommitManager = baseCommitManager;
         }
 
-        [Command(1)] // 6.0.0+
+        [CommandHipc(1)] // 6.0.0+
         // Add(object<nn::fssrv::sf::IFileSystem>)
         public ResultCode Add(ServiceCtx context)
         {
@@ -23,7 +23,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return (ResultCode)result.Value;
         }
 
-        [Command(2)] // 6.0.0+
+        [CommandHipc(2)] // 6.0.0+
         // Commit()
         public ResultCode Commit(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Fs/ISaveDataInfoReader.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/ISaveDataInfoReader.cs
@@ -12,7 +12,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             _baseReader = baseReader;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // ReadSaveDataInfo() -> (u64, buffer<unknown, 6>)
         public ResultCode ReadSaveDataInfo(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Hid/HidServer/IActiveVibrationDeviceList.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/HidServer/IActiveVibrationDeviceList.cs
@@ -4,7 +4,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid.HidServer
     {
         public IActiveApplicationDeviceList() { }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // ActivateVibrationDevice(nn::hid::VibrationDeviceHandle)
         public ResultCode ActivateVibrationDevice(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Hid/HidServer/IAppletResource.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/HidServer/IAppletResource.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid.HidServer
             _hidSharedMem = hidSharedMem;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetSharedMemoryHandle() -> handle<copy>
         public ResultCode GetSharedMemoryHandle(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
@@ -52,7 +52,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             _xpadIdEvent.ReadableEvent.Signal();
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // CreateAppletResource(nn::applet::AppletResourceUserId) -> object<nn::hid::IAppletResource>
         public ResultCode CreateAppletResource(ServiceCtx context)
         {
@@ -63,7 +63,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // ActivateDebugPad(nn::applet::AppletResourceUserId)
         public ResultCode ActivateDebugPad(ServiceCtx context)
         {
@@ -74,7 +74,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(11)]
+        [CommandHipc(11)]
         // ActivateTouchScreen(nn::applet::AppletResourceUserId)
         public ResultCode ActivateTouchScreen(ServiceCtx context)
         {
@@ -87,7 +87,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(21)]
+        [CommandHipc(21)]
         // ActivateMouse(nn::applet::AppletResourceUserId)
         public ResultCode ActivateMouse(ServiceCtx context)
         {
@@ -100,7 +100,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(31)]
+        [CommandHipc(31)]
         // ActivateKeyboard(nn::applet::AppletResourceUserId)
         public ResultCode ActivateKeyboard(ServiceCtx context)
         {
@@ -113,7 +113,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(32)]
+        [CommandHipc(32)]
         // SendKeyboardLockKeyEvent(uint flags, pid)
         public ResultCode SendKeyboardLockKeyEvent(ServiceCtx context)
         {
@@ -126,7 +126,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(40)]
+        [CommandHipc(40)]
         // AcquireXpadIdEventHandle(ulong XpadId) -> nn::sf::NativeHandle
         public ResultCode AcquireXpadIdEventHandle(ServiceCtx context)
         {
@@ -144,7 +144,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(41)]
+        [CommandHipc(41)]
         // ReleaseXpadIdEventHandle(ulong XpadId)
         public ResultCode ReleaseXpadIdEventHandle(ServiceCtx context)
         {
@@ -157,7 +157,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(51)]
+        [CommandHipc(51)]
         // ActivateXpad(nn::hid::BasicXpadId, nn::applet::AppletResourceUserId)
         public ResultCode ActivateXpad(ServiceCtx context)
         {
@@ -169,7 +169,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(55)]
+        [CommandHipc(55)]
         // GetXpadIds() -> long IdsCount, buffer<array<nn::hid::BasicXpadId>, type: 0xa>
         public ResultCode GetXpadIds(ServiceCtx context)
         {
@@ -181,7 +181,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(56)]
+        [CommandHipc(56)]
         // ActivateJoyXpad(nn::hid::JoyXpadId)
         public ResultCode ActivateJoyXpad(ServiceCtx context)
         {
@@ -192,7 +192,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(58)]
+        [CommandHipc(58)]
         // GetJoyXpadLifoHandle(nn::hid::JoyXpadId) -> nn::sf::NativeHandle
         public ResultCode GetJoyXpadLifoHandle(ServiceCtx context)
         {
@@ -207,7 +207,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(59)]
+        [CommandHipc(59)]
         // GetJoyXpadIds() -> long IdsCount, buffer<array<nn::hid::JoyXpadId>, type: 0xa>
         public ResultCode GetJoyXpadIds(ServiceCtx context)
         {
@@ -219,7 +219,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(60)]
+        [CommandHipc(60)]
         // ActivateSixAxisSensor(nn::hid::BasicXpadId)
         public ResultCode ActivateSixAxisSensor(ServiceCtx context)
         {
@@ -230,7 +230,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(61)]
+        [CommandHipc(61)]
         // DeactivateSixAxisSensor(nn::hid::BasicXpadId)
         public ResultCode DeactivateSixAxisSensor(ServiceCtx context)
         {
@@ -241,7 +241,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(62)]
+        [CommandHipc(62)]
         // GetSixAxisSensorLifoHandle(nn::hid::BasicXpadId) -> nn::sf::NativeHandle
         public ResultCode GetSixAxisSensorLifoHandle(ServiceCtx context)
         {
@@ -256,7 +256,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(63)]
+        [CommandHipc(63)]
         // ActivateJoySixAxisSensor(nn::hid::JoyXpadId)
         public ResultCode ActivateJoySixAxisSensor(ServiceCtx context)
         {
@@ -267,7 +267,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(64)]
+        [CommandHipc(64)]
         // DeactivateJoySixAxisSensor(nn::hid::JoyXpadId)
         public ResultCode DeactivateJoySixAxisSensor(ServiceCtx context)
         {
@@ -278,7 +278,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(65)]
+        [CommandHipc(65)]
         // GetJoySixAxisSensorLifoHandle(nn::hid::JoyXpadId) -> nn::sf::NativeHandle
         public ResultCode GetJoySixAxisSensorLifoHandle(ServiceCtx context)
         {
@@ -293,7 +293,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(66)]
+        [CommandHipc(66)]
         // StartSixAxisSensor(nn::hid::SixAxisSensorHandle, nn::applet::AppletResourceUserId)
         public ResultCode StartSixAxisSensor(ServiceCtx context)
         {
@@ -305,7 +305,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(67)]
+        [CommandHipc(67)]
         // StopSixAxisSensor(nn::hid::SixAxisSensorHandle, nn::applet::AppletResourceUserId)
         public ResultCode StopSixAxisSensor(ServiceCtx context)
         {
@@ -317,7 +317,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(68)]
+        [CommandHipc(68)]
         // IsSixAxisSensorFusionEnabled(nn::hid::SixAxisSensorHandle, nn::applet::AppletResourceUserId) -> bool IsEnabled
         public ResultCode IsSixAxisSensorFusionEnabled(ServiceCtx context)
         {
@@ -331,7 +331,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(69)]
+        [CommandHipc(69)]
         // EnableSixAxisSensorFusion(bool Enabled, nn::hid::SixAxisSensorHandle, nn::applet::AppletResourceUserId)
         public ResultCode EnableSixAxisSensorFusion(ServiceCtx context)
         {
@@ -344,7 +344,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(70)]
+        [CommandHipc(70)]
         // SetSixAxisSensorFusionParameters(nn::hid::SixAxisSensorHandle, float RevisePower, float ReviseRange, nn::applet::AppletResourceUserId)
         public ResultCode SetSixAxisSensorFusionParameters(ServiceCtx context)
         {
@@ -363,7 +363,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(71)]
+        [CommandHipc(71)]
         // GetSixAxisSensorFusionParameters(nn::hid::SixAxisSensorHandle, nn::applet::AppletResourceUserId) -> float RevisePower, float ReviseRange)
         public ResultCode GetSixAxisSensorFusionParameters(ServiceCtx context)
         {
@@ -378,7 +378,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(72)]
+        [CommandHipc(72)]
         // ResetSixAxisSensorFusionParameters(nn::hid::SixAxisSensorHandle, nn::applet::AppletResourceUserId)
         public ResultCode ResetSixAxisSensorFusionParameters(ServiceCtx context)
         {
@@ -393,7 +393,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(73)]
+        [CommandHipc(73)]
         // SetAccelerometerParameters(nn::hid::SixAxisSensorHandle, float X, float Y, nn::applet::AppletResourceUserId)
         public ResultCode SetAccelerometerParameters(ServiceCtx context)
         {
@@ -412,7 +412,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(74)]
+        [CommandHipc(74)]
         // GetAccelerometerParameters(nn::hid::SixAxisSensorHandle, nn::applet::AppletResourceUserId) -> float X, float Y
         public ResultCode GetAccelerometerParameters(ServiceCtx context)
         {
@@ -427,7 +427,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(75)]
+        [CommandHipc(75)]
         // ResetAccelerometerParameters(nn::hid::SixAxisSensorHandle, nn::applet::AppletResourceUserId)
         public ResultCode ResetAccelerometerParameters(ServiceCtx context)
         {
@@ -442,7 +442,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(76)]
+        [CommandHipc(76)]
         // SetAccelerometerPlayMode(nn::hid::SixAxisSensorHandle, uint PlayMode, nn::applet::AppletResourceUserId)
         public ResultCode SetAccelerometerPlayMode(ServiceCtx context)
         {
@@ -455,7 +455,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(77)]
+        [CommandHipc(77)]
         // GetAccelerometerPlayMode(nn::hid::SixAxisSensorHandle, nn::applet::AppletResourceUserId) -> uint PlayMode
         public ResultCode GetAccelerometerPlayMode(ServiceCtx context)
         {
@@ -469,7 +469,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(78)]
+        [CommandHipc(78)]
         // ResetAccelerometerPlayMode(nn::hid::SixAxisSensorHandle, nn::applet::AppletResourceUserId)
         public ResultCode ResetAccelerometerPlayMode(ServiceCtx context)
         {
@@ -483,7 +483,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(79)]
+        [CommandHipc(79)]
         // SetGyroscopeZeroDriftMode(nn::hid::SixAxisSensorHandle, uint GyroscopeZeroDriftMode, nn::applet::AppletResourceUserId)
         public ResultCode SetGyroscopeZeroDriftMode(ServiceCtx context)
         {
@@ -496,7 +496,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(80)]
+        [CommandHipc(80)]
         // GetGyroscopeZeroDriftMode(nn::applet::AppletResourceUserId, nn::hid::SixAxisSensorHandle) -> int GyroscopeZeroDriftMode
         public ResultCode GetGyroscopeZeroDriftMode(ServiceCtx context)
         {
@@ -510,7 +510,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(81)]
+        [CommandHipc(81)]
         // ResetGyroscopeZeroDriftMode(nn::hid::SixAxisSensorHandle, nn::applet::AppletResourceUserId)
         public ResultCode ResetGyroscopeZeroDriftMode(ServiceCtx context)
         {
@@ -524,7 +524,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(82)]
+        [CommandHipc(82)]
         // IsSixAxisSensorAtRest(nn::hid::SixAxisSensorHandle, nn::applet::AppletResourceUserId) -> bool IsAsRest
         public ResultCode IsSixAxisSensorAtRest(ServiceCtx context)
         {
@@ -540,7 +540,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(91)]
+        [CommandHipc(91)]
         // ActivateGesture(nn::applet::AppletResourceUserId, int Unknown0)
         public ResultCode ActivateGesture(ServiceCtx context)
         {
@@ -552,7 +552,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(100)]
+        [CommandHipc(100)]
         // SetSupportedNpadStyleSet(nn::applet::AppletResourceUserId, nn::hid::NpadStyleTag)
         public ResultCode SetSupportedNpadStyleSet(ServiceCtx context)
         {
@@ -569,7 +569,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(101)]
+        [CommandHipc(101)]
         // GetSupportedNpadStyleSet(nn::applet::AppletResourceUserId) -> uint nn::hid::NpadStyleTag
         public ResultCode GetSupportedNpadStyleSet(ServiceCtx context)
         {
@@ -585,7 +585,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(102)]
+        [CommandHipc(102)]
         // SetSupportedNpadIdType(nn::applet::AppletResourceUserId, array<NpadIdType, 9>)
         public ResultCode SetSupportedNpadIdType(ServiceCtx context)
         {
@@ -613,7 +613,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(103)]
+        [CommandHipc(103)]
         // ActivateNpad(nn::applet::AppletResourceUserId)
         public ResultCode ActivateNpad(ServiceCtx context)
         {
@@ -625,7 +625,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(104)]
+        [CommandHipc(104)]
         // DeactivateNpad(nn::applet::AppletResourceUserId)
         public ResultCode DeactivateNpad(ServiceCtx context)
         {
@@ -637,7 +637,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(106)]
+        [CommandHipc(106)]
         // AcquireNpadStyleSetUpdateEventHandle(nn::applet::AppletResourceUserId, uint, ulong) -> nn::sf::NativeHandle
         public ResultCode AcquireNpadStyleSetUpdateEventHandle(ServiceCtx context)
         {
@@ -658,7 +658,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(107)]
+        [CommandHipc(107)]
         // DisconnectNpad(nn::applet::AppletResourceUserId, uint NpadIdType)
         public ResultCode DisconnectNpad(ServiceCtx context)
         {
@@ -670,7 +670,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(108)]
+        [CommandHipc(108)]
         // GetPlayerLedPattern(uint NpadId) -> ulong LedPattern
         public ResultCode GetPlayerLedPattern(ServiceCtx context)
         {
@@ -685,7 +685,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(109)] // 5.0.0+
+        [CommandHipc(109)] // 5.0.0+
         // ActivateNpadWithRevision(nn::applet::AppletResourceUserId, int Unknown)
         public ResultCode ActivateNpadWithRevision(ServiceCtx context)
         {
@@ -697,7 +697,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(120)]
+        [CommandHipc(120)]
         // SetNpadJoyHoldType(nn::applet::AppletResourceUserId, long NpadJoyHoldType)
         public ResultCode SetNpadJoyHoldType(ServiceCtx context)
         {
@@ -712,7 +712,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(121)]
+        [CommandHipc(121)]
         // GetNpadJoyHoldType(nn::applet::AppletResourceUserId) -> long NpadJoyHoldType
         public ResultCode GetNpadJoyHoldType(ServiceCtx context)
         {
@@ -728,7 +728,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(122)]
+        [CommandHipc(122)]
         // SetNpadJoyAssignmentModeSingleByDefault(uint HidControllerId, nn::applet::AppletResourceUserId)
         public ResultCode SetNpadJoyAssignmentModeSingleByDefault(ServiceCtx context)
         {
@@ -742,7 +742,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(123)]
+        [CommandHipc(123)]
         // SetNpadJoyAssignmentModeSingle(uint HidControllerId, nn::applet::AppletResourceUserId, long HidNpadJoyDeviceType)
         public ResultCode SetNpadJoyAssignmentModeSingle(ServiceCtx context)
         {
@@ -757,7 +757,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(124)]
+        [CommandHipc(124)]
         // SetNpadJoyAssignmentModeDual(uint HidControllerId, nn::applet::AppletResourceUserId)
         public ResultCode SetNpadJoyAssignmentModeDual(ServiceCtx context)
         {
@@ -771,7 +771,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(125)]
+        [CommandHipc(125)]
         // MergeSingleJoyAsDualJoy(uint SingleJoyId0, uint SingleJoyId1, nn::applet::AppletResourceUserId)
         public ResultCode MergeSingleJoyAsDualJoy(ServiceCtx context)
         {
@@ -784,7 +784,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(126)]
+        [CommandHipc(126)]
         // StartLrAssignmentMode(nn::applet::AppletResourceUserId)
         public ResultCode StartLrAssignmentMode(ServiceCtx context)
         {
@@ -795,7 +795,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(127)]
+        [CommandHipc(127)]
         // StopLrAssignmentMode(nn::applet::AppletResourceUserId)
         public ResultCode StopLrAssignmentMode(ServiceCtx context)
         {
@@ -806,7 +806,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(128)]
+        [CommandHipc(128)]
         // SetNpadHandheldActivationMode(nn::applet::AppletResourceUserId, long HidNpadHandheldActivationMode)
         public ResultCode SetNpadHandheldActivationMode(ServiceCtx context)
         {
@@ -818,7 +818,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(129)]
+        [CommandHipc(129)]
         // GetNpadHandheldActivationMode(nn::applet::AppletResourceUserId) -> long HidNpadHandheldActivationMode
         public ResultCode GetNpadHandheldActivationMode(ServiceCtx context)
         {
@@ -831,7 +831,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(130)]
+        [CommandHipc(130)]
         // SwapNpadAssignment(uint OldNpadAssignment, uint NewNpadAssignment, nn::applet::AppletResourceUserId)
         public ResultCode SwapNpadAssignment(ServiceCtx context)
         {
@@ -844,7 +844,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(131)]
+        [CommandHipc(131)]
         // IsUnintendedHomeButtonInputProtectionEnabled(uint Unknown0, nn::applet::AppletResourceUserId) ->  bool IsEnabled
         public ResultCode IsUnintendedHomeButtonInputProtectionEnabled(ServiceCtx context)
         {
@@ -858,7 +858,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(132)]
+        [CommandHipc(132)]
         // EnableUnintendedHomeButtonInputProtection(bool Enable, uint Unknown0, nn::applet::AppletResourceUserId)
         public ResultCode EnableUnintendedHomeButtonInputProtection(ServiceCtx context)
         {
@@ -871,7 +871,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(133)] // 5.0.0+
+        [CommandHipc(133)] // 5.0.0+
         // SetNpadJoyAssignmentModeSingleWithDestination(uint HidControllerId, long HidNpadJoyDeviceType, nn::applet::AppletResourceUserId) -> bool Unknown0, uint Unknown1
         public ResultCode SetNpadJoyAssignmentModeSingleWithDestination(ServiceCtx context)
         {
@@ -896,7 +896,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(200)]
+        [CommandHipc(200)]
         // GetVibrationDeviceInfo(nn::hid::VibrationDeviceHandle) -> nn::hid::VibrationDeviceInfo
         public ResultCode GetVibrationDeviceInfo(ServiceCtx context)
         {
@@ -916,7 +916,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(201)]
+        [CommandHipc(201)]
         // SendVibrationValue(nn::hid::VibrationDeviceHandle, nn::hid::VibrationValue, nn::applet::AppletResourceUserId)
         public ResultCode SendVibrationValue(ServiceCtx context)
         {
@@ -944,7 +944,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(202)]
+        [CommandHipc(202)]
         // GetActualVibrationValue(nn::hid::VibrationDeviceHandle, nn::applet::AppletResourceUserId) -> nn::hid::VibrationValue
         public ResultCode GetActualVibrationValue(ServiceCtx context)
         {
@@ -968,7 +968,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(203)]
+        [CommandHipc(203)]
         // CreateActiveVibrationDeviceList() -> object<nn::hid::IActiveVibrationDeviceList>
         public ResultCode CreateActiveVibrationDeviceList(ServiceCtx context)
         {
@@ -977,7 +977,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(204)]
+        [CommandHipc(204)]
         // PermitVibration(bool Enable)
         public ResultCode PermitVibration(ServiceCtx context)
         {
@@ -988,7 +988,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(205)]
+        [CommandHipc(205)]
         // IsVibrationPermitted() -> bool IsEnabled
         public ResultCode IsVibrationPermitted(ServiceCtx context)
         {
@@ -999,7 +999,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(206)]
+        [CommandHipc(206)]
         // SendVibrationValues(nn::applet::AppletResourceUserId, buffer<array<nn::hid::VibrationDeviceHandle>, type: 9>, buffer<array<nn::hid::VibrationValue>, type: 9>)
         public ResultCode SendVibrationValues(ServiceCtx context)
         {
@@ -1024,7 +1024,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(207)] // 4.0.0+
+        [CommandHipc(207)] // 4.0.0+
         // SendVibrationGcErmCommand(nn::hid::VibrationDeviceHandle, nn::hid::VibrationGcErmCommand, nn::applet::AppletResourceUserId)
         public ResultCode SendVibrationGcErmCommand(ServiceCtx context)
         {
@@ -1037,7 +1037,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(208)] // 4.0.0+
+        [CommandHipc(208)] // 4.0.0+
         // GetActualVibrationGcErmCommand(nn::hid::VibrationDeviceHandle, nn::applet::AppletResourceUserId) -> nn::hid::VibrationGcErmCommand
         public ResultCode GetActualVibrationGcErmCommand(ServiceCtx context)
         {
@@ -1051,7 +1051,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(209)] // 4.0.0+
+        [CommandHipc(209)] // 4.0.0+
         // BeginPermitVibrationSession(nn::applet::AppletResourceUserId)
         public ResultCode BeginPermitVibrationSession(ServiceCtx context)
         {
@@ -1062,7 +1062,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(210)] // 4.0.0+
+        [CommandHipc(210)] // 4.0.0+
         // EndPermitVibrationSession()
         public ResultCode EndPermitVibrationSession(ServiceCtx context)
         {
@@ -1071,7 +1071,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(300)]
+        [CommandHipc(300)]
         // ActivateConsoleSixAxisSensor(nn::applet::AppletResourceUserId)
         public ResultCode ActivateConsoleSixAxisSensor(ServiceCtx context)
         {
@@ -1082,7 +1082,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(301)]
+        [CommandHipc(301)]
         // StartConsoleSixAxisSensor(nn::hid::ConsoleSixAxisSensorHandle, nn::applet::AppletResourceUserId)
         public ResultCode StartConsoleSixAxisSensor(ServiceCtx context)
         {
@@ -1094,7 +1094,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(302)]
+        [CommandHipc(302)]
         // StopConsoleSixAxisSensor(nn::hid::ConsoleSixAxisSensorHandle, nn::applet::AppletResourceUserId)
         public ResultCode StopConsoleSixAxisSensor(ServiceCtx context)
         {
@@ -1106,7 +1106,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(303)] // 5.0.0+
+        [CommandHipc(303)] // 5.0.0+
         // ActivateSevenSixAxisSensor(nn::applet::AppletResourceUserId)
         public ResultCode ActivateSevenSixAxisSensor(ServiceCtx context)
         {
@@ -1117,7 +1117,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(304)] // 5.0.0+
+        [CommandHipc(304)] // 5.0.0+
         // StartSevenSixAxisSensor(nn::applet::AppletResourceUserId)
         public ResultCode StartSevenSixAxisSensor(ServiceCtx context)
         {
@@ -1128,7 +1128,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(305)] // 5.0.0+
+        [CommandHipc(305)] // 5.0.0+
         // StopSevenSixAxisSensor(nn::applet::AppletResourceUserId)
         public ResultCode StopSevenSixAxisSensor(ServiceCtx context)
         {
@@ -1139,7 +1139,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(306)] // 5.0.0+
+        [CommandHipc(306)] // 5.0.0+
         // InitializeSevenSixAxisSensor(array<nn::sf::NativeHandle>, ulong Counter0, array<nn::sf::NativeHandle>, ulong Counter1, nn::applet::AppletResourceUserId)
         public ResultCode InitializeSevenSixAxisSensor(ServiceCtx context)
         {
@@ -1154,7 +1154,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(307)] // 5.0.0+
+        [CommandHipc(307)] // 5.0.0+
         // FinalizeSevenSixAxisSensor(nn::applet::AppletResourceUserId)
         public ResultCode FinalizeSevenSixAxisSensor(ServiceCtx context)
         {
@@ -1165,7 +1165,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(308)] // 5.0.0+
+        [CommandHipc(308)] // 5.0.0+
         // SetSevenSixAxisSensorFusionStrength(float Strength, nn::applet::AppletResourceUserId)
         public ResultCode SetSevenSixAxisSensorFusionStrength(ServiceCtx context)
         {
@@ -1177,7 +1177,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(309)] // 5.0.0+
+        [CommandHipc(309)] // 5.0.0+
         // GetSevenSixAxisSensorFusionStrength(nn::applet::AppletResourceUserId) -> float Strength
         public ResultCode GetSevenSixAxisSensorFusionStrength(ServiceCtx context)
         {
@@ -1190,7 +1190,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(310)] // 6.0.0+
+        [CommandHipc(310)] // 6.0.0+
         // ResetSevenSixAxisSensorTimestamp(pid, nn::applet::AppletResourceUserId)
         public ResultCode ResetSevenSixAxisSensorTimestamp(ServiceCtx context)
         {
@@ -1201,7 +1201,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(400)]
+        [CommandHipc(400)]
         // IsUsbFullKeyControllerEnabled() -> bool IsEnabled
         public ResultCode IsUsbFullKeyControllerEnabled(ServiceCtx context)
         {
@@ -1212,7 +1212,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(401)]
+        [CommandHipc(401)]
         // EnableUsbFullKeyController(bool Enable)
         public ResultCode EnableUsbFullKeyController(ServiceCtx context)
         {
@@ -1223,7 +1223,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(402)]
+        [CommandHipc(402)]
         // IsUsbFullKeyControllerConnected(uint Unknown0) -> bool Connected
         public ResultCode IsUsbFullKeyControllerConnected(ServiceCtx context)
         {
@@ -1236,7 +1236,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(403)] // 4.0.0+
+        [CommandHipc(403)] // 4.0.0+
         // HasBattery(uint NpadId) -> bool HasBattery
         public ResultCode HasBattery(ServiceCtx context)
         {
@@ -1249,7 +1249,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(404)] // 4.0.0+
+        [CommandHipc(404)] // 4.0.0+
         // HasLeftRightBattery(uint NpadId) -> bool HasLeftBattery, bool HasRightBattery
         public ResultCode HasLeftRightBattery(ServiceCtx context)
         {
@@ -1263,7 +1263,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(405)] // 4.0.0+
+        [CommandHipc(405)] // 4.0.0+
         // GetNpadInterfaceType(uint NpadId) -> uchar InterfaceType
         public ResultCode GetNpadInterfaceType(ServiceCtx context)
         {
@@ -1276,7 +1276,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(406)] // 4.0.0+
+        [CommandHipc(406)] // 4.0.0+
         // GetNpadLeftRightInterfaceType(uint NpadId) -> uchar LeftInterfaceType, uchar RightInterfaceType
         public ResultCode GetNpadLeftRightInterfaceType(ServiceCtx context)
         {
@@ -1290,7 +1290,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(500)] // 5.0.0+
+        [CommandHipc(500)] // 5.0.0+
         // GetPalmaConnectionHandle(uint Unknown0, nn::applet::AppletResourceUserId) -> nn::hid::PalmaConnectionHandle
         public ResultCode GetPalmaConnectionHandle(ServiceCtx context)
         {
@@ -1306,7 +1306,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(501)] // 5.0.0+
+        [CommandHipc(501)] // 5.0.0+
         // InitializePalma(nn::hid::PalmaConnectionHandle)
         public ResultCode InitializePalma(ServiceCtx context)
         {
@@ -1319,7 +1319,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(502)] // 5.0.0+
+        [CommandHipc(502)] // 5.0.0+
         // AcquirePalmaOperationCompleteEvent(nn::hid::PalmaConnectionHandle) -> nn::sf::NativeHandle
         public ResultCode AcquirePalmaOperationCompleteEvent(ServiceCtx context)
         {
@@ -1337,7 +1337,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(503)] // 5.0.0+
+        [CommandHipc(503)] // 5.0.0+
         // GetPalmaOperationInfo(nn::hid::PalmaConnectionHandle) -> long Unknown0, buffer<Unknown>
         public ResultCode GetPalmaOperationInfo(ServiceCtx context)
         {
@@ -1352,7 +1352,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(504)] // 5.0.0+
+        [CommandHipc(504)] // 5.0.0+
         // PlayPalmaActivity(nn::hid::PalmaConnectionHandle, ulong Unknown0)
         public ResultCode PlayPalmaActivity(ServiceCtx context)
         {
@@ -1366,7 +1366,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(505)] // 5.0.0+
+        [CommandHipc(505)] // 5.0.0+
         // SetPalmaFrModeType(nn::hid::PalmaConnectionHandle, ulong FrModeType)
         public ResultCode SetPalmaFrModeType(ServiceCtx context)
         {
@@ -1380,7 +1380,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(506)] // 5.0.0+
+        [CommandHipc(506)] // 5.0.0+
         // ReadPalmaStep(nn::hid::PalmaConnectionHandle)
         public ResultCode ReadPalmaStep(ServiceCtx context)
         {
@@ -1391,7 +1391,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(507)] // 5.0.0+
+        [CommandHipc(507)] // 5.0.0+
         // EnablePalmaStep(nn::hid::PalmaConnectionHandle, bool Enable)
         public ResultCode EnablePalmaStep(ServiceCtx context)
         {
@@ -1405,7 +1405,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(508)] // 5.0.0+
+        [CommandHipc(508)] // 5.0.0+
         // ResetPalmaStep(nn::hid::PalmaConnectionHandle)
         public ResultCode ResetPalmaStep(ServiceCtx context)
         {
@@ -1418,7 +1418,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(509)] // 5.0.0+
+        [CommandHipc(509)] // 5.0.0+
         // ReadPalmaApplicationSection(nn::hid::PalmaConnectionHandle, ulong Unknown0, ulong Unknown1)
         public ResultCode ReadPalmaApplicationSection(ServiceCtx context)
         {
@@ -1431,7 +1431,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(510)] // 5.0.0+
+        [CommandHipc(510)] // 5.0.0+
         // WritePalmaApplicationSection(nn::hid::PalmaConnectionHandle, ulong Unknown0, ulong Unknown1, nn::hid::PalmaApplicationSectionAccessBuffer)
         public ResultCode WritePalmaApplicationSection(ServiceCtx context)
         {
@@ -1447,7 +1447,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(511)] // 5.0.0+
+        [CommandHipc(511)] // 5.0.0+
         // ReadPalmaUniqueCode(nn::hid::PalmaConnectionHandle)
         public ResultCode ReadPalmaUniqueCode(ServiceCtx context)
         {
@@ -1458,7 +1458,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(512)] // 5.0.0+
+        [CommandHipc(512)] // 5.0.0+
         // SetPalmaUniqueCodeInvalid(nn::hid::PalmaConnectionHandle)
         public ResultCode SetPalmaUniqueCodeInvalid(ServiceCtx context)
         {
@@ -1469,7 +1469,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(522)] // 5.1.0+
+        [CommandHipc(522)] // 5.1.0+
         // SetIsPalmaAllConnectable(nn::applet::AppletResourceUserId, bool, pid)
         public ResultCode SetIsPalmaAllConnectable(ServiceCtx context)
         {
@@ -1481,7 +1481,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(525)] // 5.1.0+
+        [CommandHipc(525)] // 5.1.0+
         // SetPalmaBoostMode(bool)
         public ResultCode SetPalmaBoostMode(ServiceCtx context)
         {
@@ -1490,7 +1490,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(1000)]
+        [CommandHipc(1000)]
         // SetNpadCommunicationMode(long CommunicationMode, nn::applet::AppletResourceUserId)
         public ResultCode SetNpadCommunicationMode(ServiceCtx context)
         {
@@ -1502,7 +1502,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(1001)]
+        [CommandHipc(1001)]
         // GetNpadCommunicationMode() -> long CommunicationMode
         public ResultCode GetNpadCommunicationMode(ServiceCtx context)
         {
@@ -1513,7 +1513,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
             return ResultCode.Success;
         }
 
-        [Command(1002)] // 9.0.0+
+        [CommandHipc(1002)] // 9.0.0+
         // SetTouchScreenConfiguration(nn::hid::TouchScreenConfigurationForNx, nn::applet::AppletResourceUserId)
         public ResultCode SetTouchScreenConfiguration(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Hid/Irs/IIrSensorServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Irs/IIrSensorServer.cs
@@ -13,7 +13,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid.Irs
 
         public IIrSensorServer(ServiceCtx context) { }
 
-        [Command(302)]
+        [CommandHipc(302)]
         // ActivateIrsensor(nn::applet::AppletResourceUserId, pid)
         public ResultCode ActivateIrsensor(ServiceCtx context)
         {
@@ -24,7 +24,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid.Irs
             return ResultCode.Success;
         }
 
-        [Command(303)]
+        [CommandHipc(303)]
         // DeactivateIrsensor(nn::applet::AppletResourceUserId, pid)
         public ResultCode DeactivateIrsensor(ServiceCtx context)
         {
@@ -35,7 +35,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid.Irs
             return ResultCode.Success;
         }
 
-        [Command(304)]
+        [CommandHipc(304)]
         // GetIrsensorSharedMemoryHandle(nn::applet::AppletResourceUserId, pid) -> handle<copy>
         public ResultCode GetIrsensorSharedMemoryHandle(ServiceCtx context)
         {
@@ -52,7 +52,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid.Irs
             return ResultCode.Success;
         }
 
-        [Command(311)]
+        [CommandHipc(311)]
         // GetNpadIrCameraHandle(u32) -> nn::irsensor::IrCameraHandle
         public ResultCode GetNpadIrCameraHandle(ServiceCtx context)
         {
@@ -75,7 +75,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid.Irs
             return ResultCode.Success;
         }
 
-        [Command(319)] // 4.0.0+
+        [CommandHipc(319)] // 4.0.0+
         // ActivateIrsensorWithFunctionLevel(nn::applet::AppletResourceUserId, nn::irsensor::PackedFunctionLevel, pid)
         public ResultCode ActivateIrsensorWithFunctionLevel(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/IpcService.cs
+++ b/Ryujinx.HLE/HOS/Services/IpcService.cs
@@ -25,8 +25,8 @@ namespace Ryujinx.HLE.HOS.Services
             Commands = Assembly.GetExecutingAssembly().GetTypes()
                 .Where(type => type == GetType())
                 .SelectMany(type => type.GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public))
-                .SelectMany(methodInfo => methodInfo.GetCustomAttributes(typeof(CommandAttribute))
-                .Select(command => (((CommandAttribute)command).Id, methodInfo)))
+                .SelectMany(methodInfo => methodInfo.GetCustomAttributes(typeof(CommandHipcAttribute))
+                .Select(command => (((CommandHipcAttribute)command).Id, methodInfo)))
                 .ToDictionary(command => command.Id, command => command.methodInfo);
 
             Server = server;
@@ -53,7 +53,7 @@ namespace Ryujinx.HLE.HOS.Services
             _isDomain = false;
         }
 
-        public void CallMethod(ServiceCtx context)
+        public void CallHipcMethod(ServiceCtx context)
         {
             IpcService service = this;
 

--- a/Ryujinx.HLE/HOS/Services/IpcService.cs
+++ b/Ryujinx.HLE/HOS/Services/IpcService.cs
@@ -33,8 +33,8 @@ namespace Ryujinx.HLE.HOS.Services
             TipcCommands = Assembly.GetExecutingAssembly().GetTypes()
                 .Where(type => type == GetType())
                 .SelectMany(type => type.GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public))
-                .SelectMany(methodInfo => methodInfo.GetCustomAttributes(typeof(CommandTIpcAttribute))
-                .Select(command => (((CommandTIpcAttribute)command).Id, methodInfo)))
+                .SelectMany(methodInfo => methodInfo.GetCustomAttributes(typeof(CommandTipcAttribute))
+                .Select(command => (((CommandTipcAttribute)command).Id, methodInfo)))
                 .ToDictionary(command => command.Id, command => command.methodInfo);
 
             Server = server;

--- a/Ryujinx.HLE/HOS/Services/IpcService.cs
+++ b/Ryujinx.HLE/HOS/Services/IpcService.cs
@@ -153,13 +153,13 @@ namespace Ryujinx.HLE.HOS.Services
             {
                 string dbgMessage = $"{service.GetType().FullName}: {commandId}";
 
-                throw new ServiceNotImplementedException(service, context, dbgMessage);
+                throw new ServiceNotImplementedException(service, context, dbgMessage, false);
             }
         }
 
         public void CallTipcMethod(ServiceCtx context)
         {
-            int commandId = (int)context.Request.Type;
+            int commandId = (int)context.Request.Type - 0x10;
 
             bool serviceExists = TipcCommands.TryGetValue(commandId, out MethodInfo processRequest);
 
@@ -194,7 +194,7 @@ namespace Ryujinx.HLE.HOS.Services
             {
                 string dbgMessage = $"{GetType().FullName}: {commandId}";
 
-                throw new ServiceNotImplementedException(this, context, dbgMessage);
+                throw new ServiceNotImplementedException(this, context, dbgMessage, true);
             }
         }
 

--- a/Ryujinx.HLE/HOS/Services/IpcService.cs
+++ b/Ryujinx.HLE/HOS/Services/IpcService.cs
@@ -11,8 +11,8 @@ namespace Ryujinx.HLE.HOS.Services
 {
     abstract class IpcService
     {
-        public IReadOnlyDictionary<int, MethodInfo> HIpcCommands { get; }
-        public IReadOnlyDictionary<int, MethodInfo> TIpcCommands { get; }
+        public IReadOnlyDictionary<int, MethodInfo> HipcCommands { get; }
+        public IReadOnlyDictionary<int, MethodInfo> TipcCommands { get; }
 
         public ServerBase Server { get; private set; }
 
@@ -23,14 +23,14 @@ namespace Ryujinx.HLE.HOS.Services
 
         public IpcService(ServerBase server = null)
         {
-            HIpcCommands = Assembly.GetExecutingAssembly().GetTypes()
+            HipcCommands = Assembly.GetExecutingAssembly().GetTypes()
                 .Where(type => type == GetType())
                 .SelectMany(type => type.GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public))
                 .SelectMany(methodInfo => methodInfo.GetCustomAttributes(typeof(CommandHipcAttribute))
                 .Select(command => (((CommandHipcAttribute)command).Id, methodInfo)))
                 .ToDictionary(command => command.Id, command => command.methodInfo);
 
-            TIpcCommands = Assembly.GetExecutingAssembly().GetTypes()
+            TipcCommands = Assembly.GetExecutingAssembly().GetTypes()
                 .Where(type => type == GetType())
                 .SelectMany(type => type.GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public))
                 .SelectMany(methodInfo => methodInfo.GetCustomAttributes(typeof(CommandTIpcAttribute))
@@ -107,7 +107,7 @@ namespace Ryujinx.HLE.HOS.Services
             long sfciMagic = context.RequestData.ReadInt64();
             int commandId = (int)context.RequestData.ReadInt64();
 
-            bool serviceExists = service.HIpcCommands.TryGetValue(commandId, out MethodInfo processRequest);
+            bool serviceExists = service.HipcCommands.TryGetValue(commandId, out MethodInfo processRequest);
 
             if (ServiceConfiguration.IgnoreMissingServices || serviceExists)
             {
@@ -161,7 +161,7 @@ namespace Ryujinx.HLE.HOS.Services
         {
             int commandId = (int)context.Request.Type;
 
-            bool serviceExists = TIpcCommands.TryGetValue(commandId, out MethodInfo processRequest);
+            bool serviceExists = TipcCommands.TryGetValue(commandId, out MethodInfo processRequest);
 
             if (ServiceConfiguration.IgnoreMissingServices || serviceExists)
             {

--- a/Ryujinx.HLE/HOS/Services/Lbl/ILblController.cs
+++ b/Ryujinx.HLE/HOS/Services/Lbl/ILblController.cs
@@ -10,14 +10,14 @@
         internal abstract void DisableVrMode();
         protected abstract bool IsVrModeEnabled();
 
-        [Command(17)]
+        [CommandHipc(17)]
         // SetBrightnessReflectionDelayLevel(float, float)
         public ResultCode SetBrightnessReflectionDelayLevel(ServiceCtx context)
         {
             return ResultCode.Success;
         }
 
-        [Command(18)]
+        [CommandHipc(18)]
         // GetBrightnessReflectionDelayLevel(float) -> float
         public ResultCode GetBrightnessReflectionDelayLevel(ServiceCtx context)
         {
@@ -26,21 +26,21 @@
             return ResultCode.Success;
         }
 
-        [Command(21)]
+        [CommandHipc(21)]
         // SetCurrentAmbientLightSensorMapping(unknown<0xC>)
         public ResultCode SetCurrentAmbientLightSensorMapping(ServiceCtx context)
         {
             return ResultCode.Success;
         }
 
-        [Command(22)]
+        [CommandHipc(22)]
         // GetCurrentAmbientLightSensorMapping() -> unknown<0xC>
         public ResultCode GetCurrentAmbientLightSensorMapping(ServiceCtx context)
         {
             return ResultCode.Success;
         }
 
-        [Command(24)] // 3.0.0+
+        [CommandHipc(24)] // 3.0.0+
         // SetCurrentBrightnessSettingForVrMode(float)
         public ResultCode SetCurrentBrightnessSettingForVrMode(ServiceCtx context)
         {
@@ -51,7 +51,7 @@
             return ResultCode.Success;
         }
 
-        [Command(25)] // 3.0.0+
+        [CommandHipc(25)] // 3.0.0+
         // GetCurrentBrightnessSettingForVrMode() -> float
         public ResultCode GetCurrentBrightnessSettingForVrMode(ServiceCtx context)
         {
@@ -62,7 +62,7 @@
             return ResultCode.Success;
         }
 
-        [Command(26)] // 3.0.0+
+        [CommandHipc(26)] // 3.0.0+
         // EnableVrMode()
         public ResultCode EnableVrMode(ServiceCtx context)
         {
@@ -71,7 +71,7 @@
             return ResultCode.Success;
         }
 
-        [Command(27)] // 3.0.0+
+        [CommandHipc(27)] // 3.0.0+
         // DisableVrMode()
         public ResultCode DisableVrMode(ServiceCtx context)
         {
@@ -80,7 +80,7 @@
             return ResultCode.Success;
         }
 
-        [Command(28)] // 3.0.0+
+        [CommandHipc(28)] // 3.0.0+
         // IsVrModeEnabled() -> bool
         public ResultCode IsVrModeEnabled(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Ldn/IUserServiceCreator.cs
+++ b/Ryujinx.HLE/HOS/Services/Ldn/IUserServiceCreator.cs
@@ -7,7 +7,7 @@ namespace Ryujinx.HLE.HOS.Services.Ldn
     {
         public IUserServiceCreator(ServiceCtx context) { }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // CreateUserLocalCommunicationService() -> object<nn::ldn::detail::IUserLocalCommunicationService>
         public ResultCode CreateUserLocalCommunicationService(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/IUserLocalCommunicationService.cs
+++ b/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/IUserLocalCommunicationService.cs
@@ -20,7 +20,7 @@ namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator
             _networkInterface = new NetworkInterface(context.Device.System);
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetState() -> s32 state
         public ResultCode GetState(ServiceCtx context)
         {
@@ -41,7 +41,7 @@ namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator
             return result;
         }
 
-        [Command(100)]
+        [CommandHipc(100)]
         // AttachStateChangeEvent() -> handle<copy>
         public ResultCode AttachStateChangeEvent(ServiceCtx context)
         {
@@ -60,21 +60,21 @@ namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator
             return ResultCode.Success;
         }
 
-        [Command(400)]
+        [CommandHipc(400)]
         // InitializeOld(u64, pid)
         public ResultCode InitializeOld(ServiceCtx context)
         {
             return _networkInterface.Initialize(UnknownValue, 0, null, null);
         }
 
-        [Command(401)]
+        [CommandHipc(401)]
         // Finalize()
         public ResultCode Finalize(ServiceCtx context)
         {
             return _networkInterface.Finalize();
         }
 
-        [Command(402)] // 7.0.0+
+        [CommandHipc(402)] // 7.0.0+
         // Initialize(u64 ip_addresses, u64, pid)
         public ResultCode Initialize(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Lm/ILogService.cs
+++ b/Ryujinx.HLE/HOS/Services/Lm/ILogService.cs
@@ -7,7 +7,7 @@ namespace Ryujinx.HLE.HOS.Services.Lm
     {
         public ILogService(ServiceCtx context) { }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // Initialize(u64, pid) -> object<nn::lm::ILogger>
         public ResultCode Initialize(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Lm/LogService/ILogger.cs
+++ b/Ryujinx.HLE/HOS/Services/Lm/LogService/ILogger.cs
@@ -8,7 +8,7 @@ namespace Ryujinx.HLE.HOS.Services.Lm.LogService
     {
         public ILogger() { }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // Log(buffer<unknown, 0x21>)
         public ResultCode Log(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Mii/IStaticService.cs
+++ b/Ryujinx.HLE/HOS/Services/Mii/IStaticService.cs
@@ -18,7 +18,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii
             _databaseImpl = DatabaseImpl.Instance;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetDatabaseService(u32 mii_key_code) -> object<nn::mii::detail::IDatabaseService>
         public ResultCode GetDatabaseService(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Mii/StaticService/IDatabaseService.cs
+++ b/Ryujinx.HLE/HOS/Services/Mii/StaticService/IDatabaseService.cs
@@ -8,7 +8,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.StaticService
 {
     abstract class IDatabaseService : IpcService
     {
-        [Command(0)]
+        [CommandHipc(0)]
         // IsUpdated(SourceFlag flag) -> bool
         public ResultCode IsUpdated(ServiceCtx context)
         {
@@ -19,7 +19,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.StaticService
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // IsFullDatabase() -> bool
         public ResultCode IsFullDatabase(ServiceCtx context)
         {
@@ -28,7 +28,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.StaticService
             return ResultCode.Success;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // GetCount(SourceFlag flag) -> u32
         public ResultCode GetCount(ServiceCtx context)
         {
@@ -39,7 +39,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.StaticService
             return ResultCode.Success;
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // Get(SourceFlag flag) -> (s32 count, buffer<nn::mii::CharInfoRawElement, 6>)
         public ResultCode Get(ServiceCtx context)
         {
@@ -60,7 +60,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.StaticService
             return result;
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // Get1(SourceFlag flag) -> (s32 count, buffer<nn::mii::CharInfo, 6>)
         public ResultCode Get1(ServiceCtx context)
         {
@@ -81,7 +81,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.StaticService
             return result;
         }
 
-        [Command(5)]
+        [CommandHipc(5)]
         // UpdateLatest(nn::mii::CharInfo old_char_info, SourceFlag flag) -> nn::mii::CharInfo
         public ResultCode UpdateLatest(ServiceCtx context)
         {
@@ -95,7 +95,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.StaticService
             return result;
         }
 
-        [Command(6)]
+        [CommandHipc(6)]
         // BuildRandom(Age age, Gender gender, Race race) -> nn::mii::CharInfo
         public ResultCode BuildRandom(ServiceCtx context)
         {
@@ -110,7 +110,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.StaticService
             return result;
         }
 
-        [Command(7)]
+        [CommandHipc(7)]
         // BuildDefault(u32 index) -> nn::mii::CharInfoRaw
         public ResultCode BuildDefault(ServiceCtx context)
         {
@@ -123,7 +123,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.StaticService
             return result;
         }
 
-        [Command(8)]
+        [CommandHipc(8)]
         // Get2(SourceFlag flag) -> (u32 count, buffer<nn::mii::StoreDataElement, 6>)
         public ResultCode Get2(ServiceCtx context)
         {
@@ -144,7 +144,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.StaticService
             return result;
         }
 
-        [Command(9)]
+        [CommandHipc(9)]
         // Get3(SourceFlag flag) -> (u32 count, buffer<nn::mii::StoreData, 6>)
         public ResultCode Get3(ServiceCtx context)
         {
@@ -165,7 +165,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.StaticService
             return result;
         }
 
-        [Command(10)]
+        [CommandHipc(10)]
         // UpdateLatest1(nn::mii::StoreData old_store_data, SourceFlag flag) -> nn::mii::StoreData
         public ResultCode UpdateLatest1(ServiceCtx context)
         {
@@ -179,7 +179,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.StaticService
             return result;
         }
 
-        [Command(11)]
+        [CommandHipc(11)]
         // FindIndex(nn::mii::CreateId create_id, bool is_special) -> s32
         public ResultCode FindIndex(ServiceCtx context)
         {
@@ -193,7 +193,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.StaticService
             return result;
         }
 
-        [Command(12)]
+        [CommandHipc(12)]
         // Move(nn::mii::CreateId create_id, s32 new_index)
         public ResultCode Move(ServiceCtx context)
         {
@@ -203,7 +203,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.StaticService
             return Move(createId, newIndex);
         }
 
-        [Command(13)]
+        [CommandHipc(13)]
         // AddOrReplace(nn::mii::StoreData store_data)
         public ResultCode AddOrReplace(ServiceCtx context)
         {
@@ -212,7 +212,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.StaticService
             return AddOrReplace(storeData);
         }
 
-        [Command(14)]
+        [CommandHipc(14)]
         // Delete(nn::mii::CreateId create_id)
         public ResultCode Delete(ServiceCtx context)
         {
@@ -221,28 +221,28 @@ namespace Ryujinx.HLE.HOS.Services.Mii.StaticService
             return Delete(createId);
         }
 
-        [Command(15)]
+        [CommandHipc(15)]
         // DestroyFile()
         public ResultCode DestroyFile(ServiceCtx context)
         {
             return DestroyFile();
         }
 
-        [Command(16)]
+        [CommandHipc(16)]
         // DeleteFile()
         public ResultCode DeleteFile(ServiceCtx context)
         {
             return DeleteFile();
         }
 
-        [Command(17)]
+        [CommandHipc(17)]
         // Format()
         public ResultCode Format(ServiceCtx context)
         {
             return Format();
         }
 
-        [Command(18)]
+        [CommandHipc(18)]
         // Import(buffer<bytes, 5>)
         public ResultCode Import(ServiceCtx context)
         {
@@ -251,7 +251,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.StaticService
             return Import(data);
         }
 
-        [Command(19)]
+        [CommandHipc(19)]
         // Export() -> buffer<bytes, 6>
         public ResultCode Export(ServiceCtx context)
         {
@@ -266,7 +266,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.StaticService
             return result;
         }
 
-        [Command(20)]
+        [CommandHipc(20)]
         // IsBrokenDatabaseWithClearFlag() -> bool
         public ResultCode IsBrokenDatabaseWithClearFlag(ServiceCtx context)
         {
@@ -277,7 +277,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.StaticService
             return result;
         }
 
-        [Command(21)]
+        [CommandHipc(21)]
         // GetIndex(nn::mii::CharInfo char_info) -> s32
         public ResultCode GetIndex(ServiceCtx context)
         {
@@ -290,7 +290,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.StaticService
             return result;
         }
 
-        [Command(22)] // 5.0.0+
+        [CommandHipc(22)] // 5.0.0+
         // SetInterfaceVersion(u32 version)
         public ResultCode SetInterfaceVersion(ServiceCtx context)
         {
@@ -301,7 +301,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.StaticService
             return ResultCode.Success;
         }
 
-        [Command(23)] // 5.0.0+
+        [CommandHipc(23)] // 5.0.0+
         // Convert(nn::mii::Ver3StoreData ver3_store_data) -> nn::mii::CharInfo
         public ResultCode Convert(ServiceCtx context)
         {
@@ -314,7 +314,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.StaticService
             return result;
         }
 
-        [Command(24)] // 7.0.0+
+        [CommandHipc(24)] // 7.0.0+
         // ConvertCoreDataToCharInfo(nn::mii::CoreData core_data) -> nn::mii::CharInfo
         public ResultCode ConvertCoreDataToCharInfo(ServiceCtx context)
         {
@@ -327,7 +327,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.StaticService
             return result;
         }
 
-        [Command(25)] // 7.0.0+
+        [CommandHipc(25)] // 7.0.0+
         // ConvertCharInfoToCoreData(nn::mii::CharInfo char_info) -> nn::mii::CoreData
         public ResultCode ConvertCharInfoToCoreData(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Mm/IRequest.cs
+++ b/Ryujinx.HLE/HOS/Services/Mm/IRequest.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.HLE.HOS.Services.Mm
 
         public IRequest(ServiceCtx context) {}
 
-        [Command(0)]
+        [CommandHipc(0)]
         // InitializeOld(u32, u32, u32)
         public ResultCode InitializeOld(ServiceCtx context)
         {
@@ -29,7 +29,7 @@ namespace Ryujinx.HLE.HOS.Services.Mm
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // FinalizeOld(u32)
         public ResultCode FinalizeOld(ServiceCtx context)
         {
@@ -45,7 +45,7 @@ namespace Ryujinx.HLE.HOS.Services.Mm
             return ResultCode.Success;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // SetAndWaitOld(u32, u32, u32)
         public ResultCode SetAndWaitOld(ServiceCtx context)
         {
@@ -63,7 +63,7 @@ namespace Ryujinx.HLE.HOS.Services.Mm
             return ResultCode.Success;
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // GetOld(u32) -> u32
         public ResultCode GetOld(ServiceCtx context)
         {
@@ -83,7 +83,7 @@ namespace Ryujinx.HLE.HOS.Services.Mm
             return ResultCode.Success;
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // Initialize(u32, u32, u32) -> u32
         public ResultCode Initialize(ServiceCtx context)
         {
@@ -100,7 +100,7 @@ namespace Ryujinx.HLE.HOS.Services.Mm
             return ResultCode.Success;
         }
 
-        [Command(5)]
+        [CommandHipc(5)]
         // Finalize(u32)
         public ResultCode Finalize(ServiceCtx context)
         {
@@ -116,7 +116,7 @@ namespace Ryujinx.HLE.HOS.Services.Mm
             return ResultCode.Success;
         }
 
-        [Command(6)]
+        [CommandHipc(6)]
         // SetAndWait(u32, u32, u32)
         public ResultCode SetAndWait(ServiceCtx context)
         {
@@ -134,7 +134,7 @@ namespace Ryujinx.HLE.HOS.Services.Mm
             return ResultCode.Success;
         }
 
-        [Command(7)]
+        [CommandHipc(7)]
         // Get(u32) -> u32
         public ResultCode Get(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Ncm/Lr/ILocationResolverManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Ncm/Lr/ILocationResolverManager.cs
@@ -8,7 +8,7 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr
     {
         public ILocationResolverManager(ServiceCtx context) { }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // OpenLocationResolver()
         public ResultCode OpenLocationResolver(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Ncm/Lr/LocationResolverManager/ILocationResolver.cs
+++ b/Ryujinx.HLE/HOS/Services/Ncm/Lr/LocationResolverManager/ILocationResolver.cs
@@ -16,7 +16,7 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
             _storageId = storageId;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // ResolveProgramPath()
         public ResultCode ResolveProgramPath(ServiceCtx context)
         {
@@ -32,7 +32,7 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
             }
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // RedirectProgramPath()
         public ResultCode RedirectProgramPath(ServiceCtx context)
         {
@@ -43,7 +43,7 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
             return ResultCode.Success;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // ResolveApplicationControlPath()
         public ResultCode ResolveApplicationControlPath(ServiceCtx context)
         {
@@ -59,7 +59,7 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
             }
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // ResolveApplicationHtmlDocumentPath()
         public ResultCode ResolveApplicationHtmlDocumentPath(ServiceCtx context)
         {
@@ -75,7 +75,7 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
             }
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // ResolveDataPath()
         public ResultCode ResolveDataPath(ServiceCtx context)
         {
@@ -91,7 +91,7 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
             }
         }
 
-        [Command(5)]
+        [CommandHipc(5)]
         // RedirectApplicationControlPath()
         public ResultCode RedirectApplicationControlPath(ServiceCtx context)
         {
@@ -102,7 +102,7 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
             return ResultCode.Success;
         }
 
-        [Command(6)]
+        [CommandHipc(6)]
         // RedirectApplicationHtmlDocumentPath()
         public ResultCode RedirectApplicationHtmlDocumentPath(ServiceCtx context)
         {
@@ -113,7 +113,7 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
             return ResultCode.Success;
         }
 
-        [Command(7)]
+        [CommandHipc(7)]
         // ResolveApplicationLegalInformationPath()
         public ResultCode ResolveApplicationLegalInformationPath(ServiceCtx context)
         {
@@ -129,7 +129,7 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
             }
         }
 
-        [Command(8)]
+        [CommandHipc(8)]
         // RedirectApplicationLegalInformationPath()
         public ResultCode RedirectApplicationLegalInformationPath(ServiceCtx context)
         {
@@ -140,7 +140,7 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
             return ResultCode.Success;
         }
 
-        [Command(9)]
+        [CommandHipc(9)]
         // Refresh()
         public ResultCode Refresh(ServiceCtx context)
         {
@@ -149,7 +149,7 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
             return ResultCode.Success;
         }
 
-        [Command(10)]
+        [CommandHipc(10)]
         // SetProgramNcaPath2()
         public ResultCode SetProgramNcaPath2(ServiceCtx context)
         {
@@ -160,7 +160,7 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
             return ResultCode.Success;
         }
 
-        [Command(11)]
+        [CommandHipc(11)]
         // ClearLocationResolver2()
         public ResultCode ClearLocationResolver2(ServiceCtx context)
         {
@@ -169,7 +169,7 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
             return ResultCode.Success;
         }
 
-        [Command(12)]
+        [CommandHipc(12)]
         // DeleteProgramNcaPath()
         public ResultCode DeleteProgramNcaPath(ServiceCtx context)
         {
@@ -180,7 +180,7 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
             return ResultCode.Success;
         }
 
-        [Command(13)]
+        [CommandHipc(13)]
         // DeleteControlNcaPath()
         public ResultCode DeleteControlNcaPath(ServiceCtx context)
         {
@@ -191,7 +191,7 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
             return ResultCode.Success;
         }
 
-        [Command(14)]
+        [CommandHipc(14)]
         // DeleteDocHtmlNcaPath()
         public ResultCode DeleteDocHtmlNcaPath(ServiceCtx context)
         {
@@ -202,7 +202,7 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
             return ResultCode.Success;
         }
 
-        [Command(15)]
+        [CommandHipc(15)]
         // DeleteInfoHtmlNcaPath()
         public ResultCode DeleteInfoHtmlNcaPath(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/IUserManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/IUserManager.cs
@@ -5,7 +5,7 @@
     {
         public IUserManager(ServiceCtx context) { }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // CreateUserInterface() -> object<nn::nfp::detail::IUser>
         public ResultCode GetUserInterface(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/UserManager/IUser.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/UserManager/IUser.cs
@@ -500,7 +500,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
         // Restore(bytes<8, 4>)
         public ResultCode Restore(ServiceCtx context)
         {
-            throw new ServiceNotImplementedException(this, context);
+            throw new ServiceNotImplementedException(this, context, false);
         }
 
         [CommandHipc(12)]
@@ -966,7 +966,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
         // RecreateApplicationArea(bytes<8, 4>, u32, buffer<unknown, 5>)
         public ResultCode RecreateApplicationArea(ServiceCtx context)
         {
-            throw new ServiceNotImplementedException(this, context);
+            throw new ServiceNotImplementedException(this, context, false);
         }
 
         private ResultCode CheckNfcIsEnabled()

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/UserManager/IUser.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/UserManager/IUser.cs
@@ -30,7 +30,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
 
         public IUser() { }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // Initialize(u64, u64, pid, buffer<unknown, 5>)
         public ResultCode Initialize(ServiceCtx context)
         {
@@ -64,7 +64,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // Finalize()
         public ResultCode Finalize(ServiceCtx context)
         {
@@ -84,7 +84,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             return ResultCode.Success;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // ListDevices() -> (u32, buffer<unknown, 0xa>)
         public ResultCode ListDevices(ServiceCtx context)
         {
@@ -120,7 +120,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             return ResultCode.Success;
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // StartDetection(bytes<8, 4>)
         public ResultCode StartDetection(ServiceCtx context)
         {
@@ -171,7 +171,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             return ResultCode.Success;
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // StopDetection(bytes<8, 4>)
         public ResultCode StopDetection(ServiceCtx context)
         {
@@ -202,7 +202,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             return ResultCode.Success;
         }
 
-        [Command(5)]
+        [CommandHipc(5)]
         // Mount(bytes<8, 4>, u32, u32)
         public ResultCode Mount(ServiceCtx context)
         {
@@ -260,7 +260,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             return resultCode;
         }
 
-        [Command(6)]
+        [CommandHipc(6)]
         // Unmount(bytes<8, 4>)
         public ResultCode Unmount(ServiceCtx context)
         {
@@ -302,7 +302,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             return resultCode;
         }
 
-        [Command(7)]
+        [CommandHipc(7)]
         // OpenApplicationArea(bytes<8, 4>, u32)
         public ResultCode OpenApplicationArea(ServiceCtx context)
         {
@@ -358,7 +358,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             return resultCode;
         }
 
-        [Command(8)]
+        [CommandHipc(8)]
         // GetApplicationArea(bytes<8, 4>) -> (u32, buffer<unknown, 6>)
         public ResultCode GetApplicationArea(ServiceCtx context)
         {
@@ -426,7 +426,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             return ResultCode.Success;
         }
 
-        [Command(9)]
+        [CommandHipc(9)]
         // SetApplicationArea(bytes<8, 4>, buffer<unknown, 5>)
         public ResultCode SetApplicationArea(ServiceCtx context)
         {
@@ -480,7 +480,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             return resultCode;
         }
 
-        [Command(10)]
+        [CommandHipc(10)]
         // Flush(bytes<8, 4>)
         public ResultCode Flush(ServiceCtx context)
         {
@@ -496,14 +496,14 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             return ResultCode.Success;
         }
 
-        [Command(11)]
+        [CommandHipc(11)]
         // Restore(bytes<8, 4>)
         public ResultCode Restore(ServiceCtx context)
         {
             throw new ServiceNotImplementedException(this, context);
         }
 
-        [Command(12)]
+        [CommandHipc(12)]
         // CreateApplicationArea(bytes<8, 4>, u32, buffer<unknown, 5>)
         public ResultCode CreateApplicationArea(ServiceCtx context)
         {
@@ -566,7 +566,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             return resultCode;
         }
 
-        [Command(13)]
+        [CommandHipc(13)]
         // GetTagInfo(bytes<8, 4>) -> buffer<unknown<0x58>, 0x1a>
         public ResultCode GetTagInfo(ServiceCtx context)
         {
@@ -642,7 +642,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             return resultCode;
         }
 
-        [Command(14)]
+        [CommandHipc(14)]
         // GetRegisterInfo(bytes<8, 4>) -> buffer<unknown<0x100>, 0x1a>
         public ResultCode GetRegisterInfo(ServiceCtx context)
         {
@@ -702,7 +702,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             return resultCode;
         }
 
-        [Command(15)]
+        [CommandHipc(15)]
         // GetCommonInfo(bytes<8, 4>) -> buffer<unknown<0x40>, 0x1a>
         public ResultCode GetCommonInfo(ServiceCtx context)
         {
@@ -762,7 +762,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             return resultCode;
         }
 
-        [Command(16)]
+        [CommandHipc(16)]
         // GetModelInfo(bytes<8, 4>) -> buffer<unknown<0x40>, 0x1a>
         public ResultCode GetModelInfo(ServiceCtx context)
         {
@@ -831,7 +831,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             return resultCode;
         }
 
-        [Command(17)]
+        [CommandHipc(17)]
         // AttachActivateEvent(bytes<8, 4>) -> handle<copy>
         public ResultCode AttachActivateEvent(ServiceCtx context)
         {
@@ -857,7 +857,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             return ResultCode.DeviceNotFound;
         }
 
-        [Command(18)]
+        [CommandHipc(18)]
         // AttachDeactivateEvent(bytes<8, 4>) -> handle<copy>
         public ResultCode AttachDeactivateEvent(ServiceCtx context)
         {
@@ -883,7 +883,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             return ResultCode.DeviceNotFound;
         }
 
-        [Command(19)]
+        [CommandHipc(19)]
         // GetState() -> u32
         public ResultCode GetState(ServiceCtx context)
         {
@@ -892,7 +892,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             return ResultCode.Success;
         }
 
-        [Command(20)]
+        [CommandHipc(20)]
         // GetDeviceState(bytes<8, 4>) -> u32
         public ResultCode GetDeviceState(ServiceCtx context)
         {
@@ -918,7 +918,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             return ResultCode.DeviceNotFound;
         }
 
-        [Command(21)]
+        [CommandHipc(21)]
         // GetNpadId(bytes<8, 4>) -> u32
         public ResultCode GetNpadId(ServiceCtx context)
         {
@@ -937,7 +937,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             return ResultCode.DeviceNotFound;
         }
 
-        [Command(22)]
+        [CommandHipc(22)]
         // GetApplicationAreaSize() -> u32
         public ResultCode GetApplicationAreaSize(ServiceCtx context)
         {
@@ -946,7 +946,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             return ResultCode.Success;
         }
 
-        [Command(23)] // 3.0.0+
+        [CommandHipc(23)] // 3.0.0+
         // AttachAvailabilityChangeEvent() -> handle<copy>
         public ResultCode AttachAvailabilityChangeEvent(ServiceCtx context)
         {
@@ -962,7 +962,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             return ResultCode.Success;
         }
 
-        [Command(24)] // 3.0.0+
+        [CommandHipc(24)] // 3.0.0+
         // RecreateApplicationArea(bytes<8, 4>, u32, buffer<unknown, 5>)
         public ResultCode RecreateApplicationArea(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Ngct/IService.cs
+++ b/Ryujinx.HLE/HOS/Services/Ngct/IService.cs
@@ -7,14 +7,14 @@ namespace Ryujinx.HLE.HOS.Services.Ngct
     {
         public IService(ServiceCtx context) { }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // Match(buffer<string, 9>) -> b8
         public ResultCode Match(ServiceCtx context)
         {
             return NgctServer.Match(context);
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // Filter(buffer<string, 9>) -> buffer<filtered_string, 10>
         public ResultCode Filter(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Ngct/IServiceWithManagementApi.cs
+++ b/Ryujinx.HLE/HOS/Services/Ngct/IServiceWithManagementApi.cs
@@ -5,14 +5,14 @@
     {
         public IServiceWithManagementApi(ServiceCtx context) { }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // Match(buffer<string, 9>) -> b8
         public ResultCode Match(ServiceCtx context)
         {
             return NgctServer.Match(context);
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // Filter(buffer<string, 9>) -> buffer<filtered_string, 10>
         public ResultCode Filter(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Nifm/IStaticService.cs
+++ b/Ryujinx.HLE/HOS/Services/Nifm/IStaticService.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm
     {
         public IStaticService(ServiceCtx context) { }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // CreateGeneralServiceOld() -> object<nn::nifm::detail::IGeneralService>
         public ResultCode CreateGeneralServiceOld(ServiceCtx context)
         {
@@ -18,7 +18,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm
             return ResultCode.Success;
         }
 
-        [Command(5)] // 3.0.0+
+        [CommandHipc(5)] // 3.0.0+
         // CreateGeneralService(u64, pid) -> object<nn::nifm::detail::IGeneralService>
         public ResultCode CreateGeneralService(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Nifm/StaticService/IGeneralService.cs
+++ b/Ryujinx.HLE/HOS/Services/Nifm/StaticService/IGeneralService.cs
@@ -25,7 +25,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
             GeneralServiceManager.Add(_generalServiceDetail);
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetClientId() -> buffer<nn::nifm::ClientId, 0x1a, 4>
         public ResultCode GetClientId(ServiceCtx context)
         {
@@ -38,7 +38,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
             return ResultCode.Success;
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // CreateRequest(u32 version) -> object<nn::nifm::detail::IRequest>
         public ResultCode CreateRequest(ServiceCtx context)
         {
@@ -54,7 +54,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
             return ResultCode.Success;
         }
 
-        [Command(5)]
+        [CommandHipc(5)]
         // GetCurrentNetworkProfile() -> buffer<nn::nifm::detail::sf::NetworkProfileData, 0x1a, 0x17c>
         public ResultCode GetCurrentNetworkProfile(ServiceCtx context)
         {
@@ -86,7 +86,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
             return ResultCode.Success;
         }
 
-        [Command(12)]
+        [CommandHipc(12)]
         // GetCurrentIpAddress() -> nn::nifm::IpV4Address
         public ResultCode GetCurrentIpAddress(ServiceCtx context)
         {
@@ -104,7 +104,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
             return ResultCode.Success;
         }
 
-        [Command(15)]
+        [CommandHipc(15)]
         // GetCurrentIpConfigInfo() -> (nn::nifm::IpAddressSetting, nn::nifm::DnsSetting)
         public ResultCode GetCurrentIpConfigInfo(ServiceCtx context)
         {
@@ -123,7 +123,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
             return ResultCode.Success;
         }
 
-        [Command(18)]
+        [CommandHipc(18)]
         // GetInternetConnectionStatus() -> nn::nifm::detail::sf::InternetConnectionStatus
         public ResultCode GetInternetConnectionStatus(ServiceCtx context)
         {
@@ -144,7 +144,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
             return ResultCode.Success;
         }
 
-        [Command(21)]
+        [CommandHipc(21)]
         // IsAnyInternetRequestAccepted(buffer<nn::nifm::ClientId, 0x19, 4>) -> bool
         public ResultCode IsAnyInternetRequestAccepted(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Nifm/StaticService/IRequest.cs
+++ b/Ryujinx.HLE/HOS/Services/Nifm/StaticService/IRequest.cs
@@ -24,7 +24,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
             _version = version;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetRequestState() -> u32
         public ResultCode GetRequestState(ServiceCtx context)
         {
@@ -35,7 +35,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetResult()
         public ResultCode GetResult(ServiceCtx context)
         {
@@ -49,7 +49,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
             return ResultCode.Success;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // GetSystemEventReadableHandles() -> (handle<copy>, handle<copy>)
         public ResultCode GetSystemEventReadableHandles(ServiceCtx context)
         {
@@ -74,7 +74,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
             return ResultCode.Success;
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // Cancel()
         public ResultCode Cancel(ServiceCtx context)
         {
@@ -83,7 +83,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
             return ResultCode.Success;
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // Submit()
         public ResultCode Submit(ServiceCtx context)
         {
@@ -92,7 +92,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
             return ResultCode.Success;
         }
 
-        [Command(11)]
+        [CommandHipc(11)]
         // SetConnectionConfirmationOption(i8)
         public ResultCode SetConnectionConfirmationOption(ServiceCtx context)
         {
@@ -101,7 +101,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
             return ResultCode.Success;
         }
 
-        [Command(21)]
+        [CommandHipc(21)]
         // GetAppletInfo(u32) -> (u32, u32, u32, buffer<bytes, 6>)
         public ResultCode GetAppletInfo(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Nim/IShopServiceAccessServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Nim/IShopServiceAccessServer.cs
@@ -7,7 +7,7 @@ namespace Ryujinx.HLE.HOS.Services.Nim.ShopServiceAccessServerInterface
     {
         public IShopServiceAccessServer() { }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // CreateAccessorInterface(u8) -> object<nn::ec::IShopServiceAccessor>
         public ResultCode CreateAccessorInterface(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Nim/IShopServiceAccessServerInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Nim/IShopServiceAccessServerInterface.cs
@@ -10,7 +10,7 @@ namespace Ryujinx.HLE.HOS.Services.Nim
     {
         public IShopServiceAccessServerInterface(ServiceCtx context) { }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // CreateServerInterface(pid, handle<unknown>, u64) -> object<nn::ec::IShopServiceAccessServer>
         public ResultCode CreateServerInterface(ServiceCtx context)
         {
@@ -21,7 +21,7 @@ namespace Ryujinx.HLE.HOS.Services.Nim
             return ResultCode.Success;
         }
 
-        [Command(4)] // 10.0.0+
+        [CommandHipc(4)] // 10.0.0+
         // IsLargeResourceAvailable(pid) -> b8
         public ResultCode IsLargeResourceAvailable(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Nim/IShopServiceAccessor.cs
+++ b/Ryujinx.HLE/HOS/Services/Nim/IShopServiceAccessor.cs
@@ -18,7 +18,7 @@ namespace Ryujinx.HLE.HOS.Services.Nim.ShopServiceAccessServerInterface.ShopServ
             _event = new KEvent(system.KernelContext);
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // CreateAsyncInterface(u64) -> (handle<copy>, object<nn::ec::IShopServiceAsync>)
         public ResultCode CreateAsyncInterface(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Ns/IAddOnContentManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Ns/IAddOnContentManager.cs
@@ -18,7 +18,7 @@ namespace Ryujinx.HLE.HOS.Services.Ns
             _addOnContentListChangedEvent = new KEvent(context.Device.System.KernelContext);
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // CountAddOnContent(pid) -> u32
         public ResultCode CountAddOnContent(ServiceCtx context)
         {
@@ -47,7 +47,7 @@ namespace Ryujinx.HLE.HOS.Services.Ns
             return (uint)context.Device.System.ContentManager.GetAocCount();
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // ListAddOnContent(u32, u32, pid) -> (u32, buffer<u32>)
         public ResultCode ListAddOnContent(ServiceCtx context)
         {
@@ -84,7 +84,7 @@ namespace Ryujinx.HLE.HOS.Services.Ns
             return ResultCode.Success;
         }
 
-        [Command(5)]
+        [CommandHipc(5)]
         // GetAddOnContentBaseId(pid) -> u64
         public ResultCode GetAddonContentBaseId(ServiceCtx context)
         {
@@ -114,7 +114,7 @@ namespace Ryujinx.HLE.HOS.Services.Ns
             return aocBaseId;
         }
 
-        [Command(7)]
+        [CommandHipc(7)]
         // PrepareAddOnContent(u32, pid)
         public ResultCode PrepareAddOnContent(ServiceCtx context)
         {
@@ -131,7 +131,7 @@ namespace Ryujinx.HLE.HOS.Services.Ns
             return ResultCode.Success;
         }
 
-        [Command(8)]
+        [CommandHipc(8)]
         // GetAddOnContentListChangedEvent() -> handle<copy>
         public ResultCode GetAddOnContentListChangedEvent(ServiceCtx context)
         {
@@ -153,7 +153,7 @@ namespace Ryujinx.HLE.HOS.Services.Ns
         }
 
 
-        [Command(9)] // [10.0.0+]
+        [CommandHipc(9)] // [10.0.0+]
         // GetAddOnContentLostErrorCode() -> u64
         public ResultCode GetAddOnContentLostErrorCode(ServiceCtx context)
         {
@@ -166,7 +166,7 @@ namespace Ryujinx.HLE.HOS.Services.Ns
             return ResultCode.Success;
         }
 
-        [Command(100)]
+        [CommandHipc(100)]
         // CreateEcPurchasedEventManager() -> object<nn::ec::IPurchaseEventManager>
         public ResultCode CreateEcPurchasedEventManager(ServiceCtx context)
         {
@@ -177,7 +177,7 @@ namespace Ryujinx.HLE.HOS.Services.Ns
             return ResultCode.Success;
         }
 
-        [Command(101)]
+        [CommandHipc(101)]
         // CreatePermanentEcPurchasedEventManager() -> object<nn::ec::IPurchaseEventManager>
         public ResultCode CreatePermanentEcPurchasedEventManager(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Ns/IApplicationManagerInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Ns/IApplicationManagerInterface.cs
@@ -5,7 +5,7 @@
     {
         public IApplicationManagerInterface(ServiceCtx context) { }
 
-        [Command(400)]
+        [CommandHipc(400)]
         // GetApplicationControlData(u8, u64) -> (unknown<4>, buffer<unknown, 6>)
         public ResultCode GetApplicationControlData(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Ns/IPurchaseEventManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Ns/IPurchaseEventManager.cs
@@ -16,7 +16,7 @@ namespace Ryujinx.HLE.HOS.Services.Ns
             _purchasedEvent = new KEvent(system.KernelContext);
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // SetDefaultDeliveryTarget(pid, buffer<bytes, 5> unknown)
         public ResultCode SetDefaultDeliveryTarget(ServiceCtx context)
         {
@@ -35,7 +35,7 @@ namespace Ryujinx.HLE.HOS.Services.Ns
             return ResultCode.Success;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // GetPurchasedEventReadableHandle() -> handle<copy, event>
         public ResultCode GetPurchasedEventReadableHandle(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Ns/IReadOnlyApplicationControlDataInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Ns/IReadOnlyApplicationControlDataInterface.cs
@@ -4,7 +4,7 @@
     {
         public IReadOnlyApplicationControlDataInterface(ServiceCtx context) { }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetApplicationControlData(u8, u64) -> (unknown<4>, buffer<unknown, 6>)
         public ResultCode GetApplicationControlData(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Ns/IServiceGetterInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Ns/IServiceGetterInterface.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.HLE.HOS.Services.Ns
     {
         public IServiceGetterInterface(ServiceCtx context) { }
 
-        [Command(7996)]
+        [CommandHipc(7996)]
         // GetApplicationManagerInterface() -> object<nn::ns::detail::IApplicationManagerInterface>
         public ResultCode GetApplicationManagerInterface(ServiceCtx context)
         {
@@ -18,7 +18,7 @@ namespace Ryujinx.HLE.HOS.Services.Ns
             return ResultCode.Success;
         }
 
-        [Command(7989)]
+        [CommandHipc(7989)]
         // GetReadOnlyApplicationControlDataInterface() -> object<nn::ns::detail::IReadOnlyApplicationControlDataInterface>
         public ResultCode GetReadOnlyApplicationControlDataInterface(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Nv/INvDrvServices.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/INvDrvServices.cs
@@ -429,7 +429,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
         // ForceSetClientPid(u64) -> u32 error_code
         public ResultCode ForceSetClientPid(ServiceCtx context)
         {
-            throw new ServiceNotImplementedException(this, context);
+            throw new ServiceNotImplementedException(this, context, false);
         }
 
         [CommandHipc(8)]
@@ -456,7 +456,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
         // InitializeDevtools(u32, handle<copy>) -> u32 error_code;
         public ResultCode InitializeDevtools(ServiceCtx context)
         {
-            throw new ServiceNotImplementedException(this, context);
+            throw new ServiceNotImplementedException(this, context, false);
         }
 
         [CommandHipc(11)] // 3.0.0+

--- a/Ryujinx.HLE/HOS/Services/Nv/INvDrvServices.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/INvDrvServices.cs
@@ -217,7 +217,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
             }
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // Open(buffer<bytes, 5> path) -> (s32 fd, u32 error_code)
         public ResultCode Open(ServiceCtx context)
         {
@@ -245,7 +245,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // Ioctl(s32 fd, u32 ioctl_cmd, buffer<bytes, 0x21> in_args) -> (u32 error_code, buffer<bytes, 0x22> out_args)
         public ResultCode Ioctl(ServiceCtx context)
         {
@@ -286,7 +286,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
             return ResultCode.Success;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // Close(s32 fd) -> u32 error_code
         public ResultCode Close(ServiceCtx context)
         {
@@ -311,7 +311,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
             return ResultCode.Success;
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // Initialize(u32 transfer_memory_size, handle<copy, process> current_process, handle<copy, transfer_memory> transfer_memory) -> u32 error_code
         public ResultCode Initialize(ServiceCtx context)
         {
@@ -335,7 +335,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
             return ResultCode.Success;
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // QueryEvent(s32 fd, u32 event_id) -> (u32, handle<copy, event>)
         public ResultCode QueryEvent(ServiceCtx context)
         {
@@ -371,7 +371,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
             return ResultCode.Success;
         }
 
-        [Command(5)]
+        [CommandHipc(5)]
         // MapSharedMemory(s32 fd, u32 argument, handle<copy, shared_memory>) -> u32 error_code
         public ResultCode MapSharedMemory(ServiceCtx context)
         {
@@ -396,7 +396,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
             return ResultCode.Success;
         }
 
-        [Command(6)]
+        [CommandHipc(6)]
         // GetStatus() -> (unknown<0x20>, u32 error_code)
         public ResultCode GetStatus(ServiceCtx context)
         {
@@ -425,14 +425,14 @@ namespace Ryujinx.HLE.HOS.Services.Nv
             return ResultCode.Success;
         }
 
-        [Command(7)]
+        [CommandHipc(7)]
         // ForceSetClientPid(u64) -> u32 error_code
         public ResultCode ForceSetClientPid(ServiceCtx context)
         {
             throw new ServiceNotImplementedException(this, context);
         }
 
-        [Command(8)]
+        [CommandHipc(8)]
         // SetClientPID(u64, pid) -> u32 error_code
         public ResultCode SetClientPid(ServiceCtx context)
         {
@@ -443,7 +443,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
             return ResultCode.Success;
         }
 
-        [Command(9)]
+        [CommandHipc(9)]
         // DumpGraphicsMemoryInfo()
         public ResultCode DumpGraphicsMemoryInfo(ServiceCtx context)
         {
@@ -452,14 +452,14 @@ namespace Ryujinx.HLE.HOS.Services.Nv
             return ResultCode.Success;
         }
 
-        [Command(10)] // 3.0.0+
+        [CommandHipc(10)] // 3.0.0+
         // InitializeDevtools(u32, handle<copy>) -> u32 error_code;
         public ResultCode InitializeDevtools(ServiceCtx context)
         {
             throw new ServiceNotImplementedException(this, context);
         }
 
-        [Command(11)] // 3.0.0+
+        [CommandHipc(11)] // 3.0.0+
         // Ioctl2(s32 fd, u32 ioctl_cmd, buffer<bytes, 0x21> in_args, buffer<bytes, 0x21> inline_in_buffer) -> (u32 error_code, buffer<bytes, 0x22> out_args)
         public ResultCode Ioctl2(ServiceCtx context)
         {
@@ -508,7 +508,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
             return ResultCode.Success;
         }
 
-        [Command(12)] // 3.0.0+
+        [CommandHipc(12)] // 3.0.0+
         // Ioctl3(s32 fd, u32 ioctl_cmd, buffer<bytes, 0x21> in_args) -> (u32 error_code, buffer<bytes, 0x22> out_args,  buffer<bytes, 0x22> inline_out_buffer)
         public ResultCode Ioctl3(ServiceCtx context)
         {
@@ -558,7 +558,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
             return ResultCode.Success;
         }
 
-        [Command(13)] // 3.0.0+
+        [CommandHipc(13)] // 3.0.0+
         // FinishInitialize(unknown<8>)
         public ResultCode FinishInitialize(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Olsc/IOlscServiceForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Olsc/IOlscServiceForApplication.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.HLE.HOS.Services.Olsc
 
         public IOlscServiceForApplication(ServiceCtx context) { }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // Initialize(pid)
         public ResultCode Initialize(ServiceCtx context)
         {
@@ -25,7 +25,7 @@ namespace Ryujinx.HLE.HOS.Services.Olsc
             return ResultCode.Success;
         }
 
-        [Command(14)]
+        [CommandHipc(14)]
         // SetSaveDataBackupSettingEnabled(nn::account::Uid, bool)
         public ResultCode SetSaveDataBackupSettingEnabled(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Pctl/IParentalControlServiceFactory.cs
+++ b/Ryujinx.HLE/HOS/Services/Pctl/IParentalControlServiceFactory.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.HLE.HOS.Services.Pctl
             _permissionFlag = permissionFlag;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // CreateService(u64, pid) -> object<nn::pctl::detail::ipc::IParentalControlService>
         public ResultCode CreateService(ServiceCtx context)
         {
@@ -25,7 +25,7 @@ namespace Ryujinx.HLE.HOS.Services.Pctl
             return ResultCode.Success;
         }
 
-        [Command(1)] // 4.0.0+
+        [CommandHipc(1)] // 4.0.0+
         // CreateServiceWithoutInitialize(u64, pid) -> object<nn::pctl::detail::ipc::IParentalControlService>
         public ResultCode CreateServiceWithoutInitialize(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Pctl/ParentalControlServiceFactory/IParentalControlService.cs
+++ b/Ryujinx.HLE/HOS/Services/Pctl/ParentalControlServiceFactory/IParentalControlService.cs
@@ -28,7 +28,7 @@ namespace Ryujinx.HLE.HOS.Services.Pctl.ParentalControlServiceFactory
             }
         }
 
-        [Command(1)] // 4.0.0+
+        [CommandHipc(1)] // 4.0.0+
         // Initialize()
         public ResultCode Initialize(ServiceCtx context)
         {
@@ -73,7 +73,7 @@ namespace Ryujinx.HLE.HOS.Services.Pctl.ParentalControlServiceFactory
             return resultCode;
         }
 
-        [Command(1001)]
+        [CommandHipc(1001)]
         // CheckFreeCommunicationPermission()
         public ResultCode CheckFreeCommunicationPermission(ServiceCtx context)
         {
@@ -92,14 +92,14 @@ namespace Ryujinx.HLE.HOS.Services.Pctl.ParentalControlServiceFactory
             return ResultCode.Success;
         }
 
-        [Command(1013)] // 4.0.0+
+        [CommandHipc(1013)] // 4.0.0+
         // ConfirmStereoVisionPermission()
         public ResultCode ConfirmStereoVisionPermission(ServiceCtx context)
         {
             return IsStereoVisionPermittedImpl();
         }
 
-        [Command(1018)]
+        [CommandHipc(1018)]
         // IsFreeCommunicationAvailable()
         public ResultCode IsFreeCommunicationAvailable(ServiceCtx context)
         {
@@ -116,7 +116,7 @@ namespace Ryujinx.HLE.HOS.Services.Pctl.ParentalControlServiceFactory
             return ResultCode.Success;
         }
 
-        [Command(1031)]
+        [CommandHipc(1031)]
         // IsRestrictionEnabled() -> b8
         public ResultCode IsRestrictionEnabled(ServiceCtx context)
         {
@@ -130,7 +130,7 @@ namespace Ryujinx.HLE.HOS.Services.Pctl.ParentalControlServiceFactory
             return ResultCode.Success;
         }
 
-        [Command(1061)] // 4.0.0+
+        [CommandHipc(1061)] // 4.0.0+
         // ConfirmStereoVisionRestrictionConfigurable()
         public ResultCode ConfirmStereoVisionRestrictionConfigurable(ServiceCtx context)
         {
@@ -149,7 +149,7 @@ namespace Ryujinx.HLE.HOS.Services.Pctl.ParentalControlServiceFactory
             }
         }
 
-        [Command(1062)] // 4.0.0+
+        [CommandHipc(1062)] // 4.0.0+
         // GetStereoVisionRestriction() -> bool
         public ResultCode GetStereoVisionRestriction(ServiceCtx context)
         {
@@ -170,7 +170,7 @@ namespace Ryujinx.HLE.HOS.Services.Pctl.ParentalControlServiceFactory
             return ResultCode.Success;
         }
 
-        [Command(1063)] // 4.0.0+
+        [CommandHipc(1063)] // 4.0.0+
         // SetStereoVisionRestriction(bool)
         public ResultCode SetStereoVisionRestriction(ServiceCtx context)
         {
@@ -194,14 +194,14 @@ namespace Ryujinx.HLE.HOS.Services.Pctl.ParentalControlServiceFactory
             return ResultCode.Success;
         }
 
-        [Command(1064)] // 5.0.0+
+        [CommandHipc(1064)] // 5.0.0+
         // ResetConfirmedStereoVisionPermission()
         public ResultCode ResetConfirmedStereoVisionPermission(ServiceCtx context)
         {
             return ResultCode.Success;
         }
 
-        [Command(1065)] // 5.0.0+
+        [CommandHipc(1065)] // 5.0.0+
         // IsStereoVisionPermitted() -> bool
         public ResultCode IsStereoVisionPermitted(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Pcv/Bpc/IRtcManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Pcv/Bpc/IRtcManager.cs
@@ -7,7 +7,7 @@ namespace Ryujinx.HLE.HOS.Services.Pcv.Bpc
     {
         public IRtcManager(ServiceCtx context) { }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetRtcTime() -> u64
         public ResultCode GetRtcTime(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Pm/IShellInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Pm/IShellInterface.cs
@@ -5,7 +5,7 @@
     {
         public IShellInterface(ServiceCtx context) { }
 
-        [Command(6)]
+        [CommandHipc(6)]
         // GetApplicationPid() -> u64
         public ResultCode GetApplicationPid(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Prepo/IPrepoService.cs
+++ b/Ryujinx.HLE/HOS/Services/Prepo/IPrepoService.cs
@@ -25,9 +25,9 @@ namespace Ryujinx.HLE.HOS.Services.Prepo
             _permission = permission;
         }
 
-        [Command(10100)] // 1.0.0-5.1.0
-        [Command(10102)] // 6.0.0-9.2.0
-        [Command(10104)] // 10.0.0+
+        [CommandHipc(10100)] // 1.0.0-5.1.0
+        [CommandHipc(10102)] // 6.0.0-9.2.0
+        [CommandHipc(10104)] // 10.0.0+
         // SaveReport(u64, pid, buffer<u8, 9>, buffer<bytes, 5>)
         public ResultCode SaveReport(ServiceCtx context)
         {
@@ -40,9 +40,9 @@ namespace Ryujinx.HLE.HOS.Services.Prepo
             return ProcessReport(context, withUserID: false);
         }
 
-        [Command(10101)] // 1.0.0-5.1.0
-        [Command(10103)] // 6.0.0-9.2.0
-        [Command(10105)] // 10.0.0+
+        [CommandHipc(10101)] // 1.0.0-5.1.0
+        [CommandHipc(10103)] // 6.0.0-9.2.0
+        [CommandHipc(10105)] // 10.0.0+
         // SaveReportWithUser(nn::account::Uid, u64, pid, buffer<u8, 9>, buffer<bytes, 5>)
         public ResultCode SaveReportWithUser(ServiceCtx context)
         {
@@ -55,7 +55,7 @@ namespace Ryujinx.HLE.HOS.Services.Prepo
             return ProcessReport(context, withUserID: true);
         }
 
-        [Command(10200)]
+        [CommandHipc(10200)]
         // RequestImmediateTransmission()
         public ResultCode RequestImmediateTransmission(ServiceCtx context)
         {
@@ -65,7 +65,7 @@ namespace Ryujinx.HLE.HOS.Services.Prepo
             return ResultCode.Success;
         }
 
-        [Command(10300)]
+        [CommandHipc(10300)]
         // GetTransmissionStatus() -> u32
         public ResultCode GetTransmissionStatus(ServiceCtx context)
         {
@@ -76,7 +76,7 @@ namespace Ryujinx.HLE.HOS.Services.Prepo
             return ResultCode.Success;
         }
 
-        [Command(10400)] // 9.0.0+
+        [CommandHipc(10400)] // 9.0.0+
         // GetSystemSessionId() -> u64
         public ResultCode GetSystemSessionId(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Ptm/Psm/IPsmServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Ptm/Psm/IPsmServer.cs
@@ -7,7 +7,7 @@ namespace Ryujinx.HLE.HOS.Services.Ptm.Psm
     {
         public IPsmServer(ServiceCtx context) { }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetBatteryChargePercentage() -> u32
         public static ResultCode GetBatteryChargePercentage(ServiceCtx context)
         {
@@ -20,7 +20,7 @@ namespace Ryujinx.HLE.HOS.Services.Ptm.Psm
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetChargerType() -> u32
         public static ResultCode GetChargerType(ServiceCtx context)
         {
@@ -33,7 +33,7 @@ namespace Ryujinx.HLE.HOS.Services.Ptm.Psm
             return ResultCode.Success;
         }
 
-        [Command(7)]
+        [CommandHipc(7)]
         // OpenSession() -> IPsmSession
         public ResultCode OpenSession(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Ptm/Psm/IPsmSession.cs
+++ b/Ryujinx.HLE/HOS/Services/Ptm/Psm/IPsmSession.cs
@@ -16,7 +16,7 @@ namespace Ryujinx.HLE.HOS.Services.Ptm.Psm
             _stateChangeEventHandle = -1;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // BindStateChangeEvent() -> KObject
         public ResultCode BindStateChangeEvent(ServiceCtx context)
         {
@@ -37,7 +37,7 @@ namespace Ryujinx.HLE.HOS.Services.Ptm.Psm
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // UnbindStateChangeEvent()
         public ResultCode UnbindStateChangeEvent(ServiceCtx context)
         {
@@ -52,7 +52,7 @@ namespace Ryujinx.HLE.HOS.Services.Ptm.Psm
             return ResultCode.Success;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // SetChargerTypeChangeEventEnabled(u8)
         public ResultCode SetChargerTypeChangeEventEnabled(ServiceCtx context)
         {
@@ -63,7 +63,7 @@ namespace Ryujinx.HLE.HOS.Services.Ptm.Psm
             return ResultCode.Success;
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // SetPowerSupplyChangeEventEnabled(u8)
         public ResultCode SetPowerSupplyChangeEventEnabled(ServiceCtx context)
         {
@@ -74,7 +74,7 @@ namespace Ryujinx.HLE.HOS.Services.Ptm.Psm
             return ResultCode.Success;
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // SetBatteryVoltageStateChangeEventEnabled(u8)
         public ResultCode SetBatteryVoltageStateChangeEventEnabled(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Ptm/Ts/IMeasurementServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Ptm/Ts/IMeasurementServer.cs
@@ -10,7 +10,7 @@ namespace Ryujinx.HLE.HOS.Services.Ptm.Ts
 
         public IMeasurementServer(ServiceCtx context) { }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // GetTemperatureMilliC(Location location) -> u32
         public ResultCode GetTemperatureMilliC(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Ro/IRoInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Ro/IRoInterface.cs
@@ -430,7 +430,7 @@ namespace Ryujinx.HLE.HOS.Services.Ro
             return ResultCode.InvalidProcess;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // LoadNro(u64, u64, u64, u64, u64, pid) -> u64
         public ResultCode LoadNro(ServiceCtx context)
         {
@@ -475,7 +475,7 @@ namespace Ryujinx.HLE.HOS.Services.Ro
             return result;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // UnloadNro(u64, u64, pid)
         public ResultCode UnloadNro(ServiceCtx context)
         {
@@ -499,7 +499,7 @@ namespace Ryujinx.HLE.HOS.Services.Ro
             return result;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // LoadNrr(u64, u64, u64, pid)
         public ResultCode LoadNrr(ServiceCtx context)
         {
@@ -532,7 +532,7 @@ namespace Ryujinx.HLE.HOS.Services.Ro
             return result;
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // UnloadNrr(u64, u64, pid)
         public ResultCode UnloadNrr(ServiceCtx context)
         {
@@ -556,7 +556,7 @@ namespace Ryujinx.HLE.HOS.Services.Ro
             return result;
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // Initialize(u64, pid, KObject)
         public ResultCode Initialize(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Sdb/Pdm/IQueryService.cs
+++ b/Ryujinx.HLE/HOS/Services/Sdb/Pdm/IQueryService.cs
@@ -7,14 +7,14 @@ namespace Ryujinx.HLE.HOS.Services.Sdb.Pdm
     {
         public IQueryService(ServiceCtx context) { }
 
-        [Command(13)] // 5.0.0+
+        [CommandHipc(13)] // 5.0.0+
         // QueryApplicationPlayStatisticsForSystem(buffer<bytes, 5> title_id_list) -> (buffer<bytes, 6> entries, s32 entries_count)
         public ResultCode QueryApplicationPlayStatisticsForSystem(ServiceCtx context)
         {
             return QueryPlayStatisticsManager.GetPlayStatistics(context);
         }
 
-        [Command(16)] // 6.0.0+
+        [CommandHipc(16)] // 6.0.0+
         // QueryApplicationPlayStatisticsByUserAccountIdForSystem(nn::account::Uid, buffer<bytes, 5> title_id_list) -> (buffer<bytes, 6> entries, s32 entries_count)
         public ResultCode QueryApplicationPlayStatisticsByUserAccountIdForSystem(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Sdb/Pl/ISharedFontManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Sdb/Pl/ISharedFontManager.cs
@@ -13,7 +13,7 @@ namespace Ryujinx.HLE.HOS.Services.Sdb.Pl
 
         public ISharedFontManager(ServiceCtx context) { }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // RequestLoad(u32)
         public ResultCode RequestLoad(ServiceCtx context)
         {
@@ -24,7 +24,7 @@ namespace Ryujinx.HLE.HOS.Services.Sdb.Pl
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetLoadState(u32) -> u32
         public ResultCode GetLoadState(ServiceCtx context)
         {
@@ -37,7 +37,7 @@ namespace Ryujinx.HLE.HOS.Services.Sdb.Pl
             return ResultCode.Success;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // GetFontSize(u32) -> u32
         public ResultCode GetFontSize(ServiceCtx context)
         {
@@ -48,7 +48,7 @@ namespace Ryujinx.HLE.HOS.Services.Sdb.Pl
             return ResultCode.Success;
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // GetSharedMemoryAddressOffset(u32) -> u32
         public ResultCode GetSharedMemoryAddressOffset(ServiceCtx context)
         {
@@ -59,7 +59,7 @@ namespace Ryujinx.HLE.HOS.Services.Sdb.Pl
             return ResultCode.Success;
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // GetSharedMemoryNativeHandle() -> handle<copy>
         public ResultCode GetSharedMemoryNativeHandle(ServiceCtx context)
         {
@@ -78,7 +78,7 @@ namespace Ryujinx.HLE.HOS.Services.Sdb.Pl
             return ResultCode.Success;
         }
 
-        [Command(5)]
+        [CommandHipc(5)]
         // GetSharedFontInOrderOfPriority(bytes<8, 1>) -> (u8, u32, buffer<unknown, 6>, buffer<unknown, 6>, buffer<unknown, 6>)
         public ResultCode GetSharedFontInOrderOfPriority(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/ServerBase.cs
+++ b/Ryujinx.HLE/HOS/Services/ServerBase.cs
@@ -267,9 +267,9 @@ namespace Ryujinx.HLE.HOS.Services
                     shouldReply = false;
                 }
                 // If the type is past 0xF, we are using TIPC
-                else if ((int)request.Type > 0xF)
+                else if (request.Type > IpcMessageType.TipcCloseSession)
                 {
-                    // response type is always the same as request on TIPC.
+                    // Response type is always the same as request on TIPC.
                     response.Type = request.Type;
 
                     using (MemoryStream resMs = new MemoryStream())

--- a/Ryujinx.HLE/HOS/Services/ServerBase.cs
+++ b/Ryujinx.HLE/HOS/Services/ServerBase.cs
@@ -196,10 +196,10 @@ namespace Ryujinx.HLE.HOS.Services
             {
                 BinaryReader reqReader = new BinaryReader(raw);
 
-                if (request.Type == IpcMessageType.Request ||
-                    request.Type == IpcMessageType.RequestWithContext)
+                if (request.Type == IpcMessageType.HipcRequest ||
+                    request.Type == IpcMessageType.HipcRequestWithContext)
                 {
-                    response.Type = IpcMessageType.Response;
+                    response.Type = IpcMessageType.HipcResponse;
 
                     using (MemoryStream resMs = new MemoryStream())
                     {
@@ -215,13 +215,13 @@ namespace Ryujinx.HLE.HOS.Services
                             reqReader,
                             resWriter);
 
-                        _sessions[serverSessionHandle].CallMethod(context);
+                        _sessions[serverSessionHandle].CallHipcMethod(context);
 
                         response.RawData = resMs.ToArray();
                     }
                 }
-                else if (request.Type == IpcMessageType.Control ||
-                         request.Type == IpcMessageType.ControlWithContext)
+                else if (request.Type == IpcMessageType.HipcControl ||
+                         request.Type == IpcMessageType.HipcControlWithContext)
                 {
                     uint magic = (uint)reqReader.ReadUInt64();
                     uint cmdId = (uint)reqReader.ReadUInt64();
@@ -254,7 +254,7 @@ namespace Ryujinx.HLE.HOS.Services
                         default: throw new NotImplementedException(cmdId.ToString());
                     }
                 }
-                else if (request.Type == IpcMessageType.CloseSession)
+                else if (request.Type == IpcMessageType.HipcCloseSession)
                 {
                     _context.Syscall.CloseHandle(serverSessionHandle);
                     _sessionHandles.Remove(serverSessionHandle);
@@ -293,7 +293,7 @@ namespace Ryujinx.HLE.HOS.Services
 
         private static IpcMessage FillResponse(IpcMessage response, long result, byte[] data = null)
         {
-            response.Type = IpcMessageType.Response;
+            response.Type = IpcMessageType.HipcResponse;
 
             using (MemoryStream ms = new MemoryStream())
             {

--- a/Ryujinx.HLE/HOS/Services/Settings/ISettingsServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Settings/ISettingsServer.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.HLE.HOS.Services.Settings
     {
         public ISettingsServer(ServiceCtx context) { }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetLanguageCode() -> nn::settings::LanguageCode
         public ResultCode GetLanguageCode(ServiceCtx context)
         {
@@ -18,7 +18,7 @@ namespace Ryujinx.HLE.HOS.Services.Settings
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetAvailableLanguageCodes() -> (u32, buffer<nn::settings::LanguageCode, 0xa>)
         public ResultCode GetAvailableLanguageCodes(ServiceCtx context)
         {
@@ -29,7 +29,7 @@ namespace Ryujinx.HLE.HOS.Services.Settings
                     0xF);
         }
 
-        [Command(2)] // 4.0.0+
+        [CommandHipc(2)] // 4.0.0+
         // MakeLanguageCode(nn::settings::Language language_index) -> nn::settings::LanguageCode
         public ResultCode MakeLanguageCode(ServiceCtx context)
         {
@@ -45,7 +45,7 @@ namespace Ryujinx.HLE.HOS.Services.Settings
             return ResultCode.Success;
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // GetAvailableLanguageCodeCount() -> u32
         public ResultCode GetAvailableLanguageCodeCount(ServiceCtx context)
         {
@@ -54,7 +54,7 @@ namespace Ryujinx.HLE.HOS.Services.Settings
             return ResultCode.Success;
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // GetRegionCode() -> u32 nn::settings::RegionCode
         public ResultCode GetRegionCode(ServiceCtx context)
         {
@@ -72,7 +72,7 @@ namespace Ryujinx.HLE.HOS.Services.Settings
             return ResultCode.Success;
         }
 
-        [Command(5)]
+        [CommandHipc(5)]
         // GetAvailableLanguageCodes2() -> (u32, buffer<nn::settings::LanguageCode, 6>)
         public ResultCode GetAvailableLanguageCodes2(ServiceCtx context)
         {
@@ -83,7 +83,7 @@ namespace Ryujinx.HLE.HOS.Services.Settings
                     SystemStateMgr.LanguageCodes.Length);
         }
 
-        [Command(6)]
+        [CommandHipc(6)]
         // GetAvailableLanguageCodeCount2() -> u32
         public ResultCode GetAvailableLanguageCodeCount2(ServiceCtx context)
         {
@@ -92,14 +92,14 @@ namespace Ryujinx.HLE.HOS.Services.Settings
             return ResultCode.Success;
         }
 
-        [Command(7)] // 4.0.0+
+        [CommandHipc(7)] // 4.0.0+
         // GetKeyCodeMap() -> buffer<nn::kpr::KeyCodeMap, 0x16>
         public ResultCode GetKeyCodeMap(ServiceCtx context)
         {
             return GetKeyCodeMapImpl(context, 1);
         }
 
-        [Command(8)] // 5.0.0+
+        [CommandHipc(8)] // 5.0.0+
         // GetQuestFlag() -> bool
         public ResultCode GetQuestFlag(ServiceCtx context)
         {
@@ -110,7 +110,7 @@ namespace Ryujinx.HLE.HOS.Services.Settings
             return ResultCode.Success;
         }
 
-        [Command(9)] // 6.0.0+
+        [CommandHipc(9)] // 6.0.0+
         // GetKeyCodeMap2() -> buffer<nn::kpr::KeyCodeMap, 0x16>
         public ResultCode GetKeyCodeMap2(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
@@ -18,14 +18,14 @@ namespace Ryujinx.HLE.HOS.Services.Settings
     {
         public ISystemSettingsServer(ServiceCtx context) { }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // GetFirmwareVersion() -> buffer<nn::settings::system::FirmwareVersion, 0x1a, 0x100>
         public ResultCode GetFirmwareVersion(ServiceCtx context)
         {
             return GetFirmwareVersion2(context);
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // GetFirmwareVersion2() -> buffer<nn::settings::system::FirmwareVersion, 0x1a, 0x100>
         public ResultCode GetFirmwareVersion2(ServiceCtx context)
         {
@@ -86,7 +86,7 @@ namespace Ryujinx.HLE.HOS.Services.Settings
             return ResultCode.Success;
         }
 
-        [Command(23)]
+        [CommandHipc(23)]
         // GetColorSetId() -> i32
         public ResultCode GetColorSetId(ServiceCtx context)
         {
@@ -95,7 +95,7 @@ namespace Ryujinx.HLE.HOS.Services.Settings
             return ResultCode.Success;
         }
 
-        [Command(24)]
+        [CommandHipc(24)]
         // GetColorSetId() -> i32
         public ResultCode SetColorSetId(ServiceCtx context)
         {
@@ -106,7 +106,7 @@ namespace Ryujinx.HLE.HOS.Services.Settings
             return ResultCode.Success;
         }
 
-        [Command(37)]
+        [CommandHipc(37)]
         // GetSettingsItemValueSize(buffer<nn::settings::SettingsName, 0x19>, buffer<nn::settings::SettingsItemKey, 0x19>) -> u64
         public ResultCode GetSettingsItemValueSize(ServiceCtx context)
         {
@@ -155,7 +155,7 @@ namespace Ryujinx.HLE.HOS.Services.Settings
             return ResultCode.Success;
         }
 
-        [Command(38)]
+        [CommandHipc(38)]
         // GetSettingsItemValue(buffer<nn::settings::SettingsName, 0x19, 0x48>, buffer<nn::settings::SettingsItemKey, 0x19, 0x48>) -> (u64, buffer<unknown, 6, 0>)
         public ResultCode GetSettingsItemValue(ServiceCtx context)
         {
@@ -221,7 +221,7 @@ namespace Ryujinx.HLE.HOS.Services.Settings
             return ResultCode.Success;
         }
 
-       [Command(60)]
+       [CommandHipc(60)]
         // IsUserSystemClockAutomaticCorrectionEnabled() -> bool
         public ResultCode IsUserSystemClockAutomaticCorrectionEnabled(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Sm/IUserInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Sm/IUserInterface.cs
@@ -37,7 +37,7 @@ namespace Ryujinx.HLE.HOS.Services.Sm
         }
 
         [CommandHipc(0)]
-        [CommandTIpc(0x10)] // 12.0.0+
+        [CommandTipc(0x10)] // 12.0.0+
         // Initialize(pid, u64 reserved)
         public ResultCode Initialize(ServiceCtx context)
         {
@@ -47,7 +47,7 @@ namespace Ryujinx.HLE.HOS.Services.Sm
         }
 
         [CommandHipc(1)]
-        [CommandTIpc(0x11)] // 12.0.0+
+        [CommandTipc(0x11)] // 12.0.0+
         // GetService(ServiceName name) -> handle<move, session>
         public ResultCode GetService(ServiceCtx context)
         {
@@ -114,7 +114,7 @@ namespace Ryujinx.HLE.HOS.Services.Sm
         }
 
         [CommandHipc(2)]
-        [CommandTIpc(0x12)] // 12.0.0+
+        [CommandTipc(0x12)] // 12.0.0+
         // RegisterService(ServiceName name, u8, u32 maxHandles) -> handle<move, port>
         public ResultCode RegisterService(ServiceCtx context)
         {
@@ -158,7 +158,7 @@ namespace Ryujinx.HLE.HOS.Services.Sm
         }
 
         [CommandHipc(3)]
-        [CommandTIpc(0x13)] // 12.0.0+
+        [CommandTipc(0x13)] // 12.0.0+
         // UnregisterService(ServiceName name)
         public ResultCode UnregisterService(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Sm/IUserInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Sm/IUserInterface.cs
@@ -1,4 +1,5 @@
 using Ryujinx.Common.Logging;
+using Ryujinx.HLE.Exceptions;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Kernel;
 using Ryujinx.HLE.HOS.Kernel.Common;
@@ -37,7 +38,7 @@ namespace Ryujinx.HLE.HOS.Services.Sm
         }
 
         [CommandHipc(0)]
-        [CommandTipc(0x10)] // 12.0.0+
+        [CommandTipc(0)] // 12.0.0+
         // Initialize(pid, u64 reserved)
         public ResultCode Initialize(ServiceCtx context)
         {
@@ -47,7 +48,7 @@ namespace Ryujinx.HLE.HOS.Services.Sm
         }
 
         [CommandHipc(1)]
-        [CommandTipc(0x11)] // 12.0.0+
+        [CommandTipc(1)] // 12.0.0+
         // GetService(ServiceName name) -> handle<move, session>
         public ResultCode GetService(ServiceCtx context)
         {
@@ -114,9 +115,8 @@ namespace Ryujinx.HLE.HOS.Services.Sm
         }
 
         [CommandHipc(2)]
-        [CommandTipc(0x12)] // 12.0.0+
-        // RegisterService(ServiceName name, u8, u32 maxHandles) -> handle<move, port>
-        public ResultCode RegisterService(ServiceCtx context)
+        // RegisterService(ServiceName name, u8 isLight, u32 maxHandles) -> handle<move, port>
+        public ResultCode RegisterServiceHipc(ServiceCtx context)
         {
             if (!_isInitialized)
             {
@@ -133,6 +133,33 @@ namespace Ryujinx.HLE.HOS.Services.Sm
 
             int maxSessions = context.RequestData.ReadInt32();
 
+            return RegisterService(context, name, isLight, maxSessions);
+        }
+
+        [CommandTipc(2)] // 12.0.0+
+        // RegisterService(ServiceName name, u32 maxHandles, u8 isLight) -> handle<move, port>
+        public ResultCode RegisterServiceTipc(ServiceCtx context)
+        {
+            if (!_isInitialized)
+            {
+                return ResultCode.NotInitialized;
+            }
+
+            long namePosition = context.RequestData.BaseStream.Position;
+
+            string name = ReadName(context);
+
+            context.RequestData.BaseStream.Seek(namePosition + 8, SeekOrigin.Begin);
+
+            int maxSessions = context.RequestData.ReadInt32();
+
+            bool isLight = (context.RequestData.ReadInt32() & 1) != 0;
+
+            return RegisterService(context, name, isLight, maxSessions);
+        }
+
+        private ResultCode RegisterService(ServiceCtx context, string name, bool isLight, int maxSessions)
+        {
             if (string.IsNullOrEmpty(name))
             {
                 return ResultCode.InvalidName;
@@ -158,7 +185,7 @@ namespace Ryujinx.HLE.HOS.Services.Sm
         }
 
         [CommandHipc(3)]
-        [CommandTipc(0x13)] // 12.0.0+
+        [CommandTipc(3)] // 12.0.0+
         // UnregisterService(ServiceName name)
         public ResultCode UnregisterService(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Sm/IUserInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Sm/IUserInterface.cs
@@ -37,6 +37,7 @@ namespace Ryujinx.HLE.HOS.Services.Sm
         }
 
         [CommandHipc(0)]
+        [CommandTIpc(0x10)] // 12.0.0+
         // Initialize(pid, u64 reserved)
         public ResultCode Initialize(ServiceCtx context)
         {
@@ -46,6 +47,7 @@ namespace Ryujinx.HLE.HOS.Services.Sm
         }
 
         [CommandHipc(1)]
+        [CommandTIpc(0x11)] // 12.0.0+
         // GetService(ServiceName name) -> handle<move, session>
         public ResultCode GetService(ServiceCtx context)
         {
@@ -112,6 +114,7 @@ namespace Ryujinx.HLE.HOS.Services.Sm
         }
 
         [CommandHipc(2)]
+        [CommandTIpc(0x12)] // 12.0.0+
         // RegisterService(ServiceName name, u8, u32 maxHandles) -> handle<move, port>
         public ResultCode RegisterService(ServiceCtx context)
         {
@@ -155,6 +158,7 @@ namespace Ryujinx.HLE.HOS.Services.Sm
         }
 
         [CommandHipc(3)]
+        [CommandTIpc(0x13)] // 12.0.0+
         // UnregisterService(ServiceName name)
         public ResultCode UnregisterService(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Sm/IUserInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Sm/IUserInterface.cs
@@ -36,7 +36,7 @@ namespace Ryujinx.HLE.HOS.Services.Sm
             _commonServer = new ServerBase(context, "CommonServer");
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // Initialize(pid, u64 reserved)
         public ResultCode Initialize(ServiceCtx context)
         {
@@ -45,7 +45,7 @@ namespace Ryujinx.HLE.HOS.Services.Sm
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetService(ServiceName name) -> handle<move, session>
         public ResultCode GetService(ServiceCtx context)
         {
@@ -111,7 +111,7 @@ namespace Ryujinx.HLE.HOS.Services.Sm
             return ResultCode.Success;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // RegisterService(ServiceName name, u8, u32 maxHandles) -> handle<move, port>
         public ResultCode RegisterService(ServiceCtx context)
         {
@@ -154,7 +154,7 @@ namespace Ryujinx.HLE.HOS.Services.Sm
             return ResultCode.Success;
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // UnregisterService(ServiceName name)
         public ResultCode UnregisterService(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
@@ -225,7 +225,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             WriteSockAddr(context, bufferPosition, endPoint);
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // Initialize(nn::socket::BsdBufferConfig config, u64 pid, u64 transferMemorySize, KObject<copy, transfer_memory>, pid) -> u32 bsd_errno
         public ResultCode RegisterClient(ServiceCtx context)
         {
@@ -253,7 +253,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // StartMonitoring(u64, pid)
         public ResultCode StartMonitoring(ServiceCtx context)
         {
@@ -264,21 +264,21 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             return ResultCode.Success;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // Socket(u32 domain, u32 type, u32 protocol) -> (i32 ret, u32 bsd_errno)
         public ResultCode Socket(ServiceCtx context)
         {
             return SocketInternal(context, false);
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // SocketExempt(u32 domain, u32 type, u32 protocol) -> (i32 ret, u32 bsd_errno)
         public ResultCode SocketExempt(ServiceCtx context)
         {
             return SocketInternal(context, true);
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // Open(u32 flags, array<unknown, 0x21> path) -> (i32 ret, u32 bsd_errno)
         public ResultCode Open(ServiceCtx context)
         {
@@ -299,7 +299,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             return ResultCode.Success;
         }
 
-        [Command(5)]
+        [CommandHipc(5)]
         // Select(u32 nfds, nn::socket::timeout timeout, buffer<nn::socket::fd_set, 0x21, 0> readfds_in, buffer<nn::socket::fd_set, 0x21, 0> writefds_in, buffer<nn::socket::fd_set, 0x21, 0> errorfds_in) -> (i32 ret, u32 bsd_errno, buffer<nn::socket::fd_set, 0x22, 0> readfds_out, buffer<nn::socket::fd_set, 0x22, 0> writefds_out, buffer<nn::socket::fd_set, 0x22, 0> errorfds_out)
         public ResultCode Select(ServiceCtx context)
         {
@@ -310,7 +310,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             return ResultCode.Success;
         }
 
-        [Command(6)]
+        [CommandHipc(6)]
         // Poll(u32 nfds, u32 timeout, buffer<unknown, 0x21, 0> fds) -> (i32 ret, u32 bsd_errno, buffer<unknown, 0x22, 0>)
         public ResultCode Poll(ServiceCtx context)
         {
@@ -449,7 +449,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             return WriteBsdResult(context, readEvents.Count + writeEvents.Count + errorEvents.Count, LinuxError.SUCCESS);
         }
 
-        [Command(7)]
+        [CommandHipc(7)]
         // Sysctl(buffer<unknown, 0x21, 0>, buffer<unknown, 0x21, 0>) -> (i32 ret, u32 bsd_errno, u32, buffer<unknown, 0x22, 0>)
         public ResultCode Sysctl(ServiceCtx context)
         {
@@ -460,7 +460,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             return ResultCode.Success;
         }
 
-        [Command(8)]
+        [CommandHipc(8)]
         // Recv(u32 socket, u32 flags) -> (i32 ret, u32 bsd_errno, array<i8, 0x22> message)
         public ResultCode Recv(ServiceCtx context)
         {
@@ -500,7 +500,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             return WriteBsdResult(context, result, errno);
         }
 
-        [Command(9)]
+        [CommandHipc(9)]
         // RecvFrom(u32 sock, u32 flags) -> (i32 ret, u32 bsd_errno, u32 addrlen, buffer<i8, 0x22, 0> message, buffer<nn::socket::sockaddr_in, 0x22, 0x10>)
         public ResultCode RecvFrom(ServiceCtx context)
         {
@@ -544,7 +544,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             return WriteBsdResult(context, result, errno);
         }
 
-        [Command(10)]
+        [CommandHipc(10)]
         // Send(u32 socket, u32 flags, buffer<i8, 0x21, 0>) -> (i32 ret, u32 bsd_errno)
         public ResultCode Send(ServiceCtx context)
         {
@@ -586,7 +586,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             return WriteBsdResult(context, result, errno);
         }
 
-        [Command(11)]
+        [CommandHipc(11)]
         // SendTo(u32 socket, u32 flags, buffer<i8, 0x21, 0>, buffer<nn::socket::sockaddr_in, 0x21, 0x10>) -> (i32 ret, u32 bsd_errno)
         public ResultCode SendTo(ServiceCtx context)
         {
@@ -631,7 +631,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             return WriteBsdResult(context, result, errno);
         }
 
-        [Command(12)]
+        [CommandHipc(12)]
         // Accept(u32 socket) -> (i32 ret, u32 bsd_errno, u32 addrlen, buffer<nn::socket::sockaddr_in, 0x22, 0x10> addr)
         public ResultCode Accept(ServiceCtx context)
         {
@@ -686,7 +686,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             return WriteBsdResult(context, -1, errno);
         }
 
-        [Command(13)]
+        [CommandHipc(13)]
         // Bind(u32 socket, buffer<nn::socket::sockaddr_in, 0x21, 0x10> addr) -> (i32 ret, u32 bsd_errno)
         public ResultCode Bind(ServiceCtx context)
         {
@@ -716,7 +716,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             return WriteBsdResult(context, 0, errno);
         }
 
-        [Command(14)]
+        [CommandHipc(14)]
         // Connect(u32 socket, buffer<nn::socket::sockaddr_in, 0x21, 0x10>) -> (i32 ret, u32 bsd_errno)
         public ResultCode Connect(ServiceCtx context)
         {
@@ -745,7 +745,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             return WriteBsdResult(context, 0, errno);
         }
 
-        [Command(15)]
+        [CommandHipc(15)]
         // GetPeerName(u32 socket) -> (i32 ret, u32 bsd_errno, u32 addrlen, buffer<nn::socket::sockaddr_in, 0x22, 0x10> addr)
         public ResultCode GetPeerName(ServiceCtx context)
         {
@@ -768,7 +768,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             return WriteBsdResult(context, 0, errno);
         }
 
-        [Command(16)]
+        [CommandHipc(16)]
         // GetSockName(u32 socket) -> (i32 ret, u32 bsd_errno, u32 addrlen, buffer<nn::socket::sockaddr_in, 0x22, 0x10> addr)
         public ResultCode GetSockName(ServiceCtx context)
         {
@@ -791,7 +791,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             return WriteBsdResult(context, 0, errno);
         }
 
-        [Command(17)]
+        [CommandHipc(17)]
         // GetSockOpt(u32 socket, u32 level, u32 option_name) -> (i32 ret, u32 bsd_errno, u32, buffer<unknown, 0x22, 0>)
         public ResultCode GetSockOpt(ServiceCtx context)
         {
@@ -821,7 +821,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             return WriteBsdResult(context, 0, errno);
         }
 
-        [Command(18)]
+        [CommandHipc(18)]
         // Listen(u32 socket, u32 backlog) -> (i32 ret, u32 bsd_errno)
         public ResultCode Listen(ServiceCtx context)
         {
@@ -848,7 +848,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             return WriteBsdResult(context, 0, errno);
         }
 
-        [Command(19)]
+        [CommandHipc(19)]
         // Ioctl(u32 fd, u32 request, u32 bufcount, buffer<unknown, 0x21, 0>, buffer<unknown, 0x21, 0>, buffer<unknown, 0x21, 0>, buffer<unknown, 0x21, 0>) -> (i32 ret, u32 bsd_errno, buffer<unknown, 0x22, 0>, buffer<unknown, 0x22, 0>, buffer<unknown, 0x22, 0>, buffer<unknown, 0x22, 0>)
         public ResultCode Ioctl(ServiceCtx context)
         {
@@ -883,7 +883,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             return WriteBsdResult(context, 0, errno);
         }
 
-        [Command(20)]
+        [CommandHipc(20)]
         // Fcntl(u32 socket, u32 cmd, u32 arg) -> (i32 ret, u32 bsd_errno)
         public ResultCode Fcntl(ServiceCtx context)
         {
@@ -1005,7 +1005,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             }
         }
 
-        [Command(21)]
+        [CommandHipc(21)]
         // SetSockOpt(u32 socket, u32 level, u32 option_name, buffer<unknown, 0x21, 0> option_value) -> (i32 ret, u32 bsd_errno)
         public ResultCode SetSockOpt(ServiceCtx context)
         {
@@ -1035,7 +1035,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             return WriteBsdResult(context, 0, errno);
         }
 
-        [Command(22)]
+        [CommandHipc(22)]
         // Shutdown(u32 socket, u32 how) -> (i32 ret, u32 bsd_errno)
         public ResultCode Shutdown(ServiceCtx context)
         {
@@ -1067,7 +1067,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             return WriteBsdResult(context, 0, errno);
         }
 
-        [Command(23)]
+        [CommandHipc(23)]
         // ShutdownAllSockets(u32 how) -> (i32 ret, u32 bsd_errno)
         public ResultCode ShutdownAllSockets(ServiceCtx context)
         {
@@ -1099,7 +1099,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             return WriteBsdResult(context, 0, errno);
         }
 
-        [Command(24)]
+        [CommandHipc(24)]
         // Write(u32 socket, buffer<i8, 0x21, 0> message) -> (i32 ret, u32 bsd_errno)
         public ResultCode Write(ServiceCtx context)
         {
@@ -1131,7 +1131,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             return WriteBsdResult(context, result, errno);
         }
 
-        [Command(25)]
+        [CommandHipc(25)]
         // Read(u32 socket) -> (i32 ret, u32 bsd_errno, buffer<i8, 0x22, 0> message)
         public ResultCode Read(ServiceCtx context)
         {
@@ -1162,7 +1162,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             return WriteBsdResult(context, result, errno);
         }
 
-        [Command(26)]
+        [CommandHipc(26)]
         // Close(u32 socket) -> (i32 ret, u32 bsd_errno)
         public ResultCode Close(ServiceCtx context)
         {
@@ -1183,7 +1183,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             return WriteBsdResult(context, 0, errno);
         }
 
-        [Command(27)]
+        [CommandHipc(27)]
         // DuplicateSocket(u32 socket, u64 reserved) -> (i32 ret, u32 bsd_errno)
         public ResultCode DuplicateSocket(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Sockets/Nsd/IManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Nsd/IManager.cs
@@ -32,7 +32,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
             _isInitialized = true;
         }
 
-        [Command(10)]
+        [CommandHipc(10)]
         // GetSettingName() -> buffer<unknown<0x100>, 0x16>
         public ResultCode GetSettingName(ServiceCtx context)
         {
@@ -50,7 +50,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
             return result;
         }
 
-        [Command(11)]
+        [CommandHipc(11)]
         // GetEnvironmentIdentifier() -> buffer<unknown<8>, 0x16>
         public ResultCode GetEnvironmentIdentifier(ServiceCtx context)
         {
@@ -68,7 +68,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
             return result;
         }
 
-        [Command(12)]
+        [CommandHipc(12)]
         // GetDeviceId() -> bytes<0x10, 1>
         public ResultCode GetDeviceId(ServiceCtx context)
         {
@@ -77,7 +77,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
             return ResultCode.Success;
         }
 
-        [Command(13)]
+        [CommandHipc(13)]
         // DeleteSettings(u32)
         public ResultCode DeleteSettings(ServiceCtx context)
         {
@@ -114,21 +114,21 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
             return ResultCode.Success;
         }
 
-        [Command(14)]
+        [CommandHipc(14)]
         // ImportSettings(u32, buffer<unknown, 5>) -> buffer<unknown, 6>
         public ResultCode ImportSettings(ServiceCtx context)
         {
             throw new ServiceNotImplementedException(this, context);
         }
 
-        [Command(15)]
+        [CommandHipc(15)]
         // Unknown(bytes<1>)
         public ResultCode Unknown(ServiceCtx context)
         {
             throw new ServiceNotImplementedException(this, context);
         }
 
-        [Command(20)]
+        [CommandHipc(20)]
         // Resolve(buffer<unknown<0x100>, 0x15>) -> buffer<unknown<0x100>, 0x16>
         public ResultCode Resolve(ServiceCtx context)
         {
@@ -144,7 +144,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
             return result;
         }
 
-        [Command(21)]
+        [CommandHipc(21)]
         // ResolveEx(buffer<unknown<0x100>, 0x15>) -> (u32, buffer<unknown<0x100>, 0x16>)
         public ResultCode ResolveEx(ServiceCtx context)
         {
@@ -162,56 +162,56 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
             return result;
         }
 
-        [Command(30)]
+        [CommandHipc(30)]
         // GetNasServiceSetting(buffer<unknown<0x10>, 0x15>) -> buffer<unknown<0x108>, 0x16>
         public ResultCode GetNasServiceSetting(ServiceCtx context)
         {
             throw new ServiceNotImplementedException(this, context);
         }
 
-        [Command(31)]
+        [CommandHipc(31)]
         // GetNasServiceSettingEx(buffer<unknown<0x10>, 0x15>) -> (u32, buffer<unknown<0x108>, 0x16>)
         public ResultCode GetNasServiceSettingEx(ServiceCtx context)
         {
             throw new ServiceNotImplementedException(this, context);
         }
 
-        [Command(40)]
+        [CommandHipc(40)]
         // GetNasRequestFqdn() -> buffer<unknown<0x100>, 0x16>
         public ResultCode GetNasRequestFqdn(ServiceCtx context)
         {
             throw new ServiceNotImplementedException(this, context);
         }
 
-        [Command(41)]
+        [CommandHipc(41)]
         // GetNasRequestFqdnEx() -> (u32, buffer<unknown<0x100>, 0x16>)
         public ResultCode GetNasRequestFqdnEx(ServiceCtx context)
         {
             throw new ServiceNotImplementedException(this, context);
         }
 
-        [Command(42)]
+        [CommandHipc(42)]
         // GetNasApiFqdn() -> buffer<unknown<0x100>, 0x16>
         public ResultCode GetNasApiFqdn(ServiceCtx context)
         {
             throw new ServiceNotImplementedException(this, context);
         }
 
-        [Command(43)]
+        [CommandHipc(43)]
         // GetNasApiFqdnEx() -> (u32, buffer<unknown<0x100>, 0x16>)
         public ResultCode GetNasApiFqdnEx(ServiceCtx context)
         {
             throw new ServiceNotImplementedException(this, context);
         }
 
-        [Command(50)]
+        [CommandHipc(50)]
         // GetCurrentSetting() -> buffer<unknown<0x12bf0>, 0x16>
         public ResultCode GetCurrentSetting(ServiceCtx context)
         {
             throw new ServiceNotImplementedException(this, context);
         }
 
-        [Command(60)]
+        [CommandHipc(60)]
         // ReadSaveDataFromFsForTest() -> buffer<unknown<0x12bf0>, 0x16>
         public ResultCode ReadSaveDataFromFsForTest(ServiceCtx context)
         {
@@ -228,7 +228,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
             return ResultCode.Success;
         }
 
-        [Command(61)]
+        [CommandHipc(61)]
         // WriteSaveDataToFsForTest(buffer<unknown<0x12bf0>, 0x15>)
         public ResultCode WriteSaveDataToFsForTest(ServiceCtx context)
         {
@@ -244,7 +244,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
             }
         }
 
-        [Command(62)]
+        [CommandHipc(62)]
         // DeleteSaveDataOfFsForTest()
         public ResultCode DeleteSaveDataOfFsForTest(ServiceCtx context)
         {
@@ -260,7 +260,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
             }
         }
 
-        [Command(63)]
+        [CommandHipc(63)]
         // IsChangeEnvironmentIdentifierDisabled() -> bytes<1>
         public ResultCode IsChangeEnvironmentIdentifierDisabled(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Sockets/Nsd/IManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Nsd/IManager.cs
@@ -118,14 +118,14 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
         // ImportSettings(u32, buffer<unknown, 5>) -> buffer<unknown, 6>
         public ResultCode ImportSettings(ServiceCtx context)
         {
-            throw new ServiceNotImplementedException(this, context);
+            throw new ServiceNotImplementedException(this, context, false);
         }
 
         [CommandHipc(15)]
         // Unknown(bytes<1>)
         public ResultCode Unknown(ServiceCtx context)
         {
-            throw new ServiceNotImplementedException(this, context);
+            throw new ServiceNotImplementedException(this, context, false);
         }
 
         [CommandHipc(20)]
@@ -166,49 +166,49 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
         // GetNasServiceSetting(buffer<unknown<0x10>, 0x15>) -> buffer<unknown<0x108>, 0x16>
         public ResultCode GetNasServiceSetting(ServiceCtx context)
         {
-            throw new ServiceNotImplementedException(this, context);
+            throw new ServiceNotImplementedException(this, context, false);
         }
 
         [CommandHipc(31)]
         // GetNasServiceSettingEx(buffer<unknown<0x10>, 0x15>) -> (u32, buffer<unknown<0x108>, 0x16>)
         public ResultCode GetNasServiceSettingEx(ServiceCtx context)
         {
-            throw new ServiceNotImplementedException(this, context);
+            throw new ServiceNotImplementedException(this, context, false);
         }
 
         [CommandHipc(40)]
         // GetNasRequestFqdn() -> buffer<unknown<0x100>, 0x16>
         public ResultCode GetNasRequestFqdn(ServiceCtx context)
         {
-            throw new ServiceNotImplementedException(this, context);
+            throw new ServiceNotImplementedException(this, context, false);
         }
 
         [CommandHipc(41)]
         // GetNasRequestFqdnEx() -> (u32, buffer<unknown<0x100>, 0x16>)
         public ResultCode GetNasRequestFqdnEx(ServiceCtx context)
         {
-            throw new ServiceNotImplementedException(this, context);
+            throw new ServiceNotImplementedException(this, context, false);
         }
 
         [CommandHipc(42)]
         // GetNasApiFqdn() -> buffer<unknown<0x100>, 0x16>
         public ResultCode GetNasApiFqdn(ServiceCtx context)
         {
-            throw new ServiceNotImplementedException(this, context);
+            throw new ServiceNotImplementedException(this, context, false);
         }
 
         [CommandHipc(43)]
         // GetNasApiFqdnEx() -> (u32, buffer<unknown<0x100>, 0x16>)
         public ResultCode GetNasApiFqdnEx(ServiceCtx context)
         {
-            throw new ServiceNotImplementedException(this, context);
+            throw new ServiceNotImplementedException(this, context, false);
         }
 
         [CommandHipc(50)]
         // GetCurrentSetting() -> buffer<unknown<0x12bf0>, 0x16>
         public ResultCode GetCurrentSetting(ServiceCtx context)
         {
-            throw new ServiceNotImplementedException(this, context);
+            throw new ServiceNotImplementedException(this, context, false);
         }
 
         [CommandHipc(60)]
@@ -264,7 +264,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
         // IsChangeEnvironmentIdentifierDisabled() -> bytes<1>
         public ResultCode IsChangeEnvironmentIdentifierDisabled(ServiceCtx context)
         {
-            throw new ServiceNotImplementedException(this, context);
+            throw new ServiceNotImplementedException(this, context, false);
         }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/IResolver.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/IResolver.cs
@@ -19,7 +19,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
     {
         public IResolver(ServiceCtx context) { }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // SetDnsAddressesPrivateRequest(u32, buffer<unknown, 5, 0>)
         public ResultCode SetDnsAddressesPrivateRequest(ServiceCtx context)
         {
@@ -33,7 +33,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
             return ResultCode.NotAllocated;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetDnsAddressPrivateRequest(u32) -> buffer<unknown, 6, 0>
         public ResultCode GetDnsAddressPrivateRequest(ServiceCtx context)
         {
@@ -47,7 +47,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
             return ResultCode.NotAllocated;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // GetHostByNameRequest(u8, u32, u64, pid, buffer<unknown, 5, 0>) -> (u32, u32, u32, buffer<unknown, 6, 0>)
         public ResultCode GetHostByNameRequest(ServiceCtx context)
         {
@@ -60,7 +60,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
             return GetHostByNameRequestImpl(context, inputBufferPosition, inputBufferSize, outputBufferPosition, outputBufferSize, 0, 0);
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // GetHostByAddrRequest(u32, u32, u32, u64, pid, buffer<unknown, 5, 0>) -> (u32, u32, u32, buffer<unknown, 6, 0>)
         public ResultCode GetHostByAddrRequest(ServiceCtx context)
         {
@@ -73,7 +73,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
             return GetHostByAddrRequestImpl(context, inputBufferPosition, inputBufferSize, outputBufferPosition, outputBufferSize, 0, 0);
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // GetHostStringErrorRequest(u32) -> buffer<unknown, 6, 0>
         public ResultCode GetHostStringErrorRequest(ServiceCtx context)
         {
@@ -103,7 +103,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
             return resultCode;
         }
 
-        [Command(5)]
+        [CommandHipc(5)]
         // GetGaiStringErrorRequest(u32) -> buffer<byte, 6, 0>
         public ResultCode GetGaiStringErrorRequest(ServiceCtx context)
         {
@@ -148,7 +148,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
             return resultCode;
         }
 
-        [Command(6)]
+        [CommandHipc(6)]
         // GetAddrInfoRequest(bool enable_nsd_resolve, u32, u64 pid_placeholder, pid, buffer<i8, 5, 0> host, buffer<i8, 5, 0> service, buffer<packed_addrinfo, 5, 0> hints) -> (i32 ret, u32 bsd_errno, u32 packed_addrinfo_size, buffer<packed_addrinfo, 6, 0> response)
         public ResultCode GetAddrInfoRequest(ServiceCtx context)
         {
@@ -158,7 +158,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
             return GetAddrInfoRequestImpl(context, responseBufferPosition, responseBufferSize, 0, 0);
         }
 
-        [Command(8)]
+        [CommandHipc(8)]
         // GetCancelHandleRequest(u64, pid) -> u32
         public ResultCode GetCancelHandleRequest(ServiceCtx context)
         {
@@ -172,7 +172,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
             return ResultCode.Success;
         }
 
-        [Command(9)]
+        [CommandHipc(9)]
         // CancelRequest(u32, u64, pid)
         public ResultCode CancelRequest(ServiceCtx context)
         {
@@ -184,7 +184,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
             return ResultCode.Success;
         }
 
-        [Command(10)] // 5.0.0+
+        [CommandHipc(10)] // 5.0.0+
         // GetHostByNameRequestWithOptions(u8, u32, u64, pid, buffer<unknown, 21, 0>, buffer<unknown, 21, 0>) -> (u32, u32, u32, buffer<unknown, 22, 0>)
         public ResultCode GetHostByNameRequestWithOptions(ServiceCtx context)
         {
@@ -195,7 +195,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
             return GetHostByNameRequestImpl(context, inputBufferPosition, inputBufferSize, outputBufferPosition, outputBufferSize, optionsBufferPosition, optionsBufferSize);
         }
 
-        [Command(11)] // 5.0.0+
+        [CommandHipc(11)] // 5.0.0+
         // GetHostByAddrRequestWithOptions(u32, u32, u32, u64, pid, buffer<unknown, 21, 0>, buffer<unknown, 21, 0>) -> (u32, u32, u32, buffer<unknown, 22, 0>)
         public ResultCode GetHostByAddrRequestWithOptions(ServiceCtx context)
         {
@@ -206,7 +206,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
             return GetHostByAddrRequestImpl(context, inputBufferPosition, inputBufferSize, outputBufferPosition, outputBufferSize, optionsBufferPosition, optionsBufferSize);
         }
 
-        [Command(12)] // 5.0.0+
+        [CommandHipc(12)] // 5.0.0+
         // GetAddrInfoRequestWithOptions(bool enable_nsd_resolve, u32, u64 pid_placeholder, pid, buffer<i8, 5, 0> host, buffer<i8, 5, 0> service, buffer<packed_addrinfo, 5, 0> hints, buffer<unknown, 21, 0>) -> (i32 ret, u32 bsd_errno, u32 unknown, u32 packed_addrinfo_size, buffer<packed_addrinfo, 22, 0> response)
         public ResultCode GetAddrInfoRequestWithOptions(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Spl/IRandomInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Spl/IRandomInterface.cs
@@ -13,7 +13,7 @@ namespace Ryujinx.HLE.HOS.Services.Spl
             _rng = new RNGCryptoServiceProvider();
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetRandomBytes() -> buffer<unknown, 6>
         public ResultCode GetRandomBytes(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Ssl/ISslService.cs
+++ b/Ryujinx.HLE/HOS/Services/Ssl/ISslService.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.HLE.HOS.Services.Ssl
         //       In this case it is acceptable to stub all calls of the service.
         public ISslService(ServiceCtx context) { }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // CreateContext(nn::ssl::sf::SslVersion, u64, pid) -> object<nn::ssl::sf::ISslContext>
         public ResultCode CreateContext(ServiceCtx context)
         {
@@ -25,7 +25,7 @@ namespace Ryujinx.HLE.HOS.Services.Ssl
             return ResultCode.Success;
         }
 
-        [Command(5)]
+        [CommandHipc(5)]
         // SetInterfaceVersion(u32)
         public ResultCode SetInterfaceVersion(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Ssl/SslService/ISslConnection.cs
+++ b/Ryujinx.HLE/HOS/Services/Ssl/SslService/ISslConnection.cs
@@ -8,7 +8,7 @@ namespace Ryujinx.HLE.HOS.Services.Ssl.SslService
     {
         public ISslConnection() { }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // SetSocketDescriptor(u32) -> u32
         public ResultCode SetSocketDescriptor(ServiceCtx context)
         {
@@ -22,7 +22,7 @@ namespace Ryujinx.HLE.HOS.Services.Ssl.SslService
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // SetHostName(buffer<bytes, 5>)
         public ResultCode SetHostName(ServiceCtx context)
         {
@@ -40,7 +40,7 @@ namespace Ryujinx.HLE.HOS.Services.Ssl.SslService
             return ResultCode.Success;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // SetVerifyOption(nn::ssl::sf::VerifyOption)
         public ResultCode SetVerifyOption(ServiceCtx context)
         {
@@ -51,7 +51,7 @@ namespace Ryujinx.HLE.HOS.Services.Ssl.SslService
             return ResultCode.Success;
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // SetIoMode(nn::ssl::sf::IoMode)
         public ResultCode SetIoMode(ServiceCtx context)
         {
@@ -62,7 +62,7 @@ namespace Ryujinx.HLE.HOS.Services.Ssl.SslService
             return ResultCode.Success;
         }
 
-        [Command(8)]
+        [CommandHipc(8)]
         // DoHandshake()
         public ResultCode DoHandshake(ServiceCtx context)
         {
@@ -71,7 +71,7 @@ namespace Ryujinx.HLE.HOS.Services.Ssl.SslService
             return ResultCode.Success;
         }
 
-        [Command(11)]
+        [CommandHipc(11)]
         // Write(buffer<bytes, 5>) -> u32
         public ResultCode Write(ServiceCtx context)
         {
@@ -87,7 +87,7 @@ namespace Ryujinx.HLE.HOS.Services.Ssl.SslService
             return ResultCode.Success;
         }
 
-        [Command(17)]
+        [CommandHipc(17)]
         // SetSessionCacheMode(nn::ssl::sf::SessionCacheMode)
         public ResultCode SetSessionCacheMode(ServiceCtx context)
         {
@@ -98,7 +98,7 @@ namespace Ryujinx.HLE.HOS.Services.Ssl.SslService
             return ResultCode.Success;
         }
 
-        [Command(22)]
+        [CommandHipc(22)]
         // SetOption(b8, nn::ssl::sf::OptionType)
         public ResultCode SetOption(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Ssl/SslService/ISslContext.cs
+++ b/Ryujinx.HLE/HOS/Services/Ssl/SslService/ISslContext.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.HLE.HOS.Services.Ssl.SslService
 
         public ISslContext(ServiceCtx context) { }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // CreateConnection() -> object<nn::ssl::sf::ISslConnection>
         public ResultCode CreateConnection(ServiceCtx context)
         {
@@ -20,7 +20,7 @@ namespace Ryujinx.HLE.HOS.Services.Ssl.SslService
             return ResultCode.Success;
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // ImportServerPki(nn::ssl::sf::CertificateFormat certificateFormat, buffer<bytes, 5> certificate) -> u64 certificateId
         public ResultCode ImportServerPki(ServiceCtx context)
         {
@@ -36,7 +36,7 @@ namespace Ryujinx.HLE.HOS.Services.Ssl.SslService
             return ResultCode.Success;
         }
 
-        [Command(5)]
+        [CommandHipc(5)]
         // ImportClientPki(buffer<bytes, 5> certificate, buffer<bytes, 5> ascii_password) -> u64 certificateId
         public ResultCode ImportClientPki(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/IHOSBinderDriver.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/IHOSBinderDriver.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
     {
         public IHOSBinderDriver() { }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // TransactParcel(s32, u32, u32, buffer<unknown, 5, 0>) -> buffer<unknown, 6, 0>
         public ResultCode TransactParcel(ServiceCtx context)
         {
@@ -38,7 +38,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
             return result;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // AdjustRefcount(s32, s32, s32)
         public ResultCode AdjustRefcount(ServiceCtx context)
         {
@@ -49,7 +49,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
             return AdjustRefcount(binderId, addVal, type);
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // GetNativeHandle(s32, s32) -> handle<copy>
         public ResultCode GetNativeHandle(ServiceCtx context)
         {
@@ -69,7 +69,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
             return ResultCode.Success;
         }
 
-        [Command(3)] // 3.0.0+
+        [CommandHipc(3)] // 3.0.0+
         // TransactParcelAuto(s32, u32, u32, buffer<unknown, 21, 0>) -> buffer<unknown, 22, 0>
         public ResultCode TransactParcelAuto(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Time/IStaticServiceForGlue.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/IStaticServiceForGlue.cs
@@ -23,28 +23,28 @@ namespace Ryujinx.HLE.HOS.Services.Time
             _inner.SetParent(this);
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetStandardUserSystemClock() -> object<nn::timesrv::detail::service::ISystemClock>
         public ResultCode GetStandardUserSystemClock(ServiceCtx context)
         {
             return _inner.GetStandardUserSystemClock(context);
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetStandardNetworkSystemClock() -> object<nn::timesrv::detail::service::ISystemClock>
         public ResultCode GetStandardNetworkSystemClock(ServiceCtx context)
         {
             return _inner.GetStandardNetworkSystemClock(context);
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // GetStandardSteadyClock() -> object<nn::timesrv::detail::service::ISteadyClock>
         public ResultCode GetStandardSteadyClock(ServiceCtx context)
         {
             return _inner.GetStandardSteadyClock(context);
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // GetTimeZoneService() -> object<nn::timesrv::detail::service::ITimeZoneService>
         public ResultCode GetTimeZoneService(ServiceCtx context)
         {
@@ -53,28 +53,28 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.Success;
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // GetStandardLocalSystemClock() -> object<nn::timesrv::detail::service::ISystemClock>
         public ResultCode GetStandardLocalSystemClock(ServiceCtx context)
         {
             return _inner.GetStandardLocalSystemClock(context);
         }
 
-        [Command(5)] // 4.0.0+
+        [CommandHipc(5)] // 4.0.0+
         // GetEphemeralNetworkSystemClock() -> object<nn::timesrv::detail::service::ISystemClock>
         public ResultCode GetEphemeralNetworkSystemClock(ServiceCtx context)
         {
             return _inner.GetEphemeralNetworkSystemClock(context);
         }
 
-        [Command(20)] // 6.0.0+
+        [CommandHipc(20)] // 6.0.0+
         // GetSharedMemoryNativeHandle() -> handle<copy>
         public ResultCode GetSharedMemoryNativeHandle(ServiceCtx context)
         {
             return _inner.GetSharedMemoryNativeHandle(context);
         }
 
-        [Command(50)] // 4.0.0+
+        [CommandHipc(50)] // 4.0.0+
         // SetStandardSteadyClockInternalOffset(nn::TimeSpanType internal_offset)
         public ResultCode SetStandardSteadyClockInternalOffset(ServiceCtx context)
         {
@@ -90,7 +90,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.Success;
         }
 
-        [Command(51)] // 9.0.0+
+        [CommandHipc(51)] // 9.0.0+
         // GetStandardSteadyClockRtcValue() -> u64
         public ResultCode GetStandardSteadyClockRtcValue(ServiceCtx context)
         {
@@ -104,21 +104,21 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return result;
         }
 
-        [Command(100)]
+        [CommandHipc(100)]
         // IsStandardUserSystemClockAutomaticCorrectionEnabled() -> bool
         public ResultCode IsStandardUserSystemClockAutomaticCorrectionEnabled(ServiceCtx context)
         {
             return _inner.IsStandardUserSystemClockAutomaticCorrectionEnabled(context);
         }
 
-        [Command(101)]
+        [CommandHipc(101)]
         // SetStandardUserSystemClockAutomaticCorrectionEnabled(b8)
         public ResultCode SetStandardUserSystemClockAutomaticCorrectionEnabled(ServiceCtx context)
         {
             return _inner.SetStandardUserSystemClockAutomaticCorrectionEnabled(context);
         }
 
-        [Command(102)] // 5.0.0+
+        [CommandHipc(102)] // 5.0.0+
         // GetStandardUserSystemClockInitialYear() -> u32
         public ResultCode GetStandardUserSystemClockInitialYear(ServiceCtx context)
         {
@@ -132,49 +132,49 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.Success;
         }
 
-        [Command(200)] // 3.0.0+
+        [CommandHipc(200)] // 3.0.0+
         // IsStandardNetworkSystemClockAccuracySufficient() -> bool
         public ResultCode IsStandardNetworkSystemClockAccuracySufficient(ServiceCtx context)
         {
             return _inner.IsStandardNetworkSystemClockAccuracySufficient(context);
         }
 
-        [Command(201)] // 6.0.0+
+        [CommandHipc(201)] // 6.0.0+
         // GetStandardUserSystemClockAutomaticCorrectionUpdatedTime() -> nn::time::SteadyClockTimePoint
         public ResultCode GetStandardUserSystemClockAutomaticCorrectionUpdatedTime(ServiceCtx context)
         {
             return _inner.GetStandardUserSystemClockAutomaticCorrectionUpdatedTime(context);
         }
 
-        [Command(300)] // 4.0.0+
+        [CommandHipc(300)] // 4.0.0+
         // CalculateMonotonicSystemClockBaseTimePoint(nn::time::SystemClockContext) -> s64
         public ResultCode CalculateMonotonicSystemClockBaseTimePoint(ServiceCtx context)
         {
             return _inner.CalculateMonotonicSystemClockBaseTimePoint(context);
         }
 
-        [Command(400)] // 4.0.0+
+        [CommandHipc(400)] // 4.0.0+
         // GetClockSnapshot(u8) -> buffer<nn::time::sf::ClockSnapshot, 0x1a>
         public ResultCode GetClockSnapshot(ServiceCtx context)
         {
             return _inner.GetClockSnapshot(context);
         }
 
-        [Command(401)] // 4.0.0+
+        [CommandHipc(401)] // 4.0.0+
         // GetClockSnapshotFromSystemClockContext(u8, nn::time::SystemClockContext, nn::time::SystemClockContext) -> buffer<nn::time::sf::ClockSnapshot, 0x1a>
         public ResultCode GetClockSnapshotFromSystemClockContext(ServiceCtx context)
         {
             return _inner.GetClockSnapshotFromSystemClockContext(context);
         }
 
-        [Command(500)] // 4.0.0+
+        [CommandHipc(500)] // 4.0.0+
         // CalculateStandardUserSystemClockDifferenceByUser(buffer<nn::time::sf::ClockSnapshot, 0x19>, buffer<nn::time::sf::ClockSnapshot, 0x19>) -> nn::TimeSpanType
         public ResultCode CalculateStandardUserSystemClockDifferenceByUser(ServiceCtx context)
         {
             return _inner.CalculateStandardUserSystemClockDifferenceByUser(context);
         }
 
-        [Command(501)] // 4.0.0+
+        [CommandHipc(501)] // 4.0.0+
         // CalculateSpanBetween(buffer<nn::time::sf::ClockSnapshot, 0x19>, buffer<nn::time::sf::ClockSnapshot, 0x19>) -> nn::TimeSpanType
         public ResultCode CalculateSpanBetween(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Time/IStaticServiceForPsc.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/IStaticServiceForPsc.cs
@@ -30,7 +30,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             _timeManager = manager;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetStandardUserSystemClock() -> object<nn::timesrv::detail::service::ISystemClock>
         public ResultCode GetStandardUserSystemClock(ServiceCtx context)
         {
@@ -41,7 +41,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.Success;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetStandardNetworkSystemClock() -> object<nn::timesrv::detail::service::ISystemClock>
         public ResultCode GetStandardNetworkSystemClock(ServiceCtx context)
         {
@@ -52,7 +52,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.Success;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // GetStandardSteadyClock() -> object<nn::timesrv::detail::service::ISteadyClock>
         public ResultCode GetStandardSteadyClock(ServiceCtx context)
         {
@@ -63,7 +63,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.Success;
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // GetTimeZoneService() -> object<nn::timesrv::detail::service::ITimeZoneService>
         public ResultCode GetTimeZoneService(ServiceCtx context)
         {
@@ -73,7 +73,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.Success;
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // GetStandardLocalSystemClock() -> object<nn::timesrv::detail::service::ISystemClock>
         public ResultCode GetStandardLocalSystemClock(ServiceCtx context)
         {
@@ -84,7 +84,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.Success;
         }
 
-        [Command(5)] // 4.0.0+
+        [CommandHipc(5)] // 4.0.0+
         // GetEphemeralNetworkSystemClock() -> object<nn::timesrv::detail::service::ISystemClock>
         public ResultCode GetEphemeralNetworkSystemClock(ServiceCtx context)
         {
@@ -95,7 +95,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.Success;
         }
 
-        [Command(20)] // 6.0.0+
+        [CommandHipc(20)] // 6.0.0+
         // GetSharedMemoryNativeHandle() -> handle<copy>
         public ResultCode GetSharedMemoryNativeHandle(ServiceCtx context)
         {
@@ -112,7 +112,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.Success;
         }
 
-        [Command(50)] // 4.0.0+
+        [CommandHipc(50)] // 4.0.0+
         // SetStandardSteadyClockInternalOffset(nn::TimeSpanType internal_offset)
         public ResultCode SetStandardSteadyClockInternalOffset(ServiceCtx context)
         {
@@ -120,7 +120,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.NotImplemented;
         }
 
-        [Command(51)] // 9.0.0+
+        [CommandHipc(51)] // 9.0.0+
         // GetStandardSteadyClockRtcValue() -> u64
         public ResultCode GetStandardSteadyClockRtcValue(ServiceCtx context)
         {
@@ -128,7 +128,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.NotImplemented;
         }
 
-        [Command(100)]
+        [CommandHipc(100)]
         // IsStandardUserSystemClockAutomaticCorrectionEnabled() -> bool
         public ResultCode IsStandardUserSystemClockAutomaticCorrectionEnabled(ServiceCtx context)
         {
@@ -144,7 +144,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.Success;
         }
 
-        [Command(101)]
+        [CommandHipc(101)]
         // SetStandardUserSystemClockAutomaticCorrectionEnabled(b8)
         public ResultCode SetStandardUserSystemClockAutomaticCorrectionEnabled(ServiceCtx context)
         {
@@ -178,7 +178,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return result;
         }
 
-        [Command(102)] // 5.0.0+
+        [CommandHipc(102)] // 5.0.0+
         // GetStandardUserSystemClockInitialYear() -> u32
         public ResultCode GetStandardUserSystemClockInitialYear(ServiceCtx context)
         {
@@ -186,7 +186,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.NotImplemented;
         }
 
-        [Command(200)] // 3.0.0+
+        [CommandHipc(200)] // 3.0.0+
         // IsStandardNetworkSystemClockAccuracySufficient() -> bool
         public ResultCode IsStandardNetworkSystemClockAccuracySufficient(ServiceCtx context)
         {
@@ -195,7 +195,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.Success;
         }
 
-        [Command(201)] // 6.0.0+
+        [CommandHipc(201)] // 6.0.0+
         // GetStandardUserSystemClockAutomaticCorrectionUpdatedTime() -> nn::time::SteadyClockTimePoint
         public ResultCode GetStandardUserSystemClockAutomaticCorrectionUpdatedTime(ServiceCtx context)
         {
@@ -211,7 +211,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.Success;
         }
 
-        [Command(300)] // 4.0.0+
+        [CommandHipc(300)] // 4.0.0+
         // CalculateMonotonicSystemClockBaseTimePoint(nn::time::SystemClockContext) -> s64
         public ResultCode CalculateMonotonicSystemClockBaseTimePoint(ServiceCtx context)
         {
@@ -240,7 +240,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return result;
         }
 
-        [Command(400)] // 4.0.0+
+        [CommandHipc(400)] // 4.0.0+
         // GetClockSnapshot(u8) -> buffer<nn::time::sf::ClockSnapshot, 0x1a>
         public ResultCode GetClockSnapshot(ServiceCtx context)
         {
@@ -268,7 +268,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return result;
         }
 
-        [Command(401)] // 4.0.0+
+        [CommandHipc(401)] // 4.0.0+
         // GetClockSnapshotFromSystemClockContext(u8, nn::time::SystemClockContext, nn::time::SystemClockContext) -> buffer<nn::time::sf::ClockSnapshot, 0x1a>
         public ResultCode GetClockSnapshotFromSystemClockContext(ServiceCtx context)
         {
@@ -291,7 +291,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return result;
         }
 
-        [Command(500)] // 4.0.0+
+        [CommandHipc(500)] // 4.0.0+
         // CalculateStandardUserSystemClockDifferenceByUser(buffer<nn::time::sf::ClockSnapshot, 0x19>, buffer<nn::time::sf::ClockSnapshot, 0x19>) -> nn::TimeSpanType
         public ResultCode CalculateStandardUserSystemClockDifferenceByUser(ServiceCtx context)
         {
@@ -309,7 +309,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.Success;
         }
 
-        [Command(501)] // 4.0.0+
+        [CommandHipc(501)] // 4.0.0+
         // CalculateSpanBetween(buffer<nn::time::sf::ClockSnapshot, 0x19>, buffer<nn::time::sf::ClockSnapshot, 0x19>) -> nn::TimeSpanType
         public ResultCode CalculateSpanBetween(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Time/ITimeServiceManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/ITimeServiceManager.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             _automaticCorrectionEvent = 0;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetUserStaticService() -> object<nn::timesrv::detail::service::IStaticService>
         public ResultCode GetUserStaticService(ServiceCtx context)
         {
@@ -31,7 +31,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.Success;
         }
 
-        [Command(5)]
+        [CommandHipc(5)]
         // GetAdminStaticService() -> object<nn::timesrv::detail::service::IStaticService>
         public ResultCode GetAdminStaticService(ServiceCtx context)
         {
@@ -40,7 +40,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.Success;
         }
 
-        [Command(6)]
+        [CommandHipc(6)]
         // GetRepairStaticService() -> object<nn::timesrv::detail::service::IStaticService>
         public ResultCode GetRepairStaticService(ServiceCtx context)
         {
@@ -49,7 +49,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.Success;
         }
 
-        [Command(9)]
+        [CommandHipc(9)]
         // GetManufactureStaticService() -> object<nn::timesrv::detail::service::IStaticService>
         public ResultCode GetManufactureStaticService(ServiceCtx context)
         {
@@ -58,7 +58,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.Success;
         }
 
-        [Command(10)]
+        [CommandHipc(10)]
         // SetupStandardSteadyClock(nn::util::Uuid clock_source_id, nn::TimeSpanType setup_value,  nn::TimeSpanType internal_offset,  nn::TimeSpanType test_offset, bool is_rtc_reset_detected)
         public ResultCode SetupStandardSteadyClock(ServiceCtx context)
         {
@@ -73,7 +73,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.Success;
         }
 
-        [Command(11)]
+        [CommandHipc(11)]
         // SetupStandardLocalSystemClock(nn::time::SystemClockContext context, nn::time::PosixTime posix_time)
         public ResultCode SetupStandardLocalSystemClock(ServiceCtx context)
         {
@@ -85,7 +85,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.Success;
         }
 
-        [Command(12)]
+        [CommandHipc(12)]
         // SetupStandardNetworkSystemClock(nn::time::SystemClockContext context, nn::TimeSpanType sufficient_accuracy)
         public ResultCode SetupStandardNetworkSystemClock(ServiceCtx context)
         {
@@ -97,7 +97,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.Success;
         }
 
-        [Command(13)]
+        [CommandHipc(13)]
         // SetupStandardUserSystemClock(bool automatic_correction_enabled, nn::time::SteadyClockTimePoint steady_clock_timepoint)
         public ResultCode SetupStandardUserSystemClock(ServiceCtx context)
         {
@@ -112,7 +112,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.Success;
         }
 
-        [Command(14)]
+        [CommandHipc(14)]
         // SetupTimeZoneManager(nn::time::LocationName location_name, nn::time::SteadyClockTimePoint timezone_update_timepoint, u32 total_location_name_count, nn::time::TimeZoneRuleVersion timezone_rule_version, buffer<nn::time::TimeZoneBinary, 0x21> timezone_binary)
         public ResultCode SetupTimeZoneManager(ServiceCtx context)
         {
@@ -135,7 +135,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.Success;
         }
 
-        [Command(15)]
+        [CommandHipc(15)]
         // SetupEphemeralNetworkSystemClock()
         public ResultCode SetupEphemeralNetworkSystemClock(ServiceCtx context)
         {
@@ -144,7 +144,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.Success;
         }
 
-        [Command(50)]
+        [CommandHipc(50)]
         // Unknown50() -> handle<copy>
         public ResultCode Unknown50(ServiceCtx context)
         {
@@ -152,7 +152,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             throw new ServiceNotImplementedException(this, context);
         }
 
-        [Command(51)]
+        [CommandHipc(51)]
         // Unknown51() -> handle<copy>
         public ResultCode Unknown51(ServiceCtx context)
         {
@@ -160,7 +160,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             throw new ServiceNotImplementedException(this, context);
         }
 
-        [Command(52)]
+        [CommandHipc(52)]
         // Unknown52() -> handle<copy>
         public ResultCode Unknown52(ServiceCtx context)
         {
@@ -168,7 +168,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             throw new ServiceNotImplementedException(this, context);
         }
 
-        [Command(60)]
+        [CommandHipc(60)]
         // GetStandardUserSystemClockAutomaticCorrectionEvent() -> handle<copy>
         public ResultCode GetStandardUserSystemClockAutomaticCorrectionEvent(ServiceCtx context)
         {
@@ -185,7 +185,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.Success;
         }
 
-        [Command(100)]
+        [CommandHipc(100)]
         // SetStandardSteadyClockRtcOffset(nn::TimeSpanType rtc_offset)
         public ResultCode SetStandardSteadyClockRtcOffset(ServiceCtx context)
         {
@@ -196,7 +196,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             return ResultCode.Success;
         }
 
-        [Command(200)]
+        [CommandHipc(200)]
         // GetAlarmRegistrationEvent() -> handle<copy>
         public ResultCode GetAlarmRegistrationEvent(ServiceCtx context)
         {
@@ -204,7 +204,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             throw new ServiceNotImplementedException(this, context);
         }
 
-        [Command(201)]
+        [CommandHipc(201)]
         // UpdateSteadyAlarms()
         public ResultCode UpdateSteadyAlarms(ServiceCtx context)
         {
@@ -212,7 +212,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             throw new ServiceNotImplementedException(this, context);
         }
 
-        [Command(202)]
+        [CommandHipc(202)]
         // TryGetNextSteadyClockAlarmSnapshot() -> (bool, nn::time::SteadyClockAlarmSnapshot)
         public ResultCode TryGetNextSteadyClockAlarmSnapshot(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Time/ITimeServiceManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/ITimeServiceManager.cs
@@ -149,7 +149,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
         public ResultCode Unknown50(ServiceCtx context)
         {
             // TODO: figure out the usage of this event
-            throw new ServiceNotImplementedException(this, context);
+            throw new ServiceNotImplementedException(this, context, false);
         }
 
         [CommandHipc(51)]
@@ -157,7 +157,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
         public ResultCode Unknown51(ServiceCtx context)
         {
             // TODO: figure out the usage of this event
-            throw new ServiceNotImplementedException(this, context);
+            throw new ServiceNotImplementedException(this, context, false);
         }
 
         [CommandHipc(52)]
@@ -165,7 +165,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
         public ResultCode Unknown52(ServiceCtx context)
         {
             // TODO: figure out the usage of this event
-            throw new ServiceNotImplementedException(this, context);
+            throw new ServiceNotImplementedException(this, context, false);
         }
 
         [CommandHipc(60)]
@@ -201,7 +201,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
         public ResultCode GetAlarmRegistrationEvent(ServiceCtx context)
         {
             // TODO
-            throw new ServiceNotImplementedException(this, context);
+            throw new ServiceNotImplementedException(this, context, false);
         }
 
         [CommandHipc(201)]
@@ -209,7 +209,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
         public ResultCode UpdateSteadyAlarms(ServiceCtx context)
         {
             // TODO
-            throw new ServiceNotImplementedException(this, context);
+            throw new ServiceNotImplementedException(this, context, false);
         }
 
         [CommandHipc(202)]
@@ -217,7 +217,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
         public ResultCode TryGetNextSteadyClockAlarmSnapshot(ServiceCtx context)
         {
             // TODO
-            throw new ServiceNotImplementedException(this, context);
+            throw new ServiceNotImplementedException(this, context, false);
         }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Time/StaticService/ISteadyClock.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/StaticService/ISteadyClock.cs
@@ -16,7 +16,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             _bypassUninitializedClock = bypassUninitializedClock;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetCurrentTimePoint() -> nn::time::SteadyClockTimePoint
         public ResultCode GetCurrentTimePoint(ServiceCtx context)
         {
@@ -32,7 +32,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             return ResultCode.Success;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // GetTestOffset() -> nn::TimeSpanType
         public ResultCode GetTestOffset(ServiceCtx context)
         {
@@ -46,7 +46,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             return ResultCode.Success;
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // SetTestOffset(nn::TimeSpanType)
         public ResultCode SetTestOffset(ServiceCtx context)
         {
@@ -67,7 +67,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             return ResultCode.Success;
         }
 
-        [Command(100)] // 2.0.0+
+        [CommandHipc(100)] // 2.0.0+
         // GetRtcValue() -> u64
         public ResultCode GetRtcValue(ServiceCtx context)
         {
@@ -86,7 +86,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             return result;
         }
 
-        [Command(101)] // 2.0.0+
+        [CommandHipc(101)] // 2.0.0+
         // IsRtcResetDetected() -> bool
         public ResultCode IsRtcResetDetected(ServiceCtx context)
         {
@@ -100,7 +100,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             return ResultCode.Success;
         }
 
-        [Command(102)] // 2.0.0+
+        [CommandHipc(102)] // 2.0.0+
         // GetSetupResultValue() -> u32
         public ResultCode GetSetupResultValue(ServiceCtx context)
         {
@@ -114,7 +114,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             return ResultCode.Success;
         }
 
-        [Command(200)] // 3.0.0+
+        [CommandHipc(200)] // 3.0.0+
         // GetInternalOffset() -> nn::TimeSpanType
         public ResultCode GetInternalOffset(ServiceCtx context)
         {
@@ -128,7 +128,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             return ResultCode.Success;
         }
 
-        [Command(201)] // 3.0.0-3.0.2
+        [CommandHipc(201)] // 3.0.0-3.0.2
         // SetInternalOffset(nn::TimeSpanType)
         public ResultCode SetInternalOffset(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Time/StaticService/ISystemClock.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/StaticService/ISystemClock.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             _operationEventReadableHandle = 0;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetCurrentTime() -> nn::time::PosixTime
         public ResultCode GetCurrentTime(ServiceCtx context)
         {
@@ -41,7 +41,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             return result;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // SetCurrentTime(nn::time::PosixTime)
         public ResultCode SetCurrentTime(ServiceCtx context)
         {
@@ -60,7 +60,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             return _clockCore.SetCurrentTime(context.Thread, posixTime);
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // GetClockContext() -> nn::time::SystemClockContext
         public ResultCode GetSystemClockContext(ServiceCtx context)
         {
@@ -79,7 +79,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             return result;
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // SetClockContext(nn::time::SystemClockContext)
         public ResultCode SetSystemClockContext(ServiceCtx context)
         {
@@ -100,7 +100,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             return result;
         }
 
-        [Command(4)] // 9.0.0+
+        [CommandHipc(4)] // 9.0.0+
         // GetOperationEventReadableHandle() -> handle<copy>
         public ResultCode GetOperationEventReadableHandle(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Time/StaticService/ITimeZoneServiceForGlue.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/StaticService/ITimeZoneServiceForGlue.cs
@@ -19,14 +19,14 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             _inner                  = new ITimeZoneServiceForPsc(timeZoneContentManager.Manager, writePermission);
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetDeviceLocationName() -> nn::time::LocationName
         public ResultCode GetDeviceLocationName(ServiceCtx context)
         {
             return _inner.GetDeviceLocationName(context);
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // SetDeviceLocationName(nn::time::LocationName)
         public ResultCode SetDeviceLocationName(ServiceCtx context)
         {
@@ -40,14 +40,14 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             return _timeZoneContentManager.SetDeviceLocationName(locationName);
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // GetTotalLocationNameCount() -> u32
         public ResultCode GetTotalLocationNameCount(ServiceCtx context)
         {
             return _inner.GetTotalLocationNameCount(context);
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // LoadLocationNameList(u32 index) -> (u32 outCount, buffer<nn::time::LocationName, 6>)
         public ResultCode LoadLocationNameList(ServiceCtx context)
         {
@@ -82,7 +82,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             return errorCode;
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // LoadTimeZoneRule(nn::time::LocationName locationName) -> buffer<nn::time::TimeZoneRule, 0x16>
         public ResultCode LoadTimeZoneRule(ServiceCtx context)
         {
@@ -110,28 +110,28 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             return resultCode;
         }
 
-        [Command(100)]
+        [CommandHipc(100)]
         // ToCalendarTime(nn::time::PosixTime time, buffer<nn::time::TimeZoneRule, 0x15> rules) -> (nn::time::CalendarTime, nn::time::sf::CalendarAdditionalInfo)
         public ResultCode ToCalendarTime(ServiceCtx context)
         {
             return _inner.ToCalendarTime(context);
         }
 
-        [Command(101)]
+        [CommandHipc(101)]
         // ToCalendarTimeWithMyRule(nn::time::PosixTime) -> (nn::time::CalendarTime, nn::time::sf::CalendarAdditionalInfo)
         public ResultCode ToCalendarTimeWithMyRule(ServiceCtx context)
         {
             return _inner.ToCalendarTimeWithMyRule(context);
         }
 
-        [Command(201)]
+        [CommandHipc(201)]
         // ToPosixTime(nn::time::CalendarTime calendarTime, buffer<nn::time::TimeZoneRule, 0x15> rules) -> (u32 outCount, buffer<nn::time::PosixTime, 0xa>)
         public ResultCode ToPosixTime(ServiceCtx context)
         {
             return _inner.ToPosixTime(context);
         }
 
-        [Command(202)]
+        [CommandHipc(202)]
         // ToPosixTimeWithMyRule(nn::time::CalendarTime calendarTime) -> (u32 outCount, buffer<nn::time::PosixTime, 0xa>)
         public ResultCode ToPosixTimeWithMyRule(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Time/StaticService/ITimeZoneServiceForPsc.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/StaticService/ITimeZoneServiceForPsc.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             _writePermission = writePermission;
         }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetDeviceLocationName() -> nn::time::LocationName
         public ResultCode GetDeviceLocationName(ServiceCtx context)
         {
@@ -36,7 +36,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             return result;
         }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // SetDeviceLocationName(nn::time::LocationName)
         public ResultCode SetDeviceLocationName(ServiceCtx context)
         {
@@ -48,7 +48,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             return ResultCode.NotImplemented;
         }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // GetTotalLocationNameCount() -> u32
         public ResultCode GetTotalLocationNameCount(ServiceCtx context)
         {
@@ -62,21 +62,21 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             return ResultCode.Success;
         }
 
-        [Command(3)]
+        [CommandHipc(3)]
         // LoadLocationNameList(u32 index) -> (u32 outCount, buffer<nn::time::LocationName, 6>)
         public ResultCode LoadLocationNameList(ServiceCtx context)
         {
             return ResultCode.NotImplemented;
         }
 
-        [Command(4)]
+        [CommandHipc(4)]
         // LoadTimeZoneRule(nn::time::LocationName locationName) -> buffer<nn::time::TimeZoneRule, 0x16>
         public ResultCode LoadTimeZoneRule(ServiceCtx context)
         {
             return ResultCode.NotImplemented;
         }
 
-        [Command(5)] // 2.0.0+
+        [CommandHipc(5)] // 2.0.0+
         // GetTimeZoneRuleVersion() -> nn::time::TimeZoneRuleVersion
         public ResultCode GetTimeZoneRuleVersion(ServiceCtx context)
         {
@@ -90,7 +90,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             return result;
         }
 
-        [Command(6)] // 5.0.0+
+        [CommandHipc(6)] // 5.0.0+
         // GetDeviceLocationNameAndUpdatedTime() -> (nn::time::LocationName, nn::time::SteadyClockTimePoint)
         public ResultCode GetDeviceLocationNameAndUpdatedTime(ServiceCtx context)
         {
@@ -114,7 +114,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             return result;
         }
 
-        [Command(7)] // 9.0.0+
+        [CommandHipc(7)] // 9.0.0+
         // SetDeviceLocationNameWithTimeZoneRule(nn::time::LocationName locationName, buffer<nn::time::TimeZoneBinary, 0x21> timeZoneBinary)
         public ResultCode SetDeviceLocationNameWithTimeZoneRule(ServiceCtx context)
         {
@@ -141,7 +141,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             return result;
         }
 
-        [Command(8)] // 9.0.0+
+        [CommandHipc(8)] // 9.0.0+
         // ParseTimeZoneBinary(buffer<nn::time::TimeZoneBinary, 0x21> timeZoneBinary) -> buffer<nn::time::TimeZoneRule, 0x16>
         public ResultCode ParseTimeZoneBinary(ServiceCtx context)
         {
@@ -177,14 +177,14 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             return result;
         }
 
-        [Command(20)] // 9.0.0+
+        [CommandHipc(20)] // 9.0.0+
         // GetDeviceLocationNameOperationEventReadableHandle() -> handle<copy>
         public ResultCode GetDeviceLocationNameOperationEventReadableHandle(ServiceCtx context)
         {
             return ResultCode.NotImplemented;
         }
 
-        [Command(100)]
+        [CommandHipc(100)]
         // ToCalendarTime(nn::time::PosixTime time, buffer<nn::time::TimeZoneRule, 0x15> rules) -> (nn::time::CalendarTime, nn::time::sf::CalendarAdditionalInfo)
         public ResultCode ToCalendarTime(ServiceCtx context)
         {
@@ -212,7 +212,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             return resultCode;
         }
 
-        [Command(101)]
+        [CommandHipc(101)]
         // ToCalendarTimeWithMyRule(nn::time::PosixTime) -> (nn::time::CalendarTime, nn::time::sf::CalendarAdditionalInfo)
         public ResultCode ToCalendarTimeWithMyRule(ServiceCtx context)
         {
@@ -228,7 +228,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             return resultCode;
         }
 
-        [Command(201)]
+        [CommandHipc(201)]
         // ToPosixTime(nn::time::CalendarTime calendarTime, buffer<nn::time::TimeZoneRule, 0x15> rules) -> (u32 outCount, buffer<nn::time::PosixTime, 0xa>)
         public ResultCode ToPosixTime(ServiceCtx context)
         {
@@ -261,7 +261,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
             return resultCode;
         }
 
-        [Command(202)]
+        [CommandHipc(202)]
         // ToPosixTimeWithMyRule(nn::time::CalendarTime calendarTime) -> (u32 outCount, buffer<nn::time::PosixTime, 0xa>)
         public ResultCode ToPosixTimeWithMyRule(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Vi/IApplicationRootService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/IApplicationRootService.cs
@@ -7,7 +7,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi
     {
         public IApplicationRootService(ServiceCtx context) : base(context.Device.System.ViServer) { }
 
-        [Command(0)]
+        [CommandHipc(0)]
         // GetDisplayService(u32) -> object<nn::visrv::sf::IApplicationDisplayService>
         public ResultCode GetDisplayService(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Vi/IManagerRootService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/IManagerRootService.cs
@@ -8,7 +8,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi
         // vi:u/m/s aren't on 3 separate threads but we can't put them together with the current ServerBase
         public IManagerRootService(ServiceCtx context) : base(context.Device.System.ViServerM) { }
 
-        [Command(2)]
+        [CommandHipc(2)]
         // GetDisplayService(u32) -> object<nn::visrv::sf::IApplicationDisplayService>
         public ResultCode GetDisplayService(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Vi/ISystemRootService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/ISystemRootService.cs
@@ -8,7 +8,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi
         // vi:u/m/s aren't on 3 separate threads but we can't put them together with the current ServerBase
         public ISystemRootService(ServiceCtx context) : base(context.Device.System.ViServerS) { }
 
-        [Command(1)]
+        [CommandHipc(1)]
         // GetDisplayService(u32) -> object<nn::visrv::sf::IApplicationDisplayService>
         public ResultCode GetDisplayService(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Vi/RootService/ApplicationDisplayService/IManagerDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/RootService/ApplicationDisplayService/IManagerDisplayService.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService.ApplicationDisplayService
             _applicationDisplayService = applicationDisplayService;
         }
 
-        [Command(2010)]
+        [CommandHipc(2010)]
         // CreateManagedLayer(u32, u64, nn::applet::AppletResourceUserId) -> u64
         public ResultCode CreateManagedLayer(ServiceCtx context)
         {
@@ -29,7 +29,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService.ApplicationDisplayService
             return ResultCode.Success;
         }
 
-        [Command(2011)]
+        [CommandHipc(2011)]
         // DestroyManagedLayer(u64)
         public ResultCode DestroyManagedLayer(ServiceCtx context)
         {
@@ -40,14 +40,14 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService.ApplicationDisplayService
             return ResultCode.Success;
         }
 
-        [Command(2012)] // 7.0.0+
+        [CommandHipc(2012)] // 7.0.0+
         // CreateStrayLayer(u32, u64) -> (u64, u64, buffer<bytes, 6>)
         public ResultCode CreateStrayLayer(ServiceCtx context)
         {
             return _applicationDisplayService.CreateStrayLayer(context);
         }
 
-        [Command(6000)]
+        [CommandHipc(6000)]
         // AddToLayerStack(u32, u64)
         public ResultCode AddToLayerStack(ServiceCtx context)
         {
@@ -56,7 +56,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService.ApplicationDisplayService
             return ResultCode.Success;
         }
 
-        [Command(6002)]
+        [CommandHipc(6002)]
         // SetLayerVisibility(b8, u64)
         public ResultCode SetLayerVisibility(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Vi/RootService/ApplicationDisplayService/ISystemDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/RootService/ApplicationDisplayService/ISystemDisplayService.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService.ApplicationDisplayService
             _applicationDisplayService = applicationDisplayService;
         }
 
-        [Command(2205)]
+        [CommandHipc(2205)]
         // SetLayerZ(u64, u64)
         public ResultCode SetLayerZ(ServiceCtx context)
         {
@@ -20,7 +20,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService.ApplicationDisplayService
             return ResultCode.Success;
         }
 
-        [Command(2207)]
+        [CommandHipc(2207)]
         // SetLayerVisibility(b8, u64)
         public ResultCode SetLayerVisibility(ServiceCtx context)
         {
@@ -29,7 +29,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService.ApplicationDisplayService
             return ResultCode.Success;
         }
 
-        [Command(2312)] // 1.0.0-6.2.0
+        [CommandHipc(2312)] // 1.0.0-6.2.0
         // CreateStrayLayer(u32, u64) -> (u64, u64, buffer<bytes, 6>)
         public ResultCode CreateStrayLayer(ServiceCtx context)
         {
@@ -38,7 +38,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService.ApplicationDisplayService
             return _applicationDisplayService.CreateStrayLayer(context);
         }
 
-        [Command(3200)]
+        [CommandHipc(3200)]
         // GetDisplayMode(u64) -> nn::vi::DisplayModeInfo
         public ResultCode GetDisplayMode(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
@@ -21,7 +21,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
             _displays = new IdDictionary();
         }
 
-        [Command(100)]
+        [CommandHipc(100)]
         // GetRelayService() -> object<nns::hosbinder::IHOSBinderDriver>
         public ResultCode GetRelayService(ServiceCtx context)
         {
@@ -30,7 +30,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
             return ResultCode.Success;
         }
 
-        [Command(101)]
+        [CommandHipc(101)]
         // GetSystemDisplayService() -> object<nn::visrv::sf::ISystemDisplayService>
         public ResultCode GetSystemDisplayService(ServiceCtx context)
         {
@@ -39,7 +39,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
             return ResultCode.Success;
         }
 
-        [Command(102)]
+        [CommandHipc(102)]
         // GetManagerDisplayService() -> object<nn::visrv::sf::IManagerDisplayService>
         public ResultCode GetManagerDisplayService(ServiceCtx context)
         {
@@ -48,7 +48,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
             return ResultCode.Success;
         }
 
-        [Command(103)] // 2.0.0+
+        [CommandHipc(103)] // 2.0.0+
         // GetIndirectDisplayTransactionService() -> object<nns::hosbinder::IHOSBinderDriver>
         public ResultCode GetIndirectDisplayTransactionService(ServiceCtx context)
         {
@@ -57,7 +57,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
             return ResultCode.Success;
         }
 
-        [Command(1000)]
+        [CommandHipc(1000)]
         // ListDisplays() -> (u64, buffer<nn::vi::DisplayInfo, 6>)
         public ResultCode ListDisplays(ServiceCtx context)
         {
@@ -77,7 +77,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
             return ResultCode.Success;
         }
 
-        [Command(1010)]
+        [CommandHipc(1010)]
         // OpenDisplay(nn::vi::DisplayName) -> u64
         public ResultCode OpenDisplay(ServiceCtx context)
         {
@@ -90,7 +90,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
             return ResultCode.Success;
         }
 
-        [Command(1020)]
+        [CommandHipc(1020)]
         // CloseDisplay(u64)
         public ResultCode CloseDisplay(ServiceCtx context)
         {
@@ -101,7 +101,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
             return ResultCode.Success;
         }
 
-        [Command(1102)]
+        [CommandHipc(1102)]
         // GetDisplayResolution(u64) -> (u64, u64)
         public ResultCode GetDisplayResolution(ServiceCtx context)
         {
@@ -113,7 +113,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
             return ResultCode.Success;
         }
 
-        [Command(2020)]
+        [CommandHipc(2020)]
         // OpenLayer(nn::vi::DisplayName, u64, nn::applet::AppletResourceUserId, pid) -> (u64, buffer<bytes, 6>)
         public ResultCode OpenLayer(ServiceCtx context)
         {
@@ -141,7 +141,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
             return ResultCode.Success;
         }
 
-        [Command(2021)]
+        [CommandHipc(2021)]
         // CloseLayer(u64)
         public ResultCode CloseLayer(ServiceCtx context)
         {
@@ -152,7 +152,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
             return ResultCode.Success;
         }
 
-        [Command(2030)]
+        [CommandHipc(2030)]
         // CreateStrayLayer(u32, u64) -> (u64, u64, buffer<bytes, 6>)
         public ResultCode CreateStrayLayer(ServiceCtx context)
         {
@@ -182,7 +182,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
             return ResultCode.Success;
         }
 
-        [Command(2031)]
+        [CommandHipc(2031)]
         // DestroyStrayLayer(u64)
         public ResultCode DestroyStrayLayer(ServiceCtx context)
         {
@@ -193,7 +193,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
             return ResultCode.Success;
         }
 
-        [Command(2101)]
+        [CommandHipc(2101)]
         // SetLayerScalingMode(u32, u64)
         public ResultCode SetLayerScalingMode(ServiceCtx context)
         {
@@ -203,7 +203,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
             return ResultCode.Success;
         }
 
-        [Command(2102)] // 5.0.0+
+        [CommandHipc(2102)] // 5.0.0+
         // ConvertScalingMode(unknown) -> unknown
         public ResultCode ConvertScalingMode(ServiceCtx context)
         {
@@ -243,7 +243,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
             return null;
         }
 
-        [Command(2450)]
+        [CommandHipc(2450)]
         // GetIndirectLayerImageMap(s64 width, s64 height, u64 handle, nn::applet::AppletResourceUserId, pid) -> (s64, s64, buffer<bytes, 0x46>)
         public ResultCode GetIndirectLayerImageMap(ServiceCtx context)
         {
@@ -261,7 +261,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
             return ResultCode.Success;
         }
 
-        [Command(2460)]
+        [CommandHipc(2460)]
         // GetIndirectLayerImageRequiredMemoryInfo(u64 width, u64 height) -> (u64 size, u64 alignment)
         public ResultCode GetIndirectLayerImageRequiredMemoryInfo(ServiceCtx context)
         {
@@ -308,7 +308,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
             return ResultCode.Success;
         }
 
-        [Command(5202)]
+        [CommandHipc(5202)]
         // GetDisplayVsyncEvent(u64) -> handle<copy>
         public ResultCode GetDisplayVSyncEvent(ServiceCtx context)
         {


### PR DESCRIPTION
This PR adds very initial support for the new IPC system from 12.x (named TIPC)

This also adds support for the new SM commands ids available on TIPC.

To support this the following changes were made:
- ``CommandAttribute`` was renamed ``CommandHipcAttribute``.
- All reference to HIPC now contains the ``Hipc`` in their name to show a clear difference.
- ``CommandTipcAttribute`` was added.