### PR TITLE
Smaller initial size for BufferModifiedRangeList & directly inherit backing array

### DIFF
--- a/Ryujinx.Graphics.Gpu/Memory/BufferModifiedRangeList.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferModifiedRangeList.cs
@@ -60,6 +60,8 @@ namespace Ryujinx.Graphics.Gpu.Memory
     /// </summary>
     class BufferModifiedRangeList : RangeList<BufferModifiedRange>
     {
+        private const int BackingInitialSize = 8;
+
         private GpuContext _context;
 
         private object _lock = new object();
@@ -68,7 +70,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// Creates a new instance of a modified range list.
         /// </summary>
         /// <param name="context">GPU context that the buffer range list belongs to</param>
-        public BufferModifiedRangeList(GpuContext context)
+        public BufferModifiedRangeList(GpuContext context) : base(BackingInitialSize)
         {
             _context = context;
         }

--- a/Ryujinx.Memory/Range/RangeList.cs
+++ b/Ryujinx.Memory/Range/RangeList.cs
@@ -33,18 +33,22 @@ namespace Ryujinx.Memory.Range
             }
         }
 
+        private const int BackingInitialSize = 1024;
         private const int ArrayGrowthSize = 32;
-        private const int BackingGrowthSize = 1024;
 
         private RangeItem<T>[] _items;
+        private readonly int _backingGrowthSize;
+
         public int Count { get; protected set; }
 
         /// <summary>
         /// Creates a new range list.
         /// </summary>
-        public RangeList()
+        /// <param name="backingInitialSize">The initial size of the backing array</param>
+        public RangeList(int backingInitialSize = BackingInitialSize)
         {
-            _items = new RangeItem<T>[BackingGrowthSize];
+            _backingGrowthSize = backingInitialSize;
+            _items = new RangeItem<T>[backingInitialSize];
         }
 
         /// <summary>
@@ -68,7 +72,7 @@ namespace Ryujinx.Memory.Range
         {
             if (Count + 1 > _items.Length)
             {
-                Array.Resize(ref _items, _items.Length + ArrayGrowthSize);
+                Array.Resize(ref _items, _items.Length + _backingGrowthSize);
             }
 
             if (index >= Count)


### PR DESCRIPTION
This fixes a potential regression with the new range list changes, where the cost for creating new ones would be rather large due to creating a 1024 size array. Also reduces cost for range list inheritance by using the first existing range list as a base, rather than creating a new one then adding both lists to it.

The growth size for the RangeList is now identical to its initial size. Every 32 elements was probably a little too common - now it is 1024 for most things and 8 for the buffer modified range list.

The Unmapped and SyncMethod methods have been changed to ensure that they behave properly if the range list is set null. Cleaned up a few calls to use the null-conditional operator.