### PR TITLE
Increase height of Settings Window

### DIFF
--- a/Ryujinx/Ui/Windows/SettingsWindow.glade
+++ b/Ryujinx/Ui/Windows/SettingsWindow.glade
@@ -46,7 +46,7 @@
     <property name="modal">True</property>
     <property name="window-position">center</property>
     <property name="default-width">650</property>
-    <property name="default-height">550</property>
+    <property name="default-height">650</property>
     <child>
       <object class="GtkBox">
         <property name="visible">True</property>


### PR DESCRIPTION
This PR increases the height of the settings window, making it so that there is no need to scroll down to see options on the General & System tabs.

Before:
![2021-06-09 10_11_38-Ryujinx - Settings](https://user-images.githubusercontent.com/62343878/121390968-1dfee780-c90b-11eb-820e-dfa9976a4e90.png)

![2021-06-09 10_09_54-Ryujinx - Settings](https://user-images.githubusercontent.com/62343878/121390994-23f4c880-c90b-11eb-8d91-9e6bace7c1e1.png)

After:

![2021-06-09 10_11_22-Ryujinx - Settings](https://user-images.githubusercontent.com/62343878/121391060-33741180-c90b-11eb-8733-481902661385.png)

![2021-06-09 10_12_22-Ryujinx - Settings](https://user-images.githubusercontent.com/62343878/121391072-35d66b80-c90b-11eb-8e52-3d3da7113fa2.png)

