### PR TITLE
Ensure that DMA copy target textures are kept alive or flushed

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -816,6 +816,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 if (match)
                 {
+                    _cache.Lift(texture);
                     return texture;
                 }
             }


### PR DESCRIPTION
There is a bug where textures that are modified on the fast path of DMA copies might suffer from data loss, if the texture is deleted, because the data is never flushed. The fix here is adding the texture to the "auto delete cache", so that the data is eventually flushed when it falls out of the cache, and the texture is kept alive for longer, so even if it is removed from the texture pool, chances are that it will still exist on the next use (thus not even needing to flush and reload the data).

This fixes black portraits on Legend of Mana, might also fix the other graphical glitch that was reported.
Before:
![image](https://user-images.githubusercontent.com/5624669/125577063-7339ebf1-bd4c-461f-b76b-636ff5563e77.png)
After:
![image](https://user-images.githubusercontent.com/5624669/125577081-3726cd43-7349-46e8-979e-8b4bf7e527da.png)
Needs more testing to confirm that all instances of the bug where fixed.

It is worth nothing that images might have a similar issue. If a image is modified by a shader, but not accessed by the CPU, it will eventually have its data lost forever if it is removed from the pool. This change does not address this issue.
