### PR TITLE
Fast path for Inline2Memory buffer write that skips write tracking

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
@@ -110,9 +110,6 @@ namespace Ryujinx.Graphics.Gpu.Engine.InlineToMemory
 
             ulong dstGpuVa = ((ulong)state.OffsetOutUpperValue << 32) | state.OffsetOut;
 
-            // Trigger read tracking, to flush any managed resources in the destination region.
-            _channel.MemoryManager.GetSpan(dstGpuVa, _size, true);
-
             _dstGpuVa = dstGpuVa;
             _dstX = state.SetDstOriginBytesXV;
             _dstY = state.SetDstOriginSamplesYV;
@@ -174,7 +171,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.InlineToMemory
 
             if (_isLinear && _lineCount == 1)
             {
-                memoryManager.Write(_dstGpuVa, data);
+                memoryManager.Physical.CacheResourceWrite(memoryManager, _dstGpuVa, data);
             }
             else
             {
@@ -227,11 +224,11 @@ namespace Ryujinx.Graphics.Gpu.Engine.InlineToMemory
                         memoryManager.Write(dstAddress, data[srcOffset]);
                     }
                 }
+
+                _context.AdvanceSequence();
             }
 
             _finished = true;
-
-            _context.AdvanceSequence();
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -100,6 +100,18 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Determines if any texture exists within the target memory range.
+        /// </summary>
+        /// <param name="memoryManager">The GPU memory manager</param>
+        /// <param name="gpuVa">GPU virtual address to search for textures</param>
+        /// <param name="size">The size of the range</param>
+        /// <returns>True if any texture exists in the range, false otherwise</returns>
+        public bool IsTextureInRange(MemoryManager memoryManager, ulong gpuVa, ulong size)
+        {
+            return _textures.FindOverlaps(memoryManager.GetPhysicalRegions(gpuVa, size), ref _textureOverlaps) != 0;
+        }
+
+        /// <summary>
         /// Determines if a given texture is "safe" for upscaling from its info.
         /// Note that this is different from being compatible - this elilinates targets that would have detrimental effects when scaled.
         /// </summary>

--- a/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
@@ -97,8 +97,8 @@ namespace Ryujinx.Graphics.Gpu.Memory
             }
             else
             {
-                memoryManager.WriteUntracked(gpuVa, data);
                 BufferCache.ForceDirty(memoryManager, gpuVa, (ulong)data.Length);
+                memoryManager.WriteUntracked(gpuVa, data);
             }
         }
 

--- a/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
@@ -81,6 +81,28 @@ namespace Ryujinx.Graphics.Gpu.Memory
         }
 
         /// <summary>
+        /// Write data to memory that is destined for a resource in a cache.
+        /// This avoids triggering write tracking when possible, which can avoid flushes and incrementing sequence number.
+        /// </summary>
+        /// <param name="memoryManager">The GPU memory manager</param>
+        /// <param name="gpuVa">GPU virtual address to write the data into</param>
+        /// <param name="data">The data to be written</param>
+        public void CacheResourceWrite(MemoryManager memoryManager, ulong gpuVa, ReadOnlySpan<byte> data)
+        {
+            if (TextureCache.IsTextureInRange(memoryManager, gpuVa, (ulong)data.Length))
+            {
+                // No fast path yet - copy the data back and trigger write tracking.
+                memoryManager.Write(gpuVa, data);
+                _context.AdvanceSequence();
+            }
+            else
+            {
+                memoryManager.WriteUntracked(gpuVa, data);
+                BufferCache.ForceDirty(memoryManager, gpuVa, (ulong)data.Length);
+            }
+        }
+
+        /// <summary>
         /// Gets a span of data from the application process.
         /// </summary>
         /// <param name="address">Start address of the range</param>


### PR DESCRIPTION
This PR adds a method to PhysicalMemory that attempts to write all cached resources directly, so that memory tracking can be avoided. The goal of this is both to avoid flushing buffer data, and to avoid raising the sequence number when data is written, which causes buffer and texture handles to be re-checked.

It just uses the existing ForceDirty method that is used for updating buffer data with the ConstantBufferUpdater. This avoids going through the tracking structure, reprotection and triggering read actions. The last part is the most important - as we know the exact range being written to, we don't need to flush the entire pages that we're writing to - just punch a hole in the "modified" ranges and write the data directly.

This currently only targets buffers, with a side check on textures that falls back to a tracked write if any exist within the target range. It's not expected to write textures from here - this is just a mechanism to protect us if someone does decide to do that. It's possible to add a fast path for this in future (and for ShaderCache, once that starts using tracking)

The forced read before Inline2Memory begins has been skipped, as the data is fully written when the transfer is completed anyways. This allows us to flush on read in emergency situations, but still write the new data over the flushed data.

Improves performance on Xenoblade 2 and DE, which were flushing buffer data on the GPU thread when trying to write compute data. May improve performance in other games that write SSBOs from compute, and update data in the same/nearby pages often.

Super Smash Bros Ultimate should probably be tested to make sure the vertex explosions haven't returned, as I think that's what this AdvanceSequence was for.

### Before
![image](https://user-images.githubusercontent.com/6294155/132388297-c8cbafaf-1f67-4370-a6a9-5a6f4093e08d.png)

### After
![image](https://user-images.githubusercontent.com/6294155/132388324-8cfedbac-cc03-4298-82f0-b358873fc0c6.png)
