### PR TITLE
Fold constant offsets and group constant addresses

### DIFF
--- a/ARMeilleure/Instructions/InstEmitMemory.cs
+++ b/ARMeilleure/Instructions/InstEmitMemory.cs
@@ -87,8 +87,7 @@ namespace ARMeilleure.Instructions
             }
 
             Operand address = GetAddress(context);
-
-            Operand address2 = context.Add(address, Const(1L << op.Size));
+            Operand address2 = GetAddress(context, 1L << op.Size);
 
             EmitLoad(op.Rt,  address);
             EmitLoad(op.Rt2, address2);
@@ -112,8 +111,7 @@ namespace ARMeilleure.Instructions
             OpCodeMemPair op = (OpCodeMemPair)context.CurrOp;
 
             Operand address = GetAddress(context);
-
-            Operand address2 = context.Add(address, Const(1L << op.Size));
+            Operand address2 = GetAddress(context, 1L << op.Size);
 
             InstEmitMemoryHelper.EmitStore(context, address,  op.Rt,  op.Size);
             InstEmitMemoryHelper.EmitStore(context, address2, op.Rt2, op.Size);
@@ -121,7 +119,7 @@ namespace ARMeilleure.Instructions
             EmitWBackIfNeeded(context, address);
         }
 
-        private static Operand GetAddress(ArmEmitterContext context)
+        private static Operand GetAddress(ArmEmitterContext context, long addend = 0)
         {
             Operand address = null;
 
@@ -134,7 +132,11 @@ namespace ARMeilleure.Instructions
                     // Pre-indexing.
                     if (!op.PostIdx)
                     {
-                        address = context.Add(address, Const(op.Immediate));
+                        address = context.Add(address, Const(op.Immediate + addend));
+                    }
+                    else if (addend != 0)
+                    {
+                        address = context.Add(address, Const(addend));
                     }
 
                     break;
@@ -152,6 +154,11 @@ namespace ARMeilleure.Instructions
                     }
 
                     address = context.Add(n, m);
+
+                    if (addend != 0)
+                    {
+                        address = context.Add(address, Const(addend));
+                    }
 
                     break;
                 }

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -28,7 +28,7 @@ namespace ARMeilleure.Translation.PTC
         private const string OuterHeaderMagicString = "PTCohd\0\0";
         private const string InnerHeaderMagicString = "PTCihd\0\0";
 
-        private const uint InternalVersion = 1866; //! To be incremented manually for each change to the ARMeilleure project.
+        private const uint InternalVersion = 2285; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";


### PR DESCRIPTION
This makes a few minor improvements to the x86 backend, reducing the generated code size a little bit, and potentially improving performance (nothing really noticeable though).

Changes:
- Allow `add rax, 0x123`followed by `add rax, rbx` to be fully contained into the memory operand. Previously it was only able to contain the `add rax, rbx` leaving the constant addition. Now it can be fully contained as `mov rax, [rax+rbx*1+0x123]`.
- On blocks where the same constant value is used more than once, if the constant can't fit on a 32-bit immediate, instead of inserting a `mov` before each use, it now inserts a single move per block, and keeps the constant in a register.
- Improved codegen for pre-indexed pair Arm loads and stores a little bit. Instead of adding the offset to the base register, producing the address, and then adding another offset to that address, it now adds both offsets to the base register directly. This avoids a dependency on the previous operation, and in some cases might also lead to less registers being needed (as the register used for the first address becomes free right after the first access).