### PR TITLE
Fix buffer and texture uses not being propagated for vertex A/B shaders

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -36,7 +36,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2298;
+        private const ulong ShaderCodeGenVersion = 2300;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Shader/Translation/TranslatorContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/TranslatorContext.cs
@@ -132,10 +132,9 @@ namespace Ryujinx.Graphics.Shader.Translation
 
             if (other != null)
             {
-                _config.SetUsedFeature(other._config.UsedFeatures);
-                TextureHandlesForCache.UnionWith(other.TextureHandlesForCache);
-
                 code = Combine(EmitShader(other._cfg, other._config), code);
+
+                _config.InheritFrom(other._config);
             }
 
             return Translator.Translate(code, _config, out shaderProgramInfo);


### PR DESCRIPTION
Fix a bug introduced by #2290 (hopefully the last one this time) where buffer and texture information from one vertex shader was not propagated to the other after they were merged. This was not a problem before because the use information was only collected later, after the shaders were already merged. Now they are collected very early, before they are merged, so the information needs to be propagated after the merge.

Fixes regressions on Catherine Full Body and other games using 2 vertex shaders.