### PR TITLE
Do not clear gpu subchannel state on BindChannel

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoProcessor.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoProcessor.cs
@@ -140,7 +140,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
         {
             if ((MethodOffset)meth.Method == MethodOffset.BindChannel)
             {
-                _subChannels[meth.SubChannel] = new GpuState();
+                _subChannels[meth.SubChannel].ClearCallbacks();
 
                 _context.Methods.RegisterCallbacks(_subChannels[meth.SubChannel]);
             }

--- a/Ryujinx.Graphics.Gpu/State/GpuState.cs
+++ b/Ryujinx.Graphics.Gpu/State/GpuState.cs
@@ -211,6 +211,17 @@ namespace Ryujinx.Graphics.Gpu.State
         }
 
         /// <summary>
+        /// Clear all registered callbacks.
+        /// </summary>
+        public void ClearCallbacks()
+        {
+            for (int index = 0; index < _registers.Length; index++)
+            {
+                _registers[index].Callback = null;
+            }
+        }
+
+        /// <summary>
         /// Checks if a given register has been modified since the last call to this method.
         /// </summary>
         /// <param name="offset">Register offset</param>


### PR DESCRIPTION
This fixes a regression caused by #980, that was causing a crash on New Super Lucky's Tale.

As always, this need feedback on possible regression on any games.

Fix #2343.