### PR TITLE
HLE: Fix integer sign inconcistency accross the codebase

### DIFF
--- a/Ryujinx.Cpu/MemoryHelper.cs
+++ b/Ryujinx.Cpu/MemoryHelper.cs
@@ -8,28 +8,28 @@ namespace Ryujinx.Cpu
 {
     public static class MemoryHelper
     {
-        public static void FillWithZeros(IVirtualMemoryManager memory, long position, int size)
+        public static void FillWithZeros(IVirtualMemoryManager memory, ulong position, int size)
         {
             int size8 = size & ~(8 - 1);
 
             for (int offs = 0; offs < size8; offs += 8)
             {
-                memory.Write<long>((ulong)(position + offs), 0);
+                memory.Write<long>(position + (ulong)offs, 0);
             }
 
             for (int offs = size8; offs < (size - size8); offs++)
             {
-                memory.Write<byte>((ulong)(position + offs), 0);
+                memory.Write<byte>(position + (ulong)offs, 0);
             }
         }
 
-        public unsafe static T Read<T>(IVirtualMemoryManager memory, long position) where T : struct
+        public unsafe static T Read<T>(IVirtualMemoryManager memory, ulong position) where T : struct
         {
             long size = Marshal.SizeOf<T>();
 
             byte[] data = new byte[size];
 
-            memory.Read((ulong)position, data);
+            memory.Read(position, data);
 
             fixed (byte* ptr = data)
             {
@@ -37,7 +37,7 @@ namespace Ryujinx.Cpu
             }
         }
 
-        public unsafe static long Write<T>(IVirtualMemoryManager memory, long position, T value) where T : struct
+        public unsafe static ulong Write<T>(IVirtualMemoryManager memory, ulong position, T value) where T : struct
         {
             long size = Marshal.SizeOf<T>();
 
@@ -48,18 +48,18 @@ namespace Ryujinx.Cpu
                 Marshal.StructureToPtr<T>(value, (IntPtr)ptr, false);
             }
 
-            memory.Write((ulong)position, data);
+            memory.Write(position, data);
 
-            return size;
+            return (ulong)size;
         }
 
-        public static string ReadAsciiString(IVirtualMemoryManager memory, long position, long maxSize = -1)
+        public static string ReadAsciiString(IVirtualMemoryManager memory, ulong position, long maxSize = -1)
         {
             using (MemoryStream ms = new MemoryStream())
             {
                 for (long offs = 0; offs < maxSize || maxSize == -1; offs++)
                 {
-                    byte value = memory.Read<byte>((ulong)(position + offs));
+                    byte value = memory.Read<byte>(position + (ulong)offs);
 
                     if (value == 0)
                     {

--- a/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
+++ b/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
@@ -24,8 +24,8 @@ namespace Ryujinx.HLE.FileSystem.Content
 
         private Dictionary<StorageId, LinkedList<LocationEntry>> _locationEntries;
 
-        private Dictionary<string, ulong>   _sharedFontTitleDictionary;
-        private Dictionary<ulong, string>   _systemTitlesNameDictionary;
+        private Dictionary<string, ulong>  _sharedFontTitleDictionary;
+        private Dictionary<ulong, string>  _systemTitlesNameDictionary;
         private Dictionary<string, string> _sharedFontFilenameDictionary;
 
         private SortedDictionary<(ulong titleId, NcaContentType type), string> _contentDictionary;

--- a/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
+++ b/Ryujinx.HLE/FileSystem/Content/ContentManager.cs
@@ -24,8 +24,8 @@ namespace Ryujinx.HLE.FileSystem.Content
 
         private Dictionary<StorageId, LinkedList<LocationEntry>> _locationEntries;
 
-        private Dictionary<string, long>   _sharedFontTitleDictionary;
-        private Dictionary<long, string>   _systemTitlesNameDictionary;
+        private Dictionary<string, ulong>   _sharedFontTitleDictionary;
+        private Dictionary<ulong, string>   _systemTitlesNameDictionary;
         private Dictionary<string, string> _sharedFontFilenameDictionary;
 
         private SortedDictionary<(ulong titleId, NcaContentType type), string> _contentDictionary;
@@ -55,7 +55,7 @@ namespace Ryujinx.HLE.FileSystem.Content
             _contentDictionary = new SortedDictionary<(ulong, NcaContentType), string>();
             _locationEntries   = new Dictionary<StorageId, LinkedList<LocationEntry>>();
 
-            _sharedFontTitleDictionary = new Dictionary<string, long>
+            _sharedFontTitleDictionary = new Dictionary<string, ulong>
             {
                 { "FontStandard",                  0x0100000000000811 },
                 { "FontChineseSimplified",         0x0100000000000814 },
@@ -65,7 +65,7 @@ namespace Ryujinx.HLE.FileSystem.Content
                 { "FontNintendoExtended",          0x0100000000000810 }
             };
 
-            _systemTitlesNameDictionary = new Dictionary<long, string>()
+            _systemTitlesNameDictionary = new Dictionary<ulong, string>()
             {
                 { 0x010000000000080E, "TimeZoneBinary"         },
                 { 0x0100000000000810, "FontNintendoExtension"  },
@@ -140,7 +140,7 @@ namespace Ryujinx.HLE.FileSystem.Content
 
                                 LocationEntry entry = new LocationEntry(switchPath,
                                                                         0,
-                                                                        (long)nca.Header.TitleId,
+                                                                        nca.Header.TitleId,
                                                                         nca.Header.ContentType);
 
                                 AddEntry(entry);
@@ -167,7 +167,7 @@ namespace Ryujinx.HLE.FileSystem.Content
 
                                 LocationEntry entry = new LocationEntry(switchPath,
                                                                         0,
-                                                                        (long)nca.Header.TitleId,
+                                                                        nca.Header.TitleId,
                                                                         nca.Header.ContentType);
 
                                 AddEntry(entry);
@@ -297,7 +297,7 @@ namespace Ryujinx.HLE.FileSystem.Content
             return false;
         }
 
-        public void ClearEntry(long titleId, NcaContentType contentType, StorageId storageId)
+        public void ClearEntry(ulong titleId, NcaContentType contentType, StorageId storageId)
         {
             lock (_lock)
             {
@@ -333,7 +333,7 @@ namespace Ryujinx.HLE.FileSystem.Content
                 if (_contentDictionary.ContainsValue(ncaId))
                 {
                     var content = _contentDictionary.FirstOrDefault(x => x.Value == ncaId);
-                    long titleId = (long)content.Key.Item1;
+                    ulong titleId = content.Key.Item1;
 
                     NcaContentType contentType = content.Key.type;
                     StorageId storage = GetInstalledStorage(titleId, contentType, storageId);
@@ -345,20 +345,20 @@ namespace Ryujinx.HLE.FileSystem.Content
             return false;
         }
 
-        public UInt128 GetInstalledNcaId(long titleId, NcaContentType contentType)
+        public UInt128 GetInstalledNcaId(ulong titleId, NcaContentType contentType)
         {
             lock (_lock)
             {
-                if (_contentDictionary.ContainsKey(((ulong)titleId, contentType)))
+                if (_contentDictionary.ContainsKey((titleId, contentType)))
                 {
-                    return new UInt128(_contentDictionary[((ulong)titleId, contentType)]);
+                    return new UInt128(_contentDictionary[(titleId, contentType)]);
                 }
             }
 
             return new UInt128();
         }
 
-        public StorageId GetInstalledStorage(long titleId, NcaContentType contentType, StorageId storageId)
+        public StorageId GetInstalledStorage(ulong titleId, NcaContentType contentType, StorageId storageId)
         {
             lock (_lock)
             {
@@ -369,7 +369,7 @@ namespace Ryujinx.HLE.FileSystem.Content
             }
         }
 
-        public string GetInstalledContentPath(long titleId, StorageId storageId, NcaContentType contentType)
+        public string GetInstalledContentPath(ulong titleId, StorageId storageId, NcaContentType contentType)
         {
             lock (_lock)
             {
@@ -445,7 +445,7 @@ namespace Ryujinx.HLE.FileSystem.Content
             }
         }
 
-        private void RemoveLocationEntry(long titleId, NcaContentType contentType, StorageId storageId)
+        private void RemoveLocationEntry(ulong titleId, NcaContentType contentType, StorageId storageId)
         {
             LinkedList<LocationEntry> locationList = null;
 
@@ -466,7 +466,7 @@ namespace Ryujinx.HLE.FileSystem.Content
             }
         }
 
-        public bool TryGetFontTitle(string fontName, out long titleId)
+        public bool TryGetFontTitle(string fontName, out ulong titleId)
         {
             return _sharedFontTitleDictionary.TryGetValue(fontName, out titleId);
         }
@@ -476,12 +476,12 @@ namespace Ryujinx.HLE.FileSystem.Content
             return _sharedFontFilenameDictionary.TryGetValue(fontName, out filename);
         }
 
-        public bool TryGetSystemTitlesName(long titleId, out string name)
+        public bool TryGetSystemTitlesName(ulong titleId, out string name)
         {
             return _systemTitlesNameDictionary.TryGetValue(titleId, out name);
         }
 
-        private LocationEntry GetLocation(long titleId, NcaContentType contentType, StorageId storageId)
+        private LocationEntry GetLocation(ulong titleId, NcaContentType contentType, StorageId storageId)
         {
             LinkedList<LocationEntry> locationList = _locationEntries[storageId];
 

--- a/Ryujinx.HLE/FileSystem/Content/LocationEntry.cs
+++ b/Ryujinx.HLE/FileSystem/Content/LocationEntry.cs
@@ -6,10 +6,10 @@ namespace Ryujinx.HLE.FileSystem.Content
     {
         public string         ContentPath { get; private set; }
         public int            Flag        { get; private set; }
-        public long           TitleId     { get; private set; }
+        public ulong          TitleId     { get; private set; }
         public NcaContentType ContentType { get; private set; }
 
-        public LocationEntry(string contentPath, int flag, long titleId, NcaContentType contentType)
+        public LocationEntry(string contentPath, int flag, ulong titleId, NcaContentType contentType)
         {
             ContentPath = contentPath;
             Flag        = flag;

--- a/Ryujinx.HLE/HOS/Font/SharedFontManager.cs
+++ b/Ryujinx.HLE/HOS/Font/SharedFontManager.cs
@@ -58,7 +58,7 @@ namespace Ryujinx.HLE.HOS.Font
 
                 FontInfo CreateFont(string name)
                 {
-                    if (contentManager.TryGetFontTitle(name, out long fontTitle) &&
+                    if (contentManager.TryGetFontTitle(name, out ulong fontTitle) &&
                         contentManager.TryGetFontFilename(name, out string fontFilename))
                     {
                         string contentPath = contentManager.GetInstalledContentPath(fontTitle, StorageId.NandSystem, NcaContentType.Data);

--- a/Ryujinx.HLE/HOS/Ipc/IpcBuffDesc.cs
+++ b/Ryujinx.HLE/HOS/Ipc/IpcBuffDesc.cs
@@ -4,15 +4,15 @@ namespace Ryujinx.HLE.HOS.Ipc
 {
     struct IpcBuffDesc
     {
-        public long Position { get; private set; }
-        public long Size     { get; private set; }
-        public int  Flags    { get; private set; }
+        public ulong Position { get; private set; }
+        public ulong Size     { get; private set; }
+        public byte  Flags    { get; private set; }
 
         public IpcBuffDesc(BinaryReader reader)
         {
-            long word0 = reader.ReadUInt32();
-            long word1 = reader.ReadUInt32();
-            long word2 = reader.ReadUInt32();
+            ulong word0 = reader.ReadUInt32();
+            ulong word1 = reader.ReadUInt32();
+            ulong word2 = reader.ReadUInt32();
 
             Position  =  word1;
             Position |= (word2 <<  4) & 0x0f00000000;
@@ -21,7 +21,7 @@ namespace Ryujinx.HLE.HOS.Ipc
             Size  =  word0;
             Size |= (word2 << 8) & 0xf00000000;
 
-            Flags = (int)word2 & 3;
+            Flags = (byte)(word2 & 3);
         }
     }
 }

--- a/Ryujinx.HLE/HOS/Ipc/IpcMessage.cs
+++ b/Ryujinx.HLE/HOS/Ipc/IpcMessage.cs
@@ -196,7 +196,7 @@ namespace Ryujinx.HLE.HOS.Ipc
         }
 
         // ReSharper disable once InconsistentNaming
-        public (long Position, long Size) GetBufferType0x21(int index = 0)
+        public (ulong Position, ulong Size) GetBufferType0x21(int index = 0)
         {
             if (PtrBuff.Count > index &&
                 PtrBuff[index].Position != 0 &&
@@ -216,7 +216,7 @@ namespace Ryujinx.HLE.HOS.Ipc
         }
 
         // ReSharper disable once InconsistentNaming
-        public (long Position, long Size) GetBufferType0x22(int index = 0)
+        public (ulong Position, ulong Size) GetBufferType0x22(int index = 0)
         {
             if (RecvListBuff.Count > index &&
                 RecvListBuff[index].Position != 0 &&

--- a/Ryujinx.HLE/HOS/Ipc/IpcPtrBuffDesc.cs
+++ b/Ryujinx.HLE/HOS/Ipc/IpcPtrBuffDesc.cs
@@ -4,11 +4,11 @@ namespace Ryujinx.HLE.HOS.Ipc
 {
     struct IpcPtrBuffDesc
     {
-        public long  Position { get; private set; }
-        public int   Index    { get; private set; }
-        public long  Size     { get; private set; }
+        public ulong Position { get; private set; }
+        public uint  Index    { get; private set; }
+        public ulong Size     { get; private set; }
 
-        public IpcPtrBuffDesc(long position, int index, long size)
+        public IpcPtrBuffDesc(ulong position, uint index, ulong size)
         {
             Position = position;
             Index = index;
@@ -17,20 +17,20 @@ namespace Ryujinx.HLE.HOS.Ipc
 
         public IpcPtrBuffDesc(BinaryReader reader)
         {
-            long word0 = reader.ReadUInt32();
-            long word1 = reader.ReadUInt32();
+            ulong word0 = reader.ReadUInt32();
+            ulong word1 = reader.ReadUInt32();
 
-            Position  =  word1;
+            Position =  word1;
             Position |= (word0 << 20) & 0x0f00000000;
             Position |= (word0 << 30) & 0x7000000000;
 
-            Index  = ((int)word0 >> 0) & 0x03f;
-            Index |= ((int)word0 >> 3) & 0x1c0;
+            Index  = ((uint)word0 >> 0) & 0x03f;
+            Index |= ((uint)word0 >> 3) & 0x1c0;
 
             Size = (ushort)(word0 >> 16);
         }
 
-        public IpcPtrBuffDesc WithSize(long size)
+        public IpcPtrBuffDesc WithSize(ulong size)
         {
             return new IpcPtrBuffDesc(Position, Index, size);
         }
@@ -42,8 +42,8 @@ namespace Ryujinx.HLE.HOS.Ipc
             word0  = (uint)((Position & 0x0f00000000) >> 20);
             word0 |= (uint)((Position & 0x7000000000) >> 30);
 
-            word0 |= (uint)(Index & 0x03f) << 0;
-            word0 |= (uint)(Index & 0x1c0) << 3;
+            word0 |= (Index & 0x03f) << 0;
+            word0 |= (Index & 0x1c0) << 3;
 
             word0 |= (uint)Size << 16;
 

--- a/Ryujinx.HLE/HOS/Ipc/IpcRecvListBuffDesc.cs
+++ b/Ryujinx.HLE/HOS/Ipc/IpcRecvListBuffDesc.cs
@@ -4,10 +4,10 @@ namespace Ryujinx.HLE.HOS.Ipc
 {
     struct IpcRecvListBuffDesc
     {
-        public long Position { get; private set; }
-        public long Size     { get; private set; }
+        public ulong Position { get; private set; }
+        public ulong Size     { get; private set; }
 
-        public IpcRecvListBuffDesc(long position, long size)
+        public IpcRecvListBuffDesc(ulong position, ulong size)
         {
             Position = position;
             Size = size;
@@ -15,7 +15,7 @@ namespace Ryujinx.HLE.HOS.Ipc
 
         public IpcRecvListBuffDesc(BinaryReader reader)
         {
-            long value = reader.ReadInt64();
+            ulong value = reader.ReadUInt64();
 
             Position = value & 0xffffffffffff;
 

--- a/Ryujinx.HLE/HOS/Kernel/Common/KernelTransfer.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Common/KernelTransfer.cs
@@ -50,7 +50,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Common
             if (currentProcess.CpuMemory.IsMapped(address) &&
                 currentProcess.CpuMemory.IsMapped(address + (ulong)size - 1))
             {
-                value = MemoryHelper.ReadAsciiString(currentProcess.CpuMemory, (long)address, size);
+                value = MemoryHelper.ReadAsciiString(currentProcess.CpuMemory, address, size);
 
                 return true;
             }

--- a/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
@@ -340,7 +340,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
             UserExceptionContextAddress = userExceptionContextAddress;
 
-            MemoryHelper.FillWithZeros(CpuMemory, (long)userExceptionContextAddress, KTlsPageInfo.TlsEntrySize);
+            MemoryHelper.FillWithZeros(CpuMemory, userExceptionContextAddress, KTlsPageInfo.TlsEntrySize);
 
             Name = creationInfo.Name;
 
@@ -461,7 +461,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
             {
                 pageInfo = new KTlsPageInfo(tlsPageVa);
 
-                MemoryHelper.FillWithZeros(CpuMemory, (long)tlsPageVa, KMemoryManager.PageSize);
+                MemoryHelper.FillWithZeros(CpuMemory, tlsPageVa, KMemoryManager.PageSize);
             }
 
             return result;

--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
@@ -1431,7 +1431,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
         {
             KProcess process = KernelStatic.GetCurrentProcess();
 
-            string str = MemoryHelper.ReadAsciiString(process.CpuMemory, (long)strPtr, (long)size);
+            string str = MemoryHelper.ReadAsciiString(process.CpuMemory, strPtr, (long)size);
 
             Logger.Warning?.Print(LogClass.KernelSvc, str);
         }

--- a/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
@@ -161,7 +161,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
 
                 TlsDramAddress = owner.MemoryManager.GetDramAddressFromVa(_tlsAddress);
 
-                MemoryHelper.FillWithZeros(owner.CpuMemory, (long)_tlsAddress, KTlsPageInfo.TlsEntrySize);
+                MemoryHelper.FillWithZeros(owner.CpuMemory, _tlsAddress, KTlsPageInfo.TlsEntrySize);
             }
 
             bool is64Bits;

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/AccountService/ManagerServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/AccountService/ManagerServer.cs
@@ -73,8 +73,8 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc.AccountService
 
         public ResultCode LoadIdTokenCache(ServiceCtx context)
         {
-            long bufferPosition = context.Request.ReceiveBuff[0].Position;
-            long bufferSize     = context.Request.ReceiveBuff[0].Size;
+            ulong bufferPosition = context.Request.ReceiveBuff[0].Position;
+            ulong bufferSize     = context.Request.ReceiveBuff[0].Size;
 
             // NOTE: This opens the file at "su/cache/USERID_IN_UUID_STRING.dat" (where USERID_IN_UUID_STRING is formatted as "%08x-%04x-%04x-%02x%02x-%08x%04x")
             //       in the "account:/" savedata and writes some data in the buffer.

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/AccountService/ProfileServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/AccountService/ProfileServer.cs
@@ -65,7 +65,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc.AccountService
                 return ResultCode.InvalidBufferSize;
             }
 
-            context.Memory.Write((ulong)bufferPosition, _profile.Image);
+            context.Memory.Write(bufferPosition, _profile.Image);
 
             context.ResponseData.Write(_profile.Image.Length);
 
@@ -79,7 +79,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc.AccountService
 
             byte[] userData = new byte[userDataSize];
 
-            context.Memory.Read((ulong)userDataPosition, userData);
+            context.Memory.Read(userDataPosition, userData);
 
             // TODO: Read the nn::account::profile::ProfileBase and store everything in the savedata.
 

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/AccountService/ProfileServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/AccountService/ProfileServer.cs
@@ -16,16 +16,16 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc.AccountService
 
         public ResultCode Get(ServiceCtx context)
         {
-            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize(0x80L);
+            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize(0x80UL);
 
-            long bufferPosition = context.Request.RecvListBuff[0].Position;
+            ulong bufferPosition = context.Request.RecvListBuff[0].Position;
 
             MemoryHelper.FillWithZeros(context.Memory, bufferPosition, 0x80);
 
             // TODO: Determine the struct.
-            context.Memory.Write((ulong)bufferPosition,           0); // Unknown
-            context.Memory.Write((ulong)bufferPosition + 4,       1); // Icon ID. 0 = Mii, the rest are character icon IDs.
-            context.Memory.Write((ulong)bufferPosition + 8, (byte)1); // Profile icon background color ID
+            context.Memory.Write(bufferPosition,           0); // Unknown
+            context.Memory.Write(bufferPosition + 4,       1); // Icon ID. 0 = Mii, the rest are character icon IDs.
+            context.Memory.Write(bufferPosition + 8, (byte)1); // Profile icon background color ID
             // 0x07 bytes - Unknown
             // 0x10 bytes - Some ID related to the Mii? All zeros when a character icon is used.
             // 0x60 bytes - Usually zeros?
@@ -57,10 +57,10 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc.AccountService
 
         public ResultCode LoadImage(ServiceCtx context)
         {
-            long bufferPosition = context.Request.ReceiveBuff[0].Position;
-            long bufferLen      = context.Request.ReceiveBuff[0].Size;
+            ulong bufferPosition = context.Request.ReceiveBuff[0].Position;
+            ulong bufferLen      = context.Request.ReceiveBuff[0].Size;
 
-            if (_profile.Image.Length > bufferLen)
+            if ((ulong)_profile.Image.Length > bufferLen)
             {
                 return ResultCode.InvalidBufferSize;
             }
@@ -74,8 +74,8 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc.AccountService
 
         public ResultCode Store(ServiceCtx context)
         {
-            long userDataPosition = context.Request.PtrBuff[0].Position;
-            long userDataSize     = context.Request.PtrBuff[0].Size;
+            ulong userDataPosition = context.Request.PtrBuff[0].Position;
+            ulong userDataSize     = context.Request.PtrBuff[0].Size;
 
             byte[] userData = new byte[userDataSize];
 
@@ -90,19 +90,19 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc.AccountService
 
         public ResultCode StoreWithImage(ServiceCtx context)
         {
-            long userDataPosition = context.Request.PtrBuff[0].Position;
-            long userDataSize     = context.Request.PtrBuff[0].Size;
+            ulong userDataPosition = context.Request.PtrBuff[0].Position;
+            ulong userDataSize     = context.Request.PtrBuff[0].Size;
 
             byte[] userData = new byte[userDataSize];
 
-            context.Memory.Read((ulong)userDataPosition, userData);
+            context.Memory.Read(userDataPosition, userData);
 
-            long profileImagePosition = context.Request.SendBuff[0].Position;
-            long profileImageSize     = context.Request.SendBuff[0].Size;
+            ulong profileImagePosition = context.Request.SendBuff[0].Position;
+            ulong profileImageSize     = context.Request.SendBuff[0].Size;
 
             byte[] profileImageData = new byte[profileImageSize];
 
-            context.Memory.Read((ulong)profileImagePosition, profileImageData);
+            context.Memory.Read(profileImagePosition, profileImageData);
 
             // TODO: Read the nn::account::profile::ProfileBase and store everything in the savedata.
 

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/ApplicationServiceServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/ApplicationServiceServer.cs
@@ -67,8 +67,8 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
                     break;
                 }
 
-                context.Memory.Write((ulong)outputPosition + offset,     userProfile.UserId.High);
-                context.Memory.Write((ulong)outputPosition + offset + 8, userProfile.UserId.Low);
+                context.Memory.Write(outputPosition + offset,     userProfile.UserId.High);
+                context.Memory.Write(outputPosition + offset + 8, userProfile.UserId.Low);
 
                 offset += 0x10;
             }

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/ApplicationServiceServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/ApplicationServiceServer.cs
@@ -53,8 +53,8 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
                 return ResultCode.InvalidBuffer;
             }
 
-            long outputPosition = context.Request.RecvListBuff[0].Position;
-            long outputSize     = context.Request.RecvListBuff[0].Size;
+            ulong outputPosition = context.Request.RecvListBuff[0].Position;
+            ulong outputSize     = context.Request.RecvListBuff[0].Size;
 
             MemoryHelper.FillWithZeros(context.Memory, outputPosition, (int)outputSize);
 
@@ -156,8 +156,8 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
                 return ResultCode.InvalidBuffer;
             }
 
-            long inputPosition = context.Request.SendBuff[0].Position;
-            long inputSize     = context.Request.SendBuff[0].Size;
+            ulong inputPosition = context.Request.SendBuff[0].Position;
+            ulong inputSize     = context.Request.SendBuff[0].Size;
 
             if (inputSize != 0x24000)
             {
@@ -166,7 +166,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
 
             byte[] thumbnailBuffer = new byte[inputSize];
 
-            context.Memory.Read((ulong)inputPosition, thumbnailBuffer);
+            context.Memory.Read(inputPosition, thumbnailBuffer);
 
             // NOTE: Account service call nn::fs::WriteSaveDataThumbnailFile().
             // TODO: Store thumbnailBuffer somewhere, in save data 0x8000000000000010 ?

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
@@ -142,8 +142,8 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
         // ListOpenContextStoredUsers() -> array<nn::account::Uid, 0xa>
         public ResultCode ListOpenContextStoredUsers(ServiceCtx context)
         {
-            long outputPosition = context.Request.RecvListBuff[0].Position;
-            long outputSize     = context.Request.RecvListBuff[0].Size;
+            ulong outputPosition = context.Request.RecvListBuff[0].Position;
+            ulong outputSize     = context.Request.RecvListBuff[0].Size;
 
             MemoryHelper.FillWithZeros(context.Memory, outputPosition, (int)outputSize);
 

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/IStorageAccessor.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/IStorageAccessor.cs
@@ -29,20 +29,20 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE
                 return ResultCode.ObjectInvalid;
             }
 
-            long writePosition = context.RequestData.ReadInt64();
+            ulong writePosition = context.RequestData.ReadUInt64();
 
-            if (writePosition > _storage.Data.Length)
+            if (writePosition > (ulong)_storage.Data.Length)
             {
                 return ResultCode.OutOfBounds;
             }
 
-            (long position, long size) = context.Request.GetBufferType0x21();
+            (ulong position, ulong size) = context.Request.GetBufferType0x21();
 
-            size = Math.Min(size, _storage.Data.Length - writePosition);
+            size = Math.Min(size, (ulong)_storage.Data.Length - writePosition);
 
             if (size > 0)
             {
-                long maxSize = _storage.Data.Length - writePosition;
+                ulong maxSize = (ulong)_storage.Data.Length - writePosition;
 
                 if (size > maxSize)
                 {
@@ -51,7 +51,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE
 
                 byte[] data = new byte[size];
 
-                context.Memory.Read((ulong)position, data);
+                context.Memory.Read(position, data);
 
                 Buffer.BlockCopy(data, 0, _storage.Data, (int)writePosition, (int)size);
             }
@@ -63,22 +63,22 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE
         // Read(u64) -> buffer<bytes, 0x22>
         public ResultCode Read(ServiceCtx context)
         {
-            long readPosition = context.RequestData.ReadInt64();
+            ulong readPosition = context.RequestData.ReadUInt64();
 
-            if (readPosition > _storage.Data.Length)
+            if (readPosition > (ulong)_storage.Data.Length)
             {
                 return ResultCode.OutOfBounds;
             }
 
-            (long position, long size) = context.Request.GetBufferType0x22();
+            (ulong position, ulong size) = context.Request.GetBufferType0x22();
 
-            size = Math.Min(size, _storage.Data.Length - readPosition);
+            size = Math.Min(size, (ulong)_storage.Data.Length - readPosition);
 
             byte[] data = new byte[size];
 
             Buffer.BlockCopy(_storage.Data, (int)readPosition, data, 0, (int)size);
 
-            context.Memory.Write((ulong)position, data);
+            context.Memory.Write(position, data);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
@@ -359,13 +359,13 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
         // SetApplicationCopyrightImage(buffer<bytes, 0x45> frame_buffer, s32 x, s32 y, s32 width, s32 height, s32 window_origin_mode)
         public ResultCode SetApplicationCopyrightImage(ServiceCtx context)
         {
-            ulong frameBufferPos  = context.Request.SendBuff[0].Position;
-            ulong frameBufferSize = context.Request.SendBuff[0].Size;
-            int  x                = context.RequestData.ReadInt32();
-            int  y                = context.RequestData.ReadInt32();
-            int  width            = context.RequestData.ReadInt32();
-            int  height           = context.RequestData.ReadInt32();
-            uint windowOriginMode = context.RequestData.ReadUInt32();
+            ulong frameBufferPos   = context.Request.SendBuff[0].Position;
+            ulong frameBufferSize  = context.Request.SendBuff[0].Size;
+            int   x                = context.RequestData.ReadInt32();
+            int   y                = context.RequestData.ReadInt32();
+            int   width            = context.RequestData.ReadInt32();
+            int   height           = context.RequestData.ReadInt32();
+            uint  windowOriginMode = context.RequestData.ReadUInt32();
 
             ResultCode resultCode = ResultCode.InvalidParameters;
 

--- a/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
@@ -359,13 +359,13 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
         // SetApplicationCopyrightImage(buffer<bytes, 0x45> frame_buffer, s32 x, s32 y, s32 width, s32 height, s32 window_origin_mode)
         public ResultCode SetApplicationCopyrightImage(ServiceCtx context)
         {
-            long frameBufferPos   = context.Request.SendBuff[0].Position;
-            long frameBufferSize  = context.Request.SendBuff[0].Size;
-            int  x                = context.RequestData.ReadInt32();
-            int  y                = context.RequestData.ReadInt32();
-            int  width            = context.RequestData.ReadInt32();
-            int  height           = context.RequestData.ReadInt32();
-            uint windowOriginMode = context.RequestData.ReadUInt32();
+            ulong frameBufferPos   = context.Request.SendBuff[0].Position;
+            ulong frameBufferSize  = context.Request.SendBuff[0].Size;
+            int  x                 = context.RequestData.ReadInt32();
+            int  y                 = context.RequestData.ReadInt32();
+            int  width             = context.RequestData.ReadInt32();
+            int  height            = context.RequestData.ReadInt32();
+            uint windowOriginMode  = context.RequestData.ReadUInt32();
 
             ResultCode resultCode = ResultCode.InvalidParameters;
 
@@ -388,7 +388,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return resultCode;
         }
 
-        private ResultCode SetApplicationCopyrightImageImpl(int x, int y, int width, int height, long frameBufferPos, long frameBufferSize, uint windowOriginMode)
+        private ResultCode SetApplicationCopyrightImageImpl(int x, int y, int width, int height, ulong frameBufferPos, ulong frameBufferSize, uint windowOriginMode)
         {
             /*
             if (_copyrightBuffer == null)

--- a/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
@@ -359,13 +359,13 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
         // SetApplicationCopyrightImage(buffer<bytes, 0x45> frame_buffer, s32 x, s32 y, s32 width, s32 height, s32 window_origin_mode)
         public ResultCode SetApplicationCopyrightImage(ServiceCtx context)
         {
-            ulong frameBufferPos   = context.Request.SendBuff[0].Position;
-            ulong frameBufferSize  = context.Request.SendBuff[0].Size;
-            int  x                 = context.RequestData.ReadInt32();
-            int  y                 = context.RequestData.ReadInt32();
-            int  width             = context.RequestData.ReadInt32();
-            int  height            = context.RequestData.ReadInt32();
-            uint windowOriginMode  = context.RequestData.ReadUInt32();
+            ulong frameBufferPos  = context.Request.SendBuff[0].Position;
+            ulong frameBufferSize = context.Request.SendBuff[0].Size;
+            int  x                = context.RequestData.ReadInt32();
+            int  y                = context.RequestData.ReadInt32();
+            int  width            = context.RequestData.ReadInt32();
+            int  height           = context.RequestData.ReadInt32();
+            uint windowOriginMode = context.RequestData.ReadUInt32();
 
             ResultCode resultCode = ResultCode.InvalidParameters;
 

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioIn/AudioInServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioIn/AudioInServer.cs
@@ -45,7 +45,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioIn
         // AppendAudioInBuffer(u64 tag, buffer<nn::audio::AudioInBuffer, 5>)
         public ResultCode AppendAudioInBuffer(ServiceCtx context)
         {
-            long position = context.Request.SendBuff[0].Position;
+            ulong position = context.Request.SendBuff[0].Position;
 
             ulong bufferTag = context.RequestData.ReadUInt64();
 
@@ -74,8 +74,8 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioIn
         // GetReleasedAudioInBuffers() -> (u32 count, buffer<u64, 6> tags)
         public ResultCode GetReleasedAudioInBuffers(ServiceCtx context)
         {
-            long position = context.Request.ReceiveBuff[0].Position;
-            long size = context.Request.ReceiveBuff[0].Size;
+            ulong position = context.Request.ReceiveBuff[0].Position;
+            ulong size = context.Request.ReceiveBuff[0].Size;
 
             using (WritableRegion outputRegion = context.Memory.GetWritableRegion((ulong)position, (int)size))
             {
@@ -102,7 +102,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioIn
         // AppendUacInBuffer(u64 tag, handle<copy, unknown>, buffer<nn::audio::AudioInBuffer, 5>)
         public ResultCode AppendUacInBuffer(ServiceCtx context)
         {
-            long position = context.Request.SendBuff[0].Position;
+            ulong position = context.Request.SendBuff[0].Position;
 
             ulong bufferTag = context.RequestData.ReadUInt64();
             uint handle = (uint)context.Request.HandleDesc.ToCopy[0];
@@ -116,7 +116,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioIn
         // AppendAudioInBufferAuto(u64 tag, buffer<nn::audio::AudioInBuffer, 0x21>)
         public ResultCode AppendAudioInBufferAuto(ServiceCtx context)
         {
-            (long position, _) = context.Request.GetBufferType0x21();
+            (ulong position, _) = context.Request.GetBufferType0x21();
 
             ulong bufferTag = context.RequestData.ReadUInt64();
 
@@ -129,9 +129,9 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioIn
         // GetReleasedAudioInBuffersAuto() -> (u32 count, buffer<u64, 0x22> tags)
         public ResultCode GetReleasedAudioInBuffersAuto(ServiceCtx context)
         {
-            (long position, long size) = context.Request.GetBufferType0x22();
+            (ulong position, ulong size) = context.Request.GetBufferType0x22();
 
-            using (WritableRegion outputRegion = context.Memory.GetWritableRegion((ulong)position, (int)size))
+            using (WritableRegion outputRegion = context.Memory.GetWritableRegion(position, (int)size))
             {
                 ResultCode result = _impl.GetReleasedBuffers(MemoryMarshal.Cast<byte, ulong>(outputRegion.Memory.Span), out uint releasedCount);
 
@@ -145,7 +145,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioIn
         // AppendUacInBufferAuto(u64 tag, handle<copy, event>, buffer<nn::audio::AudioInBuffer, 0x21>)
         public ResultCode AppendUacInBufferAuto(ServiceCtx context)
         {
-            (long position, _) = context.Request.GetBufferType0x21();
+            (ulong position, _) = context.Request.GetBufferType0x21();
 
             ulong bufferTag = context.RequestData.ReadUInt64();
             uint handle = (uint)context.Request.HandleDesc.ToCopy[0];

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioInManagerServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioInManagerServer.cs
@@ -27,10 +27,10 @@ namespace Ryujinx.HLE.HOS.Services.Audio
         {
             string[] deviceNames = _impl.ListAudioIns(false);
 
-            long position = context.Request.ReceiveBuff[0].Position;
-            long size = context.Request.ReceiveBuff[0].Size;
+            ulong position = context.Request.ReceiveBuff[0].Position;
+            ulong size = context.Request.ReceiveBuff[0].Size;
 
-            long basePosition = position;
+            ulong basePosition = position;
 
             int count = 0;
 
@@ -38,15 +38,15 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             {
                 byte[] buffer = Encoding.ASCII.GetBytes(name);
 
-                if ((position - basePosition) + buffer.Length > size)
+                if ((position - basePosition) + (ulong)buffer.Length > size)
                 {
                     Logger.Error?.Print(LogClass.ServiceAudio, $"Output buffer size {size} too small!");
 
                     break;
                 }
 
-                context.Memory.Write((ulong)position, buffer);
-                MemoryHelper.FillWithZeros(context.Memory, position + buffer.Length, AudioInNameSize - buffer.Length);
+                context.Memory.Write(position, buffer);
+                MemoryHelper.FillWithZeros(context.Memory, position + (ulong)buffer.Length, AudioInNameSize - buffer.Length);
 
                 position += AudioInNameSize;
                 count++;
@@ -65,15 +65,15 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             AudioInputConfiguration inputConfiguration = context.RequestData.ReadStruct<AudioInputConfiguration>();
             ulong appletResourceUserId = context.RequestData.ReadUInt64();
 
-            long deviceNameInputPosition = context.Request.SendBuff[0].Position;
-            long deviceNameInputSize = context.Request.SendBuff[0].Size;
+            ulong deviceNameInputPosition = context.Request.SendBuff[0].Position;
+            ulong deviceNameInputSize = context.Request.SendBuff[0].Size;
 
-            long deviceNameOutputPosition = context.Request.ReceiveBuff[0].Position;
-            long deviceNameOutputSize = context.Request.ReceiveBuff[0].Size;
+            ulong deviceNameOutputPosition = context.Request.ReceiveBuff[0].Position;
+            ulong deviceNameOutputSize = context.Request.ReceiveBuff[0].Size;
 
             uint processHandle = (uint)context.Request.HandleDesc.ToCopy[0];
 
-            string inputDeviceName = MemoryHelper.ReadAsciiString(context.Memory, deviceNameInputPosition, deviceNameInputSize);
+            string inputDeviceName = MemoryHelper.ReadAsciiString(context.Memory, deviceNameInputPosition, (long)deviceNameInputSize);
 
             ResultCode resultCode = _impl.OpenAudioIn(context, out string outputDeviceName, out AudioOutputConfiguration outputConfiguration, out IAudioIn obj, inputDeviceName, ref inputConfiguration, appletResourceUserId, processHandle);
 
@@ -84,7 +84,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
                 byte[] outputDeviceNameRaw = Encoding.ASCII.GetBytes(outputDeviceName);
 
                 context.Memory.Write((ulong)deviceNameOutputPosition, outputDeviceNameRaw);
-                MemoryHelper.FillWithZeros(context.Memory, deviceNameOutputPosition + outputDeviceNameRaw.Length, AudioInNameSize - outputDeviceNameRaw.Length);
+                MemoryHelper.FillWithZeros(context.Memory, deviceNameOutputPosition + (ulong)outputDeviceNameRaw.Length, AudioInNameSize - outputDeviceNameRaw.Length);
 
                 MakeObject(context, new AudioInServer(obj));
             }
@@ -98,9 +98,9 @@ namespace Ryujinx.HLE.HOS.Services.Audio
         {
             string[] deviceNames = _impl.ListAudioIns(false);
 
-            (long position, long size) = context.Request.GetBufferType0x22();
+            (ulong position, ulong size) = context.Request.GetBufferType0x22();
 
-            long basePosition = position;
+            ulong basePosition = position;
 
             int count = 0;
 
@@ -108,15 +108,15 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             {
                 byte[] buffer = Encoding.ASCII.GetBytes(name);
 
-                if ((position - basePosition) + buffer.Length > size)
+                if ((position - basePosition) + (ulong)buffer.Length > size)
                 {
                     Logger.Error?.Print(LogClass.ServiceAudio, $"Output buffer size {size} too small!");
 
                     break;
                 }
 
-                context.Memory.Write((ulong)position, buffer);
-                MemoryHelper.FillWithZeros(context.Memory, position + buffer.Length, AudioInNameSize - buffer.Length);
+                context.Memory.Write(position, buffer);
+                MemoryHelper.FillWithZeros(context.Memory, position + (ulong)buffer.Length, AudioInNameSize - buffer.Length);
 
                 position += AudioInNameSize;
                 count++;
@@ -135,12 +135,12 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             AudioInputConfiguration inputConfiguration = context.RequestData.ReadStruct<AudioInputConfiguration>();
             ulong appletResourceUserId = context.RequestData.ReadUInt64();
 
-            (long deviceNameInputPosition, long deviceNameInputSize) = context.Request.GetBufferType0x21();
-            (long deviceNameOutputPosition, long deviceNameOutputSize) = context.Request.GetBufferType0x22();
+            (ulong deviceNameInputPosition, ulong deviceNameInputSize) = context.Request.GetBufferType0x21();
+            (ulong deviceNameOutputPosition, ulong deviceNameOutputSize) = context.Request.GetBufferType0x22();
 
             uint processHandle = (uint)context.Request.HandleDesc.ToCopy[0];
 
-            string inputDeviceName = MemoryHelper.ReadAsciiString(context.Memory, deviceNameInputPosition, deviceNameInputSize);
+            string inputDeviceName = MemoryHelper.ReadAsciiString(context.Memory, deviceNameInputPosition, (long)deviceNameInputSize);
 
             ResultCode resultCode = _impl.OpenAudioIn(context, out string outputDeviceName, out AudioOutputConfiguration outputConfiguration, out IAudioIn obj, inputDeviceName, ref inputConfiguration, appletResourceUserId, processHandle);
 
@@ -150,8 +150,8 @@ namespace Ryujinx.HLE.HOS.Services.Audio
 
                 byte[] outputDeviceNameRaw = Encoding.ASCII.GetBytes(outputDeviceName);
 
-                context.Memory.Write((ulong)deviceNameOutputPosition, outputDeviceNameRaw);
-                MemoryHelper.FillWithZeros(context.Memory, deviceNameOutputPosition + outputDeviceNameRaw.Length, AudioInNameSize - outputDeviceNameRaw.Length);
+                context.Memory.Write(deviceNameOutputPosition, outputDeviceNameRaw);
+                MemoryHelper.FillWithZeros(context.Memory, deviceNameOutputPosition + (ulong)outputDeviceNameRaw.Length, AudioInNameSize - outputDeviceNameRaw.Length);
 
                 MakeObject(context, new AudioInServer(obj));
             }
@@ -165,9 +165,9 @@ namespace Ryujinx.HLE.HOS.Services.Audio
         {
             string[] deviceNames = _impl.ListAudioIns(true);
 
-            (long position, long size) = context.Request.GetBufferType0x22();
+            (ulong position, ulong size) = context.Request.GetBufferType0x22();
 
-            long basePosition = position;
+            ulong basePosition = position;
 
             int count = 0;
 
@@ -175,15 +175,15 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             {
                 byte[] buffer = Encoding.ASCII.GetBytes(name);
 
-                if ((position - basePosition) + buffer.Length > size)
+                if ((position - basePosition) + (ulong)buffer.Length > size)
                 {
                     Logger.Error?.Print(LogClass.ServiceAudio, $"Output buffer size {size} too small!");
 
                     break;
                 }
 
-                context.Memory.Write((ulong)position, buffer);
-                MemoryHelper.FillWithZeros(context.Memory, position + buffer.Length, AudioInNameSize - buffer.Length);
+                context.Memory.Write(position, buffer);
+                MemoryHelper.FillWithZeros(context.Memory, position + (ulong)buffer.Length, AudioInNameSize - buffer.Length);
 
                 position += AudioInNameSize;
                 count++;
@@ -205,15 +205,15 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             AudioInputConfiguration inputConfiguration = context.RequestData.ReadStruct<AudioInputConfiguration>();
             ulong appletResourceUserId = context.RequestData.ReadUInt64();
 
-            long deviceNameInputPosition = context.Request.SendBuff[0].Position;
-            long deviceNameInputSize = context.Request.SendBuff[0].Size;
+            ulong deviceNameInputPosition = context.Request.SendBuff[0].Position;
+            ulong deviceNameInputSize = context.Request.SendBuff[0].Size;
 
-            long deviceNameOutputPosition = context.Request.ReceiveBuff[0].Position;
-            long deviceNameOutputSize = context.Request.ReceiveBuff[0].Size;
+            ulong deviceNameOutputPosition = context.Request.ReceiveBuff[0].Position;
+            ulong deviceNameOutputSize = context.Request.ReceiveBuff[0].Size;
 
             uint processHandle = (uint)context.Request.HandleDesc.ToCopy[0];
 
-            string inputDeviceName = MemoryHelper.ReadAsciiString(context.Memory, deviceNameInputPosition, deviceNameInputSize);
+            string inputDeviceName = MemoryHelper.ReadAsciiString(context.Memory, deviceNameInputPosition, (long)deviceNameInputSize);
 
             ResultCode resultCode = _impl.OpenAudioIn(context, out string outputDeviceName, out AudioOutputConfiguration outputConfiguration, out IAudioIn obj, inputDeviceName, ref inputConfiguration, appletResourceUserId, processHandle);
 
@@ -224,7 +224,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
                 byte[] outputDeviceNameRaw = Encoding.ASCII.GetBytes(outputDeviceName);
 
                 context.Memory.Write((ulong)deviceNameOutputPosition, outputDeviceNameRaw);
-                MemoryHelper.FillWithZeros(context.Memory, deviceNameOutputPosition + outputDeviceNameRaw.Length, AudioInNameSize - outputDeviceNameRaw.Length);
+                MemoryHelper.FillWithZeros(context.Memory, deviceNameOutputPosition + (ulong)outputDeviceNameRaw.Length, AudioInNameSize - outputDeviceNameRaw.Length);
 
                 MakeObject(context, new AudioInServer(obj));
             }

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioInManagerServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioInManagerServer.cs
@@ -83,7 +83,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
 
                 byte[] outputDeviceNameRaw = Encoding.ASCII.GetBytes(outputDeviceName);
 
-                context.Memory.Write((ulong)deviceNameOutputPosition, outputDeviceNameRaw);
+                context.Memory.Write(deviceNameOutputPosition, outputDeviceNameRaw);
                 MemoryHelper.FillWithZeros(context.Memory, deviceNameOutputPosition + (ulong)outputDeviceNameRaw.Length, AudioInNameSize - outputDeviceNameRaw.Length);
 
                 MakeObject(context, new AudioInServer(obj));
@@ -223,7 +223,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
 
                 byte[] outputDeviceNameRaw = Encoding.ASCII.GetBytes(outputDeviceName);
 
-                context.Memory.Write((ulong)deviceNameOutputPosition, outputDeviceNameRaw);
+                context.Memory.Write(deviceNameOutputPosition, outputDeviceNameRaw);
                 MemoryHelper.FillWithZeros(context.Memory, deviceNameOutputPosition + (ulong)outputDeviceNameRaw.Length, AudioInNameSize - outputDeviceNameRaw.Length);
 
                 MakeObject(context, new AudioInServer(obj));

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioOut/AudioOutServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioOut/AudioOutServer.cs
@@ -45,7 +45,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioOut
         // AppendAudioOutBuffer(u64 bufferTag, buffer<nn::audio::AudioOutBuffer, 5> buffer)
         public ResultCode AppendAudioOutBuffer(ServiceCtx context)
         {
-            long position = context.Request.SendBuff[0].Position;
+            ulong position = context.Request.SendBuff[0].Position;
 
             ulong bufferTag = context.RequestData.ReadUInt64();
 
@@ -74,10 +74,10 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioOut
         // GetReleasedAudioOutBuffers() -> (u32 count, buffer<u64, 6> tags)
         public ResultCode GetReleasedAudioOutBuffers(ServiceCtx context)
         {
-            long position = context.Request.ReceiveBuff[0].Position;
-            long size = context.Request.ReceiveBuff[0].Size;
+            ulong position = context.Request.ReceiveBuff[0].Position;
+            ulong size = context.Request.ReceiveBuff[0].Size;
 
-            using (WritableRegion outputRegion = context.Memory.GetWritableRegion((ulong)position, (int)size))
+            using (WritableRegion outputRegion = context.Memory.GetWritableRegion(position, (int)size))
             {
                 ResultCode result = _impl.GetReleasedBuffers(MemoryMarshal.Cast<byte, ulong>(outputRegion.Memory.Span), out uint releasedCount);
 
@@ -102,7 +102,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioOut
         // AppendAudioOutBufferAuto(u64 tag, buffer<nn::audio::AudioOutBuffer, 0x21>)
         public ResultCode AppendAudioOutBufferAuto(ServiceCtx context)
         {
-            (long position, _) = context.Request.GetBufferType0x21();
+            (ulong position, _) = context.Request.GetBufferType0x21();
 
             ulong bufferTag = context.RequestData.ReadUInt64();
 
@@ -115,9 +115,9 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioOut
         // GetReleasedAudioOutBuffersAuto() -> (u32 count, buffer<u64, 0x22> tags)
         public ResultCode GetReleasedAudioOutBuffersAuto(ServiceCtx context)
         {
-            (long position, long size) = context.Request.GetBufferType0x22();
+            (ulong position, ulong size) = context.Request.GetBufferType0x22();
 
-            using (WritableRegion outputRegion = context.Memory.GetWritableRegion((ulong)position, (int)size))
+            using (WritableRegion outputRegion = context.Memory.GetWritableRegion(position, (int)size))
             {
                 ResultCode result = _impl.GetReleasedBuffers(MemoryMarshal.Cast<byte, ulong>(outputRegion.Memory.Span), out uint releasedCount);
 

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioOutManagerServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioOutManagerServer.cs
@@ -27,10 +27,10 @@ namespace Ryujinx.HLE.HOS.Services.Audio
         {
             string[] deviceNames = _impl.ListAudioOuts();
 
-            long position = context.Request.ReceiveBuff[0].Position;
-            long size = context.Request.ReceiveBuff[0].Size;
+            ulong position = context.Request.ReceiveBuff[0].Position;
+            ulong size = context.Request.ReceiveBuff[0].Size;
 
-            long basePosition = position;
+            ulong basePosition = position;
 
             int count = 0;
 
@@ -38,15 +38,15 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             {
                 byte[] buffer = Encoding.ASCII.GetBytes(name);
 
-                if ((position - basePosition) + buffer.Length > size)
+                if ((position - basePosition) + (ulong)buffer.Length > size)
                 {
                     Logger.Error?.Print(LogClass.ServiceAudio, $"Output buffer size {size} too small!");
 
                     break;
                 }
 
-                context.Memory.Write((ulong)position, buffer);
-                MemoryHelper.FillWithZeros(context.Memory, position + buffer.Length, AudioOutNameSize - buffer.Length);
+                context.Memory.Write(position, buffer);
+                MemoryHelper.FillWithZeros(context.Memory, position + (ulong)buffer.Length, AudioOutNameSize - buffer.Length);
 
                 position += AudioOutNameSize;
                 count++;
@@ -65,15 +65,15 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             AudioInputConfiguration inputConfiguration = context.RequestData.ReadStruct<AudioInputConfiguration>();
             ulong appletResourceUserId = context.RequestData.ReadUInt64();
 
-            long deviceNameInputPosition = context.Request.SendBuff[0].Position;
-            long deviceNameInputSize = context.Request.SendBuff[0].Size;
+            ulong deviceNameInputPosition = context.Request.SendBuff[0].Position;
+            ulong deviceNameInputSize = context.Request.SendBuff[0].Size;
 
-            long deviceNameOutputPosition = context.Request.ReceiveBuff[0].Position;
-            long deviceNameOutputSize = context.Request.ReceiveBuff[0].Size;
+            ulong deviceNameOutputPosition = context.Request.ReceiveBuff[0].Position;
+            ulong deviceNameOutputSize = context.Request.ReceiveBuff[0].Size;
 
             uint processHandle = (uint)context.Request.HandleDesc.ToCopy[0];
 
-            string inputDeviceName = MemoryHelper.ReadAsciiString(context.Memory, deviceNameInputPosition, deviceNameInputSize);
+            string inputDeviceName = MemoryHelper.ReadAsciiString(context.Memory, deviceNameInputPosition, (long)deviceNameInputSize);
 
             ResultCode resultCode = _impl.OpenAudioOut(context, out string outputDeviceName, out AudioOutputConfiguration outputConfiguration, out IAudioOut obj, inputDeviceName, ref inputConfiguration, appletResourceUserId, processHandle);
 
@@ -84,7 +84,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
                 byte[] outputDeviceNameRaw = Encoding.ASCII.GetBytes(outputDeviceName);
 
                 context.Memory.Write((ulong)deviceNameOutputPosition, outputDeviceNameRaw);
-                MemoryHelper.FillWithZeros(context.Memory, deviceNameOutputPosition + outputDeviceNameRaw.Length, AudioOutNameSize - outputDeviceNameRaw.Length);
+                MemoryHelper.FillWithZeros(context.Memory, deviceNameOutputPosition + (ulong)outputDeviceNameRaw.Length, AudioOutNameSize - outputDeviceNameRaw.Length);
 
                 MakeObject(context, new AudioOutServer(obj));
             }
@@ -98,9 +98,9 @@ namespace Ryujinx.HLE.HOS.Services.Audio
         {
             string[] deviceNames = _impl.ListAudioOuts();
 
-            (long position, long size) = context.Request.GetBufferType0x22();
+            (ulong position, ulong size) = context.Request.GetBufferType0x22();
 
-            long basePosition = position;
+            ulong basePosition = position;
 
             int count = 0;
 
@@ -108,7 +108,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             {
                 byte[] buffer = Encoding.ASCII.GetBytes(name);
 
-                if ((position - basePosition) + buffer.Length > size)
+                if ((position - basePosition) + (ulong)buffer.Length > size)
                 {
                     Logger.Error?.Print(LogClass.ServiceAudio, $"Output buffer size {size} too small!");
 
@@ -116,7 +116,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
                 }
 
                 context.Memory.Write((ulong)position, buffer);
-                MemoryHelper.FillWithZeros(context.Memory, position + buffer.Length, AudioOutNameSize - buffer.Length);
+                MemoryHelper.FillWithZeros(context.Memory, position + (ulong)buffer.Length, AudioOutNameSize - buffer.Length);
 
                 position += AudioOutNameSize;
                 count++;
@@ -135,12 +135,12 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             AudioInputConfiguration inputConfiguration = context.RequestData.ReadStruct<AudioInputConfiguration>();
             ulong appletResourceUserId = context.RequestData.ReadUInt64();
 
-            (long deviceNameInputPosition, long deviceNameInputSize) = context.Request.GetBufferType0x21();
-            (long deviceNameOutputPosition, long deviceNameOutputSize) = context.Request.GetBufferType0x22();
+            (ulong deviceNameInputPosition, ulong deviceNameInputSize) = context.Request.GetBufferType0x21();
+            (ulong deviceNameOutputPosition, ulong deviceNameOutputSize) = context.Request.GetBufferType0x22();
 
             uint processHandle = (uint)context.Request.HandleDesc.ToCopy[0];
 
-            string inputDeviceName = MemoryHelper.ReadAsciiString(context.Memory, deviceNameInputPosition, deviceNameInputSize);
+            string inputDeviceName = MemoryHelper.ReadAsciiString(context.Memory, deviceNameInputPosition, (long)deviceNameInputSize);
 
             ResultCode resultCode = _impl.OpenAudioOut(context, out string outputDeviceName, out AudioOutputConfiguration outputConfiguration, out IAudioOut obj, inputDeviceName, ref inputConfiguration, appletResourceUserId, processHandle);
 
@@ -150,8 +150,8 @@ namespace Ryujinx.HLE.HOS.Services.Audio
 
                 byte[] outputDeviceNameRaw = Encoding.ASCII.GetBytes(outputDeviceName);
 
-                context.Memory.Write((ulong)deviceNameOutputPosition, outputDeviceNameRaw);
-                MemoryHelper.FillWithZeros(context.Memory, deviceNameOutputPosition + outputDeviceNameRaw.Length, AudioOutNameSize - outputDeviceNameRaw.Length);
+                context.Memory.Write(deviceNameOutputPosition, outputDeviceNameRaw);
+                MemoryHelper.FillWithZeros(context.Memory, deviceNameOutputPosition + (ulong)outputDeviceNameRaw.Length, AudioOutNameSize - outputDeviceNameRaw.Length);
 
                 MakeObject(context, new AudioOutServer(obj));
             }

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioOutManagerServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioOutManagerServer.cs
@@ -83,7 +83,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
 
                 byte[] outputDeviceNameRaw = Encoding.ASCII.GetBytes(outputDeviceName);
 
-                context.Memory.Write((ulong)deviceNameOutputPosition, outputDeviceNameRaw);
+                context.Memory.Write(deviceNameOutputPosition, outputDeviceNameRaw);
                 MemoryHelper.FillWithZeros(context.Memory, deviceNameOutputPosition + (ulong)outputDeviceNameRaw.Length, AudioOutNameSize - outputDeviceNameRaw.Length);
 
                 MakeObject(context, new AudioOutServer(obj));
@@ -115,7 +115,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
                     break;
                 }
 
-                context.Memory.Write((ulong)position, buffer);
+                context.Memory.Write(position, buffer);
                 MemoryHelper.FillWithZeros(context.Memory, position + (ulong)buffer.Length, AudioOutNameSize - buffer.Length);
 
                 position += AudioOutNameSize;

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/AudioDeviceServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/AudioDeviceServer.cs
@@ -25,10 +25,10 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
         {
             string[] deviceNames = _impl.ListAudioDeviceName();
 
-            long position = context.Request.ReceiveBuff[0].Position;
-            long size = context.Request.ReceiveBuff[0].Size;
+            ulong position = context.Request.ReceiveBuff[0].Position;
+            ulong size = context.Request.ReceiveBuff[0].Size;
 
-            long basePosition = position;
+            ulong basePosition = position;
 
             int count = 0;
 
@@ -36,7 +36,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             {
                 byte[] buffer = Encoding.ASCII.GetBytes(name);
 
-                if ((position - basePosition) + buffer.Length > size)
+                if ((position - basePosition) + (ulong)buffer.Length > size)
                 {
                     Logger.Error?.Print(LogClass.ServiceAudio, $"Output buffer size {size} too small!");
 
@@ -44,7 +44,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
                 }
 
                 context.Memory.Write((ulong)position, buffer);
-                MemoryHelper.FillWithZeros(context.Memory, position + buffer.Length, AudioDeviceNameSize - buffer.Length);
+                MemoryHelper.FillWithZeros(context.Memory, position + (ulong)buffer.Length, AudioDeviceNameSize - buffer.Length);
 
                 position += AudioDeviceNameSize;
                 count++;
@@ -61,10 +61,10 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
         {
             float volume = context.RequestData.ReadSingle();
 
-            long position = context.Request.SendBuff[0].Position;
-            long size = context.Request.SendBuff[0].Size;
+            ulong position = context.Request.SendBuff[0].Position;
+            ulong size = context.Request.SendBuff[0].Size;
 
-            string deviceName = MemoryHelper.ReadAsciiString(context.Memory, position, size);
+            string deviceName = MemoryHelper.ReadAsciiString(context.Memory, position, (long)size);
 
             return _impl.SetAudioDeviceOutputVolume(deviceName, volume);
         }
@@ -73,10 +73,10 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
         // GetAudioDeviceOutputVolume(buffer<bytes, 5> name) -> f32 volume
         public ResultCode GetAudioDeviceOutputVolume(ServiceCtx context)
         {
-            long position = context.Request.SendBuff[0].Position;
-            long size = context.Request.SendBuff[0].Size;
+            ulong position = context.Request.SendBuff[0].Position;
+            ulong size = context.Request.SendBuff[0].Size;
 
-            string deviceName = MemoryHelper.ReadAsciiString(context.Memory, position, size);
+            string deviceName = MemoryHelper.ReadAsciiString(context.Memory, position, (long)size);
 
             ResultCode result = _impl.GetAudioDeviceOutputVolume(deviceName, out float volume);
 
@@ -94,14 +94,14 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
         {
             string name = _impl.GetActiveAudioDeviceName();
 
-            long position = context.Request.ReceiveBuff[0].Position;
-            long size = context.Request.ReceiveBuff[0].Size;
+            ulong position = context.Request.ReceiveBuff[0].Position;
+            ulong size = context.Request.ReceiveBuff[0].Size;
 
             byte[] deviceNameBuffer = Encoding.ASCII.GetBytes(name + "\0");
 
-            if ((ulong)deviceNameBuffer.Length <= (ulong)size)
+            if ((ulong)deviceNameBuffer.Length <= size)
             {
-                context.Memory.Write((ulong)position, deviceNameBuffer);
+                context.Memory.Write(position, deviceNameBuffer);
             }
             else
             {
@@ -146,9 +146,9 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
         {
             string[] deviceNames = _impl.ListAudioDeviceName();
 
-            (long position, long size) = context.Request.GetBufferType0x22();
+            (ulong position, ulong size) = context.Request.GetBufferType0x22();
 
-            long basePosition = position;
+            ulong basePosition = position;
 
             int count = 0;
 
@@ -156,7 +156,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             {
                 byte[] buffer = Encoding.ASCII.GetBytes(name);
 
-                if ((position - basePosition) + buffer.Length > size)
+                if ((position - basePosition) + (ulong)buffer.Length > size)
                 {
                     Logger.Error?.Print(LogClass.ServiceAudio, $"Output buffer size {size} too small!");
 
@@ -164,7 +164,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
                 }
 
                 context.Memory.Write((ulong)position, buffer);
-                MemoryHelper.FillWithZeros(context.Memory, position + buffer.Length, AudioDeviceNameSize - buffer.Length);
+                MemoryHelper.FillWithZeros(context.Memory, position + (ulong)buffer.Length, AudioDeviceNameSize - buffer.Length);
 
                 position += AudioDeviceNameSize;
                 count++;
@@ -181,9 +181,9 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
         {
             float volume = context.RequestData.ReadSingle();
 
-            (long position, long size) = context.Request.GetBufferType0x21();
+            (ulong position, ulong size) = context.Request.GetBufferType0x21();
 
-            string deviceName = MemoryHelper.ReadAsciiString(context.Memory, position, size);
+            string deviceName = MemoryHelper.ReadAsciiString(context.Memory, position, (long)size);
 
             return _impl.SetAudioDeviceOutputVolume(deviceName, volume);
         }
@@ -192,9 +192,9 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
         // GetAudioDeviceOutputVolumeAuto(buffer<bytes, 0x21> name) -> f32
         public ResultCode GetAudioDeviceOutputVolumeAuto(ServiceCtx context)
         {
-            (long position, long size) = context.Request.GetBufferType0x21();
+            (ulong position, ulong size) = context.Request.GetBufferType0x21();
 
-            string deviceName = MemoryHelper.ReadAsciiString(context.Memory, position, size);
+            string deviceName = MemoryHelper.ReadAsciiString(context.Memory, position, (long)size);
 
             ResultCode result = _impl.GetAudioDeviceOutputVolume(deviceName, out float volume);
 
@@ -212,13 +212,13 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
         {
             string name = _impl.GetActiveAudioDeviceName();
 
-            (long position, long size) = context.Request.GetBufferType0x22();
+            (ulong position, ulong size) = context.Request.GetBufferType0x22();
 
             byte[] deviceNameBuffer = Encoding.UTF8.GetBytes(name + '\0');
 
-            if ((ulong)deviceNameBuffer.Length <= (ulong)size)
+            if ((ulong)deviceNameBuffer.Length <= size)
             {
-                context.Memory.Write((ulong)position, deviceNameBuffer);
+                context.Memory.Write(position, deviceNameBuffer);
             }
             else
             {
@@ -268,10 +268,10 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
         // GetAudioSystemMasterVolumeSetting(buffer<bytes, 5> name) -> f32
         public ResultCode GetAudioSystemMasterVolumeSetting(ServiceCtx context)
         {
-            long position = context.Request.SendBuff[0].Position;
-            long size = context.Request.SendBuff[0].Size;
+            ulong position = context.Request.SendBuff[0].Position;
+            ulong size = context.Request.SendBuff[0].Size;
 
-            string deviceName = MemoryHelper.ReadAsciiString(context.Memory, position, size);
+            string deviceName = MemoryHelper.ReadAsciiString(context.Memory, position, (long)size);
 
             ResultCode result = _impl.GetAudioSystemMasterVolumeSetting(deviceName, out float systemMasterVolume);
 

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/AudioDeviceServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/AudioDeviceServer.cs
@@ -43,7 +43,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
                     break;
                 }
 
-                context.Memory.Write((ulong)position, buffer);
+                context.Memory.Write(position, buffer);
                 MemoryHelper.FillWithZeros(context.Memory, position + (ulong)buffer.Length, AudioDeviceNameSize - buffer.Length);
 
                 position += AudioDeviceNameSize;
@@ -163,7 +163,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
                     break;
                 }
 
-                context.Memory.Write((ulong)position, buffer);
+                context.Memory.Write(position, buffer);
                 MemoryHelper.FillWithZeros(context.Memory, position + (ulong)buffer.Length, AudioDeviceNameSize - buffer.Length);
 
                 position += AudioDeviceNameSize;

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/AudioRendererServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/AudioRendererServer.cs
@@ -57,16 +57,16 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
         // -> (buffer<nn::audio::detail::AudioRendererUpdateDataHeader, 6> output, buffer<nn::audio::detail::AudioRendererUpdateDataHeader, 6> performanceOutput)
         public ResultCode RequestUpdate(ServiceCtx context)
         {
-            long inputPosition = context.Request.SendBuff[0].Position;
-            long inputSize = context.Request.SendBuff[0].Size;
+            ulong inputPosition = context.Request.SendBuff[0].Position;
+            ulong inputSize = context.Request.SendBuff[0].Size;
 
-            long outputPosition = context.Request.ReceiveBuff[0].Position;
-            long outputSize = context.Request.ReceiveBuff[0].Size;
+            ulong outputPosition = context.Request.ReceiveBuff[0].Position;
+            ulong outputSize = context.Request.ReceiveBuff[0].Size;
 
-            long performanceOutputPosition = context.Request.ReceiveBuff[1].Position;
-            long performanceOutputSize = context.Request.ReceiveBuff[1].Size;
+            ulong performanceOutputPosition = context.Request.ReceiveBuff[1].Position;
+            ulong performanceOutputSize = context.Request.ReceiveBuff[1].Size;
 
-            ReadOnlyMemory<byte> input = context.Memory.GetSpan((ulong)inputPosition, (int)inputSize).ToArray();
+            ReadOnlyMemory<byte> input = context.Memory.GetSpan(inputPosition, (int)inputSize).ToArray();
 
             Memory<byte> output = new byte[outputSize];
             Memory<byte> performanceOutput = new byte[performanceOutputSize];
@@ -78,8 +78,8 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
 
             if (result == ResultCode.Success)
             {
-                context.Memory.Write((ulong)outputPosition, output.Span);
-                context.Memory.Write((ulong)performanceOutputPosition, performanceOutput.Span);
+                context.Memory.Write(outputPosition, output.Span);
+                context.Memory.Write(performanceOutputPosition, performanceOutput.Span);
             }
             else
             {
@@ -149,11 +149,11 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
         // -> (buffer<nn::audio::detail::AudioRendererUpdateDataHeader, 0x22> output, buffer<nn::audio::detail::AudioRendererUpdateDataHeader, 0x22> performanceOutput)
         public ResultCode RequestUpdateAuto(ServiceCtx context)
         {
-            (long inputPosition, long inputSize) = context.Request.GetBufferType0x21();
-            (long outputPosition, long outputSize) = context.Request.GetBufferType0x22(0);
-            (long performanceOutputPosition, long performanceOutputSize) = context.Request.GetBufferType0x22(1);
+            (ulong inputPosition, ulong inputSize) = context.Request.GetBufferType0x21();
+            (ulong outputPosition, ulong outputSize) = context.Request.GetBufferType0x22(0);
+            (ulong performanceOutputPosition, ulong performanceOutputSize) = context.Request.GetBufferType0x22(1);
 
-            ReadOnlyMemory<byte> input = context.Memory.GetSpan((ulong)inputPosition, (int)inputSize).ToArray();
+            ReadOnlyMemory<byte> input = context.Memory.GetSpan(inputPosition, (int)inputSize).ToArray();
 
             Memory<byte> output = new byte[outputSize];
             Memory<byte> performanceOutput = new byte[performanceOutputSize];
@@ -165,8 +165,8 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
 
             if (result == ResultCode.Success)
             {
-                context.Memory.Write((ulong)outputPosition, output.Span);
-                context.Memory.Write((ulong)performanceOutputPosition, performanceOutput.Span);
+                context.Memory.Write(outputPosition, output.Span);
+                context.Memory.Write(performanceOutputPosition, performanceOutput.Span);
             }
 
             return result;

--- a/Ryujinx.HLE/HOS/Services/Audio/HardwareOpusDecoderManager/IHardwareOpusDecoder.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/HardwareOpusDecoderManager/IHardwareOpusDecoder.cs
@@ -106,18 +106,18 @@ namespace Ryujinx.HLE.HOS.Services.Audio.HardwareOpusDecoderManager
         {
             ResultCode result;
 
-            long inPosition     = context.Request.SendBuff[0].Position;
-            long inSize         = context.Request.SendBuff[0].Size;
-            long outputPosition = context.Request.ReceiveBuff[0].Position;
-            long outputSize     = context.Request.ReceiveBuff[0].Size;
+            ulong inPosition     = context.Request.SendBuff[0].Position;
+            ulong inSize         = context.Request.SendBuff[0].Size;
+            ulong outputPosition = context.Request.ReceiveBuff[0].Position;
+            ulong outputSize     = context.Request.ReceiveBuff[0].Size;
 
             byte[] buffer = new byte[inSize];
 
-            context.Memory.Read((ulong)inPosition, buffer);
+            context.Memory.Read(inPosition, buffer);
 
             using (BinaryReader inputStream = new BinaryReader(new MemoryStream(buffer)))
             {
-                result = DecodeInterleavedInternal(inputStream, out short[] outPcmData, outputSize, out uint outConsumed, out int outSamples);
+                result = DecodeInterleavedInternal(inputStream, out short[] outPcmData, (long)outputSize, out uint outConsumed, out int outSamples);
 
                 if (result == ResultCode.Success)
                 {
@@ -139,24 +139,24 @@ namespace Ryujinx.HLE.HOS.Services.Audio.HardwareOpusDecoderManager
         {
             ResultCode result;
 
-            long inPosition     = context.Request.SendBuff[0].Position;
-            long inSize         = context.Request.SendBuff[0].Size;
-            long outputPosition = context.Request.ReceiveBuff[0].Position;
-            long outputSize     = context.Request.ReceiveBuff[0].Size;
+            ulong inPosition     = context.Request.SendBuff[0].Position;
+            ulong inSize         = context.Request.SendBuff[0].Size;
+            ulong outputPosition = context.Request.ReceiveBuff[0].Position;
+            ulong outputSize     = context.Request.ReceiveBuff[0].Size;
 
             byte[] buffer = new byte[inSize];
 
-            context.Memory.Read((ulong)inPosition, buffer);
+            context.Memory.Read(inPosition, buffer);
 
             using (BinaryReader inputStream = new BinaryReader(new MemoryStream(buffer)))
             {
-                result = DecodeInterleavedInternal(inputStream, out short[] outPcmData, outputSize, out uint outConsumed, out int outSamples);
+                result = DecodeInterleavedInternal(inputStream, out short[] outPcmData, (long)outputSize, out uint outConsumed, out int outSamples);
 
                 if (result == ResultCode.Success)
                 {
                     byte[] pcmDataBytes = new byte[outPcmData.Length * sizeof(short)];
                     Buffer.BlockCopy(outPcmData, 0, pcmDataBytes, 0, pcmDataBytes.Length);
-                    context.Memory.Write((ulong)outputPosition, pcmDataBytes);
+                    context.Memory.Write(outputPosition, pcmDataBytes);
 
                     context.ResponseData.Write(outConsumed);
                     context.ResponseData.Write(outSamples);
@@ -177,24 +177,24 @@ namespace Ryujinx.HLE.HOS.Services.Audio.HardwareOpusDecoderManager
 
             _reset = context.RequestData.ReadBoolean();
 
-            long inPosition     = context.Request.SendBuff[0].Position;
-            long inSize         = context.Request.SendBuff[0].Size;
-            long outputPosition = context.Request.ReceiveBuff[0].Position;
-            long outputSize     = context.Request.ReceiveBuff[0].Size;
+            ulong inPosition     = context.Request.SendBuff[0].Position;
+            ulong inSize         = context.Request.SendBuff[0].Size;
+            ulong outputPosition = context.Request.ReceiveBuff[0].Position;
+            ulong outputSize     = context.Request.ReceiveBuff[0].Size;
 
             byte[] buffer = new byte[inSize];
 
-            context.Memory.Read((ulong)inPosition, buffer);
+            context.Memory.Read(inPosition, buffer);
 
             using (BinaryReader inputStream = new BinaryReader(new MemoryStream(buffer)))
             {
-                result = DecodeInterleavedInternal(inputStream, out short[] outPcmData, outputSize, out uint outConsumed, out int outSamples);
+                result = DecodeInterleavedInternal(inputStream, out short[] outPcmData, (long)outputSize, out uint outConsumed, out int outSamples);
 
                 if (result == ResultCode.Success)
                 {
                     byte[] pcmDataBytes = new byte[outPcmData.Length * sizeof(short)];
                     Buffer.BlockCopy(outPcmData, 0, pcmDataBytes, 0, pcmDataBytes.Length);
-                    context.Memory.Write((ulong)outputPosition, pcmDataBytes);
+                    context.Memory.Write(outputPosition, pcmDataBytes);
 
                     context.ResponseData.Write(outConsumed);
                     context.ResponseData.Write(outSamples);
@@ -215,24 +215,24 @@ namespace Ryujinx.HLE.HOS.Services.Audio.HardwareOpusDecoderManager
 
             _reset = context.RequestData.ReadBoolean();
 
-            long inPosition     = context.Request.SendBuff[0].Position;
-            long inSize         = context.Request.SendBuff[0].Size;
-            long outputPosition = context.Request.ReceiveBuff[0].Position;
-            long outputSize     = context.Request.ReceiveBuff[0].Size;
+            ulong inPosition     = context.Request.SendBuff[0].Position;
+            ulong inSize         = context.Request.SendBuff[0].Size;
+            ulong outputPosition = context.Request.ReceiveBuff[0].Position;
+            ulong outputSize     = context.Request.ReceiveBuff[0].Size;
 
             byte[] buffer = new byte[inSize];
 
-            context.Memory.Read((ulong)inPosition, buffer);
+            context.Memory.Read(inPosition, buffer);
 
             using (BinaryReader inputStream = new BinaryReader(new MemoryStream(buffer)))
             {
-                result = DecodeInterleavedInternal(inputStream, out short[] outPcmData, outputSize, out uint outConsumed, out int outSamples);
+                result = DecodeInterleavedInternal(inputStream, out short[] outPcmData, (long)outputSize, out uint outConsumed, out int outSamples);
 
                 if (result == ResultCode.Success)
                 {
                     byte[] pcmDataBytes = new byte[outPcmData.Length * sizeof(short)];
                     Buffer.BlockCopy(outPcmData, 0, pcmDataBytes, 0, pcmDataBytes.Length);
-                    context.Memory.Write((ulong)outputPosition, pcmDataBytes);
+                    context.Memory.Write(outputPosition, pcmDataBytes);
 
                     context.ResponseData.Write(outConsumed);
                     context.ResponseData.Write(outSamples);

--- a/Ryujinx.HLE/HOS/Services/Audio/HardwareOpusDecoderManager/IHardwareOpusDecoder.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/HardwareOpusDecoderManager/IHardwareOpusDecoder.cs
@@ -123,7 +123,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.HardwareOpusDecoderManager
                 {
                     byte[] pcmDataBytes = new byte[outPcmData.Length * sizeof(short)];
                     Buffer.BlockCopy(outPcmData, 0, pcmDataBytes, 0, pcmDataBytes.Length);
-                    context.Memory.Write((ulong)outputPosition, pcmDataBytes);
+                    context.Memory.Write(outputPosition, pcmDataBytes);
 
                     context.ResponseData.Write(outConsumed);
                     context.ResponseData.Write(outSamples);

--- a/Ryujinx.HLE/HOS/Services/Bcat/ServiceCreator/IDeliveryCacheDirectoryService.cs
+++ b/Ryujinx.HLE/HOS/Services/Bcat/ServiceCreator/IDeliveryCacheDirectoryService.cs
@@ -30,14 +30,14 @@ namespace Ryujinx.HLE.HOS.Services.Bcat.ServiceCreator
         // Read() -> (u32, buffer<nn::bcat::DeliveryCacheDirectoryEntry, 6>)
         public ResultCode Read(ServiceCtx context)
         {
-            long position = context.Request.ReceiveBuff[0].Position;
-            long size = context.Request.ReceiveBuff[0].Size;
+            ulong position = context.Request.ReceiveBuff[0].Position;
+            ulong size = context.Request.ReceiveBuff[0].Size;
 
             byte[] data = new byte[size];
 
             Result result = _base.Read(out int entriesRead, MemoryMarshal.Cast<byte, DeliveryCacheDirectoryEntry>(data));
 
-            context.Memory.Write((ulong)position, data);
+            context.Memory.Write(position, data);
 
             context.ResponseData.Write(entriesRead);
 

--- a/Ryujinx.HLE/HOS/Services/Bcat/ServiceCreator/IDeliveryCacheFileService.cs
+++ b/Ryujinx.HLE/HOS/Services/Bcat/ServiceCreator/IDeliveryCacheFileService.cs
@@ -30,8 +30,8 @@ namespace Ryujinx.HLE.HOS.Services.Bcat.ServiceCreator
         // Read(u64) -> (u64, buffer<bytes, 6>)
         public ResultCode Read(ServiceCtx context)
         {
-            long position = context.Request.ReceiveBuff[0].Position;
-            long size = context.Request.ReceiveBuff[0].Size;
+            ulong position = context.Request.ReceiveBuff[0].Position;
+            ulong size = context.Request.ReceiveBuff[0].Size;
 
             long offset = context.RequestData.ReadInt64();
 
@@ -39,7 +39,7 @@ namespace Ryujinx.HLE.HOS.Services.Bcat.ServiceCreator
 
             Result result = _base.Read(out long bytesRead, offset, data);
 
-            context.Memory.Write((ulong)position, data);
+            context.Memory.Write(position, data);
 
             context.ResponseData.Write(bytesRead);
 

--- a/Ryujinx.HLE/HOS/Services/Bcat/ServiceCreator/IDeliveryCacheProgressService.cs
+++ b/Ryujinx.HLE/HOS/Services/Bcat/ServiceCreator/IDeliveryCacheProgressService.cs
@@ -49,7 +49,7 @@ namespace Ryujinx.HLE.HOS.Services.Bcat.ServiceCreator
                 Result = 0
             };
 
-            long dcpSize = WriteDeliveryCacheProgressImpl(context, context.Request.RecvListBuff[0], deliveryCacheProgress);
+            ulong dcpSize = WriteDeliveryCacheProgressImpl(context, context.Request.RecvListBuff[0], deliveryCacheProgress);
             context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize(dcpSize);
 
             Logger.Stub?.PrintStub(LogClass.ServiceBcat);
@@ -57,7 +57,7 @@ namespace Ryujinx.HLE.HOS.Services.Bcat.ServiceCreator
             return ResultCode.Success;
         }
 
-        private long WriteDeliveryCacheProgressImpl(ServiceCtx context, IpcRecvListBuffDesc ipcDesc, DeliveryCacheProgressImpl deliveryCacheProgress)
+        private ulong WriteDeliveryCacheProgressImpl(ServiceCtx context, IpcRecvListBuffDesc ipcDesc, DeliveryCacheProgressImpl deliveryCacheProgress)
         {
             return MemoryHelper.Write(context.Memory, ipcDesc.Position, deliveryCacheProgress);
         }

--- a/Ryujinx.HLE/HOS/Services/Bcat/ServiceCreator/IDeliveryCacheStorageService.cs
+++ b/Ryujinx.HLE/HOS/Services/Bcat/ServiceCreator/IDeliveryCacheStorageService.cs
@@ -46,14 +46,14 @@ namespace Ryujinx.HLE.HOS.Services.Bcat.ServiceCreator
         // EnumerateDeliveryCacheDirectory() -> (u32, buffer<nn::bcat::DirectoryName, 6>)
         public ResultCode EnumerateDeliveryCacheDirectory(ServiceCtx context)
         {
-            long position = context.Request.ReceiveBuff[0].Position;
-            long size = context.Request.ReceiveBuff[0].Size;
+            ulong position = context.Request.ReceiveBuff[0].Position;
+            ulong size = context.Request.ReceiveBuff[0].Size;
 
             byte[] data = new byte[size];
 
             Result result = _base.EnumerateDeliveryCacheDirectory(out int count, MemoryMarshal.Cast<byte, DirectoryName>(data));
 
-            context.Memory.Write((ulong)position, data);
+            context.Memory.Write(position, data);
 
             context.ResponseData.Write(count);
 

--- a/Ryujinx.HLE/HOS/Services/Caps/IScreenShotApplicationService.cs
+++ b/Ryujinx.HLE/HOS/Services/Caps/IScreenShotApplicationService.cs
@@ -26,8 +26,8 @@ namespace Ryujinx.HLE.HOS.Services.Caps
             ulong appletResourceUserId = context.RequestData.ReadUInt64();
             ulong pidPlaceholder       = context.RequestData.ReadUInt64();
 
-            long screenshotDataPosition = context.Request.SendBuff[0].Position;
-            long screenshotDataSize     = context.Request.SendBuff[0].Size;
+            ulong screenshotDataPosition = context.Request.SendBuff[0].Position;
+            ulong screenshotDataSize     = context.Request.SendBuff[0].Size;
 
             byte[] screenshotData = context.Memory.GetSpan((ulong)screenshotDataPosition, (int)screenshotDataSize, true).ToArray();
 
@@ -49,16 +49,16 @@ namespace Ryujinx.HLE.HOS.Services.Caps
             ulong appletResourceUserId = context.RequestData.ReadUInt64();
             ulong pidPlaceholder       = context.RequestData.ReadUInt64();
 
-            long applicationDataPosition = context.Request.SendBuff[0].Position;
-            long applicationDataSize     = context.Request.SendBuff[0].Size;
+            ulong applicationDataPosition = context.Request.SendBuff[0].Position;
+            ulong applicationDataSize     = context.Request.SendBuff[0].Size;
 
-            long screenshotDataPosition = context.Request.SendBuff[1].Position;
-            long screenshotDataSize     = context.Request.SendBuff[1].Size;
+            ulong screenshotDataPosition = context.Request.SendBuff[1].Position;
+            ulong screenshotDataSize     = context.Request.SendBuff[1].Size;
 
             // TODO: Parse the application data: At 0x00 it's UserData (Size of 0x400), at 0x404 it's a uint UserDataSize (Always empty for now).
-            byte[] applicationData = context.Memory.GetSpan((ulong)applicationDataPosition, (int)applicationDataSize).ToArray();
+            byte[] applicationData = context.Memory.GetSpan(applicationDataPosition, (int)applicationDataSize).ToArray();
 
-            byte[] screenshotData = context.Memory.GetSpan((ulong)screenshotDataPosition, (int)screenshotDataSize, true).ToArray();
+            byte[] screenshotData = context.Memory.GetSpan(screenshotDataPosition, (int)screenshotDataSize, true).ToArray();
 
             ResultCode resultCode = context.Device.System.CaptureManager.SaveScreenShot(screenshotData, appletResourceUserId, context.Device.Application.TitleId, out ApplicationAlbumEntry applicationAlbumEntry);
 
@@ -77,11 +77,11 @@ namespace Ryujinx.HLE.HOS.Services.Caps
             uint  unknown              = context.RequestData.ReadUInt32();
             ulong appletResourceUserId = context.RequestData.ReadUInt64();
 
-            long userIdListPosition = context.Request.SendBuff[0].Position;
-            long userIdListSize     = context.Request.SendBuff[0].Size;
+            ulong userIdListPosition = context.Request.SendBuff[0].Position;
+            ulong userIdListSize     = context.Request.SendBuff[0].Size;
 
-            long screenshotDataPosition = context.Request.SendBuff[1].Position;
-            long screenshotDataSize     = context.Request.SendBuff[1].Size;
+            ulong screenshotDataPosition = context.Request.SendBuff[1].Position;
+            ulong screenshotDataSize     = context.Request.SendBuff[1].Size;
 
             // TODO: Parse the UserIdList.
             byte[] userIdList = context.Memory.GetSpan((ulong)userIdListPosition, (int)userIdListSize).ToArray();

--- a/Ryujinx.HLE/HOS/Services/Caps/IScreenShotApplicationService.cs
+++ b/Ryujinx.HLE/HOS/Services/Caps/IScreenShotApplicationService.cs
@@ -29,7 +29,7 @@ namespace Ryujinx.HLE.HOS.Services.Caps
             ulong screenshotDataPosition = context.Request.SendBuff[0].Position;
             ulong screenshotDataSize     = context.Request.SendBuff[0].Size;
 
-            byte[] screenshotData = context.Memory.GetSpan((ulong)screenshotDataPosition, (int)screenshotDataSize, true).ToArray();
+            byte[] screenshotData = context.Memory.GetSpan(screenshotDataPosition, (int)screenshotDataSize, true).ToArray();
 
             ResultCode resultCode = context.Device.System.CaptureManager.SaveScreenShot(screenshotData, appletResourceUserId, context.Device.Application.TitleId, out ApplicationAlbumEntry applicationAlbumEntry);
 
@@ -84,9 +84,9 @@ namespace Ryujinx.HLE.HOS.Services.Caps
             ulong screenshotDataSize     = context.Request.SendBuff[1].Size;
 
             // TODO: Parse the UserIdList.
-            byte[] userIdList = context.Memory.GetSpan((ulong)userIdListPosition, (int)userIdListSize).ToArray();
+            byte[] userIdList = context.Memory.GetSpan(userIdListPosition, (int)userIdListSize).ToArray();
 
-            byte[] screenshotData = context.Memory.GetSpan((ulong)screenshotDataPosition, (int)screenshotDataSize, true).ToArray();
+            byte[] screenshotData = context.Memory.GetSpan(screenshotDataPosition, (int)screenshotDataSize, true).ToArray();
 
             ResultCode resultCode = context.Device.System.CaptureManager.SaveScreenShot(screenshotData, appletResourceUserId, context.Device.Application.TitleId, out ApplicationAlbumEntry applicationAlbumEntry);
 

--- a/Ryujinx.HLE/HOS/Services/Friend/ServiceCreator/IFriendService.cs
+++ b/Ryujinx.HLE/HOS/Services/Friend/ServiceCreator/IFriendService.cs
@@ -190,12 +190,12 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
             // Pid placeholder
             context.RequestData.ReadInt64();
 
-            long position = context.Request.PtrBuff[0].Position;
-            long size     = context.Request.PtrBuff[0].Size;
+            ulong position = context.Request.PtrBuff[0].Position;
+            ulong size     = context.Request.PtrBuff[0].Size;
 
             byte[] bufferContent = new byte[size];
 
-            context.Memory.Read((ulong)position, bufferContent);
+            context.Memory.Read(position, bufferContent);
 
             if (uuid.IsNull)
             {
@@ -221,9 +221,9 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
             bool   unknownBool = context.RequestData.ReadBoolean();
             UserId userId      = context.RequestData.ReadStruct<UserId>();
 
-            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize(0x40L);
+            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize(0x40UL);
 
-            long bufferPosition  = context.Request.RecvListBuff[0].Position;
+            ulong bufferPosition  = context.Request.RecvListBuff[0].Position;
 
             if (userId.IsNull)
             {
@@ -271,8 +271,8 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
 
             */
 
-            context.Memory.Write((ulong)bufferPosition,        playHistoryRegistrationKeyBuffer);
-            context.Memory.Write((ulong)bufferPosition + 0x20, new byte[0x20]); // HmacHash
+            context.Memory.Write(bufferPosition,        playHistoryRegistrationKeyBuffer);
+            context.Memory.Write(bufferPosition + 0x20, new byte[0x20]); // HmacHash
 
             return ResultCode.Success;
         }
@@ -287,14 +287,14 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
             context.RequestData.ReadInt64();
             long pid = context.Process.Pid;
 
-            long playHistoryRegistrationKeyPosition = context.Request.PtrBuff[0].Position;
-            long PlayHistoryRegistrationKeySize     = context.Request.PtrBuff[0].Size;
+            ulong playHistoryRegistrationKeyPosition = context.Request.PtrBuff[0].Position;
+            ulong PlayHistoryRegistrationKeySize     = context.Request.PtrBuff[0].Size;
 
-            long inAppScreenName1Position = context.Request.PtrBuff[1].Position;
-            long inAppScreenName1Size     = context.Request.PtrBuff[1].Size;
+            ulong inAppScreenName1Position = context.Request.PtrBuff[1].Position;
+            ulong inAppScreenName1Size     = context.Request.PtrBuff[1].Size;
 
-            long inAppScreenName2Position = context.Request.PtrBuff[2].Position;
-            long inAppScreenName2Size     = context.Request.PtrBuff[2].Size;
+            ulong inAppScreenName2Position = context.Request.PtrBuff[2].Position;
+            ulong inAppScreenName2Size     = context.Request.PtrBuff[2].Size;
 
             if (userId.IsNull || inAppScreenName1Size > 0x48 || inAppScreenName2Size > 0x48)
             {

--- a/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/FileSystemProxyHelper.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/FileSystemProxyHelper.cs
@@ -116,12 +116,12 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
 
         public static Result ReadFsPath(out FsPath path, ServiceCtx context, int index = 0)
         {
-            long position = context.Request.PtrBuff[index].Position;
-            long size     = context.Request.PtrBuff[index].Size;
+            ulong position = context.Request.PtrBuff[index].Position;
+            ulong size     = context.Request.PtrBuff[index].Size;
 
             byte[] pathBytes = new byte[size];
 
-            context.Memory.Read((ulong)position, pathBytes);
+            context.Memory.Read(position, pathBytes);
 
             return FsPath.FromSpan(out path, pathBytes);
         }

--- a/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IDirectory.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IDirectory.cs
@@ -18,15 +18,15 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
         // Read() -> (u64 count, buffer<nn::fssrv::sf::IDirectoryEntry, 6, 0> entries)
         public ResultCode Read(ServiceCtx context)
         {
-            long bufferPosition = context.Request.ReceiveBuff[0].Position;
-            long bufferLen      = context.Request.ReceiveBuff[0].Size;
+            ulong bufferPosition = context.Request.ReceiveBuff[0].Position;
+            ulong bufferLen      = context.Request.ReceiveBuff[0].Size;
 
             byte[]               entriesBytes = new byte[bufferLen];
             Span<DirectoryEntry> entries      = MemoryMarshal.Cast<byte, DirectoryEntry>(entriesBytes);
 
             Result result = _baseDirectory.Read(out long entriesRead, entries);
 
-            context.Memory.Write((ulong)bufferPosition, entriesBytes);
+            context.Memory.Write(bufferPosition, entriesBytes);
             context.ResponseData.Write(entriesRead);
 
             return (ResultCode)result.Value;

--- a/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IFile.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IFile.cs
@@ -17,7 +17,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
         // Read(u32 readOption, u64 offset, u64 size) -> (u64 out_size, buffer<u8, 0x46, 0> out_buf)
         public ResultCode Read(ServiceCtx context)
         {
-            long position = context.Request.ReceiveBuff[0].Position;
+            ulong position = context.Request.ReceiveBuff[0].Position;
 
             ReadOption readOption = new ReadOption(context.RequestData.ReadInt32());
             context.RequestData.BaseStream.Position += 4;
@@ -29,7 +29,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
 
             Result result = _baseFile.Read(out long bytesRead, offset, data, readOption);
 
-            context.Memory.Write((ulong)position, data);
+            context.Memory.Write(position, data);
 
             context.ResponseData.Write(bytesRead);
 
@@ -40,7 +40,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
         // Write(u32 writeOption, u64 offset, u64 size, buffer<u8, 0x45, 0>)
         public ResultCode Write(ServiceCtx context)
         {
-            long position = context.Request.SendBuff[0].Position;
+            ulong position = context.Request.SendBuff[0].Position;
 
             WriteOption writeOption = new WriteOption(context.RequestData.ReadInt32());
             context.RequestData.BaseStream.Position += 4;
@@ -50,7 +50,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
 
             byte[] data = new byte[size];
 
-            context.Memory.Read((ulong)position, data);
+            context.Memory.Read(position, data);
 
             return (ResultCode)_baseFile.Write(offset, data, writeOption).Value;
         }

--- a/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IStorage.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IStorage.cs
@@ -17,8 +17,8 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
         // Read(u64 offset, u64 length) -> buffer<u8, 0x46, 0> buffer
         public ResultCode Read(ServiceCtx context)
         {
-            long offset = context.RequestData.ReadInt64();
-            long size   = context.RequestData.ReadInt64();
+            ulong offset = context.RequestData.ReadUInt64();
+            ulong size   = context.RequestData.ReadUInt64();
 
             if (context.Request.ReceiveBuff.Count > 0)
             {
@@ -32,9 +32,9 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
 
                 byte[] data = new byte[size];
 
-                Result result = _baseStorage.Read(offset, data);
+                Result result = _baseStorage.Read((long)offset, data);
 
-                context.Memory.Write((ulong)buffDesc.Position, data);
+                context.Memory.Write(buffDesc.Position, data);
 
                 return (ResultCode)result.Value;
             }

--- a/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
@@ -38,7 +38,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
         public ResultCode OpenFileSystemWithId(ServiceCtx context)
         {
             FileSystemType fileSystemType = (FileSystemType)context.RequestData.ReadInt32();
-            long titleId = context.RequestData.ReadInt64();
+            ulong titleId = context.RequestData.ReadUInt64();
             string switchPath = ReadUtf8String(context);
             string fullPath = context.Device.FileSystem.SwitchPathToSystemPath(switchPath);
 
@@ -392,7 +392,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
         {
             StorageId storageId = (StorageId)context.RequestData.ReadByte();
             byte[] padding = context.RequestData.ReadBytes(7);
-            long titleId = context.RequestData.ReadInt64();
+            ulong titleId = context.RequestData.ReadUInt64();
 
             // We do a mitm here to find if the request is for an AOC.
             // This is because AOC can be distributed over multiple containers in the emulator.

--- a/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
@@ -337,14 +337,14 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             SaveDataSpaceId spaceId = (SaveDataSpaceId)context.RequestData.ReadInt64();
             SaveDataFilter filter = context.RequestData.ReadStruct<SaveDataFilter>();
 
-            long bufferPosition = context.Request.ReceiveBuff[0].Position;
-            long bufferLen = context.Request.ReceiveBuff[0].Size;
+            ulong bufferPosition = context.Request.ReceiveBuff[0].Position;
+            ulong bufferLen = context.Request.ReceiveBuff[0].Size;
 
             byte[] infoBuffer = new byte[bufferLen];
 
             Result result = _baseFileSystemProxy.FindSaveDataWithFilter(out long count, infoBuffer, spaceId, ref filter);
 
-            context.Memory.Write((ulong)bufferPosition, infoBuffer);
+            context.Memory.Write(bufferPosition, infoBuffer);
             context.ResponseData.Write(count);
 
             return (ResultCode)result.Value;

--- a/Ryujinx.HLE/HOS/Services/Fs/ISaveDataInfoReader.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/ISaveDataInfoReader.cs
@@ -16,14 +16,14 @@ namespace Ryujinx.HLE.HOS.Services.Fs
         // ReadSaveDataInfo() -> (u64, buffer<unknown, 6>)
         public ResultCode ReadSaveDataInfo(ServiceCtx context)
         {
-            long bufferPosition = context.Request.ReceiveBuff[0].Position;
-            long bufferLen      = context.Request.ReceiveBuff[0].Size;
+            ulong bufferPosition = context.Request.ReceiveBuff[0].Position;
+            ulong bufferLen      = context.Request.ReceiveBuff[0].Size;
 
             byte[] infoBuffer = new byte[bufferLen];
 
             Result result = _baseReader.Target.Read(out long readCount, infoBuffer);
 
-            context.Memory.Write((ulong)bufferPosition, infoBuffer);
+            context.Memory.Write(bufferPosition, infoBuffer);
             context.ResponseData.Write(readCount);
 
             return (ResultCode)result.Value;

--- a/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
@@ -1005,11 +1005,11 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             byte[] vibrationDeviceHandleBuffer = new byte[context.Request.PtrBuff[0].Size];
 
-            context.Memory.Read((ulong)context.Request.PtrBuff[0].Position, vibrationDeviceHandleBuffer);
+            context.Memory.Read(context.Request.PtrBuff[0].Position, vibrationDeviceHandleBuffer);
 
             byte[] vibrationValueBuffer = new byte[context.Request.PtrBuff[1].Size];
 
-            context.Memory.Read((ulong)context.Request.PtrBuff[1].Position, vibrationValueBuffer);
+            context.Memory.Read(context.Request.PtrBuff[1].Position, vibrationValueBuffer);
 
             // TODO: Read all handles and values from buffer.
 

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/Npad/NpadIdType.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/Npad/NpadIdType.cs
@@ -1,6 +1,6 @@
 ﻿namespace Ryujinx.HLE.HOS.Services.Hid
 {
-    public enum NpadIdType
+    public enum NpadIdType : uint
     {
         Player1  = 0,
         Player2  = 1,

--- a/Ryujinx.HLE/HOS/Services/Lm/LogService/ILogger.cs
+++ b/Ryujinx.HLE/HOS/Services/Lm/LogService/ILogger.cs
@@ -19,11 +19,11 @@ namespace Ryujinx.HLE.HOS.Services.Lm.LogService
 
         private string LogImpl(ServiceCtx context)
         {
-            (long bufPos, long bufSize) = context.Request.GetBufferType0x21();
+            (ulong bufPos, ulong bufSize) = context.Request.GetBufferType0x21();
 
             byte[] logBuffer = new byte[bufSize];
 
-            context.Memory.Read((ulong)bufPos, logBuffer);
+            context.Memory.Read(bufPos, logBuffer);
 
             using MemoryStream ms = new MemoryStream(logBuffer);
 

--- a/Ryujinx.HLE/HOS/Services/Mii/StaticService/IDatabaseService.cs
+++ b/Ryujinx.HLE/HOS/Services/Mii/StaticService/IDatabaseService.cs
@@ -261,7 +261,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.StaticService
 
             ResultCode result = Export(data);
 
-            context.Memory.Write((ulong)outputBuffer.Position, data.ToArray());
+            context.Memory.Write(outputBuffer.Position, data.ToArray());
 
             return result;
         }
@@ -352,7 +352,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.StaticService
             {
                 rawData = new byte[ipcBuff.Size];
 
-                context.Memory.Read((ulong)ipcBuff.Position, rawData);
+                context.Memory.Read(ipcBuff.Position, rawData);
             }
 
             return new Span<byte>(rawData);
@@ -367,7 +367,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.StaticService
         {
             Span<byte> rawData = MemoryMarshal.Cast<T, byte>(span);
 
-            context.Memory.Write((ulong)ipcBuff.Position, rawData);
+            context.Memory.Write(ipcBuff.Position, rawData);
         }
 
         protected abstract bool IsUpdated(SourceFlag flag);

--- a/Ryujinx.HLE/HOS/Services/Ncm/Lr/LocationResolverManager/ILocationResolver.cs
+++ b/Ryujinx.HLE/HOS/Services/Ncm/Lr/LocationResolverManager/ILocationResolver.cs
@@ -17,10 +17,10 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
         }
 
         [CommandHipc(0)]
-        // ResolveProgramPath()
+        // ResolveProgramPath(u64 titleId)
         public ResultCode ResolveProgramPath(ServiceCtx context)
         {
-            long titleId = context.RequestData.ReadInt64();
+            ulong titleId = context.RequestData.ReadUInt64();
 
             if (ResolvePath(context, titleId, NcaContentType.Program))
             {
@@ -33,10 +33,10 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
         }
 
         [CommandHipc(1)]
-        // RedirectProgramPath()
+        // RedirectProgramPath(u64 titleId)
         public ResultCode RedirectProgramPath(ServiceCtx context)
         {
-            long titleId = context.RequestData.ReadInt64();
+            ulong titleId = context.RequestData.ReadUInt64();
 
             RedirectPath(context, titleId, 0, NcaContentType.Program);
 
@@ -44,10 +44,10 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
         }
 
         [CommandHipc(2)]
-        // ResolveApplicationControlPath()
+        // ResolveApplicationControlPath(u64 titleId)
         public ResultCode ResolveApplicationControlPath(ServiceCtx context)
         {
-            long titleId = context.RequestData.ReadInt64();
+            ulong titleId = context.RequestData.ReadUInt64();
 
             if (ResolvePath(context, titleId, NcaContentType.Control))
             {
@@ -60,10 +60,10 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
         }
 
         [CommandHipc(3)]
-        // ResolveApplicationHtmlDocumentPath()
+        // ResolveApplicationHtmlDocumentPath(u64 titleId)
         public ResultCode ResolveApplicationHtmlDocumentPath(ServiceCtx context)
         {
-            long titleId = context.RequestData.ReadInt64();
+            ulong titleId = context.RequestData.ReadUInt64();
 
             if (ResolvePath(context, titleId, NcaContentType.Manual))
             {
@@ -76,10 +76,10 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
         }
 
         [CommandHipc(4)]
-        // ResolveDataPath()
+        // ResolveDataPath(u64 titleId)
         public ResultCode ResolveDataPath(ServiceCtx context)
         {
-            long titleId = context.RequestData.ReadInt64();
+            ulong titleId = context.RequestData.ReadUInt64();
 
             if (ResolvePath(context, titleId, NcaContentType.Data) || ResolvePath(context, titleId, NcaContentType.PublicData))
             {
@@ -92,10 +92,10 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
         }
 
         [CommandHipc(5)]
-        // RedirectApplicationControlPath()
+        // RedirectApplicationControlPath(u64 titleId)
         public ResultCode RedirectApplicationControlPath(ServiceCtx context)
         {
-            long titleId = context.RequestData.ReadInt64();
+            ulong titleId = context.RequestData.ReadUInt64();
 
             RedirectPath(context, titleId, 1, NcaContentType.Control);
 
@@ -103,10 +103,10 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
         }
 
         [CommandHipc(6)]
-        // RedirectApplicationHtmlDocumentPath()
+        // RedirectApplicationHtmlDocumentPath(u64 titleId)
         public ResultCode RedirectApplicationHtmlDocumentPath(ServiceCtx context)
         {
-            long titleId = context.RequestData.ReadInt64();
+            ulong titleId = context.RequestData.ReadUInt64();
 
             RedirectPath(context, titleId, 1, NcaContentType.Manual);
 
@@ -114,10 +114,10 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
         }
 
         [CommandHipc(7)]
-        // ResolveApplicationLegalInformationPath()
+        // ResolveApplicationLegalInformationPath(u64 titleId)
         public ResultCode ResolveApplicationLegalInformationPath(ServiceCtx context)
         {
-            long titleId = context.RequestData.ReadInt64();
+            ulong titleId = context.RequestData.ReadUInt64();
 
             if (ResolvePath(context, titleId, NcaContentType.Manual))
             {
@@ -130,10 +130,10 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
         }
 
         [CommandHipc(8)]
-        // RedirectApplicationLegalInformationPath()
+        // RedirectApplicationLegalInformationPath(u64 titleId)
         public ResultCode RedirectApplicationLegalInformationPath(ServiceCtx context)
         {
-            long titleId = context.RequestData.ReadInt64();
+            ulong titleId = context.RequestData.ReadUInt64();
 
             RedirectPath(context, titleId, 1, NcaContentType.Manual);
 
@@ -150,10 +150,10 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
         }
 
         [CommandHipc(10)]
-        // SetProgramNcaPath2()
+        // SetProgramNcaPath2(u64 titleId)
         public ResultCode SetProgramNcaPath2(ServiceCtx context)
         {
-            long titleId = context.RequestData.ReadInt64();
+            ulong titleId = context.RequestData.ReadUInt64();
 
             RedirectPath(context, titleId, 1, NcaContentType.Program);
 
@@ -170,10 +170,10 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
         }
 
         [CommandHipc(12)]
-        // DeleteProgramNcaPath()
+        // DeleteProgramNcaPath(u64 titleId)
         public ResultCode DeleteProgramNcaPath(ServiceCtx context)
         {
-            long titleId = context.RequestData.ReadInt64();
+            ulong titleId = context.RequestData.ReadUInt64();
 
             DeleteContentPath(context, titleId, NcaContentType.Program);
 
@@ -181,10 +181,10 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
         }
 
         [CommandHipc(13)]
-        // DeleteControlNcaPath()
+        // DeleteControlNcaPath(u64 titleId)
         public ResultCode DeleteControlNcaPath(ServiceCtx context)
         {
-            long titleId = context.RequestData.ReadInt64();
+            ulong titleId = context.RequestData.ReadUInt64();
 
             DeleteContentPath(context, titleId, NcaContentType.Control);
 
@@ -192,10 +192,10 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
         }
 
         [CommandHipc(14)]
-        // DeleteDocHtmlNcaPath()
+        // DeleteDocHtmlNcaPath(u64 titleId)
         public ResultCode DeleteDocHtmlNcaPath(ServiceCtx context)
         {
-            long titleId = context.RequestData.ReadInt64();
+            ulong titleId = context.RequestData.ReadUInt64();
 
             DeleteContentPath(context, titleId, NcaContentType.Manual);
 
@@ -203,17 +203,17 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
         }
 
         [CommandHipc(15)]
-        // DeleteInfoHtmlNcaPath()
+        // DeleteInfoHtmlNcaPath(u64 titleId)
         public ResultCode DeleteInfoHtmlNcaPath(ServiceCtx context)
         {
-            long titleId = context.RequestData.ReadInt64();
+            ulong titleId = context.RequestData.ReadUInt64();
 
             DeleteContentPath(context, titleId, NcaContentType.Manual);
 
             return ResultCode.Success;
         }
 
-        private void RedirectPath(ServiceCtx context, long titleId, int flag, NcaContentType contentType)
+        private void RedirectPath(ServiceCtx context, ulong titleId, int flag, NcaContentType contentType)
         {
             string        contentPath = ReadUtf8String(context);
             LocationEntry newLocation = new LocationEntry(contentPath, flag, titleId, contentType);
@@ -221,7 +221,7 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
             context.Device.System.ContentManager.RedirectLocation(newLocation, _storageId);
         }
 
-        private bool ResolvePath(ServiceCtx context, long titleId, NcaContentType contentType)
+        private bool ResolvePath(ServiceCtx context, ulong titleId, NcaContentType contentType)
         {
             ContentManager contentManager = context.Device.System.ContentManager;
             string         contentPath    = contentManager.GetInstalledContentPath(titleId, _storageId, NcaContentType.Program);
@@ -243,7 +243,7 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
             return true;
         }
 
-        private void DeleteContentPath(ServiceCtx context, long titleId, NcaContentType contentType)
+        private void DeleteContentPath(ServiceCtx context, ulong titleId, NcaContentType contentType)
         {
             ContentManager contentManager = context.Device.System.ContentManager;
             string         contentPath    = contentManager.GetInstalledContentPath(titleId, _storageId, NcaContentType.Manual);

--- a/Ryujinx.HLE/HOS/Services/Ncm/Lr/LocationResolverManager/ILocationResolver.cs
+++ b/Ryujinx.HLE/HOS/Services/Ncm/Lr/LocationResolverManager/ILocationResolver.cs
@@ -228,12 +228,12 @@ namespace Ryujinx.HLE.HOS.Services.Ncm.Lr.LocationResolverManager
 
             if (!string.IsNullOrWhiteSpace(contentPath))
             {
-                long position = context.Request.RecvListBuff[0].Position;
-                long size     = context.Request.RecvListBuff[0].Size;
+                ulong position = context.Request.RecvListBuff[0].Position;
+                ulong size     = context.Request.RecvListBuff[0].Size;
 
                 byte[] contentPathBuffer = Encoding.UTF8.GetBytes(contentPath);
 
-                context.Memory.Write((ulong)position, contentPathBuffer);
+                context.Memory.Write(position, contentPathBuffer);
             }
             else
             {

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/UserManager/IUser.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/UserManager/IUser.cs
@@ -37,8 +37,8 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             _appletResourceUserId = context.RequestData.ReadUInt64();
             _mcuVersionData       = context.RequestData.ReadUInt64();
 
-            long inputPosition = context.Request.SendBuff[0].Position;
-            long inputSize     = context.Request.SendBuff[0].Size;
+            ulong inputPosition = context.Request.SendBuff[0].Position;
+            ulong inputSize     = context.Request.SendBuff[0].Size;
 
             _mcuData = new byte[inputSize];
 
@@ -93,8 +93,8 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
                 return ResultCode.WrongArgument;
             }
 
-            long outputPosition = context.Request.RecvListBuff[0].Position;
-            long outputSize      = context.Request.RecvListBuff[0].Size;
+            ulong outputPosition = context.Request.RecvListBuff[0].Position;
+            ulong outputSize      = context.Request.RecvListBuff[0].Size;
 
             if (context.Device.System.NfpDevices.Count == 0)
             {
@@ -107,7 +107,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             {
                 for (int i = 0; i < context.Device.System.NfpDevices.Count; i++)
                 {
-                    context.Memory.Write((ulong)(outputPosition + (i * sizeof(long))), (uint)context.Device.System.NfpDevices[i].Handle);
+                    context.Memory.Write((ulong)(outputPosition + ((uint)i * sizeof(long))), (uint)context.Device.System.NfpDevices[i].Handle);
                 }
 
                 context.ResponseData.Write(context.Device.System.NfpDevices.Count);
@@ -376,8 +376,8 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
                 return ResultCode.DeviceNotFound;
             }
 
-            long outputPosition = context.Request.ReceiveBuff[0].Position;
-            long outputSize     = context.Request.ReceiveBuff[0].Size;
+            ulong outputPosition = context.Request.ReceiveBuff[0].Position;
+            ulong outputSize     = context.Request.ReceiveBuff[0].Size;
 
             MemoryHelper.FillWithZeros(context.Memory, outputPosition, (int)outputSize);
 
@@ -444,8 +444,8 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
                 return ResultCode.DeviceNotFound;
             }
 
-            long inputPosition = context.Request.SendBuff[0].Position;
-            long inputSize     = context.Request.SendBuff[0].Size;
+            ulong inputPosition = context.Request.SendBuff[0].Position;
+            ulong inputSize     = context.Request.SendBuff[0].Size;
 
             byte[] applicationArea = new byte[inputSize];
 
@@ -523,8 +523,8 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
 
             uint applicationAreaId = context.RequestData.ReadUInt32();
 
-            long inputPosition = context.Request.SendBuff[0].Position;
-            long inputSize     = context.Request.SendBuff[0].Size;
+            ulong inputPosition = context.Request.SendBuff[0].Position;
+            ulong inputSize     = context.Request.SendBuff[0].Size;
 
             byte[] applicationArea = new byte[inputSize];
 
@@ -582,9 +582,9 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
                 return ResultCode.WrongArgument;
             }
 
-            long outputPosition = context.Request.RecvListBuff[0].Position;
+            ulong outputPosition = context.Request.RecvListBuff[0].Position;
 
-            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize(Marshal.SizeOf(typeof(TagInfo)));
+            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize((uint)Marshal.SizeOf(typeof(TagInfo)));
 
             MemoryHelper.FillWithZeros(context.Memory, outputPosition, Marshal.SizeOf(typeof(TagInfo)));
 
@@ -625,7 +625,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
 
                             Uuid.CopyTo(tagInfo.Uuid.ToSpan());
 
-                            context.Memory.Write((ulong)outputPosition, tagInfo);
+                            context.Memory.Write(outputPosition, tagInfo);
 
                             resultCode = ResultCode.Success;
                         }
@@ -658,9 +658,9 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
                 return ResultCode.WrongArgument;
             }
 
-            long outputPosition = context.Request.RecvListBuff[0].Position;
+            ulong outputPosition = context.Request.RecvListBuff[0].Position;
 
-            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize(Marshal.SizeOf(typeof(RegisterInfo)));
+            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize((uint)Marshal.SizeOf(typeof(RegisterInfo)));
 
             MemoryHelper.FillWithZeros(context.Memory, outputPosition, Marshal.SizeOf(typeof(RegisterInfo)));
 
@@ -718,9 +718,9 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
                 return ResultCode.WrongArgument;
             }
 
-            long outputPosition = context.Request.RecvListBuff[0].Position;
+            ulong outputPosition = context.Request.RecvListBuff[0].Position;
 
-            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize(Marshal.SizeOf(typeof(CommonInfo)));
+            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize((uint)Marshal.SizeOf(typeof(CommonInfo)));
 
             MemoryHelper.FillWithZeros(context.Memory, outputPosition, Marshal.SizeOf(typeof(CommonInfo)));
 
@@ -745,7 +745,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
                         {
                             CommonInfo commonInfo = VirtualAmiibo.GetCommonInfo(context.Device.System.NfpDevices[i].AmiiboId);
 
-                            context.Memory.Write((ulong)outputPosition, commonInfo);
+                            context.Memory.Write(outputPosition, commonInfo);
 
                             resultCode = ResultCode.Success;
                         }
@@ -778,9 +778,9 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
                 return ResultCode.WrongArgument;
             }
 
-            long outputPosition = context.Request.RecvListBuff[0].Position;
+            ulong outputPosition = context.Request.RecvListBuff[0].Position;
 
-            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize(Marshal.SizeOf(typeof(ModelInfo)));
+            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize((uint)Marshal.SizeOf(typeof(ModelInfo)));
 
             MemoryHelper.FillWithZeros(context.Memory, outputPosition, Marshal.SizeOf(typeof(ModelInfo)));
 
@@ -814,7 +814,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
                             modelInfo.ModelNumber      = ushort.Parse(context.Device.System.NfpDevices[i].AmiiboId.Substring(8, 4), NumberStyles.HexNumber);
                             modelInfo.Type             = byte.Parse(context.Device.System.NfpDevices[i].AmiiboId.Substring(6, 2), NumberStyles.HexNumber);
 
-                            context.Memory.Write((ulong)outputPosition, modelInfo);
+                            context.Memory.Write(outputPosition, modelInfo);
 
                             resultCode = ResultCode.Success;
                         }

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/UserManager/IUser.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/UserManager/IUser.cs
@@ -42,7 +42,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
 
             _mcuData = new byte[inputSize];
 
-            context.Memory.Read((ulong)inputPosition, _mcuData);
+            context.Memory.Read(inputPosition, _mcuData);
 
             // TODO: The mcuData buffer seems to contains entries with a size of 0x40 bytes each. Usage of the data needs to be determined.
 
@@ -107,7 +107,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             {
                 for (int i = 0; i < context.Device.System.NfpDevices.Count; i++)
                 {
-                    context.Memory.Write((ulong)(outputPosition + ((uint)i * sizeof(long))), (uint)context.Device.System.NfpDevices[i].Handle);
+                    context.Memory.Write(outputPosition + ((uint)i * sizeof(long)), (uint)context.Device.System.NfpDevices[i].Handle);
                 }
 
                 context.ResponseData.Write(context.Device.System.NfpDevices.Count);
@@ -397,7 +397,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
                         {
                             byte[] applicationArea = VirtualAmiibo.GetApplicationArea(context.Device.System.NfpDevices[i].AmiiboId);
 
-                            context.Memory.Write((ulong)outputPosition, applicationArea);
+                            context.Memory.Write(outputPosition, applicationArea);
 
                             size = (uint)applicationArea.Length;
 
@@ -449,7 +449,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
 
             byte[] applicationArea = new byte[inputSize];
 
-            context.Memory.Read((ulong)inputPosition, applicationArea);
+            context.Memory.Read(inputPosition, applicationArea);
 
             for (int i = 0; i < context.Device.System.NfpDevices.Count; i++)
             {
@@ -528,7 +528,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
 
             byte[] applicationArea = new byte[inputSize];
 
-            context.Memory.Read((ulong)inputPosition, applicationArea);
+            context.Memory.Read(inputPosition, applicationArea);
 
             bool isCreated = false;
 
@@ -685,7 +685,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
                         {
                             RegisterInfo registerInfo = VirtualAmiibo.GetRegisterInfo(context.Device.System.NfpDevices[i].AmiiboId);
 
-                            context.Memory.Write((ulong)outputPosition, registerInfo);
+                            context.Memory.Write(outputPosition, registerInfo);
 
                             resultCode = ResultCode.Success;
                         }

--- a/Ryujinx.HLE/HOS/Services/Ngct/NgctServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Ngct/NgctServer.cs
@@ -27,7 +27,7 @@ namespace Ryujinx.HLE.HOS.Services.Ngct
                 {
                     byte[] buffer = new byte[bufferSize];
 
-                    context.Memory.Read((ulong)bufferPosition, buffer);
+                    context.Memory.Read(bufferPosition, buffer);
 
                     text = Encoding.ASCII.GetString(buffer);
 
@@ -66,13 +66,13 @@ namespace Ryujinx.HLE.HOS.Services.Ngct
                 {
                     textFiltered = new string('*', text.Length);
 
-                    context.Memory.Write((ulong)bufferFilteredPosition, Encoding.ASCII.GetBytes(textFiltered));
+                    context.Memory.Write(bufferFilteredPosition, Encoding.ASCII.GetBytes(textFiltered));
                 }
                 else
                 {
                     byte[] buffer = new byte[bufferSize];
 
-                    context.Memory.Read((ulong)bufferPosition, buffer);
+                    context.Memory.Read(bufferPosition, buffer);
 
                     // NOTE: Ngct use the archive 0100000000001034 which contains a words table. This is pushed on Chinese Switchs using Bcat service.
                     //       This call check if the string contains words which are in the table then returns the same string with each matched words replaced by '*'.
@@ -80,7 +80,7 @@ namespace Ryujinx.HLE.HOS.Services.Ngct
 
                     textFiltered = text = Encoding.ASCII.GetString(buffer);
 
-                    context.Memory.Write((ulong)bufferFilteredPosition, buffer);
+                    context.Memory.Write(bufferFilteredPosition, buffer);
                 }
             }
 

--- a/Ryujinx.HLE/HOS/Services/Ngct/NgctServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Ngct/NgctServer.cs
@@ -11,8 +11,8 @@ namespace Ryujinx.HLE.HOS.Services.Ngct
             //       Then it checks if ngc.t!functionality_override_enabled is enabled and if sys:set GetT is == 2.
             //       If both conditions are true, it does this following code. Since we currently stub it, it's fine to don't check settings service values.
 
-            long bufferPosition = context.Request.PtrBuff[0].Position;
-            long bufferSize     = context.Request.PtrBuff[0].Size;
+            ulong bufferPosition = context.Request.PtrBuff[0].Position;
+            ulong bufferSize     = context.Request.PtrBuff[0].Size;
 
             bool   isMatch = false;
             string text    = "";
@@ -52,10 +52,10 @@ namespace Ryujinx.HLE.HOS.Services.Ngct
             //       Then it checks if ngc.t!functionality_override_enabled is enabled and if sys:set GetT is == 2.
             //       If both conditions are true, it does this following code. Since we currently stub it, it's fine to don't check settings service values.
 
-            long bufferPosition = context.Request.PtrBuff[0].Position;
-            long bufferSize     = context.Request.PtrBuff[0].Size;
+            ulong bufferPosition = context.Request.PtrBuff[0].Position;
+            ulong bufferSize     = context.Request.PtrBuff[0].Size;
 
-            long bufferFilteredPosition = context.Request.RecvListBuff[0].Position;
+            ulong bufferFilteredPosition = context.Request.RecvListBuff[0].Position;
 
             string text         = "";
             string textFiltered = "";

--- a/Ryujinx.HLE/HOS/Services/Nifm/StaticService/IGeneralService.cs
+++ b/Ryujinx.HLE/HOS/Services/Nifm/StaticService/IGeneralService.cs
@@ -29,11 +29,11 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
         // GetClientId() -> buffer<nn::nifm::ClientId, 0x1a, 4>
         public ResultCode GetClientId(ServiceCtx context)
         {
-            long position = context.Request.RecvListBuff[0].Position;
+            ulong position = context.Request.RecvListBuff[0].Position;
 
-            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize(4);
+            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize(sizeof(int));
 
-            context.Memory.Write((ulong)position, _generalServiceDetail.ClientId);
+            context.Memory.Write(position, _generalServiceDetail.ClientId);
 
             return ResultCode.Success;
         }
@@ -58,7 +58,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
         // GetCurrentNetworkProfile() -> buffer<nn::nifm::detail::sf::NetworkProfileData, 0x1a, 0x17c>
         public ResultCode GetCurrentNetworkProfile(ServiceCtx context)
         {
-            long networkProfileDataPosition = context.Request.RecvListBuff[0].Position;
+            ulong networkProfileDataPosition = context.Request.RecvListBuff[0].Position;
 
             (IPInterfaceProperties interfaceProperties, UnicastIPAddressInformation unicastAddress) = GetLocalInterface();
 
@@ -69,7 +69,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
 
             Logger.Info?.Print(LogClass.ServiceNifm, $"Console's local IP is \"{unicastAddress.Address}\".");
 
-            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize(Unsafe.SizeOf<NetworkProfileData>());
+            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize((uint)Unsafe.SizeOf<NetworkProfileData>());
 
             NetworkProfileData networkProfile = new NetworkProfileData
             {
@@ -81,7 +81,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
 
             Encoding.ASCII.GetBytes("RyujinxNetwork").CopyTo(networkProfile.Name.ToSpan());
 
-            context.Memory.Write((ulong)networkProfileDataPosition, networkProfile);
+            context.Memory.Write(networkProfileDataPosition, networkProfile);
 
             return ResultCode.Success;
         }
@@ -148,10 +148,10 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
         // IsAnyInternetRequestAccepted(buffer<nn::nifm::ClientId, 0x19, 4>) -> bool
         public ResultCode IsAnyInternetRequestAccepted(ServiceCtx context)
         {
-            long position = context.Request.PtrBuff[0].Position;
-            long size     = context.Request.PtrBuff[0].Size;
+            ulong position = context.Request.PtrBuff[0].Position;
+            ulong size     = context.Request.PtrBuff[0].Size;
 
-            int clientId = context.Memory.Read<int>((ulong)position);
+            int clientId = context.Memory.Read<int>(position);
 
             context.ResponseData.Write(GeneralServiceManager.Get(clientId).IsAnyInternetRequestAccepted);
 

--- a/Ryujinx.HLE/HOS/Services/Ns/IApplicationManagerInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Ns/IApplicationManagerInterface.cs
@@ -12,11 +12,11 @@
             byte  source  = (byte)context.RequestData.ReadInt64();
             ulong titleId = context.RequestData.ReadUInt64();
 
-            long position = context.Request.ReceiveBuff[0].Position;
+            ulong position = context.Request.ReceiveBuff[0].Position;
 
             byte[] nacpData = context.Device.Application.ControlData.ByteSpan.ToArray();
 
-            context.Memory.Write((ulong)position, nacpData);
+            context.Memory.Write(position, nacpData);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Ns/IPurchaseEventManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Ns/IPurchaseEventManager.cs
@@ -20,8 +20,8 @@ namespace Ryujinx.HLE.HOS.Services.Ns
         // SetDefaultDeliveryTarget(pid, buffer<bytes, 5> unknown)
         public ResultCode SetDefaultDeliveryTarget(ServiceCtx context)
         {
-            long   inBufferPosition = context.Request.SendBuff[0].Position;
-            long   inBufferSize     = context.Request.SendBuff[0].Size;
+            ulong   inBufferPosition = context.Request.SendBuff[0].Position;
+            ulong   inBufferSize     = context.Request.SendBuff[0].Size;
             byte[] buffer           = new byte[inBufferSize];
 
             context.Memory.Read((ulong)inBufferPosition, buffer);

--- a/Ryujinx.HLE/HOS/Services/Ns/IPurchaseEventManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Ns/IPurchaseEventManager.cs
@@ -24,7 +24,7 @@ namespace Ryujinx.HLE.HOS.Services.Ns
             ulong   inBufferSize     = context.Request.SendBuff[0].Size;
             byte[] buffer           = new byte[inBufferSize];
 
-            context.Memory.Read((ulong)inBufferPosition, buffer);
+            context.Memory.Read(inBufferPosition, buffer);
 
             // NOTE: Service use the pid to call arp:r GetApplicationLaunchProperty and store it in internal field.
             //       Then it seems to use the buffer content and compare it with a stored linked instrusive list.

--- a/Ryujinx.HLE/HOS/Services/Ns/IReadOnlyApplicationControlDataInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Ns/IReadOnlyApplicationControlDataInterface.cs
@@ -15,7 +15,7 @@
 
             byte[] nacpData = context.Device.Application.ControlData.ByteSpan.ToArray();
 
-            context.Memory.Write((ulong)position, nacpData);
+            context.Memory.Write(position, nacpData);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Ns/IReadOnlyApplicationControlDataInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Ns/IReadOnlyApplicationControlDataInterface.cs
@@ -11,7 +11,7 @@
             byte source = (byte)context.RequestData.ReadInt64();
             ulong titleId = context.RequestData.ReadUInt64();
 
-            long position = context.Request.ReceiveBuff[0].Position;
+            ulong position = context.Request.ReceiveBuff[0].Position;
 
             byte[] nacpData = context.Device.Application.ControlData.ByteSpan.ToArray();
 

--- a/Ryujinx.HLE/HOS/Services/Nv/INvDrvServices.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/INvDrvServices.cs
@@ -73,8 +73,8 @@ namespace Ryujinx.HLE.HOS.Services.Nv
 
         private NvResult GetIoctlArgument(ServiceCtx context, NvIoctl ioctlCommand, out Span<byte> arguments)
         {
-            (long inputDataPosition,  long inputDataSize)  = context.Request.GetBufferType0x21(0);
-            (long outputDataPosition, long outputDataSize) = context.Request.GetBufferType0x22(0);
+            (ulong inputDataPosition,  ulong inputDataSize)  = context.Request.GetBufferType0x21(0);
+            (ulong outputDataPosition, ulong outputDataSize) = context.Request.GetBufferType0x22(0);
 
             NvIoctl.Direction ioctlDirection = ioctlCommand.DirectionValue;
             uint              ioctlSize      = ioctlCommand.Size;
@@ -106,7 +106,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
 
                 byte[] temp = new byte[inputDataSize];
 
-                context.Memory.Read((ulong)inputDataPosition, temp);
+                context.Memory.Read(inputDataPosition, temp);
 
                 Buffer.BlockCopy(temp, 0, outputData, 0, temp.Length);
 
@@ -122,7 +122,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
             {
                 byte[] temp = new byte[inputDataSize];
 
-                context.Memory.Read((ulong)inputDataPosition, temp);
+                context.Memory.Read(inputDataPosition, temp);
 
                 arguments = new Span<byte>(temp);
             }
@@ -226,10 +226,10 @@ namespace Ryujinx.HLE.HOS.Services.Nv
 
             if (errorCode == NvResult.Success)
             {
-                long pathPtr = context.Request.SendBuff[0].Position;
-                long pathSize = context.Request.SendBuff[0].Size;
+                ulong pathPtr = context.Request.SendBuff[0].Position;
+                ulong pathSize = context.Request.SendBuff[0].Size;
 
-                string path = MemoryHelper.ReadAsciiString(context.Memory, pathPtr, pathSize);
+                string path = MemoryHelper.ReadAsciiString(context.Memory, pathPtr, (long)pathSize);
 
                 fd = Open(context, path);
 
@@ -470,7 +470,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
                 int     fd           = context.RequestData.ReadInt32();
                 NvIoctl ioctlCommand = context.RequestData.ReadStruct<NvIoctl>();
 
-                (long inlineInBufferPosition, long inlineInBufferSize) = context.Request.GetBufferType0x21(1);
+                (ulong inlineInBufferPosition, ulong inlineInBufferSize) = context.Request.GetBufferType0x21(1);
 
                 errorCode = GetIoctlArgument(context, ioctlCommand, out Span<byte> arguments);
 
@@ -519,13 +519,13 @@ namespace Ryujinx.HLE.HOS.Services.Nv
                 int     fd           = context.RequestData.ReadInt32();
                 NvIoctl ioctlCommand = context.RequestData.ReadStruct<NvIoctl>();
 
-                (long inlineOutBufferPosition, long inlineOutBufferSize) = context.Request.GetBufferType0x22(1);
+                (ulong inlineOutBufferPosition, ulong inlineOutBufferSize) = context.Request.GetBufferType0x22(1);
 
                 errorCode = GetIoctlArgument(context, ioctlCommand, out Span<byte> arguments);
 
                 byte[] temp = new byte[inlineOutBufferSize];
 
-                context.Memory.Read((ulong)inlineOutBufferPosition, temp);
+                context.Memory.Read(inlineOutBufferPosition, temp);
 
                 Span<byte> inlineOutBuffer = new Span<byte>(temp);
 
@@ -546,8 +546,8 @@ namespace Ryujinx.HLE.HOS.Services.Nv
 
                         if ((ioctlCommand.DirectionValue & NvIoctl.Direction.Write) != 0)
                         {
-                            context.Memory.Write((ulong)context.Request.GetBufferType0x22(0).Position, arguments.ToArray());
-                            context.Memory.Write((ulong)inlineOutBufferPosition, inlineOutBuffer.ToArray());
+                            context.Memory.Write(context.Request.GetBufferType0x22(0).Position, arguments.ToArray());
+                            context.Memory.Write(inlineOutBufferPosition, inlineOutBuffer.ToArray());
                         }
                     }
                 }

--- a/Ryujinx.HLE/HOS/Services/Nv/INvDrvServices.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/INvDrvServices.cs
@@ -275,7 +275,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
 
                         if ((ioctlCommand.DirectionValue & NvIoctl.Direction.Write) != 0)
                         {
-                            context.Memory.Write((ulong)context.Request.GetBufferType0x22(0).Position, arguments.ToArray());
+                            context.Memory.Write(context.Request.GetBufferType0x22(0).Position, arguments.ToArray());
                         }
                     }
                 }
@@ -476,7 +476,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
 
                 byte[] temp = new byte[inlineInBufferSize];
 
-                context.Memory.Read((ulong)inlineInBufferPosition, temp);
+                context.Memory.Read(inlineInBufferPosition, temp);
 
                 Span<byte> inlineInBuffer = new Span<byte>(temp);
 
@@ -497,7 +497,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
 
                         if ((ioctlCommand.DirectionValue & NvIoctl.Direction.Write) != 0)
                         {
-                            context.Memory.Write((ulong)context.Request.GetBufferType0x22(0).Position, arguments.ToArray());
+                            context.Memory.Write(context.Request.GetBufferType0x22(0).Position, arguments.ToArray());
                         }
                     }
                 }

--- a/Ryujinx.HLE/HOS/Services/Prepo/IPrepoService.cs
+++ b/Ryujinx.HLE/HOS/Services/Prepo/IPrepoService.cs
@@ -117,8 +117,8 @@ namespace Ryujinx.HLE.HOS.Services.Prepo
                 return ResultCode.InvalidState;
             }
 
-            long inputPosition = context.Request.SendBuff[0].Position;
-            long inputSize     = context.Request.SendBuff[0].Size;
+            ulong inputPosition = context.Request.SendBuff[0].Position;
+            ulong inputSize     = context.Request.SendBuff[0].Size;
 
             if (inputSize == 0)
             {

--- a/Ryujinx.HLE/HOS/Services/Prepo/IPrepoService.cs
+++ b/Ryujinx.HLE/HOS/Services/Prepo/IPrepoService.cs
@@ -127,7 +127,7 @@ namespace Ryujinx.HLE.HOS.Services.Prepo
 
             byte[] inputBuffer = new byte[inputSize];
 
-            context.Memory.Read((ulong)inputPosition, inputBuffer);
+            context.Memory.Read(inputPosition, inputBuffer);
 
             Logger.Info?.Print(LogClass.ServicePrepo, ReadReportBuffer(inputBuffer, gameRoom, userId));
 

--- a/Ryujinx.HLE/HOS/Services/Ro/IRoInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Ro/IRoInterface.cs
@@ -40,7 +40,7 @@ namespace Ryujinx.HLE.HOS.Services.Ro
             _owner    = null;
         }
 
-        private ResultCode ParseNrr(out NrrInfo nrrInfo, ServiceCtx context, long nrrAddress, long nrrSize)
+        private ResultCode ParseNrr(out NrrInfo nrrInfo, ServiceCtx context, ulong nrrAddress, ulong nrrSize)
         {
             nrrInfo = null;
 
@@ -71,12 +71,12 @@ namespace Ryujinx.HLE.HOS.Services.Ro
             {
                 byte[] temp = new byte[0x20];
 
-                _owner.CpuMemory.Read((ulong)(nrrAddress + header.HashOffset + (i * 0x20)), temp);
+                _owner.CpuMemory.Read(nrrAddress + header.HashOffset + (uint)(i * 0x20), temp);
 
                 hashes.Add(temp);
             }
 
-            nrrInfo = new NrrInfo(nrrAddress, header, hashes);
+            nrrInfo = new NrrInfo((ulong)nrrAddress, header, hashes);
 
             return ResultCode.Success;
         }
@@ -333,7 +333,7 @@ namespace Ryujinx.HLE.HOS.Services.Ro
             process.CpuMemory.Write(roStart,   relocatableObject.Ro);
             process.CpuMemory.Write(dataStart, relocatableObject.Data);
 
-            MemoryHelper.FillWithZeros(process.CpuMemory, (long)bssStart, (int)(bssEnd - bssStart));
+            MemoryHelper.FillWithZeros(process.CpuMemory, bssStart, (int)(bssEnd - bssStart));
 
             KernelResult result;
 
@@ -354,7 +354,7 @@ namespace Ryujinx.HLE.HOS.Services.Ro
             return process.MemoryManager.SetProcessMemoryPermission(dataStart, bssEnd - dataStart, KMemoryPermission.ReadAndWrite);
         }
 
-        private ResultCode RemoveNrrInfo(long nrrAddress)
+        private ResultCode RemoveNrrInfo(ulong nrrAddress)
         {
             foreach (NrrInfo info in _nrrInfos)
             {
@@ -508,8 +508,8 @@ namespace Ryujinx.HLE.HOS.Services.Ro
             // pid placeholder, zero
             context.RequestData.ReadUInt64();
 
-            long nrrAddress = context.RequestData.ReadInt64();
-            long nrrSize    = context.RequestData.ReadInt64();
+            ulong nrrAddress = context.RequestData.ReadUInt64();
+            ulong nrrSize    = context.RequestData.ReadUInt64();
 
             if (result == ResultCode.Success)
             {
@@ -541,7 +541,7 @@ namespace Ryujinx.HLE.HOS.Services.Ro
             // pid placeholder, zero
             context.RequestData.ReadUInt64();
 
-            long nrrHeapAddress = context.RequestData.ReadInt64();
+            ulong nrrHeapAddress = context.RequestData.ReadUInt64();
 
             if (result == ResultCode.Success)
             {

--- a/Ryujinx.HLE/HOS/Services/Ro/Types/NrrInfo.cs
+++ b/Ryujinx.HLE/HOS/Services/Ro/Types/NrrInfo.cs
@@ -6,9 +6,9 @@ namespace Ryujinx.HLE.HOS.Services.Ro
     {
         public NrrHeader    Header     { get; private set; }
         public List<byte[]> Hashes     { get; private set; }
-        public long         NrrAddress { get; private set; }
+        public ulong        NrrAddress { get; private set; }
 
-        public NrrInfo(long nrrAddress, NrrHeader header, List<byte[]> hashes)
+        public NrrInfo(ulong nrrAddress, NrrHeader header, List<byte[]> hashes)
         {
             NrrAddress = nrrAddress;
             Header     = header;

--- a/Ryujinx.HLE/HOS/Services/Sdb/Pdm/QueryService/QueryPlayStatisticsManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Sdb/Pdm/QueryService/QueryPlayStatisticsManager.cs
@@ -15,11 +15,11 @@ namespace Ryujinx.HLE.HOS.Services.Sdb.Pdm.QueryService
 
         internal static ResultCode GetPlayStatistics(ServiceCtx context, bool byUserId = false)
         {
-            long inputPosition = context.Request.SendBuff[0].Position;
-            long inputSize     = context.Request.SendBuff[0].Size;
+            ulong inputPosition = context.Request.SendBuff[0].Position;
+            ulong inputSize     = context.Request.SendBuff[0].Size;
 
-            long outputPosition = context.Request.ReceiveBuff[0].Position;
-            long outputSize     = context.Request.ReceiveBuff[0].Size;
+            ulong outputPosition = context.Request.ReceiveBuff[0].Position;
+            ulong outputSize     = context.Request.ReceiveBuff[0].Size;
 
             UserId userId = byUserId ? context.RequestData.ReadStruct<UserId>() : new UserId();
 
@@ -35,9 +35,9 @@ namespace Ryujinx.HLE.HOS.Services.Sdb.Pdm.QueryService
 
             List<ulong> titleIds = new List<ulong>();
 
-            for (int i = 0; i < inputSize / sizeof(ulong); i++)
+            for (ulong i = 0; i < inputSize / sizeof(ulong); i++)
             {
-                titleIds.Add(context.Memory.Read<ulong>((ulong)inputPosition));
+                titleIds.Add(context.Memory.Read<ulong>(inputPosition));
             }
 
             if (queryCapability == PlayLogQueryCapability.WhiteList)
@@ -73,7 +73,7 @@ namespace Ryujinx.HLE.HOS.Services.Sdb.Pdm.QueryService
 
             for (int i = 0; i < filteredApplicationPlayStatistics.Count(); i++)
             {
-                MemoryHelper.Write(context.Memory, outputPosition + (i * Marshal.SizeOf<ApplicationPlayStatistics>()), filteredApplicationPlayStatistics.ElementAt(i).Value);
+                MemoryHelper.Write(context.Memory, outputPosition + (ulong)(i * Marshal.SizeOf<ApplicationPlayStatistics>()), filteredApplicationPlayStatistics.ElementAt(i).Value);
             }
 
             context.ResponseData.Write(filteredApplicationPlayStatistics.Count());

--- a/Ryujinx.HLE/HOS/Services/Sdb/Pl/ISharedFontManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Sdb/Pl/ISharedFontManager.cs
@@ -87,7 +87,7 @@ namespace Ryujinx.HLE.HOS.Services.Sdb.Pl
 
             for (SharedFontType type = 0; type < SharedFontType.Count; type++)
             {
-                int offset = (int)type * 4;
+                uint offset = (uint)type * 4;
 
                 if (!AddFontToOrderOfPriorityList(context, type, offset))
                 {
@@ -103,27 +103,27 @@ namespace Ryujinx.HLE.HOS.Services.Sdb.Pl
             return ResultCode.Success;
         }
 
-        private bool AddFontToOrderOfPriorityList(ServiceCtx context, SharedFontType fontType, int offset)
+        private bool AddFontToOrderOfPriorityList(ServiceCtx context, SharedFontType fontType, uint offset)
         {
-            long typesPosition = context.Request.ReceiveBuff[0].Position;
-            long typesSize     = context.Request.ReceiveBuff[0].Size;
+            ulong typesPosition = context.Request.ReceiveBuff[0].Position;
+            ulong typesSize     = context.Request.ReceiveBuff[0].Size;
 
-            long offsetsPosition = context.Request.ReceiveBuff[1].Position;
-            long offsetsSize     = context.Request.ReceiveBuff[1].Size;
+            ulong offsetsPosition = context.Request.ReceiveBuff[1].Position;
+            ulong offsetsSize     = context.Request.ReceiveBuff[1].Size;
 
-            long fontSizeBufferPosition = context.Request.ReceiveBuff[2].Position;
-            long fontSizeBufferSize     = context.Request.ReceiveBuff[2].Size;
+            ulong fontSizeBufferPosition = context.Request.ReceiveBuff[2].Position;
+            ulong fontSizeBufferSize     = context.Request.ReceiveBuff[2].Size;
 
-            if ((uint)offset + 4 > (uint)typesSize   ||
-                (uint)offset + 4 > (uint)offsetsSize ||
-                (uint)offset + 4 > (uint)fontSizeBufferSize)
+            if (offset + 4 > (uint)typesSize   ||
+                offset + 4 > (uint)offsetsSize ||
+                offset + 4 > (uint)fontSizeBufferSize)
             {
                 return false;
             }
 
-            context.Memory.Write((ulong)(typesPosition + offset), (int)fontType);
-            context.Memory.Write((ulong)(offsetsPosition + offset), context.Device.System.Font.GetSharedMemoryAddressOffset(fontType));
-            context.Memory.Write((ulong)(fontSizeBufferPosition + offset), context.Device.System.Font.GetFontSize(fontType));
+            context.Memory.Write(typesPosition + offset, (int)fontType);
+            context.Memory.Write(offsetsPosition + offset, context.Device.System.Font.GetSharedMemoryAddressOffset(fontType));
+            context.Memory.Write(fontSizeBufferPosition + offset, context.Device.System.Font.GetFontSize(fontType));
 
             return true;
         }

--- a/Ryujinx.HLE/HOS/Services/ServerBase.cs
+++ b/Ryujinx.HLE/HOS/Services/ServerBase.cs
@@ -180,13 +180,13 @@ namespace Ryujinx.HLE.HOS.Services
             {
                 for (int i = 0; i < request.RecvListBuff.Count; i++)
                 {
-                    int size = BinaryPrimitives.ReadInt16LittleEndian(request.RawData.AsSpan().Slice(sizesOffset + i * 2, 2));
+                    ulong size = (ulong)BinaryPrimitives.ReadInt16LittleEndian(request.RawData.AsSpan().Slice(sizesOffset + i * 2, 2));
 
-                    response.PtrBuff.Add(new IpcPtrBuffDesc((long)tempAddr, i, size));
+                    response.PtrBuff.Add(new IpcPtrBuffDesc(tempAddr, (uint)i, size));
 
-                    request.RecvListBuff[i] = new IpcRecvListBuffDesc((long)tempAddr, size);
+                    request.RecvListBuff[i] = new IpcRecvListBuffDesc(tempAddr, size);
 
-                    tempAddr += (ulong)size;
+                    tempAddr += size;
                 }
             }
 

--- a/Ryujinx.HLE/HOS/Services/Settings/ISettingsServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Settings/ISettingsServer.cs
@@ -190,11 +190,11 @@ namespace Ryujinx.HLE.HOS.Services.Settings
                     break;
             }
 
-            context.Memory.Write((ulong)context.Request.ReceiveBuff[0].Position, keyCodeMap);
+            context.Memory.Write(context.Request.ReceiveBuff[0].Position, keyCodeMap);
 
             if (version == 1 && context.Device.System.State.DesiredKeyboardLayout == (long)KeyboardLayout.Default)
             {
-                context.Memory.Write((ulong)context.Request.ReceiveBuff[0].Position, (byte)0x01);
+                context.Memory.Write(context.Request.ReceiveBuff[0].Position, (byte)0x01);
             }
 
             return ResultCode.Success;

--- a/Ryujinx.HLE/HOS/Services/Settings/ISettingsServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Settings/ISettingsServer.cs
@@ -200,7 +200,7 @@ namespace Ryujinx.HLE.HOS.Services.Settings
             return ResultCode.Success;
         }
 
-        public ResultCode GetAvailableLanguagesCodesImpl(ServiceCtx context, long position, long size, int maxSize)
+        public ResultCode GetAvailableLanguagesCodesImpl(ServiceCtx context, ulong position, ulong size, int maxSize)
         {
             int count = (int)(size / 8);
 
@@ -211,7 +211,7 @@ namespace Ryujinx.HLE.HOS.Services.Settings
 
             for (int index = 0; index < count; index++)
             {
-                context.Memory.Write((ulong)position, SystemStateMgr.GetLanguageCode(index));
+                context.Memory.Write(position, SystemStateMgr.GetLanguageCode(index));
 
                 position += 8;
             }

--- a/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
@@ -235,8 +235,9 @@ namespace Ryujinx.HLE.HOS.Services.Settings
 
         public byte[] GetFirmwareData(Switch device)
         {
-            long   titleId     = 0x0100000000000809;
-            string contentPath = device.System.ContentManager.GetInstalledContentPath(titleId, StorageId.NandSystem, NcaContentType.Data);
+            const ulong SystemVersionTitleId = 0x0100000000000809;
+
+            string contentPath = device.System.ContentManager.GetInstalledContentPath(SystemVersionTitleId, StorageId.NandSystem, NcaContentType.Data);
 
             if (string.IsNullOrWhiteSpace(contentPath))
             {

--- a/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
@@ -29,7 +29,7 @@ namespace Ryujinx.HLE.HOS.Services.Settings
         // GetFirmwareVersion2() -> buffer<nn::settings::system::FirmwareVersion, 0x1a, 0x100>
         public ResultCode GetFirmwareVersion2(ServiceCtx context)
         {
-            long replyPos  = context.Request.RecvListBuff[0].Position;
+            ulong replyPos  = context.Request.RecvListBuff[0].Position;
 
             context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize(0x100L);
 
@@ -37,7 +37,7 @@ namespace Ryujinx.HLE.HOS.Services.Settings
 
             if (firmwareData != null)
             {
-                context.Memory.Write((ulong)replyPos, firmwareData);
+                context.Memory.Write(replyPos, firmwareData);
 
                 return ResultCode.Success;
             }
@@ -110,19 +110,19 @@ namespace Ryujinx.HLE.HOS.Services.Settings
         // GetSettingsItemValueSize(buffer<nn::settings::SettingsName, 0x19>, buffer<nn::settings::SettingsItemKey, 0x19>) -> u64
         public ResultCode GetSettingsItemValueSize(ServiceCtx context)
         {
-            long classPos  = context.Request.PtrBuff[0].Position;
-            long classSize = context.Request.PtrBuff[0].Size;
+            ulong classPos  = context.Request.PtrBuff[0].Position;
+            ulong classSize = context.Request.PtrBuff[0].Size;
 
-            long namePos  = context.Request.PtrBuff[1].Position;
-            long nameSize = context.Request.PtrBuff[1].Size;
+            ulong namePos  = context.Request.PtrBuff[1].Position;
+            ulong nameSize = context.Request.PtrBuff[1].Size;
 
             byte[] classBuffer = new byte[classSize];
 
-            context.Memory.Read((ulong)classPos, classBuffer);
+            context.Memory.Read(classPos, classBuffer);
 
             byte[] nameBuffer = new byte[nameSize];
 
-            context.Memory.Read((ulong)namePos, nameBuffer);
+            context.Memory.Read(namePos, nameBuffer);
 
             string askedSetting = Encoding.ASCII.GetString(classBuffer).Trim('\0') + "!" + Encoding.ASCII.GetString(nameBuffer).Trim('\0');
 
@@ -159,22 +159,22 @@ namespace Ryujinx.HLE.HOS.Services.Settings
         // GetSettingsItemValue(buffer<nn::settings::SettingsName, 0x19, 0x48>, buffer<nn::settings::SettingsItemKey, 0x19, 0x48>) -> (u64, buffer<unknown, 6, 0>)
         public ResultCode GetSettingsItemValue(ServiceCtx context)
         {
-            long classPos  = context.Request.PtrBuff[0].Position;
-            long classSize = context.Request.PtrBuff[0].Size;
+            ulong classPos  = context.Request.PtrBuff[0].Position;
+            ulong classSize = context.Request.PtrBuff[0].Size;
 
-            long namePos  = context.Request.PtrBuff[1].Position;
-            long nameSize = context.Request.PtrBuff[1].Size;
+            ulong namePos  = context.Request.PtrBuff[1].Position;
+            ulong nameSize = context.Request.PtrBuff[1].Size;
 
-            long replyPos  = context.Request.ReceiveBuff[0].Position;
-            long replySize = context.Request.ReceiveBuff[0].Size;
+            ulong replyPos  = context.Request.ReceiveBuff[0].Position;
+            ulong replySize = context.Request.ReceiveBuff[0].Size;
 
             byte[] classBuffer = new byte[classSize];
 
-            context.Memory.Read((ulong)classPos, classBuffer);
+            context.Memory.Read(classPos, classBuffer);
 
             byte[] nameBuffer = new byte[nameSize];
 
-            context.Memory.Read((ulong)namePos, nameBuffer);
+            context.Memory.Read(namePos, nameBuffer);
 
             string askedSetting = Encoding.ASCII.GetString(classBuffer).Trim('\0') + "!" + Encoding.ASCII.GetString(nameBuffer).Trim('\0');
 
@@ -186,7 +186,7 @@ namespace Ryujinx.HLE.HOS.Services.Settings
 
                 if (nxSetting is string stringValue)
                 {
-                    if (stringValue.Length + 1 > replySize)
+                    if ((ulong)(stringValue.Length + 1) > replySize)
                     {
                         Logger.Error?.Print(LogClass.ServiceSet, $"{askedSetting} String value size is too big!");
                     }
@@ -209,7 +209,7 @@ namespace Ryujinx.HLE.HOS.Services.Settings
                     throw new NotImplementedException(nxSetting.GetType().Name);
                 }
 
-                context.Memory.Write((ulong)replyPos, settingBuffer);
+                context.Memory.Write(replyPos, settingBuffer);
 
                 Logger.Debug?.Print(LogClass.ServiceSet, $"{askedSetting} set value: {nxSetting} as {nxSetting.GetType()}");
             }

--- a/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
@@ -80,7 +80,7 @@ namespace Ryujinx.HLE.HOS.Services.Settings
 
                 writer.Write(Encoding.ASCII.GetBytes(build));
 
-                context.Memory.Write((ulong)replyPos, ms.ToArray());
+                context.Memory.Write(replyPos, ms.ToArray());
             }
 
             return ResultCode.Success;

--- a/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
@@ -197,28 +197,28 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             return WriteBsdResult(context, _sockets.Count - 1);
         }
 
-        private IPEndPoint ParseSockAddr(ServiceCtx context, long bufferPosition, long bufferSize)
+        private IPEndPoint ParseSockAddr(ServiceCtx context, ulong bufferPosition, ulong bufferSize)
         {
-            int size   = context.Memory.Read<byte>((ulong)bufferPosition);
-            int family = context.Memory.Read<byte>((ulong)bufferPosition + 1);
-            int port   = BinaryPrimitives.ReverseEndianness(context.Memory.Read<ushort>((ulong)bufferPosition + 2));
+            int size   = context.Memory.Read<byte>(bufferPosition);
+            int family = context.Memory.Read<byte>(bufferPosition + 1);
+            int port   = BinaryPrimitives.ReverseEndianness(context.Memory.Read<ushort>(bufferPosition + 2));
 
             byte[] rawIp = new byte[4];
 
-            context.Memory.Read((ulong)bufferPosition + 4, rawIp);
+            context.Memory.Read(bufferPosition + 4, rawIp);
 
             return new IPEndPoint(new IPAddress(rawIp), port);
         }
 
-        private void WriteSockAddr(ServiceCtx context, long bufferPosition, IPEndPoint endPoint)
+        private void WriteSockAddr(ServiceCtx context, ulong bufferPosition, IPEndPoint endPoint)
         {
-            context.Memory.Write((ulong)bufferPosition, (byte)0);
-            context.Memory.Write((ulong)bufferPosition + 1, (byte)endPoint.AddressFamily);
-            context.Memory.Write((ulong)bufferPosition + 2, BinaryPrimitives.ReverseEndianness((ushort)endPoint.Port));
-            context.Memory.Write((ulong)bufferPosition + 4, endPoint.Address.GetAddressBytes());
+            context.Memory.Write(bufferPosition, (byte)0);
+            context.Memory.Write(bufferPosition + 1, (byte)endPoint.AddressFamily);
+            context.Memory.Write(bufferPosition + 2, BinaryPrimitives.ReverseEndianness((ushort)endPoint.Port));
+            context.Memory.Write(bufferPosition + 4, endPoint.Address.GetAddressBytes());
         }
 
-        private void WriteSockAddr(ServiceCtx context, long bufferPosition, BsdSocket socket, bool isRemote)
+        private void WriteSockAddr(ServiceCtx context, ulong bufferPosition, BsdSocket socket, bool isRemote)
         {
             IPEndPoint endPoint = (isRemote ? socket.Handle.RemoteEndPoint : socket.Handle.LocalEndPoint) as IPEndPoint;
 
@@ -282,13 +282,13 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
         // Open(u32 flags, array<unknown, 0x21> path) -> (i32 ret, u32 bsd_errno)
         public ResultCode Open(ServiceCtx context)
         {
-            (long bufferPosition, long bufferSize) = context.Request.GetBufferType0x21();
+            (ulong bufferPosition, ulong bufferSize) = context.Request.GetBufferType0x21();
 
             int flags = context.RequestData.ReadInt32();
 
             byte[] rawPath = new byte[bufferSize];
 
-            context.Memory.Read((ulong)bufferPosition, rawPath);
+            context.Memory.Read(bufferPosition, rawPath);
 
             string path = Encoding.ASCII.GetString(rawPath);
 
@@ -317,10 +317,10 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             int fdsCount = context.RequestData.ReadInt32();
             int timeout  = context.RequestData.ReadInt32();
 
-            (long bufferPosition, long bufferSize) = context.Request.GetBufferType0x21();
+            (ulong bufferPosition, ulong bufferSize) = context.Request.GetBufferType0x21();
 
 
-            if (timeout < -1 || fdsCount < 0 || (fdsCount * 8) > bufferSize)
+            if (timeout < -1 || fdsCount < 0 || (ulong)(fdsCount * 8) > bufferSize)
             {
                 return WriteBsdResult(context, -1, LinuxError.EINVAL);
             }
@@ -329,7 +329,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
 
             for (int i = 0; i < fdsCount; i++)
             {
-                int socketFd = context.Memory.Read<int>((ulong)(bufferPosition + i * 8));
+                int socketFd = context.Memory.Read<int>(bufferPosition + (ulong)i * 8);
 
                 BsdSocket socket = RetrieveSocket(socketFd);
 
@@ -337,8 +337,8 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                 {
                     return WriteBsdResult(context, -1, LinuxError.EBADF);}
 
-                PollEvent.EventTypeMask inputEvents  = (PollEvent.EventTypeMask)context.Memory.Read<short>((ulong)(bufferPosition + i * 8 + 4));
-                PollEvent.EventTypeMask outputEvents = (PollEvent.EventTypeMask)context.Memory.Read<short>((ulong)(bufferPosition + i * 8 + 6));
+                PollEvent.EventTypeMask inputEvents  = (PollEvent.EventTypeMask)context.Memory.Read<short>(bufferPosition + (ulong)i * 8 + 4);
+                PollEvent.EventTypeMask outputEvents = (PollEvent.EventTypeMask)context.Memory.Read<short>(bufferPosition + (ulong)i * 8 + 6);
 
                 events[i] = new PollEvent(socketFd, socket, inputEvents, outputEvents);
             }
@@ -413,8 +413,8 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             for (int i = 0; i < fdsCount; i++)
             {
                 PollEvent Event = events[i];
-                context.Memory.Write((ulong)(bufferPosition + i * 8), Event.SocketFd);
-                context.Memory.Write((ulong)(bufferPosition + i * 8 + 4), (short)Event.InputEvents);
+                context.Memory.Write((ulong)(bufferPosition + (ulong)i * 8), Event.SocketFd);
+                context.Memory.Write((ulong)(bufferPosition + (ulong)i * 8 + 4), (short)Event.InputEvents);
 
                 PollEvent.EventTypeMask outputEvents = 0;
 
@@ -443,7 +443,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                     outputEvents |= PollEvent.EventTypeMask.Output;
                 }
 
-                context.Memory.Write((ulong)(bufferPosition + i * 8 + 6), (short)outputEvents);
+                context.Memory.Write((ulong)(bufferPosition + (ulong)i * 8 + 6), (short)outputEvents);
             }
 
             return WriteBsdResult(context, readEvents.Count + writeEvents.Count + errorEvents.Count, LinuxError.SUCCESS);
@@ -467,7 +467,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             int         socketFd    = context.RequestData.ReadInt32();
             SocketFlags socketFlags = (SocketFlags)context.RequestData.ReadInt32();
 
-            (long receivePosition, long receiveLength) = context.Request.GetBufferType0x22();
+            (ulong receivePosition, ulong receiveLength) = context.Request.GetBufferType0x22();
 
             LinuxError errno  = LinuxError.EBADF;
             BsdSocket  socket = RetrieveSocket(socketFd);
@@ -507,8 +507,8 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             int         socketFd    = context.RequestData.ReadInt32();
             SocketFlags socketFlags = (SocketFlags)context.RequestData.ReadInt32();
 
-            (long receivePosition,     long receiveLength)   = context.Request.GetBufferType0x22();
-            (long sockAddrOutPosition, long sockAddrOutSize) = context.Request.GetBufferType0x22(1);
+            (ulong receivePosition,     ulong receiveLength)   = context.Request.GetBufferType0x22();
+            (ulong sockAddrOutPosition, ulong sockAddrOutSize) = context.Request.GetBufferType0x22(1);
 
             LinuxError errno  = LinuxError.EBADF;
             BsdSocket  socket = RetrieveSocket(socketFd);
@@ -551,7 +551,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             int         socketFd    = context.RequestData.ReadInt32();
             SocketFlags socketFlags = (SocketFlags)context.RequestData.ReadInt32();
 
-            (long sendPosition, long sendSize) = context.Request.GetBufferType0x21();
+            (ulong sendPosition, ulong sendSize) = context.Request.GetBufferType0x21();
 
             LinuxError errno  = LinuxError.EBADF;
             BsdSocket  socket = RetrieveSocket(socketFd);
@@ -593,8 +593,8 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             int         socketFd    = context.RequestData.ReadInt32();
             SocketFlags socketFlags = (SocketFlags)context.RequestData.ReadInt32();
 
-            (long sendPosition,   long sendSize)   = context.Request.GetBufferType0x21();
-            (long bufferPosition, long bufferSize) = context.Request.GetBufferType0x21(1);
+            (ulong sendPosition,   ulong sendSize)   = context.Request.GetBufferType0x21();
+            (ulong bufferPosition, ulong bufferSize) = context.Request.GetBufferType0x21(1);
 
             LinuxError errno  = LinuxError.EBADF;
             BsdSocket  socket = RetrieveSocket(socketFd);
@@ -612,7 +612,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
 
                 byte[] sendBuffer = new byte[sendSize];
 
-                context.Memory.Read((ulong)sendPosition, sendBuffer);
+                context.Memory.Read(sendPosition, sendBuffer);
 
                 EndPoint endPoint = ParseSockAddr(context, bufferPosition, bufferSize);
 
@@ -637,7 +637,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
         {
             int socketFd = context.RequestData.ReadInt32();
 
-            (long bufferPos, long bufferSize) = context.Request.GetBufferType0x22();
+            (ulong bufferPos, ulong bufferSize) = context.Request.GetBufferType0x22();
 
             LinuxError errno  = LinuxError.EBADF;
             BsdSocket  socket = RetrieveSocket(socketFd);
@@ -692,7 +692,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
         {
             int socketFd = context.RequestData.ReadInt32();
 
-            (long bufferPos, long bufferSize) = context.Request.GetBufferType0x21();
+            (ulong bufferPos, ulong bufferSize) = context.Request.GetBufferType0x21();
 
             LinuxError errno  = LinuxError.EBADF;
             BsdSocket  socket = RetrieveSocket(socketFd);
@@ -722,7 +722,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
         {
             int socketFd = context.RequestData.ReadInt32();
 
-            (long bufferPos, long bufferSize) = context.Request.GetBufferType0x21();
+            (ulong bufferPos, ulong bufferSize) = context.Request.GetBufferType0x21();
 
             LinuxError errno  = LinuxError.EBADF;
             BsdSocket  socket = RetrieveSocket(socketFd);
@@ -751,7 +751,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
         {
             int socketFd = context.RequestData.ReadInt32();
 
-            (long bufferPos, long bufferSize) = context.Request.GetBufferType0x22();
+            (ulong bufferPos, ulong bufferSize) = context.Request.GetBufferType0x22();
 
             LinuxError  errno  = LinuxError.EBADF;
             BsdSocket socket = RetrieveSocket(socketFd);
@@ -774,7 +774,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
         {
             int socketFd = context.RequestData.ReadInt32();
 
-            (long bufferPos, long bufferSize) = context.Request.GetBufferType0x22();
+            (ulong bufferPos, ulong bufferSize) = context.Request.GetBufferType0x22();
 
             LinuxError errno  = LinuxError.EBADF;
             BsdSocket  socket = RetrieveSocket(socketFd);
@@ -799,7 +799,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             int level      = context.RequestData.ReadInt32();
             int optionName = context.RequestData.ReadInt32();
 
-            (long bufferPosition, long bufferSize) = context.Request.GetBufferType0x22();
+            (ulong bufferPosition, ulong bufferSize) = context.Request.GetBufferType0x22();
 
             LinuxError errno  = LinuxError.EBADF;
             BsdSocket  socket = RetrieveSocket(socketFd);
@@ -866,7 +866,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                     case BsdIoctl.AtMark:
                         errno = LinuxError.SUCCESS;
 
-                        (long bufferPosition, long bufferSize) = context.Request.GetBufferType0x22();
+                        (ulong bufferPosition, ulong bufferSize) = context.Request.GetBufferType0x22();
 
                         // FIXME: OOB not implemented.
                         context.Memory.Write((ulong)bufferPosition, 0);
@@ -917,7 +917,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             return WriteBsdResult(context, result, errno);
         }
 
-        private LinuxError HandleGetSocketOption(ServiceCtx context, BsdSocket socket, SocketOptionName optionName, long optionValuePosition, long optionValueSize)
+        private LinuxError HandleGetSocketOption(ServiceCtx context, BsdSocket socket, SocketOptionName optionName, ulong optionValuePosition, ulong optionValueSize)
         {
             try
             {
@@ -960,7 +960,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             }
         }
 
-        private LinuxError HandleSetSocketOption(ServiceCtx context, BsdSocket socket, SocketOptionName optionName, long optionValuePosition, long optionValueSize)
+        private LinuxError HandleSetSocketOption(ServiceCtx context, BsdSocket socket, SocketOptionName optionName, ulong optionValuePosition, ulong optionValueSize)
         {
             try
             {
@@ -1013,7 +1013,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             int level      = context.RequestData.ReadInt32();
             int optionName = context.RequestData.ReadInt32();
 
-            (long bufferPos, long bufferSize) = context.Request.GetBufferType0x21();
+            (ulong bufferPos, ulong bufferSize) = context.Request.GetBufferType0x21();
 
             LinuxError errno  = LinuxError.EBADF;
             BsdSocket  socket = RetrieveSocket(socketFd);
@@ -1105,7 +1105,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
         {
             int socketFd = context.RequestData.ReadInt32();
 
-            (long sendPosition, long sendSize) = context.Request.GetBufferType0x21();
+            (ulong sendPosition, ulong sendSize) = context.Request.GetBufferType0x21();
 
             LinuxError errno  = LinuxError.EBADF;
             BsdSocket  socket = RetrieveSocket(socketFd);
@@ -1137,7 +1137,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
         {
             int socketFd = context.RequestData.ReadInt32();
 
-            (long receivePosition, long receiveLength) = context.Request.GetBufferType0x22();
+            (ulong receivePosition, ulong receiveLength) = context.Request.GetBufferType0x22();
 
             LinuxError errno  = LinuxError.EBADF;
             BsdSocket  socket = RetrieveSocket(socketFd);
@@ -1151,7 +1151,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                 {
                     result = socket.Handle.Receive(receivedBuffer);
                     errno  = SetResultErrno(socket.Handle, result);
-                    context.Memory.Write((ulong)receivePosition, receivedBuffer);
+                    context.Memory.Write(receivePosition, receivedBuffer);
                 }
                 catch (SocketException exception)
                 {

--- a/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
@@ -413,8 +413,8 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             for (int i = 0; i < fdsCount; i++)
             {
                 PollEvent Event = events[i];
-                context.Memory.Write((ulong)(bufferPosition + (ulong)i * 8), Event.SocketFd);
-                context.Memory.Write((ulong)(bufferPosition + (ulong)i * 8 + 4), (short)Event.InputEvents);
+                context.Memory.Write(bufferPosition + (ulong)i * 8, Event.SocketFd);
+                context.Memory.Write(bufferPosition + (ulong)i * 8 + 4, (short)Event.InputEvents);
 
                 PollEvent.EventTypeMask outputEvents = 0;
 
@@ -443,7 +443,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                     outputEvents |= PollEvent.EventTypeMask.Output;
                 }
 
-                context.Memory.Write((ulong)(bufferPosition + (ulong)i * 8 + 6), (short)outputEvents);
+                context.Memory.Write(bufferPosition + (ulong)i * 8 + 6, (short)outputEvents);
             }
 
             return WriteBsdResult(context, readEvents.Count + writeEvents.Count + errorEvents.Count, LinuxError.SUCCESS);
@@ -489,7 +489,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                     result = socket.Handle.Receive(receivedBuffer, socketFlags);
                     errno  = SetResultErrno(socket.Handle, result);
 
-                    context.Memory.Write((ulong)receivePosition, receivedBuffer);
+                    context.Memory.Write(receivePosition, receivedBuffer);
                 }
                 catch (SocketException exception)
                 {
@@ -532,7 +532,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                     result = socket.Handle.ReceiveFrom(receivedBuffer, receivedBuffer.Length, socketFlags, ref endPoint);
                     errno  = SetResultErrno(socket.Handle, result);
 
-                    context.Memory.Write((ulong)receivePosition, receivedBuffer);
+                    context.Memory.Write(receivePosition, receivedBuffer);
                     WriteSockAddr(context, sockAddrOutPosition, (IPEndPoint)endPoint);
                 }
                 catch (SocketException exception)
@@ -569,7 +569,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
 
                 byte[] sendBuffer = new byte[sendSize];
 
-                context.Memory.Read((ulong)sendPosition, sendBuffer);
+                context.Memory.Read(sendPosition, sendBuffer);
 
                 try
                 {
@@ -869,7 +869,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                         (ulong bufferPosition, ulong bufferSize) = context.Request.GetBufferType0x22();
 
                         // FIXME: OOB not implemented.
-                        context.Memory.Write((ulong)bufferPosition, 0);
+                        context.Memory.Write(bufferPosition, 0);
                         break;
 
                     default:
@@ -938,13 +938,13 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                     case SocketOptionName.Type:
                     case SocketOptionName.Linger:
                         socket.Handle.GetSocketOption(SocketOptionLevel.Socket, optionName, optionValue);
-                        context.Memory.Write((ulong)optionValuePosition, optionValue);
+                        context.Memory.Write(optionValuePosition, optionValue);
 
                         return LinuxError.SUCCESS;
 
                     case (SocketOptionName)0x200:
                         socket.Handle.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, optionValue);
-                        context.Memory.Write((ulong)optionValuePosition, optionValue);
+                        context.Memory.Write(optionValuePosition, optionValue);
 
                         return LinuxError.SUCCESS;
 
@@ -1115,7 +1115,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             {
                 byte[] sendBuffer = new byte[sendSize];
 
-                context.Memory.Read((ulong)sendPosition, sendBuffer);
+                context.Memory.Read(sendPosition, sendBuffer);
 
                 try
                 {

--- a/Ryujinx.HLE/HOS/Services/Sockets/Nsd/IManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Nsd/IManager.cs
@@ -37,7 +37,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
         // GetSettingName() -> buffer<unknown<0x100>, 0x16>
         public ResultCode GetSettingName(ServiceCtx context)
         {
-            (long outputPosition, long outputSize) = context.Request.GetBufferType0x22();
+            (ulong outputPosition, ulong outputSize) = context.Request.GetBufferType0x22();
 
             ResultCode result = _fqdnResolver.GetSettingName(context, out string settingName);
 
@@ -55,7 +55,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
         // GetEnvironmentIdentifier() -> buffer<unknown<8>, 0x16>
         public ResultCode GetEnvironmentIdentifier(ServiceCtx context)
         {
-            (long outputPosition, long outputSize) = context.Request.GetBufferType0x22();
+            (ulong outputPosition, ulong outputSize) = context.Request.GetBufferType0x22();
 
             ResultCode result = _fqdnResolver.GetEnvironmentIdentifier(context, out string identifier);
 
@@ -133,12 +133,12 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
         // Resolve(buffer<unknown<0x100>, 0x15>) -> buffer<unknown<0x100>, 0x16>
         public ResultCode Resolve(ServiceCtx context)
         {
-            long outputPosition = context.Request.ReceiveBuff[0].Position;
-            long outputSize     = context.Request.ReceiveBuff[0].Size;
+            ulong outputPosition = context.Request.ReceiveBuff[0].Position;
+            ulong outputSize     = context.Request.ReceiveBuff[0].Size;
 
             ResultCode result = _fqdnResolver.ResolveEx(context, out _, out string resolvedAddress);
 
-            if (resolvedAddress.Length > outputSize)
+            if ((ulong)resolvedAddress.Length > outputSize)
             {
                 return ResultCode.InvalidArgument;
             }
@@ -147,7 +147,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
 
             MemoryHelper.FillWithZeros(context.Memory, outputPosition, (int)outputSize);
 
-            context.Memory.Write((ulong)outputPosition, resolvedAddressBuffer);
+            context.Memory.Write(outputPosition, resolvedAddressBuffer);
 
             return result;
         }
@@ -156,12 +156,12 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
         // ResolveEx(buffer<unknown<0x100>, 0x15>) -> (u32, buffer<unknown<0x100>, 0x16>)
         public ResultCode ResolveEx(ServiceCtx context)
         {
-            long outputPosition = context.Request.ReceiveBuff[0].Position;
-            long outputSize     = context.Request.ReceiveBuff[0].Size;
+            ulong outputPosition = context.Request.ReceiveBuff[0].Position;
+            ulong outputSize     = context.Request.ReceiveBuff[0].Size;
 
             ResultCode result = _fqdnResolver.ResolveEx(context, out ResultCode errorCode, out string resolvedAddress);
 
-            if (resolvedAddress.Length > outputSize)
+            if ((ulong)resolvedAddress.Length > outputSize)
             {
                 return ResultCode.InvalidArgument;
             }
@@ -170,7 +170,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
 
             MemoryHelper.FillWithZeros(context.Memory, outputPosition, (int)outputSize);
 
-            context.Memory.Write((ulong)outputPosition, resolvedAddressBuffer);
+            context.Memory.Write(outputPosition, resolvedAddressBuffer);
 
             context.ResponseData.Write((int)errorCode);
 

--- a/Ryujinx.HLE/HOS/Services/Sockets/Nsd/IManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Nsd/IManager.cs
@@ -45,7 +45,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
             {
                 byte[] settingNameBuffer = Encoding.UTF8.GetBytes(settingName + '\0');
 
-                context.Memory.Write((ulong)outputPosition, settingNameBuffer);
+                context.Memory.Write(outputPosition, settingNameBuffer);
             }
 
             return result;
@@ -63,7 +63,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
             {
                 byte[] identifierBuffer = Encoding.UTF8.GetBytes(identifier + '\0');
 
-                context.Memory.Write((ulong)outputPosition, identifierBuffer);
+                context.Memory.Write(outputPosition, identifierBuffer);
             }
 
             return result;

--- a/Ryujinx.HLE/HOS/Services/Sockets/Nsd/Manager/FqdnResolver.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Nsd/Manager/FqdnResolver.cs
@@ -97,12 +97,12 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd.Manager
 
         public ResultCode ResolveEx(ServiceCtx context, out ResultCode resultCode, out string resolvedAddress)
         {
-            long inputPosition = context.Request.SendBuff[0].Position;
-            long inputSize     = context.Request.SendBuff[0].Size;
+            ulong inputPosition = context.Request.SendBuff[0].Position;
+            ulong inputSize     = context.Request.SendBuff[0].Size;
 
             byte[] addressBuffer = new byte[inputSize];
 
-            context.Memory.Read((ulong)inputPosition, addressBuffer);
+            context.Memory.Read(inputPosition, addressBuffer);
 
             string address = Encoding.UTF8.GetString(addressBuffer).TrimEnd('\0');
 

--- a/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/IResolver.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/IResolver.cs
@@ -24,8 +24,8 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
         public ResultCode SetDnsAddressesPrivateRequest(ServiceCtx context)
         {
             uint cancelHandleRequest = context.RequestData.ReadUInt32();
-            ulong bufferPosition      = context.Request.SendBuff[0].Position;
-            ulong bufferSize          = context.Request.SendBuff[0].Size;
+            ulong bufferPosition     = context.Request.SendBuff[0].Position;
+            ulong bufferSize         = context.Request.SendBuff[0].Size;
 
             // TODO: This is stubbed in 2.0.0+, reverse 1.0.0 version for the sake of completeness.
             Logger.Stub?.PrintStub(LogClass.ServiceSfdnsres, new { cancelHandleRequest });
@@ -38,8 +38,8 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
         public ResultCode GetDnsAddressPrivateRequest(ServiceCtx context)
         {
             uint cancelHandleRequest = context.RequestData.ReadUInt32();
-            ulong bufferPosition      = context.Request.ReceiveBuff[0].Position;
-            ulong bufferSize          = context.Request.ReceiveBuff[0].Size;
+            ulong bufferPosition     = context.Request.ReceiveBuff[0].Position;
+            ulong bufferSize         = context.Request.ReceiveBuff[0].Size;
 
             // TODO: This is stubbed in 2.0.0+, reverse 1.0.0 version for the sake of completeness.
             Logger.Stub?.PrintStub(LogClass.ServiceSfdnsres, new { cancelHandleRequest });

--- a/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/IResolver.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/IResolver.cs
@@ -220,7 +220,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
         {
             byte[] rawName = new byte[inputBufferSize];
 
-            context.Memory.Read((ulong)inputBufferPosition, rawName);
+            context.Memory.Read(inputBufferPosition, rawName);
 
             string name = Encoding.ASCII.GetString(rawName).TrimEnd('\0');
 

--- a/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/IResolver.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/IResolver.cs
@@ -24,8 +24,8 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
         public ResultCode SetDnsAddressesPrivateRequest(ServiceCtx context)
         {
             uint cancelHandleRequest = context.RequestData.ReadUInt32();
-            long bufferPosition      = context.Request.SendBuff[0].Position;
-            long bufferSize          = context.Request.SendBuff[0].Size;
+            ulong bufferPosition      = context.Request.SendBuff[0].Position;
+            ulong bufferSize          = context.Request.SendBuff[0].Size;
 
             // TODO: This is stubbed in 2.0.0+, reverse 1.0.0 version for the sake of completeness.
             Logger.Stub?.PrintStub(LogClass.ServiceSfdnsres, new { cancelHandleRequest });
@@ -38,8 +38,8 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
         public ResultCode GetDnsAddressPrivateRequest(ServiceCtx context)
         {
             uint cancelHandleRequest = context.RequestData.ReadUInt32();
-            long bufferPosition      = context.Request.ReceiveBuff[0].Position;
-            long bufferSize          = context.Request.ReceiveBuff[0].Size;
+            ulong bufferPosition      = context.Request.ReceiveBuff[0].Position;
+            ulong bufferSize          = context.Request.ReceiveBuff[0].Size;
 
             // TODO: This is stubbed in 2.0.0+, reverse 1.0.0 version for the sake of completeness.
             Logger.Stub?.PrintStub(LogClass.ServiceSfdnsres, new { cancelHandleRequest });
@@ -51,11 +51,11 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
         // GetHostByNameRequest(u8, u32, u64, pid, buffer<unknown, 5, 0>) -> (u32, u32, u32, buffer<unknown, 6, 0>)
         public ResultCode GetHostByNameRequest(ServiceCtx context)
         {
-            long inputBufferPosition = context.Request.SendBuff[0].Position;
-            long inputBufferSize     = context.Request.SendBuff[0].Size;
+            ulong inputBufferPosition = context.Request.SendBuff[0].Position;
+            ulong inputBufferSize     = context.Request.SendBuff[0].Size;
 
-            long outputBufferPosition = context.Request.ReceiveBuff[0].Position;
-            long outputBufferSize     = context.Request.ReceiveBuff[0].Size;
+            ulong outputBufferPosition = context.Request.ReceiveBuff[0].Position;
+            ulong outputBufferSize     = context.Request.ReceiveBuff[0].Size;
 
             return GetHostByNameRequestImpl(context, inputBufferPosition, inputBufferSize, outputBufferPosition, outputBufferSize, 0, 0);
         }
@@ -64,11 +64,11 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
         // GetHostByAddrRequest(u32, u32, u32, u64, pid, buffer<unknown, 5, 0>) -> (u32, u32, u32, buffer<unknown, 6, 0>)
         public ResultCode GetHostByAddrRequest(ServiceCtx context)
         {
-            long inputBufferPosition = context.Request.SendBuff[0].Position;
-            long inputBufferSize     = context.Request.SendBuff[0].Size;
+            ulong inputBufferPosition = context.Request.SendBuff[0].Position;
+            ulong inputBufferSize     = context.Request.SendBuff[0].Size;
 
-            long outputBufferPosition = context.Request.ReceiveBuff[0].Position;
-            long outputBufferSize     = context.Request.ReceiveBuff[0].Size;
+            ulong outputBufferPosition = context.Request.ReceiveBuff[0].Position;
+            ulong outputBufferSize     = context.Request.ReceiveBuff[0].Size;
 
             return GetHostByAddrRequestImpl(context, inputBufferPosition, inputBufferSize, outputBufferPosition, outputBufferSize, 0, 0);
         }
@@ -90,12 +90,12 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
                 _                       => (errorCode <= NetDbError.Internal) ? "Resolver internal error" : "Unknown resolver error"
             };
 
-            long bufferPosition = context.Request.ReceiveBuff[0].Position;
-            long bufferSize     = context.Request.ReceiveBuff[0].Size;
+            ulong bufferPosition = context.Request.ReceiveBuff[0].Position;
+            ulong bufferSize     = context.Request.ReceiveBuff[0].Size;
 
-            if (errorString.Length + 1 <= bufferSize)
+            if ((ulong)(errorString.Length + 1) <= bufferSize)
             {
-                context.Memory.Write((ulong)bufferPosition, Encoding.ASCII.GetBytes(errorString + '\0'));
+                context.Memory.Write(bufferPosition, Encoding.ASCII.GetBytes(errorString + '\0'));
 
                 resultCode = ResultCode.Success;
             }
@@ -135,12 +135,12 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
                 _                      => "Success"
             };
 
-            long bufferPosition = context.Request.ReceiveBuff[0].Position;
-            long bufferSize     = context.Request.ReceiveBuff[0].Size;
+            ulong bufferPosition = context.Request.ReceiveBuff[0].Position;
+            ulong bufferSize     = context.Request.ReceiveBuff[0].Size;
 
-            if (errorString.Length + 1 <= bufferSize)
+            if ((ulong)(errorString.Length + 1) <= bufferSize)
             {
-                context.Memory.Write((ulong)bufferPosition, Encoding.ASCII.GetBytes(errorString + '\0'));
+                context.Memory.Write(bufferPosition, Encoding.ASCII.GetBytes(errorString + '\0'));
 
                 resultCode = ResultCode.Success;
             }
@@ -152,8 +152,8 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
         // GetAddrInfoRequest(bool enable_nsd_resolve, u32, u64 pid_placeholder, pid, buffer<i8, 5, 0> host, buffer<i8, 5, 0> service, buffer<packed_addrinfo, 5, 0> hints) -> (i32 ret, u32 bsd_errno, u32 packed_addrinfo_size, buffer<packed_addrinfo, 6, 0> response)
         public ResultCode GetAddrInfoRequest(ServiceCtx context)
         {
-            long responseBufferPosition = context.Request.ReceiveBuff[0].Position;
-            long responseBufferSize     = context.Request.ReceiveBuff[0].Size;
+            ulong responseBufferPosition = context.Request.ReceiveBuff[0].Position;
+            ulong responseBufferSize     = context.Request.ReceiveBuff[0].Size;
 
             return GetAddrInfoRequestImpl(context, responseBufferPosition, responseBufferSize, 0, 0);
         }
@@ -188,9 +188,9 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
         // GetHostByNameRequestWithOptions(u8, u32, u64, pid, buffer<unknown, 21, 0>, buffer<unknown, 21, 0>) -> (u32, u32, u32, buffer<unknown, 22, 0>)
         public ResultCode GetHostByNameRequestWithOptions(ServiceCtx context)
         {
-            (long inputBufferPosition,   long inputBufferSize)   = context.Request.GetBufferType0x21();
-            (long outputBufferPosition,  long outputBufferSize)  = context.Request.GetBufferType0x22();
-            (long optionsBufferPosition, long optionsBufferSize) = context.Request.GetBufferType0x21();
+            (ulong inputBufferPosition,   ulong inputBufferSize)   = context.Request.GetBufferType0x21();
+            (ulong outputBufferPosition,  ulong outputBufferSize)  = context.Request.GetBufferType0x22();
+            (ulong optionsBufferPosition, ulong optionsBufferSize) = context.Request.GetBufferType0x21();
 
             return GetHostByNameRequestImpl(context, inputBufferPosition, inputBufferSize, outputBufferPosition, outputBufferSize, optionsBufferPosition, optionsBufferSize);
         }
@@ -199,9 +199,9 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
         // GetHostByAddrRequestWithOptions(u32, u32, u32, u64, pid, buffer<unknown, 21, 0>, buffer<unknown, 21, 0>) -> (u32, u32, u32, buffer<unknown, 22, 0>)
         public ResultCode GetHostByAddrRequestWithOptions(ServiceCtx context)
         {
-            (long inputBufferPosition,   long inputBufferSize)   = context.Request.GetBufferType0x21();
-            (long outputBufferPosition,  long outputBufferSize)  = context.Request.GetBufferType0x22();
-            (long optionsBufferPosition, long optionsBufferSize) = context.Request.GetBufferType0x21();
+            (ulong inputBufferPosition,   ulong inputBufferSize)   = context.Request.GetBufferType0x21();
+            (ulong outputBufferPosition,  ulong outputBufferSize)  = context.Request.GetBufferType0x22();
+            (ulong optionsBufferPosition, ulong optionsBufferSize) = context.Request.GetBufferType0x21();
 
             return GetHostByAddrRequestImpl(context, inputBufferPosition, inputBufferSize, outputBufferPosition, outputBufferSize, optionsBufferPosition, optionsBufferSize);
         }
@@ -210,13 +210,13 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
         // GetAddrInfoRequestWithOptions(bool enable_nsd_resolve, u32, u64 pid_placeholder, pid, buffer<i8, 5, 0> host, buffer<i8, 5, 0> service, buffer<packed_addrinfo, 5, 0> hints, buffer<unknown, 21, 0>) -> (i32 ret, u32 bsd_errno, u32 unknown, u32 packed_addrinfo_size, buffer<packed_addrinfo, 22, 0> response)
         public ResultCode GetAddrInfoRequestWithOptions(ServiceCtx context)
         {
-            (long responseBufferPosition, long responseBufferSize) = context.Request.GetBufferType0x22();
-            (long optionsBufferPosition,  long optionsBufferSize)  = context.Request.GetBufferType0x21();
+            (ulong responseBufferPosition, ulong responseBufferSize) = context.Request.GetBufferType0x22();
+            (ulong optionsBufferPosition,  ulong optionsBufferSize)  = context.Request.GetBufferType0x21();
 
             return GetAddrInfoRequestImpl(context, responseBufferPosition, responseBufferSize, optionsBufferPosition, optionsBufferSize);
         }
 
-        private ResultCode GetHostByNameRequestImpl(ServiceCtx context, long inputBufferPosition, long inputBufferSize, long outputBufferPosition, long outputBufferSize, long optionsBufferPosition, long optionsBufferSize)
+        private ResultCode GetHostByNameRequestImpl(ServiceCtx context, ulong inputBufferPosition, ulong inputBufferSize, ulong outputBufferPosition, ulong outputBufferSize, ulong optionsBufferPosition, ulong optionsBufferSize)
         {
             byte[] rawName = new byte[inputBufferSize];
 
@@ -238,7 +238,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
 
             NetDbError netDbErrorCode = NetDbError.Success;
             GaiError   errno          = GaiError.Overflow;
-            long       serializedSize = 0;
+            ulong      serializedSize = 0;
 
             if (name.Length <= byte.MaxValue)
             {
@@ -294,11 +294,11 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
             return ResultCode.Success;
         }
 
-        private ResultCode GetHostByAddrRequestImpl(ServiceCtx context, long inputBufferPosition, long inputBufferSize, long outputBufferPosition, long outputBufferSize, long optionsBufferPosition, long optionsBufferSize)
+        private ResultCode GetHostByAddrRequestImpl(ServiceCtx context, ulong inputBufferPosition, ulong inputBufferSize, ulong outputBufferPosition, ulong outputBufferSize, ulong optionsBufferPosition, ulong optionsBufferSize)
         {
             byte[] rawIp = new byte[inputBufferSize];
 
-            context.Memory.Read((ulong)inputBufferPosition, rawIp);
+            context.Memory.Read(inputBufferPosition, rawIp);
 
             // TODO: Use params.
             uint  socketLength   = context.RequestData.ReadUInt32();
@@ -315,7 +315,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
 
             NetDbError netDbErrorCode = NetDbError.Success;
             GaiError   errno          = GaiError.AddressFamily;
-            long       serializedSize = 0;
+            ulong      serializedSize = 0;
 
             if (rawIp.Length == 4)
             {
@@ -349,59 +349,59 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
             return ResultCode.Success;
         }
 
-        private long SerializeHostEntries(ServiceCtx context, long outputBufferPosition, long outputBufferSize, IPHostEntry hostEntry, IEnumerable<IPAddress> addresses = null)
+        private ulong SerializeHostEntries(ServiceCtx context, ulong outputBufferPosition, ulong outputBufferSize, IPHostEntry hostEntry, IEnumerable<IPAddress> addresses = null)
         {
-            long originalBufferPosition = outputBufferPosition;
-            long bufferPosition         = originalBufferPosition;
+            ulong originalBufferPosition = outputBufferPosition;
+            ulong bufferPosition         = originalBufferPosition;
 
             string hostName = hostEntry.HostName + '\0';
 
             // h_name
-            context.Memory.Write((ulong)bufferPosition, Encoding.ASCII.GetBytes(hostName));
-            bufferPosition += hostName.Length;
+            context.Memory.Write(bufferPosition, Encoding.ASCII.GetBytes(hostName));
+            bufferPosition += (ulong)hostName.Length;
 
             // h_aliases list size
-            context.Memory.Write((ulong)bufferPosition, BinaryPrimitives.ReverseEndianness(hostEntry.Aliases.Length));
-            bufferPosition += 4;
+            context.Memory.Write(bufferPosition, BinaryPrimitives.ReverseEndianness(hostEntry.Aliases.Length));
+            bufferPosition += sizeof(int);
 
             // Actual aliases
             foreach (string alias in hostEntry.Aliases)
             {
-                context.Memory.Write((ulong)bufferPosition, Encoding.ASCII.GetBytes(alias + '\0'));
-                bufferPosition += alias.Length + 1;
+                context.Memory.Write(bufferPosition, Encoding.ASCII.GetBytes(alias + '\0'));
+                bufferPosition += (ulong)(alias.Length + 1);
             }
 
             // h_addrtype but it's a short (also only support IPv4)
-            context.Memory.Write((ulong)bufferPosition, BinaryPrimitives.ReverseEndianness((short)AddressFamily.InterNetwork));
-            bufferPosition += 2;
+            context.Memory.Write(bufferPosition, BinaryPrimitives.ReverseEndianness((short)AddressFamily.InterNetwork));
+            bufferPosition += sizeof(short);
 
             // h_length but it's a short
-            context.Memory.Write((ulong)bufferPosition, BinaryPrimitives.ReverseEndianness((short)4));
-            bufferPosition += 2;
+            context.Memory.Write(bufferPosition, BinaryPrimitives.ReverseEndianness((short)4));
+            bufferPosition += sizeof(short);
 
             // Ip address count, we can only support ipv4 (blame Nintendo)
-            context.Memory.Write((ulong)bufferPosition, addresses != null ? BinaryPrimitives.ReverseEndianness(addresses.Count()) : 0);
-            bufferPosition += 4;
+            context.Memory.Write(bufferPosition, addresses != null ? BinaryPrimitives.ReverseEndianness(addresses.Count()) : 0);
+            bufferPosition += sizeof(int);
 
             if (addresses != null)
             {
                 foreach (IPAddress ip in addresses)
                 {
-                    context.Memory.Write((ulong)bufferPosition, BinaryPrimitives.ReverseEndianness(BitConverter.ToInt32(ip.GetAddressBytes(), 0)));
-                    bufferPosition += 4;
+                    context.Memory.Write(bufferPosition, BinaryPrimitives.ReverseEndianness(BitConverter.ToInt32(ip.GetAddressBytes(), 0)));
+                    bufferPosition += sizeof(int);
                 }
             }
 
             return bufferPosition - originalBufferPosition;
         }
 
-        private ResultCode GetAddrInfoRequestImpl(ServiceCtx context, long responseBufferPosition, long responseBufferSize, long optionsBufferPosition, long optionsBufferSize)
+        private ResultCode GetAddrInfoRequestImpl(ServiceCtx context, ulong responseBufferPosition, ulong responseBufferSize, ulong optionsBufferPosition, ulong optionsBufferSize)
         {
             bool enableNsdResolve = (context.RequestData.ReadInt32() & 1) != 0;
             uint cancelHandle     = context.RequestData.ReadUInt32();
 
-            string host    = MemoryHelper.ReadAsciiString(context.Memory, context.Request.SendBuff[0].Position, context.Request.SendBuff[0].Size);
-            string service = MemoryHelper.ReadAsciiString(context.Memory, context.Request.SendBuff[1].Position, context.Request.SendBuff[1].Size);
+            string host    = MemoryHelper.ReadAsciiString(context.Memory, context.Request.SendBuff[0].Position, (long)context.Request.SendBuff[0].Size);
+            string service = MemoryHelper.ReadAsciiString(context.Memory, context.Request.SendBuff[1].Position, (long)context.Request.SendBuff[1].Size);
 
             // NOTE: We ignore hints for now.
             DeserializeAddrInfos(context.Memory, (ulong)context.Request.SendBuff[2].Position, (ulong)context.Request.SendBuff[2].Size);
@@ -500,7 +500,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
             }
         }
 
-        private ulong SerializeAddrInfos(ServiceCtx context, long responseBufferPosition, long responseBufferSize, IPHostEntry hostEntry, int port)
+        private ulong SerializeAddrInfos(ServiceCtx context, ulong responseBufferPosition, ulong responseBufferSize, IPHostEntry hostEntry, int port)
         {
             ulong originalBufferPosition = (ulong)responseBufferPosition;
             ulong bufferPosition         = originalBufferPosition;
@@ -533,7 +533,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
 
             // Termination zero value.
             context.Memory.Write(bufferPosition, 0);
-            bufferPosition += 4;
+            bufferPosition += sizeof(int);
 
             return bufferPosition - originalBufferPosition;
         }

--- a/Ryujinx.HLE/HOS/Services/Spl/IRandomInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Spl/IRandomInterface.cs
@@ -21,7 +21,7 @@ namespace Ryujinx.HLE.HOS.Services.Spl
 
             _rng.GetBytes(randomBytes);
 
-            context.Memory.Write((ulong)context.Request.ReceiveBuff[0].Position, randomBytes);
+            context.Memory.Write(context.Request.ReceiveBuff[0].Position, randomBytes);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Ssl/SslService/ISslConnection.cs
+++ b/Ryujinx.HLE/HOS/Services/Ssl/SslService/ISslConnection.cs
@@ -26,12 +26,12 @@ namespace Ryujinx.HLE.HOS.Services.Ssl.SslService
         // SetHostName(buffer<bytes, 5>)
         public ResultCode SetHostName(ServiceCtx context)
         {
-            long hostNameDataPosition = context.Request.SendBuff[0].Position;
-            long hostNameDataSize     = context.Request.SendBuff[0].Size;
+            ulong hostNameDataPosition = context.Request.SendBuff[0].Position;
+            ulong hostNameDataSize     = context.Request.SendBuff[0].Size;
 
             byte[] hostNameData = new byte[hostNameDataSize];
 
-            context.Memory.Read((ulong)hostNameDataPosition, hostNameData);
+            context.Memory.Read(hostNameDataPosition, hostNameData);
 
             string hostName = Encoding.ASCII.GetString(hostNameData).Trim('\0');
 
@@ -75,12 +75,12 @@ namespace Ryujinx.HLE.HOS.Services.Ssl.SslService
         // Write(buffer<bytes, 5>) -> u32
         public ResultCode Write(ServiceCtx context)
         {
-            long inputDataPosition = context.Request.SendBuff[0].Position;
-            long inputDataSize     = context.Request.SendBuff[0].Size;
+            ulong inputDataPosition = context.Request.SendBuff[0].Position;
+            ulong inputDataSize     = context.Request.SendBuff[0].Size;
 
             byte[] data = new byte[inputDataSize];
 
-            context.Memory.Read((ulong)inputDataPosition, data);
+            context.Memory.Read(inputDataPosition, data);
 
             // NOTE: Tell the guest everything is transferred.
             uint transferredSize = (uint)inputDataSize;

--- a/Ryujinx.HLE/HOS/Services/Ssl/SslService/ISslContext.cs
+++ b/Ryujinx.HLE/HOS/Services/Ssl/SslService/ISslContext.cs
@@ -41,8 +41,8 @@ namespace Ryujinx.HLE.HOS.Services.Ssl.SslService
         {
             CertificateFormat certificateFormat = (CertificateFormat)context.RequestData.ReadUInt32();
 
-            long certificateDataPosition = context.Request.SendBuff[0].Position;
-            long certificateDataSize     = context.Request.SendBuff[0].Size;
+            ulong certificateDataPosition = context.Request.SendBuff[0].Position;
+            ulong certificateDataSize     = context.Request.SendBuff[0].Size;
 
             context.ResponseData.Write(_serverCertificateId++);
 
@@ -55,11 +55,11 @@ namespace Ryujinx.HLE.HOS.Services.Ssl.SslService
         // ImportClientPki(buffer<bytes, 5> certificate, buffer<bytes, 5> ascii_password) -> u64 certificateId
         public ResultCode ImportClientPki(ServiceCtx context)
         {
-            long certificateDataPosition = context.Request.SendBuff[0].Position;
-            long certificateDataSize     = context.Request.SendBuff[0].Size;
+            ulong certificateDataPosition = context.Request.SendBuff[0].Position;
+            ulong certificateDataSize     = context.Request.SendBuff[0].Size;
 
-            long asciiPasswordDataPosition = context.Request.SendBuff[1].Position;
-            long asciiPasswordDataSize     = context.Request.SendBuff[1].Size;
+            ulong asciiPasswordDataPosition = context.Request.SendBuff[1].Position;
+            ulong asciiPasswordDataSize     = context.Request.SendBuff[1].Size;
 
             byte[] asciiPasswordData = new byte[asciiPasswordDataSize];
 

--- a/Ryujinx.HLE/HOS/Services/Ssl/SslService/ISslContext.cs
+++ b/Ryujinx.HLE/HOS/Services/Ssl/SslService/ISslContext.cs
@@ -63,7 +63,7 @@ namespace Ryujinx.HLE.HOS.Services.Ssl.SslService
 
             byte[] asciiPasswordData = new byte[asciiPasswordDataSize];
 
-            context.Memory.Read((ulong)asciiPasswordDataPosition, asciiPasswordData);
+            context.Memory.Read(asciiPasswordDataPosition, asciiPasswordData);
 
             string asciiPassword = Encoding.ASCII.GetString(asciiPasswordData).Trim('\0');
 

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/IHOSBinderDriver.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/IHOSBinderDriver.cs
@@ -32,7 +32,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
             if (result == ResultCode.Success)
             {
-                context.Memory.Write((ulong)replyPos, outputParcel);
+                context.Memory.Write(replyPos, outputParcel);
             }
 
             return result;
@@ -81,7 +81,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
             (ulong dataPos, ulong dataSize)   = context.Request.GetBufferType0x21();
             (ulong replyPos, ulong replySize) = context.Request.GetBufferType0x22();
 
-            ReadOnlySpan<byte> inputParcel = context.Memory.GetSpan((ulong)dataPos, (int)dataSize);
+            ReadOnlySpan<byte> inputParcel = context.Memory.GetSpan(dataPos, (int)dataSize);
 
             Span<byte> outputParcel = new Span<byte>(new byte[replySize]);
 
@@ -89,7 +89,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
             if (result == ResultCode.Success)
             {
-                context.Memory.Write((ulong)replyPos, outputParcel);
+                context.Memory.Write(replyPos, outputParcel);
             }
 
             return result;

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/IHOSBinderDriver.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/IHOSBinderDriver.cs
@@ -18,11 +18,11 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
             uint code  = context.RequestData.ReadUInt32();
             uint flags = context.RequestData.ReadUInt32();
 
-            ulong dataPos  = (ulong)context.Request.SendBuff[0].Position;
-            ulong dataSize = (ulong)context.Request.SendBuff[0].Size;
+            ulong dataPos  = context.Request.SendBuff[0].Position;
+            ulong dataSize = context.Request.SendBuff[0].Size;
 
-            long replyPos  = context.Request.ReceiveBuff[0].Position;
-            long replySize = context.Request.ReceiveBuff[0].Size;
+            ulong replyPos  = context.Request.ReceiveBuff[0].Position;
+            ulong replySize = context.Request.ReceiveBuff[0].Size;
 
             ReadOnlySpan<byte> inputParcel = context.Memory.GetSpan(dataPos, (int)dataSize);
 
@@ -78,8 +78,8 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
             uint code  = context.RequestData.ReadUInt32();
             uint flags = context.RequestData.ReadUInt32();
 
-            (long dataPos, long dataSize)   = context.Request.GetBufferType0x21();
-            (long replyPos, long replySize) = context.Request.GetBufferType0x22();
+            (ulong dataPos, ulong dataSize)   = context.Request.GetBufferType0x21();
+            (ulong replyPos, ulong replySize) = context.Request.GetBufferType0x22();
 
             ReadOnlySpan<byte> inputParcel = context.Memory.GetSpan((ulong)dataPos, (int)dataSize);
 

--- a/Ryujinx.HLE/HOS/Services/Time/IStaticServiceForPsc.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/IStaticServiceForPsc.cs
@@ -246,7 +246,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
         {
             byte type = context.RequestData.ReadByte();
 
-            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize(Marshal.SizeOf<ClockSnapshot>());
+            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize((uint)Marshal.SizeOf<ClockSnapshot>());
 
             ResultCode result = _timeManager.StandardUserSystemClock.GetClockContext(context.Thread, out SystemClockContext userContext);
 
@@ -274,7 +274,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
         {
             byte type = context.RequestData.ReadByte();
 
-            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize(Marshal.SizeOf<ClockSnapshot>());
+            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize((uint)Marshal.SizeOf<ClockSnapshot>());
 
             context.RequestData.BaseStream.Position += 7;
 
@@ -404,7 +404,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
 
         private ClockSnapshot ReadClockSnapshotFromBuffer(ServiceCtx context, IpcPtrBuffDesc ipcDesc)
         {
-            Debug.Assert(ipcDesc.Size == Marshal.SizeOf<ClockSnapshot>());
+            Debug.Assert(ipcDesc.Size == (ulong)Marshal.SizeOf<ClockSnapshot>());
 
             byte[] temp = new byte[ipcDesc.Size];
 

--- a/Ryujinx.HLE/HOS/Services/Time/IStaticServiceForPsc.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/IStaticServiceForPsc.cs
@@ -408,7 +408,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
 
             byte[] temp = new byte[ipcDesc.Size];
 
-            context.Memory.Read((ulong)ipcDesc.Position, temp);
+            context.Memory.Read(ipcDesc.Position, temp);
 
             using (BinaryReader bufferReader = new BinaryReader(new MemoryStream(temp)))
             {

--- a/Ryujinx.HLE/HOS/Services/Time/ITimeServiceManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/ITimeServiceManager.cs
@@ -121,11 +121,11 @@ namespace Ryujinx.HLE.HOS.Services.Time
             uint                 totalLocationNameCount  = context.RequestData.ReadUInt32();
             UInt128              timeZoneRuleVersion     = context.RequestData.ReadStruct<UInt128>();
 
-            (long bufferPosition, long bufferSize) = context.Request.GetBufferType0x21();
+            (ulong bufferPosition, ulong bufferSize) = context.Request.GetBufferType0x21();
 
             byte[] temp = new byte[bufferSize];
 
-            context.Memory.Read((ulong)bufferPosition, temp);
+            context.Memory.Read(bufferPosition, temp);
 
             using (MemoryStream timeZoneBinaryStream = new MemoryStream(temp))
             {

--- a/Ryujinx.HLE/HOS/Services/Time/StaticService/ITimeZoneServiceForGlue.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/StaticService/ITimeZoneServiceForGlue.cs
@@ -70,7 +70,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
                         return ResultCode.LocationNameTooLong;
                     }
 
-                    context.Memory.Write((ulong)bufferPosition + offset, Encoding.ASCII.GetBytes(locationName));
+                    context.Memory.Write(bufferPosition + offset, Encoding.ASCII.GetBytes(locationName));
                     MemoryHelper.FillWithZeros(context.Memory, bufferPosition + offset + (ulong)locationName.Length, padding);
 
                     offset += 0x24;

--- a/Ryujinx.HLE/HOS/Services/Time/StaticService/ITimeZoneServiceForGlue.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/StaticService/ITimeZoneServiceForGlue.cs
@@ -51,9 +51,9 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
         // LoadLocationNameList(u32 index) -> (u32 outCount, buffer<nn::time::LocationName, 6>)
         public ResultCode LoadLocationNameList(ServiceCtx context)
         {
-            uint index          = context.RequestData.ReadUInt32();
-            long bufferPosition = context.Request.ReceiveBuff[0].Position;
-            long bufferSize     = context.Request.ReceiveBuff[0].Size;
+            uint  index          = context.RequestData.ReadUInt32();
+            ulong bufferPosition = context.Request.ReceiveBuff[0].Position;
+            ulong bufferSize     = context.Request.ReceiveBuff[0].Size;
 
             ResultCode errorCode = _timeZoneContentManager.LoadLocationNameList(index, out string[] locationNameArray, (uint)bufferSize / 0x24);
 
@@ -71,7 +71,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
                     }
 
                     context.Memory.Write((ulong)bufferPosition + offset, Encoding.ASCII.GetBytes(locationName));
-                    MemoryHelper.FillWithZeros(context.Memory, bufferPosition + offset + locationName.Length, padding);
+                    MemoryHelper.FillWithZeros(context.Memory, bufferPosition + offset + (ulong)locationName.Length, padding);
 
                     offset += 0x24;
                 }
@@ -86,8 +86,8 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
         // LoadTimeZoneRule(nn::time::LocationName locationName) -> buffer<nn::time::TimeZoneRule, 0x16>
         public ResultCode LoadTimeZoneRule(ServiceCtx context)
         {
-            long bufferPosition = context.Request.ReceiveBuff[0].Position;
-            long bufferSize     = context.Request.ReceiveBuff[0].Size;
+            ulong bufferPosition = context.Request.ReceiveBuff[0].Position;
+            ulong bufferSize     = context.Request.ReceiveBuff[0].Size;
 
             if (bufferSize != 0x4000)
             {

--- a/Ryujinx.HLE/HOS/Services/Time/StaticService/ITimeZoneServiceForPsc.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/StaticService/ITimeZoneServiceForPsc.cs
@@ -123,7 +123,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
                 return ResultCode.PermissionDenied;
             }
 
-            (long bufferPosition, long bufferSize) = context.Request.GetBufferType0x21();
+            (ulong bufferPosition, ulong bufferSize) = context.Request.GetBufferType0x21();
 
             string locationName = Encoding.ASCII.GetString(context.RequestData.ReadBytes(0x24)).TrimEnd('\0');
 
@@ -131,7 +131,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
 
             byte[] temp = new byte[bufferSize];
 
-            context.Memory.Read((ulong)bufferPosition, temp);
+            context.Memory.Read(bufferPosition, temp);
 
             using (MemoryStream timeZoneBinaryStream = new MemoryStream(temp))
             {
@@ -145,10 +145,10 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
         // ParseTimeZoneBinary(buffer<nn::time::TimeZoneBinary, 0x21> timeZoneBinary) -> buffer<nn::time::TimeZoneRule, 0x16>
         public ResultCode ParseTimeZoneBinary(ServiceCtx context)
         {
-            (long bufferPosition, long bufferSize) = context.Request.GetBufferType0x21();
+            (ulong bufferPosition, ulong bufferSize) = context.Request.GetBufferType0x21();
 
-            long timeZoneRuleBufferPosition = context.Request.ReceiveBuff[0].Position;
-            long timeZoneRuleBufferSize     = context.Request.ReceiveBuff[0].Size;
+            ulong timeZoneRuleBufferPosition = context.Request.ReceiveBuff[0].Position;
+            ulong timeZoneRuleBufferSize     = context.Request.ReceiveBuff[0].Size;
 
             if (timeZoneRuleBufferSize != 0x4000)
             {
@@ -162,7 +162,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
 
             byte[] temp = new byte[bufferSize];
 
-            context.Memory.Read((ulong)bufferPosition, temp);
+            context.Memory.Read(bufferPosition, temp);
 
             using (MemoryStream timeZoneBinaryStream = new MemoryStream(temp))
             {
@@ -188,9 +188,9 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
         // ToCalendarTime(nn::time::PosixTime time, buffer<nn::time::TimeZoneRule, 0x15> rules) -> (nn::time::CalendarTime, nn::time::sf::CalendarAdditionalInfo)
         public ResultCode ToCalendarTime(ServiceCtx context)
         {
-            long posixTime      = context.RequestData.ReadInt64();
-            long bufferPosition = context.Request.SendBuff[0].Position;
-            long bufferSize     = context.Request.SendBuff[0].Size;
+            long posixTime       = context.RequestData.ReadInt64();
+            ulong bufferPosition = context.Request.SendBuff[0].Position;
+            ulong bufferSize     = context.Request.SendBuff[0].Size;
 
             if (bufferSize != 0x4000)
             {
@@ -220,7 +220,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
 
             ResultCode resultCode = _timeZoneManager.ToCalendarTimeWithMyRules(posixTime, out CalendarInfo calendar);
 
-            if (resultCode == 0)
+            if (resultCode == ResultCode.Success)
             {
                 context.ResponseData.WriteStruct(calendar);
             }
@@ -232,8 +232,8 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
         // ToPosixTime(nn::time::CalendarTime calendarTime, buffer<nn::time::TimeZoneRule, 0x15> rules) -> (u32 outCount, buffer<nn::time::PosixTime, 0xa>)
         public ResultCode ToPosixTime(ServiceCtx context)
         {
-            long inBufferPosition = context.Request.SendBuff[0].Position;
-            long inBufferSize     = context.Request.SendBuff[0].Size;
+            ulong inBufferPosition = context.Request.SendBuff[0].Position;
+            ulong inBufferSize     = context.Request.SendBuff[0].Size;
 
             CalendarTime calendarTime = context.RequestData.ReadStruct<CalendarTime>();
 
@@ -249,10 +249,10 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
 
             ResultCode resultCode = _timeZoneManager.ToPosixTime(rules, calendarTime, out long posixTime);
 
-            if (resultCode == 0)
+            if (resultCode == ResultCode.Success)
             {
-                long outBufferPosition = context.Request.RecvListBuff[0].Position;
-                long outBufferSize     = context.Request.RecvListBuff[0].Size;
+                ulong outBufferPosition = context.Request.RecvListBuff[0].Position;
+                ulong outBufferSize     = context.Request.RecvListBuff[0].Size;
 
                 context.Memory.Write((ulong)outBufferPosition, posixTime);
                 context.ResponseData.Write(1);
@@ -269,12 +269,12 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
 
             ResultCode resultCode = _timeZoneManager.ToPosixTimeWithMyRules(calendarTime, out long posixTime);
 
-            if (resultCode == 0)
+            if (resultCode == ResultCode.Success)
             {
-                long outBufferPosition = context.Request.RecvListBuff[0].Position;
-                long outBufferSize     = context.Request.RecvListBuff[0].Size;
+                ulong outBufferPosition = context.Request.RecvListBuff[0].Position;
+                ulong outBufferSize     = context.Request.RecvListBuff[0].Size;
 
-                context.Memory.Write((ulong)outBufferPosition, posixTime);
+                context.Memory.Write(outBufferPosition, posixTime);
 
                 // There could be only one result on one calendar as leap seconds aren't supported.
                 context.ResponseData.Write(1);

--- a/Ryujinx.HLE/HOS/Services/Time/StaticService/ITimeZoneServiceForPsc.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/StaticService/ITimeZoneServiceForPsc.cs
@@ -188,7 +188,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
         // ToCalendarTime(nn::time::PosixTime time, buffer<nn::time::TimeZoneRule, 0x15> rules) -> (nn::time::CalendarTime, nn::time::sf::CalendarAdditionalInfo)
         public ResultCode ToCalendarTime(ServiceCtx context)
         {
-            long posixTime       = context.RequestData.ReadInt64();
+            long  posixTime      = context.RequestData.ReadInt64();
             ulong bufferPosition = context.Request.SendBuff[0].Position;
             ulong bufferSize     = context.Request.SendBuff[0].Size;
 

--- a/Ryujinx.HLE/HOS/Services/Time/StaticService/ITimeZoneServiceForPsc.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/StaticService/ITimeZoneServiceForPsc.cs
@@ -254,7 +254,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.StaticService
                 ulong outBufferPosition = context.Request.RecvListBuff[0].Position;
                 ulong outBufferSize     = context.Request.RecvListBuff[0].Size;
 
-                context.Memory.Write((ulong)outBufferPosition, posixTime);
+                context.Memory.Write(outBufferPosition, posixTime);
                 context.ResponseData.Write(1);
             }
 

--- a/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
@@ -134,7 +134,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
 
             ReadOnlySpan<byte> parcelData = parcel.Finish();
 
-            context.Memory.Write((ulong)parcelPtr, parcelData);
+            context.Memory.Write(parcelPtr, parcelData);
 
             context.ResponseData.Write((long)parcelData.Length);
 

--- a/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
@@ -67,10 +67,10 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
 
             // Add only the default display to buffer
             context.Memory.Write(recBuffPtr, Encoding.ASCII.GetBytes("Default"));
-            context.Memory.Write(recBuffPtr + 0x40, 0x1L);
-            context.Memory.Write(recBuffPtr + 0x48, 0x1L);
-            context.Memory.Write(recBuffPtr + 0x50, 1280L);
-            context.Memory.Write(recBuffPtr + 0x58, 720L);
+            context.Memory.Write(recBuffPtr + 0x40, 0x1UL);
+            context.Memory.Write(recBuffPtr + 0x48, 0x1UL);
+            context.Memory.Write(recBuffPtr + 0x50, 1280UL);
+            context.Memory.Write(recBuffPtr + 0x58, 720UL);
 
             context.ResponseData.Write(1L);
 

--- a/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
@@ -61,16 +61,16 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
         // ListDisplays() -> (u64, buffer<nn::vi::DisplayInfo, 6>)
         public ResultCode ListDisplays(ServiceCtx context)
         {
-            long recBuffPtr = context.Request.ReceiveBuff[0].Position;
+            ulong recBuffPtr = context.Request.ReceiveBuff[0].Position;
 
             MemoryHelper.FillWithZeros(context.Memory, recBuffPtr, 0x60);
 
             // Add only the default display to buffer
-            context.Memory.Write((ulong)recBuffPtr, Encoding.ASCII.GetBytes("Default"));
-            context.Memory.Write((ulong)recBuffPtr + 0x40, 0x1L);
-            context.Memory.Write((ulong)recBuffPtr + 0x48, 0x1L);
-            context.Memory.Write((ulong)recBuffPtr + 0x50, 1280L);
-            context.Memory.Write((ulong)recBuffPtr + 0x58, 720L);
+            context.Memory.Write(recBuffPtr, Encoding.ASCII.GetBytes("Default"));
+            context.Memory.Write(recBuffPtr + 0x40, 0x1L);
+            context.Memory.Write(recBuffPtr + 0x48, 0x1L);
+            context.Memory.Write(recBuffPtr + 0x50, 1280L);
+            context.Memory.Write(recBuffPtr + 0x58, 720L);
 
             context.ResponseData.Write(1L);
 
@@ -120,9 +120,9 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
             // TODO: support multi display.
             byte[] displayName = context.RequestData.ReadBytes(0x40);
 
-            long layerId   = context.RequestData.ReadInt64();
-            long userId    = context.RequestData.ReadInt64();
-            long parcelPtr = context.Request.ReceiveBuff[0].Position;
+            long  layerId   = context.RequestData.ReadInt64();
+            long  userId    = context.RequestData.ReadInt64();
+            ulong parcelPtr = context.Request.ReceiveBuff[0].Position;
 
             IBinder producer = context.Device.System.SurfaceFlinger.OpenLayer(context.Request.HandleDesc.PId, layerId);
 
@@ -159,7 +159,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
             long layerFlags = context.RequestData.ReadInt64();
             long displayId  = context.RequestData.ReadInt64();
 
-            long parcelPtr = context.Request.ReceiveBuff[0].Position;
+            ulong parcelPtr = context.Request.ReceiveBuff[0].Position;
 
             // TODO: support multi display.
             Display disp = _displays.GetData<Display>((int)displayId);
@@ -174,7 +174,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
 
             ReadOnlySpan<byte> parcelData = parcel.Finish();
 
-            context.Memory.Write((ulong)parcelPtr, parcelData);
+            context.Memory.Write(parcelPtr, parcelData);
 
             context.ResponseData.Write(layerId);
             context.ResponseData.Write((long)parcelData.Length);
@@ -250,11 +250,11 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
             // The size of the layer buffer should be an aligned multiple of width * height
             // because it was created using GetIndirectLayerImageRequiredMemoryInfo as a guide.
 
-            long layerBuffPosition = context.Request.ReceiveBuff[0].Position;
-            long layerBuffSize     = context.Request.ReceiveBuff[0].Size;
+            ulong layerBuffPosition = context.Request.ReceiveBuff[0].Position;
+            ulong layerBuffSize     = context.Request.ReceiveBuff[0].Size;
 
             // Fill the layer with zeros.
-            context.Memory.Fill((ulong)layerBuffPosition, (ulong)layerBuffSize, 0x00);
+            context.Memory.Fill(layerBuffPosition, layerBuffSize, 0x00);
 
             Logger.Stub?.PrintStub(LogClass.ServiceVi);
 

--- a/Ryujinx.HLE/Utilities/StringUtils.cs
+++ b/Ryujinx.HLE/Utilities/StringUtils.cs
@@ -53,14 +53,14 @@ namespace Ryujinx.HLE.Utilities
 
         public static string ReadUtf8String(ServiceCtx context, int index = 0)
         {
-            long position = context.Request.PtrBuff[index].Position;
-            long size     = context.Request.PtrBuff[index].Size;
+            ulong position = context.Request.PtrBuff[index].Position;
+            ulong size     = context.Request.PtrBuff[index].Size;
 
             using (MemoryStream ms = new MemoryStream())
             {
                 while (size-- > 0)
                 {
-                    byte value = context.Memory.Read<byte>((ulong)position++);
+                    byte value = context.Memory.Read<byte>(position++);
 
                     if (value == 0)
                     {
@@ -86,8 +86,8 @@ namespace Ryujinx.HLE.Utilities
 
         public static string ReadUtf8StringSend(ServiceCtx context, int index = 0)
         {
-            long position = context.Request.SendBuff[index].Position;
-            long size     = context.Request.SendBuff[index].Size;
+            ulong position = context.Request.SendBuff[index].Position;
+            ulong size     = context.Request.SendBuff[index].Size;
 
             using (MemoryStream ms = new MemoryStream())
             {

--- a/Ryujinx.HLE/Utilities/StructWriter.cs
+++ b/Ryujinx.HLE/Utilities/StructWriter.cs
@@ -8,9 +8,9 @@ namespace Ryujinx.HLE.Utilities
     {
         private IVirtualMemoryManager _memory;
 
-        public long Position { get; private set; }
+        public ulong Position { get; private set; }
 
-        public StructWriter(IVirtualMemoryManager memory, long position)
+        public StructWriter(IVirtualMemoryManager memory, ulong position)
         {
             _memory  = memory;
             Position = position;
@@ -20,10 +20,10 @@ namespace Ryujinx.HLE.Utilities
         {
             MemoryHelper.Write(_memory, Position, value);
 
-            Position += Marshal.SizeOf<T>();
+            Position += (ulong)Marshal.SizeOf<T>();
         }
 
-        public void SkipBytes(long count)
+        public void SkipBytes(ulong count)
         {
             Position += count;
         }


### PR DESCRIPTION
This PR is the first step of an overdue code clean up for code from 2018.
Some types were wrongly made signed across all Ryujinx.HLE causing cast all over the place.
This PR address this for memory address and size but also title ids.

As this changes, might bring regressions, this needs intensive testing and careful reviews.