### PR TITLE
Fix depop mixing

### DIFF
--- a/Ryujinx.Audio/Renderer/Dsp/Command/DepopForMixBuffersCommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/DepopForMixBuffersCommand.cs
@@ -59,27 +59,29 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         private float ProcessDepopMix(Span<float> buffer, float depopValue, uint sampleCount)
         {
+            float value = Math.Abs(depopValue);
+
             if (depopValue <= 0)
             {
                 for (int i = 0; i < sampleCount; i++)
                 {
-                    depopValue = FloatingPointHelper.MultiplyRoundDown(Decay, depopValue);
+                    value = FloatingPointHelper.MultiplyRoundDown(Decay, value);
 
-                    buffer[i] -= depopValue;
+                    buffer[i] -= value;
                 }
 
-                return -depopValue;
+                return -value;
             }
             else
             {
                 for (int i = 0; i < sampleCount; i++)
                 {
-                    depopValue = FloatingPointHelper.MultiplyRoundDown(Decay, depopValue);
+                    value = FloatingPointHelper.MultiplyRoundDown(Decay, value);
 
-                    buffer[i] += depopValue;
+                    buffer[i] += value;
                 }
 
-                return depopValue;
+                return value;
             }
 
         }

--- a/Ryujinx.Audio/Renderer/Dsp/FloatingPointHelper.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/FloatingPointHelper.cs
@@ -31,7 +31,7 @@ namespace Ryujinx.Audio.Renderer.Dsp
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float RoundDown(float a)
         {
-            return MathF.Round(a, 0);
+            return MathF.Floor(a);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
This PR does 2 things:

1. Depopping gets stuck due to rounding. `MathF.Round(a, 0);` still rounds the number up when above .5. Specifically at 13, depopping gets stuck forever. `0.962189 * 13 = 12.508457`, which rounds back to 13. Instead, take the floor result, as I think was the intention in RoundDown, and depopping can now clear itself.

2. Take the absolute of the depop value instead. Without the abs, this function always flips a negative depop into a positive, which seems wrong, as well as doing negatives minus negatives and such. I'm not 100% sure on this one, but this seems more right, so please check this part.