### PR TITLE
Fix constant buffer array size when indexing is used and other buffer descriptor and resolution scale regressions

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -36,7 +36,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2290;
+        private const ulong ShaderCodeGenVersion = 2298;
 
         // Progress reporting helpers
         private volatile int _shaderCount;
@@ -415,7 +415,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
                     if (activeTasks.Count == maxTaskCount)
                     {
                         // Wait for a task to be done, or for 1ms.
-                        // Host shader compilation cannot signal when it is done, 
+                        // Host shader compilation cannot signal when it is done,
                         // so the 1ms timeout is required to poll status.
 
                         taskDoneEvent.WaitOne(1);

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
@@ -262,10 +262,10 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
                 string blockName = $"{ubName}_{DefaultNames.BlockSuffix}";
 
-                context.AppendLine($"layout (binding = {descriptors[0].Binding}, std140) uniform {blockName}");
+                context.AppendLine($"layout (binding = {context.Config.FirstConstantBufferBinding}, std140) uniform {blockName}");
                 context.EnterScope();
                 context.AppendLine("vec4 " + DefaultNames.DataName + ubSize + ";");
-                context.LeaveScope($" {ubName}[{NumberFormatter.FormatInt(descriptors.Length)}];");
+                context.LeaveScope($" {ubName}[{NumberFormatter.FormatInt(descriptors.Max(x => x.Slot) + 1)}];");
             }
             else
             {
@@ -291,10 +291,10 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
             string blockName = $"{sbName}_{DefaultNames.BlockSuffix}";
 
-            context.AppendLine($"layout (binding = {descriptors[0].Binding}, std430) buffer {blockName}");
+            context.AppendLine($"layout (binding = {context.Config.FirstStorageBufferBinding}, std430) buffer {blockName}");
             context.EnterScope();
             context.AppendLine("uint " + DefaultNames.DataName + "[];");
-            context.LeaveScope($" {sbName}[{NumberFormatter.FormatInt(descriptors.Length)}];");
+            context.LeaveScope($" {sbName}[{NumberFormatter.FormatInt(descriptors.Max(x => x.Slot) + 1)}];");
         }
 
         private static void DeclareSamplers(CodeGenContext context, TextureDescriptor[] descriptors)

--- a/Ryujinx.Graphics.Shader/IGpuAccessor.cs
+++ b/Ryujinx.Graphics.Shader/IGpuAccessor.cs
@@ -41,7 +41,7 @@
 
         uint QueryConstantBufferUse()
         {
-            return 0xffff;
+            return 0;
         }
 
         bool QueryIsTextureBuffer(int handle, int cbufSlot = -1)

--- a/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgram.cs
+++ b/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgram.cs
@@ -293,7 +293,7 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
                 Instruction.Branch or
                 Instruction.BranchIfFalse or
                 Instruction.BranchIfTrue => true,
-                _ => false,
+                _ => false
             };
         }
 

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -293,6 +293,7 @@ namespace Ryujinx.Graphics.Shader.Translation
 
             if (UsedFeatures.HasFlag(FeatureFlags.CbIndexing))
             {
+                usedMask |= (int)GpuAccessor.QueryConstantBufferUse();
                 usedMask = FillMask(usedMask);
             }
 

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -91,6 +91,9 @@ namespace Ryujinx.Graphics.Shader.Translation
         private TextureDescriptor[] _cachedTextureDescriptors;
         private TextureDescriptor[] _cachedImageDescriptors;
 
+        public int FirstConstantBufferBinding { get; private set; }
+        public int FirstStorageBufferBinding { get; private set; }
+
         public ShaderConfig(IGpuAccessor gpuAccessor, TranslationFlags flags, TranslationCounts counts)
         {
             Stage                  = ShaderStage.Compute;
@@ -215,7 +218,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             }
         }
 
-        private static void SetUsedTextureOrImage(
+        private void SetUsedTextureOrImage(
             Dictionary<TextureInfo, TextureMeta> dict,
             int cbufSlot,
             int handle,
@@ -235,7 +238,10 @@ namespace Ryujinx.Graphics.Shader.Translation
             {
                 usageFlags |= TextureUsageFlags.NeedsScaleValue;
 
-                var canScale = (dimensions == 2 && !isArray) || (dimensions == 3 && isArray);
+                var canScale = (Stage == ShaderStage.Fragment || Stage == ShaderStage.Compute) && !isIndexed && !write &&
+                    (dimensions == 2 && !isArray) ||
+                    (dimensions == 3 && isArray);
+
                 if (!canScale)
                 {
                     // Resolution scaling cannot be applied to this texture right now.
@@ -294,33 +300,57 @@ namespace Ryujinx.Graphics.Shader.Translation
             if (UsedFeatures.HasFlag(FeatureFlags.CbIndexing))
             {
                 usedMask |= (int)GpuAccessor.QueryConstantBufferUse();
-                usedMask = FillMask(usedMask);
             }
 
-            return _cachedConstantBufferDescriptors = GetBufferDescriptors(usedMask, 0, _counts.IncrementUniformBuffersCount);
+            FirstConstantBufferBinding = _counts.UniformBuffersCount;
+
+            return _cachedConstantBufferDescriptors = GetBufferDescriptors(
+                usedMask,
+                0,
+                UsedFeatures.HasFlag(FeatureFlags.CbIndexing),
+                _counts.IncrementUniformBuffersCount);
         }
 
         public BufferDescriptor[] GetStorageBufferDescriptors()
         {
-            return _cachedStorageBufferDescriptors ??= GetBufferDescriptors(FillMask(_usedStorageBuffers), _usedStorageBuffersWrite, _counts.IncrementStorageBuffersCount);
+            if (_cachedStorageBufferDescriptors != null)
+            {
+                return _cachedStorageBufferDescriptors;
+            }
+
+            FirstStorageBufferBinding = _counts.StorageBuffersCount;
+
+            return _cachedStorageBufferDescriptors = GetBufferDescriptors(
+                _usedStorageBuffers,
+                _usedStorageBuffersWrite,
+                true,
+                _counts.IncrementStorageBuffersCount);
         }
 
-        private static int FillMask(int mask)
-        {
-            // When the storage or uniform buffers are used as array, we must allocate a binding
-            // even for the "gaps" that are not used on the shader.
-            // For this reason, fill up the gaps so that all slots up to the highest one are
-            // marked as "used".
-            return mask != 0 ? (int)(uint.MaxValue >> BitOperations.LeadingZeroCount((uint)mask)) : 0;
-        }
-
-        private static BufferDescriptor[] GetBufferDescriptors(int usedMask, int writtenMask, Func<int> getBindingCallback)
+        private static BufferDescriptor[] GetBufferDescriptors(
+            int usedMask,
+            int writtenMask,
+            bool isArray,
+            Func<int> getBindingCallback)
         {
             var descriptors = new BufferDescriptor[BitOperations.PopCount((uint)usedMask)];
+
+            int lastSlot = -1;
 
             for (int i = 0; i < descriptors.Length; i++)
             {
                 int slot = BitOperations.TrailingZeroCount(usedMask);
+
+                if (isArray)
+                {
+                    // The next array entries also consumes bindings, even if they are unused.
+                    for (int j = lastSlot + 1; j < slot; j++)
+                    {
+                        getBindingCallback();
+                    }
+                }
+
+                lastSlot = slot;
 
                 descriptors[i] = new BufferDescriptor(getBindingCallback(), slot);
 

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -239,8 +239,8 @@ namespace Ryujinx.Graphics.Shader.Translation
                 usageFlags |= TextureUsageFlags.NeedsScaleValue;
 
                 var canScale = (Stage == ShaderStage.Fragment || Stage == ShaderStage.Compute) && !isIndexed && !write &&
-                    (dimensions == 2 && !isArray) ||
-                    (dimensions == 3 && isArray);
+                    ((dimensions == 2 && !isArray) ||
+                    (dimensions == 3 && isArray));
 
                 if (!canScale)
                 {


### PR DESCRIPTION
Fixes a potential regression introduced on #2290 where the constant buffer array size would be incorrect on games that uses non-constant constant buffer slots. Note that the only game that is know to do that is Super Mario 3D All-Stars, and from what I was able to test, it is fine even without that fix, probably because all the constant buffers that it accesses on the shader using the non-constant indexing are also used elsewhere.

While testing, I also found a shader cache related issue. The `QueryConstantBufferUse` value is not saved on the cache, which causes it to use the default one of `0xffff`, which equals to 16 constant buffers used. This is too high, higher than the amount of uniform buffers allowed on the host, so it may cause a compilation error. It seems to be a existing issue that would trigger if the shader cache has to recompile from guest source. To fix it I just changed the default value to `0`, which seems to work on Super Mario Galaxy, but the correct fix here would be storing the value on the cache.

Other regressions fixed:
- Only report storage buffers (and constant buffers when non-constant indexing is used) that are actually used on the shader, instead of all the ones that consumes bindings.
- Add back some resolution scaling checks that were missing.