### PR TITLE
Ensure render scale is initialized to 1 on the backend

### DIFF
--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -144,6 +144,7 @@ namespace Ryujinx.Graphics.OpenGL
                 GL.Arb.MaxShaderCompilerThreads(Math.Min(Environment.ProcessorCount, 8));
             }
 
+            _pipeline.Initialize();
             _counters.Initialize();
         }
 

--- a/Ryujinx.Graphics.Shader/SupportBuffer.cs
+++ b/Ryujinx.Graphics.Shader/SupportBuffer.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.Graphics.Shader
         public const int ComputeRenderScaleOffset = FragmentRenderScaleOffset + FieldSize; // Skip first scale that is used for the render target
 
         // One for the render target, 32 for the textures, and 8 for the images.
-        private const int RenderScaleMaxCount = 1 + 32 + 8;
+        public const int RenderScaleMaxCount = 1 + 32 + 8;
 
         public const int RequiredSize = FragmentRenderScaleOffset + RenderScaleMaxCount * FieldSize;
     }


### PR DESCRIPTION
Fixes a regression caused by #2496 when combined with #2537, that broke rendering on some cases due to the scale not being initialized.