### PR TITLE
kernel: Fix sleep timing accuracy

### DIFF
--- a/Ryujinx.HLE/HOS/Kernel/Common/KTimeManager.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Common/KTimeManager.cs
@@ -8,6 +8,8 @@ namespace Ryujinx.HLE.HOS.Kernel.Common
 {
     class KTimeManager : IDisposable
     {
+        public static readonly long DefaultTimeIncrementNanoSeconds = ConvertGuestTicksToNanoSeconds(2);
+
         private class WaitingObject
         {
             public IKFutureSchedulerObject Object { get; }
@@ -41,7 +43,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Common
 
         public void ScheduleFutureInvocation(IKFutureSchedulerObject schedulerObj, long timeout)
         {
-            long timePoint = PerformanceCounter.ElapsedMilliseconds + ConvertNanosecondsToMilliseconds(timeout);
+            long timePoint = PerformanceCounter.ElapsedTicks + ConvertNanosecondsToHostTicks(timeout);
 
             lock (_context.CriticalSection.Lock)
             {
@@ -74,14 +76,19 @@ namespace Ryujinx.HLE.HOS.Kernel.Common
 
                     if (next != null)
                     {
-                        long timePoint = PerformanceCounter.ElapsedMilliseconds;
+                        long timePoint = PerformanceCounter.ElapsedTicks;
 
                         if (next.TimePoint > timePoint)
                         {
-                            _waitEvent.WaitOne((int)(next.TimePoint - timePoint));
+                            int ms = (int)((next.TimePoint - timePoint) / PerformanceCounter.TicksPerMillisecond);
+
+                            if (ms > 0)
+                            {
+                                _waitEvent.WaitOne(ms);
+                            }
                         }
 
-                        bool timeUp = PerformanceCounter.ElapsedMilliseconds >= next.TimePoint;
+                        bool timeUp = PerformanceCounter.ElapsedTicks >= next.TimePoint;
 
                         if (timeUp)
                         {
@@ -117,6 +124,22 @@ namespace Ryujinx.HLE.HOS.Kernel.Common
         public static long ConvertMillisecondsToNanoseconds(long time)
         {
             return time * 1000000;
+        }
+
+        public static long ConvertNanosecondsToHostTicks(long ns)
+        {
+            long nsDiv = ns / 1000000000;
+            long nsMod = ns % 1000000000;
+            long tickDiv = PerformanceCounter.TicksPerSecond / 1000000000;
+            long tickMod = PerformanceCounter.TicksPerSecond % 1000000000;
+
+            long baseTicks = (nsMod * tickMod + PerformanceCounter.TicksPerSecond - 1) / 1000000000;
+            return (nsDiv * tickDiv) * 1000000000 + nsDiv * tickMod + nsMod * tickDiv + baseTicks;
+        }
+
+        public static long ConvertGuestTicksToNanoSeconds(long ticks)
+        {
+            return (long)Math.Ceiling(ticks * (1000000000.0 / 19200000.0));
         }
 
         public static long ConvertHostTicksToTicks(long time)

--- a/Ryujinx.HLE/HOS/Kernel/Common/KTimeManager.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Common/KTimeManager.cs
@@ -89,11 +89,11 @@ namespace Ryujinx.HLE.HOS.Kernel.Common
 
                         if (next.TimePoint > timePoint)
                         {
-                            int ms = (int)((next.TimePoint - timePoint) / PerformanceCounter.TicksPerMillisecond);
+                            long ms = Math.Min((next.TimePoint - timePoint) / PerformanceCounter.TicksPerMillisecond, int.MaxValue);
 
                             if (ms > 0)
                             {
-                                _waitEvent.WaitOne(ms);
+                                _waitEvent.WaitOne((int)ms);
                             }
                             else
                             {

--- a/Ryujinx.HLE/HOS/Kernel/Common/KTimeManager.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Common/KTimeManager.cs
@@ -8,7 +8,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Common
 {
     class KTimeManager : IDisposable
     {
-        public static readonly long DefaultTimeIncrementNanoSeconds = ConvertGuestTicksToNanoSeconds(2);
+        public static readonly long DefaultTimeIncrementNanoseconds = ConvertGuestTicksToNanoseconds(2);
 
         private class WaitingObject
         {
@@ -49,7 +49,11 @@ namespace Ryujinx.HLE.HOS.Kernel.Common
             lock (_context.CriticalSection.Lock)
             {
                 _waitingObjects.Add(new WaitingObject(schedulerObj, timePoint));
-                Interlocked.Exchange(ref _enforceWakeupFromSpinWait, timeout < 1000000 ? 1 : 0);
+
+                if (timeout < 1000000)
+                {
+                    Interlocked.Exchange(ref _enforceWakeupFromSpinWait, 1);
+                }
             }
 
             _waitEvent.Set();
@@ -104,6 +108,8 @@ namespace Ryujinx.HLE.HOS.Kernel.Common
 
                                     spinWait.SpinOnce();
                                 }
+
+                                spinWait.Reset();
                             }
                         }
 
@@ -156,7 +162,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Common
             return (nsDiv * tickDiv) * 1000000000 + nsDiv * tickMod + nsMod * tickDiv + baseTicks;
         }
 
-        public static long ConvertGuestTicksToNanoSeconds(long ticks)
+        public static long ConvertGuestTicksToNanoseconds(long ticks)
         {
             return (long)Math.Ceiling(ticks * (1000000000.0 / 19200000.0));
         }

--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
@@ -508,7 +508,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
 
             if (timeout > 0)
             {
-                timeout += KTimeManager.DefaultTimeIncrementNanoSeconds;
+                timeout += KTimeManager.DefaultTimeIncrementNanoseconds;
             }
 
             return ReplyAndReceive(handles, replyTargetHandle, timeout, out handleIndex);
@@ -554,7 +554,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             {
                 if (timeout > 0)
                 {
-                    timeout += KTimeManager.DefaultTimeIncrementNanoSeconds;
+                    timeout += KTimeManager.DefaultTimeIncrementNanoseconds;
                 }
 
                 while ((result = _context.Synchronization.WaitFor(syncObjs, timeout, out handleIndex)) == KernelResult.Success)
@@ -656,7 +656,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             {
                 if (timeout > 0)
                 {
-                    timeout += KTimeManager.DefaultTimeIncrementNanoSeconds;
+                    timeout += KTimeManager.DefaultTimeIncrementNanoseconds;
                 }
 
                 while ((result = _context.Synchronization.WaitFor(syncObjs, timeout, out handleIndex)) == KernelResult.Success)
@@ -2132,7 +2132,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             }
             else
             {
-                KernelStatic.GetCurrentThread().Sleep(timeout + KTimeManager.DefaultTimeIncrementNanoSeconds);
+                KernelStatic.GetCurrentThread().Sleep(timeout + KTimeManager.DefaultTimeIncrementNanoseconds);
             }
         }
 
@@ -2475,7 +2475,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
 
             if (timeout > 0)
             {
-                timeout += KTimeManager.DefaultTimeIncrementNanoSeconds;
+                timeout += KTimeManager.DefaultTimeIncrementNanoseconds;
             }
 
             KernelResult result = _context.Synchronization.WaitFor(syncObjs, timeout, out handleIndex);
@@ -2563,7 +2563,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
 
             if (timeout > 0)
             {
-                timeout += KTimeManager.DefaultTimeIncrementNanoSeconds;
+                timeout += KTimeManager.DefaultTimeIncrementNanoseconds;
             }
 
             return currentProcess.AddressArbiter.WaitProcessWideKeyAtomic(
@@ -2598,7 +2598,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
 
             if (timeout > 0)
             {
-                timeout += KTimeManager.DefaultTimeIncrementNanoSeconds;
+                timeout += KTimeManager.DefaultTimeIncrementNanoseconds;
             }
 
             return type switch

--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
@@ -506,6 +506,11 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
                 return KernelResult.UserCopyFailed;
             }
 
+            if (timeout > 0)
+            {
+                timeout += KTimeManager.DefaultTimeIncrementNanoSeconds;
+            }
+
             return ReplyAndReceive(handles, replyTargetHandle, timeout, out handleIndex);
         }
 
@@ -547,6 +552,11 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
 
             if (result == KernelResult.Success)
             {
+                if (timeout > 0)
+                {
+                    timeout += KTimeManager.DefaultTimeIncrementNanoSeconds;
+                }
+
                 while ((result = _context.Synchronization.WaitFor(syncObjs, timeout, out handleIndex)) == KernelResult.Success)
                 {
                     KServerSession session = currentProcess.HandleTable.GetObject<KServerSession>(handles[handleIndex]);
@@ -644,6 +654,11 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
 
             if (result == KernelResult.Success)
             {
+                if (timeout > 0)
+                {
+                    timeout += KTimeManager.DefaultTimeIncrementNanoSeconds;
+                }
+
                 while ((result = _context.Synchronization.WaitFor(syncObjs, timeout, out handleIndex)) == KernelResult.Success)
                 {
                     KServerSession session = currentProcess.HandleTable.GetObject<KServerSession>(handles[handleIndex]);
@@ -2117,7 +2132,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             }
             else
             {
-                KernelStatic.GetCurrentThread().Sleep(timeout);
+                KernelStatic.GetCurrentThread().Sleep(timeout + KTimeManager.DefaultTimeIncrementNanoSeconds);
             }
         }
 
@@ -2458,6 +2473,11 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
                 }
             }
 
+            if (timeout > 0)
+            {
+                timeout += KTimeManager.DefaultTimeIncrementNanoSeconds;
+            }
+
             KernelResult result = _context.Synchronization.WaitFor(syncObjs, timeout, out handleIndex);
 
             if (result == KernelResult.PortRemoteClosed)
@@ -2541,6 +2561,11 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
 
             KProcess currentProcess = KernelStatic.GetCurrentProcess();
 
+            if (timeout > 0)
+            {
+                timeout += KTimeManager.DefaultTimeIncrementNanoSeconds;
+            }
+
             return currentProcess.AddressArbiter.WaitProcessWideKeyAtomic(
                 mutexAddress,
                 condVarAddress,
@@ -2570,6 +2595,11 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             }
 
             KProcess currentProcess = KernelStatic.GetCurrentProcess();
+
+            if (timeout > 0)
+            {
+                timeout += KTimeManager.DefaultTimeIncrementNanoSeconds;
+            }
 
             return type switch
             {


### PR DESCRIPTION
This PR corrects some mistake while comparing my reversing of kernel 13.x with our own.

``WaitAndCheckScheduledObjects`` timing accuracy was also improved.