### PR TITLE
Hide UI rework/arrow key fix

### DIFF
--- a/Ryujinx.Common/Configuration/Hid/KeyboardHotkeys.cs
+++ b/Ryujinx.Common/Configuration/Hid/KeyboardHotkeys.cs
@@ -4,5 +4,6 @@
     {
         public Key ToggleVsync { get; set; }
         public Key Screenshot { get; set; }
+        public Key ShowUi { get; set; }
     }
 }

--- a/Ryujinx/Config.json
+++ b/Ryujinx/Config.json
@@ -1,5 +1,5 @@
 {
-  "version": 28,
+  "version": 29,
   "enable_file_log": true,
   "res_scale": 1,
   "res_scale_custom": 1,
@@ -58,7 +58,8 @@
   "enable_mouse": false,
   "hotkeys": {
     "toggle_vsync": "Tab",
-    "screenshot": "F8"
+    "screenshot": "F8",
+    "show_ui": "F4"
   },
   "keyboard_config": [],
   "controller_config": [],

--- a/Ryujinx/Configuration/ConfigurationFileFormat.cs
+++ b/Ryujinx/Configuration/ConfigurationFileFormat.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.Configuration
         /// <summary>
         /// The current version of the file format
         /// </summary>
-        public const int CurrentVersion = 28;
+        public const int CurrentVersion = 29;
 
         public int Version { get; set; }
 

--- a/Ryujinx/Configuration/ConfigurationState.cs
+++ b/Ryujinx/Configuration/ConfigurationState.cs
@@ -543,7 +543,8 @@ namespace Ryujinx.Configuration
             Hid.Hotkeys.Value = new KeyboardHotkeys
             {
                 ToggleVsync = Key.Tab,
-                Screenshot = Key.F8
+                Screenshot = Key.F8,
+                ShowUi = Key.F4
             };
             Hid.InputConfig.Value = new List<InputConfig>
             {
@@ -854,6 +855,20 @@ namespace Ryujinx.Configuration
                 {
                     ToggleVsync = Key.Tab,
                     Screenshot = Key.F8
+                };
+
+                configurationFileUpdated = true;
+            }
+
+            if (configurationFileFormat.Version < 29)
+            {
+                Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 29.");
+
+                configurationFileFormat.Hotkeys = new KeyboardHotkeys
+                {
+                    ToggleVsync = Key.Tab,
+                    Screenshot = Key.F8,
+                    ShowUi = Key.F4
                 };
 
                 configurationFileUpdated = true;

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -101,6 +101,7 @@ namespace Ryujinx.Ui
         [GUI] MenuItem        _simulateWakeUpMessage;
         [GUI] MenuItem        _scanAmiibo;
         [GUI] MenuItem        _takeScreenshot;
+        [GUI] MenuItem        _hideUi;
         [GUI] MenuItem        _fullScreen;
         [GUI] CheckMenuItem   _startFullScreen;
         [GUI] CheckMenuItem   _favToggle;
@@ -242,6 +243,8 @@ namespace Ryujinx.Ui
             _gameTable.EnableSearch = true;
             _gameTable.SearchColumn = 2;
             _gameTable.SearchEqualFunc = (model, col, key, iter) => !((string)model.GetValue(iter, col)).Contains(key, StringComparison.InvariantCultureIgnoreCase);
+
+            _hideUi.Label = _hideUi.Label.Replace("SHOWUIKEY", ConfigurationState.Instance.Hid.Hotkeys.Value.ShowUi.ToString());
 
             UpdateColumns();
             UpdateGameTable();
@@ -1070,15 +1073,6 @@ namespace Ryujinx.Ui
             AspectRatio aspectRatio = ConfigurationState.Instance.Graphics.AspectRatio.Value;
 
             ConfigurationState.Instance.Graphics.AspectRatio.Value = ((int)aspectRatio + 1) > Enum.GetNames(typeof(AspectRatio)).Length - 1 ? AspectRatio.Fixed4x3 : aspectRatio + 1;
-        }
-
-        private void Focus_Menu_Bar(object sender, KeyReleaseEventArgs args)
-        {
-            if (args.Event.Key == Gdk.Key.Alt_L)
-            {
-                ToggleExtraWidgets(true);
-                _menuBar.GrabFocus();
-            }
         }
 
         private void Row_Clicked(object sender, ButtonReleaseEventArgs args)

--- a/Ryujinx/Ui/MainWindow.glade
+++ b/Ryujinx/Ui/MainWindow.glade
@@ -6,7 +6,6 @@
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Ryujinx</property>
     <property name="window_position">center</property>
-    <signal name="key-release-event" handler="Focus_Menu_Bar" swapped="no" />
     <child>
       <object class="GtkBox" id="_box">
         <property name="visible">True</property>
@@ -15,7 +14,7 @@
         <child>
           <object class="GtkMenuBar" id="_menuBar">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
+            <property name="can_focus">False</property>
             <child>
               <object class="GtkMenuItem" id="_fileMenu">
                 <property name="visible">True</property>
@@ -343,7 +342,7 @@
                       <object class="GtkMenuItem" id="_hideUi">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Hide UI (Alt to show)</property>
+                        <property name="label" translatable="yes">Hide UI (SHOWUIKEY to show)</property>
                         <property name="use_underline">True</property>
                         <signal name="activate" handler="HideUi_Pressed" swapped="no" />
                       </object>

--- a/Ryujinx/Ui/RendererWidgetBase.cs
+++ b/Ryujinx/Ui/RendererWidgetBase.cs
@@ -571,6 +571,12 @@ namespace Ryujinx.Ui
                     Renderer.Screenshot();
                 }
 
+                if (currentHotkeyState.HasFlag(KeyboardHotkeyState.ShowUi) &&
+                    !_prevHotkeyState.HasFlag(KeyboardHotkeyState.ShowUi))
+                {
+                    (Toplevel as MainWindow).ToggleExtraWidgets(true);
+                }
+
                 _prevHotkeyState = currentHotkeyState;
             }
 
@@ -596,9 +602,10 @@ namespace Ryujinx.Ui
         [Flags]
         private enum KeyboardHotkeyState
         {
-            None,
-            ToggleVSync,
-            Screenshot
+            None = 0,
+            ToggleVSync = 1,
+            Screenshot = 2,
+            ShowUi = 4
         }
 
         private KeyboardHotkeyState GetHotkeyState()
@@ -613,6 +620,11 @@ namespace Ryujinx.Ui
             if (_keyboardInterface.IsPressed((Key)ConfigurationState.Instance.Hid.Hotkeys.Value.Screenshot))
             {
                 state |= KeyboardHotkeyState.Screenshot;
+            }
+
+            if (_keyboardInterface.IsPressed((Key)ConfigurationState.Instance.Hid.Hotkeys.Value.ShowUi))
+            {
+                state |= KeyboardHotkeyState.ShowUi;
             }
 
             return state;

--- a/Ryujinx/Ui/RendererWidgetBase.cs
+++ b/Ryujinx/Ui/RendererWidgetBase.cs
@@ -603,9 +603,9 @@ namespace Ryujinx.Ui
         private enum KeyboardHotkeyState
         {
             None = 0,
-            ToggleVSync = 1,
-            Screenshot = 2,
-            ShowUi = 4
+            ToggleVSync = 1 << 0,
+            Screenshot = 1 << 1,
+            ShowUi = 1 << 2
         }
 
         private KeyboardHotkeyState GetHotkeyState()


### PR DESCRIPTION
This fixes #2502, which was a regression caused by #2411 (I'm sorry! 😅)

For one, Alt no longer focuses the menu bar (this is the part of my implementation that caused the issue). That functionality wasn't really relevant to the original intent of #2411, and the main purpose of the PR remains usable. Focus on Alt is something I might fix later, as I can't seem to figure out what broke it in the first place.

Secondly, this reworks the entire flow of how the "Show UI" hotkey works. Note that it is specifically a "Show UI" hotkey, and hiding the UI still has to be done via the Actions menu, as we don't want users to trigger it by accident (there was some relevant discussion in #2411).
1. It is now a legitimate entry in the `KeyboardHotkeys` struct, rather than being hacked on via `MainWindow`. Since we no longer need menubar access for this, this makes more sense.
2. The key is now configurable (via `Config.json`).
3. The key now defaults to F4. I found several annoyances with Alt, as it's part of the language-switching combination and also getting in the way of taking a (regular, non-Ryujinx) screenshot. Something that's not commonly used made more sense. Of course, due to the point 2 above, users are welcome to switch it back to Alt if they are so inclined.
4. The key is read from the config file at startup and inserted into the menu label so that the user is clear on the exact key that needs to be pressed, even if it's changed from the default. The user has to know how to bring the UI back.

Additionally, I ended up fixing a problem with the implementation of the `KeyboardHotkeyState` enum which would cause it to break were we to add any more hotkeys. The default values set here are 1, 2, 3 etc, so adding a third hotkey would make it automatically press the first two, as 1+2 would equal to 3. I switched the values to powers of 2, which is a safe approach for this kind of thing.