### PR TITLE
Update SDL2-CS

### DIFF
--- a/Ryujinx.SDL2.Common/Ryujinx.SDL2.Common.csproj
+++ b/Ryujinx.SDL2.Common/Ryujinx.SDL2.Common.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ppy.SDL2-CS" Version="1.0.225-alpha" />
+    <PackageReference Include="Ryujinx.SDL2-CS" Version="2.0.15-build9" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Changelog:
- SDL2 was updated to lastest master
- DInput was disabled from build configuration (Close #2238)
- HIDAPI was forced enabled on Linux and libusb library name was fixed (Close #2226)

NOTE about HIDAPI support on Linux:
Make sure that your gamepad is accesible to your user for it to be detected by HIDAPI. This can be done via a udev rule like:

```
KERNEL=="hidraw*", MODE="0660", TAG+="uaccess"
```

**NOTE: This rule is given as an example, this can present a security risk. Make sure to filter by vendor and product ids.**