### PR TITLE
Implement VQMOVN/VQMOVUN instruction

### DIFF
--- a/ARMeilleure/Decoders/OpCode32SimdMovNarrow.cs
+++ b/ARMeilleure/Decoders/OpCode32SimdMovNarrow.cs
@@ -1,0 +1,19 @@
+﻿namespace ARMeilleure.Decoders
+{
+    class OpCode32SimdMovNarrow : OpCode32Simd
+    {
+        public new static OpCode Create(InstDescriptor inst, ulong address, int opCode) => new OpCode32SimdMovNarrow(inst, address, opCode);
+
+        public OpCode32SimdMovNarrow(InstDescriptor inst, ulong address, int opCode) : base(inst, address, opCode)
+        {
+            Size = (opCode >> 18) & 0x3;
+            Opc = (opCode >> 6) & 0x3;
+            RegisterSize = RegisterSize.Simd128;
+
+            if (Size == 3 || ((Vm & 1) == 1))
+            {
+                Instruction = InstDescriptor.Undefined;
+            }
+        }
+    }
+}

--- a/ARMeilleure/Decoders/OpCodeTable.cs
+++ b/ARMeilleure/Decoders/OpCodeTable.cs
@@ -917,6 +917,7 @@ namespace ARMeilleure.Decoders
             SetA32("111100110x00xxxxxxxx1111x0x0xxxx", InstName.Vpmax,    InstEmit32.Vpmax_V,  OpCode32SimdReg.Create);
             SetA32("1111001x0x<<xxxxxxxx1010x0x1xxxx", InstName.Vpmin,    InstEmit32.Vpmin_I,  OpCode32SimdReg.Create);
             SetA32("111100110x10xxxxxxxx1111x0x0xxxx", InstName.Vpmin,    InstEmit32.Vpmin_V,  OpCode32SimdReg.Create);
+            SetA32("111100111x11xx10xxxx0010xxx0xxx0", InstName.Vqmovn,   InstEmit32.Vqmovn,   OpCode32SimdMovNarrow.Create);
             SetA32("1111001x1x>>>xxxxxxx100101x1xxx0", InstName.Vqrshrn,  InstEmit32.Vqrshrn,  OpCode32SimdShImmNarrow.Create);
             SetA32("111100111x>>>xxxxxxx100001x1xxx0", InstName.Vqrshrun, InstEmit32.Vqrshrun, OpCode32SimdShImmNarrow.Create);
             SetA32("1111001x1x>>>xxxxxxx100100x1xxx0", InstName.Vqshrn,   InstEmit32.Vqshrn,   OpCode32SimdShImmNarrow.Create);

--- a/ARMeilleure/Instructions/InstEmitSimdArithmetic32.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdArithmetic32.cs
@@ -417,6 +417,25 @@ namespace ARMeilleure.Instructions
             EmitVectorUnaryNarrowOp32(context, (op1) => op1);
         }
 
+        public static void Vqmovn(ArmEmitterContext context)
+        {
+            OpCode32SimdMovNarrow op = (OpCode32SimdMovNarrow)context.CurrOp;
+
+            bool srcUnsigned = op.Opc == 3;
+            bool destUnsigned = (op.Opc & 1) != 0;
+
+            EmitVectorUnaryNarrowOp32(context, (op1) => {
+                op1 = op.Size switch
+                {
+                    2 => op1,
+                    1 => srcUnsigned ? context.ZeroExtend32(OperandType.I64, op1) : context.SignExtend32(OperandType.I64, op1),
+                    0 => srcUnsigned ? context.ZeroExtend16(OperandType.I64, op1) : context.SignExtend16(OperandType.I64, op1),
+                    _ => throw new InvalidOperationException($"Invalid VQMOVN size \"{op.Size}\".")
+                };
+                return InstEmitSimdHelper.EmitSatQ(context, op1, op.Size, !srcUnsigned, !destUnsigned);
+            });
+        }
+
         public static void Vneg_S(ArmEmitterContext context)
         {
             OpCode32SimdS op = (OpCode32SimdS)context.CurrOp;

--- a/ARMeilleure/Instructions/InstName.cs
+++ b/ARMeilleure/Instructions/InstName.cs
@@ -610,6 +610,7 @@ namespace ARMeilleure.Instructions
         Vpadd,
         Vpmax,
         Vpmin,
+        Vqmovn,
         Vqrshrn,
         Vqrshrun,
         Vqshrn,

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -27,7 +27,7 @@ namespace ARMeilleure.Translation.PTC
         private const string OuterHeaderMagicString = "PTCohd\0\0";
         private const string InnerHeaderMagicString = "PTCihd\0\0";
 
-        private const uint InternalVersion = 2721; //! To be incremented manually for each change to the ARMeilleure project.
+        private const uint InternalVersion = 2916; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";

--- a/Ryujinx.Tests/Cpu/CpuTestSimdMov32.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestSimdMov32.cs
@@ -595,6 +595,78 @@ namespace Ryujinx.Tests.Cpu
 
             CompareAgainstUnicorn();
         }
+
+        [Test, Pairwise, Description("VQMOVN.S<size> <Dd>, <Qm>")]
+        public void Vqmovn_S([Values(0u, 1u, 2u)] uint size,
+                          [Values(0u, 1u, 2u, 3u)] uint vd,
+                          [Values(0u, 2u, 4u, 8u)] uint vm)
+        {
+            uint opcode = 0xf3b20280u; // VQMOVN.S16 D0, Q0
+
+            opcode |= (size & 0x3) << 18;
+            opcode |= ((vm & 0x10) << 1);
+            opcode |= ((vm & 0xf) << 0);
+
+            opcode |= ((vd & 0x10) << 18);
+            opcode |= ((vd & 0xf) << 12);
+
+            V128 v0 = new V128(TestContext.CurrentContext.Random.NextULong(), TestContext.CurrentContext.Random.NextULong());
+            V128 v1 = new V128(TestContext.CurrentContext.Random.NextULong(), TestContext.CurrentContext.Random.NextULong());
+            V128 v2 = new V128(TestContext.CurrentContext.Random.NextULong(), TestContext.CurrentContext.Random.NextULong());
+            V128 v3 = new V128(TestContext.CurrentContext.Random.NextULong(), TestContext.CurrentContext.Random.NextULong());
+
+            SingleOpcode(opcode, v0: v0, v1: v1, v2: v2, v3: v3);
+
+            CompareAgainstUnicorn();
+        }
+
+        [Test, Pairwise, Description("VQMOVN.U<size> <Dd>, <Qm>")]
+        public void Vqmovn_U([Values(0u, 1u, 2u)] uint size,
+                           [Values(0u, 1u, 2u, 3u)] uint vd,
+                           [Values(0u, 2u, 4u, 8u)] uint vm)
+        {
+            uint opcode = 0xf3b202c0u; // VQMOVN.U16 D0, Q0
+
+            opcode |= (size & 0x3) << 18;
+            opcode |= ((vm & 0x10) << 1);
+            opcode |= ((vm & 0xf) << 0);
+
+            opcode |= ((vd & 0x10) << 18);
+            opcode |= ((vd & 0xf) << 12);
+
+            V128 v0 = new V128(TestContext.CurrentContext.Random.NextULong(), TestContext.CurrentContext.Random.NextULong());
+            V128 v1 = new V128(TestContext.CurrentContext.Random.NextULong(), TestContext.CurrentContext.Random.NextULong());
+            V128 v2 = new V128(TestContext.CurrentContext.Random.NextULong(), TestContext.CurrentContext.Random.NextULong());
+            V128 v3 = new V128(TestContext.CurrentContext.Random.NextULong(), TestContext.CurrentContext.Random.NextULong());
+
+            SingleOpcode(opcode, v0: v0, v1: v1, v2: v2, v3: v3);
+
+            CompareAgainstUnicorn();
+        }
+
+        [Test, Pairwise, Description("VQMOVUN.S<size> <Dd>, <Qm>")]
+        public void Vqmovun([Values(0u, 1u, 2u)] uint size,
+                           [Values(0u, 1u, 2u, 3u)] uint vd,
+                           [Values(0u, 2u, 4u, 8u)] uint vm)
+        {
+            uint opcode = 0xf3b20240u; // VQMOVUN.S16 D0, Q0
+
+            opcode |= (size & 0x3) << 18;
+            opcode |= ((vm & 0x10) << 1);
+            opcode |= ((vm & 0xf) << 0);
+
+            opcode |= ((vd & 0x10) << 18);
+            opcode |= ((vd & 0xf) << 12);
+
+            V128 v0 = new V128(TestContext.CurrentContext.Random.NextULong(), TestContext.CurrentContext.Random.NextULong());
+            V128 v1 = new V128(TestContext.CurrentContext.Random.NextULong(), TestContext.CurrentContext.Random.NextULong());
+            V128 v2 = new V128(TestContext.CurrentContext.Random.NextULong(), TestContext.CurrentContext.Random.NextULong());
+            V128 v3 = new V128(TestContext.CurrentContext.Random.NextULong(), TestContext.CurrentContext.Random.NextULong());
+
+            SingleOpcode(opcode, v0: v0, v1: v1, v2: v2, v3: v3);
+
+            CompareAgainstUnicorn();
+        }
 #endif
     }
 }


### PR DESCRIPTION
Implemented instructions
- VQMOVN
- VQMOVUN

Fixes #1811 

I originally implemented this instruction in #2242 but to make it easier for the maintainers to review, I've decided to split it into a separate pull request.

Note: VCVT and VQMOVN/VQMOVUN are needed to play Limbo. VCVT is implemented in #2915 .