### PR TITLE
nfp: Increase Amiibo scanning delay

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/UserManager/IUser.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/UserManager/IUser.cs
@@ -159,7 +159,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
                         if (context.Device.System.NfpDevices[i].State == NfpDeviceState.TagFound)
                         {
                             context.Device.System.NfpDevices[i].SignalActivate();
-                            Thread.Sleep(50); // NOTE: Simulate amiibo scanning delay.
+                            Thread.Sleep(125); // NOTE: Simulate amiibo scanning delay.
                             context.Device.System.NfpDevices[i].SignalDeactivate();
 
                             break;


### PR DESCRIPTION
This PR increase the Amiibo scanning delay which simulate the scanning. Previously we used 50ms which seems to work in all of games. But sadly games like FE3H or Hyrule Warriors AoC seems to need more delay to validate a scan. It's fixed with 125ms. (should partially fixes issue https://github.com/Ryujinx/Ryujinx/issues/2122)

![image](https://user-images.githubusercontent.com/4905390/116635179-61eeec00-a95e-11eb-8e44-709aabb23588.png)
![image](https://user-images.githubusercontent.com/4905390/116635196-6d421780-a95e-11eb-9274-b68099f98614.png)
