### PR TITLE
Amadeus: Allow out of bound read on empty delay lines

### DIFF
--- a/Ryujinx.Audio/Renderer/Dsp/Effect/DelayLine.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Effect/DelayLine.cs
@@ -33,7 +33,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Effect
         {
             _sampleRate = sampleRate;
             SampleCountMax = IDelayLine.GetSampleCount(_sampleRate, delayTimeMax);
-            _workBuffer = new float[SampleCountMax];
+            _workBuffer = new float[SampleCountMax + 1];
 
             SetDelay(delayTimeMax);
         }


### PR DESCRIPTION
This allows to handle an OOB with delay lines when DelayTimeMax = 0.
On real hardware, it will end up reading garbage at the given user work buffer address.
As we do not use those buffers and allocate them ourself for simplicy, this could possibly cause a crash.

Proposed solution here is to only increase the size of _workBuffer by one like what is done in DelayLineReverb3d already.

This fixes FEZ. (Ryujinx/Ryujinx-Games-List#3526)

![image](https://user-images.githubusercontent.com/1760003/115129812-bd79bb00-9fe9-11eb-838e-9fe96c45df04.png)
