### PR TITLE
Share scales array for graphics and compute

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -62,12 +62,14 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="context">The GPU context that the texture bindings manager belongs to</param>
         /// <param name="channel">The GPU channel that the texture bindings manager belongs to</param>
         /// <param name="poolCache">Texture pools cache used to get texture pools from</param>
+        /// <param name="scales">Array where the scales for the currently bound textures are stored</param>
         /// <param name="isCompute">True if the bindings manager is used for the compute engine</param>
-        public TextureBindingsManager(GpuContext context, GpuChannel channel, TexturePoolCache poolCache, bool isCompute)
+        public TextureBindingsManager(GpuContext context, GpuChannel channel, TexturePoolCache poolCache, float[] scales, bool isCompute)
         {
             _context          = context;
             _channel          = channel;
             _texturePoolCache = poolCache;
+            _scales           = scales;
             _isCompute        = isCompute;
 
             int stages = isCompute ? 1 : Constants.ShaderStages;
@@ -88,13 +90,6 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 _textureState[stage] = new TextureStatePerStage[InitialTextureStateSize];
                 _imageState[stage] = new TextureStatePerStage[InitialImageStateSize];
-            }
-
-            _scales = new float[64];
-
-            for (int i = 0; i < 64; i++)
-            {
-                _scales[i] = 1f;
             }
         }
 

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -35,8 +35,11 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             TexturePoolCache texturePoolCache = new TexturePoolCache(context);
 
-            _cpBindingsManager = new TextureBindingsManager(context, channel, texturePoolCache, isCompute: true);
-            _gpBindingsManager = new TextureBindingsManager(context, channel, texturePoolCache, isCompute: false);
+            float[] scales = new float[64];
+            new Span<float>(scales).Fill(1f);
+
+            _cpBindingsManager = new TextureBindingsManager(context, channel, texturePoolCache, scales, isCompute: true);
+            _gpBindingsManager = new TextureBindingsManager(context, channel, texturePoolCache, scales, isCompute: false);
 
             _rtColors = new Texture[Constants.TotalRenderTargets];
             _rtHostColors = new ITexture[Constants.TotalRenderTargets];


### PR DESCRIPTION
Fixes an issue where scales might not be properly updated on games that uses compute. The issue happens because the backend is using a single array to store both fragment and compute scales, while the GPU emulation is using 2 (and is working with the assumption that the backend also uses 2). This change simply shares the same array for both compute and graphics, which solves the problem and the scale changing on one will also force the other to be updated later.

This fixes resolution scale issues on NI no Kuni 2:
Before:
![image](https://user-images.githubusercontent.com/5624669/133859597-851f6667-e8d1-47b4-a00f-81590c659cd8.png)
After:
![image](https://user-images.githubusercontent.com/5624669/133859605-1cf027d8-f3cf-446d-b2e9-67922ea45c26.png)

This might potentially also fix the resolution scale regression that was reported on Discord on Mario Rabbids Kingdom Battle, but I did not test it myself.
This is potentially a regression caused by #2595, but I did not confirm.