### PR TITLE
Nickname! - Init Amiibos with Profile's name!

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/INfp.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/INfp.cs
@@ -688,7 +688,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
                     {
                         if (context.Device.System.NfpDevices[i].State == NfpDeviceState.TagMounted)
                         {
-                            RegisterInfo registerInfo = VirtualAmiibo.GetRegisterInfo(context.Device.System.NfpDevices[i].AmiiboId);
+                            RegisterInfo registerInfo = VirtualAmiibo.GetRegisterInfo(context.Device.System.NfpDevices[i].AmiiboId, context.Device.System.AccountManager.LastOpenedUser.Name);
 
                             context.Memory.Write(outputPosition, registerInfo);
 

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
@@ -72,8 +72,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
 
             charInfo.SetFromStoreData(StoreData.BuildDefault(utilityImpl, 0));
 
-            // TODO: Maybe change the "no name" by the player name when user profile will be implemented.
-            // charInfo.Nickname = Nickname.FromString("Nickname");
+            charInfo.Nickname = Nickname.FromString("Nickname");
 
             RegisterInfo registerInfo = new RegisterInfo()
             {

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
@@ -85,8 +85,6 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
                 Reserved2       = new Array58<byte>()
             };
 
-            Encoding.ASCII.GetBytes("Ryujinx").CopyTo(registerInfo.Nickname.ToSpan());
-
             return registerInfo;
         }
 

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
@@ -84,7 +84,6 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
                 Reserved1       = new Array64<byte>(),
                 Reserved2       = new Array58<byte>()
             };
-            
             Encoding.ASCII.GetBytes("Ryujinx").CopyTo(registerInfo.Nickname.ToSpan());
 
             return registerInfo;

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
@@ -72,7 +72,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
 
             charInfo.SetFromStoreData(StoreData.BuildDefault(utilityImpl, 0));
 
-            charInfo.Nickname = Nickname.FromString("Nickname");
+            charInfo.Nickname = Nickname.FromString(nickname);
 
             RegisterInfo registerInfo = new RegisterInfo()
             {

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
@@ -63,7 +63,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
             };
         }
 
-        public static RegisterInfo GetRegisterInfo(string amiiboId)
+        public static RegisterInfo GetRegisterInfo(string amiiboId, string nickname)
         {
             VirtualAmiiboFile amiiboFile = LoadAmiiboFile(amiiboId);
 

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
@@ -84,6 +84,8 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
                 Reserved1       = new Array64<byte>(),
                 Reserved2       = new Array58<byte>()
             };
+            
+            Encoding.ASCII.GetBytes("Ryujinx").CopyTo(registerInfo.Nickname.ToSpan());
 
             return registerInfo;
         }


### PR DESCRIPTION
# No Name? Nickname!
*Totally not a joke to an earlier implementation*

Instead of the user being a blank "No Name", I decided to attempt to change a Todo to be actually functional now that we have UserProfiles. Now when amiibos request to have their owner's name, instead of "No Name" being used, it uses the name of the current profile!