### PR TITLE
Map home button

### DIFF
--- a/Ryujinx.Common/Combo/ComboPressedEventArgs.cs
+++ b/Ryujinx.Common/Combo/ComboPressedEventArgs.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Ryujinx.Common.Combo
+{
+    public enum ComboType : uint
+    {
+        SpecialOne,
+        SpecialTwo
+    }
+
+    public class ComboPressedEventArgs : EventArgs
+    {
+        public ComboType Combo;
+
+        public ComboPressedEventArgs(ComboType combo)
+        {
+            Combo = combo;
+        }
+    }
+}

--- a/Ryujinx.Common/Combo/ComboPressedEventArgs.cs
+++ b/Ryujinx.Common/Combo/ComboPressedEventArgs.cs
@@ -4,17 +4,33 @@ namespace Ryujinx.Common.Combo
 {
     public enum ComboType : uint
     {
+        Start,
+        Capture,
         SpecialOne,
         SpecialTwo
     }
 
     public class ComboPressedEventArgs : EventArgs
     {
-        public ComboType Combo;
+        private ComboType Combo;
+        private bool consumed;
 
         public ComboPressedEventArgs(ComboType combo)
         {
             Combo = combo;
+            consumed = false;
+        }
+
+        public ComboType GetCombo() {
+            return Combo;
+        }
+
+        public bool GetConsumed() {
+            return consumed;
+        }
+
+        public void SetConsumed(bool consumed) {
+            this.consumed = consumed;
         }
     }
 }

--- a/Ryujinx.Common/Configuration/Hid/Controller/GamepadInputId.cs
+++ b/Ryujinx.Common/Configuration/Hid/Controller/GamepadInputId.cs
@@ -30,8 +30,8 @@
         Back = Minus,
         Start = Plus,
 
-        Guide,
-        Misc1,
+        Home = Minus,
+        Capture = Plus,
 
         // Xbox Elite paddle
         Paddle1,

--- a/Ryujinx.Common/Configuration/Hid/LeftJoyconCommonConfig.cs
+++ b/Ryujinx.Common/Configuration/Hid/LeftJoyconCommonConfig.cs
@@ -11,5 +11,6 @@
         public Button DpadDown { get; set; }
         public Button DpadLeft { get; set; }
         public Button DpadRight { get; set; }
+        public Button Capture { get; set; }
     }
 }

--- a/Ryujinx.Common/Configuration/Hid/RightJoyconCommonConfig.cs
+++ b/Ryujinx.Common/Configuration/Hid/RightJoyconCommonConfig.cs
@@ -11,5 +11,6 @@
         public Button ButtonB { get; set; }
         public Button ButtonY { get; set; }
         public Button ButtonA { get; set; }
+        public Button Start { get; set; }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/Npad/ControllerKeys.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/Npad/ControllerKeys.cs
@@ -33,6 +33,8 @@ namespace Ryujinx.HLE.HOS.Services.Hid
         SrLeft      = 1 << 25,
         SlRight     = 1 << 26,
         SrRight     = 1 << 27,
+        Home        = 1 << 28,
+        Capture     = 1 << 29,
 
         // Generic Catch-all
         Up    = DpadUp    | LStickUp    | RStickUp,

--- a/Ryujinx.Headless.SDL2/Program.cs
+++ b/Ryujinx.Headless.SDL2/Program.cs
@@ -148,8 +148,8 @@ namespace Ryujinx.Headless.SDL2
                             ButtonMinus  = Key.Minus,
                             ButtonL      = Key.E,
                             ButtonZl     = Key.Q,
-                            ButtonSl     = Key.Unbound,
-                            ButtonSr     = Key.Unbound
+                            ButtonSl     = Key.R,
+                            ButtonSr     = Key.V
                         },
 
                         LeftJoyconStick  = new JoyconConfigKeyboardStick<Key>
@@ -170,8 +170,8 @@ namespace Ryujinx.Headless.SDL2
                             ButtonPlus   = Key.Plus,
                             ButtonR      = Key.U,
                             ButtonZr     = Key.O,
-                            ButtonSl     = Key.Unbound,
-                            ButtonSr     = Key.Unbound
+                            ButtonSl     = Key.Y,
+                            ButtonSr     = Key.N
                         },
 
                         RightJoyconStick = new JoyconConfigKeyboardStick<Key>
@@ -208,8 +208,8 @@ namespace Ryujinx.Headless.SDL2
                             ButtonMinus  = ConfigGamepadInputId.Minus,
                             ButtonL      = ConfigGamepadInputId.LeftShoulder,
                             ButtonZl     = ConfigGamepadInputId.LeftTrigger,
-                            ButtonSl     = ConfigGamepadInputId.Unbound,
-                            ButtonSr     = ConfigGamepadInputId.Unbound,
+                            ButtonSl     = ConfigGamepadInputId.SingleLeftTrigger0,
+                            ButtonSr     = ConfigGamepadInputId.SingleRightTrigger0,
                         },
 
                         LeftJoyconStick = new JoyconConfigControllerStick<ConfigGamepadInputId, ConfigStickInputId>
@@ -230,8 +230,8 @@ namespace Ryujinx.Headless.SDL2
                             ButtonPlus   = ConfigGamepadInputId.Plus,
                             ButtonR      = ConfigGamepadInputId.RightShoulder,
                             ButtonZr     = ConfigGamepadInputId.RightTrigger,
-                            ButtonSl     = ConfigGamepadInputId.Unbound,
-                            ButtonSr     = ConfigGamepadInputId.Unbound,
+                            ButtonSl     = ConfigGamepadInputId.SingleLeftTrigger1,
+                            ButtonSr     = ConfigGamepadInputId.SingleRightTrigger1,
                         },
 
                         RightJoyconStick = new JoyconConfigControllerStick<ConfigGamepadInputId, ConfigStickInputId>

--- a/Ryujinx.Input.SDL2/SDL2Gamepad.cs
+++ b/Ryujinx.Input.SDL2/SDL2Gamepad.cs
@@ -244,6 +244,7 @@ namespace Ryujinx.Input.SDL2
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.LeftTrigger, (GamepadButtonInputId)_configuration.LeftJoycon.ButtonZl));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.SingleRightTrigger0, (GamepadButtonInputId)_configuration.LeftJoycon.ButtonSr));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.SingleLeftTrigger0, (GamepadButtonInputId)_configuration.LeftJoycon.ButtonSl));
+                _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.Capture, (GamepadButtonInputId)_configuration.LeftJoycon.Capture));
 
                 // Finally right joycon
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.RightStick, (GamepadButtonInputId)_configuration.RightJoyconStick.StickButton));
@@ -256,6 +257,7 @@ namespace Ryujinx.Input.SDL2
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.RightTrigger, (GamepadButtonInputId)_configuration.RightJoycon.ButtonZr));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.SingleRightTrigger1, (GamepadButtonInputId)_configuration.RightJoycon.ButtonSr));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.SingleLeftTrigger1, (GamepadButtonInputId)_configuration.RightJoycon.ButtonSl));
+                _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.Home, (GamepadButtonInputId)_configuration.RightJoycon.Home));
 
                 SetTriggerThreshold(_configuration.TriggerThreshold);
             }

--- a/Ryujinx.Input.SDL2/SDL2Keyboard.cs
+++ b/Ryujinx.Input.SDL2/SDL2Keyboard.cs
@@ -384,6 +384,7 @@ namespace Ryujinx.Input.SDL2
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.LeftTrigger, (Key)_configuration.LeftJoycon.ButtonZl));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.SingleRightTrigger0, (Key)_configuration.LeftJoycon.ButtonSr));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.SingleLeftTrigger0, (Key)_configuration.LeftJoycon.ButtonSl));
+                _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.Capture, (Key)_configuration.LeftJoycon.Capture));
 
                 // Finally configure right joycon
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.RightStick, (Key)_configuration.RightJoyconStick.StickButton));
@@ -396,6 +397,7 @@ namespace Ryujinx.Input.SDL2
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.RightTrigger, (Key)_configuration.RightJoycon.ButtonZr));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.SingleRightTrigger1, (Key)_configuration.RightJoycon.ButtonSr));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.SingleLeftTrigger1, (Key)_configuration.RightJoycon.ButtonSl));
+                _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.Home, (Key)_configuration.RightJoycon.Home));
             }
         }
 

--- a/Ryujinx.Input/GamepadButtonInputId.cs
+++ b/Ryujinx.Input/GamepadButtonInputId.cs
@@ -33,8 +33,8 @@
         Back = Minus,
         Start = Plus,
 
-        Guide,
-        Misc1,
+        Home,
+        Capture,
 
         // Xbox Elite paddle
         Paddle1,

--- a/Ryujinx.Input/HLE/NpadController.cs
+++ b/Ryujinx.Input/HLE/NpadController.cs
@@ -47,6 +47,8 @@ namespace Ryujinx.Input.HLE
             new HLEButtonMappingEntry(GamepadButtonInputId.DpadRight, ControllerKeys.DpadRight),
             new HLEButtonMappingEntry(GamepadButtonInputId.Minus, ControllerKeys.Minus),
             new HLEButtonMappingEntry(GamepadButtonInputId.Plus, ControllerKeys.Plus),
+            new HLEButtonMappingEntry(GamepadButtonInputId.Home, ControllerKeys.Home),
+            new HLEButtonMappingEntry(GamepadButtonInputId.Capture, ControllerKeys.Capture),
 
             new HLEButtonMappingEntry(GamepadButtonInputId.SingleLeftTrigger0, ControllerKeys.SlLeft),
             new HLEButtonMappingEntry(GamepadButtonInputId.SingleRightTrigger0, ControllerKeys.SrLeft),

--- a/Ryujinx.Input/HLE/NpadManager.cs
+++ b/Ryujinx.Input/HLE/NpadManager.cs
@@ -1,3 +1,4 @@
+using Ryujinx.Common.Combo;
 using Ryujinx.Common.Configuration.Hid;
 using Ryujinx.Common.Configuration.Hid.Controller;
 using Ryujinx.Common.Configuration.Hid.Controller.Motion;
@@ -34,6 +35,7 @@ namespace Ryujinx.Input.HLE
         private bool _enableKeyboard;
         private bool _enableMouse;
         private Switch _device;
+        public event EventHandler<ComboPressedEventArgs> ComboPressed;
 
         public NpadManager(IGamepadDriver keyboardDriver, IGamepadDriver gamepadDriver, IGamepadDriver mouseDriver)
         {
@@ -185,6 +187,16 @@ namespace Ryujinx.Input.HLE
 
                         inputState.Buttons |= _device.Hid.UpdateStickButtons(inputState.LStick, inputState.RStick);
 
+                        ControllerKeys specialCombo1 = ControllerKeys.Minus|ControllerKeys.L|ControllerKeys.Plus|ControllerKeys.R;
+                        ControllerKeys specialCombo2 = ControllerKeys.Minus|ControllerKeys.Plus;
+
+                        if ((inputState.Buttons & specialCombo1) == specialCombo1) {
+                            OnComboPressed(new ComboPressedEventArgs(ComboType.SpecialOne));
+                        }
+                        else if ((inputState.Buttons & specialCombo2) == specialCombo2) {
+                            OnComboPressed(new ComboPressedEventArgs(ComboType.SpecialTwo));
+                        }
+
                         isJoyconPair = inputConfig.ControllerType == Common.Configuration.Hid.ControllerType.JoyconPair;
 
                         var altMotionState = isJoyconPair ? controller.GetHLEMotionState(true) : default;
@@ -268,6 +280,11 @@ namespace Ryujinx.Input.HLE
 
                 _device.TamperMachine.UpdateInput(hleInputStates);
             }
+        }
+
+        protected void OnComboPressed(ComboPressedEventArgs args)
+        {
+            ComboPressed?.Invoke(null, args);
         }
 
         internal InputConfig GetPlayerInputConfigByIndex(int index)

--- a/Ryujinx.Input/HLE/NpadManager.cs
+++ b/Ryujinx.Input/HLE/NpadManager.cs
@@ -155,6 +155,11 @@ namespace Ryujinx.Input.HLE
             ReloadConfiguration(inputConfig, enableKeyboard, enableMouse);
         }
 
+        private static bool checkButton(ControllerKeys buttons, ControllerKeys check)
+        {
+            return (buttons & check) == check;
+        }
+
         public void Update(float aspectRatio = 0)
         {
             lock (_lock)
@@ -187,14 +192,25 @@ namespace Ryujinx.Input.HLE
 
                         inputState.Buttons |= _device.Hid.UpdateStickButtons(inputState.LStick, inputState.RStick);
 
-                        ControllerKeys specialCombo1 = ControllerKeys.Minus|ControllerKeys.L|ControllerKeys.Plus|ControllerKeys.R;
-                        ControllerKeys specialCombo2 = ControllerKeys.Minus|ControllerKeys.Plus;
+                        ControllerKeys SpecialCombo1 = ControllerKeys.Minus|ControllerKeys.L|ControllerKeys.Plus|ControllerKeys.R;
+                        ControllerKeys SpecialCombo2 = ControllerKeys.Minus|ControllerKeys.Plus;
 
-                        if ((inputState.Buttons & specialCombo1) == specialCombo1) {
+                        if (checkButton(inputState.Buttons, SpecialCombo1)) {
                             OnComboPressed(new ComboPressedEventArgs(ComboType.SpecialOne));
                         }
-                        else if ((inputState.Buttons & specialCombo2) == specialCombo2) {
+                        else if (checkButton(inputState.Buttons, SpecialCombo2)) {
                             OnComboPressed(new ComboPressedEventArgs(ComboType.SpecialTwo));
+                        }
+                        /*else if (checkButton(inputState.Buttons, ControllerKeys.Home)) {
+                            ComboPressedEventArgs args = new ComboPressedEventArgs(ComboType.Home);
+                            OnComboPressed(args);
+                            if (args.GetConsumed()) {
+                               Dispose();
+                               return;
+                            }
+                        }*/
+                        else if (checkButton(inputState.Buttons, ControllerKeys.Capture)) {
+                            OnComboPressed(new ComboPressedEventArgs(ComboType.Capture));
                         }
 
                         isJoyconPair = inputConfig.ControllerType == Common.Configuration.Hid.ControllerType.JoyconPair;

--- a/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
+++ b/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
@@ -670,8 +670,9 @@ namespace Ryujinx.Ui.Common.Configuration
                             ButtonMinus  = Key.Minus,
                             ButtonL      = Key.E,
                             ButtonZl     = Key.Q,
-                            ButtonSl     = Key.Unbound,
-                            ButtonSr     = Key.Unbound
+                            ButtonSl     = Key.R,
+                            ButtonSr     = Key.V,
+                            Capture      = Key.PrintScreen
                         },
 
                         LeftJoyconStick  = new JoyconConfigKeyboardStick<Key>
@@ -692,8 +693,9 @@ namespace Ryujinx.Ui.Common.Configuration
                             ButtonPlus   = Key.Plus,
                             ButtonR      = Key.U,
                             ButtonZr     = Key.O,
-                            ButtonSl     = Key.Unbound,
-                            ButtonSr     = Key.Unbound
+                            ButtonSl     = Key.Y,
+                            ButtonSr     = Key.N,
+                            Home         = Key.Home
                         },
 
                         RightJoyconStick = new JoyconConfigKeyboardStick<Key>
@@ -888,8 +890,9 @@ namespace Ryujinx.Ui.Common.Configuration
                                 ButtonMinus  = Key.Minus,
                                 ButtonL      = Key.E,
                                 ButtonZl     = Key.Q,
-                                ButtonSl     = Key.Unbound,
-                                ButtonSr     = Key.Unbound
+                                ButtonSl     = Key.R,
+                                ButtonSr     = Key.V,
+                                Capture      = Key.PrintScreen
                             },
 
                             LeftJoyconStick  = new JoyconConfigKeyboardStick<Key>
@@ -910,8 +913,9 @@ namespace Ryujinx.Ui.Common.Configuration
                                 ButtonPlus   = Key.Plus,
                                 ButtonR      = Key.U,
                                 ButtonZr     = Key.O,
-                                ButtonSl     = Key.Unbound,
-                                ButtonSr     = Key.Unbound
+                                ButtonSl     = Key.Y,
+                                ButtonSr     = Key.N,
+                                Home         = Key.Home
                             },
 
                             RightJoyconStick = new JoyconConfigKeyboardStick<Key>

--- a/Ryujinx/Input/GTK3/GTK3Keyboard.cs
+++ b/Ryujinx/Input/GTK3/GTK3Keyboard.cs
@@ -52,7 +52,8 @@ namespace Ryujinx.Input.GTK3
 
         public KeyboardStateSnapshot GetKeyboardStateSnapshot()
         {
-            return IKeyboard.GetStateSnapshot(this);
+            KeyboardStateSnapshot snapshot = IKeyboard.GetStateSnapshot(this);
+            return snapshot;
         }
 
         private static float ConvertRawStickValue(short value)
@@ -169,6 +170,7 @@ namespace Ryujinx.Input.GTK3
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.LeftTrigger, (Key)_configuration.LeftJoycon.ButtonZl));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.SingleRightTrigger0, (Key)_configuration.LeftJoycon.ButtonSr));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.SingleLeftTrigger0, (Key)_configuration.LeftJoycon.ButtonSl));
+                _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.Capture, (Key)_configuration.LeftJoycon.Capture));
 
                 // Finally right joycon
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.RightStick, (Key)_configuration.RightJoyconStick.StickButton));
@@ -181,6 +183,7 @@ namespace Ryujinx.Input.GTK3
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.RightTrigger, (Key)_configuration.RightJoycon.ButtonZr));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.SingleRightTrigger1, (Key)_configuration.RightJoycon.ButtonSr));
                 _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.SingleLeftTrigger1, (Key)_configuration.RightJoycon.ButtonSl));
+                _buttonsUserMapping.Add(new ButtonMappingEntry(GamepadButtonInputId.Home, (Key)_configuration.RightJoycon.Home));
             }
         }
 

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -13,6 +13,7 @@ using Ryujinx.Audio.Backends.SDL2;
 using Ryujinx.Audio.Backends.SoundIo;
 using Ryujinx.Audio.Integration;
 using Ryujinx.Common;
+using Ryujinx.Common.Combo;
 using Ryujinx.Common.Configuration;
 using Ryujinx.Common.Logging;
 using Ryujinx.Common.System;
@@ -963,6 +964,11 @@ namespace Ryujinx.Ui
 
             DisplaySleep.Prevent();
 
+            if (runOnce)
+            {
+                RendererWidget.ComboPressed += Combo_Pressed;
+            }
+
             RendererWidget.Initialize(_emulationContext);
 
             RendererWidget.WaitEvent.WaitOne();
@@ -980,6 +986,26 @@ namespace Ryujinx.Ui
             {
                 SwitchToGameTable();
             });
+        }
+
+        private void Combo_Pressed(object sender, ComboPressedEventArgs args)
+        {
+            if (args.Combo == ComboType.SpecialOne)
+            {
+                Logger.Info?.Print(LogClass.Application, "Exit from game");
+                Thread applicationLibraryThread = new Thread(() =>
+                {
+                    End();
+                });
+                applicationLibraryThread.Name         = "GUI.ApplicationLibraryThread";
+                applicationLibraryThread.IsBackground = true;
+                applicationLibraryThread.Start();
+            }
+            else if (args.Combo == ComboType.SpecialTwo)
+            {
+                Logger.Info?.Print(LogClass.Application, "WakeupCombo");
+                Simulate_WakeUp_Message_Pressed(null, null);
+            }
         }
 
         private void RecreateFooterForMenu()

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -964,10 +964,10 @@ namespace Ryujinx.Ui
 
             DisplaySleep.Prevent();
 
-            if (runOnce)
-            {
-                RendererWidget.ComboPressed += Combo_Pressed;
-            }
+            //if (runOnce)
+            //{
+                RendererWidget.ComboPressed += OnComboPressed;
+            //}
 
             RendererWidget.Initialize(_emulationContext);
 
@@ -988,11 +988,12 @@ namespace Ryujinx.Ui
             });
         }
 
-        private void Combo_Pressed(object sender, ComboPressedEventArgs args)
+        private void OnComboPressed(object sender, ComboPressedEventArgs args)
         {
-            if (args.Combo == ComboType.SpecialOne)
+            ComboType Combo = args.GetCombo();
+            if (Combo == ComboType.SpecialOne)
             {
-                Logger.Info?.Print(LogClass.Application, "Exit from game");
+                Logger.Info?.Print(LogClass.Application, "Exit from Ryujinx");
                 Thread applicationLibraryThread = new Thread(() =>
                 {
                     End();
@@ -1001,10 +1002,15 @@ namespace Ryujinx.Ui
                 applicationLibraryThread.IsBackground = true;
                 applicationLibraryThread.Start();
             }
-            else if (args.Combo == ComboType.SpecialTwo)
+            else if (Combo == ComboType.SpecialTwo)
             {
                 Logger.Info?.Print(LogClass.Application, "WakeupCombo");
                 Simulate_WakeUp_Message_Pressed(null, null);
+            }
+            else if (Combo == ComboType.Capture)
+            {
+                Logger.Info?.Print(LogClass.Application, "Capture button pressed");
+                TakeScreenshot();
             }
         }
 
@@ -1349,6 +1355,11 @@ namespace Ryujinx.Ui
 
         private void StopEmulation_Pressed(object sender, EventArgs args)
         {
+            StopEmulation();
+        }
+
+        private void StopEmulation()
+        {
             if (_emulationContext != null)
             {
                 UpdateGameMetadata(_emulationContext.Application.TitleIdText);
@@ -1647,7 +1658,12 @@ namespace Ryujinx.Ui
             }
         }
 
-        private void Take_Screenshot(object sender, EventArgs args)
+        private void TakeScreenshot_pressed(object sender, EventArgs args)
+        {
+            TakeScreenshot();
+        }
+
+        private void TakeScreenshot()
         {
             if (_emulationContext != null && RendererWidget != null)
             {

--- a/Ryujinx/Ui/MainWindow.glade
+++ b/Ryujinx/Ui/MainWindow.glade
@@ -364,7 +364,7 @@
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Take a screenshot</property>
                         <property name="label" translatable="yes">Take Screenshot</property>
-                        <signal name="activate" handler="Take_Screenshot" swapped="no"/>
+                        <signal name="activate" handler="TakeScreenshot_pressed" swapped="no"/>
                       </object>
                     </child>
                     <child>

--- a/Ryujinx/Ui/RendererWidgetBase.cs
+++ b/Ryujinx/Ui/RendererWidgetBase.cs
@@ -3,6 +3,7 @@ using ARMeilleure.Translation.PTC;
 using Gdk;
 using Gtk;
 using Ryujinx.Common;
+using Ryujinx.Common.Combo;
 using Ryujinx.Common.Configuration;
 using Ryujinx.Common.Logging;
 using Ryujinx.Ui.Common.Configuration;
@@ -47,6 +48,7 @@ namespace Ryujinx.Ui
         protected int WindowHeight { get; private set; }
 
         public static event EventHandler<StatusUpdatedEventArgs> StatusUpdatedEvent;
+        public event EventHandler<ComboPressedEventArgs>         ComboPressed;
 
         private bool _isActive;
         private bool _isStopped;
@@ -84,6 +86,7 @@ namespace Ryujinx.Ui
             _inputManager = inputManager;
             _inputManager.SetMouseDriver(mouseDriver);
             NpadManager = _inputManager.CreateNpadManager();
+            NpadManager.ComboPressed += Combo_Pressed;
             TouchScreenManager = _inputManager.CreateTouchScreenManager();
             _keyboardInterface = (IKeyboard)_inputManager.KeyboardDriver.GetGamepad("0");
 
@@ -708,6 +711,11 @@ namespace Ryujinx.Ui
             }
 
             return state;
+        }
+
+        private void Combo_Pressed(object sender, ComboPressedEventArgs args)
+        {
+            ComboPressed?.Invoke(null, args);
         }
     }
 }

--- a/Ryujinx/Ui/Windows/ControllerWindow.cs
+++ b/Ryujinx/Ui/Windows/ControllerWindow.cs
@@ -603,7 +603,8 @@ namespace Ryujinx.Ui.Windows
                         DpadUp       = lDPadUp,
                         DpadDown     = lDPadDown,
                         DpadLeft     = lDPadLeft,
-                        DpadRight    = lDPadRight
+                        DpadRight    = lDPadRight,
+                        Capture      = Key.PrintScreen
                     },
                     LeftJoyconStick = new JoyconConfigKeyboardStick<Key>
                     {
@@ -623,7 +624,8 @@ namespace Ryujinx.Ui.Windows
                         ButtonR      = rButtonR,
                         ButtonZr     = rButtonZr,
                         ButtonSl     = rButtonSl,
-                        ButtonSr     = rButtonSr
+                        ButtonSr     = rButtonSr,
+                        Home         = Key.Home
                     },
                     RightJoyconStick = new JoyconConfigKeyboardStick<Key>
                     {
@@ -714,7 +716,8 @@ namespace Ryujinx.Ui.Windows
                         DpadUp       = lDPadUp,
                         DpadDown     = lDPadDown,
                         DpadLeft     = lDPadLeft,
-                        DpadRight    = lDPadRight
+                        DpadRight    = lDPadRight,
+                        Capture      = ConfigGamepadInputId.Capture
                     },
                     LeftJoyconStick = new JoyconConfigControllerStick<ConfigGamepadInputId, ConfigStickInputId>
                     {
@@ -734,7 +737,8 @@ namespace Ryujinx.Ui.Windows
                         ButtonR      = rButtonR,
                         ButtonZr     = rButtonZr,
                         ButtonSl     = rButtonSl,
-                        ButtonSr     = rButtonSr
+                        ButtonSr     = rButtonSr,
+                        Home         = ConfigGamepadInputId.Home
                     },
                     RightJoyconStick = new JoyconConfigControllerStick<ConfigGamepadInputId, ConfigStickInputId>
                     {
@@ -992,8 +996,9 @@ namespace Ryujinx.Ui.Windows
                             ButtonMinus  = Key.Minus,
                             ButtonL      = Key.E,
                             ButtonZl     = Key.Q,
-                            ButtonSl     = Key.Unbound,
-                            ButtonSr     = Key.Unbound
+                            ButtonSl     = Key.R,
+                            ButtonSr     = Key.V,
+                            Capture      = Key.PrintScreen
                         },
 
                         LeftJoyconStick  = new JoyconConfigKeyboardStick<Key>
@@ -1014,8 +1019,9 @@ namespace Ryujinx.Ui.Windows
                             ButtonPlus   = Key.Plus,
                             ButtonR      = Key.U,
                             ButtonZr     = Key.O,
-                            ButtonSl     = Key.Unbound,
-                            ButtonSr     = Key.Unbound
+                            ButtonSl     = Key.Y,
+                            ButtonSr     = Key.N,
+                            Home         = Key.Home
                         },
 
                         RightJoyconStick = new JoyconConfigKeyboardStick<Key>


### PR DESCRIPTION
Implemented on top of #2131 (to be removed)

Fixes #2718 

Allow to listen to home butotn in joycon or keyboard.

final goal is to be able to go back to game selection (so it will ask to stop emulation with emulation dialog) but it can ask to setup new controllers.

Nowadays this are the only functions I use home for in real nintendo switch and I miss that on emulator (stop game, select another, setup new controllers)


