### PR TITLE
Implement 12.0.0 hwopus functions

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Audio/Types/OpusDecoderFlags.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/Types/OpusDecoderFlags.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Ryujinx.HLE.HOS.Services.Audio.Types
+{
+    [Flags]
+    enum OpusDecoderFlags : uint
+    {
+        None,
+        LargeFrameSize = 1 << 0,
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Audio/Types/OpusParametersEx.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/Types/OpusParametersEx.cs
@@ -1,0 +1,15 @@
+﻿using Ryujinx.Common.Memory;
+using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Audio.Types
+{
+    [StructLayout(LayoutKind.Sequential, Size = 0x10)]
+    struct OpusParametersEx
+    {
+        public int SampleRate;
+        public int ChannelCount;
+        public OpusDecoderFlags UseLargeFrameSize;
+
+        Array4<byte> Padding1;
+    }
+}


### PR DESCRIPTION
This is based off of my RE of 12.0.2 audio services, the newly added parameter can be safely ignored due to ryujinx not using fixed-size I/O buffers. I also included a minor fixup to avoid returning incorrect error codes to callers as HOS always aborts (aside from one special case however nothing actually returns that 😖)

This is completely untested as I don't own any games using the new 12.0.0+ SDK so it should probably be tested on one of them before merging.
