### PR TITLE
caps: Stubs GetAlbumFileList0AafeAruidDeprecated and GetAlbumFileList3AaeAruid

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Caps/IAlbumApplicationService.cs
+++ b/Ryujinx.HLE/HOS/Services/Caps/IAlbumApplicationService.cs
@@ -1,4 +1,6 @@
 using Ryujinx.Common.Logging;
+using Ryujinx.Cpu;
+using Ryujinx.HLE.HOS.Services.Caps.Types;
 
 namespace Ryujinx.HLE.HOS.Services.Caps
 {
@@ -12,6 +14,56 @@ namespace Ryujinx.HLE.HOS.Services.Caps
         public ResultCode SetShimLibraryVersion(ServiceCtx context)
         {
             return context.Device.System.CaptureManager.SetShimLibraryVersion(context);
+        }
+
+        [CommandHipc(102)]
+        // GetAlbumFileList0AafeAruidDeprecated(pid, u16 content_type, u64 start_time, u64 end_time, nn::applet::AppletResourceUserId) -> (u64 count, buffer<ApplicationAlbumFileEntry, 0x6>)
+        public ResultCode GetAlbumFileList0AafeAruidDeprecated(ServiceCtx context) 
+        {
+            // NOTE: ApplicationAlbumFileEntry size is 0x30.
+            return GetAlbumFileList(context);
+        }
+
+        [CommandHipc(142)]
+        // GetAlbumFileList3AaeAruid(pid, u16 content_type, u64 start_time, u64 end_time, nn::applet::AppletResourceUserId) -> (u64 count, buffer<ApplicationAlbumFileEntry, 0x6>)
+        public ResultCode GetAlbumFileList3AaeAruid(ServiceCtx context)
+        {
+            // NOTE: ApplicationAlbumFileEntry size is 0x20.
+            return GetAlbumFileList(context);
+        }
+
+        private ResultCode GetAlbumFileList(ServiceCtx context)
+        {
+            ResultCode resultCode = ResultCode.Success;
+            ulong      count      = 0;
+
+            ContentType contentType = (ContentType)context.RequestData.ReadUInt16();
+            ulong       startTime   = context.RequestData.ReadUInt64();
+            ulong       endTime     = context.RequestData.ReadUInt64();
+
+            context.RequestData.ReadUInt16(); // Alignment.
+
+            ulong appletResourceUserId = context.RequestData.ReadUInt64();
+
+            ulong applicationAlbumFileEntryPosition = context.Request.ReceiveBuff[0].Position;
+            ulong applicationAlbumFileEntrySize     = context.Request.ReceiveBuff[0].Size;
+
+            MemoryHelper.FillWithZeros(context.Memory, applicationAlbumFileEntryPosition, (int)applicationAlbumFileEntrySize);
+
+            if (contentType > ContentType.Unknown || contentType == ContentType.ExtraMovie)
+            {
+                resultCode = ResultCode.InvalidContentType;
+            }
+
+            // TODO: Service checks if the pid is present in an internal list and returns ResultCode.BlacklistedPid if it is.
+            //       The list contents needs to be determined.
+            //       Service populate the buffer with a ApplicationAlbumFileEntry related to the pid.
+
+            Logger.Stub?.PrintStub(LogClass.ServiceCaps, new { contentType, startTime, endTime, appletResourceUserId });
+
+            context.ResponseData.Write(count);
+
+            return resultCode;
         }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Caps/ResultCode.cs
+++ b/Ryujinx.HLE/HOS/Services/Caps/ResultCode.cs
@@ -10,6 +10,7 @@
         InvalidArgument              = (2   << ErrorCodeShift) | ModuleId,
         ShimLibraryVersionAlreadySet = (7   << ErrorCodeShift) | ModuleId,
         OutOfRange                   = (8   << ErrorCodeShift) | ModuleId,
+        InvalidContentType           = (14  << ErrorCodeShift) | ModuleId,
         NullOutputBuffer             = (141 << ErrorCodeShift) | ModuleId,
         NullInputBuffer              = (142 << ErrorCodeShift) | ModuleId,
         BlacklistedPid               = (822 << ErrorCodeShift) | ModuleId

--- a/Ryujinx.HLE/HOS/Services/Caps/Types/ContentType.cs
+++ b/Ryujinx.HLE/HOS/Services/Caps/Types/ContentType.cs
@@ -4,6 +4,7 @@
     {
         Screenshot,
         Movie,
-        ExtraMovie
+        ExtraMovie,
+        Unknown
     }
 }


### PR DESCRIPTION
This PR stubs caps service call `GetAlbumFileList0AafeAruidDeprecated` and `GetAlbumFileList3AaeAruid` (Closes #2035, Closes #2401), both are checked by RE.
This avoid using "ignore missing services" when you want to play World of Light in Super Smash Bros Ultimate.