### PR TITLE
Workaround for Intel FrontFacing built-in variable bug

### DIFF
--- a/Ryujinx.Graphics.GAL/Capabilities.cs
+++ b/Ryujinx.Graphics.GAL/Capabilities.cs
@@ -2,37 +2,44 @@ namespace Ryujinx.Graphics.GAL
 {
     public struct Capabilities
     {
-        public bool SupportsAstcCompression          { get; }
-        public bool SupportsImageLoadFormatted       { get; }
-        public bool SupportsMismatchingViewFormat    { get; }
-        public bool SupportsNonConstantTextureOffset { get; }
-        public bool SupportsTextureShadowLod         { get; }
-        public bool SupportsViewportSwizzle          { get; }
+        public bool HasFrontFacingBug { get; }
+        public bool HasVectorIndexingBug { get; }
 
-        public int   MaximumComputeSharedMemorySize { get; }
-        public float MaximumSupportedAnisotropy     { get; }
-        public int   StorageBufferOffsetAlignment   { get; }
+        public bool SupportsAstcCompression { get; }
+        public bool SupportsImageLoadFormatted { get; }
+        public bool SupportsMismatchingViewFormat { get; }
+        public bool SupportsNonConstantTextureOffset { get; }
+        public bool SupportsTextureShadowLod { get; }
+        public bool SupportsViewportSwizzle { get; }
+
+        public int MaximumComputeSharedMemorySize { get; }
+        public float MaximumSupportedAnisotropy { get; }
+        public int StorageBufferOffsetAlignment { get; }
 
         public Capabilities(
-            bool  supportsAstcCompression,
-            bool  supportsImageLoadFormatted,
-            bool  supportsMismatchingViewFormat,
-            bool  supportsNonConstantTextureOffset,
-            bool  supportsTextureShadowLod,
-            bool  supportsViewportSwizzle,
-            int   maximumComputeSharedMemorySize,
+            bool hasFrontFacingBug,
+            bool hasVectorIndexingBug,
+            bool supportsAstcCompression,
+            bool supportsImageLoadFormatted,
+            bool supportsMismatchingViewFormat,
+            bool supportsNonConstantTextureOffset,
+            bool supportsTextureShadowLod,
+            bool supportsViewportSwizzle,
+            int maximumComputeSharedMemorySize,
             float maximumSupportedAnisotropy,
-            int   storageBufferOffsetAlignment)
+            int storageBufferOffsetAlignment)
         {
-            SupportsAstcCompression          = supportsAstcCompression;
-            SupportsImageLoadFormatted       = supportsImageLoadFormatted;
-            SupportsMismatchingViewFormat    = supportsMismatchingViewFormat;
+            HasFrontFacingBug = hasFrontFacingBug;
+            HasVectorIndexingBug = hasVectorIndexingBug;
+            SupportsAstcCompression = supportsAstcCompression;
+            SupportsImageLoadFormatted = supportsImageLoadFormatted;
+            SupportsMismatchingViewFormat = supportsMismatchingViewFormat;
             SupportsNonConstantTextureOffset = supportsNonConstantTextureOffset;
-            SupportsTextureShadowLod         = supportsTextureShadowLod;
-            SupportsViewportSwizzle          = supportsViewportSwizzle;
-            MaximumComputeSharedMemorySize   = maximumComputeSharedMemorySize;
-            MaximumSupportedAnisotropy       = maximumSupportedAnisotropy;
-            StorageBufferOffsetAlignment     = storageBufferOffsetAlignment;
+            SupportsTextureShadowLod = supportsTextureShadowLod;
+            SupportsViewportSwizzle = supportsViewportSwizzle;
+            MaximumComputeSharedMemorySize = maximumComputeSharedMemorySize;
+            MaximumSupportedAnisotropy = maximumSupportedAnisotropy;
+            StorageBufferOffsetAlignment = storageBufferOffsetAlignment;
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Shader/CachedGpuAccessor.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/CachedGpuAccessor.cs
@@ -9,7 +9,6 @@ namespace Ryujinx.Graphics.Gpu.Shader
 {
     class CachedGpuAccessor : TextureDescriptorCapableGpuAccessor, IGpuAccessor
     {
-        private readonly GpuContext _context;
         private readonly ReadOnlyMemory<byte> _data;
         private readonly ReadOnlyMemory<byte> _cb1Data;
         private readonly GuestGpuAccessorHeader _header;
@@ -28,9 +27,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
             ReadOnlyMemory<byte> data,
             ReadOnlyMemory<byte> cb1Data,
             GuestGpuAccessorHeader header,
-            Dictionary<int, GuestTextureDescriptor> guestTextureDescriptors)
+            IReadOnlyDictionary<int, GuestTextureDescriptor> guestTextureDescriptors) : base(context)
         {
-            _context = context;
             _data = data;
             _cb1Data = cb1Data;
             _header = header;
@@ -135,24 +133,6 @@ namespace Ryujinx.Graphics.Gpu.Shader
         {
             return _header.PrimitiveTopology;
         }
-
-        /// <summary>
-        /// Queries host storage buffer alignment required.
-        /// </summary>
-        /// <returns>Host storage buffer alignment in bytes</returns>
-        public int QueryStorageBufferOffsetAlignment() => _context.Capabilities.StorageBufferOffsetAlignment;
-
-        /// <summary>
-        /// Queries host support for readable images without a explicit format declaration on the shader.
-        /// </summary>
-        /// <returns>True if formatted image load is supported, false otherwise</returns>
-        public bool QuerySupportsImageLoadFormatted() => _context.Capabilities.SupportsImageLoadFormatted;
-
-        /// <summary>
-        /// Queries host GPU non-constant texture offset support.
-        /// </summary>
-        /// <returns>True if the GPU and driver supports non-constant texture offsets, false otherwise</returns>
-        public bool QuerySupportsNonConstantTextureOffset() => _context.Capabilities.SupportsNonConstantTextureOffset;
 
         /// <summary>
         /// Gets the texture descriptor for a given texture on the pool.

--- a/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
@@ -7,9 +7,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
     /// <summary>
     /// Represents a GPU state and memory accessor.
     /// </summary>
-    class GpuAccessor : TextureDescriptorCapableGpuAccessor, IGpuAccessor
+    class GpuAccessor : TextureDescriptorCapableGpuAccessor
     {
-        private readonly GpuContext _context;
         private readonly GpuChannel _channel;
         private readonly GpuAccessorState _state;
         private readonly int _stageIndex;
@@ -29,9 +28,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <param name="channel">GPU channel</param>
         /// <param name="state">Current GPU state</param>
         /// <param name="stageIndex">Graphics shader stage index (0 = Vertex, 4 = Fragment)</param>
-        public GpuAccessor(GpuContext context, GpuChannel channel, GpuAccessorState state, int stageIndex)
+        public GpuAccessor(GpuContext context, GpuChannel channel, GpuAccessorState state, int stageIndex) : base(context)
         {
-            _context = context;
             _channel = channel;
             _state = state;
             _stageIndex = stageIndex;
@@ -56,9 +54,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
             int localSizeY,
             int localSizeZ,
             int localMemorySize,
-            int sharedMemorySize)
+            int sharedMemorySize) : base(context)
         {
-            _context = context;
             _channel = channel;
             _state = state;
             _compute = true;
@@ -181,30 +178,6 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 _ => InputTopology.Points,
             };
         }
-
-        /// <summary>
-        /// Queries host storage buffer alignment required.
-        /// </summary>
-        /// <returns>Host storage buffer alignment in bytes</returns>
-        public int QueryStorageBufferOffsetAlignment() => _context.Capabilities.StorageBufferOffsetAlignment;
-
-        /// <summary>
-        /// Queries host support for readable images without a explicit format declaration on the shader.
-        /// </summary>
-        /// <returns>True if formatted image load is supported, false otherwise</returns>
-        public bool QuerySupportsImageLoadFormatted() => _context.Capabilities.SupportsImageLoadFormatted;
-
-        /// <summary>
-        /// Queries host GPU non-constant texture offset support.
-        /// </summary>
-        /// <returns>True if the GPU and driver supports non-constant texture offsets, false otherwise</returns>
-        public bool QuerySupportsNonConstantTextureOffset() => _context.Capabilities.SupportsNonConstantTextureOffset;
-
-        /// <summary>
-        /// Queries host GPU texture shadow LOD support.
-        /// </summary>
-        /// <returns>True if the GPU and driver supports texture shadow LOD, false otherwise</returns>
-        public bool QuerySupportsTextureShadowLod() => _context.Capabilities.SupportsTextureShadowLod;
 
         /// <summary>
         /// Gets the texture descriptor for a given texture on the pool.

--- a/Ryujinx.Graphics.Gpu/Shader/GpuAccessorBase.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/GpuAccessorBase.cs
@@ -1,0 +1,55 @@
+namespace Ryujinx.Graphics.Gpu.Shader
+{
+    /// <summary>
+    /// Represents a GPU state and memory accessor.
+    /// </summary>
+    class GpuAccessorBase
+    {
+        private readonly GpuContext _context;
+
+        /// <summary>
+        /// Creates a new instance of the GPU state accessor.
+        /// </summary>
+        /// <param name="context">GPU context</param>
+        public GpuAccessorBase(GpuContext context)
+        {
+            _context = context;
+        }
+
+        /// <summary>
+        /// Queries host about the presence of the FrontFacing built-in variable bug.
+        /// </summary>
+        /// <returns>True if the bug is present on the host device used, false otherwise</returns>
+        public bool QueryHostHasFrontFacingBug() => _context.Capabilities.HasFrontFacingBug;
+
+        /// <summary>
+        /// Queries host about the presence of the vector indexing bug.
+        /// </summary>
+        /// <returns>True if the bug is present on the host device used, false otherwise</returns>
+        public bool QueryHostHasVectorIndexingBug() => _context.Capabilities.HasVectorIndexingBug;
+
+        /// <summary>
+        /// Queries host storage buffer alignment required.
+        /// </summary>
+        /// <returns>Host storage buffer alignment in bytes</returns>
+        public int QueryHostStorageBufferOffsetAlignment() => _context.Capabilities.StorageBufferOffsetAlignment;
+
+        /// <summary>
+        /// Queries host support for readable images without a explicit format declaration on the shader.
+        /// </summary>
+        /// <returns>True if formatted image load is supported, false otherwise</returns>
+        public bool QueryHostSupportsImageLoadFormatted() => _context.Capabilities.SupportsImageLoadFormatted;
+
+        /// <summary>
+        /// Queries host GPU non-constant texture offset support.
+        /// </summary>
+        /// <returns>True if the GPU and driver supports non-constant texture offsets, false otherwise</returns>
+        public bool QueryHostSupportsNonConstantTextureOffset() => _context.Capabilities.SupportsNonConstantTextureOffset;
+
+        /// <summary>
+        /// Queries host GPU texture shadow LOD support.
+        /// </summary>
+        /// <returns>True if the GPU and driver supports texture shadow LOD, false otherwise</returns>
+        public bool QueryHostSupportsTextureShadowLod() => _context.Capabilities.SupportsTextureShadowLod;
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -38,7 +38,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2538;
+        private const ulong ShaderCodeGenVersion = 2540;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Gpu/Shader/TextureDescriptorCapableGpuAccessor.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/TextureDescriptorCapableGpuAccessor.cs
@@ -4,8 +4,12 @@ using Ryujinx.Graphics.Shader;
 
 namespace Ryujinx.Graphics.Gpu.Shader
 {
-    abstract class TextureDescriptorCapableGpuAccessor : IGpuAccessor
+    abstract class TextureDescriptorCapableGpuAccessor : GpuAccessorBase, IGpuAccessor
     {
+        public TextureDescriptorCapableGpuAccessor(GpuContext context) : base(context)
+        {
+        }
+
         public abstract T MemoryRead<T>(ulong address) where T : unmanaged;
 
         public abstract ITextureDescriptor GetTextureDescriptor(int handle, int cbufSlot);

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -99,6 +99,8 @@ namespace Ryujinx.Graphics.OpenGL
         public Capabilities GetCapabilities()
         {
             return new Capabilities(
+                HwCapabilities.Vendor == HwCapabilities.GpuVendor.IntelWindows,
+                HwCapabilities.Vendor == HwCapabilities.GpuVendor.AmdWindows,
                 HwCapabilities.SupportsAstcCompression,
                 HwCapabilities.SupportsImageLoadFormatted,
                 HwCapabilities.SupportsMismatchingViewFormat,

--- a/Ryujinx.Graphics.Shader/IGpuAccessor.cs
+++ b/Ryujinx.Graphics.Shader/IGpuAccessor.cs
@@ -49,6 +49,36 @@
             return 0;
         }
 
+        bool QueryHostHasFrontFacingBug()
+        {
+            return false;
+        }
+
+        bool QueryHostHasVectorIndexingBug()
+        {
+            return false;
+        }
+
+        int QueryHostStorageBufferOffsetAlignment()
+        {
+            return 16;
+        }
+
+        bool QueryHostSupportsImageLoadFormatted()
+        {
+            return true;
+        }
+
+        bool QueryHostSupportsNonConstantTextureOffset()
+        {
+            return true;
+        }
+
+        bool QueryHostSupportsTextureShadowLod()
+        {
+            return true;
+        }
+
         bool QueryIsTextureBuffer(int handle, int cbufSlot = -1)
         {
             return false;
@@ -62,26 +92,6 @@
         InputTopology QueryPrimitiveTopology()
         {
             return InputTopology.Points;
-        }
-
-        int QueryStorageBufferOffsetAlignment()
-        {
-            return 16;
-        }
-
-        bool QuerySupportsImageLoadFormatted()
-        {
-            return true;
-        }
-
-        bool QuerySupportsNonConstantTextureOffset()
-        {
-            return true;
-        }
-
-        bool QuerySupportsTextureShadowLod()
-        {
-            return true;
         }
 
         TextureFormat QueryTextureFormat(int handle, int cbufSlot = -1)

--- a/Ryujinx.Graphics.Shader/Translation/Optimizations/GlobalToStorage.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Optimizations/GlobalToStorage.cs
@@ -71,7 +71,7 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
 
                 Operand baseAddrTrunc = Local();
 
-                Operand alignMask = Const(-config.GpuAccessor.QueryStorageBufferOffsetAlignment());
+                Operand alignMask = Const(-config.GpuAccessor.QueryHostStorageBufferOffsetAlignment());
 
                 Operation andOp = new Operation(Instruction.BitwiseAnd, baseAddrTrunc, baseAddrLow, alignMask);
 
@@ -142,7 +142,7 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
 
                 Operand baseAddrTrunc = Local();
 
-                Operand alignMask = Const(-config.GpuAccessor.QueryStorageBufferOffsetAlignment());
+                Operand alignMask = Const(-config.GpuAccessor.QueryHostStorageBufferOffsetAlignment());
 
                 Operation andOp = new Operation(Instruction.BitwiseAnd, baseAddrTrunc, baseAddrLow, alignMask);
 

--- a/Ryujinx.Graphics.Shader/Translation/Rewriter.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Rewriter.cs
@@ -93,7 +93,7 @@ namespace Ryujinx.Graphics.Shader.Translation
                 sbSlot        = PrependOperation(Instruction.ConditionalSelect, inRange, Const(slot), sbSlot);
             }
 
-            Operand alignMask = Const(-config.GpuAccessor.QueryStorageBufferOffsetAlignment());
+            Operand alignMask = Const(-config.GpuAccessor.QueryHostStorageBufferOffsetAlignment());
 
             Operand baseAddrTrunc = PrependOperation(Instruction.BitwiseAnd,    sbBaseAddrLow, alignMask);
             Operand byteOffset    = PrependOperation(Instruction.Subtract,      addrLow, baseAddrTrunc);
@@ -145,7 +145,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             bool hasOffset  = (texOp.Flags & TextureFlags.Offset)  != 0;
             bool hasOffsets = (texOp.Flags & TextureFlags.Offsets) != 0;
 
-            bool hasInvalidOffset = (hasOffset || hasOffsets) && !config.GpuAccessor.QuerySupportsNonConstantTextureOffset();
+            bool hasInvalidOffset = (hasOffset || hasOffsets) && !config.GpuAccessor.QueryHostSupportsNonConstantTextureOffset();
 
             bool isBindless = (texOp.Flags & TextureFlags.Bindless) != 0;
 

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -145,7 +145,7 @@ namespace Ryujinx.Graphics.Shader.Translation
         {
             // When the formatted load extension is supported, we don't need to
             // specify a format, we can just declare it without a format and the GPU will handle it.
-            if (GpuAccessor.QuerySupportsImageLoadFormatted())
+            if (GpuAccessor.QueryHostSupportsImageLoadFormatted())
             {
                 return TextureFormat.Unknown;
             }


### PR DESCRIPTION
This is a workaround for yet another bug on Intel where `gl_FrontFacing` returns incorrect values (it seems to be flipped?), the solution here is casting the bool to float and then bitcasting to integer and checking if its non-zero. The solution was found by trial and error, if someone knows a better way, please let me know.

Fixes rendering of mario mustache on Super Mario Odyssey on Intel (affects both Vulkan and OpenGL):
Before:
![image](https://user-images.githubusercontent.com/5624669/128948699-4fe305a6-9256-4e25-889d-0f0eea45184b.png)
(Note that the screenshot is a bit old, the shadow glitch on cappy was already fixed).
After:
![image](https://user-images.githubusercontent.com/5624669/128948664-daae3b57-f0e5-458b-be21-7c48e53cfa66.png)

This also fixes the "dead" palette on Zelda Link's Awakening, however the game is not rendering correctly on OpenGL, so the fix is only visible on Vulkan.

Other changes here includes:
- Added 2 new functions to the IGpuAccessor interface, used to check if the host has the vector indexing bug (present on AMD) and the front facing bug (present on Intel).
- LDC now uses vector indexing of the form `data[offset >> 2][offset & 3]` on NVIDIA and Intel, which produces better codegen (and makes shaders easier to read).
- Functions that just returns a host capability on `GpuAcessor` and `CachedGpuAccessor` were moved to a common base class to avoid duplication and bugs. In fact, one of them (the one to check the texture shadow LOD capability) was missing from the `CachedGpuAccessor`, which likely means those shaders were broken on shader cache rebuild on the vendors/drivers that does not support the extension (as the default interface implementation returns true). Now this is fixed.