### PR TITLE
Removed not accurate stub log

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/IResolver.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/IResolver.cs
@@ -410,8 +410,6 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
 
             ulong pidPlaceHolder = context.RequestData.ReadUInt64();
 
-            Logger.Stub?.PrintStub(LogClass.ServiceSfdnsres, new { enableNsdResolve, cancelHandle, pidPlaceHolder, host, service });
-
             IPHostEntry hostEntry = null;
 
             NetDbError netDbErrorCode = NetDbError.Success;


### PR DESCRIPTION
Hi
A really tiny thing I saw while fiddling around on the codebase

As far as I'm aware. The `GetAddrInfoRequestImpl` method is indeed working.

Unless the stub logging is there because of the method ignoring things, which I don't think it's the case.

Sorry if this is not useful and thanks for maintaining this great project.
Thanks.