### PR TITLE
Fix IsRegionInUse check on NV memory allocator

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Nv/NvMemoryAllocator.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvMemoryAllocator.cs
@@ -1,6 +1,5 @@
 ﻿using Ryujinx.Common.Collections;
 using System.Collections.Generic;
-using Ryujinx.Common;
 using System;
 using Ryujinx.Graphics.Gpu.Memory;
 using Ryujinx.Common.Logging;
@@ -198,7 +197,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices
                 {
                     bool reachedEndOfAddresses = false;
                     ulong targetAddress;
-                    if(start == DefaultStart)
+                    if (start == DefaultStart)
                     {
                         Logger.Debug?.Print(LogClass.ServiceNv, $"Target address set to start of the last available range: 0x{_list.Last.Value:X}.");
                         targetAddress = _list.Last.Value;
@@ -301,7 +300,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices
                 freeAddressStartPosition = floorAddress;
                 if (floorAddress != InvalidAddress)
                 {
-                    return !(gpuVa >= floorAddress && ((gpuVa + size) < _tree.Get(floorAddress)));
+                    return !(gpuVa >= floorAddress && ((gpuVa + size) <= _tree.Get(floorAddress)));
                 }
             }
             return true;


### PR DESCRIPTION
This fixes the region in use check. Previous it was failing if the checked range would end at the start of an already mapped range. For example:
- A check at address 0xFFFFFF0000 with size 0x10000 is done.
- Free region starts at 0x1000 and ends at 0x10000000000
- `(gpuVa + size) < _tree.Get(floorAddress)` returns false because `0xFFFFFF0000 + 0x1000` is not less than 0x10000000000.

This is incorrect because the range being requested *is* free, it just happens to end at the same address as the end of the free range (and of the address space). So the fix here is changing the `<` to `<=` to allow the cases where the end address is exactly equal to match aswell.

This fixes a failure calling the `AllocSpace` ioctl on a few games. However no effect was observed with this fix, because the `AllocSpace` failure was not considered fatal by those games, it would just continue running anyway.