### PR TITLE
Fix bindless/global memory elimination with inverted predicates

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -40,7 +40,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2822;
+        private const ulong ShaderCodeGenVersion = 2826;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Shader/Translation/Optimizations/Utils.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Optimizations/Utils.cs
@@ -10,11 +10,7 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
             {
                 if (sourceBlock.Operations.Count > 0)
                 {
-                    Operation lastOp = sourceBlock.Operations.Last.Value as Operation;
-
-                    if (lastOp != null &&
-                        ((sourceBlock.Next == block && lastOp.Inst == Instruction.BranchIfFalse) ||
-                        (sourceBlock.Branch == block && lastOp.Inst == Instruction.BranchIfTrue)))
+                    if (sourceBlock.GetLastOp() is Operation lastOp && IsConditionalBranch(lastOp.Inst) && sourceBlock.Next == block)
                     {
                         return lastOp;
                     }
@@ -22,6 +18,11 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
             }
 
             return null;
+        }
+
+        private static bool IsConditionalBranch(Instruction inst)
+        {
+            return inst == Instruction.BranchIfFalse || inst == Instruction.BranchIfTrue;
         }
 
         private static bool BlockConditionsMatch(BasicBlock currentBlock, BasicBlock queryBlock)


### PR DESCRIPTION
This fixes bindless texture elimination with inverted predicates (like `@!P0`). Before, it was working with the assumption that the branch would always enter the predicated block if the condition is true, but this is not exactly the case. What the branch does is skip the predicated instruction if the condition is false. So for non-inverted predicates, it will skip it if the condition is *false*, and for inverted ones, it will skip it if the condition is *true* (as if it is false, then the instruction is supposed to execute). In both cases, the branch not taken case is where it enters the block, so in both cases, the `Next` block is the one that should match the Phi incoming block.

This fixes lighting issues on Disaster Report 4, and maybe other games. Should also allow global memory SSBO replacement to work in more cases.

Master:
![image](https://user-images.githubusercontent.com/5624669/140756310-d0c5bd7b-643d-4eb4-a5a6-5f6f4e3af14b.png)
PR:
![image](https://user-images.githubusercontent.com/5624669/140756326-3fc9a43e-0938-47ea-a671-036389ba51b2.png)

I recommend testing a few UE4 games with it to ensure they didn't regress. Could also be worth to test games that uses both SSBOs and bindless textures and images like Mario Party Superstars.