### PR TITLE
Fix InvocationInfo on geometry shader and bindless default integer const

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -40,7 +40,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2768;
+        private const ulong ShaderCodeGenVersion = 2822;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
@@ -18,12 +18,16 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
             // TODO: Bindless texture support. For now we just return 0/do nothing.
             if (isBindless)
             {
-                return texOp.Inst switch
+                switch (texOp.Inst)
                 {
-                    Instruction.ImageStore => "// imageStore(bindless)",
-                    Instruction.ImageLoad => NumberFormatter.FormatFloat(0),
-                    _ => NumberFormatter.FormatInt(0)
-                };
+                    case Instruction.ImageStore:
+                        return "// imageStore(bindless)";
+                    case Instruction.ImageLoad:
+                        NumberFormatter.TryFormat(0, texOp.Format.GetComponentType(), out string imageConst);
+                        return imageConst;
+                    default:
+                        return NumberFormatter.FormatInt(0);
+                }
             }
 
             bool isArray   = (texOp.Type & SamplerType.Array)   != 0;

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitMove.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitMove.cs
@@ -112,7 +112,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
                                 InputTopology.LinesAdjacency => 2,
                                 InputTopology.Triangles or
                                 InputTopology.TrianglesAdjacency => 3,
-                                _ => 3
+                                _ => 1
                             };
 
                             patchVerticesIn = Const(inputVertices << 16);

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitMove.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitMove.cs
@@ -95,9 +95,28 @@ namespace Ryujinx.Graphics.Shader.Instructions
                     if (context.Config.Stage != ShaderStage.Compute && context.Config.Stage != ShaderStage.Fragment)
                     {
                         Operand primitiveId = Attribute(AttributeConsts.PrimitiveId);
-                        Operand patchVerticesIn = Attribute(AttributeConsts.PatchVerticesIn);
+                        Operand patchVerticesIn;
 
-                        patchVerticesIn = context.ShiftLeft(patchVerticesIn, Const(16));
+                        if (context.Config.Stage == ShaderStage.TessellationEvaluation)
+                        {
+                            patchVerticesIn = context.ShiftLeft(Attribute(AttributeConsts.PatchVerticesIn), Const(16));
+                        }
+                        else
+                        {
+                            InputTopology inputTopology = context.Config.GpuAccessor.QueryPrimitiveTopology();
+
+                            int inputVertices = inputTopology switch
+                            {
+                                InputTopology.Points => 1,
+                                InputTopology.Lines or
+                                InputTopology.LinesAdjacency => 2,
+                                InputTopology.Triangles or
+                                InputTopology.TrianglesAdjacency => 3,
+                                _ => 3
+                            };
+
+                            patchVerticesIn = Const(inputVertices << 16);
+                        }
 
                         src = context.BitwiseOr(primitiveId, patchVerticesIn);
                     }


### PR DESCRIPTION
This fixes a regression introduced on #2534 where shaders would be generated trying to access `gl_PatchPrimitivesIn` on geometry shaders, because the invocation info system register is accessed on those shaders, however this built-in can only be accessed on tessellation evaluation shaders according to the spec.

Also contains a fix for another issue I found while testing this, bindless images with unknown handle source uses a 0 constant right now. However, it was using a float constant for images with integer formats, which is incorrect. Change it to use the proper integer type, this fixes some shader compilation errors.

The first issue apparently doesn't affect NVIDIA, as apparently their compiler doesn't complain on OpenGL and it "just works".
On AMD and Intel, this fixes a regression that broke geometry shaders, they caused some UE4 games to only show a black screen there because those games writes a 3D LUT texture from a draw that uses geometry shaders (to specify the slice). This is also most likely what caused the regression on Vulkan.

Fixes #2821.