### PR TITLE
Implement a fast path for I2M transfers

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Compute/ComputeClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Compute/ComputeClass.cs
@@ -69,6 +69,15 @@ namespace Ryujinx.Graphics.Gpu.Engine.Compute
         }
 
         /// <summary>
+        /// Pushes a block of data to the Inline-to-Memory engine.
+        /// </summary>
+        /// <param name="data">Data to push</param>
+        public void LoadInlineData(ReadOnlySpan<int> data)
+        {
+            _i2mClass.LoadInlineData(data);
+        }
+
+        /// <summary>
         /// Pushes a word of data to the Inline-to-Memory engine.
         /// </summary>
         /// <param name="argument">Method call argument</param>

--- a/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
@@ -128,6 +128,26 @@ namespace Ryujinx.Graphics.Gpu.Engine.InlineToMemory
         }
 
         /// <summary>
+        /// Pushes a block of data to the Inline-to-Memory engine.
+        /// </summary>
+        /// <param name="data">Data to push</param>
+        public void LoadInlineData(ReadOnlySpan<int> data)
+        {
+            if (!_finished)
+            {
+                int copySize = Math.Min(data.Length, _buffer.Length - _offset);
+                data.Slice(0, copySize).CopyTo(new Span<int>(_buffer).Slice(_offset, copySize));
+
+                _offset += copySize;
+
+                if (_offset * 4 >= _size)
+                {
+                    FinishTransfer();
+                }
+            }
+        }
+
+        /// <summary>
         /// Pushes a word of data to the Inline-to-Memory engine.
         /// </summary>
         /// <param name="argument">Method call argument</param>

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
@@ -184,6 +184,15 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         }
 
         /// <summary>
+        /// Pushes a block of data to the Inline-to-Memory engine.
+        /// </summary>
+        /// <param name="data">Data to push</param>
+        public void LoadInlineData(ReadOnlySpan<int> data)
+        {
+            _i2mClass.LoadInlineData(data);
+        }
+
+        /// <summary>
         /// Pushes a word of data to the Inline-to-Memory engine.
         /// </summary>
         /// <param name="argument">Method call argument</param>


### PR DESCRIPTION
This improves the performance of Inline-to-Memory engine data transfers by pusing all the data at once, instead of word by word. This is similar to the optimization that is done for constant buffer updates.

Mostly expected to affect Switch games using the OpenGL API as those use Inline-to-Memory a lot more. NVN only uses it to write the compute QMD structure afaik (which is small). Might reduce the loading times or stutters on said OpenGL games a little bit. I noticed that they have an issue where they simply pause for a few seconds sometimes though, and it doesn't seems to be a GPU related issue.