### PR TITLE
Limit Custom Anisotropic Filtering to mipmapped textures with many levels

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
@@ -373,7 +373,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
             _context.Renderer.Pipeline.DrawTexture(
                 texture?.HostTexture,
-                sampler?.HostSampler,
+                sampler?.GetHostSampler(texture),
                 new Extents2DF(srcX0, srcY0, srcX1, srcY1),
                 new Extents2DF(dstX0, dstY0, dstX1, dstY1));
         }

--- a/Ryujinx.Graphics.Gpu/Image/Sampler.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Sampler.cs
@@ -9,15 +9,17 @@ namespace Ryujinx.Graphics.Gpu.Image
     /// </summary>
     class Sampler : IDisposable
     {
+        private const int MinLevelsForAnisotropic = 5;
+
         /// <summary>
         /// Host sampler object.
         /// </summary>
-        private ISampler _hostSampler { get; }
+        private readonly ISampler _hostSampler;
 
         /// <summary>
         /// Host sampler object, with anisotropy forced.
         /// </summary>
-        private ISampler _anisoSampler { get; }
+        private readonly ISampler _anisoSampler;
 
         /// <summary>
         /// Creates a new instance of the cached sampler.
@@ -99,7 +101,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
         /// <summary>
         /// Determine if the given texture can have anisotropic filtering forced.
-        /// Filtered textures that we might want to force anisotropy on should have a full set of mip levels.
+        /// Filtered textures that we might want to force anisotropy on should have a lot of mip levels.
         /// </summary>
         /// <param name="texture">The texture</param>
         /// <returns>True if anisotropic filtering can be forced, false otherwise</returns>
@@ -113,7 +115,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             int maxSize = Math.Max(texture.Info.Width, texture.Info.Height);
             int maxLevels = BitOperations.Log2((uint)maxSize) + 1;
 
-            return texture.Info.Levels >= maxLevels;
+            return texture.Info.Levels >= Math.Min(MinLevelsForAnisotropic, maxLevels);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/Sampler.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Sampler.cs
@@ -107,7 +107,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>True if anisotropic filtering can be forced, false otherwise</returns>
         private static bool AllowForceAnisotropy(Texture texture)
         {
-            if (!(texture.Target == Target.Texture2D || texture.Target == Target.Texture2DArray))
+            if (texture == null || !(texture.Target == Target.Texture2D || texture.Target == Target.Texture2DArray))
             {
                 return false;
             }

--- a/Ryujinx.Graphics.Gpu/Image/Sampler.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Sampler.cs
@@ -107,7 +107,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>True if anisotropic filtering can be forced, false otherwise</returns>
         private static bool AllowForceAnisotropy(Texture texture)
         {
-            if (!(texture.Info.Target == Target.Texture2D || texture.Info.Target == Target.Texture2DArray))
+            if (!(texture.Target == Target.Texture2D || texture.Target == Target.Texture2DArray))
             {
                 return false;
             }

--- a/Ryujinx.Graphics.Gpu/Image/Sampler.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Sampler.cs
@@ -1,5 +1,6 @@
 using Ryujinx.Graphics.GAL;
 using System;
+using System.Numerics;
 
 namespace Ryujinx.Graphics.Gpu.Image
 {
@@ -11,7 +12,12 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <summary>
         /// Host sampler object.
         /// </summary>
-        public ISampler HostSampler { get; }
+        private ISampler _hostSampler { get; }
+
+        /// <summary>
+        /// Host sampler object, with anisotropy forced.
+        /// </summary>
+        private ISampler _anisoSampler { get; }
 
         /// <summary>
         /// Creates a new instance of the cached sampler.
@@ -42,13 +48,10 @@ namespace Ryujinx.Graphics.Gpu.Image
             float maxLod     = descriptor.UnpackMaxLod();
             float mipLodBias = descriptor.UnpackMipLodBias();
 
-            float maxRequestedAnisotropy = GraphicsConfig.MaxAnisotropy >= 0 && GraphicsConfig.MaxAnisotropy <= 16 ? GraphicsConfig.MaxAnisotropy : descriptor.UnpackMaxAnisotropy();
+            float maxRequestedAnisotropy = descriptor.UnpackMaxAnisotropy();
             float maxSupportedAnisotropy = context.Capabilities.MaximumSupportedAnisotropy;
 
-            if (maxRequestedAnisotropy > maxSupportedAnisotropy)
-                maxRequestedAnisotropy = maxSupportedAnisotropy;
-
-            HostSampler = context.Renderer.CreateSampler(new SamplerCreateInfo(
+            _hostSampler = context.Renderer.CreateSampler(new SamplerCreateInfo(
                 minFilter,
                 magFilter,
                 seamlessCubemap,
@@ -61,7 +64,56 @@ namespace Ryujinx.Graphics.Gpu.Image
                 minLod,
                 maxLod,
                 mipLodBias,
-                maxRequestedAnisotropy));
+                Math.Min(maxRequestedAnisotropy, maxSupportedAnisotropy)));
+
+            if (GraphicsConfig.MaxAnisotropy >= 0 && GraphicsConfig.MaxAnisotropy <= 16 && (minFilter == MinFilter.LinearMipmapNearest || minFilter == MinFilter.LinearMipmapLinear))
+            {
+                maxRequestedAnisotropy = GraphicsConfig.MaxAnisotropy;
+
+                _anisoSampler = context.Renderer.CreateSampler(new SamplerCreateInfo(
+                    minFilter,
+                    magFilter,
+                    seamlessCubemap,
+                    addressU,
+                    addressV,
+                    addressP,
+                    compareMode,
+                    compareOp,
+                    color,
+                    minLod,
+                    maxLod,
+                    mipLodBias,
+                    Math.Min(maxRequestedAnisotropy, maxSupportedAnisotropy)));
+            }
+        }
+
+        /// <summary>
+        /// Gets a host sampler for the given texture.
+        /// </summary>
+        /// <param name="texture">Texture to be sampled</param>
+        /// <returns>A host sampler</returns>
+        public ISampler GetHostSampler(Texture texture)
+        {
+            return _anisoSampler != null && AllowForceAnisotropy(texture) ? _anisoSampler : _hostSampler;
+        }
+
+        /// <summary>
+        /// Determine if the given texture can have anisotropic filtering forced.
+        /// Filtered textures that we might want to force anisotropy on should have a full set of mip levels.
+        /// </summary>
+        /// <param name="texture">The texture</param>
+        /// <returns>True if anisotropic filtering can be forced, false otherwise</returns>
+        private static bool AllowForceAnisotropy(Texture texture)
+        {
+            if (!(texture.Info.Target == Target.Texture2D || texture.Info.Target == Target.Texture2DArray))
+            {
+                return false;
+            }
+
+            int maxSize = Math.Max(texture.Info.Width, texture.Info.Height);
+            int maxLevels = BitOperations.Log2((uint)maxSize) + 1;
+
+            return texture.Info.Levels >= maxLevels;
         }
 
         /// <summary>
@@ -69,7 +121,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         public void Dispose()
         {
-            HostSampler.Dispose();
+            _hostSampler.Dispose();
+            _anisoSampler?.Dispose();
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Image/SamplerPool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/SamplerPool.cs
@@ -7,6 +7,8 @@ namespace Ryujinx.Graphics.Gpu.Image
     /// </summary>
     class SamplerPool : Pool<Sampler, SamplerDescriptor>
     {
+        private float _forcedAnisotropy;
+
         /// <summary>
         /// Constructs a new instance of the sampler pool.
         /// </summary>
@@ -14,7 +16,10 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="physicalMemory">Physical memory where the sampler descriptors are mapped</param>
         /// <param name="address">Address of the sampler pool in guest memory</param>
         /// <param name="maximumId">Maximum sampler ID of the sampler pool (equal to maximum samplers minus one)</param>
-        public SamplerPool(GpuContext context, PhysicalMemory physicalMemory, ulong address, int maximumId) : base(context, physicalMemory, address, maximumId) { }
+        public SamplerPool(GpuContext context, PhysicalMemory physicalMemory, ulong address, int maximumId) : base(context, physicalMemory, address, maximumId)
+        {
+            _forcedAnisotropy = GraphicsConfig.MaxAnisotropy;
+        }
 
         /// <summary>
         /// Gets the sampler with the given ID.
@@ -30,6 +35,21 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             if (SequenceNumber != Context.SequenceNumber)
             {
+                if (_forcedAnisotropy != GraphicsConfig.MaxAnisotropy)
+                {
+                    _forcedAnisotropy = GraphicsConfig.MaxAnisotropy;
+
+                    for (int i = 0; i < Items.Length; i++)
+                    {
+                        if (Items[i] != null)
+                        {
+                            Items[i].Dispose();
+
+                            Items[i] = null;
+                        }
+                    }
+                }
+
                 SequenceNumber = Context.SequenceNumber;
 
                 SynchronizeMemory();

--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -399,7 +399,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 Sampler sampler = samplerPool?.Get(samplerId);
 
-                ISampler hostSampler = sampler?.HostSampler;
+                ISampler hostSampler = sampler?.GetHostSampler(texture);
 
                 if (_textureState[stageIndex][index].Sampler != hostSampler || _rebind)
                 {


### PR DESCRIPTION
There's a major flaw with the anisotropic filtering setting that causes @GamerzHell9137 to report graphical bugs that otherwise wouldn't be there, because he just won't set it to Auto. This should fix those issues, hopefully.

These bugs are generally because anisotropic filtering is enabled on something that it shouldn't be, such as a post process filter or some data texture. This PR maintains two host samplers when custom AF is enabled, and only uses the forced AF one when the texture is 2d and fully mipmapped (goes down to 1x1). This is because game textures are the ideal target for this filtering, and they are typically fully mipmapped, unlike things like screen render targets which usually have 1 or just a few levels.

This also only enables AF on mipmapped samplers where the filtering is bilinear or trilinear. This should be self explanatory.

**This PR also allows the changing of Anisotropic Filtering at runtime, and you can immediately see the changes.** All samplers are flushed from the cache if the setting changes, causing them to be recreated with the new custom AF value. This brings it in line with our resolution scale. :relieved:

Before (16x Handheld):
![image](https://user-images.githubusercontent.com/6294155/141167212-4892bc2c-dfb0-4467-9e6b-8bf2ba1fd11b.png)

1x Handheld:
![image](https://user-images.githubusercontent.com/6294155/141166856-1f015711-17bd-4309-83b5-bcc2e7326b00.png)

16x Handheld:
![image](https://user-images.githubusercontent.com/6294155/141166917-d89afa3f-e676-4947-b60b-d6e7a7cbcb78.png)
