### PR TITLE
Add mod manager 

### DIFF
--- a/Ryujinx.Common/Configuration/ModEntry.cs
+++ b/Ryujinx.Common/Configuration/ModEntry.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace Ryujinx.Common.Configuration
+{
+    public struct ModEntry
+    {
+        public string Name { get; set; }
+        public string Path { get; set; }
+
+        public ModEntry(string name, string path)
+        {
+            Name = name;
+            Path = path;
+        }
+    }
+}

--- a/Ryujinx.HLE/HOS/ModLoader.cs
+++ b/Ryujinx.HLE/HOS/ModLoader.cs
@@ -448,9 +448,9 @@ namespace Ryujinx.HLE.HOS
 
                 FilterMods(unfilteredModCache.RomfsContainers, filteredModCache.RomfsContainers, enabledMods);
                 FilterMods(unfilteredModCache.ExefsContainers, filteredModCache.ExefsContainers, enabledMods);
-                FilterMods(unfilteredModCache.RomfsDirs      , filteredModCache.RomfsDirs      , enabledMods);
-                FilterMods(unfilteredModCache.ExefsDirs      , filteredModCache.ExefsDirs      , enabledMods);
-                FilterMods(unfilteredModCache.Cheats         , filteredModCache.Cheats         , enabledMods);
+                FilterMods(unfilteredModCache.RomfsDirs,       filteredModCache.RomfsDirs,       enabledMods);
+                FilterMods(unfilteredModCache.ExefsDirs,       filteredModCache.ExefsDirs,       enabledMods);
+                FilterMods(unfilteredModCache.Cheats,          filteredModCache.Cheats,          enabledMods);
 
                 AppMods[titleId] = filteredModCache;
             }

--- a/Ryujinx/Ryujinx.csproj
+++ b/Ryujinx/Ryujinx.csproj
@@ -86,6 +86,7 @@
     <None Remove="Ui\Widgets\ProfileDialog.glade" />
     <None Remove="Ui\Windows\ControllerWindow.glade" />
     <None Remove="Ui\Windows\DlcWindow.glade" />
+    <None Remove="Ui\Windows\ModsWindow.glade" />
     <None Remove="Ui\Windows\SettingsWindow.glade" />
     <None Remove="Ui\Windows\TitleUpdateWindow.glade" />
     <None Remove="Modules\Updater\UpdateDialog.glade" />
@@ -111,6 +112,7 @@
     <EmbeddedResource Include="Ui\Widgets\ProfileDialog.glade" />
     <EmbeddedResource Include="Ui\Windows\ControllerWindow.glade" />
     <EmbeddedResource Include="Ui\Windows\DlcWindow.glade" />
+    <EmbeddedResource Include="Ui\Windows\ModsWindow.glade" />
     <EmbeddedResource Include="Ui\Windows\SettingsWindow.glade" />
     <EmbeddedResource Include="Ui\Windows\TitleUpdateWindow.glade" />
     <EmbeddedResource Include="Modules\Updater\UpdateDialog.glade" />

--- a/Ryujinx/Ui/Widgets/GameTableContextMenu.Designer.cs
+++ b/Ryujinx/Ui/Widgets/GameTableContextMenu.Designer.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Ui.Widgets
         private MenuItem _openSaveBcatDirMenuItem;
         private MenuItem _manageTitleUpdatesMenuItem;
         private MenuItem _manageDlcMenuItem;
-        private MenuItem _openTitleModDirMenuItem;
+        private MenuItem _manageModsMenuItem;
         private Menu     _extractSubMenu;
         private MenuItem _extractMenuItem;
         private MenuItem _extractRomFsMenuItem;
@@ -70,13 +70,13 @@ namespace Ryujinx.Ui.Widgets
             _manageDlcMenuItem.Activated += ManageDlc_Clicked;
 
             //
-            // _openTitleModDirMenuItem
+            // _manageModsMenuItem
             //
-            _openTitleModDirMenuItem = new MenuItem("Open Mods Directory")
+            _manageModsMenuItem = new MenuItem("Manage Mods")
             {
                 TooltipText = "Open the directory which contains Application's Mods."
             };
-            _openTitleModDirMenuItem.Activated += OpenTitleModDir_Clicked;
+            _manageModsMenuItem.Activated += ManageMods_Clicked;
 
             //
             // _extractSubMenu
@@ -187,7 +187,7 @@ namespace Ryujinx.Ui.Widgets
             Add(new SeparatorMenuItem());
             Add(_manageTitleUpdatesMenuItem);
             Add(_manageDlcMenuItem);
-            Add(_openTitleModDirMenuItem);
+            Add(_manageModsMenuItem);
             Add(new SeparatorMenuItem());
             Add(_manageCacheMenuItem);
             Add(_extractMenuItem);

--- a/Ryujinx/Ui/Widgets/GameTableContextMenu.cs
+++ b/Ryujinx/Ui/Widgets/GameTableContextMenu.cs
@@ -541,7 +541,7 @@ namespace Ryujinx.Ui.Widgets
                     {
                         file.Delete();
                     }
-                    catch(Exception e)
+                    catch (Exception e)
                     {
                         GtkDialog.CreateErrorDialog($"Error purging PPTC cache {file.Name}: {e}");
                     }

--- a/Ryujinx/Ui/Widgets/GameTableContextMenu.cs
+++ b/Ryujinx/Ui/Widgets/GameTableContextMenu.cs
@@ -189,7 +189,7 @@ namespace Ryujinx.Ui.Widgets
 
             ResponseType response    = (ResponseType)fileChooser.Run();
             string       destination = fileChooser.Filename;
-            
+
             fileChooser.Dispose();
 
             if (response == ResponseType.Accept)
@@ -465,12 +465,9 @@ namespace Ryujinx.Ui.Widgets
             new DlcWindow(_virtualFileSystem, _titleIdText, _titleName).Show();
         }
 
-        private void OpenTitleModDir_Clicked(object sender, EventArgs args)
+        private void ManageMods_Clicked(object sender, EventArgs args)
         {
-            string modsBasePath  = _virtualFileSystem.ModLoader.GetModsBasePath();
-            string titleModsPath = _virtualFileSystem.ModLoader.GetTitleDir(modsBasePath, _titleIdText);
-
-            OpenHelper.OpenFolder(titleModsPath);
+            new ModsWindow(_virtualFileSystem, _titleId, _titleIdText, _titleName).Show();
         }
 
         private void ExtractRomFs_Clicked(object sender, EventArgs args)
@@ -491,7 +488,7 @@ namespace Ryujinx.Ui.Widgets
         private void OpenPtcDir_Clicked(object sender, EventArgs args)
         {
             string ptcDir  = System.IO.Path.Combine(AppDataManager.GamesDirPath, _titleIdText, "cache", "cpu");
-            
+
             string mainPath   = System.IO.Path.Combine(ptcDir, "0");
             string backupPath = System.IO.Path.Combine(ptcDir, "1");
 
@@ -516,7 +513,7 @@ namespace Ryujinx.Ui.Widgets
 
             OpenHelper.OpenFolder(shaderCacheDir);
         }
-        
+
         private void PurgePtcCache_Clicked(object sender, EventArgs args)
         {
             DirectoryInfo mainDir   = new DirectoryInfo(System.IO.Path.Combine(AppDataManager.GamesDirPath, _titleIdText, "cache", "cpu", "0"));
@@ -527,7 +524,7 @@ namespace Ryujinx.Ui.Widgets
             List<FileInfo> cacheFiles = new List<FileInfo>();
 
             if (mainDir.Exists)
-            { 
+            {
                 cacheFiles.AddRange(mainDir.EnumerateFiles("*.cache"));
             }
 
@@ -540,9 +537,9 @@ namespace Ryujinx.Ui.Widgets
             {
                 foreach (FileInfo file in cacheFiles)
                 {
-                    try 
-                    { 
-                        file.Delete(); 
+                    try
+                    {
+                        file.Delete();
                     }
                     catch(Exception e)
                     {

--- a/Ryujinx/Ui/Widgets/ModsTreeViewContextMenu.Designer.cs
+++ b/Ryujinx/Ui/Widgets/ModsTreeViewContextMenu.Designer.cs
@@ -1,0 +1,30 @@
+﻿using Gtk;
+
+namespace Ryujinx.Ui.Widgets
+{
+    public partial class ModsTreeViewContextMenu : Menu
+    {
+        private MenuItem _openModFolderMenuItem;
+
+        private void InitializeComponent()
+        {
+            //
+            // _openModFolderMenuItem
+            //
+            _openModFolderMenuItem = new MenuItem("Open mod folder")
+            {
+                TooltipText = "Open the directory which contains the mod.",
+            };
+            _openModFolderMenuItem.Activated += OpenModFolderMenuItem_Activated;
+
+            ShowComponent();
+        }
+
+        private void ShowComponent()
+        {
+            Add(_openModFolderMenuItem);
+
+            ShowAll();
+        }
+    }
+}

--- a/Ryujinx/Ui/Widgets/ModsTreeViewContextMenu.cs
+++ b/Ryujinx/Ui/Widgets/ModsTreeViewContextMenu.cs
@@ -1,0 +1,25 @@
+﻿using Gtk;
+using Ryujinx.Ui.Helper;
+using System;
+
+namespace Ryujinx.Ui.Widgets
+{
+    public partial class ModsTreeViewContextMenu : Menu
+    {
+        private readonly string _modFolder;
+
+        public ModsTreeViewContextMenu(string modFolder)
+        {
+            InitializeComponent();
+
+            _modFolder = modFolder;
+
+            PopupAtPointer(null);
+        }
+
+        private void OpenModFolderMenuItem_Activated(object sender, EventArgs args)
+        {
+            OpenHelper.OpenFolder(_modFolder);
+        }
+    }
+}

--- a/Ryujinx/Ui/Windows/DlcWindow.cs
+++ b/Ryujinx/Ui/Windows/DlcWindow.cs
@@ -38,7 +38,7 @@ namespace Ryujinx.Ui.Windows
 
             _titleId                 = titleId;
             _virtualFileSystem       = virtualFileSystem;
-            _dlcJsonPath             = System.IO.Path.Combine(AppDataManager.GamesDirPath, _titleId, "dlc.json");
+            _dlcJsonPath             = GetDLCJsonPath(_titleId);
             _baseTitleInfoLabel.Text = $"DLC Available for {titleName} [{titleId.ToUpper()}]";
 
             try
@@ -92,6 +92,11 @@ namespace Ryujinx.Ui.Windows
                     }
                 }
             }
+        }
+
+        public static string GetDLCJsonPath(string titleId)
+        {
+            return System.IO.Path.Combine(AppDataManager.GamesDirPath, titleId, "dlc.json");
         }
 
         private Nca TryCreateNca(IStorage ncaStorage, string containerPath)

--- a/Ryujinx/Ui/Windows/ModsWindow.cs
+++ b/Ryujinx/Ui/Windows/ModsWindow.cs
@@ -71,7 +71,7 @@ namespace Ryujinx.Ui.Windows
             Refresh();
         }
 
-        public static string GetModsJsonPath(string titleId)
+        private static string GetModsJsonPath(string titleId)
         {
             return System.IO.Path.Combine(AppDataManager.GamesDirPath, titleId, "enabled_mods.json");
         }

--- a/Ryujinx/Ui/Windows/ModsWindow.cs
+++ b/Ryujinx/Ui/Windows/ModsWindow.cs
@@ -236,6 +236,7 @@ namespace Ryujinx.Ui.Windows
                 enabledModsFound++;
             }
         }
+
         private void ModsWindow_DeleteEvent(object sender, DeleteEventArgs args)
         {
             Save();

--- a/Ryujinx/Ui/Windows/ModsWindow.cs
+++ b/Ryujinx/Ui/Windows/ModsWindow.cs
@@ -66,7 +66,6 @@ namespace Ryujinx.Ui.Windows
             _modsTreeView.AppendColumn("Name",    new CellRendererText(), "text",   1);
             _modsTreeView.AppendColumn("Type",    new CellRendererText(), "text",   2);
             _modsTreeView.AppendColumn("Path",    new CellRendererText(), "text",   3);
-            _modsTreeView.ButtonReleaseEvent += Row_Clicked;
 
             Refresh();
         }
@@ -296,7 +295,7 @@ namespace Ryujinx.Ui.Windows
             OpenHelper.OpenFolder(titleModsPath);
         }
 
-        private void Row_Clicked(object sender, ButtonReleaseEventArgs args)
+        private void ModsTreeView_RowClicked(object sender, ButtonReleaseEventArgs args)
         {
             if (args.Event.Button != 3 /* Right Click */)
             {

--- a/Ryujinx/Ui/Windows/ModsWindow.cs
+++ b/Ryujinx/Ui/Windows/ModsWindow.cs
@@ -247,7 +247,7 @@ namespace Ryujinx.Ui.Windows
             Refresh();
         }
 
-        private void SelectAllButton_Clicked(object sender, EventArgs args)
+        private void EnableAllButton_Clicked(object sender, EventArgs args)
         {
             _selectedMods = 0;
 
@@ -264,7 +264,7 @@ namespace Ryujinx.Ui.Windows
             UpdateInfoLabel();
         }
 
-        private void DeselectAllButton_Clicked(object sender, EventArgs args)
+        private void DisableAllButton_Clicked(object sender, EventArgs args)
         {
             List<ModEntry> enabledMods = new List<ModEntry>();
 

--- a/Ryujinx/Ui/Windows/ModsWindow.cs
+++ b/Ryujinx/Ui/Windows/ModsWindow.cs
@@ -59,8 +59,7 @@ namespace Ryujinx.Ui.Windows
                 bool newValue = !(bool)_modsTreeView.Model.GetValue(treeIter, 0);
                 _selectedMods += newValue ? 1 : -1;
                 _modsTreeView.Model.SetValue(treeIter, 0, newValue);
-                _modsInfoLabel.Text = string.Format(_modsInfoLabelFormat, _titleName, _selectedMods);
-
+                UpdateInfoLabel();
             };
 
             _modsTreeView.AppendColumn("Enabled", enableToggle,           "active", 0);
@@ -195,6 +194,11 @@ namespace Ryujinx.Ui.Windows
 
             Logger.Info?.Print(LogClass.Application, $"Loaded {titleIds.Count} title ids for title");
 
+            UpdateInfoLabel();
+        }
+
+        private void UpdateInfoLabel()
+        {
             _modsInfoLabel.Text = string.Format(_modsInfoLabelFormat, _titleName, _selectedMods);
         }
 
@@ -237,24 +241,45 @@ namespace Ryujinx.Ui.Windows
             Save();
         }
 
-        private Nca TryCreateNca(IStorage ncaStorage, string containerPath)
-        {
-            try
-            {
-                return new Nca(_virtualFileSystem.KeySet, ncaStorage);
-            }
-            catch (Exception exception)
-            {
-                GtkDialog.CreateErrorDialog($"{exception.Message}. Errored File: {containerPath}");
-            }
-
-            return null;
-        }
-
         private void RefreshButton_Clicked(object sender, EventArgs args)
         {
             Save();
             Refresh();
+        }
+
+        private void SelectAllButton_Clicked(object sender, EventArgs args)
+        {
+            _selectedMods = 0;
+
+            if (_modsTreeView.Model.GetIterFirst(out TreeIter parentIter))
+            {
+                do
+                {
+                    _modsTreeView.Model.SetValue(parentIter, 0, true);
+                    _selectedMods++;
+                }
+                while (_modsTreeView.Model.IterNext(ref parentIter));
+            }
+
+            UpdateInfoLabel();
+        }
+
+        private void DeselectAllButton_Clicked(object sender, EventArgs args)
+        {
+            List<ModEntry> enabledMods = new List<ModEntry>();
+
+            if (_modsTreeView.Model.GetIterFirst(out TreeIter parentIter))
+            {
+                do
+                {
+                    _modsTreeView.Model.SetValue(parentIter, 0, false);
+                    _selectedMods++;
+                }
+                while (_modsTreeView.Model.IterNext(ref parentIter));
+            }
+
+            _selectedMods = 0;
+            UpdateInfoLabel();
         }
 
         private void OpenGlobalFolderButton_Clicked(object sender, EventArgs args)

--- a/Ryujinx/Ui/Windows/ModsWindow.cs
+++ b/Ryujinx/Ui/Windows/ModsWindow.cs
@@ -1,0 +1,266 @@
+using Gtk;
+using LibHac.Common;
+using LibHac.Fs;
+using LibHac.Fs.Fsa;
+using LibHac.FsSystem;
+using LibHac.FsSystem.NcaUtils;
+using Ryujinx.Common.Configuration;
+using Ryujinx.Common.Logging;
+using Ryujinx.HLE.FileSystem;
+using Ryujinx.HLE.HOS;
+using Ryujinx.Ui.Helper;
+using Ryujinx.Ui.Widgets;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+using GUI        = Gtk.Builder.ObjectAttribute;
+using JsonHelper = Ryujinx.Common.Utilities.JsonHelper;
+
+namespace Ryujinx.Ui.Windows
+{
+    public class ModsWindow : Window
+    {
+        private readonly string             _modsInfoLabelFormat;
+        private readonly VirtualFileSystem  _virtualFileSystem;
+        private readonly ulong              _titleId;
+        private readonly string             _titleIdText;
+        private readonly string             _titleName;
+        private readonly string             _modsJsonPath;
+
+        private int _selectedMods = 0;
+
+#pragma warning disable CS0649, IDE0044
+        [GUI] Label         _modsInfoLabel;
+        [GUI] TreeView      _modsTreeView;
+        [GUI] TreeSelection _modsTreeSelection;
+#pragma warning restore CS0649, IDE0044
+
+        public ModsWindow(VirtualFileSystem virtualFileSystem, ulong titleId, string titleIdText, string titleName) : this(new Builder("Ryujinx.Ui.Windows.ModsWindow.glade"), virtualFileSystem, titleId, titleIdText, titleName) { }
+
+        private ModsWindow(Builder builder, VirtualFileSystem virtualFileSystem, ulong titleId, string titleIdText, string titleName) : base(builder.GetObject("_modsWindow").Handle)
+        {
+            builder.Autoconnect(this);
+
+            _titleId             = titleId;
+            _titleIdText         = titleIdText;
+            _titleName           = titleName;
+            _virtualFileSystem   = virtualFileSystem;
+            _modsJsonPath        = GetModsJsonPath(_titleIdText);
+            _modsInfoLabelFormat = _modsInfoLabel.Text;
+
+            _modsTreeView.Model = new TreeStore(typeof(bool), typeof(string), typeof(string), typeof(string));
+
+            CellRendererToggle enableToggle = new CellRendererToggle();
+            enableToggle.Toggled += (sender, args) =>
+            {
+                _modsTreeView.Model.GetIter(out TreeIter treeIter, new TreePath(args.Path));
+                bool newValue = !(bool)_modsTreeView.Model.GetValue(treeIter, 0);
+                _selectedMods += newValue ? 1 : -1;
+                _modsTreeView.Model.SetValue(treeIter, 0, newValue);
+                _modsInfoLabel.Text = string.Format(_modsInfoLabelFormat, _titleName, _selectedMods);
+
+            };
+
+            _modsTreeView.AppendColumn("Enabled", enableToggle,           "active", 0);
+            _modsTreeView.AppendColumn("Name",    new CellRendererText(), "text",   1);
+            _modsTreeView.AppendColumn("Type",    new CellRendererText(), "text",   2);
+            _modsTreeView.AppendColumn("Path",    new CellRendererText(), "text",   3);
+
+            Refresh();
+        }
+
+        public static string GetModsJsonPath(string titleId)
+        {
+            return System.IO.Path.Combine(AppDataManager.GamesDirPath, titleId, "enabled_mods.json");
+        }
+
+        private void Clear()
+        {
+            List<TreeIter> toRemove = new List<TreeIter>();
+
+            if (_modsTreeView.Model.GetIterFirst(out TreeIter iter))
+            {
+                do
+                {
+                    toRemove.Add(iter);
+                }
+                while (_modsTreeView.Model.IterNext(ref iter));
+            }
+
+            foreach (TreeIter i in toRemove)
+            {
+                TreeIter j = i;
+                ((TreeStore)_modsTreeView.Model).Remove(ref j);
+            }
+
+            _selectedMods = 0;
+        }
+
+        private void Refresh()
+        {
+            Clear();
+
+            // Load the enabled mods
+
+            HashSet<ModEntry> enabledMods = new HashSet<ModEntry>();
+
+            try
+            {
+                enabledMods.UnionWith(JsonHelper.DeserializeFromFile<List<ModEntry>>(_modsJsonPath));
+            }
+            catch
+            {
+                Logger.Error?.Print(LogClass.Application, "Failed to load list of enabled mods for title");
+            }
+
+            // Create a list of ids which mods can be applied when loading the game, this includes the game itself and its DLCs.
+
+            List<ulong> titleIds = new List<ulong>();
+
+            titleIds.Add(_titleId);
+
+            try
+            {
+                string dlcJsonPath = DlcWindow.GetDLCJsonPath(_titleIdText);
+                var dlcContainerList = JsonHelper.DeserializeFromFile<List<DlcContainer>>(dlcJsonPath);
+
+                // Consider even DLCs that are not enabled.
+                foreach (var dlc in dlcContainerList)
+                {
+                    foreach (var nca in dlc.DlcNcaList)
+                    {
+                        titleIds.Add(nca.TitleId);
+                    }
+                }
+            }
+            catch
+            {
+                Logger.Error?.Print(LogClass.Application, "Failed to load DLCs for title");
+            }
+
+            Logger.Info?.Print(LogClass.Application, $"Loaded {titleIds.Count} title ids for title");
+
+            Dictionary<ulong, ModLoader.ModCache> modCaches  = new Dictionary<ulong, ModLoader.ModCache>();
+            ModLoader.PatchCache                  patchCache = new ModLoader.PatchCache();
+
+            foreach (ulong titleId in titleIds)
+            {
+                modCaches[titleId] = new ModLoader.ModCache();
+            }
+
+            // Todo instantiate ModLoader
+            ModLoader.CollectMods(modCaches, patchCache, _virtualFileSystem.ModLoader.GetModsBasePath());
+
+            AddModsToTree(patchCache.KipPatches, "Patch (global)", enabledMods, ref _selectedMods);
+            AddModsToTree(patchCache.NroPatches, "Patch (global)", enabledMods, ref _selectedMods);
+            AddModsToTree(patchCache.NsoPatches, "Patch (global)", enabledMods, ref _selectedMods);
+
+            foreach (var modCache in modCaches)
+            {
+                AddModsToTree(modCache.Value.Cheats         , "Cheat", enabledMods, ref _selectedMods);
+                AddModsToTree(modCache.Value.ExefsContainers, "Exefs", enabledMods, ref _selectedMods);
+                AddModsToTree(modCache.Value.ExefsDirs      , "Exefs", enabledMods, ref _selectedMods);
+                AddModsToTree(modCache.Value.RomfsContainers, "Romfs", enabledMods, ref _selectedMods);
+                AddModsToTree(modCache.Value.RomfsDirs      , "Romfs", enabledMods, ref _selectedMods);
+            }
+
+            Logger.Info?.Print(LogClass.Application, $"Loaded {titleIds.Count} title ids for title");
+
+            _modsInfoLabel.Text = string.Format(_modsInfoLabelFormat, _titleName, _selectedMods);
+        }
+
+        private string GetRelativeModPath(string absolutePath)
+        {
+            return System.IO.Path.GetRelativePath(_virtualFileSystem.ModLoader.GetModsBasePath(), absolutePath);
+        }
+
+        private void AddModsToTree(IEnumerable<ModLoader.Cheat> mods, string type, HashSet<ModEntry> enabledMods, ref int enabledModsFound)
+        {
+            foreach (var mod in mods)
+            {
+                AddModToTree(mod.Path, mod.Name, type, enabledMods, ref enabledModsFound);
+            }
+        }
+
+        private void AddModsToTree<T>(IEnumerable<ModLoader.Mod<T>> mods, string type, HashSet<ModEntry> enabledMods, ref int enabledModsFound) where T : FileSystemInfo
+        {
+            foreach (var mod in mods)
+            {
+                AddModToTree(mod.Path, mod.Name, type, enabledMods, ref enabledModsFound);
+            }
+        }
+
+        private void AddModToTree(FileSystemInfo path, string name, string type, HashSet<ModEntry> enabledMods, ref int enabledModsFound)
+        {
+            string relativePath = GetRelativeModPath(path.FullName);
+            var    key          = new ModEntry(name, relativePath);
+            bool   enabled      = enabledMods.Contains(key);
+
+            ((TreeStore)_modsTreeView.Model).AppendValues(enabled, name, type, relativePath);
+
+            if (enabled)
+            {
+                enabledModsFound++;
+            }
+        }
+        private void ModsWindow_DeleteEvent(object sender, DeleteEventArgs args)
+        {
+            // Save the list of enabled mods
+
+            List<ModEntry> enabledMods = new List<ModEntry>();
+
+            if (_modsTreeView.Model.GetIterFirst(out TreeIter parentIter))
+            {
+                do
+                {
+                    if ((bool)_modsTreeView.Model.GetValue(parentIter, 0))
+                    {
+                        string name = (string)_modsTreeView.Model.GetValue(parentIter, 1);
+                        string path = (string)_modsTreeView.Model.GetValue(parentIter, 3);
+                        enabledMods.Add(new ModEntry(name, path));
+                    }
+                }
+                while (_modsTreeView.Model.IterNext(ref parentIter));
+            }
+
+            using (FileStream modsJsonStream = File.Create(_modsJsonPath, 4096, FileOptions.WriteThrough))
+            {
+                modsJsonStream.Write(Encoding.UTF8.GetBytes(JsonHelper.Serialize(enabledMods, true)));
+            }
+        }
+
+        private Nca TryCreateNca(IStorage ncaStorage, string containerPath)
+        {
+            try
+            {
+                return new Nca(_virtualFileSystem.KeySet, ncaStorage);
+            }
+            catch (Exception exception)
+            {
+                GtkDialog.CreateErrorDialog($"{exception.Message}. Errored File: {containerPath}");
+            }
+
+            return null;
+        }
+
+        private void RefreshButton_Clicked(object sender, EventArgs args)
+        {
+            Refresh();
+        }
+
+        private void OpenGlobalFolderButton_Clicked(object sender, EventArgs args)
+        {
+            OpenHelper.OpenFolder(_virtualFileSystem.ModLoader.GetModsBasePath());
+        }
+
+        private void OpenGameFolderButton_Clicked(object sender, EventArgs args)
+        {
+            string modsBasePath  = _virtualFileSystem.ModLoader.GetModsBasePath();
+            string titleModsPath = _virtualFileSystem.ModLoader.GetTitleDir(modsBasePath, _titleIdText);
+
+            OpenHelper.OpenFolder(titleModsPath);
+        }
+    }
+}

--- a/Ryujinx/Ui/Windows/ModsWindow.cs
+++ b/Ryujinx/Ui/Windows/ModsWindow.cs
@@ -67,6 +67,7 @@ namespace Ryujinx.Ui.Windows
             _modsTreeView.AppendColumn("Name",    new CellRendererText(), "text",   1);
             _modsTreeView.AppendColumn("Type",    new CellRendererText(), "text",   2);
             _modsTreeView.AppendColumn("Path",    new CellRendererText(), "text",   3);
+            _modsTreeView.ButtonReleaseEvent += Row_Clicked;
 
             Refresh();
         }
@@ -267,6 +268,36 @@ namespace Ryujinx.Ui.Windows
             string titleModsPath = _virtualFileSystem.ModLoader.GetTitleDir(modsBasePath, _titleIdText);
 
             OpenHelper.OpenFolder(titleModsPath);
+        }
+
+        private void Row_Clicked(object sender, ButtonReleaseEventArgs args)
+        {
+            if (args.Event.Button != 3 /* Right Click */)
+            {
+                return;
+            }
+
+            _modsTreeSelection.GetSelected(out TreeIter treeIter);
+
+            if (treeIter.UserData == IntPtr.Zero)
+            {
+                return;
+            }
+
+            string path = System.IO.Path.Combine(_virtualFileSystem.ModLoader.GetModsBasePath(), (string)_modsTreeView.Model.GetValue(treeIter, 3));
+
+            if (!Directory.Exists(path))
+            {
+                // Open the containing directory if the mod is a single file.
+                path = new DirectoryInfo(path).Parent.FullName;
+            }
+
+            _ = new ModsTreeViewContextMenu(path);
+        }
+
+        private void OpenModFolderMenuItem_Activated(object sender, EventArgs e)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/Ryujinx/Ui/Windows/ModsWindow.glade
+++ b/Ryujinx/Ui/Windows/ModsWindow.glade
@@ -52,6 +52,7 @@
                       <object class="GtkTreeView" id="_modsTreeView">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
+                        <signal name="button-release-event" handler="ModsTreeView_RowClicked" swapped="no"/>
                         <child internal-child="selection">
                           <object class="GtkTreeSelection" id="_modsTreeSelection"/>
                         </child>

--- a/Ryujinx/Ui/Windows/ModsWindow.glade
+++ b/Ryujinx/Ui/Windows/ModsWindow.glade
@@ -101,13 +101,13 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="_selectAll">
-                    <property name="label" translatable="yes">Select all</property>
+                    <property name="label" translatable="yes">Enable all</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Enables all mods from the list</property>
                     <property name="margin_left">10</property>
-                    <signal name="clicked" handler="SelectAllButton_Clicked" swapped="no"/>
+                    <signal name="clicked" handler="EnableAllButton_Clicked" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">True</property>
@@ -117,13 +117,13 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="_deselectAll">
-                    <property name="label" translatable="yes">Deselect all</property>
+                    <property name="label" translatable="yes">Disable all</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Disables all mods from the list</property>
                     <property name="margin_left">10</property>
-                    <signal name="clicked" handler="DeselectAllButton_Clicked" swapped="no"/>
+                    <signal name="clicked" handler="DisableAllButton_Clicked" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">True</property>

--- a/Ryujinx/Ui/Windows/ModsWindow.glade
+++ b/Ryujinx/Ui/Windows/ModsWindow.glade
@@ -17,6 +17,8 @@
       <object class="GtkBox" id="MainPatchesBox">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <property name="margin_left">10</property>
+        <property name="margin_right">10</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkBox" id="PatchesBox">
@@ -95,6 +97,38 @@
                     <property name="expand">True</property>
                     <property name="fill">True</property>
                     <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="_selectAll">
+                    <property name="label" translatable="yes">Select all</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="tooltip_text" translatable="yes">Enables all mods from the list</property>
+                    <property name="margin_left">10</property>
+                    <signal name="clicked" handler="SelectAllButton_Clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="_deselectAll">
+                    <property name="label" translatable="yes">Deselect all</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="tooltip_text" translatable="yes">Disables all mods from the list</property>
+                    <property name="margin_left">10</property>
+                    <signal name="clicked" handler="DeselectAllButton_Clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
                   </packing>
                 </child>
               </object>

--- a/Ryujinx/Ui/Windows/ModsWindow.glade
+++ b/Ryujinx/Ui/Windows/ModsWindow.glade
@@ -118,8 +118,8 @@
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Open the mod folder shared by all games in file explorer</property>
-                    <property name="margin_right">10</property>
                     <property name="margin_left">10</property>
+                    <property name="margin_right">10</property>
                     <signal name="clicked" handler="OpenGlobalFolderButton_Clicked" swapped="no"/>
                   </object>
                   <packing>

--- a/Ryujinx/Ui/Windows/ModsWindow.glade
+++ b/Ryujinx/Ui/Windows/ModsWindow.glade
@@ -88,7 +88,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="tooltip_text" translatable="yes">Adds an update to this list</property>
+                    <property name="tooltip_text" translatable="yes">Update the list of mods available for the title</property>
                     <signal name="clicked" handler="RefreshButton_Clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -117,7 +117,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="tooltip_text" translatable="yes">Removes the selected update</property>
+                    <property name="tooltip_text" translatable="yes">Open the mod folder shared by all games in file explorer</property>
                     <property name="margin_right">10</property>
                     <property name="margin_left">10</property>
                     <signal name="clicked" handler="OpenGlobalFolderButton_Clicked" swapped="no"/>
@@ -134,7 +134,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="tooltip_text" translatable="yes">Removes the selected update</property>
+                    <property name="tooltip_text" translatable="yes">Open the mod folder specific to each game in file explorer</property>
                     <signal name="clicked" handler="OpenGameFolderButton_Clicked" swapped="no"/>
                   </object>
                   <packing>

--- a/Ryujinx/Ui/Windows/ModsWindow.glade
+++ b/Ryujinx/Ui/Windows/ModsWindow.glade
@@ -97,6 +97,20 @@
                     <property name="position">0</property>
                   </packing>
                 </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButtonBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">10</property>
+                <property name="margin_bottom">10</property>
+                <property name="layout_style">end</property>
                 <child>
                   <object class="GtkButton" id="_openGlobalFolder">
                     <property name="label" translatable="yes">Open global mods folder</property>
@@ -104,12 +118,14 @@
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
                     <property name="tooltip_text" translatable="yes">Removes the selected update</property>
+                    <property name="margin_right">10</property>
+                    <property name="margin_left">10</property>
                     <signal name="clicked" handler="OpenGlobalFolderButton_Clicked" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
-                    <property name="position">1</property>
+                    <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
@@ -124,14 +140,14 @@
                   <packing>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
-                    <property name="position">2</property>
+                    <property name="position">1</property>
                   </packing>
                 </child>
               </object>
               <packing>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
-                <property name="position">0</property>
+                <property name="position">1</property>
               </packing>
             </child>
           </object>

--- a/Ryujinx/Ui/Windows/ModsWindow.glade
+++ b/Ryujinx/Ui/Windows/ModsWindow.glade
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.2 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <object class="GtkWindow" id="_modsWindow">
+    <property name="can_focus">False</property>
+    <property name="title" translatable="yes">Ryujinx - Mod Manager</property>
+    <property name="modal">True</property>
+    <property name="window_position">center</property>
+    <property name="default_width">550</property>
+    <property name="default_height">350</property>
+    <signal name="delete-event" handler="ModsWindow_DeleteEvent" swapped="no"/>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
+    <child>
+      <object class="GtkBox" id="MainPatchesBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkBox" id="PatchesBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel" id="_modsInfoLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">10</property>
+                <property name="margin_bottom">10</property>
+                <property name="label" translatable="yes">Available mods for {0} and DLCs - {1} enabled</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkScrolledWindow">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="shadow_type">in</property>
+                <child>
+                  <object class="GtkViewport">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkTreeView" id="_modsTreeView">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <child internal-child="selection">
+                          <object class="GtkTreeSelection"/>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkButtonBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">10</property>
+                <property name="margin_bottom">10</property>
+                <property name="layout_style">start</property>
+                <child>
+                  <object class="GtkButton" id="_refresh">
+                    <property name="label" translatable="yes">Refresh</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="tooltip_text" translatable="yes">Adds an update to this list</property>
+                    <signal name="clicked" handler="RefreshButton_Clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="_openGlobalFolder">
+                    <property name="label" translatable="yes">Open global mods folder</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="tooltip_text" translatable="yes">Removes the selected update</property>
+                    <signal name="clicked" handler="OpenGlobalFolderButton_Clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="_openGameFolder">
+                    <property name="label" translatable="yes">Open game mods folder</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="tooltip_text" translatable="yes">Removes the selected update</property>
+                    <signal name="clicked" handler="OpenGameFolderButton_Clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/Ryujinx/Ui/Windows/ModsWindow.glade
+++ b/Ryujinx/Ui/Windows/ModsWindow.glade
@@ -51,7 +51,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <child internal-child="selection">
-                          <object class="GtkTreeSelection"/>
+                          <object class="GtkTreeSelection" id="_modsTreeSelection"/>
                         </child>
                       </object>
                     </child>


### PR DESCRIPTION
This PR replaces the "Open mod directory" option with a mod manager window that allows inspecting mods and selecting which ones will be activated when the game starts. It also allows quick access to the per-game and global mod directories, as well as the directory of each individual mod.

![ModManager](https://user-images.githubusercontent.com/2220062/133865718-51787785-8929-4eb5-a797-136b0641ffbc.PNG)

It can detect that a mod previously enabled has been removed and warn the user about it:

![mods2](https://user-images.githubusercontent.com/2220062/135428464-47f51f3f-a9fa-4629-b3c5-216ed7293ad4.PNG)

There are also additional log messages to indicate excluded mods when starting a game:

```
00:00:17.189 |I| ModLoader FilterMods: Mod <60 FPS Cheat> is not enabled
00:00:17.189 |I| ModLoader FilterMods: Mod <30 FPS Cheat> is not enabled
00:00:17.189 |I| ModLoader FilterMods: Mod <60 FPS Cheat> is not enabled
```

Closes #1566.