### PR TITLE
(CPU) Fix CRC32 instruction when constant values are used as input

### DIFF
--- a/ARMeilleure/CodeGen/X86/PreAllocator.cs
+++ b/ARMeilleure/CodeGen/X86/PreAllocator.cs
@@ -135,7 +135,7 @@ namespace ARMeilleure.CodeGen.X86
 
         private static void HandleConstantRegCopy(IntrusiveList<Node> nodes, Node node, Operation operation)
         {
-            if (operation.SourcesCount == 0 || IsIntrinsic(operation.Instruction))
+            if (operation.SourcesCount == 0 || IsXmmIntrinsic(operation))
             {
                 return;
             }
@@ -1399,6 +1399,19 @@ namespace ARMeilleure.CodeGen.X86
         private static bool IsIntrinsic(Instruction inst)
         {
             return inst == Instruction.Extended;
+        }
+
+        private static bool IsXmmIntrinsic(Operation operation)
+        {
+            if (operation.Instruction != Instruction.Extended)
+            {
+                return false;
+            }
+
+            IntrinsicOperation intrinOp = (IntrinsicOperation)operation;
+            IntrinsicInfo info = IntrinsicTable.GetInfo(intrinOp.Intrinsic);
+
+            return info.Type != IntrinsicType.Crc32;
         }
     }
 }


### PR DESCRIPTION
There is a bug with the CRC32 intrinsic were the JIT does not force a copy when a constant value is used as input for this instruction. On debug, this will cause an assert as this specific instruction does not support immediate operands on x86, and in release, it will just generate invalid code. This fixes the issue by forcing the value to be copied to a register, and then replacing the operation input with the register.

Fixes #1457

A user ("yunny") reported the assert firing while rebuilding PPTC cache for Monster Hunter Rise, I have reproduced the issue and verified that the assert no longer fires with the fix, however, I also did not notice any visible improvement on the game.

I also ran all CRC32 tests locally in both LCQ and HCQ modes, and they all pass.