### PR TITLE
Ensure right joycon motion data is set

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Hid/HidDevices/NpadDevices.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/HidDevices/NpadDevices.cs
@@ -569,7 +569,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
                 UpdateUnusedSixInputIfNotEqual(ref lifo, ref currentNpad.JoyRightSixAxisSensor);
             }
 
-            if (!needUpdateRight)
+            if (!needUpdateRight && !isRightPair)
             {
                 SixAxisSensorState emptyState = new SixAxisSensorState();
 

--- a/Ryujinx.Input/HLE/NpadController.cs
+++ b/Ryujinx.Input/HLE/NpadController.cs
@@ -302,6 +302,11 @@ namespace Ryujinx.Input.HLE
                             gyroscope = new Vector3(gyroscope.X, gyroscope.Z, gyroscope.Y);
 
                             _mainMotionInput.Update(accelerometer, gyroscope, (ulong)PerformanceCounter.ElapsedNanoseconds / 1000, controllerConfig.Motion.Sensitivity, (float)controllerConfig.Motion.GyroDeadzone);
+
+                            if (controllerConfig.ControllerType == ConfigControllerType.JoyconPair)
+                            {
+                                _secondaryMotionInput = _mainMotionInput;
+                            }
                         }
                     }
                     else if (controllerConfig.Motion.MotionBackend == MotionInputBackendType.CemuHook && controllerConfig.Motion is CemuHookMotionConfigController cemuControllerConfig)
@@ -311,9 +316,8 @@ namespace Ryujinx.Input.HLE
                         // First of all ensure we are registered
                         _cemuHookClient.RegisterClient(clientId, cemuControllerConfig.DsuServerHost, cemuControllerConfig.DsuServerPort);
 
-                        // Then request and retrive the data
+                        // Then request and retrieve the data
                         _cemuHookClient.RequestData(clientId, cemuControllerConfig.Slot);
-
                         _cemuHookClient.TryGetData(clientId, cemuControllerConfig.Slot, out _mainMotionInput);
 
                         if (controllerConfig.ControllerType == ConfigControllerType.JoyconPair)

--- a/Ryujinx.Input/HLE/NpadManager.cs
+++ b/Ryujinx.Input/HLE/NpadManager.cs
@@ -1,5 +1,6 @@
 using Ryujinx.Common.Configuration.Hid;
 using Ryujinx.Common.Configuration.Hid.Controller;
+using Ryujinx.Common.Configuration.Hid.Controller.Motion;
 using Ryujinx.Common.Configuration.Hid.Keyboard;
 using Ryujinx.HLE.HOS.Services.Hid;
 using System;
@@ -163,9 +164,11 @@ namespace Ryujinx.Input.HLE
                 foreach (InputConfig inputConfig in _inputConfig)
                 {
                     GamepadInput inputState = default;
-                    SixAxisInput motionState = default;
+                    (SixAxisInput, SixAxisInput) motionState = default;
 
                     NpadController controller = _controllers[(int)inputConfig.PlayerIndex];
+
+                    bool isCemuMotion = false;
 
                     // Do we allow input updates and is a controller connected?
                     if (!_blockInputUpdates && controller != null)
@@ -179,7 +182,12 @@ namespace Ryujinx.Input.HLE
 
                         inputState.Buttons |= _device.Hid.UpdateStickButtons(inputState.LStick, inputState.RStick);
 
-                        motionState = controller.GetHLEMotionState();
+                        isCemuMotion =
+                            (inputConfig is StandardControllerInputConfig controllerInputConfig) &&
+                            (controllerInputConfig.Motion is CemuHookMotionConfigController cemuHookMotion) &&
+                            inputConfig.ControllerType == Common.Configuration.Hid.ControllerType.JoyconPair;
+
+                        motionState = (controller.GetHLEMotionState(), isCemuMotion ? controller.GetHLEMotionState(true) : default);
 
                         if (_enableKeyboard)
                         {
@@ -189,14 +197,21 @@ namespace Ryujinx.Input.HLE
                     else
                     {
                         // Ensure that orientation isn't null
-                        motionState.Orientation = new float[9];
+                        motionState.Item1.Orientation = new float[9];
                     }
 
                     inputState.PlayerId = (Ryujinx.HLE.HOS.Services.Hid.PlayerIndex)inputConfig.PlayerIndex;
-                    motionState.PlayerId = (Ryujinx.HLE.HOS.Services.Hid.PlayerIndex)inputConfig.PlayerIndex;
+                    motionState.Item1.PlayerId = (Ryujinx.HLE.HOS.Services.Hid.PlayerIndex)inputConfig.PlayerIndex;
 
                     hleInputStates.Add(inputState);
-                    hleMotionStates.Add(motionState);
+                    hleMotionStates.Add(motionState.Item1);
+
+                    if(isCemuMotion && !motionState.Item2.Equals(default))
+                    {
+                        motionState.Item2.PlayerId = (Ryujinx.HLE.HOS.Services.Hid.PlayerIndex)inputConfig.PlayerIndex;
+
+                        hleMotionStates.Add(motionState.Item2);
+                    }
                 }
 
                 _device.Hid.Npads.Update(hleInputStates);

--- a/Ryujinx.Input/HLE/NpadManager.cs
+++ b/Ryujinx.Input/HLE/NpadManager.cs
@@ -168,7 +168,7 @@ namespace Ryujinx.Input.HLE
 
                     NpadController controller = _controllers[(int)inputConfig.PlayerIndex];
 
-                    bool isCemuMotion = false;
+                    bool isJoyconPair = false;
 
                     // Do we allow input updates and is a controller connected?
                     if (!_blockInputUpdates && controller != null)
@@ -182,12 +182,9 @@ namespace Ryujinx.Input.HLE
 
                         inputState.Buttons |= _device.Hid.UpdateStickButtons(inputState.LStick, inputState.RStick);
 
-                        isCemuMotion =
-                            (inputConfig is StandardControllerInputConfig controllerInputConfig) &&
-                            (controllerInputConfig.Motion is CemuHookMotionConfigController cemuHookMotion) &&
-                            inputConfig.ControllerType == Common.Configuration.Hid.ControllerType.JoyconPair;
+                        isJoyconPair = inputConfig.ControllerType == Common.Configuration.Hid.ControllerType.JoyconPair;
 
-                        motionState = (controller.GetHLEMotionState(), isCemuMotion ? controller.GetHLEMotionState(true) : default);
+                        motionState = (controller.GetHLEMotionState(), isJoyconPair ? controller.GetHLEMotionState(true) : default);
 
                         if (_enableKeyboard)
                         {
@@ -206,7 +203,7 @@ namespace Ryujinx.Input.HLE
                     hleInputStates.Add(inputState);
                     hleMotionStates.Add(motionState.Item1);
 
-                    if(isCemuMotion && !motionState.Item2.Equals(default))
+                    if(isJoyconPair && !motionState.Item2.Equals(default))
                     {
                         motionState.Item2.PlayerId = (Ryujinx.HLE.HOS.Services.Hid.PlayerIndex)inputConfig.PlayerIndex;
 

--- a/Ryujinx.Input/HLE/NpadManager.cs
+++ b/Ryujinx.Input/HLE/NpadManager.cs
@@ -205,7 +205,7 @@ namespace Ryujinx.Input.HLE
                     hleInputStates.Add(inputState);
                     hleMotionStates.Add(motionState.Item1);
 
-                    if(isJoyconPair && !motionState.Item2.Equals(default))
+                    if (isJoyconPair && !motionState.Item2.Equals(default))
                     {
                         motionState.Item2.PlayerId = (Ryujinx.HLE.HOS.Services.Hid.PlayerIndex)inputConfig.PlayerIndex;
 

--- a/Ryujinx.Input/HLE/NpadManager.cs
+++ b/Ryujinx.Input/HLE/NpadManager.cs
@@ -184,7 +184,9 @@ namespace Ryujinx.Input.HLE
 
                         isJoyconPair = inputConfig.ControllerType == Common.Configuration.Hid.ControllerType.JoyconPair;
 
-                        motionState = (controller.GetHLEMotionState(), isJoyconPair ? controller.GetHLEMotionState(true) : default);
+                        var altMotionState = isJoyconPair ? controller.GetHLEMotionState(true) : default;
+
+                        motionState = (controller.GetHLEMotionState(), altMotionState);
 
                         if (_enableKeyboard)
                         {


### PR DESCRIPTION
There's a bug where the right joycon is not retrieved from cemuhook, and that the right joycon motion shared mem is cleared after update. This aims to fix that issue. 
This should allow right joycon to work in Skyward Sword.