### PR TITLE
Fix intel view copy workaround.

### DIFF
--- a/Ryujinx.Graphics.OpenGL/Image/ITextureInfo.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/ITextureInfo.cs
@@ -4,8 +4,8 @@ namespace Ryujinx.Graphics.OpenGL.Image
 {
     interface ITextureInfo
     {
+        ITextureInfo Storage { get; }
         int Handle { get; }
-        int StorageHandle { get; }
         int FirstLayer => 0;
         int FirstLevel => 0;
 

--- a/Ryujinx.Graphics.OpenGL/Image/TextureCopy.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureCopy.cs
@@ -208,14 +208,14 @@ namespace Ryujinx.Graphics.OpenGL.Image
                     if (HwCapabilities.Vendor == HwCapabilities.GpuVendor.Intel)
                     {
                         GL.CopyImageSubData(
-                            src.StorageHandle,
-                            srcInfo.Target.ConvertToImageTarget(),
+                            src.Storage.Handle,
+                            src.Storage.Info.Target.ConvertToImageTarget(),
                             src.FirstLevel + srcLevel + level,
                             0,
                             0,
                             src.FirstLayer + srcLayer,
-                            dst.StorageHandle,
-                            dstInfo.Target.ConvertToImageTarget(),
+                            dst.Storage.Handle,
+                            dst.Storage.Info.Target.ConvertToImageTarget(),
                             dst.FirstLevel + dstLevel + level,
                             0,
                             0,

--- a/Ryujinx.Graphics.OpenGL/Image/TextureStorage.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureStorage.cs
@@ -4,10 +4,10 @@ using Ryujinx.Graphics.GAL;
 
 namespace Ryujinx.Graphics.OpenGL.Image
 {
-    class TextureStorage : ITextureInfo 
+    class TextureStorage : ITextureInfo
     {
+        public ITextureInfo Storage => this;
         public int Handle { get; private set; }
-        public int StorageHandle => Handle;
         public float ScaleFactor { get; private set; }
 
         public TextureCreateInfo Info { get; }

--- a/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
@@ -10,9 +10,9 @@ namespace Ryujinx.Graphics.OpenGL.Image
 
         private readonly TextureStorage _parent;
 
-        public int StorageHandle => _parent.Handle;
-
         private TextureView _incompatibleFormatView;
+
+        public ITextureInfo Storage => _parent;
 
         public int FirstLayer { get; private set; }
         public int FirstLevel { get; private set; }


### PR DESCRIPTION
The texture target must be taken from the storage rather than the view, when using the storage handle for the copy.

Screenshots with workaround artificially enabled on NVIDIA.

Before:
![image](https://user-images.githubusercontent.com/6294155/115054924-bb740700-9ed8-11eb-97c4-612bc0458ba2.png)

After:
![image](https://user-images.githubusercontent.com/6294155/115054952-c3cc4200-9ed8-11eb-9465-da1b1cbc97b9.png)

Related to https://github.com/Ryujinx/Ryujinx/pull/2213 , but mesa should probably be explicitly detected to disable other workarounds anyways (specifically the view format one).