### PR TITLE
Make audio disposal thread safe on all 3 backends

### DIFF
--- a/Ryujinx.Audio.Backends.OpenAL/OpenALHardwareDeviceDriver.cs
+++ b/Ryujinx.Audio.Backends.OpenAL/OpenALHardwareDeviceDriver.cs
@@ -3,7 +3,7 @@ using Ryujinx.Audio.Common;
 using Ryujinx.Audio.Integration;
 using Ryujinx.Memory;
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading;
 using static Ryujinx.Audio.Integration.IHardwareDeviceDriver;
@@ -12,11 +12,10 @@ namespace Ryujinx.Audio.Backends.OpenAL
 {
     public class OpenALHardwareDeviceDriver : IHardwareDeviceDriver
     {
-        private object _lock = new object();
-        private ALDevice _device;
-        private ALContext _context;
-        private ManualResetEvent _updateRequiredEvent;
-        private List<OpenALHardwareDeviceSession> _sessions;
+        private readonly ALDevice _device;
+        private readonly ALContext _context;
+        private readonly ManualResetEvent _updateRequiredEvent;
+        private readonly ConcurrentDictionary<OpenALHardwareDeviceSession, object> _sessions;
         private bool _stillRunning;
         private Thread _updaterThread;
 
@@ -25,7 +24,7 @@ namespace Ryujinx.Audio.Backends.OpenAL
             _device = ALC.OpenDevice("");
             _context = ALC.CreateContext(_device, new ALContextAttributes());
             _updateRequiredEvent = new ManualResetEvent(false);
-            _sessions = new List<OpenALHardwareDeviceSession>();
+            _sessions = new ConcurrentDictionary<OpenALHardwareDeviceSession, object>();
 
             _stillRunning = true;
             _updaterThread = new Thread(Update)
@@ -72,22 +71,16 @@ namespace Ryujinx.Audio.Backends.OpenAL
                 throw new ArgumentException($"{channelCount}");
             }
 
-            lock (_lock)
-            {
-                OpenALHardwareDeviceSession session = new OpenALHardwareDeviceSession(this, memoryManager, sampleFormat, sampleRate, channelCount);
+            OpenALHardwareDeviceSession session = new OpenALHardwareDeviceSession(this, memoryManager, sampleFormat, sampleRate, channelCount);
 
-                _sessions.Add(session);
+            _sessions.TryAdd(session, null);
 
-                return session;
-            }
+            return session;
         }
 
-        internal void Unregister(OpenALHardwareDeviceSession session)
+        internal bool Unregister(OpenALHardwareDeviceSession session)
         {
-            lock (_lock)
-            {
-                _sessions.Remove(session);
-            }
+            return _sessions.TryRemove(session, out _);
         }
 
         public ManualResetEvent GetUpdateRequiredEvent()
@@ -103,14 +96,11 @@ namespace Ryujinx.Audio.Backends.OpenAL
             {
                 bool updateRequired = false;
 
-                lock (_lock)
+                foreach (OpenALHardwareDeviceSession session in _sessions.Keys)
                 {
-                    foreach (OpenALHardwareDeviceSession session in _sessions)
+                    if (session.Update())
                     {
-                        if (session.Update())
-                        {
-                            updateRequired = true;
-                        }
+                        updateRequired = true;
                     }
                 }
 
@@ -135,26 +125,10 @@ namespace Ryujinx.Audio.Backends.OpenAL
             {
                 _stillRunning = false;
 
-                int sessionCount = 0;
-
-                // NOTE: This is done in a way to avoid possible situations when the OpenALHardwareDeviceSession is already being dispose in another thread but doesn't hold the lock and tries to Unregister.
-                do
+                foreach (OpenALHardwareDeviceSession session in _sessions.Keys)
                 {
-                    lock (_lock)
-                    {
-                        if (_sessions.Count == 0)
-                        {
-                            break;
-                        }
-
-                        OpenALHardwareDeviceSession session = _sessions[_sessions.Count - 1];
-
-                        session.Dispose();
-
-                        sessionCount = _sessions.Count;
-                    }
+                    session.Dispose();
                 }
-                while (sessionCount > 0);
 
                 ALC.DestroyContext(_context);
                 ALC.CloseDevice(_device);

--- a/Ryujinx.Audio.Backends.OpenAL/OpenALHardwareDeviceDriver.cs
+++ b/Ryujinx.Audio.Backends.OpenAL/OpenALHardwareDeviceDriver.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.Audio.Backends.OpenAL
         private readonly ALDevice _device;
         private readonly ALContext _context;
         private readonly ManualResetEvent _updateRequiredEvent;
-        private readonly ConcurrentDictionary<OpenALHardwareDeviceSession, object> _sessions;
+        private readonly ConcurrentDictionary<OpenALHardwareDeviceSession, byte> _sessions;
         private bool _stillRunning;
         private Thread _updaterThread;
 
@@ -24,7 +24,7 @@ namespace Ryujinx.Audio.Backends.OpenAL
             _device = ALC.OpenDevice("");
             _context = ALC.CreateContext(_device, new ALContextAttributes());
             _updateRequiredEvent = new ManualResetEvent(false);
-            _sessions = new ConcurrentDictionary<OpenALHardwareDeviceSession, object>();
+            _sessions = new ConcurrentDictionary<OpenALHardwareDeviceSession, byte>();
 
             _stillRunning = true;
             _updaterThread = new Thread(Update)
@@ -73,7 +73,7 @@ namespace Ryujinx.Audio.Backends.OpenAL
 
             OpenALHardwareDeviceSession session = new OpenALHardwareDeviceSession(this, memoryManager, sampleFormat, sampleRate, channelCount);
 
-            _sessions.TryAdd(session, null);
+            _sessions.TryAdd(session, 0);
 
             return session;
         }

--- a/Ryujinx.Audio.Backends.OpenAL/OpenALHardwareDeviceSession.cs
+++ b/Ryujinx.Audio.Backends.OpenAL/OpenALHardwareDeviceSession.cs
@@ -190,17 +190,14 @@ namespace Ryujinx.Audio.Backends.OpenAL
 
         protected virtual void Dispose(bool disposing)
         {
-            if (disposing)
+            if (disposing && _driver.Unregister(this))
             {
-                if (_driver.Unregister(this))
+                lock (_lock)
                 {
-                    lock (_lock)
-                    {
-                        PrepareToClose();
-                        Stop();
+                    PrepareToClose();
+                    Stop();
 
-                        AL.DeleteSource(_sourceId);
-                    }
+                    AL.DeleteSource(_sourceId);
                 }
             }
         }

--- a/Ryujinx.Audio.Backends.OpenAL/OpenALHardwareDeviceSession.cs
+++ b/Ryujinx.Audio.Backends.OpenAL/OpenALHardwareDeviceSession.cs
@@ -192,14 +192,15 @@ namespace Ryujinx.Audio.Backends.OpenAL
         {
             if (disposing)
             {
-                lock (_lock)
+                if (_driver.Unregister(this))
                 {
-                    PrepareToClose();
-                    Stop();
+                    lock (_lock)
+                    {
+                        PrepareToClose();
+                        Stop();
 
-                    AL.DeleteSource(_sourceId);
-
-                    _driver.Unregister(this);
+                        AL.DeleteSource(_sourceId);
+                    }
                 }
             }
         }

--- a/Ryujinx.Audio.Backends.SDL2/SDL2HardwareDeviceDriver.cs
+++ b/Ryujinx.Audio.Backends.SDL2/SDL2HardwareDeviceDriver.cs
@@ -1,10 +1,9 @@
-﻿using Ryujinx.Audio.Backends.Common;
-using Ryujinx.Audio.Common;
+﻿using Ryujinx.Audio.Common;
 using Ryujinx.Audio.Integration;
 using Ryujinx.Memory;
 using Ryujinx.SDL2.Common;
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
 using System.Threading;
 
@@ -15,15 +14,13 @@ namespace Ryujinx.Audio.Backends.SDL2
 {
     public class SDL2HardwareDeviceDriver : IHardwareDeviceDriver
     {
-        private object _lock = new object();
-
-        private ManualResetEvent _updateRequiredEvent;
-        private List<SDL2HardwareDeviceSession> _sessions;
+        private readonly ManualResetEvent _updateRequiredEvent;
+        private readonly ConcurrentDictionary<SDL2HardwareDeviceSession, object> _sessions;
 
         public SDL2HardwareDeviceDriver()
         {
             _updateRequiredEvent = new ManualResetEvent(false);
-            _sessions = new List<SDL2HardwareDeviceSession>();
+            _sessions = new ConcurrentDictionary<SDL2HardwareDeviceSession, object>();
 
             SDL2Driver.Instance.Initialize();
         }
@@ -64,22 +61,16 @@ namespace Ryujinx.Audio.Backends.SDL2
                 throw new NotImplementedException("Input direction is currently not implemented on SDL2 backend!");
             }
 
-            lock (_lock)
-            {
-                SDL2HardwareDeviceSession session = new SDL2HardwareDeviceSession(this, memoryManager, sampleFormat, sampleRate, channelCount);
+            SDL2HardwareDeviceSession session = new SDL2HardwareDeviceSession(this, memoryManager, sampleFormat, sampleRate, channelCount);
 
-                _sessions.Add(session);
+            _sessions.TryAdd(session, null);
 
-                return session;
-            }
+            return session;
         }
 
-        internal void Unregister(SDL2HardwareDeviceSession session)
+        internal bool Unregister(SDL2HardwareDeviceSession session)
         {
-            lock (_lock)
-            {
-                _sessions.Remove(session);
-            }
+            return _sessions.TryRemove(session, out _);
         }
 
         private static SDL_AudioSpec GetSDL2Spec(SampleFormat requestedSampleFormat, uint requestedSampleRate, uint requestedChannelCount, uint sampleCount)
@@ -149,10 +140,8 @@ namespace Ryujinx.Audio.Backends.SDL2
         {
             if (disposing)
             {
-                while (_sessions.Count > 0)
+                foreach (SDL2HardwareDeviceSession session in _sessions.Keys)
                 {
-                    SDL2HardwareDeviceSession session = _sessions[_sessions.Count - 1];
-
                     session.Dispose();
                 }
 

--- a/Ryujinx.Audio.Backends.SDL2/SDL2HardwareDeviceDriver.cs
+++ b/Ryujinx.Audio.Backends.SDL2/SDL2HardwareDeviceDriver.cs
@@ -15,12 +15,12 @@ namespace Ryujinx.Audio.Backends.SDL2
     public class SDL2HardwareDeviceDriver : IHardwareDeviceDriver
     {
         private readonly ManualResetEvent _updateRequiredEvent;
-        private readonly ConcurrentDictionary<SDL2HardwareDeviceSession, object> _sessions;
+        private readonly ConcurrentDictionary<SDL2HardwareDeviceSession, byte> _sessions;
 
         public SDL2HardwareDeviceDriver()
         {
             _updateRequiredEvent = new ManualResetEvent(false);
-            _sessions = new ConcurrentDictionary<SDL2HardwareDeviceSession, object>();
+            _sessions = new ConcurrentDictionary<SDL2HardwareDeviceSession, byte>();
 
             SDL2Driver.Instance.Initialize();
         }
@@ -63,7 +63,7 @@ namespace Ryujinx.Audio.Backends.SDL2
 
             SDL2HardwareDeviceSession session = new SDL2HardwareDeviceSession(this, memoryManager, sampleFormat, sampleRate, channelCount);
 
-            _sessions.TryAdd(session, null);
+            _sessions.TryAdd(session, 0);
 
             return session;
         }

--- a/Ryujinx.Audio.Backends.SDL2/SDL2HardwareDeviceSession.cs
+++ b/Ryujinx.Audio.Backends.SDL2/SDL2HardwareDeviceSession.cs
@@ -201,7 +201,7 @@ namespace Ryujinx.Audio.Backends.SDL2
 
         protected virtual void Dispose(bool disposing)
         {
-            if (disposing)
+            if (disposing && _driver.Unregister(this))
             {
                 PrepareToClose();
                 Stop();
@@ -210,8 +210,6 @@ namespace Ryujinx.Audio.Backends.SDL2
                 {
                     SDL_CloseAudioDevice(_outputStream);
                 }
-
-                _driver.Unregister(this);
             }
         }
 

--- a/Ryujinx.Audio.Backends.SoundIo/SoundIoHardwareDeviceDriver.cs
+++ b/Ryujinx.Audio.Backends.SoundIo/SoundIoHardwareDeviceDriver.cs
@@ -15,14 +15,14 @@ namespace Ryujinx.Audio.Backends.SoundIo
         private readonly SoundIO _audioContext;
         private readonly SoundIODevice _audioDevice;
         private readonly ManualResetEvent _updateRequiredEvent;
-        private readonly ConcurrentDictionary<SoundIoHardwareDeviceSession, object> _sessions;
+        private readonly ConcurrentDictionary<SoundIoHardwareDeviceSession, byte> _sessions;
         private int _disposeState;
 
         public SoundIoHardwareDeviceDriver()
         {
             _audioContext = new SoundIO();
             _updateRequiredEvent = new ManualResetEvent(false);
-            _sessions = new ConcurrentDictionary<SoundIoHardwareDeviceSession, object>();
+            _sessions = new ConcurrentDictionary<SoundIoHardwareDeviceSession, byte>();
 
             _audioContext.Connect();
             _audioContext.FlushEvents();
@@ -142,7 +142,7 @@ namespace Ryujinx.Audio.Backends.SoundIo
 
             SoundIoHardwareDeviceSession session = new SoundIoHardwareDeviceSession(this, memoryManager, sampleFormat, sampleRate, channelCount);
 
-            _sessions.TryAdd(session, null);
+            _sessions.TryAdd(session, 0);
 
             return session;
         }

--- a/Ryujinx.Audio.Backends.SoundIo/SoundIoHardwareDeviceDriver.cs
+++ b/Ryujinx.Audio.Backends.SoundIo/SoundIoHardwareDeviceDriver.cs
@@ -3,7 +3,7 @@ using Ryujinx.Audio.Integration;
 using Ryujinx.Memory;
 using SoundIOSharp;
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Threading;
 
 using static Ryujinx.Audio.Integration.IHardwareDeviceDriver;
@@ -12,19 +12,17 @@ namespace Ryujinx.Audio.Backends.SoundIo
 {
     public class SoundIoHardwareDeviceDriver : IHardwareDeviceDriver
     {
-        private object _lock = new object();
-
-        private SoundIO _audioContext;
-        private SoundIODevice _audioDevice;
-        private ManualResetEvent _updateRequiredEvent;
-        private List<SoundIoHardwareDeviceSession> _sessions;
+        private readonly SoundIO _audioContext;
+        private readonly SoundIODevice _audioDevice;
+        private readonly ManualResetEvent _updateRequiredEvent;
+        private readonly ConcurrentDictionary<SoundIoHardwareDeviceSession, object> _sessions;
         private int _disposeState;
 
         public SoundIoHardwareDeviceDriver()
         {
             _audioContext = new SoundIO();
             _updateRequiredEvent = new ManualResetEvent(false);
-            _sessions = new List<SoundIoHardwareDeviceSession>();
+            _sessions = new ConcurrentDictionary<SoundIoHardwareDeviceSession, object>();
 
             _audioContext.Connect();
             _audioContext.FlushEvents();
@@ -142,22 +140,16 @@ namespace Ryujinx.Audio.Backends.SoundIo
                 throw new NotImplementedException("Input direction is currently not implemented on SoundIO backend!");
             }
 
-            lock (_lock)
-            {
-                SoundIoHardwareDeviceSession session = new SoundIoHardwareDeviceSession(this, memoryManager, sampleFormat, sampleRate, channelCount);
+            SoundIoHardwareDeviceSession session = new SoundIoHardwareDeviceSession(this, memoryManager, sampleFormat, sampleRate, channelCount);
 
-                _sessions.Add(session);
+            _sessions.TryAdd(session, null);
 
-                return session;
-            }
+            return session;
         }
 
-        internal void Unregister(SoundIoHardwareDeviceSession session)
+        internal bool Unregister(SoundIoHardwareDeviceSession session)
         {
-            lock (_lock)
-            {
-                _sessions.Remove(session);
-            }
+            return _sessions.TryRemove(session, out _);
         }
 
         public static SoundIOFormat GetSoundIoFormat(SampleFormat format)
@@ -219,26 +211,10 @@ namespace Ryujinx.Audio.Backends.SoundIo
         {
             if (disposing)
             {
-                int sessionCount = 0;
-
-                // NOTE: This is done in a way to avoid possible situations when the SoundIoHardwareDeviceSession is already being dispose in another thread but doesn't hold the lock and tries to Unregister.
-                do
+                foreach (SoundIoHardwareDeviceSession session in _sessions.Keys)
                 {
-                    lock (_lock)
-                    {
-                        if (_sessions.Count == 0)
-                        {
-                            break;
-                        }
-
-                        SoundIoHardwareDeviceSession session = _sessions[_sessions.Count - 1];
-
-                        session.Dispose();
-
-                        sessionCount = _sessions.Count;
-                    }
+                    session.Dispose();
                 }
-                while (sessionCount > 0);
 
                 _audioContext.Disconnect();
                 _audioContext.Dispose();

--- a/Ryujinx.Audio.Backends.SoundIo/SoundIoHardwareDeviceSession.cs
+++ b/Ryujinx.Audio.Backends.SoundIo/SoundIoHardwareDeviceSession.cs
@@ -423,14 +423,12 @@ namespace Ryujinx.Audio.Backends.SoundIo
 
         protected virtual void Dispose(bool disposing)
         {
-            if (disposing)
+            if (disposing && _driver.Unregister(this))
             {
                 PrepareToClose();
                 Stop();
 
                 _outputStream.Dispose();
-
-                _driver.Unregister(this);
             }
         }
 

--- a/Ryujinx/Ui/RendererWidgetBase.cs
+++ b/Ryujinx/Ui/RendererWidgetBase.cs
@@ -137,11 +137,6 @@ namespace Ryujinx.Ui
         {
             ConfigurationState.Instance.HideCursorOnIdle.Event -= HideCursorStateChanged;
 
-            if (Window != null)
-            {
-                Window.Cursor = null;
-            }
-
             NpadManager.Dispose();
             Dispose();
         }
@@ -611,7 +606,7 @@ namespace Ryujinx.Ui
             {
                 state |= KeyboardHotkeyState.ToggleVSync;
             }
-            
+
             if (_keyboardInterface.IsPressed((Key)ConfigurationState.Instance.Hid.Hotkeys.Value.Screenshot))
             {
                 state |= KeyboardHotkeyState.Screenshot;

--- a/Ryujinx/Ui/RendererWidgetBase.cs
+++ b/Ryujinx/Ui/RendererWidgetBase.cs
@@ -7,7 +7,6 @@ using Ryujinx.Common.Configuration;
 using Ryujinx.Common.Logging;
 using Ryujinx.Configuration;
 using Ryujinx.Graphics.GAL;
-using Ryujinx.HLE.HOS.Services.Hid;
 using Ryujinx.Input;
 using Ryujinx.Input.GTK3;
 using Ryujinx.Input.HLE;
@@ -138,7 +137,10 @@ namespace Ryujinx.Ui
         {
             ConfigurationState.Instance.HideCursorOnIdle.Event -= HideCursorStateChanged;
 
-            Window.Cursor = null;
+            if (Window != null)
+            {
+                Window.Cursor = null;
+            }
 
             NpadManager.Dispose();
             Dispose();
@@ -151,7 +153,7 @@ namespace Ryujinx.Ui
                 _lastCursorMoveTime = Stopwatch.GetTimestamp();
             }
 
-            if(ConfigurationState.Instance.Hid.EnableMouse)
+            if (ConfigurationState.Instance.Hid.EnableMouse)
             {
                 Window.Cursor = _invisibleCursor;
             }


### PR DESCRIPTION
This fixes a bunch of issues, mostly related to the audio backends.

First, `SDLHardwareDeviceSession` can't be disposed twice. Attempting to do so will cause a crash due to a double free. This was happening most of the time here when I use the SDL2 backend. What was causing the double dispose was the session being disposed from the audio out server thread, and from some other thread disposed the `Switch` instance (which disposes the audio device driver, which in turn disposes all the existing sessions). There is a race when the driver and session dispose methods are called the same time, which in turn can cause the session dispose to be called twice, and then free it twice, causing the crash.

OpenAL sessions would deadlock most of the time when disposed. This caused the emulator to hang while closing when the OpenAL backend was used here.

SoundIO seems to be... fine? I rarely use it, but on the few tests I made the disposal seemed to work fine. Maybe the library already handles double free internally.

Anyway, I fixed all the issues above by changing how the session disposal works. First I got rid of the lock on driver, and replaced the sessions list with a thread safe data structure (`ConcurrentDictionary`). `Unregister` is still thread safe because the `TryRemove` method is guaranteed to be thread safe. `Unregister` now returns a bool indicating if the session was still on the list, if it was not on the list, that means another thread tried to dispose it already -- and won the race, so we don't need to do anything in this case.

This fixes the emulator deadlocking on exit trying to dispose OpenAL (can't deadlock when you don't have locks ;) ) and also fixes the crash on exit when SDL2 is disposed.

Additionally, this fixes a NRE on `Window.Cursor = null`. To be honest, I'm not sure why this code was added, `Window` is null at that point... I added a null check there, but it would be nice to hear from the author of this code, I think the line should be removed.