### PR TITLE
Fix shader texture LOD query

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -36,7 +36,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2362;
+        private const ulong ShaderCodeGenVersion = 2397;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
@@ -889,7 +889,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
                             type,
                             flags,
                             handle,
-                            compIndex,
+                            compIndex ^ 1, // The instruction component order is the inverse of GLSL's.
                             tempDest,
                             sources);
 
@@ -897,9 +897,9 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
                         tempDest = context.FPMultiply(tempDest, ConstF(256.0f));
 
-                        Operand finalValue = context.FPConvertToS32(tempDest);
+                        Operand fixedPointValue = context.FPConvertToS32(tempDest);
 
-                        context.Copy(dest, finalValue);
+                        context.Copy(dest, fixedPointValue);
                     }
                 }
             }

--- a/Ryujinx.Graphics.Shader/Translation/Rewriter.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Rewriter.cs
@@ -155,7 +155,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             {
                 return node;
             }
-            
+
             bool isGather       = (texOp.Flags & TextureFlags.Gather)      != 0;
             bool hasDerivatives = (texOp.Flags & TextureFlags.Derivatives) != 0;
             bool intCoords      = (texOp.Flags & TextureFlags.IntCoords)   != 0;
@@ -360,7 +360,7 @@ namespace Ryujinx.Graphics.Shader.Translation
                         texOp.Format,
                         texOp.Flags,
                         texOp.Handle,
-                        1,
+                        0,
                         lod,
                         lodSources));
 


### PR DESCRIPTION
The component order of the instruction is the inverse of the vector returned by `textureQueryLod`.
Fixes blurry graphics on Mario + Rabbids Kingdom Battle, caused by the shader sampling from the wrong texture level (due to the incorrect LOD value).
Before:
![image](https://user-images.githubusercontent.com/5624669/123162290-d027ca80-d446-11eb-9958-bd02518f24a3.png)
After:
![image](https://user-images.githubusercontent.com/5624669/123162321-d9189c00-d446-11eb-9719-6e8d5b5b5087.png)