### PR TITLE
Fix value of constant vertex attributes

### DIFF
--- a/Ryujinx.Graphics.OpenGL/VertexArray.cs
+++ b/Ryujinx.Graphics.OpenGL/VertexArray.cs
@@ -80,7 +80,7 @@ namespace Ryujinx.Graphics.OpenGL
                 if (attrib.IsZero)
                 {
                     // Disabling the attribute causes the shader to read a constant value.
-                    // The value is configurable, but by default is a vector of (0, 0, 0, 1).
+                    // We currently set the constant to (0, 0, 0, 0).
                     DisableVertexAttrib(index);
                 }
                 else
@@ -176,6 +176,7 @@ namespace Ryujinx.Graphics.OpenGL
             {
                 _vertexAttribsInUse &= ~mask;
                 GL.DisableVertexAttribArray(index);
+                GL.VertexAttrib4(index, 0f, 0f, 0f, 0f);
             }
         }
 

--- a/Ryujinx.Graphics.Shader/Translation/Translator.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Translator.cs
@@ -129,19 +129,20 @@ namespace Ryujinx.Graphics.Shader.Translation
             {
                 config.SetUsedFeature(FeatureFlags.Bindless);
             }
-            else // Not bindless, fill up texture handles
+
+            for (int funcIndex = 0; funcIndex < cfg.Length; funcIndex++)
             {
-                for (int funcIndex = 0; funcIndex < cfg.Length; funcIndex++)
+                for (int blkIndex = 0; blkIndex < cfg[funcIndex].Length; blkIndex++)
                 {
-                    for (int blkIndex = 0; blkIndex < cfg[funcIndex].Length; blkIndex++)
+                    Block block = cfg[funcIndex][blkIndex];
+
+                    if (maxEndAddress < block.EndAddress)
                     {
-                        Block block = cfg[funcIndex][blkIndex];
+                        maxEndAddress = block.EndAddress;
+                    }
 
-                        if (maxEndAddress < block.EndAddress)
-                        {
-                            maxEndAddress = block.EndAddress;
-                        }
-
+                    if (!hasBindless)
+                    {
                         for (int index = 0; index < block.OpCodes.Count; index++)
                         {
                             if (block.OpCodes[index] is OpCodeTextureBase texture)


### PR DESCRIPTION
This fixes the value of the constant vertex attribute, which was being set to `1, 1, 1, 1` for some reason. According to the spec
> When values for a vertex shader attribute variable are sourced from a current generic attribute value, the attribute must be specified by a command compatible with the data type of the variable. The values loaded into a shader attribute variable bound to generic attribute index are undefined if the current value for attribute index was not specified by [...]

So this explicitly sets the value now, which fixes one of the issues reported on https://github.com/Ryujinx/Ryujinx-Games-List/issues/3599
Before:
![image](https://user-images.githubusercontent.com/5624669/119298700-ebc76780-bc33-11eb-977c-d893f4741370.png)
After:
![image](https://user-images.githubusercontent.com/5624669/119298711-f124b200-bc33-11eb-9293-a65248fddd62.png)
![image](https://user-images.githubusercontent.com/5624669/119298720-f3870c00-bc33-11eb-8166-fcdcf8df923f.png)

The other issue (missing clouds in the background) is fixed by #2005.

While I was at it, I also fixed an issue introduced on #2145 that broke shader dumping on shaders with bindless texture. The size of the shader code was not being calculated since it was just skipping the calculation when the shader has bindless instructions, which means that the shader dumper would just save empty shaders as the size was 0. This doesn't affect end users as shader dumping is a debugging feature.
