### PR TITLE
Do not require texture and sampler pools being initialized

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -1,3 +1,4 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Engine.Types;
 using Ryujinx.Graphics.Shader;
@@ -119,19 +120,24 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="samplerIndex">Type of the sampler pool indexing used for bound samplers</param>
         public void SetSamplerPool(ulong gpuVa, int maximumId, SamplerIndex samplerIndex)
         {
-            ulong address = _channel.MemoryManager.Translate(gpuVa);
-
-            if (_samplerPool != null)
+            if (gpuVa != 0)
             {
-                if (_samplerPool.Address == address && _samplerPool.MaximumId >= maximumId)
+                ulong address = _channel.MemoryManager.Translate(gpuVa);
+
+                if (_samplerPool != null && _samplerPool.Address == address && _samplerPool.MaximumId >= maximumId)
                 {
                     return;
                 }
 
-                _samplerPool.Dispose();
+                _samplerPool?.Dispose();
+                _samplerPool = new SamplerPool(_context, _channel.MemoryManager.Physical, address, maximumId);
+            }
+            else
+            {
+                _samplerPool?.Dispose();
+                _samplerPool = null;
             }
 
-            _samplerPool = new SamplerPool(_context, _channel.MemoryManager.Physical, address, maximumId);
             _samplerIndex = samplerIndex;
         }
 
@@ -142,10 +148,18 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="maximumId">Maximum ID of the pool (total count minus one)</param>
         public void SetTexturePool(ulong gpuVa, int maximumId)
         {
-            ulong address = _channel.MemoryManager.Translate(gpuVa);
+            if (gpuVa != 0)
+            {
+                ulong address = _channel.MemoryManager.Translate(gpuVa);
 
-            _texturePoolAddress   = address;
-            _texturePoolMaximumId = maximumId;
+                _texturePoolAddress = address;
+                _texturePoolMaximumId = maximumId;
+            }
+            else
+            {
+                _texturePoolAddress = 0;
+                _texturePoolMaximumId = 0;
+            }
         }
 
         /// <summary>
@@ -227,10 +241,11 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         public void CommitBindings()
         {
-            TexturePool texturePool = _texturePoolCache.FindOrCreate(
-                _channel,
-                _texturePoolAddress,
-                _texturePoolMaximumId);
+            ulong texturePoolAddress = _texturePoolAddress;
+
+            TexturePool texturePool = texturePoolAddress != 0
+                ? _texturePoolCache.FindOrCreate(_channel, texturePoolAddress, _texturePoolMaximumId)
+                : null;
 
             if (_isCompute)
             {
@@ -264,8 +279,22 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="stageIndex">The stage number of the specified shader stage</param>
         private void CommitTextureBindings(TexturePool pool, ShaderStage stage, int stageIndex)
         {
-            if (_textureBindings[stageIndex] == null)
+            if (_textureBindings[stageIndex] == null || _textureBindings[stageIndex].Length == 0)
             {
+                return;
+            }
+
+            var samplerPool = _samplerPool;
+
+            if (pool == null)
+            {
+                Logger.Error?.Print(LogClass.Gpu, $"Shader stage \"{stage}\" uses textures, but texture pool was not set.");
+                return;
+            }
+
+            if (samplerPool == null)
+            {
+                Logger.Error?.Print(LogClass.Gpu, $"Shader stage \"{stage}\" uses textures, but sampler pool was not set.");
                 return;
             }
 
@@ -324,7 +353,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     _channel.BufferManager.SetBufferTextureStorage(hostTexture, texture.Range.GetSubRange(0).Address, texture.Size, bindingInfo, bindingInfo.Format, false);
                 }
 
-                Sampler sampler = _samplerPool.Get(samplerId);
+                Sampler sampler = samplerPool.Get(samplerId);
 
                 ISampler hostSampler = sampler?.HostSampler;
 
@@ -348,6 +377,12 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             if (_imageBindings[stageIndex] == null)
             {
+                return;
+            }
+
+            if (pool == null && _imageBindings[stageIndex].Length != 0)
+            {
+                Logger.Error?.Print(LogClass.Gpu, $"Shader stage \"{stage}\" uses images, but texture pool was not set.");
                 return;
             }
 


### PR DESCRIPTION
If the shader does not use textures or images at all, then theres no need to initialize those pools. This fixes a `InvalidMemoryRegionException` that would happen on the emulator if there was a draw/compute dispatch without setting the pools address. This is handled by simply setting them to null if the GPU VA is 0. Additionally, if the shader does access textures and they are null, its prints an error to the log.

Fixes regression on https://github.com/Ryujinx/Ryujinx-Games-List/issues/1020 (unsure on which version it started).
Btw, no errors are logged on this game, so the shader where this used to happen is not accessing textures.