### PR TITLE
Fix non-independent blend state not being updated

### DIFF
--- a/Ryujinx.Graphics.Gpu/State/GpuStateTable.cs
+++ b/Ryujinx.Graphics.Gpu/State/GpuStateTable.cs
@@ -78,6 +78,8 @@ namespace Ryujinx.Graphics.Gpu.State
             new TableItem(MethodOffset.RtColorMask,            typeof(RtColorMask),            Constants.TotalRenderTargets),
             new TableItem(MethodOffset.VertexBufferState,      typeof(VertexBufferState),      Constants.TotalVertexBuffers),
             new TableItem(MethodOffset.BlendConstant,          typeof(ColorF),                 1),
+            new TableItem(MethodOffset.BlendStateCommon,       typeof(BlendStateCommon),       1),
+            new TableItem(MethodOffset.BlendEnableCommon,      typeof(Boolean32),              1),
             new TableItem(MethodOffset.BlendState,             typeof(BlendState),             Constants.TotalRenderTargets),
             new TableItem(MethodOffset.VertexBufferEndAddress, typeof(GpuVa),                  Constants.TotalVertexBuffers),
             new TableItem(MethodOffset.ShaderState,            typeof(ShaderState),            Constants.ShaderStages + 1),

--- a/Ryujinx.Graphics.Gpu/State/GpuStateTable.cs
+++ b/Ryujinx.Graphics.Gpu/State/GpuStateTable.cs
@@ -79,7 +79,6 @@ namespace Ryujinx.Graphics.Gpu.State
             new TableItem(MethodOffset.VertexBufferState,      typeof(VertexBufferState),      Constants.TotalVertexBuffers),
             new TableItem(MethodOffset.BlendConstant,          typeof(ColorF),                 1),
             new TableItem(MethodOffset.BlendStateCommon,       typeof(BlendStateCommon),       1),
-            new TableItem(MethodOffset.BlendEnableCommon,      typeof(Boolean32),              1),
             new TableItem(MethodOffset.BlendState,             typeof(BlendState),             Constants.TotalRenderTargets),
             new TableItem(MethodOffset.VertexBufferEndAddress, typeof(GpuVa),                  Constants.TotalVertexBuffers),
             new TableItem(MethodOffset.ShaderState,            typeof(ShaderState),            Constants.ShaderStages + 1),


### PR DESCRIPTION
The entries for non-independent blend state were missing from the state table, which means it wouldn't detect modification for most of those blend registers, and this not update the blend state. This only affects OpenGL games as NVN and Vulkan always have independent blend enabled (which is working properly).

This fixes broken blend on some OpenGL games, like Code of Princess EX.
Before (from gamedb):
![image](https://user-images.githubusercontent.com/5624669/119197787-af8ede00-ba5e-11eb-8e3c-e44ca2f46982.png)
With PR:
![image](https://user-images.githubusercontent.com/5624669/119197802-b584bf00-ba5e-11eb-8932-dda519e8bfb6.png)