### PR TITLE
Allow setting texture data from 1x to fix some textures resetting randomly

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Twod/TwodClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Twod/TwodClass.cs
@@ -349,6 +349,11 @@ namespace Ryujinx.Graphics.Gpu.Engine.Twod
                 return;
             }
 
+            if (srcTexture.Info.Samples > 1 || dstTexture.Info.Samples > 1)
+            {
+                srcTexture.PropagateScale(dstTexture);
+            }
+
             float scale = srcTexture.ScaleFactor;
             float dstScale = dstTexture.ScaleFactor;
 

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -28,8 +28,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         // Tuning for blacklisting textures from scaling when their data is updated from CPU.
         // Each write adds the weight, each GPU modification subtracts 1.
         // Exceeding the threshold blacklists the texture.
-        private const int ScaledSetWeight = 25;
-        private const int ScaledSetThreshold = 75;
+        private const int ScaledSetWeight = 10;
+        private const int ScaledSetThreshold = 30;
 
         private const int MinLevelsForForceAnisotropy = 5;
 
@@ -757,6 +757,8 @@ namespace Ryujinx.Graphics.Gpu.Image
                 texture.SetData(result);
 
                 texture.CopyTo(HostTexture, new Extents2D(0, 0, texture.Width, texture.Height), new Extents2D(0, 0, HostTexture.Width, HostTexture.Height), true);
+
+                Logger.Error?.PrintMsg(LogClass.Gpu, $"Wrote and upscaled data for {Info.Width}x{Info.Height} {Info.Levels}lv {Format}");
             }
             else
             {

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -728,7 +728,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 // If needed, create a texture to load from 1x scale.
                 ITexture texture = _setHostTexture = GetScaledHostTexture(1f, false, _setHostTexture);
 
-                texture.SetData(data);
+                texture.SetData(result);
 
                 texture.CopyTo(HostTexture, new Extents2D(0, 0, texture.Width, texture.Height), new Extents2D(0, 0, HostTexture.Width, HostTexture.Height), true);
             }

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -1512,6 +1512,11 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="bound">True if the texture has been bound, false if it has been unbound</param>
         public void SignalModifying(bool bound)
         {
+            if (bound)
+            {
+                _scaledSetScore = Math.Max(0, _scaledSetScore - 1);
+            }
+
             if (_modifiedStale || Group.HasCopyDependencies)
             {
                 _modifiedStale = false;

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -757,8 +757,6 @@ namespace Ryujinx.Graphics.Gpu.Image
                 texture.SetData(result);
 
                 texture.CopyTo(HostTexture, new Extents2D(0, 0, texture.Width, texture.Height), new Extents2D(0, 0, HostTexture.Width, HostTexture.Height), true);
-
-                Logger.Error?.PrintMsg(LogClass.Gpu, $"Wrote and upscaled data for {Info.Width}x{Info.Height} {Info.Levels}lv {Format}");
             }
             else
             {

--- a/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -112,7 +112,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>True if eligible</returns>
         private static TextureScaleMode IsUpscaleCompatible(TextureInfo info, bool withUpscale)
         {
-            if ((info.Target == Target.Texture2D || info.Target == Target.Texture2DArray) && !info.FormatInfo.IsCompressed)
+            if ((info.Target == Target.Texture2D || info.Target == Target.Texture2DArray || info.Target == Target.Texture2DMultisample) && !info.FormatInfo.IsCompressed)
             {
                 return UpscaleSafeMode(info) ? (withUpscale ? TextureScaleMode.Scaled : TextureScaleMode.Eligible) : TextureScaleMode.Undesired;
             }


### PR DESCRIPTION
Expected targets:

- Deltarune Chapter 1+2
- Crash Team Racing
- Those new pokemon games idk (reset scale after battle/menu?)

This won’t help all games- for example SMTV issues. This might also be an aggressive solution, so it would be good to test if this has negative effects in other games.

I won’t be able to complete this for a bit so testing would help me make a decision when I can.