### PR TITLE
Improve firmware install error due to outdated keys

### DIFF
--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -1292,7 +1292,7 @@ namespace Ryujinx.Ui
                 catch (LibHac.MissingKeyException ex)
                 {
                     Logger.Error?.Print(LogClass.Application, ex.ToString());
-                    UserErrorDialog.CreateUserErrorDialog(UserError.NoKeys);
+                    UserErrorDialog.CreateUserErrorDialog(UserError.FirmwareParsingFailed);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
We have a constant of `UserError.FirmwareParsingFailed`, which when used produces the following message:

> Ryujinx was unable to parse the provided firmware. This is usually caused by outdated keys.

This is a better description of the firmware installation problems that a lot of users face than the currently used `UserError.NoKeys`, that simply states:

> Ryujinx was unable to find your 'prod.keys' file

This PR changes the generated error message to the more relevant one.