### PR TITLE
Fix sub-image copies on intel GPUs

### DIFF
--- a/Ryujinx.Graphics.OpenGL/Image/ITextureInfo.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/ITextureInfo.cs
@@ -5,6 +5,10 @@ namespace Ryujinx.Graphics.OpenGL.Image
     interface ITextureInfo
     {
         int Handle { get; }
+        int StorageHandle { get; }
+        int FirstLayer => 0;
+        int FirstLevel => 0;
+
         TextureCreateInfo Info { get; }
     }
 }

--- a/Ryujinx.Graphics.OpenGL/Image/TextureBase.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureBase.cs
@@ -3,7 +3,7 @@ using Ryujinx.Graphics.GAL;
 
 namespace Ryujinx.Graphics.OpenGL.Image
 {
-    class TextureBase : ITextureInfo
+    class TextureBase
     {
         public int Handle { get; protected set; }
 

--- a/Ryujinx.Graphics.OpenGL/Image/TextureCopy.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureCopy.cs
@@ -205,22 +205,44 @@ namespace Ryujinx.Graphics.OpenGL.Image
                     int copyWidth = sizeInBlocks ? BitUtils.DivRoundUp(width, blockWidth) : width;
                     int copyHeight = sizeInBlocks ? BitUtils.DivRoundUp(height, blockHeight) : height;
 
-                    GL.CopyImageSubData(
-                        srcHandle,
-                        srcInfo.Target.ConvertToImageTarget(),
-                        srcLevel + level,
-                        0,
-                        0,
-                        srcLayer,
-                        dstHandle,
-                        dstInfo.Target.ConvertToImageTarget(),
-                        dstLevel + level,
-                        0,
-                        0,
-                        dstLayer,
-                        copyWidth,
-                        copyHeight,
-                        depth);
+                    if (HwCapabilities.Vendor == HwCapabilities.GpuVendor.Intel)
+                    {
+                        GL.CopyImageSubData(
+                            src.StorageHandle,
+                            srcInfo.Target.ConvertToImageTarget(),
+                            src.FirstLevel + srcLevel + level,
+                            0,
+                            0,
+                            src.FirstLayer + srcLayer,
+                            dst.StorageHandle,
+                            dstInfo.Target.ConvertToImageTarget(),
+                            dst.FirstLevel + dstLevel + level,
+                            0,
+                            0,
+                            dst.FirstLayer + dstLayer,
+                            copyWidth,
+                            copyHeight,
+                            depth);
+                    }
+                    else
+                    {
+                        GL.CopyImageSubData(
+                            srcHandle,
+                            srcInfo.Target.ConvertToImageTarget(),
+                            srcLevel + level,
+                            0,
+                            0,
+                            srcLayer,
+                            dstHandle,
+                            dstInfo.Target.ConvertToImageTarget(),
+                            dstLevel + level,
+                            0,
+                            0,
+                            dstLayer,
+                            copyWidth,
+                            copyHeight,
+                            depth);
+                    }
                 }
 
                 width = Math.Max(1, width >> 1);

--- a/Ryujinx.Graphics.OpenGL/Image/TextureStorage.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureStorage.cs
@@ -1,13 +1,13 @@
 using OpenTK.Graphics.OpenGL;
 using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.GAL;
-using System;
 
 namespace Ryujinx.Graphics.OpenGL.Image
 {
     class TextureStorage : ITextureInfo 
     {
         public int Handle { get; private set; }
+        public int StorageHandle => Handle;
         public float ScaleFactor { get; private set; }
 
         public TextureCreateInfo Info { get; }

--- a/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
@@ -4,11 +4,13 @@ using System;
 
 namespace Ryujinx.Graphics.OpenGL.Image
 {
-    class TextureView : TextureBase, ITexture
+    class TextureView : TextureBase, ITexture, ITextureInfo
     {
         private readonly Renderer _renderer;
 
         private readonly TextureStorage _parent;
+
+        public int StorageHandle => _parent.Handle;
 
         private TextureView _incompatibleFormatView;
 


### PR DESCRIPTION
When doing sub-image copies with `glCopyImageSubData` on Intel, the driver seems to ignore the specified `dstLayer` for some reason (and also `dstLevel` I'm guessing), and always copies the data to the base layer. This problem doesn't happens when passing the storage handle rather than the view handle, so to fix this, the change adds a special path for intel, that passes storage handles rather than view handles, and adds the view base layer and level to the source and destination layer and level. In theory, this should work on all vendors without any performance penalty, but I decided to play safe here and only do this for Intel, to avoid the risk of breaking it for other vendors.

Some comparison screenshots:
Before:
![image](https://user-images.githubusercontent.com/5624669/114320790-06afa380-9aee-11eb-8ccb-c75166a12e46.png)
![image](https://user-images.githubusercontent.com/5624669/114320793-0adbc100-9aee-11eb-90c3-62faee6c837c.png)
After:
![image](https://user-images.githubusercontent.com/5624669/114320796-1202cf00-9aee-11eb-9d63-d3c5b74e7fc1.png)
![image](https://user-images.githubusercontent.com/5624669/114320800-16c78300-9aee-11eb-899e-8a44cf57cbe7.png)

**Note:** This only affects Intel iGPUs, other vendors are not affected.
**Note 2:** `glGetTexSubImage` also seems to be ignoring the layer/level, which means that PBO copies have the same issues.
It is a simple change that improves things for Intel on OpenGL, even if we have Vulkan coming, so why not, right?