### PR TITLE
Fix Unicorn Warnings (Missing files)

### DIFF
--- a/Ryujinx.Tests/Ryujinx.Tests.csproj
+++ b/Ryujinx.Tests/Ryujinx.Tests.csproj
@@ -32,8 +32,6 @@
 
   <Target Name="CopyUnicorn" AfterTargets="Build">
     <Copy SourceFiles="..\Ryujinx.Tests.Unicorn\libs\$(TargetOS)\unicorn.dll" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
-    <Copy SourceFiles="..\Ryujinx.Tests.Unicorn\libs\$(TargetOS)\libunicorn.dylib" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
-    <Copy SourceFiles="..\Ryujinx.Tests.Unicorn\libs\$(TargetOS)\libunicorn.so" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
   </Target>
 
 </Project>


### PR DESCRIPTION
```
D:\a\Ryujinx\Ryujinx\Ryujinx.Tests\Ryujinx.Tests.csproj(35,5): warning MSB3030: Could not copy the file "..\Ryujinx.Tests.Unicorn\libs\windows\libunicorn.dylib" because it was not found.
D:\a\Ryujinx\Ryujinx\Ryujinx.Tests\Ryujinx.Tests.csproj(35,5): warning MSB4181: The "Copy" task returned false but did not log an error.
D:\a\Ryujinx\Ryujinx\Ryujinx.Tests\Ryujinx.Tests.csproj(36,5): warning MSB3030: Could not copy the file "..\Ryujinx.Tests.Unicorn\libs\windows\libunicorn.so" because it was not found.
D:\a\Ryujinx\Ryujinx\Ryujinx.Tests\Ryujinx.Tests.csproj(36,5): warning MSB4181: The "Copy" task returned false but did not log an error.
```
These files are currently missing and producing warnings, maybe let's just remove it for now?