### PR TITLE
Remove motion filter reset

### DIFF
--- a/Ryujinx.Input/Motion/MotionInput.cs
+++ b/Ryujinx.Input/Motion/MotionInput.cs
@@ -39,8 +39,6 @@ namespace Ryujinx.Input
 
                         Rotation = Vector3.Zero;
 
-                        _filter.Reset();
-
                         _calibrationFrame = 0;
                     }
                 }


### PR DESCRIPTION
The motion filter is reset on a regular basis in order to avoid drift when the controller is in a rest position. This behavior has a downside (at least) on PS4/PS5 controller in native SDL motion on Splatoon 2, where your aim is reset to the ground after the filter reset. It does work properly with Pro Controller though.

Removing the reset fix Splatoon 2 and doesn't seems to break other controller or other game but it needs to be tested on various configurations.