### PR TITLE
irs: Stub some service calls

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Hid/Irs/IIrSensorServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Irs/IIrSensorServer.cs
@@ -1,7 +1,9 @@
+using Ryujinx.Common;
 using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Kernel.Common;
 using Ryujinx.HLE.HOS.Services.Hid.HidServer;
+using Ryujinx.HLE.HOS.Services.Hid.Irs.Types;
 using System;
 
 namespace Ryujinx.HLE.HOS.Services.Hid.Irs
@@ -17,7 +19,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid.Irs
         // ActivateIrsensor(nn::applet::AppletResourceUserId, pid)
         public ResultCode ActivateIrsensor(ServiceCtx context)
         {
-            long appletResourceUserId = context.RequestData.ReadInt64();
+            ulong appletResourceUserId = context.RequestData.ReadUInt64();
+
+            // NOTE: This seems to initialize the shared memory for irs service.
 
             Logger.Stub?.PrintStub(LogClass.ServiceIrs, new { appletResourceUserId });
 
@@ -28,7 +32,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid.Irs
         // DeactivateIrsensor(nn::applet::AppletResourceUserId, pid)
         public ResultCode DeactivateIrsensor(ServiceCtx context)
         {
-            long appletResourceUserId = context.RequestData.ReadInt64();
+            ulong appletResourceUserId = context.RequestData.ReadUInt64();
+
+            // NOTE: This seems to deinitialize the shared memory for irs service.
 
             Logger.Stub?.PrintStub(LogClass.ServiceIrs, new { appletResourceUserId });
 
@@ -39,6 +45,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid.Irs
         // GetIrsensorSharedMemoryHandle(nn::applet::AppletResourceUserId, pid) -> handle<copy>
         public ResultCode GetIrsensorSharedMemoryHandle(ServiceCtx context)
         {
+            // NOTE: Shared memory should use the appletResourceUserId.
+            // ulong appletResourceUserId = context.RequestData.ReadUInt64();
+
             if (_irsensorSharedMemoryHandle == 0)
             {
                 if (context.Process.HandleTable.GenerateHandle(context.Device.System.IirsSharedMem, out _irsensorSharedMemoryHandle) != KernelResult.Success)
@@ -48,6 +57,111 @@ namespace Ryujinx.HLE.HOS.Services.Hid.Irs
             }
 
             context.Response.HandleDesc = IpcHandleDesc.MakeCopy(_irsensorSharedMemoryHandle);
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(305)]
+        // StopImageProcessor(pid, nn::irsensor::IrCameraHandle, nn::applet::AppletResourceUserId)
+        public ResultCode StopImageProcessor(ServiceCtx context)
+        {
+            IrCameraHandle irCameraHandle       = context.RequestData.ReadStruct<IrCameraHandle>();
+            ulong          appletResourceUserId = context.RequestData.ReadUInt64();
+
+            CheckCameraHandle(irCameraHandle);
+
+            Logger.Stub?.PrintStub(LogClass.ServiceIrs, new { appletResourceUserId, irCameraHandle.PlayerNumber, irCameraHandle.DeviceType });
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(306)]
+        // RunMomentProcessor(pid, nn::irsensor::IrCameraHandle, nn::applet::AppletResourceUserId, PackedMomentProcessorConfig)
+        public ResultCode RunMomentProcessor(ServiceCtx context)
+        {
+            IrCameraHandle irCameraHandle              = context.RequestData.ReadStruct<IrCameraHandle>();
+            ulong          appletResourceUserId        = context.RequestData.ReadUInt64();
+            var            packedMomentProcessorConfig = context.RequestData.ReadStruct<PackedMomentProcessorConfig>();
+
+            CheckCameraHandle(irCameraHandle);
+
+            Logger.Stub?.PrintStub(LogClass.ServiceIrs, new { appletResourceUserId, irCameraHandle.PlayerNumber, irCameraHandle.DeviceType, packedMomentProcessorConfig.ExposureTime });
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(307)]
+        // RunClusteringProcessor(pid, nn::irsensor::IrCameraHandle, nn::applet::AppletResourceUserId, PackedClusteringProcessorConfig)
+        public ResultCode RunClusteringProcessor(ServiceCtx context)
+        {
+            IrCameraHandle irCameraHandle                  = context.RequestData.ReadStruct<IrCameraHandle>();
+            ulong          appletResourceUserId            = context.RequestData.ReadUInt64();
+            var            packedClusteringProcessorConfig = context.RequestData.ReadStruct<PackedClusteringProcessorConfig>();
+
+            CheckCameraHandle(irCameraHandle);
+
+            Logger.Stub?.PrintStub(LogClass.ServiceIrs, new { appletResourceUserId, irCameraHandle.PlayerNumber, irCameraHandle.DeviceType, packedClusteringProcessorConfig.ExposureTime });
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(308)]
+        // RunImageTransferProcessor(pid, nn::irsensor::IrCameraHandle, nn::applet::AppletResourceUserId, PackedImageTransferProcessorConfig, u64 TransferMemorySize, TransferMemoryHandle)
+        public ResultCode RunImageTransferProcessor(ServiceCtx context)
+        {
+            IrCameraHandle irCameraHandle                     = context.RequestData.ReadStruct<IrCameraHandle>();
+            ulong          appletResourceUserId               = context.RequestData.ReadUInt64();
+            var            packedImageTransferProcessorConfig = context.RequestData.ReadStruct<PackedImageTransferProcessorConfig>();
+
+            CheckCameraHandle(irCameraHandle);
+
+            // TODO: Handle the Transfer Memory.
+
+            Logger.Stub?.PrintStub(LogClass.ServiceIrs, new { appletResourceUserId, irCameraHandle.PlayerNumber, irCameraHandle.DeviceType, packedImageTransferProcessorConfig.ExposureTime });
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(309)]
+        // GetImageTransferProcessorState(pid, nn::irsensor::IrCameraHandle, nn::applet::AppletResourceUserId)
+        public ResultCode GetImageTransferProcessorState(ServiceCtx context)
+        {
+            IrCameraHandle irCameraHandle       = context.RequestData.ReadStruct<IrCameraHandle>();
+            ulong          appletResourceUserId = context.RequestData.ReadUInt64();
+
+            // ulong imageTransferBufferAddress = context.Request.ReceiveBuff[0].Position;
+            ulong imageTransferBufferSize = context.Request.ReceiveBuff[0].Size;
+
+            if (imageTransferBufferSize == 0)
+            {
+                return ResultCode.InvalidBufferSize;
+            }
+
+            CheckCameraHandle(irCameraHandle);
+
+            Logger.Stub?.PrintStub(LogClass.ServiceIrs, new { appletResourceUserId, irCameraHandle.PlayerNumber, irCameraHandle.DeviceType });
+
+            // TODO: Uses the buffer to copy the JoyCon IR data (by using a JoyCon driver) and update the following struct.
+            context.ResponseData.WriteStruct(new ImageTransferProcessorState()
+            {
+                SamplingNumber    = 0,
+                AmbientNoiseLevel = 0
+            });
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(310)]
+        // RunTeraPluginProcessor(pid, nn::irsensor::IrCameraHandle, nn::applet::AppletResourceUserId, PackedTeraPluginProcessorConfig)
+        public ResultCode RunTeraPluginProcessor(ServiceCtx context)
+        {
+            IrCameraHandle irCameraHandle                  = context.RequestData.ReadStruct<IrCameraHandle>();
+            ulong          appletResourceUserId            = context.RequestData.ReadUInt64();
+            var            packedTeraPluginProcessorConfig = context.RequestData.ReadStruct<PackedTeraPluginProcessorConfig>();
+
+            CheckCameraHandle(irCameraHandle);
+
+            Logger.Stub?.PrintStub(LogClass.ServiceIrs, new { appletResourceUserId, irCameraHandle.PlayerNumber, irCameraHandle.DeviceType, packedTeraPluginProcessorConfig.RequiredMcuVersion });
 
             return ResultCode.Success;
         }
@@ -97,6 +211,16 @@ namespace Ryujinx.HLE.HOS.Services.Hid.Irs
             long packedFunctionLevel  = context.RequestData.ReadInt64();
 
             Logger.Stub?.PrintStub(LogClass.ServiceIrs, new { appletResourceUserId, packedFunctionLevel });
+
+            return ResultCode.Success;
+        }
+
+        private ResultCode CheckCameraHandle(IrCameraHandle irCameraHandle)
+        {
+            if (irCameraHandle.DeviceType == 1 || (PlayerIndex)irCameraHandle.PlayerNumber >= PlayerIndex.Unknown)
+            {
+                return ResultCode.InvalidCameraHandle;
+            }
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Hid/Irs/ResultCode.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Irs/ResultCode.cs
@@ -7,6 +7,8 @@
 
         Success = 0,
 
+        InvalidCameraHandle = (204 << ErrorCodeShift) | ModuleId,
+        InvalidBufferSize   = (207 << ErrorCodeShift) | ModuleId,
         HandlePointerIsNull = (212 << ErrorCodeShift) | ModuleId,
         NpadIdOutOfRange    = (709 << ErrorCodeShift) | ModuleId
     }

--- a/Ryujinx.HLE/HOS/Services/Hid/Irs/Types/ImageTransferProcessorState.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Irs/Types/ImageTransferProcessorState.cs
@@ -1,0 +1,12 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Hid.Irs.Types
+{
+    [StructLayout(LayoutKind.Sequential, Size = 0x10)]
+    struct ImageTransferProcessorState
+    {
+        public ulong SamplingNumber;
+        public uint  AmbientNoiseLevel;
+        public uint  Reserved;
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Hid/Irs/Types/IrCameraHandle.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Irs/Types/IrCameraHandle.cs
@@ -1,0 +1,12 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Hid.Irs.Types
+{
+    [StructLayout(LayoutKind.Sequential, Size = 0x4)]
+    struct IrCameraHandle
+    {
+        public byte   PlayerNumber;
+        public byte   DeviceType;
+        public ushort Reserved;
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Hid/Irs/Types/PackedClusteringProcessorConfig.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Irs/Types/PackedClusteringProcessorConfig.cs
@@ -1,0 +1,25 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Hid.Irs.Types
+{
+    [StructLayout(LayoutKind.Sequential, Size = 0x28)]
+    struct PackedClusteringProcessorConfig
+    {
+        public long   ExposureTime;
+        public byte   LightTarget;
+        public byte   Gain;
+        public byte   IsNegativeImageUsed;
+        public byte   Reserved1;
+        public uint   Reserved2;
+        public ushort WindowOfInterestX;
+        public ushort WindowOfInterestY;
+        public ushort WindowOfInterestWidth;
+        public ushort WindowOfInterestHeight;
+        public uint   RequiredMcuVersion;
+        public uint   ObjectPixelCountMin;
+        public uint   ObjectPixelCountMax;
+        public byte   ObjectIntensityMin;
+        public byte   IsExternalLightFilterEnabled;
+        public ushort Reserved3;
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Hid/Irs/Types/PackedImageTransferProcessorConfig.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Irs/Types/PackedImageTransferProcessorConfig.cs
@@ -1,0 +1,19 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Hid.Irs.Types
+{
+    [StructLayout(LayoutKind.Sequential, Size = 0x18)]
+    struct PackedImageTransferProcessorConfig
+    {
+        public long   ExposureTime;
+        public byte   LightTarget;
+        public byte   Gain;
+        public byte   IsNegativeImageUsed;
+        public byte   Reserved1;
+        public uint   Reserved2;
+        public uint   RequiredMcuVersion;
+        public byte   Format;
+        public byte   Reserved3;
+        public ushort Reserved4;
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Hid/Irs/Types/PackedMomentProcessorConfig.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Irs/Types/PackedMomentProcessorConfig.cs
@@ -1,0 +1,23 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Hid.Irs.Types
+{
+    [StructLayout(LayoutKind.Sequential, Size = 0x20)]
+    struct PackedMomentProcessorConfig
+    {
+        public long   ExposureTime;
+        public byte   LightTarget;
+        public byte   Gain;
+        public byte   IsNegativeImageUsed;
+        public byte   Reserved1;
+        public uint   Reserved2;
+        public ushort WindowOfInterestX;
+        public ushort WindowOfInterestY;
+        public ushort WindowOfInterestWidth;
+        public ushort WindowOfInterestHeight;
+        public uint   RequiredMcuVersion;
+        public byte   Preprocess;
+        public byte   PreprocessIntensityThreshold;
+        public ushort Reserved3;
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Hid/Irs/Types/PackedTeraPluginProcessorConfig.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Irs/Types/PackedTeraPluginProcessorConfig.cs
@@ -1,0 +1,14 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Hid.Irs.Types
+{
+    [StructLayout(LayoutKind.Sequential, Size = 0x8)]
+    struct PackedTeraPluginProcessorConfig
+    {
+        public uint RequiredMcuVersion;
+        public byte Mode;
+        public byte Unknown1;
+        public byte Unknown2;
+        public byte Unknown3;
+    }
+}


### PR DESCRIPTION
This PR stubs some irs service calls which are needed to get some games playable or at least bootable since we don't support IR data throught real JoyCon for now.

- Stubs `IIrSensorServer` `StopImageProcessor`, `RunMomentProcessor`, `RunClusteringProcessor`, `RunImageTransferProcessor`, `GetImageTransferProcessorState`, `RunTeraPluginProcessor`. All calls are a bit checked by RE.

Closes #2267, Closes #2248, Closes #2126

Night Vision and Spy Alarm are now bootable (but still unplayable due to the lack of the IR data):
![image](https://user-images.githubusercontent.com/4905390/133946798-c5354488-ee17-49bb-8a2c-83692a23e688.png)
![image](https://user-images.githubusercontent.com/4905390/133946781-01a24301-cb5a-4d0f-8278-9c0613994de0.png)

Doukoku Soshite... is now playable:
![image](https://user-images.githubusercontent.com/4905390/133946821-a2d66bc3-51a3-4a26-a18f-052db430cd3f.png)
![image](https://user-images.githubusercontent.com/4905390/133946824-00b51cc8-4820-4e50-a591-db2ce92fe003.png)

And probably some other games...
