### PR TITLE
Inherit buffer tracking handles rather than recreating on resize.

### DIFF
--- a/Ryujinx.Cpu/IVirtualMemoryManagerTracked.cs
+++ b/Ryujinx.Cpu/IVirtualMemoryManagerTracked.cs
@@ -1,6 +1,8 @@
 ﻿using Ryujinx.Cpu.Tracking;
 using Ryujinx.Memory;
+using Ryujinx.Memory.Tracking;
 using System;
+using System.Collections.Generic;
 
 namespace Ryujinx.Cpu
 {
@@ -26,9 +28,10 @@ namespace Ryujinx.Cpu
         /// </summary>
         /// <param name="address">CPU virtual address of the region</param>
         /// <param name="size">Size of the region</param>
+        /// <param name="handles">Handles to inherit state from or reuse. When none are present, provide null</param>
         /// <param name="granularity">Desired granularity of write tracking</param>
         /// <returns>The memory tracking handle</returns>
-        CpuMultiRegionHandle BeginGranularTracking(ulong address, ulong size, ulong granularity);
+        CpuMultiRegionHandle BeginGranularTracking(ulong address, ulong size, IEnumerable<IRegionHandle> handles, ulong granularity);
 
         /// <summary>
         /// Obtains a smart memory tracking handle for the given virtual region, with a specified granularity. This should be disposed when finished with.

--- a/Ryujinx.Cpu/MemoryManager.cs
+++ b/Ryujinx.Cpu/MemoryManager.cs
@@ -550,9 +550,9 @@ namespace Ryujinx.Cpu
         }
 
         /// <inheritdoc/>
-        public CpuMultiRegionHandle BeginGranularTracking(ulong address, ulong size, ulong granularity)
+        public CpuMultiRegionHandle BeginGranularTracking(ulong address, ulong size, IEnumerable<IRegionHandle> handles, ulong granularity)
         {
-            return new CpuMultiRegionHandle(Tracking.BeginGranularTracking(address, size, granularity));
+            return new CpuMultiRegionHandle(Tracking.BeginGranularTracking(address, size, handles, granularity));
         }
 
         /// <inheritdoc/>

--- a/Ryujinx.Cpu/MemoryManagerHostMapped.cs
+++ b/Ryujinx.Cpu/MemoryManagerHostMapped.cs
@@ -586,9 +586,9 @@ namespace Ryujinx.Cpu
         }
 
         /// <inheritdoc/>
-        public CpuMultiRegionHandle BeginGranularTracking(ulong address, ulong size, ulong granularity)
+        public CpuMultiRegionHandle BeginGranularTracking(ulong address, ulong size, IEnumerable<IRegionHandle> handles, ulong granularity)
         {
-            return new CpuMultiRegionHandle(Tracking.BeginGranularTracking(address, size, granularity));
+            return new CpuMultiRegionHandle(Tracking.BeginGranularTracking(address, size, handles, granularity));
         }
 
         /// <inheritdoc/>

--- a/Ryujinx.Cpu/Tracking/CpuMultiRegionHandle.cs
+++ b/Ryujinx.Cpu/Tracking/CpuMultiRegionHandle.cs
@@ -1,5 +1,6 @@
 ﻿using Ryujinx.Memory.Tracking;
 using System;
+using System.Collections.Generic;
 
 namespace Ryujinx.Cpu.Tracking
 {
@@ -16,6 +17,7 @@ namespace Ryujinx.Cpu.Tracking
 
         public void Dispose() => _impl.Dispose();
         public void ForceDirty(ulong address, ulong size) => _impl.ForceDirty(address, size);
+        public IEnumerable<IRegionHandle> GetHandles() => _impl.GetHandles();
         public void QueryModified(Action<ulong, ulong> modifiedAction) => _impl.QueryModified(modifiedAction);
         public void QueryModified(ulong address, ulong size, Action<ulong, ulong> modifiedAction) => _impl.QueryModified(address, size, modifiedAction);
         public void QueryModified(ulong address, ulong size, Action<ulong, ulong> modifiedAction, int sequenceNumber) => _impl.QueryModified(address, size, modifiedAction, sequenceNumber);

--- a/Ryujinx.Cpu/Tracking/CpuRegionHandle.cs
+++ b/Ryujinx.Cpu/Tracking/CpuRegionHandle.cs
@@ -21,6 +21,7 @@ namespace Ryujinx.Cpu.Tracking
         public void Dispose() => _impl.Dispose();
         public bool DirtyOrVolatile() => _impl.DirtyOrVolatile();
         public void ForceDirty() => _impl.ForceDirty();
+        public IRegionHandle GetHandle() => _impl;
         public void RegisterAction(RegionSignal action) => _impl.RegisterAction(action);
         public void RegisterDirtyEvent(Action action) => _impl.RegisterDirtyEvent(action);
         public void Reprotect(bool asDirty = false) => _impl.Reprotect(asDirty);

--- a/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -533,8 +533,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                         }
                     }
 
-                    Buffer newBuffer = new Buffer(_context, address, endAddress - address);
-                    newBuffer.SynchronizeMemory(address, endAddress - address);
+                    Buffer newBuffer = new Buffer(_context, address, endAddress - address, _bufferOverlaps.Take(overlapsCount));
 
                     lock (_buffers)
                     {
@@ -547,13 +546,13 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
                         int dstOffset = (int)(buffer.Address - newBuffer.Address);
 
-                        buffer.ForceSynchronizeMemory(buffer.Address, buffer.Size);
-
                         buffer.CopyTo(newBuffer, dstOffset);
                         newBuffer.InheritModifiedRanges(buffer);
 
-                        buffer.Dispose();
+                        buffer.DisposeData();
                     }
+
+                    newBuffer.SynchronizeMemory(address, endAddress - address);
 
                     // Existing buffers were modified, we need to rebind everything.
                     _rebind = true;

--- a/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
@@ -2,7 +2,9 @@ using Ryujinx.Cpu;
 using Ryujinx.Cpu.Tracking;
 using Ryujinx.Memory;
 using Ryujinx.Memory.Range;
+using Ryujinx.Memory.Tracking;
 using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -200,11 +202,12 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// </summary>
         /// <param name="address">CPU virtual address of the region</param>
         /// <param name="size">Size of the region</param>
+        /// <param name="handles">Handles to inherit state from or reuse</param>
         /// <param name="granularity">Desired granularity of write tracking</param>
         /// <returns>The memory tracking handle</returns>
-        public CpuMultiRegionHandle BeginGranularTracking(ulong address, ulong size, ulong granularity = 4096)
+        public CpuMultiRegionHandle BeginGranularTracking(ulong address, ulong size, IEnumerable<IRegionHandle> handles = null, ulong granularity = 4096)
         {
-            return _cpuMemory.BeginGranularTracking(address, size, granularity);
+            return _cpuMemory.BeginGranularTracking(address, size, handles, granularity);
         }
 
         /// <summary>

--- a/Ryujinx.Memory/Tracking/MemoryTracking.cs
+++ b/Ryujinx.Memory/Tracking/MemoryTracking.cs
@@ -134,13 +134,14 @@ namespace Ryujinx.Memory.Tracking
         /// </summary>
         /// <param name="address">CPU virtual address of the region</param>
         /// <param name="size">Size of the region</param>
+        /// <param name="handles">Handles to inherit state from or reuse. When none are present, provide null</param>
         /// <param name="granularity">Desired granularity of write tracking</param>
         /// <returns>The memory tracking handle</returns>
-        public MultiRegionHandle BeginGranularTracking(ulong address, ulong size, ulong granularity)
+        public MultiRegionHandle BeginGranularTracking(ulong address, ulong size, IEnumerable<IRegionHandle> handles, ulong granularity)
         {
             (address, size) = PageAlign(address, size);
 
-            return new MultiRegionHandle(this, address, size, granularity);
+            return new MultiRegionHandle(this, address, size, handles, granularity);
         }
 
         /// <summary>

--- a/Ryujinx.Memory/Tracking/MultiRegionHandle.cs
+++ b/Ryujinx.Memory/Tracking/MultiRegionHandle.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Ryujinx.Memory.Tracking
 {
@@ -18,16 +19,68 @@ namespace Ryujinx.Memory.Tracking
 
         public bool Dirty { get; private set; } = true;
 
-        internal MultiRegionHandle(MemoryTracking tracking, ulong address, ulong size, ulong granularity)
+        internal MultiRegionHandle(MemoryTracking tracking, ulong address, ulong size, IEnumerable<IRegionHandle> handles, ulong granularity)
         {
             _handles = new RegionHandle[size / granularity];
             Granularity = granularity;
 
-            for (int i = 0; i < _handles.Length; i++)
+            int i = 0;
+
+            if (handles != null)
+            {
+                // Inherit from the handles we were given. Any gaps must be filled with new handles,
+                // and old handles larger than our granularity must copy their state onto new granular handles and dispose.
+                // It is assumed that the provided handles do not overlap, in order, are on page boundaries,
+                // and don't extend past the requested range.
+
+                foreach (RegionHandle handle in handles)
+                {
+                    int startIndex = (int)((handle.Address - address) / granularity);
+
+                    // Fill any gap left before this handle.
+                    while (i < startIndex)
+                    {
+                        RegionHandle fillHandle = tracking.BeginTracking(address + (ulong)i * granularity, granularity);
+                        fillHandle.Parent = this;
+                        _handles[i++] = fillHandle;
+                    }
+
+                    if (handle.Size == granularity)
+                    {
+                        handle.Parent = this;
+                        _handles[i++] = handle;
+                    }
+                    else
+                    {
+                        int endIndex = (int)((handle.EndAddress - address) / granularity);
+
+                        while (i < endIndex)
+                        {
+                            RegionHandle splitHandle = tracking.BeginTracking(address + (ulong)i * granularity, granularity);
+                            splitHandle.Parent = this;
+
+                            splitHandle.Reprotect(handle.Dirty);
+
+                            RegionSignal signal = handle.PreAction;
+                            if (signal != null)
+                            {
+                                splitHandle.RegisterAction(signal);
+                            }
+
+                            _handles[i++] = splitHandle;
+                        }
+
+                        handle.Dispose();
+                    }
+                }
+            }
+
+            // Fill any remaining space with new handles.
+            while (i < _handles.Length)
             {
                 RegionHandle handle = tracking.BeginTracking(address + (ulong)i * granularity, granularity);
                 handle.Parent = this;
-                _handles[i] = handle;
+                _handles[i++] = handle;
             }
 
             Address = address;
@@ -46,6 +99,11 @@ namespace Ryujinx.Memory.Tracking
                 _handles[i].SequenceNumber--;
                 _handles[i].ForceDirty();
             }
+        }
+
+        public IEnumerable<RegionHandle> GetHandles()
+        {
+            return _handles;
         }
 
         public void SignalWrite()


### PR DESCRIPTION
This greatly speeds up games that constantly resize buffers, and removes stuttering on games that resize large buffers occasionally:

- Large improvement on Super Mario 3D All-Stars. Slowdown now is just due to the creation of the OGL buffer resources. (#1663 needed for best performance)
- Improvement to Hyrule Warriors: AoC, and UE4 games. These games still stutter in general due to texture creation/loading.
- Small improvement to other games, potential 1-frame stutters avoided.

`ForceSynchronizeMemory`, which was added with POWER, is no longer needed. Some tests have been added for the MultiRegionHandle.