### PR TITLE
Handle indirect draw counts with non-zero draw starts properly

### DIFF
--- a/Ryujinx.Cpu/IVirtualMemoryManagerTracked.cs
+++ b/Ryujinx.Cpu/IVirtualMemoryManagerTracked.cs
@@ -9,6 +9,14 @@ namespace Ryujinx.Cpu
     public interface IVirtualMemoryManagerTracked : IVirtualMemoryManager
     {
         /// <summary>
+        /// Reads data from CPU mapped memory, with read tracking
+        /// </summary>
+        /// <typeparam name="T">Type of the data being read</typeparam>
+        /// <param name="va">Virtual address of the data in memory</param>
+        /// <returns>The data</returns>
+        T ReadTracked<T>(ulong va) where T : unmanaged;
+
+        /// <summary>
         /// Writes data to CPU mapped memory, without write tracking.
         /// </summary>
         /// <param name="va">Virtual address to write the data into</param>

--- a/Ryujinx.Cpu/MemoryManager.cs
+++ b/Ryujinx.Cpu/MemoryManager.cs
@@ -117,7 +117,7 @@ namespace Ryujinx.Cpu
         /// <inheritdoc/>
         public T Read<T>(ulong va) where T : unmanaged
         {
-            return MemoryMarshal.Cast<byte, T>(GetSpan(va, Unsafe.SizeOf<T>(), true))[0];
+            return MemoryMarshal.Cast<byte, T>(GetSpan(va, Unsafe.SizeOf<T>()))[0];
         }
 
         /// <inheritdoc/>

--- a/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
@@ -139,11 +139,22 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// Reads data from the application process.
         /// </summary>
         /// <typeparam name="T">Type of the structure</typeparam>
-        /// <param name="gpuVa">Address to read from</param>
+        /// <param name="address">Address to read from</param>
         /// <returns>The data at the specified memory location</returns>
         public T Read<T>(ulong address) where T : unmanaged
         {
-            return MemoryMarshal.Cast<byte, T>(GetSpan(address, Unsafe.SizeOf<T>()))[0];
+            return _cpuMemory.Read<T>(address);
+        }
+
+        /// <summary>
+        /// Reads data from the application process, with write tracking.
+        /// </summary>
+        /// <typeparam name="T">Type of the structure</typeparam>
+        /// <param name="address">Address to read from</param>
+        /// <returns>The data at the specified memory location</returns>
+        public T ReadTracked<T>(ulong address) where T : unmanaged
+        {
+            return _cpuMemory.ReadTracked<T>(address);
         }
 
         /// <summary>


### PR DESCRIPTION
This addresses one of the TODOs from #2557. If the first draw is non-zero, we need to calculate a correct maximum draw count in order to only do the missing draws, or just do nothing if all draws were already done.

In addition, this includes a few other improvements:
- The `Read<T>` method on the memory manager now takes an optional `tracked` argument to flush on read. This is required to flush the draw count.
- The `Read<T>` method now calls `Read<T>` on the "physical memory" instead of `GetSpan`, to avoid casting the span etc. Should have better codegen.
- Software `MemoryManager` `Read<T>` is no longer tracked (as it was never supposed to be, only `ReadTracked<T>` should be tracked). Should be a low risk change as we use the host mapped memory manager by default (which should already handle that correctly).