### PR TITLE
Change disabled vertex attribute value to (0, 0, 0, 1)

### DIFF
--- a/Ryujinx.Graphics.OpenGL/VertexArray.cs
+++ b/Ryujinx.Graphics.OpenGL/VertexArray.cs
@@ -176,7 +176,7 @@ namespace Ryujinx.Graphics.OpenGL
             {
                 _vertexAttribsInUse &= ~mask;
                 GL.DisableVertexAttribArray(index);
-                GL.VertexAttrib4(index, 0f, 0f, 0f, 0f);
+                GL.VertexAttrib4(index, 0f, 0f, 0f, 1f);
             }
         }
 


### PR DESCRIPTION
This seems to be the default value when the vertex attribute is disabled, or components aren't defined.

This fixes a regression from #2307 in SMO where a plant in the Wooded Kingdom would draw slightly differently in the depth prepass, leading to depth test failing later on. This broke a few things, the worst being the bloom when NaN/Inf values got introduced.

Example of drawing slightly differently ("depth pass" renderdoc mode, for effect, where the largely passing draw is the depth prepass):
https://gyazo.com/69480a340120a74e66d293bb45c61883

GDK has stated that the specific case in Gundam only expects x and y to be 0, and NVIDIA's undefined value for z does appear to be 0 when a vertex attribute type does not have that component, hence the value (0, 0, 0, 1).

This worked in Vulkan despite also providing an all 0s attribute due to the vertex attribute binding being R32Float, so the other values were undefined. It should be changed there separately.