### PR TITLE
Don't blow up everything if a DLC file is moved or renamed.

### DIFF
--- a/Ryujinx.HLE/HOS/ApplicationLoader.cs
+++ b/Ryujinx.HLE/HOS/ApplicationLoader.cs
@@ -335,7 +335,14 @@ namespace Ryujinx.HLE.HOS
                 {
                     foreach (DlcNca dlcNca in dlcContainer.DlcNcaList)
                     {
-                        _device.Configuration.ContentManager.AddAocItem(dlcNca.TitleId, dlcContainer.Path, dlcNca.Path, dlcNca.Enabled);
+                        if (File.Exists(dlcContainer.Path))
+                        {
+                            _device.Configuration.ContentManager.AddAocItem(dlcNca.TitleId, dlcContainer.Path, dlcNca.Path, dlcNca.Enabled);
+                        }
+                        else
+                        {
+                            Logger.Warning?.Print(LogClass.Application, $"Cannot find AddOnContent file {dlcContainer.Path}. It may have been moved or renamed");
+                        }
                     }
                 }
             }

--- a/Ryujinx.HLE/HOS/ApplicationLoader.cs
+++ b/Ryujinx.HLE/HOS/ApplicationLoader.cs
@@ -341,7 +341,7 @@ namespace Ryujinx.HLE.HOS
                         }
                         else
                         {
-                            Logger.Warning?.Print(LogClass.Application, $"Cannot find AddOnContent file {dlcContainer.Path}. It may have been moved or renamed");
+                            Logger.Warning?.Print(LogClass.Application, $"Cannot find AddOnContent file {dlcContainer.Path}. It may have been moved or renamed.");
                         }
                     }
                 }

--- a/Ryujinx/Ui/Windows/DlcWindow.cs
+++ b/Ryujinx/Ui/Windows/DlcWindow.cs
@@ -95,7 +95,7 @@ namespace Ryujinx.Ui.Windows
                 }
                 else
                 {
-                    // DLC file moved or renamed. Show an alert of some kind?
+                    // DLC file moved or renamed. Allow the user to remove it without crashing the whole dialog.
                     TreeIter parentIter = ((TreeStore)_dlcTreeView.Model).AppendValues(false, "", $"(MISSING) {dlcContainer.Path}");
                 }
             }

--- a/Ryujinx/Ui/Windows/DlcWindow.cs
+++ b/Ryujinx/Ui/Windows/DlcWindow.cs
@@ -77,7 +77,12 @@ namespace Ryujinx.Ui.Windows
             {
                 if (File.Exists(dlcContainer.Path))
                 {
-                    TreeIter parentIter = ((TreeStore)_dlcTreeView.Model).AppendValues(true, "", dlcContainer.Path);
+                    // The parent tree item has its own "enabled" check box, but it's the actual
+                    // nca entries that store the enabled / disabled state. A bit of a UI inconsistency.
+                    // Maybe a tri-state check box would be better, but for now we check the parent
+                    // "enabled" box if all child NCAs are enabled. Usually fine since each nsp has only one nca.
+                    bool areAllContentPacksEnabled = dlcContainer.DlcNcaList.TrueForAll((nca) => nca.Enabled);
+                    TreeIter parentIter = ((TreeStore)_dlcTreeView.Model).AppendValues(areAllContentPacksEnabled, "", dlcContainer.Path);
                     using FileStream containerFile = File.OpenRead(dlcContainer.Path);
                     PartitionFileSystem pfs = new PartitionFileSystem(containerFile.AsStorage());
                     _virtualFileSystem.ImportTickets(pfs);


### PR DESCRIPTION
If a DLC file goes missing, the user can't even open the DLC dialog to fix it, which leads to bad user experience. This PR adds File.Exists() checks to both the DLC dialog window and the content loader to ignore missing files rather than crashing the program.