### PR TITLE
Fix texture sampling with depth compare and LOD level or bias

### DIFF
--- a/Ryujinx.Graphics.GAL/Capabilities.cs
+++ b/Ryujinx.Graphics.GAL/Capabilities.cs
@@ -4,8 +4,9 @@ namespace Ryujinx.Graphics.GAL
     {
         public bool SupportsAstcCompression          { get; }
         public bool SupportsImageLoadFormatted       { get; }
-        public bool SupportsNonConstantTextureOffset { get; }
         public bool SupportsMismatchingViewFormat    { get; }
+        public bool SupportsNonConstantTextureOffset { get; }
+        public bool SupportsTextureShadowLod         { get; }
         public bool SupportsViewportSwizzle          { get; }
 
         public int   MaximumComputeSharedMemorySize { get; }
@@ -15,8 +16,9 @@ namespace Ryujinx.Graphics.GAL
         public Capabilities(
             bool  supportsAstcCompression,
             bool  supportsImageLoadFormatted,
-            bool  supportsNonConstantTextureOffset,
             bool  supportsMismatchingViewFormat,
+            bool  supportsNonConstantTextureOffset,
+            bool  supportsTextureShadowLod,
             bool  supportsViewportSwizzle,
             int   maximumComputeSharedMemorySize,
             float maximumSupportedAnisotropy,
@@ -24,8 +26,9 @@ namespace Ryujinx.Graphics.GAL
         {
             SupportsAstcCompression          = supportsAstcCompression;
             SupportsImageLoadFormatted       = supportsImageLoadFormatted;
-            SupportsNonConstantTextureOffset = supportsNonConstantTextureOffset;
             SupportsMismatchingViewFormat    = supportsMismatchingViewFormat;
+            SupportsNonConstantTextureOffset = supportsNonConstantTextureOffset;
+            SupportsTextureShadowLod         = supportsTextureShadowLod;
             SupportsViewportSwizzle          = supportsViewportSwizzle;
             MaximumComputeSharedMemorySize   = maximumComputeSharedMemorySize;
             MaximumSupportedAnisotropy       = maximumSupportedAnisotropy;

--- a/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
@@ -181,6 +181,12 @@ namespace Ryujinx.Graphics.Gpu.Shader
         public bool QuerySupportsNonConstantTextureOffset() => _context.Capabilities.SupportsNonConstantTextureOffset;
 
         /// <summary>
+        /// Queries host GPU texture shadow LOD support.
+        /// </summary>
+        /// <returns>True if the GPU and driver supports texture shadow LOD, false otherwise</returns>
+        public bool QuerySupportsTextureShadowLod() => _context.Capabilities.SupportsTextureShadowLod;
+
+        /// <summary>
         /// Gets the texture descriptor for a given texture on the pool.
         /// </summary>
         /// <param name="handle">Index of the texture (this is the word offset of the handle in the constant buffer)</param>

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -36,7 +36,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2397;
+        private const ulong ShaderCodeGenVersion = 2404;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.OpenGL/HwCapabilities.cs
+++ b/Ryujinx.Graphics.OpenGL/HwCapabilities.cs
@@ -7,11 +7,12 @@ namespace Ryujinx.Graphics.OpenGL
     {
         private static readonly Lazy<bool> _supportsAstcCompression           = new Lazy<bool>(() => HasExtension("GL_KHR_texture_compression_astc_ldr"));
         private static readonly Lazy<bool> _supportsImageLoadFormatted        = new Lazy<bool>(() => HasExtension("GL_EXT_shader_image_load_formatted"));
+        private static readonly Lazy<bool> _supportsParallelShaderCompile     = new Lazy<bool>(() => HasExtension("GL_ARB_parallel_shader_compile"));
         private static readonly Lazy<bool> _supportsPolygonOffsetClamp        = new Lazy<bool>(() => HasExtension("GL_EXT_polygon_offset_clamp"));
+        private static readonly Lazy<bool> _supportsQuads                     = new Lazy<bool>(SupportsQuadsCheck);
+        private static readonly Lazy<bool> _supportsTextureShadowLod          = new Lazy<bool>(() => HasExtension("GL_EXT_texture_shadow_lod"));
         private static readonly Lazy<bool> _supportsViewportSwizzle           = new Lazy<bool>(() => HasExtension("GL_NV_viewport_swizzle"));
         private static readonly Lazy<bool> _supportsSeamlessCubemapPerTexture = new Lazy<bool>(() => HasExtension("GL_ARB_seamless_cubemap_per_texture"));
-        private static readonly Lazy<bool> _supportsParallelShaderCompile     = new Lazy<bool>(() => HasExtension("GL_ARB_parallel_shader_compile"));
-        private static readonly Lazy<bool> _supportsQuads                     = new Lazy<bool>(SupportsQuadsCheck);
 
         private static readonly Lazy<int> _maximumComputeSharedMemorySize = new Lazy<int>(() => GetLimit(All.MaxComputeSharedMemorySize));
         private static readonly Lazy<int> _storageBufferOffsetAlignment   = new Lazy<int>(() => GetLimit(All.ShaderStorageBufferOffsetAlignment));
@@ -33,11 +34,12 @@ namespace Ryujinx.Graphics.OpenGL
 
         public static bool SupportsAstcCompression           => _supportsAstcCompression.Value;
         public static bool SupportsImageLoadFormatted        => _supportsImageLoadFormatted.Value;
+        public static bool SupportsParallelShaderCompile     => _supportsParallelShaderCompile.Value;
         public static bool SupportsPolygonOffsetClamp        => _supportsPolygonOffsetClamp.Value;
+        public static bool SupportsQuads                     => _supportsQuads.Value;
         public static bool SupportsViewportSwizzle           => _supportsViewportSwizzle.Value;
         public static bool SupportsSeamlessCubemapPerTexture => _supportsSeamlessCubemapPerTexture.Value;
-        public static bool SupportsParallelShaderCompile     => _supportsParallelShaderCompile.Value;
-        public static bool SupportsQuads                     => _supportsQuads.Value;
+        public static bool SupportsTextureShadowLod          => _supportsTextureShadowLod.Value;
         public static bool SupportsNonConstantTextureOffset  => _gpuVendor.Value == GpuVendor.Nvidia;
         public static bool RequiresSyncFlush                 => _gpuVendor.Value == GpuVendor.Amd || _gpuVendor.Value == GpuVendor.IntelWindows || _gpuVendor.Value == GpuVendor.IntelUnix;
         public static bool SupportsMismatchingViewFormat     => _gpuVendor.Value != GpuVendor.Amd && _gpuVendor.Value != GpuVendor.IntelWindows;
@@ -78,7 +80,7 @@ namespace Ryujinx.Graphics.OpenGL
             else if (vendor == "intel")
             {
                 string renderer = GL.GetString(StringName.Renderer).ToLower();
-                
+
                 return renderer.Contains("mesa") ? GpuVendor.IntelUnix : GpuVendor.IntelWindows;
             }
             else if (vendor == "ati technologies inc." || vendor == "advanced micro devices, inc.")

--- a/Ryujinx.Graphics.OpenGL/HwCapabilities.cs
+++ b/Ryujinx.Graphics.OpenGL/HwCapabilities.cs
@@ -10,9 +10,9 @@ namespace Ryujinx.Graphics.OpenGL
         private static readonly Lazy<bool> _supportsParallelShaderCompile     = new Lazy<bool>(() => HasExtension("GL_ARB_parallel_shader_compile"));
         private static readonly Lazy<bool> _supportsPolygonOffsetClamp        = new Lazy<bool>(() => HasExtension("GL_EXT_polygon_offset_clamp"));
         private static readonly Lazy<bool> _supportsQuads                     = new Lazy<bool>(SupportsQuadsCheck);
+        private static readonly Lazy<bool> _supportsSeamlessCubemapPerTexture = new Lazy<bool>(() => HasExtension("GL_ARB_seamless_cubemap_per_texture"));
         private static readonly Lazy<bool> _supportsTextureShadowLod          = new Lazy<bool>(() => HasExtension("GL_EXT_texture_shadow_lod"));
         private static readonly Lazy<bool> _supportsViewportSwizzle           = new Lazy<bool>(() => HasExtension("GL_NV_viewport_swizzle"));
-        private static readonly Lazy<bool> _supportsSeamlessCubemapPerTexture = new Lazy<bool>(() => HasExtension("GL_ARB_seamless_cubemap_per_texture"));
 
         private static readonly Lazy<int> _maximumComputeSharedMemorySize = new Lazy<int>(() => GetLimit(All.MaxComputeSharedMemorySize));
         private static readonly Lazy<int> _storageBufferOffsetAlignment   = new Lazy<int>(() => GetLimit(All.ShaderStorageBufferOffsetAlignment));
@@ -37,12 +37,13 @@ namespace Ryujinx.Graphics.OpenGL
         public static bool SupportsParallelShaderCompile     => _supportsParallelShaderCompile.Value;
         public static bool SupportsPolygonOffsetClamp        => _supportsPolygonOffsetClamp.Value;
         public static bool SupportsQuads                     => _supportsQuads.Value;
-        public static bool SupportsViewportSwizzle           => _supportsViewportSwizzle.Value;
         public static bool SupportsSeamlessCubemapPerTexture => _supportsSeamlessCubemapPerTexture.Value;
         public static bool SupportsTextureShadowLod          => _supportsTextureShadowLod.Value;
-        public static bool SupportsNonConstantTextureOffset  => _gpuVendor.Value == GpuVendor.Nvidia;
-        public static bool RequiresSyncFlush                 => _gpuVendor.Value == GpuVendor.Amd || _gpuVendor.Value == GpuVendor.IntelWindows || _gpuVendor.Value == GpuVendor.IntelUnix;
-        public static bool SupportsMismatchingViewFormat     => _gpuVendor.Value != GpuVendor.Amd && _gpuVendor.Value != GpuVendor.IntelWindows;
+        public static bool SupportsViewportSwizzle           => _supportsViewportSwizzle.Value;
+
+        public static bool SupportsMismatchingViewFormat    => _gpuVendor.Value != GpuVendor.Amd && _gpuVendor.Value != GpuVendor.IntelWindows;
+        public static bool SupportsNonConstantTextureOffset => _gpuVendor.Value == GpuVendor.Nvidia;
+        public static bool RequiresSyncFlush                => _gpuVendor.Value == GpuVendor.Amd || _gpuVendor.Value == GpuVendor.IntelWindows || _gpuVendor.Value == GpuVendor.IntelUnix;
 
         public static int MaximumComputeSharedMemorySize => _maximumComputeSharedMemorySize.Value;
         public static int StorageBufferOffsetAlignment   => _storageBufferOffsetAlignment.Value;

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -1,4 +1,4 @@
-using OpenTK.Graphics;
+﻿using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL;
 using Ryujinx.Common.Configuration;
 using Ryujinx.Common.Logging;
@@ -96,8 +96,9 @@ namespace Ryujinx.Graphics.OpenGL
             return new Capabilities(
                 HwCapabilities.SupportsAstcCompression,
                 HwCapabilities.SupportsImageLoadFormatted,
-                HwCapabilities.SupportsNonConstantTextureOffset,
                 HwCapabilities.SupportsMismatchingViewFormat,
+                HwCapabilities.SupportsNonConstantTextureOffset,
+                HwCapabilities.SupportsTextureShadowLod,
                 HwCapabilities.SupportsViewportSwizzle,
                 HwCapabilities.MaximumComputeSharedMemorySize,
                 HwCapabilities.MaximumSupportedAnisotropy,

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
@@ -20,6 +20,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
             context.AppendLine("#extension GL_ARB_shader_ballot : enable");
             context.AppendLine("#extension GL_ARB_shader_group_vote : enable");
             context.AppendLine("#extension GL_EXT_shader_image_load_formatted : enable");
+            context.AppendLine("#extension GL_EXT_texture_shadow_lod : enable");
 
             if (context.Config.Stage == ShaderStage.Compute)
             {
@@ -32,7 +33,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
             }
 
             context.AppendLine("#pragma optionNV(fastmath off)");
-
             context.AppendLine();
 
             context.AppendLine($"const int {DefaultNames.UndefinedName} = 0;");

--- a/Ryujinx.Graphics.Shader/IGpuAccessor.cs
+++ b/Ryujinx.Graphics.Shader/IGpuAccessor.cs
@@ -74,6 +74,11 @@
             return true;
         }
 
+        bool QuerySupportsTextureShadowLod()
+        {
+            return true;
+        }
+
         TextureFormat QueryTextureFormat(int handle, int cbufSlot = -1)
         {
             return TextureFormat.R8G8B8A8Unorm;


### PR DESCRIPTION
Some overloads of the texture sample functions (in special, those that take a 2D or Cube shadow sampler, with a LOD level or LOD bias parameter) requires an extension, namely the [texture shadow LOD](https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_texture_shadow_lod.txt) extension. This PR enables the extension on shaders, fixing a compilation failure that would otherwise occur on those shaders. Additionally, since the extension is not widely supported, this removes the LOD parameters if the GPU doesn't support the extension. Note that it was already removing the parameter in one case (any array shadow sampler that had explicit LOD levels). Now this case is handled properly if the extension is supported, which is more accurate.

Fixes lighting on Mario Golf Super Rush, and possibly other games.
Before:
![image](https://user-images.githubusercontent.com/5624669/123340756-20745a80-d523-11eb-92d9-3d72431cd001.png)
![image](https://user-images.githubusercontent.com/5624669/123340764-2407e180-d523-11eb-81aa-f71c60421bb2.png)
After:
![image](https://user-images.githubusercontent.com/5624669/123340781-2a965900-d523-11eb-9c8b-e997e4e1f092.png)
![image](https://user-images.githubusercontent.com/5624669/123340793-2e29e000-d523-11eb-8f1f-0f40814d18d9.png)