### PR TITLE
Pass all inputs when geometry shader passthrough is enabled

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -36,7 +36,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2367;
+        private const ulong ShaderCodeGenVersion = 2362;
 
         // Progress reporting helpers
         private volatile int _shaderCount;


### PR DESCRIPTION
Not passing those inputs was generating a link error on the shaders, as the fragment shader was consuming inputs that were not explicitly passed from the geometry shader. This change makes it pass all possible inputs when the passthrough is enabled.

Fixes some missing graphics on Game Builder Garage.
Before:
![image](https://user-images.githubusercontent.com/5624669/121768036-5cc2b680-cb32-11eb-8167-ee708a741c7a.png)
After:
![image](https://user-images.githubusercontent.com/5624669/121768042-60eed400-cb32-11eb-9662-37725c898fc0.png)
Note: Doesn't fix apple not showing on the first tutorial, this looks more like a logic bug rather than just something not being rendered (but existing).