### PR TITLE
Upload textures data through a persistent mapped buffer

### DIFF
--- a/Ryujinx.Graphics.OpenGL/PersistentBuffers.cs
+++ b/Ryujinx.Graphics.OpenGL/PersistentBuffers.cs
@@ -45,7 +45,7 @@ namespace Ryujinx.Graphics.OpenGL
                 _copyBufferHandle = GL.GenBuffer();
 
                 GL.BindBuffer(BufferTarget.CopyWriteBuffer, _copyBufferHandle);
-                GL.BufferStorage(BufferTarget.CopyWriteBuffer, CopyBufferSize, IntPtr.Zero, BufferStorageFlags.MapWriteBit | BufferStorageFlags.MapPersistentBit | BufferStorageFlags.MapCoherentBit);
+                GL.BufferStorage(BufferTarget.CopyWriteBuffer, CopyBufferSize, IntPtr.Zero, BufferStorageFlags.MapWriteBit | BufferStorageFlags.MapPersistentBit | BufferStorageFlags.MapCoherentBit | BufferStorageFlags.ClientStorageBit);
 
                 _bufferMap = GL.MapBufferRange(BufferTarget.CopyWriteBuffer, IntPtr.Zero, CopyBufferSize, BufferAccessMask.MapWriteBit | BufferAccessMask.MapPersistentBit | BufferAccessMask.MapCoherentBit);
                 _syncs = new IntPtr[TextureMaxNumber];

--- a/Ryujinx.Graphics.OpenGL/PersistentBuffers.cs
+++ b/Ryujinx.Graphics.OpenGL/PersistentBuffers.cs
@@ -14,11 +14,102 @@ namespace Ryujinx.Graphics.OpenGL
         private PersistentBuffer _background = new PersistentBuffer();
 
         public PersistentBuffer Default => BackgroundContextWorker.InBackground ? _background : _main;
+        public PersistentTextureBuffer Textures = new PersistentTextureBuffer();
 
         public void Dispose()
         {
             _main?.Dispose();
             _background?.Dispose();
+
+            Textures?.Dispose();
+        }
+    }
+
+    class PersistentTextureBuffer : IDisposable
+    {
+        public const int TextureMaxSize = 1 * 1024 * 1024;
+        public const int TextureMaxNumber = 3;
+
+        private const int CopyBufferSize = TextureMaxNumber * TextureMaxSize;
+
+        private IntPtr _bufferMap;
+        private IntPtr[] _syncs;
+        private int _copyBufferHandle = 0;
+        private int _currentIndex = 0;
+
+        private void Init()
+        {
+            if (_copyBufferHandle == 0)
+            {
+                _copyBufferHandle = GL.GenBuffer();
+
+                GL.BindBuffer(BufferTarget.CopyWriteBuffer, _copyBufferHandle);
+                GL.BufferStorage(BufferTarget.CopyWriteBuffer, CopyBufferSize, IntPtr.Zero, BufferStorageFlags.MapWriteBit | BufferStorageFlags.MapPersistentBit | BufferStorageFlags.MapCoherentBit);
+
+                _bufferMap = GL.MapBufferRange(BufferTarget.CopyWriteBuffer, IntPtr.Zero, CopyBufferSize, BufferAccessMask.MapWriteBit | BufferAccessMask.MapPersistentBit | BufferAccessMask.MapCoherentBit);
+                _syncs = new IntPtr[TextureMaxNumber];
+
+                for (int i = 0; i < TextureMaxNumber; i++)
+                {
+                    _syncs[i] = IntPtr.Zero;
+                }
+            }
+        }
+
+        public unsafe void SetTextureData(TextureView view, ReadOnlySpan<byte> data, int size, int layer = -1, int level = -1, int width = -1, int height = -1)
+        {
+            Init();
+
+            int offset = _currentIndex * TextureMaxSize;
+
+            if (_syncs[_currentIndex] != IntPtr.Zero)
+            {
+                WaitSyncStatus syncResult = GL.ClientWaitSync(_syncs[_currentIndex], ClientWaitSyncFlags.SyncFlushCommandsBit, 1000000000);
+
+                if (syncResult == WaitSyncStatus.TimeoutExpired)
+                {
+                    Logger.Error?.PrintMsg(LogClass.Gpu, $"Failed to sync persistent buffer state within 1000ms. Continuing...");
+                }
+
+                GL.DeleteSync(_syncs[_currentIndex]);
+                _syncs[_currentIndex] = IntPtr.Zero;
+            }
+
+            Span<byte> buffer = new Span<byte>((_bufferMap + offset).ToPointer(), size);
+            data.CopyTo(buffer);
+
+            GL.BindBuffer(BufferTarget.PixelUnpackBuffer, _copyBufferHandle);
+
+            if (layer == -1)
+            {
+                view.ReadFromPbo(offset, size);
+            }
+            else
+            {
+                view.ReadFromPbo2D(offset, layer, level, width, height);
+            }
+
+            GL.BindBuffer(BufferTarget.PixelUnpackBuffer, 0);
+
+            _syncs[_currentIndex] = GL.FenceSync(SyncCondition.SyncGpuCommandsComplete, WaitSyncFlags.None);
+
+            _currentIndex = (_currentIndex + 1) % TextureMaxNumber;
+        }
+
+        public void Dispose()
+        {
+            if (_copyBufferHandle != 0)
+            {
+                GL.DeleteBuffer(_copyBufferHandle);
+            }
+
+            for (int i = 0; i < TextureMaxNumber; i++)
+            {
+                if (_syncs[i] != IntPtr.Zero)
+                {
+                    GL.DeleteSync(_syncs[i]);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Following #2481, this PR use a persistent mapped buffers to handle textures upload. The buffer is split into 3 parts, textures are uploaded to one part and once this part is full and can't handle the next texture upload, the next part is used and the previous is protected by a fence. Part size is 16Mb and textures larger than that are managed as they were before. The number and the size of those parts could be adjusted if needed after more tests.

This could increase performances for some games that constantly upload textures.

