### PR TITLE
GAL: Fix sampler leaks on exit

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -1,13 +1,14 @@
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.State;
 using Ryujinx.Graphics.Shader;
+using System;
 
 namespace Ryujinx.Graphics.Gpu.Image
 {
     /// <summary>
     /// Texture bindings manager.
     /// </summary>
-    class TextureBindingsManager
+    class TextureBindingsManager : IDisposable
     {
         private const int HandleHigh = 16;
         private const int HandleMask = (1 << HandleHigh) - 1;
@@ -479,6 +480,14 @@ namespace Ryujinx.Graphics.Gpu.Image
         public void Rebind()
         {
             _rebind = true;
+        }
+
+        /// <summary>
+        /// Disposes all textures and samplers in the cache.
+        /// </summary>
+        public void Dispose()
+        {
+            _samplerPool?.Dispose();
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -1286,7 +1286,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Disposes all textures in the cache.
+        /// Disposes all textures and samplers in the cache.
         /// It's an error to use the texture manager after disposal.
         /// </summary>
         public void Dispose()
@@ -1297,6 +1297,9 @@ namespace Ryujinx.Graphics.Gpu.Image
                 {
                     texture.Dispose();
                 }
+
+                _cpBindingsManager.Dispose();
+                _gpBindingsManager.Dispose();
             }
         }
     }


### PR DESCRIPTION
Before this, all samplers instance were leaking on exit because the
dispose method was never getting called.

This fix this issue by making TextureBindingsManager disposable and
calling the dispose method in the TextureManager.

This was found thanks to the Vulkan spec layer.