### PR TITLE
Reduce `Operand[]` & `List<Operand>` allocations

### DIFF
--- a/ARMeilleure/IntermediateRepresentation/Node.cs
+++ b/ARMeilleure/IntermediateRepresentation/Node.cs
@@ -13,8 +13,10 @@ namespace ARMeilleure.IntermediateRepresentation
         private int _destCount;
         private Operand _dest0;
         private Operand _src0;
+#pragma warning disable CS0414
         private Operand _src1;
         private Operand _src2;
+#pragma warning restore CS0414
         private Operand[] _operands;
 
         public Node ListPrevious { get; set; }
@@ -72,9 +74,6 @@ namespace ARMeilleure.IntermediateRepresentation
             {
                 operands[i] = null;
             }
-
-            _ = _src1;
-            _ = _src2;
         }
 
         public Node With(Operand dest, int srcCount)
@@ -103,7 +102,7 @@ namespace ARMeilleure.IntermediateRepresentation
         {
             if ((uint)index >= _destCount)
             {
-                ThrowIndexOutOfRange();
+                ThrowIndexOutOfRange(nameof(index));
             }
 
             if (index < InlinedDestinationsCount)
@@ -126,7 +125,7 @@ namespace ARMeilleure.IntermediateRepresentation
         {
             if ((uint)index >= _srcCount)
             {
-                ThrowIndexOutOfRange();
+                ThrowIndexOutOfRange(nameof(index));
             }
 
             if (index < InlinedSourcesCount)
@@ -304,7 +303,7 @@ namespace ARMeilleure.IntermediateRepresentation
             int n = _operands != null ? _operands.Length : 0;
 
             // If no extra operands are needed, allow the array to be garbaged collected if its large enough.
-            if (count == 0 && n >= 4)
+            if (count == 0)
             {
                 _operands = null;
             }
@@ -424,6 +423,6 @@ namespace ARMeilleure.IntermediateRepresentation
             }
         }
 
-        private static void ThrowIndexOutOfRange() => throw new ArgumentOutOfRangeException("index");
+        private static void ThrowIndexOutOfRange(string param) => throw new ArgumentOutOfRangeException(param);
     }
 }


### PR DESCRIPTION
This reduces the amount of `Operand[]` and `List<Operand>` allocated in `Node` by the making general case not require a `List<Operand>`, i.e 1 destination operand and 3 source operands are inlined in the `Node` structure itself. In the case where there are more than 1 destination and 3 sources, the extra operands are stored in an array. This array is partitioned such that the start of the array contains sources and then destinations.

Master:
![Screenshot 2021-05-20 145743](https://user-images.githubusercontent.com/8182340/118969818-957dce80-b97e-11eb-8ba2-3f574ffa68e0.png)

PR:
![Screenshot 2021-05-20 151200](https://user-images.githubusercontent.com/8182340/118969894-ab8b8f00-b97e-11eb-9495-e9c5876f5007.png)

If the extra complexity is concerning, I can write some unit tests. An alternative, perhaps simpler, would be to allocate a large `Operand[]` block and represent the sources and destinations by allocating 2 `ArraySegment` into that block using arena allocator. Then reset the arena after each compilation.

Something like that should probably be done for `BasicBlock._successors` because its allocating a lot.