### PR TITLE
Swap BGR components for 16-bit BGR texture formats

### DIFF
--- a/Ryujinx.Graphics.GAL/Format.cs
+++ b/Ryujinx.Graphics.GAL/Format.cs
@@ -235,14 +235,17 @@ namespace Ryujinx.Graphics.GAL
         }
 
         /// <summary>
-        /// Checks if the texture format is a BGRA format with 8-bit components.
+        /// Checks if the texture format is a BGR format.
         /// </summary>
         /// <param name="format">Texture format</param>
-        /// <returns>True if the texture format is a BGRA format with 8-bit components, false otherwise</returns>
-        public static bool IsBgra8(this Format format)
+        /// <returns>True if the texture format is a BGR format, false otherwise</returns>
+        public static bool IsBgr(this Format format)
         {
             switch (format)
             {
+                case Format.B5G6R5Unorm:
+                case Format.B5G5R5X1Unorm:
+                case Format.B5G5R5A1Unorm:
                 case Format.B8G8R8X8Unorm:
                 case Format.B8G8R8A8Unorm:
                 case Format.B8G8R8X8Srgb:

--- a/Ryujinx.Graphics.OpenGL/FormatTable.cs
+++ b/Ryujinx.Graphics.OpenGL/FormatTable.cs
@@ -168,9 +168,9 @@ namespace Ryujinx.Graphics.OpenGL
             Add(Format.Astc10x10Srgb,       new FormatInfo(4, false, false, All.CompressedSrgb8Alpha8Astc10X10Khr));
             Add(Format.Astc12x10Srgb,       new FormatInfo(4, false, false, All.CompressedSrgb8Alpha8Astc12X10Khr));
             Add(Format.Astc12x12Srgb,       new FormatInfo(4, false, false, All.CompressedSrgb8Alpha8Astc12X12Khr));
-            Add(Format.B5G6R5Unorm,         new FormatInfo(3, true,  false, All.Rgb565,            PixelFormat.Rgb,            PixelType.UnsignedShort565));
-            Add(Format.B5G5R5X1Unorm,       new FormatInfo(4, true,  false, All.Rgb5,              PixelFormat.Bgra,           PixelType.UnsignedShort5551));
-            Add(Format.B5G5R5A1Unorm,       new FormatInfo(4, true,  false, All.Rgb5A1,            PixelFormat.Bgra,           PixelType.UnsignedShort5551));
+            Add(Format.B5G6R5Unorm,         new FormatInfo(3, true,  false, All.Rgb565,            PixelFormat.Rgb,            PixelType.UnsignedShort565Reversed));
+            Add(Format.B5G5R5X1Unorm,       new FormatInfo(4, true,  false, All.Rgb5,              PixelFormat.Rgba,           PixelType.UnsignedShort1555Reversed));
+            Add(Format.B5G5R5A1Unorm,       new FormatInfo(4, true,  false, All.Rgb5A1,            PixelFormat.Rgba,           PixelType.UnsignedShort1555Reversed));
             Add(Format.A1B5G5R5Unorm,       new FormatInfo(4, true,  false, All.Rgb5A1,            PixelFormat.Bgra,           PixelType.UnsignedShort1555Reversed));
             Add(Format.B8G8R8X8Unorm,       new FormatInfo(4, true,  false, All.Rgba8,             PixelFormat.Rgba,           PixelType.UnsignedByte));
             Add(Format.B8G8R8A8Unorm,       new FormatInfo(4, true,  false, All.Rgba8,             PixelFormat.Rgba,           PixelType.UnsignedByte));

--- a/Ryujinx.Graphics.OpenGL/Image/TextureCopy.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureCopy.cs
@@ -27,7 +27,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
             Extents2D   dstRegion,
             bool        linearFilter)
         {
-            TextureView srcConverted = src.Format.IsBgra8() != dst.Format.IsBgra8() ? BgraSwap(src) : src;
+            TextureView srcConverted = src.Format.IsBgr() != dst.Format.IsBgr() ? BgraSwap(src) : src;
 
             (int oldDrawFramebufferHandle, int oldReadFramebufferHandle) = ((Pipeline)_renderer.Pipeline).GetBoundFramebuffers();
 

--- a/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
@@ -70,7 +70,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
                 (int)Info.SwizzleA.Convert()
             };
 
-            if (Info.Format.IsBgra8())
+            if (Info.Format.IsBgr())
             {
                 // Swap B <-> R for BGRA formats, as OpenGL has no support for them
                 // and we need to manually swap the components on read/write on the GPU.

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -879,7 +879,7 @@ namespace Ryujinx.Graphics.OpenGL
 
                 _framebuffer.AttachColor(index, color);
 
-                int isBgra = color != null && color.Format.IsBgra8() ? 1 : 0;
+                int isBgra = color != null && color.Format.IsBgr() ? 1 : 0;
 
                 if (_fpIsBgra[index].X != isBgra)
                 {

--- a/Ryujinx.Graphics.OpenGL/Window.cs
+++ b/Ryujinx.Graphics.OpenGL/Window.cs
@@ -45,7 +45,7 @@ namespace Ryujinx.Graphics.OpenGL
             GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, drawFramebuffer);
             GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, readFramebuffer);
 
-            TextureView viewConverted = view.Format.IsBgra8() ? _renderer.TextureCopy.BgraSwap(view) : view;
+            TextureView viewConverted = view.Format.IsBgr() ? _renderer.TextureCopy.BgraSwap(view) : view;
 
             GL.FramebufferTexture(
                 FramebufferTarget.ReadFramebuffer,
@@ -110,7 +110,7 @@ namespace Ryujinx.Graphics.OpenGL
 
             if (ScreenCaptureRequested)
             {
-                CaptureFrame(srcX0, srcY0, srcX1, srcY1, view.Format.IsBgra8(), crop.FlipX, crop.FlipY);
+                CaptureFrame(srcX0, srcY0, srcX1, srcY1, view.Format.IsBgr(), crop.FlipX, crop.FlipY);
 
                 ScreenCaptureRequested = false;
             }
@@ -174,7 +174,7 @@ namespace Ryujinx.Graphics.OpenGL
             byte[] bitmap = new byte[size];
 
             GL.ReadPixels(x, y, width, height, isBgra ? PixelFormat.Bgra : PixelFormat.Rgba, PixelType.UnsignedByte, bitmap);
-            
+
             _renderer.OnScreenCaptured(new ScreenCaptureImageInfo(width, height, isBgra, bitmap, flipX, flipY));
         }
 


### PR DESCRIPTION
This is similar to #1418, but handles packed 16-bit texture formats instead of 32-bit ones. Namely this one does the R<->B swap trick with the B5G6R5 and B5G5R5A1 formats. I forgot that you can actually render to those too back then.

This fixes the blue and red swapped issue on Pokkén Tournament DX.
Before:
![image](https://user-images.githubusercontent.com/5624669/130006821-c9763401-c45d-4a40-bff2-e3480329c70d.png)
After:
![image](https://user-images.githubusercontent.com/5624669/130006838-04c4f43a-40ef-46b6-a0b3-c8c8e7590959.png)
The A1B5G5R5 format seems wrong aswell, but this one is not as simple to fix as all components needs to be swapped rather than just R and B.
Also fixes a similar issue on Pokémon Stadium on Super Smash Bros Ultimate:
![image](https://user-images.githubusercontent.com/5624669/130008230-a95b515a-c8b1-4752-9103-8c0678db2edf.png)
![image](https://user-images.githubusercontent.com/5624669/130008789-8f83c83a-03e7-4f1b-b0b3-8b6747512bfe.png)
Fixes #2093.
Side note: All the different component ordering between the APIs and documentation is an eternal source of confusion to me.