### PR TITLE
Fix SUATOM and other texture shader instructions with RZ dest

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -40,7 +40,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2845;
+        private const ulong ShaderCodeGenVersion = 2885;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitSurface.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitSurface.cs
@@ -219,9 +219,9 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
             Operand GetDest()
             {
-                if (dest > RegisterConsts.RegisterZeroIndex)
+                if (dest >= RegisterConsts.RegisterZeroIndex)
                 {
-                    return Const(0);
+                    return null;
                 }
 
                 return Register(dest++, RegisterType.Gpr);

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
@@ -306,9 +306,9 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
             Operand GetDest()
             {
-                if (rdIndex > RegisterConsts.RegisterZeroIndex)
+                if (rdIndex >= RegisterConsts.RegisterZeroIndex)
                 {
-                    return Const(0);
+                    return null;
                 }
 
                 return Register(rdIndex++, RegisterType.Gpr);
@@ -321,6 +321,11 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 if ((compMask & 1) != 0)
                 {
                     Operand dest = GetDest();
+
+                    if (dest == null)
+                    {
+                        break;
+                    }
 
                     TextureOperation operation = context.CreateTextureOperation(
                         Instruction.TextureSample,
@@ -795,9 +800,9 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
             Operand GetDest()
             {
-                if (dest > RegisterConsts.RegisterZeroIndex)
+                if (dest >= RegisterConsts.RegisterZeroIndex)
                 {
-                    return Const(0);
+                    return null;
                 }
 
                 return Register(dest++, RegisterType.Gpr);
@@ -809,13 +814,20 @@ namespace Ryujinx.Graphics.Shader.Instructions
             {
                 if ((compMask & 1) != 0)
                 {
+                    Operand destOperand = GetDest();
+
+                    if (destOperand == null)
+                    {
+                        break;
+                    }
+
                     TextureOperation operation = context.CreateTextureOperation(
                         Instruction.TextureSample,
                         type,
                         flags,
                         handle,
                         compIndex,
-                        GetDest(),
+                        destOperand,
                         sources);
 
                     context.Add(operation);
@@ -902,9 +914,9 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
             Operand GetDest()
             {
-                if (dest > RegisterConsts.RegisterZeroIndex)
+                if (dest >= RegisterConsts.RegisterZeroIndex)
                 {
-                    return Const(0);
+                    return null;
                 }
 
                 return Register(dest++, RegisterType.Gpr);
@@ -916,11 +928,18 @@ namespace Ryujinx.Graphics.Shader.Instructions
             {
                 if ((compMask & 1) != 0)
                 {
+                    Operand destOperand = GetDest();
+
+                    if (destOperand == null)
+                    {
+                        break;
+                    }
+
                     // Components z and w aren't standard, we return 0 in this case and add a comment.
                     if (compIndex >= 2)
                     {
                         context.Add(new CommentNode("Unsupported component z or w found"));
-                        context.Copy(GetDest(), Const(0));
+                        context.Copy(destOperand, Const(0));
                     }
                     else
                     {
@@ -941,7 +960,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
                         Operand fixedPointValue = context.FP32ConvertToS32(tempDest);
 
-                        context.Copy(GetDest(), fixedPointValue);
+                        context.Copy(destOperand, fixedPointValue);
                     }
                 }
             }
@@ -1055,9 +1074,9 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
             Operand GetDest()
             {
-                if (dest > RegisterConsts.RegisterZeroIndex)
+                if (dest >= RegisterConsts.RegisterZeroIndex)
                 {
-                    return Const(0);
+                    return null;
                 }
 
                 return Register(dest++, RegisterType.Gpr);
@@ -1069,13 +1088,20 @@ namespace Ryujinx.Graphics.Shader.Instructions
             {
                 if ((compMask & 1) != 0)
                 {
+                    Operand destOperand = GetDest();
+
+                    if (destOperand == null)
+                    {
+                        break;
+                    }
+
                     TextureOperation operation = context.CreateTextureOperation(
                         Instruction.TextureSample,
                         type,
                         flags,
                         handle,
                         compIndex,
-                        GetDest(),
+                        destOperand,
                         sources);
 
                     context.Add(operation);
@@ -1126,9 +1152,9 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
             Operand GetDest()
             {
-                if (dest > RegisterConsts.RegisterZeroIndex)
+                if (dest >= RegisterConsts.RegisterZeroIndex)
                 {
-                    return Const(0);
+                    return null;
                 }
 
                 return Register(dest++, RegisterType.Gpr);
@@ -1149,13 +1175,20 @@ namespace Ryujinx.Graphics.Shader.Instructions
             {
                 if ((compMask & 1) != 0)
                 {
+                    Operand destOperand = GetDest();
+
+                    if (destOperand == null)
+                    {
+                        break;
+                    }
+
                     TextureOperation operation = context.CreateTextureOperation(
                         inst,
                         type,
                         flags,
                         imm,
                         compIndex,
-                        GetDest(),
+                        destOperand,
                         sources);
 
                     context.Add(operation);


### PR DESCRIPTION
When the register is RZ, it should set the destination operand to null, because setting it to a constant of zero would cause it to generate `0 = ...;` which is obviously not valid GLSL code. I found the issue only on SUATOM, but other texture instructions also had a similar issue, but unlike SUATOM, I don't think it would be ever RZ on  regular shader code, as doing a texture sample but discarding the results makes no sense.

I'm not sure which games this affects as this bug was found using a fuzzer. Testing is welcome.