### PR TITLE
Reduce number of dlls on distribution with single file publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Test
         run: dotnet test -c "${{ matrix.configuration }}"
       - name: Publish
-        run: dotnet publish -c "${{ matrix.configuration }}" -r "${{ matrix.DOTNET_RUNTIME_IDENTIFIER }}" -o ./publish /p:Version="1.0.0" /p:SourceRevisionId="${{ steps.git_short_hash.outputs.result }}" /p:ExtraDefineConstants=DISABLE_UPDATER Ryujinx
+        run: dotnet publish -c "${{ matrix.configuration }}" -r "${{ matrix.DOTNET_RUNTIME_IDENTIFIER }}" -o ./publish /p:Version="1.0.0" /p:DebugType=embedded /p:SourceRevisionId="${{ steps.git_short_hash.outputs.result }}" /p:ExtraDefineConstants=DISABLE_UPDATER Ryujinx
         if: github.event_name == 'pull_request'
       - name: Upload artifacts
         uses: actions/upload-artifact@v2

--- a/Ryujinx/Ryujinx.csproj
+++ b/Ryujinx/Ryujinx.csproj
@@ -11,6 +11,11 @@
     <DefineConstants Condition=" '$(ExtraDefineConstants)' != '' ">$(DefineConstants);$(ExtraDefineConstants)</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' != ''">
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishTrimmed>true</PublishTrimmed>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="DiscordRichPresence" Version="1.0.175" />
     <PackageReference Include="GtkSharp" Version="3.22.25.128" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,11 +12,11 @@ build_script:
 - ps: >-
     dotnet --version
 
-    dotnet publish -c $env:config -r win-x64 /p:Version=$env:APPVEYOR_BUILD_VERSION
+    dotnet publish -c $env:config -r win-x64 /p:Version=$env:APPVEYOR_BUILD_VERSION /p:DebugType=embedded
 
-    dotnet publish -c $env:config -r linux-x64 /p:Version=$env:APPVEYOR_BUILD_VERSION
+    dotnet publish -c $env:config -r linux-x64 /p:Version=$env:APPVEYOR_BUILD_VERSION /p:DebugType=embedded
 
-    dotnet publish -c $env:config -r osx-x64 /p:Version=$env:APPVEYOR_BUILD_VERSION
+    dotnet publish -c $env:config -r osx-x64 /p:Version=$env:APPVEYOR_BUILD_VERSION /p:DebugType=embedded
 
     7z a ryujinx$env:config_name$env:APPVEYOR_BUILD_VERSION-win_x64.zip $env:APPVEYOR_BUILD_FOLDER\Ryujinx\bin\$env:config\$env:appveyor_dotnet_runtime\win-x64\publish\
 


### PR DESCRIPTION
This enables the single file publish feature at the project level to embed the managed dependencies on the executable, and remove some unused dependencies/files.

Here is what the publish folder looks like with this change:
![image](https://user-images.githubusercontent.com/5624669/114794802-885c3700-9d63-11eb-8c44-6aad0484b144.png)

Needs feedback, currently I still need to decide what to do about the PDBs:
- Embeding them requires adding `<DebugType>embedded</DebugType>` to each project which is not exactly ideal.
- Also, embeding is not working properly, stack traces are not showing the file and line numbers.

Easiest solution is simply including the PDBs on the output if we decide this information is desirable to have on release aswell, but it will be one extra file per project.