### PR TITLE
Dynamically increase buffer size when resizing

### DIFF
--- a/Ryujinx.Graphics.Gpu/Memory/BufferCache.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferCache.cs
@@ -168,11 +168,23 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 // Otherwise, we must delete the overlapping buffers and create a bigger buffer
                 // that fits all the data we need. We also need to copy the contents from the
                 // old buffer(s) to the new buffer.
+
                 ulong endAddress = address + size;
 
                 if (_bufferOverlaps[0].Address > address || _bufferOverlaps[0].EndAddress < endAddress)
                 {
-                    if (overlapsCount == 1)
+                    // Check if the following conditions are met:
+                    // - We have a single overlap.
+                    // - The overlap starts at or before the requested range. That is, the overlap happens at the end.
+                    // - The size delta between the new, merged buffer and the old one is of at most 2 pages.
+                    // In this case, we attempt to extend the buffer further than the requested range,
+                    // this can potentially avoid future resizes if the application keeps using overlapping
+                    // sequential memory.
+                    // Allowing for 2 pages (rather than just one) is necessary to catch cases where the
+                    // range crosses a page, and after alignment, ends having a size of 2 pages.
+                    if (overlapsCount == 1 &&
+                        address >= _bufferOverlaps[0].Address &&
+                        endAddress - _bufferOverlaps[0].EndAddress <= BufferAlignmentSize * 2)
                     {
                         // Try to grow the buffer by 1.5x of its current size.
                         // This improves performance in the cases where the buffer is resized often by small amounts.


### PR DESCRIPTION
Some games have a buffer usage pattern where it uses small adjacent buffers with increasing addresses. Right now this causes a new buffer to be created each time, merging the existing overlapping buffers. So that is effectively resizing the existing buffer all the time, page by page which is very inefficient.

This change attempts to address that by dynamically increasing the size based on the current buffer size. Currently it uses a growth rate of 1.5x. So if the existing buffer has 64KB and it attempts to extend it by one page to 68KB, then the new size will be 64KB * 1.5 = 96KB. Further attempts to extend it again by 4KB to 72KB, 76KB, 80KB etc, will be effectively a no-op since the 96KB buffer can already fit all the data.

The downsize of this approach is that it can use a bit more memory (which might not be necessary if the extended region is never used).

This reduces the load time (from black screen to Game Freak logo etc) on Pokémon Brilliant Diamond and Shining Pearl by almost half with PPTC enabled (from 1m34s to 52s here). Also greatly improves title screen animation and overall performance on Super Mario Galaxy, which has a similar issue. Other games might also be improved.

This is very similar to #1607, but with some small differences on the implementation.

I'd recommend testing this on a number of games to make sure they did not break.