### PR TITLE
Fix GTK3 mapping for single quote key

### DIFF
--- a/Ryujinx/Input/GTK3/GTK3MappingHelper.cs
+++ b/Ryujinx/Input/GTK3/GTK3MappingHelper.cs
@@ -134,7 +134,7 @@ namespace Ryujinx.Input.GTK3
             GtkKey.bracketleft,
             GtkKey.bracketright,
             GtkKey.semicolon,
-            GtkKey.quotedbl,
+            GtkKey.quoteright,
             GtkKey.comma,
             GtkKey.period,
             GtkKey.slash,


### PR DESCRIPTION
The single quote key (') was incorrectly mapped to the gtk key quotedbl. This fixes #2514