### PR TITLE
nifm: Fixes IsDynamicDnsEnabled not supported

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Nifm/StaticService/Types/DnsSetting.cs
+++ b/Ryujinx.HLE/HOS/Services/Nifm/StaticService/Types/DnsSetting.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.NetworkInformation;
+﻿using System;
+using System.Net.NetworkInformation;
 using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService.Types
@@ -13,7 +14,14 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService.Types
 
         public DnsSetting(IPInterfaceProperties interfaceProperties)
         {
-            IsDynamicDnsEnabled = interfaceProperties.IsDynamicDnsEnabled;
+            try
+            {
+                IsDynamicDnsEnabled = interfaceProperties.IsDynamicDnsEnabled;
+            }
+            catch (PlatformNotSupportedException)
+            {
+                IsDynamicDnsEnabled = false;
+            }
 
             if (interfaceProperties.DnsAddresses.Count == 0)
             {


### PR DESCRIPTION
For a strange reason `IPInterfaceProperties.IsDynamicDnsEnabled` throws a `PlatformNotSupported` exception in Linux.
This PR fixes this issue with a `try/catch` and set the value to false. Closes #2415.

Now games can be playable back. Thanks to @SeraUQ and @pineappleEA for the tests.
![image](https://user-images.githubusercontent.com/4905390/124390705-199cd300-dced-11eb-82d1-1ee2ade005da.png)
![image](https://user-images.githubusercontent.com/4905390/124390711-215c7780-dced-11eb-8289-b21d4c0fae2c.png)


