### PR TITLE
Remove usage of Mono.Posix.NETStandard accross all projects

### DIFF
--- a/ARMeilleure/ARMeilleure.csproj
+++ b/ARMeilleure/ARMeilleure.csproj
@@ -6,10 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Posix.NETStandard" Version="5.20.1-preview" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Ryujinx.Common\Ryujinx.Common.csproj" />
   </ItemGroup>
 

--- a/ARMeilleure/Signal/UnixSignalHandlerRegistration.cs
+++ b/ARMeilleure/Signal/UnixSignalHandlerRegistration.cs
@@ -1,5 +1,4 @@
-﻿using Mono.Unix.Native;
-using System;
+﻿using System;
 using System.Runtime.InteropServices;
 
 namespace ARMeilleure.Signal
@@ -21,6 +20,7 @@ namespace ARMeilleure.Signal
 
     static class UnixSignalHandlerRegistration
     {
+        private const int SIGSEGV = 11;
         private const int SA_SIGINFO = 0x00000004;
 
         [DllImport("libc", SetLastError = true)]
@@ -39,7 +39,7 @@ namespace ARMeilleure.Signal
 
             sigemptyset(ref sig.sa_mask);
 
-            int result = sigaction((int)Signum.SIGSEGV, ref sig, out SigAction old);
+            int result = sigaction(SIGSEGV, ref sig, out SigAction old);
 
             if (result != 0)
             {
@@ -51,7 +51,7 @@ namespace ARMeilleure.Signal
 
         public static bool RestoreExceptionHandler(SigAction oldAction)
         {
-            return sigaction((int)Signum.SIGSEGV, ref oldAction, out SigAction _) == 0;
+            return sigaction(SIGSEGV, ref oldAction, out SigAction _) == 0;
         }
     }
 }

--- a/Ryujinx.Memory/MemoryManagementUnix.cs
+++ b/Ryujinx.Memory/MemoryManagementUnix.cs
@@ -19,15 +19,6 @@ namespace Ryujinx.Memory
             public IntPtr SourcePointer;
         }
 
-        [DllImport("libc", SetLastError = true)]
-        public static extern IntPtr mremap(IntPtr old_address, ulong old_size, ulong new_size, int flags, IntPtr new_address);
-
-        [DllImport("libc", SetLastError = true)]
-        public static extern int madvise(IntPtr address, ulong size, int advice);
-
-        private const int MADV_DONTNEED = 4;
-        private const int MADV_REMOVE = 9;
-
         private static readonly List<UnixSharedMemory> _sharedMemory = new List<UnixSharedMemory>();
         private static readonly ConcurrentDictionary<IntPtr, ulong> _sharedMemorySource = new ConcurrentDictionary<IntPtr, ulong>();
         private static readonly ConcurrentDictionary<IntPtr, ulong> _allocations = new ConcurrentDictionary<IntPtr, ulong>();

--- a/Ryujinx.Memory/MemoryManagerUnixHelper.cs
+++ b/Ryujinx.Memory/MemoryManagerUnixHelper.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Ryujinx.Memory
+{
+    public static class MemoryManagerUnixHelper
+    {
+        [Flags]
+        public enum MmapProts : uint
+        {
+            PROT_NONE = 0,
+            PROT_READ = 1,
+            PROT_WRITE = 2,
+            PROT_EXEC = 4
+        }
+
+        [Flags]
+        public enum MmapFlags : uint
+        {
+            MAP_SHARED = 1,
+            MAP_PRIVATE = 2,
+            MAP_ANONYMOUS = 4,
+            MAP_NORESERVE = 8,
+            MAP_UNLOCKED = 16
+        }
+
+        private const int MAP_ANONYMOUS_LINUX_GENERIC = 0x20;
+        private const int MAP_NORESERVE_LINUX_GENERIC = 0x4000;
+        private const int MAP_UNLOCKED_LINUX_GENERIC = 0x80000;
+
+        private const int MAP_NORESERVE_DARWIN = 0x40;
+        private const int MAP_JIT_DARWIN = 0x800;
+        private const int MAP_ANONYMOUS_DARWIN = 0x1000;
+
+
+        [DllImport("libc", EntryPoint = "mmap", SetLastError = true)]
+        private static extern IntPtr Internal_mmap(IntPtr address, ulong length, MmapProts prot, int flags, int fd, long offset);
+
+        [DllImport("libc", SetLastError = true)]
+        public static extern int mprotect(IntPtr address, ulong length, MmapProts prot);
+
+        [DllImport("libc", SetLastError = true)]
+        public static extern int munmap(IntPtr address, ulong length);
+
+        private static int MmapFlagsToSystemFlags(MmapFlags flags)
+        {
+            int result = 0;
+
+            if (flags.HasFlag(MmapFlags.MAP_SHARED))
+            {
+                result |= (int)MmapFlags.MAP_SHARED;
+            }
+
+            if (flags.HasFlag(MmapFlags.MAP_PRIVATE))
+            {
+                result |= (int)MmapFlags.MAP_PRIVATE;
+            }
+
+            if (flags.HasFlag(MmapFlags.MAP_ANONYMOUS))
+            {
+                if (OperatingSystem.IsLinux())
+                {
+                    result |= MAP_ANONYMOUS_LINUX_GENERIC;
+                }
+                else if (OperatingSystem.IsMacOS())
+                {
+                    result |= MAP_ANONYMOUS_DARWIN;
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            if (flags.HasFlag(MmapFlags.MAP_NORESERVE))
+            {
+                if (OperatingSystem.IsLinux())
+                {
+                    result |= MAP_NORESERVE_LINUX_GENERIC;
+                }
+                else if (OperatingSystem.IsMacOS())
+                {
+                    result |= MAP_NORESERVE_DARWIN;
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            if (flags.HasFlag(MmapFlags.MAP_UNLOCKED))
+            {
+                if (OperatingSystem.IsLinux())
+                {
+                    result |= MAP_UNLOCKED_LINUX_GENERIC;
+                }
+                else if (OperatingSystem.IsMacOS())
+                {
+                    // FIXME: Doesn't exist on Darwin
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            if (OperatingSystem.IsMacOSVersionAtLeast(10, 14))
+            {
+                result |= MAP_JIT_DARWIN;
+            }
+
+            return result;
+        }
+
+        public static IntPtr mmap(IntPtr address, ulong length, MmapProts prot, MmapFlags flags, int fd, long offset)
+        {
+            return Internal_mmap(address, length, prot, MmapFlagsToSystemFlags(flags), fd, offset);
+        }
+    }
+}

--- a/Ryujinx.Memory/MemoryManagerUnixHelper.cs
+++ b/Ryujinx.Memory/MemoryManagerUnixHelper.cs
@@ -32,6 +32,8 @@ namespace Ryujinx.Memory
         private const int MAP_JIT_DARWIN = 0x800;
         private const int MAP_ANONYMOUS_DARWIN = 0x1000;
 
+        public const int MADV_DONTNEED = 4;
+        public const int MADV_REMOVE = 9;
 
         [DllImport("libc", EntryPoint = "mmap", SetLastError = true)]
         private static extern IntPtr Internal_mmap(IntPtr address, ulong length, MmapProts prot, int flags, int fd, long offset);
@@ -41,6 +43,12 @@ namespace Ryujinx.Memory
 
         [DllImport("libc", SetLastError = true)]
         public static extern int munmap(IntPtr address, ulong length);
+
+        [DllImport("libc", SetLastError = true)]
+        public static extern IntPtr mremap(IntPtr old_address, ulong old_size, ulong new_size, int flags, IntPtr new_address);
+
+        [DllImport("libc", SetLastError = true)]
+        public static extern int madvise(IntPtr address, ulong size, int advice);
 
         private static int MmapFlagsToSystemFlags(MmapFlags flags)
         {

--- a/Ryujinx.Memory/Ryujinx.Memory.csproj
+++ b/Ryujinx.Memory/Ryujinx.Memory.csproj
@@ -6,10 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Posix.NETStandard" Version="5.20.1-preview" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Ryujinx.Common\Ryujinx.Common.csproj" />
   </ItemGroup>
 

--- a/Ryujinx/Modules/Updater/UpdateDialog.cs
+++ b/Ryujinx/Modules/Updater/UpdateDialog.cs
@@ -1,12 +1,10 @@
 using Gdk;
 using Gtk;
-using Mono.Unix;
 using Ryujinx.Ui;
 using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.InteropServices;
 
 namespace Ryujinx.Modules
 {

--- a/Ryujinx/Modules/Updater/Updater.cs
+++ b/Ryujinx/Modules/Updater/Updater.cs
@@ -2,7 +2,6 @@ using Gtk;
 using ICSharpCode.SharpZipLib.GZip;
 using ICSharpCode.SharpZipLib.Tar;
 using ICSharpCode.SharpZipLib.Zip;
-using Mono.Unix;
 using Newtonsoft.Json.Linq;
 using Ryujinx.Common.Logging;
 using Ryujinx.Ui;
@@ -355,14 +354,16 @@ namespace Ryujinx.Modules
             worker.Start();
         }
 
+        [DllImport("libc", SetLastError = true)]
+        private static extern int chmod(string path, uint mode);
+
         private static void SetUnixPermissions()
         {
             string ryuBin = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Ryujinx");
 
             if (!OperatingSystem.IsWindows())
             {
-                UnixFileInfo unixFileInfo = new UnixFileInfo(ryuBin);
-                unixFileInfo.FileAccessPermissions |= FileAccessPermissions.UserExecute;
+                chmod(ryuBin, 0777);
             }
         }
 

--- a/Ryujinx/Program.cs
+++ b/Ryujinx/Program.cs
@@ -61,9 +61,6 @@ namespace Ryujinx
                 }
             }
 
-            // Enforce loading of Mono.Posix to avoid .NET runtime lazy loading it during an update.
-            Assembly.Load("Mono.Posix.NETStandard");
-
             // Make process DPI aware for proper window sizing on high-res screens.
             ForceDpiAware.Windows();
             WindowScaleFactor = ForceDpiAware.GetWindowScaleFactor();

--- a/Ryujinx/Ryujinx.csproj
+++ b/Ryujinx/Ryujinx.csproj
@@ -25,7 +25,6 @@
     <PackageReference Include="OpenTK.Graphics" Version="4.5.0" />
     <PackageReference Include="SPB" Version="0.0.3-build15" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
-    <PackageReference Include="Mono.Posix.NETStandard" Version="5.20.1-preview" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This remove the usage of the ``Mono.Posix.NETStandard`` package, saving ~1.5MB on releases and removing an external C library.

Need testing on Linux.