### PR TITLE
Only use persistent buffers to flush on NVIDIA and Windows+AMD

### DIFF
--- a/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
@@ -121,7 +121,31 @@ namespace Ryujinx.Graphics.OpenGL.Image
 
         public byte[] GetData()
         {
-            return _renderer.PersistentBuffers.Default.GetTextureData(this);
+            int size = 0;
+
+            for (int level = 0; level < Info.Levels; level++)
+            {
+                size += Info.GetMipSize(level);
+            }
+
+            if (HwCapabilities.UsePersistentBufferForFlush)
+            {
+                return _renderer.PersistentBuffers.Default.GetTextureData(this, size);
+            }
+            else
+            {
+                byte[] data = new byte[size];
+
+                unsafe
+                {
+                    fixed (byte* ptr = data)
+                    {
+                        WriteTo((IntPtr)ptr);
+                    }
+                }
+
+                return data;
+            }
         }
 
         public void WriteToPbo(int offset, bool forceBgra)

--- a/Ryujinx.Graphics.OpenGL/PersistentBuffers.cs
+++ b/Ryujinx.Graphics.OpenGL/PersistentBuffers.cs
@@ -63,15 +63,8 @@ namespace Ryujinx.Graphics.OpenGL
             GL.DeleteSync(sync);
         }
 
-        public byte[] GetTextureData(TextureView view)
+        public byte[] GetTextureData(TextureView view, int size)
         {
-            int size = 0;
-
-            for (int level = 0; level < view.Info.Levels; level++)
-            {
-                size += view.Info.GetMipSize(level);
-            }
-
             EnsureBuffer(size);
 
             GL.BindBuffer(BufferTarget.PixelPackBuffer, _copyBufferHandle);

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -93,7 +93,14 @@ namespace Ryujinx.Graphics.OpenGL
 
         public byte[] GetBufferData(BufferHandle buffer, int offset, int size)
         {
-            return PersistentBuffers.Default.GetBufferData(buffer, offset, size);
+            if (HwCapabilities.UsePersistentBufferForFlush)
+            {
+                return PersistentBuffers.Default.GetBufferData(buffer, offset, size);
+            }
+            else
+            {
+                return Buffer.GetData(buffer, offset, size);
+            }
         }
 
         public Capabilities GetCapabilities()


### PR DESCRIPTION
It seems like this method of flushing data is much slower on Mesa drivers, and slightly slower on Intel Windows. Have not tested Intel Mesa, but I'm assuming it is the same as AMD. The game in question is Skyward Sword HD, as it had the greatest effect from the last PR.

This also adds vendor detection for AMD on Unix, which counted as "Unknown" before.