### PR TITLE
End shader decoding when reaching a block that starts with an infinite loop (after BRX)

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -36,7 +36,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2329;
+        private const ulong ShaderCodeGenVersion = 2330;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -36,7 +36,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2330;
+        private const ulong ShaderCodeGenVersion = 2367;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Shader/Decoders/Decoder.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/Decoder.cs
@@ -9,6 +9,8 @@ namespace Ryujinx.Graphics.Shader.Decoders
 {
     static class Decoder
     {
+        public const ulong ShaderEndDelimiter = 0xe2400fffff87000f;
+
         public static Block[][] Decode(IGpuAccessor gpuAccessor, ulong startAddress, out bool hasBindless)
         {
             hasBindless = false;
@@ -190,7 +192,7 @@ namespace Ryujinx.Graphics.Shader.Decoders
 
             ulong inst = gpuAccessor.MemoryRead<ulong>(startAdddress + currBlock.EndAddress);
 
-            return inst != 0UL;
+            return inst != 0UL && inst != ShaderEndDelimiter;
         }
 
         private static bool BinarySearch(List<Block> blocks, ulong address, out int index)


### PR DESCRIPTION
The NV shader compiler puts these at the end of shaders. This is needed when a shader includes a BRX instruction, as we continue decoding past all exits in order to catch potential branch targets. Before, this would terminate when it encountered a 0, but some shaders did not have a 0 at the end and ended up decoding forever, possibly because the shader data _did_ end at the infinite loop, and the "instruction" afterwards was just leftover data from earlier rather than 0.

Note that a better solution would probably be identifying the BRX targets rather than continuing to decode like this, but this workaround is functional for now.

A few games with complex shaders should be tested, maybe Fire Emblem to make sure it still works. Fixes Dark Devotion.