### PR TITLE
Support non-contiguous copies on I2M and DMA engines

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -152,14 +152,11 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                     dst.MemoryLayout.UnpackGobBlocksInZ(),
                     dstBpp);
 
-                ulong srcBaseAddress = memoryManager.Translate(srcGpuVa);
-                ulong dstBaseAddress = memoryManager.Translate(dstGpuVa);
-
                 (int srcBaseOffset, int srcSize) = srcCalculator.GetRectangleRange(src.RegionX, src.RegionY, xCount, yCount);
                 (int dstBaseOffset, int dstSize) = dstCalculator.GetRectangleRange(dst.RegionX, dst.RegionY, xCount, yCount);
 
-                ReadOnlySpan<byte> srcSpan = memoryManager.Physical.GetSpan(srcBaseAddress + (ulong)srcBaseOffset, srcSize, true);
-                Span<byte> dstSpan = memoryManager.Physical.GetSpan(dstBaseAddress + (ulong)dstBaseOffset, dstSize).ToArray();
+                ReadOnlySpan<byte> srcSpan = memoryManager.GetSpan(srcGpuVa + (ulong)srcBaseOffset, srcSize, true);
+                Span<byte> dstSpan = memoryManager.GetSpan(dstGpuVa + (ulong)dstBaseOffset, dstSize).ToArray();
 
                 bool completeSource = IsTextureCopyComplete(src, srcLinear, srcBpp, srcStride, xCount, yCount);
                 bool completeDest = IsTextureCopyComplete(dst, dstLinear, dstBpp, dstStride, xCount, yCount);
@@ -217,7 +214,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                     {
                         srcSpan.CopyTo(dstSpan); // No layout conversion has to be performed, just copy the data entirely.
 
-                        memoryManager.Physical.Write(dstBaseAddress + (ulong)dstBaseOffset, dstSpan);
+                        memoryManager.Write(dstGpuVa + (ulong)dstBaseOffset, dstSpan);
 
                         return;
                     }
@@ -258,7 +255,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                     _ => throw new NotSupportedException($"Unable to copy ${srcBpp} bpp pixel format.")
                 };
 
-                memoryManager.Physical.Write(dstBaseAddress + (ulong)dstBaseOffset, dstSpan);
+                memoryManager.Write(dstGpuVa + (ulong)dstBaseOffset, dstSpan);
             }
             else
             {

--- a/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -155,8 +155,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                 (int srcBaseOffset, int srcSize) = srcCalculator.GetRectangleRange(src.RegionX, src.RegionY, xCount, yCount);
                 (int dstBaseOffset, int dstSize) = dstCalculator.GetRectangleRange(dst.RegionX, dst.RegionY, xCount, yCount);
 
-                ReadOnlySpan<byte> srcSpan = memoryManager.GetSpan(srcGpuVa + (ulong)srcBaseOffset, srcSize, true);
-                Span<byte> dstSpan = memoryManager.GetSpan(dstGpuVa + (ulong)dstBaseOffset, dstSize).ToArray();
+                ReadOnlySpan<byte> srcSpan = memoryManager.GetSpan(srcGpuVa + (uint)srcBaseOffset, srcSize, true);
+                Span<byte> dstSpan = memoryManager.GetSpan(dstGpuVa + (uint)dstBaseOffset, dstSize).ToArray();
 
                 bool completeSource = IsTextureCopyComplete(src, srcLinear, srcBpp, srcStride, xCount, yCount);
                 bool completeDest = IsTextureCopyComplete(dst, dstLinear, dstBpp, dstStride, xCount, yCount);
@@ -214,7 +214,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                     {
                         srcSpan.CopyTo(dstSpan); // No layout conversion has to be performed, just copy the data entirely.
 
-                        memoryManager.Write(dstGpuVa + (ulong)dstBaseOffset, dstSpan);
+                        memoryManager.Write(dstGpuVa + (uint)dstBaseOffset, dstSpan);
 
                         return;
                     }

--- a/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -255,7 +255,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                     _ => throw new NotSupportedException($"Unable to copy ${srcBpp} bpp pixel format.")
                 };
 
-                memoryManager.Write(dstGpuVa + (ulong)dstBaseOffset, dstSpan);
+                memoryManager.Write(dstGpuVa + (uint)dstBaseOffset, dstSpan);
             }
             else
             {

--- a/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
@@ -173,9 +173,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.InlineToMemory
 
             if (_isLinear && _lineCount == 1)
             {
-                ulong address = _channel.MemoryManager.Translate(_dstGpuVa);
-
-                _channel.MemoryManager.Physical.Write(address, data);
+                _channel.MemoryManager.Write(_dstGpuVa, data);
             }
             else
             {
@@ -189,8 +187,6 @@ namespace Ryujinx.Graphics.Gpu.Engine.InlineToMemory
 
                 int srcOffset = 0;
 
-                ulong dstBaseAddress = _channel.MemoryManager.Translate(_dstGpuVa);
-
                 for (int y = _dstY; y < _dstY + _lineCount; y++)
                 {
                     int x1 = _dstX;
@@ -203,22 +199,22 @@ namespace Ryujinx.Graphics.Gpu.Engine.InlineToMemory
                     {
                         int dstOffset = dstCalculator.GetOffset(x, y);
 
-                        ulong dstAddress = dstBaseAddress + (ulong)dstOffset;
+                        ulong dstAddress = _dstGpuVa + (ulong)dstOffset;
 
                         Span<byte> pixel = data.Slice(srcOffset, 16);
 
-                        _channel.MemoryManager.Physical.Write(dstAddress, pixel);
+                        _channel.MemoryManager.Write(dstAddress, pixel);
                     }
 
                     for (; x < x2; x++, srcOffset++)
                     {
                         int dstOffset = dstCalculator.GetOffset(x, y);
 
-                        ulong dstAddress = dstBaseAddress + (ulong)dstOffset;
+                        ulong dstAddress = _dstGpuVa + (ulong)dstOffset;
 
                         Span<byte> pixel = data.Slice(srcOffset, 1);
 
-                        _channel.MemoryManager.Physical.Write(dstAddress, pixel);
+                        _channel.MemoryManager.Write(dstAddress, pixel);
                     }
                 }
             }

--- a/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
@@ -176,7 +176,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.InlineToMemory
 
             if (_isLinear && _lineCount == 1)
             {
-                _channel.MemoryManager.Write(_dstGpuVa, data);
+                memoryManager.Write(_dstGpuVa, data);
             }
             else
             {


### PR DESCRIPTION
Makes more copies respect non-contiguous GPU virtual memory regions, instead of assuming it is contiguous. After this, the main thing missing will be support for non-contiguous buffers, which will be more complicated, and will be done on a separate PR.

This also fixes a bug that I noticed on I2M, where the copy would be incorrect for block linear textures, if destination X was not a multiple of 16. This was fixed by aligning the start of the vector copy, which should start and end of a multiple of 16. I'm not aware of any games that uses it with a X value that is not a multiple of 16 though (it is usually 0), so maybe nothing was affected by this bug.