### PR TITLE
Update to LibHac v0.14.3

### DIFF
--- a/Ryujinx.HLE/FileSystem/EncryptedFileSystemCreator.cs
+++ b/Ryujinx.HLE/FileSystem/EncryptedFileSystemCreator.cs
@@ -3,25 +3,23 @@ using LibHac.Common;
 using LibHac.Fs;
 using LibHac.Fs.Fsa;
 using LibHac.FsSrv.FsCreator;
-using LibHac.FsSystem;
 
 namespace Ryujinx.HLE.FileSystem
 {
     public class EncryptedFileSystemCreator : IEncryptedFileSystemCreator
     {
-        public Result Create(out ReferenceCountedDisposable<IFileSystem> encryptedFileSystem, ReferenceCountedDisposable<IFileSystem> baseFileSystem,
-            EncryptedFsKeyId keyId, in EncryptionSeed encryptionSeed)
-        {
-            UnsafeHelpers.SkipParamInit(out encryptedFileSystem);
 
-            if (keyId < EncryptedFsKeyId.Save || keyId > EncryptedFsKeyId.CustomStorage)
+        public Result Create(ref SharedRef<IFileSystem> outEncryptedFileSystem,
+            ref SharedRef<IFileSystem> baseFileSystem, IEncryptedFileSystemCreator.KeyId idIndex,
+            in EncryptionSeed encryptionSeed)
+        {
+            if (idIndex < IEncryptedFileSystemCreator.KeyId.Save || idIndex > IEncryptedFileSystemCreator.KeyId.CustomStorage)
             {
                 return ResultFs.InvalidArgument.Log();
             }
 
-            // Force all-zero keys for now since people can open the emulator with different keys or sd seeds sometimes
-            var fs = new AesXtsFileSystem(baseFileSystem, new byte[0x32], 0x4000);
-            encryptedFileSystem = new ReferenceCountedDisposable<IFileSystem>(fs);
+            // Todo: Reenable when AesXtsFileSystem is fixed
+            outEncryptedFileSystem = SharedRef<IFileSystem>.CreateMove(ref baseFileSystem);
 
             return Result.Success;
         }

--- a/Ryujinx.HLE/HOS/Applets/Error/ErrorApplet.cs
+++ b/Ryujinx.HLE/HOS/Applets/Error/ErrorApplet.cs
@@ -116,8 +116,10 @@ namespace Ryujinx.HLE.HOS.Applets.Error
 
                 if (romfs.FileExists(filePath))
                 {
-                    romfs.OpenFile(out IFile binaryFile, filePath.ToU8Span(), OpenMode.Read).ThrowIfFailure();
-                    StreamReader reader = new StreamReader(binaryFile.AsStream(), Encoding.Unicode);
+                    using var binaryFile = new UniqueRef<IFile>();
+
+                    romfs.OpenFile(ref binaryFile.Ref(), filePath.ToU8Span(), OpenMode.Read).ThrowIfFailure();
+                    StreamReader reader = new StreamReader(binaryFile.Get.AsStream(), Encoding.Unicode);
 
                     return CleanText(reader.ReadToEnd());
                 }

--- a/Ryujinx.HLE/HOS/ApplicationLoader.cs
+++ b/Ryujinx.HLE/HOS/ApplicationLoader.cs
@@ -119,7 +119,7 @@ namespace Ryujinx.HLE.HOS
                 {
                     int dataIndex = Nca.GetSectionIndexFromType(NcaSectionType.Data, NcaContentType.Program);
 
-                    if (nca.Header.GetFsHeader(dataIndex).IsPatchSection())
+                    if (nca.SectionExists(NcaSectionType.Data) && nca.Header.GetFsHeader(dataIndex).IsPatchSection())
                     {
                         patchNca = nca;
                     }
@@ -704,7 +704,7 @@ namespace Ryujinx.HLE.HOS
 
                 int dataIndex = Nca.GetSectionIndexFromType(NcaSectionType.Data, NcaContentType.Program);
 
-                if (nca.Header.GetFsHeader(dataIndex).IsPatchSection())
+                if (nca.SectionExists(NcaSectionType.Data) && nca.Header.GetFsHeader(dataIndex).IsPatchSection())
                 {
                     continue;
                 }

--- a/Ryujinx.HLE/HOS/ApplicationLoader.cs
+++ b/Ryujinx.HLE/HOS/ApplicationLoader.cs
@@ -25,6 +25,7 @@ using System.Reflection;
 using static LibHac.Fs.ApplicationSaveDataManagement;
 using static Ryujinx.HLE.HOS.ModLoader;
 using ApplicationId = LibHac.Ncm.ApplicationId;
+using Path = System.IO.Path;
 
 namespace Ryujinx.HLE.HOS
 {
@@ -101,9 +102,11 @@ namespace Ryujinx.HLE.HOS
 
             foreach (DirectoryEntryEx fileEntry in pfs.EnumerateEntries("/", "*.nca"))
             {
-                pfs.OpenFile(out IFile ncaFile, fileEntry.FullPath.ToU8Span(), OpenMode.Read).ThrowIfFailure();
+                using var ncaFile = new UniqueRef<IFile>();
 
-                Nca nca = new Nca(fileSystem.KeySet, ncaFile.AsStorage());
+                pfs.OpenFile(ref ncaFile.Ref(), fileEntry.FullPath.ToU8Span(), OpenMode.Read).ThrowIfFailure();
+
+                Nca nca = new Nca(fileSystem.KeySet, ncaFile.Release().AsStorage());
 
                 int ncaProgramIndex = (int)(nca.Header.TitleId & 0xF);
 
@@ -143,9 +146,11 @@ namespace Ryujinx.HLE.HOS
 
             foreach (DirectoryEntryEx fileEntry in pfs.EnumerateEntries("/", "*.nca"))
             {
-                pfs.OpenFile(out IFile ncaFile, fileEntry.FullPath.ToU8Span(), OpenMode.Read).ThrowIfFailure();
+                using var ncaFile = new UniqueRef<IFile>();
 
-                Nca nca = new Nca(fileSystem.KeySet, ncaFile.AsStorage());
+                pfs.OpenFile(ref ncaFile.Ref(), fileEntry.FullPath.ToU8Span(), OpenMode.Read).ThrowIfFailure();
+
+                Nca nca = new Nca(fileSystem.KeySet, ncaFile.Release().AsStorage());
 
                 int ncaProgramIndex = (int)(nca.Header.TitleId & 0xF);
 
@@ -429,7 +434,9 @@ namespace Ryujinx.HLE.HOS
         // Sets TitleId, so be sure to call before using it
         private MetaLoader ReadNpdm(IFileSystem fs)
         {
-            Result result = fs.OpenFile(out IFile npdmFile, "/main.npdm".ToU8Span(), OpenMode.Read);
+            using var npdmFile = new UniqueRef<IFile>();
+
+            Result result = fs.OpenFile(ref npdmFile.Ref(), "/main.npdm".ToU8Span(), OpenMode.Read);
 
             MetaLoader metaData;
 
@@ -441,10 +448,10 @@ namespace Ryujinx.HLE.HOS
             }
             else
             {
-                npdmFile.GetSize(out long fileSize).ThrowIfFailure();
+                npdmFile.Get.GetSize(out long fileSize).ThrowIfFailure();
 
                 var npdmBuffer = new byte[fileSize];
-                npdmFile.Read(out _, 0, npdmBuffer).ThrowIfFailure();
+                npdmFile.Get.Read(out _, 0, npdmBuffer).ThrowIfFailure();
 
                 metaData = new MetaLoader();
                 metaData.Load(npdmBuffer).ThrowIfFailure();
@@ -461,12 +468,14 @@ namespace Ryujinx.HLE.HOS
 
         private static void ReadControlData(Switch device, Nca controlNca, ref BlitStruct<ApplicationControlProperty> controlData, ref string titleName, ref string displayVersion)
         {
+            using var controlFile = new UniqueRef<IFile>();
+
             IFileSystem controlFs = controlNca.OpenFileSystem(NcaSectionType.Data, device.System.FsIntegrityCheckLevel);
-            Result result = controlFs.OpenFile(out IFile controlFile, "/control.nacp".ToU8Span(), OpenMode.Read);
+            Result result = controlFs.OpenFile(ref controlFile.Ref(), "/control.nacp".ToU8Span(), OpenMode.Read);
 
             if (result.IsSuccess())
             {
-                result = controlFile.Read(out long bytesRead, 0, controlData.ByteSpan, ReadOption.None);
+                result = controlFile.Get.Read(out long bytesRead, 0, controlData.ByteSpan, ReadOption.None);
 
                 if (result.IsSuccess() && bytesRead == controlData.ByteSpan.Length)
                 {
@@ -508,9 +517,11 @@ namespace Ryujinx.HLE.HOS
 
                 Logger.Info?.Print(LogClass.Loader, $"Loading {name}...");
 
-                codeFs.OpenFile(out IFile nsoFile, $"/{name}".ToU8Span(), OpenMode.Read).ThrowIfFailure();
+                using var nsoFile = new UniqueRef<IFile>();
 
-                nsos[i] = new NsoExecutable(nsoFile.AsStorage(), name);
+                codeFs.OpenFile(ref nsoFile.Ref(), $"/{name}".ToU8Span(), OpenMode.Read).ThrowIfFailure();
+
+                nsos[i] = new NsoExecutable(nsoFile.Release().AsStorage(), name);
             }
 
             // ExeFs file replacements
@@ -680,9 +691,11 @@ namespace Ryujinx.HLE.HOS
 
             foreach (DirectoryEntryEx fileEntry in pfs.EnumerateEntries("/", "*.nca"))
             {
-                pfs.OpenFile(out IFile ncaFile, fileEntry.FullPath.ToU8Span(), OpenMode.Read).ThrowIfFailure();
+                using var ncaFile = new UniqueRef<IFile>();
 
-                Nca nca = new Nca(fileSystem.KeySet, ncaFile.AsStorage());
+                pfs.OpenFile(ref ncaFile.Ref(), fileEntry.FullPath.ToU8Span(), OpenMode.Read).ThrowIfFailure();
+
+                Nca nca = new Nca(fileSystem.KeySet, ncaFile.Release().AsStorage());
 
                 if (nca.Header.ContentType != NcaContentType.Program)
                 {

--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -1,3 +1,4 @@
+using LibHac.Common;
 using LibHac.Common.Keys;
 using LibHac.Fs;
 using LibHac.Fs.Shim;
@@ -304,9 +305,9 @@ namespace Ryujinx.HLE.HOS
 
         public void LoadKip(string kipPath)
         {
-            using IStorage kipFile = new LocalStorage(kipPath, FileAccess.Read);
+            using var kipFile = new SharedRef<IStorage>(new LocalStorage(kipPath, FileAccess.Read));
 
-            ProgramLoader.LoadKip(KernelContext, new KipExecutable(kipFile));
+            ProgramLoader.LoadKip(KernelContext, new KipExecutable(in kipFile));
         }
 
         public void ChangeDockedModeState(bool newState)

--- a/Ryujinx.HLE/HOS/LibHacHorizonManager.cs
+++ b/Ryujinx.HLE/HOS/LibHacHorizonManager.cs
@@ -26,7 +26,8 @@ namespace Ryujinx.HLE.HOS
         public HorizonClient NsClient          { get; private set; }
         public HorizonClient SdbClient         { get; private set; }
 
-        internal LibHacIReader ArpIReader { get; private set; }
+        private SharedRef<LibHacIReader> _arpIReader;
+        internal LibHacIReader ArpIReader => _arpIReader.Get;
 
         public LibHacHorizonManager()
         {
@@ -42,8 +43,8 @@ namespace Ryujinx.HLE.HOS
 
         public void InitializeArpServer()
         {
-            ArpIReader = new LibHacIReader();
-            RyujinxClient.Sm.RegisterService(new LibHacArpServiceObject(ArpIReader), "arp:r").ThrowIfFailure();
+            _arpIReader.Reset(new LibHacIReader());
+            RyujinxClient.Sm.RegisterService(new LibHacArpServiceObject(ref _arpIReader), "arp:r").ThrowIfFailure();
         }
 
         public void InitializeBcatServer()

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/AccountManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/AccountManager.cs
@@ -1,4 +1,5 @@
 ﻿using LibHac;
+using LibHac.Common;
 using LibHac.Fs;
 using LibHac.Fs.Shim;
 using Ryujinx.Common;
@@ -170,13 +171,15 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             SaveDataFilter saveDataFilter = new SaveDataFilter();
             saveDataFilter.SetUserId(new LibHac.Fs.UserId((ulong)userId.High, (ulong)userId.Low));
 
-            _horizonClient.Fs.OpenSaveDataIterator(out SaveDataIterator saveDataIterator, SaveDataSpaceId.User, in saveDataFilter).ThrowIfFailure();
+            using var saveDataIterator = new UniqueRef<SaveDataIterator>();
+
+            _horizonClient.Fs.OpenSaveDataIterator(ref saveDataIterator.Ref(), SaveDataSpaceId.User, in saveDataFilter).ThrowIfFailure();
 
             Span<SaveDataInfo> saveDataInfo = stackalloc SaveDataInfo[10];
 
             while (true)
             {
-                saveDataIterator.ReadSaveDataInfo(out long readCount, saveDataInfo).ThrowIfFailure();
+                saveDataIterator.Get.ReadSaveDataInfo(out long readCount, saveDataInfo).ThrowIfFailure();
 
                 if (readCount == 0)
                 {

--- a/Ryujinx.HLE/HOS/Services/Arp/LibHacIReader.cs
+++ b/Ryujinx.HLE/HOS/Services/Arp/LibHacIReader.cs
@@ -1,4 +1,5 @@
 ﻿using LibHac;
+using LibHac.Common;
 using LibHac.Ncm;
 using LibHac.Ns;
 using System;
@@ -21,6 +22,8 @@ namespace Ryujinx.HLE.HOS.Services.Arp
 
             return Result.Success;
         }
+
+        public void Dispose() { }
 
         public Result GetApplicationLaunchPropertyWithApplicationId(out LibHac.Arp.ApplicationLaunchProperty launchProperty, ApplicationId applicationId)
         {
@@ -51,16 +54,21 @@ namespace Ryujinx.HLE.HOS.Services.Arp
 
     internal class LibHacArpServiceObject : LibHac.Sm.IServiceObject
     {
-        private LibHacIReader _serviceObject;
+        private SharedRef<LibHacIReader> _serviceObject;
 
-        public LibHacArpServiceObject(LibHacIReader serviceObject)
+        public LibHacArpServiceObject(ref SharedRef<LibHacIReader> serviceObject)
         {
-            _serviceObject = serviceObject;
+            _serviceObject = SharedRef<LibHacIReader>.CreateCopy(in serviceObject);
         }
 
-        public Result GetServiceObject(out object serviceObject)
+        public void Dispose()
         {
-            serviceObject = _serviceObject;
+            _serviceObject.Destroy();
+        }
+
+        public Result GetServiceObject(ref SharedRef<IDisposable> serviceObject)
+        {
+            serviceObject.SetByCopy(in _serviceObject);
 
             return Result.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IFile.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IFile.cs
@@ -1,4 +1,5 @@
 using LibHac;
+using LibHac.Common;
 using LibHac.Fs;
 using LibHac.Sf;
 using Ryujinx.Common;
@@ -7,11 +8,11 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
 {
     class IFile : DisposableIpcService
     {
-        private ReferenceCountedDisposable<LibHac.FsSrv.Sf.IFile> _baseFile;
+        private SharedRef<LibHac.FsSrv.Sf.IFile> _baseFile;
 
-        public IFile(ReferenceCountedDisposable<LibHac.FsSrv.Sf.IFile> baseFile)
+        public IFile(ref SharedRef<LibHac.FsSrv.Sf.IFile> baseFile)
         {
-            _baseFile = baseFile;
+            _baseFile = SharedRef<LibHac.FsSrv.Sf.IFile>.CreateMove(ref baseFile);
         }
 
         [CommandHipc(0)]
@@ -28,7 +29,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
 
             byte[] data = new byte[context.Request.ReceiveBuff[0].Size];
 
-            Result result = _baseFile.Target.Read(out long bytesRead, offset, new OutBuffer(data), size, readOption);
+            Result result = _baseFile.Get.Read(out long bytesRead, offset, new OutBuffer(data), size, readOption);
 
             context.Memory.Write(position, data);
 
@@ -53,14 +54,14 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
 
             context.Memory.Read(position, data);
 
-            return (ResultCode)_baseFile.Target.Write(offset, new InBuffer(data), size, writeOption).Value;
+            return (ResultCode)_baseFile.Get.Write(offset, new InBuffer(data), size, writeOption).Value;
         }
 
         [CommandHipc(2)]
         // Flush()
         public ResultCode Flush(ServiceCtx context)
         {
-            return (ResultCode)_baseFile.Target.Flush().Value;
+            return (ResultCode)_baseFile.Get.Flush().Value;
         }
 
         [CommandHipc(3)]
@@ -69,14 +70,14 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
         {
             long size = context.RequestData.ReadInt64();
 
-            return (ResultCode)_baseFile.Target.SetSize(size).Value;
+            return (ResultCode)_baseFile.Get.SetSize(size).Value;
         }
 
         [CommandHipc(4)]
         // GetSize() -> u64 fileSize
         public ResultCode GetSize(ServiceCtx context)
         {
-            Result result = _baseFile.Target.GetSize(out long size);
+            Result result = _baseFile.Get.GetSize(out long size);
 
             context.ResponseData.Write(size);
 
@@ -87,7 +88,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
         {
             if (isDisposing)
             {
-                _baseFile?.Dispose();
+                _baseFile.Destroy();
             }
         }
     }

--- a/Ryujinx.HLE/HOS/Services/Fs/IDeviceOperator.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/IDeviceOperator.cs
@@ -1,22 +1,23 @@
 ﻿using LibHac;
+using LibHac.Common;
 using LibHac.FsSrv;
 
 namespace Ryujinx.HLE.HOS.Services.Fs
 {
     class IDeviceOperator : DisposableIpcService
     {
-        private ReferenceCountedDisposable<LibHac.FsSrv.Sf.IDeviceOperator> _baseOperator;
+        private SharedRef<LibHac.FsSrv.Sf.IDeviceOperator> _baseOperator;
 
-        public IDeviceOperator(ReferenceCountedDisposable<LibHac.FsSrv.Sf.IDeviceOperator> baseOperator)
+        public IDeviceOperator(ref SharedRef<LibHac.FsSrv.Sf.IDeviceOperator> baseOperator)
         {
-            _baseOperator = baseOperator;
+            _baseOperator = SharedRef<LibHac.FsSrv.Sf.IDeviceOperator>.CreateMove(ref baseOperator);
         }
 
         [CommandHipc(0)]
         // IsSdCardInserted() -> b8 is_inserted
         public ResultCode IsSdCardInserted(ServiceCtx context)
         {
-            Result result = _baseOperator.Target.IsSdCardInserted(out bool isInserted);
+            Result result = _baseOperator.Get.IsSdCardInserted(out bool isInserted);
 
             context.ResponseData.Write(isInserted);
 
@@ -27,7 +28,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
         // IsGameCardInserted() -> b8 is_inserted
         public ResultCode IsGameCardInserted(ServiceCtx context)
         {
-            Result result = _baseOperator.Target.IsGameCardInserted(out bool isInserted);
+            Result result = _baseOperator.Get.IsGameCardInserted(out bool isInserted);
 
             context.ResponseData.Write(isInserted);
 
@@ -38,7 +39,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
         // GetGameCardHandle() -> u32 gamecard_handle
         public ResultCode GetGameCardHandle(ServiceCtx context)
         {
-            Result result = _baseOperator.Target.GetGameCardHandle(out GameCardHandle handle);
+            Result result = _baseOperator.Get.GetGameCardHandle(out GameCardHandle handle);
 
             context.ResponseData.Write(handle.Value);
 
@@ -49,7 +50,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
         {
             if (isDisposing)
             {
-                _baseOperator?.Dispose();
+                _baseOperator.Destroy();
             }
         }
     }

--- a/Ryujinx.HLE/HOS/Services/Fs/ISaveDataInfoReader.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/ISaveDataInfoReader.cs
@@ -1,15 +1,16 @@
 ﻿using LibHac;
+using LibHac.Common;
 using LibHac.Sf;
 
 namespace Ryujinx.HLE.HOS.Services.Fs
 {
     class ISaveDataInfoReader : DisposableIpcService
     {
-        private ReferenceCountedDisposable<LibHac.FsSrv.Sf.ISaveDataInfoReader> _baseReader;
+        private SharedRef<LibHac.FsSrv.Sf.ISaveDataInfoReader> _baseReader;
 
-        public ISaveDataInfoReader(ReferenceCountedDisposable<LibHac.FsSrv.Sf.ISaveDataInfoReader> baseReader)
+        public ISaveDataInfoReader(ref SharedRef<LibHac.FsSrv.Sf.ISaveDataInfoReader> baseReader)
         {
-            _baseReader = baseReader;
+            _baseReader = SharedRef<LibHac.FsSrv.Sf.ISaveDataInfoReader>.CreateMove(ref baseReader);
         }
 
         [CommandHipc(0)]
@@ -17,11 +18,11 @@ namespace Ryujinx.HLE.HOS.Services.Fs
         public ResultCode ReadSaveDataInfo(ServiceCtx context)
         {
             ulong bufferPosition = context.Request.ReceiveBuff[0].Position;
-            ulong bufferLen      = context.Request.ReceiveBuff[0].Size;
+            ulong bufferLen = context.Request.ReceiveBuff[0].Size;
 
             byte[] infoBuffer = new byte[bufferLen];
 
-            Result result = _baseReader.Target.Read(out long readCount, new OutBuffer(infoBuffer));
+            Result result = _baseReader.Get.Read(out long readCount, new OutBuffer(infoBuffer));
 
             context.Memory.Write(bufferPosition, infoBuffer);
             context.ResponseData.Write(readCount);
@@ -33,7 +34,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
         {
             if (isDisposing)
             {
-                _baseReader?.Dispose();
+                _baseReader.Destroy();
             }
         }
     }

--- a/Ryujinx.HLE/HOS/Services/Sdb/Pl/SharedFontManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Sdb/Pl/SharedFontManager.cs
@@ -74,9 +74,11 @@ namespace Ryujinx.HLE.HOS.Services.Sdb.Pl
                                 Nca         nca   = new Nca(_device.System.KeySet, ncaFileStream);
                                 IFileSystem romfs = nca.OpenFileSystem(NcaSectionType.Data, _device.System.FsIntegrityCheckLevel);
 
-                                romfs.OpenFile(out IFile fontFile, ("/" + fontFilename).ToU8Span(), OpenMode.Read).ThrowIfFailure();
+                                using var fontFile = new UniqueRef<IFile>();
 
-                                data = DecryptFont(fontFile.AsStream());
+                                romfs.OpenFile(ref fontFile.Ref(), ("/" + fontFilename).ToU8Span(), OpenMode.Read).ThrowIfFailure();
+
+                                data = DecryptFont(fontFile.Get.AsStream());
                             }
 
                             FontInfo info = new FontInfo((int)fontOffset, data.Length);

--- a/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
@@ -310,13 +310,15 @@ namespace Ryujinx.HLE.HOS.Services.Settings
 
                 IFileSystem firmwareRomFs = firmwareContent.OpenFileSystem(NcaSectionType.Data, device.System.FsIntegrityCheckLevel);
 
-                Result result = firmwareRomFs.OpenFile(out IFile firmwareFile, "/file".ToU8Span(), OpenMode.Read);
+                using var firmwareFile = new UniqueRef<IFile>();
+
+                Result result = firmwareRomFs.OpenFile(ref firmwareFile.Ref(), "/file".ToU8Span(), OpenMode.Read);
                 if (result.IsFailure())
                 {
                     return null;
                 }
 
-                result = firmwareFile.GetSize(out long fileSize);
+                result = firmwareFile.Get.GetSize(out long fileSize);
                 if (result.IsFailure())
                 {
                     return null;
@@ -324,7 +326,7 @@ namespace Ryujinx.HLE.HOS.Services.Settings
 
                 byte[] data = new byte[fileSize];
 
-                result = firmwareFile.Read(out _, 0, data);
+                result = firmwareFile.Get.Read(out _, 0, data);
                 if (result.IsFailure())
                 {
                     return null;

--- a/Ryujinx.HLE/Loaders/Executables/KipExecutable.cs
+++ b/Ryujinx.HLE/Loaders/Executables/KipExecutable.cs
@@ -1,3 +1,4 @@
+using LibHac.Common;
 using LibHac.Fs;
 using LibHac.Kernel;
 using System;
@@ -32,11 +33,11 @@ namespace Ryujinx.HLE.Loaders.Executables
         public int Version              { get; }
         public string Name              { get; }
 
-        public KipExecutable(IStorage inStorage)
+        public KipExecutable(in SharedRef<IStorage> inStorage)
         {
             KipReader reader = new KipReader();
 
-            reader.Initialize(inStorage).ThrowIfFailure();
+            reader.Initialize(in inStorage).ThrowIfFailure();
 
             TextOffset = (uint)reader.Segments[0].MemoryOffset;
             RoOffset   = (uint)reader.Segments[1].MemoryOffset;

--- a/Ryujinx.HLE/Ryujinx.HLE.csproj
+++ b/Ryujinx.HLE/Ryujinx.HLE.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Concentus" Version="1.1.7" />
-    <PackageReference Include="LibHac" Version="0.13.3" />
+    <PackageReference Include="LibHac" Version="0.14.3" />
     <PackageReference Include="MsgPack.Cli" Version="1.0.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta11" />

--- a/Ryujinx/Ui/App/ApplicationLibrary.cs
+++ b/Ryujinx/Ui/App/ApplicationLibrary.cs
@@ -198,7 +198,8 @@ namespace Ryujinx.Ui.App
                                             Nca nca       = new Nca(_virtualFileSystem.KeySet, ncaFile.Get.AsStorage());
                                             int dataIndex = Nca.GetSectionIndexFromType(NcaSectionType.Data, NcaContentType.Program);
 
-                                            if (nca.Header.ContentType == NcaContentType.Program && !nca.Header.GetFsHeader(dataIndex).IsPatchSection())
+                                            // Some main NCAs don't have a data partition, so check if the partition exists before opening it
+                                            if (nca.Header.ContentType == NcaContentType.Program && !(nca.SectionExists(NcaSectionType.Data) && nca.Header.GetFsHeader(dataIndex).IsPatchSection()))
                                             {
                                                 hasMainNca = true;
 
@@ -373,7 +374,7 @@ namespace Ryujinx.Ui.App
                                 Nca nca       = new Nca(_virtualFileSystem.KeySet, new FileStream(applicationPath, FileMode.Open, FileAccess.Read).AsStorage());
                                 int dataIndex = Nca.GetSectionIndexFromType(NcaSectionType.Data, NcaContentType.Program);
 
-                                if (nca.Header.ContentType != NcaContentType.Program || nca.Header.GetFsHeader(dataIndex).IsPatchSection())
+                                if (nca.Header.ContentType != NcaContentType.Program || (nca.SectionExists(NcaSectionType.Data) && nca.Header.GetFsHeader(dataIndex).IsPatchSection()))
                                 {
                                     numApplicationsFound--;
 

--- a/Ryujinx/Ui/App/ApplicationLibrary.cs
+++ b/Ryujinx/Ui/App/ApplicationLibrary.cs
@@ -19,6 +19,7 @@ using System.Text;
 using System.Text.Json;
 
 using JsonHelper = Ryujinx.Common.Utilities.JsonHelper;
+using Path = System.IO.Path;
 
 namespace Ryujinx.Ui.App
 {
@@ -106,8 +107,10 @@ namespace Ryujinx.Ui.App
 
         public void ReadControlData(IFileSystem controlFs, Span<byte> outProperty)
         {
-            controlFs.OpenFile(out IFile controlFile, "/control.nacp".ToU8Span(), OpenMode.Read).ThrowIfFailure();
-            controlFile.Read(out _, 0, outProperty, ReadOption.None).ThrowIfFailure();
+            using var controlFile = new UniqueRef<IFile>();
+
+            controlFs.OpenFile(ref controlFile.Ref(), "/control.nacp".ToU8Span(), OpenMode.Read).ThrowIfFailure();
+            controlFile.Get.Read(out _, 0, outProperty, ReadOption.None).ThrowIfFailure();
         }
 
         public void LoadApplications(List<string> appDirs, Language desiredTitleLanguage)
@@ -188,9 +191,11 @@ namespace Ryujinx.Ui.App
                                     {
                                         if (Path.GetExtension(fileEntry.FullPath).ToLower() == ".nca")
                                         {
-                                            pfs.OpenFile(out IFile ncaFile, fileEntry.FullPath.ToU8Span(), OpenMode.Read).ThrowIfFailure();
+                                            using var ncaFile = new UniqueRef<IFile>();
 
-                                            Nca nca       = new Nca(_virtualFileSystem.KeySet, ncaFile.AsStorage());
+                                            pfs.OpenFile(ref ncaFile.Ref(), fileEntry.FullPath.ToU8Span(), OpenMode.Read).ThrowIfFailure();
+
+                                            Nca nca       = new Nca(_virtualFileSystem.KeySet, ncaFile.Get.AsStorage());
                                             int dataIndex = Nca.GetSectionIndexFromType(NcaSectionType.Data, NcaContentType.Program);
 
                                             if (nca.Header.ContentType == NcaContentType.Program && !nca.Header.GetFsHeader(dataIndex).IsPatchSection())
@@ -218,11 +223,13 @@ namespace Ryujinx.Ui.App
                                 {
                                     applicationIcon = _nspIcon;
 
-                                    Result result = pfs.OpenFile(out IFile npdmFile, "/main.npdm".ToU8Span(), OpenMode.Read);
+                                    using var npdmFile = new UniqueRef<IFile>();
+
+                                    Result result = pfs.OpenFile(ref npdmFile.Ref(), "/main.npdm".ToU8Span(), OpenMode.Read);
 
                                     if (ResultFs.PathNotFound.Includes(result))
                                     {
-                                        Npdm npdm = new Npdm(npdmFile.AsStream());
+                                        Npdm npdm = new Npdm(npdmFile.Get.AsStream());
 
                                         titleName = npdm.TitleName;
                                         titleId   = npdm.Aci0.TitleId.ToString("x16");
@@ -243,11 +250,13 @@ namespace Ryujinx.Ui.App
                                     // Read the icon from the ControlFS and store it as a byte array
                                     try
                                     {
-                                        controlFs.OpenFile(out IFile icon, $"/icon_{_desiredTitleLanguage}.dat".ToU8Span(), OpenMode.Read).ThrowIfFailure();
+                                        using var icon = new UniqueRef<IFile>();
+
+                                        controlFs.OpenFile(ref icon.Ref(), $"/icon_{_desiredTitleLanguage}.dat".ToU8Span(), OpenMode.Read).ThrowIfFailure();
 
                                         using (MemoryStream stream = new MemoryStream())
                                         {
-                                            icon.AsStream().CopyTo(stream);
+                                            icon.Get.AsStream().CopyTo(stream);
                                             applicationIcon = stream.ToArray();
                                         }
                                     }
@@ -260,11 +269,13 @@ namespace Ryujinx.Ui.App
                                                 continue;
                                             }
 
-                                            controlFs.OpenFile(out IFile icon, entry.FullPath.ToU8Span(), OpenMode.Read).ThrowIfFailure();
+                                            using var icon = new UniqueRef<IFile>();
+
+                                            controlFs.OpenFile(ref icon.Ref(), entry.FullPath.ToU8Span(), OpenMode.Read).ThrowIfFailure();
 
                                             using (MemoryStream stream = new MemoryStream())
                                             {
-                                                icon.AsStream().CopyTo(stream);
+                                                icon.Get.AsStream().CopyTo(stream);
                                                 applicationIcon = stream.ToArray();
                                             }
 
@@ -540,7 +551,7 @@ namespace Ryujinx.Ui.App
 
         private void GetNameIdDeveloper(ref ApplicationControlProperty controlData, out string titleName, out string titleId, out string publisher)
         {
-            _ = Enum.TryParse(_desiredTitleLanguage.ToString(), out TitleLanguage desiredTitleLanguage);
+            _ = Enum.TryParse(_desiredTitleLanguage.ToString(), out LibHac.Settings.Language desiredTitleLanguage);
 
             if (controlData.Titles.Length > (int)desiredTitleLanguage)
             {
@@ -608,10 +619,11 @@ namespace Ryujinx.Ui.App
                 if (patchNca != null && controlNca != null)
                 {
                     ApplicationControlProperty controlData = new ApplicationControlProperty();
+                    using var nacpFile = new UniqueRef<IFile>();
 
-                    controlNca.OpenFileSystem(NcaSectionType.Data, IntegrityCheckLevel.None).OpenFile(out IFile nacpFile, "/control.nacp".ToU8Span(), OpenMode.Read).ThrowIfFailure();
+                    controlNca.OpenFileSystem(NcaSectionType.Data, IntegrityCheckLevel.None).OpenFile(ref nacpFile.Ref(), "/control.nacp".ToU8Span(), OpenMode.Read).ThrowIfFailure();
 
-                    nacpFile.Read(out _, 0, SpanHelpers.AsByteSpan(ref controlData), ReadOption.None).ThrowIfFailure();
+                    nacpFile.Get.Read(out _, 0, SpanHelpers.AsByteSpan(ref controlData), ReadOption.None).ThrowIfFailure();
 
                     version = controlData.DisplayVersion.ToString();
 

--- a/Ryujinx/Ui/Widgets/GameTableContextMenu.cs
+++ b/Ryujinx/Ui/Widgets/GameTableContextMenu.cs
@@ -247,7 +247,7 @@ namespace Ryujinx.Ui.Widgets
                                 {
                                     int dataIndex = Nca.GetSectionIndexFromType(NcaSectionType.Data, NcaContentType.Program);
 
-                                    if (nca.Header.GetFsHeader(dataIndex).IsPatchSection())
+                                    if (nca.SectionExists(NcaSectionType.Data) && nca.Header.GetFsHeader(dataIndex).IsPatchSection())
                                     {
                                         patchNca = nca;
                                     }

--- a/Ryujinx/Ui/Widgets/GameTableContextMenu.cs
+++ b/Ryujinx/Ui/Widgets/GameTableContextMenu.cs
@@ -237,9 +237,11 @@ namespace Ryujinx.Ui.Widgets
 
                             foreach (DirectoryEntryEx fileEntry in pfs.EnumerateEntries("/", "*.nca"))
                             {
-                                pfs.OpenFile(out IFile ncaFile, fileEntry.FullPath.ToU8Span(), OpenMode.Read).ThrowIfFailure();
+                                using var ncaFile = new UniqueRef<IFile>();
 
-                                Nca nca = new Nca(_virtualFileSystem.KeySet, ncaFile.AsStorage());
+                                pfs.OpenFile(ref ncaFile.Ref(), fileEntry.FullPath.ToU8Span(), OpenMode.Read).ThrowIfFailure();
+
+                                Nca nca = new Nca(_virtualFileSystem.KeySet, ncaFile.Release().AsStorage());
 
                                 if (nca.Header.ContentType == NcaContentType.Program)
                                 {
@@ -290,8 +292,11 @@ namespace Ryujinx.Ui.Widgets
                         string source = DateTime.Now.ToFileTime().ToString()[10..];
                         string output = DateTime.Now.ToFileTime().ToString()[10..];
 
-                        fsClient.Register(source.ToU8Span(), ncaFileSystem);
-                        fsClient.Register(output.ToU8Span(), new LocalFileSystem(destination));
+                        using var uniqueSourceFs = new UniqueRef<IFileSystem>(ncaFileSystem);
+                        using var uniqueOutputFs = new UniqueRef<IFileSystem>(new LocalFileSystem(destination));
+
+                        fsClient.Register(source.ToU8Span(), ref uniqueSourceFs.Ref());
+                        fsClient.Register(output.ToU8Span(), ref uniqueOutputFs.Ref());
 
                         (Result? resultCode, bool canceled) = CopyDirectory(fsClient, $"{source}:/", $"{output}:/");
 

--- a/Ryujinx/Ui/Windows/AvatarWindow.cs
+++ b/Ryujinx/Ui/Windows/AvatarWindow.cs
@@ -130,12 +130,14 @@ namespace Ryujinx.Ui.Windows
 
                         if (item.Type == DirectoryEntryType.File && item.FullPath.Contains("chara") && item.FullPath.Contains("szs"))
                         {
-                            romfs.OpenFile(out IFile file, ("/" + item.FullPath).ToU8Span(), OpenMode.Read).ThrowIfFailure();
+                            using var file = new UniqueRef<IFile>();
+
+                            romfs.OpenFile(ref file.Ref(), ("/" + item.FullPath).ToU8Span(), OpenMode.Read).ThrowIfFailure();
 
                             using (MemoryStream stream    = new MemoryStream())
                             using (MemoryStream streamPng = new MemoryStream())
                             {
-                                file.AsStream().CopyTo(stream);
+                                file.Get.AsStream().CopyTo(stream);
 
                                 stream.Position = 0;
 

--- a/Ryujinx/Ui/Windows/DlcWindow.cs
+++ b/Ryujinx/Ui/Windows/DlcWindow.cs
@@ -89,8 +89,10 @@ namespace Ryujinx.Ui.Windows
 
                     foreach (DlcNca dlcNca in dlcContainer.DlcNcaList)
                     {
-                        pfs.OpenFile(out IFile ncaFile, dlcNca.Path.ToU8Span(), OpenMode.Read).ThrowIfFailure();
-                        Nca nca = TryCreateNca(ncaFile.AsStorage(), dlcContainer.Path);
+                        using var ncaFile = new UniqueRef<IFile>();
+
+                        pfs.OpenFile(ref ncaFile.Ref(), dlcNca.Path.ToU8Span(), OpenMode.Read).ThrowIfFailure();
+                        Nca nca = TryCreateNca(ncaFile.Get.AsStorage(), dlcContainer.Path);
 
                         if (nca != null)
                         {
@@ -155,9 +157,11 @@ namespace Ryujinx.Ui.Windows
 
                         foreach (DirectoryEntryEx fileEntry in pfs.EnumerateEntries("/", "*.nca"))
                         {
-                            pfs.OpenFile(out IFile ncaFile, fileEntry.FullPath.ToU8Span(), OpenMode.Read).ThrowIfFailure();
+                            using var ncaFile = new UniqueRef<IFile>();
 
-                            Nca nca = TryCreateNca(ncaFile.AsStorage(), containerPath);
+                            pfs.OpenFile(ref ncaFile.Ref(), fileEntry.FullPath.ToU8Span(), OpenMode.Read).ThrowIfFailure();
+
+                            Nca nca = TryCreateNca(ncaFile.Get.AsStorage(), containerPath);
 
                             if (nca == null) continue;
 

--- a/Ryujinx/Ui/Windows/TitleUpdateWindow.cs
+++ b/Ryujinx/Ui/Windows/TitleUpdateWindow.cs
@@ -99,8 +99,10 @@ namespace Ryujinx.Ui.Windows
                         {
                             ApplicationControlProperty controlData = new ApplicationControlProperty();
 
-                            controlNca.OpenFileSystem(NcaSectionType.Data, IntegrityCheckLevel.None).OpenFile(out IFile nacpFile, "/control.nacp".ToU8Span(), OpenMode.Read).ThrowIfFailure();
-                            nacpFile.Read(out _, 0, SpanHelpers.AsByteSpan(ref controlData), ReadOption.None).ThrowIfFailure();
+                            using var nacpFile = new UniqueRef<IFile>();
+
+                            controlNca.OpenFileSystem(NcaSectionType.Data, IntegrityCheckLevel.None).OpenFile(ref nacpFile.Ref(), "/control.nacp".ToU8Span(), OpenMode.Read).ThrowIfFailure();
+                            nacpFile.Get.Read(out _, 0, SpanHelpers.AsByteSpan(ref controlData), ReadOption.None).ThrowIfFailure();
 
                             RadioButton radioButton = new RadioButton($"Version {controlData.DisplayVersion.ToString()} - {path}");
                             radioButton.JoinGroup(_noUpdateRadioButton);


### PR DESCRIPTION
- Support reading NCAs with sparse partitions (Fixes #2853)
- Allow deleting read-only files and directories in `LocalFileSystem` (Fixes #2841)
- Disable `AesXtsFileSystem` (Fixes #1947)
- The `IFileSystem` interface has been updated for system version 12.0.0. Now it uses the `Fs.Path` type for paths instead of a `Span<byte>`
- LibHac now uses `SharedRef<T>` and `UniqueRef<T>` types which are similar to the `std::shared_ptr` and `std::unique_ptr` types used in Horizon. These help ensure resources are properly closed. FS IPC interfaces were updated to use these types.
- Fix loading NCAs that don't have a data partition