### PR TITLE
Remove SD card directory cleaning workaround

### DIFF
--- a/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
+++ b/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
@@ -273,9 +273,6 @@ namespace Ryujinx.HLE.FileSystem
             rc = FixExtraDataInSpaceId(hos, SaveDataSpaceId.User);
             if (rc.IsFailure()) return rc;
 
-            rc = FixExtraDataInSpaceId(hos, SaveDataSpaceId.SdCache);
-            if (rc.IsFailure()) return rc;
-
             return Result.Success;
         }
 

--- a/Ryujinx.HLE/HOS/LibHacHorizonManager.cs
+++ b/Ryujinx.HLE/HOS/LibHacHorizonManager.cs
@@ -97,17 +97,8 @@ namespace Ryujinx.HLE.HOS
 
             try
             {
-                try
-                {
-                    RyujinxClient.Fs.CleanDirectoryRecursively("sdcard:/Nintendo/save".ToU8Span()).IgnoreResult();
-                }
-                catch (Exception) { /* We don't care about the result */ }
-
-                try
-                {
-                    RyujinxClient.Fs.DeleteDirectoryRecursively("sdcard:/save".ToU8Span()).IgnoreResult();
-                }
-                catch (Exception) { /* We don't care about the result */ }
+                RyujinxClient.Fs.CleanDirectoryRecursively("sdcard:/Nintendo/save".ToU8Span()).IgnoreResult();
+                RyujinxClient.Fs.DeleteDirectoryRecursively("sdcard:/save".ToU8Span()).IgnoreResult();
             }
             finally
             {

--- a/Ryujinx.HLE/Ryujinx.HLE.csproj
+++ b/Ryujinx.HLE/Ryujinx.HLE.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Concentus" Version="1.1.7" />
-    <PackageReference Include="LibHac" Version="0.13.2" />
+    <PackageReference Include="LibHac" Version="0.13.3" />
     <PackageReference Include="MsgPack.Cli" Version="1.0.1" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta11" />
   </ItemGroup>


### PR DESCRIPTION
- Updates to a bugfix release of LibHac and removes the workaround introduced in #2576
- Regression fix: SD card saves will now be placed in `/Nintendo/save` instead of `/save/Nintendo`