### PR TITLE
Replace BGRA and scale uniforms with a uniform block

### DIFF
--- a/Ryujinx.Graphics.GAL/IPipeline.cs
+++ b/Ryujinx.Graphics.GAL/IPipeline.cs
@@ -73,12 +73,12 @@ namespace Ryujinx.Graphics.GAL
 
         void SetStencilTest(StencilTestDescriptor stencilTest);
 
-        void SetStorageBuffers(ReadOnlySpan<BufferRange> buffers);
+        void SetStorageBuffers(int first, ReadOnlySpan<BufferRange> buffers);
 
         void SetTexture(int binding, ITexture texture);
 
         void SetTransformFeedbackBuffers(ReadOnlySpan<BufferRange> buffers);
-        void SetUniformBuffers(ReadOnlySpan<BufferRange> buffers);
+        void SetUniformBuffers(int first, ReadOnlySpan<BufferRange> buffers);
 
         void SetUserClipDistance(int index, bool enableClip);
 

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -957,9 +957,6 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 UpdateUserClipState();
             }
 
-            int storageBufferBindingsCount = 0;
-            int uniformBufferBindingsCount = 0;
-
             for (int stage = 0; stage < Constants.ShaderStages; stage++)
             {
                 ShaderProgramInfo info = gs.Shaders[stage]?.Info;
@@ -1015,20 +1012,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
                 _channel.BufferManager.SetGraphicsStorageBufferBindings(stage, info.SBuffers);
                 _channel.BufferManager.SetGraphicsUniformBufferBindings(stage, info.CBuffers);
-
-                if (info.SBuffers.Count != 0)
-                {
-                    storageBufferBindingsCount = Math.Max(storageBufferBindingsCount, info.SBuffers.Max(x => x.Binding) + 1);
-                }
-
-                if (info.CBuffers.Count != 0)
-                {
-                    uniformBufferBindingsCount = Math.Max(uniformBufferBindingsCount, info.CBuffers.Max(x => x.Binding) + 1);
-                }
             }
-
-            _channel.BufferManager.SetGraphicsStorageBufferBindingsCount(storageBufferBindingsCount);
-            _channel.BufferManager.SetGraphicsUniformBufferBindingsCount(uniformBufferBindingsCount);
 
             _context.Renderer.Pipeline.SetProgram(gs.HostProgram);
         }

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -38,7 +38,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2530;
+        private const ulong ShaderCodeGenVersion = 2494;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -80,11 +80,17 @@ namespace Ryujinx.Graphics.OpenGL
             for (int index = 0; index < _fpRenderScale.Length; index++)
             {
                 _fpRenderScale[index].X = 1f;
+                _fpRenderScale[index].Y = 0f;
+                _fpRenderScale[index].Z = 0f;
+                _fpRenderScale[index].W = 0f;
             }
 
             for (int index = 0; index < _cpRenderScale.Length; index++)
             {
                 _cpRenderScale[index].X = 1f;
+                _cpRenderScale[index].Y = 0f;
+                _cpRenderScale[index].Z = 0f;
+                _cpRenderScale[index].W = 0f;
             }
 
             _tfbs = new BufferHandle[Constants.MaxTransformFeedbackBuffers];
@@ -1192,9 +1198,9 @@ namespace Ryujinx.Graphics.OpenGL
         {
             static void Copy(float[] from, int fromIndex, Vector4<float>[] to, int toIndex, int count)
             {
-                for (int i = 0; i < count; i++)
+                for (int index = 0; index < count; index++)
                 {
-                    to[toIndex + i].X = from[fromIndex + i];
+                    to[toIndex + index].X = from[fromIndex + index];
                 }
             }
 

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -5,6 +5,8 @@ using Ryujinx.Graphics.OpenGL.Image;
 using Ryujinx.Graphics.OpenGL.Queries;
 using Ryujinx.Graphics.Shader;
 using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace Ryujinx.Graphics.OpenGL
 {
@@ -31,9 +33,17 @@ namespace Ryujinx.Graphics.OpenGL
         private int _boundDrawFramebuffer;
         private int _boundReadFramebuffer;
 
-        private int[] _fpIsBgra = new int[8];
-        private float[] _fpRenderScale = new float[65];
-        private float[] _cpRenderScale = new float[64];
+        private struct Vector4<T>
+        {
+            public T X;
+            public T Y;
+            public T Z;
+            public T W;
+        }
+
+        private Vector4<int>[] _fpIsBgra = new Vector4<int>[SupportBuffer.FragmentIsBgraCount];
+        private Vector4<float>[] _fpRenderScale = new Vector4<float>[65];
+        private Vector4<float>[] _cpRenderScale = new Vector4<float>[64];
 
         private TextureBase _unit0Texture;
 
@@ -48,6 +58,7 @@ namespace Ryujinx.Graphics.OpenGL
         private bool _tfEnabled;
         private TransformFeedbackPrimitiveType _tfTopology;
 
+        private BufferHandle _supportBuffer;
         private readonly BufferHandle[] _tfbs;
         private readonly BufferRange[] _tfbTargets;
 
@@ -68,12 +79,12 @@ namespace Ryujinx.Graphics.OpenGL
 
             for (int index = 0; index < _fpRenderScale.Length; index++)
             {
-                _fpRenderScale[index] = 1f;
+                _fpRenderScale[index].X = 1f;
             }
 
             for (int index = 0; index < _cpRenderScale.Length; index++)
             {
-                _cpRenderScale[index] = 1f;
+                _cpRenderScale[index].X = 1f;
             }
 
             _tfbs = new BufferHandle[Constants.MaxTransformFeedbackBuffers];
@@ -825,7 +836,7 @@ namespace Ryujinx.Graphics.OpenGL
             }
 
             UpdateFpIsBgra();
-            SetRenderTargetScale(_fpRenderScale[0]);
+            SetRenderTargetScale(_fpRenderScale[0].X);
         }
 
         public void SetRasterizerDiscard(bool discard)
@@ -844,12 +855,8 @@ namespace Ryujinx.Graphics.OpenGL
 
         public void SetRenderTargetScale(float scale)
         {
-            _fpRenderScale[0] = scale;
-
-            if (_program != null && _program.FragmentRenderScaleUniform != -1)
-            {
-                GL.Uniform1(_program.FragmentRenderScaleUniform, 1, _fpRenderScale); // Just the first element.
-            }
+            _fpRenderScale[0].X = scale;
+            SetSupportBufferData<Vector4<float>>(SupportBuffer.FragmentRenderScaleOffset, _fpRenderScale, 1); // Just the first element.
         }
 
         public void SetRenderTargetColorMasks(ReadOnlySpan<uint> componentMasks)
@@ -874,9 +881,9 @@ namespace Ryujinx.Graphics.OpenGL
 
                 int isBgra = color != null && color.Format.IsBgra8() ? 1 : 0;
 
-                if (_fpIsBgra[index] != isBgra)
+                if (_fpIsBgra[index].X != isBgra)
                 {
-                    _fpIsBgra[index] = isBgra;
+                    _fpIsBgra[index].X = isBgra;
 
                     RestoreComponentMask(index);
                 }
@@ -965,9 +972,9 @@ namespace Ryujinx.Graphics.OpenGL
             _stencilFrontMask = stencilTest.FrontMask;
         }
 
-        public void SetStorageBuffers(ReadOnlySpan<BufferRange> buffers)
+        public void SetStorageBuffers(int first, ReadOnlySpan<BufferRange> buffers)
         {
-            SetBuffers(buffers, isStorage: true);
+            SetBuffers(first, buffers, isStorage: true);
         }
 
         public void SetTexture(int binding, ITexture texture)
@@ -1023,9 +1030,9 @@ namespace Ryujinx.Graphics.OpenGL
             }
         }
 
-        public void SetUniformBuffers(ReadOnlySpan<BufferRange> buffers)
+        public void SetUniformBuffers(int first, ReadOnlySpan<BufferRange> buffers)
         {
-            SetBuffers(buffers, isStorage: false);
+            SetBuffers(first, buffers, isStorage: false);
         }
 
         public void SetUserClipDistance(int index, bool enableClip)
@@ -1103,7 +1110,7 @@ namespace Ryujinx.Graphics.OpenGL
             GL.MemoryBarrier(MemoryBarrierFlags.TextureFetchBarrierBit);
         }
 
-        private void SetBuffers(ReadOnlySpan<BufferRange> buffers, bool isStorage)
+        private void SetBuffers(int first, ReadOnlySpan<BufferRange> buffers, bool isStorage)
         {
             BufferRangeTarget target = isStorage ? BufferRangeTarget.ShaderStorageBuffer : BufferRangeTarget.UniformBuffer;
 
@@ -1113,11 +1120,11 @@ namespace Ryujinx.Graphics.OpenGL
 
                 if (buffer.Handle == BufferHandle.Null)
                 {
-                    GL.BindBufferRange(target, index, 0, IntPtr.Zero, 0);
+                    GL.BindBufferRange(target, first + index, 0, IntPtr.Zero, 0);
                     continue;
                 }
 
-                GL.BindBufferRange(target, index, buffer.Handle.ToInt32(), (IntPtr)buffer.Offset, buffer.Size);
+                GL.BindBufferRange(target, first + index, buffer.Handle.ToInt32(), (IntPtr)buffer.Offset, buffer.Size);
             }
         }
 
@@ -1181,35 +1188,41 @@ namespace Ryujinx.Graphics.OpenGL
 
         private void UpdateFpIsBgra()
         {
-            if (_program != null)
-            {
-                GL.Uniform1(_program.FragmentIsBgraUniform, 8, _fpIsBgra);
-            }
+            SetSupportBufferData<Vector4<int>>(SupportBuffer.FragmentIsBgraOffset, _fpIsBgra, SupportBuffer.FragmentIsBgraCount);
         }
 
         public void UpdateRenderScale(ShaderStage stage, float[] scales, int textureCount, int imageCount)
         {
-            if (_program != null)
+            static void Copy(float[] from, int fromIndex, Vector4<float>[] to, int toIndex, int count)
             {
-                switch (stage)
+                for (int i = 0; i < count; i++)
                 {
-                    case ShaderStage.Fragment:
-                        if (_program.FragmentRenderScaleUniform != -1)
-                        {
-                            Array.Copy(scales, 0, _fpRenderScale, 1, textureCount + imageCount);
-                            GL.Uniform1(_program.FragmentRenderScaleUniform, 1 + textureCount + imageCount, _fpRenderScale);
-                        }
-                        break;
-
-                    case ShaderStage.Compute:
-                        if (_program.ComputeRenderScaleUniform != -1)
-                        {
-                            Array.Copy(scales, 0, _cpRenderScale, 0, textureCount + imageCount);
-                            GL.Uniform1(_program.ComputeRenderScaleUniform, textureCount + imageCount, _cpRenderScale);
-                        }
-                        break;
+                    to[toIndex + i].X = from[fromIndex + i];
                 }
             }
+
+            switch (stage)
+            {
+                case ShaderStage.Fragment:
+                    Copy(scales, 0, _fpRenderScale, 1, textureCount + imageCount);
+                    SetSupportBufferData<Vector4<float>>(SupportBuffer.FragmentRenderScaleOffset, _fpRenderScale, 1 + textureCount + imageCount);
+                    break;
+                case ShaderStage.Compute:
+                    Copy(scales, 0, _cpRenderScale, 0, textureCount + imageCount);
+                    SetSupportBufferData<Vector4<float>>(SupportBuffer.ComputeRenderScaleOffset, _cpRenderScale, textureCount + imageCount);
+                    break;
+            }
+        }
+
+        private void SetSupportBufferData<T>(int offset, ReadOnlySpan<T> data, int count) where T : unmanaged
+        {
+            if (_supportBuffer == BufferHandle.Null)
+            {
+                _supportBuffer = Buffer.Create(SupportBuffer.RequiredSize);
+                GL.BindBufferBase(BufferRangeTarget.UniformBuffer, 0, Unsafe.As<BufferHandle, int>(ref _supportBuffer));
+            }
+
+            Buffer.SetData(_supportBuffer, offset, MemoryMarshal.Cast<T, byte>(data.Slice(0, count)));
         }
 
         private void PrepareForDispatch()
@@ -1249,8 +1262,8 @@ namespace Ryujinx.Graphics.OpenGL
         public void RestoreComponentMask(int index)
         {
             // If the bound render target is bgra, swap the red and blue masks.
-            uint redMask = _fpIsBgra[index] == 0 ? 1u : 4u;
-            uint blueMask = _fpIsBgra[index] == 0 ? 4u : 1u;
+            uint redMask = _fpIsBgra[index].X == 0 ? 1u : 4u;
+            uint blueMask = _fpIsBgra[index].X == 0 ? 4u : 1u;
 
             GL.ColorMask(
                 index,
@@ -1322,6 +1335,12 @@ namespace Ryujinx.Graphics.OpenGL
 
         public void Dispose()
         {
+            if (_supportBuffer != BufferHandle.Null)
+            {
+                Buffer.Delete(_supportBuffer);
+                _supportBuffer = BufferHandle.Null;
+            }
+
             for (int i = 0; i < Constants.MaxTransformFeedbackBuffers; i++)
             {
                 if (_tfbs[i] != BufferHandle.Null)

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -834,9 +834,6 @@ namespace Ryujinx.Graphics.OpenGL
             {
                 _program.Bind();
             }
-
-            UpdateFpIsBgra();
-            SetRenderTargetScale(_fpRenderScale[0].X);
         }
 
         public void SetRasterizerDiscard(bool discard)

--- a/Ryujinx.Graphics.OpenGL/Program.cs
+++ b/Ryujinx.Graphics.OpenGL/Program.cs
@@ -13,10 +13,6 @@ namespace Ryujinx.Graphics.OpenGL
     {
         public int Handle { get; private set; }
 
-        public int FragmentIsBgraUniform { get; private set; }
-        public int FragmentRenderScaleUniform { get; private set; }
-        public int ComputeRenderScaleUniform { get; private set; }
-
         public bool IsLinked
         {
             get
@@ -30,7 +26,6 @@ namespace Ryujinx.Graphics.OpenGL
             }
         }
 
-        private bool _initialized;
         private ProgramLinkStatus _status = ProgramLinkStatus.Incomplete;
         private IShader[] _shaders;
 
@@ -117,15 +112,6 @@ namespace Ryujinx.Graphics.OpenGL
 
         public void Bind()
         {
-            if (!_initialized)
-            {
-                FragmentIsBgraUniform = GL.GetUniformLocation(Handle, "is_bgra");
-                FragmentRenderScaleUniform = GL.GetUniformLocation(Handle, "fp_renderScale");
-                ComputeRenderScaleUniform = GL.GetUniformLocation(Handle, "cp_renderScale");
-
-                _initialized = true;
-            }
-
             GL.UseProgram(Handle);
         }
 

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/DefaultNames.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/DefaultNames.cs
@@ -14,6 +14,11 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
         public const string DataName = "data";
 
+        public const string SupportBlockName = "support_block";
+        public const string SupportBlockAlphaTestName = "s_alpha_test";
+        public const string SupportBlockIsBgraName = "s_is_bgra";
+        public const string SupportBlockRenderScaleName = "s_render_scale";
+
         public const string BlockSuffix = "block";
 
         public const string UniformNamePrefix = "c";
@@ -25,7 +30,5 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
         public const string ArgumentNamePrefix = "a";
 
         public const string UndefinedName = "undef";
-
-        public const string IsBgraName = "is_bgra";
     }
 }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_cp.glsl
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_cp.glsl
@@ -1,6 +1,6 @@
 ﻿ivec2 Helper_TexelFetchScale(ivec2 inputVec, int samplerIndex)
 {
-    float scale = cp_renderScale[samplerIndex];
+    float scale = s_render_scale[samplerIndex];
     if (scale == 1.0)
     {
         return inputVec;
@@ -10,7 +10,7 @@
 
 int Helper_TextureSizeUnscale(int size, int samplerIndex)
 {
-    float scale = cp_renderScale[samplerIndex];
+    float scale = s_render_scale[samplerIndex];
     if (scale == 1.0)
     {
         return size;

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_fp.glsl
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_fp.glsl
@@ -1,6 +1,6 @@
 ﻿ivec2 Helper_TexelFetchScale(ivec2 inputVec, int samplerIndex)
 {
-    float scale = fp_renderScale[1 + samplerIndex];
+    float scale = s_render_scale[1 + samplerIndex];
     if (scale == 1.0)
     {
         return inputVec;
@@ -17,7 +17,7 @@
 
 int Helper_TextureSizeUnscale(int size, int samplerIndex)
 {
-    float scale = abs(fp_renderScale[1 + samplerIndex]);
+    float scale = abs(s_render_scale[1 + samplerIndex]);
     if (scale == 1.0)
     {
         return size;

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
@@ -68,14 +68,14 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
             { AttributeConsts.LtMask,              new BuiltInAttribute("unpackUint2x32(gl_SubGroupLtMaskARB).x", VariableType.U32)  },
 
             // Support uniforms.
-            { AttributeConsts.FragmentOutputIsBgraBase + 0,  new BuiltInAttribute($"{DefaultNames.IsBgraName}[0]",  VariableType.Bool) },
-            { AttributeConsts.FragmentOutputIsBgraBase + 4,  new BuiltInAttribute($"{DefaultNames.IsBgraName}[1]",  VariableType.Bool) },
-            { AttributeConsts.FragmentOutputIsBgraBase + 8,  new BuiltInAttribute($"{DefaultNames.IsBgraName}[2]",  VariableType.Bool) },
-            { AttributeConsts.FragmentOutputIsBgraBase + 12, new BuiltInAttribute($"{DefaultNames.IsBgraName}[3]",  VariableType.Bool) },
-            { AttributeConsts.FragmentOutputIsBgraBase + 16, new BuiltInAttribute($"{DefaultNames.IsBgraName}[4]",  VariableType.Bool) },
-            { AttributeConsts.FragmentOutputIsBgraBase + 20, new BuiltInAttribute($"{DefaultNames.IsBgraName}[5]",  VariableType.Bool) },
-            { AttributeConsts.FragmentOutputIsBgraBase + 24, new BuiltInAttribute($"{DefaultNames.IsBgraName}[6]",  VariableType.Bool) },
-            { AttributeConsts.FragmentOutputIsBgraBase + 28, new BuiltInAttribute($"{DefaultNames.IsBgraName}[7]",  VariableType.Bool) }
+            { AttributeConsts.FragmentOutputIsBgraBase + 0,  new BuiltInAttribute($"{DefaultNames.SupportBlockIsBgraName}[0]",  VariableType.Bool) },
+            { AttributeConsts.FragmentOutputIsBgraBase + 4,  new BuiltInAttribute($"{DefaultNames.SupportBlockIsBgraName}[1]",  VariableType.Bool) },
+            { AttributeConsts.FragmentOutputIsBgraBase + 8,  new BuiltInAttribute($"{DefaultNames.SupportBlockIsBgraName}[2]",  VariableType.Bool) },
+            { AttributeConsts.FragmentOutputIsBgraBase + 12, new BuiltInAttribute($"{DefaultNames.SupportBlockIsBgraName}[3]",  VariableType.Bool) },
+            { AttributeConsts.FragmentOutputIsBgraBase + 16, new BuiltInAttribute($"{DefaultNames.SupportBlockIsBgraName}[4]",  VariableType.Bool) },
+            { AttributeConsts.FragmentOutputIsBgraBase + 20, new BuiltInAttribute($"{DefaultNames.SupportBlockIsBgraName}[5]",  VariableType.Bool) },
+            { AttributeConsts.FragmentOutputIsBgraBase + 24, new BuiltInAttribute($"{DefaultNames.SupportBlockIsBgraName}[6]",  VariableType.Bool) },
+            { AttributeConsts.FragmentOutputIsBgraBase + 28, new BuiltInAttribute($"{DefaultNames.SupportBlockIsBgraName}[7]",  VariableType.Bool) }
         };
 
         private Dictionary<AstOperand, string> _locals;
@@ -194,8 +194,8 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
                     {
                         switch (value & ~3)
                         {
-                            case AttributeConsts.PositionX: return "(gl_FragCoord.x / fp_renderScale[0])";
-                            case AttributeConsts.PositionY: return "(gl_FragCoord.y / fp_renderScale[0])";
+                            case AttributeConsts.PositionX: return $"(gl_FragCoord.x / {DefaultNames.SupportBlockRenderScaleName}[0])";
+                            case AttributeConsts.PositionY: return $"(gl_FragCoord.y / {DefaultNames.SupportBlockRenderScaleName}[0])";
                             case AttributeConsts.PositionZ: return "gl_FragCoord.z";
                             case AttributeConsts.PositionW: return "gl_FragCoord.w";
                         }

--- a/Ryujinx.Graphics.Shader/SupportBuffer.cs
+++ b/Ryujinx.Graphics.Shader/SupportBuffer.cs
@@ -1,0 +1,18 @@
+namespace Ryujinx.Graphics.Shader
+{
+    public static class SupportBuffer
+    {
+        public const int FieldSize = 16; // Each field takes 16 bytes on default layout, even bool.
+
+        public const int FragmentAlphaTestOffset = 0;
+        public const int FragmentIsBgraOffset = FieldSize;
+        public const int FragmentIsBgraCount = 8;
+        public const int FragmentRenderScaleOffset = FragmentIsBgraOffset + FragmentIsBgraCount * FieldSize;
+        public const int ComputeRenderScaleOffset = FragmentRenderScaleOffset + FieldSize; // Skip first scale that is used for the render target
+
+        // One for the render target, 32 for the textures, and 8 for the images.
+        private const int RenderScaleMaxCount = 1 + 32 + 8;
+
+        public const int RequiredSize = FragmentRenderScaleOffset + RenderScaleMaxCount * FieldSize;
+    }
+}

--- a/Ryujinx.Graphics.Shader/Translation/TranslationCounts.cs
+++ b/Ryujinx.Graphics.Shader/Translation/TranslationCounts.cs
@@ -7,6 +7,12 @@ namespace Ryujinx.Graphics.Shader.Translation
         public int TexturesCount { get; private set; }
         public int ImagesCount { get; private set; }
 
+        public TranslationCounts()
+        {
+            // The first binding is reserved for the support buffer.
+            UniformBuffersCount = 1;
+        }
+
         internal int IncrementUniformBuffersCount()
         {
             return UniformBuffersCount++;


### PR DESCRIPTION
Currently we have some "loose" uniforms on shaders that are being used for the texture scales, and the value that indicates if a texture is BGRA or not. They require a `glGetUniformLocation` to get the location the compiler assigned to them, and also requires setting the new uniform data every time the shader change. The motivator for this change though, was the fact those uniform variables are not support on SPIR-V, and I believe its better to handle things in a similar way between the backends. Plus, if we want to produce SPIR-V from GLSL, this change is necessary (otherwise it will fail to compile).

With the new approach, a single buffer that can fit everything (the render scales, IsBGRA, and a new alpha test field) is created. Data is written to the buffer using the current `SetBufferData` methods. The shader now reserves the binding 0 for this new uniform block, which allows the buffer is only bound once (right after it is created) since the binding is the same across all shaders. The `SetUniformBuffers` method previously assumed the binding always started at 0. This is no longer the case due to it reserving binding 0, so the method was changed to take a `first` parameter that tells the first binding number. For consistency, `SetStorageBuffers` was also changed. On the GPU emulator, the buffer manager no longer assumes that the bindings are in sequence, it can now handle "gaps" on the bindings, by making one backend `Set*Buffers` call per sequential range.

On compute shaders, the uniform block layout was made to match the fragment one. So, since it doesn't need the alpha test and IsBGRA fields, it simply inserts an array at the bedding in place of the fields that are not needed. That way, the scales falls at the same offset as the fragment shader block. This makes things simpler as we don't need to know the shader type to set this data.

The alpha test field was added in preparation for a future change were I will add alpha test emulation code at the end of the fragment shaders, which is required on OpenGL if the GPU/driver doesn't support it (it's a deprecated feature). On Vulkan, it is also needed as there's no support for alpha test at all there.

On the backend, some `int` and `float` arrays had to be changed to `Vector4<int>` and `Vector4<float>`, to match the uniform buffer layout. On OpenGL, uniforms have its elements aligned to 16 bytes by default, even array elements are aligned to 16, so this changes makes the C# array match the OpenGL uniform layout.

**What to test:**
In general, I recommend testing a few games to ensure they didn't regress, including making sure that resolution scale still works as before, and also testing games using BGRA textures, and ensure they also work as before.