### PR TITLE
nfc/nfp: Implement ISystemManager and ISystem

### DIFF
--- a/Ryujinx.Common/Logging/LogClass.cs
+++ b/Ryujinx.Common/Logging/LogClass.cs
@@ -38,6 +38,7 @@ namespace Ryujinx.Common.Logging
         ServiceLdr,
         ServiceLm,
         ServiceMm,
+        ServiceNfc,
         ServiceNfp,
         ServiceNgct,
         ServiceNifm,

--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -22,7 +22,7 @@ using Ryujinx.HLE.HOS.Services.Arp;
 using Ryujinx.HLE.HOS.Services.Audio.AudioRenderer;
 using Ryujinx.HLE.HOS.Services.Caps;
 using Ryujinx.HLE.HOS.Services.Mii;
-using Ryujinx.HLE.HOS.Services.Nfc.Nfp.UserManager;
+using Ryujinx.HLE.HOS.Services.Nfc.Nfp.NfpManager;
 using Ryujinx.HLE.HOS.Services.Nv;
 using Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostCtrl;
 using Ryujinx.HLE.HOS.Services.Pcv.Bpc;

--- a/Ryujinx.HLE/HOS/Services/Nfc/ISystemManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/ISystemManager.cs
@@ -1,8 +1,19 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Nfc
+﻿using Ryujinx.HLE.HOS.Services.Nfc.NfcManager;
+
+namespace Ryujinx.HLE.HOS.Services.Nfc
 {
     [Service("nfc:sys")]
     class ISystemManager : IpcService
     {
         public ISystemManager(ServiceCtx context) { }
+
+        [CommandHipc(0)]
+        // CreateSystemInterface() -> object<nn::nfc::detail::ISystem>
+        public ResultCode CreateSystemInterface(ServiceCtx context)
+        {
+            MakeObject(context, new INfc(NfcPermissionLevel.ISystem));
+
+            return ResultCode.Success;
+        }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Nfc/ISystemManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/ISystemManager.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc
         // CreateSystemInterface() -> object<nn::nfc::detail::ISystem>
         public ResultCode CreateSystemInterface(ServiceCtx context)
         {
-            MakeObject(context, new INfc(NfcPermissionLevel.ISystem));
+            MakeObject(context, new INfc(NfcPermissionLevel.System));
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Nfc/IUserManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/IUserManager.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc
         // CreateUserInterface() -> object<nn::nfc::detail::IUser>
         public ResultCode CreateUserInterface(ServiceCtx context)
         {
-            MakeObject(context, new INfc(NfcPermissionLevel.IUser));
+            MakeObject(context, new INfc(NfcPermissionLevel.User));
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Nfc/IUserManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/IUserManager.cs
@@ -1,8 +1,19 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Nfc
+﻿using Ryujinx.HLE.HOS.Services.Nfc.NfcManager;
+
+namespace Ryujinx.HLE.HOS.Services.Nfc
 {
     [Service("nfc:user")]
     class IUserManager : IpcService
     {
         public IUserManager(ServiceCtx context) { }
+
+        [CommandHipc(0)]
+        // CreateUserInterface() -> object<nn::nfc::detail::IUser>
+        public ResultCode CreateUserInterface(ServiceCtx context)
+        {
+            MakeObject(context, new INfc(NfcPermissionLevel.IUser));
+
+            return ResultCode.Success;
+        }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Nfc/NfcManager/INfc.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/NfcManager/INfc.cs
@@ -1,0 +1,37 @@
+﻿using Ryujinx.Common.Logging;
+
+namespace Ryujinx.HLE.HOS.Services.Nfc.NfcManager
+{
+    class INfc : IpcService
+    {
+        private NfcPermissionLevel _permissionLevel;
+
+        public INfc(NfcPermissionLevel permissionLevel)
+        {
+            _permissionLevel = permissionLevel;
+        }
+
+        [CommandHipc(0)]
+        [CommandHipc(400)] // 4.0.0+
+        // Initialize()
+        public ResultCode Initialize(ServiceCtx context)
+        {
+            Logger.Stub?.PrintStub(LogClass.ServiceNfc, new { _permissionLevel });
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(3)]
+        [CommandHipc(403)] // 4.0.0+
+        // IsNfcEnabled() -> b8
+        public ResultCode IsNfcEnabled(ServiceCtx context)
+        {
+            // NOTE: Write false value here could make nfp service not called.
+            context.ResponseData.Write(true);
+
+            Logger.Stub?.PrintStub(LogClass.ServiceNfc, new { _permissionLevel });
+
+            return ResultCode.Success;
+        }
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Nfc/NfcManager/Types/NfcPermissionLevel.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/NfcManager/Types/NfcPermissionLevel.cs
@@ -1,0 +1,8 @@
+﻿namespace Ryujinx.HLE.HOS.Services.Nfc.NfcManager
+{
+    enum NfcPermissionLevel
+    {
+        IUser,
+        ISystem
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Nfc/NfcManager/Types/NfcPermissionLevel.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/NfcManager/Types/NfcPermissionLevel.cs
@@ -2,7 +2,7 @@
 {
     enum NfcPermissionLevel
     {
-        IUser,
-        ISystem
+        User,
+        System
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/IDebugManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/IDebugManager.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
         // CreateDebugInterface() -> object<nn::nfp::detail::IDebug>
         public ResultCode CreateDebugInterface(ServiceCtx context)
         {
-            MakeObject(context, new INfp(NfpPermissionLevel.IDebug));
+            MakeObject(context, new INfp(NfpPermissionLevel.Debug));
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/IDebugManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/IDebugManager.cs
@@ -1,8 +1,19 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
+﻿using Ryujinx.HLE.HOS.Services.Nfc.Nfp.NfpManager;
+
+namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
 {
     [Service("nfp:dbg")]
     class IAmManager : IpcService
     {
         public IAmManager(ServiceCtx context) { }
+
+        [CommandHipc(0)]
+        // CreateDebugInterface() -> object<nn::nfp::detail::IDebug>
+        public ResultCode CreateDebugInterface(ServiceCtx context)
+        {
+            MakeObject(context, new INfp(NfpPermissionLevel.IDebug));
+
+            return ResultCode.Success;
+        }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/ISystemManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/ISystemManager.cs
@@ -1,8 +1,19 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
+﻿using Ryujinx.HLE.HOS.Services.Nfc.Nfp.NfpManager;
+
+namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
 {
     [Service("nfp:sys")]
     class ISystemManager : IpcService
     {
         public ISystemManager(ServiceCtx context) { }
+
+        [CommandHipc(0)]
+        // CreateSystemInterface() -> object<nn::nfp::detail::ISystem>
+        public ResultCode CreateSystemInterface(ServiceCtx context)
+        {
+            MakeObject(context, new INfp(NfpPermissionLevel.ISystem));
+
+            return ResultCode.Success;
+        }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/ISystemManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/ISystemManager.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
         // CreateSystemInterface() -> object<nn::nfp::detail::ISystem>
         public ResultCode CreateSystemInterface(ServiceCtx context)
         {
-            MakeObject(context, new INfp(NfpPermissionLevel.ISystem));
+            MakeObject(context, new INfp(NfpPermissionLevel.System));
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/IUserManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/IUserManager.cs
@@ -1,4 +1,6 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
+﻿using Ryujinx.HLE.HOS.Services.Nfc.Nfp.NfpManager;
+
+namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
 {
     [Service("nfp:user")]
     class IUserManager : IpcService
@@ -7,9 +9,9 @@
 
         [CommandHipc(0)]
         // CreateUserInterface() -> object<nn::nfp::detail::IUser>
-        public ResultCode GetUserInterface(ServiceCtx context)
+        public ResultCode CreateUserInterface(ServiceCtx context)
         {
-            MakeObject(context, new IUser());
+            MakeObject(context, new INfp(NfpPermissionLevel.IUser));
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/IUserManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/IUserManager.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
         // CreateUserInterface() -> object<nn::nfp::detail::IUser>
         public ResultCode CreateUserInterface(ServiceCtx context)
         {
-            MakeObject(context, new INfp(NfpPermissionLevel.IUser));
+            MakeObject(context, new INfp(NfpPermissionLevel.User));
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/INfp.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/INfp.cs
@@ -980,7 +980,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
         {
             // TODO: Find the differencies between IUser and ISystem/IDebug.
 
-            if (_permissionLevel == NfpPermissionLevel.IDebug || _permissionLevel == NfpPermissionLevel.ISystem)
+            if (_permissionLevel == NfpPermissionLevel.Debug || _permissionLevel == NfpPermissionLevel.System)
             {
                 return GetRegisterInfo(context);
             }

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/INfp.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/INfp.cs
@@ -6,7 +6,7 @@ using Ryujinx.HLE.HOS.Kernel.Common;
 using Ryujinx.HLE.HOS.Kernel.Threading;
 using Ryujinx.HLE.HOS.Services.Hid;
 using Ryujinx.HLE.HOS.Services.Hid.HidServer;
-using Ryujinx.HLE.HOS.Services.Nfc.Nfp.UserManager;
+using Ryujinx.HLE.HOS.Services.Nfc.Nfp.NfpManager;
 using System;
 using System.Buffers.Binary;
 using System.Globalization;
@@ -16,7 +16,7 @@ using System.Threading.Tasks;
 
 namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
 {
-    class IUser : IpcService
+    class INfp : IpcService
     {
         private ulong  _appletResourceUserId;
         private ulong  _mcuVersionData;
@@ -28,7 +28,12 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
 
         private CancellationTokenSource _cancelTokenSource;
 
-        public IUser() { }
+        private NfpPermissionLevel _permissionLevel;
+
+        public INfp(NfpPermissionLevel permissionLevel)
+        {
+            _permissionLevel = permissionLevel;
+        }
 
         [CommandHipc(0)]
         // Initialize(u64, u64, pid, buffer<unknown, 5>)
@@ -213,9 +218,9 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
                 return resultCode;
             }
 
-            uint                   deviceHandle = (uint)context.RequestData.ReadUInt64();
-            UserManager.DeviceType deviceType   = (UserManager.DeviceType)context.RequestData.ReadUInt32();
-            MountTarget            mountTarget  = (MountTarget)context.RequestData.ReadUInt32();
+            uint        deviceHandle = (uint)context.RequestData.ReadUInt64();
+            DeviceType  deviceType   = (DeviceType)context.RequestData.ReadUInt32();
+            MountTarget mountTarget  = (MountTarget)context.RequestData.ReadUInt32();
 
             if (deviceType != 0)
             {
@@ -967,6 +972,20 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
         public ResultCode RecreateApplicationArea(ServiceCtx context)
         {
             throw new ServiceNotImplementedException(this, context, false);
+        }
+
+        [CommandHipc(102)]
+        // GetRegisterInfo2(bytes<8, 4>) -> buffer<unknown<0x100>, 0x1a>
+        public ResultCode GetRegisterInfo2(ServiceCtx context)
+        {
+            // TODO: Find the differencies between IUser and ISystem/IDebug.
+
+            if (_permissionLevel == NfpPermissionLevel.IDebug || _permissionLevel == NfpPermissionLevel.ISystem)
+            {
+                return GetRegisterInfo(context);
+            }
+
+            return ResultCode.DeviceNotFound;
         }
 
         private ResultCode CheckNfcIsEnabled()

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/AmiiboConstants.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/AmiiboConstants.cs
@@ -1,4 +1,4 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp.UserManager
+﻿namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp.NfpManager
 {
     static class AmiiboConstants
     {

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/CommonInfo.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/CommonInfo.cs
@@ -1,7 +1,7 @@
 ﻿using Ryujinx.Common.Memory;
 using System.Runtime.InteropServices;
 
-namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp.UserManager
+namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp.NfpManager
 {
     [StructLayout(LayoutKind.Sequential, Size = 0x40)]
     struct CommonInfo

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/DeviceType.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/DeviceType.cs
@@ -1,0 +1,7 @@
+﻿namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp.NfpManager
+{
+    enum DeviceType : uint
+    {
+        Amiibo
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/ModelInfo.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/ModelInfo.cs
@@ -1,7 +1,7 @@
 ﻿using Ryujinx.Common.Memory;
 using System.Runtime.InteropServices;
 
-namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp.UserManager
+namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp.NfpManager
 {
     [StructLayout(LayoutKind.Sequential, Size = 0x40)]
     struct ModelInfo

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/MountTarget.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/MountTarget.cs
@@ -1,4 +1,4 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp.UserManager
+﻿namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp.NfpManager
 {
     enum MountTarget : uint
     {

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/NfpDevice.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/NfpDevice.cs
@@ -1,7 +1,7 @@
 ﻿using Ryujinx.HLE.HOS.Kernel.Threading;
 using Ryujinx.HLE.HOS.Services.Hid;
 
-namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp.UserManager
+namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp.NfpManager
 {
     class NfpDevice
     {

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/NfpDeviceState.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/NfpDeviceState.cs
@@ -1,4 +1,4 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp.UserManager
+﻿namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp.NfpManager
 {
     enum NfpDeviceState
     {

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/NfpPermissionLevel.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/NfpPermissionLevel.cs
@@ -2,8 +2,8 @@
 {
     enum NfpPermissionLevel
     {
-        IDebug,
-        IUser,
-        ISystem
+        Debug,
+        User,
+        System
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/NfpPermissionLevel.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/NfpPermissionLevel.cs
@@ -1,0 +1,9 @@
+﻿namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp.NfpManager
+{
+    enum NfpPermissionLevel
+    {
+        IDebug,
+        IUser,
+        ISystem
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/RegisterInfo.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/RegisterInfo.cs
@@ -2,7 +2,7 @@
 using Ryujinx.HLE.HOS.Services.Mii.Types;
 using System.Runtime.InteropServices;
 
-namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp.UserManager
+namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp.NfpManager
 {
     [StructLayout(LayoutKind.Sequential, Size = 0x100)]
     struct RegisterInfo
@@ -11,7 +11,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp.UserManager
         public ushort        FirstWriteYear;
         public byte          FirstWriteMonth;
         public byte          FirstWriteDay;
-        public Array11<byte> Nickname;
+        public Array41<byte> Nickname;
         public byte          FontRegion;
         public Array64<byte> Reserved1;
         public Array58<byte> Reserved2;

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/State.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/State.cs
@@ -1,4 +1,4 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp.UserManager
+﻿namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp.NfpManager
 {
     enum State
     {

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/TagInfo.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/TagInfo.cs
@@ -1,7 +1,7 @@
 ﻿using Ryujinx.Common.Memory;
 using System.Runtime.InteropServices;
 
-namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp.UserManager
+namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp.NfpManager
 {
     [StructLayout(LayoutKind.Sequential, Size = 0x58)]
     struct TagInfo

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/VirtualAmiiboFile.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/Types/VirtualAmiiboFile.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp.UserManager
+namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp.NfpManager
 {
     struct VirtualAmiiboFile
     {

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/UserManager/Types/DeviceType.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/UserManager/Types/DeviceType.cs
@@ -1,7 +1,0 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp.UserManager
-{
-    enum DeviceType : uint
-    {
-        Amiibo
-    }
-}

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
@@ -2,7 +2,7 @@
 using Ryujinx.Common.Memory;
 using Ryujinx.HLE.HOS.Services.Mii;
 using Ryujinx.HLE.HOS.Services.Mii.Types;
-using Ryujinx.HLE.HOS.Services.Nfc.Nfp.UserManager;
+using Ryujinx.HLE.HOS.Services.Nfc.Nfp.NfpManager;
 using System;
 using System.Collections.Generic;
 using System.IO;


### PR DESCRIPTION
This PR add permission levels for `nfc` and `nfp` services:
- `nfc`: `CreateUserInterface` and `CreateSystemInterface` are implemented.
- `INfc`: `Initialize` and `IsNfcEnabled` calls are stubbed.
- `nfp`: `CreateDebugInterface` and `CreateSystemInterface` are implemented.
- `INfp`: `GetRegisterInfo2` for `IDebug` and `ISystem` are implemented.

Additionnally to that, a wrong size in `RegisterInfo` struct is now fixed.