### PR TITLE
settings: Implement GetDeviceNickName and SetDeviceNickName

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Settings/ISettingsServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Settings/ISettingsServer.cs
@@ -1,6 +1,7 @@
 using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.SystemState;
 using System;
+using System.Text;
 
 namespace Ryujinx.HLE.HOS.Services.Settings
 {
@@ -117,11 +118,31 @@ namespace Ryujinx.HLE.HOS.Services.Settings
             return GetKeyCodeMapImpl(context, 2);
         }
 
-        public ResultCode GetKeyCodeMapImpl(ServiceCtx context, int version)
+        [CommandHipc(11)] // 10.1.0+
+        // GetDeviceNickName() -> buffer<nn::settings::system::DeviceNickName, 0x16>
+        public ResultCode GetDeviceNickName(ServiceCtx context)
+        {
+            // NOTE: If deviceNickNameBuffer is null ResultCode.NullDeviceNicknameBuffer is returned.
+            //       Doesn't occur in our case.
+
+            ulong deviceNickNameBufferPosition = context.Request.ReceiveBuff[0].Position;
+            ulong deviceNickNameBufferSize     = context.Request.ReceiveBuff[0].Size;
+
+            if (deviceNickNameBufferSize != 0x80)
+            {
+                Logger.Warning?.Print(LogClass.ServiceSet, "Wrong buffer size");
+            }
+
+            context.Memory.Write(deviceNickNameBufferPosition, Encoding.ASCII.GetBytes(context.Device.System.State.DeviceNickName + '\0'));
+
+            return ResultCode.Success;
+        }
+
+        private ResultCode GetKeyCodeMapImpl(ServiceCtx context, int version)
         {
             if (context.Request.ReceiveBuff[0].Size != 0x1000)
             {
-                Logger.Warning?.Print(LogClass.ServiceSet, "Bad size");
+                Logger.Warning?.Print(LogClass.ServiceSet, "Wrong buffer size");
             }
 
             byte[] keyCodeMap;
@@ -200,7 +221,7 @@ namespace Ryujinx.HLE.HOS.Services.Settings
             return ResultCode.Success;
         }
 
-        public ResultCode GetAvailableLanguagesCodesImpl(ServiceCtx context, ulong position, ulong size, int maxSize)
+        private ResultCode GetAvailableLanguagesCodesImpl(ServiceCtx context, ulong position, ulong size, int maxSize)
         {
             int count = (int)(size / 8);
 

--- a/Ryujinx.HLE/HOS/Services/Settings/ISettingsServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Settings/ISettingsServer.cs
@@ -122,11 +122,13 @@ namespace Ryujinx.HLE.HOS.Services.Settings
         // GetDeviceNickName() -> buffer<nn::settings::system::DeviceNickName, 0x16>
         public ResultCode GetDeviceNickName(ServiceCtx context)
         {
-            // NOTE: If deviceNickNameBuffer is null ResultCode.NullDeviceNicknameBuffer is returned.
-            //       Doesn't occur in our case.
-
             ulong deviceNickNameBufferPosition = context.Request.ReceiveBuff[0].Position;
             ulong deviceNickNameBufferSize     = context.Request.ReceiveBuff[0].Size;
+
+            if (deviceNickNameBufferPosition == 0)
+            {
+                return ResultCode.NullDeviceNicknameBuffer;
+            }
 
             if (deviceNickNameBufferSize != 0x80)
             {

--- a/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
@@ -228,7 +228,43 @@ namespace Ryujinx.HLE.HOS.Services.Settings
             // NOTE: When set to true, is automatically synced with the internet.
             context.ResponseData.Write(true);
 
-            Logger.Stub?.PrintStub(LogClass.ServiceSet, "Stubbed");
+            Logger.Stub?.PrintStub(LogClass.ServiceSet);
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(77)]
+        // GetDeviceNickName() -> buffer<nn::settings::system::DeviceNickName, 0x16>
+        public ResultCode GetDeviceNickName(ServiceCtx context)
+        {
+            // NOTE: If deviceNickNameBuffer is null ResultCode.NullDeviceNicknameBuffer is returned.
+            //       Doesn't occur in our case.
+
+            ulong deviceNickNameBufferPosition = context.Request.ReceiveBuff[0].Position;
+            ulong deviceNickNameBufferSize     = context.Request.ReceiveBuff[0].Size;
+
+            if (deviceNickNameBufferSize != 0x80)
+            {
+                Logger.Warning?.Print(LogClass.ServiceSet, "Wrong buffer size");
+            }
+
+            context.Memory.Write(deviceNickNameBufferPosition, Encoding.ASCII.GetBytes(context.Device.System.State.DeviceNickName + '\0'));
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(78)]
+        // SetDeviceNickName(buffer<nn::settings::system::DeviceNickName, 0x15>)
+        public ResultCode SetDeviceNickName(ServiceCtx context)
+        {
+            ulong deviceNickNameBufferPosition = context.Request.SendBuff[0].Position;
+            ulong deviceNickNameBufferSize     = context.Request.SendBuff[0].Size;
+
+            byte[] deviceNickNameBuffer = new byte[deviceNickNameBufferSize];
+
+            context.Memory.Read(deviceNickNameBufferPosition, deviceNickNameBuffer);
+
+            context.Device.System.State.DeviceNickName = Encoding.ASCII.GetString(deviceNickNameBuffer);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
@@ -237,11 +237,13 @@ namespace Ryujinx.HLE.HOS.Services.Settings
         // GetDeviceNickName() -> buffer<nn::settings::system::DeviceNickName, 0x16>
         public ResultCode GetDeviceNickName(ServiceCtx context)
         {
-            // NOTE: If deviceNickNameBuffer is null ResultCode.NullDeviceNicknameBuffer is returned.
-            //       Doesn't occur in our case.
-
             ulong deviceNickNameBufferPosition = context.Request.ReceiveBuff[0].Position;
             ulong deviceNickNameBufferSize     = context.Request.ReceiveBuff[0].Size;
+
+            if (deviceNickNameBufferPosition == 0)
+            {
+                return ResultCode.NullDeviceNicknameBuffer;
+            }
 
             if (deviceNickNameBufferSize != 0x80)
             {

--- a/Ryujinx.HLE/HOS/SystemState/SystemStateMgr.cs
+++ b/Ryujinx.HLE/HOS/SystemState/SystemStateMgr.cs
@@ -55,9 +55,11 @@ namespace Ryujinx.HLE.HOS.SystemState
 
             DesiredTitleLanguage = language switch
             {
-                SystemLanguage.Taiwanese or SystemLanguage.TraditionalChinese => TitleLanguage.Taiwanese,
-                SystemLanguage.Chinese   or SystemLanguage.SimplifiedChinese  => TitleLanguage.Chinese,
-                _                                                             => Enum.Parse<TitleLanguage>(Enum.GetName(typeof(SystemLanguage), language)),
+                SystemLanguage.Taiwanese or
+                SystemLanguage.TraditionalChinese => TitleLanguage.Taiwanese,
+                SystemLanguage.Chinese or
+                SystemLanguage.SimplifiedChinese  => TitleLanguage.Chinese,
+                _                                 => Enum.Parse<TitleLanguage>(Enum.GetName(typeof(SystemLanguage), language)),
             };
         }
 

--- a/Ryujinx.HLE/HOS/SystemState/SystemStateMgr.cs
+++ b/Ryujinx.HLE/HOS/SystemState/SystemStateMgr.cs
@@ -35,39 +35,30 @@ namespace Ryujinx.HLE.HOS.SystemState
 
         public TitleLanguage DesiredTitleLanguage { get; private set; }
 
-        internal string ActiveAudioOutput { get; private set; }
-
         public bool DockedMode { get; set; }
 
         public ColorSet ThemeColor { get; set; }
 
-        public bool InstallContents { get; set; }
+        public string DeviceNickName { get; set; }
 
         public SystemStateMgr()
         {
-            // TODO: Let user specify.
+            // TODO: Let user specify fields.
             DesiredKeyboardLayout = (long)KeyboardLayout.Default;
+            DeviceNickName        = "Ryujinx's Switch";
         }
 
         public void SetLanguage(SystemLanguage language)
         {
             DesiredSystemLanguage = language;
-            DesiredLanguageCode = GetLanguageCode((int)DesiredSystemLanguage);
+            DesiredLanguageCode   = GetLanguageCode((int)DesiredSystemLanguage);
 
-            switch (language)
+            DesiredTitleLanguage = language switch
             {
-                case SystemLanguage.Taiwanese:
-                case SystemLanguage.TraditionalChinese:
-                    DesiredTitleLanguage = TitleLanguage.Taiwanese;
-                    break;
-                case SystemLanguage.Chinese:
-                case SystemLanguage.SimplifiedChinese:
-                    DesiredTitleLanguage = TitleLanguage.Chinese;
-                    break;
-                default:
-                    DesiredTitleLanguage = Enum.Parse<TitleLanguage>(Enum.GetName(typeof(SystemLanguage), language));
-                    break;
-            }
+                SystemLanguage.Taiwanese or SystemLanguage.TraditionalChinese => TitleLanguage.Taiwanese,
+                SystemLanguage.Chinese   or SystemLanguage.SimplifiedChinese  => TitleLanguage.Chinese,
+                _                                                             => Enum.Parse<TitleLanguage>(Enum.GetName(typeof(SystemLanguage), language)),
+            };
         }
 
         public void SetRegion(RegionCode region)


### PR DESCRIPTION
This PR implement `set` and `sys:set` calls : `GetDeviceNickName` and `SetDeviceNickName` accordingly to RE.
I've cleaned up both services a bit and `SystemStateMgr` class too.

Closes #2110