### PR TITLE
Optimize `HybridAllocator`

### DIFF
--- a/ARMeilleure/CodeGen/RegisterAllocators/HybridAllocator.cs
+++ b/ARMeilleure/CodeGen/RegisterAllocators/HybridAllocator.cs
@@ -88,7 +88,7 @@ namespace ARMeilleure.CodeGen.RegisterAllocators
 
             void ThrowNotVisisted()
             {
-                throw new InvalidOperationException("Local was not visisted yet. Used before defined?");
+                throw new InvalidOperationException("Local was not visited yet. Used before defined?");
             }
 
             // The "visited" state is stored in the MSB of the local's value.

--- a/ARMeilleure/CodeGen/RegisterAllocators/HybridAllocator.cs
+++ b/ARMeilleure/CodeGen/RegisterAllocators/HybridAllocator.cs
@@ -86,7 +86,7 @@ namespace ARMeilleure.CodeGen.RegisterAllocators
             var localInfo = new LocalInfo[cfg.Blocks.Count * 3];
             int localInfoCount = 0;
 
-            void ThrowNotVisisted()
+            void ThrowNotVisited()
             {
                 throw new InvalidOperationException("Local was not visited yet. Used before defined?");
             }
@@ -110,7 +110,7 @@ namespace ARMeilleure.CodeGen.RegisterAllocators
 
                 if (!IsVisited(local))
                 {
-                    ThrowNotVisisted();
+                    ThrowNotVisited();
                 }
 
                 return ref localInfo[(uint)local.GetValueUnsafe() - 1];

--- a/ARMeilleure/CodeGen/RegisterAllocators/HybridAllocator.cs
+++ b/ARMeilleure/CodeGen/RegisterAllocators/HybridAllocator.cs
@@ -86,6 +86,11 @@ namespace ARMeilleure.CodeGen.RegisterAllocators
             var localInfo = new LocalInfo[cfg.Blocks.Count * 3];
             int localInfoCount = 0;
 
+            void ThrowNotVisisted()
+            {
+                throw new InvalidOperationException("Local was not visisted yet. Used before defined?");
+            }
+
             // The "visited" state is stored in the MSB of the local's value.
             const ulong VisitedMask = 1ul << 63;
 
@@ -105,7 +110,7 @@ namespace ARMeilleure.CodeGen.RegisterAllocators
 
                 if (!IsVisited(local))
                 {
-                    throw new InvalidOperationException("Local was not visisted yet. Used before defined?");
+                    ThrowNotVisisted();
                 }
 
                 return ref localInfo[(uint)local.GetValueUnsafe() - 1];

--- a/ARMeilleure/CodeGen/X86/CodeGenerator.cs
+++ b/ARMeilleure/CodeGen/X86/CodeGenerator.cs
@@ -97,15 +97,17 @@ namespace ARMeilleure.CodeGen.X86
 
             Logger.StartPass(PassName.Optimization);
 
-            if ((cctx.Options & CompilerOptions.SsaForm)  != 0 &&
-                (cctx.Options & CompilerOptions.Optimize) != 0)
+            if (cctx.Options.HasFlag(CompilerOptions.Optimize))
             {
-                Optimizer.RunPass(cfg);
+                if (cctx.Options.HasFlag(CompilerOptions.SsaForm))
+                {
+                    Optimizer.RunPass(cfg);
+                }
+
+                BlockPlacement.RunPass(cfg);
             }
 
             X86Optimizer.RunPass(cfg);
-
-            BlockPlacement.RunPass(cfg);
 
             Logger.EndPass(PassName.Optimization, cfg);
 
@@ -119,14 +121,14 @@ namespace ARMeilleure.CodeGen.X86
 
             Logger.StartPass(PassName.RegisterAllocation);
 
-            if ((cctx.Options & CompilerOptions.SsaForm) != 0)
+            if (cctx.Options.HasFlag(CompilerOptions.SsaForm))
             {
                 Ssa.Deconstruct(cfg);
             }
 
             IRegisterAllocator regAlloc;
 
-            if ((cctx.Options & CompilerOptions.Lsra) != 0)
+            if (cctx.Options.HasFlag(CompilerOptions.Lsra))
             {
                 regAlloc = new LinearScanAllocator();
             }

--- a/ARMeilleure/IntermediateRepresentation/Operand.cs
+++ b/ARMeilleure/IntermediateRepresentation/Operand.cs
@@ -146,6 +146,7 @@ namespace ARMeilleure.IntermediateRepresentation
             return BitConverter.Int64BitsToDouble((long)Value);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal ref ulong GetValueUnsafe()
         {
             return ref _data->Value;

--- a/ARMeilleure/IntermediateRepresentation/Operation.cs
+++ b/ARMeilleure/IntermediateRepresentation/Operation.cs
@@ -53,8 +53,8 @@ namespace ARMeilleure.IntermediateRepresentation
         public int DestinationsCount => _data->DestinationsCount;
         public int SourcesCount => _data->SourcesCount;
 
-        private Span<Operand> Destinations => new(_data->Destinations, _data->DestinationsCount);
-        private Span<Operand> Sources => new(_data->Sources, _data->SourcesCount);
+        internal Span<Operand> DestinationsUnsafe => new(_data->Destinations, _data->DestinationsCount);
+        internal Span<Operand> SourcesUnsafe => new(_data->Sources, _data->SourcesCount);
 
         public PhiOperation AsPhi()
         {
@@ -65,17 +65,17 @@ namespace ARMeilleure.IntermediateRepresentation
 
         public Operand GetDestination(int index)
         {
-            return Destinations[index];
+            return DestinationsUnsafe[index];
         }
 
         public Operand GetSource(int index)
         {
-            return Sources[index];
+            return SourcesUnsafe[index];
         }
 
         public void SetDestination(int index, Operand dest)
         {
-            ref Operand curDest = ref Destinations[index];
+            ref Operand curDest = ref DestinationsUnsafe[index];
 
             RemoveAssignment(curDest);
             AddAssignment(dest);
@@ -85,7 +85,7 @@ namespace ARMeilleure.IntermediateRepresentation
 
         public void SetSource(int index, Operand src)
         {
-            ref Operand curSrc = ref Sources[index];
+            ref Operand curSrc = ref SourcesUnsafe[index];
 
             RemoveUse(curSrc);
             AddUse(src);
@@ -274,8 +274,8 @@ namespace ARMeilleure.IntermediateRepresentation
                 EnsureCapacity(ref result._data->Destinations, ref result._data->DestinationsCount, destCount);
                 EnsureCapacity(ref result._data->Sources, ref result._data->SourcesCount, srcCount);
 
-                result.Destinations.Clear();
-                result.Sources.Clear();
+                result.DestinationsUnsafe.Clear();
+                result.SourcesUnsafe.Clear();
 
                 return result;
             }


### PR DESCRIPTION
This brings a set of optimizations to the `HybridAllocator` which increases the throughput of LCQ, and usually shaves a couple of seconds from boot time. I also disabled `BlockPlacement` in LCQ to get some extra throughput since with the host mapped memory manager, there is a lot less cold code to split from hot code.