### PR TITLE
Fix type mismatch in `BitwiseAnd` simplification

### DIFF
--- a/ARMeilleure/CodeGen/Optimizations/Simplification.cs
+++ b/ARMeilleure/CodeGen/Optimizations/Simplification.cs
@@ -71,7 +71,7 @@ namespace ARMeilleure.CodeGen.Optimizations
             }
             else if (IsConstEqual(x, 0) || IsConstEqual(y, 0))
             {
-                operation.TurnIntoCopy(Const(0));
+                operation.TurnIntoCopy(Const(x.Type, 0));
             }
         }
 

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -27,7 +27,7 @@ namespace ARMeilleure.Translation.PTC
         private const string OuterHeaderMagicString = "PTCohd\0\0";
         private const string InnerHeaderMagicString = "PTCihd\0\0";
 
-        private const uint InternalVersion = 2515; //! To be incremented manually for each change to the ARMeilleure project.
+        private const uint InternalVersion = 2571; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";


### PR DESCRIPTION
`TryEliminateBitwiseAnd` would turn the `BitwiseAnd` operation into a copy of the wrong type. E.g:

Before `Simplification`:
```llvm
i64 %0 = BitwiseAnd i64 0x0, i64 %1
```

After `Simplication`:
```llvm
i64 %0 = Copy i32 0x0
```

Since the with the changes in #2515, we iterate in reverse order and `Simplication`, `ConstantFolding` does not indicate if it modified the CFG, the second pass to "retype" the copy into the proper destination type does not happen.

This also blocked copy propagation since its destination type did not match with its source type. But in the cases I've seen, the
`PreAllocator` would insert a copy for the propagated constant, which results in no diffs.

Since the copy remained as is, asserts are fired when generating it.