### PR TITLE
am: Implement CreateApplicationAndRequestToStart

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
@@ -79,6 +79,26 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return ResultCode.Success;
         }
 
+        [CommandHipc(12)] // 4.0.0+
+        // CreateApplicationAndRequestToStart(u64 title_id)
+        public ResultCode CreateApplicationAndRequestToStart(ServiceCtx context)
+        {
+            ulong titleId = context.RequestData.ReadUInt64();
+
+            Logger.Stub?.PrintStub(LogClass.ServiceAm, new { titleId });
+
+            if (titleId == 0)
+            {
+                context.Device.UiHandler.ExecuteProgram(context.Device, ProgramSpecifyKind.RestartProgram, titleId);
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+
+            return ResultCode.Success;
+        }
+
         [CommandHipc(20)]
         // EnsureSaveData(nn::account::Uid) -> u64
         public ResultCode EnsureSaveData(ServiceCtx context)


### PR DESCRIPTION
This PR implement `CreateApplicationAndRequestToStart` call, result code is checked by RE.
Now we can restart a guest program by itself. This is needed by SSBU when you changes the game language.

NOTE: This currently don't works using OpenAL backend due to another issue.

Closes #2108