### PR TITLE
Fix out-of-bounds shader thread shuffle

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -40,7 +40,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2546;
+        private const ulong ShaderCodeGenVersion = 2605;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/Shuffle.glsl
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/Shuffle.glsl
@@ -6,5 +6,6 @@ float Helper_Shuffle(float x, uint index, uint mask, out bool valid)
     uint maxThreadId = minThreadId | (clamp & ~segMask);
     uint srcThreadId = (index & ~segMask) | minThreadId;
     valid = srcThreadId <= maxThreadId;
-    return valid ? readInvocationARB(x, srcThreadId) : x;
+    float v = readInvocationARB(x, srcThreadId);
+    return valid ? v : x;
 }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/ShuffleDown.glsl
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/ShuffleDown.glsl
@@ -6,5 +6,6 @@ float Helper_ShuffleDown(float x, uint index, uint mask, out bool valid)
     uint maxThreadId = minThreadId | (clamp & ~segMask);
     uint srcThreadId = gl_SubGroupInvocationARB + index;
     valid = srcThreadId <= maxThreadId;
-    return valid ? readInvocationARB(x, srcThreadId) : x;
+    float v = readInvocationARB(x, srcThreadId);
+    return valid ? v : x;
 }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/ShuffleUp.glsl
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/ShuffleUp.glsl
@@ -1,9 +1,9 @@
 float Helper_ShuffleUp(float x, uint index, uint mask, out bool valid)
 {
-    uint clamp = mask & 0x1fu;
     uint segMask = (mask >> 8) & 0x1fu;
     uint minThreadId = gl_SubGroupInvocationARB & segMask;
     uint srcThreadId = gl_SubGroupInvocationARB - index;
-    valid = srcThreadId >= minThreadId;
-    return valid ? readInvocationARB(x, srcThreadId) : x;
+    valid = int(srcThreadId) >= int(minThreadId);
+    float v = readInvocationARB(x, srcThreadId);
+    return valid ? v : x;
 }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/ShuffleXor.glsl
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/ShuffleXor.glsl
@@ -6,5 +6,6 @@ float Helper_ShuffleXor(float x, uint index, uint mask, out bool valid)
     uint maxThreadId = minThreadId | (clamp & ~segMask);
     uint srcThreadId = gl_SubGroupInvocationARB ^ index;
     valid = srcThreadId <= maxThreadId;
-    return valid ? readInvocationARB(x, srcThreadId) : x;
+    float v = readInvocationARB(x, srcThreadId);
+    return valid ? v : x;
 }


### PR DESCRIPTION
Fixes some issues with thread shuffles, mainly shuffle up that was not taking negative threads IDs into account. If the source thread ID is negative after the subtraction by the index, it is *not* valid (but it was returning valid before because the comparison was unsigned, and 0xFFFFFFFF (-1) for example, is >= 0. I also made it *always* read the value from the source thread, rather than doing it conditionally, as the latter also caused graphical glitches.

Fixes vertex explosion on Marvel Ultimate Alliance 3.
Before (from gamedb):
![image](https://user-images.githubusercontent.com/5624669/131295703-d0f4b412-ea75-4d19-a0a6-aacaf5bfa817.png)
Now:
![image](https://user-images.githubusercontent.com/5624669/131295444-4e9b7bfd-622b-426d-88f9-71cc4f302c55.png)

When combined with #2090, also fixes block flickering on shadows. See screenshots below.
master:
![image](https://user-images.githubusercontent.com/5624669/131295847-dcf9374d-9501-4aeb-8588-c7b2e3ae57cf.png)
(Lighting is broken, water is dark etc).
riperiperi's PR without this fix:
![image](https://user-images.githubusercontent.com/5624669/131295911-2913d9ec-c2c3-4a80-8c62-882e39fcb0bc.png)
(Lighting works but flickers, see the lamp pole only being half lit, the water with weird colouring, etc).
riperiperi's PR with this fix:
![image](https://user-images.githubusercontent.com/5624669/131295985-f4d560b4-e99f-4254-bd18-2b16d313397d.png)
(100% correct as far I can tell).
