### PR TITLE
Fix PTC count table relocation patching

### DIFF
--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -681,7 +681,10 @@ namespace ARMeilleure.Translation.PTC
                 }
                 else if (symbol == CountTableSymbol)
                 {
-                    callCounter = new Counter<uint>(translator.CountTable);
+                    if (callCounter == null)
+                    {
+                        callCounter = new Counter<uint>(translator.CountTable);
+                    }
 
                     unsafe { imm = (IntPtr)Unsafe.AsPointer(ref callCounter.Value); }
                 }


### PR DESCRIPTION
Fix an issue introduced in #2190 where by 2 different count table entry addresses were used for LCQ functions. E.g:

```asm
 .L1:
   mov rbp,COUNT_TABLE_0   ;; This gets an address.
   mov ebp,[rbp]
   lea esi,[rbp+1]
   mov rdi,COUNT_TABLE_1   ;; This gets another address.
   mov [rdi],esi
   cmp ebp,64h
   je near .L34
```

This caused LCQ functions to not tier up when they're loaded from the PTC cache. This does not happen when they're freshly compiled.

This PR fixes the issue by ensuring only a single counter is created per translation when they're loaded from the cache.