### PR TITLE
Fix default value for unwritten shader outputs

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -36,7 +36,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2404;
+        private const ulong ShaderCodeGenVersion = 2412;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/GlslGenerator.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/GlslGenerator.cs
@@ -76,14 +76,14 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
                         if ((context.Config.Flags & TranslationFlags.Feedback) != 0)
                         {
-                            context.AppendLine($"{DefaultNames.OAttributePrefix}{attr}_x = 0;");
-                            context.AppendLine($"{DefaultNames.OAttributePrefix}{attr}_y = 0;");
-                            context.AppendLine($"{DefaultNames.OAttributePrefix}{attr}_z = 0;");
-                            context.AppendLine($"{DefaultNames.OAttributePrefix}{attr}_w = 0;");
+                            context.AppendLine($"{DefaultNames.OAttributePrefix}{attr}_x = 0.0;");
+                            context.AppendLine($"{DefaultNames.OAttributePrefix}{attr}_y = 0.0;");
+                            context.AppendLine($"{DefaultNames.OAttributePrefix}{attr}_z = 0.0;");
+                            context.AppendLine($"{DefaultNames.OAttributePrefix}{attr}_w = 1.0;");
                         }
                         else
                         {
-                            context.AppendLine($"{DefaultNames.OAttributePrefix}{attr} = vec4(0);");
+                            context.AppendLine($"{DefaultNames.OAttributePrefix}{attr} = vec4(0.0, 0.0, 0.0, 1.0);");
                         }
                     }
                 }


### PR DESCRIPTION
Fixes default output values for shader outputs, which was `vec4(0, 0, 0, 0)` before but should be `vec4(0, 0, 0, 1)`.
Fixes missing geometry on Monster Hunter Stories 2: WIngs of Ruin (Trial Version).
Before:
![image](https://user-images.githubusercontent.com/5624669/123487455-4f063a00-d5e4-11eb-8ac4-069065d31890.png)
After:
![image](https://user-images.githubusercontent.com/5624669/123487467-5594b180-d5e4-11eb-8375-ea5de4940d42.png)
![image](https://user-images.githubusercontent.com/5624669/123487490-5cbbbf80-d5e4-11eb-8d8a-eb5cada86e4f.png)
