### PR TITLE
Fix uint -> int typo in NpadIdType

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Hid/Types/Npad/NpadIdType.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/Npad/NpadIdType.cs
@@ -1,6 +1,6 @@
 ﻿namespace Ryujinx.HLE.HOS.Services.Hid
 {
-    public enum NpadIdType : uint
+    public enum NpadIdType : int
     {
         Player1  = 0,
         Player2  = 1,


### PR DESCRIPTION
As discussed with @Thog , this value should be `int`, not `uint`.

Fixes [a crash](https://github.com/Ryujinx/Ryujinx/issues/2244) on launch on Bayonetta 2 (and potentially other games that call this similarly).