### PR TITLE
ffmpeg: Attempt to fix RootPath on some linux distributions

### DIFF
--- a/Ryujinx.Graphics.Nvdec.H264/FFmpegContext.cs
+++ b/Ryujinx.Graphics.Nvdec.H264/FFmpegContext.cs
@@ -16,8 +16,6 @@ namespace Ryujinx.Graphics.Nvdec.H264
 
         public FFmpegContext()
         {
-            SetRootPath();
-
             _logFunc = Log;
 
             // Redirect log output
@@ -32,7 +30,12 @@ namespace Ryujinx.Graphics.Nvdec.H264
             _packet = ffmpeg.av_packet_alloc();
         }
 
-        private void SetRootPath()
+        static FFmpegContext()
+        {
+            SetRootPath();
+        }
+
+        private static void SetRootPath()
         {
             if (OperatingSystem.IsLinux())
             {

--- a/Ryujinx.Graphics.Nvdec.H264/FFmpegContext.cs
+++ b/Ryujinx.Graphics.Nvdec.H264/FFmpegContext.cs
@@ -4,14 +4,11 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Threading;
 
 namespace Ryujinx.Graphics.Nvdec.H264
 {
     unsafe class FFmpegContext : IDisposable
     {
-        private static int _isInitialized;
-
         private readonly av_log_set_callback_callback _logFunc;
         private readonly AVCodec* _codec;
         private AVPacket* _packet;
@@ -35,10 +32,7 @@ namespace Ryujinx.Graphics.Nvdec.H264
 
         static FFmpegContext()
         {
-            if (Interlocked.Exchange(ref _isInitialized, 1) == 0)
-            {
-                SetRootPath();
-            }
+            SetRootPath();
         }
 
         private static void SetRootPath()

--- a/Ryujinx.Graphics.Nvdec.H264/FFmpegContext.cs
+++ b/Ryujinx.Graphics.Nvdec.H264/FFmpegContext.cs
@@ -1,6 +1,8 @@
 ﻿using FFmpeg.AutoGen;
 using Ryujinx.Common.Logging;
 using System;
+using System.Diagnostics;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace Ryujinx.Graphics.Nvdec.H264
@@ -14,6 +16,8 @@ namespace Ryujinx.Graphics.Nvdec.H264
 
         public FFmpegContext()
         {
+            SetRootPath();
+
             _logFunc = Log;
 
             // Redirect log output
@@ -26,6 +30,35 @@ namespace Ryujinx.Graphics.Nvdec.H264
             ffmpeg.avcodec_open2(_context, _codec, null);
 
             _packet = ffmpeg.av_packet_alloc();
+        }
+
+        private void SetRootPath()
+        {
+            if (OperatingSystem.IsLinux())
+            {
+                // Configure FFmpeg search path
+                Process lddProcess = Process.Start(new ProcessStartInfo
+                {
+                    FileName               = "/bin/sh",
+                    Arguments              = "-c \"ldd $(which ffmpeg 2>/dev/null) | grep libavfilter\" 2>/dev/null",
+                    UseShellExecute        = false,
+                    RedirectStandardOutput = true
+                });
+
+                string lddOutput = lddProcess.StandardOutput.ReadToEnd();
+
+                lddProcess.WaitForExit();
+                lddProcess.Close();
+
+                if (lddOutput.Contains(" => "))
+                {
+                    ffmpeg.RootPath = Path.GetDirectoryName(lddOutput.Split(" => ")[1]);
+                }
+                else
+                {
+                    Logger.Error?.PrintMsg(LogClass.FFmpeg, "FFmpeg wasn't found. Make sure that you have it installed and up to date.");
+                }
+            }
         }
 
         private void Log(void* p0, int level, string format, byte* vl)

--- a/Ryujinx.Graphics.Nvdec.H264/FFmpegContext.cs
+++ b/Ryujinx.Graphics.Nvdec.H264/FFmpegContext.cs
@@ -16,6 +16,8 @@ namespace Ryujinx.Graphics.Nvdec.H264
 
         public FFmpegContext()
         {
+            SetRootPath();
+
             _logFunc = Log;
 
             // Redirect log output
@@ -30,12 +32,7 @@ namespace Ryujinx.Graphics.Nvdec.H264
             _packet = ffmpeg.av_packet_alloc();
         }
 
-        static FFmpegContext()
-        {
-            SetRootPath();
-        }
-
-        private static void SetRootPath()
+        private void SetRootPath()
         {
             if (OperatingSystem.IsLinux())
             {

--- a/Ryujinx.Graphics.Nvdec.H264/FFmpegContext.cs
+++ b/Ryujinx.Graphics.Nvdec.H264/FFmpegContext.cs
@@ -4,11 +4,14 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace Ryujinx.Graphics.Nvdec.H264
 {
     unsafe class FFmpegContext : IDisposable
     {
+        private static int _isInitialized;
+
         private readonly av_log_set_callback_callback _logFunc;
         private readonly AVCodec* _codec;
         private AVPacket* _packet;
@@ -32,7 +35,10 @@ namespace Ryujinx.Graphics.Nvdec.H264
 
         static FFmpegContext()
         {
-            SetRootPath();
+            if (Interlocked.Exchange(ref _isInitialized, 1) == 0)
+            {
+                SetRootPath();
+            }
         }
 
         private static void SetRootPath()

--- a/Ryujinx/Program.cs
+++ b/Ryujinx/Program.cs
@@ -12,6 +12,7 @@ using Ryujinx.Ui;
 using Ryujinx.Ui.Widgets;
 using SixLabors.ImageSharp.Formats.Jpeg;
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -80,7 +81,18 @@ namespace Ryujinx
                 XInitThreads();
 
                 // Configure FFmpeg search path
-                ffmpeg.RootPath = "/lib";
+                Process lddProcess = Process.Start(new ProcessStartInfo
+                {
+                    FileName               = "/bin/sh",
+                    Arguments              = "-c \"ldd $(which ffmpeg) | grep libavfilter\"",
+                    UseShellExecute        = false,
+                    RedirectStandardOutput = true
+                });
+
+                ffmpeg.RootPath = Path.GetDirectoryName(lddProcess.StandardOutput.ReadToEnd().Split(" => ")[1]);
+
+                lddProcess.WaitForExit();
+                lddProcess.Close();
             }
 
             string systemPath = Environment.GetEnvironmentVariable("Path", EnvironmentVariableTarget.Machine);

--- a/Ryujinx/Program.cs
+++ b/Ryujinx/Program.cs
@@ -89,10 +89,19 @@ namespace Ryujinx
                     RedirectStandardOutput = true
                 });
 
-                ffmpeg.RootPath = Path.GetDirectoryName(lddProcess.StandardOutput.ReadToEnd().Split(" => ")[1]);
+                string lddOutput = lddProcess.StandardOutput.ReadToEnd();
 
                 lddProcess.WaitForExit();
                 lddProcess.Close();
+
+                if (lddOutput.Contains(" => "))
+                {
+                    ffmpeg.RootPath = Path.GetDirectoryName(lddOutput.Split(" => ")[1]);
+                }
+                else
+                {
+                    Logger.Error?.PrintMsg(LogClass.FFmpeg, "FFmpeg wasn't found. Make sure that you have it installed and up to date.");
+                }
             }
 
             string systemPath = Environment.GetEnvironmentVariable("Path", EnvironmentVariableTarget.Machine);

--- a/Ryujinx/Program.cs
+++ b/Ryujinx/Program.cs
@@ -1,5 +1,4 @@
 using ARMeilleure.Translation.PTC;
-using FFmpeg.AutoGen;
 using Gtk;
 using Ryujinx.Common.Configuration;
 using Ryujinx.Common.GraphicsDriver;
@@ -12,7 +11,6 @@ using Ryujinx.Ui;
 using Ryujinx.Ui.Widgets;
 using SixLabors.ImageSharp.Formats.Jpeg;
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -79,29 +77,6 @@ namespace Ryujinx
             if (OperatingSystem.IsLinux())
             {
                 XInitThreads();
-
-                // Configure FFmpeg search path
-                Process lddProcess = Process.Start(new ProcessStartInfo
-                {
-                    FileName               = "/bin/sh",
-                    Arguments              = "-c \"ldd $(which ffmpeg) | grep libavfilter\"",
-                    UseShellExecute        = false,
-                    RedirectStandardOutput = true
-                });
-
-                string lddOutput = lddProcess.StandardOutput.ReadToEnd();
-
-                lddProcess.WaitForExit();
-                lddProcess.Close();
-
-                if (lddOutput.Contains(" => "))
-                {
-                    ffmpeg.RootPath = Path.GetDirectoryName(lddOutput.Split(" => ")[1]);
-                }
-                else
-                {
-                    Logger.Error?.PrintMsg(LogClass.FFmpeg, "FFmpeg wasn't found. Make sure that you have it installed and up to date.");
-                }
             }
 
             string systemPath = Environment.GetEnvironmentVariable("Path", EnvironmentVariableTarget.Machine);


### PR DESCRIPTION
This should fixes #2284 where the lib folder set in RootPath isn't the same between some linux distributions.
Since I don't use linux I can't really test it so feedbacks are really appreciate.