### PR TITLE
Fix for texture pool not being updated when it should + buffer texture fixes

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
@@ -34,6 +34,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 { nameof(ThreedClassState.LaunchDma), new RwCallback(LaunchDma, null) },
                 { nameof(ThreedClassState.LoadInlineData), new RwCallback(LoadInlineData, null) },
                 { nameof(ThreedClassState.SyncpointAction), new RwCallback(IncrementSyncpoint, null) },
+                { nameof(ThreedClassState.InvalidateSamplerCacheNoWfi), new RwCallback(InvalidateSamplerCacheNoWfi, null) },
+                { nameof(ThreedClassState.InvalidateTextureHeaderCacheNoWfi), new RwCallback(InvalidateTextureHeaderCacheNoWfi, null) },
                 { nameof(ThreedClassState.TextureBarrier), new RwCallback(TextureBarrier, null) },
                 { nameof(ThreedClassState.TextureBarrierTiled), new RwCallback(TextureBarrierTiled, null) },
                 { nameof(ThreedClassState.DrawTextureSrcY), new RwCallback(DrawTexture, null) },
@@ -225,6 +227,24 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             _context.CreateHostSyncIfNeeded();
             _context.Renderer.UpdateCounters(); // Poll the query counters, the game may want an updated result.
             _context.Synchronization.IncrementSyncpoint(syncpointId);
+        }
+
+        /// <summary>
+        /// Invalidates the cache with the sampler descriptors from the sampler pool.
+        /// </summary>
+        /// <param name="argument">Method call argument (unused)</param>
+        private void InvalidateSamplerCacheNoWfi(int argument)
+        {
+            _context.AdvanceSequence();
+        }
+
+        /// <summary>
+        /// Invalidates the cache with the texture descriptors from the texture pool.
+        /// </summary>
+        /// <param name="argument">Method call argument (unused)</param>
+        private void InvalidateTextureHeaderCacheNoWfi(int argument)
+        {
+            _context.AdvanceSequence();
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClassState.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClassState.cs
@@ -784,7 +784,10 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         public YControl YControl;
         public float LineWidthSmooth;
         public float LineWidthAliased;
-        public fixed uint Reserved13B8[31];
+        public fixed uint Reserved13B8[27];
+        public uint InvalidateSamplerCacheNoWfi;
+        public uint InvalidateTextureHeaderCacheNoWfi;
+        public fixed uint Reserved142C[2];
         public uint FirstVertex;
         public uint FirstInstance;
         public fixed uint Reserved143C[53];

--- a/Ryujinx.Graphics.OpenGL/Image/TextureBuffer.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureBuffer.cs
@@ -56,6 +56,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
         public void SetStorage(BufferRange buffer)
         {
             if (_buffer != BufferHandle.Null &&
+                _buffer == buffer.Handle &&
                 buffer.Offset == _bufferOffset &&
                 buffer.Size == _bufferSize &&
                 _renderer.BufferCount == _bufferCount)


### PR DESCRIPTION
This PR fixes the following issues:
- Outdated descriptors were used in some cases, because the `SequenceNumber` optimization, intended to avoid checking for memory modifications when not necessary made it miss some updates. To fix this, the GPU methods `InvalidateTextureHeaderCacheNoWfi` and `InvalidateSamplerCacheNoWfi` were added, and now increments the `SequenceNumber`. Said methods *should* be called to invalidate the GPU caches for those pools on the Switch, so we can take advantage of that and note that they were probably modified.
- `CommitTextureBindings` and `CommitImageBindings` would try to bind *buffer textures* before setting the buffer storage. This causes an OpenGL error the first time the texture is used, because it has not been initialized at this point (with a call to `glTexBufferRange`). It is also useless, since `CommitBufferTextureBindings` initializes it with the buffer storage *and* binds it (again). This could potentially lead to a minor performance improvement from the reduced amount of GL calls.
- `TextureBuffer.SetStorage` has an optimization that skips calling `glTexBufferRange` if the offset and size of the buffer are the same. But it doesn't check if the buffer itself changed, which could cause it to use an old buffer if an attempt was made to bind a different buffer with the same offset and size (and without any other buffer being created in the meantime, since it also checks the buffers count). In pratice I didn't find any issue caused by this, but decided to fix anyway. Perhaps there is something that makes this scenario impossible right now and I'm missing it.

First point fixes black vertex explosions on Dragon Quest XI S (and maybe other UE4 games?)
Before:
![image](https://user-images.githubusercontent.com/5624669/144928790-04eb8dfc-2832-462a-b257-447d618e9ee6.png)
![image](https://user-images.githubusercontent.com/5624669/144928810-9e1ef055-facb-476b-8d87-73160df6acdd.png)
After:
![image](https://user-images.githubusercontent.com/5624669/144928828-d4bdfbb5-a9ff-4a64-9793-68c29655a5ee.png)

Would be nice to test a few games (I think the GTA trilogy might also be fixed by this?), and also see if they had any performance regression from the first change.