### PR TITLE
Avoid clearing alpha channel by handle when presenting

### DIFF
--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -1232,7 +1232,7 @@ namespace Ryujinx.Graphics.OpenGL
             }
         }
 
-        private void RestoreComponentMask(int index)
+        public void RestoreComponentMask(int index)
         {
             // If the bound render target is bgra, swap the red and blue masks.
             uint redMask = _fpIsBgra[index] == 0 ? 1u : 4u;

--- a/Ryujinx.Graphics.OpenGL/Window.cs
+++ b/Ryujinx.Graphics.OpenGL/Window.cs
@@ -1,4 +1,3 @@
-using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.OpenGL.Image;
@@ -119,18 +118,11 @@ namespace Ryujinx.Graphics.OpenGL
                 ClearBufferMask.ColorBufferBit,
                 BlitFramebufferFilter.Linear);
 
-            bool[] oldGloballorWritemask = new bool[4];
-
-            GL.GetBoolean(GetPName.ColorWritemask, oldGloballorWritemask);
-
             // Remove Alpha channel
-            GL.ColorMask(false, false, false, true);
+            GL.ColorMask(0, false, false, false, true);
             GL.ClearColor(0.0f, 0.0f, 0.0f, 1.0f);
             GL.Clear(ClearBufferMask.ColorBufferBit);
-            GL.ColorMask(oldGloballorWritemask[0],
-                oldGloballorWritemask[1],
-                oldGloballorWritemask[2],
-                oldGloballorWritemask[3]);
+            ((Pipeline)_renderer.Pipeline).RestoreComponentMask(0);
 
             GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, oldReadFramebufferHandle);
             GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, oldDrawFramebufferHandle);

--- a/Ryujinx.Graphics.OpenGL/Window.cs
+++ b/Ryujinx.Graphics.OpenGL/Window.cs
@@ -119,10 +119,14 @@ namespace Ryujinx.Graphics.OpenGL
                 BlitFramebufferFilter.Linear);
 
             // Remove Alpha channel
-            GL.ColorMask(0, false, false, false, true);
+            GL.ColorMask(false, false, false, true);
             GL.ClearColor(0.0f, 0.0f, 0.0f, 1.0f);
             GL.Clear(ClearBufferMask.ColorBufferBit);
-            ((Pipeline)_renderer.Pipeline).RestoreComponentMask(0);
+
+            for (int i = 0; i < Constants.MaxRenderTargets; i++)
+            {
+                ((Pipeline)_renderer.Pipeline).RestoreComponentMask(i);
+            }
 
             GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, oldReadFramebufferHandle);
             GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, oldDrawFramebufferHandle);

--- a/Ryujinx.Graphics.OpenGL/Window.cs
+++ b/Ryujinx.Graphics.OpenGL/Window.cs
@@ -39,11 +39,7 @@ namespace Ryujinx.Graphics.OpenGL
 
         private void CopyTextureToFrameBufferRGB(int drawFramebuffer, int readFramebuffer, TextureView view, ImageCrop crop)
         {
-            bool[] oldFramebufferColorWritemask = new bool[4];
-
             (int oldDrawFramebufferHandle, int oldReadFramebufferHandle) = ((Pipeline)_renderer.Pipeline).GetBoundFramebuffers();
-
-            GL.GetBoolean(GetIndexedPName.ColorWritemask, drawFramebuffer, oldFramebufferColorWritemask);
 
             GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, drawFramebuffer);
             GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, readFramebuffer);
@@ -123,14 +119,18 @@ namespace Ryujinx.Graphics.OpenGL
                 ClearBufferMask.ColorBufferBit,
                 BlitFramebufferFilter.Linear);
 
+            bool[] oldGloballorWritemask = new bool[4];
+
+            GL.GetBoolean(GetPName.ColorWritemask, oldGloballorWritemask);
+
             // Remove Alpha channel
-            GL.ColorMask(drawFramebuffer, false, false, false, true);
-            GL.ClearBuffer(ClearBuffer.Color, drawFramebuffer, new float[] { 0.0f, 0.0f, 0.0f, 1.0f });
-            GL.ColorMask(drawFramebuffer,
-                oldFramebufferColorWritemask[0],
-                oldFramebufferColorWritemask[1],
-                oldFramebufferColorWritemask[2],
-                oldFramebufferColorWritemask[3]);
+            GL.ColorMask(false, false, false, true);
+            GL.ClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+            GL.Clear(ClearBufferMask.ColorBufferBit);
+            GL.ColorMask(oldGloballorWritemask[0],
+                oldGloballorWritemask[1],
+                oldGloballorWritemask[2],
+                oldGloballorWritemask[3]);
 
             GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, oldReadFramebufferHandle);
             GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, oldDrawFramebufferHandle);


### PR DESCRIPTION
Previous code was binding then blitting while the framebuffer was bound
and then clearing the alpha channel by its handle.

This ended up triggering a bug since AMD driver 21.4.1 ending up
clearing the whole framebuffer as a result.

New code fix this weird logic by applying the clear on the bound
framebuffer.

Close #2236.