### PR TITLE
Creating a central pool for large buffers and using these pooled buffers for moving texture data around.

### DIFF
--- a/Ryujinx.Common/Pools/BufferPool.cs
+++ b/Ryujinx.Common/Pools/BufferPool.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Buffers;
+
+namespace Ryujinx.Common.Pools
+{
+    /// <summary>
+    /// A centralized, static pool for getting multipurpose buffers of any type.
+    /// "But why does this exist when you have <see cref="ArrayPool{T}"/>?" This actually just wraps around
+    /// ArrayPool. The difference is that this also tracks the requested size of the allocated
+    /// buffer, so you can pass it around and users of it know how much of the data is actually valid,
+    /// compared to ArrayPool which just gives you an arbitrary sized array. Also, returning a strongly
+    /// typed <see cref="PooledBuffer{T}"/> codifies the fact that the buffer is part of a pool, and that code
+    /// can more clearly manage lifetime and disposal automatically.
+    /// </summary>
+    public static class BufferPool<T>
+    {
+        public const int DEFAULT_BUFFER_SIZE = 65536;
+
+        private static readonly PooledBuffer<T> EMPTY_POOLED_BUFFER = new PooledBuffer<T>(Array.Empty<T>(), -1);
+
+        /// <summary>
+        /// Returns a disposable <see cref="PooledBuffer{T}" /> instance containing an array of at least the specified number of elements.
+        /// </summary>
+        /// <param name="minimumRequestedSize">The minimum number of elements that you require</param>
+        /// <returns>A pooled buffer of at least the requested size. Buffers are not cleared between rentals, so it may initially contain garbage.</returns>
+        public static PooledBuffer<T> Rent(int minimumRequestedSize = DEFAULT_BUFFER_SIZE)
+        {
+            if (minimumRequestedSize < 0)
+            {
+                throw new ArgumentOutOfRangeException("Requested buffer size must be a positive number");
+            }
+
+            if (minimumRequestedSize == 0)
+            {
+                return EMPTY_POOLED_BUFFER;
+            }
+
+            PooledBuffer<T> returnVal = new PooledBuffer<T>(ArrayPool<T>.Shared.Rent(minimumRequestedSize), minimumRequestedSize);
+#if DEBUG
+            returnVal.MarkRented();
+#endif
+            return returnVal;
+        }
+    }
+}

--- a/Ryujinx.Common/Pools/BufferPool.cs
+++ b/Ryujinx.Common/Pools/BufferPool.cs
@@ -45,7 +45,7 @@ namespace Ryujinx.Common.Pools
             }
 
             PooledBuffer<T> returnVal = new PooledBuffer<T>(array, minimumRequestedSize);
-#if DEBUG
+#if TRACK_BUFFERPOOL_LEAKS
             returnVal.MarkRented();
 #endif
             return returnVal;

--- a/Ryujinx.Common/Pools/BufferPool.cs
+++ b/Ryujinx.Common/Pools/BufferPool.cs
@@ -6,11 +6,12 @@ namespace Ryujinx.Common.Pools
     /// <summary>
     /// A centralized, static pool for getting multipurpose buffers of any type.
     /// "But why does this exist when you have <see cref="ArrayPool{T}"/>?" This actually just wraps around
-    /// ArrayPool. The difference is that this also tracks the requested size of the allocated
-    /// buffer, so you can pass it around and users of it know how much of the data is actually valid,
-    /// compared to ArrayPool which just gives you an arbitrary sized array. Also, returning a strongly
-    /// typed <see cref="PooledBuffer{T}"/> codifies the fact that the buffer is part of a pool, and that code
-    /// can more clearly manage lifetime and disposal automatically.
+    /// ArrayPool. The difference is that the rented array is hidden inside of a <see cref="PooledBuffer{T}"/>
+    /// handle and is only exposed as a <see cref="Span{T}"/>. This makes it harder to leak references to the
+    /// pooled array, which makes it a bit easier to track ownership. The PooledBuffer handle is <see cref="IDisposable"/>
+    /// so code analysis can enforce better practice as well. In addition, it also tracks the initial requested
+    /// size of the allocated buffer, so you can pass it around and users of it know how much of the data
+    /// is actually valid, compared to ArrayPool which just gives you an arbitrary sized array.
     /// </summary>
     public static class BufferPool<T>
     {

--- a/Ryujinx.Common/Pools/PooledBuffer.cs
+++ b/Ryujinx.Common/Pools/PooledBuffer.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Threading;
+
+namespace Ryujinx.Common.Pools
+{
+    /// <summary>
+    /// Represents a reusable pooled buffer of some type T that was rented from a <see cref="BufferPool{T}"/>.
+    /// The actual length of the array may be longer than the actual valid contents; to codify the difference, the Length
+    /// parameter is used (in cases where you pass a buffered pool to some function like a reader that parses data from it).
+    /// This pool should be disposed when you are done using it, after which it is returned to the pool to be reclaimed.
+    /// </summary>
+    /// <typeparam name="T">The type of data that this buffer holds.</typeparam>
+    public class PooledBuffer<T> : IDisposable
+    {
+        private int _disposed = 0;
+
+        internal PooledBuffer(T[] data, int length)
+        {
+            Buffer = data;
+            Length = length;
+        }
+
+#if DEBUG
+        private string _lastRentalStackTrace = "Unknown";
+
+#pragma warning disable CA1063 // suppress "improper" finalizer style
+        ~PooledBuffer()
+        {
+            if (Length > 0)
+            {
+                Console.WriteLine("Buffer pool leak detected: Buffer was rented by " + _lastRentalStackTrace);
+                Dispose(false);
+            }
+        }
+#pragma warning restore CA1063
+
+        internal void MarkRented()
+        {
+            string stackTrace = new StackTrace().ToString();
+            string objectTypeName = nameof(BufferPool<T>);
+            string traceLine;
+            int startIdx = 0;
+            while (startIdx < stackTrace.Length)
+            {
+                startIdx = stackTrace.IndexOf('\n', startIdx);
+                if (startIdx < 0)
+                {
+                    break;
+                }
+
+                startIdx += 7; // trim the "   at " prefix
+
+                int endIdx = stackTrace.IndexOf('\n', startIdx) - 1;
+                if (endIdx < 0)
+                {
+                    endIdx = stackTrace.Length;
+                }
+
+                traceLine = stackTrace.Substring(startIdx, endIdx - startIdx);
+                if (!traceLine.Contains(objectTypeName))
+                {
+                    _lastRentalStackTrace = traceLine;
+                    return;
+                }
+            }
+        }
+#endif // DEBUG
+
+        /// <summary>
+        /// The contiguous buffer to store data in.
+        /// </summary>
+        public T[] Buffer { get; private set; }
+
+        /// <summary>
+        /// The buffer's intended length. This may be smaller than what is actually available (since a larger pooled buffer may have been used
+        /// to satisfy the request). This can be used as a signal to indicate the intended data size this buffer is used for.
+        /// </summary>
+        public int Length { get; private set; }
+
+        /// <summary>
+        /// Returns a pointer to this buffer's data as a span. The pointer will be invalid after the buffer is reclaimed. In other words, this is just a view over the data in-place.
+        /// </summary>
+        public Span<T> AsSpan => new Span<T>(Buffer, 0, Length);
+
+        [SuppressMessage("Usage", "CA1816:Dispose methods should call SuppressFinalize", Justification = "Disposal semantics are different here; we are not freeing memory but instead returning objects to a pool")]
+        public void Dispose()
+        {
+            Dispose(true);
+#if DEBUG
+            GC.SuppressFinalize(this);
+#endif
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (Interlocked.CompareExchange(ref _disposed, 1, 0) != 0)
+            {
+                return;
+            }
+
+            if (disposing && Length > 0)
+            {
+                // if the buffer is zero-length, just keep it zero (this prevents us from corrupting the state of the empty singleton buffer)
+                ArrayPool<T>.Shared.Return(Buffer);
+                Buffer = null;
+                Length = -1;
+            }
+        }
+    }
+}

--- a/Ryujinx.Common/Pools/PooledBuffer.cs
+++ b/Ryujinx.Common/Pools/PooledBuffer.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Ryujinx.Common.Logging;
+using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -25,7 +26,7 @@ namespace Ryujinx.Common.Pools
             Length = length;
         }
 
-#if DEBUG
+#if TRACK_BUFFERPOOL_LEAKS
         private string _lastRentalStackTrace = "Unknown";
 
 #pragma warning disable CA1063 // suppress "improper" finalizer style
@@ -33,7 +34,7 @@ namespace Ryujinx.Common.Pools
         {
             if (Length > 0)
             {
-                Console.WriteLine("Buffer pool leak detected: Buffer was rented by " + _lastRentalStackTrace);
+                Logger.Warning?.Print(LogClass.Application, $"Buffer pool leak detected: Buffer was rented by {_lastRentalStackTrace}");
                 Dispose(false);
             }
         }
@@ -69,7 +70,7 @@ namespace Ryujinx.Common.Pools
                 }
             }
         }
-#endif // DEBUG
+#endif // TRACK_BUFFERPOOL_LEAKS
 
         /// <summary>
         /// The contiguous buffer to store data in.
@@ -96,7 +97,7 @@ namespace Ryujinx.Common.Pools
         public void Dispose()
         {
             Dispose(true);
-#if DEBUG
+#if TRACK_BUFFERPOOL_LEAKS
             GC.SuppressFinalize(this);
 #endif
         }

--- a/Ryujinx.Common/Pools/PooledBuffer.cs
+++ b/Ryujinx.Common/Pools/PooledBuffer.cs
@@ -85,12 +85,12 @@ namespace Ryujinx.Common.Pools
         /// <summary>
         /// Returns a pointer to this buffer's data as a span.
         /// </summary>
-        public Span<T> AsSpan => _buffer[0..Length];
+        public Span<T> AsSpan => _buffer.AsSpan(0, Length);
 
         /// <summary>
         /// Returns a pointer to this buffer's data as a read-only span.
         /// </summary>
-        public ReadOnlySpan<T> AsReadOnlySpan => _buffer[0..Length];
+        public ReadOnlySpan<T> AsReadOnlySpan => _buffer.AsSpan(0, Length);
 
         [SuppressMessage("Usage", "CA1816:Dispose methods should call SuppressFinalize", Justification = "Disposal semantics are different here; we are not freeing memory but instead returning objects to a pool")]
         public void Dispose()

--- a/Ryujinx.Graphics.GAL/ITexture.cs
+++ b/Ryujinx.Graphics.GAL/ITexture.cs
@@ -1,3 +1,4 @@
+using Ryujinx.Common.Pools;
 using System;
 
 namespace Ryujinx.Graphics.GAL
@@ -16,8 +17,8 @@ namespace Ryujinx.Graphics.GAL
 
         ReadOnlySpan<byte> GetData();
 
-        void SetData(ReadOnlySpan<byte> data);
-        void SetData(ReadOnlySpan<byte> data, int layer, int level);
+        void SetData(PooledBuffer<byte> data);
+        void SetData(PooledBuffer<byte> data, int layer, int level);
         void SetStorage(BufferRange buffer);
         void Release();
     }

--- a/Ryujinx.Graphics.GAL/Multithreading/Commands/Texture/TextureSetDataCommand.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/Commands/Texture/TextureSetDataCommand.cs
@@ -1,4 +1,5 @@
-﻿using Ryujinx.Graphics.GAL.Multithreading.Model;
+﻿using Ryujinx.Common.Pools;
+using Ryujinx.Graphics.GAL.Multithreading.Model;
 using Ryujinx.Graphics.GAL.Multithreading.Resources;
 using System;
 
@@ -8,9 +9,9 @@ namespace Ryujinx.Graphics.GAL.Multithreading.Commands.Texture
     {
         public CommandType CommandType => CommandType.TextureSetData;
         private TableRef<ThreadedTexture> _texture;
-        private TableRef<byte[]> _data;
+        private TableRef<PooledBuffer<byte>> _data;
 
-        public void Set(TableRef<ThreadedTexture> texture, TableRef<byte[]> data)
+        public void Set(TableRef<ThreadedTexture> texture, TableRef<PooledBuffer<byte>> data)
         {
             _texture = texture;
             _data = data;
@@ -19,7 +20,7 @@ namespace Ryujinx.Graphics.GAL.Multithreading.Commands.Texture
         public static void Run(ref TextureSetDataCommand command, ThreadedRenderer threaded, IRenderer renderer)
         {
             ThreadedTexture texture = command._texture.Get(threaded);
-            texture.Base.SetData(new ReadOnlySpan<byte>(command._data.Get(threaded)));
+            texture.Base.SetData(command._data.Get(threaded));
         }
     }
 }

--- a/Ryujinx.Graphics.GAL/Multithreading/Commands/Texture/TextureSetDataSliceCommand.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/Commands/Texture/TextureSetDataSliceCommand.cs
@@ -1,4 +1,5 @@
-﻿using Ryujinx.Graphics.GAL.Multithreading.Model;
+﻿using Ryujinx.Common.Pools;
+using Ryujinx.Graphics.GAL.Multithreading.Model;
 using Ryujinx.Graphics.GAL.Multithreading.Resources;
 using System;
 
@@ -8,11 +9,11 @@ namespace Ryujinx.Graphics.GAL.Multithreading.Commands.Texture
     {
         public CommandType CommandType => CommandType.TextureSetDataSlice;
         private TableRef<ThreadedTexture> _texture;
-        private TableRef<byte[]> _data;
+        private TableRef<PooledBuffer<byte>> _data;
         private int _layer;
         private int _level;
 
-        public void Set(TableRef<ThreadedTexture> texture, TableRef<byte[]> data, int layer, int level)
+        public void Set(TableRef<ThreadedTexture> texture, TableRef<PooledBuffer<byte>> data, int layer, int level)
         {
             _texture = texture;
             _data = data;
@@ -23,7 +24,7 @@ namespace Ryujinx.Graphics.GAL.Multithreading.Commands.Texture
         public static void Run(ref TextureSetDataSliceCommand command, ThreadedRenderer threaded, IRenderer renderer)
         {
             ThreadedTexture texture = command._texture.Get(threaded);
-            texture.Base.SetData(new ReadOnlySpan<byte>(command._data.Get(threaded)), command._layer, command._level);
+            texture.Base.SetData(command._data.Get(threaded), command._layer, command._level);
         }
     }
 }

--- a/Ryujinx.Graphics.GAL/Multithreading/Resources/ThreadedTexture.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/Resources/ThreadedTexture.cs
@@ -1,4 +1,5 @@
-﻿using Ryujinx.Graphics.GAL.Multithreading.Commands.Texture;
+﻿using Ryujinx.Common.Pools;
+using Ryujinx.Graphics.GAL.Multithreading.Commands.Texture;
 using Ryujinx.Graphics.GAL.Multithreading.Model;
 using System;
 
@@ -89,15 +90,15 @@ namespace Ryujinx.Graphics.GAL.Multithreading.Resources
             }
         }
 
-        public void SetData(ReadOnlySpan<byte> data)
+        public void SetData(PooledBuffer<byte> data)
         {
-            _renderer.New<TextureSetDataCommand>().Set(Ref(this), Ref(data.ToArray()));
+            _renderer.New<TextureSetDataCommand>().Set(Ref(this), Ref(data));
             _renderer.QueueCommand();
         }
 
-        public void SetData(ReadOnlySpan<byte> data, int layer, int level)
+        public void SetData(PooledBuffer<byte> data, int layer, int level)
         {
-            _renderer.New<TextureSetDataSliceCommand>().Set(Ref(this), Ref(data.ToArray()), layer, level);
+            _renderer.New<TextureSetDataSliceCommand>().Set(Ref(this), Ref(data), layer, level);
             _renderer.QueueCommand();
         }
 

--- a/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -1,4 +1,5 @@
 ﻿using Ryujinx.Common;
+using Ryujinx.Common.Pools;
 using Ryujinx.Graphics.Device;
 using Ryujinx.Graphics.Gpu.Engine.Threed;
 using Ryujinx.Graphics.Texture;
@@ -173,7 +174,6 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                 }
 
                 ReadOnlySpan<byte> srcSpan = memoryManager.GetSpan(srcGpuVa + (ulong)srcBaseOffset, srcSize, true);
-                Span<byte> dstSpan = memoryManager.GetSpan(dstGpuVa + (ulong)dstBaseOffset, dstSize).ToArray();
 
                 bool completeSource = IsTextureCopyComplete(src, srcLinear, srcBpp, srcStride, xCount, yCount);
                 bool completeDest = IsTextureCopyComplete(dst, dstLinear, dstBpp, dstStride, xCount, yCount);
@@ -192,7 +192,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
 
                     if (target != null)
                     {
-                        ReadOnlySpan<byte> data;
+                        PooledBuffer<byte> data;
                         if (srcLinear)
                         {
                             data = LayoutConverter.ConvertLinearStridedToLinear(
@@ -229,50 +229,76 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                     }
                     else if (srcCalculator.LayoutMatches(dstCalculator))
                     {
-                        srcSpan.CopyTo(dstSpan); // No layout conversion has to be performed, just copy the data entirely.
-
-                        memoryManager.Write(dstGpuVa + (ulong)dstBaseOffset, dstSpan);
-
+                        // No layout conversion has to be performed, just copy the data entirely.
+                        memoryManager.Write(dstGpuVa + (ulong)dstBaseOffset, srcSpan);
                         return;
                     }
                 }
 
                 unsafe bool Convert<T>(Span<byte> dstSpan, ReadOnlySpan<byte> srcSpan) where T : unmanaged
                 {
-                    fixed (byte* dstPtr = dstSpan, srcPtr = srcSpan)
+                    if (srcLinear && dstLinear &&
+                        srcBpp == dstBpp)
                     {
-                        byte* dstBase = dstPtr - dstBaseOffset; // Layout offset is relative to the base, so we need to subtract the span's offset.
-                        byte* srcBase = srcPtr - srcBaseOffset;
-
+                        // Optimized path for purely linear copies - we don't need to calculate every single byte offset,
+                        // and we can make use of Span.CopyTo which is very very fast (even compared to pointers)
                         for (int y = 0; y < yCount; y++)
                         {
                             srcCalculator.SetY(src.RegionY + y);
                             dstCalculator.SetY(dst.RegionY + y);
+                            int srcOffset = srcCalculator.GetOffset(src.RegionX);
+                            int dstOffset = dstCalculator.GetOffset(dst.RegionX);
+                            srcSpan.Slice(srcOffset - srcBaseOffset, xCount * srcBpp)
+                                .CopyTo(dstSpan.Slice(dstOffset - dstBaseOffset, xCount * dstBpp));
+                        }
+                    }
+                    else
+                    {
+                        fixed (byte* dstPtr = dstSpan, srcPtr = srcSpan)
+                        {
+                            byte* dstBase = dstPtr - dstBaseOffset; // Layout offset is relative to the base, so we need to subtract the span's offset.
+                            byte* srcBase = srcPtr - srcBaseOffset;
 
-                            for (int x = 0; x < xCount; x++)
+                            for (int y = 0; y < yCount; y++)
                             {
-                                int srcOffset = srcCalculator.GetOffset(src.RegionX + x);
-                                int dstOffset = dstCalculator.GetOffset(dst.RegionX + x);
+                                srcCalculator.SetY(src.RegionY + y);
+                                dstCalculator.SetY(dst.RegionY + y);
 
-                                *(T*)(dstBase + dstOffset) = *(T*)(srcBase + srcOffset);
+                                for (int x = 0; x < xCount; x++)
+                                {
+                                    int srcOffset = srcCalculator.GetOffset(src.RegionX + x);
+                                    int dstOffset = dstCalculator.GetOffset(dst.RegionX + x);
+
+                                    *(T*)(dstBase + dstOffset) = *(T*)(srcBase + srcOffset);
+                                }
                             }
                         }
                     }
+
                     return true;
                 }
 
-                bool _ = srcBpp switch
+                using (PooledBuffer<byte> scratch = BufferPool<byte>.Rent(dstSize))
                 {
-                    1 => Convert<byte>(dstSpan, srcSpan),
-                    2 => Convert<ushort>(dstSpan, srcSpan),
-                    4 => Convert<uint>(dstSpan, srcSpan),
-                    8 => Convert<ulong>(dstSpan, srcSpan),
-                    12 => Convert<Bpp12Pixel>(dstSpan, srcSpan),
-                    16 => Convert<Vector128<byte>>(dstSpan, srcSpan),
-                    _ => throw new NotSupportedException($"Unable to copy ${srcBpp} bpp pixel format.")
-                };
+                    Span<byte> dstSpan = scratch.AsSpan;
 
-                memoryManager.Write(dstGpuVa + (ulong)dstBaseOffset, dstSpan);
+                    // need to prepopulate the data that's already in the destination span because we won't
+                    // necessarily overwrite all of it
+                    memoryManager.GetSpan(dstGpuVa + (ulong)dstBaseOffset, dstSize).CopyTo(dstSpan);
+
+                    bool _ = srcBpp switch
+                    {
+                        1 => Convert<byte>(dstSpan, srcSpan),
+                        2 => Convert<ushort>(dstSpan, srcSpan),
+                        4 => Convert<uint>(dstSpan, srcSpan),
+                        8 => Convert<ulong>(dstSpan, srcSpan),
+                        12 => Convert<Bpp12Pixel>(dstSpan, srcSpan),
+                        16 => Convert<Vector128<byte>>(dstSpan, srcSpan),
+                        _ => throw new NotSupportedException($"Unable to copy ${srcBpp} bpp pixel format.")
+                    };
+
+                    memoryManager.Write(dstGpuVa + (ulong)dstBaseOffset, dstSpan);
+                }
             }
             else
             {

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -1,4 +1,5 @@
-﻿using Ryujinx.Cpu.Tracking;
+﻿using Ryujinx.Common.Pools;
+using Ryujinx.Cpu.Tracking;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Memory;
 using Ryujinx.Graphics.Texture;
@@ -223,9 +224,9 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                             ReadOnlySpan<byte> data = _physicalMemory.GetSpan(Storage.Range.GetSlice((ulong)offset, (ulong)size));
 
-                            data = Storage.ConvertToHostCompatibleFormat(data, info.BaseLevel, true);
+                            PooledBuffer<byte> convertedData = Storage.ConvertToHostCompatibleFormat(data, info.BaseLevel, true);
 
-                            Storage.SetData(data, info.BaseLayer, info.BaseLevel);
+                            Storage.SetData(convertedData, info.BaseLayer, info.BaseLevel);
 
                             offsetIndex++;
                         }

--- a/Ryujinx.Graphics.OpenGL/Image/TextureBuffer.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureBuffer.cs
@@ -1,4 +1,5 @@
 ﻿using OpenTK.Graphics.OpenGL;
+using Ryujinx.Common.Pools;
 using Ryujinx.Graphics.GAL;
 using System;
 
@@ -43,12 +44,15 @@ namespace Ryujinx.Graphics.OpenGL.Image
             return Buffer.GetData(_renderer, _buffer, _bufferOffset, _bufferSize);
         }
 
-        public void SetData(ReadOnlySpan<byte> data)
+        public void SetData(PooledBuffer<byte> data)
         {
-            Buffer.SetData(_buffer, _bufferOffset, data.Slice(0, Math.Min(data.Length, _bufferSize)));
+            Buffer.SetData(_buffer, _bufferOffset, data.AsSpan.Slice(0, Math.Min(data.Length, _bufferSize)));
+
+            // The pooled data has now been put where it needs to go, so we can dispose of the pool.
+            data.Dispose();
         }
 
-        public void SetData(ReadOnlySpan<byte> data, int layer, int level)
+        public void SetData(PooledBuffer<byte> data, int layer, int level)
         {
             throw new NotSupportedException();
         }

--- a/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
@@ -257,7 +257,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
         {
             unsafe
             {
-                fixed (byte* ptr = data.Buffer)
+                fixed (byte* ptr = data.AsReadOnlySpan)
                 {
                     ReadFrom((IntPtr)ptr, data.Length);
                 }
@@ -271,7 +271,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
         {
             unsafe
             {
-                fixed (byte* ptr = data.Buffer)
+                fixed (byte* ptr = data.AsReadOnlySpan)
                 {
                     int width = Math.Max(Info.Width >> level, 1);
                     int height = Math.Max(Info.Height >> level, 1);

--- a/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
@@ -1,4 +1,5 @@
 using OpenTK.Graphics.OpenGL;
+using Ryujinx.Common.Pools;
 using Ryujinx.Graphics.GAL;
 using System;
 
@@ -252,22 +253,25 @@ namespace Ryujinx.Graphics.OpenGL.Image
             }
         }
 
-        public void SetData(ReadOnlySpan<byte> data)
+        public void SetData(PooledBuffer<byte> data)
         {
             unsafe
             {
-                fixed (byte* ptr = data)
+                fixed (byte* ptr = data.Buffer)
                 {
                     ReadFrom((IntPtr)ptr, data.Length);
                 }
             }
+
+            // The pooled data has now been put where it needs to go, so we can dispose of the pool.
+            data.Dispose();
         }
 
-        public void SetData(ReadOnlySpan<byte> data, int layer, int level)
+        public void SetData(PooledBuffer<byte> data, int layer, int level)
         {
             unsafe
             {
-                fixed (byte* ptr = data)
+                fixed (byte* ptr = data.Buffer)
                 {
                     int width = Math.Max(Info.Width >> level, 1);
                     int height = Math.Max(Info.Height >> level, 1);
@@ -275,6 +279,9 @@ namespace Ryujinx.Graphics.OpenGL.Image
                     ReadFrom2D((IntPtr)ptr, layer, level, width, height);
                 }
             }
+
+            // The pooled data has now been put where it needs to go, so we can dispose of the pool.
+            data.Dispose();
         }
 
         public void ReadFromPbo(int offset, int size)

--- a/Ryujinx.Graphics.Texture/Astc/AstcDecoder.cs
+++ b/Ryujinx.Graphics.Texture/Astc/AstcDecoder.cs
@@ -1,4 +1,5 @@
-﻿using Ryujinx.Common.Utilities;
+﻿using Ryujinx.Common.Pools;
+using Ryujinx.Common.Utilities;
 using System;
 using System.Diagnostics;
 using System.Linq;
@@ -291,11 +292,11 @@ namespace Ryujinx.Graphics.Texture.Astc
             int depth,
             int levels,
             int layers,
-            out Span<byte> decoded)
+            out PooledBuffer<byte> decoded)
         {
-            byte[] output = new byte[QueryDecompressedSize(width, height, depth, levels, layers)];
+            PooledBuffer<byte> output = BufferPool<byte>.Rent(QueryDecompressedSize(width, height, depth, levels, layers));
 
-            AstcDecoder decoder = new AstcDecoder(data, output, blockWidth, blockHeight, width, height, depth, levels, layers);
+            AstcDecoder decoder = new AstcDecoder(data, output.Buffer, blockWidth, blockHeight, width, height, depth, levels, layers);
 
             Enumerable.Range(0, decoder.TotalBlockCount).AsParallel().ForAll(x => decoder.ProcessBlock(x));
 

--- a/Ryujinx.Graphics.Texture/Astc/AstcDecoder.cs
+++ b/Ryujinx.Graphics.Texture/Astc/AstcDecoder.cs
@@ -11,8 +11,8 @@ namespace Ryujinx.Graphics.Texture.Astc
     // https://github.com/GammaUNC/FasTC/blob/master/ASTCEncoder/src/Decompressor.cpp
     public class AstcDecoder
     {
-        private ReadOnlyMemory<byte> InputBuffer { get; }
-        private Memory<byte> OutputBuffer { get; }
+        private PooledBuffer<byte> InputBuffer { get; }
+        private PooledBuffer<byte> OutputBuffer { get; }
 
         private int BlockSizeX { get; }
         private int BlockSizeY { get; }
@@ -24,8 +24,8 @@ namespace Ryujinx.Graphics.Texture.Astc
         public int TotalBlockCount { get; }
 
         public AstcDecoder(
-            ReadOnlyMemory<byte> inputBuffer,
-            Memory<byte> outputBuffer,
+            PooledBuffer<byte> inputBuffer,
+            PooledBuffer<byte> outputBuffer,
             int blockWidth,
             int blockHeight,
             int width,
@@ -117,7 +117,7 @@ namespace Ryujinx.Graphics.Texture.Astc
 
         public void ProcessBlock(int index)
         {
-            Buffer16 inputBlock = MemoryMarshal.Cast<byte, Buffer16>(InputBuffer.Span)[index];
+            Buffer16 inputBlock = MemoryMarshal.Cast<byte, Buffer16>(InputBuffer.AsSpan)[index];
 
             Span<int> decompressedData = stackalloc int[144];
 
@@ -134,7 +134,7 @@ namespace Ryujinx.Graphics.Texture.Astc
 
             AstcLevel levelInfo = GetLevelInfo(index);
 
-            WriteDecompressedBlock(decompressedBytes, OutputBuffer.Span.Slice(levelInfo.OutputByteOffset),
+            WriteDecompressedBlock(decompressedBytes, OutputBuffer.AsSpan.Slice(levelInfo.OutputByteOffset),
                 index - levelInfo.StartBlock, levelInfo);
         }
 
@@ -219,7 +219,7 @@ namespace Ryujinx.Graphics.Texture.Astc
         }
 
         public static bool TryDecodeToRgba8(
-            ReadOnlyMemory<byte> data,
+            PooledBuffer<byte> data,
             int blockWidth,
             int blockHeight,
             int width,
@@ -227,9 +227,9 @@ namespace Ryujinx.Graphics.Texture.Astc
             int depth,
             int levels,
             int layers,
-            out Span<byte> decoded)
+            out PooledBuffer<byte> decoded)
         {
-            byte[] output = new byte[QueryDecompressedSize(width, height, depth, levels, layers)];
+            PooledBuffer<byte> output = BufferPool<byte>.Rent(QueryDecompressedSize(width, height, depth, levels, layers));
 
             AstcDecoder decoder = new AstcDecoder(data, output, blockWidth, blockHeight, width, height, depth, levels, layers);
 
@@ -244,8 +244,8 @@ namespace Ryujinx.Graphics.Texture.Astc
         }
 
         public static bool TryDecodeToRgba8(
-            ReadOnlyMemory<byte> data,
-            Memory<byte> outputBuffer,
+            PooledBuffer<byte> data,
+            PooledBuffer<byte> outputBuffer,
             int blockWidth,
             int blockHeight,
             int width,
@@ -265,8 +265,8 @@ namespace Ryujinx.Graphics.Texture.Astc
         }
 
         public static bool TryDecodeToRgba8P(
-            ReadOnlyMemory<byte> data,
-            Memory<byte> outputBuffer,
+            PooledBuffer<byte> data,
+            PooledBuffer<byte> outputBuffer,
             int blockWidth,
             int blockHeight,
             int width,
@@ -284,7 +284,7 @@ namespace Ryujinx.Graphics.Texture.Astc
         }
 
         public static bool TryDecodeToRgba8P(
-            ReadOnlyMemory<byte> data,
+            PooledBuffer<byte> data,
             int blockWidth,
             int blockHeight,
             int width,
@@ -296,7 +296,7 @@ namespace Ryujinx.Graphics.Texture.Astc
         {
             PooledBuffer<byte> output = BufferPool<byte>.Rent(QueryDecompressedSize(width, height, depth, levels, layers));
 
-            AstcDecoder decoder = new AstcDecoder(data, output.Buffer, blockWidth, blockHeight, width, height, depth, levels, layers);
+            AstcDecoder decoder = new AstcDecoder(data, output, blockWidth, blockHeight, width, height, depth, levels, layers);
 
             Enumerable.Range(0, decoder.TotalBlockCount).AsParallel().ForAll(x => decoder.ProcessBlock(x));
 

--- a/Ryujinx.Graphics.Texture/BCnDecoder.cs
+++ b/Ryujinx.Graphics.Texture/BCnDecoder.cs
@@ -1,4 +1,5 @@
 using Ryujinx.Common;
+using Ryujinx.Common.Pools;
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -10,7 +11,7 @@ namespace Ryujinx.Graphics.Texture
         private const int BlockWidth = 4;
         private const int BlockHeight = 4;
 
-        public static byte[] DecodeBC4(ReadOnlySpan<byte> data, int width, int height, int depth, int levels, int layers, bool signed)
+        public static PooledBuffer<byte> DecodeBC4(ReadOnlySpan<byte> data, int width, int height, int depth, int levels, int layers, bool signed)
         {
             int size = 0;
 
@@ -19,8 +20,8 @@ namespace Ryujinx.Graphics.Texture
                 size += Math.Max(1, width >> l) * Math.Max(1, height >> l) * Math.Max(1, depth >> l) * layers;
             }
 
-            byte[] output = new byte[size];
-
+            PooledBuffer<byte> output = BufferPool<byte>.Rent(size);
+            Span<byte> outputData = output.AsSpan;
             ReadOnlySpan<ulong> data64 = MemoryMarshal.Cast<byte, ulong>(data);
 
             Span<byte> rPal = stackalloc byte[8];
@@ -77,7 +78,7 @@ namespace Ryujinx.Graphics.Texture
 
                                     int oOffs = lineBaseOOffs + tY * width + tX;
 
-                                    output[oOffs] = r;
+                                    outputData[oOffs] = r;
                                 }
 
                                 data64 = data64.Slice(1);
@@ -96,7 +97,7 @@ namespace Ryujinx.Graphics.Texture
             return output;
         }
 
-        public static byte[] DecodeBC5(ReadOnlySpan<byte> data, int width, int height, int depth, int levels, int layers, bool signed)
+        public static PooledBuffer<byte> DecodeBC5(ReadOnlySpan<byte> data, int width, int height, int depth, int levels, int layers, bool signed)
         {
             int size = 0;
 
@@ -105,7 +106,8 @@ namespace Ryujinx.Graphics.Texture
                 size += Math.Max(1, width >> l) * Math.Max(1, height >> l) * Math.Max(1, depth >> l) * layers * 2;
             }
 
-            byte[] output = new byte[size];
+            PooledBuffer<byte> output = BufferPool<byte>.Rent(size);
+            Span<byte> outputData = output.AsSpan;
 
             ReadOnlySpan<ulong> data64 = MemoryMarshal.Cast<byte, ulong>(data);
 
@@ -171,8 +173,8 @@ namespace Ryujinx.Graphics.Texture
 
                                     int oOffs = (lineBaseOOffs + tY * width + tX) * 2;
 
-                                    output[oOffs + 0] = r;
-                                    output[oOffs + 1] = g;
+                                    outputData[oOffs + 0] = r;
+                                    outputData[oOffs + 1] = g;
                                 }
 
                                 data64 = data64.Slice(2);


### PR DESCRIPTION
This will likely conflict heavily with changes in the Vulkan branch so I am just throwing this out as a draft for now. I know the comments on that branch mentioned reducing copies for texture and maybe vertex data too, and I don't know if there is a solid plan for that, but consider this as one proposed design?

This PR reduces the CLR heap allocation rate in Mario Odyssey by a whopping 40-50%, from ~166MB / sec to ~81MB / sec. This means less GC stutter, better performance on things like FMVs which do frequent large buffer->texture copies, and likely better performance on CPUs where memory is a bottleneck (haven't fully tested perf yet).