### PR TITLE
misc: Fix alsoft.ini being present on Linux releases

### DIFF
--- a/Ryujinx/Ryujinx.csproj
+++ b/Ryujinx/Ryujinx.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="alsoft.ini">
+    <None Update="alsoft.ini" Condition="'$(RuntimeIdentifier)' != 'linux-x64' AND '$(RuntimeIdentifier)' != 'osx-x64'">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="Config.json" Condition="'$(Configuration)' == 'Debug' OR '$(Configuration)' == 'Profile Debug'">


### PR DESCRIPTION
https://github.com/Ryujinx/Ryujinx/commit/39f171ece5df6ba07f1d4a5aaf6f3026ce15833e added ``alsoft.ini`` to fix issues on headphones on WIndows for OpenAL Soft.

However, ``alsoft.ini`` was supposed to only be deployed on Windows releases, and is in fact [not supported by OpenAL Soft on Linux](https://github.com/kcat/openal-soft/blob/f963a2c543a35edf4810c5a1c106d6162e51b274/alc/alconfig.cpp#L365-L361).

This PR add a condition check to avoid adding it to Linux releases.