### PR TITLE
Fix separate bindless sampler at offset 0

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -473,7 +473,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     ? bufferManager.GetComputeUniformBufferAddress(samplerBufferIndex)
                     : bufferManager.GetGraphicsUniformBufferAddress(stageIndex, samplerBufferIndex);
 
-                handle |= _context.PhysicalMemory.Read<int>(samplerBufferAddress + (ulong)((uint)wordOffset >> HandleHigh) * 4);
+                handle |= _context.PhysicalMemory.Read<int>(samplerBufferAddress + (ulong)((wordOffset >> HandleHigh) - 1) * 4);
             }
 
             return handle;

--- a/Ryujinx.Graphics.Shader/Translation/Optimizations/BindlessElimination.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Optimizations/BindlessElimination.cs
@@ -58,7 +58,7 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
                     SetHandle(
                         config,
                         texOp,
-                        src0.GetCbufOffset() | (src1.GetCbufOffset() << 16),
+                        src0.GetCbufOffset() | ((src1.GetCbufOffset() + 1) << 16),
                         src0.GetCbufSlot() | ((src1.GetCbufSlot() + 1) << 16));
                 }
                 else if (texOp.Inst == Instruction.ImageLoad || texOp.Inst == Instruction.ImageStore)


### PR DESCRIPTION
When the (separate) sampler bindless handle comes from the offset 0 of the constant buffer, it was being ignored which caused the wrong sampler to be used. This correct the bug by adding 1 to the offset on the shader translator, and then subtracting 1 on the GPU emulator to ensure that it is never 0 if a separate bindless sampler is used.

Fix incorrect sampling on Final Fantasy XII.
Before:
![image](https://user-images.githubusercontent.com/5624669/121628918-8f947e00-ca50-11eb-82c1-00f931070a82.png)
After:
![image](https://user-images.githubusercontent.com/5624669/121628927-94593200-ca50-11eb-80fd-1e55e0019eb1.png)