### PR TITLE
Add another Depth32F texture format variant

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/FormatTable.cs
+++ b/Ryujinx.Graphics.Gpu/Image/FormatTable.cs
@@ -50,6 +50,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             { 0x49201, new FormatInfo(Format.R32G32B32A32Uint,  1,  1,  16, 4) },
             { 0x36d81, new FormatInfo(Format.R32G32B32A32Sint,  1,  1,  16, 4) },
             { 0x2493a, new FormatInfo(Format.D16Unorm,          1,  1,  2,  1) },
+            { 0x493af, new FormatInfo(Format.D32Float,          1,  1,  4,  1) },
             { 0x7ffaf, new FormatInfo(Format.D32Float,          1,  1,  4,  1) },
             { 0x24a0e, new FormatInfo(Format.D24UnormS8Uint,    1,  1,  4,  2) },
             { 0x24a29, new FormatInfo(Format.D24UnormS8Uint,    1,  1,  4,  2) },


### PR DESCRIPTION
This is used by Yokai Watch 1.
Together with #2302 and #2303, it improves rendering on this game.
Before (from gamedb):
![image](https://user-images.githubusercontent.com/5624669/119205611-0dc3bd00-ba6f-11eb-85c0-b4a30925c726.png)
With PR:
![image](https://user-images.githubusercontent.com/5624669/119205558-e53bc300-ba6e-11eb-9ff1-a73301899db2.png)

I actually implemented it quite some time ago, but the game was still very broken so I didn't submit it for this reason. Now it seems much better with the other fixes I linked.

Theres still a issue similar to what was recently fixed on Super Mario Party where the screen is overlayed by a solid colour.
