### PR TITLE
Implement GetVaRegions on nvservices

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostAsGpu/NvHostAsGpuDeviceFile.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostAsGpu/NvHostAsGpuDeviceFile.cs
@@ -5,11 +5,39 @@ using Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostChannel;
 using Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvMap;
 using Ryujinx.Memory;
 using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostAsGpu
 {
     class NvHostAsGpuDeviceFile : NvDeviceFile
     {
+        private const uint SmallPageSize = 0x1000;
+        private const uint BigPageSize = 0x10000;
+
+        private static readonly uint[] _pageSizes = new uint[] { SmallPageSize, BigPageSize };
+
+        private const ulong SmallRegionLimit = 0x400000000UL; // 16 GB
+        private const ulong DefaultUserSize = 1UL << 37;
+
+        private struct VmRegion
+        {
+            public ulong Start { get; }
+            public ulong Limit { get; }
+
+            public VmRegion(ulong start, ulong limit)
+            {
+                Start = start;
+                Limit = limit;
+            }
+        }
+
+        private static readonly VmRegion[] _vmRegions = new VmRegion[]
+        {
+            new VmRegion(BigPageSize << 16, SmallRegionLimit),
+            new VmRegion(SmallRegionLimit, DefaultUserSize)
+        };
+
         private readonly AddressSpaceContext _asContext;
         private readonly NvMemoryAllocator _memoryAllocator;
 
@@ -296,7 +324,31 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostAsGpu
 
         private NvInternalResult GetVaRegions(ref GetVaRegionsArguments arguments)
         {
-            Logger.Stub?.PrintStub(LogClass.ServiceNv);
+            int vaRegionStructSize = Unsafe.SizeOf<VaRegion>();
+
+            Debug.Assert(vaRegionStructSize == 0x18);
+            Debug.Assert(_pageSizes.Length == 2);
+
+            uint writeEntries = (uint)(arguments.BufferSize / vaRegionStructSize);
+            if (writeEntries > _pageSizes.Length)
+            {
+                writeEntries = (uint)_pageSizes.Length;
+            }
+
+            for (uint i = 0; i < writeEntries; i++)
+            {
+                ref var region = ref arguments.Regions[(int)i];
+
+                var vmRegion = _vmRegions[i];
+                uint pageSize = _pageSizes[i];
+
+                region.PageSize = pageSize;
+                region.Offset = vmRegion.Start;
+                region.Pages = (vmRegion.Limit - vmRegion.Start) / pageSize;
+                region.Padding = 0;
+            }
+
+            arguments.BufferSize = (uint)(_pageSizes.Length * vaRegionStructSize);
 
             return NvInternalResult.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostAsGpu/NvHostAsGpuDeviceFile.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostAsGpu/NvHostAsGpuDeviceFile.cs
@@ -34,7 +34,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostAsGpu
 
         private static readonly VmRegion[] _vmRegions = new VmRegion[]
         {
-            new VmRegion(BigPageSize << 16, SmallRegionLimit),
+            new VmRegion((ulong)BigPageSize << 16, SmallRegionLimit),
             new VmRegion(SmallRegionLimit, DefaultUserSize)
         };
 

--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostAsGpu/Types/GetVaRegionsArguments.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostAsGpu/Types/GetVaRegionsArguments.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using Ryujinx.Common.Memory;
+using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostAsGpu.Types
 {
@@ -6,18 +7,17 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostAsGpu.Types
     struct VaRegion
     {
         public ulong Offset;
-        public uint  PageSize;
-        public uint  Padding;
+        public uint PageSize;
+        public uint Padding;
         public ulong Pages;
     }
 
     [StructLayout(LayoutKind.Sequential)]
     struct GetVaRegionsArguments
     {
-        public ulong    Unused;
-        public uint     BufferSize;
-        public uint     Padding;
-        public VaRegion Region0;
-        public VaRegion Region1;
+        public ulong Unused;
+        public uint BufferSize;
+        public uint Padding;
+        public Array2<VaRegion> Regions;
     }
 }


### PR DESCRIPTION
This implements the `GetVaRegions` ioctl, which is used to get the ranges of the address space that the application can actually use. It returns two ranges, one for small pages and one for big pages. The Vulkan driver uses this to calculate the usable address space size (calculated as the maximum end address of all VA regions returned). Since it was not writing anything before, I believe it could just return stack garbage.

This fixes a crash on Quake due to `VK_ERROR_OUT_OF_DEVICE_MEMORY` being returned by the guest driver, caused by the fact that it assumed that the usable address space size was 0, which would fail the check for any buffer size that is greater than 0.

The game can progress further now, but crashes due to Sockets issues.
![image](https://user-images.githubusercontent.com/5624669/132109768-b7498f7d-76a5-41ef-9a2a-e2b5e3be1804.png)

I recommend testing this on a few games as Im not sure of the effect this change might have on them.