### PR TITLE
Fix inverted low/high mask value on GetThreadCoreMask32 syscall

### DIFF
--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall32.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall32.cs
@@ -333,8 +333,8 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
         {
             KernelResult result = _syscall.GetThreadCoreMask(handle, out preferredCore, out long affinityMask);
 
-            affinityMaskLow = (int)(affinityMask >> 32);
-            affinityMaskHigh = (int)(affinityMask & uint.MaxValue);
+            affinityMaskLow = (int)(affinityMask & uint.MaxValue);
+            affinityMaskHigh = (int)(affinityMask >> 32);
 
             return result;
         }


### PR DESCRIPTION
The values were inverted, causing games to get a invalid mask value.
Only affects 32-bit games.
Allows https://github.com/Ryujinx/Ryujinx-Games-List/issues/1350 to progress further.
![image](https://user-images.githubusercontent.com/5624669/120108610-5436ad00-c13c-11eb-8973-e184cec2da37.png)