### PR TITLE
Implement CSDB instruction

### DIFF
--- a/ARMeilleure/Decoders/OpCodeTable.cs
+++ b/ARMeilleure/Decoders/OpCodeTable.cs
@@ -661,6 +661,7 @@ namespace ARMeilleure.Decoders
             SetA32("<<<<00010100xxxxxxxx00100100xxxx", InstName.Crc32cw, InstEmit32.Crc32cw, OpCode32AluReg.Create);
             SetA32("<<<<00010010xxxxxxxx00000100xxxx", InstName.Crc32h,  InstEmit32.Crc32h,  OpCode32AluReg.Create);
             SetA32("<<<<00010100xxxxxxxx00000100xxxx", InstName.Crc32w,  InstEmit32.Crc32w,  OpCode32AluReg.Create);
+            SetA32("<<<<0011001000001111000000010100", InstName.Csdb,    InstEmit32.Csdb,    OpCode32.Create);
             SetA32("1111010101111111111100000101xxxx", InstName.Dmb,     InstEmit32.Dmb,     OpCode32.Create);
             SetA32("1111010101111111111100000100xxxx", InstName.Dsb,     InstEmit32.Dsb,     OpCode32.Create);
             SetA32("<<<<0010001xxxxxxxxxxxxxxxxxxxxx", InstName.Eor,     InstEmit32.Eor,     OpCode32AluImm.Create);

--- a/ARMeilleure/Instructions/InstEmitMemoryEx32.cs
+++ b/ARMeilleure/Instructions/InstEmitMemoryEx32.cs
@@ -16,6 +16,11 @@ namespace ARMeilleure.Instructions
             EmitClearExclusive(context);
         }
 
+        public static void Csdb(ArmEmitterContext context)
+        {
+            // Execute as no-op.
+        }
+
         public static void Dmb(ArmEmitterContext context) => EmitBarrier(context);
 
         public static void Dsb(ArmEmitterContext context) => EmitBarrier(context);

--- a/ARMeilleure/Instructions/InstEmitSimdMemory32.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdMemory32.cs
@@ -99,7 +99,7 @@ namespace ARMeilleure.Instructions
                                         EmitLoadSimd(context, address, GetVecA32(dreg >> 1), dreg >> 1, rIndex++, op.Size);
                                     }
                                 }
-                            } 
+                            }
                             else
                             {
                                 EmitLoadSimd(context, address, GetVecA32(d >> 1), d >> 1, index, op.Size);
@@ -120,13 +120,13 @@ namespace ARMeilleure.Instructions
                     {
                         Operand m = GetIntA32(context, op.Rm);
                         SetIntA32(context, op.Rn, context.Add(n, m));
-                    } 
+                    }
                     else
                     {
                         SetIntA32(context, op.Rn, context.Add(n, Const(count * eBytes)));
                     }
                 }
-            } 
+            }
             else
             {
                 OpCode32SimdMemPair op = (OpCode32SimdMemPair)context.CurrOp;
@@ -161,7 +161,7 @@ namespace ARMeilleure.Instructions
                             }
                             else
                             {
-                                
+
                                 if (load)
                                 {
                                     EmitLoadSimd(context, address, GetVecA32(elemD >> 1), elemD >> 1, index, op.Size);
@@ -213,7 +213,7 @@ namespace ARMeilleure.Instructions
             int sReg = (op.DoubleWidth) ? (op.Vd << 1) : op.Vd;
             int offset = 0;
             int byteSize = 4;
-            
+
             for (int num = 0; num < range; num++, sReg++)
             {
                 Operand address = context.Add(baseAddress, Const(offset));

--- a/ARMeilleure/Instructions/InstName.cs
+++ b/ARMeilleure/Instructions/InstName.cs
@@ -36,6 +36,7 @@ namespace ARMeilleure.Instructions
         Crc32ch,
         Crc32cw,
         Crc32cx,
+        Csdb,
         Csel,
         Csinc,
         Csinv,


### PR DESCRIPTION
> Consumption of Speculative Data Barrier is a memory barrier that controls speculative execution and data value
prediction.

Implemented as no-op since that's how it should behave on the Switch CPU. This instruction has been added in new-ish Arm processors to mitigate side-channel attacks that takes advantage of the processors speculative execution. The Switch CPU does not actually support, on an older version of the Arm architecture reference manual, this encoding is documented to be a reserved hint instruction that should execute as NOP.
![image](https://user-images.githubusercontent.com/5624669/146677393-f7990151-bdad-4d5d-a7ac-5b377ff7a226.png)
![image](https://user-images.githubusercontent.com/5624669/146677415-8bda2cdf-6ba6-4c8a-9b31-0b3a3dc935b5.png)
This is required by Monster Rancher 1 & 2 DX, which now works.
![image](https://user-images.githubusercontent.com/5624669/146677428-2fb23e1e-2d9c-49f6-8026-fcae6210c133.png)
![image](https://user-images.githubusercontent.com/5624669/146677431-a3b1862d-14cc-429a-ac36-66ebc39ccfa5.png)
![image](https://user-images.githubusercontent.com/5624669/146677434-346992c7-1e70-434a-8874-d6a773d917df.png)
![image](https://user-images.githubusercontent.com/5624669/146677440-4e9372a6-9020-40de-8ebf-def3a3cc6e3d.png)
Fixes #2918.