### PR TITLE
Only enable clip distance if written to on shader

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/Cache/Definition/HostShaderCacheEntry.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/Cache/Definition/HostShaderCacheEntry.cs
@@ -75,7 +75,8 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache.Definition
                                                     programInfo.SBuffers.Count,
                                                     programInfo.Textures.Count,
                                                     programInfo.Images.Count,
-                                                    programInfo.UsesInstanceId);
+                                                    programInfo.UsesInstanceId,
+                                                    programInfo.ClipDistancesWritten);
             CBuffers = programInfo.CBuffers.ToArray();
             SBuffers = programInfo.SBuffers.ToArray();
             Textures = programInfo.Textures.ToArray();
@@ -88,7 +89,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache.Definition
         /// <returns>A new <see cref="ShaderProgramInfo"/> from this instance</returns>
         internal ShaderProgramInfo ToShaderProgramInfo()
         {
-            return new ShaderProgramInfo(CBuffers, SBuffers, Textures, Images, Header.UsesInstanceId);
+            return new ShaderProgramInfo(CBuffers, SBuffers, Textures, Images, Header.UsesInstanceId, Header.ClipDistancesWritten);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Shader/Cache/Definition/HostShaderCacheEntryHeader.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/Cache/Definition/HostShaderCacheEntryHeader.cs
@@ -42,9 +42,14 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache.Definition
         public bool InUse;
 
         /// <summary>
+        /// Mask of clip distances that are written to on the shader.
+        /// </summary>
+        public byte ClipDistancesWritten;
+
+        /// <summary>
         /// Reserved / unused.
         /// </summary>
-        public short Reserved;
+        public byte Reserved;
 
         /// <summary>
         /// Create a new host shader cache entry header.
@@ -54,14 +59,21 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache.Definition
         /// <param name="texturesCount">Count of texture descriptors</param>
         /// <param name="imagesCount">Count of image descriptors</param>
         /// <param name="usesInstanceId">Set to true if the shader uses instance id</param>
-        public HostShaderCacheEntryHeader(int cBuffersCount, int sBuffersCount, int texturesCount, int imagesCount, bool usesInstanceId) : this()
+        public HostShaderCacheEntryHeader(
+            int cBuffersCount,
+            int sBuffersCount,
+            int texturesCount,
+            int imagesCount,
+            bool usesInstanceId,
+            byte clipDistancesWritten) : this()
         {
-            CBuffersCount  = cBuffersCount;
-            SBuffersCount  = sBuffersCount;
-            TexturesCount  = texturesCount;
-            ImagesCount    = imagesCount;
-            UsesInstanceId = usesInstanceId;
-            InUse          = true;
+            CBuffersCount        = cBuffersCount;
+            SBuffersCount        = sBuffersCount;
+            TexturesCount        = texturesCount;
+            ImagesCount          = imagesCount;
+            UsesInstanceId       = usesInstanceId;
+            ClipDistancesWritten = clipDistancesWritten;
+            InUse                = true;
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -35,7 +35,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2200;
+        private const ulong ShaderCodeGenVersion = 2217;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitMemory.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitMemory.cs
@@ -53,6 +53,8 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
                 Operand dest = Attribute(op.AttributeOffset + index * 4);
 
+                context.FlagAttributeWritten(dest.Value);
+
                 context.Copy(dest, Register(rd));
             }
         }

--- a/Ryujinx.Graphics.Shader/ShaderProgramInfo.cs
+++ b/Ryujinx.Graphics.Shader/ShaderProgramInfo.cs
@@ -11,13 +11,15 @@ namespace Ryujinx.Graphics.Shader
         public ReadOnlyCollection<TextureDescriptor> Images   { get; }
 
         public bool UsesInstanceId { get; }
+        public byte ClipDistancesWritten { get; }
 
         public ShaderProgramInfo(
             BufferDescriptor[]  cBuffers,
             BufferDescriptor[]  sBuffers,
             TextureDescriptor[] textures,
             TextureDescriptor[] images,
-            bool                usesInstanceId)
+            bool                usesInstanceId,
+            byte                clipDistancesWritten)
         {
             CBuffers = Array.AsReadOnly(cBuffers);
             SBuffers = Array.AsReadOnly(sBuffers);
@@ -25,6 +27,7 @@ namespace Ryujinx.Graphics.Shader
             Images   = Array.AsReadOnly(images);
 
             UsesInstanceId = usesInstanceId;
+            ClipDistancesWritten = clipDistancesWritten;
         }
     }
 }

--- a/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgramContext.cs
+++ b/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgramContext.cs
@@ -291,10 +291,6 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
             {
                 Info.IAttributes.Add(attrIndex);
             }
-            else if (operand.Type == OperandType.Attribute && operand.Value == AttributeConsts.InstanceId)
-            {
-                Info.UsesInstanceId = true;
-            }
             else if (operand.Type == OperandType.ConstantBuffer)
             {
                 Info.CBuffers.Add(operand.GetCbufSlot());

--- a/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgramInfo.cs
+++ b/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgramInfo.cs
@@ -12,7 +12,6 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
         public HashSet<int> IAttributes { get; }
         public HashSet<int> OAttributes { get; }
 
-        public bool UsesInstanceId { get; set; }
         public bool UsesCbIndexing { get; set; }
 
         public HelperFunctionsMask HelperFunctionsMask { get; set; }

--- a/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -55,7 +55,11 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public void FlagAttributeRead(int attribute)
         {
-            if (Config.Stage == ShaderStage.Fragment)
+            if (Config.Stage == ShaderStage.Vertex && attribute == AttributeConsts.InstanceId)
+            {
+                Config.SetUsedFeature(FeatureFlags.InstanceId);
+            }
+            else if (Config.Stage == ShaderStage.Fragment)
             {
                 switch (attribute)
                 {

--- a/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -67,6 +67,26 @@ namespace Ryujinx.Graphics.Shader.Translation
             }
         }
 
+        public void FlagAttributeWritten(int attribute)
+        {
+            if (Config.Stage == ShaderStage.Vertex)
+            {
+                switch (attribute)
+                {
+                    case AttributeConsts.ClipDistance0:
+                    case AttributeConsts.ClipDistance1:
+                    case AttributeConsts.ClipDistance2:
+                    case AttributeConsts.ClipDistance3:
+                    case AttributeConsts.ClipDistance4:
+                    case AttributeConsts.ClipDistance5:
+                    case AttributeConsts.ClipDistance6:
+                    case AttributeConsts.ClipDistance7:
+                        Config.SetClipDistanceWritten((attribute - AttributeConsts.ClipDistance0) / 4);
+                        break;
+                }
+            }
+        }
+
         public void MarkLabel(Operand label)
         {
             Add(Instruction.MarkLabel, label);

--- a/Ryujinx.Graphics.Shader/Translation/FeatureFlags.cs
+++ b/Ryujinx.Graphics.Shader/Translation/FeatureFlags.cs
@@ -12,9 +12,11 @@ namespace Ryujinx.Graphics.Shader.Translation
         None = 0,
 
         // Affected by resolution scaling.
-        FragCoordXY     = 1 << 1,
         IntegerSampling = 1 << 0,
+        FragCoordXY     = 1 << 1,
 
-        Bindless        = 1 << 2,
+        Bindless = 1 << 2,
+
+        InstanceId = 1 << 3
     }
 }

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -28,6 +28,8 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public int Size { get; private set; }
 
+        public byte ClipDistancesWritten { get; private set; }
+
         public FeatureFlags UsedFeatures { get; private set; }
 
         public HashSet<int> TextureHandlesForCache { get; }
@@ -113,6 +115,11 @@ namespace Ryujinx.Graphics.Shader.Translation
         public void SizeAdd(int size)
         {
             Size += size;
+        }
+
+        public void SetClipDistanceWritten(int index)
+        {
+            ClipDistancesWritten |= (byte)(1 << index);
         }
 
         public void SetUsedFeature(FeatureFlags flags)

--- a/Ryujinx.Graphics.Shader/Translation/Translator.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Translator.cs
@@ -94,7 +94,7 @@ namespace Ryujinx.Graphics.Shader.Translation
                 program.SBufferDescriptors,
                 program.TextureDescriptors,
                 program.ImageDescriptors,
-                sInfo.UsesInstanceId,
+                config.UsedFeatures.HasFlag(FeatureFlags.InstanceId),
                 config.ClipDistancesWritten);
 
             string glslCode = program.Code;

--- a/Ryujinx.Graphics.Shader/Translation/Translator.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Translator.cs
@@ -94,7 +94,8 @@ namespace Ryujinx.Graphics.Shader.Translation
                 program.SBufferDescriptors,
                 program.TextureDescriptors,
                 program.ImageDescriptors,
-                sInfo.UsesInstanceId);
+                sInfo.UsesInstanceId,
+                config.ClipDistancesWritten);
 
             string glslCode = program.Code;
 


### PR DESCRIPTION
This changes clip distances to only be enabled if they are actually written to on the vertex shader, since otherwise the results are undefined according to the spec.
No changes were observed on NVIDIA, but on Intel, this fixes flashing triangles on games that uses custom clip distances (most first party games).

Before:
![image](https://user-images.githubusercontent.com/5624669/115068658-ec4c4000-9ec8-11eb-9e88-5dd2cec82fe3.png)
After:
![image](https://user-images.githubusercontent.com/5624669/115068615-dc346080-9ec8-11eb-80a8-318367bc2c33.png)

Should be tested on all games that were fixed by the original implementation: https://github.com/Ryujinx/Ryujinx/pull/1118
(I was not able to reproduce the bug on Super Mario Odyssey even without clip distances).

I also changed the way how InstanceId use is reported slightly, it now uses `FeatureFlags` to be consistent with how the other built-in uses are reported.
