### PR TITLE
Improve gameTable search

### DIFF
--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -227,9 +227,6 @@ namespace Ryujinx.Ui
             _gameTable.EnableSearch = true;
             _gameTable.SearchColumn = 2;
             _gameTable.SearchEqualFunc = (model, col, key, iter) => !((string)model.GetValue(iter, col)).Contains(key, StringComparison.InvariantCultureIgnoreCase);
-                string NameAndTitleId = (string) model.GetValue(iter, col);
-                return !NameAndTitleId.Contains(key, StringComparison.InvariantCultureIgnoreCase);
-            };
 
             UpdateColumns();
             UpdateGameTable();

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -227,7 +227,7 @@ namespace Ryujinx.Ui
             _gameTable.EnableSearch = true;
             _gameTable.SearchColumn = 2;
             _gameTable.SearchEqualFunc = (model, col, key, iter) => {
-                string NameAndTitleId = ((string) model.GetValue(iter, col));
+                string NameAndTitleId = (string) model.GetValue(iter, col);
                 return !NameAndTitleId.Contains(key, StringComparison.InvariantCultureIgnoreCase);
             };
 

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -227,13 +227,8 @@ namespace Ryujinx.Ui
             _gameTable.EnableSearch = true;
             _gameTable.SearchColumn = 2;
             _gameTable.SearchEqualFunc = (model, col, key, iter) => {
-                string[] NameAndTitleId = ((string) model.GetValue(iter, col)).Split("\n");
-                string Name = NameAndTitleId[0];
-                string TitleId = NameAndTitleId[1];
-                return !(
-                    Name.Contains(key, StringComparison.InvariantCultureIgnoreCase)
-                    || TitleId.StartsWith(key, StringComparison.InvariantCultureIgnoreCase)
-                );
+                string NameAndTitleId = ((string) model.GetValue(iter, col));
+                return !NameAndTitleId.Contains(key, StringComparison.InvariantCultureIgnoreCase);
             };
 
             UpdateColumns();

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -226,6 +226,15 @@ namespace Ryujinx.Ui
 
             _gameTable.EnableSearch = true;
             _gameTable.SearchColumn = 2;
+            _gameTable.SearchEqualFunc = (model, col, key, iter) => {
+                string[] NameAndTitleId = ((string) model.GetValue(iter, col)).Split("\n");
+                string Name = NameAndTitleId[0];
+                string TitleId = NameAndTitleId[1];
+                return !(
+                    Name.Contains(key, StringComparison.InvariantCultureIgnoreCase)
+                    || TitleId.StartsWith(key, StringComparison.InvariantCultureIgnoreCase)
+                );
+            };
 
             UpdateColumns();
             UpdateGameTable();

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -226,7 +226,7 @@ namespace Ryujinx.Ui
 
             _gameTable.EnableSearch = true;
             _gameTable.SearchColumn = 2;
-            _gameTable.SearchEqualFunc = (model, col, key, iter) => {
+            _gameTable.SearchEqualFunc = (model, col, key, iter) => !((string)model.GetValue(iter, col)).Contains(key, StringComparison.InvariantCultureIgnoreCase);
                 string NameAndTitleId = (string) model.GetValue(iter, col);
                 return !NameAndTitleId.Contains(key, StringComparison.InvariantCultureIgnoreCase);
             };


### PR DESCRIPTION
This adds two improvements to the `_gameTable` search that pops up when you start typing something while browsing the game list.

First, it allows searching by TitleID instead of name. This was brought up on Discord as a useful way to figure out what game you have mods for, and allows to more easily find games with weird titles that cannot be easily typed out (*stares at Pokémon*).

Second, instead of using the default `StartsWith` search behaviour for names, it instead uses `Contains`. This, for example, allows to type "odyssey" and find Super Mario Odyssey. The current behaviour would not return any result when such a search was made.

Note that the `SearchEqualFunc` here returns `false` if there *is* a match. This is intentional, though incredibly counter-intuitive. It's just how these callbacks work in Gtk.