### PR TITLE
nsd/ssl: Fix Resolve/ResolveEx and stub GetConnectionCount

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Sockets/Nsd/IManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Nsd/IManager.cs
@@ -1,4 +1,5 @@
 ﻿using Ryujinx.Common.Logging;
+using Ryujinx.Cpu;
 using Ryujinx.HLE.Exceptions;
 using Ryujinx.HLE.HOS.Services.Settings;
 using Ryujinx.HLE.HOS.Services.Sockets.Nsd.Manager;
@@ -135,9 +136,16 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
             long outputPosition = context.Request.ReceiveBuff[0].Position;
             long outputSize     = context.Request.ReceiveBuff[0].Size;
 
-            ResultCode result = _fqdnResolver.ResolveEx(context, out ResultCode errorCode, out string resolvedAddress);
+            ResultCode result = _fqdnResolver.ResolveEx(context, out _, out string resolvedAddress);
 
-            byte[] resolvedAddressBuffer = Encoding.UTF8.GetBytes(resolvedAddress + '\0');
+            if (resolvedAddress.Length > outputSize)
+            {
+                return ResultCode.InvalidArgument;
+            }
+
+            byte[] resolvedAddressBuffer = Encoding.UTF8.GetBytes(resolvedAddress);
+
+            MemoryHelper.FillWithZeros(context.Memory, outputPosition, (int)outputSize);
 
             context.Memory.Write((ulong)outputPosition, resolvedAddressBuffer);
 
@@ -153,7 +161,14 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
 
             ResultCode result = _fqdnResolver.ResolveEx(context, out ResultCode errorCode, out string resolvedAddress);
 
-            byte[] resolvedAddressBuffer = Encoding.UTF8.GetBytes(resolvedAddress + '\0');
+            if (resolvedAddress.Length > outputSize)
+            {
+                return ResultCode.InvalidArgument;
+            }
+
+            byte[] resolvedAddressBuffer = Encoding.UTF8.GetBytes(resolvedAddress);
+
+            MemoryHelper.FillWithZeros(context.Memory, outputPosition, (int)outputSize);
 
             context.Memory.Write((ulong)outputPosition, resolvedAddressBuffer);
 

--- a/Ryujinx.HLE/HOS/Services/Sockets/Nsd/Manager/FqdnResolver.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Nsd/Manager/FqdnResolver.cs
@@ -104,7 +104,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd.Manager
 
             context.Memory.Read((ulong)inputPosition, addressBuffer);
 
-            string address = Encoding.UTF8.GetString(addressBuffer);
+            string address = Encoding.UTF8.GetString(addressBuffer).TrimEnd('\0');
 
             resultCode = Resolve(context, address, out resolvedAddress);
 

--- a/Ryujinx.HLE/HOS/Services/Ssl/SslService/ISslConnection.cs
+++ b/Ryujinx.HLE/HOS/Services/Ssl/SslService/ISslConnection.cs
@@ -78,7 +78,12 @@ namespace Ryujinx.HLE.HOS.Services.Ssl.SslService
             long inputDataPosition = context.Request.SendBuff[0].Position;
             long inputDataSize     = context.Request.SendBuff[0].Size;
 
-            uint transferredSize = 0;
+            byte[] data = new byte[inputDataSize];
+
+            context.Memory.Read((ulong)inputDataPosition, data);
+
+            // NOTE: Tell the guest everything is transferred.
+            uint transferredSize = (uint)inputDataSize;
 
             context.ResponseData.Write(transferredSize);
 

--- a/Ryujinx.HLE/HOS/Services/Ssl/SslService/ISslContext.cs
+++ b/Ryujinx.HLE/HOS/Services/Ssl/SslService/ISslContext.cs
@@ -6,6 +6,8 @@ namespace Ryujinx.HLE.HOS.Services.Ssl.SslService
 {
     class ISslContext : IpcService
     {
+        private uint _connectionCount;
+
         private ulong _serverCertificateId;
         private ulong _clientCertificateId;
 
@@ -16,6 +18,19 @@ namespace Ryujinx.HLE.HOS.Services.Ssl.SslService
         public ResultCode CreateConnection(ServiceCtx context)
         {
             MakeObject(context, new ISslConnection());
+
+            _connectionCount++;
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(3)]
+        // GetConnectionCount() -> u32 count
+        public ResultCode GetConnectionCount(ServiceCtx context)
+        {
+            context.ResponseData.Write(_connectionCount);
+
+            Logger.Stub?.PrintStub(LogClass.ServiceSsl, new { _connectionCount });
 
             return ResultCode.Success;
         }


### PR DESCRIPTION
This PR fixes a little regression introduced in #2186 at the `IManage` `Resolve`/`ResolveEx` calls, there was an overflow caused by added an empty char at the end of a not trimmed input buffer and then write the result in a too small output buffer. (https://github.com/Ryujinx/Ryujinx-Games-List/issues?q=is%3Aissue+is%3Aopen+nsd)

Additionnally to that, I've stubbed `ISslContext` `GetConnectionCount` which fixes #2206 and I've fixed a spamming of `ISslConnection` `Write` by returning a transferred size.

Some game are now playable:
![image](https://user-images.githubusercontent.com/4905390/114638338-b1c98400-9ccb-11eb-963d-ea38da7a4ae6.png)
![image](https://user-images.githubusercontent.com/4905390/114638343-b3934780-9ccb-11eb-9f07-3679378599d9.png)
![image](https://user-images.githubusercontent.com/4905390/114638349-b857fb80-9ccb-11eb-8d6a-e1a8bd1ce3af.png)
