### PR TITLE
Honour copy dependencies when switching render target

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -154,8 +154,12 @@ namespace Ryujinx.Graphics.Gpu.Image
             if (_rtColors[index] != color)
             {
                 _rtColors[index]?.SignalModifying(false);
-                color?.SynchronizeMemory();
-                color?.SignalModifying(true);
+
+                if (color != null)
+                {
+                    color.SynchronizeMemory();
+                    color.SignalModifying(true);
+                }
 
                 _rtColors[index] = color;
             }
@@ -176,8 +180,12 @@ namespace Ryujinx.Graphics.Gpu.Image
             if (_rtDepthStencil != depthStencil)
             {
                 _rtDepthStencil?.SignalModifying(false);
-                depthStencil?.SynchronizeMemory();
-                depthStencil?.SignalModifying(true);
+
+                if (depthStencil != null)
+                {
+                    depthStencil.SynchronizeMemory();
+                    depthStencil.SignalModifying(true);
+                }
 
                 _rtDepthStencil = depthStencil;
             }

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -154,6 +154,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             if (_rtColors[index] != color)
             {
                 _rtColors[index]?.SignalModifying(false);
+                color?.SynchronizeMemory();
                 color?.SignalModifying(true);
 
                 _rtColors[index] = color;
@@ -175,6 +176,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             if (_rtDepthStencil != depthStencil)
             {
                 _rtDepthStencil?.SignalModifying(false);
+                depthStencil?.SynchronizeMemory();
                 depthStencil?.SignalModifying(true);
 
                 _rtDepthStencil = depthStencil;


### PR DESCRIPTION
When switching from one render target to another, when both have a copy dependency to each other, a copy can be deferred on the second target when unbinding the first.

Before, this would not be honoured before binding the new texture, so the copy would stay deferred until the render targets change again, at which point it would copy in old data and essentially clear all the draws done during that time.

This change runs synchronize memory to make sure that copies are honoured. This can cause a redundant copy, but this is a rare situation and it's better than it breaking for now.

This should fix miiedit on AMD/Intel GPUs on windows. May fix other games, or perhaps rare copy dependency bugs on NVIDIA too.