### PR TITLE
Workaround for cb indexing error on shader cache rebuild

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -36,7 +36,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2317;
+        private const ulong ShaderCodeGenVersion = 2336;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Shader/IGpuAccessor.cs
+++ b/Ryujinx.Graphics.Shader/IGpuAccessor.cs
@@ -41,7 +41,7 @@
 
         uint QueryConstantBufferUse()
         {
-            return 0;
+            return 0x1fff;
         }
 
         bool QueryIsTextureBuffer(int handle, int cbufSlot = -1)

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -11,6 +11,8 @@ namespace Ryujinx.Graphics.Shader.Translation
         // TODO: Non-hardcoded array size.
         public const int SamplerArraySize = 4;
 
+        private const int TotalConstantBuffers = 18;
+
         public ShaderStage Stage { get; }
 
         public bool GpPassthrough { get; }
@@ -203,6 +205,12 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public Operand CreateCbuf(int slot, int offset)
         {
+            if ((uint)slot >= TotalConstantBuffers)
+            {
+                GpuAccessor.Log($"Shader accesses invalid constant buffer {slot} at offset 0x{offset:X}.");
+                slot = 0;
+            }
+
             SetUsedConstantBuffer(slot);
             return OperandHelper.Cbuf(slot, offset);
         }


### PR DESCRIPTION
This contains a workaround for a bug that can occur if a shader cache rebuild is triggered (due to a cache version change) on a shader that uses constant buffer slot indexing. Currently the shader cache does not store the constant buffer use information, so it doesn't know the array size. This changes the default mask to one with the 13 least significant bits set, since a maximum of 13 uniform buffers can be used on OpenGL (on NVIDIA, other vendors are usually a bit higher).

Additionally, this also has a different change that validates the constant buffer slots, and logs a warning if its invalid (and then replaces the value by 0). This prevents invalid constant buffer slots to be output on the buffer descriptor, which would later cause a `IndexOutOfRangeException` when attempting to bind it. Of course this should never happen, and is a indication that the shader code is corrupted, but at least it prevents the emulator from crashing for those invalid shaders. I'm happy to remove the change if its not seem as appropriate.