### PR TITLE
no name: Mii Editor applet support

### DIFF
--- a/Ryujinx.Common/Logging/LogClass.cs
+++ b/Ryujinx.Common/Logging/LogClass.cs
@@ -37,6 +37,7 @@ namespace Ryujinx.Common.Logging
         ServiceLdn,
         ServiceLdr,
         ServiceLm,
+        ServiceMii,
         ServiceMm,
         ServiceNfc,
         ServiceNfp,

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/ILibraryAppletProxy.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/ILibraryAppletProxy.cs
@@ -1,13 +1,13 @@
+﻿using Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.LibraryAppletProxy;
 using Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.SystemAppletProxy;
-using Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.ApplicationProxy;
 
-namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService
+namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService
 {
-    class IApplicationProxy : IpcService
+    class ILibraryAppletProxy : IpcService
     {
         private readonly long _pid;
 
-        public IApplicationProxy(long pid)
+        public ILibraryAppletProxy(long pid)
         {
             _pid = pid;
         }
@@ -57,6 +57,15 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService
             return ResultCode.Success;
         }
 
+        [CommandHipc(10)]
+        // GetProcessWindingController() -> object<nn::am::service::IProcessWindingController>
+        public ResultCode GetProcessWindingController(ServiceCtx context)
+        {
+            MakeObject(context, new IProcessWindingController());
+
+            return ResultCode.Success;
+        }
+
         [CommandHipc(11)]
         // GetLibraryAppletCreator() -> object<nn::am::service::ILibraryAppletCreator>
         public ResultCode GetLibraryAppletCreator(ServiceCtx context)
@@ -67,10 +76,19 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService
         }
 
         [CommandHipc(20)]
-        // GetApplicationFunctions() -> object<nn::am::service::IApplicationFunctions>
-        public ResultCode GetApplicationFunctions(ServiceCtx context)
+        // OpenLibraryAppletSelfAccessor() -> object<nn::am::service::ILibraryAppletSelfAccessor>
+        public ResultCode OpenLibraryAppletSelfAccessor(ServiceCtx context)
         {
-            MakeObject(context, new IApplicationFunctions(context.Device.System));
+            MakeObject(context, new ILibraryAppletSelfAccessor(context));
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(21)]
+        // GetAppletCommonFunctions() -> object<nn::am::service::IAppletCommonFunctions>
+        public ResultCode GetAppletCommonFunctions(ServiceCtx context)
+        {
+            MakeObject(context, new IAppletCommonFunctions());
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/ISystemAppletProxy.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/ISystemAppletProxy.cs
@@ -24,7 +24,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService
         // GetSelfController() -> object<nn::am::service::ISelfController>
         public ResultCode GetSelfController(ServiceCtx context)
         {
-            MakeObject(context, new ISelfController(context.Device.System, _pid));
+            MakeObject(context, new ISelfController(context, _pid));
 
             return ResultCode.Success;
         }
@@ -51,7 +51,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService
         // GetDisplayController() -> object<nn::am::service::IDisplayController>
         public ResultCode GetDisplayController(ServiceCtx context)
         {
-            MakeObject(context, new IDisplayController());
+            MakeObject(context, new IDisplayController(context));
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/LibraryAppletProxy/AppletStandalone.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/LibraryAppletProxy/AppletStandalone.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.LibraryAppletProxy
+{
+    class AppletStandalone
+    {
+        public AppletId          AppletId;
+        public LibraryAppletMode LibraryAppletMode;
+        public Queue<byte[]>     InputData;
+
+        public AppletStandalone()
+        {
+            InputData = new Queue<byte[]>();
+        }
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/LibraryAppletProxy/ILibraryAppletSelfAccessor.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/LibraryAppletProxy/ILibraryAppletSelfAccessor.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Lib
         {
             if (context.Device.Application.TitleId == 0x0100000000001009)
             {
-                // Add MiiEdit to standalone data list.
+                // Create MiiEdit data.
                 _appletStandalone = new AppletStandalone()
                 {
                     AppletId          = AppletId.MiiEdit,

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/LibraryAppletProxy/ILibraryAppletSelfAccessor.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/LibraryAppletProxy/ILibraryAppletSelfAccessor.cs
@@ -1,0 +1,74 @@
+﻿using Ryujinx.Common;
+using System.Collections.Generic;
+
+namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.LibraryAppletProxy
+{
+    class ILibraryAppletSelfAccessor : IpcService
+    {
+        private Dictionary<ulong, AppletStandalone> _appletStandalone = new Dictionary<ulong, AppletStandalone>();
+
+        public ILibraryAppletSelfAccessor(ServiceCtx context)
+        {
+            if (context.Device.Application.TitleId == 0x0100000000001009)
+            {
+                // Add MiiEdit to standalone data list.
+                _appletStandalone.Add(context.Device.Application.TitleId, new AppletStandalone()
+                {
+                    AppletId = AppletId.MiiEdit,
+                    LibraryAppletMode = LibraryAppletMode.AllForeground
+                });
+
+                byte[] miiEditInputData = new byte[0x100];
+                miiEditInputData[0] = 0x03; // Hardcoded unknown value.
+
+                _appletStandalone[context.Device.Application.TitleId].InputData.Enqueue(miiEditInputData);
+            }
+        }
+
+        [CommandHipc(0)]
+        // PopInData() -> object<nn::am::service::IStorage>
+        public ResultCode PopInData(ServiceCtx context)
+        {
+            byte[] appletData = _appletStandalone[context.Device.Application.TitleId].InputData.Dequeue();
+
+            if (appletData.Length == 0)
+            {
+                return ResultCode.NotAvailable;
+            }
+
+            MakeObject(context, new IStorage(appletData));
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(11)]
+        // GetLibraryAppletInfo() -> nn::am::service::LibraryAppletInfo
+        public ResultCode GetLibraryAppletInfo(ServiceCtx context)
+        {
+            LibraryAppletInfo libraryAppletInfo = new LibraryAppletInfo()
+            {
+                AppletId          = _appletStandalone[context.Device.Application.TitleId].AppletId,
+                LibraryAppletMode = _appletStandalone[context.Device.Application.TitleId].LibraryAppletMode
+            };
+
+            context.ResponseData.WriteStruct(libraryAppletInfo);
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(14)]
+        // GetCallerAppletIdentityInfo() -> nn::am::service::AppletIdentityInfo
+        public ResultCode GetCallerAppletIdentityInfo(ServiceCtx context)
+        {
+            AppletIdentifyInfo appletIdentifyInfo = new AppletIdentifyInfo()
+            {
+                AppletId = AppletId.QLaunch,
+                TitleId  = 0x0100000000001000
+            };
+
+            context.ResponseData.WriteStruct(appletIdentifyInfo);
+
+            return ResultCode.Success;
+        }
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/LibraryAppletProxy/IProcessWindingController.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/LibraryAppletProxy/IProcessWindingController.cs
@@ -1,0 +1,24 @@
+﻿using Ryujinx.Common;
+
+namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.LibraryAppletProxy
+{
+    class IProcessWindingController : IpcService
+    {
+        public IProcessWindingController() { }
+
+        [CommandHipc(0)]
+        // GetLaunchReason() -> nn::am::service::AppletProcessLaunchReason
+        public ResultCode GetLaunchReason(ServiceCtx context)
+        {
+            // NOTE: Flag is set by using an internal field.
+            AppletProcessLaunchReason appletProcessLaunchReason = new AppletProcessLaunchReason()
+            {
+                Flag = 0
+            };
+
+            context.ResponseData.WriteStruct(appletProcessLaunchReason);
+
+            return ResultCode.Success;
+        }
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/IAppletCommonFunctions.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/IAppletCommonFunctions.cs
@@ -1,0 +1,7 @@
+﻿namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.SystemAppletProxy
+{
+    class IAppletCommonFunctions : IpcService
+    {
+        public IAppletCommonFunctions() { }
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
@@ -241,6 +241,16 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             return (ResultCode)_apmSystemManagerServer.GetCurrentPerformanceConfiguration(context);
         }
 
+        [CommandHipc(300)] // 9.0.0+
+        // GetSettingsPlatformRegion() -> u8
+        public ResultCode GetSettingsPlatformRegion(ServiceCtx context)
+        {
+            // FIXME: Call set:sys GetPlatformRegion
+            context.ResponseData.Write((byte)context.Device.System.State.DesiredRegionCode);
+
+            return ResultCode.Success;
+        }
+
         [CommandHipc(900)] // 11.0.0+
         // SetRequestExitToLibraryAppletAtExecuteNextProgramEnabled()
         public ResultCode SetRequestExitToLibraryAppletAtExecuteNextProgramEnabled(ServiceCtx context)

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
@@ -2,6 +2,7 @@ using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Kernel.Common;
 using Ryujinx.HLE.HOS.Kernel.Threading;
+using Ryujinx.HLE.HOS.Services.Settings.Types;
 using System;
 
 namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.SystemAppletProxy
@@ -245,8 +246,10 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // GetSettingsPlatformRegion() -> u8
         public ResultCode GetSettingsPlatformRegion(ServiceCtx context)
         {
+            PlatformRegion platformRegion = context.Device.System.State.DesiredRegionCode == 4 ? PlatformRegion.China : PlatformRegion.Global;
+
             // FIXME: Call set:sys GetPlatformRegion
-            context.ResponseData.Write((byte)context.Device.System.State.DesiredRegionCode);
+            context.ResponseData.Write((byte)platformRegion);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
@@ -3,6 +3,7 @@ using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Kernel.Common;
 using Ryujinx.HLE.HOS.Kernel.Threading;
 using Ryujinx.HLE.HOS.Services.Settings.Types;
+using Ryujinx.HLE.HOS.SystemState;
 using System;
 
 namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.SystemAppletProxy
@@ -246,7 +247,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // GetSettingsPlatformRegion() -> u8
         public ResultCode GetSettingsPlatformRegion(ServiceCtx context)
         {
-            PlatformRegion platformRegion = context.Device.System.State.DesiredRegionCode == 4 ? PlatformRegion.China : PlatformRegion.Global;
+            PlatformRegion platformRegion = context.Device.System.State.DesiredRegionCode == (uint)RegionCode.China ? PlatformRegion.China : PlatformRegion.Global;
 
             // FIXME: Call set:sys GetPlatformRegion
             context.ResponseData.Write((byte)platformRegion);

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/IDisplayController.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/IDisplayController.cs
@@ -1,7 +1,106 @@
+using Ryujinx.Common.Logging;
+using Ryujinx.HLE.HOS.Ipc;
+using Ryujinx.HLE.HOS.Kernel.Common;
+using Ryujinx.HLE.HOS.Kernel.Memory;
+using System;
+
 namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.SystemAppletProxy
 {
     class IDisplayController : IpcService
     {
-        public IDisplayController() { }
+        private KTransferMemory _transferMem;
+        private bool            _lastApplicationCaptureBufferAcquired;
+        private bool            _callerAppletCaptureBufferAcquired;
+
+        public IDisplayController(ServiceCtx context)
+        {
+            _transferMem = context.Device.System.AppletCaptureBufferTransfer;
+        }
+
+        [CommandHipc(8)] // 2.0.0+
+        // TakeScreenShotOfOwnLayer(b8, s32)
+        public ResultCode TakeScreenShotOfOwnLayer(ServiceCtx context)
+        {
+            bool unknown1 = context.RequestData.ReadBoolean();
+            int  unknown2 = context.RequestData.ReadInt32();
+
+            Logger.Stub?.PrintStub(LogClass.ServiceAm, new { unknown1, unknown2 });
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(11)]
+        // ReleaseLastApplicationCaptureBuffer()
+        public ResultCode ReleaseLastApplicationCaptureBuffer(ServiceCtx context)
+        {
+            if (!_lastApplicationCaptureBufferAcquired)
+            {
+                return ResultCode.BufferNotAcquired;
+            }
+
+            _lastApplicationCaptureBufferAcquired = false;
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(15)]
+        // ReleaseCallerAppletCaptureBuffer()
+        public ResultCode ReleaseCallerAppletCaptureBuffer(ServiceCtx context)
+        {
+            if (!_callerAppletCaptureBufferAcquired)
+            {
+                return ResultCode.BufferNotAcquired;
+            }
+
+            _callerAppletCaptureBufferAcquired = false;
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(16)]
+        // AcquireLastApplicationCaptureBufferEx() -> (b8, handle<copy>)
+        public ResultCode AcquireLastApplicationCaptureBufferEx(ServiceCtx context)
+        {
+            if (_lastApplicationCaptureBufferAcquired)
+            {
+                return ResultCode.BufferAlreadyAcquired;
+            }
+
+            if (context.Process.HandleTable.GenerateHandle(_transferMem, out int handle) != KernelResult.Success)
+            {
+                throw new InvalidOperationException("Out of handles!");
+            }
+
+            context.Response.HandleDesc = IpcHandleDesc.MakeCopy(handle);
+
+            _lastApplicationCaptureBufferAcquired = true;
+
+            context.ResponseData.Write(_lastApplicationCaptureBufferAcquired);
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(18)]
+        // AcquireCallerAppletCaptureBufferEx() -> (b8, handle<copy>)
+        public ResultCode AcquireCallerAppletCaptureBufferEx(ServiceCtx context)
+        {
+            if (_callerAppletCaptureBufferAcquired)
+            {
+                return ResultCode.BufferAlreadyAcquired;
+            }
+
+            if (context.Process.HandleTable.GenerateHandle(_transferMem, out int handle) != KernelResult.Success)
+            {
+                throw new InvalidOperationException("Out of handles!");
+            }
+
+            context.Response.HandleDesc = IpcHandleDesc.MakeCopy(handle);
+
+            _callerAppletCaptureBufferAcquired = true;
+
+            context.ResponseData.Write(_callerAppletCaptureBufferAcquired);
+
+            return ResultCode.Success;
+        }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ISelfController.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ISelfController.cs
@@ -35,9 +35,9 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         private uint _screenShotImageOrientation = 0;
         private uint _idleTimeDetectionExtension = 0;
 
-        public ISelfController(Horizon system, long pid)
+        public ISelfController(ServiceCtx context, long pid)
         {
-            _libraryAppletLaunchableEvent = new KEvent(system.KernelContext);
+            _libraryAppletLaunchableEvent = new KEvent(context.Device.System.KernelContext);
             _pid = pid;
         }
 
@@ -223,6 +223,15 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
             context.ResponseData.Write(layerId);
 
             return ResultCode.Success;
+        }
+
+        [CommandHipc(41)] // 4.0.0+
+        // IsSystemBufferSharingEnabled()
+        public ResultCode IsSystemBufferSharingEnabled(ServiceCtx context)
+        {
+            // NOTE: Service checks a private field and return an error if the SystemBufferSharing is disabled.
+
+            return ResultCode.NotImplemented;
         }
 
         [CommandHipc(44)] // 10.0.0+

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/IAllSystemAppletProxiesService.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/IAllSystemAppletProxiesService.cs
@@ -15,5 +15,15 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE
 
             return ResultCode.Success;
         }
+
+        [CommandHipc(200)]
+        [CommandHipc(201)] // 3.0.0+
+        // OpenLibraryAppletProxy (u64, pid, handle<copy>) -> object<nn::am::service::ILibraryAppletProxy>
+        public ResultCode OpenLibraryAppletProxy(ServiceCtx context)
+        {
+            MakeObject(context, new ILibraryAppletProxy(context.Request.HandleDesc.PId));
+
+            return ResultCode.Success;
+        }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/IAllSystemAppletProxiesService.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/IAllSystemAppletProxiesService.cs
@@ -18,7 +18,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE
 
         [CommandHipc(200)]
         [CommandHipc(201)] // 3.0.0+
-        // OpenLibraryAppletProxy (u64, pid, handle<copy>) -> object<nn::am::service::ILibraryAppletProxy>
+        // OpenLibraryAppletProxy(u64, pid, handle<copy>) -> object<nn::am::service::ILibraryAppletProxy>
         public ResultCode OpenLibraryAppletProxy(ServiceCtx context)
         {
             MakeObject(context, new ILibraryAppletProxy(context.Request.HandleDesc.PId));

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/Types/AppletIdentityInfo.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/Types/AppletIdentityInfo.cs
@@ -1,0 +1,12 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Am.AppletAE
+{
+    [StructLayout(LayoutKind.Sequential, Size = 0x10)]
+    struct AppletIdentifyInfo
+    {
+        public AppletId AppletId;
+        public uint     Padding;
+        public ulong    TitleId;
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/Types/AppletProcessLaunchReason.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/Types/AppletProcessLaunchReason.cs
@@ -1,0 +1,12 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Am.AppletAE
+{
+    [StructLayout(LayoutKind.Sequential, Size = 0x4)]
+    struct AppletProcessLaunchReason
+    {
+        public byte   Flag;
+        public ushort Unknown1;
+        public byte   Unknown2;
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/Types/LibraryAppletInfo.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/Types/LibraryAppletInfo.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Am.AppletAE
+{
+    [StructLayout(LayoutKind.Sequential, Size = 0x8)]
+    struct LibraryAppletInfo
+    {
+        public AppletId          AppletId;
+        public LibraryAppletMode LibraryAppletMode;
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/Types/LibraryAppletMode.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/Types/LibraryAppletMode.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Ryujinx.HLE.HOS.Services.Am.AppletAE
+{
+    [Flags]
+    enum LibraryAppletMode : uint
+    {
+        AllForeground,
+        PartialForeground,
+        NoUi,
+        PartialForegroundWithIndirectDisplay,
+        AllForegroundInitiallyHidden
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Am/ResultCode.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/ResultCode.cs
@@ -14,6 +14,8 @@ namespace Ryujinx.HLE.HOS.Services.Am
         ObjectInvalid          = (500 << ErrorCodeShift) | ModuleId,
         IStorageInUse          = (502 << ErrorCodeShift) | ModuleId,
         OutOfBounds            = (503 << ErrorCodeShift) | ModuleId,
+        BufferNotAcquired      = (504 << ErrorCodeShift) | ModuleId,
+        BufferAlreadyAcquired  = (505 << ErrorCodeShift) | ModuleId,
         InvalidParameters      = (506 << ErrorCodeShift) | ModuleId,
         OpenedAsWrongType      = (511 << ErrorCodeShift) | ModuleId,
         UnbalancedFatalSection = (512 << ErrorCodeShift) | ModuleId,

--- a/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
@@ -499,6 +499,15 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             return (ResultCode)result.Value;
         }
 
+        [CommandHipc(1003)]
+        // DisableAutoSaveDataCreation()
+        public ResultCode DisableAutoSaveDataCreation(ServiceCtx context)
+        {
+            // NOTE: This call does nothing in original service.
+
+            return ResultCode.Success;
+        }
+
         [CommandHipc(1004)]
         // SetGlobalAccessLogMode(u32 mode)
         public ResultCode SetGlobalAccessLogMode(ServiceCtx context)

--- a/Ryujinx.HLE/HOS/Services/Mii/Helper.cs
+++ b/Ryujinx.HLE/HOS/Services/Mii/Helper.cs
@@ -36,7 +36,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii
         public static UInt128 GetDeviceId()
         {
             // FIXME: call set:sys GetMiiAuthorId
-            return new UInt128(0, 1);
+            return new UInt128("5279754d69694e780000000000000000"); // RyuMiiNx
         }
 
         public static ReadOnlySpan<byte> Ver3FacelineColorTable => new byte[] { 0, 1, 2, 3, 4, 5 };

--- a/Ryujinx.HLE/HOS/Services/Mii/IImageDatabaseService.cs
+++ b/Ryujinx.HLE/HOS/Services/Mii/IImageDatabaseService.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii
         // Initialize(b8) -> b8
         public ResultCode Initialize(ServiceCtx context)
         {
-            // TODO: Service uses MiiImage:/database.dat if true, seems use hardcoded data if false.
+            // TODO: Service uses MiiImage:/database.dat if true, seems to use hardcoded data if false.
             bool useHardcodedData = context.RequestData.ReadBoolean();
 
             _imageCount = 0;

--- a/Ryujinx.HLE/HOS/Services/Mii/IImageDatabaseService.cs
+++ b/Ryujinx.HLE/HOS/Services/Mii/IImageDatabaseService.cs
@@ -1,8 +1,41 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Mii
+﻿using Ryujinx.Common.Logging;
+
+namespace Ryujinx.HLE.HOS.Services.Mii
 {
     [Service("miiimg")] // 5.0.0+
     class IImageDatabaseService : IpcService
     {
+        private uint _imageCount;
+        private bool _isDirty;
+
         public IImageDatabaseService(ServiceCtx context) { }
+
+        [CommandHipc(0)]
+        // Initialize(b8) -> b8
+        public ResultCode Initialize(ServiceCtx context)
+        {
+            // TODO: Service uses MiiImage:/database.dat if true, seems use hardcoded data if false.
+            bool useHardcodedData = context.RequestData.ReadBoolean();
+
+            _imageCount = 0;
+            _isDirty    = false;
+
+            context.ResponseData.Write(_isDirty);
+
+            Logger.Stub?.PrintStub(LogClass.ServiceMii, new { useHardcodedData });
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(11)]
+        // GetCount() -> u32
+        public ResultCode GetCount(ServiceCtx context)
+        {
+            context.ResponseData.Write(_imageCount);
+
+            Logger.Stub?.PrintStub(LogClass.ServiceMii);
+
+            return ResultCode.Success;
+        }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Mii/MiiDatabaseManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Mii/MiiDatabaseManager.cs
@@ -101,6 +101,9 @@ namespace Ryujinx.HLE.HOS.Services.Mii
             // Ensure we have valid data in the database
             _database.Format();
 
+            // TODO: Unmount is currently not implemented properly at dispose, implement that and decrement MountCounter.
+            MountCounter = 0;
+
             MountSave();
         }
 
@@ -151,8 +154,6 @@ namespace Ryujinx.HLE.HOS.Services.Mii
                 }
             }
 
-
-
             return result;
         }
 
@@ -183,6 +184,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii
             if (result.IsSuccess())
             {
                 result = _filesystemClient.GetFileSize(out long fileSize, handle);
+
                 if (result.IsSuccess())
                 {
                     if (fileSize == Unsafe.SizeOf<NintendoFigurineDatabase>())

--- a/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
@@ -279,7 +279,7 @@ namespace Ryujinx.HLE.HOS.Services.Settings
             // NOTE: If miiAuthorId is null ResultCode.NullMiiAuthorIdBuffer is returned.
             //       Doesn't occur in our case.
 
-            UInt128 miiAuthorId = new UInt128("5279754d69694e780000000000000000"); // RyuMiiNx
+            UInt128 miiAuthorId = Mii.Helper.GetDeviceId();
 
             miiAuthorId.Write(context.ResponseData);
 

--- a/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
@@ -7,6 +7,7 @@ using LibHac.FsSystem.NcaUtils;
 using Ryujinx.Common.Logging;
 using Ryujinx.HLE.FileSystem;
 using Ryujinx.HLE.HOS.SystemState;
+using Ryujinx.HLE.Utilities;
 using System;
 using System.IO;
 using System.Text;
@@ -267,6 +268,20 @@ namespace Ryujinx.HLE.HOS.Services.Settings
             context.Memory.Read(deviceNickNameBufferPosition, deviceNickNameBuffer);
 
             context.Device.System.State.DeviceNickName = Encoding.ASCII.GetString(deviceNickNameBuffer);
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(90)]
+        // GetMiiAuthorId() -> nn::util::Uuid
+        public ResultCode GetMiiAuthorId(ServiceCtx context)
+        {
+            // NOTE: If miiAuthorId is null ResultCode.NullMiiAuthorIdBuffer is returned.
+            //       Doesn't occur in our case.
+
+            UInt128 miiAuthorId = new UInt128("5279754d69694e780000000000000000"); // RyuMiiNx
+
+            miiAuthorId.Write(context.ResponseData);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Settings/Types/PlatformRegion.cs
+++ b/Ryujinx.HLE/HOS/Services/Settings/Types/PlatformRegion.cs
@@ -1,0 +1,8 @@
+﻿namespace Ryujinx.HLE.HOS.Services.Settings.Types
+{
+    enum PlatformRegion
+    {
+        Global = 1,
+        China  = 2
+    }
+}

--- a/Ryujinx.HLE/HOS/SystemState/SystemStateMgr.cs
+++ b/Ryujinx.HLE/HOS/SystemState/SystemStateMgr.cs
@@ -55,11 +55,11 @@ namespace Ryujinx.HLE.HOS.SystemState
 
             DesiredTitleLanguage = language switch
             {
-                SystemLanguage.Taiwanese or
-                SystemLanguage.TraditionalChinese => TitleLanguage.Taiwanese,
+                SystemLanguage.Taiwanese         => TitleLanguage.Taiwanese,
+                SystemLanguage.TraditionalChinese or
                 SystemLanguage.Chinese or
-                SystemLanguage.SimplifiedChinese  => TitleLanguage.Chinese,
-                _                                 => Enum.Parse<TitleLanguage>(Enum.GetName(typeof(SystemLanguage), language)),
+                SystemLanguage.SimplifiedChinese => TitleLanguage.Chinese,
+                _                                => Enum.Parse<TitleLanguage>(Enum.GetName(typeof(SystemLanguage), language)),
             };
         }
 

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -1122,7 +1122,7 @@ namespace Ryujinx.Ui
 
         private void FileMenu_StateChanged(object o, StateChangedArgs args)
         {
-            _appletMenu.Sensitive            = _emulationContext == null && _contentManager.GetCurrentFirmwareVersion() != null;
+            _appletMenu.Sensitive            = _emulationContext == null && _contentManager.GetCurrentFirmwareVersion() != null && _contentManager.GetCurrentFirmwareVersion().Major > 3;
             _loadApplicationFile.Sensitive   = _emulationContext == null;
             _loadApplicationFolder.Sensitive = _emulationContext == null;
         }

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -3,6 +3,7 @@ using ARMeilleure.Translation.PTC;
 using Gtk;
 using LibHac.Common;
 using LibHac.FsSystem;
+using LibHac.FsSystem.NcaUtils;
 using LibHac.Ns;
 using Ryujinx.Audio.Backends.Dummy;
 using Ryujinx.Audio.Backends.OpenAL;
@@ -87,6 +88,10 @@ namespace Ryujinx.Ui
         [GUI] Box             _statusBar;
         [GUI] MenuItem        _optionMenu;
         [GUI] MenuItem        _manageUserProfiles;
+        [GUI] MenuItem        _fileMenu;
+        [GUI] MenuItem        _loadApplicationFile;
+        [GUI] MenuItem        _loadApplicationFolder;
+        [GUI] MenuItem        _appletMenu;
         [GUI] MenuItem        _actionMenu;
         [GUI] MenuItem        _stopEmulation;
         [GUI] MenuItem        _simulateWakeUpMessage;
@@ -165,6 +170,7 @@ namespace Ryujinx.Ui
             _applicationLibrary.ApplicationAdded        += Application_Added;
             _applicationLibrary.ApplicationCountUpdated += ApplicationCount_Updated;
 
+            _fileMenu.StateChanged   += FileMenu_StateChanged;
             _actionMenu.StateChanged += ActionMenu_StateChanged;
             _optionMenu.StateChanged += OptionMenu_StateChanged;
 
@@ -575,7 +581,15 @@ namespace Ryujinx.Ui
 
                 SystemVersion firmwareVersion = _contentManager.GetCurrentFirmwareVersion();
 
-                bool isDirectory = Directory.Exists(path);
+                bool isDirectory     = Directory.Exists(path);
+                bool isFirmwareTitle = false;
+
+                if (path.StartsWith("@SystemContent"))
+                {
+                    path = _virtualFileSystem.SwitchPathToSystemPath(path);
+
+                    isFirmwareTitle = true;
+                }
 
                 if (!SetupValidator.CanStartApplication(_contentManager, path, out UserError userError))
                 {
@@ -636,7 +650,13 @@ namespace Ryujinx.Ui
 
                 Logger.Notice.Print(LogClass.Application, $"Using Firmware Version: {firmwareVersion?.VersionString}");
 
-                if (Directory.Exists(path))
+                if (isFirmwareTitle)
+                {
+                    Logger.Info?.Print(LogClass.Application, "Loading as Firmware Title (NCA).");
+
+                    _emulationContext.LoadNca(path);
+                }
+                else if (Directory.Exists(path))
                 {
                     string[] romFsFiles = Directory.GetFiles(path, "*.istorage");
 
@@ -1100,6 +1120,20 @@ namespace Ryujinx.Ui
             }
         }
 
+        private void FileMenu_StateChanged(object o, StateChangedArgs args)
+        {
+            _appletMenu.Sensitive            = _emulationContext == null && _contentManager.GetCurrentFirmwareVersion() != null;
+            _loadApplicationFile.Sensitive   = _emulationContext == null;
+            _loadApplicationFolder.Sensitive = _emulationContext == null;
+        }
+
+        private void Load_Mii_Edit_Applet(object sender, EventArgs args)
+        {
+            string contentPath = _contentManager.GetInstalledContentPath(0x0100000000001009, StorageId.NandSystem, NcaContentType.Program);
+
+            LoadApplication(contentPath);
+        }
+
         private void Open_Ryu_Folder(object sender, EventArgs args)
         {
             OpenHelper.OpenFolder(AppDataManager.BaseDirPath);
@@ -1217,6 +1251,15 @@ namespace Ryujinx.Ui
 
                                     GtkDialog.CreateInfoDialog(dialogTitle, message);
                                     Logger.Info?.Print(LogClass.Application, message);
+
+                                    // Purge Applet Cache.
+
+                                    DirectoryInfo miiEditorCacheFolder = new DirectoryInfo(System.IO.Path.Combine(AppDataManager.GamesDirPath, "0100000000001009", "cache"));
+
+                                    if (miiEditorCacheFolder.Exists)
+                                    {
+                                        miiEditorCacheFolder.Delete(true);
+                                    }
                                 });
                             }
                             catch (Exception ex)

--- a/Ryujinx/Ui/MainWindow.glade
+++ b/Ryujinx/Ui/MainWindow.glade
@@ -19,7 +19,7 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <child>
-              <object class="GtkMenuItem" id="FileMenu">
+              <object class="GtkMenuItem" id="_fileMenu">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">File</property>
@@ -29,7 +29,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <child>
-                      <object class="GtkMenuItem" id="LoadApplicationFile">
+                      <object class="GtkMenuItem" id="_loadApplicationFile">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Open a file chooser to chose a switch compatible file to load</property>
@@ -39,13 +39,37 @@
                       </object>
                     </child>
                     <child>
-                      <object class="GtkMenuItem" id="LoadApplicationFolder">
+                      <object class="GtkMenuItem" id="_loadApplicationFolder">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Open a file chooser to chose a switch compatible, unpacked application to load</property>
                         <property name="label" translatable="yes">Load Unpacked Game</property>
                         <property name="use_underline">True</property>
                         <signal name="activate" handler="Load_Application_Folder" swapped="no"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkMenuItem" id="_appletMenu">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Load Applet</property>
+                        <property name="use_underline">True</property>
+                        <child type="submenu">
+                          <object class="GtkMenu">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkMenuItem" id="LoadMiiEditApplet">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="tooltip_text" translatable="yes">Open Mii Editor Applet in Standalone mode</property>
+                                <property name="label" translatable="yes">Mii Editor</property>
+                                <property name="use_underline">True</property>
+                                <signal name="activate" handler="Load_Mii_Edit_Applet" swapped="no"/>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
                       </object>
                     </child>
                     <child>


### PR DESCRIPTION
# Project no name

Why "no name"? Because it's the Miis default name in the Switch service so yeah, let's introduce a standalone mode for official Mii Editor applet.
Since Ryujinx requires a Switch firmware to be installed, we can run applets directly from the firmware's files. In that way we can run the Mii Editor applet in a standalone mode.
That allows you to create, edit, rename, save, move and delete Miis in the `mii` service system save data, which is required by some games such as Mario Kart 8 Deluxe, Miitopia or more recently Mario Golf (in adventure mode). Now save files aren't needed.

![image](https://user-images.githubusercontent.com/4905390/123555837-80b80600-d788-11eb-86d6-e99785dfa0e6.png)
![image](https://user-images.githubusercontent.com/4905390/123555845-84e42380-d788-11eb-9b29-8e578d22ff43.png)
![image](https://user-images.githubusercontent.com/4905390/123555851-90cfe580-d788-11eb-9e01-927c990d7d0f.png)
![image](https://user-images.githubusercontent.com/4905390/123555849-8c0b3180-d788-11eb-94f5-a3bf0c42bcd0.png)
![image](https://user-images.githubusercontent.com/4905390/123555855-95949980-d788-11eb-960e-a36a9d678545.png)
![image](https://user-images.githubusercontent.com/4905390/123555857-988f8a00-d788-11eb-874b-8a11bd5c28b6.png)
![image](https://user-images.githubusercontent.com/4905390/123555863-a04f2e80-d788-11eb-875f-fe2ca9488170.png)
![image](https://user-images.githubusercontent.com/4905390/123555888-bb21a300-d788-11eb-8d62-aa9c0ffff699.png)

Launching applets from games is not supported. For this reason, if you play a game that requires having Miis created, you need to first launch the Mii applet (from the File > Launch Mii Applet menu), create a Mii of your liking, and then launch the game. The Mii should be available for selection when you start a new game. Not following those steps will result in a crash when the game requests the Mii.

![image](https://user-images.githubusercontent.com/4905390/123555828-73028080-d788-11eb-87ea-5243c3d50591.png)
![image](https://user-images.githubusercontent.com/4905390/123555893-bfe65700-d788-11eb-9f62-55587f3ef86b.png)

### What's implemented
- A bunch of services calls needed to get it working.
- You can run applets directly from the File menu.
  
![image](https://user-images.githubusercontent.com/4905390/123555901-cb398280-d788-11eb-8437-c7a25d8e94be.png)

- When you install a new (or old) firmware, all caches related to the applet are purged automatically to avoid any issues.
- Touch is supported aswell, that means you can drag and drop Miis with your mouse to sort them.

![image](https://user-images.githubusercontent.com/4905390/123555908-d9879e80-d788-11eb-9e62-43e7e09773ee.png)

### Known Issues
- Mii Editor from Firmware < 3.0.1 seems to crash with a GPU issue.
- If you press B on the main screen, it will try to exit the applet and crash because of unimplemented call of am service.
- "Send/Receive" currently don't work due to unimplemented call of nifm service.
- If you try to "Copy Mii from amiibo" in "Create New Mii", you will be able to scan a virtual amiibo by checking "Show All Amiibo", but the returned mii values are wrong.
- That doesn't let you run the Mii Editor applet from a running game.

Tests are welcome, don't hesitate to post any feedbacks or issues that aren't known.

Thanks to @riperiperi , @Thog and @gdkchan for their precious help as usual.

![image](https://user-images.githubusercontent.com/4905390/123555923-ee643200-d788-11eb-8a12-10ace6c5a618.png)
![image](https://user-images.githubusercontent.com/4905390/123555928-f4f2a980-d788-11eb-83fd-26ed0d71fab9.png)
![image](https://user-images.githubusercontent.com/4905390/123555932-f9b75d80-d788-11eb-99ff-e605e58a47c8.png)
![image](https://user-images.githubusercontent.com/4905390/123555934-fcb24e00-d788-11eb-9d90-f3d871dff715.png)

