### PR TITLE
Reduce some unnecessary allocations in DMA handler

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -1,11 +1,9 @@
 ﻿using Ryujinx.Common;
-using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.Device;
 using Ryujinx.Graphics.Gpu.Engine.Threed;
 using Ryujinx.Graphics.Gpu.Memory;
 using Ryujinx.Graphics.Texture;
 using System;
-using System.Buffers;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;

--- a/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -214,8 +214,6 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                 bool completeSource = IsTextureCopyComplete(src, srcLinear, srcBpp, srcStride, xCount, yCount);
                 bool completeDest = IsTextureCopyComplete(dst, dstLinear, dstBpp, dstStride, xCount, yCount);
 
-                Logger.Info?.PrintMsg(LogClass.Gpu, $"DMA Copy srcSize {srcSize} dstSize {dstSize} srcBpp {srcBpp} dstBpp {dstBpp} cS {completeSource} cD {completeDest} sL {srcLinear} dL {dstLinear}");
-
                 if (completeSource && completeDest)
                 {
                     var target = memoryManager.Physical.TextureCache.FindTexture(

--- a/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -273,8 +273,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
 
                 unsafe bool Convert<T>(Span<byte> dstSpan, ReadOnlySpan<byte> srcSpan) where T : unmanaged
                 {
-                    if (srcLinear && dstLinear &&
-                        srcBpp == dstBpp)
+                    if (srcLinear && dstLinear && srcBpp == dstBpp)
                     {
                         // Optimized path for purely linear copies - we don't need to calculate every single byte offset,
                         // and we can make use of Span.CopyTo which is very very fast (even compared to pointers)

--- a/Ryujinx.HLE/HOS/Kernel/Threading/KSynchronization.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Threading/KSynchronization.cs
@@ -65,8 +65,8 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
                     syncNodes[index] = syncObjs[index].AddWaitingThread(currentThread);
                 }
 
-                currentThread.WaitingSync = true;
-                currentThread.SignaledObj = null;
+                currentThread.WaitingSync   = true;
+                currentThread.SignaledObj   = null;
                 currentThread.ObjSyncResult = result;
 
                 currentThread.Reschedule(ThreadSchedState.Paused);


### PR DESCRIPTION
Reduce cases where unnecessary copies of data are made in DMA handler, and also add a fast path for pure linear transfers where we can bypass the stride offset calculator on each element and thus use a faster copy method. Should reduce load times slightly and give better performance / less GC stutter during FMVs