### PR TITLE
Fix dimensions check for scale eligibility

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -36,7 +36,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2300;
+        private const ulong ShaderCodeGenVersion = 2301;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -257,7 +257,6 @@ namespace Ryujinx.Graphics.Shader.Translation
             bool accurateType)
         {
             var dimensions = type.GetDimensions();
-            var isArray = type.HasFlag(SamplerType.Array);
             var isIndexed = type.HasFlag(SamplerType.Indexed);
 
             var usageFlags = TextureUsageFlags.None;
@@ -266,9 +265,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             {
                 usageFlags |= TextureUsageFlags.NeedsScaleValue;
 
-                var canScale = (Stage == ShaderStage.Fragment || Stage == ShaderStage.Compute) && !isIndexed && !write &&
-                    ((dimensions == 2 && !isArray) ||
-                    (dimensions == 3 && isArray));
+                var canScale = (Stage == ShaderStage.Fragment || Stage == ShaderStage.Compute) && !isIndexed && !write && dimensions == 2;
 
                 if (!canScale)
                 {


### PR DESCRIPTION
Fix a regression with res scale where the old logic from the glsl emitter for detecting 2d array textures, but our new dimension count did not include a dimension for array index anyways.

Fixes res scale in the warriors games. 1D or 3D sampled textures should remain blacklisted.