### PR TITLE
Relax sampler pool requirement

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -344,12 +344,6 @@ namespace Ryujinx.Graphics.Gpu.Image
                 return;
             }
 
-            if (samplerPool == null)
-            {
-                Logger.Error?.Print(LogClass.Gpu, $"Shader stage \"{stage}\" uses textures, but sampler pool was not set.");
-                return;
-            }
-
             for (int index = 0; index < textureCount; index++)
             {
                 TextureBindingInfo bindingInfo = _textureBindings[stageIndex][index];
@@ -405,7 +399,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     _channel.BufferManager.SetBufferTextureStorage(hostTexture, texture.Range.GetSubRange(0).Address, texture.Size, bindingInfo, bindingInfo.Format, false);
                 }
 
-                Sampler sampler = samplerPool.Get(samplerId);
+                Sampler sampler = samplerPool?.Get(samplerId);
 
                 ISampler hostSampler = sampler?.HostSampler;
 


### PR DESCRIPTION
Right now, the emulator will print an error and exit early if an attempt is made to use textures without having a sampler pool currenntly bound. That is because accessing a texture without a sampler is usually not valid. But there are one case where the sampler is not needed, which is when textures are accessed with `texelFetch`, as those are not filtered in any way.

This is usually not a problem, because it's not common for a game to only ever use `texelFetch`, but it turns out Cotton Guardian Force does this. This change allows the texture to be bound without a sampler, which improves rendering on this title.

Before:
![image](https://user-images.githubusercontent.com/5624669/135774210-01585874-5807-46a6-9567-a9ec4073677b.png)
With this PR:
![image](https://user-images.githubusercontent.com/5624669/135774214-95e45008-a872-46a9-8c31-ec22ef04f2a3.png)
I also investigated the weird lines above, as it looked like an issue that could be caused by incorrect sampling, but it wasn't. Instead, it was caused by the lack of the SHF shader instruction, which is implemented on #2702. With the PR, the game renders correctly:
![image](https://user-images.githubusercontent.com/5624669/135774252-a9714048-e76a-4b05-9d92-572130652340.png)
![image](https://user-images.githubusercontent.com/5624669/135774245-f95f08db-45f9-4302-8489-8db9c93a3a27.png)