### PR TITLE
Report 1080p resolution when in docked mode

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ICommonStateGetter.cs
@@ -193,8 +193,16 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         // GetDefaultDisplayResolution() -> (u32, u32)
         public ResultCode GetDefaultDisplayResolution(ServiceCtx context)
         {
-            context.ResponseData.Write(1280);
-            context.ResponseData.Write(720);
+            if (context.Device.System.State.DockedMode)
+            {
+                context.ResponseData.Write(1920);
+                context.ResponseData.Write(1080);
+            }
+            else
+            {
+                context.ResponseData.Write(1280);
+                context.ResponseData.Write(720);
+            }
 
             return ResultCode.Success;
         }


### PR DESCRIPTION
The `GetDefaultDisplayResolution` function was returning a 720p resolution even when docked. While I believe this is technically not incorrect, most of the benefit of enabling docked mode on the emulator is getting a higher resolution, so I believe increasing the resolution in this case is desirable.

Note that there are a bunch of other functions where a 720p resolution is hardcoded, namely: `GetDisplayMode`, `GetDisplayResolution` and `ListDisplays`. I can also switch up to 1080p in all those functions when docked, but I'm not sure if that's the correct behaviour, so at this time I have left it as is, but can change if anyone think it's better or can confirm that doing so is the correct behaviour.

Allows Tsukihime -A piece of blue glass moon- to render at higher resolution when docked.
Before:
![image](https://user-images.githubusercontent.com/5624669/132086781-ba36242d-363e-4e66-931f-739b316dd554.png)
After:
![image](https://user-images.githubusercontent.com/5624669/132086783-b658be22-4a28-47e2-aef7-7946a6027b99.png)
(Both are docked and full screen).
Closes #2596.