### PR TITLE
Assign _backgroundContext before starting its worker thread.

### DIFF
--- a/Ryujinx.Graphics.OpenGL/BackgroundContextWorker.cs
+++ b/Ryujinx.Graphics.OpenGL/BackgroundContextWorker.cs
@@ -19,6 +19,7 @@ namespace Ryujinx.Graphics.OpenGL
 
         public BackgroundContextWorker(IOpenGLContext backgroundContext)
         {
+            _backgroundContext = backgroundContext;
             _running = true;
 
             _signal = new AutoResetEvent(false);
@@ -27,7 +28,6 @@ namespace Ryujinx.Graphics.OpenGL
 
             _thread = new Thread(Run);
             _thread.Start();
-            _backgroundContext = backgroundContext;
         }
 
         private void Run()


### PR DESCRIPTION
Fixes a random crash when starting an embedded game.