### PR TITLE
gui: Hotfix for FileChooserNative during section extraction

### DIFF
--- a/Ryujinx/Ui/Widgets/GameTableContextMenu.cs
+++ b/Ryujinx/Ui/Widgets/GameTableContextMenu.cs
@@ -184,7 +184,7 @@ namespace Ryujinx.Ui.Widgets
 
         private void ExtractSection(NcaSectionType ncaSectionType, int programIndex = 0)
         {
-            FileChooserNative fileChooser = new FileChooserNative("Choose the folder to extract into", null, FileChooserAction.SelectFolder, "Extract", "Cancel");
+            FileChooserNative fileChooser = new FileChooserNative("Choose the folder to extract into", _parent, FileChooserAction.SelectFolder, "Extract", "Cancel");
 
             ResponseType response    = (ResponseType)fileChooser.Run();
             string       destination = fileChooser.Filename;


### PR DESCRIPTION
Fix a regression introduced in #2633, FileChooserNative parent can't be set to null because it's running in modal.