### PR TITLE
kernel: Add support for CFI

### DIFF
--- a/Ryujinx.HLE/HOS/Kernel/Common/KSystemControl.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Common/KSystemControl.cs
@@ -58,6 +58,12 @@ namespace Ryujinx.HLE.HOS.Kernel.Common
             return DramMemoryMap.DramBase + GetDramSize(size);
         }
 
+        public static ulong GenerateRandom()
+        {
+            // TODO
+            return 0;
+        }
+
         public static ulong GetDramSize(MemorySize size)
         {
             return size switch

--- a/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
@@ -187,6 +187,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
 
             if (is64Bits)
             {
+                Context.SetX(18, KSystemControl.GenerateRandom() | 1);
                 Context.SetX(31, stackTop);
             }
             else


### PR DESCRIPTION
Add basic support for the CFI value being passed in X18 since 11.0.0 by the official kernel.
We do not implement any random generator atm in the kernel and as such the KSystemControl.GenerateRandom function is stubbed.
