### PR TITLE
Ensure syncpoints are released and event handles closed on channel close

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostChannel/NvHostChannelDeviceFile.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostChannel/NvHostChannelDeviceFile.cs
@@ -542,6 +542,18 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostChannel
         {
             _host1xContext.Host1x.DestroyContext(_contextId);
             Channel.Dispose();
+
+            for (int i = 0; i < MaxModuleSyncpoint; i++)
+            {
+                if (ChannelSyncpoints[i] != 0)
+                {
+                    _device.System.HostSyncpoint.ReleaseSyncpoint(ChannelSyncpoints[i]);
+                    ChannelSyncpoints[i] = 0;
+                }
+            }
+
+            _device.System.HostSyncpoint.ReleaseSyncpoint(_channelSyncpoint.Id);
+            _channelSyncpoint.Id = 0;
         }
 
         private static Host1xContext GetHost1XContext(GpuContext gpu, long pid)

--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostChannel/NvHostGpuDeviceFile.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostChannel/NvHostGpuDeviceFile.cs
@@ -12,11 +12,27 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostChannel
         private KEvent _smExceptionBptPauseReportEvent;
         private KEvent _errorNotifierEvent;
 
+        private int _smExceptionBptIntReportEventHandle;
+        private int _smExceptionBptPauseReportEventHandle;
+        private int _errorNotifierEventHandle;
+
         public NvHostGpuDeviceFile(ServiceCtx context, IVirtualMemoryManager memory, long owner) : base(context, memory, owner)
         {
-            _smExceptionBptIntReportEvent   = new KEvent(context.Device.System.KernelContext);
-            _smExceptionBptPauseReportEvent = new KEvent(context.Device.System.KernelContext);
-            _errorNotifierEvent             = new KEvent(context.Device.System.KernelContext);
+            _smExceptionBptIntReportEvent   = CreateEvent(context, out _smExceptionBptIntReportEventHandle);
+            _smExceptionBptPauseReportEvent = CreateEvent(context, out _smExceptionBptPauseReportEventHandle);
+            _errorNotifierEvent             = CreateEvent(context, out _errorNotifierEventHandle);
+        }
+
+        private static KEvent CreateEvent(ServiceCtx context, out int handle)
+        {
+            KEvent evnt = new KEvent(context.Device.System.KernelContext);
+
+            if (context.Process.HandleTable.GenerateHandle(evnt.ReadableEvent, out handle) != KernelResult.Success)
+            {
+                throw new InvalidOperationException("Out of handles!");
+            }
+
+            return evnt;
         }
 
         public override NvInternalResult Ioctl2(NvIoctl command, Span<byte> arguments, Span<byte> inlineInBuffer)
@@ -39,41 +55,51 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostChannel
         public override NvInternalResult QueryEvent(out int eventHandle, uint eventId)
         {
             // TODO: accurately represent and implement those events.
-            KEvent targetEvent = null;
-
             switch (eventId)
             {
                 case 0x1:
-                    targetEvent = _smExceptionBptIntReportEvent;
+                    eventHandle = _smExceptionBptIntReportEventHandle;
                     break;
                 case 0x2:
-                    targetEvent = _smExceptionBptPauseReportEvent;
+                    eventHandle = _smExceptionBptPauseReportEventHandle;
                     break;
                 case 0x3:
-                    targetEvent = _errorNotifierEvent;
+                    eventHandle = _errorNotifierEventHandle;
+                    break;
+                default:
+                    eventHandle = 0;
                     break;
             }
 
-            if (targetEvent != null)
-            {
-                if (Context.Process.HandleTable.GenerateHandle(targetEvent.ReadableEvent, out eventHandle) != KernelResult.Success)
-                {
-                    throw new InvalidOperationException("Out of handles!");
-                }
-            }
-            else
-            {
-                eventHandle = 0;
-
-                return NvInternalResult.InvalidInput;
-            }
-
-            return NvInternalResult.Success;
+            return eventHandle != 0 ? NvInternalResult.Success : NvInternalResult.InvalidInput;
         }
 
         private NvInternalResult SubmitGpfifoEx(ref SubmitGpfifoArguments arguments, Span<ulong> inlineData)
         {
             return SubmitGpfifo(ref arguments, inlineData);
+        }
+
+        public override void Close()
+        {
+            if (_smExceptionBptIntReportEventHandle != 0)
+            {
+                Context.Process.HandleTable.CloseHandle(_smExceptionBptIntReportEventHandle);
+                _smExceptionBptIntReportEventHandle = 0;
+            }
+
+            if (_smExceptionBptPauseReportEventHandle != 0)
+            {
+                Context.Process.HandleTable.CloseHandle(_smExceptionBptPauseReportEventHandle);
+                _smExceptionBptPauseReportEventHandle = 0;
+            }
+
+            if (_errorNotifierEventHandle != 0)
+            {
+                Context.Process.HandleTable.CloseHandle(_errorNotifierEventHandle);
+                _errorNotifierEventHandle = 0;
+            }
+
+            base.Close();
         }
     }
 }


### PR DESCRIPTION
First, fixes syncpoints not being released when the channel is closed. This fixes this error:
```
Cannot allocate a new syncpoint!
```
that would be printed on the log on games that creates lots of channels. I'm not sure what the effect of this syncpoint allocation failing was, but it did not cause games to crash as far I can tell.

The second issue this fixes is event handles not being closed. In special those returned by `QueryEvent`. This was causing Legend of Mana and maybe other games to crash with the "Out of handles!" exception. This should be also fixed now, as events are closed when the channel is closed, or when the event is unregistered.

I recommend testing a few games to be sure nothing regressed.

Closes #2809.