### PR TITLE
Force copy when auto-deleting a texture with dependencies

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
@@ -41,14 +41,14 @@ namespace Ryujinx.Graphics.Gpu.Image
             {
                 Texture oldestTexture = _textures.First.Value;
 
-                oldestTexture.SynchronizeMemory();
-
-                if (oldestTexture.IsModified && !oldestTexture.CheckModified(true))
+                if (oldestTexture.IsModified && !oldestTexture.CheckModified(false))
                 {
                     // The texture must be flushed if it falls out of the auto delete cache.
                     // Flushes out of the auto delete cache do not trigger write tracking,
                     // as it is expected that other overlapping textures exist that have more up-to-date contents.
-                    oldestTexture.Flush(false); 
+
+                    oldestTexture.Group.SynchronizeDependents(oldestTexture);
+                    oldestTexture.Flush(false);
                 }
 
                 _textures.RemoveFirst();

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -235,6 +235,23 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Synchronize dependent textures, if any of them have deferred a copy from the given texture.
+        /// </summary>
+        /// <param name="texture">The texture to synchronize dependents of</param>
+        public void SynchronizeDependents(Texture texture)
+        {
+            EvaluateRelevantHandles(texture, (baseHandle, regionCount, split) =>
+            {
+                for (int i = 0; i < regionCount; i++)
+                {
+                    TextureGroupHandle group = _handles[baseHandle + i];
+
+                    group.SynchronizeDependents();
+                }
+            });
+        }
+
+        /// <summary>
         /// Signal that a texture in the group has been modified by the GPU.
         /// </summary>
         /// <param name="texture">The texture that has been modified</param>

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
@@ -141,6 +141,22 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Synchronize dependent textures, if any of them have deferred a copy from this texture.
+        /// </summary>
+        public void SynchronizeDependents()
+        {
+            foreach (TextureDependency dependency in Dependencies)
+            {
+                TextureGroupHandle otherHandle = dependency.Other.Handle;
+
+                if (otherHandle.DeferredCopy == this)
+                {
+                    otherHandle._group.Storage.SynchronizeMemory();
+                }
+            }
+        }
+
+        /// <summary>
         /// Signal that a copy dependent texture has been modified, and must have its data copied to this one.
         /// </summary>
         /// <param name="copyFrom">The texture handle that must defer a copy to this one</param>


### PR DESCRIPTION
When a texture is deleted by falling to the bottom of the AutoDeleteCache, its data is flushed to preserve any GPU writes that occurred. This ensures that the data appears in any textures recreated in the future, but didn't account for a texture that already existed with a copy dependency.

This change forces copy dependencies to complete if a texture falls out from from the AutoDeleteCache. (not removed via overlap, as that would be wasted effort) This is done via a full sync of the storage texture right now, as that's the best way to ensure all the rules are followed.

Fixes broken lighting caused by pausing in SMO's Metro Kingdom. May fix some other infrequent issues. 

I'd recommend testing games that do a lot of render to texture / copies, like 1st party games and UE4 games.

### Before (pause+unpause)
![image](https://user-images.githubusercontent.com/6294155/134787070-2f834aee-c491-4995-9de9-b015e588bf65.png)
(too bright, weird directional lighting on mario)

### After (pause+unpause)
![image](https://user-images.githubusercontent.com/6294155/134787036-e741a116-cc7e-49f9-b172-637935d805a1.png)
