### PR TITLE
input: Fixes TouchPoint wrong attribute

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Hid/HidDevices/TouchDevice.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/HidDevices/TouchDevice.cs
@@ -31,6 +31,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
                     newState.Touches[i] = new TouchState
                     {
                         DeltaTime = newState.SamplingNumber,
+                        Attribute = pi.Attribute,
                         X = pi.X,
                         Y = pi.Y,
                         FingerId = (uint)i,

--- a/Ryujinx.HLE/HOS/Services/Hid/HidDevices/Types/TouchPoint.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/HidDevices/Types/TouchPoint.cs
@@ -1,7 +1,10 @@
+using Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.TouchScreen;
+
 namespace Ryujinx.HLE.HOS.Services.Hid
 {
     public struct TouchPoint
     {
+        public TouchAttribute Attribute;
         public uint X;
         public uint Y;
         public uint DiameterX;

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/TouchScreen/TouchAttribute.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/TouchScreen/TouchAttribute.cs
@@ -3,7 +3,7 @@
 namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.TouchScreen
 {
     [Flags]
-    enum TouchAttribute : uint
+    public enum TouchAttribute : uint
     {
         None = 0,
         Start = 1 << 0,

--- a/Ryujinx.Input/HLE/TouchScreenManager.cs
+++ b/Ryujinx.Input/HLE/TouchScreenManager.cs
@@ -1,5 +1,6 @@
 using Ryujinx.HLE;
 using Ryujinx.HLE.HOS.Services.Hid;
+using Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.TouchScreen;
 using System;
 
 namespace Ryujinx.Input.HLE
@@ -35,6 +36,8 @@ namespace Ryujinx.Input.HLE
 
                 TouchPoint currentPoint = new TouchPoint
                 {
+                    Attribute = TouchAttribute.End,
+
                     X = (uint)touchPosition.X,
                     Y = (uint)touchPosition.Y,
 

--- a/Ryujinx.Input/HLE/TouchScreenManager.cs
+++ b/Ryujinx.Input/HLE/TouchScreenManager.cs
@@ -36,7 +36,7 @@ namespace Ryujinx.Input.HLE
 
                 TouchPoint currentPoint = new TouchPoint
                 {
-                    Attribute = TouchAttribute.End,
+                    Attribute = TouchAttribute.Start,
 
                     X = (uint)touchPosition.X,
                     Y = (uint)touchPosition.Y,
@@ -46,6 +46,11 @@ namespace Ryujinx.Input.HLE
                     DiameterY = 10,
                     Angle = 90
                 };
+
+                _device.Hid.Touchscreen.Update(currentPoint);
+
+                // FIXME: We simulate an end of tap here. We do need a better and more way accurate to handle this.
+                currentPoint.Attribute = TouchAttribute.End;
 
                 _device.Hid.Touchscreen.Update(currentPoint);
 

--- a/Ryujinx.Input/HLE/TouchScreenManager.cs
+++ b/Ryujinx.Input/HLE/TouchScreenManager.cs
@@ -9,6 +9,7 @@ namespace Ryujinx.Input.HLE
     {
         private readonly IMouse _mouse;
         private Switch _device;
+        private bool _wasClicking;
 
         public TouchScreenManager(IMouse mouse)
         {
@@ -20,10 +21,35 @@ namespace Ryujinx.Input.HLE
             _device = device;
         }
 
-        public bool Update(bool isFocused, float aspectRatio = 0)
+        public bool Update(bool isFocused, bool isClicking = false, float aspectRatio = 0)
         {
-            if (!isFocused)
+            if (!isFocused || (!_wasClicking && !isClicking))
             {
+                // In case we lost focus, send the end touch.
+                if (_wasClicking && !isClicking)
+                {
+                    MouseStateSnapshot snapshot = IMouse.GetMouseStateSnapshot(_mouse);
+                    var touchPosition = IMouse.GetTouchPosition(snapshot.Position, _mouse.ClientSize, aspectRatio);
+
+                    TouchPoint currentPoint = new TouchPoint
+                    {
+                        Attribute = TouchAttribute.End,
+
+                        X = (uint)touchPosition.X,
+                        Y = (uint)touchPosition.Y,
+
+                        // Placeholder values till more data is acquired
+                        DiameterX = 10,
+                        DiameterY = 10,
+                        Angle = 90
+                    };
+
+                    _device.Hid.Touchscreen.Update(currentPoint);
+
+                }
+
+                _wasClicking = false;
+
                 _device.Hid.Touchscreen.Update();
 
                 return false;
@@ -31,12 +57,23 @@ namespace Ryujinx.Input.HLE
 
             if (aspectRatio > 0)
             {
-                var snapshot = IMouse.GetMouseStateSnapshot(_mouse);
+                MouseStateSnapshot snapshot = IMouse.GetMouseStateSnapshot(_mouse);
                 var touchPosition = IMouse.GetTouchPosition(snapshot.Position, _mouse.ClientSize, aspectRatio);
+
+                TouchAttribute attribute = TouchAttribute.None;
+
+                if (!_wasClicking && isClicking)
+                {
+                    attribute = TouchAttribute.Start;
+                }
+                else if (_wasClicking && !isClicking)
+                {
+                    attribute = TouchAttribute.End;
+                }
 
                 TouchPoint currentPoint = new TouchPoint
                 {
-                    Attribute = TouchAttribute.Start,
+                    Attribute = attribute,
 
                     X = (uint)touchPosition.X,
                     Y = (uint)touchPosition.Y,
@@ -49,10 +86,7 @@ namespace Ryujinx.Input.HLE
 
                 _device.Hid.Touchscreen.Update(currentPoint);
 
-                // FIXME: We simulate an end of tap here. We do need a better and more way accurate to handle this.
-                currentPoint.Attribute = TouchAttribute.End;
-
-                _device.Hid.Touchscreen.Update(currentPoint);
+                _wasClicking = isClicking;
 
                 return true;
             }

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -74,6 +74,8 @@ namespace Ryujinx.Ui
         public RendererWidgetBase RendererWidget;
         public InputManager InputManager;
 
+        public bool IsFocused;
+
         private static bool UseVulkan = false;
 
 #pragma warning disable CS0169, CS0649, IDE0044
@@ -157,6 +159,8 @@ namespace Ryujinx.Ui
 
             WindowStateEvent += WindowStateEvent_Changed;
             DeleteEvent      += Window_Close;
+            FocusInEvent     += MainWindow_FocusInEvent;
+            FocusOutEvent    += MainWindow_FocusOutEvent;
 
             _applicationLibrary.ApplicationAdded        += Application_Added;
             _applicationLibrary.ApplicationCountUpdated += ApplicationCount_Updated;
@@ -270,6 +274,16 @@ namespace Ryujinx.Ui
         private void WindowStateEvent_Changed(object o, WindowStateEventArgs args)
         {
             _fullScreen.Label = args.Event.NewWindowState.HasFlag(Gdk.WindowState.Fullscreen) ? "Exit Fullscreen" : "Enter Fullscreen";
+        }
+
+        private void MainWindow_FocusOutEvent(object o, FocusOutEventArgs args)
+        {
+            IsFocused = false;
+        }
+
+        private void MainWindow_FocusInEvent(object o, FocusInEventArgs args)
+        {
+            IsFocused = true;
         }
 
         private void UpdateColumns()

--- a/Ryujinx/Ui/RendererWidgetBase.cs
+++ b/Ryujinx/Ui/RendererWidgetBase.cs
@@ -37,7 +37,6 @@ namespace Ryujinx.Ui
 
         private bool _isActive;
         private bool _isStopped;
-        private bool _isFocused;
 
         private bool _toggleFullscreen;
         private bool _toggleDockedMode;
@@ -91,8 +90,6 @@ namespace Ryujinx.Ui
                           | EventMask.KeyPressMask
                           | EventMask.KeyReleaseMask));
 
-            Shown += Renderer_Shown;
-
             _exitEvent = new ManualResetEvent(false);
 
             _hideCursorOnIdle = ConfigurationState.Instance.HideCursorOnIdle;
@@ -124,27 +121,12 @@ namespace Ryujinx.Ui
             });
         }
 
-        private void Parent_FocusOutEvent(object o, Gtk.FocusOutEventArgs args)
-        {
-            _isFocused = false;
-        }
-
-        private void Parent_FocusInEvent(object o, Gtk.FocusInEventArgs args)
-        {
-            _isFocused = true;
-        }
-
         private void Renderer_Destroyed(object sender, EventArgs e)
         {
             ConfigurationState.Instance.HideCursorOnIdle.Event -= HideCursorStateChanged;
 
             NpadManager.Dispose();
             Dispose();
-        }
-
-        private void Renderer_Shown(object sender, EventArgs e)
-        {
-            _isFocused = ParentWindow.State.HasFlag(Gdk.WindowState.Focused);
         }
 
         protected override bool OnMotionNotifyEvent(EventMotion evnt)
@@ -341,10 +323,7 @@ namespace Ryujinx.Ui
 
             _isActive = true;
 
-            Gtk.Window parent = this.Toplevel as Gtk.Window;
-
-            parent.FocusInEvent += Parent_FocusInEvent;
-            parent.FocusOutEvent += Parent_FocusOutEvent;
+            Gtk.Window parent = Toplevel as Gtk.Window;
 
             Application.Invoke(delegate
             {
@@ -445,9 +424,9 @@ namespace Ryujinx.Ui
                 return false;
             }
 
-            if (_isFocused)
+            if ((Toplevel as MainWindow).IsFocused)
             {
-                Gtk.Application.Invoke(delegate
+                Application.Invoke(delegate
                 {
                     KeyboardStateSnapshot keyboard = _keyboardInterface.GetKeyboardStateSnapshot();
 
@@ -465,7 +444,7 @@ namespace Ryujinx.Ui
 
             NpadManager.Update();
 
-            if (_isFocused)
+            if ((Toplevel as MainWindow).IsFocused)
             {
                 KeyboardHotkeyState currentHotkeyState = GetHotkeyState();
 
@@ -482,7 +461,7 @@ namespace Ryujinx.Ui
             bool hasTouch = false;
 
             // Get screen touch position
-            if (_isFocused)
+            if ((Toplevel as MainWindow).IsFocused)
             {
                 hasTouch = TouchScreenManager.Update(true, (_inputManager.MouseDriver as GTK3MouseDriver).IsButtonPressed(MouseButton.Button1), ConfigurationState.Instance.Graphics.AspectRatio.Value.ToFloat());
             }

--- a/Ryujinx/Ui/RendererWidgetBase.cs
+++ b/Ryujinx/Ui/RendererWidgetBase.cs
@@ -481,10 +481,10 @@ namespace Ryujinx.Ui
             // Touchscreen
             bool hasTouch = false;
 
-            // Get screen touch position from left mouse click
-            if (_isFocused && (_inputManager.MouseDriver as GTK3MouseDriver).IsButtonPressed(MouseButton.Button1))
+            // Get screen touch position
+            if (_isFocused)
             {
-                hasTouch = TouchScreenManager.Update(true, ConfigurationState.Instance.Graphics.AspectRatio.Value.ToFloat());
+                hasTouch = TouchScreenManager.Update(true, (_inputManager.MouseDriver as GTK3MouseDriver).IsButtonPressed(MouseButton.Button1), ConfigurationState.Instance.Graphics.AspectRatio.Value.ToFloat());
             }
 
             if (!hasTouch)


### PR DESCRIPTION
Even if Touch works in some games, we didn't set the `End` attribute and then the wrong value is written in the shared memory. That could lead to some touch issues in some specific games.

While testing, a bug was found about MainWindow focus, it's fixed now.

It could be nice to get some feedbacks, if anyone knows games with touch issues feel free to test if that fixes it.

Fixes #2351
Now Mini Metro, Umineko no Naku Koro ni Saku and probably more games:
![image](https://user-images.githubusercontent.com/4905390/122959465-5b3f8c80-d383-11eb-8041-1847fb356d20.png)
