### PR TITLE
Use a semaphore signal instead of Thread.Sleep to handle blocking on threaded renderer queue

### DIFF
--- a/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -255,7 +255,6 @@ namespace Ryujinx.Graphics.Gpu
         /// </summary>
         public void Dispose()
         {
-            Renderer.Dispose();
             GPFifo.Dispose();
             HostInitalized.Dispose();
 
@@ -268,6 +267,10 @@ namespace Ryujinx.Graphics.Gpu
             PhysicalMemoryRegistry.Clear();
 
             RunDeferredActions();
+
+            // We must dispose of the actual renderer at the very end because RunDeferredActions()
+            // dispatches Destroy() commands that need to be handled on the renderer thread
+            Renderer.Dispose();
         }
     }
 }


### PR DESCRIPTION
Rather than doing `Thread.Sleep` to wait on the queue if the threaded renderer gets backed up, use a semaphore to manage the number of available resources, so waiters will be automatically signaled as soon as the queue is available again. This should theoretically reduce microstutter in GPU heavy workloads.