### PR TITLE
Log shader compile errors with Warning level

### DIFF
--- a/Ryujinx.Graphics.OpenGL/Program.cs
+++ b/Ryujinx.Graphics.OpenGL/Program.cs
@@ -115,9 +115,8 @@ namespace Ryujinx.Graphics.OpenGL
 
             if (status == 0)
             {
-                // Use GL.GetProgramInfoLog(Handle), it may be too long to print on the log.
                 _status = ProgramLinkStatus.Failure;
-                Logger.Debug?.Print(LogClass.Gpu, "Shader linking failed.");
+                Logger.Warning?.Print(LogClass.Gpu, $"Shader linking failed: \n{GL.GetProgramInfoLog(Handle)}");
             }
             else
             {

--- a/Ryujinx.Graphics.OpenGL/Program.cs
+++ b/Ryujinx.Graphics.OpenGL/Program.cs
@@ -10,6 +10,8 @@ namespace Ryujinx.Graphics.OpenGL
 {
     class Program : IProgram
     {
+        private const int MaxShaderLogLength = 2048;
+
         public int Handle { get; private set; }
 
         public bool IsLinked
@@ -116,7 +118,15 @@ namespace Ryujinx.Graphics.OpenGL
             if (status == 0)
             {
                 _status = ProgramLinkStatus.Failure;
-                Logger.Warning?.Print(LogClass.Gpu, $"Shader linking failed: \n{GL.GetProgramInfoLog(Handle)}");
+
+                string log = GL.GetProgramInfoLog(Handle);
+
+                if (log.Length > MaxShaderLogLength)
+                {
+                    log = log.Substring(0, MaxShaderLogLength) + "...";
+                }
+
+                Logger.Warning?.Print(LogClass.Gpu, $"Shader linking failed: \n{log}");
             }
             else
             {


### PR DESCRIPTION
These are infrequent enough that I think it's worth dumping any errors into the log. They also keep causing graphical glitches, and the only indication that anything went wrong is a debug log that is never enabled.