### PR TITLE
Miria: Fix GTK3 keyboard mapping

### DIFF
--- a/Ryujinx/Input/GTK3/GTK3MappingHelper.cs
+++ b/Ryujinx/Input/GTK3/GTK3MappingHelper.cs
@@ -48,7 +48,7 @@ namespace Ryujinx.Input.GTK3
             GtkKey.F27,
             GtkKey.F28,
             GtkKey.F29,
-            GtkKey.F29,
+            GtkKey.F30,
             GtkKey.F31,
             GtkKey.F32,
             GtkKey.F33,
@@ -128,6 +128,7 @@ namespace Ryujinx.Input.GTK3
             GtkKey.Key_8,
             GtkKey.Key_9,
             GtkKey.grave,
+            GtkKey.grave,
             GtkKey.minus,
             GtkKey.plus,
             GtkKey.bracketleft,
@@ -137,7 +138,6 @@ namespace Ryujinx.Input.GTK3
             GtkKey.comma,
             GtkKey.period,
             GtkKey.slash,
-            GtkKey.backslash,
             GtkKey.backslash,
 
             // NOTE: invalid


### PR DESCRIPTION
I found some mistake I made back when I first wrote the mapping for
Miria.

This fix:
- an offset by one after the tilde key in the mapping.
- F30 being mapped to F29.