### PR TITLE
Fix DisplayInfo struct

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Vi/RootService/ApplicationDisplayService/Types/DisplayInfo.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/RootService/ApplicationDisplayService/Types/DisplayInfo.cs
@@ -6,7 +6,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService.ApplicationDisplayService.Type
     [StructLayout(LayoutKind.Sequential, Size = 0x60)]
     struct DisplayInfo
     {
-        public Array40<byte> Name;
+        public Array64<byte> Name;
         public bool          LayerLimitEnabled;
         public Array7<byte>  Padding;
         public ulong         LayerLimitMax;

--- a/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
@@ -34,7 +34,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
             {
                 DisplayInfo displayInfo = new DisplayInfo()
                 {
-                    Name              = new Array40<byte>(),
+                    Name              = new Array64<byte>(),
                     LayerLimitEnabled = layerLimitEnabled,
                     Padding           = new Array7<byte>(),
                     LayerLimitMax     = layerLimitMax,
@@ -123,8 +123,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
 
             for (int i = 0; i < (int)displayCount; i++)
             {
-                context.Memory.Fill(displayInfoBuffer + (ulong)(i * Unsafe.SizeOf<DisplayInfo>()), (ulong)(Unsafe.SizeOf<DisplayInfo>()), 0x00);
-                context.Memory.Write(displayInfoBuffer, _displayInfo[i]);
+                context.Memory.Write(displayInfoBuffer + (ulong)(i * Unsafe.SizeOf<DisplayInfo>()), _displayInfo[i]);
             }
 
             context.ResponseData.Write(displayCount);


### PR DESCRIPTION
Fixes a regression caused by #2640. The `DisplayInfo` struct was incorrect, the `Array40` struct was used for the name fixed buffer, that has a size of 0x40 bytes. However, the size on the `Array` struct name is decimal, not hexadecimal, so the correct type here is `Array64`.

Fixes regression that would cause Dragon Ball Xenoverse 2 to no longer boot, as it would pass a invalid size of 0 to surface flinger initialization, which would later cause other failures.

I also removed the `Fill` call as it was useless, the `Write` already writes all the 0x60 bytes. Also fixed the write address, that was not taking the current `i` value into account, although it was not an issue right now as only one entry is ever written on `ListDisplays` currently.