### PR TITLE
Unref frames before decoding with FFMPEG

### DIFF
--- a/Ryujinx.Graphics.Nvdec.H264/FFmpegContext.cs
+++ b/Ryujinx.Graphics.Nvdec.H264/FFmpegContext.cs
@@ -106,6 +106,8 @@ namespace Ryujinx.Graphics.Nvdec.H264
 
         public int DecodeFrame(Surface output, ReadOnlySpan<byte> bitstream)
         {
+            ffmpeg.av_frame_unref(output.Frame);
+
             int result;
             int gotFrame;
 


### PR DESCRIPTION
Fix memory leaks that started happening while playing some videos after #2671.