### PR TITLE
Account for negative strides on DMA copy

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
@@ -110,10 +110,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.InlineToMemory
 
             ulong dstGpuVa = ((ulong)state.OffsetOutUpperValue << 32) | state.OffsetOut;
 
-            ulong dstBaseAddress = _channel.MemoryManager.Translate(dstGpuVa);
-
             // Trigger read tracking, to flush any managed resources in the destination region.
-            _channel.MemoryManager.Physical.GetSpan(dstBaseAddress, _size, true);
+            _channel.MemoryManager.GetSpan(dstGpuVa, _size, true);
 
             _dstGpuVa = dstGpuVa;
             _dstX = state.SetDstOriginBytesXV;

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -892,7 +892,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 {
                     _physicalMemory.Write(Range, GetTextureDataFromGpu(Span<byte>.Empty, true, texture));
                 }
-                else 
+                else
                 {
                     _physicalMemory.WriteUntracked(Range, GetTextureDataFromGpu(Span<byte>.Empty, false, texture));
                 }

--- a/Ryujinx.Graphics.Texture/OffsetCalculator.cs
+++ b/Ryujinx.Graphics.Texture/OffsetCalculator.cs
@@ -1,4 +1,5 @@
 using Ryujinx.Common;
+using System;
 using System.Runtime.CompilerServices;
 using static Ryujinx.Graphics.Texture.BlockLinearConstants;
 
@@ -112,7 +113,7 @@ namespace Ryujinx.Graphics.Texture
             if (_isLinear)
             {
                 int start = y * _stride + x * _bytesPerPixel;
-                int end = (y + height - 1) * _stride + (x + width) * _bytesPerPixel;
+                int end = (y + height - 1) * Math.Abs(_stride) + (x + width) * _bytesPerPixel;
                 return (start, end - start);
             }
             else

--- a/Ryujinx.Graphics.Texture/OffsetCalculator.cs
+++ b/Ryujinx.Graphics.Texture/OffsetCalculator.cs
@@ -112,9 +112,9 @@ namespace Ryujinx.Graphics.Texture
         {
             if (_isLinear)
             {
-                int start = y * _stride + x * _bytesPerPixel;
+                int start = y * Math.Abs(_stride) + x * _bytesPerPixel;
                 int end = (y + height - 1) * Math.Abs(_stride) + (x + width) * _bytesPerPixel;
-                return (start, end - start);
+                return (y * _stride + x * _bytesPerPixel, end - start);
             }
             else
             {


### PR DESCRIPTION
Some OpenGL games (such as https://github.com/Ryujinx/Ryujinx-Games-List/issues/3704) are using negative stride values. This would cause the copy to advance backwards, which I imagine might be useful if the copy is also supposed to flip the image vertically. This should actually "just work" with our simple offset calculation, but does not due to the fact that the current code uses spans, and the code to get the span is not aware of the fact the stride (and consequently the size) might be negative.

To account for that, the following changes were made.
- `Math.Abs` is used on the stride to calculate the size, to ensure it is positive.
- If stride is negative, the base offset is adjusted to the real start offset of the copy.

Nothing else needs to be changed, as the base pointers and the offsets returned by the offset calculator already accounts for negative strides (the former will add an offset to make the pointer point to the last line of the image, while the latter already returns negative offsets, that when added to the pointer will fall into the correct location).

While I was at it, I also changed the flush call on `InlineToMemory` to use the GPU memory manager rather than the physical one, to account for non-contiguous memory.

With this change the game I mentioned before (IdolDays) no longer crashes when trying to open the log or load/save the game, although it does have other issues there that don't seem to be caused by this change (for example, texture/buffer flush for the thumbnails seems unreliable).