### PR TITLE
Unscale textureSize when resolution scaling is used

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -37,7 +37,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2441;
+        private const ulong ShaderCodeGenVersion = 2440;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -37,7 +37,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2412;
+        private const ulong ShaderCodeGenVersion = 2441;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -37,7 +37,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2440;
+        private const ulong ShaderCodeGenVersion = 2439;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_cp.glsl
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_cp.glsl
@@ -7,3 +7,13 @@
     }
     return ivec2(vec2(inputVec) * scale);
 }
+
+int Helper_TextureSizeUnscale(int size, int samplerIndex)
+{
+    float scale = fp_renderScale[samplerIndex];
+    if (scale == 1.0)
+    {
+        return size;
+    }
+    return int(float(size) / scale);
+}

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_cp.glsl
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_cp.glsl
@@ -10,7 +10,7 @@
 
 int Helper_TextureSizeUnscale(int size, int samplerIndex)
 {
-    float scale = fp_renderScale[samplerIndex];
+    float scale = cp_renderScale[samplerIndex];
     if (scale == 1.0)
     {
         return size;

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_fp.glsl
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_fp.glsl
@@ -14,3 +14,13 @@
         return ivec2(vec2(inputVec) * scale);
     }
 }
+
+int Helper_TextureSizeUnscale(int size, int samplerIndex)
+{
+    float scale = abs(fp_renderScale[1 + samplerIndex]);
+    if (scale == 1.0)
+    {
+        return size;
+    }
+    return int(float(size) / scale);
+}

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
@@ -55,15 +55,13 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
 
             string ApplyScaling(string vector)
             {
-                int index = context.FindImageDescriptorIndex(texOp);
-
                 if ((context.Config.Stage == ShaderStage.Fragment || context.Config.Stage == ShaderStage.Compute) &&
                     texOp.Inst == Instruction.ImageLoad &&
                     !isBindless &&
                     !isIndexed)
                 {
                     // Image scales start after texture ones.
-                    int scaleIndex = context.Config.GetTextureDescriptors().Length + index;
+                    int scaleIndex = context.Config.GetTextureDescriptors().Length + context.FindImageDescriptorIndex(texOp);
 
                     if (pCount == 3 && isArray)
                     {
@@ -461,12 +459,12 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
             {
                 if (intCoords)
                 {
-                    int index = context.FindTextureDescriptorIndex(texOp);
-
                     if ((context.Config.Stage == ShaderStage.Fragment || context.Config.Stage == ShaderStage.Compute) &&
                         !isBindless &&
                         !isIndexed)
                     {
+                        int index = context.FindTextureDescriptorIndex(texOp);
+
                         if (pCount == 3 && isArray)
                         {
                             // The array index is not scaled, just x and y.
@@ -608,7 +606,16 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
             }
             else
             {
-                return $"textureSize({samplerName}, {lodExpr}){GetMask(texOp.Index)}";
+                string texCall = $"textureSize({samplerName}, {lodExpr}){GetMask(texOp.Index)}";
+
+                if (context.Config.Stage == ShaderStage.Fragment || context.Config.Stage == ShaderStage.Compute)
+                {
+                    int index = context.FindTextureDescriptorIndex(texOp);
+
+                    texCall = "Helper_TextureSizeUnscale(" + texCall + ", " + index + ")";
+                }
+
+                return texCall;
             }
         }
 

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
@@ -608,7 +608,9 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
             {
                 string texCall = $"textureSize({samplerName}, {lodExpr}){GetMask(texOp.Index)}";
 
-                if (context.Config.Stage == ShaderStage.Fragment || context.Config.Stage == ShaderStage.Compute)
+                if ((context.Config.Stage == ShaderStage.Fragment || context.Config.Stage == ShaderStage.Compute) &&
+                    !isBindless &&
+                    !isIndexed)
                 {
                     int index = context.FindTextureDescriptorIndex(texOp);
 

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
@@ -1056,6 +1056,8 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 return;
             }
 
+            context.Config.SetUsedFeature(FeatureFlags.IntegerSampling);
+
             TextureProperty property = (TextureProperty)op.RawOpCode.Extract(22, 6);
 
             // TODO: Validate and use property.

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -242,7 +242,8 @@ namespace Ryujinx.Graphics.Shader.Translation
             }
             else
             {
-                SetUsedTextureOrImage(_usedTextures, cbufSlot, handle, type, TextureFormat.Unknown, flags.HasFlag(TextureFlags.IntCoords), false, accurateType);
+                bool intCoords = flags.HasFlag(TextureFlags.IntCoords) || inst == Instruction.TextureSize;
+                SetUsedTextureOrImage(_usedTextures, cbufSlot, handle, type, TextureFormat.Unknown, intCoords, false, accurateType);
             }
         }
 


### PR DESCRIPTION
Monster Hunter Rise has a shader that divides `gl_FragCoord` by screen size, then multiplies it by the texture size and uses the result on `texelFetch`. This doesn't work because while `gl_FragCoord` is unscaled, the `textureSize` isn't. This change also unscales the size which fixes the issue.
Before:
![image](https://user-images.githubusercontent.com/5624669/124346832-75654000-dbb7-11eb-883f-cc2dffead548.png)
After:
![image](https://user-images.githubusercontent.com/5624669/124346821-5d8dbc00-dbb7-11eb-891e-0cb88a4d2f4f.png)
Might also fix a similar issue on Monster Hunter Stories 2 (#2436). Needs testing.