### PR TITLE
Enable transform feedback buffer flush

### DIFF
--- a/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -503,7 +503,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                         continue;
                     }
 
-                    tfbs[index] = bufferCache.GetBufferRange(tfb.Address, tfb.Size);
+                    tfbs[index] = bufferCache.GetBufferRange(tfb.Address, tfb.Size, write: true);
                 }
 
                 _context.Renderer.Pipeline.SetTransformFeedbackBuffers(tfbs);


### PR DESCRIPTION
Transform feedback buffers can be modified by the GPU, so they must have the `write` flag set to true to indicate they might have been modified.

Seems to fix vertex explosion in SNK Heroines Tag Team Frenzy.
Before:
![image](https://user-images.githubusercontent.com/5624669/129428095-b7dd4bf2-9966-4fa9-9d1a-cdcad977c578.png)
After:
![image](https://user-images.githubusercontent.com/5624669/129428102-0ab9f547-8cab-438b-afa0-96b5f0b488f4.png)
Worth noting that it seems somewhat random, but I was getting the same corruption with this character selection. There's still some vertex explosions on some special effects, but I suspect this is a different problem since those seems more consistent.