### PR TITLE
Lift textures in the AutoDeleteCache for all modifications.

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Twod/TwodClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Twod/TwodClass.cs
@@ -127,6 +127,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Twod
                 return;
             }
 
+            memoryManager.Physical.TextureCache.Lift(srcTexture);
+
             // When the source texture that was found has a depth format,
             // we must enforce the target texture also has a depth format,
             // as copies between depth and color formats are not allowed.

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -1235,6 +1235,8 @@ namespace Ryujinx.Graphics.Gpu.Image
                 IsModified = true;
                 Group.SignalModified(this, !wasModified);
             }
+
+            _physicalMemory.TextureCache.Lift(this);
         }
 
         /// <summary>
@@ -1260,6 +1262,8 @@ namespace Ryujinx.Graphics.Gpu.Image
             {
                 DecrementReferenceCount();
             }
+
+            _physicalMemory.TextureCache.Lift(this);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -1254,6 +1254,8 @@ namespace Ryujinx.Graphics.Gpu.Image
                 Group.SignalModifying(this, bound, !wasModified);
             }
 
+            _physicalMemory.TextureCache.Lift(this);
+
             if (bound)
             {
                 IncrementReferenceCount();
@@ -1262,8 +1264,6 @@ namespace Ryujinx.Graphics.Gpu.Image
             {
                 DecrementReferenceCount();
             }
-
-            _physicalMemory.TextureCache.Lift(this);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -155,6 +155,17 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Lifts the texture to the top of the AutoDeleteCache. This is primarily used to enforce that
+        /// data written to a target will be flushed to memory should the texture be deleted, but also
+        /// keeps rendered textures alive without a pool reference.
+        /// </summary>
+        /// <param name="texture">Texture to lift</param>
+        public void Lift(Texture texture)
+        {
+            _cache.Lift(texture);
+        }
+
+        /// <summary>
         /// Tries to find an existing texture, or create a new one if not found.
         /// </summary>
         /// <param name="memoryManager">GPU memory manager where the texture is mapped</param>
@@ -442,14 +453,6 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             if (texture != null)
             {
-                if (!isSamplerTexture)
-                {
-                    // If not a sampler texture, it is managed by the auto delete
-                    // cache, ensure that it is on the "top" of the list to avoid
-                    // deletion.
-                    _cache.Lift(texture);
-                }
-
                 ChangeSizeIfNeeded(info, texture, isSamplerTexture, sizeHint);
 
                 texture.SynchronizeMemory();
@@ -849,7 +852,6 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 if (match)
                 {
-                    _cache.Lift(texture);
                     return texture;
                 }
             }


### PR DESCRIPTION
Before, this would only apply to render targets and texture blit. Now it applies to image stores, the fast dma copy path and any other type of modification.

Image store textures always have at least one reference in the texture pool, so the function of the AutoDeleteCache keeping textures _alive_ is not useful, but a very important function for a while has been its use to _flush textures in order of modification_ when they are dereferenced, so that their data is not lost.

Before, textures populated using image stores were being dereferenced and reloaded as garbage. Now, when these textures are dereferenced, their data will be put back into memory, and everything stays intact.

Fixes lighting breaking when switching levels in THPS1+2, and potentially some more UE4 games. I've tested a bunch more games for regressions and performance impact, but they all seem fine.

## Test case (THPS1+2)
Start on the level Hangar, end the run and switch to Marseille. Sometimes even happens without switching level.

### Before
![image](https://user-images.githubusercontent.com/6294155/131908410-0d46b035-13ac-482e-bfee-9b44a71cfa0a.png)

### After
![image](https://user-images.githubusercontent.com/6294155/131908617-a631a311-af35-4dfe-a339-53d3509b47b3.png)
