### PR TITLE
When waiting on CPU, do not return a time out error from EventWait

### DIFF
--- a/Ryujinx.Graphics.Gpu/Synchronization/SyncpointWaiterHandle.cs
+++ b/Ryujinx.Graphics.Gpu/Synchronization/SyncpointWaiterHandle.cs
@@ -4,7 +4,7 @@ namespace Ryujinx.Graphics.Gpu.Synchronization
 {
     public class SyncpointWaiterHandle
     {
-        internal uint   Threshold;
+        internal uint Threshold;
         internal Action<SyncpointWaiterHandle> Callback;
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostCtrl/Types/NvHostEvent.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostCtrl/Types/NvHostEvent.cs
@@ -130,11 +130,11 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostCtrl
                 {
                     Logger.Warning?.Print(LogClass.ServiceNv, "GPU processing thread is too slow, waiting on CPU...");
 
-                    bool timedOut = Fence.Wait(gpuContext, Timeout.InfiniteTimeSpan);
+                    Fence.Wait(gpuContext, Timeout.InfiniteTimeSpan);
 
                     ResetFailingState();
 
-                    return timedOut;
+                    return false;
                 }
                 else
                 {


### PR DESCRIPTION
It seems that #2739 introduced timeouts where they didn't exist before. This might be because before this change, it could return without waiting in some cases (which is not correct). After the change that allows it to actually wait properly, things like shader compilation started causing timeouts which makes some game assert. Now the CPU waits are supposed to prevent this, and I assumed they could never timeout since it passes a infinite timespan, but...
```cs
            // TODO: Remove this when GPU channel scheduling will be implemented.
            if (timeout == Timeout.InfiniteTimeSpan)
            {
                timeout = TimeSpan.FromSeconds(1);
            }
```
This codes forces the timeout to 1s when it is infinite, so it *might* timeout. So to fix this, I changed it to return "false" even when there is a timeout, to avoid guest asserts. Also the code is not set up to avoid this right now, as it does not set the state to `Waiting` for example.