### PR TITLE
Return focus from controller applet after completion

### DIFF
--- a/Ryujinx.HLE/HOS/Applets/Controller/ControllerApplet.cs
+++ b/Ryujinx.HLE/HOS/Applets/Controller/ControllerApplet.cs
@@ -105,6 +105,8 @@ namespace Ryujinx.HLE.HOS.Applets
             _normalSession.Push(BuildResponse(result));
             AppletStateChanged?.Invoke(this, null);
 
+            _system.ReturnFocus();
+
             return ResultCode.Success;
         }
 

--- a/Ryujinx.HLE/HOS/Applets/PlayerSelect/PlayerSelectApplet.cs
+++ b/Ryujinx.HLE/HOS/Applets/PlayerSelect/PlayerSelectApplet.cs
@@ -30,6 +30,8 @@ namespace Ryujinx.HLE.HOS.Applets
 
             AppletStateChanged?.Invoke(this, null);
 
+            _system.ReturnFocus();
+
             return ResultCode.Success;
         }
 

--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -330,6 +330,11 @@ namespace Ryujinx.HLE.HOS
             }
         }
 
+        public void ReturnFocus()
+        {
+            AppletState.SetFocus(true);
+        }
+
         public void SimulateWakeUpMessage()
         {
             AppletState.Messages.Enqueue(MessageInfo.Resume);


### PR DESCRIPTION
This fixes controller applet related in Mario Kart 8 Deluxe, in 2-4 player mode or when opening the applet in character select.

Not sure if this should be added to other foreground applets. If anyone knows of any other games with applet related softlocks, speak now or forever hold your peace.