### PR TITLE
Clamp controller sticks to circle, instead of square

### DIFF
--- a/Ryujinx.Input/HLE/NpadController.cs
+++ b/Ryujinx.Input/HLE/NpadController.cs
@@ -3,7 +3,6 @@ using Ryujinx.Common.Configuration.Hid;
 using Ryujinx.Common.Configuration.Hid.Controller;
 using Ryujinx.Common.Configuration.Hid.Controller.Motion;
 using Ryujinx.HLE.HOS.Services.Hid;
-using SixLabors.ImageSharp;
 using System;
 using System.Numerics;
 using System.Runtime.CompilerServices;
@@ -347,7 +346,7 @@ namespace Ryujinx.Input.HLE
 
             if (_gamepad is IKeyboard)
             {
-                (float leftAxisX,  float leftAxisY)  = State.GetStick(StickInputId.Left);
+                (float leftAxisX, float leftAxisY) = State.GetStick(StickInputId.Left);
                 (float rightAxisX, float rightAxisY) = State.GetStick(StickInputId.Right);
 
                 state.LStick = new JoystickPosition
@@ -364,10 +363,10 @@ namespace Ryujinx.Input.HLE
             }
             else if (_config is StandardControllerInputConfig controllerConfig)
             {
-                (float leftAxisX,  float leftAxisY)  = State.GetStick(StickInputId.Left);
+                (float leftAxisX, float leftAxisY) = State.GetStick(StickInputId.Left);
                 (float rightAxisX, float rightAxisY) = State.GetStick(StickInputId.Right);
 
-                state.LStick = ClampToCircle(ApplyDeadzone(leftAxisX, leftAxisY,  controllerConfig.DeadzoneLeft));
+                state.LStick = ClampToCircle(ApplyDeadzone(leftAxisX, leftAxisY, controllerConfig.DeadzoneLeft));
                 state.RStick = ClampToCircle(ApplyDeadzone(rightAxisX, rightAxisY, controllerConfig.DeadzoneRight));
             }
 
@@ -396,7 +395,6 @@ namespace Ryujinx.Input.HLE
                 return (short)(value * short.MaxValue);
             }
         }
-
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static JoystickPosition ClampToCircle(JoystickPosition position)

--- a/Ryujinx.Input/HLE/NpadController.cs
+++ b/Ryujinx.Input/HLE/NpadController.cs
@@ -367,13 +367,22 @@ namespace Ryujinx.Input.HLE
                 (float leftAxisX,  float leftAxisY)  = State.GetStick(StickInputId.Left);
                 (float rightAxisX, float rightAxisY) = State.GetStick(StickInputId.Right);
 
-                state.LStick = ClampToCircle(ClampAxis(leftAxisX),  ClampAxis(leftAxisY),  controllerConfig.DeadzoneLeft);
-                state.RStick = ClampToCircle(ClampAxis(rightAxisX), ClampAxis(rightAxisY), controllerConfig.DeadzoneRight);
+                state.LStick = ClampToCircle(ApplyDeadzone(leftAxisX, leftAxisY,  controllerConfig.DeadzoneLeft));
+                state.RStick = ClampToCircle(ApplyDeadzone(rightAxisX, rightAxisY, controllerConfig.DeadzoneRight));
             }
 
             return state;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static JoystickPosition ApplyDeadzone(float x, float y, float deadzone)
+        {
+            return new JoystickPosition
+            {
+                Dx = ClampAxis(MathF.Abs(x) > deadzone ? x : 0.0f),
+                Dy = ClampAxis(MathF.Abs(y) > deadzone ? y : 0.0f)
+            };
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static short ClampAxis(float value)
@@ -390,9 +399,9 @@ namespace Ryujinx.Input.HLE
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static JoystickPosition ClampToCircle(float x, float y, float deadzone)
+        private static JoystickPosition ClampToCircle(JoystickPosition position)
         {
-            Vector2 point = new Vector2(x, y);
+            Vector2 point = new Vector2(position.Dx, position.Dy);
 
             if (point.Length() > short.MaxValue)
             {
@@ -401,8 +410,8 @@ namespace Ryujinx.Input.HLE
 
             return new JoystickPosition
             {
-                Dx = Math.Abs(point.X) > deadzone ? (int)point.X : 0,
-                Dy = Math.Abs(point.Y) > deadzone ? (int)point.Y : 0,
+                Dx = (int)point.X,
+                Dy = (int)point.Y
             };
         }
 


### PR DESCRIPTION
Xinput devices provides axis data with square ranges, ie +-32767. Moving the sticks to diagonal ends means that it will have the max range values for both axes. This causes fast motion of player characters in games that do not clamp their input. 

This fixes it by clamping the input to a circle. Fixes Link sprinting without using up stamina when the controller sticks are at diagonals