### PR TITLE
Fix Amiibo hanging since .NET 6 changes

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
@@ -1,6 +1,5 @@
 ﻿using Ryujinx.Common.Configuration;
 using Ryujinx.Common.Memory;
-using Ryujinx.Common.Utilities;
 using Ryujinx.HLE.HOS.Services.Mii;
 using Ryujinx.HLE.HOS.Services.Mii.Types;
 using Ryujinx.HLE.HOS.Services.Nfc.Nfp.NfpManager;
@@ -173,7 +172,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
 
             if (File.Exists(filePath))
             {
-                virtualAmiiboFile = JsonHelper.DeserializeFromFile<VirtualAmiiboFile>(filePath);
+                virtualAmiiboFile = JsonSerializer.Deserialize<VirtualAmiiboFile>(File.ReadAllText(filePath), new JsonSerializerOptions(JsonSerializerDefaults.General));
             }
             else
             {


### PR DESCRIPTION
The .NET 6 changes ended up causing a difference in the way we deserialise and would end up deserializing wrongly.

This PR fixes it by restoring the previous behaviour while still fixing the illink warning that caused that change in the first place.