### PR TITLE
Don't force scaling on 2D copy sources

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Twod/TwodClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Twod/TwodClass.cs
@@ -119,7 +119,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Twod
                 srcCopyTexture,
                 offset,
                 srcCopyTextureFormat,
-                true,
+                false,
                 srcHint);
 
             if (srcTexture == null)


### PR DESCRIPTION
Some games (GameMaker Studio) build texture atlases out of sprites during initialization, using the 2D copy method. These copies are done from textures loaded into memory, not rendered, so they are not scaled to begin with.

I had set srcTexture in these copies to force scaling, but really it only needs to scale if the texture already exists and was scaled by rendering or something else. I just set that to false, so it doesn't change if the texture is scaled or not. This will also avoid the destination being scaled if the source wasn't. The copy can handle mismatching scales just fine.

This prevents scaling artifacts in GMS games, and maybe others (not Super Mario Maker 2, that has another issue).

Before (2x):
![image](https://user-images.githubusercontent.com/6294155/135768283-10b900f4-1cd9-426c-99f2-9380f4256257.png)

After (2x):
![image](https://user-images.githubusercontent.com/6294155/135768254-e0bb6f79-e486-4c0d-b20e-bc1f1b4b2893.png)

This will probably not prevent scale blacklisting (forced 1x) in Deltarune Chapters 1&2.