### PR TITLE
Compare aligned size for largest mip level when considering sampler resize

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -941,7 +941,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 return TextureMatchQuality.NoMatch;
             }
 
-            if (!TextureCompatibility.SizeMatches(Info, info, (flags & TextureSearchFlags.Strict) == 0))
+            if (!TextureCompatibility.SizeMatches(Info, info, (flags & TextureSearchFlags.Strict) == 0, FirstLevel))
             {
                 return TextureMatchQuality.NoMatch;
             }

--- a/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -343,17 +343,16 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Gets the aligned sizes of the specified texture information, shifted to the largest mip from a given level.
+        /// Gets the aligned sizes for the given dimensions, using the specified texture information.
         /// The alignment depends on the texture layout and format bytes per pixel.
         /// </summary>
         /// <param name="info">Texture information to calculate the aligned size from</param>
-        /// <param name="level">Mipmap level for texture views. Shifts the aligned size to represent the largest mip level</param>
-        /// <returns>The aligned texture size of the largest mip level</returns>
-        public static Size GetLargestAlignedSize(TextureInfo info, int level)
+        /// <param name="width">The width to be aligned</param>
+        /// <param name="height">The height to be aligned</param>
+        /// <param name="depth">The depth to be aligned</param>
+        /// <returns>The aligned texture size</returns>
+        private static Size GetAlignedSize(TextureInfo info, int width, int height, int depth)
         {
-            int width = info.Width << level;
-            int height = info.Height << level;
-
             if (info.IsLinear)
             {
                 return SizeCalculator.GetLinearAlignedSize(
@@ -365,8 +364,6 @@ namespace Ryujinx.Graphics.Gpu.Image
             }
             else
             {
-                int depth = info.GetDepth() << level;
-
                 return SizeCalculator.GetBlockLinearAlignedSize(
                     width,
                     height,
@@ -381,6 +378,22 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Gets the aligned sizes of the specified texture information, shifted to the largest mip from a given level.
+        /// The alignment depends on the texture layout and format bytes per pixel.
+        /// </summary>
+        /// <param name="info">Texture information to calculate the aligned size from</param>
+        /// <param name="level">Mipmap level for texture views. Shifts the aligned size to represent the largest mip level</param>
+        /// <returns>The aligned texture size of the largest mip level</returns>
+        public static Size GetLargestAlignedSize(TextureInfo info, int level)
+        {
+            int width = info.Width << level;
+            int height = info.Height << level;
+            int depth = info.GetDepth() << level;
+
+            return GetAlignedSize(info, width, height, depth);
+        }
+
+        /// <summary>
         /// Gets the aligned sizes of the specified texture information.
         /// The alignment depends on the texture layout and format bytes per pixel.
         /// </summary>
@@ -391,31 +404,9 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             int width = Math.Max(1, info.Width >> level);
             int height = Math.Max(1, info.Height >> level);
+            int depth = Math.Max(1, info.GetDepth() >> level);
 
-            if (info.IsLinear)
-            {
-                return SizeCalculator.GetLinearAlignedSize(
-                    width,
-                    height,
-                    info.FormatInfo.BlockWidth,
-                    info.FormatInfo.BlockHeight,
-                    info.FormatInfo.BytesPerPixel);
-            }
-            else
-            {
-                int depth = Math.Max(1, info.GetDepth() >> level);
-
-                return SizeCalculator.GetBlockLinearAlignedSize(
-                    width,
-                    height,
-                    depth,
-                    info.FormatInfo.BlockWidth,
-                    info.FormatInfo.BlockHeight,
-                    info.FormatInfo.BytesPerPixel,
-                    info.GobBlocksInY,
-                    info.GobBlocksInZ,
-                    info.GobBlocksInTileX);
-            }
+            return GetAlignedSize(info, width, height, depth);
         }
 
         /// <summary>


### PR DESCRIPTION
When selecting a texture that's a view for a sampler resize, we should take care that resizing it doesn't change the aligned size of any larger mip levels.

This PR covers two cases:
- When creating a view of the texture, we check that the aligned size of the view shifted up to level 0 still matches the aligned size of the container. If it does not, a copy dependency is created rather than resizing.
- When searching for a texture for sampler, textures that do _not_ match our aligned size when both are shifted up by its base level are not considered an exact match, as resizing the found texture will cause the mip 0 aligned size to change. It will create a copy dependency view instead.

Fixes graphical errors and crashes (on flush) in various Unity games that use render-to-texture. This likely also fixes infrequent graphical errors and crashes in Mario Kart 8 Deluxe.

Please test across various games to ensure there are no regressions.

## Example - Moving Out Demo

### Before
![image](https://user-images.githubusercontent.com/6294155/119268119-6d45d800-bbe9-11eb-8043-d8bed9012b28.png)

```
Fatal error. Internal CLR error. (0x80131506)
```

### After:
![image](https://user-images.githubusercontent.com/6294155/119268060-14763f80-bbe9-11eb-9e5a-d938551070c2.png)

![image](https://user-images.githubusercontent.com/6294155/119268220-e9d8b680-bbe9-11eb-96f2-cd17a0b32d27.png)
