### PR TITLE
Use "Undesired" scale mode for certain textures rather than blacklisting

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -363,11 +363,16 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
             if (changedScale)
             {
+                float oldScale = _channel.TextureManager.RenderTargetScale;
                 _channel.TextureManager.UpdateRenderTargetScale(singleUse);
-                _context.Renderer.Pipeline.SetRenderTargetScale(_channel.TextureManager.RenderTargetScale);
 
-                UpdateViewportTransform();
-                UpdateScissorState();
+                if (oldScale != _channel.TextureManager.RenderTargetScale)
+                {
+                    _context.Renderer.Pipeline.SetRenderTargetScale(_channel.TextureManager.RenderTargetScale);
+
+                    UpdateViewportTransform();
+                    UpdateScissorState();
+                }
             }
         }
 

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -549,7 +549,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="scale">The new scale factor for this texture</param>
         public void SetScale(float scale)
         {
-            TextureScaleMode newScaleMode = ScaleMode == TextureScaleMode.Blacklisted ? ScaleMode : TextureScaleMode.Scaled;
+            bool unscaled = ScaleMode == TextureScaleMode.Blacklisted || (ScaleMode == TextureScaleMode.Undesired && scale == 1);
+            TextureScaleMode newScaleMode = unscaled ? ScaleMode : TextureScaleMode.Scaled;
 
             if (_viewStorage != this)
             {

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -141,6 +141,16 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Check if a texture's scale must be updated to match the configured res scale.
+        /// </summary>
+        /// <param name="texture">The texture to check</param>
+        /// <returns>True if the scale needs updating, false if the scale is up to date</returns>
+        private bool ScaleNeedsUpdated(Texture texture)
+        {
+            return texture != null && !(texture.ScaleMode == TextureScaleMode.Blacklisted || texture.ScaleMode == TextureScaleMode.Undesired) && texture.ScaleFactor != GraphicsConfig.ResScale;
+        }
+
+        /// <summary>
         /// Sets the render target color buffer.
         /// </summary>
         /// <param name="index">The index of the color buffer to set (up to 8)</param>
@@ -164,7 +174,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 _rtColors[index] = color;
             }
 
-            return changesScale || (hasValue && color.ScaleMode != TextureScaleMode.Blacklisted && color.ScaleFactor != GraphicsConfig.ResScale);
+            return changesScale || ScaleNeedsUpdated(color);
         }
 
         /// <summary>
@@ -190,7 +200,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 _rtDepthStencil = depthStencil;
             }
 
-            return changesScale || (hasValue && depthStencil.ScaleMode != TextureScaleMode.Blacklisted && depthStencil.ScaleFactor != GraphicsConfig.ResScale);
+            return changesScale || ScaleNeedsUpdated(depthStencil);
         }
 
         /// <summary>
@@ -214,6 +224,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             bool mismatch = false;
             bool blacklisted = false;
             bool hasUpscaled = false;
+            bool hasUndesired = false;
             float targetScale = GraphicsConfig.ResScale;
 
             void ConsiderTarget(Texture target)
@@ -230,9 +241,13 @@ namespace Ryujinx.Graphics.Gpu.Image
                     case TextureScaleMode.Eligible:
                         mismatch = true; // We must make a decision.
                         break;
+                    case TextureScaleMode.Undesired:
+                        hasUndesired = true;
+                        mismatch |= scale != 1f || hasUpscaled; // If another target is upscaled, scale this one up too.
+                        break;
                     case TextureScaleMode.Scaled:
                         hasUpscaled = true;
-                        mismatch |= scale != targetScale; // If the target scale has changed, reset the scale for all targets.
+                        mismatch |= hasUndesired || scale != targetScale; // If the target scale has changed, reset the scale for all targets.
                         break;
                 }
             }
@@ -254,7 +269,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             mismatch |= blacklisted && hasUpscaled;
 
-            if (blacklisted)
+            if (blacklisted || (hasUndesired && !hasUpscaled))
             {
                 targetScale = 1f;
             }

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -141,7 +141,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Check if a texture's scale must be updated to match the configured res scale.
+        /// Check if a texture's scale must be updated to match the configured resolution scale.
         /// </summary>
         /// <param name="texture">The texture to check</param>
         /// <returns>True if the scale needs updating, false if the scale is up to date</returns>

--- a/Ryujinx.Graphics.Gpu/Image/TextureScaleMode.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureScaleMode.cs
@@ -4,11 +4,13 @@
     /// The scale mode for a given texture.
     /// Blacklisted textures cannot be scaled, Eligible textures have not been scaled yet,
     /// and Scaled textures have been scaled already.
+    /// Undesired textures will stay at 1x until a situation where they must match a scaled texture.
     /// </summary>
     enum TextureScaleMode
     {
         Eligible = 0,
         Scaled = 1,
-        Blacklisted = 2
+        Blacklisted = 2,
+        Undesired = 3
     }
 }


### PR DESCRIPTION
There are a number of textures where it is definitely _possible_ to scale them, but we don't scale them due to the potential for wasted work (depth of field need not be high res) and undesired effects (blur shaders do not behave correctly when scaled, scaling texture atlases results in ugly linear blending blur).

This PR gives these types of texture a new scale mode, rather than blacklisting them entirely. This mode is "Undesired", as we don't _want_ to scale the texture, but if it's bound alongside another texture that is scaled, we'd rather scale them _both_ than blacklist and potentially lose res scale entirely.

### Effects:
- Games that reuse depth stencil between a lot of unrelated draws to textures of different sizes will no longer blacklist from scaling forever. (Bayonetta 2)
- Textures that are detected as being atlas-like or dof-like will not be locked out of scaling forever - if a depth stencil target is bound when drawing, they can gain res scale. This might result in more 3D UI elements seeing resolution scale. (Xenoblade DE menus, though they're still heavily antialiased)
- Some other games that randomly blacklist to 1x, or don't scale at all may now work.

### Other changes:
- The approach for blur/dof texture detection has been updated to take into account width alignment, as it can greatly alter the aspect ratio. This fixes small textures failing to detect, which would have cascaded across mipmap texture views and forced textures to scale.
- Render target scale is now only sent to the backend when its value has changed, rather than each time the scales are evaluated.
- Scissor and Viewport are only recalculated when the value changes too.

![image](https://user-images.githubusercontent.com/6294155/128756570-0357d51a-60a9-4d70-b05b-11db5bff1b5e.png)

### Testing
Please make sure that no existing games break as a result! Test your favourites. 😌 