### PR TITLE
Close transfer memory properly on nvservices

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Nv/INvDrvServices.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/INvDrvServices.cs
@@ -314,7 +314,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv
         public ResultCode Initialize(ServiceCtx context)
         {
             long transferMemSize   = context.RequestData.ReadInt64();
-            int  transferMemHandle = context.Request.HandleDesc.ToCopy[0];
+            int  transferMemHandle = context.Request.HandleDesc.ToCopy[1];
 
             // TODO: When transfer memory will be implemented, this could be removed.
             _transferMemInitialized = true;
@@ -327,7 +327,8 @@ namespace Ryujinx.HLE.HOS.Services.Nv
 
             context.ResponseData.Write((uint)NvResult.Success);
 
-            // Close transfer memory immediately as we don't use it.
+            // Close the process and transfer memory handles immediately as we don't use them.
+            context.Device.System.KernelContext.Syscall.CloseHandle(clientHandle);
             context.Device.System.KernelContext.Syscall.CloseHandle(transferMemHandle);
 
             return ResultCode.Success;


### PR DESCRIPTION
Fixes an oversight where it was getting the transfer memory handle from the wrong location, leading to only the process handle being closed.

Fixes crash with some homebrew that initializes nvservices more than once, I'm not sure if games can do this, and I'm not aware of any game being affected by this change.