### PR TITLE
Remove pool cache entries for incompatible overlapping textures

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
@@ -43,7 +43,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 oldestTexture.SynchronizeMemory();
 
-                if (oldestTexture.IsModified && !oldestTexture.ConsumeModified())
+                if (oldestTexture.IsModified && !oldestTexture.CheckModified(true))
                 {
                     // The texture must be flushed if it falls out of the auto delete cache.
                     // Flushes out of the auto delete cache do not trigger write tracking,

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -252,7 +252,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 if (!isView)
                 {
                     // Don't update this texture the next time we synchronize.
-                    ConsumeModified();
+                    CheckModified(true);
 
                     if (ScaleMode == TextureScaleMode.Scaled)
                     {
@@ -599,12 +599,13 @@ namespace Ryujinx.Graphics.Gpu.Image
 
         /// <summary>
         /// Checks if the memory for this texture was modified, and returns true if it was.
-        /// The modified flags are consumed as a result.
+        /// The modified flags are optionally consumed as a result.
         /// </summary>
+        /// <param name="consume">True to consume the dirty flags and reprotect, false to leave them as is</param>
         /// <returns>True if the texture was modified, false otherwise.</returns>
-        public bool ConsumeModified()
+        public bool CheckModified(bool consume)
         {
-            return Group.ConsumeDirty(this);
+            return Group.CheckDirty(this, consume);
         }
 
         /// <summary>
@@ -634,7 +635,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             }
             else
             {
-                Group.ConsumeDirty(this);
+                Group.CheckDirty(this, true);
                 SynchronizeFull();
             }
         }
@@ -698,7 +699,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             BlacklistScale();
 
-            Group.ConsumeDirty(this);
+            Group.CheckDirty(this, true);
 
             IsModified = false;
 

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -83,11 +83,13 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Consume the dirty flags for a given texture. The state is shared between views of the same layers and levels.
+        /// Check and optionally consume the dirty flags for a given texture.
+        /// The state is shared between views of the same layers and levels.
         /// </summary>
         /// <param name="texture">The texture being used</param>
+        /// <param name="consume">True to consume the dirty flags and reprotect, false to leave them as is</param>
         /// <returns>True if a flag was dirty, false otherwise</returns>
-        public bool ConsumeDirty(Texture texture)
+        public bool CheckDirty(Texture texture, bool consume)
         {
             bool dirty = false;
 
@@ -101,7 +103,11 @@ namespace Ryujinx.Graphics.Gpu.Image
                     {
                         if (handle.Dirty)
                         {
-                            handle.Reprotect();
+                            if (consume)
+                            {
+                                handle.Reprotect();
+                            }
+
                             dirty = true;
                         }
                     }


### PR DESCRIPTION
This greatly reduces memory usage in games that aggressively reuse memory without removing dead textures from the pool, such as the Xenoblade games, UE3 games, and to a lesser extent, UE4/unity games.

This change stops memory usage from ballooning in xenoblade and some other games. It will also reduce texture view/dependency complexity in some games - for example in MK8D it will reduce the number of surface copies between lighting cubemaps generated for actors.

There shouldn't be any performance impact from doing this, though the deletion and creation of textures could be improved by improving the OpenGL texture storage cache, which is very simple and limited right now. This will be improved in future.

I've been meaning to do this for a while, it's just recently I got around to doing it, and realized we can use the modified flags for some neat tricks. The change itself is pretty simple - if a texture being overlapped by a new sample has been modified by cpu, then its modified data is likely destined for the new texture being sampled, and the old texture should be deleted as it contains invalid data and likely won't be used for some time.

Another potential error has been fixed with the texture cache, which could prevent data loss when data is interchangably written to textures from both the GPU and CPU. It was possible that the dirty flag for a texture would be consumed without the data being synchronized on next use, due to the old overlap check. This check no longer consumes the dirty flag.

Please test a bunch of games to make sure they still work, and there are no performance regressions. Most games I have tested do not trigger texture deletion during gameplay at all - the exception obviously being games that stream textures, and triggering it doesn't appear to hinder performance or cause issues.

Closes #2344 