### PR TITLE
Implement remaining shader double-precision instructions

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -40,7 +40,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2876;
+        private const ulong ShaderCodeGenVersion = 2845;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGen.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGen.cs
@@ -35,8 +35,16 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
             VariableType type = GetSrcVarType(operation.Inst, 0);
 
             string srcExpr = GetSoureExpr(context, src, type);
+            string zero;
 
-            NumberFormatter.TryFormat(0, type, out string zero);
+            if (type == VariableType.F64)
+            {
+                zero = "0.0";
+            }
+            else
+            {
+                NumberFormatter.TryFormat(0, type, out zero);
+            }
 
             // Starting in the 496.13 NVIDIA driver, there's an issue with assigning variables to negated expressions.
             // (-expr) does not work, but (0.0 - expr) does. This should be removed once the issue is resolved.

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/NumberFormatter.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/NumberFormatter.cs
@@ -10,7 +10,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
         public static bool TryFormat(int value, VariableType dstType, out string formatted)
         {
-            if (dstType == VariableType.F32 || dstType == VariableType.F64)
+            if (dstType == VariableType.F32)
             {
                 return TryFormatFloat(BitConverter.Int32BitsToSingle(value), out formatted);
             }

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmit.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmit.cs
@@ -75,69 +75,6 @@ namespace Ryujinx.Graphics.Shader.Instructions
             context.Config.GpuAccessor.Log("Shader instruction Cs2r is not implemented.");
         }
 
-        public static void DmnmxR(EmitterContext context)
-        {
-            InstDmnmxR op = context.GetOp<InstDmnmxR>();
-
-            context.Config.GpuAccessor.Log("Shader instruction DmnmxR is not implemented.");
-        }
-
-        public static void DmnmxI(EmitterContext context)
-        {
-            InstDmnmxI op = context.GetOp<InstDmnmxI>();
-
-            context.Config.GpuAccessor.Log("Shader instruction DmnmxI is not implemented.");
-        }
-
-        public static void DmnmxC(EmitterContext context)
-        {
-            InstDmnmxC op = context.GetOp<InstDmnmxC>();
-
-            context.Config.GpuAccessor.Log("Shader instruction DmnmxC is not implemented.");
-        }
-
-        public static void DsetR(EmitterContext context)
-        {
-            InstDsetR op = context.GetOp<InstDsetR>();
-
-            context.Config.GpuAccessor.Log("Shader instruction DsetR is not implemented.");
-        }
-
-        public static void DsetI(EmitterContext context)
-        {
-            InstDsetI op = context.GetOp<InstDsetI>();
-
-            context.Config.GpuAccessor.Log("Shader instruction DsetI is not implemented.");
-        }
-
-        public static void DsetC(EmitterContext context)
-        {
-            InstDsetC op = context.GetOp<InstDsetC>();
-
-            context.Config.GpuAccessor.Log("Shader instruction DsetC is not implemented.");
-        }
-
-        public static void DsetpR(EmitterContext context)
-        {
-            InstDsetpR op = context.GetOp<InstDsetpR>();
-
-            context.Config.GpuAccessor.Log("Shader instruction DsetpR is not implemented.");
-        }
-
-        public static void DsetpI(EmitterContext context)
-        {
-            InstDsetpI op = context.GetOp<InstDsetpI>();
-
-            context.Config.GpuAccessor.Log("Shader instruction DsetpI is not implemented.");
-        }
-
-        public static void DsetpC(EmitterContext context)
-        {
-            InstDsetpC op = context.GetOp<InstDsetpC>();
-
-            context.Config.GpuAccessor.Log("Shader instruction DsetpC is not implemented.");
-        }
-
         public static void FchkR(EmitterContext context)
         {
             InstFchkR op = context.GetOp<InstFchkR>();

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitFloatArithmetic.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitFloatArithmetic.cs
@@ -528,18 +528,5 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
             context.Copy(GetDest(rd), GetHalfPacked(context, swizzle, res, rd));
         }
-
-        private static void SetDest(EmitterContext context, Operand value, int rd, bool isFP64)
-        {
-            if (isFP64)
-            {
-                context.Copy(GetDest(rd), context.UnpackDouble2x32Low(value));
-                context.Copy(GetDest2(rd), context.UnpackDouble2x32High(value));
-            }
-            else
-            {
-                context.Copy(GetDest(rd), value);
-            }
-        }
     }
 }

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitFloatComparison.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitFloatComparison.cs
@@ -11,6 +11,156 @@ namespace Ryujinx.Graphics.Shader.Instructions
 {
     static partial class InstEmit
     {
+        public static void DsetR(EmitterContext context)
+        {
+            InstDsetR op = context.GetOp<InstDsetR>();
+
+            var srcA = GetSrcReg(context, op.SrcA, isFP64: true);
+            var srcB = GetSrcReg(context, op.SrcB, isFP64: true);
+
+            EmitFset(
+                context,
+                op.FComp,
+                op.Bop,
+                srcA,
+                srcB,
+                op.SrcPred,
+                op.SrcPredInv,
+                op.Dest,
+                op.AbsA,
+                op.AbsB,
+                op.NegA,
+                op.NegB,
+                op.BVal,
+                op.WriteCC,
+                isFP64: true);
+        }
+
+        public static void DsetI(EmitterContext context)
+        {
+            InstDsetI op = context.GetOp<InstDsetI>();
+
+            var srcA = GetSrcReg(context, op.SrcA, isFP64: true);
+            var srcB = GetSrcImm(context, Imm20ToFloat(op.Imm20), isFP64: true);
+
+            EmitFset(
+                context,
+                op.FComp,
+                op.Bop,
+                srcA,
+                srcB,
+                op.SrcPred,
+                op.SrcPredInv,
+                op.Dest,
+                op.AbsA,
+                op.AbsB,
+                op.NegA,
+                op.NegB,
+                op.BVal,
+                op.WriteCC,
+                isFP64: true);
+        }
+
+        public static void DsetC(EmitterContext context)
+        {
+            InstDsetC op = context.GetOp<InstDsetC>();
+
+            var srcA = GetSrcReg(context, op.SrcA, isFP64: true);
+            var srcB = GetSrcCbuf(context, op.CbufSlot, op.CbufOffset, isFP64: true);
+
+            EmitFset(
+                context,
+                op.FComp,
+                op.Bop,
+                srcA,
+                srcB,
+                op.SrcPred,
+                op.SrcPredInv,
+                op.Dest,
+                op.AbsA,
+                op.AbsB,
+                op.NegA,
+                op.NegB,
+                op.BVal,
+                op.WriteCC,
+                isFP64: true);
+        }
+
+        public static void DsetpR(EmitterContext context)
+        {
+            InstDsetpR op = context.GetOp<InstDsetpR>();
+
+            var srcA = GetSrcReg(context, op.SrcA, isFP64: true);
+            var srcB = GetSrcReg(context, op.SrcB, isFP64: true);
+
+            EmitFsetp(
+                context,
+                op.FComp,
+                op.Bop,
+                srcA,
+                srcB,
+                op.SrcPred,
+                op.SrcPredInv,
+                op.DestPred,
+                op.DestPredInv,
+                op.AbsA,
+                op.AbsB,
+                op.NegA,
+                op.NegB,
+                writeCC: false,
+                isFP64: true);
+        }
+
+        public static void DsetpI(EmitterContext context)
+        {
+            InstDsetpI op = context.GetOp<InstDsetpI>();
+
+            var srcA = GetSrcReg(context, op.SrcA, isFP64: true);
+            var srcB = GetSrcImm(context, Imm20ToFloat(op.Imm20), isFP64: true);
+
+            EmitFsetp(
+                context,
+                op.FComp,
+                op.Bop,
+                srcA,
+                srcB,
+                op.SrcPred,
+                op.SrcPredInv,
+                op.DestPred,
+                op.DestPredInv,
+                op.AbsA,
+                op.AbsB,
+                op.NegA,
+                op.NegB,
+                writeCC: false,
+                isFP64: true);
+        }
+
+        public static void DsetpC(EmitterContext context)
+        {
+            InstDsetpC op = context.GetOp<InstDsetpC>();
+
+            var srcA = GetSrcReg(context, op.SrcA, isFP64: true);
+            var srcB = GetSrcCbuf(context, op.CbufSlot, op.CbufOffset, isFP64: true);
+
+            EmitFsetp(
+                context,
+                op.FComp,
+                op.Bop,
+                srcA,
+                srcB,
+                op.SrcPred,
+                op.SrcPredInv,
+                op.DestPred,
+                op.DestPredInv,
+                op.AbsA,
+                op.AbsB,
+                op.NegA,
+                op.NegB,
+                writeCC: false,
+                isFP64: true);
+        }
+
         public static void FcmpR(EmitterContext context)
         {
             InstFcmpR op = context.GetOp<InstFcmpR>();
@@ -240,12 +390,15 @@ namespace Ryujinx.Graphics.Shader.Instructions
             bool negateA,
             bool negateB,
             bool boolFloat,
-            bool writeCC)
+            bool writeCC,
+            bool isFP64 = false)
         {
-            srcA = context.FPAbsNeg(srcA, absoluteA, negateA);
-            srcB = context.FPAbsNeg(srcB, absoluteB, negateB);
+            Instruction fpType = isFP64 ? Instruction.FP64 : Instruction.FP32;
 
-            Operand res = GetFPComparison(context, cmpOp, srcA, srcB);
+            srcA = context.FPAbsNeg(srcA, absoluteA, negateA, fpType);
+            srcB = context.FPAbsNeg(srcB, absoluteB, negateB, fpType);
+
+            Operand res = GetFPComparison(context, cmpOp, srcA, srcB, fpType);
             Operand pred = GetPredicate(context, srcPred, srcPredInv);
 
             res = GetPredLogicalOp(context, logicOp, res, pred);
@@ -282,12 +435,15 @@ namespace Ryujinx.Graphics.Shader.Instructions
             bool absoluteB,
             bool negateA,
             bool negateB,
-            bool writeCC)
+            bool writeCC,
+            bool isFP64 = false)
         {
-            srcA = context.FPAbsNeg(srcA, absoluteA, negateA);
-            srcB = context.FPAbsNeg(srcB, absoluteB, negateB);
+            Instruction fpType = isFP64 ? Instruction.FP64 : Instruction.FP32;
 
-            Operand p0Res = GetFPComparison(context, cmpOp, srcA, srcB);
+            srcA = context.FPAbsNeg(srcA, absoluteA, negateA, fpType);
+            srcB = context.FPAbsNeg(srcB, absoluteB, negateB, fpType);
+
+            Operand p0Res = GetFPComparison(context, cmpOp, srcA, srcB, fpType);
             Operand p1Res = context.BitwiseNot(p0Res);
             Operand pred = GetPredicate(context, srcPred, srcPredInv);
 
@@ -367,7 +523,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
             context.Copy(Register(destPredInv, RegisterType.Predicate), p1Res);
         }
 
-        private static Operand GetFPComparison(EmitterContext context, FComp cond, Operand srcA, Operand srcB)
+        private static Operand GetFPComparison(EmitterContext context, FComp cond, Operand srcA, Operand srcB, Instruction fpType = Instruction.FP32)
         {
             Operand res;
 
@@ -381,7 +537,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
             }
             else if (cond == FComp.Nan || cond == FComp.Num)
             {
-                res = context.BitwiseOr(context.IsNan(srcA), context.IsNan(srcB));
+                res = context.BitwiseOr(context.IsNan(srcA, fpType), context.IsNan(srcB, fpType));
 
                 if (cond == FComp.Num)
                 {
@@ -404,12 +560,12 @@ namespace Ryujinx.Graphics.Shader.Instructions
                     default: throw new ArgumentException($"Unexpected condition \"{cond}\".");
                 }
 
-                res = context.Add(inst | Instruction.FP32, Local(), srcA, srcB);
+                res = context.Add(inst | fpType, Local(), srcA, srcB);
 
                 if ((cond & FComp.Nan) != 0)
                 {
-                    res = context.BitwiseOr(res, context.IsNan(srcA));
-                    res = context.BitwiseOr(res, context.IsNan(srcB));
+                    res = context.BitwiseOr(res, context.IsNan(srcA, fpType));
+                    res = context.BitwiseOr(res, context.IsNan(srcB, fpType));
                 }
             }
 

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitFloatMinMax.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitFloatMinMax.cs
@@ -9,6 +9,39 @@ namespace Ryujinx.Graphics.Shader.Instructions
 {
     static partial class InstEmit
     {
+        public static void DmnmxR(EmitterContext context)
+        {
+            InstDmnmxR op = context.GetOp<InstDmnmxR>();
+
+            var srcA = GetSrcReg(context, op.SrcA, isFP64: true);
+            var srcB = GetSrcReg(context, op.SrcB, isFP64: true);
+            var srcPred = GetPredicate(context, op.SrcPred, op.SrcPredInv);
+
+            EmitFmnmx(context, srcA, srcB, srcPred, op.Dest, op.AbsA, op.AbsB, op.NegA, op.NegB, op.WriteCC, isFP64: true);
+        }
+
+        public static void DmnmxI(EmitterContext context)
+        {
+            InstDmnmxI op = context.GetOp<InstDmnmxI>();
+
+            var srcA = GetSrcReg(context, op.SrcA, isFP64: true);
+            var srcB = GetSrcImm(context, Imm20ToFloat(op.Imm20), isFP64: true);
+            var srcPred = GetPredicate(context, op.SrcPred, op.SrcPredInv);
+
+            EmitFmnmx(context, srcA, srcB, srcPred, op.Dest, op.AbsA, op.AbsB, op.NegA, op.NegB, op.WriteCC, isFP64: true);
+        }
+
+        public static void DmnmxC(EmitterContext context)
+        {
+            InstDmnmxC op = context.GetOp<InstDmnmxC>();
+
+            var srcA = GetSrcReg(context, op.SrcA, isFP64: true);
+            var srcB = GetSrcCbuf(context, op.CbufSlot, op.CbufOffset, isFP64: true);
+            var srcPred = GetPredicate(context, op.SrcPred, op.SrcPredInv);
+
+            EmitFmnmx(context, srcA, srcB, srcPred, op.Dest, op.AbsA, op.AbsB, op.NegA, op.NegB, op.WriteCC, isFP64: true);
+        }
+
         public static void FmnmxR(EmitterContext context)
         {
             InstFmnmxR op = context.GetOp<InstFmnmxR>();
@@ -52,19 +85,22 @@ namespace Ryujinx.Graphics.Shader.Instructions
             bool absoluteB,
             bool negateA,
             bool negateB,
-            bool writeCC)
+            bool writeCC,
+            bool isFP64 = false)
         {
-            srcA = context.FPAbsNeg(srcA, absoluteA, negateA);
-            srcB = context.FPAbsNeg(srcB, absoluteB, negateB);
+            Instruction fpType = isFP64 ? Instruction.FP64 : Instruction.FP32;
 
-            Operand resMin = context.FPMinimum(srcA, srcB);
-            Operand resMax = context.FPMaximum(srcA, srcB);
+            srcA = context.FPAbsNeg(srcA, absoluteA, negateA, fpType);
+            srcB = context.FPAbsNeg(srcB, absoluteB, negateB, fpType);
 
-            Operand dest = GetDest(rd);
+            Operand resMin = context.FPMinimum(srcA, srcB, fpType);
+            Operand resMax = context.FPMaximum(srcA, srcB, fpType);
 
-            context.Copy(dest, context.ConditionalSelect(srcPred, resMin, resMax));
+            Operand res = context.ConditionalSelect(srcPred, resMin, resMax);
 
-            SetFPZnFlags(context, dest, writeCC);
+            SetDest(context, res, rd, isFP64);
+
+            SetFPZnFlags(context, res, writeCC, fpType);
         }
     }
 }

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitHelper.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitHelper.cs
@@ -58,7 +58,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
         {
             if (isFP64)
             {
-                return context.FP32ConvertToFP64(Const(imm));
+                return context.PackDouble2x32(Const(0), Const(imm));
             }
             else
             {
@@ -216,6 +216,19 @@ namespace Ryujinx.Graphics.Shader.Instructions
             }
 
             return local;
+        }
+
+        public static void SetDest(EmitterContext context, Operand value, int rd, bool isFP64)
+        {
+            if (isFP64)
+            {
+                context.Copy(GetDest(rd), context.UnpackDouble2x32Low(value));
+                context.Copy(GetDest2(rd), context.UnpackDouble2x32High(value));
+            }
+            else
+            {
+                context.Copy(GetDest(rd), value);
+            }
         }
 
         public static int Imm16ToSInt(int imm16)

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitMultifunction.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitMultifunction.cs
@@ -61,11 +61,23 @@ namespace Ryujinx.Graphics.Shader.Instructions
                     res = context.FPReciprocalSquareRoot(res);
                     break;
 
+                case MufuOp.Rcp64h:
+                    res = context.PackDouble2x32(OperandHelper.Const(0), res);
+                    res = context.UnpackDouble2x32High(context.FPReciprocal(res, Instruction.FP64));
+                    break;
+
+                case MufuOp.Rsq64h:
+                    res = context.PackDouble2x32(OperandHelper.Const(0), res);
+                    res = context.UnpackDouble2x32High(context.FPReciprocalSquareRoot(res, Instruction.FP64));
+                    break;
+
                 case MufuOp.Sqrt:
                     res = context.FPSquareRoot(res);
                     break;
 
-                default: /* TODO */ break;
+                default:
+                    context.Config.GpuAccessor.Log($"Invalid MUFU operation \"{op.MufuOp}\".");
+                    break;
             }
 
             context.Copy(GetDest(op.Dest), context.FPSaturate(res, op.Sat));

--- a/Ryujinx.Graphics.Shader/StructuredIr/InstructionInfo.cs
+++ b/Ryujinx.Graphics.Shader/StructuredIr/InstructionInfo.cs
@@ -87,7 +87,7 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
             Add(Instruction.ImageLoad,                VariableType.F32);
             Add(Instruction.ImageStore,               VariableType.None);
             Add(Instruction.ImageAtomic,              VariableType.S32);
-            Add(Instruction.IsNan,                    VariableType.Bool,   VariableType.F32);
+            Add(Instruction.IsNan,                    VariableType.Bool,   VariableType.Scalar);
             Add(Instruction.LoadAttribute,            VariableType.F32,    VariableType.S32,    VariableType.S32,    VariableType.S32);
             Add(Instruction.LoadConstant,             VariableType.F32,    VariableType.S32,    VariableType.S32);
             Add(Instruction.LoadGlobal,               VariableType.U32,    VariableType.S32,    VariableType.S32);


### PR DESCRIPTION
Changes:
- Implements remaining double instructions: DMNMX, DSET and DSETP.
- Implements remaining double-precision operations on MUFU instruction: RCP64H and RSQ64H.
- Fix immediate operands on all double-precision instruction. Before it was being interpreted as a the higher 20-bits of a float value converted to double, when it should be the higher 20-bits of a double value.

I know that World War Z uses the DSET/DSETP instruction, but I don't know which impact those changes would have on this title, and I don't know many other games using them, as double-precision is rarely used on shaders for performance reasons.