### PR TITLE
Improve `HyrbidAllocator`

### DIFF
--- a/ARMeilleure/IntermediateRepresentation/BasicBlock.cs
+++ b/ARMeilleure/IntermediateRepresentation/BasicBlock.cs
@@ -118,7 +118,7 @@ namespace ARMeilleure.IntermediateRepresentation
             oldBlock = block;
         }
 
-        public void Append(Operation node)
+        public Operation Append(Operation node)
         {
             Operation last = Operations.Last;
 
@@ -127,7 +127,7 @@ namespace ARMeilleure.IntermediateRepresentation
             {
                 Operations.AddLast(node);
 
-                return;
+                return node;
             }
 
             switch (last.Instruction)
@@ -135,12 +135,10 @@ namespace ARMeilleure.IntermediateRepresentation
                 case Instruction.Return:
                 case Instruction.Tailcall:
                 case Instruction.BranchIf:
-                    Operations.AddBefore(last, node);
-                    break;
+                    return Operations.AddBefore(last, node);
 
                 default:
-                    Operations.AddLast(node);
-                    break;
+                    return Operations.AddLast(node);
             }
         }
 


### PR DESCRIPTION
Currently once a local has been marked for spilling, it is spilled for its entire lifetime, i.e: a spill when it is defined and fill when it is used. This simplifies and speeds up allocation a lot, but at the cost of CQ.

This PR attempts to improve CQ of the allocator by tracking more precisely the lifetime of locals in registers as they are allocated. It removes the notion of spill set, instead every register in the free set is a candidate for spilling and filling. The allocator has an active set like the LSRA, and has 2 primary operations: `DefRegister` and `UseRegister`. The allocation is done as we're walking through the operations of the block in forward order. The free set still have the constraints of the current approach.

### `DefRegsister`
It is called when a local is defined/assigned:
1. If the local already has a register assigned, return that register.
2. If there is a free register (i.e: not in active set), return that register.
   * This could be based on a heuristic, but is not at the moment.
   * The register is moved to the active set.
3. Otherwise select a register from the active set to spill, return that register.
   * This is based on a simple heuristic.

### `UseRegister`
It is called when a local is used:
1. If the local already has a register, return that register.
2. If it does not, allocate one using `DefRegister` , fill the register, return that register.
   * Using `DefRegister` will take care of the case where we need to spill.
3. If the local has reached the last use, we can free the register and remove it from the active set.
   * The register is spilled when the local is not a block local, this is to avoid issues with loops.

After allocating the operations in the block, the active set may not be empty. In this case we spill everything in it. This is essentially a local linear scan second chance register allocator. Since when locals are evicted, they have chance to live in another register later on.

___
In the majority of cases this is an improvement over the current allocator, in term of code size (7415 improved, 1948 regressed).

#### CQ Improvements
Typical improvements looks like this.

<table>
  <tr><th>Master</th><th>PR</th></tr>
  <tr>
  <td>

  ```asm
  .L17:
    mov rax,9150000h
    mov [rsp+60h],rax
    mov rax,[rsp+60h]
    lea rbp,[rax+53Eh]
    mov rax,rbp
    mov [rsp+60h],rax
    mov rax,801D6BCh
    mov [rsp+68h],rax
    mov rbp,[rsp+4Ch]
    mov rax,[rsp+60h]
    mov [rbp],rax
    mov rax,[rsp+68h]
    mov [rbp+0F0h],rax
    mov rbx,[rsp+4Ch]
    mov qword [rbx+408h],8DE5730h
    mov rbp,DISPATCH_TABLE_8DE5730
    mov rbp,[rbp]
    mov rcx,rbx
    call rbp
    mov rdx,rax
    mov [rsp+0A0h],rdx
    mov rax,[rsp+0A0h]
    cmp rax,801D6BCh
    je near .L19
  ```
  </td>
  <td>

  ```asm
  .L17:
    mov rax,9150000h
    lea rcx,[rax+53Eh]
    mov rax,rcx
    mov rcx,801D6BCh
    mov rdx,[rsp+44h]
    mov [rdx],rax
    mov [rdx+0F0h],rcx
    mov [rsp+58h],rax
    mov [rsp+60h],rcx
    mov rbx,[rsp+44h]
    mov qword [rbx+408h],8DE5730h
    mov rbp,DISPATCH_TABLE_8DE5730
    mov rsi,[rbp]
    mov rcx,rbx
    call rsi
    mov rbx,rax
    mov [rsp+98h],rbx
    mov rax,[rsp+98h]
    mov [rsp+98h],rax
    cmp rax,801D6BCh
    je near .L19
  ```
  </td>
  </tr>
  <tr>
  <td>

  ```asm
  .L5:
    mov rbp,[rsp+4Ch]
    mov rsi,PAGE_TABLE
    mov rbp,[rsi+rbp+8]
    mov rax,rbp
    mov [rsp+60h],rax
    mov rax,[rsp+60h]
    mov [rsp+60h],rax
    mov rax,[rsp+60h]
    test rax,rax
    jne near .L7
  ```
  </td>
  <td>

  ```asm
  .L5:
    mov rax,[rsp+54h]
    mov rcx,PAGE_TABLE
    mov rdx,[rcx+rax+8]
    mov rax,rdx
    mov [rsp+60h],rax
    test rax,rax
    jne near .L7
  ```
  </td>
  </tr>
</table>

#### CQ Regressions
I have also seen some regressions, but I did not have the chance to investigate them yet.
* Because of the sub-rule of rule 3 of `UseRegister` we over spill sometimes.

  <table>
    <tr><th>Master</th><th>PR</th></tr>
    <tr>
    <td>
    
    ```asm
    .L2:
      mov ebp,[rsp+84h]
      sub ebp,1
      mov rax,[rsp+7Ch]
      mov [rax+400h],ebp
    ```
    </td>
    <td>
    
    ```asm
    .L2:
      mov eax,[rsp+84h]
      sub eax,1
      mov rcx,[rsp+54h]
      mov [rsp+54h],rcx  ;; This is the last use and a non-block local so we spill.
      mov [rcx+400h],eax
    ```
    </td>
    </tr>
  </table>
  This could be fixed by doing a more precise liveness analysis and checking if the local lives out the block, but it might throw throughput out of the window.
* It uses more registers than the current approach which causes epilogue size to increase.

#### Throughput
I also did not have the chance to investigate throughput or boot time yet. Will probably close this if I can't get it to be close to the current approach, if it happens to be slower.