### PR TITLE
Changes ordering of config.json and configuration files

### DIFF
--- a/Ryujinx.Common/Configuration/ConfigurationFileFormat.cs
+++ b/Ryujinx.Common/Configuration/ConfigurationFileFormat.cs
@@ -19,6 +19,11 @@ namespace Ryujinx.Configuration
         public int Version { get; set; }
 
         /// <summary>
+        /// Enables or disables logging to a file on disk
+        /// </summary>
+        public bool EnableFileLog { get; set; }
+
+        /// <summary>
         /// Resolution Scale. An integer scale applied to applicable render targets. Values 1-4, or -1 to use a custom floating point scale instead.
         /// </summary>
         public int ResScale { get; set; }
@@ -88,10 +93,6 @@ namespace Ryujinx.Configuration
         /// </summary>
         public GraphicsDebugLevel LoggingGraphicsDebugLevel { get; set; }
 
-        /// <summary>
-        /// Enables or disables logging to a file on disk
-        /// </summary>
-        public bool EnableFileLog { get; set; }
 
         /// <summary>
         /// Change System Language

--- a/Ryujinx.Common/Configuration/ConfigurationState.cs
+++ b/Ryujinx.Common/Configuration/ConfigurationState.cs
@@ -408,6 +408,7 @@ namespace Ryujinx.Configuration
             ConfigurationFileFormat configurationFile = new ConfigurationFileFormat
             {
                 Version                   = ConfigurationFileFormat.CurrentVersion,
+                EnableFileLog             = Logger.EnableFileLog,
                 ResScale                  = Graphics.ResScale,
                 ResScaleCustom            = Graphics.ResScaleCustom,
                 MaxAnisotropy             = Graphics.MaxAnisotropy,
@@ -422,7 +423,6 @@ namespace Ryujinx.Configuration
                 LoggingEnableFsAccessLog  = Logger.EnableFsAccessLog,
                 LoggingFilteredClasses    = Logger.FilteredClasses,
                 LoggingGraphicsDebugLevel = Logger.GraphicsDebugLevel,
-                EnableFileLog             = Logger.EnableFileLog,
                 SystemLanguage            = System.Language,
                 SystemRegion              = System.Region,
                 SystemTimeZone            = System.TimeZone,
@@ -474,6 +474,7 @@ namespace Ryujinx.Configuration
 
         public void LoadDefault()
         {
+            Logger.EnableFileLog.Value             = true;
             Graphics.ResScale.Value                = 1;
             Graphics.ResScaleCustom.Value          = 1.0f;
             Graphics.MaxAnisotropy.Value           = -1.0f;
@@ -488,7 +489,6 @@ namespace Ryujinx.Configuration
             Logger.EnableFsAccessLog.Value         = false;
             Logger.FilteredClasses.Value           = Array.Empty<LogClass>();
             Logger.GraphicsDebugLevel.Value        = GraphicsDebugLevel.None;
-            Logger.EnableFileLog.Value             = true;
             System.Language.Value                  = Language.AmericanEnglish;
             System.Region.Value                    = Region.USA;
             System.TimeZone.Value                  = "UTC";
@@ -803,6 +803,7 @@ namespace Ryujinx.Configuration
                 configurationFileUpdated = true;
             }
 
+            Logger.EnableFileLog.Value             = configurationFileFormat.EnableFileLog;
             Graphics.ResScale.Value                = configurationFileFormat.ResScale;
             Graphics.ResScaleCustom.Value          = configurationFileFormat.ResScaleCustom;
             Graphics.MaxAnisotropy.Value           = configurationFileFormat.MaxAnisotropy;
@@ -817,7 +818,6 @@ namespace Ryujinx.Configuration
             Logger.EnableFsAccessLog.Value         = configurationFileFormat.LoggingEnableFsAccessLog;
             Logger.FilteredClasses.Value           = configurationFileFormat.LoggingFilteredClasses;
             Logger.GraphicsDebugLevel.Value        = configurationFileFormat.LoggingGraphicsDebugLevel;
-            Logger.EnableFileLog.Value             = configurationFileFormat.EnableFileLog;
             System.Language.Value                  = configurationFileFormat.SystemLanguage;
             System.Region.Value                    = configurationFileFormat.SystemRegion;
             System.TimeZone.Value                  = configurationFileFormat.SystemTimeZone;

--- a/Ryujinx/Config.json
+++ b/Ryujinx/Config.json
@@ -1,5 +1,6 @@
 {
   "version": 24,
+  "enable_file_log": true,
   "res_scale": 1,
   "res_scale_custom": 1,
   "max_anisotropy": -1,
@@ -14,7 +15,6 @@
   "logging_enable_fs_access_log": false,
   "logging_filtered_classes": [],
   "logging_graphics_debug_level": "None",
-  "enable_file_log": true,
   "system_language": "AmericanEnglish",
   "system_region": "USA",
   "system_time_zone": "UTC",


### PR DESCRIPTION
This allows configuration values to be written to log file for analysis, since file log was being enabled after the values were set. Setting file log to be first, allows file to be written to, exposing the user changeable settings in the actual log file instead of just the console.

Before:
![image](https://user-images.githubusercontent.com/36304206/116477006-edd81980-a873-11eb-8262-963204a480a2.png)

After:
![image](https://user-images.githubusercontent.com/36304206/116477157-224bd580-a874-11eb-8458-37e70e6b8d23.png)
