### PR TITLE
Add inlined on translation call counting

### DIFF
--- a/ARMeilleure/Common/Counter.cs
+++ b/ARMeilleure/Common/Counter.cs
@@ -1,0 +1,48 @@
+﻿namespace ARMeilleure.Common
+{
+    /// <summary>
+    /// Represents an 8-bit counter.
+    /// </summary>
+    class Counter
+    {
+        private readonly int _index;
+        private readonly EntryTable<byte> _countTable;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Counter"/> class from the specified
+        /// <see cref="EntryTable{byte}"/> instance and index.
+        /// </summary>
+        /// <param name="countTable"><see cref="EntryTable{byte}"/> instance</param>
+        /// <param name="index">Index in the <see cref="EntryTable{TEntry}"/></param>
+        private Counter(EntryTable<byte> countTable, int index)
+        {
+            _countTable = countTable;
+            _index = index;
+        }
+
+        /// <summary>
+        /// Gets a reference to the value of the counter.
+        /// </summary>
+        public ref byte Value => ref _countTable.GetValue(_index);
+
+        /// <summary>
+        /// Tries to create a <see cref="Counter"/> instance from the specified <see cref="EntryTable{byte}"/> instance.
+        /// </summary>
+        /// <param name="countTable"><see cref="EntryTable{TEntry}"/> from which to create the <see cref="Counter"/></param>
+        /// <param name="counter"><see cref="Counter"/> instance if success; otherwise <see langword="null"/></param>
+        /// <returns><see langword="true"/> if success; otherwise <see langword="false"/></returns>
+        public static bool TryCreate(EntryTable<byte> countTable, out Counter counter)
+        {
+            if (countTable.TryAllocate(out int index))
+            {
+                counter = new Counter(countTable, index);
+
+                return true;
+            }
+
+            counter = null;
+
+            return false;
+        }
+    }
+}

--- a/ARMeilleure/Common/Counter.cs
+++ b/ARMeilleure/Common/Counter.cs
@@ -40,7 +40,7 @@ namespace ARMeilleure.Common
         /// Gets a reference to the value of the counter.
         /// </summary>
         /// <exception cref="ObjectDisposedException"><see cref="Counter{T}"/> instance was disposed</exception>
-        public ref T Value 
+        public ref T Value
         {
             get
             {
@@ -49,7 +49,7 @@ namespace ARMeilleure.Common
                     throw new ObjectDisposedException(null);
                 }
 
-                return ref _countTable.GetValue(_index); 
+                return ref _countTable.GetValue(_index);
             }
         }
 

--- a/ARMeilleure/Common/Counter.cs
+++ b/ARMeilleure/Common/Counter.cs
@@ -6,8 +6,9 @@ namespace ARMeilleure.Common
     /// Represents a numeric counter.
     /// </summary>
     /// <typeparam name="T">Type of the counter</typeparam>
-    class Counter<T> where T : unmanaged
+    class Counter<T> : IDisposable where T : unmanaged
     {
+        private bool _disposed;
         private readonly int _index;
         private readonly EntryTable<T> _countTable;
 
@@ -26,7 +27,18 @@ namespace ARMeilleure.Common
         /// <summary>
         /// Gets a reference to the value of the counter.
         /// </summary>
-        public ref T Value => ref _countTable.GetValue(_index);
+        public ref T Value 
+        {
+            get
+            {
+                if (_disposed)
+                {
+                    throw new ObjectDisposedException(null);
+                }
+
+                return ref _countTable.GetValue(_index); 
+            }
+        }
 
         /// <summary>
         /// Tries to create a <see cref="Counter"/> instance from the specified <see cref="EntryTable{byte}"/> instance.
@@ -63,6 +75,19 @@ namespace ARMeilleure.Common
             counter = null;
 
             return false;
+        }
+
+        /// <summary>
+        /// Releases all resources used by the <see cref="Counter{T}"/> instance.
+        /// </summary>
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _countTable.Free(_index);
+
+                _disposed = true;
+            }
         }
     }
 }

--- a/ARMeilleure/Common/Counter.cs
+++ b/ARMeilleure/Common/Counter.cs
@@ -3,7 +3,7 @@
 namespace ARMeilleure.Common
 {
     /// <summary>
-    /// Represents a numeric counter.
+    /// Represents a numeric counter which can be used for instrumentation of compiled code.
     /// </summary>
     /// <typeparam name="T">Type of the counter</typeparam>
     class Counter<T> : IDisposable where T : unmanaged
@@ -27,6 +27,7 @@ namespace ARMeilleure.Common
         /// <summary>
         /// Gets a reference to the value of the counter.
         /// </summary>
+        /// <exception cref="ObjectDisposedException"><see cref="Counter{T}"/> instance was disposed</exception>
         public ref T Value 
         {
             get
@@ -41,10 +42,10 @@ namespace ARMeilleure.Common
         }
 
         /// <summary>
-        /// Tries to create a <see cref="Counter"/> instance from the specified <see cref="EntryTable{T}"/> instance.
+        /// Tries to create a <see cref="Counter{T}"/> instance from the specified <see cref="EntryTable{T}"/> instance.
         /// </summary>
-        /// <param name="countTable"><see cref="EntryTable{T}"/> from which to create the <see cref="Counter"/></param>
-        /// <param name="counter"><see cref="Counter"/> instance if success; otherwise <see langword="null"/></param>
+        /// <param name="countTable"><see cref="EntryTable{T}"/> from which to create the <see cref="Counter{T}"/></param>
+        /// <param name="counter"><see cref="Counter{T}"/> instance if success; otherwise <see langword="null"/></param>
         /// <returns><see langword="true"/> if success; otherwise <see langword="false"/></returns>
         /// <exception cref="ArgumentNullException"><paramref name="countTable"/> is <see langword="null"/></exception>
         /// <exception cref="ArgumentException"><typeparamref name="T"/> is unsupported</exception>

--- a/ARMeilleure/Common/Counter.cs
+++ b/ARMeilleure/Common/Counter.cs
@@ -42,6 +42,39 @@ namespace ARMeilleure.Common
         }
 
         /// <summary>
+        /// Releases all resources used by the <see cref="Counter{T}"/> instance.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases all unmanaged and optionally managed resources used by the <see cref="Counter{T}"/> instance.
+        /// </summary>
+        /// <param name="disposing"><see langword="true"/> to dispose managed resources also; otherwise just unmanaged resouces</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                // The index into the EntryTable is essentially an unmanaged resource since we allocate and free the
+                // resource ourselves.
+                _countTable.Free(_index);
+
+                _disposed = true;
+            }
+        }
+
+        /// <summary>
+        /// Frees resources used by <see cref="Counter{T}"/> instance.
+        /// </summary>
+        ~Counter()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
         /// Tries to create a <see cref="Counter{T}"/> instance from the specified <see cref="EntryTable{T}"/> instance.
         /// </summary>
         /// <param name="countTable"><see cref="EntryTable{T}"/> from which to create the <see cref="Counter{T}"/></param>
@@ -76,19 +109,6 @@ namespace ARMeilleure.Common
             counter = null;
 
             return false;
-        }
-
-        /// <summary>
-        /// Releases all resources used by the <see cref="Counter{T}"/> instance.
-        /// </summary>
-        public void Dispose()
-        {
-            if (!_disposed)
-            {
-                _countTable.Free(_index);
-
-                _disposed = true;
-            }
         }
     }
 }

--- a/ARMeilleure/Common/Counter.cs
+++ b/ARMeilleure/Common/Counter.cs
@@ -1,20 +1,23 @@
-﻿namespace ARMeilleure.Common
+﻿using System;
+
+namespace ARMeilleure.Common
 {
     /// <summary>
-    /// Represents an 8-bit counter.
+    /// Represents a numeric counter.
     /// </summary>
-    class Counter
+    /// <typeparam name="T">Type of the counter</typeparam>
+    class Counter<T> where T : unmanaged
     {
         private readonly int _index;
-        private readonly EntryTable<byte> _countTable;
+        private readonly EntryTable<T> _countTable;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Counter"/> class from the specified
-        /// <see cref="EntryTable{byte}"/> instance and index.
+        /// Initializes a new instance of the <see cref="Counter{T}"/> class from the specified
+        /// <see cref="EntryTable{T}"/> instance and index.
         /// </summary>
         /// <param name="countTable"><see cref="EntryTable{byte}"/> instance</param>
-        /// <param name="index">Index in the <see cref="EntryTable{TEntry}"/></param>
-        private Counter(EntryTable<byte> countTable, int index)
+        /// <param name="index">Index in the <see cref="EntryTable{T}"/></param>
+        private Counter(EntryTable<T> countTable, int index)
         {
             _countTable = countTable;
             _index = index;
@@ -23,7 +26,7 @@
         /// <summary>
         /// Gets a reference to the value of the counter.
         /// </summary>
-        public ref byte Value => ref _countTable.GetValue(_index);
+        public ref T Value => ref _countTable.GetValue(_index);
 
         /// <summary>
         /// Tries to create a <see cref="Counter"/> instance from the specified <see cref="EntryTable{byte}"/> instance.
@@ -31,11 +34,28 @@
         /// <param name="countTable"><see cref="EntryTable{TEntry}"/> from which to create the <see cref="Counter"/></param>
         /// <param name="counter"><see cref="Counter"/> instance if success; otherwise <see langword="null"/></param>
         /// <returns><see langword="true"/> if success; otherwise <see langword="false"/></returns>
-        public static bool TryCreate(EntryTable<byte> countTable, out Counter counter)
+        /// <exception cref="ArgumentNullException"><paramref name="countTable"/> is <see langword="null"/></exception>
+        /// <exception cref="ArgumentException"><typeparamref name="T"/> is unsupported</exception>
+        public static bool TryCreate(EntryTable<T> countTable, out Counter<T> counter)
         {
+            if (countTable == null)
+            {
+                throw new ArgumentNullException(nameof(countTable));
+            }
+
+            if (typeof(T) != typeof(byte) && typeof(T) != typeof(sbyte) &&
+                typeof(T) != typeof(short) && typeof(T) != typeof(ushort) &&
+                typeof(T) != typeof(int) && typeof(T) != typeof(uint) &&
+                typeof(T) != typeof(long) && typeof(T) != typeof(ulong) &&
+                typeof(T) != typeof(nint) && typeof(T) != typeof(nuint) &&
+                typeof(T) != typeof(float) && typeof(T) != typeof(double))
+            {
+                throw new ArgumentException("Counter does not support the specified type", nameof(countTable));
+            }
+
             if (countTable.TryAllocate(out int index))
             {
-                counter = new Counter(countTable, index);
+                counter = new Counter<T>(countTable, index);
 
                 return true;
             }

--- a/ARMeilleure/Common/Counter.cs
+++ b/ARMeilleure/Common/Counter.cs
@@ -16,7 +16,7 @@ namespace ARMeilleure.Common
         /// Initializes a new instance of the <see cref="Counter{T}"/> class from the specified
         /// <see cref="EntryTable{T}"/> instance and index.
         /// </summary>
-        /// <param name="countTable"><see cref="EntryTable{byte}"/> instance</param>
+        /// <param name="countTable"><see cref="EntryTable{T}"/> instance</param>
         /// <param name="index">Index in the <see cref="EntryTable{T}"/></param>
         private Counter(EntryTable<T> countTable, int index)
         {
@@ -41,9 +41,9 @@ namespace ARMeilleure.Common
         }
 
         /// <summary>
-        /// Tries to create a <see cref="Counter"/> instance from the specified <see cref="EntryTable{byte}"/> instance.
+        /// Tries to create a <see cref="Counter"/> instance from the specified <see cref="EntryTable{T}"/> instance.
         /// </summary>
-        /// <param name="countTable"><see cref="EntryTable{TEntry}"/> from which to create the <see cref="Counter"/></param>
+        /// <param name="countTable"><see cref="EntryTable{T}"/> from which to create the <see cref="Counter"/></param>
         /// <param name="counter"><see cref="Counter"/> instance if success; otherwise <see langword="null"/></param>
         /// <returns><see langword="true"/> if success; otherwise <see langword="false"/></returns>
         /// <exception cref="ArgumentNullException"><paramref name="countTable"/> is <see langword="null"/></exception>

--- a/ARMeilleure/Common/Counter.cs
+++ b/ARMeilleure/Common/Counter.cs
@@ -40,6 +40,9 @@ namespace ARMeilleure.Common
         /// Gets a reference to the value of the counter.
         /// </summary>
         /// <exception cref="ObjectDisposedException"><see cref="Counter{T}"/> instance was disposed</exception>
+        /// <remarks>
+        /// This can refer to freed memory if the owning <see cref="EntryTable{TEntry}"/> is disposed.
+        /// </remarks>
         public ref T Value
         {
             get
@@ -70,9 +73,16 @@ namespace ARMeilleure.Common
         {
             if (!_disposed)
             {
-                // The index into the EntryTable is essentially an unmanaged resource since we allocate and free the
-                // resource ourselves.
-                _countTable.Free(_index);
+                try
+                {
+                    // The index into the EntryTable is essentially an unmanaged resource since we allocate and free the
+                    // resource ourselves.
+                    _countTable.Free(_index);
+                }
+                catch (ObjectDisposedException)
+                {
+                    // Can happen because _countTable may be disposed before the Counter instance.
+                }
 
                 _disposed = true;
             }

--- a/ARMeilleure/Common/Counter.cs
+++ b/ARMeilleure/Common/Counter.cs
@@ -18,10 +18,22 @@ namespace ARMeilleure.Common
         /// </summary>
         /// <param name="countTable"><see cref="EntryTable{T}"/> instance</param>
         /// <param name="index">Index in the <see cref="EntryTable{T}"/></param>
-        private Counter(EntryTable<T> countTable, int index)
+        /// <exception cref="ArgumentNullException"><paramref name="countTable"/> is <see langword="null"/></exception>
+        /// <exception cref="ArgumentException"><typeparamref name="T"/> is unsupported</exception>
+        public Counter(EntryTable<T> countTable)
         {
-            _countTable = countTable;
-            _index = index;
+            if (typeof(T) != typeof(byte) && typeof(T) != typeof(sbyte) &&
+                typeof(T) != typeof(short) && typeof(T) != typeof(ushort) &&
+                typeof(T) != typeof(int) && typeof(T) != typeof(uint) &&
+                typeof(T) != typeof(long) && typeof(T) != typeof(ulong) &&
+                typeof(T) != typeof(nint) && typeof(T) != typeof(nuint) &&
+                typeof(T) != typeof(float) && typeof(T) != typeof(double))
+            {
+                throw new ArgumentException("Counter does not support the specified type.");
+            }
+
+            _countTable = countTable ?? throw new ArgumentNullException(nameof(countTable));
+            _index = countTable.Allocate();
         }
 
         /// <summary>
@@ -67,48 +79,11 @@ namespace ARMeilleure.Common
         }
 
         /// <summary>
-        /// Frees resources used by <see cref="Counter{T}"/> instance.
+        /// Frees resources used by the <see cref="Counter{T}"/> instance.
         /// </summary>
         ~Counter()
         {
             Dispose(false);
-        }
-
-        /// <summary>
-        /// Tries to create a <see cref="Counter{T}"/> instance from the specified <see cref="EntryTable{T}"/> instance.
-        /// </summary>
-        /// <param name="countTable"><see cref="EntryTable{T}"/> from which to create the <see cref="Counter{T}"/></param>
-        /// <param name="counter"><see cref="Counter{T}"/> instance if success; otherwise <see langword="null"/></param>
-        /// <returns><see langword="true"/> if success; otherwise <see langword="false"/></returns>
-        /// <exception cref="ArgumentNullException"><paramref name="countTable"/> is <see langword="null"/></exception>
-        /// <exception cref="ArgumentException"><typeparamref name="T"/> is unsupported</exception>
-        public static bool TryCreate(EntryTable<T> countTable, out Counter<T> counter)
-        {
-            if (countTable == null)
-            {
-                throw new ArgumentNullException(nameof(countTable));
-            }
-
-            if (typeof(T) != typeof(byte) && typeof(T) != typeof(sbyte) &&
-                typeof(T) != typeof(short) && typeof(T) != typeof(ushort) &&
-                typeof(T) != typeof(int) && typeof(T) != typeof(uint) &&
-                typeof(T) != typeof(long) && typeof(T) != typeof(ulong) &&
-                typeof(T) != typeof(nint) && typeof(T) != typeof(nuint) &&
-                typeof(T) != typeof(float) && typeof(T) != typeof(double))
-            {
-                throw new ArgumentException("Counter does not support the specified type", nameof(countTable));
-            }
-
-            if (countTable.TryAllocate(out int index))
-            {
-                counter = new Counter<T>(countTable, index);
-
-                return true;
-            }
-
-            counter = null;
-
-            return false;
         }
     }
 }

--- a/ARMeilleure/Common/EntryTable.cs
+++ b/ARMeilleure/Common/EntryTable.cs
@@ -1,0 +1,100 @@
+﻿using System;
+
+namespace ARMeilleure.Common
+{
+    /// <summary>
+    /// Represents a fixed size table of the type <typeparamref name="TEntry"/>, whose entries will remain at the same
+    /// address through out the table's lifetime.
+    /// </summary>
+    /// <typeparam name="TEntry">Type of the entry in the table</typeparam>
+    class EntryTable<TEntry> where TEntry : unmanaged
+    {
+        private int _freeHint;
+        private readonly TEntry[] _table;
+        private readonly BitMap _allocated;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EntryTable{TValue}"/> class with the specified capacity.
+        /// </summary>
+        /// <param name="capacity">Capacity of the table</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is less than 0</exception>
+        public EntryTable(int capacity)
+        {
+            if (capacity < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(capacity));
+            }
+
+            _freeHint = 0;
+            _allocated = new BitMap();
+            _table = GC.AllocateArray<TEntry>(capacity, pinned: true);
+        }
+
+        /// <summary>
+        /// Tries to allocate an entry in the <see cref="EntryTable{TValue}"/>. Returns <see langword="true"/> if
+        /// success; otherwise returns <see langword="false"/>.
+        /// </summary>
+        /// <param name="index">Index of entry allocated in the table</param>
+        /// <returns><see langword="true"/> if success; otherwise <see langword="false"/></returns>
+        public bool TryAllocate(out int index)
+        {
+            lock (_allocated)
+            {
+                if (_allocated.IsSet(_freeHint))
+                {
+                    _freeHint = _allocated.FindFirstUnset();
+                }
+
+                if (_freeHint < _table.Length)
+                {
+                    index = checked(_freeHint++);
+
+                    _allocated.Set(index);
+
+                    return true;
+                }
+            }
+
+            index = 0;
+
+            return false;
+        }
+
+        /// <summary>
+        /// Frees the entry at the specified <paramref name="index"/>.
+        /// </summary>
+        /// <param name="index">Index of entry to free</param>
+        public void Free(int index)
+        {
+            lock (_allocated)
+            {
+                _allocated.Clear(index);
+            }
+        }
+
+        /// <summary>
+        /// Gets a reference to the entry at the specified allocated <paramref name="index"/>.
+        /// </summary>
+        /// <param name="index">Index of the entry</param>
+        /// <returns>Reference to the entry at the specified index</returns>
+        /// <exception cref="ArgumentException">Entry at <paramref name="index"/> is not allocated</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is outside of the table</exception>
+        public ref TEntry GetValue(int index)
+        {
+            if (index < 0 || index >= _table.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+
+            lock (_allocated)
+            {
+                if (!_allocated.IsSet(index))
+                {
+                    throw new ArgumentException("Entry at the specified index was not allocated", nameof(index));
+                }
+            }
+
+            return ref _table[index];
+        }
+    }
+}

--- a/ARMeilleure/Common/EntryTable.cs
+++ b/ARMeilleure/Common/EntryTable.cs
@@ -51,6 +51,8 @@ namespace ARMeilleure.Common
 
                     _allocated.Set(index);
 
+                    GetValue(index) = default;
+
                     return true;
                 }
             }

--- a/ARMeilleure/Common/EntryTable.cs
+++ b/ARMeilleure/Common/EntryTable.cs
@@ -20,9 +20,10 @@ namespace ARMeilleure.Common
         private readonly BitMap _allocated;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="EntryTable{TEntry}"/> class with the desired page size.
+        /// Initializes a new instance of the <see cref="EntryTable{TEntry}"/> class with the desired page size in
+        /// bytes.
         /// </summary>
-        /// <param name="pageSize">Desired page size</param>
+        /// <param name="pageSize">Desired page size in bytes</param>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="pageSize"/> is less than 0</exception>
         /// <exception cref="ArgumentException"><typeparamref name="TEntry"/>'s size is zero</exception>
         /// <remarks>
@@ -113,8 +114,6 @@ namespace ARMeilleure.Common
                 throw new ObjectDisposedException(null);
             }
 
-            Span<TEntry> page;
-
             lock (_allocated)
             {
                 if (!_allocated.IsSet(index))
@@ -122,10 +121,10 @@ namespace ARMeilleure.Common
                     throw new ArgumentException("Entry at the specified index was not allocated", nameof(index));
                 }
 
-                page = GetPage(index);
-            }
+                var page = GetPage(index);
 
-            return ref GetValue(page, index);
+                return ref GetValue(page, index);
+            }
         }
 
         /// <summary>

--- a/ARMeilleure/Common/EntryTable.cs
+++ b/ARMeilleure/Common/EntryTable.cs
@@ -45,9 +45,9 @@ namespace ARMeilleure.Common
                     _freeHint = _allocated.FindFirstUnset();
                 }
 
-                if (_freeHint < _table.Length)
+                if (_freeHint >= 0 && _freeHint < _table.Length)
                 {
-                    index = checked(_freeHint++);
+                    index = _freeHint++;
 
                     _allocated.Set(index);
 

--- a/ARMeilleure/Common/EntryTable.cs
+++ b/ARMeilleure/Common/EntryTable.cs
@@ -14,7 +14,7 @@ namespace ARMeilleure.Common
         private readonly BitMap _allocated;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="EntryTable{TValue}"/> class with the specified capacity.
+        /// Initializes a new instance of the <see cref="EntryTable{TEntry}"/> class with the specified capacity.
         /// </summary>
         /// <param name="capacity">Capacity of the table</param>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is less than 0</exception>
@@ -31,7 +31,7 @@ namespace ARMeilleure.Common
         }
 
         /// <summary>
-        /// Tries to allocate an entry in the <see cref="EntryTable{TValue}"/>. Returns <see langword="true"/> if
+        /// Tries to allocate an entry in the <see cref="EntryTable{TEntry}"/>. Returns <see langword="true"/> if
         /// success; otherwise returns <see langword="false"/>.
         /// </summary>
         /// <param name="index">Index of entry allocated in the table</param>

--- a/ARMeilleure/Common/EntryTable.cs
+++ b/ARMeilleure/Common/EntryTable.cs
@@ -10,13 +10,13 @@ namespace ARMeilleure.Common
     /// address through out the table's lifetime.
     /// </summary>
     /// <typeparam name="TEntry">Type of the entry in the table</typeparam>
-    class EntryTable<TEntry> : IDisposable where TEntry : unmanaged
+    class EntryTable<TEntry> where TEntry : unmanaged
     {
         private bool _disposed;
         private int _freeHint;
         private readonly int _pageCapacity; // Number of entries per page.
         private readonly int _pageLogCapacity;
-        private readonly Dictionary<int, IntPtr> _pages;
+        private readonly Dictionary<int, TEntry[]> _pages;
         private readonly BitMap _allocated;
 
         /// <summary>
@@ -41,7 +41,7 @@ namespace ARMeilleure.Common
             }
 
             _allocated = new BitMap();
-            _pages = new Dictionary<int, IntPtr>();
+            _pages = new Dictionary<int, TEntry[]>();
             _pageLogCapacity = BitOperations.Log2((uint)(pageSize / sizeof(TEntry)));
             _pageCapacity = 1 << _pageLogCapacity;
         }
@@ -149,49 +149,14 @@ namespace ARMeilleure.Common
         {
             var pageIndex = (int)((uint)(index & ~(_pageCapacity - 1)) >> _pageLogCapacity);
 
-            if (!_pages.TryGetValue(pageIndex, out IntPtr page))
+            if (!_pages.TryGetValue(pageIndex, out TEntry[] page))
             {
-                page = Marshal.AllocHGlobal(sizeof(TEntry) * _pageCapacity);
+                page = GC.AllocateUninitializedArray<TEntry>(_pageCapacity, pinned: true);
 
                 _pages.Add(pageIndex, page);
             }
 
-            return new Span<TEntry>((void*)page, _pageCapacity);
-        }
-
-        /// <summary>
-        /// Releases all resources used by the <see cref="EntryTable{TEntry}"/> instance.
-        /// </summary>
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// Releases all unmanaged and optionally managed resources used by the <see cref="EntryTable{TEntry}{T}"/>
-        /// instance.
-        /// </summary>
-        /// <param name="disposing"><see langword="true"/> to dispose managed resources also; otherwise just unmanaged resouces</param>
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!_disposed)
-            {
-                foreach (var page in _pages.Values)
-                {
-                    Marshal.FreeHGlobal(page);
-                }
-
-                _disposed = true;
-            }
-        }
-
-        /// <summary>
-        /// Frees resources used by the <see cref="EntryTable{TEntry}"/> instance.
-        /// </summary>
-        ~EntryTable()
-        {
-            Dispose(false);
+            return page;
         }
     }
 }

--- a/ARMeilleure/Decoders/Block.cs
+++ b/ARMeilleure/Decoders/Block.cs
@@ -11,8 +11,7 @@ namespace ARMeilleure.Decoders
         public Block Next   { get; set; }
         public Block Branch { get; set; }
 
-        public bool TailCall { get; set; }
-        public bool Exit     { get; set; }
+        public bool Exit { get; set; }
 
         public List<OpCode> OpCodes { get; }
 

--- a/ARMeilleure/Decoders/Optimizations/TailCallRemover.cs
+++ b/ARMeilleure/Decoders/Optimizations/TailCallRemover.cs
@@ -58,15 +58,14 @@ namespace ARMeilleure.Decoders.Optimizations
                 return blocks.ToArray(); // Nothing to do here.
             }
             
-            // Mark branches outside of contiguous region as exit blocks.
+            // Mark branches whose target is outside of the contiguous region as an exit block.
             for (int i = startBlockIndex; i <= endBlockIndex; i++)
             {
                 Block block = blocks[i];
 
                 if (block.Branch != null && (block.Branch.Address > endBlock.EndAddress || block.Branch.EndAddress < startBlock.Address))
                 {
-                    block.Branch.Exit     = true;
-                    block.Branch.TailCall = true;
+                    block.Branch.Exit = true;
                 }
             }
 

--- a/ARMeilleure/Instructions/InstEmitFlowHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitFlowHelper.cs
@@ -200,7 +200,7 @@ namespace ARMeilleure.Instructions
             }
         }
 
-        public static void EmitTailContinue(ArmEmitterContext context, Operand address, bool allowRejit)
+        public static void EmitTailContinue(ArmEmitterContext context, Operand address)
         {
             // Left option here as it may be useful if we need to return to managed rather than tail call in future.
             // (eg. for debug)
@@ -218,9 +218,8 @@ namespace ARMeilleure.Instructions
                 {
                     context.StoreToContext();
 
-                    Operand fallbackAddr = context.Call(typeof(NativeInterface).GetMethod(allowRejit
-                        ? nameof(NativeInterface.GetFunctionAddress)
-                        : nameof(NativeInterface.GetFunctionAddressWithoutRejit)), address);
+                    Operand fallbackAddr = context.Call(
+                        typeof(NativeInterface).GetMethod(nameof(NativeInterface.GetFunctionAddress)), address);
 
                     EmitNativeCall(context, fallbackAddr, isJump: true);
                 }

--- a/ARMeilleure/Instructions/InstEmitFlowHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitFlowHelper.cs
@@ -218,8 +218,7 @@ namespace ARMeilleure.Instructions
                 {
                     context.StoreToContext();
 
-                    Operand fallbackAddr = context.Call(
-                        typeof(NativeInterface).GetMethod(nameof(NativeInterface.GetFunctionAddress)), address);
+                    Operand fallbackAddr = context.Call(typeof(NativeInterface).GetMethod(nameof(NativeInterface.GetFunctionAddress)), address);
 
                     EmitNativeCall(context, fallbackAddr, isJump: true);
                 }

--- a/ARMeilleure/Instructions/NativeInterface.cs
+++ b/ARMeilleure/Instructions/NativeInterface.cs
@@ -220,6 +220,11 @@ namespace ARMeilleure.Instructions
         }
         #endregion
 
+        public static void EnqueueForRejit(ulong address)
+        {
+            Context.Translator.EnqueueForRejit(address, GetContext().ExecutionMode);
+        }
+
         public static void SignalMemoryTracking(ulong address, ulong size, bool write)
         {
             GetMemoryManager().SignalMemoryTracking(address, size, write);
@@ -232,24 +237,14 @@ namespace ARMeilleure.Instructions
 
         public static ulong GetFunctionAddress(ulong address)
         {
-            return GetFunctionAddressWithHint(address, true);
-        }
-
-        public static ulong GetFunctionAddressWithoutRejit(ulong address)
-        {
-            return GetFunctionAddressWithHint(address, false);
-        }
-
-        private static ulong GetFunctionAddressWithHint(ulong address, bool hintRejit)
-        {
-            TranslatedFunction function = Context.Translator.GetOrTranslate(address, GetContext().ExecutionMode, hintRejit);
+            TranslatedFunction function = Context.Translator.GetOrTranslate(address, GetContext().ExecutionMode);
 
             return (ulong)function.FuncPtr.ToInt64();
         }
 
         public static ulong GetIndirectFunctionAddress(ulong address, ulong entryAddress)
         {
-            TranslatedFunction function = Context.Translator.GetOrTranslate(address, GetContext().ExecutionMode, hintRejit: true);
+            TranslatedFunction function = Context.Translator.GetOrTranslate(address, GetContext().ExecutionMode);
 
             ulong ptr = (ulong)function.FuncPtr.ToInt64();
 

--- a/ARMeilleure/IntermediateRepresentation/OperandHelper.cs
+++ b/ARMeilleure/IntermediateRepresentation/OperandHelper.cs
@@ -35,9 +35,9 @@ namespace ARMeilleure.IntermediateRepresentation
             return Operand().With(value);
         }
 
-        public static unsafe Operand Const<T>(ref T reference)
+        public static unsafe Operand Const<T>(ref T reference, int? index = null)
         {
-            return Operand().With((ulong)Unsafe.AsPointer(ref reference));
+            return Operand().With((long)Unsafe.AsPointer(ref reference), index != null, index);
         }
 
         public static Operand ConstF(float value)

--- a/ARMeilleure/IntermediateRepresentation/OperandHelper.cs
+++ b/ARMeilleure/IntermediateRepresentation/OperandHelper.cs
@@ -1,4 +1,5 @@
 using ARMeilleure.Common;
+using System.Runtime.CompilerServices;
 
 namespace ARMeilleure.IntermediateRepresentation
 {
@@ -32,6 +33,11 @@ namespace ARMeilleure.IntermediateRepresentation
         public static Operand Const(ulong value)
         {
             return Operand().With(value);
+        }
+
+        public static unsafe Operand Const<T>(ref T reference)
+        {
+            return Operand().With((ulong)Unsafe.AsPointer(ref reference));
         }
 
         public static Operand ConstF(float value)

--- a/ARMeilleure/Translation/ArmEmitterContext.cs
+++ b/ARMeilleure/Translation/ArmEmitterContext.cs
@@ -1,3 +1,4 @@
+using ARMeilleure.Common;
 using ARMeilleure.Decoders;
 using ARMeilleure.Instructions;
 using ARMeilleure.IntermediateRepresentation;
@@ -41,18 +42,26 @@ namespace ARMeilleure.Translation
         public IMemoryManager Memory { get; }
 
         public JumpTable JumpTable { get; }
+        public EntryTable<byte> CountTable { get; }
 
         public ulong EntryAddress { get; }
         public bool HighCq { get; }
         public Aarch32Mode Mode { get; }
 
-        public ArmEmitterContext(IMemoryManager memory, JumpTable jumpTable, ulong entryAddress, bool highCq, Aarch32Mode mode)
+        public ArmEmitterContext(
+            IMemoryManager memory,
+            JumpTable jumpTable,
+            EntryTable<byte> countTable,
+            ulong entryAddress,
+            bool highCq,
+            Aarch32Mode mode)
         {
-            Memory       = memory;
-            JumpTable    = jumpTable;
+            Memory = memory;
+            JumpTable = jumpTable;
+            CountTable = countTable;
             EntryAddress = entryAddress;
-            HighCq       = highCq;
-            Mode         = mode;
+            HighCq = highCq;
+            Mode = mode;
 
             _labels = new Dictionary<ulong, Operand>();
         }

--- a/ARMeilleure/Translation/ArmEmitterContext.cs
+++ b/ARMeilleure/Translation/ArmEmitterContext.cs
@@ -42,7 +42,7 @@ namespace ARMeilleure.Translation
         public IMemoryManager Memory { get; }
 
         public JumpTable JumpTable { get; }
-        public EntryTable<byte> CountTable { get; }
+        public EntryTable<uint> CountTable { get; }
 
         public ulong EntryAddress { get; }
         public bool HighCq { get; }
@@ -51,7 +51,7 @@ namespace ARMeilleure.Translation
         public ArmEmitterContext(
             IMemoryManager memory,
             JumpTable jumpTable,
-            EntryTable<byte> countTable,
+            EntryTable<uint> countTable,
             ulong entryAddress,
             bool highCq,
             Aarch32Mode mode)

--- a/ARMeilleure/Translation/Delegates.cs
+++ b/ARMeilleure/Translation/Delegates.cs
@@ -103,6 +103,7 @@ namespace ARMeilleure.Translation
 
             SetDelegateInfo(typeof(NativeInterface).GetMethod(nameof(NativeInterface.Break)));
             SetDelegateInfo(typeof(NativeInterface).GetMethod(nameof(NativeInterface.CheckSynchronization)));
+            SetDelegateInfo(typeof(NativeInterface).GetMethod(nameof(NativeInterface.EnqueueForRejit)));
             SetDelegateInfo(typeof(NativeInterface).GetMethod(nameof(NativeInterface.GetCntfrqEl0)));
             SetDelegateInfo(typeof(NativeInterface).GetMethod(nameof(NativeInterface.GetCntpctEl0)));
             SetDelegateInfo(typeof(NativeInterface).GetMethod(nameof(NativeInterface.GetCntvctEl0)));
@@ -113,7 +114,6 @@ namespace ARMeilleure.Translation
             SetDelegateInfo(typeof(NativeInterface).GetMethod(nameof(NativeInterface.GetFpscr))); // A32 only.
             SetDelegateInfo(typeof(NativeInterface).GetMethod(nameof(NativeInterface.GetFpsr)));
             SetDelegateInfo(typeof(NativeInterface).GetMethod(nameof(NativeInterface.GetFunctionAddress)));
-            SetDelegateInfo(typeof(NativeInterface).GetMethod(nameof(NativeInterface.GetFunctionAddressWithoutRejit)));
             SetDelegateInfo(typeof(NativeInterface).GetMethod(nameof(NativeInterface.GetIndirectFunctionAddress)));
             SetDelegateInfo(typeof(NativeInterface).GetMethod(nameof(NativeInterface.GetTpidr)));
             SetDelegateInfo(typeof(NativeInterface).GetMethod(nameof(NativeInterface.GetTpidr32))); // A32 only.

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -540,7 +540,8 @@ namespace ARMeilleure.Translation.PTC
             }
         }
 
-        internal static void LoadTranslations(ConcurrentDictionary<ulong, TranslatedFunction> funcs, IMemoryManager memory, JumpTable jumpTable, EntryTable<byte> countTable)
+        internal static void LoadTranslations(ConcurrentDictionary<ulong, TranslatedFunction> funcs, IMemoryManager memory,
+            JumpTable jumpTable, EntryTable<uint> countTable)
         {
             if (AreCarriersEmpty())
             {
@@ -569,7 +570,7 @@ namespace ARMeilleure.Translation.PTC
                     {
                         byte[] code = ReadCode(index, infoEntry.CodeLength);
 
-                        Counter callCounter = null;
+                        Counter<uint> callCounter = null;
 
                         if (infoEntry.RelocEntriesCount != 0)
                         {
@@ -679,7 +680,8 @@ namespace ARMeilleure.Translation.PTC
             return relocEntries;
         }
 
-        private static bool PatchCode(Span<byte> code, RelocEntry[] relocEntries, IntPtr pageTablePointer, JumpTable jumpTable, EntryTable<byte> countTable, out Counter callCounter)
+        private static bool PatchCode(Span<byte> code, RelocEntry[] relocEntries, IntPtr pageTablePointer,
+            JumpTable jumpTable, EntryTable<uint> countTable, out Counter<uint> callCounter)
         {
             callCounter = null;
 
@@ -702,7 +704,7 @@ namespace ARMeilleure.Translation.PTC
                 else if (relocEntry.Index == CountTableIndex)
                 {
                     // If we could not allocate an entry on the count table we dip.
-                    if (!Counter.TryCreate(countTable, out Counter counter))
+                    if (!Counter<uint>.TryCreate(countTable, out Counter<uint> counter))
                     {
                         return false;
                     }
@@ -745,7 +747,8 @@ namespace ARMeilleure.Translation.PTC
             return new UnwindInfo(pushEntries, prologueSize);
         }
 
-        private static TranslatedFunction FastTranslate(byte[] code, Counter callCounter, ulong guestSize, UnwindInfo unwindInfo, bool highCq)
+        private static TranslatedFunction FastTranslate(byte[] code, Counter<uint> callCounter, ulong guestSize,
+            UnwindInfo unwindInfo, bool highCq)
         {
             CompiledFunction cFunc = new CompiledFunction(code, unwindInfo);
 
@@ -794,7 +797,8 @@ namespace ARMeilleure.Translation.PTC
             }
         }
 
-        internal static void MakeAndSaveTranslations(ConcurrentDictionary<ulong, TranslatedFunction> funcs, IMemoryManager memory, JumpTable jumpTable, EntryTable<byte> countTable)
+        internal static void MakeAndSaveTranslations(ConcurrentDictionary<ulong, TranslatedFunction> funcs, IMemoryManager memory,
+            JumpTable jumpTable, EntryTable<uint> countTable)
         {
             var profiledFuncsToTranslate = PtcProfiler.GetProfiledFuncsToTranslate(funcs);
 

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -1,6 +1,7 @@
 using ARMeilleure.CodeGen;
 using ARMeilleure.CodeGen.Unwinding;
 using ARMeilleure.CodeGen.X86;
+using ARMeilleure.Common;
 using ARMeilleure.Memory;
 using ARMeilleure.Translation.Cache;
 using Ryujinx.Common;
@@ -771,7 +772,7 @@ namespace ARMeilleure.Translation.PTC
             }
         }
 
-        internal static void MakeAndSaveTranslations(ConcurrentDictionary<ulong, TranslatedFunction> funcs, IMemoryManager memory, JumpTable jumpTable)
+        internal static void MakeAndSaveTranslations(ConcurrentDictionary<ulong, TranslatedFunction> funcs, IMemoryManager memory, JumpTable jumpTable, EntryTable<byte> countTable)
         {
             var profiledFuncsToTranslate = PtcProfiler.GetProfiledFuncsToTranslate(funcs);
 
@@ -813,7 +814,7 @@ namespace ARMeilleure.Translation.PTC
 
                     Debug.Assert(PtcProfiler.IsAddressInStaticCodeRange(address));
 
-                    TranslatedFunction func = Translator.Translate(memory, jumpTable, address, item.mode, item.highCq);
+                    TranslatedFunction func = Translator.Translate(memory, jumpTable, countTable, address, item.mode, item.highCq);
 
                     bool isAddressUnique = funcs.TryAdd(address, func);
 

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -28,7 +28,7 @@ namespace ARMeilleure.Translation.PTC
         private const string OuterHeaderMagicString = "PTCohd\0\0";
         private const string InnerHeaderMagicString = "PTCihd\0\0";
 
-        private const uint InternalVersion = 2169; //! To be incremented manually for each change to the ARMeilleure project.
+        private const uint InternalVersion = 2190; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -540,8 +540,11 @@ namespace ARMeilleure.Translation.PTC
             }
         }
 
-        internal static void LoadTranslations(ConcurrentDictionary<ulong, TranslatedFunction> funcs, IMemoryManager memory,
-            JumpTable jumpTable, EntryTable<uint> countTable)
+        internal static void LoadTranslations(
+            ConcurrentDictionary<ulong, TranslatedFunction> funcs,
+            IMemoryManager memory,
+            JumpTable jumpTable,
+            EntryTable<uint> countTable)
         {
             if (AreCarriersEmpty())
             {
@@ -680,8 +683,13 @@ namespace ARMeilleure.Translation.PTC
             return relocEntries;
         }
 
-        private static bool PatchCode(Span<byte> code, RelocEntry[] relocEntries, IntPtr pageTablePointer,
-            JumpTable jumpTable, EntryTable<uint> countTable, out Counter<uint> callCounter)
+        private static bool PatchCode(
+            Span<byte> code,
+            RelocEntry[] relocEntries,
+            IntPtr pageTablePointer,
+            JumpTable jumpTable,
+            EntryTable<uint> countTable,
+            out Counter<uint> callCounter)
         {
             callCounter = null;
 
@@ -747,8 +755,12 @@ namespace ARMeilleure.Translation.PTC
             return new UnwindInfo(pushEntries, prologueSize);
         }
 
-        private static TranslatedFunction FastTranslate(byte[] code, Counter<uint> callCounter, ulong guestSize,
-            UnwindInfo unwindInfo, bool highCq)
+        private static TranslatedFunction FastTranslate(
+            byte[] code,
+            Counter<uint> callCounter,
+            ulong guestSize,
+            UnwindInfo unwindInfo,
+            bool highCq)
         {
             CompiledFunction cFunc = new CompiledFunction(code, unwindInfo);
 
@@ -797,8 +809,11 @@ namespace ARMeilleure.Translation.PTC
             }
         }
 
-        internal static void MakeAndSaveTranslations(ConcurrentDictionary<ulong, TranslatedFunction> funcs, IMemoryManager memory,
-            JumpTable jumpTable, EntryTable<uint> countTable)
+        internal static void MakeAndSaveTranslations(
+            ConcurrentDictionary<ulong, TranslatedFunction> funcs,
+            IMemoryManager memory,
+            JumpTable jumpTable,
+            EntryTable<uint> countTable)
         {
             var profiledFuncsToTranslate = PtcProfiler.GetProfiledFuncsToTranslate(funcs);
 

--- a/ARMeilleure/Translation/TranslatedFunction.cs
+++ b/ARMeilleure/Translation/TranslatedFunction.cs
@@ -1,24 +1,22 @@
+using ARMeilleure.Common;
 using System;
 using System.Runtime.InteropServices;
-using System.Threading;
 
 namespace ARMeilleure.Translation
 {
     class TranslatedFunction
     {
-        private const int MinCallsForRejit = 100;
-
         private readonly GuestFunction _func; // Ensure that this delegate will not be garbage collected.
 
-        private int _callCount;
-
+        public Counter CallCounter { get; }
         public ulong GuestSize { get; }
         public bool HighCq { get; }
         public IntPtr FuncPtr { get; }
 
-        public TranslatedFunction(GuestFunction func, ulong guestSize, bool highCq)
+        public TranslatedFunction(GuestFunction func, Counter callCounter, ulong guestSize, bool highCq)
         {
             _func = func;
+            CallCounter = callCounter;
             GuestSize = guestSize;
             HighCq = highCq;
             FuncPtr = Marshal.GetFunctionPointerForDelegate(func);
@@ -27,16 +25,6 @@ namespace ARMeilleure.Translation
         public ulong Execute(State.ExecutionContext context)
         {
             return _func(context.NativeContextPtr);
-        }
-
-        public bool ShouldRejit()
-        {
-            return !HighCq && Interlocked.Increment(ref _callCount) == MinCallsForRejit;
-        }
-
-        public void ResetCallCount()
-        {
-            Interlocked.Exchange(ref _callCount, 0);
         }
     }
 }

--- a/ARMeilleure/Translation/TranslatedFunction.cs
+++ b/ARMeilleure/Translation/TranslatedFunction.cs
@@ -8,12 +8,12 @@ namespace ARMeilleure.Translation
     {
         private readonly GuestFunction _func; // Ensure that this delegate will not be garbage collected.
 
-        public Counter CallCounter { get; }
+        public Counter<uint> CallCounter { get; }
         public ulong GuestSize { get; }
         public bool HighCq { get; }
         public IntPtr FuncPtr { get; }
 
-        public TranslatedFunction(GuestFunction func, Counter callCounter, ulong guestSize, bool highCq)
+        public TranslatedFunction(GuestFunction func, Counter<uint> callCounter, ulong guestSize, bool highCq)
         {
             _func = func;
             CallCounter = callCounter;

--- a/ARMeilleure/Translation/Translator.cs
+++ b/ARMeilleure/Translation/Translator.cs
@@ -174,8 +174,6 @@ namespace ARMeilleure.Translation
                 _jumpTable.Dispose();
                 _jumpTable = null;
 
-                CountTable.Dispose();
-
                 GCSettings.LargeObjectHeapCompactionMode = GCLargeObjectHeapCompactionMode.CompactOnce;
             }
         }

--- a/ARMeilleure/Translation/Translator.cs
+++ b/ARMeilleure/Translation/Translator.cs
@@ -395,7 +395,7 @@ namespace ARMeilleure.Translation
             return context.GetControlFlowGraph();
         }
 
-        internal static Counter<uint> EmitRejitCheck(ArmEmitterContext context, out Counter<uint> counter)
+        internal static void EmitRejitCheck(ArmEmitterContext context, out Counter<uint> counter)
         {
             const int MinsCallForRejit = 100;
 
@@ -412,8 +412,6 @@ namespace ARMeilleure.Translation
             context.Call(typeof(NativeInterface).GetMethod(nameof(NativeInterface.EnqueueForRejit)), Const(context.EntryAddress));
 
             context.MarkLabel(lblEnd);
-
-            return counter;
         }
 
         internal static void EmitSynchronization(EmitterContext context)

--- a/ARMeilleure/Translation/Translator.cs
+++ b/ARMeilleure/Translation/Translator.cs
@@ -174,6 +174,8 @@ namespace ARMeilleure.Translation
                 _jumpTable.Dispose();
                 _jumpTable = null;
 
+                CountTable.Dispose();
+
                 GCSettings.LargeObjectHeapCompactionMode = GCLargeObjectHeapCompactionMode.CompactOnce;
             }
         }

--- a/ARMeilleure/Translation/Translator.cs
+++ b/ARMeilleure/Translation/Translator.cs
@@ -22,6 +22,8 @@ namespace ARMeilleure.Translation
 {
     public class Translator
     {
+        private const int CountTableCapacity = 4 * 1024 * 1024;
+
         private long _nextUpdate;
         private long _requestAdded;
         private long _requestRemoved;
@@ -61,7 +63,7 @@ namespace ARMeilleure.Translation
             _backgroundTranslatorEvent = new AutoResetEvent(false);
             _backgroundTranslatorLock = new ReaderWriterLock();
 
-            CountTable = new EntryTable<uint>(capacity: 4 * 1024 * 1024);
+            CountTable = new EntryTable<uint>(CountTableCapacity);
 
             JitCache.Initialize(allocator);
 


### PR DESCRIPTION
Contributes to #2158.

* Add re-usable structures to do on translation counting ~(might want to make `Counter` a generic though)~.
* Add on translation call counting.
* Change call counting behavior to be associated with nodes (i.e head of translations) instead of edges (i.e out of translation branches). Before if all incoming branches to a translation was not hinted for rejit, it would never tier up even though it could be hot.
  * **Pros**: Improves hot code discovery.
  * **Cons**: Increase in code size. -- Because we may discover more code to rejit, and the decoder may produce a far larger output for HCQ than for LCQ.

PPTC integration is done this way for the sake of simplicity and because it allows `EntryTable` to be dynamic/expandable. ~although it currently is not.~

Call counting is not implemented as an atomic operation currently, so `EnqueueForRejit` needs to ensure the rejit queue contains unique requests so as to not waste time compiling the same stuff. I held back from implementing an IR instruction for this because I figure it would require some discussion to model it in IR, and I am not entirely if its worth. If you think so let me know :>