### PR TITLE
Fix shaders with mixed PBK and SSY addresses on the stack

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -36,7 +36,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2317;
+        private const ulong ShaderCodeGenVersion = 2329;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Shader/Decoders/Decoder.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/Decoder.cs
@@ -278,7 +278,7 @@ namespace Ryujinx.Graphics.Shader.Decoders
                 OpCode op = makeOp(emitter, opAddress, opCode);
 
                 // We check these patterns to figure out the presence of bindless access
-                hasBindless |= (op is OpCodeImage image && image.IsBindless) || 
+                hasBindless |= (op is OpCodeImage image && image.IsBindless) ||
                     (op is OpCodeTxd txd && txd.IsBindless) ||
                     (op is OpCodeTld4B) ||
                     (emitter == InstEmit.TexB) ||
@@ -332,35 +332,39 @@ namespace Ryujinx.Graphics.Shader.Decoders
             private RestoreType _restoreType;
 
             private ulong _restoreValue;
+            private MergeType _restoreMergeType;
 
             public bool ReturningFromVisit => _restoreType != RestoreType.None;
 
             public PathBlockState(Block block)
             {
-                Block         = block;
-                _restoreType  = RestoreType.None;
-                _restoreValue = 0;
+                Block             = block;
+                _restoreType      = RestoreType.None;
+                _restoreValue     = 0;
+                _restoreMergeType = 0;
             }
 
             public PathBlockState(int oldStackSize)
             {
-                Block         = null;
-                _restoreType  = RestoreType.PopPushOp;
-                _restoreValue = (ulong)oldStackSize;
+                Block             = null;
+                _restoreType      = RestoreType.PopPushOp;
+                _restoreValue     = (ulong)oldStackSize;
+                _restoreMergeType = 0;
             }
 
-            public PathBlockState(ulong syncAddress)
+            public PathBlockState(ulong syncAddress, MergeType mergeType)
             {
-                Block         = null;
-                _restoreType  = RestoreType.PushBranchOp;
-                _restoreValue = syncAddress;
+                Block             = null;
+                _restoreType      = RestoreType.PushBranchOp;
+                _restoreValue     = syncAddress;
+                _restoreMergeType = mergeType;
             }
 
-            public void RestoreStackState(Stack<ulong> branchStack)
+            public void RestoreStackState(Stack<(ulong, MergeType)> branchStack)
             {
                 if (_restoreType == RestoreType.PushBranchOp)
                 {
-                    branchStack.Push(_restoreValue);
+                    branchStack.Push((_restoreValue, _restoreMergeType));
                 }
                 else if (_restoreType == RestoreType.PopPushOp)
                 {
@@ -380,7 +384,7 @@ namespace Ryujinx.Graphics.Shader.Decoders
 
             HashSet<Block> visited = new HashSet<Block>();
 
-            Stack<ulong> branchStack = new Stack<ulong>();
+            Stack<(ulong, MergeType)> branchStack = new Stack<(ulong, MergeType)>();
 
             void Push(PathBlockState pbs)
             {
@@ -426,7 +430,9 @@ namespace Ryujinx.Graphics.Shader.Decoders
 
                     for (int index = pushOpIndex; index < pushOpsCount; index++)
                     {
-                        branchStack.Push(current.PushOpCodes[index].GetAbsoluteAddress());
+                        OpCodePush currentPushOp = current.PushOpCodes[index];
+                        MergeType pushMergeType = currentPushOp.Emitter == InstEmit.Ssy ? MergeType.Sync : MergeType.Brk;
+                        branchStack.Push((currentPushOp.GetAbsoluteAddress(), pushMergeType));
                     }
                 }
 
@@ -452,24 +458,48 @@ namespace Ryujinx.Graphics.Shader.Decoders
                 }
                 else if (current.GetLastOp() is OpCodeBranchPop op)
                 {
-                    ulong targetAddress = branchStack.Pop();
+                    MergeType popMergeType = op.Emitter == InstEmit.Sync ? MergeType.Sync : MergeType.Brk;
 
-                    if (branchStack.Count == 0)
+                    bool found = true;
+                    ulong targetAddress = 0UL;
+                    MergeType mergeType;
+
+                    do
                     {
-                        branchStack.Push(targetAddress);
+                        if (branchStack.Count == 0)
+                        {
+                            found = false;
+                            break;
+                        }
 
-                        op.Targets.Add(pushOp, op.Targets.Count);
+                        (targetAddress, mergeType) = branchStack.Pop();
 
-                        pushOp.PopOps.TryAdd(op, Local());
+                        // Push the target address (this will be used to push the address
+                        // back into the SSY/PBK stack when we return from that block),
+                        Push(new PathBlockState(targetAddress, mergeType));
                     }
-                    else
+                    while (mergeType != popMergeType);
+
+                    // Make sure we found the correct address,
+                    // the push and pop instruction types must match, so:
+                    // - BRK can only consume addresses pushed by PBK.
+                    // - SYNC can only consume addresses pushed by SSY.
+                    if (found)
                     {
-                        // First we push the target address (this will be used to push the
-                        // address back into the SSY/PBK stack when we return from that block),
-                        // then we push the block itself into the work "queue" (well, it's a stack)
-                        // for processing.
-                        Push(new PathBlockState(targetAddress));
-                        Push(new PathBlockState(blocks[targetAddress]));
+                        if (branchStack.Count == 0)
+                        {
+                            // If the entire stack was consumed, then the current pop instruction
+                            // just consumed the address from out push instruction.
+                            op.Targets.Add(pushOp, op.Targets.Count);
+
+                            pushOp.PopOps.TryAdd(op, Local());
+                        }
+                        else
+                        {
+                            // Push the block itself into the work "queue" (well, it's a stack)
+                            // for processing.
+                            Push(new PathBlockState(blocks[targetAddress]));
+                        }
                     }
                 }
             }

--- a/Ryujinx.Graphics.Shader/Decoders/Decoder.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/Decoder.cs
@@ -318,6 +318,12 @@ namespace Ryujinx.Graphics.Shader.Decoders
                     opCode is OpCodeExit;
         }
 
+        private enum MergeType
+        {
+            Brk = 0,
+            Sync = 1
+        }
+
         private struct PathBlockState
         {
             public Block Block { get; }
@@ -341,7 +347,7 @@ namespace Ryujinx.Graphics.Shader.Decoders
                 Block             = block;
                 _restoreType      = RestoreType.None;
                 _restoreValue     = 0;
-                _restoreMergeType = 0;
+                _restoreMergeType = default;
             }
 
             public PathBlockState(int oldStackSize)
@@ -349,7 +355,7 @@ namespace Ryujinx.Graphics.Shader.Decoders
                 Block             = null;
                 _restoreType      = RestoreType.PopPushOp;
                 _restoreValue     = (ulong)oldStackSize;
-                _restoreMergeType = 0;
+                _restoreMergeType = default;
             }
 
             public PathBlockState(ulong syncAddress, MergeType mergeType)

--- a/Ryujinx.Graphics.Shader/Decoders/MergeType.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/MergeType.cs
@@ -1,0 +1,8 @@
+namespace Ryujinx.Graphics.Shader.Decoders
+{
+    enum MergeType
+    {
+        Brk = 0,
+        Sync = 1
+    }
+}

--- a/Ryujinx.Graphics.Shader/Decoders/MergeType.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/MergeType.cs
@@ -1,8 +1,0 @@
-namespace Ryujinx.Graphics.Shader.Decoders
-{
-    enum MergeType
-    {
-        Brk = 0,
-        Sync = 1
-    }
-}

--- a/Ryujinx.Graphics.Shader/Translation/Optimizations/Optimizer.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Optimizations/Optimizer.cs
@@ -1,5 +1,4 @@
 using Ryujinx.Graphics.Shader.IntermediateRepresentation;
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;


### PR DESCRIPTION
PBK and SSY shader instruction pushes an address to a stack, which is poped by BRK and SYNC instructions respectively. When the addresses on stack are mixed, only the address for the matching instruction should be used.
Consider the following example:
- PBK pushes address 0xA00.
- SSY pushes address 0xB00.
- BRK is executed.
The current behaviour is that the shader translator assumes that BRK would jump to 0xB00, which is incorrect as the address was pushed by a SSY instruction, not PBK. This changes makes it discard the 0xB00 address, then use the 0xA00 since the type of this instruction matches.

Fixes pink sky on Dead or Alive Xtreme 3.
Before (from gamedb):
![image](https://user-images.githubusercontent.com/5624669/120160435-a0c9c900-c1cc-11eb-8da4-a577f0b2452a.png)
PR:
![image](https://user-images.githubusercontent.com/5624669/120160374-914a8000-c1cc-11eb-8b39-4b96f4601e57.png)
Things to look for while testing:
- Any regression caused by this change.
- Shader compilation being slower, since it needs to do a bit more work on the decoder now (in special the function that propagates the PBK and SSY addresses). I wouldn't expect a noticeable impact though.