### PR TITLE
Intel: OpenGL: No sub-image copies fix on Linux

### DIFF
--- a/Ryujinx.Graphics.OpenGL/Image/TextureCopy.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureCopy.cs
@@ -205,7 +205,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
                     int copyWidth = sizeInBlocks ? BitUtils.DivRoundUp(width, blockWidth) : width;
                     int copyHeight = sizeInBlocks ? BitUtils.DivRoundUp(height, blockHeight) : height;
 
-                    if (HwCapabilities.Vendor == HwCapabilities.GpuVendor.Intel)
+                    if (!OperatingSystem.IsLinux() && HwCapabilities.Vendor == HwCapabilities.GpuVendor.Intel)
                     {
                         GL.CopyImageSubData(
                             src.StorageHandle,


### PR DESCRIPTION
Intel OpenGL is fully working in Linux, lets not break it!

Fixes multiple regressions in Linux

ps: please do not apply Windows fixes on Linux