### PR TITLE
Fix GetWritableRegion write-back

### DIFF
--- a/Ryujinx.Memory/IVirtualMemoryManager.cs
+++ b/Ryujinx.Memory/IVirtualMemoryManager.cs
@@ -66,7 +66,9 @@ namespace Ryujinx.Memory
             {
                 int copySize = (int)Math.Min(MaxChunkSize, size - subOffset);
 
-                GetWritableRegion(va + subOffset, copySize).Memory.Span.Fill(0);
+                using var writableRegion = GetWritableRegion(va + subOffset, copySize);
+
+                writableRegion.Memory.Span.Fill(0);
             }
         }
 

--- a/Ryujinx.Memory/MemoryBlock.cs
+++ b/Ryujinx.Memory/MemoryBlock.cs
@@ -333,7 +333,7 @@ namespace Ryujinx.Memory
         /// <exception cref="InvalidMemoryRegionException">Throw when either <paramref name="offset"/> or <paramref name="size"/> are out of range</exception>
         public WritableRegion GetWritableRegion(ulong offset, int size)
         {
-            return new WritableRegion(this, offset, GetMemory(offset, size));
+            return new WritableRegion(null, offset, GetMemory(offset, size));
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes issues pointed out by FICTURE7:
- `MemoryBlock` returned `WritableRegion` dispose method never needs to perform a write-back, as `MemoryBlock` regions are always contiguous.
- Added missing `using` on the IVirtualMemoryManager.Fill` method, before there was the possibility that the value was never written back to memory if the region was not contiguous.

Closes #2445