### PR TITLE
Use a different method for out of bounds blit

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/MethodCopyTexture.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodCopyTexture.cs
@@ -1,3 +1,4 @@
+using Ryujinx.Common;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Image;
 using Ryujinx.Graphics.Gpu.State;
@@ -43,7 +44,26 @@ namespace Ryujinx.Graphics.Gpu.Engine
 
             var srcCopyTextureFormat = srcCopyTexture.Format.Convert();
 
-            Texture srcTexture = TextureManager.FindOrCreateTexture(srcCopyTexture, srcCopyTextureFormat, true, srcHint);
+            int srcWidthAligned = srcCopyTexture.Stride / srcCopyTextureFormat.BytesPerPixel;
+
+            ulong offset = 0;
+
+            // For an out of bounds copy, we must ensure that the copy wraps to the next line,
+            // so for a copy from a 64x64 texture, in the region [32, 96[, there are 32 pixels that are
+            // outside the bounds of the texture. We fill the destination with the first 32 pixels
+            // of the next line on the source texture.
+            // This can be done by simply adding an offset to the texture address, so that the initial
+            // gap is skipped and the copy is inside bounds again.
+            // This is required by the proprietary guest OpenGL driver.
+            if (srcCopyTexture.LinearLayout && srcCopyTexture.Width == srcX2 && srcX2 > srcWidthAligned && srcX1 > 0)
+            {
+                offset = (ulong)(srcX1 * srcCopyTextureFormat.BytesPerPixel);
+                srcCopyTexture.Width -= srcX1;
+                srcX2 -= srcX1;
+                srcX1 = 0;
+            }
+
+            Texture srcTexture = TextureManager.FindOrCreateTexture(srcCopyTexture, offset, srcCopyTextureFormat, true, srcHint);
 
             if (srcTexture == null)
             {
@@ -64,7 +84,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
                 dstCopyTextureFormat = dstCopyTexture.Format.Convert();
             }
 
-            Texture dstTexture = TextureManager.FindOrCreateTexture(dstCopyTexture, dstCopyTextureFormat, srcTexture.ScaleMode == TextureScaleMode.Scaled, dstHint);
+            Texture dstTexture = TextureManager.FindOrCreateTexture(dstCopyTexture, 0, dstCopyTextureFormat, srcTexture.ScaleMode == TextureScaleMode.Scaled, dstHint);
 
             if (dstTexture == null)
             {
@@ -89,30 +109,6 @@ namespace Ryujinx.Graphics.Gpu.Engine
             bool linearFilter = control.UnpackLinearFilter();
 
             srcTexture.HostTexture.CopyTo(dstTexture.HostTexture, srcRegion, dstRegion, linearFilter);
-
-            // For an out of bounds copy, we must ensure that the copy wraps to the next line,
-            // so for a copy from a 64x64 texture, in the region [32, 96[, there are 32 pixels that are
-            // outside the bounds of the texture. We fill the destination with the first 32 pixels
-            // of the next line on the source texture.
-            // This can be emulated with 2 copies (the first copy handles the region inside the bounds,
-            // the second handles the region outside of the bounds).
-            // We must also extend the source texture by one line to ensure we can wrap on the last line.
-            // This is required by the (guest) OpenGL driver.
-            if (srcX2 / srcTexture.Info.SamplesInX > srcTexture.Info.Width)
-            {
-                srcCopyTexture.Height++;
-
-                srcTexture = TextureManager.FindOrCreateTexture(srcCopyTexture, srcCopyTextureFormat, srcTexture.ScaleMode == TextureScaleMode.Scaled, srcHint);
-                scale = srcTexture.ScaleFactor;
-
-                srcRegion = new Extents2D(
-                    (int)Math.Ceiling(scale * ((srcX1 / srcTexture.Info.SamplesInX) - srcTexture.Info.Width)),
-                    (int)Math.Ceiling(scale * ((srcY1 / srcTexture.Info.SamplesInY) + 1)),
-                    (int)Math.Ceiling(scale * ((srcX2 / srcTexture.Info.SamplesInX) - srcTexture.Info.Width)),
-                    (int)Math.Ceiling(scale * ((srcY2 / srcTexture.Info.SamplesInY) + 1)));
-
-                srcTexture.HostTexture.CopyTo(dstTexture.HostTexture, srcRegion, dstRegion, linearFilter);
-            }
 
             dstTexture.SignalModified();
         }

--- a/Ryujinx.Graphics.Gpu/Engine/MethodCopyTexture.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MethodCopyTexture.cs
@@ -1,4 +1,3 @@
-using Ryujinx.Common;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Image;
 using Ryujinx.Graphics.Gpu.State;

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -476,11 +476,12 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Tries to find an existing texture, or create a new one if not found.
         /// </summary>
         /// <param name="copyTexture">Copy texture to find or create</param>
+        /// <param name="offset">Offset to be added to the physical texture address</param>
         /// <param name="formatInfo">Format information of the copy texture</param>
         /// <param name="preferScaling">Indicates if the texture should be scaled from the start</param>
         /// <param name="sizeHint">A hint indicating the minimum used size for the texture</param>
         /// <returns>The texture</returns>
-        public Texture FindOrCreateTexture(CopyTexture copyTexture, FormatInfo formatInfo, bool preferScaling = true, Size? sizeHint = null)
+        public Texture FindOrCreateTexture(CopyTexture copyTexture, ulong offset, FormatInfo formatInfo, bool preferScaling = true, Size? sizeHint = null)
         {
             int gobBlocksInY = copyTexture.MemoryLayout.UnpackGobBlocksInY();
             int gobBlocksInZ = copyTexture.MemoryLayout.UnpackGobBlocksInZ();
@@ -497,7 +498,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             }
 
             TextureInfo info = new TextureInfo(
-                copyTexture.Address.Pack(),
+                copyTexture.Address.Pack() + offset,
                 width,
                 copyTexture.Height,
                 copyTexture.Depth,


### PR DESCRIPTION
The guest OpenGL driver does out of bounds copies when copying textures for layout conversion. The way how this is supposed to work is that the copy should wrap to the next line of the texture and continue copying from there. Before this was being emulated on the host with two blits, which did work but had the issue that the second copy required the source texture to have one extra line. This extra line could sometimes have pixels fall into unmapped memory regions, which would cause a crash with a invalid memory region exception.

This uses a new approach that only requires a single bit. It simply adds an offset to the texture address, that way the copy is "in bounds" and no wrap to the next line is necessary. It also doesn't need to read any extra pixel.

This fixes the crash due to invalid memory regions being accessed on Rune Factory 5 and Shantae (the GBC emulator). Also tested another 2 OpenGL games, and they are fine with this change.