### PR TITLE
Allow any shader SSBO constant buffer slot and offset

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Compute.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Compute.cs
@@ -89,11 +89,8 @@ namespace Ryujinx.Graphics.Gpu.Engine
             {
                 BufferDescriptor sb = info.SBuffers[index];
 
-                ulong sbDescAddress = BufferManager.GetComputeUniformBufferAddress(0);
-
-                int sbDescOffset = 0x310 + sb.Slot * 0x10;
-
-                sbDescAddress += (ulong)sbDescOffset;
+                ulong sbDescAddress = BufferManager.GetComputeUniformBufferAddress(sb.SbCbSlot);
+                sbDescAddress += (ulong)sb.SbCbOffset * 4;
 
                 SbDescriptor sbDescriptor = _context.PhysicalMemory.Read<SbDescriptor>(sbDescAddress);
 

--- a/Ryujinx.Graphics.Gpu/Engine/Methods.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Methods.cs
@@ -327,11 +327,8 @@ namespace Ryujinx.Graphics.Gpu.Engine
                 {
                     BufferDescriptor sb = info.SBuffers[index];
 
-                    ulong sbDescAddress = BufferManager.GetGraphicsUniformBufferAddress(stage, 0);
-
-                    int sbDescOffset = 0x110 + stage * 0x100 + sb.Slot * 0x10;
-
-                    sbDescAddress += (ulong)sbDescOffset;
+                    ulong sbDescAddress = BufferManager.GetGraphicsUniformBufferAddress(stage, sb.SbCbSlot);
+                    sbDescAddress += (ulong)sb.SbCbOffset * 4;
 
                     SbDescriptor sbDescriptor = _context.PhysicalMemory.Read<SbDescriptor>(sbDescAddress);
 

--- a/Ryujinx.Graphics.Shader/BufferDescriptor.cs
+++ b/Ryujinx.Graphics.Shader/BufferDescriptor.cs
@@ -3,13 +3,27 @@ namespace Ryujinx.Graphics.Shader
     public struct BufferDescriptor
     {
         public readonly int Binding;
-        public readonly int Slot;
+        public readonly byte Slot;
+        public readonly byte SbCbSlot;
+        public readonly ushort SbCbOffset;
         public BufferUsageFlags Flags;
 
         public BufferDescriptor(int binding, int slot)
         {
             Binding = binding;
-            Slot = slot;
+            Slot = (byte)slot;
+            SbCbSlot = 0;
+            SbCbOffset = 0;
+
+            Flags = BufferUsageFlags.None;
+        }
+
+        public BufferDescriptor(int binding, int slot, int sbCbSlot, int sbCbOffset)
+        {
+            Binding = binding;
+            Slot = (byte)slot;
+            SbCbSlot = (byte)sbCbSlot;
+            SbCbOffset = (ushort)sbCbOffset;
 
             Flags = BufferUsageFlags.None;
         }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
@@ -316,7 +316,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
             foreach (int sbufSlot in info.SBuffers)
             {
-                context.SBufferDescriptors.Add(new BufferDescriptor(bindings[sbufSlot], sbufSlot));
+                context.SBufferDescriptors.Add(context.Config.GetSbDescriptor(bindings[sbufSlot], sbufSlot));
             }
 
             context.AppendLine($"layout (binding = {bindings[0]}, std430) buffer {blockName}");

--- a/Ryujinx.Graphics.Shader/Translation/GlobalMemory.cs
+++ b/Ryujinx.Graphics.Shader/Translation/GlobalMemory.cs
@@ -16,6 +16,8 @@ namespace Ryujinx.Graphics.Shader.Translation
         public const int UbeDescsSize  = StorageDescSize * UbeMaxCount;
         public const int UbeFirstCbuf  = 8;
 
+        public const int DriverReservedCb = 0;
+
         public static bool UsesGlobalMemory(Instruction inst)
         {
             return (inst.IsAtomic() && IsGlobalMr(inst)) ||

--- a/Ryujinx.Graphics.Shader/Translation/Optimizations/GlobalToStorage.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Optimizations/GlobalToStorage.cs
@@ -8,12 +8,22 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
 {
     static class GlobalToStorage
     {
+        private struct SearchResult
+        {
+            public static SearchResult NotFound => new SearchResult(-1, 0);
+            public bool Found => SbCbSlot != -1;
+            public int SbCbSlot { get; }
+            public int SbCbOffset { get; }
+
+            public SearchResult(int sbCbSlot, int sbCbOffset)
+            {
+                SbCbSlot = sbCbSlot;
+                SbCbOffset = sbCbOffset;
+            }
+        }
+
         public static void RunPass(BasicBlock block, ShaderConfig config)
         {
-            int sbStart = GetStorageBaseCbOffset(config.Stage);
-
-            int sbEnd = sbStart + StorageDescsSize;
-
             for (LinkedListNode<INode> node = block.Operations.First; node != null; node = node.Next)
             {
                 if (!(node.Value is Operation operation))
@@ -25,30 +35,33 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
                 {
                     Operand source = operation.GetSource(0);
 
-                    int storageIndex = SearchForStorageBase(block, source, sbStart, sbEnd);
-
-                    if (storageIndex >= 0)
+                    var result = SearchForStorageBase(config, block, source);
+                    if (!result.Found)
                     {
-                        // Storage buffers are implemented using global memory access.
-                        // If we know from where the base address of the access is loaded,
-                        // we can guess which storage buffer it is accessing.
-                        // We can then replace the global memory access with a storage
-                        // buffer access.
-                        node = ReplaceGlobalWithStorage(node, config, storageIndex);
+                        continue;
                     }
-                    else if (config.Stage == ShaderStage.Compute && operation.Inst == Instruction.LoadGlobal)
+
+                    if (config.Stage == ShaderStage.Compute &&
+                        operation.Inst == Instruction.LoadGlobal &&
+                        result.SbCbSlot == DriverReservedCb &&
+                        result.SbCbOffset >= UbeBaseOffset &&
+                        result.SbCbOffset < UbeBaseOffset + UbeDescsSize)
                     {
                         // Here we effectively try to replace a LDG instruction with LDC.
                         // The hardware only supports a limited amount of constant buffers
                         // so NVN "emulates" more constant buffers using global memory access.
                         // Here we try to replace the global access back to a constant buffer
                         // load.
-                        storageIndex = SearchForStorageBase(block, source, UbeBaseOffset, UbeBaseOffset + UbeDescsSize);
-
-                        if (storageIndex >= 0)
-                        {
-                            node = ReplaceLdgWithLdc(node, config, storageIndex);
-                        }
+                        node = ReplaceLdgWithLdc(node, config, (result.SbCbOffset - UbeBaseOffset) / StorageDescSize);
+                    }
+                    else
+                    {
+                        // Storage buffers are implemented using global memory access.
+                        // If we know from where the base address of the access is loaded,
+                        // we can guess which storage buffer it is accessing.
+                        // We can then replace the global memory access with a storage
+                        // buffer access.
+                        node = ReplaceGlobalWithStorage(node, config, config.GetSbSlot((byte)result.SbCbSlot, (ushort)result.SbCbOffset));
                     }
                 }
             }
@@ -62,7 +75,9 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
             {
                 Operand addrLow = operation.GetSource(0);
 
-                Operand baseAddrLow = Cbuf(0, GetStorageCbOffset(config.Stage, storageIndex));
+                (int sbCbSlot, int sbCbOffset) = config.GetSbCbInfo(storageIndex);
+
+                Operand baseAddrLow = Cbuf(sbCbSlot, sbCbOffset);
 
                 Operand baseAddrTrunc = Local();
 
@@ -181,20 +196,20 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
             return node;
         }
 
-        private static int SearchForStorageBase(BasicBlock block, Operand globalAddress, int sbStart, int sbEnd)
+        private static SearchResult SearchForStorageBase(ShaderConfig config, BasicBlock block, Operand globalAddress)
         {
             globalAddress = Utils.FindLastOperation(globalAddress, block);
 
             if (globalAddress.Type == OperandType.ConstantBuffer)
             {
-                return GetStorageIndex(globalAddress, sbStart, sbEnd);
+                return GetStorageIndex(config, globalAddress);
             }
 
             Operation operation = globalAddress.AsgOp as Operation;
 
             if (operation == null || operation.Inst != Instruction.Add)
             {
-                return -1;
+                return SearchResult.NotFound;
             }
 
             Operand src1 = operation.GetSource(0);
@@ -214,7 +229,7 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
 
                 if (operation == null || operation.Inst != Instruction.Add)
                 {
-                    return -1;
+                    return SearchResult.NotFound;
                 }
             }
 
@@ -222,33 +237,27 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
             {
                 Operand source = operation.GetSource(index);
 
-                int storageIndex = GetStorageIndex(source, sbStart, sbEnd);
-
-                if (storageIndex != -1)
+                var result = GetStorageIndex(config, source);
+                if (result.Found)
                 {
-                    return storageIndex;
+                    return result;
                 }
             }
 
-            return -1;
+            return SearchResult.NotFound;
         }
 
-        private static int GetStorageIndex(Operand operand, int sbStart, int sbEnd)
+        private static SearchResult GetStorageIndex(ShaderConfig config, Operand operand)
         {
             if (operand.Type == OperandType.ConstantBuffer)
             {
                 int slot   = operand.GetCbufSlot();
                 int offset = operand.GetCbufOffset();
 
-                if (slot == 0 && offset >= sbStart && offset < sbEnd)
-                {
-                    int storageIndex = (offset - sbStart) / StorageDescSize;
-
-                    return storageIndex;
-                }
+                return new SearchResult(slot, offset);
             }
 
-            return -1;
+            return SearchResult.NotFound;
         }
     }
 }

--- a/Ryujinx.Graphics.Shader/Translation/Rewriter.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Rewriter.cs
@@ -69,9 +69,9 @@ namespace Ryujinx.Graphics.Shader.Translation
             {
                 int cbOffset = GetStorageCbOffset(config.Stage, slot);
 
-                Operand baseAddrLow  = Cbuf(0, cbOffset);
-                Operand baseAddrHigh = Cbuf(0, cbOffset + 1);
-                Operand size         = Cbuf(0, cbOffset + 2);
+                Operand baseAddrLow  = Cbuf(DriverReservedCb, cbOffset);
+                Operand baseAddrHigh = Cbuf(DriverReservedCb, cbOffset + 1);
+                Operand size         = Cbuf(DriverReservedCb, cbOffset + 2);
 
                 Operand offset = PrependOperation(Instruction.Subtract,       addrLow, baseAddrLow);
                 Operand borrow = PrependOperation(Instruction.CompareLessU32, addrLow, baseAddrLow);
@@ -85,7 +85,7 @@ namespace Ryujinx.Graphics.Shader.Translation
                 Operand inRange = PrependOperation(Instruction.BitwiseAnd, inRangeLow, inRangeHigh);
 
                 sbBaseAddrLow = PrependOperation(Instruction.ConditionalSelect, inRange, baseAddrLow, sbBaseAddrLow);
-                sbSlot        = PrependOperation(Instruction.ConditionalSelect, inRange, Const(slot), sbSlot);
+                sbSlot        = PrependOperation(Instruction.ConditionalSelect, inRange, Const(config.GetSbSlot(DriverReservedCb, (ushort)cbOffset)), sbSlot);
             }
 
             Operand alignMask = Const(-config.GpuAccessor.QueryStorageBufferOffsetAlignment());


### PR DESCRIPTION
The Switch GPU supports memory access on shaders from anywhere on the GPU mapped memory. However, games don't just pass raw GPU pointers to the shaders, they use "storage buffers", which are buffers that can be read and written to by shaders. The game binds the storage buffer to binding N, and then the shader can access the data through binding N. The information for each storage buffer (base address and size) is stored on a driver reserved constant buffer (constant buffer #0 for NVN), and the shader reads the base address from there.

The shader translator tries to undo what the compiler does by trying to find from where the base address is read, this way it can find the binding number, and then bind all the buffers upfront as needed. Right now the translator is making assumptions about where this information is stored. It assumes that it is always stored on the constant buffer and range that NVN uses. This doesn't work for other APIs that uses different locations to store this information (such as homebrew APIs).

This change removes the assumption about NVN, and for each global memory access, it will just use whichever constant buffer it can find, and assume that contains the storage buffer information (base address and size). The information is propagated to the GPU emulator to allow the buffer to be bound. The `BufferDescriptor` struct was updated to hold this information.

Benefits:
SSBOs on APIs other than NVN works, as long the shader translator can find from where the base address comes from.

Issues to be discussed:
Being too lenient about where the storage buffer information can possibly be can lead to false positives (for example, it may find a constant buffer and assume it holds the base address, when it doesn't). It might be better to limit the match to only match for constant buffer 0 (which is NVN reserved constant buffer, and I believe other APIs uses this constant buffer for this purpose aswell).