### PR TITLE
sdl2: Enable GameCube controller support

### DIFF
--- a/Ryujinx.SDL2.Common/SDL2Driver.cs
+++ b/Ryujinx.SDL2.Common/SDL2Driver.cs
@@ -58,6 +58,7 @@ namespace Ryujinx.SDL2.Common
                 SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
                 SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_SWITCH_HOME_LED, "0");
                 SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_JOY_CONS, "1");
+                SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_GAMECUBE, "1");
 
                 if (SDL_Init(SdlInitFlags) != 0)
                 {


### PR DESCRIPTION
This PR set the SDL2 hint to allow GameCube controller to be supported.

Feedback as always needed.