### PR TITLE
ipc: Remove size checks for buffer type 0x21/0x22

### DIFF
--- a/Ryujinx.HLE/HOS/Ipc/IpcMessage.cs
+++ b/Ryujinx.HLE/HOS/Ipc/IpcMessage.cs
@@ -247,15 +247,13 @@ namespace Ryujinx.HLE.HOS.Ipc
         public (ulong Position, ulong Size) GetBufferType0x21(int index = 0)
         {
             if (PtrBuff.Count > index &&
-                PtrBuff[index].Position != 0 &&
-                PtrBuff[index].Size     != 0)
+                PtrBuff[index].Position != 0)
             {
                 return (PtrBuff[index].Position, PtrBuff[index].Size);
             }
 
             if (SendBuff.Count > index &&
-                SendBuff[index].Position != 0 &&
-                SendBuff[index].Size     != 0)
+                SendBuff[index].Position != 0)
             {
                 return (SendBuff[index].Position, SendBuff[index].Size);
             }
@@ -267,15 +265,13 @@ namespace Ryujinx.HLE.HOS.Ipc
         public (ulong Position, ulong Size) GetBufferType0x22(int index = 0)
         {
             if (RecvListBuff.Count > index &&
-                RecvListBuff[index].Position != 0 &&
-                RecvListBuff[index].Size     != 0)
+                RecvListBuff[index].Position != 0)
             {
                 return (RecvListBuff[index].Position, RecvListBuff[index].Size);
             }
 
             if (ReceiveBuff.Count > index &&
-                ReceiveBuff[index].Position != 0 &&
-                ReceiveBuff[index].Size     != 0)
+                ReceiveBuff[index].Position != 0)
             {
                 return (ReceiveBuff[index].Position, ReceiveBuff[index].Size);
             }

--- a/Ryujinx.HLE/HOS/Ipc/IpcMessage.cs
+++ b/Ryujinx.HLE/HOS/Ipc/IpcMessage.cs
@@ -246,14 +246,12 @@ namespace Ryujinx.HLE.HOS.Ipc
         // ReSharper disable once InconsistentNaming
         public (ulong Position, ulong Size) GetBufferType0x21(int index = 0)
         {
-            if (PtrBuff.Count > index &&
-                PtrBuff[index].Position != 0)
+            if (PtrBuff.Count > index && PtrBuff[index].Position != 0)
             {
                 return (PtrBuff[index].Position, PtrBuff[index].Size);
             }
 
-            if (SendBuff.Count > index &&
-                SendBuff[index].Position != 0)
+            if (SendBuff.Count > index)
             {
                 return (SendBuff[index].Position, SendBuff[index].Size);
             }
@@ -264,14 +262,12 @@ namespace Ryujinx.HLE.HOS.Ipc
         // ReSharper disable once InconsistentNaming
         public (ulong Position, ulong Size) GetBufferType0x22(int index = 0)
         {
-            if (RecvListBuff.Count > index &&
-                RecvListBuff[index].Position != 0)
+            if (RecvListBuff.Count > index && RecvListBuff[index].Position != 0)
             {
                 return (RecvListBuff[index].Position, RecvListBuff[index].Size);
             }
 
-            if (ReceiveBuff.Count > index &&
-                ReceiveBuff[index].Position != 0)
+            if (ReceiveBuff.Count > index)
             {
                 return (ReceiveBuff[index].Position, ReceiveBuff[index].Size);
             }


### PR DESCRIPTION
Since original IPC implementation doesn't check the buffers size, there is no reason to check them so I've removed it. Checking the buffers addresses could prevent to unexpected behaviors.

That fixes a bsd service issue with some homebrews and some games included Knockout City (https://github.com/Ryujinx/Ryujinx-Games-List/issues/3622) which is now bootable (but not playable since online is required):

![image](https://user-images.githubusercontent.com/4905390/122850601-c77fa900-d30d-11eb-865c-299bfa2094fd.png)
