### PR TITLE
gui: Replace FileChooserDialog with FileChooserNative

### DIFF
--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -1201,15 +1201,20 @@ namespace Ryujinx.Ui
 
         private void Load_Application_File(object sender, EventArgs args)
         {
-            using (FileChooserDialog fileChooser = new FileChooserDialog("Choose the file to open", this, FileChooserAction.Open, "Cancel", ResponseType.Cancel, "Open", ResponseType.Accept))
+            using (FileChooserNative fileChooser = new FileChooserNative("Choose the file to open", this, FileChooserAction.Open, "Open", "Cancel"))
             {
-                fileChooser.Filter = new FileFilter();
-                fileChooser.Filter.AddPattern("*.nsp");
-                fileChooser.Filter.AddPattern("*.pfs0");
-                fileChooser.Filter.AddPattern("*.xci");
-                fileChooser.Filter.AddPattern("*.nca");
-                fileChooser.Filter.AddPattern("*.nro");
-                fileChooser.Filter.AddPattern("*.nso");
+                FileFilter filter = new FileFilter()
+                {
+                    Name = "Switch Executables"
+                };
+                filter.AddPattern("*.xci");
+                filter.AddPattern("*.nsp");
+                filter.AddPattern("*.pfs0");
+                filter.AddPattern("*.nca");
+                filter.AddPattern("*.nro");
+                filter.AddPattern("*.nso");
+
+                fileChooser.AddFilter(filter);
 
                 if (fileChooser.Run() == (int)ResponseType.Accept)
                 {
@@ -1220,7 +1225,7 @@ namespace Ryujinx.Ui
 
         private void Load_Application_Folder(object sender, EventArgs args)
         {
-            using (FileChooserDialog fileChooser = new FileChooserDialog("Choose the folder to open", this, FileChooserAction.SelectFolder, "Cancel", ResponseType.Cancel, "Open", ResponseType.Accept))
+            using (FileChooserNative fileChooser = new FileChooserNative("Choose the folder to open", this, FileChooserAction.SelectFolder, "Open", "Cancel"))
             {
                 if (fileChooser.Run() == (int)ResponseType.Accept)
                 {
@@ -1318,23 +1323,28 @@ namespace Ryujinx.Ui
 
         private void Installer_File_Pressed(object o, EventArgs args)
         {
-            FileChooserDialog fileChooser = new FileChooserDialog("Choose the firmware file to open", this, FileChooserAction.Open, "Cancel", ResponseType.Cancel, "Open", ResponseType.Accept);
+            FileChooserNative fileChooser = new FileChooserNative("Choose the firmware file to open", this, FileChooserAction.Open, "Open", "Cancel");
 
-            fileChooser.Filter = new FileFilter();
-            fileChooser.Filter.AddPattern("*.zip");
-            fileChooser.Filter.AddPattern("*.xci");
+            FileFilter filter = new FileFilter
+            {
+                Name = "Switch Firmware Files"
+            };
+            filter.AddPattern("*.zip");
+            filter.AddPattern("*.xci");
+
+            fileChooser.AddFilter(filter);
 
             HandleInstallerDialog(fileChooser);
         }
 
         private void Installer_Directory_Pressed(object o, EventArgs args)
         {
-            FileChooserDialog directoryChooser = new FileChooserDialog("Choose the firmware directory to open", this, FileChooserAction.SelectFolder, "Cancel", ResponseType.Cancel, "Open", ResponseType.Accept);
+            FileChooserNative directoryChooser = new FileChooserNative("Choose the firmware directory to open", this, FileChooserAction.SelectFolder, "Open", "Cancel");
 
             HandleInstallerDialog(directoryChooser);
         }
 
-        private void HandleInstallerDialog(FileChooserDialog fileChooser)
+        private void HandleInstallerDialog(FileChooserNative fileChooser)
         {
             if (fileChooser.Run() == (int)ResponseType.Accept)
             {

--- a/Ryujinx/Ui/Widgets/GameTableContextMenu.cs
+++ b/Ryujinx/Ui/Widgets/GameTableContextMenu.cs
@@ -184,8 +184,7 @@ namespace Ryujinx.Ui.Widgets
 
         private void ExtractSection(NcaSectionType ncaSectionType, int programIndex = 0)
         {
-            FileChooserDialog fileChooser = new FileChooserDialog("Choose the folder to extract into", null, FileChooserAction.SelectFolder, "Cancel", ResponseType.Cancel, "Extract", ResponseType.Accept);
-            fileChooser.SetPosition(WindowPosition.Center);
+            FileChooserNative fileChooser = new FileChooserNative("Choose the folder to extract into", null, FileChooserAction.SelectFolder, "Extract", "Cancel");
 
             ResponseType response    = (ResponseType)fileChooser.Run();
             string       destination = fileChooser.Filename;

--- a/Ryujinx/Ui/Windows/DlcWindow.cs
+++ b/Ryujinx/Ui/Windows/DlcWindow.cs
@@ -110,13 +110,18 @@ namespace Ryujinx.Ui.Windows
 
         private void AddButton_Clicked(object sender, EventArgs args)
         {
-            FileChooserDialog fileChooser = new FileChooserDialog("Select DLC files", this, FileChooserAction.Open, "Cancel", ResponseType.Cancel, "Add", ResponseType.Accept)
+            FileChooserNative fileChooser = new FileChooserNative("Select DLC files", this, FileChooserAction.Open, "Add", "Cancel")
             {
-                SelectMultiple = true,
-                Filter         = new FileFilter()
+                SelectMultiple = true
             };
-            fileChooser.SetPosition(WindowPosition.Center);
-            fileChooser.Filter.AddPattern("*.nsp");
+
+            FileFilter filter = new FileFilter()
+            {
+                Name = "Switch Game DLCs"
+            };
+            filter.AddPattern("*.nsp");
+
+            fileChooser.AddFilter(filter);
 
             if (fileChooser.Run() == (int)ResponseType.Accept)
             {

--- a/Ryujinx/Ui/Windows/SettingsWindow.cs
+++ b/Ryujinx/Ui/Windows/SettingsWindow.cs
@@ -563,7 +563,7 @@ namespace Ryujinx.Ui.Windows
             }
             else
             {
-                FileChooserDialog fileChooser = new FileChooserDialog("Choose the game directory to add to the list", this, FileChooserAction.SelectFolder, "Cancel", ResponseType.Cancel, "Add", ResponseType.Accept)
+                FileChooserNative fileChooser = new FileChooserNative("Choose the game directory to add to the list", this, FileChooserAction.SelectFolder, "Add", "Cancel")
                 {
                     SelectMultiple = true
                 };
@@ -622,10 +622,15 @@ namespace Ryujinx.Ui.Windows
 
         private void BrowseThemeDir_Pressed(object sender, EventArgs args)
         {
-            using (FileChooserDialog fileChooser = new FileChooserDialog("Choose the theme to load", this, FileChooserAction.Open, "Cancel", ResponseType.Cancel, "Select", ResponseType.Accept))
+            using (FileChooserNative fileChooser = new FileChooserNative("Choose the theme to load", this, FileChooserAction.Open, "Select", "Cancel"))
             {
-                fileChooser.Filter = new FileFilter();
-                fileChooser.Filter.AddPattern("*.css");
+                FileFilter filter = new FileFilter()
+                {
+                    Name = "Theme Files"
+                };
+                filter.AddPattern("*.css");
+
+                fileChooser.AddFilter(filter);
 
                 if (fileChooser.Run() == (int)ResponseType.Accept)
                 {

--- a/Ryujinx/Ui/Windows/TitleUpdateWindow.cs
+++ b/Ryujinx/Ui/Windows/TitleUpdateWindow.cs
@@ -139,12 +139,17 @@ namespace Ryujinx.Ui.Windows
 
         private void AddButton_Clicked(object sender, EventArgs args)
         {
-            using (FileChooserDialog fileChooser = new FileChooserDialog("Select update files", this, FileChooserAction.Open, "Cancel", ResponseType.Cancel, "Add", ResponseType.Accept))
+            using (FileChooserNative fileChooser = new FileChooserNative("Select update files", this, FileChooserAction.Open, "Add", "Cancel"))
             {
                 fileChooser.SelectMultiple = true;
-                fileChooser.SetPosition(WindowPosition.Center);
-                fileChooser.Filter = new FileFilter();
-                fileChooser.Filter.AddPattern("*.nsp");
+
+                FileFilter filter = new FileFilter()
+                {
+                    Name = "Switch Game Updates"
+                };
+                filter.AddPattern("*.nsp");
+
+                fileChooser.AddFilter(filter);
 
                 if (fileChooser.Run() == (int)ResponseType.Accept)
                 {

--- a/Ryujinx/Ui/Windows/UserProfilesManagerWindow.cs
+++ b/Ryujinx/Ui/Windows/UserProfilesManagerWindow.cs
@@ -193,17 +193,21 @@ namespace Ryujinx.Ui.Windows
 
         private void ProfileImageFileChooser()
         {
-            FileChooserDialog fileChooser = new FileChooserDialog("Import Custom Profile Image", this, FileChooserAction.Open, "Cancel", ResponseType.Cancel, "Import", ResponseType.Accept)
+            FileChooserNative fileChooser = new FileChooserNative("Import Custom Profile Image", this, FileChooserAction.Open, "Import", "Cancel")
             {
-                SelectMultiple = false,
-                Filter         = new FileFilter()
+                SelectMultiple = false
             };
 
-            fileChooser.SetPosition(WindowPosition.Center);
-            fileChooser.Filter.AddPattern("*.jpg");
-            fileChooser.Filter.AddPattern("*.jpeg");
-            fileChooser.Filter.AddPattern("*.png");
-            fileChooser.Filter.AddPattern("*.bmp");
+            FileFilter filter = new FileFilter()
+            {
+                Name = "Custom Profile Images"
+            };
+            filter.AddPattern("*.jpg");
+            filter.AddPattern("*.jpeg");
+            filter.AddPattern("*.png");
+            filter.AddPattern("*.bmp");
+
+            fileChooser.AddFilter(filter);
 
             if (fileChooser.Run() == (int)ResponseType.Accept)
             {


### PR DESCRIPTION
We currently use the FileChooser from GTK, which is a bit mess. Instead of it we could use the native FileChooser from all specifics OS. This is what this PR attempt to fix.

![image](https://user-images.githubusercontent.com/4905390/132962800-daa9d3e4-41f8-451a-be72-05f8bfdd5f90.png)

It could be nice to get a test under linux since I've only tested it under Windows without any issues.

Fixes #2584 and fixes #2530