### PR TITLE
Avoid deleting textures when their data does not overlap.

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -636,6 +636,12 @@ namespace Ryujinx.Graphics.Gpu.Image
                                 continue;
                             }
 
+                            if (!texture.DataOverlaps(overlap))
+                            {
+                                // Allow textures to overlap if their data does not actually overlap.
+                                continue;
+                            }
+
                             // The overlap texture is going to contain garbage data after we draw, or is generally incompatible.
                             // If the texture cannot be entirely contained in the new address space, and one of its view children is compatible with us,
                             // it must be flushed before removal, so that the data is not lost.

--- a/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -639,6 +639,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                             if (!texture.DataOverlaps(overlap))
                             {
                                 // Allow textures to overlap if their data does not actually overlap.
+                                // This typically happens when mip level subranges of a layered texture are used. (each texture fills the gaps of the others)
                                 continue;
                             }
 

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -85,8 +85,9 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                     TextureDescriptor descriptor = GetDescriptor(id);
 
-                    int width = descriptor.UnpackWidth();
-                    int height = descriptor.UnpackHeight();
+                    int baseLevel = descriptor.UnpackBaseLevel();
+                    int width = Math.Max(1, descriptor.UnpackWidth() >> baseLevel);
+                    int height = Math.Max(1, descriptor.UnpackHeight() >> baseLevel);
 
                     if (texture.Info.Width != width || texture.Info.Height != height)
                     {

--- a/Ryujinx.Graphics.Texture/Region.cs
+++ b/Ryujinx.Graphics.Texture/Region.cs
@@ -1,0 +1,14 @@
+﻿namespace Ryujinx.Graphics.Texture
+{
+    public struct Region
+    {
+        public int Offset;
+        public int Size;
+
+        public Region(int offset, int size)
+        {
+            Offset = offset;
+            Size = size;
+        }
+    }
+}

--- a/Ryujinx.Graphics.Texture/Region.cs
+++ b/Ryujinx.Graphics.Texture/Region.cs
@@ -2,8 +2,8 @@
 {
     public struct Region
     {
-        public int Offset;
-        public int Size;
+        public int Offset { get; }
+        public int Size { get; }
 
         public Region(int offset, int size)
         {

--- a/Ryujinx.Graphics.Texture/SizeInfo.cs
+++ b/Ryujinx.Graphics.Texture/SizeInfo.cs
@@ -96,17 +96,18 @@ namespace Ryujinx.Graphics.Texture
 
         public IEnumerable<Region> AllRegions()
         {
-            for (int i = 0; i < AllOffsets.Length; i++)
+            if (_is3D)
             {
-                int offset = AllOffsets[i];
-
-                if (_is3D)
+                for (int i = 0; i < _mipOffsets.Length; i++)
                 {
-                    yield return new Region(offset, SliceSizes[i / _depth]);
+                    yield return new Region(_mipOffsets[i], SliceSizes[i]);
                 }
-                else
+            }
+            else
+            {
+                for (int i = 0; i < AllOffsets.Length; i++)
                 {
-                    yield return new Region(offset, SliceSizes[i % _levels]);
+                    yield return new Region(AllOffsets[i], SliceSizes[i % _levels]);
                 }
             }
         }

--- a/Ryujinx.Graphics.Texture/SizeInfo.cs
+++ b/Ryujinx.Graphics.Texture/SizeInfo.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
 
 namespace Ryujinx.Graphics.Texture
 {
@@ -90,6 +92,23 @@ namespace Ryujinx.Graphics.Texture
             }
 
             return true;
+        }
+
+        public IEnumerable<Region> AllRegions()
+        {
+            for (int i = 0; i < AllOffsets.Length; i++)
+            {
+                int offset = AllOffsets[i];
+
+                if (_is3D)
+                {
+                    yield return new Region(offset, SliceSizes[i / _depth]);
+                }
+                else
+                {
+                    yield return new Region(offset, SliceSizes[i % _levels]);
+                }
+            }
         }
     }
 }

--- a/Ryujinx.Graphics.Texture/SizeInfo.cs
+++ b/Ryujinx.Graphics.Texture/SizeInfo.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 
 namespace Ryujinx.Graphics.Texture


### PR DESCRIPTION
It's possible that while two textures start and end addresses indicate an overlap, that the actual data contained within them is sparse due to a layer stride. One such possibility is array slices of a cubemap at different mip levels - they overlap on a whole, but the actual texture data fills the gaps between each other's layers rather than actually overlapping.

This fixes issues with UE4 games having incorrect lighting (solid white screen or really dark shadows). There are still remaining issues with games that use the 3D texture prebaked lighting, such as THPS1+2, and games that use SUATOM/SURED like BD2 and Triangle Strategy.

This PR also fixes a bug with TexturePool's resized texture handling where the base level in the descriptor was not considered. This was causing data loss in some UE4 cubemaps.

## Example

### Title Screen

#### Before

![image](https://user-images.githubusercontent.com/6294155/131234475-e947b7ea-cc76-4f94-8755-b0bbe2b3e576.png)

#### After

![image](https://user-images.githubusercontent.com/6294155/131234479-f1b87e82-35dc-46de-88e2-d2a98be6ba7c.png)

### Ingame

#### Before (on a bad day)
![image](https://user-images.githubusercontent.com/6294155/131234503-a860eedc-08e3-4956-b977-dbde5488565c.png)

#### Before (on a good day)
![image](https://user-images.githubusercontent.com/6294155/131234497-e55c24ee-7d66-4821-a68e-9e385c4fc175.png)

#### After
![image](https://user-images.githubusercontent.com/6294155/131234499-2d45dcdb-5aa7-4f8b-98cf-550337e4564b.png)