### PR TITLE
Set texture/image bindings in place rather than allocating and passing an array

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Compute/ComputeClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Compute/ComputeClass.cs
@@ -191,7 +191,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Compute
             _channel.BufferManager.SetComputeStorageBufferBindings(info.SBuffers);
             _channel.BufferManager.SetComputeUniformBufferBindings(info.CBuffers);
 
-            var textureBindings = new TextureBindingInfo[info.Textures.Count];
+            Span<TextureBindingInfo> textureBindings = stackalloc TextureBindingInfo[info.Textures.Count];
 
             for (int index = 0; index < info.Textures.Count; index++)
             {
@@ -209,7 +209,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Compute
 
             _channel.TextureManager.SetComputeTextures(textureBindings);
 
-            var imageBindings = new TextureBindingInfo[info.Images.Count];
+            Span<TextureBindingInfo> imageBindings = stackalloc TextureBindingInfo[info.Images.Count];
 
             for (int index = 0; index < info.Images.Count; index++)
             {

--- a/Ryujinx.Graphics.Gpu/Engine/Compute/ComputeClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Compute/ComputeClass.cs
@@ -191,7 +191,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Compute
             _channel.BufferManager.SetComputeStorageBufferBindings(info.SBuffers);
             _channel.BufferManager.SetComputeUniformBufferBindings(info.CBuffers);
 
-            Span<TextureBindingInfo> textureBindings = stackalloc TextureBindingInfo[info.Textures.Count];
+            TextureBindingInfo[] textureBindings = _channel.TextureManager.RentComputeTextureBindings(info.Textures.Count);
 
             for (int index = 0; index < info.Textures.Count; index++)
             {
@@ -207,9 +207,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Compute
                     descriptor.Flags);
             }
 
-            _channel.TextureManager.SetComputeTextures(textureBindings);
-
-            Span<TextureBindingInfo> imageBindings = stackalloc TextureBindingInfo[info.Images.Count];
+            TextureBindingInfo[] imageBindings = _channel.TextureManager.RentComputeImageBindings(info.Images.Count);
 
             for (int index = 0; index < info.Images.Count; index++)
             {
@@ -226,8 +224,6 @@ namespace Ryujinx.Graphics.Gpu.Engine.Compute
                     descriptor.HandleIndex,
                     descriptor.Flags);
             }
-
-            _channel.TextureManager.SetComputeImages(imageBindings);
 
             _channel.TextureManager.CommitComputeBindings();
             _channel.BufferManager.CommitComputeBindings();

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -962,6 +962,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 UpdateUserClipState();
             }
 
+#pragma warning disable CA2014 // Do not use stackalloc in loops - ShaderStages is constant, so the loop won't cause unbounded allocation.
             for (int stage = 0; stage < Constants.ShaderStages; stage++)
             {
                 ShaderProgramInfo info = gs.Shaders[stage]?.Info;
@@ -977,7 +978,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                     continue;
                 }
 
-                var textureBindings = new TextureBindingInfo[info.Textures.Count];
+                Span<TextureBindingInfo> textureBindings = stackalloc TextureBindingInfo[info.Textures.Count];
 
                 for (int index = 0; index < info.Textures.Count; index++)
                 {
@@ -995,7 +996,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
                 _channel.TextureManager.SetGraphicsTextures(stage, textureBindings);
 
-                var imageBindings = new TextureBindingInfo[info.Images.Count];
+                Span<TextureBindingInfo> imageBindings = stackalloc TextureBindingInfo[info.Images.Count];
 
                 for (int index = 0; index < info.Images.Count; index++)
                 {
@@ -1018,6 +1019,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 _channel.BufferManager.SetGraphicsStorageBufferBindings(stage, info.SBuffers);
                 _channel.BufferManager.SetGraphicsUniformBufferBindings(stage, info.CBuffers);
             }
+
+#pragma warning restore CA2014 // Do not use stackalloc in loops
 
             _context.Renderer.Pipeline.SetProgram(gs.HostProgram);
         }

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -962,7 +962,6 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 UpdateUserClipState();
             }
 
-#pragma warning disable CA2014 // Do not use stackalloc in loops - ShaderStages is constant, so the loop won't cause unbounded allocation.
             for (int stage = 0; stage < Constants.ShaderStages; stage++)
             {
                 ShaderProgramInfo info = gs.Shaders[stage]?.Info;
@@ -971,14 +970,14 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
                 if (info == null)
                 {
-                    _channel.TextureManager.SetGraphicsTextures(stage, Array.Empty<TextureBindingInfo>());
-                    _channel.TextureManager.SetGraphicsImages(stage, Array.Empty<TextureBindingInfo>());
+                    _channel.TextureManager.RentGraphicsTextureBindings(stage, 0);
+                    _channel.TextureManager.RentGraphicsImageBindings(stage, 0);
                     _channel.BufferManager.SetGraphicsStorageBufferBindings(stage, null);
                     _channel.BufferManager.SetGraphicsUniformBufferBindings(stage, null);
                     continue;
                 }
 
-                Span<TextureBindingInfo> textureBindings = stackalloc TextureBindingInfo[info.Textures.Count];
+                Span<TextureBindingInfo> textureBindings = _channel.TextureManager.RentGraphicsTextureBindings(stage, info.Textures.Count);
 
                 for (int index = 0; index < info.Textures.Count; index++)
                 {
@@ -994,9 +993,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                         descriptor.Flags);
                 }
 
-                _channel.TextureManager.SetGraphicsTextures(stage, textureBindings);
-
-                Span<TextureBindingInfo> imageBindings = stackalloc TextureBindingInfo[info.Images.Count];
+                TextureBindingInfo[] imageBindings = _channel.TextureManager.RentGraphicsImageBindings(stage, info.Images.Count);
 
                 for (int index = 0; index < info.Images.Count; index++)
                 {
@@ -1014,13 +1011,9 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                         descriptor.Flags);
                 }
 
-                _channel.TextureManager.SetGraphicsImages(stage, imageBindings);
-
                 _channel.BufferManager.SetGraphicsStorageBufferBindings(stage, info.SBuffers);
                 _channel.BufferManager.SetGraphicsUniformBufferBindings(stage, info.CBuffers);
             }
-
-#pragma warning restore CA2014 // Do not use stackalloc in loops
 
             _context.Renderer.Pipeline.SetProgram(gs.HostProgram);
         }

--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -99,49 +99,57 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Binds textures for a given shader stage.
+        /// Rents the texture bindings array for a given stage, so that they can be modified.
         /// </summary>
         /// <param name="stage">Shader stage number, or 0 for compute shaders</param>
-        /// <param name="bindings">Texture bindings</param>
-        public void SetTextures(int stage, Span<TextureBindingInfo> bindings)
+        /// <param name="count">The number of bindings needed</param>
+        /// <returns>The texture bindings array</returns>
+        public TextureBindingInfo[] RentTextureBindings(int stage, int count)
         {
-            if (bindings.Length > _textureBindings[stage].Length)
+            if (count > _textureBindings[stage].Length)
             {
-                Array.Resize(ref _textureBindings[stage], bindings.Length);
-                Array.Resize(ref _textureState[stage], bindings.Length);
+                Array.Resize(ref _textureBindings[stage], count);
+                Array.Resize(ref _textureState[stage], count);
             }
 
-            bindings.CopyTo(_textureBindings[stage]);
+            int toClear = Math.Max(_textureBindingsCount[stage], count);
+            TextureStatePerStage[] state = _textureState[stage];
 
-            for (int i = 0; i < bindings.Length; i++)
+            for (int i = 0; i < toClear; i++)
             {
-                _textureState[stage][i] = new TextureStatePerStage();
+                state[i] = new TextureStatePerStage();
             }
 
-            _textureBindingsCount[stage] = bindings.Length;
+            _textureBindingsCount[stage] = count;
+
+            return _textureBindings[stage];
         }
 
         /// <summary>
-        /// Binds images for a given shader stage.
+        /// Rents the image bindings array for a given stage, so that they can be modified.
         /// </summary>
         /// <param name="stage">Shader stage number, or 0 for compute shaders</param>
-        /// <param name="bindings">Image bindings</param>
-        public void SetImages(int stage, Span<TextureBindingInfo> bindings)
+        /// <param name="count">The number of bindings needed</param>
+        /// <returns>The image bindings array</returns>
+        public TextureBindingInfo[] RentImageBindings(int stage, int count)
         {
-            if (bindings.Length > _imageBindings[stage].Length)
+            if (count > _imageBindings[stage].Length)
             {
-                Array.Resize(ref _imageBindings[stage], bindings.Length);
-                Array.Resize(ref _imageState[stage], bindings.Length);
+                Array.Resize(ref _imageBindings[stage], count);
+                Array.Resize(ref _imageState[stage], count);
             }
 
-            bindings.CopyTo(_imageBindings[stage]);
+            int toClear = Math.Max(_imageBindingsCount[stage], count);
+            TextureStatePerStage[] state = _imageState[stage];
 
-            for (int i = 0; i < bindings.Length; i++)
+            for (int i = 0; i < toClear; i++)
             {
-                _imageState[stage][i] = new TextureStatePerStage();
+                state[i] = new TextureStatePerStage();
             }
 
-            _imageBindingsCount[stage] = bindings.Length;
+            _imageBindingsCount[stage] = count;
+
+            return _imageBindings[stage];
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -46,7 +46,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Sets texture bindings on the compute pipeline.
         /// </summary>
         /// <param name="bindings">The texture bindings</param>
-        public void SetComputeTextures(TextureBindingInfo[] bindings)
+        public void SetComputeTextures(Span<TextureBindingInfo> bindings)
         {
             _cpBindingsManager.SetTextures(0, bindings);
         }
@@ -56,7 +56,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         /// <param name="stage">The index of the shader stage to bind the textures</param>
         /// <param name="bindings">The texture bindings</param>
-        public void SetGraphicsTextures(int stage, TextureBindingInfo[] bindings)
+        public void SetGraphicsTextures(int stage, Span<TextureBindingInfo> bindings)
         {
             _gpBindingsManager.SetTextures(stage, bindings);
         }
@@ -65,7 +65,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Sets image bindings on the compute pipeline.
         /// </summary>
         /// <param name="bindings">The image bindings</param>
-        public void SetComputeImages(TextureBindingInfo[] bindings)
+        public void SetComputeImages(Span<TextureBindingInfo> bindings)
         {
             _cpBindingsManager.SetImages(0, bindings);
         }
@@ -75,7 +75,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         /// <param name="stage">The index of the shader stage to bind the images</param>
         /// <param name="bindings">The image bindings</param>
-        public void SetGraphicsImages(int stage, TextureBindingInfo[] bindings)
+        public void SetGraphicsImages(int stage, Span<TextureBindingInfo> bindings)
         {
             _gpBindingsManager.SetImages(stage, bindings);
         }

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -43,41 +43,45 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Sets texture bindings on the compute pipeline.
+        /// Rents the texture bindings array of the compute pipeline.
         /// </summary>
-        /// <param name="bindings">The texture bindings</param>
-        public void SetComputeTextures(Span<TextureBindingInfo> bindings)
+        /// <param name="count">The number of bindings needed</param>
+        /// <returns>The texture bindings array</returns>
+        public TextureBindingInfo[] RentComputeTextureBindings(int count)
         {
-            _cpBindingsManager.SetTextures(0, bindings);
+            return _cpBindingsManager.RentTextureBindings(0, count);
         }
 
         /// <summary>
-        /// Sets texture bindings on the graphics pipeline.
+        /// Rents the texture bindings array for a given stage on the graphics pipeline.
         /// </summary>
         /// <param name="stage">The index of the shader stage to bind the textures</param>
-        /// <param name="bindings">The texture bindings</param>
-        public void SetGraphicsTextures(int stage, Span<TextureBindingInfo> bindings)
+        /// <param name="count">The number of bindings needed</param>
+        /// <returns>The texture bindings array</returns>
+        public TextureBindingInfo[] RentGraphicsTextureBindings(int stage, int count)
         {
-            _gpBindingsManager.SetTextures(stage, bindings);
+            return _gpBindingsManager.RentTextureBindings(stage, count);
         }
 
         /// <summary>
-        /// Sets image bindings on the compute pipeline.
+        /// Rents the image bindings array of the compute pipeline.
         /// </summary>
-        /// <param name="bindings">The image bindings</param>
-        public void SetComputeImages(Span<TextureBindingInfo> bindings)
+        /// <param name="count">The number of bindings needed</param>
+        /// <returns>The image bindings array</returns>
+        public TextureBindingInfo[] RentComputeImageBindings(int count)
         {
-            _cpBindingsManager.SetImages(0, bindings);
+            return _cpBindingsManager.RentImageBindings(0, count);
         }
 
         /// <summary>
-        /// Sets image bindings on the graphics pipeline.
+        /// Rents the image bindings array for a given stage on the graphics pipeline.
         /// </summary>
         /// <param name="stage">The index of the shader stage to bind the images</param>
-        /// <param name="bindings">The image bindings</param>
-        public void SetGraphicsImages(int stage, Span<TextureBindingInfo> bindings)
+        /// <param name="count">The number of bindings needed</param>
+        /// <returns>The image bindings array</returns>
+        public TextureBindingInfo[] RentGraphicsImageBindings(int stage, int count)
         {
-            _gpBindingsManager.SetImages(stage, bindings);
+            return _gpBindingsManager.RentImageBindings(stage, count);
         }
 
         /// <summary>


### PR DESCRIPTION
This was allocating multiple arrays per draw or compute invocation. Noticed it on a profile, its cost was significant but not mind blowing. Figured like the other change, removing these allocations might have some small effects on performance outside this method. Good to remove costs like this either way.

I've changed the SetTextures and SetImages method to instead rent the bindings array for modification, now called RentTextureBindings, which is in charge of ensuring the arrays are the correct size, and clearing the state arrays. This is done to set the data directly, rather than allocate or copy into the bindings manager. 

They now use arrays that are pre-allocated with a default size, but can be increased in size to fit shaders that bind way more textures, such as bindless accesses.