### PR TITLE
Better depth range detection

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -533,7 +533,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                     }
                     else
                     {
-                        // If we can't from the viewport transform, then just use the depth mode register.
+                        // If we can't guess from the viewport transform, then just use the depth mode register.
                         depthMode = (DepthMode)(_state.State.DepthMode & 1);
                     }
 

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -485,6 +485,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             var face = _state.State.FaceState;
 
             UpdateFrontFace(yControl, face.FrontFace);
+            UpdateDepthMode();
 
             bool flipY = yControl.HasFlag(YControl.NegateY);
 
@@ -492,8 +493,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
             for (int index = 0; index < Constants.TotalViewports; index++)
             {
-                var transform = _state.State.ViewportTransform[index];
-                var extents = _state.State.ViewportExtents[index];
+                ref var transform = ref _state.State.ViewportTransform[index];
+                ref var extents = ref _state.State.ViewportExtents[index];
 
                 float scaleX = MathF.Abs(transform.ScaleX);
                 float scaleY = transform.ScaleY;
@@ -506,38 +507,6 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 if (!_context.Capabilities.SupportsViewportSwizzle && transform.UnpackSwizzleY() == ViewportSwizzle.NegativeY)
                 {
                     scaleY = -scaleY;
-                }
-
-                if (index == 0 && (extents.DepthFar - extents.DepthNear) != 0)
-                {
-                    DepthMode depthMode;
-
-                    if (!float.IsInfinity(extents.DepthNear) &&
-                        !float.IsInfinity(extents.DepthFar) &&
-                        (extents.DepthFar - extents.DepthNear) != 0)
-                    {
-                        // Try to guess the depth mode being used on the high level API
-                        // based on current transform.
-                        // It is setup like so by said APIs:
-                        // If depth mode is ZeroToOne:
-                        //  TranslateZ = Near
-                        //  ScaleZ = Far - Near
-                        // If depth mode is MinusOneToOne:
-                        //  TranslateZ = (Near + Far) / 2
-                        //  ScaleZ = (Far - Near) / 2
-                        // DepthNear/Far are sorted such as that Near is always less than Far.
-                        depthMode = extents.DepthNear != transform.TranslateZ &&
-                                    extents.DepthFar  != transform.TranslateZ
-                            ? DepthMode.MinusOneToOne
-                            : DepthMode.ZeroToOne;
-                    }
-                    else
-                    {
-                        // If we can't guess from the viewport transform, then just use the depth mode register.
-                        depthMode = (DepthMode)(_state.State.DepthMode & 1);
-                    }
-
-                    _context.Renderer.Pipeline.SetDepthMode(depthMode);
                 }
 
                 float x = transform.TranslateX - scaleX;
@@ -576,6 +545,44 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             }
 
             _context.Renderer.Pipeline.SetViewports(0, viewports);
+        }
+
+        /// <summary>
+        /// Updates the depth mode (0 to 1 or -1 to 1) based on the current viewport and depth mode register state.
+        /// </summary>
+        private void UpdateDepthMode()
+        {
+            ref var transform = ref _state.State.ViewportTransform[0];
+            ref var extents = ref _state.State.ViewportExtents[0];
+
+            DepthMode depthMode;
+
+            if (!float.IsInfinity(extents.DepthNear) &&
+                !float.IsInfinity(extents.DepthFar) &&
+                (extents.DepthFar - extents.DepthNear) != 0)
+            {
+                // Try to guess the depth mode being used on the high level API
+                // based on current transform.
+                // It is setup like so by said APIs:
+                // If depth mode is ZeroToOne:
+                //  TranslateZ = Near
+                //  ScaleZ = Far - Near
+                // If depth mode is MinusOneToOne:
+                //  TranslateZ = (Near + Far) / 2
+                //  ScaleZ = (Far - Near) / 2
+                // DepthNear/Far are sorted such as that Near is always less than Far.
+                depthMode = extents.DepthNear != transform.TranslateZ &&
+                            extents.DepthFar  != transform.TranslateZ
+                    ? DepthMode.MinusOneToOne
+                    : DepthMode.ZeroToOne;
+            }
+            else
+            {
+                // If we can't guess from the viewport transform, then just use the depth mode register.
+                depthMode = (DepthMode)(_state.State.DepthMode & 1);
+            }
+
+            _context.Renderer.Pipeline.SetDepthMode(depthMode);
         }
 
         /// <summary>


### PR DESCRIPTION
This contains some of the changes on #2458, where it reads the depth range from the register when it determines it can't guess it from the depth near/far + translate values. On top of that, it adds another case where it uses the register, which is when both near and far values are 0, as in this case too the assumption that `TranslateZ = (Near + Far) / 2` for -1 to 1 and `TranslateZ = Near` for 0 to 1 no longer holds, as 0 divided by 2 is still 0, so there's no way to tell the depth range in this case using this method.

This improves rendering of Bastion on OpenGL:
![image](https://user-images.githubusercontent.com/5624669/137798148-655ea038-649b-4026-96c5-c9bafb08510a.png)

Fixes #1628.