### PR TITLE
Update game metadata when stopping emulation

### DIFF
--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -1276,6 +1276,10 @@ namespace Ryujinx.Ui
 
         private void StopEmulation_Pressed(object sender, EventArgs args)
         {
+            if (_emulationContext != null)
+            {
+                UpdateGameMetadata(_emulationContext.Application.TitleIdText);
+            }
             RendererWidget?.Exit();
         }
 

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -1280,6 +1280,7 @@ namespace Ryujinx.Ui
             {
                 UpdateGameMetadata(_emulationContext.Application.TitleIdText);
             }
+
             RendererWidget?.Exit();
         }
 


### PR DESCRIPTION
Game metadata (specifically, time played staying at 0s was the obvious symptom) was not being updated when clicking Actions->Stop Emulation. This works as expected when exiting the emulator because UpdateGameMetadata is called from MainWindow.End, which is called from both Exit_Pressed  and Window_Close.

This PR updates the game metadata in this case