### PR TITLE
SM instance & TIPC fixes

### DIFF
--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -274,6 +274,7 @@ namespace Ryujinx.HLE.HOS
         public void InitializeServices()
         {
             IUserInterface sm = new IUserInterface(KernelContext);
+            sm.TrySetServer(new ServerBase(KernelContext, "SmServer") { SmObjectFactory = () => new IUserInterface(KernelContext) });
 
             // Wait until SM server thread is done with initialization,
             // only then doing connections to SM is safe.


### PR DESCRIPTION
This PR addresses the following issues:
- SM was previously instancied once and reused on all sessions. This
  could cause inconsistency on the service initialization.
- TIPC replies were not matching what is generated on hardware.