### PR TITLE
Swap BGR565 components by changing the format

### DIFF
--- a/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
@@ -204,7 +204,18 @@ namespace Ryujinx.Graphics.OpenGL.Image
 
             if (forceBgra)
             {
-                pixelFormat = PixelFormat.Bgra;
+                if (pixelType == PixelType.UnsignedShort565)
+                {
+                    pixelType = PixelType.UnsignedShort565Reversed;
+                }
+                else if (pixelType == PixelType.UnsignedShort565Reversed)
+                {
+                    pixelType = PixelType.UnsignedShort565;
+                }
+                else
+                {
+                    pixelFormat = PixelFormat.Bgra;
+                }
             }
 
             int faces = 1;


### PR DESCRIPTION
Using the UnsignedShort565{Reversed} format with a Bgr order is not valid. Use the alternative "Reversed" version of the format instead. Fixes regression on some homebrew using a BGR565 framebuffer that stopped rendering.