### PR TITLE
Flush UBO updates more frequently

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoProcessor.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoProcessor.cs
@@ -126,6 +126,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
                     }
                 }
             }
+
+            _context.Methods.FlushUboDirty(MemoryManager);
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes a regression introduced on #2286. This PR made buffer updates are batched, but sometimes the updates are delayed way too much, and when it gets to actually write the data, the buffer was already unmapped, leading to a NRE as the address is invalid and the buffer no longer exists. This attempts to solve this by making those updates happen more frequently (at the end of every command buffer).

Note: This has the potential to reduce performance, so it has to be tested to make sure that performance was not regressed. If it was, then it will need to be fixed using a different method.

Affected games:
https://github.com/Ryujinx/Ryujinx-Games-List/issues/876 (probably?)
https://github.com/Ryujinx/Ryujinx-Games-List/issues/1096
Maybe more...