### PR TITLE
Fix guest stack trace inexistent function names

### DIFF
--- a/Ryujinx.HLE/HOS/Kernel/Process/HleProcessDebugger.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/HleProcessDebugger.cs
@@ -167,17 +167,6 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
                     return true;
                 }
 
-                if (middle + 1 < image.Symbols.Length)
-                {
-                    ElfSymbol next = image.Symbols[middle + 1];
-                    
-                    // If our symbol points inbetween two symbols, we can *guess* that it's referring to the first one
-                    if (address >= symbol.Value && address < next.Value)
-                    {
-                        return true;
-                    }
-                }
-
                 if (address < symbol.Value)
                 {
                     right = middle - 1;


### PR DESCRIPTION
Fixes a regression introduced on #1845 where a incorrect function name would be included on the trace if the function had its name stripped. Now it is just empty, like it was before the change.

Before:
```
   0x000000003cac6114	sdk:0x58114	nn::diag::detail::VAbortImpl(char const*, char const*, char const*, int, nn::Result const*, nn::os::UserExceptionInfo const*, char const*, std::__va_list):0x00b8
   0x000000003cac61a0	sdk:0x581a0	nn::diag::detail::AbortImpl(char const*, char const*, char const*, int, char const*, ...)
   0x000000003cb4b894	sdk:0xdd894	nn::os::detail::ThreadManagerImplByHorizon::SetThreadCoreMask(nn::os::ThreadType*, int, unsigned long long) const:0x0058
   0x000000003cb45dcc	sdk:0xd7dcc	nn::os::SetThreadCoreMask(nn::os::ThreadType*, int, unsigned long long):0x002c
   0x0000000000415a04	main:0x211a04	void std::__1::__tree_remove<std::__1::__tree_node_base<void*>*>(std::__1::__tree_node_base<void*>*, std::__1::__tree_node_base<void*>*):0xb6230
   0x0000000000415b7c	main:0x211b7c	void std::__1::__tree_remove<std::__1::__tree_node_base<void*>*>(std::__1::__tree_node_base<void*>*, std::__1::__tree_node_base<void*>*):0xb63a8
   0x00000000003ec7cc	main:0x1e87cc	void std::__1::__tree_remove<std::__1::__tree_node_base<void*>*>(std::__1::__tree_node_base<void*>*, std::__1::__tree_node_base<void*>*):0x8cff8
   0x00000000002dbe50	main:0xd7e50	void std::__1::__tree_balance_after_insert<std::__1::__tree_node_base<void*>*>(std::__1::__tree_node_base<void*>*, std::__1::__tree_node_base<void*>*):0xca894
   0x0000000000204ac4	main:0x0ac4	main:0x0018
   0x0000000000204628	main:0x0628	nnMain:0x00b4
   0x000000003cb17a44	sdk:0xa9a44	nn::init::Start(unsigned int, unsigned int, void (*)(), void (*)()):0x0044
   0x00000000002000b4	rtld:0x00b4
```
After:
```
   0x000000003cac6114   sdk:0x58114     nn::diag::detail::VAbortImpl(char const*, char const*, char const*, int, nn::Result const*, nn::os::UserExceptionInfo const*, char const*, std::__va_list):0x00b8
   0x000000003cac61a0   sdk:0x581a0     nn::diag::detail::AbortImpl(char const*, char const*, char const*, int, char const*, ...)
   0x000000003cb4b894   sdk:0xdd894     nn::os::detail::ThreadManagerImplByHorizon::SetThreadCoreMask(nn::os::ThreadType*, int, unsigned long long) const:0x0058
   0x000000003cb45dcc   sdk:0xd7dcc     nn::os::SetThreadCoreMask(nn::os::ThreadType*, int, unsigned long long):0x002c
   0x0000000000415a04   main:0x211a04
   0x0000000000415b7c   main:0x211b7c
   0x00000000003ec7cc   main:0x1e87cc
   0x00000000002dbe50   main:0xd7e50
   0x0000000000204ac4   main:0x0ac4     main:0x0018
   0x0000000000204628   main:0x0628     nnMain:0x00b4
   0x000000003cb17a44   sdk:0xa9a44     nn::init::Start(unsigned int, unsigned int, void (*)(), void (*)()):0x0044
   0x00000000002000b4   rtld:0x00b4
```
Note: Does not impact end users as this is only used for debugging.