### PR TITLE
Implement VCVT (between floating-point and fixed-point) instruction

### DIFF
--- a/ARMeilleure/Decoders/OpCode32SimdCvtFFixed.cs
+++ b/ARMeilleure/Decoders/OpCode32SimdCvtFFixed.cs
@@ -1,0 +1,27 @@
+﻿namespace ARMeilleure.Decoders
+{
+    class OpCode32SimdCvtFFixed : OpCode32Simd
+    {
+        public int Fbits { get; protected set; }
+
+        public new static OpCode Create(InstDescriptor inst, ulong address, int opCode) => new OpCode32SimdCvtFFixed(inst, address, opCode);
+
+        public OpCode32SimdCvtFFixed(InstDescriptor inst, ulong address, int opCode) : base(inst, address, opCode)
+        {
+            Opc = (opCode >> 8) & 0x1;
+
+            Size = Opc == 1 ? 0 : 2;
+            Fbits = 64 - ((opCode >> 16) & 0x3f);
+
+            if (((opCode >> 21) & 0x1) == 0)
+            {
+                Instruction = InstDescriptor.Undefined;
+            }
+
+            if (DecoderHelper.VectorArgumentsInvalid(Q, Vd, Vm))
+            {
+                Instruction = InstDescriptor.Undefined;
+            }
+        }
+    }
+}

--- a/ARMeilleure/Decoders/OpCodeTable.cs
+++ b/ARMeilleure/Decoders/OpCodeTable.cs
@@ -825,6 +825,7 @@ namespace ARMeilleure.Decoders
             SetA32("<<<<11101x111000xxxx101xx1x0xxxx", InstName.Vcvt,     InstEmit32.Vcvt_FI,  OpCode32SimdCvtFI.Create); // Int to FP32.
             SetA32("111111101x1111xxxxxx101xx1x0xxxx", InstName.Vcvt,     InstEmit32.Vcvt_RM,  OpCode32SimdCvtFI.Create); // The many FP32 to int encodings (fp).
             SetA32("111100111x111011xxxx011xxxx0xxxx", InstName.Vcvt,     InstEmit32.Vcvt_V,   OpCode32SimdCmpZ.Create); // FP and integer, vector.
+            SetA32("1111001x1x>>>xxxxxxx111x0xx1xxxx", InstName.Vcvt,     InstEmit32.Vcvt_V2,  OpCode32SimdCvtFFixed.Create); // Between floating point and fixed point, vector
             SetA32("<<<<11101x00xxxxxxxx101xx0x0xxxx", InstName.Vdiv,     InstEmit32.Vdiv_S,   OpCode32SimdRegS.Create);
             SetA32("<<<<11101xx0xxxxxxxx1011x0x10000", InstName.Vdup,     InstEmit32.Vdup,     OpCode32SimdDupGP.Create);
             SetA32("111100111x11xxxxxxxx11000xx0xxxx", InstName.Vdup,     InstEmit32.Vdup_1,   OpCode32SimdDupElem.Create);

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -27,7 +27,7 @@ namespace ARMeilleure.Translation.PTC
         private const string OuterHeaderMagicString = "PTCohd\0\0";
         private const string InnerHeaderMagicString = "PTCihd\0\0";
 
-        private const uint InternalVersion = 2721; //! To be incremented manually for each change to the ARMeilleure project.
+        private const uint InternalVersion = 2915; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";

--- a/Ryujinx.Tests/Cpu/CpuTestSimdCvt32.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestSimdCvt32.cs
@@ -259,6 +259,86 @@ namespace Ryujinx.Tests.Cpu
 
             CompareAgainstUnicorn();
         }
+
+        [Test, Pairwise, Description("VCVT.I32.F32 <Vd>, <Vm>, #<fbits>")]
+        public void Vcvt_V2_F32_I32([Values(0u, 1u, 2u, 3u)] uint vd,
+                                    [Values(0u, 1u, 2u, 3u)] uint vm,
+                                    [ValueSource(nameof(_1S_F_))][Random(RndCnt)] ulong s0,
+                                    [ValueSource(nameof(_1S_F_))][Random(RndCnt)] ulong s1,
+                                    [ValueSource(nameof(_1S_F_))][Random(RndCnt)] ulong s2,
+                                    [ValueSource(nameof(_1S_F_))][Random(RndCnt)] ulong s3,
+                                    [Random(32u, 63u, 1)] uint fixImm,
+                                    [Values] bool unsigned,
+                                    [Values] bool q)
+        {
+            uint opcode = 0xF2800F10u; // VCVT.U32.F32 D0, D0, #0
+
+            if (q)
+            {
+                opcode |= 1 << 6;
+                vm <<= 1;
+                vd <<= 1;
+            }
+
+            if (unsigned)
+            {
+                opcode |= 1 << 24;
+            }
+
+            opcode |= ((vm & 0x10) << 1);
+            opcode |= ((vm & 0xf) << 0);
+
+            opcode |= ((vd & 0x10) << 18);
+            opcode |= ((vd & 0xf) << 12);
+
+            opcode |= (fixImm & 0x3f) << 16;
+
+            V128 v0 = new V128((uint)s0, (uint)s1, (uint)s2, (uint)s3);
+
+            SingleOpcode(opcode, v0: v0);
+
+            CompareAgainstUnicorn();
+        }
+
+        [Test, Pairwise, Description("VCVT.F32.I32 <Vd>, <Vm>, #<fbits>")]
+        public void Vcvt_V2_I32_F32([Values(0u, 1u, 2u, 3u)] uint vd,
+                                    [Values(0u, 1u, 2u, 3u)] uint vm,
+                                    [ValueSource(nameof(_1S_))][Random(RndCnt)] uint s0,
+                                    [ValueSource(nameof(_1S_))][Random(RndCnt)] uint s1,
+                                    [ValueSource(nameof(_1S_))][Random(RndCnt)] uint s2,
+                                    [ValueSource(nameof(_1S_))][Random(RndCnt)] uint s3,
+                                    [Range(32u, 63u, 1)] uint fixImm,
+                                    [Values] bool unsigned,
+                                    [Values] bool q)
+        {
+            uint opcode = 0xF2800E10u; // VCVT.F32.U32 D0, D0, #0
+
+            if (q)
+            {
+                opcode |= 1 << 6;
+                vm <<= 1;
+                vd <<= 1;
+            }
+
+            if (unsigned)
+            {
+                opcode |= 1 << 24;
+            }
+
+            opcode |= ((vm & 0x10) << 1);
+            opcode |= ((vm & 0xf) << 0);
+
+            opcode |= ((vd & 0x10) << 18);
+            opcode |= ((vd & 0xf) << 12);
+
+            opcode |= (fixImm & 0x3f) << 16;
+
+            V128 v0 = new V128(s0, s1, s2, s3);
+
+            SingleOpcode(opcode, v0: v0);
+
+            CompareAgainstUnicorn();
+        }
 #endif
     }
 }


### PR DESCRIPTION
Implemented instruction
- VCVT (between floating-point and fixed-point)

Fixes #1344

I originally implemented this instruction in #2242 but to make it easier for the maintainers to review, I've decided to split it into a separate pull request.

Note: This and VQMOVN/VQMOVUN are needed to play Limbo. VQMOVN/VQMOVUN is implemented in #2916 .