### PR TITLE
Make sure attributes used on subsequent shader stages are initialized

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -38,7 +38,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2494;
+        private const ulong ShaderCodeGenVersion = 2538;
 
         // Progress reporting helpers
         private volatile int _shaderCount;
@@ -290,6 +290,43 @@ namespace Ryujinx.Graphics.Gpu.Shader
                             {
                                 Task compileTask = Task.Run(() =>
                                 {
+                                    TranslatorContext[] shaderContexts = null;
+
+                                    if (!isHostProgramValid)
+                                    {
+                                        shaderContexts = new TranslatorContext[1 + entries.Length];
+
+                                        for (int i = 0; i < entries.Length; i++)
+                                        {
+                                            GuestShaderCacheEntry entry = entries[i];
+
+                                            if (entry == null)
+                                            {
+                                                continue;
+                                            }
+
+                                            var binaryCode = new Memory<byte>(entry.Code);
+
+                                            var gpuAccessor = new CachedGpuAccessor(
+                                                _context,
+                                                binaryCode,
+                                                binaryCode.Slice(binaryCode.Length - entry.Header.Cb1DataSize),
+                                                entry.Header.GpuAccessorHeader,
+                                                entry.TextureDescriptors);
+
+                                            var options = new TranslationOptions(TargetLanguage.Glsl, TargetApi.OpenGL, flags);
+
+                                            shaderContexts[i + 1] = Translator.CreateContext(0, gpuAccessor, options, counts);
+
+                                            if (entry.Header.SizeA != 0)
+                                            {
+                                                var options2 = new TranslationOptions(TargetLanguage.Glsl, TargetApi.OpenGL, flags | TranslationFlags.VertexA);
+
+                                                shaderContexts[0] = Translator.CreateContext((ulong)entry.Header.Size, gpuAccessor, options2, counts);
+                                            }
+                                        }
+                                    }
+
                                     // Reconstruct code holder.
                                     for (int i = 0; i < entries.Length; i++)
                                     {
@@ -301,70 +338,29 @@ namespace Ryujinx.Graphics.Gpu.Shader
                                         }
 
                                         ShaderProgram program;
+                                        ShaderProgramInfo shaderProgramInfo;
 
-                                        if (entry.Header.SizeA != 0)
+                                        if (isHostProgramValid)
                                         {
-                                            ShaderProgramInfo shaderProgramInfo;
-
-                                            if (isHostProgramValid)
-                                            {
-                                                program = new ShaderProgram(entry.Header.Stage, "");
-                                                shaderProgramInfo = hostShaderEntries[i].ToShaderProgramInfo();
-                                            }
-                                            else
-                                            {
-                                                var binaryCode = new Memory<byte>(entry.Code);
-
-                                                var gpuAccessor = new CachedGpuAccessor(
-                                                    _context,
-                                                    binaryCode,
-                                                    binaryCode.Slice(binaryCode.Length - entry.Header.Cb1DataSize),
-                                                    entry.Header.GpuAccessorHeader,
-                                                    entry.TextureDescriptors);
-
-                                                var options = new TranslationOptions(TargetLanguage.Glsl, TargetApi.OpenGL, flags);
-                                                var options2 = new TranslationOptions(TargetLanguage.Glsl, TargetApi.OpenGL, flags | TranslationFlags.VertexA);
-
-                                                TranslatorContext translatorContext = Translator.CreateContext(0, gpuAccessor, options, counts);
-                                                TranslatorContext translatorContext2 = Translator.CreateContext((ulong)entry.Header.Size, gpuAccessor, options2, counts);
-
-                                                program = translatorContext.Translate(out shaderProgramInfo, translatorContext2);
-                                            }
-
-                                            // NOTE: Vertex B comes first in the shader cache.
-                                            byte[] code = entry.Code.AsSpan().Slice(0, entry.Header.Size - entry.Header.Cb1DataSize).ToArray();
-                                            byte[] code2 = entry.Code.AsSpan().Slice(entry.Header.Size, entry.Header.SizeA).ToArray();
-
-                                            shaders[i] = new ShaderCodeHolder(program, shaderProgramInfo, code, code2);
+                                            program = new ShaderProgram(entry.Header.Stage, "");
+                                            shaderProgramInfo = hostShaderEntries[i].ToShaderProgramInfo();
                                         }
                                         else
                                         {
-                                            ShaderProgramInfo shaderProgramInfo;
+                                            int stageIndex = i + 1;
 
-                                            if (isHostProgramValid)
-                                            {
-                                                program = new ShaderProgram(entry.Header.Stage, "");
-                                                shaderProgramInfo = hostShaderEntries[i].ToShaderProgramInfo();
-                                            }
-                                            else
-                                            {
-                                                var binaryCode = new Memory<byte>(entry.Code);
+                                            TranslatorContext currentStage = shaderContexts[stageIndex];
+                                            TranslatorContext nextStage = GetNextStageContext(shaderContexts, stageIndex);
+                                            TranslatorContext vertexA = stageIndex == 1 ? shaderContexts[0] : null;
 
-                                                var gpuAccessor = new CachedGpuAccessor(
-                                                    _context,
-                                                    binaryCode,
-                                                    binaryCode.Slice(binaryCode.Length - entry.Header.Cb1DataSize),
-                                                    entry.Header.GpuAccessorHeader,
-                                                    entry.TextureDescriptors);
-
-                                                var options = new TranslationOptions(TargetLanguage.Glsl, TargetApi.OpenGL, flags);
-                                                program = Translator.CreateContext(0, gpuAccessor, options, counts).Translate(out shaderProgramInfo);
-                                            }
-
-                                            byte[] code = entry.Code.AsSpan().Slice(0, entry.Header.Size - entry.Header.Cb1DataSize).ToArray();
-
-                                            shaders[i] = new ShaderCodeHolder(program, shaderProgramInfo, code);
+                                            program = currentStage.Translate(out shaderProgramInfo, nextStage, vertexA);
                                         }
+
+                                        // NOTE: Vertex B comes first in the shader cache.
+                                        byte[] code = entry.Code.AsSpan().Slice(0, entry.Header.Size - entry.Header.Cb1DataSize).ToArray();
+                                        byte[] code2 = entry.Header.SizeA != 0 ? entry.Code.AsSpan().Slice(entry.Header.Size, entry.Header.SizeA).ToArray() : null;
+
+                                        shaders[i] = new ShaderCodeHolder(program, shaderProgramInfo, code, code2);
 
                                         shaderPrograms.Add(program);
                                     }
@@ -591,7 +587,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 }
 
                 // The shader isn't currently cached, translate it and compile it.
-                ShaderCodeHolder shader = TranslateShader(channel.MemoryManager, shaderContexts[0]);
+                ShaderCodeHolder shader = TranslateShader(_dumper, channel.MemoryManager, shaderContexts[0], null, null);
 
                 shader.HostShader = _context.Renderer.CompileShader(ShaderStage.Compute, shader.Program.Code);
 
@@ -715,11 +711,10 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 // The shader isn't currently cached, translate it and compile it.
                 ShaderCodeHolder[] shaders = new ShaderCodeHolder[Constants.ShaderStages];
 
-                shaders[0] = TranslateShader(channel.MemoryManager, shaderContexts[1], shaderContexts[0]);
-                shaders[1] = TranslateShader(channel.MemoryManager, shaderContexts[2]);
-                shaders[2] = TranslateShader(channel.MemoryManager, shaderContexts[3]);
-                shaders[3] = TranslateShader(channel.MemoryManager, shaderContexts[4]);
-                shaders[4] = TranslateShader(channel.MemoryManager, shaderContexts[5]);
+                for (int stageIndex = 0; stageIndex < Constants.ShaderStages; stageIndex++)
+                {
+                    shaders[stageIndex] = TranslateShader(_dumper, channel.MemoryManager, shaderContexts, stageIndex + 1);
+                }
 
                 List<IShader> hostShaders = new List<IShader>();
 
@@ -942,53 +937,94 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Translates a previously generated translator context to something that the host API accepts.
         /// </summary>
+        /// <param name="dumper">Optional shader code dumper</param>
         /// <param name="memoryManager">Memory manager used to access the GPU memory where the shader is located</param>
-        /// <param name="translatorContext">Current translator context to translate</param>
-        /// <param name="translatorContext2">Optional translator context of the shader that should be combined</param>
+        /// <param name="stages">Translator context of all available shader stages</param>
+        /// <param name="stageIndex">Index on the stages array to translate</param>
         /// <returns>Compiled graphics shader code</returns>
-        private ShaderCodeHolder TranslateShader(
+        private static ShaderCodeHolder TranslateShader(
+            ShaderDumper dumper,
             MemoryManager memoryManager,
-            TranslatorContext translatorContext,
-            TranslatorContext translatorContext2 = null)
+            TranslatorContext[] stages,
+            int stageIndex)
         {
-            if (translatorContext == null)
+            TranslatorContext currentStage = stages[stageIndex];
+            TranslatorContext nextStage = GetNextStageContext(stages, stageIndex);
+            TranslatorContext vertexA = stageIndex == 1 ? stages[0] : null;
+
+            return TranslateShader(dumper, memoryManager, currentStage, nextStage, vertexA);
+        }
+
+        /// <summary>
+        /// Gets the next shader stage context, from an array of contexts and index of the current stage.
+        /// </summary>
+        /// <param name="stages">Translator context of all available shader stages</param>
+        /// <param name="stageIndex">Index on the stages array to translate</param>
+        /// <returns>The translator context of the next stage, or null if inexistent</returns>
+        private static TranslatorContext GetNextStageContext(TranslatorContext[] stages, int stageIndex)
+        {
+            for (int nextStageIndex = stageIndex + 1; nextStageIndex < stages.Length; nextStageIndex++)
+            {
+                if (stages[nextStageIndex] != null)
+                {
+                    return stages[nextStageIndex];
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Translates a previously generated translator context to something that the host API accepts.
+        /// </summary>
+        /// <param name="dumper">Optional shader code dumper</param>
+        /// <param name="memoryManager">Memory manager used to access the GPU memory where the shader is located</param>
+        /// <param name="currentStage">Translator context of the stage to be translated</param>
+        /// <param name="nextStage">Translator context of the next active stage, if existent</param>
+        /// <param name="vertexA">Optional translator context of the shader that should be combined</param>
+        /// <returns>Compiled graphics shader code</returns>
+        private static ShaderCodeHolder TranslateShader(
+            ShaderDumper dumper,
+            MemoryManager memoryManager,
+            TranslatorContext currentStage,
+            TranslatorContext nextStage,
+            TranslatorContext vertexA)
+        {
+            if (currentStage == null)
             {
                 return null;
             }
 
-            if (translatorContext2 != null)
+            if (vertexA != null)
             {
-                byte[] codeA = memoryManager.GetSpan(translatorContext2.Address, translatorContext2.Size).ToArray();
-                byte[] codeB = memoryManager.GetSpan(translatorContext.Address, translatorContext.Size).ToArray();
+                byte[] codeA = memoryManager.GetSpan(vertexA.Address, vertexA.Size).ToArray();
+                byte[] codeB = memoryManager.GetSpan(currentStage.Address, currentStage.Size).ToArray();
 
-                _dumper.Dump(codeA, compute: false, out string fullPathA, out string codePathA);
-                _dumper.Dump(codeB, compute: false, out string fullPathB, out string codePathB);
+                ShaderDumpPaths pathsA = default;
+                ShaderDumpPaths pathsB = default;
 
-                ShaderProgram program = translatorContext.Translate(out ShaderProgramInfo shaderProgramInfo, translatorContext2);
-
-                if (fullPathA != null && fullPathB != null && codePathA != null && codePathB != null)
+                if (dumper != null)
                 {
-                    program.Prepend("// " + codePathB);
-                    program.Prepend("// " + fullPathB);
-                    program.Prepend("// " + codePathA);
-                    program.Prepend("// " + fullPathA);
+                    pathsA = dumper.Dump(codeA, compute: false);
+                    pathsB = dumper.Dump(codeB, compute: false);
                 }
+
+                ShaderProgram program = currentStage.Translate(out ShaderProgramInfo shaderProgramInfo, nextStage, vertexA);
+
+                pathsB.Prepend(program);
+                pathsA.Prepend(program);
 
                 return new ShaderCodeHolder(program, shaderProgramInfo, codeB, codeA);
             }
             else
             {
-                byte[] code = memoryManager.GetSpan(translatorContext.Address, translatorContext.Size).ToArray();
+                byte[] code = memoryManager.GetSpan(currentStage.Address, currentStage.Size).ToArray();
 
-                _dumper.Dump(code, translatorContext.Stage == ShaderStage.Compute, out string fullPath, out string codePath);
+                ShaderDumpPaths paths = dumper?.Dump(code, currentStage.Stage == ShaderStage.Compute) ?? default;
 
-                ShaderProgram program = translatorContext.Translate(out ShaderProgramInfo shaderProgramInfo);
+                ShaderProgram program = currentStage.Translate(out ShaderProgramInfo shaderProgramInfo, nextStage);
 
-                if (fullPath != null && codePath != null)
-                {
-                    program.Prepend("// " + codePath);
-                    program.Prepend("// " + fullPath);
-                }
+                paths.Prepend(program);
 
                 return new ShaderCodeHolder(program, shaderProgramInfo, code);
             }

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderDumpPaths.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderDumpPaths.cs
@@ -1,0 +1,49 @@
+using Ryujinx.Graphics.Shader;
+
+namespace Ryujinx.Graphics.Gpu.Shader
+{
+    /// <summary>
+    /// Paths where shader code was dumped on disk.
+    /// </summary>
+    struct ShaderDumpPaths
+    {
+        /// <summary>
+        /// Path where the full shader code with header was dumped, or null if not dumped.
+        /// </summary>
+        public string FullPath { get; }
+
+        /// <summary>
+        /// Path where the shader code without header was dumped, or null if not dumped.
+        /// </summary>
+        public string CodePath { get; }
+
+        /// <summary>
+        /// True if the shader was dumped, false otherwise.
+        /// </summary>
+        public bool HasPath => FullPath != null && CodePath != null;
+
+        /// <summary>
+        /// Creates a new shader dumps path structure.
+        /// </summary>
+        /// <param name="fullPath">Path where the full shader code with header was dumped, or null if not dumped</param>
+        /// <param name="codePath">Path where the shader code without header was dumped, or null if not dumped</param>
+        public ShaderDumpPaths(string fullPath, string codePath)
+        {
+            FullPath = fullPath;
+            CodePath = codePath;
+        }
+
+        /// <summary>
+        /// Prepends the shader paths on the program source, as a comment.
+        /// </summary>
+        /// <param name="program">Program to prepend into</param>
+        public void Prepend(ShaderProgram program)
+        {
+            if (HasPath)
+            {
+                program.Prepend("// " + CodePath);
+                program.Prepend("// " + FullPath);
+            }
+        }
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderDumper.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderDumper.cs
@@ -1,4 +1,4 @@
-using System;
+using Ryujinx.Graphics.Shader;
 using System.IO;
 
 namespace Ryujinx.Graphics.Gpu.Shader
@@ -30,24 +30,20 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// </summary>
         /// <param name="code">Code to be dumped</param>
         /// <param name="compute">True for compute shader code, false for graphics shader code</param>
-        /// <param name="fullPath">Output path for the shader code with header included</param>
-        /// <param name="codePath">Output path for the shader code without header</param>
-        public void Dump(byte[] code, bool compute, out string fullPath, out string codePath)
+        /// <returns>Paths where the shader code was dumped</returns>
+        public ShaderDumpPaths Dump(byte[] code, bool compute)
         {
             _dumpPath = GraphicsConfig.ShadersDumpPath;
 
             if (string.IsNullOrWhiteSpace(_dumpPath))
             {
-                fullPath = null;
-                codePath = null;
-
-                return;
+                return default;
             }
 
             string fileName = "Shader" + CurrentDumpIndex.ToString("d4") + ".bin";
 
-            fullPath = Path.Combine(FullDir(), fileName);
-            codePath = Path.Combine(CodeDir(), fileName);
+            string fullPath = Path.Combine(FullDir(), fileName);
+            string codePath = Path.Combine(CodeDir(), fileName);
 
             CurrentDumpIndex++;
 
@@ -73,6 +69,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
             {
                 codeWriter.Write(0);
             }
+
+            return new ShaderDumpPaths(fullPath, codePath);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/GlslGenerator.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/GlslGenerator.cs
@@ -49,46 +49,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
             Declarations.DeclareLocals(context, function);
 
-            if (funcName == MainFunctionName)
-            {
-                // Some games will leave some elements of gl_Position uninitialized,
-                // in those cases, the elements will contain undefined values according
-                // to the spec, but on NVIDIA they seems to be always initialized to (0, 0, 0, 1),
-                // so we do explicit initialization to avoid UB on non-NVIDIA gpus.
-                if (context.Config.Stage == ShaderStage.Vertex)
-                {
-                    context.AppendLine("gl_Position = vec4(0.0, 0.0, 0.0, 1.0);");
-                }
-
-                // Ensure that unused attributes are set, otherwise the downstream
-                // compiler may eliminate them.
-                // (Not needed for fragment shader as it is the last stage).
-                if (context.Config.Stage != ShaderStage.Compute &&
-                    context.Config.Stage != ShaderStage.Fragment &&
-                    !context.Config.GpPassthrough)
-                {
-                    for (int attr = 0; attr < Declarations.MaxAttributes; attr++)
-                    {
-                        if (info.OAttributes.Contains(attr))
-                        {
-                            continue;
-                        }
-
-                        if ((context.Config.Options.Flags & TranslationFlags.Feedback) != 0)
-                        {
-                            context.AppendLine($"{DefaultNames.OAttributePrefix}{attr}_x = 0.0;");
-                            context.AppendLine($"{DefaultNames.OAttributePrefix}{attr}_y = 0.0;");
-                            context.AppendLine($"{DefaultNames.OAttributePrefix}{attr}_z = 0.0;");
-                            context.AppendLine($"{DefaultNames.OAttributePrefix}{attr}_w = 1.0;");
-                        }
-                        else
-                        {
-                            context.AppendLine($"{DefaultNames.OAttributePrefix}{attr} = vec4(0.0, 0.0, 0.0, 1.0);");
-                        }
-                    }
-                }
-            }
-
             PrintBlock(context, function.MainBlock);
 
             context.LeaveScope();

--- a/Ryujinx.Graphics.Shader/Decoders/IOpCodeAttribute.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/IOpCodeAttribute.cs
@@ -1,0 +1,8 @@
+namespace Ryujinx.Graphics.Shader.Decoders
+{
+    interface IOpCodeAttribute
+    {
+        int AttributeOffset { get; }
+        int Count { get; }
+    }
+}

--- a/Ryujinx.Graphics.Shader/Decoders/OpCodeAttribute.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/OpCodeAttribute.cs
@@ -2,7 +2,7 @@ using Ryujinx.Graphics.Shader.Instructions;
 
 namespace Ryujinx.Graphics.Shader.Decoders
 {
-    class OpCodeAttribute : OpCodeAluReg
+    class OpCodeAttribute : OpCodeAluReg, IOpCodeAttribute
     {
         public int AttributeOffset { get; }
         public int Count           { get; }

--- a/Ryujinx.Graphics.Shader/Decoders/OpCodeIpa.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/OpCodeIpa.cs
@@ -2,9 +2,10 @@ using Ryujinx.Graphics.Shader.Instructions;
 
 namespace Ryujinx.Graphics.Shader.Decoders
 {
-    class OpCodeIpa : OpCodeAluReg
+    class OpCodeIpa : OpCodeAluReg, IOpCodeAttribute
     {
         public int AttributeOffset { get; }
+        public int Count => 1;
 
         public InterpolationMode Mode { get; }
 

--- a/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgramContext.cs
+++ b/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgramContext.cs
@@ -277,21 +277,11 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
 
         public AstOperand GetOperandDef(Operand operand)
         {
-            if (TryGetUserAttributeIndex(operand, out int attrIndex))
-            {
-                Info.OAttributes.Add(attrIndex);
-            }
-
             return GetOperand(operand);
         }
 
         public AstOperand GetOperandUse(Operand operand)
         {
-            if (TryGetUserAttributeIndex(operand, out int attrIndex))
-            {
-                Info.IAttributes.Add(attrIndex);
-            }
-
             return GetOperand(operand);
         }
 
@@ -317,31 +307,6 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
             }
 
             return astOperand;
-        }
-
-        private static bool TryGetUserAttributeIndex(Operand operand, out int attrIndex)
-        {
-            if (operand.Type == OperandType.Attribute)
-            {
-                if (operand.Value >= AttributeConsts.UserAttributeBase &&
-                    operand.Value <  AttributeConsts.UserAttributeEnd)
-                {
-                    attrIndex = (operand.Value - AttributeConsts.UserAttributeBase) >> 4;
-
-                    return true;
-                }
-                else if (operand.Value >= AttributeConsts.FragmentOutputColorBase &&
-                         operand.Value <  AttributeConsts.FragmentOutputColorEnd)
-                {
-                    attrIndex = (operand.Value - AttributeConsts.FragmentOutputColorBase) >> 4;
-
-                    return true;
-                }
-            }
-
-            attrIndex = 0;
-
-            return false;
         }
     }
 }

--- a/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgramInfo.cs
+++ b/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgramInfo.cs
@@ -6,17 +6,11 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
     {
         public List<StructuredFunction> Functions { get; }
 
-        public HashSet<int> IAttributes { get; }
-        public HashSet<int> OAttributes { get; }
-
         public HelperFunctionsMask HelperFunctionsMask { get; set; }
 
         public StructuredProgramInfo()
         {
             Functions = new List<StructuredFunction>();
-
-            IAttributes = new HashSet<int>();
-            OAttributes = new HashSet<int>();
         }
     }
 }

--- a/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -15,6 +15,8 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public bool IsNonMain { get; }
 
+        public int OperationsCount => _operations.Count;
+
         private readonly IReadOnlyDictionary<ulong, int> _funcs;
         private readonly List<Operation> _operations;
         private readonly Dictionary<ulong, Operand> _labels;
@@ -200,6 +202,7 @@ namespace Ryujinx.Graphics.Shader.Translation
 
                     if (target.Enabled)
                     {
+                        Config.SetOutputUserAttribute(rtIndex);
                         regIndexBase += 4;
                     }
                 }

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -41,6 +41,10 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         private readonly TranslationCounts _counts;
 
+        public int UsedInputAttributes { get; private set; }
+        public int UsedOutputAttributes { get; private set; }
+        public int PassthroughAttributes { get; private set; }
+
         private int _usedConstantBuffers;
         private int _usedStorageBuffers;
         private int _usedStorageBuffersWrite;
@@ -170,6 +174,8 @@ namespace Ryujinx.Graphics.Shader.Translation
 
             TextureHandlesForCache.UnionWith(other.TextureHandlesForCache);
 
+            UsedInputAttributes |= other.UsedInputAttributes;
+            UsedOutputAttributes |= other.UsedOutputAttributes;
             _usedConstantBuffers |= other._usedConstantBuffers;
             _usedStorageBuffers |= other._usedStorageBuffers;
             _usedStorageBuffersWrite |= other._usedStorageBuffersWrite;
@@ -188,6 +194,28 @@ namespace Ryujinx.Graphics.Shader.Translation
                 {
                     _usedImages[kv.Key] = MergeTextureMeta(kv.Value, _usedImages[kv.Key]);
                 }
+            }
+        }
+
+        public void SetInputUserAttribute(int index)
+        {
+            UsedInputAttributes |= 1 << index;
+        }
+
+        public void SetOutputUserAttribute(int index)
+        {
+            UsedOutputAttributes |= 1 << index;
+        }
+
+        public void MergeOutputUserAttributes(int mask)
+        {
+            if (GpPassthrough)
+            {
+                PassthroughAttributes = mask & ~UsedOutputAttributes;
+            }
+            else
+            {
+                UsedOutputAttributes |= mask;
             }
         }
 

--- a/Ryujinx.Graphics.Shader/Translation/Translator.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Translator.cs
@@ -5,6 +5,7 @@ using Ryujinx.Graphics.Shader.StructuredIr;
 using Ryujinx.Graphics.Shader.Translation.Optimizations;
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 
 using static Ryujinx.Graphics.Shader.IntermediateRepresentation.OperandHelper;
 
@@ -120,24 +121,17 @@ namespace Ryujinx.Graphics.Shader.Translation
             Block[][] cfg;
             ulong maxEndAddress = 0;
 
-            bool hasBindless;
-
             if ((options.Flags & TranslationFlags.Compute) != 0)
             {
                 config = new ShaderConfig(gpuAccessor, options, counts);
 
-                cfg = Decoder.Decode(gpuAccessor, address, out hasBindless);
+                cfg = Decoder.Decode(config, address);
             }
             else
             {
                 config = new ShaderConfig(new ShaderHeader(gpuAccessor, address), gpuAccessor, options, counts);
 
-                cfg = Decoder.Decode(gpuAccessor, address + HeaderSize, out hasBindless);
-            }
-
-            if (hasBindless)
-            {
-                config.SetUsedFeature(FeatureFlags.Bindless);
+                cfg = Decoder.Decode(config, address + HeaderSize);
             }
 
             for (int funcIndex = 0; funcIndex < cfg.Length; funcIndex++)
@@ -151,7 +145,7 @@ namespace Ryujinx.Graphics.Shader.Translation
                         maxEndAddress = block.EndAddress;
                     }
 
-                    if (!hasBindless)
+                    if (!config.UsedFeatures.HasFlag(FeatureFlags.Bindless))
                     {
                         for (int index = 0; index < block.OpCodes.Count; index++)
                         {
@@ -169,8 +163,10 @@ namespace Ryujinx.Graphics.Shader.Translation
             return cfg;
         }
 
-        internal static FunctionCode[] EmitShader(Block[][] cfg, ShaderConfig config)
+        internal static FunctionCode[] EmitShader(Block[][] cfg, ShaderConfig config, bool initializeOutputs, out int initializationOperations)
         {
+            initializationOperations = 0;
+
             Dictionary<ulong, int> funcIds = new Dictionary<ulong, int>();
 
             for (int funcIndex = 0; funcIndex < cfg.Length; funcIndex++)
@@ -183,6 +179,12 @@ namespace Ryujinx.Graphics.Shader.Translation
             for (int funcIndex = 0; funcIndex < cfg.Length; funcIndex++)
             {
                 EmitterContext context = new EmitterContext(config, funcIndex != 0, funcIds);
+
+                if (initializeOutputs && funcIndex == 0)
+                {
+                    EmitOutputsInitialization(context, config);
+                    initializationOperations = context.OperationsCount;
+                }
 
                 for (int blkIndex = 0; blkIndex < cfg[funcIndex].Length; blkIndex++)
                 {
@@ -199,6 +201,39 @@ namespace Ryujinx.Graphics.Shader.Translation
             }
 
             return funcs.ToArray();
+        }
+
+        private static void EmitOutputsInitialization(EmitterContext context, ShaderConfig config)
+        {
+            // Compute has no output attributes, and fragment is the last stage, so we
+            // don't need to initialize outputs on those stages.
+            if (config.Stage == ShaderStage.Compute || config.Stage == ShaderStage.Fragment)
+            {
+                return;
+            }
+
+            void InitializeOutput(int baseAttr)
+            {
+                for (int c = 0; c < 4; c++)
+                {
+                    context.Copy(Attribute(baseAttr + c * 4), ConstF(c == 3 ? 1f : 0f));
+                }
+            }
+
+            if (config.Stage == ShaderStage.Vertex)
+            {
+                InitializeOutput(AttributeConsts.PositionX);
+            }
+
+            int usedAttribtes = context.Config.UsedOutputAttributes;
+            while (usedAttribtes != 0)
+            {
+                int index = BitOperations.TrailingZeroCount(usedAttribtes);
+
+                InitializeOutput(AttributeConsts.UserAttributeBase + index * 16);
+
+                usedAttribtes &= ~(1 << index);
+            }
         }
 
         private static void EmitOps(EmitterContext context, Block block)


### PR DESCRIPTION
Sometimes, an shader attribute is consumed on a later stage, but the previous stage does not write it. On NVIDIA, all attributes that are not written to are initialized with a default value of (0, 0, 0, 1). This is not the case for other vendors however, and according to the spec, the values on them are "undefined". This causes problems for AMD and Intel as the attributes have different values.

The current approach taken is assuming all the first 16 attributes are used, so initializes the first 16.  That's because on desktop, usually only 16 attributes are supported (at least on OpenGL, Vulkan might allow more?). This causes shaders to fail to compile if the previous stage does not write the attribute at all. For example, one shader in Yo-kai Watch 4 fails to compile due to this, I'm not sure for what the shader is used though, the game seems to render fine regardless.

Additionally, there is another problem where partially written attributes are not initialized. So if the vertex shader writes X, Y and Z, and the  fragment shader reads W, the value will be undefined. This causes eyes to be solid blue on Hatsune Miku, and shadows to break in Zelda Link's Awakening on Intel and AMD.

This change fixes all the issues above by propagating attribute use information backwards (from later stages to early ones, like from fragment to vertex etc). That way, all attributes that are used on the subsequent stages can be properly initialized. Attribute use information is now computed very early (on the decode step) rather than later (on the structured program construction step), this was done to allow the uses to be propagated after decode, but before translation. Attribute initialization is also done earlier now, it is done at the IR level instead of the backend, this reduces code duplication between GLSL and SPIR-V.

So, to sum it up, those issues should be fixed:
- Shadows not working on Zelda Link's awakening (Intel and AMD).
- Hatsune Miku eyes being black (Intel and AMD).
- Shader failing to compile on Yo-kai Watch 4 (all vendors, no visible effect though?).

Probably more...

Would be nice to get a confirmation that those games were fixed on AMD, as I did not test them *on AMD*, and they still don't render properly on Intel OpenGL due to other issues (I will be fixing some of them soon), also helps Vulkan.

Fixes #1895 and #1109.
