### PR TITLE
JIT Cache Exhausted Temporary Fix.

### DIFF
--- a/ARMeilleure/Translation/Cache/CacheEntry.cs
+++ b/ARMeilleure/Translation/Cache/CacheEntry.cs
@@ -6,12 +6,12 @@ namespace ARMeilleure.Translation.Cache
 {
     struct CacheEntry : IComparable<CacheEntry>
     {
-        public int Offset { get; }
-        public int Size   { get; }
+        public uint Offset { get; }
+        public uint Size   { get; }
 
         public UnwindInfo UnwindInfo { get; }
 
-        public CacheEntry(int offset, int size, UnwindInfo unwindInfo)
+        public CacheEntry(uint offset, uint size, UnwindInfo unwindInfo)
         {
             Offset     = offset;
             Size       = size;


### PR DESCRIPTION
Temporary increase of JIT cache size to 3 GiB.
When the extra size is no longer needed, just edit this single line:
`private const uint CacheSize = 3U * 1024 * 1024 * 1024; // Default cache size = 2047 * 1024 * 1024.`
(@ ARMeilleure/Translation/Cache/JitCache.cs#L17).