### PR TITLE
Fix GetClockSnapshot not writing steady clock timepoint

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Time/IStaticServiceForPsc.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/IStaticServiceForPsc.cs
@@ -354,6 +354,7 @@ namespace Ryujinx.HLE.HOS.Services.Time
             clockSnapshot.IsAutomaticCorrectionEnabled = _timeManager.StandardUserSystemClock.IsAutomaticCorrectionEnabled();
             clockSnapshot.UserContext                  = userContext;
             clockSnapshot.NetworkContext               = networkContext;
+            clockSnapshot.SteadyClockTimePoint         = currentTimePoint;
 
             ResultCode result = _timeManager.TimeZone.Manager.GetDeviceLocationName(out string deviceLocationName);
 


### PR DESCRIPTION
The timepoint was not being written, which caused Shantae (https://github.com/Ryujinx/Ryujinx-Games-List/issues/3555) to softlock on the Limited Runs logo as time did not advance. This fixes the issue. Might also affect other games of course, but this is the only one known to be affected so far.
![image](https://user-images.githubusercontent.com/5624669/116143717-dbae7d80-a6b1-11eb-9743-017da711b919.png)
![image](https://user-images.githubusercontent.com/5624669/116143740-e2d58b80-a6b1-11eb-9edb-8c982fcb37dd.png)