### PR TITLE
Remove PortRemoteClosed warning

### DIFF
--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SyscallTable.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/SyscallTable.cs
@@ -467,9 +467,10 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
 
         private static void PrintResult(KernelResult result, string svcName)
         {
-            if (result != KernelResult.Success   &&
-                result != KernelResult.TimedOut  &&
+            if (result != KernelResult.Success &&
+                result != KernelResult.TimedOut &&
                 result != KernelResult.Cancelled &&
+                result != KernelResult.PortRemoteClosed &&
                 result != KernelResult.InvalidState)
             {
                 Logger.Warning?.Print(LogClass.KernelSvc, $"{svcName} returned error {result}.");


### PR DESCRIPTION
We get people asking how to fix the "PortRemoteClosed" error all the time. This removes the warning as the result is not really an error, it is a normal result that is returned under normal operation, when a service session is closed. Now the result is only printed as "Debug" level, like the other non-Success results that happens under normal operation.