### PR TITLE
Use single block translations in LCQ

### DIFF
--- a/ARMeilleure/Decoders/Block.cs
+++ b/ARMeilleure/Decoders/Block.cs
@@ -5,23 +5,19 @@ namespace ARMeilleure.Decoders
 {
     class Block
     {
-        public ulong Address    { get; set; }
+        public ulong Address { get; set; }
         public ulong EndAddress { get; set; }
 
-        public Block Next   { get; set; }
+        public Block Next { get; set; }
         public Block Branch { get; set; }
 
         public bool Exit { get; set; }
 
         public List<OpCode> OpCodes { get; }
 
-        public Block()
+        public Block(ulong address)
         {
             OpCodes = new List<OpCode>();
-        }
-
-        public Block(ulong address) : this()
-        {
             Address = address;
         }
 

--- a/ARMeilleure/State/NativeContext.cs
+++ b/ARMeilleure/State/NativeContext.cs
@@ -18,6 +18,7 @@ namespace ARMeilleure.State
             public ulong ExclusiveAddress;
             public ulong ExclusiveValueLow;
             public ulong ExclusiveValueHigh;
+            public int RejitHint;
             public int Running;
         }
 
@@ -32,6 +33,7 @@ namespace ARMeilleure.State
             _block = allocator.Allocate((ulong)Unsafe.SizeOf<NativeCtxStorage>());
 
             GetStorage().ExclusiveAddress = ulong.MaxValue;
+            GetStorage().RejitHint = 1;
         }
 
         public unsafe ulong GetX(int index)
@@ -184,6 +186,11 @@ namespace ARMeilleure.State
         public static int GetRunningOffset()
         {
             return StorageOffset(ref _dummyStorage, ref _dummyStorage.Running);
+        }
+
+        public static int GetRejitHintOffset()
+        {
+            return StorageOffset(ref _dummyStorage, ref _dummyStorage.RejitHint);
         }
 
         private static int StorageOffset<T>(ref NativeCtxStorage storage, ref T target)

--- a/ARMeilleure/Translation/PTC/PtcProfiler.cs
+++ b/ARMeilleure/Translation/PTC/PtcProfiler.cs
@@ -20,7 +20,7 @@ namespace ARMeilleure.Translation.PTC
     {
         private const string OuterHeaderMagicString = "Pohd\0\0\0\0";
 
-        private const uint InternalVersion = 1866; //! Not to be incremented manually for each change to the ARMeilleure project.
+        private const uint InternalVersion = 2324; //! Not to be incremented manually for each change to the ARMeilleure project.
 
         private const int SaveInterval = 30; // Seconds.
 


### PR DESCRIPTION
Use single block translations in LCQ. This changes the rejit policy to be very similar to how it was before #2190. A flag `RejitHint`, is stored on the `NativeContext` which the rejit check will check to determine if it should count this transition. A transition is counted if it is a:

* Direct/Indirect call
* Indirect jump
* A continuation from an HCQ translation

Still haven't got the chance to thoroughly check this causes performance regression or collected metrics in regards to guest bytes jitted and stuff like that. Expect PTC profile info to blow up.