### PR TITLE
Potential fix for hanging/crashing when stopping emulation

### DIFF
--- a/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
@@ -154,6 +154,7 @@ namespace Ryujinx.Graphics.GAL.Multithreading
 
         internal ref T New<T>() where T : struct
         {
+            // TODO: remove the disposed check when rendering loop issue is resolved.
             while ((_producerPtr == (_consumerPtr + QueueCount - 1) % QueueCount) && !_disposed)
             {
                 // If incrementing the producer pointer would overflow, we need to wait.

--- a/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
@@ -154,7 +154,7 @@ namespace Ryujinx.Graphics.GAL.Multithreading
 
         internal ref T New<T>() where T : struct
         {
-            while (_producerPtr == (_consumerPtr + QueueCount - 1) % QueueCount)
+            while ((_producerPtr == (_consumerPtr + QueueCount - 1) % QueueCount) && !_disposed)
             {
                 // If incrementing the producer pointer would overflow, we need to wait.
                 // _consumerPtr can only move forward, so there's no race to worry about here.


### PR DESCRIPTION
**Edit 2:** Memory leak issue seems to also occur on mainline as per my testing (can provide pictures as needed). I know @gdkchan is also looking into this issue so I'll leave this as a PR pending being superseded with a TODO marking that the code may not be needed if the issue with the render loop can be worked out. For now, this does seem to solve the hanging issue from all testing I've been able to do. The memory leak would be outside the scope of this since it's a different issue. Up to the maintainers if they'd like to produce artifacts so more people can test it. 

**Edit:** Not ready for merge yet, fixes the issue but causes a memory leak/doesn't clear memory. Converting to draft and investigating.


Hello, I saw pull #2875 but as others have stated as well as for myself, the issue persists with that fix. In doing so, I decided to take a shot at this myself and I believe I have a working solution. 

I went back to the original issue #2863 and the OP of that post was correct that the code he highlighted 

```
while (_producerPtr == (_consumerPtr + QueueCount - 1) % QueueCount)
{
    // If incrementing the producer pointer would overflow, we need to wait.
    // _consumerPtr can only move forward, so there's no race to worry about here.

    Thread.Sleep(1);
}
```

Ends up creating an infinite loop (sometimes) during dispose, but I found that even though this creates an infinite loop, the disposed flag is still set to true when trying to stop emulation and entering the infinite loop. By checking for this in the while statement of the loop, we know that if it's supposed to be disposed we can just break the loop. By doing so, emulation now properly ends when stopping and no longer hangs the UI, returning you to the game selection screen; the intended behavior without a huge performance penalty or unnecessary overhead.

Additionally, I found that even jumping between problematic games like Pokemon -> SMT5 -> Pokemon Sw/Sh -> XBDE all had no issues ending emulation and returning to the menu and then booting into other games and so on. 

This should properly close #2850 and close #2863, and may or may not require #2875 because from my testing on master+only this fix, it worked without #2875. As always, please make some artifacts so that others can test this and any feedback is appreciated. 