### PR TITLE
Amadeus: Fix low pass base gain related issues on delay effect in mono

### DIFF
--- a/Ryujinx.Audio/Renderer/Dsp/Command/DelayCommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/DelayCommand.cs
@@ -78,7 +78,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
                 float input = inputBuffer[i] * 64;
                 float delayLineValue = state.DelayLines[0].Read();
 
-                float lowPassResult = input * inGain + delayLineValue * feedbackGain * state.LowPassBaseGain + state.LowPassZ[0] * state.LowPassFeedbackGain;
+                float lowPassResult = (input * inGain + delayLineValue * feedbackGain) * state.LowPassBaseGain + state.LowPassZ[0] * state.LowPassFeedbackGain;
 
                 state.LowPassZ[0] = lowPassResult;
 


### PR DESCRIPTION
This adds missing parenthesis around low pass z computation.

This fixes FEZ audio gain issues inside rooms. (Ryujinx/Ryujinx-Games-List#3526)