### PR TITLE
Fix problems added by Pause

### DIFF
--- a/Ryujinx.Audio/Renderer/Server/AudioRenderSystem.cs
+++ b/Ryujinx.Audio/Renderer/Server/AudioRenderSystem.cs
@@ -395,6 +395,14 @@ namespace Ryujinx.Audio.Renderer.Server
             Logger.Info?.Print(LogClass.AudioRenderer, $"Stopped renderer id {_sessionId}");
         }
 
+        public void Disable()
+        {
+            lock (_lock)
+            {
+                _isActive = false;
+            }
+        }
+
         public ResultCode Update(Memory<byte> output, Memory<byte> performanceOutput, ReadOnlyMemory<byte> input)
         {
             lock (_lock)

--- a/Ryujinx.Audio/Renderer/Server/AudioRendererManager.cs
+++ b/Ryujinx.Audio/Renderer/Server/AudioRendererManager.cs
@@ -219,7 +219,21 @@ namespace Ryujinx.Audio.Renderer.Server
         /// </summary>
         public void StopSendingCommands()
         {
-            _isRunning = false;
+            lock (_sessionLock)
+            {
+                foreach (AudioRenderSystem renderer in _sessions)
+                {
+                    renderer?.Disable();
+                }
+            }
+
+            lock (_audioProcessorLock)
+            {
+                if (_isRunning)
+                {
+                    StopLocked();
+                }
+            }
         }
 
         /// <summary>
@@ -234,7 +248,7 @@ namespace Ryujinx.Audio.Renderer.Server
             {
                 lock (_sessionLock)
                 {
-                    foreach(AudioRenderSystem renderer in _sessions)
+                    foreach (AudioRenderSystem renderer in _sessions)
                     {
                         renderer?.SendCommands();
                     }

--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -386,10 +386,14 @@ namespace Ryujinx.HLE.HOS
                 _isDisposed = true;
 
                 // "Soft" stops AudioRenderer and AudioManager to avoid some sound between resume and stop.
-                AudioRendererManager.StopSendingCommands();
-                AudioManager.StopUpdates();
+                if (IsPaused)
+                {
+                    AudioManager.StopUpdates();
 
-                TogglePauseEmulation(false);
+                    TogglePauseEmulation(false);
+
+                    AudioRendererManager.StopSendingCommands();
+                }
 
                 KProcess terminationProcess = new KProcess(KernelContext);
                 KThread terminationThread = new KThread(KernelContext);

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -214,6 +214,7 @@ namespace Ryujinx.Ui
 
             _actionMenu.Sensitive = false;
             _pauseEmulation.Sensitive = false;
+            _resumeEmulation.Sensitive = false;
 
             if (ConfigurationState.Instance.Ui.GuiColumns.FavColumn)        _favToggle.Active        = true;
             if (ConfigurationState.Instance.Ui.GuiColumns.IconColumn)       _iconToggle.Active       = true;

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -1289,36 +1289,36 @@ namespace Ryujinx.Ui
                 UpdateGameMetadata(_emulationContext.Application.TitleIdText);
             }
 
-            _pauseEmulation.Visible = true;
             _pauseEmulation.Sensitive = false;
-            _resumeEmulation.Visible = false;
+            _resumeEmulation.Sensitive = false;
             RendererWidget?.Exit();
         }
 
         private void PauseEmulation_Pressed(object sender, EventArgs args)
         {
-            _pauseEmulation.Visible = false;
-            _resumeEmulation.Visible = true;
+            _pauseEmulation.Sensitive = false;
+            _resumeEmulation.Sensitive = true;
             _emulationContext.System.TogglePauseEmulation(true);
         }
 
         private void ResumeEmulation_Pressed(object sender, EventArgs args)
         {
-            _pauseEmulation.Visible = true;
-            _resumeEmulation.Visible = false;
+            _pauseEmulation.Sensitive = true;
+            _resumeEmulation.Sensitive = false;
             _emulationContext.System.TogglePauseEmulation(false);
         }
 
         public void ActivatePauseMenu()
         {
             _pauseEmulation.Sensitive = true;
+            _resumeEmulation.Sensitive = false;
         }
 
         public void TogglePause()
         {
-            _pauseEmulation.Visible ^= true;
-            _resumeEmulation.Visible ^= true;
-            _emulationContext.System.TogglePauseEmulation(_resumeEmulation.Visible);
+            _pauseEmulation.Sensitive ^= true;
+            _resumeEmulation.Sensitive ^= true;
+            _emulationContext.System.TogglePauseEmulation(_resumeEmulation.Sensitive);
         }
 
         private void Installer_File_Pressed(object o, EventArgs args)

--- a/Ryujinx/Ui/MainWindow.glade
+++ b/Ryujinx/Ui/MainWindow.glade
@@ -305,7 +305,7 @@
 					</child>
 					  <child>
 						  <object class="GtkMenuItem" id="_resumeEmulation">
-							  <property name="visible">False</property>
+							  <property name="visible">True</property>
 							  <property name="can_focus">False</property>
 							  <property name="tooltip_text" translatable="yes">Resume emulation</property>
 							  <property name="label" translatable="yes">Resume Emulation</property>


### PR DESCRIPTION
This PR fixes two problems :
- Hiding Pause/Resume entry in Action menu doesn't work properly after switching fullscreen mode. With this PR, the entries are always shown but contextually disabled
- Since #2428, Ryujinx can't be properly closed because of a remaining audio thread. This should be fixed now.