### PR TITLE
Fix size of cached compute shaders

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -179,7 +179,9 @@ namespace Ryujinx.Graphics.Gpu.Shader
                                     program = new ShaderProgram(entry.Header.Stage, "");
                                     shaderProgramInfo = hostShaderEntries[0].ToShaderProgramInfo();
 
-                                    ShaderCodeHolder shader = new ShaderCodeHolder(program, shaderProgramInfo, entry.Code);
+                                    byte[] code = entry.Code.AsSpan().Slice(0, entry.Header.Size - entry.Header.Cb1DataSize).ToArray();
+
+                                    ShaderCodeHolder shader = new ShaderCodeHolder(program, shaderProgramInfo, code);
 
                                     _cpProgramsDiskCache.Add(key, new ShaderBundle(hostProgram, shader));
 

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -214,7 +214,9 @@ namespace Ryujinx.Graphics.Gpu.Shader
                                             return true; // Exit early, the decoding step failed.
                                         }
 
-                                        ShaderCodeHolder shader = new ShaderCodeHolder(program, shaderProgramInfo, entry.Code);
+                                        byte[] code = entry.Code.AsSpan().Slice(0, entry.Header.Size - entry.Header.Cb1DataSize).ToArray();
+
+                                        ShaderCodeHolder shader = new ShaderCodeHolder(program, shaderProgramInfo, code);
 
                                         Logger.Info?.Print(LogClass.Gpu, $"Host shader {key} got invalidated, rebuilding from guest...");
 


### PR DESCRIPTION
Fix regression that could cause the same compute shader being compiled over and over due  to the code size being too large and the shader containing garbage. Regression was introduced with #2532 or something after that.

Thanks to @riperiperi for finding the issue and confirming that it fixes the performance regression on Hyrule Warriors: Ages of Calamity.