### PR TITLE
Fix shader buffer write flag on atomic instructions

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -35,7 +35,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2217;
+        private const ulong ShaderCodeGenVersion = 2261;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGen.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGen.cs
@@ -61,8 +61,8 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
 
                         switch (memRegion)
                         {
-                            case Instruction.MrShared:  args += LoadShared (context, operation); break;
-                            case Instruction.MrStorage: args += LoadStorage(context, operation); break;
+                            case Instruction.MrShared: args += LoadShared(context, operation); break;
+                            case Instruction.MrStorage: args += LoadStorage(context, operation, forAtomic: true); break;
 
                             default: throw new InvalidOperationException($"Invalid memory region \"{memRegion}\".");
                         }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
@@ -205,13 +205,18 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
             return $"{arrayName}[{offsetExpr}]";
         }
 
-        public static string LoadStorage(CodeGenContext context, AstOperation operation)
+        public static string LoadStorage(CodeGenContext context, AstOperation operation, bool forAtomic = false)
         {
             IAstNode src1 = operation.GetSource(0);
             IAstNode src2 = operation.GetSource(1);
 
             string indexExpr  = GetSoureExpr(context, src1, GetSrcVarType(operation.Inst, 0));
             string offsetExpr = GetSoureExpr(context, src2, GetSrcVarType(operation.Inst, 1));
+
+            if (forAtomic)
+            {
+                SetStorageWriteFlag(context, src1, context.Config.Stage);
+            }
 
             return GetStorageBufferAccessor(indexExpr, offsetExpr, context.Config.Stage);
         }
@@ -485,7 +490,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
                         {
                             flags |= TextureUsageFlags.ResScaleUnsupported;
                         }
-                    } 
+                    }
                     else
                     {
                         // Resolution scaling cannot be applied to this texture right now.


### PR DESCRIPTION
Fix a bug that caused buffer memory modified by atomic instructions only on shaders to not be flushed.
This fixes Pokémon not being identified on photos in New Pokémon Snap.
![image](https://user-images.githubusercontent.com/5624669/116791613-df674900-aa91-11eb-9166-000fdb8c2d73.png)
![image](https://user-images.githubusercontent.com/5624669/116791620-e7bf8400-aa91-11eb-8a06-d3e94501849b.png)
Fixes #2254