### PR TITLE
Fix shader compilation on shaders that uses rectangle textures

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -38,7 +38,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2439;
+        private const ulong ShaderCodeGenVersion = 2469;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Shader/IntermediateRepresentation/TextureOperation.cs
+++ b/Ryujinx.Graphics.Shader/IntermediateRepresentation/TextureOperation.cs
@@ -16,16 +16,29 @@ namespace Ryujinx.Graphics.Shader.IntermediateRepresentation
             SamplerType type,
             TextureFormat format,
             TextureFlags flags,
+            int cbufSlot,
             int handle,
             int compIndex,
             Operand dest,
-            params Operand[] sources) : base(inst, compIndex, dest, sources)
+            Operand[] sources) : base(inst, compIndex, dest, sources)
         {
             Type = type;
             Format = format;
             Flags = flags;
-            CbufSlot = DefaultCbufSlot;
+            CbufSlot = cbufSlot;
             Handle = handle;
+        }
+
+        public TextureOperation(
+            Instruction inst,
+            SamplerType type,
+            TextureFormat format,
+            TextureFlags flags,
+            int handle,
+            int compIndex,
+            Operand dest,
+            Operand[] sources) : this(inst, type, format, flags, DefaultCbufSlot, handle, compIndex, dest, sources)
+        {
         }
 
         public void TurnIntoIndexed(int handle)

--- a/Ryujinx.Graphics.Shader/Translation/Rewriter.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Rewriter.cs
@@ -291,6 +291,8 @@ namespace Ryujinx.Graphics.Shader.Translation
             // We normalize by dividing the coords by the texture size.
             if (isRect && !intCoords)
             {
+                config.SetUsedFeature(FeatureFlags.IntegerSampling);
+
                 for (int index = 0; index < coordsCount; index++)
                 {
                     Operand coordSize = Local();
@@ -311,10 +313,13 @@ namespace Ryujinx.Graphics.Shader.Translation
                         texOp.Type,
                         texOp.Format,
                         texOp.Flags,
+                        texOp.CbufSlot,
                         texOp.Handle,
                         index,
                         coordSize,
                         texSizeSources));
+
+                    config.SetUsedTexture(Instruction.TextureSize, texOp.Type, texOp.Format, texOp.Flags, texOp.CbufSlot, texOp.Handle);
 
                     Operand source = sources[coordsIndex + index];
 
@@ -352,6 +357,8 @@ namespace Ryujinx.Graphics.Shader.Translation
                 }
                 else
                 {
+                    config.SetUsedFeature(FeatureFlags.IntegerSampling);
+
                     Operand lod = Local();
 
                     node.List.AddBefore(node, new TextureOperation(
@@ -359,6 +366,7 @@ namespace Ryujinx.Graphics.Shader.Translation
                         texOp.Type,
                         texOp.Format,
                         texOp.Flags,
+                        texOp.CbufSlot,
                         texOp.Handle,
                         0,
                         lod,
@@ -384,10 +392,13 @@ namespace Ryujinx.Graphics.Shader.Translation
                             texOp.Type,
                             texOp.Format,
                             texOp.Flags,
+                            texOp.CbufSlot,
                             texOp.Handle,
                             index,
                             coordSize,
                             texSizeSources));
+
+                        config.SetUsedTexture(Instruction.TextureSize, texOp.Type, texOp.Format, texOp.Flags, texOp.CbufSlot, texOp.Handle);
 
                         Operand offset = Local();
 
@@ -420,6 +431,7 @@ namespace Ryujinx.Graphics.Shader.Translation
                 texOp.Type,
                 texOp.Format,
                 texOp.Flags & ~(TextureFlags.Offset | TextureFlags.Offsets),
+                texOp.CbufSlot,
                 texOp.Handle,
                 componentIndex,
                 texOp.Dest,


### PR DESCRIPTION
Fixes a regression introduced on #2441 where shaders using rectangle textures wouldn't have their `textureSize` used for the coordinates normalization operation flagged and wouldn't be able to get the texture scale. While I was at it, I also fixed a issue that I noticed where the constant buffer slot wouldn't be added to the new texture operations inserted on the rewrite pass, which could cause them to fail with bindless textures.

Fixes regression on The Touryst. One thing to note is that I found high memory usage when testing this title. I'm not sure if it's a leak, but as I have a low amount of RAM, this leads to graphical glitches and crashes. However I believe this is not a new issue, someone else reported high memory usage on this game too a while ago.

Closes #2469 