### PR TITLE
Do not attempt to normalize SNORM image buffers on shaders

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -365,7 +365,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     }
 
                     _context.Methods.BufferManager.SetBufferTextureStorage(hostTexture, texture.Range.GetSubRange(0).Address, texture.Size, bindingInfo, format, true);
-                } 
+                }
                 else if (isStore)
                 {
                     texture?.SignalModified();

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -36,7 +36,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2301;
+        private const ulong ShaderCodeGenVersion = 2317;
 
         // Progress reporting helpers
         private volatile int _shaderCount;


### PR DESCRIPTION
This would fix a bug in the shader translator where it would try to normalize image load/store colours. Normalizing for `imageLoad` "works", but would provide incorrect results as it already uses a snorm format for the image when it is bound. For `imageStore`, it causes a NRE as the current code tries to get the "destination" operands from the operation, but fails as theres none on `imageStore`. It would also try to normalize the value of other texture operations such as `TextureSize` which is obviously wrong as normalizing the sizes of a texture because the format is SNORM makes no sense.

Fix a crash on https://github.com/Ryujinx/Ryujinx-Games-List/issues/3611 but the game does not render properly (seems to be a problem elsewhere, maybe the lack of atomic image instructions since the game seems to use them).