### PR TITLE
Add support for render scale to vertex stage.

### DIFF
--- a/Ryujinx.Graphics.GAL/IPipeline.cs
+++ b/Ryujinx.Graphics.GAL/IPipeline.cs
@@ -104,6 +104,6 @@ namespace Ryujinx.Graphics.GAL
         bool TryHostConditionalRendering(ICounterEvent value, ICounterEvent compare, bool isEqual);
         void EndHostConditionalRendering();
 
-        void UpdateRenderScale(ShaderStage stage, ReadOnlySpan<float> scales, int textureCount, int imageCount);
+        void UpdateRenderScale(ReadOnlySpan<float> scales, int totalCount, int fragmentCount);
     }
 }

--- a/Ryujinx.Graphics.GAL/Multithreading/Commands/UpdateRenderScaleCommand.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/Commands/UpdateRenderScaleCommand.cs
@@ -6,22 +6,20 @@ namespace Ryujinx.Graphics.GAL.Multithreading.Commands
     struct UpdateRenderScaleCommand : IGALCommand
     {
         public CommandType CommandType => CommandType.UpdateRenderScale;
-        private ShaderStage _stage;
         private SpanRef<float> _scales;
-        private int _textureCount;
-        private int _imageCount;
+        private int _totalCount;
+        private int _fragmentCount;
 
-        public void Set(ShaderStage stage, SpanRef<float> scales, int textureCount, int imageCount)
+        public void Set(SpanRef<float> scales, int totalCount, int fragmentCount)
         {
-            _stage = stage;
             _scales = scales;
-            _textureCount = textureCount;
-            _imageCount = imageCount;
+            _totalCount = totalCount;
+            _fragmentCount = fragmentCount;
         }
 
         public static void Run(ref UpdateRenderScaleCommand command, ThreadedRenderer threaded, IRenderer renderer)
         {
-            renderer.Pipeline.UpdateRenderScale(command._stage, command._scales.Get(threaded), command._textureCount, command._imageCount);
+            renderer.Pipeline.UpdateRenderScale(command._scales.Get(threaded), command._totalCount, command._fragmentCount);
             command._scales.Dispose(threaded);
         }
     }

--- a/Ryujinx.Graphics.GAL/Multithreading/ThreadedPipeline.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/ThreadedPipeline.cs
@@ -353,9 +353,9 @@ namespace Ryujinx.Graphics.GAL.Multithreading
             return false;
         }
 
-        public void UpdateRenderScale(ShaderStage stage, ReadOnlySpan<float> scales, int textureCount, int imageCount)
+        public void UpdateRenderScale(ReadOnlySpan<float> scales, int totalCount, int fragmentCount)
         {
-            _renderer.New<UpdateRenderScaleCommand>().Set(stage, _renderer.CopySpan(scales.Slice(0, textureCount + imageCount)), textureCount, imageCount);
+            _renderer.New<UpdateRenderScaleCommand>().Set(_renderer.CopySpan(scales.Slice(0, totalCount)), totalCount, fragmentCount);
             _renderer.QueueCommand();
         }
     }

--- a/Ryujinx.Graphics.GAL/SupportBufferUpdater.cs
+++ b/Ryujinx.Graphics.GAL/SupportBufferUpdater.cs
@@ -1,0 +1,93 @@
+﻿using Ryujinx.Graphics.Shader;
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace Ryujinx.Graphics.GAL
+{
+    public class SupportBufferUpdater : IDisposable
+    {
+        public SupportBuffer Data;
+        public BufferHandle Handle;
+
+        private IRenderer _renderer;
+        private int _startOffset;
+        private int _endOffset;
+
+        public SupportBufferUpdater(IRenderer renderer)
+        {
+            _renderer = renderer;
+            Handle = renderer.CreateBuffer(SupportBuffer.RequiredSize);
+        }
+
+        private void MarkDirty(int startOffset, int byteSize)
+        {
+            int endOffset = startOffset + byteSize;
+
+            if (_startOffset == -1)
+            {
+                _startOffset = startOffset;
+                _endOffset = endOffset;
+            }
+            else
+            {
+                if (startOffset < _startOffset)
+                {
+                    _startOffset = startOffset;
+                }
+
+                if (endOffset > _endOffset)
+                {
+                    _endOffset = endOffset;
+                }
+            }
+        }
+
+        public void UpdateFragmentRenderScaleCount(int count)
+        {
+            if (Data.FragmentRenderScaleCount.X != count)
+            {
+                Data.FragmentRenderScaleCount.X = count;
+
+                MarkDirty(SupportBuffer.FragmentRenderScaleCountOffset, sizeof(int));
+            }
+        }
+
+        private void UpdateGenericField<T>(int baseOffset, ReadOnlySpan<T> data, Span<T> target, int offset, int count) where T : unmanaged
+        {
+            data.Slice(0, count).CopyTo(target.Slice(offset));
+
+            int elemSize = Unsafe.SizeOf<T>();
+
+            MarkDirty(baseOffset + offset * elemSize, count * elemSize);
+        }
+
+        public void UpdateRenderScale(ReadOnlySpan<Vector4<float>> data, int offset, int count)
+        {
+            UpdateGenericField(SupportBuffer.GraphicsRenderScaleOffset, data, Data.RenderScale.ToSpan(), offset, count);
+        }
+
+        public void UpdateFragmentIsBgra(ReadOnlySpan<Vector4<int>> data, int offset, int count)
+        {
+            UpdateGenericField(SupportBuffer.FragmentIsBgraOffset, data, Data.FragmentIsBgra.ToSpan(), offset, count);
+        }
+
+        public void Commit()
+        {
+            if (_startOffset != -1)
+            {
+                ReadOnlySpan<byte> data = MemoryMarshal.Cast<SupportBuffer, byte>(MemoryMarshal.CreateSpan(ref Data, 1));
+
+                _renderer.SetBufferData(Handle, _startOffset, data.Slice(_startOffset, _endOffset - _startOffset));
+
+                _startOffset = -1;
+                _endOffset = -1;
+            }
+        }
+
+        public void Dispose()
+        {
+            _renderer.DeleteBuffer(Handle);
+        }
+    }
+}

--- a/Ryujinx.Graphics.GAL/SupportBufferUpdater.cs
+++ b/Ryujinx.Graphics.GAL/SupportBufferUpdater.cs
@@ -11,8 +11,8 @@ namespace Ryujinx.Graphics.GAL
         public BufferHandle Handle;
 
         private IRenderer _renderer;
-        private int _startOffset;
-        private int _endOffset;
+        private int _startOffset = -1;
+        private int _endOffset = -1;
 
         public SupportBufferUpdater(IRenderer renderer)
         {

--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -232,42 +232,44 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             if ((binding.Flags & TextureUsageFlags.NeedsScaleValue) != 0 && texture != null)
             {
-                switch (stage)
+                if ((binding.Flags & TextureUsageFlags.ResScaleUnsupported) != 0)
                 {
-                    case ShaderStage.Fragment:
-                        if ((binding.Flags & TextureUsageFlags.ResScaleUnsupported) != 0)
-                        {
-                            changed |= texture.ScaleMode != TextureScaleMode.Blacklisted;
-                            texture.BlacklistScale();
-                            break;
-                        }
+                    changed = texture.ScaleMode != TextureScaleMode.Blacklisted;
+                    texture.BlacklistScale();
+                }
+                else
+                {
+                    switch (stage)
+                    {
+                        case ShaderStage.Fragment:
+                            float scale = texture.ScaleFactor;
 
-                        float scale = texture.ScaleFactor;
-
-                        if (scale != 1)
-                        {
-                            Texture activeTarget = _channel.TextureManager.GetAnyRenderTarget();
-
-                            if (activeTarget != null && activeTarget.Info.Width / (float)texture.Info.Width == activeTarget.Info.Height / (float)texture.Info.Height)
+                            if (scale != 1)
                             {
-                                // If the texture's size is a multiple of the sampler size, enable interpolation using gl_FragCoord. (helps "invent" new integer values between scaled pixels)
-                                result = -scale;
-                                break;
+                                Texture activeTarget = _channel.TextureManager.GetAnyRenderTarget();
+
+                                if (activeTarget != null && activeTarget.Info.Width / (float)texture.Info.Width == activeTarget.Info.Height / (float)texture.Info.Height)
+                                {
+                                    // If the texture's size is a multiple of the sampler size, enable interpolation using gl_FragCoord. (helps "invent" new integer values between scaled pixels)
+                                    result = -scale;
+                                    break;
+                                }
                             }
-                        }
 
-                        result = scale;
-                        break;
+                            result = scale;
+                            break;
 
-                    case ShaderStage.Compute:
-                        if ((binding.Flags & TextureUsageFlags.ResScaleUnsupported) != 0)
-                        {
-                            changed |= texture.ScaleMode != TextureScaleMode.Blacklisted;
-                            texture.BlacklistScale();
-                        }
+                        case ShaderStage.Vertex:
+                            int fragmentIndex = (int)ShaderStage.Fragment - 1;
+                            index += _textureBindingsCount[fragmentIndex] + _imageBindingsCount[fragmentIndex];
 
-                        result = texture.ScaleFactor;
-                        break;
+                            result = texture.ScaleFactor;
+                            break;
+
+                        case ShaderStage.Compute:
+                            result = texture.ScaleFactor;
+                            break;
+                    }
                 }
             }
 
@@ -284,13 +286,29 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <summary>
         /// Uploads texture and image scales to the backend when they are used.
         /// </summary>
-        /// <param name="stage">Current shader stage</param>
-        /// <param name="stageIndex">Shader stage index</param>
-        private void CommitRenderScale(ShaderStage stage, int stageIndex)
+        private void CommitRenderScale()
         {
             if (_scaleChanged)
             {
-                _context.Renderer.Pipeline.UpdateRenderScale(stage, _scales, _textureBindingsCount[stageIndex], _imageBindingsCount[stageIndex]);
+                int fragmentTotal = 0;
+                int total;
+
+                if (!_isCompute)
+                {
+                    int fragmentIndex = (int)ShaderStage.Fragment - 1;
+                    fragmentTotal = _textureBindingsCount[fragmentIndex] + _imageBindingsCount[fragmentIndex];
+
+                    int vertexIndex = (int)ShaderStage.Vertex - 1;
+                    int vertexTotal = _textureBindingsCount[vertexIndex] + _imageBindingsCount[vertexIndex];
+
+                    total = fragmentTotal + vertexTotal;
+                }
+                else
+                {
+                    total = _textureBindingsCount[0] + _imageBindingsCount[0];
+                }
+
+                _context.Renderer.Pipeline.UpdateRenderScale(_scales, total, fragmentTotal);
 
                 _scaleChanged = false;
             }
@@ -312,8 +330,6 @@ namespace Ryujinx.Graphics.Gpu.Image
             {
                 CommitTextureBindings(texturePool, ShaderStage.Compute, 0);
                 CommitImageBindings  (texturePool, ShaderStage.Compute, 0);
-
-                CommitRenderScale(ShaderStage.Compute, 0);
             }
             else
             {
@@ -323,10 +339,10 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                     CommitTextureBindings(texturePool, stage, stageIndex);
                     CommitImageBindings  (texturePool, stage, stageIndex);
-
-                    CommitRenderScale(stage, stageIndex);
                 }
             }
+
+            CommitRenderScale();
 
             _rebind = false;
         }

--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -248,7 +248,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                             {
                                 Texture activeTarget = _channel.TextureManager.GetAnyRenderTarget();
 
-                                if (activeTarget != null && activeTarget.Info.Width / (float)texture.Info.Width == activeTarget.Info.Height / (float)texture.Info.Height)
+                                if (activeTarget != null && (activeTarget.Info.Width / (float)texture.Info.Width) == (activeTarget.Info.Height / (float)texture.Info.Height))
                                 {
                                     // If the texture's size is a multiple of the sampler size, enable interpolation using gl_FragCoord. (helps "invent" new integer values between scaled pixels)
                                     result = -scale;

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -40,7 +40,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2885;
+        private const ulong ShaderCodeGenVersion = 2764;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -90,7 +90,7 @@ namespace Ryujinx.Graphics.OpenGL
 
         public void Initialize(Renderer renderer)
         {
-            _supportBuffer = new GAL.SupportBufferUpdater(renderer);
+            _supportBuffer = new SupportBufferUpdater(renderer);
             GL.BindBufferBase(BufferRangeTarget.UniformBuffer, 0, Unsafe.As<BufferHandle, int>(ref _supportBuffer.Handle));
 
             _supportBuffer.UpdateFragmentIsBgra(_fpIsBgra, 0, SupportBuffer.FragmentIsBgraCount);

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -61,7 +61,7 @@ namespace Ryujinx.Graphics.OpenGL
         private bool _tfEnabled;
         private TransformFeedbackPrimitiveType _tfTopology;
 
-        private GAL.SupportBufferUpdater _supportBuffer;
+        private SupportBufferUpdater _supportBuffer;
         private readonly BufferHandle[] _tfbs;
         private readonly BufferRange[] _tfbTargets;
 

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -1408,6 +1408,7 @@ namespace Ryujinx.Graphics.OpenGL
         private void PrepareForDispatch()
         {
             _unit0Texture?.Bind(0);
+            _supportBuffer.Commit();
         }
 
         private void PreDraw()

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -150,7 +150,7 @@ namespace Ryujinx.Graphics.OpenGL
                 GL.Arb.MaxShaderCompilerThreads(Math.Min(Environment.ProcessorCount, 8));
             }
 
-            _pipeline.Initialize();
+            _pipeline.Initialize(this);
             _counters.Initialize();
         }
 

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/DefaultNames.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/DefaultNames.cs
@@ -18,6 +18,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
         public const string SupportBlockName = "support_block";
         public const string SupportBlockAlphaTestName = "s_alpha_test";
         public const string SupportBlockIsBgraName = "s_is_bgra";
+        public const string SupportBlockFragmentScaleCount = "s_frag_scale_count";
         public const string SupportBlockRenderScaleName = "s_render_scale";
 
         public const string BlockSuffix = "block";

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_fp.glsl
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_fp.glsl
@@ -7,7 +7,7 @@
     }
     if (scale < 0.0) // If less than 0, try interpolate between texels by using the screen position.
     {
-        return ivec2(vec2(inputVec) * (-scale) + mod(gl_FragCoord.xy, -scale));
+        return ivec2(vec2(inputVec) * (-scale) + mod(gl_FragCoord.xy, 0.0 - scale));
     }
     else
     {

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_vp.glsl
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_vp.glsl
@@ -1,0 +1,20 @@
+﻿ivec2 Helper_TexelFetchScale(ivec2 inputVec, int samplerIndex)
+{
+    float scale = abs(s_render_scale[1 + samplerIndex + s_frag_scale_count]);
+    if (scale == 1.0)
+    {
+        return inputVec;
+    }
+
+    return ivec2(vec2(inputVec) * scale);
+}
+
+int Helper_TextureSizeUnscale(int size, int samplerIndex)
+{
+    float scale = abs(s_render_scale[1 + samplerIndex + s_frag_scale_count]);
+    if (scale == 1.0)
+    {
+        return size;
+    }
+    return int(float(size) / scale);
+}

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
@@ -85,7 +85,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
 
             string ApplyScaling(string vector)
             {
-                if ((context.Config.Stage == ShaderStage.Fragment || context.Config.Stage == ShaderStage.Compute) &&
+                if ((context.Config.Stage.SupportsRenderScale()) &&
                     texOp.Inst == Instruction.ImageLoad &&
                     !isBindless &&
                     !isIndexed)
@@ -621,7 +621,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
             {
                 if (intCoords)
                 {
-                    if ((context.Config.Stage == ShaderStage.Fragment || context.Config.Stage == ShaderStage.Compute) &&
+                    if ((context.Config.Stage.SupportsRenderScale()) &&
                         !isBindless &&
                         !isIndexed)
                     {
@@ -770,7 +770,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
             {
                 string texCall = $"textureSize({samplerName}, {lodExpr}){GetMask(texOp.Index)}";
 
-                if ((context.Config.Stage == ShaderStage.Fragment || context.Config.Stage == ShaderStage.Compute) &&
+                if (context.Config.Stage.SupportsRenderScale() &&
                     !isBindless &&
                     !isIndexed)
                 {

--- a/Ryujinx.Graphics.Shader/Ryujinx.Graphics.Shader.csproj
+++ b/Ryujinx.Graphics.Shader/Ryujinx.Graphics.Shader.csproj
@@ -5,6 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="CodeGen\Glsl\HelperFunctions\TexelFetchScale_vp.glsl" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Ryujinx.Common\Ryujinx.Common.csproj" />
   </ItemGroup>
 
@@ -20,6 +24,7 @@
     <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\StoreSharedSmallInt.glsl" />
     <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\StoreStorageSmallInt.glsl" />
     <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\SwizzleAdd.glsl" />
+    <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\TexelFetchScale_vp.glsl" />
     <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\TexelFetchScale_fp.glsl" />
     <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\TexelFetchScale_cp.glsl" />
   </ItemGroup>

--- a/Ryujinx.Graphics.Shader/ShaderStage.cs
+++ b/Ryujinx.Graphics.Shader/ShaderStage.cs
@@ -11,4 +11,17 @@ namespace Ryujinx.Graphics.Shader
 
         Count
     }
+
+    public static class ShaderStageExtensions
+    {
+        /// <summary>
+        /// Checks if the shader stage supports render scale.
+        /// </summary>
+        /// <param name="stage">Shader stage</param>
+        /// <returns>True if the shader stage supports render scale, false otherwise</returns>
+        public static bool SupportsRenderScale(this ShaderStage stage)
+        {
+            return stage == ShaderStage.Vertex || stage == ShaderStage.Fragment || stage == ShaderStage.Compute;
+        }
+    }
 }

--- a/Ryujinx.Graphics.Shader/SupportBuffer.cs
+++ b/Ryujinx.Graphics.Shader/SupportBuffer.cs
@@ -7,12 +7,13 @@ namespace Ryujinx.Graphics.Shader
         public const int FragmentAlphaTestOffset = 0;
         public const int FragmentIsBgraOffset = FieldSize;
         public const int FragmentIsBgraCount = 8;
-        public const int FragmentRenderScaleOffset = FragmentIsBgraOffset + FragmentIsBgraCount * FieldSize;
-        public const int ComputeRenderScaleOffset = FragmentRenderScaleOffset + FieldSize; // Skip first scale that is used for the render target
+        public const int FragmentRenderScaleCount = FragmentIsBgraOffset + FragmentIsBgraCount * FieldSize; // Number of fragment render scales. Vertex scales appear after.
+        public const int GraphicsRenderScaleOffset = FragmentRenderScaleCount + FieldSize;
+        public const int ComputeRenderScaleOffset = GraphicsRenderScaleOffset + FieldSize; // Skip first scale that is used for the render target
 
         // One for the render target, 32 for the textures, and 8 for the images.
         public const int RenderScaleMaxCount = 1 + 32 + 8;
 
-        public const int RequiredSize = FragmentRenderScaleOffset + RenderScaleMaxCount * FieldSize;
+        public const int RequiredSize = GraphicsRenderScaleOffset + RenderScaleMaxCount * FieldSize;
     }
 }

--- a/Ryujinx.Graphics.Shader/SupportBuffer.cs
+++ b/Ryujinx.Graphics.Shader/SupportBuffer.cs
@@ -1,19 +1,49 @@
+using Ryujinx.Common.Memory;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
 namespace Ryujinx.Graphics.Shader
 {
-    public static class SupportBuffer
+    public struct Vector4<T>
     {
-        public const int FieldSize = 16; // Each field takes 16 bytes on default layout, even bool.
+        public T X;
+        public T Y;
+        public T Z;
+        public T W;
+    }
 
-        public const int FragmentAlphaTestOffset = 0;
-        public const int FragmentIsBgraOffset = FieldSize;
+    public struct SupportBuffer
+    {
+        public static int FieldSize;
+        public static int RequiredSize;
+
+        public static int FragmentAlphaTestOffset;
+        public static int FragmentIsBgraOffset;
+        public static int FragmentRenderScaleCountOffset;
+        public static int GraphicsRenderScaleOffset;
+        public static int ComputeRenderScaleOffset;
+
         public const int FragmentIsBgraCount = 8;
-        public const int FragmentRenderScaleCount = FragmentIsBgraOffset + FragmentIsBgraCount * FieldSize; // Number of fragment render scales. Vertex scales appear after.
-        public const int GraphicsRenderScaleOffset = FragmentRenderScaleCount + FieldSize;
-        public const int ComputeRenderScaleOffset = GraphicsRenderScaleOffset + FieldSize; // Skip first scale that is used for the render target
-
         // One for the render target, 32 for the textures, and 8 for the images.
         public const int RenderScaleMaxCount = 1 + 32 + 8;
 
-        public const int RequiredSize = GraphicsRenderScaleOffset + RenderScaleMaxCount * FieldSize;
+        static SupportBuffer()
+        {
+            FieldSize = Unsafe.SizeOf<Vector4<float>>();
+            RequiredSize = Unsafe.SizeOf<SupportBuffer>();
+
+            FragmentAlphaTestOffset = (int)Marshal.OffsetOf<SupportBuffer>(nameof(FragmentAlphaTest));
+            FragmentIsBgraOffset = (int)Marshal.OffsetOf<SupportBuffer>(nameof(FragmentIsBgra));
+            FragmentRenderScaleCountOffset = (int)Marshal.OffsetOf<SupportBuffer>(nameof(FragmentRenderScaleCount));
+            GraphicsRenderScaleOffset = (int)Marshal.OffsetOf<SupportBuffer>(nameof(RenderScale));
+            ComputeRenderScaleOffset = GraphicsRenderScaleOffset + FieldSize;
+        }
+
+        public Vector4<int> FragmentAlphaTest;
+        public Array8<Vector4<int>> FragmentIsBgra;
+        public Vector4<int> FragmentRenderScaleCount;
+
+        // Render scale max count: 1 + 32 + 8. First scale is fragment output scale, others are textures/image inputs.
+        public Array41<Vector4<float>> RenderScale;
     }
 }

--- a/Ryujinx.Graphics.Shader/SupportBuffer.cs
+++ b/Ryujinx.Graphics.Shader/SupportBuffer.cs
@@ -1,6 +1,5 @@
 using Ryujinx.Common.Memory;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 namespace Ryujinx.Graphics.Shader
 {
@@ -27,15 +26,22 @@ namespace Ryujinx.Graphics.Shader
         // One for the render target, 32 for the textures, and 8 for the images.
         public const int RenderScaleMaxCount = 1 + 32 + 8;
 
+        private static int OffsetOf<T>(ref SupportBuffer storage, ref T target)
+        {
+            return (int)Unsafe.ByteOffset(ref Unsafe.As<SupportBuffer, T>(ref storage), ref target);
+        }
+
         static SupportBuffer()
         {
             FieldSize = Unsafe.SizeOf<Vector4<float>>();
             RequiredSize = Unsafe.SizeOf<SupportBuffer>();
 
-            FragmentAlphaTestOffset = (int)Marshal.OffsetOf<SupportBuffer>(nameof(FragmentAlphaTest));
-            FragmentIsBgraOffset = (int)Marshal.OffsetOf<SupportBuffer>(nameof(FragmentIsBgra));
-            FragmentRenderScaleCountOffset = (int)Marshal.OffsetOf<SupportBuffer>(nameof(FragmentRenderScaleCount));
-            GraphicsRenderScaleOffset = (int)Marshal.OffsetOf<SupportBuffer>(nameof(RenderScale));
+            SupportBuffer instance = new SupportBuffer();
+
+            FragmentAlphaTestOffset = OffsetOf(ref instance, ref instance.FragmentAlphaTest);
+            FragmentIsBgraOffset = OffsetOf(ref instance, ref instance.FragmentIsBgra);
+            FragmentRenderScaleCountOffset = OffsetOf(ref instance, ref instance.FragmentRenderScaleCount);
+            GraphicsRenderScaleOffset = OffsetOf(ref instance, ref instance.RenderScale);
             ComputeRenderScaleOffset = GraphicsRenderScaleOffset + FieldSize;
         }
 

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -413,7 +413,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             {
                 usageFlags |= TextureUsageFlags.NeedsScaleValue;
 
-                var canScale = (Stage == ShaderStage.Fragment || Stage == ShaderStage.Compute) && !isIndexed && !write && dimensions == 2;
+                var canScale = Stage.SupportsRenderScale() && !isIndexed && !write && dimensions == 2;
 
                 if (!canScale)
                 {


### PR DESCRIPTION
Occasionally games read off textureSize on the vertex stage to inform the fragment shader what size a texture is without querying in there. Scales were not present in the vertex shader to correct the sizes, so games were providing the raw upscaled texture size to the fragment shader, which was incorrect.

One downside is that the fragment and vertex support buffer description must be identical, so the full size scales array must be defined when used. I don't think this will have an impact though. Another is that the fragment texture count must be updated when vertex shader textures are used. I'd like to correct this so that the update is folded into the update for the scales.

Also cleans up a bunch of things, like it making no sense to call CommitRenderScale for each stage.

Fixes render scale causing a weird offset bloom in Super Mario Party and Clubhouse Games. Clubhouse Games still has a pixelated look in a number of its games due to something else it does in the shader.

Before:
![image](https://user-images.githubusercontent.com/6294155/138155541-161beddf-16a1-49be-b605-7f2557a388f8.png)

After:
![smp3x](https://user-images.githubusercontent.com/6294155/138156085-3e7fa756-0b5e-4b10-acfc-e8b633812c2c.jpg)
