### PR TITLE
Replace CacheResourceWrite with more general "precise" write

### DIFF
--- a/ARMeilleure/Memory/IMemoryManager.cs
+++ b/ARMeilleure/Memory/IMemoryManager.cs
@@ -70,6 +70,7 @@ namespace ARMeilleure.Memory
         /// <param name="va">Virtual address of the region</param>
         /// <param name="size">Size of the region</param>
         /// <param name="write">True if the region was written, false if read</param>
-        void SignalMemoryTracking(ulong va, ulong size, bool write);
+        /// <param name="precise">True if the access is precise, false otherwise</param>
+        void SignalMemoryTracking(ulong va, ulong size, bool write, bool precise = false);
     }
 }

--- a/ARMeilleure/Signal/NativeSignalHandler.cs
+++ b/ARMeilleure/Signal/NativeSignalHandler.cs
@@ -202,7 +202,7 @@ namespace ARMeilleure.Signal
 
                 // Call the tracking action, with the pointer's relative offset to the base address.
                 Operand trackingActionPtr = context.Load(OperandType.I64, Const((ulong)signalStructPtr + rangeBaseOffset + 20));
-                context.Call(trackingActionPtr, OperandType.I32, offset, Const(PageSize), isWrite);
+                context.Call(trackingActionPtr, OperandType.I32, offset, Const(PageSize), isWrite, Const(0));
 
                 context.Branch(endLabel);
 

--- a/Ryujinx.Cpu/MemoryEhMeilleure.cs
+++ b/Ryujinx.Cpu/MemoryEhMeilleure.cs
@@ -8,7 +8,7 @@ namespace Ryujinx.Cpu
 {
     class MemoryEhMeilleure : IDisposable
     {
-        private delegate bool TrackingEventDelegate(ulong address, ulong size, bool write);
+        private delegate bool TrackingEventDelegate(ulong address, ulong size, bool write, bool precise = false);
 
         private readonly MemoryBlock _addressSpace;
         private readonly MemoryTracking _tracking;

--- a/Ryujinx.Cpu/MemoryManager.cs
+++ b/Ryujinx.Cpu/MemoryManager.cs
@@ -567,9 +567,15 @@ namespace Ryujinx.Cpu
         }
 
         /// <inheritdoc/>
-        public void SignalMemoryTracking(ulong va, ulong size, bool write)
+        public void SignalMemoryTracking(ulong va, ulong size, bool write, bool precise = false)
         {
             AssertValidAddressAndSize(va, size);
+
+            if (precise)
+            {
+                Tracking.VirtualMemoryEvent(va, size, write, precise: true);
+                return;
+            }
 
             // We emulate guard pages for software memory access. This makes for an easy transition to
             // tracking using host guard pages in future, but also supporting platforms where this is not possible.

--- a/Ryujinx.Cpu/MemoryManagerHostMapped.cs
+++ b/Ryujinx.Cpu/MemoryManagerHostMapped.cs
@@ -405,9 +405,15 @@ namespace Ryujinx.Cpu
         /// <remarks>
         /// This function also validates that the given range is both valid and mapped, and will throw if it is not.
         /// </remarks>
-        public void SignalMemoryTracking(ulong va, ulong size, bool write)
+        public void SignalMemoryTracking(ulong va, ulong size, bool write, bool precise = false)
         {
             AssertValidAddressAndSize(va, size);
+
+            if (precise)
+            {
+                Tracking.VirtualMemoryEvent(va, size, write, precise: true);
+                return;
+            }
 
             // Software table, used for managed memory tracking.
 

--- a/Ryujinx.Cpu/Tracking/CpuMultiRegionHandle.cs
+++ b/Ryujinx.Cpu/Tracking/CpuMultiRegionHandle.cs
@@ -22,6 +22,7 @@ namespace Ryujinx.Cpu.Tracking
         public void QueryModified(ulong address, ulong size, Action<ulong, ulong> modifiedAction) => _impl.QueryModified(address, size, modifiedAction);
         public void QueryModified(ulong address, ulong size, Action<ulong, ulong> modifiedAction, int sequenceNumber) => _impl.QueryModified(address, size, modifiedAction, sequenceNumber);
         public void RegisterAction(ulong address, ulong size, RegionSignal action) => _impl.RegisterAction(address, size, action);
+        public void RegisterPreciseAction(ulong address, ulong size, PreciseRegionSignal action) => _impl.RegisterPreciseAction(address, size, action);
         public void SignalWrite() => _impl.SignalWrite();
     }
 }

--- a/Ryujinx.Cpu/Tracking/CpuRegionHandle.cs
+++ b/Ryujinx.Cpu/Tracking/CpuRegionHandle.cs
@@ -23,6 +23,7 @@ namespace Ryujinx.Cpu.Tracking
         public void ForceDirty() => _impl.ForceDirty();
         public IRegionHandle GetHandle() => _impl;
         public void RegisterAction(RegionSignal action) => _impl.RegisterAction(action);
+        public void RegisterPreciseAction(PreciseRegionSignal action) => _impl.RegisterPreciseAction(action);
         public void RegisterDirtyEvent(Action action) => _impl.RegisterDirtyEvent(action);
         public void Reprotect(bool asDirty = false) => _impl.Reprotect(asDirty);
 

--- a/Ryujinx.Cpu/Tracking/CpuSmartMultiRegionHandle.cs
+++ b/Ryujinx.Cpu/Tracking/CpuSmartMultiRegionHandle.cs
@@ -17,6 +17,7 @@ namespace Ryujinx.Cpu.Tracking
         public void Dispose() => _impl.Dispose();
         public void ForceDirty(ulong address, ulong size) => _impl.ForceDirty(address, size);
         public void RegisterAction(RegionSignal action) => _impl.RegisterAction(action);
+        public void RegisterPreciseAction(PreciseRegionSignal action) => _impl.RegisterPreciseAction(action);
         public void QueryModified(Action<ulong, ulong> modifiedAction) => _impl.QueryModified(modifiedAction);
         public void QueryModified(ulong address, ulong size, Action<ulong, ulong> modifiedAction) => _impl.QueryModified(address, size, modifiedAction);
         public void QueryModified(ulong address, ulong size, Action<ulong, ulong> modifiedAction, int sequenceNumber) => _impl.QueryModified(address, size, modifiedAction, sequenceNumber);

--- a/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
@@ -171,7 +171,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.InlineToMemory
 
             if (_isLinear && _lineCount == 1)
             {
-                memoryManager.Physical.CacheResourceWrite(memoryManager, _dstGpuVa, data);
+                memoryManager.WriteTrackedResource(_dstGpuVa, data);
+                _context.AdvanceSequence();
             }
             else
             {

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
@@ -210,6 +210,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         {
             uint syncpointId = (uint)argument & 0xFFFF;
 
+            _context.AdvanceSequence();
             _context.CreateHostSyncIfNeeded();
             _context.Renderer.UpdateCounters(); // Poll the query counters, the game may want an updated result.
             _context.Synchronization.IncrementSyncpoint(syncpointId);

--- a/Ryujinx.Graphics.Gpu/Image/SamplerPool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/SamplerPool.cs
@@ -7,8 +7,6 @@ namespace Ryujinx.Graphics.Gpu.Image
     /// </summary>
     class SamplerPool : Pool<Sampler, SamplerDescriptor>
     {
-        private int _sequenceNumber;
-
         /// <summary>
         /// Constructs a new instance of the sampler pool.
         /// </summary>
@@ -30,9 +28,9 @@ namespace Ryujinx.Graphics.Gpu.Image
                 return null;
             }
 
-            if (_sequenceNumber != Context.SequenceNumber)
+            if (SequenceNumber != Context.SequenceNumber)
             {
-                _sequenceNumber = Context.SequenceNumber;
+                SequenceNumber = Context.SequenceNumber;
 
                 SynchronizeMemory();
             }

--- a/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -100,18 +100,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Determines if any texture exists within the target memory range.
-        /// </summary>
-        /// <param name="memoryManager">The GPU memory manager</param>
-        /// <param name="gpuVa">GPU virtual address to search for textures</param>
-        /// <param name="size">The size of the range</param>
-        /// <returns>True if any texture exists in the range, false otherwise</returns>
-        public bool IsTextureInRange(MemoryManager memoryManager, ulong gpuVa, ulong size)
-        {
-            return _textures.FindOverlaps(memoryManager.GetPhysicalRegions(gpuVa, size), ref _textureOverlaps) != 0;
-        }
-
-        /// <summary>
         /// Determines if a given texture is "safe" for upscaling from its info.
         /// Note that this is different from being compatible - this elilinates targets that would have detrimental effects when scaled.
         /// </summary>

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -12,7 +12,6 @@ namespace Ryujinx.Graphics.Gpu.Image
     /// </summary>
     class TexturePool : Pool<Texture, TextureDescriptor>
     {
-        private int _sequenceNumber;
         private readonly GpuChannel _channel;
         private readonly ConcurrentQueue<Texture> _dereferenceQueue = new ConcurrentQueue<Texture>();
 
@@ -45,9 +44,9 @@ namespace Ryujinx.Graphics.Gpu.Image
                 return null;
             }
 
-            if (_sequenceNumber != Context.SequenceNumber)
+            if (SequenceNumber != Context.SequenceNumber)
             {
-                _sequenceNumber = Context.SequenceNumber;
+                SequenceNumber = Context.SequenceNumber;
 
                 SynchronizeMemory();
             }

--- a/Ryujinx.Graphics.Gpu/Memory/GpuRegionHandle.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/GpuRegionHandle.cs
@@ -4,6 +4,9 @@ using System;
 
 namespace Ryujinx.Graphics.Gpu.Memory
 {
+    /// <summary>
+    /// A tracking handle for a region of GPU VA, represented by one or more tracking handles in CPU VA.
+    /// </summary>
     class GpuRegionHandle : IRegionHandle
     {
         private readonly CpuRegionHandle[] _cpuRegionHandles;
@@ -28,11 +31,18 @@ namespace Ryujinx.Graphics.Gpu.Memory
         public ulong Size => throw new NotSupportedException();
         public ulong EndAddress => throw new NotSupportedException();
 
+        /// <summary>
+        /// Create a new GpuRegionHandle, made up of mulitple CpuRegionHandles.
+        /// </summary>
+        /// <param name="cpuRegionHandles">The CpuRegionHandles that make up this handle</param>
         public GpuRegionHandle(CpuRegionHandle[] cpuRegionHandles)
         {
             _cpuRegionHandles = cpuRegionHandles;
         }
 
+        /// <summary>
+        /// Dispose the child handles.
+        /// </summary>
         public void Dispose()
         {
             foreach (var regionHandle in _cpuRegionHandles)
@@ -41,6 +51,11 @@ namespace Ryujinx.Graphics.Gpu.Memory
             }
         }
 
+        /// <summary>
+        /// Register an action to perform when the tracked region is read or written.
+        /// The action is automatically removed after it runs.
+        /// </summary>
+        /// <param name="action">Action to call on read or write</param>
         public void RegisterAction(RegionSignal action)
         {
             foreach (var regionHandle in _cpuRegionHandles)
@@ -49,6 +64,11 @@ namespace Ryujinx.Graphics.Gpu.Memory
             }
         }
 
+        /// <summary>
+        /// Register an action to perform when a precise access occurs (one with exact address and size).
+        /// If the action returns true, read/write tracking are skipped.
+        /// </summary>
+        /// <param name="action">Action to call on read or write</param>
         public void RegisterPreciseAction(PreciseRegionSignal action)
         {
             foreach (var regionHandle in _cpuRegionHandles)
@@ -57,6 +77,9 @@ namespace Ryujinx.Graphics.Gpu.Memory
             }
         }
 
+        /// <summary>
+        /// Consume the dirty flag for the handles, and reprotect so it can be set on the next write.
+        /// </summary>
         public void Reprotect(bool asDirty = false)
         {
             foreach (var regionHandle in _cpuRegionHandles)
@@ -65,6 +88,9 @@ namespace Ryujinx.Graphics.Gpu.Memory
             }
         }
 
+        /// <summary>
+        /// Force the handles to be dirty, without reprotecting.
+        /// </summary>
         public void ForceDirty()
         {
             foreach (var regionHandle in _cpuRegionHandles)

--- a/Ryujinx.Graphics.Gpu/Memory/GpuRegionHandle.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/GpuRegionHandle.cs
@@ -49,6 +49,14 @@ namespace Ryujinx.Graphics.Gpu.Memory
             }
         }
 
+        public void RegisterPreciseAction(PreciseRegionSignal action)
+        {
+            foreach (var regionHandle in _cpuRegionHandles)
+            {
+                regionHandle.RegisterPreciseAction(action);
+            }
+        }
+
         public void Reprotect(bool asDirty = false)
         {
             foreach (var regionHandle in _cpuRegionHandles)

--- a/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
@@ -195,6 +195,16 @@ namespace Ryujinx.Graphics.Gpu.Memory
         }
 
         /// <summary>
+        /// Writes data to GPU mapped memory, destined for a tracked resource.
+        /// </summary>
+        /// <param name="va">GPU virtual address to write the data into</param>
+        /// <param name="data">The data to be written</param>
+        public void WriteTrackedResource(ulong va, ReadOnlySpan<byte> data)
+        {
+            WriteImpl(va, data, Physical.WriteTrackedResource);
+        }
+
+        /// <summary>
         /// Writes data to GPU mapped memory without write tracking.
         /// </summary>
         /// <param name="va">GPU virtual address to write the data into</param>

--- a/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
@@ -81,28 +81,6 @@ namespace Ryujinx.Graphics.Gpu.Memory
         }
 
         /// <summary>
-        /// Write data to memory that is destined for a resource in a cache.
-        /// This avoids triggering write tracking when possible, which can avoid flushes and incrementing sequence number.
-        /// </summary>
-        /// <param name="memoryManager">The GPU memory manager</param>
-        /// <param name="gpuVa">GPU virtual address to write the data into</param>
-        /// <param name="data">The data to be written</param>
-        public void CacheResourceWrite(MemoryManager memoryManager, ulong gpuVa, ReadOnlySpan<byte> data)
-        {
-            if (TextureCache.IsTextureInRange(memoryManager, gpuVa, (ulong)data.Length))
-            {
-                // No fast path yet - copy the data back and trigger write tracking.
-                memoryManager.Write(gpuVa, data);
-                _context.AdvanceSequence();
-            }
-            else
-            {
-                BufferCache.ForceDirty(memoryManager, gpuVa, (ulong)data.Length);
-                memoryManager.WriteUntracked(gpuVa, data);
-            }
-        }
-
-        /// <summary>
         /// Gets a span of data from the application process.
         /// </summary>
         /// <param name="address">Start address of the range</param>
@@ -177,6 +155,17 @@ namespace Ryujinx.Graphics.Gpu.Memory
         public T ReadTracked<T>(ulong address) where T : unmanaged
         {
             return _cpuMemory.ReadTracked<T>(address);
+        }
+
+        /// <summary>
+        /// Writes data to the application process, triggering a precise memory tracking event.
+        /// </summary>
+        /// <param name="address">Address to write into</param>
+        /// <param name="data">Data to be written</param>
+        public void WriteTrackedResource(ulong address, ReadOnlySpan<byte> data)
+        {
+            _cpuMemory.SignalMemoryTracking(address, (ulong)data.Length, true, precise: true);
+            _cpuMemory.WriteUntracked(address, data);
         }
 
         /// <summary>

--- a/Ryujinx.Memory.Tests/MockVirtualMemoryManager.cs
+++ b/Ryujinx.Memory.Tests/MockVirtualMemoryManager.cs
@@ -79,7 +79,7 @@ namespace Ryujinx.Memory.Tests
             throw new NotImplementedException();
         }
 
-        public void SignalMemoryTracking(ulong va, ulong size, bool write)
+        public void SignalMemoryTracking(ulong va, ulong size, bool write, bool precise = false)
         {
             throw new NotImplementedException();
         }

--- a/Ryujinx.Memory/AddressSpaceManager.cs
+++ b/Ryujinx.Memory/AddressSpaceManager.cs
@@ -481,7 +481,7 @@ namespace Ryujinx.Memory
             throw new NotImplementedException();
         }
 
-        public void SignalMemoryTracking(ulong va, ulong size, bool write)
+        public void SignalMemoryTracking(ulong va, ulong size, bool write, bool precise = false)
         {
             // Only the ARM Memory Manager has tracking for now.
         }

--- a/Ryujinx.Memory/IVirtualMemoryManager.cs
+++ b/Ryujinx.Memory/IVirtualMemoryManager.cs
@@ -135,7 +135,8 @@ namespace Ryujinx.Memory
         /// <param name="va">Virtual address of the region</param>
         /// <param name="size">Size of the region</param>
         /// <param name="write">True if the region was written, false if read</param>
-        void SignalMemoryTracking(ulong va, ulong size, bool write);
+        /// <param name="precise">True if the access is precise, false otherwise</param>
+        void SignalMemoryTracking(ulong va, ulong size, bool write, bool precise = false);
 
         /// <summary>
         /// Reprotect a region of virtual memory for tracking.

--- a/Ryujinx.Memory/Tracking/AbstractRegion.cs
+++ b/Ryujinx.Memory/Tracking/AbstractRegion.cs
@@ -53,6 +53,14 @@ namespace Ryujinx.Memory.Tracking
         public abstract void Signal(ulong address, ulong size, bool write);
 
         /// <summary>
+        /// Signals to the handles that a precise memory event has occurred. Assumes that the tracking lock has been obtained.
+        /// </summary>
+        /// <param name="address">Address accessed</param>
+        /// <param name="size">Size of the region affected in bytes</param>
+        /// <param name="write">Whether the region was written to or read</param>
+        public abstract void SignalPrecise(ulong address, ulong size, bool write);
+
+        /// <summary>
         /// Split this region into two, around the specified address. 
         /// This region is updated to end at the split address, and a new region is created to represent past that point.
         /// </summary>

--- a/Ryujinx.Memory/Tracking/IRegionHandle.cs
+++ b/Ryujinx.Memory/Tracking/IRegionHandle.cs
@@ -13,5 +13,6 @@ namespace Ryujinx.Memory.Tracking
         void ForceDirty();
         void Reprotect(bool asDirty = false);
         void RegisterAction(RegionSignal action);
+        void RegisterPreciseAction(PreciseRegionSignal action);
     }
 }

--- a/Ryujinx.Memory/Tracking/MultiRegionHandle.cs
+++ b/Ryujinx.Memory/Tracking/MultiRegionHandle.cs
@@ -206,6 +206,17 @@ namespace Ryujinx.Memory.Tracking
             }
         }
 
+        public void RegisterPreciseAction(ulong address, ulong size, PreciseRegionSignal action)
+        {
+            int startHandle = (int)((address - Address) / Granularity);
+            int lastHandle = (int)((address + (size - 1) - Address) / Granularity);
+
+            for (int i = startHandle; i <= lastHandle; i++)
+            {
+                _handles[i].RegisterPreciseAction(action);
+            }
+        }
+
         public void Dispose()
         {
             foreach (var handle in _handles)

--- a/Ryujinx.Memory/Tracking/PreciseRegionSignal.cs
+++ b/Ryujinx.Memory/Tracking/PreciseRegionSignal.cs
@@ -1,0 +1,4 @@
+﻿namespace Ryujinx.Memory.Tracking
+{
+    public delegate bool PreciseRegionSignal(ulong address, ulong size, bool write);
+}

--- a/Ryujinx.Memory/Tracking/RegionHandle.cs
+++ b/Ryujinx.Memory/Tracking/RegionHandle.cs
@@ -175,14 +175,17 @@ namespace Ryujinx.Memory.Tracking
         /// <param name="size">Size of the region affected in bytes</param>
         /// <param name="write">Whether the region was written to or read</param>
         /// <param name="handleIterable">Reference to the handles being iterated, in case the list needs to be copied</param>
-        internal void SignalPrecise(ulong address, ulong size, bool write, ref IList<RegionHandle> handleIterable)
+        /// <returns>True if a precise action was performed and returned true, false otherwise</returns>
+        internal bool SignalPrecise(ulong address, ulong size, bool write, ref IList<RegionHandle> handleIterable)
         {
             if (!Unmapped && _preciseAction != null && _preciseAction(address, size, write))
             {
-                return;
+                return true;
             }
 
             Signal(address, size, write, ref handleIterable);
+
+            return false;
         }
 
         /// <summary>

--- a/Ryujinx.Memory/Tracking/RegionHandle.cs
+++ b/Ryujinx.Memory/Tracking/RegionHandle.cs
@@ -37,6 +37,7 @@ namespace Ryujinx.Memory.Tracking
 
         private object _preActionLock = new object();
         private RegionSignal _preAction; // Action to perform before a read or write. This will block the memory access.
+        private PreciseRegionSignal _preciseAction; // Action to perform on a precise read or write.
         private readonly List<VirtualRegion> _regions;
         private readonly MemoryTracking _tracking;
         private bool _disposed;
@@ -113,7 +114,10 @@ namespace Ryujinx.Memory.Tracking
         /// <summary>
         /// Signal that a memory action occurred within this handle's virtual regions.
         /// </summary>
+        /// <param name="address">Address accessed</param>
+        /// <param name="size">Size of the region affected in bytes</param>
         /// <param name="write">Whether the region was written to or read</param>
+        /// <param name="handleIterable">Reference to the handles being iterated, in case the list needs to be copied</param>
         internal void Signal(ulong address, ulong size, bool write, ref IList<RegionHandle> handleIterable)
         {
             // If this handle was already unmapped (even if just partially),
@@ -161,6 +165,24 @@ namespace Ryujinx.Memory.Tracking
                 }
                 Parent?.SignalWrite();
             }
+        }
+
+        /// <summary>
+        /// Signal that a precise memory action occurred within this handle's virtual regions.
+        /// If there is no precise action, or the action returns false, the normal signal handler will be called.
+        /// </summary>
+        /// <param name="address">Address accessed</param>
+        /// <param name="size">Size of the region affected in bytes</param>
+        /// <param name="write">Whether the region was written to or read</param>
+        /// <param name="handleIterable">Reference to the handles being iterated, in case the list needs to be copied</param>
+        internal void SignalPrecise(ulong address, ulong size, bool write, ref IList<RegionHandle> handleIterable)
+        {
+            if (!Unmapped && _preciseAction != null && _preciseAction(address, size, write))
+            {
+                return;
+            }
+
+            Signal(address, size, write, ref handleIterable);
         }
 
         /// <summary>
@@ -241,6 +263,16 @@ namespace Ryujinx.Memory.Tracking
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Register an action to perform when a precise access occurs (one with exact address and size).
+        /// If the action returns true, read/write tracking are skipped.
+        /// </summary>
+        /// <param name="action">Action to call on read or write</param>
+        public void RegisterPreciseAction(PreciseRegionSignal action)
+        {
+            _preciseAction = action;
         }
 
         /// <summary>

--- a/Ryujinx.Memory/Tracking/SmartMultiRegionHandle.cs
+++ b/Ryujinx.Memory/Tracking/SmartMultiRegionHandle.cs
@@ -63,6 +63,17 @@ namespace Ryujinx.Memory.Tracking
             }
         }
 
+        public void RegisterPreciseAction(PreciseRegionSignal action)
+        {
+            foreach (var handle in _handles)
+            {
+                if (handle != null)
+                {
+                    handle?.RegisterPreciseAction((address, size, write) => action(handle.Address, handle.Size, write));
+                }
+            }
+        }
+
         public void QueryModified(Action<ulong, ulong> modifiedAction)
         {
             if (!Dirty)

--- a/Ryujinx.Memory/Tracking/VirtualRegion.cs
+++ b/Ryujinx.Memory/Tracking/VirtualRegion.cs
@@ -35,12 +35,19 @@ namespace Ryujinx.Memory.Tracking
         {
             IList<RegionHandle> handles = Handles;
 
+            bool allPrecise = true;
+
             for (int i = 0; i < handles.Count; i++)
             {
-                handles[i].SignalPrecise(address, size, write, ref handles);
+                allPrecise &= handles[i].SignalPrecise(address, size, write, ref handles);
             }
 
-            UpdateProtection();
+            // Only update protection if a regular signal handler was called.
+            // This allows precise actions to skip reprotection costs if they want (they can still do it manually).
+            if (!allPrecise)
+            {
+                UpdateProtection();
+            }
         }
 
         /// <summary>

--- a/Ryujinx.Memory/Tracking/VirtualRegion.cs
+++ b/Ryujinx.Memory/Tracking/VirtualRegion.cs
@@ -31,6 +31,18 @@ namespace Ryujinx.Memory.Tracking
             UpdateProtection();
         }
 
+        public override void SignalPrecise(ulong address, ulong size, bool write)
+        {
+            IList<RegionHandle> handles = Handles;
+
+            for (int i = 0; i < handles.Count; i++)
+            {
+                handles[i].SignalPrecise(address, size, write, ref handles);
+            }
+
+            UpdateProtection();
+        }
+
         /// <summary>
         /// Signal that this region has been mapped or unmapped.
         /// </summary>


### PR DESCRIPTION
The goal of CacheResourceWrite was to notify GPU resources when they were modified directly, by looking up the modified address/size in a structure and calling a method on each resource. The downside of this is that each resource cache has to be queried individually, they all have to implement their own way to do this, and it can only signal to resources using the same PhysicalMemory instance.

This PR adds the ability to signal a write as "precise" on the tracking, which signals a special handler (if present) which can be used to avoid unnecessary flush actions, or maybe even more. For buffers, precise writes specifically do not flush, and instead punch a hole in the modified range list to indicate that the data on GPU has been replaced.

The downside is that precise actions must ignore the page protection bits and always signal - as they need to notify the target resource to ignore the sequence number optimization.

I had to reintroduce the sequence number increment after I2M, as removing it was causing issues in rabbids kingdom battle. However - all resources modified by I2M are notified directly to lower their sequence number, so the problem is likely that another unrelated resource is not being properly updated. Thankfully, doing this does not affect performance in the games I tested. I'd like to remove this again once I figure out what the problem actually is.

This should fix regressions from #2624. Test any games that were broken by that. **(RF4, rabbids kingdom battle)**

I've also added a sequence number increment to ThreedClass.IncrementSyncpoint, as it seems to fix buffer corruption in OpenGL homebrew. (this was a regression from removing sequence number increment from constant buffer update - another unrelated resource thing)

Fixes #2690