### PR TITLE
Add Application Content Explorer

### DIFF
--- a/Ryujinx/Ryujinx.csproj
+++ b/Ryujinx/Ryujinx.csproj
@@ -86,6 +86,7 @@
     <None Remove="Ui\Widgets\ProfileDialog.glade" />
     <None Remove="Ui\Windows\ControllerWindow.glade" />
     <None Remove="Ui\Windows\DlcWindow.glade" />
+    <None Remove="Ui\Windows\AppExplorerWindow.glade" />
     <None Remove="Ui\Windows\SettingsWindow.glade" />
     <None Remove="Ui\Windows\TitleUpdateWindow.glade" />
     <None Remove="Modules\Updater\UpdateDialog.glade" />
@@ -111,6 +112,7 @@
     <EmbeddedResource Include="Ui\Widgets\ProfileDialog.glade" />
     <EmbeddedResource Include="Ui\Windows\ControllerWindow.glade" />
     <EmbeddedResource Include="Ui\Windows\DlcWindow.glade" />
+    <EmbeddedResource Include="Ui\Windows\AppExplorerWindow.glade" />
     <EmbeddedResource Include="Ui\Windows\SettingsWindow.glade" />
     <EmbeddedResource Include="Ui\Windows\TitleUpdateWindow.glade" />
     <EmbeddedResource Include="Modules\Updater\UpdateDialog.glade" />

--- a/Ryujinx/Ui/Widgets/GameTableContextMenu.Designer.cs
+++ b/Ryujinx/Ui/Widgets/GameTableContextMenu.Designer.cs
@@ -1,4 +1,6 @@
 ﻿using Gtk;
+using Ryujinx.Ui.Windows;
+using System;
 
 namespace Ryujinx.Ui.Widgets
 {
@@ -15,6 +17,7 @@ namespace Ryujinx.Ui.Widgets
         private MenuItem _extractRomFsMenuItem;
         private MenuItem _extractExeFsMenuItem;
         private MenuItem _extractLogoMenuItem;
+        private MenuItem _exploreMenuItem;
         private Menu     _manageSubMenu;
         private MenuItem _manageCacheMenuItem;
         private MenuItem _purgePtcCacheMenuItem;
@@ -119,6 +122,15 @@ namespace Ryujinx.Ui.Widgets
             _extractLogoMenuItem.Activated += ExtractLogo_Clicked;
 
             //
+            // _exploreMenuItem
+            //
+            _exploreMenuItem = new MenuItem("Expore Contents")
+            {
+                TooltipText = "Explore App Contents"
+            };
+            _exploreMenuItem.Activated += Explore_Clicked;
+
+            //
             // _manageSubMenu
             //
             _manageSubMenu = new Menu();
@@ -170,11 +182,17 @@ namespace Ryujinx.Ui.Widgets
             ShowComponent();
         }
 
+        private void Explore_Clicked(object sender, EventArgs e)
+        {
+            new AppExplorerWindow(_parent, _virtualFileSystem, _titleFilePath, _titleName, $"{_titleId:x16}").ShowAll();
+        }
+
         private void ShowComponent()
         {
             _extractSubMenu.Append(_extractExeFsMenuItem);
             _extractSubMenu.Append(_extractRomFsMenuItem);
             _extractSubMenu.Append(_extractLogoMenuItem);
+            _extractSubMenu.Append(_exploreMenuItem);
 
             _manageSubMenu.Append(_purgePtcCacheMenuItem);
             _manageSubMenu.Append(_purgeShaderCacheMenuItem);

--- a/Ryujinx/Ui/Widgets/GameTableContextMenu.Designer.cs
+++ b/Ryujinx/Ui/Widgets/GameTableContextMenu.Designer.cs
@@ -184,7 +184,10 @@ namespace Ryujinx.Ui.Widgets
 
         private void Explore_Clicked(object sender, EventArgs e)
         {
-            new AppExplorerWindow(_parent, _virtualFileSystem, _titleFilePath, _titleName, $"{_titleId:x16}").ShowAll();
+            var explorer = new AppExplorerWindow(_virtualFileSystem, _titleFilePath, _titleName, $"{_titleId:x16}");
+
+            explorer.Modal = true;
+            explorer.ShowAll();
         }
 
         private void ShowComponent()

--- a/Ryujinx/Ui/Windows/AppExplorerWindow.cs
+++ b/Ryujinx/Ui/Windows/AppExplorerWindow.cs
@@ -1,0 +1,1012 @@
+using Gtk;
+using LibHac;
+using LibHac.Common;
+using LibHac.Fs;
+using LibHac.Fs.Fsa;
+using LibHac.FsSystem;
+using LibHac.FsSystem.NcaUtils;
+using Ryujinx.HLE.FileSystem;
+using System;
+using System.IO;
+using System.Linq;
+
+using GUI = Gtk.Builder.ObjectAttribute;
+
+namespace Ryujinx.Ui.Windows
+{
+    public class AppExplorerWindow : Window
+    {
+        private readonly MainWindow _parent;
+        private Xci _xci;
+        private PartitionFileSystem _fs;
+        private string _appType = "";
+        private string _titleName;
+        private string _titleId;
+
+#pragma warning disable CS0649, IDE0044
+        [GUI] TreeView _explorerView;
+        [GUI] Label _nameLabel;
+        [GUI] Label _idLabel;
+        [GUI] Label _sizeLabel;
+        [GUI] Label _typeLabel;
+        [GUI] TreeSelection _explorerSelection;
+
+#pragma warning restore CS0649, IDE0044
+
+        public string AppPath { get; }
+
+        public VirtualFileSystem VirtualFileSystem { get; }
+
+        public AppExplorerWindow(MainWindow parent, VirtualFileSystem virtualFileSystem, string titlePath, string titleName, string titleId) : this(new Builder("Ryujinx.Ui.Windows.AppExplorerWindow.glade"), parent, virtualFileSystem, titlePath, titleName, titleId) { }
+
+        private AppExplorerWindow(Builder builder, MainWindow parent, VirtualFileSystem virtualFileSystem, string appPath, string titleName, string titleId) : base(builder.GetObject("_explorerWindow").Handle)
+        {
+            _parent = parent;
+            VirtualFileSystem = virtualFileSystem;
+            AppPath = appPath;
+            builder.Autoconnect(this);
+
+            _titleName = titleName;
+            _titleId = titleId;
+
+            _explorerView.AppendColumn("Name", new CellRendererText(), "text", 0);
+            _explorerView.AppendColumn("Size", new CellRendererText(), "text", 1);
+            _explorerView.AppendColumn("Path", new CellRendererText(), "text", 2);
+            _explorerView.AppendColumn("Type", new CellRendererText(), "text", 3);
+
+            _explorerView.Columns[2].Visible = false;
+            _explorerView.Columns[0].MinWidth = 250;
+
+            Title = $"Ryujinx - Exploring {titleName} Contents";
+
+            _nameLabel.Text = titleName;
+            _idLabel.Text = titleId;
+
+            _explorerView.RowExpanded += ExplorerView_RowExpanded;
+            _explorerView.ButtonReleaseEvent += ExplorerView_RowClicked;
+
+            LoadApp();
+        }
+
+        private void ExplorerView_RowClicked(object o, ButtonReleaseEventArgs args)
+        {
+            if (args.Event.Button != 3)
+            {
+                return;
+            }
+
+            _explorerSelection.GetSelected(out TreeIter treeIter);
+
+            if (treeIter.UserData == IntPtr.Zero)
+            {
+                return;
+            }
+
+            string type = _explorerView.Model.GetValue(treeIter, 3).ToString();
+
+            Menu menu = new Menu();
+
+            if(type == "Section" || type == "Partition" || type == "DIR")
+            {
+                MenuItem extractToMenuItem = new MenuItem("Extract To ...");
+
+                menu.Add(extractToMenuItem);
+
+                extractToMenuItem.Activated += ExtractToMenuItem_Activated;
+            }
+
+            if (type != "DIR" && type != "Partition")
+            {
+                MenuItem saveToMenuItem = new MenuItem("Save To ...");
+
+                menu.Add(saveToMenuItem);
+
+                saveToMenuItem.Activated += SaveToMenuItem_Activated;
+            }
+
+            if (menu.Children.Length > 0)
+            {
+                menu.ShowAll();
+
+                menu.PopupAtPointer(null);
+            }
+        }
+
+        private string GetSaveToPath(string title)
+        {
+            FileChooserDialog dialog = new FileChooserDialog(title, this, FileChooserAction.SelectFolder, "Cancel", ResponseType.Cancel, "Choose", ResponseType.Accept)
+            {
+                SelectMultiple = false,
+            };
+
+            try
+            {
+                if (dialog.Run() == (int)ResponseType.Accept)
+                {
+                    return dialog.Filename;
+                }
+            }
+            finally
+            {
+                dialog.Dispose();
+            }
+
+            return string.Empty;
+        }
+
+        private void SaveToMenuItem_Activated(object sender, EventArgs e)
+        {
+            _explorerSelection.GetSelected(out TreeIter treeIter);
+
+            string path = _explorerView.Model.GetValue(treeIter, 2).ToString();
+
+            string savePath = GetSaveToPath("Save To...");
+
+            string fileName = string.Empty;
+
+            FileStream destination;
+
+            if(!string.IsNullOrWhiteSpace(savePath) && Directory.Exists(savePath))
+            {
+                var levels = path.Split("/", StringSplitOptions.RemoveEmptyEntries);
+
+                switch (_appType)
+                {
+                    case "xci":
+                        var partitionType = Enum.Parse<XciPartitionType>(levels[0], true);
+                        if (_xci.HasPartition(partitionType))
+                        {
+                            var partition = _xci.OpenPartition(partitionType);
+
+                            fileName = levels[1];
+
+                            if (fileName.ToLower().EndsWith(".nca"))
+                            {
+                                if (partition.FileExists(fileName))
+                                {
+                                    var entry = partition.Files.ToList().Find(x => x.Name == fileName);
+
+                                    var ncaStorage = partition.OpenFile(entry, OpenMode.Read).AsStorage();
+
+                                    if (levels.Length == 2)
+                                    {
+                                        using (destination = File.OpenWrite(System.IO.Path.Combine(savePath, fileName)))
+                                        {
+                                            ncaStorage.CopyToStream(destination);
+                                        }
+
+                                        return;
+                                    }
+
+                                    var nca = new Nca(VirtualFileSystem.KeySet, ncaStorage);
+
+                                    var ncaSectionType = Enum.Parse<NcaSectionType>(levels[2], true);
+
+                                    if (levels.Length == 3)
+                                    {
+                                        if (nca.CanOpenSection(ncaSectionType))
+                                        {
+                                            var section = nca.OpenStorage(ncaSectionType, IntegrityCheckLevel.IgnoreOnInvalid);
+
+                                            savePath = System.IO.Path.Combine(savePath, fileName, ncaSectionType.ToString());
+
+                                            Directory.CreateDirectory(new FileInfo(savePath).DirectoryName);
+
+                                            using (destination = File.OpenWrite(savePath))
+                                            {
+                                                section.CopyToStream(destination);
+                                            }
+                                        }
+                                        return;
+                                    }
+                                    string relativePath = string.Join('/', levels.AsSpan().Slice(3).ToArray());
+
+                                    TransverseNca(nca, ncaSectionType, "/" + relativePath);
+                                }
+                            }
+                            else
+                            {
+                                savePath = System.IO.Path.Combine(savePath, fileName);
+
+                                Directory.CreateDirectory(new FileInfo(savePath).DirectoryName);
+
+                                using (destination = File.OpenWrite(savePath))
+                                {
+                                    if (partition.OpenFile(out var file, fileName.ToU8Span(), OpenMode.Read) == Result.Success)
+                                    {
+                                        file.AsStorage().CopyToStream(destination);
+                                    }
+                                }
+                            }
+                        }
+                        break;
+                    case "nsp":
+                        fileName = levels[0];
+                        if (fileName.ToLower().EndsWith(".nca"))
+                        {
+                            if (_fs.FileExists(fileName))
+                            {
+                                var entry = _fs.Files.ToList().Find(x => x.Name == fileName);
+
+                                var ncaStorage = _fs.OpenFile(entry, OpenMode.Read).AsStorage();
+
+                                if (levels.Length == 1)
+                                {
+                                    using (destination = File.OpenWrite(System.IO.Path.Combine(savePath, fileName)))
+                                    {
+                                        ncaStorage.CopyToStream(destination);
+                                    }
+
+                                    return;
+                                }
+
+                                var nca = new Nca(VirtualFileSystem.KeySet, ncaStorage);
+
+                                if (levels.Last() != fileName)
+                                {
+                                    var ncaSection = Enum.Parse<NcaSectionType>(levels[1], true);
+
+                                    string relativePath = string.Join('/', levels.AsSpan().Slice(2).ToArray());
+
+                                    TransverseNca(nca, ncaSection, "/" + relativePath);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            savePath = System.IO.Path.Combine(savePath, fileName);
+
+                            Directory.CreateDirectory(new FileInfo(savePath).DirectoryName);
+
+                            using (destination = File.OpenWrite(savePath))
+                            {
+                                if (_fs.OpenFile(out var file, fileName.ToU8Span(), OpenMode.Read) == Result.Success)
+                                {
+                                    file.AsStorage().CopyToStream(destination);
+                                }
+                            }
+                        }
+                        break;
+                }
+            }
+
+            void TransverseNca(Nca nca, NcaSectionType sectionType, string relativePath)
+            {
+                if (nca.CanOpenSection(sectionType))
+                {
+                    var section = nca.OpenFileSystem(sectionType, IntegrityCheckLevel.IgnoreOnInvalid);
+
+                    if (section != null)
+                    {
+                        if (section.FileExists("/" + relativePath))
+                        {
+                            if(section.OpenFile(out var file, relativePath.ToU8Span(), OpenMode.Read) == Result.Success)
+                            {
+                                savePath = System.IO.Path.Combine(savePath, new FileInfo(relativePath).Name);
+
+                                Directory.CreateDirectory(new FileInfo(savePath).DirectoryName);
+
+                                using (destination = File.OpenWrite(savePath))
+                                {
+                                    file.AsStorage().CopyToStream(destination);
+                                }
+                            }
+
+
+                        }
+                    }
+                }
+            }
+        }
+
+        private void ExtractToMenuItem_Activated(object sender, EventArgs e)
+        {
+            _explorerSelection.GetSelected(out TreeIter treeIter);
+
+            string path = _explorerView.Model.GetValue(treeIter, 2).ToString();
+
+            string savePath = GetSaveToPath("Extract To...");
+
+            string fileName = string.Empty;
+
+            if (!string.IsNullOrWhiteSpace(savePath) && Directory.Exists(savePath))
+            {
+                var levels = path.Split("/", StringSplitOptions.RemoveEmptyEntries);
+
+                switch (_appType)
+                {
+                    case "xci":
+                        var partitionType = Enum.Parse<XciPartitionType>(levels[0], true);
+                        if (_xci.HasPartition(partitionType))
+                        {
+                            var partition = _xci.OpenPartition(partitionType);
+
+                            if(levels.Length == 1)
+                            {
+                                savePath = System.IO.Path.Combine(savePath, partitionType.ToString());
+
+                                Directory.CreateDirectory(savePath);
+
+                                partition.Extract(savePath);
+
+                                return;
+                            }
+
+                            fileName = levels[1];
+
+                            if (fileName.ToLower().EndsWith(".nca"))
+                            {
+                                if (partition.FileExists(fileName))
+                                {
+                                    var entry = partition.Files.ToList().Find(x => x.Name == fileName);
+
+                                    var ncaStorage = partition.OpenFile(entry, OpenMode.Read).AsStorage();
+
+                                    var nca = new Nca(VirtualFileSystem.KeySet, ncaStorage);
+
+                                    var ncaSectionType = Enum.Parse<NcaSectionType>(levels[2], true);
+
+                                    if (levels.Length == 3)
+                                    {
+                                        if (nca.CanOpenSection(ncaSectionType))
+                                        {
+                                            var section = nca.OpenFileSystem(ncaSectionType, IntegrityCheckLevel.IgnoreOnInvalid);
+
+                                            savePath = System.IO.Path.Combine(savePath, ncaSectionType.ToString());
+
+                                            Directory.CreateDirectory(savePath);
+
+                                            section.Extract(savePath);
+                                        }
+                                        return;
+                                    }
+                                    string relativePath = string.Join('/', levels.AsSpan().Slice(3).ToArray());
+
+                                    TransverseNca(nca, ncaSectionType, "/" + relativePath);
+                                }
+                            }
+                        }
+                        break;
+                    case "nsp":
+                    if(levels.Length == 0)
+                    {
+                            _fs.Extract(savePath);
+
+                            return;
+                        }
+                        fileName = levels[0];
+                        if (fileName.ToLower().EndsWith(".nca"))
+                        {
+                            if (_fs.FileExists(fileName))
+                            {
+                                var entry = _fs.Files.ToList().Find(x => x.Name == fileName);
+
+                                var ncaStorage = _fs.OpenFile(entry, OpenMode.Read).AsStorage();
+
+                                var nca = new Nca(VirtualFileSystem.KeySet, ncaStorage);
+
+                                if (levels.Last() != fileName)
+                                {
+                                    var ncaSectionType = Enum.Parse<NcaSectionType>(levels[1], true);
+
+                                    if (levels.Length == 2)
+                                    {
+                                        if (nca.CanOpenSection(ncaSectionType))
+                                        {
+                                            var section = nca.OpenFileSystem(ncaSectionType, IntegrityCheckLevel.IgnoreOnInvalid);
+
+                                            savePath = System.IO.Path.Combine(savePath, ncaSectionType.ToString());
+
+                                            Directory.CreateDirectory(savePath);
+
+                                            section.Extract(savePath);
+                                        }
+                                        return;
+                                    }
+
+                                    string relativePath = string.Join('/', levels.AsSpan().Slice(2).ToArray());
+
+                                    TransverseNca(nca, ncaSectionType, "/" + relativePath);
+                                }
+                            }
+                        }
+                        break;
+                }
+            }
+
+            void TransverseNca(Nca nca, NcaSectionType sectionType, string relativePath)
+            {
+                if (nca.CanOpenSection(sectionType))
+                {
+                    var section = nca.OpenFileSystem(sectionType, IntegrityCheckLevel.IgnoreOnInvalid);
+
+                    if (section != null)
+                    {
+                        relativePath = "/" + relativePath;
+
+                        if (section.DirectoryExists(relativePath))
+                        {
+                            if (section.OpenDirectory(out var directory, relativePath.ToU8Span(), OpenDirectoryMode.All) == Result.Success)
+                            {
+                                savePath = System.IO.Path.Combine(savePath, new FileInfo(relativePath).Name);
+
+                                Directory.CreateDirectory(savePath);
+
+                                directory.GetEntryCount(out long count);
+
+                                var entries = new DirectoryEntry[count];
+                                long entriesRead = 0;
+                                do
+                                {
+                                    directory.Read(out entriesRead, entries.AsSpan());
+                                }
+                                while (entriesRead == 0);
+
+                                foreach (var directoryEntry in entries)
+                                {
+                                    string name = System.Text.Encoding.UTF8.GetString(directoryEntry.Name).TrimEnd('\0');
+
+                                    string fullPath = relativePath + "/" + name;
+
+                                    string extractionPath = System.IO.Path.Combine(savePath, name);
+
+                                    switch (directoryEntry.Type)
+                                    {
+                                        case DirectoryEntryType.File:
+                                            section.OpenFile(out var file, fullPath.ToU8Span(), OpenMode.Read);
+
+                                            Directory.CreateDirectory(new FileInfo(extractionPath).DirectoryName);
+
+                                            using(var stream = File.OpenWrite(extractionPath))
+                                            {
+                                                file.AsStorage().CopyToStream(stream);
+                                            }
+                                            break;
+                                        case DirectoryEntryType.Directory:
+                                            ExtractDirectory(extractionPath, fullPath);
+                                            break;
+                                    }
+                                }
+                            }
+                        }
+
+                        void ExtractDirectory(string path, string fsPath)
+                        {
+                            if (section.DirectoryExists(fsPath))
+                            {
+                                if (section.OpenDirectory(out var directory, fsPath.ToU8Span(), OpenDirectoryMode.All) == Result.Success)
+                                {
+                                    savePath = System.IO.Path.Combine(savePath, new FileInfo(fsPath).Name);
+
+                                    Directory.CreateDirectory(savePath);
+
+                                    directory.GetEntryCount(out long count);
+
+                                    var entries = new DirectoryEntry[count];
+                                    long entriesRead = 0;
+                                    do
+                                    {
+                                        directory.Read(out entriesRead, entries.AsSpan());
+                                    }
+                                    while (entriesRead == 0);
+
+                                    foreach (var directoryEntry in entries)
+                                    {
+                                        string name = System.Text.Encoding.UTF8.GetString(directoryEntry.Name).TrimEnd('\0');
+
+                                        string fullPath = fsPath + "/" + name;
+
+                                        string extractionPath = System.IO.Path.Combine(path, name);
+
+                                        switch (directoryEntry.Type)
+                                        {
+                                            case DirectoryEntryType.File:
+                                                section.OpenFile(out var file, fullPath.ToU8Span(), OpenMode.Read);
+
+                                                Directory.CreateDirectory(new FileInfo(extractionPath).DirectoryName);
+
+                                                using (var stream = File.OpenWrite(extractionPath))
+                                                {
+                                                    file.AsStorage().CopyToStream(stream);
+                                                }
+                                                break;
+                                            case DirectoryEntryType.Directory:
+                                                ExtractDirectory(extractionPath, fullPath);
+                                                break;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private void ExplorerView_RowExpanded(object o, RowExpandedArgs args)
+        {
+            var treeStore = _explorerView.Model as TreeStore;
+
+            if(treeStore.IterNChildren(args.Iter) == 1 && treeStore.IterChildren(out var child, args.Iter))
+            {
+                string path = (string)treeStore.GetValue(args.Iter, 2);
+                bool isPlaceHolder = (string)treeStore.GetValue(child, 0) == "[expand]";
+
+                if (isPlaceHolder)
+                {
+                    treeStore.Remove(ref child);
+
+                    TranverseAndExpand(args.Iter, path);
+
+                    _explorerView.ExpandToPath(treeStore.GetPath(args.Iter));
+                }
+            }
+        }
+
+        private void TranverseAndExpand(TreeIter parentIter, string path)
+        {
+            var levels = path.Split("/", StringSplitOptions.RemoveEmptyEntries);
+
+            string ncaName = string.Empty;
+
+            switch (_appType)
+            {
+                case "xci":
+                    var partitionType = Enum.Parse<XciPartitionType>(levels[0], true);
+                    if (_xci.HasPartition(partitionType))
+                    {
+                        var partition = _xci.OpenPartition(partitionType);
+
+                        ncaName = levels[1];
+
+                        if (ncaName.ToLower().EndsWith(".nca"))
+                        {
+                            if (partition.FileExists(ncaName))
+                            {
+                                var entry = partition.Files.ToList().Find(x => x.Name == ncaName);
+
+                                var nca = new Nca(VirtualFileSystem.KeySet, partition.OpenFile(entry, OpenMode.Read).AsStorage());
+
+                                if (levels.Last() != ncaName)
+                                {
+                                    var ncaSection = Enum.Parse<NcaSectionType>(levels[2], true);
+
+                                    string relativePath = string.Join('/', levels.AsSpan().Slice(3).ToArray());
+
+                                    TransverseNca(nca, ncaSection, "/" + relativePath);
+                                }
+                                else
+                                {
+                                    ExpandNca(parentIter, nca, path);
+                                }
+                            }
+                        }
+                    }
+                    break;
+                case "nsp":
+                    ncaName = levels[0];
+                    if (ncaName.ToLower().EndsWith(".nca"))
+                    {
+                        if (_fs.FileExists(ncaName))
+                        {
+                            var entry = _fs.Files.ToList().Find(x => x.Name == ncaName);
+
+                            var nca = new Nca(VirtualFileSystem.KeySet, _fs.OpenFile(entry, OpenMode.Read).AsStorage());
+
+                            if (levels.Last() != ncaName)
+                            {
+                                var ncaSection = Enum.Parse<NcaSectionType>(levels[1], true);
+
+                                string relativePath = string.Join('/', levels.AsSpan().Slice(2).ToArray());
+
+                                TransverseNca(nca, ncaSection, "/" + relativePath);
+                            }
+                            else
+                            {
+                                ExpandNca(parentIter, nca, path);
+                            }
+                        }
+                    }
+                    break;
+            }
+
+            void TransverseNca(Nca nca, NcaSectionType sectionType, string relativePath)
+            {
+                if(nca.CanOpenSection(sectionType))
+                {
+                    var section = nca.OpenFileSystem(sectionType, IntegrityCheckLevel.IgnoreOnInvalid);
+
+                    if (section != null)
+                    {
+                        if(section.DirectoryExists("/" + relativePath))
+                        {
+                            section.OpenDirectory(out var directory, relativePath.ToU8Span(), OpenDirectoryMode.All);
+
+                            ExpandDirectory(parentIter, directory, section, path, relativePath);
+                        }
+                    }
+                }
+            }
+        }
+
+        private void CloseButton_Clicked(object sender, EventArgs args)
+        {
+            Dispose();
+        }
+
+        private void LoadApp()
+        {
+            if (File.Exists(AppPath))
+            {
+                var fileInfo = new FileInfo(AppPath);
+
+                FileStream file = null;
+
+                TreeIter iter;
+
+                try
+                {
+                    ulong size = 0;
+                    switch (fileInfo.Extension.ToLower())
+                    {
+                        case ".xci":
+                            file = File.OpenRead(AppPath);
+                            _xci = new Xci(VirtualFileSystem.KeySet, file.AsStorage());
+
+                            foreach (var partitionType in Enum.GetValues<XciPartitionType>())
+                            {
+                                if (_xci.HasPartition(partitionType))
+                                {
+                                    var partition = _xci.OpenPartition(partitionType);
+
+                                    size = (ulong)partition.Files.Sum(x => x.Size);
+
+                                    iter = AddNode(TreeIter.Zero, partitionType.ToString(), partitionType.ToString(), size, "Partition");
+
+                                    foreach (var entry in partition.Files)
+                                    {
+                                        string path = partitionType.ToString() + "/" + entry.Name;
+
+                                        size = (ulong)entry.Size;
+
+                                        string name = entry.Name;
+
+                                        if (path.EndsWith(".nca"))
+                                        {
+                                            AddNca(iter, partition.OpenFile(entry, OpenMode.Read).AsStorage(), path, name);
+                                        }
+                                        else
+                                        {
+                                            AddNode(iter, name, path, size);
+                                        }
+                                    }
+                                }
+                            }
+
+                            _appType = "xci";
+                            break;
+                        case ".nsp":
+                        case ".pfs0":
+                            file = File.OpenRead(AppPath);
+                            _fs = new PartitionFileSystem(file.AsStorage());
+
+                            size = (ulong)_fs.Files.Sum(x => x.Size);
+
+                            iter = AddNode(TreeIter.Zero, "/", "/", size, "Partition");
+
+                            foreach (var entry in _fs.Files)
+                            {
+                                string path = "/" + entry.Name;
+
+                                size = (ulong)entry.Size;
+
+                                string name = entry.Name;
+
+                                if (path.EndsWith(".nca"))
+                                {
+                                    AddNca(iter, _fs.OpenFile(entry, OpenMode.Read).AsStorage(), path, name);
+                                }
+                                else if (_fs.DirectoryExists(path))
+                                {
+                                    iter = AddNode(iter, entry.Name, path, (ulong)entry.Size, "DIR");
+
+                                    ExpandDirectory(iter, entry, _fs, path, path);
+                                }
+                                else
+                                {
+                                    AddNode(iter, name, path, size);
+                                }
+                            }
+
+                            _appType = "nsp";
+                            break;
+                        default:
+                            break;
+                    }
+
+                    if (file != null)
+                    {
+                        _sizeLabel.Text = $"{file.Length} bytes";
+                        _typeLabel.Text = _appType.ToUpper();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Dispose();
+                }
+            }
+            else
+            {
+                Dispose();
+            }
+        }
+
+        private TreeIter AddNode(TreeIter parentIter, string name, string fullPath, ulong size, string dataType = "")
+        {
+            if(parentIter.Equals(TreeIter.Zero))
+            {
+                return (_explorerView.Model as TreeStore).AppendValues(name, size, fullPath, dataType);
+            }
+            else 
+            {
+               return (_explorerView.Model as TreeStore).AppendValues(parentIter, name, size, fullPath, dataType);
+            }
+        }
+
+        private TreeIter AddNca(TreeIter parentIter, IStorage storage, string path, string name)
+        {
+            Nca nca = new Nca(VirtualFileSystem.KeySet, storage);
+
+            TreeIter iter = TreeIter.Zero;
+
+            storage.GetSize(out var size);
+
+            iter = AddNode(parentIter, name, path, (ulong)size, nca.Header.ContentType.ToString());
+
+            ExpandNca(iter, nca, path);
+
+            return iter;
+        }
+
+        private void ExpandNca(TreeIter parentIter, Nca nca, string path)
+        {
+            foreach(var sectionType in Enum.GetValues<NcaSectionType>())
+            {
+                TreeIter iter = TreeIter.Zero;
+
+                long size = 0;
+
+                string contentPath = string.Empty;
+
+                if(nca.CanOpenSection(sectionType))
+                {
+                    contentPath = path + "/" + sectionType.ToString().ToUpper();
+
+                    var data = nca.OpenFileSystem(sectionType, IntegrityCheckLevel.IgnoreOnInvalid);
+
+                    if (data != null)
+                    {
+                        data.GetTotalSpaceSize(out size, "/".ToU8Span());
+
+                        iter = AddNode(parentIter, sectionType.ToString(), contentPath, (ulong)size, "Section");
+
+                        ExpandFilesystem(iter, data, contentPath);
+                    }
+                }
+            }
+        }
+
+        private void ExpandFilesystem(TreeIter parentIter, IFileSystem fileSystem, string path, bool recursive = false)
+        {
+            foreach(var entry in fileSystem.EnumerateEntries("*", SearchOptions.Default))
+            {
+                TreeIter iter = TreeIter.Zero;
+                string entryPath = $"{path}/{entry.Name}";
+                switch(entry.Type)
+                {
+                    case DirectoryEntryType.File:
+                        fileSystem.OpenFile(out var file, entry.FullPath.ToU8Span(), OpenMode.Read);
+                        file.GetSize(out var size);
+                        iter = AddNode(parentIter, entry.Name, entryPath, (ulong)size, "");
+                        break;
+                    case DirectoryEntryType.Directory:
+                        iter = AddNode(parentIter, entry.Name, entryPath, (ulong)entry.Size, "DIR");
+                        if (recursive)
+                        {
+                            ExpandDirectory(iter, entry, fileSystem, entryPath);
+                        }
+                        else
+                        {
+                            iter = AddNode(iter, "[expand]", entryPath, 0, "");
+                        }
+                        break;
+                }
+            }
+        }
+
+        private void ExpandDirectory(TreeIter parentIter, DirectoryEntryEx entry, IFileSystem fileSystem, string path, bool recursive = false)
+        {
+            if(fileSystem.OpenDirectory(out var directory, entry.FullPath.ToU8Span(), OpenDirectoryMode.All) == Result.Success)
+            {
+                if (directory.GetEntryCount(out var count) == Result.Success)
+                {
+                    var entries = new DirectoryEntry[count];
+                    long entriesRead = 0;
+                    do
+                    {
+                        directory.Read(out entriesRead, entries.AsSpan());
+                    }
+                    while (entriesRead == 0);
+
+                    foreach (var directoryEntry in entries)
+                    {
+                        string name = System.Text.Encoding.UTF8.GetString(directoryEntry.Name).TrimEnd('\0');
+                        string fullPath = entry.FullPath + "/" + name;
+
+                        TreeIter iter = TreeIter.Zero;
+                        string entryPath = $"{path}/{name}";
+                        switch (directoryEntry.Type)
+                        {
+                            case DirectoryEntryType.File:
+                                fileSystem.OpenFile(out var file, fullPath.ToU8Span(), OpenMode.Read);
+                                file.GetSize(out var size);
+                                iter = AddNode(parentIter, name, entryPath, (ulong)size, "");
+                                break;
+                            case DirectoryEntryType.Directory:
+                                iter = AddNode(parentIter, name, entryPath, (ulong)directoryEntry.Size, "DIR");
+                                if (recursive)
+                                {
+                                    ExpandDirectory(iter, directoryEntry, fileSystem, entryPath, fullPath);
+                                }
+                                else
+                                {
+                                    iter = AddNode(iter, "[expand]", entryPath, 0, "");
+                                }
+                                break;
+                        }
+                    }
+                }
+            }
+        }
+
+        private void ExpandDirectory(TreeIter parentIter, DirectoryEntry entry, IFileSystem fileSystem, string path, string fsPath, bool recursive = false)
+        {
+            if (fileSystem.OpenDirectory(out var directory, fsPath.ToU8Span(), OpenDirectoryMode.All) == Result.Success)
+            {
+                if (directory.GetEntryCount(out var count) == Result.Success)
+                {
+                    var entries = new DirectoryEntry[count];
+                    long entriesRead = 0;
+                    do
+                    {
+                        directory.Read(out entriesRead, entries.AsSpan());
+                    }
+                    while (entriesRead == 0);
+
+                    foreach (var directoryEntry in entries)
+                    {
+                        string name = System.Text.Encoding.UTF8.GetString(directoryEntry.Name).TrimEnd('\0');
+                        string fullPath = fsPath + "/" + name;
+
+                        TreeIter iter = TreeIter.Zero;
+                        string entryPath = $"{path}/{name}";
+                        switch (directoryEntry.Type)
+                        {
+                            case DirectoryEntryType.File:
+                                fileSystem.OpenFile(out var file, fullPath.ToU8Span(), OpenMode.Read);
+                                file.GetSize(out var size);
+                                iter = AddNode(parentIter, name, entryPath, (ulong)size, "");
+                                break;
+                            case DirectoryEntryType.Directory:
+                                iter = AddNode(parentIter, name, entryPath, (ulong)entry.Size, "DIR");
+                                if (recursive)
+                                {
+                                    ExpandDirectory(iter, directoryEntry, fileSystem, entryPath, fullPath);
+                                }
+                                else
+                                {
+                                    iter = AddNode(iter, "[expand]", entryPath, 0, "");
+                                }
+                                break;
+                        }
+                    }
+                }
+            }
+        }
+
+        private void ExpandDirectory(TreeIter parentIter, IDirectory directory, IFileSystem fileSystem, string path, string fsPath, bool recursive = false)
+        {
+            if (directory.GetEntryCount(out var count) == Result.Success)
+            {
+                var entries = new DirectoryEntry[count];
+                long entriesRead = 0;
+                do
+                {
+                    directory.Read(out entriesRead, entries.AsSpan());
+                }
+                while (entriesRead == 0);
+
+                foreach (var directoryEntry in entries)
+                {
+                    string name = System.Text.Encoding.UTF8.GetString(directoryEntry.Name).TrimEnd('\0');
+                    string fullPath = fsPath + "/" + name;
+
+                    TreeIter iter = TreeIter.Zero;
+                    string entryPath = $"{path}/{name}";
+                    switch (directoryEntry.Type)
+                    {
+                        case DirectoryEntryType.File:
+                            fileSystem.OpenFile(out var file, fullPath.ToU8Span(), OpenMode.Read);
+                            file.GetSize(out var size);
+                            iter = AddNode(parentIter, name, entryPath, (ulong)size, "");
+                            break;
+                        case DirectoryEntryType.Directory:
+                            iter = AddNode(parentIter, name, entryPath, 0, "DIR");
+                            if (recursive)
+                            {
+                                ExpandDirectory(iter, directoryEntry, fileSystem, entryPath, fullPath);
+                            }
+                            else
+                            {
+                                iter = AddNode(iter, "[expand]", entryPath, 0, "");
+                            }
+                            break;
+                    }
+                }
+            }
+        }
+
+        private void ExpandDirectory(TreeIter parentIter, PartitionFileEntry entry, IFileSystem fileSystem, string path, string fsPath,bool recursive = false)
+        {
+            if (fileSystem.OpenDirectory(out var directory, fsPath.ToU8Span(), OpenDirectoryMode.All) == Result.Success)
+            {
+                if (directory.GetEntryCount(out var count) == Result.Success)
+                {
+                    var entries = new DirectoryEntry[count];
+                    long entriesRead = 0;
+                    do
+                    {
+                        directory.Read(out entriesRead, entries.AsSpan());
+                    }
+                    while (entriesRead == 0);
+
+                    foreach (var directoryEntry in entries)
+                    {
+                        string name = System.Text.Encoding.UTF8.GetString(directoryEntry.Name).TrimEnd('\0');
+                        string fullPath = fsPath + "/" + name;
+
+                        TreeIter iter = TreeIter.Zero;
+                        string entryPath = $"{path}/{name}";
+                        switch (directoryEntry.Type)
+                        {
+                            case DirectoryEntryType.File:
+                                fileSystem.OpenFile(out var file, fullPath.ToU8Span(), OpenMode.Read);
+                                file.GetSize(out var size);
+                                iter = AddNode(parentIter, name, entryPath, (ulong)size, "");
+                                break;
+                            case DirectoryEntryType.Directory:
+                                iter = AddNode(parentIter, name, entryPath, (ulong)entry.Size, "DIR");
+                                if (recursive)
+                                {
+                                    ExpandDirectory(iter, directoryEntry, fileSystem, entryPath, fullPath);
+                                }
+                                else
+                                {
+                                    iter = AddNode(iter, "[expand]", entryPath, 0, "");
+                                }
+                                break;
+                        }
+                    }
+                }
+            }
+        }
+
+        protected override void OnDestroyed()
+        {
+            _xci = null;
+            _fs = null;
+
+            base.OnDestroyed();
+        }
+    }
+}

--- a/Ryujinx/Ui/Windows/AppExplorerWindow.glade
+++ b/Ryujinx/Ui/Windows/AppExplorerWindow.glade
@@ -1,0 +1,250 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
+<interface>
+  <requires lib="gtk+" version="3.24"/>
+  <object class="GtkTreeStore" id="_explorerModel">
+    <columns>
+      <!-- column-name Name -->
+      <column type="gchararray"/>
+      <!-- column-name Size -->
+      <column type="guint64"/>
+      <!-- column-name Path -->
+      <column type="gchararray"/>
+      <!-- column-name gchararray1 -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
+  <object class="GtkWindow" id="_explorerWindow">
+    <property name="width-request">640</property>
+    <property name="height-request">680</property>
+    <property name="can-focus">False</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="margin-start">5</property>
+        <property name="margin-end">5</property>
+        <property name="margin-top">5</property>
+        <property name="margin-bottom">5</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">10</property>
+        <child>
+          <object class="GtkScrolledWindow">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="shadow-type">in</property>
+            <child>
+              <object class="GtkTreeView" id="_explorerView">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="margin-start">5</property>
+                <property name="margin-end">5</property>
+                <property name="margin-top">5</property>
+                <property name="margin-bottom">5</property>
+                <property name="model">_explorerModel</property>
+                <child internal-child="selection">
+                  <object class="GtkTreeSelection" id="_explorerSelection"/>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="margin-start">5</property>
+            <property name="margin-end">5</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">5</property>
+            <property name="homogeneous">True</property>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="margin-end">52</property>
+                    <property name="label" translatable="yes">Name</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="_nameLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="margin-right">50</property>
+                    <property name="margin-end">51</property>
+                    <property name="label" translatable="yes">TitleId</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="_idLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="margin-right">50</property>
+                    <property name="margin-end">63</property>
+                    <property name="label" translatable="yes">Size</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="_sizeLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="margin-right">50</property>
+                    <property name="margin-end">58</property>
+                    <property name="label" translatable="yes">Type</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="_typeLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <child>
+              <object class="GtkButton" id="_closeButton">
+                <property name="label" translatable="yes">Close</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <signal name="clicked" handler="CloseButton_Clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="pack-type">end</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack-type">end</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/Ryujinx/Ui/Windows/AppExplorerWindow.glade
+++ b/Ryujinx/Ui/Windows/AppExplorerWindow.glade
@@ -10,14 +10,18 @@
       <column type="guint64"/>
       <!-- column-name Path -->
       <column type="gchararray"/>
-      <!-- column-name gchararray1 -->
+      <!-- column-name Type -->
+      <column type="gchararray"/>
+      <!-- column-name Title Id -->
       <column type="gchararray"/>
     </columns>
   </object>
   <object class="GtkWindow" id="_explorerWindow">
-    <property name="width-request">640</property>
+    <property name="width-request">900</property>
     <property name="height-request">680</property>
     <property name="can-focus">False</property>
+    <property name="window-position">center-on-parent</property>
+    <property name="type-hint">dialog</property>
     <child>
       <object class="GtkBox">
         <property name="visible">True</property>
@@ -28,6 +32,47 @@
         <property name="margin-bottom">5</property>
         <property name="orientation">vertical</property>
         <property name="spacing">10</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="margin-start">10</property>
+            <property name="margin-end">10</property>
+            <property name="spacing">10</property>
+            <property name="baseline-position">top</property>
+            <child>
+              <object class="GtkEntry" id="_searchEntry">
+                <property name="width-request">200</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="pack-type">end</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Search </property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="pack-type">end</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
         <child>
           <object class="GtkScrolledWindow">
             <property name="visible">True</property>
@@ -51,7 +96,7 @@
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">0</property>
+            <property name="position">1</property>
           </packing>
         </child>
         <child>
@@ -210,11 +255,33 @@
                 <property name="position">3</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkProgressBar" id="_progressBar">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">4</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="_progressLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">5</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
         <child>
@@ -241,7 +308,7 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="pack-type">end</property>
-            <property name="position">2</property>
+            <property name="position">3</property>
           </packing>
         </child>
       </object>

--- a/Ryujinx/Ui/Windows/DlcWindow.cs
+++ b/Ryujinx/Ui/Windows/DlcWindow.cs
@@ -183,6 +183,32 @@ namespace Ryujinx.Ui.Windows
                 }
             }
         }
+
+        private void ExploreButton_Clicked(object sender, EventArgs args)
+        {
+            if (_dlcTreeSelection.GetSelected(out ITreeModel treeModel, out TreeIter treeIter))
+            {
+                string path;
+
+                if (_dlcTreeView.Model.IterParent(out TreeIter parentIter, treeIter))
+                {
+                    path = (string)_dlcTreeView.Model.GetValue(parentIter, 2);
+                }
+                else
+                {
+                    path = (string)_dlcTreeView.Model.GetValue(treeIter, 2);
+                }
+
+                if(path.ToLower().EndsWith(".nsp"))
+                {
+                    var explorer = new AppExplorerWindow(_virtualFileSystem, path, "DLC", "");
+
+                    explorer.Modal = true;
+
+                    explorer.ShowAll();
+                }
+            }
+        }
         
         private void RemoveAllButton_Clicked(object sender, EventArgs args)
         {

--- a/Ryujinx/Ui/Windows/DlcWindow.glade
+++ b/Ryujinx/Ui/Windows/DlcWindow.glade
@@ -1,32 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.36.0 -->
+<!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkWindow" id="_dlcWindow">
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="title" translatable="yes">Ryujinx - DLC Manager</property>
     <property name="modal">True</property>
-    <property name="window_position">center</property>
-    <property name="default_width">550</property>
-    <property name="default_height">350</property>
+    <property name="window-position">center</property>
+    <property name="default-width">550</property>
+    <property name="default-height">350</property>
     <child>
       <object class="GtkBox" id="MainBox">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkBox" id="DlcBox">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkLabel" id="_baseTitleInfoLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">10</property>
-                <property name="margin_right">10</property>
-                <property name="margin_top">10</property>
-                <property name="margin_bottom">10</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">10</property>
+                <property name="margin-right">10</property>
+                <property name="margin-top">10</property>
+                <property name="margin-bottom">10</property>
                 <property name="label" translatable="yes">Available DLC</property>
               </object>
               <packing>
@@ -38,19 +38,19 @@
             <child>
               <object class="GtkScrolledWindow">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="margin_left">10</property>
-                <property name="margin_right">10</property>
-                <property name="shadow_type">in</property>
+                <property name="can-focus">True</property>
+                <property name="margin-left">10</property>
+                <property name="margin-right">10</property>
+                <property name="shadow-type">in</property>
                 <child>
                   <object class="GtkViewport">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <child>
                       <object class="GtkTreeView" id="_dlcTreeView">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="headers_clickable">False</property>
+                        <property name="can-focus">True</property>
+                        <property name="headers-clickable">False</property>
                         <child internal-child="selection">
                           <object class="GtkTreeSelection" id="_dlcTreeSelection"/>
                         </child>
@@ -75,22 +75,22 @@
         <child>
           <object class="GtkBox">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <child>
               <object class="GtkButtonBox">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_top">10</property>
-                <property name="margin_bottom">10</property>
-                <property name="layout_style">start</property>
+                <property name="can-focus">False</property>
+                <property name="margin-top">10</property>
+                <property name="margin-bottom">10</property>
+                <property name="layout-style">start</property>
                 <child>
                   <object class="GtkButton" id="_addUpdate">
                     <property name="label" translatable="yes">Add</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="tooltip_text" translatable="yes">Adds an update to this list</property>
-                    <property name="margin_left">10</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="tooltip-text" translatable="yes">Adds an update to this list</property>
+                    <property name="margin-left">10</property>
                     <signal name="clicked" handler="AddButton_Clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -100,14 +100,13 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkButton" id="_removeUpdate">
-                    <property name="label" translatable="yes">Remove</property>
+                  <object class="GtkButton" id="_exploreButton">
+                    <property name="label" translatable="yes">Explore</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="tooltip_text" translatable="yes">Removes the selected update</property>
-                    <property name="margin_left">10</property>
-                    <signal name="clicked" handler="RemoveButton_Clicked" swapped="no"/>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="margin-start">10</property>
+                    <signal name="clicked" handler="ExploreButton_Clicked" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">True</property>
@@ -116,19 +115,35 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkButton" id="_removeAllButton">
-                    <property name="label" translatable="yes">Remove All</property>
+                  <object class="GtkButton" id="_removeUpdate">
+                    <property name="label" translatable="yes">Remove</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="tooltip_text" translatable="yes">Removes the selected update</property>
-                    <property name="margin_left">10</property>
-                    <signal name="clicked" handler="RemoveAllButton_Clicked" swapped="no"/>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="tooltip-text" translatable="yes">Removes the selected update</property>
+                    <property name="margin-start">10</property>
+                    <signal name="clicked" handler="RemoveButton_Clicked" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
                     <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="_removeAllButton">
+                    <property name="label" translatable="yes">Remove All</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="tooltip-text" translatable="yes">Removes the selected update</property>
+                    <property name="margin-left">10</property>
+                    <signal name="clicked" handler="RemoveAllButton_Clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
                   </packing>
                 </child>
               </object>
@@ -141,19 +156,19 @@
             <child>
               <object class="GtkButtonBox">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_top">10</property>
-                <property name="margin_bottom">10</property>
-                <property name="layout_style">end</property>
+                <property name="can-focus">False</property>
+                <property name="margin-top">10</property>
+                <property name="margin-bottom">10</property>
+                <property name="layout-style">end</property>
                 <child>
                   <object class="GtkButton" id="_saveButton">
                     <property name="label" translatable="yes">Save</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="margin_right">10</property>
-                    <property name="margin_top">2</property>
-                    <property name="margin_bottom">2</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="margin-right">10</property>
+                    <property name="margin-top">2</property>
+                    <property name="margin-bottom">2</property>
                     <signal name="clicked" handler="SaveButton_Clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -166,11 +181,11 @@
                   <object class="GtkButton" id="_cancelButton">
                     <property name="label" translatable="yes">Cancel</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="margin_right">10</property>
-                    <property name="margin_top">2</property>
-                    <property name="margin_bottom">2</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="margin-right">10</property>
+                    <property name="margin-top">2</property>
+                    <property name="margin-bottom">2</property>
                     <signal name="clicked" handler="CancelButton_Clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -194,9 +209,6 @@
           </packing>
         </child>
       </object>
-    </child>
-    <child type="titlebar">
-      <placeholder/>
     </child>
   </object>
 </interface>

--- a/Ryujinx/Ui/Windows/TitleUpdateWindow.glade
+++ b/Ryujinx/Ui/Windows/TitleUpdateWindow.glade
@@ -1,32 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.36.0 -->
+<!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkWindow" id="_titleUpdateWindow">
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="title" translatable="yes">Ryujinx - Title Update Manager</property>
     <property name="modal">True</property>
-    <property name="window_position">center</property>
-    <property name="default_width">550</property>
-    <property name="default_height">250</property>
+    <property name="window-position">center</property>
+    <property name="default-width">550</property>
+    <property name="default-height">250</property>
     <child>
       <object class="GtkBox" id="MainBox">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkBox" id="UpdatesBox">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkLabel" id="_baseTitleInfoLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">10</property>
-                <property name="margin_right">10</property>
-                <property name="margin_top">10</property>
-                <property name="margin_bottom">10</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">10</property>
+                <property name="margin-right">10</property>
+                <property name="margin-top">10</property>
+                <property name="margin-bottom">10</property>
                 <property name="label" translatable="yes">Available Updates</property>
               </object>
               <packing>
@@ -38,27 +38,27 @@
             <child>
               <object class="GtkScrolledWindow">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="margin_left">10</property>
-                <property name="margin_right">10</property>
-                <property name="shadow_type">in</property>
+                <property name="can-focus">True</property>
+                <property name="margin-left">10</property>
+                <property name="margin-right">10</property>
+                <property name="shadow-type">in</property>
                 <child>
                   <object class="GtkViewport">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <child>
                       <object class="GtkBox" id="_availableUpdatesBox">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="orientation">vertical</property>
                         <child>
                           <object class="GtkRadioButton" id="_noUpdateRadioButton">
                             <property name="label" translatable="yes">No Update</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
                             <property name="active">True</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="draw-indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -87,22 +87,22 @@
         <child>
           <object class="GtkBox">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <child>
               <object class="GtkButtonBox">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_top">10</property>
-                <property name="margin_bottom">10</property>
-                <property name="layout_style">start</property>
+                <property name="can-focus">False</property>
+                <property name="margin-top">10</property>
+                <property name="margin-bottom">10</property>
+                <property name="layout-style">start</property>
                 <child>
                   <object class="GtkButton" id="_addUpdate">
                     <property name="label" translatable="yes">Add</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="tooltip_text" translatable="yes">Adds an update to this list</property>
-                    <property name="margin_left">10</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="tooltip-text" translatable="yes">Adds an update to this list</property>
+                    <property name="margin-left">10</property>
                     <signal name="clicked" handler="AddButton_Clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -112,35 +112,38 @@
                   </packing>
                 </child>
                 <child>
+                  <placeholder/>
+                </child>
+                <child>
                   <object class="GtkButton" id="_removeUpdate">
                     <property name="label" translatable="yes">Remove</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="tooltip_text" translatable="yes">Removes the selected update</property>
-                    <property name="margin_left">10</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="tooltip-text" translatable="yes">Removes the selected update</property>
+                    <property name="margin-left">10</property>
                     <signal name="clicked" handler="RemoveButton_Clicked" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
-                    <property name="position">1</property>
+                    <property name="position">2</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkButton" id="_removeAllButton">
                     <property name="label" translatable="yes">Remove All</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="tooltip_text" translatable="yes">Removes the selected update</property>
-                    <property name="margin_left">10</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="tooltip-text" translatable="yes">Removes the selected update</property>
+                    <property name="margin-left">10</property>
                     <signal name="clicked" handler="RemoveAllButton_Clicked" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
-                    <property name="position">2</property>
+                    <property name="position">3</property>
                   </packing>
                 </child>
               </object>
@@ -153,19 +156,19 @@
             <child>
               <object class="GtkButtonBox">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_top">10</property>
-                <property name="margin_bottom">10</property>
-                <property name="layout_style">end</property>
+                <property name="can-focus">False</property>
+                <property name="margin-top">10</property>
+                <property name="margin-bottom">10</property>
+                <property name="layout-style">end</property>
                 <child>
                   <object class="GtkButton" id="_saveButton">
                     <property name="label" translatable="yes">Save</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="margin_right">10</property>
-                    <property name="margin_top">2</property>
-                    <property name="margin_bottom">2</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="margin-right">10</property>
+                    <property name="margin-top">2</property>
+                    <property name="margin-bottom">2</property>
                     <signal name="clicked" handler="SaveButton_Clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -178,11 +181,11 @@
                   <object class="GtkButton" id="_cancelButton">
                     <property name="label" translatable="yes">Cancel</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">True</property>
-                    <property name="margin_right">10</property>
-                    <property name="margin_top">2</property>
-                    <property name="margin_bottom">2</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="margin-right">10</property>
+                    <property name="margin-top">2</property>
+                    <property name="margin-bottom">2</property>
                     <signal name="clicked" handler="CancelButton_Clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -206,9 +209,6 @@
           </packing>
         </child>
       </object>
-    </child>
-    <child type="titlebar">
-      <placeholder/>
     </child>
   </object>
 </interface>


### PR DESCRIPTION
Adds a content explorer to game files in the game list, specifically nsp and xci files. This allows viewing the content of the game's filesystems, including xci partitions, filesystems, archives like nca, etc. It also supports extracting filesystems and saving binary or blocks to the local filesystem. Extraction is found in the context menu after selecting an applicable item.
The feature can be found in the Extract Data submenu in the game list context menu, or using the Explore button in the dlc window if you want to view the contents of a dlc archive.
![Screenshot from 2021-07-15 08-55-44](https://user-images.githubusercontent.com/5307160/125760809-20253c85-fcd2-41fc-8645-6b4ac94e2b5b.png)
