### PR TITLE
Allow textures to have their data partially mapped

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -40,6 +40,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         private readonly PhysicalMemory _physicalMemory;
 
         private readonly MultiRangeList<Texture> _textures;
+        private readonly HashSet<Texture> _partiallyMappedTextures;
 
         private Texture[] _textureOverlaps;
         private OverlapInfo[] _overlapInfo;
@@ -57,6 +58,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             _physicalMemory = physicalMemory;
 
             _textures = new MultiRangeList<Texture>();
+            _partiallyMappedTextures = new HashSet<Texture>();
 
             _textureOverlaps = new Texture[OverlapsBufferInitialCapacity];
             _overlapInfo = new OverlapInfo[OverlapsBufferInitialCapacity];
@@ -74,17 +76,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             Texture[] overlaps = new Texture[10];
             int overlapCount;
 
-            MultiRange unmapped;
-
-            try
-            {
-                unmapped = ((MemoryManager)sender).GetPhysicalRegions(e.Address, e.Size);
-            }
-            catch (InvalidMemoryRegionException)
-            {
-                // This event fires on Map in case any mappings are overwritten. In that case, there may not be an existing mapping.
-                return;
-            }
+            MultiRange unmapped = ((MemoryManager)sender).GetPhysicalRegions(e.Address, e.Size);
 
             lock (_textures)
             {
@@ -94,6 +86,24 @@ namespace Ryujinx.Graphics.Gpu.Image
             for (int i = 0; i < overlapCount; i++)
             {
                 overlaps[i].Unmapped(unmapped);
+            }
+
+            // If any range was previously unmapped, we also need to purge
+            // all partially mapped texture, as they might be fully mapped now.
+            for (int i = 0; i < unmapped.Count; i++)
+            {
+                if (unmapped.GetSubRange(i).Address == MemoryManager.PteUnmapped)
+                {
+                    lock (_partiallyMappedTextures)
+                    {
+                        foreach (var texture in _partiallyMappedTextures)
+                        {
+                            texture.Unmapped(unmapped);
+                        }
+                    }
+
+                    break;
+                }
             }
         }
 
@@ -485,10 +495,20 @@ namespace Ryujinx.Graphics.Gpu.Image
             SizeInfo sizeInfo = info.CalculateSizeInfo(layerSize);
 
             ulong size = (ulong)sizeInfo.TotalSize;
+            bool partiallyMapped = false;
 
             if (range == null)
             {
                 range = memoryManager.GetPhysicalRegions(info.GpuAddress, size);
+
+                for (int i = 0; i < range.Value.Count; i++)
+                {
+                    if (range.Value.GetSubRange(i).Address == MemoryManager.PteUnmapped)
+                    {
+                        partiallyMapped = true;
+                        break;
+                    }
+                }
             }
 
             // Find view compatible matches.
@@ -658,7 +678,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     else
                     {
                         bool dataOverlaps = texture.DataOverlaps(overlap, compatibility);
-                        
+
                         if (!overlap.IsView && dataOverlaps && !incompatibleOverlaps.Exists(incompatible => incompatible.Group == overlap.Group))
                         {
                             incompatibleOverlaps.Add(new TextureIncompatibleOverlap(overlap.Group, compatibility));
@@ -772,6 +792,14 @@ namespace Ryujinx.Graphics.Gpu.Image
             lock (_textures)
             {
                 _textures.Add(texture);
+            }
+
+            if (partiallyMapped)
+            {
+                lock (_partiallyMappedTextures)
+                {
+                    _partiallyMappedTextures.Add(texture);
+                }
             }
 
             ShrinkOverlapsBufferIfNeeded();
@@ -1068,6 +1096,11 @@ namespace Ryujinx.Graphics.Gpu.Image
             lock (_textures)
             {
                 _textures.Remove(texture);
+            }
+
+            lock (_partiallyMappedTextures)
+            {
+                _partiallyMappedTextures.Remove(texture);
             }
         }
 

--- a/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
@@ -28,7 +28,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         private const int PtLvl1Bit = PtPageBits;
         private const int AddressSpaceBits = PtPageBits + PtLvl1Bits + PtLvl0Bits;
 
-        public const ulong PteUnmapped = 0xffffffff_ffffffff;
+        public const ulong PteUnmapped = ulong.MaxValue;
 
         private readonly ulong[][] _pageTable;
 
@@ -339,17 +339,11 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="va">Virtual address of the range</param>
         /// <param name="size">Size of the range</param>
         /// <returns>Multi-range with the physical regions</returns>
-        /// <exception cref="InvalidMemoryRegionException">The memory region specified by <paramref name="va"/> and <paramref name="size"/> is not fully mapped</exception>
         public MultiRange GetPhysicalRegions(ulong va, ulong size)
         {
             if (IsContiguous(va, (int)size))
             {
                 return new MultiRange(Translate(va), size);
-            }
-
-            if (!IsMapped(va))
-            {
-                throw new InvalidMemoryRegionException($"The specified GPU virtual address 0x{va:X} is not mapped.");
             }
 
             ulong regionStart = Translate(va);
@@ -366,14 +360,10 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
             for (int page = 0; page < pages - 1; page++)
             {
-                if (!IsMapped(va + PageSize))
-                {
-                    throw new InvalidMemoryRegionException($"The specified GPU virtual memory range 0x{va:X}..0x{(va + size):X} is not fully mapped.");
-                }
-
+                ulong currPa = Translate(va);
                 ulong newPa = Translate(va + PageSize);
 
-                if (Translate(va) + PageSize != newPa)
+                if ((currPa != PteUnmapped || newPa != PteUnmapped) && currPa + PageSize != newPa)
                 {
                     regions.Add(new MemoryRange(regionStart, regionSize));
                     regionStart = newPa;
@@ -404,18 +394,35 @@ namespace Ryujinx.Graphics.Gpu.Memory
             {
                 MemoryRange currentRange = range.GetSubRange(i);
 
-                ulong address = currentRange.Address & ~PageMask;
-                ulong endAddress = (currentRange.EndAddress + PageMask) & ~PageMask;
-
-                while (address < endAddress)
+                if (currentRange.Address != PteUnmapped)
                 {
-                    if (Translate(va) != address)
-                    {
-                        return false;
-                    }
+                    ulong address = currentRange.Address & ~PageMask;
+                    ulong endAddress = (currentRange.EndAddress + PageMask) & ~PageMask;
 
-                    va += PageSize;
-                    address += PageSize;
+                    while (address < endAddress)
+                    {
+                        if (Translate(va) != address)
+                        {
+                            return false;
+                        }
+
+                        va += PageSize;
+                        address += PageSize;
+                    }
+                }
+                else
+                {
+                    ulong endVa = va + (((currentRange.Size) + PageMask) & ~PageMask);
+
+                    while (va < endVa)
+                    {
+                        if (Translate(va) != PteUnmapped)
+                        {
+                            return false;
+                        }
+
+                        va += PageSize;
+                    }
                 }
             }
 

--- a/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
@@ -156,11 +156,13 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 int offset = 0;
                 for (int i = 0; i < range.Count; i++)
                 {
-                    MemoryRange subrange = range.GetSubRange(i);
-
-                    GetSpan(subrange.Address, (int)subrange.Size).CopyTo(memory.Span.Slice(offset, (int)subrange.Size));
-
-                    offset += (int)subrange.Size;
+                    var currentRange = range.GetSubRange(i);
+                    int size = (int)currentRange.Size;
+                    if (currentRange.Address != MemoryManager.PteUnmapped)
+                    {
+                        GetSpan(currentRange.Address, size).CopyTo(memory.Span.Slice(offset, size));
+                    }
+                    offset += size;
                 }
 
                 return new WritableRegion(new MultiRangeWritableBlock(range, this), 0, memory, tracked);

--- a/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
@@ -7,8 +7,6 @@ using Ryujinx.Memory.Range;
 using Ryujinx.Memory.Tracking;
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Threading;
 
 namespace Ryujinx.Graphics.Gpu.Memory
@@ -19,8 +17,6 @@ namespace Ryujinx.Graphics.Gpu.Memory
     /// </summary>
     class PhysicalMemory : IDisposable
     {
-        public const int PageSize = 0x1000;
-
         private readonly GpuContext _context;
         private IVirtualMemoryManagerTracked _cpuMemory;
         private int _referenceCount;
@@ -103,24 +99,28 @@ namespace Ryujinx.Graphics.Gpu.Memory
             if (range.Count == 1)
             {
                 var singleRange = range.GetSubRange(0);
-                return _cpuMemory.GetSpan(singleRange.Address, (int)singleRange.Size, tracked);
-            }
-            else
-            {
-                Span<byte> data = new byte[range.GetSize()];
-
-                int offset = 0;
-
-                for (int i = 0; i < range.Count; i++)
+                if (singleRange.Address != MemoryManager.PteUnmapped)
                 {
-                    var currentRange = range.GetSubRange(i);
-                    int size = (int)currentRange.Size;
-                    _cpuMemory.GetSpan(currentRange.Address, size, tracked).CopyTo(data.Slice(offset, size));
-                    offset += size;
+                    return _cpuMemory.GetSpan(singleRange.Address, (int)singleRange.Size, tracked);
                 }
-
-                return data;
             }
+
+            Span<byte> data = new byte[range.GetSize()];
+
+            int offset = 0;
+
+            for (int i = 0; i < range.Count; i++)
+            {
+                var currentRange = range.GetSubRange(i);
+                int size = (int)currentRange.Size;
+                if (currentRange.Address != MemoryManager.PteUnmapped)
+                {
+                    _cpuMemory.GetSpan(currentRange.Address, size, tracked).CopyTo(data.Slice(offset, size));
+                }
+                offset += size;
+            }
+
+            return data;
         }
 
         /// <summary>
@@ -253,7 +253,10 @@ namespace Ryujinx.Graphics.Gpu.Memory
             if (range.Count == 1)
             {
                 var singleRange = range.GetSubRange(0);
-                writeCallback(singleRange.Address, data);
+                if (singleRange.Address != MemoryManager.PteUnmapped)
+                {
+                    writeCallback(singleRange.Address, data);
+                }
             }
             else
             {
@@ -263,7 +266,10 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 {
                     var currentRange = range.GetSubRange(i);
                     int size = (int)currentRange.Size;
-                    writeCallback(currentRange.Address, data.Slice(offset, size));
+                    if (currentRange.Address != MemoryManager.PteUnmapped)
+                    {
+                        writeCallback(currentRange.Address, data.Slice(offset, size));
+                    }
                     offset += size;
                 }
             }
@@ -288,11 +294,20 @@ namespace Ryujinx.Graphics.Gpu.Memory
         public GpuRegionHandle BeginTracking(MultiRange range)
         {
             var cpuRegionHandles = new CpuRegionHandle[range.Count];
+            int count = 0;
 
             for (int i = 0; i < range.Count; i++)
             {
                 var currentRange = range.GetSubRange(i);
-                cpuRegionHandles[i] = _cpuMemory.BeginTracking(currentRange.Address, currentRange.Size);
+                if (currentRange.Address != MemoryManager.PteUnmapped)
+                {
+                    cpuRegionHandles[count++] = _cpuMemory.BeginTracking(currentRange.Address, currentRange.Size);
+                }
+            }
+
+            if (count != range.Count)
+            {
+                Array.Resize(ref cpuRegionHandles, count);
             }
 
             return new GpuRegionHandle(cpuRegionHandles);

--- a/Ryujinx.Memory/Range/MemoryRange.cs
+++ b/Ryujinx.Memory/Range/MemoryRange.cs
@@ -50,6 +50,13 @@ namespace Ryujinx.Memory.Range
             ulong otherAddress = other.Address;
             ulong otherEndAddress = other.EndAddress;
 
+            // If any of the ranges if invalid (address + size overflows),
+            // then they are never considered to overlap.
+            if (thisEndAddress < thisAddress || otherEndAddress < otherAddress)
+            {
+                return false;
+            }
+
             return thisAddress < otherEndAddress && otherAddress < thisEndAddress;
         }
 

--- a/Ryujinx.Memory/Range/MultiRangeList.cs
+++ b/Ryujinx.Memory/Range/MultiRangeList.cs
@@ -29,6 +29,12 @@ namespace Ryujinx.Memory.Range
             for (int i = 0; i < range.Count; i++)
             {
                 var subrange = range.GetSubRange(i);
+
+                if (IsInvalid(ref subrange))
+                {
+                    continue;
+                }
+
                 _items.Add(subrange.Address, subrange.EndAddress, item);
             }
 
@@ -49,6 +55,12 @@ namespace Ryujinx.Memory.Range
             for (int i = 0; i < range.Count; i++)
             {
                 var subrange = range.GetSubRange(i);
+
+                if (IsInvalid(ref subrange))
+                {
+                    continue;
+                }
+
                 removed += _items.Remove(subrange.Address, item);
             }
 
@@ -86,6 +98,12 @@ namespace Ryujinx.Memory.Range
             for (int i = 0; i < range.Count; i++)
             {
                 var subrange = range.GetSubRange(i);
+
+                if (IsInvalid(ref subrange))
+                {
+                    continue;
+                }
+
                 overlapCount = _items.Get(subrange.Address, subrange.EndAddress, ref output, overlapCount);
             }
 
@@ -122,6 +140,17 @@ namespace Ryujinx.Memory.Range
             }
 
             return overlapCount;
+        }
+
+        /// <summary>
+        /// Checks if a given sub-range of memory is invalid.
+        /// Those are used to represent unmapped memory regions (holes in the region mapping).
+        /// </summary>
+        /// <param name="subRange">Memory range to checl</param>
+        /// <returns>True if the memory range is considered invalid, false otherwise</returns>
+        private static bool IsInvalid(ref MemoryRange subRange)
+        {
+            return subRange.Address == ulong.MaxValue;
         }
 
         /// <summary>


### PR DESCRIPTION
We are currently hiting a case in some games where the texture data is only partially mapped, so for example, some mipmap levels are not mapped, which causes an exception to be throw on the call to `GetPhysicalRegions`, as it expects the full texture region to be mapped.

This change allows the textures to be created even if their data is not fully mapped. For the ranges that are not mapped, the data is read as 0, and writes goes nowhere. Mapped regions are read/written as normal. This should match hardware behaviour, which needs to work this way most likely to support sparse textures, as unmapped regions being accessed shouldn't cause a crash.

A few methods were adjusted to take this into account:
- `GetPhysicalRegions` now returns `ulong.MaxValue` and the size for unmapped ranges, instead of throwing.
- `CompareRange` can now handle `ulong.MaxValue` unmapped ranges, by checking if the GPU VA range is also unmapped.
- All methods on the `PhysicalMemory` that takes a `MultiRange` now ignores `ulong.MaxValue` ranges (except the read method, which now effectively reads them as 0).
- `TextureGroup` also now ignores `ulong.MaxValue` ranges when "generating handles".
- `MemoryRange` overlap check now returns false if any of the range overflows (which is the case when the address is `ulong.MaxValue`, which is the special value used for unmapped ranges).

**Open questions:**
- Should we print a warning for partially mapped textures? In some cases, it might be caused by a bug on the emulator, so perhaps having a warning could be useful.
- Should we handle cases where the *start* address is unmapped? My opinion is yes, but right now the fast path just looks for the base address and tries to find a perfect match, or returns null if unmapped, so changing that could degrade performance.
- With the current approach, it is still possible to write the data from the GPU, and it would read as whatever was written there later. This does not match hardware behaviour. Is it worth addressing this? It would require using sparse textures on the host, and I haven't looked at what vendor/GPU support for this extension looks like.

**What to test:** Games that had the `InvalidMemoryRegionException: The specified GPU virtual memory range [...] is not fully mapped.` crash, and games that torture the texture cache like UE4 games would be good candidates.

Fixes #2463, fixes #3077.
