### PR TITLE
misc: Fix default value for GraphicsConfig.MaxAnisotropy

### DIFF
--- a/Ryujinx.Graphics.Gpu/GraphicsConfig.cs
+++ b/Ryujinx.Graphics.Gpu/GraphicsConfig.cs
@@ -13,7 +13,7 @@ namespace Ryujinx.Graphics.Gpu
         /// <summary>
         /// Max Anisotropy. Values range from 0 - 16. Set to -1 to let the game decide.
         /// </summary>
-        public static float MaxAnisotropy;
+        public static float MaxAnisotropy = -1;
 
         /// <summary>
         /// Base directory used to write shader code dumps.


### PR DESCRIPTION
As title say.
Doesn't change anything as the Ryujinx project set it.