### PR TITLE
Fix virtual memory allocation being out of range

### DIFF
--- a/Ryujinx.HLE/HOS/Kernel/Memory/KPageTableBase.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Memory/KPageTableBase.cs
@@ -2411,8 +2411,10 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
             {
                 if (info.State == MemoryState.Unmapped)
                 {
-                    ulong currBaseAddr = info.Address + reservedSize;
+                    ulong currBaseAddr = info.Address <= regionStart ? regionStart : info.Address;
                     ulong currEndAddr = info.Address + info.Size - 1;
+
+                    currBaseAddr += reservedSize;
 
                     ulong address = BitUtils.AlignDown(currBaseAddr, alignment) + reservedStart;
 
@@ -2423,9 +2425,10 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
 
                     ulong allocationEndAddr = address + totalNeededSize - 1;
 
-                    if (allocationEndAddr <= regionEndAddr &&
-                        allocationEndAddr <= currEndAddr &&
-                        address < allocationEndAddr)
+                    if (info.Address <= address &&
+                        address < allocationEndAddr &&
+                        allocationEndAddr <= regionEndAddr &&
+                        allocationEndAddr <= currEndAddr)
                     {
                         return address;
                     }


### PR DESCRIPTION
This fixes a bug where virtual memory allocation could be out of range, as it was using the memory block address without enforcing it to be inside the requested range.

This fixes memory corruption that leads to crashes in some games that makes assumptions about the virtual memory, without first checking if it is in use. As far I can tell, only games using `MapPhysicalMemory`/`UnmapPhysicalMemory` are affected, but it could affect more too.

Fixes crash on boot on Disaster Report 4, now ingame (however suffers from typical UE4 texture corruption, so not playable).
![image](https://user-images.githubusercontent.com/5624669/125204347-312b0d00-e253-11eb-8787-5c4ef6a542fc.png)
Likely also affects other games, it's worth trying games that crashes very early on boot due to invalid memory region exceptions or aborts, especially if they are UE4 games.