### PR TITLE
Add Direct Mouse Support

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Hid/HidDevices/MouseDevice.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/HidDevices/MouseDevice.cs
@@ -1,5 +1,6 @@
 using Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Common;
 using Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Mouse;
+using System;
 
 namespace Ryujinx.HLE.HOS.Services.Hid
 {
@@ -7,7 +8,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
     {
         public MouseDevice(Switch device, bool active) : base(device, active) { }
 
-        public void Update(int mouseX, int mouseY, uint buttons = 0, int scrollX = 0, int scrollY = 0)
+        public void Update(int mouseX, int mouseY, uint buttons = 0, int scrollX = 0, int scrollY = 0, bool connected = false)
         {
             ref RingLifo<MouseState> lifo = ref _device.Hid.SharedMemory.Mouse;
 
@@ -27,6 +28,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
                 newState.DeltaY = mouseY - previousEntry.DeltaY;
                 newState.WheelDeltaX = scrollX;
                 newState.WheelDeltaY = scrollY;
+                newState.Attributes = connected ? MouseAttribute.IsConnected : MouseAttribute.None;
             }
 
             lifo.Write(ref newState);

--- a/Ryujinx.HLE/HOS/Services/Hid/HidDevices/MouseDevice.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/HidDevices/MouseDevice.cs
@@ -1,6 +1,5 @@
 using Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Common;
 using Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Mouse;
-using System;
 
 namespace Ryujinx.HLE.HOS.Services.Hid
 {

--- a/Ryujinx.Input/HLE/InputManager.cs
+++ b/Ryujinx.Input/HLE/InputManager.cs
@@ -23,7 +23,7 @@ namespace Ryujinx.Input.HLE
 
         public NpadManager CreateNpadManager()
         {
-            return new NpadManager(KeyboardDriver, GamepadDriver);
+            return new NpadManager(KeyboardDriver, GamepadDriver, MouseDriver);
         }
         
         public TouchScreenManager CreateTouchScreenManager()

--- a/Ryujinx.Input/HLE/NpadManager.cs
+++ b/Ryujinx.Input/HLE/NpadManager.cs
@@ -1,13 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.CompilerServices;
-
 using Ryujinx.Common.Configuration.Hid;
 using Ryujinx.Common.Configuration.Hid.Controller;
 using Ryujinx.Common.Configuration.Hid.Keyboard;
 using Ryujinx.HLE.HOS.Services.Hid;
-
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using CemuHookClient = Ryujinx.Input.Motion.CemuHook.Client;
 using Switch = Ryujinx.HLE.Switch;
 

--- a/Ryujinx.Input/HLE/NpadManager.cs
+++ b/Ryujinx.Input/HLE/NpadManager.cs
@@ -1,11 +1,12 @@
-﻿using Ryujinx.Common.Configuration.Hid;
-using Ryujinx.Common.Configuration.Hid.Controller;
-using Ryujinx.Common.Configuration.Hid.Keyboard;
-using Ryujinx.HLE.HOS.Services.Hid;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+
+using Ryujinx.Common.Configuration.Hid;
+using Ryujinx.Common.Configuration.Hid.Controller;
+using Ryujinx.Common.Configuration.Hid.Keyboard;
+using Ryujinx.HLE.HOS.Services.Hid;
 
 using CemuHookClient = Ryujinx.Input.Motion.CemuHook.Client;
 using Switch = Ryujinx.HLE.Switch;
@@ -26,22 +27,23 @@ namespace Ryujinx.Input.HLE
 
         private readonly IGamepadDriver _keyboardDriver;
         private readonly IGamepadDriver _gamepadDriver;
-
+        private readonly IGamepadDriver _mouseDriver;
         private bool _isDisposed;
 
         private List<InputConfig> _inputConfig;
         private bool _enableKeyboard;
+        private bool _enableMouse;
         private Switch _device;
 
-        public NpadManager(IGamepadDriver keyboardDriver, IGamepadDriver gamepadDriver)
+        public NpadManager(IGamepadDriver keyboardDriver, IGamepadDriver gamepadDriver, IGamepadDriver mouseDriver)
         {
             _controllers = new NpadController[MaxControllers];
             _cemuHookClient = new CemuHookClient(this);
 
             _keyboardDriver = keyboardDriver;
             _gamepadDriver = gamepadDriver;
+            _mouseDriver = mouseDriver;
             _inputConfig = new List<InputConfig>();
-            _enableKeyboard = false;
 
             _gamepadDriver.OnGamepadConnected += HandleOnGamepadConnected;
             _gamepadDriver.OnGamepadDisconnected += HandleOnGamepadDisconnected;
@@ -58,13 +60,13 @@ namespace Ryujinx.Input.HLE
         private void HandleOnGamepadDisconnected(string obj)
         {
             // Force input reload
-            ReloadConfiguration(_inputConfig, _enableKeyboard);
+            ReloadConfiguration(_inputConfig, _enableKeyboard, _enableMouse);
         }
 
         private void HandleOnGamepadConnected(string id)
         {
             // Force input reload
-            ReloadConfiguration(_inputConfig, _enableKeyboard);
+            ReloadConfiguration(_inputConfig, _enableKeyboard, _enableMouse);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -93,7 +95,7 @@ namespace Ryujinx.Input.HLE
             }
         }
 
-        public void ReloadConfiguration(List<InputConfig> inputConfig, bool enableKeyboard)
+        public void ReloadConfiguration(List<InputConfig> inputConfig, bool enableKeyboard, bool enableMouse)
         {
             lock (_lock)
             {
@@ -119,8 +121,9 @@ namespace Ryujinx.Input.HLE
                     }
                 }
 
-                _inputConfig = inputConfig;
+                _inputConfig    = inputConfig;
                 _enableKeyboard = enableKeyboard;
+                _enableMouse    = enableMouse;
 
                 _device.Hid.RefreshInputConfig(inputConfig);
             }
@@ -142,15 +145,15 @@ namespace Ryujinx.Input.HLE
             }
         }
 
-        public void Initialize(Switch device, List<InputConfig> inputConfig, bool enableKeyboard)
+        public void Initialize(Switch device, List<InputConfig> inputConfig, bool enableKeyboard, bool enableMouse)
         {
             _device = device;
             _device.Configuration.RefreshInputConfig = RefreshInputConfigForHLE;
 
-            ReloadConfiguration(inputConfig, enableKeyboard);
+            ReloadConfiguration(inputConfig, enableKeyboard, enableMouse);
         }
 
-        public void Update()
+        public void Update(float aspectRatio = 0)
         {
             lock (_lock)
             {
@@ -204,6 +207,48 @@ namespace Ryujinx.Input.HLE
                 if (hleKeyboardInput.HasValue)
                 {
                     _device.Hid.Keyboard.Update(hleKeyboardInput.Value);
+                }
+
+                if (_enableMouse)
+                {
+                    var mouse = _mouseDriver.GetGamepad("0") as IMouse;
+
+                    var mouseInput = IMouse.GetMouseStateSnapshot(mouse);
+
+                    uint buttons = 0;
+
+                    if (mouseInput.IsPressed(MouseButton.Button1))
+                    {
+                        buttons |= 1 << 0;
+                    }
+
+                    if (mouseInput.IsPressed(MouseButton.Button2))
+                    {
+                        buttons |= 1 << 1;
+                    }
+
+                    if (mouseInput.IsPressed(MouseButton.Button3))
+                    {
+                        buttons |= 1 << 2;
+                    }
+
+                    if (mouseInput.IsPressed(MouseButton.Button4))
+                    {
+                        buttons |= 1 << 3;
+                    }
+
+                    if (mouseInput.IsPressed(MouseButton.Button5))
+                    {
+                        buttons |= 1 << 4;
+                    }
+
+                    var position = IMouse.GetScreenPosition(mouseInput.Position, mouse.ClientSize, aspectRatio);
+
+                    _device.Hid.Mouse.Update((int)position.X, (int)position.Y, buttons, (int)mouseInput.Scroll.X, (int)mouseInput.Scroll.Y, true);
+                }
+                else 
+                {
+                    _device.Hid.Mouse.Update(0, 0);
                 }
 
                 _device.TamperMachine.UpdateInput(hleInputStates);

--- a/Ryujinx.Input/HLE/TouchScreenManager.cs
+++ b/Ryujinx.Input/HLE/TouchScreenManager.cs
@@ -29,7 +29,7 @@ namespace Ryujinx.Input.HLE
                 if (_wasClicking && !isClicking)
                 {
                     MouseStateSnapshot snapshot = IMouse.GetMouseStateSnapshot(_mouse);
-                    var touchPosition = IMouse.GetTouchPosition(snapshot.Position, _mouse.ClientSize, aspectRatio);
+                    var touchPosition = IMouse.GetScreenPosition(snapshot.Position, _mouse.ClientSize, aspectRatio);
 
                     TouchPoint currentPoint = new TouchPoint
                     {
@@ -58,7 +58,7 @@ namespace Ryujinx.Input.HLE
             if (aspectRatio > 0)
             {
                 MouseStateSnapshot snapshot = IMouse.GetMouseStateSnapshot(_mouse);
-                var touchPosition = IMouse.GetTouchPosition(snapshot.Position, _mouse.ClientSize, aspectRatio);
+                var touchPosition = IMouse.GetScreenPosition(snapshot.Position, _mouse.ClientSize, aspectRatio);
 
                 TouchAttribute attribute = TouchAttribute.None;
 

--- a/Ryujinx.Input/IMouse.cs
+++ b/Ryujinx.Input/IMouse.cs
@@ -24,6 +24,11 @@ namespace Ryujinx.Input
         Vector2 GetPosition();
 
         /// <summary>
+        /// Get the mouse scroll delta.
+        /// </summary>
+        Vector2 GetScroll();
+
+        /// <summary>
         /// Get the client size.
         /// </summary>
         Size ClientSize { get; }
@@ -40,12 +45,11 @@ namespace Ryujinx.Input
         /// <returns>A snaphost of the state of the mouse.</returns>
         public static MouseStateSnapshot GetMouseStateSnapshot(IMouse mouse)
         {
-            var position = mouse.GetPosition();
             bool[] buttons = new bool[(int)MouseButton.Count];
 
             mouse.Buttons.CopyTo(buttons, 0);
 
-            return new MouseStateSnapshot(buttons, position);
+            return new MouseStateSnapshot(buttons, mouse.GetPosition(), mouse.GetScroll());
         }
 
         /// <summary>
@@ -55,7 +59,7 @@ namespace Ryujinx.Input
         /// <param name="clientSize">The size of the client</param>
         /// <param name="aspectRatio">The aspect ratio of the view</param>
         /// <returns>A snaphost of the state of the mouse.</returns>
-        public static Vector2 GetTouchPosition(Vector2 mousePosition, Size clientSize, float aspectRatio)
+        public static Vector2 GetScreenPosition(Vector2 mousePosition, Size clientSize, float aspectRatio)
         {
             float mouseX = mousePosition.X;
             float mouseY = mousePosition.Y;

--- a/Ryujinx.Input/IMouse.cs
+++ b/Ryujinx.Input/IMouse.cs
@@ -53,7 +53,7 @@ namespace Ryujinx.Input
         }
 
         /// <summary>
-        /// Get the touch position of a mouse position relative to the app's view
+        /// Get the position of a mouse on screen relative to the app's view
         /// </summary>
         /// <param name="mousePosition">The position of the mouse in the client</param>
         /// <param name="clientSize">The size of the client</param>

--- a/Ryujinx.Input/MouseStateSnapshot.cs
+++ b/Ryujinx.Input/MouseStateSnapshot.cs
@@ -11,16 +11,18 @@ namespace Ryujinx.Input
         private bool[] _buttonState;
 
         public Vector2 Position { get; }
+        public Vector2 Scroll { get; }
 
         /// <summary>
         /// Create a new <see cref="MouseStateSnapshot"/>.
         /// </summary>
         /// <param name="buttonState">The keys state</param>
-        public MouseStateSnapshot(bool[] buttonState, Vector2 position)
+        public MouseStateSnapshot(bool[] buttonState, Vector2 position, Vector2 scroll)
         {
             _buttonState = buttonState;
 
             Position = position;
+            Scroll   = scroll;
         }
 
         /// <summary>

--- a/Ryujinx.Input/MouseStateSnapshot.cs
+++ b/Ryujinx.Input/MouseStateSnapshot.cs
@@ -10,13 +10,22 @@ namespace Ryujinx.Input
     {
         private bool[] _buttonState;
 
+        /// <summary>
+        /// The position of the mouse cursor
+        /// </summary>
         public Vector2 Position { get; }
+
+        /// <summary>
+        /// The scroll delta of the mouse
+        /// </summary>
         public Vector2 Scroll { get; }
 
         /// <summary>
         /// Create a new <see cref="MouseStateSnapshot"/>.
         /// </summary>
-        /// <param name="buttonState">The keys state</param>
+        /// <param name="buttonState">The button state</param>
+        /// <param name="position">The position of the cursor</param>
+        /// <param name="scroll">The scroll delta</param>
         public MouseStateSnapshot(bool[] buttonState, Vector2 position, Vector2 scroll)
         {
             _buttonState = buttonState;

--- a/Ryujinx/Config.json
+++ b/Ryujinx/Config.json
@@ -1,5 +1,5 @@
 {
-  "version": 24,
+  "version": 27,
   "enable_file_log": true,
   "res_scale": 1,
   "res_scale_custom": 1,
@@ -55,6 +55,7 @@
   "custom_theme_path": "",
   "start_fullscreen": false,
   "enable_keyboard": false,
+  "enable_mouse": false,
   "hotkeys": {
     "toggle_vsync": "Tab"
   },

--- a/Ryujinx/Configuration/ConfigurationFileFormat.cs
+++ b/Ryujinx/Configuration/ConfigurationFileFormat.cs
@@ -225,6 +225,11 @@ namespace Ryujinx.Configuration
         public bool EnableKeyboard { get; set; }
 
         /// <summary>
+        /// Enable or disable mouse support (Independent from controllers binding)
+        /// </summary>
+        public bool EnableMouse { get; set; }
+
+        /// <summary>
         /// Hotkey Keyboard Bindings
         /// </summary>
         public KeyboardHotkeys Hotkeys { get; set; }

--- a/Ryujinx/Configuration/ConfigurationFileFormat.cs
+++ b/Ryujinx/Configuration/ConfigurationFileFormat.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.Configuration
         /// <summary>
         /// The current version of the file format
         /// </summary>
-        public const int CurrentVersion = 26;
+        public const int CurrentVersion = 27;
 
         public int Version { get; set; }
 

--- a/Ryujinx/Configuration/ConfigurationState.cs
+++ b/Ryujinx/Configuration/ConfigurationState.cs
@@ -268,6 +268,11 @@ namespace Ryujinx.Configuration
             /// Enable or disable keyboard support (Independent from controllers binding)
             /// </summary>
             public ReactiveObject<bool> EnableKeyboard { get; private set; }
+            
+            /// <summary>
+            /// Enable or disable mouse support (Independent from controllers binding)
+            /// </summary>
+            public ReactiveObject<bool> EnableMouse { get; private set; }
 
             /// <summary>
             /// Hotkey Keyboard Bindings
@@ -284,6 +289,7 @@ namespace Ryujinx.Configuration
             public HidSection()
             {
                 EnableKeyboard = new ReactiveObject<bool>();
+                EnableMouse    = new ReactiveObject<bool>();
                 Hotkeys        = new ReactiveObject<KeyboardHotkeys>();
                 InputConfig    = new ReactiveObject<List<InputConfig>>();
             }
@@ -471,6 +477,7 @@ namespace Ryujinx.Configuration
                 CustomThemePath           = Ui.CustomThemePath,
                 StartFullscreen           = Ui.StartFullscreen,
                 EnableKeyboard            = Hid.EnableKeyboard,
+                EnableMouse               = Hid.EnableMouse,
                 Hotkeys                   = Hid.Hotkeys,
                 KeyboardConfig            = new List<object>(),
                 ControllerConfig          = new List<object>(),
@@ -532,6 +539,7 @@ namespace Ryujinx.Configuration
             Ui.CustomThemePath.Value               = "";
             Ui.StartFullscreen.Value               = false;
             Hid.EnableKeyboard.Value               = false;
+            Hid.EnableMouse.Value                  = false;
             Hid.Hotkeys.Value = new KeyboardHotkeys
             {
                 ToggleVsync = Key.Tab
@@ -878,6 +886,7 @@ namespace Ryujinx.Configuration
             Ui.CustomThemePath.Value               = configurationFileFormat.CustomThemePath;
             Ui.StartFullscreen.Value               = configurationFileFormat.StartFullscreen;
             Hid.EnableKeyboard.Value               = configurationFileFormat.EnableKeyboard;
+            Hid.EnableMouse.Value                  = configurationFileFormat.EnableMouse;
             Hid.Hotkeys.Value                      = configurationFileFormat.Hotkeys;
             Hid.InputConfig.Value                  = configurationFileFormat.InputConfig;
 

--- a/Ryujinx/Configuration/ConfigurationState.cs
+++ b/Ryujinx/Configuration/ConfigurationState.cs
@@ -836,6 +836,15 @@ namespace Ryujinx.Configuration
                 configurationFileUpdated = true;
             }
 
+            if (configurationFileFormat.Version < 27)
+            {
+                Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 27.");
+
+                configurationFileFormat.EnableMouse = false;
+
+                configurationFileUpdated = true;
+            }
+
             Logger.EnableFileLog.Value             = configurationFileFormat.EnableFileLog;
             Graphics.ResScale.Value                = configurationFileFormat.ResScale;
             Graphics.ResScaleCustom.Value          = configurationFileFormat.ResScaleCustom;

--- a/Ryujinx/Input/GTK3/GTK3Mouse.cs
+++ b/Ryujinx/Input/GTK3/GTK3Mouse.cs
@@ -31,6 +31,11 @@ namespace Ryujinx.Input.GTK3
             return _driver.CurrentPosition;
         }
 
+        public Vector2 GetScroll()
+        {
+            return _driver.Scroll;
+        }
+
         public GamepadStateSnapshot GetMappedStateSnapshot()
         {
             throw new NotImplementedException();

--- a/Ryujinx/Input/GTK3/GTK3MouseDriver.cs
+++ b/Ryujinx/Input/GTK3/GTK3MouseDriver.cs
@@ -14,16 +14,25 @@ namespace Ryujinx.Input.GTK3
         public bool[] PressedButtons { get; }
         
         public Vector2 CurrentPosition { get; private set; }
+        public Vector2 Scroll{ get; private set; }
 
         public GTK3MouseDriver(Widget parent)
         {
             _widget = parent;
 
-            _widget.MotionNotifyEvent += Parent_MotionNotifyEvent;
-            _widget.ButtonPressEvent += Parent_ButtonPressEvent;
+            _widget.MotionNotifyEvent  += Parent_MotionNotifyEvent;
+            _widget.ButtonPressEvent   += Parent_ButtonPressEvent;
             _widget.ButtonReleaseEvent += Parent_ButtonReleaseEvent;
+            _widget.ScrollEvent        += Parent_ScrollEvent;
 
             PressedButtons = new bool[(int)MouseButton.Count];
+        }
+
+
+        [GLib.ConnectBefore]
+        private void Parent_ScrollEvent(object o, ScrollEventArgs args)
+        {
+            Scroll = new Vector2((float)args.Event.X, (float)args.Event.Y);
         }
 
         [GLib.ConnectBefore]

--- a/Ryujinx/Ui/RendererWidgetBase.cs
+++ b/Ryujinx/Ui/RendererWidgetBase.cs
@@ -87,6 +87,7 @@ namespace Ryujinx.Ui
             AddEvents((int)(EventMask.ButtonPressMask
                           | EventMask.ButtonReleaseMask
                           | EventMask.PointerMotionMask
+                          | EventMask.ScrollMask
                           | EventMask.KeyPressMask
                           | EventMask.KeyReleaseMask));
 
@@ -254,7 +255,7 @@ namespace Ryujinx.Ui
             Renderer = Device.Gpu.Renderer;
             Renderer?.Window.SetSize(_windowWidth, _windowHeight);
 
-            NpadManager.Initialize(device, ConfigurationState.Instance.Hid.InputConfig, ConfigurationState.Instance.Hid.EnableKeyboard);
+            NpadManager.Initialize(device, ConfigurationState.Instance.Hid.InputConfig, ConfigurationState.Instance.Hid.EnableKeyboard, ConfigurationState.Instance.Hid.EnableMouse);
             TouchScreenManager.Initialize(device);
         }
 
@@ -442,7 +443,7 @@ namespace Ryujinx.Ui
                 });
             }
 
-            NpadManager.Update();
+            NpadManager.Update(ConfigurationState.Instance.Graphics.AspectRatio.Value.ToFloat());
 
             if ((Toplevel as MainWindow).IsFocused)
             {
@@ -461,7 +462,7 @@ namespace Ryujinx.Ui
             bool hasTouch = false;
 
             // Get screen touch position
-            if ((Toplevel as MainWindow).IsFocused)
+            if ((Toplevel as MainWindow).IsFocused && !ConfigurationState.Instance.Hid.EnableMouse)
             {
                 hasTouch = TouchScreenManager.Update(true, (_inputManager.MouseDriver as GTK3MouseDriver).IsButtonPressed(MouseButton.Button1), ConfigurationState.Instance.Graphics.AspectRatio.Value.ToFloat());
             }

--- a/Ryujinx/Ui/Windows/ControllerWindow.cs
+++ b/Ryujinx/Ui/Windows/ControllerWindow.cs
@@ -1150,7 +1150,7 @@ namespace Ryujinx.Ui.Windows
 
             if (_mainWindow.RendererWidget != null)
             {
-                _mainWindow.RendererWidget.NpadManager.ReloadConfiguration(newConfig, ConfigurationState.Instance.Hid.EnableKeyboard);
+                _mainWindow.RendererWidget.NpadManager.ReloadConfiguration(newConfig, ConfigurationState.Instance.Hid.EnableKeyboard, ConfigurationState.Instance.Hid.EnableMouse);
             }
 
             // Atomically replace and signal input change.

--- a/Ryujinx/Ui/Windows/SettingsWindow.cs
+++ b/Ryujinx/Ui/Windows/SettingsWindow.cs
@@ -56,6 +56,7 @@ namespace Ryujinx.Ui.Windows
         [GUI] CheckButton     _expandRamToggle;
         [GUI] CheckButton     _ignoreToggle;
         [GUI] CheckButton     _directKeyboardAccess;
+        [GUI] CheckButton     _directMouseAccess;
         [GUI] ComboBoxText    _systemLanguageSelect;
         [GUI] ComboBoxText    _systemRegionSelect;
         [GUI] Entry           _systemTimeZoneEntry;
@@ -243,6 +244,11 @@ namespace Ryujinx.Ui.Windows
             if (ConfigurationState.Instance.Hid.EnableKeyboard)
             {
                 _directKeyboardAccess.Click();
+            }
+
+            if (ConfigurationState.Instance.Hid.EnableMouse)
+            {
+                _directMouseAccess.Click();
             }
 
             if (ConfigurationState.Instance.Ui.EnableCustomTheme)
@@ -461,6 +467,7 @@ namespace Ryujinx.Ui.Windows
             ConfigurationState.Instance.System.ExpandRam.Value                 = _expandRamToggle.Active;
             ConfigurationState.Instance.System.IgnoreMissingServices.Value     = _ignoreToggle.Active;
             ConfigurationState.Instance.Hid.EnableKeyboard.Value               = _directKeyboardAccess.Active;
+            ConfigurationState.Instance.Hid.EnableMouse.Value                  = _directMouseAccess.Active;
             ConfigurationState.Instance.Ui.EnableCustomTheme.Value             = _custThemeToggle.Active;
             ConfigurationState.Instance.System.Language.Value                  = Enum.Parse<Language>(_systemLanguageSelect.ActiveId);
             ConfigurationState.Instance.System.Region.Value                    = Enum.Parse<Configuration.System.Region>(_systemRegionSelect.ActiveId);

--- a/Ryujinx/Ui/Windows/SettingsWindow.glade
+++ b/Ryujinx/Ui/Windows/SettingsWindow.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.1 -->
+<!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="_fsLogSpinAdjustment">
@@ -518,6 +518,22 @@
                                 <property name="fill">False</property>
                                 <property name="padding">10</property>
                                 <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="_directMouseAccess">
+                                <property name="label" translatable="yes">Direct Mouse Access</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="tooltip-text" translatable="yes">Enable or disable "direct keyboard access (HID) support" (Provides games access to your keyboard as a text entry device)</property>
+                                <property name="draw-indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="padding">10</property>
+                                <property name="position">2</property>
                               </packing>
                             </child>
                           </object>

--- a/Ryujinx/_schema.json
+++ b/Ryujinx/_schema.json
@@ -22,6 +22,7 @@
     "enable_fs_integrity_checks",
     "fs_global_access_log_mode",
     "enable_keyboard",
+    "enable_mouse",
     "keyboard_config",
     "controller_config"
   ],
@@ -1433,6 +1434,17 @@
       "title": "(HID) Keyboard Enable",
       "description": "Enable or disable direct keyboard access (HID) support (Provides games access to your keyboard as a text entry device)",
       "default": true,
+      "examples": [
+        true,
+        false
+      ]
+    },
+    "enable_mouse": {
+      "$id": "#/properties/enable_mouse",
+      "type": "boolean",
+      "title": "(HID) Mouse Enable",
+      "description": "Enable or disable direct mouse access (HID) support (Provides games access to your mouse as a pointing device)",
+      "default": false,
       "examples": [
         true,
         false


### PR DESCRIPTION
Add direct mouse support, similar to the direct keyboard support. This enables games and homebrew that support usb mouse to have that option enabled.
Touchscreen is disabled when direct mouse is enabled. Also, the real cursor is hidden while inside the client area, but gtk seems to reset the mouse cursor state often, so you will see the mouse pop in once in a short while.