### PR TITLE
Ensure that all threads wait for a read tracking action to complete.

### DIFF
--- a/Ryujinx.Memory/Tracking/RegionHandle.cs
+++ b/Ryujinx.Memory/Tracking/RegionHandle.cs
@@ -140,12 +140,9 @@ namespace Ryujinx.Memory.Tracking
                 {
                     lock (_preActionLock)
                     {
-                        if (_preAction != null)
-                        {
-                            _preAction.Invoke(address, size);
+                        _preAction?.Invoke(address, size);
 
-                            _preAction = null;
-                        }
+                        _preAction = null;
                     }
                 }
                 finally

--- a/Ryujinx.Memory/Tracking/RegionHandle.cs
+++ b/Ryujinx.Memory/Tracking/RegionHandle.cs
@@ -35,6 +35,7 @@ namespace Ryujinx.Memory.Tracking
 
         private event Action _onDirty;
 
+        private object _preActionLock = new object();
         private RegionSignal _preAction; // Action to perform before a read or write. This will block the memory access.
         private readonly List<VirtualRegion> _regions;
         private readonly MemoryTracking _tracking;
@@ -137,7 +138,7 @@ namespace Ryujinx.Memory.Tracking
 
                 try
                 {
-                    lock (this)
+                    lock (_preActionLock)
                     {
                         if (_preAction != null)
                         {
@@ -227,7 +228,7 @@ namespace Ryujinx.Memory.Tracking
         {
             ClearVolatile();
 
-            lock (this)
+            lock (_preActionLock)
             {
                 RegionSignal lastAction = _preAction;
                 _preAction = action;


### PR DESCRIPTION
This fixes a regression that occurred when allowing tracking actions to release the tracking lock. If multiple threads were to trigger a read action in the same handle at the same time, then it was possible for one of the threads to continue almost immediately without flushing, as the action would have been consumed on the other. This would result in the thread that skipped the action either reading/writing old data, then the action would complete and overwrite it, causing weird issues.

The fix is just to replace the _preAction consumption with a handle level lock. The action is not set as null until it completes, and the lock prevents multiple threads from triggering the action.

This was causing crashes in catherine full body.