### PR TITLE
Fix GetAddrInfoWithOptions and some sockets issues

### DIFF
--- a/Ryujinx.HLE/HLEConfiguration.cs
+++ b/Ryujinx.HLE/HLEConfiguration.cs
@@ -99,6 +99,11 @@ namespace Ryujinx.HLE
         internal readonly bool EnablePtc;
 
         /// <summary>
+        /// Control if the guest application should be told that there is a Internet connection available.
+        /// </summary>
+        internal readonly bool EnableInternetAccess;
+
+        /// <summary>
         /// Control LibHac's integrity check level.
         /// </summary>
         /// <remarks>This cannot be changed after <see cref="Switch"/> instantiation.</remarks>
@@ -122,8 +127,8 @@ namespace Ryujinx.HLE
         /// <remarks>This cannot be changed after <see cref="Switch"/> instantiation.</remarks>
         internal readonly string TimeZone;
 
-
         /// <summary>
+        /// Type of the memory manager used on CPU emulation.
         /// </summary>
         public MemoryManagerMode MemoryManagerMode { internal get; set; }
 
@@ -163,6 +168,7 @@ namespace Ryujinx.HLE
                                 bool                   enableVsync,
                                 bool                   enableDockedMode,
                                 bool                   enablePtc,
+                                bool                   enableInternetAccess,
                                 IntegrityCheckLevel    fsIntegrityCheckLevel,
                                 int                    fsGlobalAccessLogMode,
                                 long                   systemTimeOffset,
@@ -186,6 +192,7 @@ namespace Ryujinx.HLE
             EnableVsync            = enableVsync;
             EnableDockedMode       = enableDockedMode;
             EnablePtc              = enablePtc;
+            EnableInternetAccess   = enableInternetAccess;
             FsIntegrityCheckLevel  = fsIntegrityCheckLevel;
             FsGlobalAccessLogMode  = fsGlobalAccessLogMode;
             SystemTimeOffset       = systemTimeOffset;

--- a/Ryujinx.HLE/HOS/Services/Nifm/StaticService/IRequest.cs
+++ b/Ryujinx.HLE/HOS/Services/Nifm/StaticService/IRequest.cs
@@ -8,6 +8,13 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
 {
     class IRequest : IpcService
     {
+        private enum RequestState
+        {
+            Error = 1,
+            OnHold = 2,
+            Available = 3
+        }
+
         private KEvent _event0;
         private KEvent _event1;
 
@@ -28,7 +35,11 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
         // GetRequestState() -> u32
         public ResultCode GetRequestState(ServiceCtx context)
         {
-            context.ResponseData.Write(1);
+            RequestState requestState = context.Device.Configuration.EnableInternetAccess
+                ? RequestState.Available
+                : RequestState.Error;
+
+            context.ResponseData.Write((int)requestState);
 
             Logger.Stub?.PrintStub(LogClass.ServiceNifm);
 

--- a/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Types/BsdSocketFlags.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Types/BsdSocketFlags.cs
@@ -1,0 +1,24 @@
+using System.Net.Sockets;
+
+namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
+{
+    enum BsdSocketFlags
+    {
+        None = 0,
+        Oob = 0x1,
+        Peek = 0x2,
+        DontRoute = 0x4,
+        Eor = 0x8,
+        Trunc = 0x10,
+        CTrunc = 0x20,
+        WaitAll = 0x40,
+        DontWait = 0x80,
+        Eof = 0x100,
+        Notification = 0x2000,
+        Nbio = 0x4000,
+        Compat = 0x8000,
+        SoCallbck = 0x10000,
+        NoSignal = 0x20000,
+        CMsgCloExec = 0x40000
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/IResolver.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/IResolver.cs
@@ -155,7 +155,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
             ulong responseBufferPosition = context.Request.ReceiveBuff[0].Position;
             ulong responseBufferSize     = context.Request.ReceiveBuff[0].Size;
 
-            return GetAddrInfoRequestImpl(context, responseBufferPosition, responseBufferSize, 0, 0);
+            return GetAddrInfoRequestImpl(context, responseBufferPosition, responseBufferSize, false, 0, 0);
         }
 
         [CommandHipc(8)]
@@ -213,7 +213,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
             (ulong responseBufferPosition, ulong responseBufferSize) = context.Request.GetBufferType0x22();
             (ulong optionsBufferPosition,  ulong optionsBufferSize)  = context.Request.GetBufferType0x21();
 
-            return GetAddrInfoRequestImpl(context, responseBufferPosition, responseBufferSize, optionsBufferPosition, optionsBufferSize);
+            return GetAddrInfoRequestImpl(context, responseBufferPosition, responseBufferSize, true, optionsBufferPosition, optionsBufferSize);
         }
 
         private ResultCode GetHostByNameRequestImpl(ServiceCtx context, ulong inputBufferPosition, ulong inputBufferSize, ulong outputBufferPosition, ulong outputBufferSize, ulong optionsBufferPosition, ulong optionsBufferSize)
@@ -391,7 +391,13 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
             return bufferPosition - originalBufferPosition;
         }
 
-        private ResultCode GetAddrInfoRequestImpl(ServiceCtx context, ulong responseBufferPosition, ulong responseBufferSize, ulong optionsBufferPosition, ulong optionsBufferSize)
+        private ResultCode GetAddrInfoRequestImpl(
+            ServiceCtx context,
+            ulong responseBufferPosition,
+            ulong responseBufferSize,
+            bool withOptions,
+            ulong optionsBufferPosition,
+            ulong optionsBufferSize)
         {
             bool enableNsdResolve = (context.RequestData.ReadInt32() & 1) != 0;
             uint cancelHandle     = context.RequestData.ReadUInt32();
@@ -402,7 +408,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
             // NOTE: We ignore hints for now.
             DeserializeAddrInfos(context.Memory, (ulong)context.Request.SendBuff[2].Position, (ulong)context.Request.SendBuff[2].Size);
 
-            if (optionsBufferSize > 0)
+            if (withOptions)
             {
                 // TODO: Find unknown, Parse and use options.
                 uint unknown = context.RequestData.ReadUInt32();
@@ -431,8 +437,6 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
                 }
                 else
                 {
-                    Logger.Info?.Print(LogClass.ServiceSfdnsres, $"Trying to resolve: {host}");
-
                     try
                     {
                         hostEntry = Dns.GetHostEntry(targetHost);
@@ -457,9 +461,19 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
                 serializedSize = SerializeAddrInfos(context, responseBufferPosition, responseBufferSize, hostEntry, port);
             }
 
-            context.ResponseData.Write((int)netDbErrorCode);
-            context.ResponseData.Write((int)errno);
-            context.ResponseData.Write(serializedSize);
+            if (withOptions)
+            {
+                context.ResponseData.Write(serializedSize);
+                context.ResponseData.Write((int)errno);
+                context.ResponseData.Write((int)netDbErrorCode);
+                context.ResponseData.Write(0);
+            }
+            else
+            {
+                context.ResponseData.Write((int)netDbErrorCode);
+                context.ResponseData.Write((int)errno);
+                context.ResponseData.Write(serializedSize);
+            }
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/IResolver.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/IResolver.cs
@@ -437,6 +437,8 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
                 }
                 else
                 {
+                    Logger.Info?.Print(LogClass.ServiceSfdnsres, $"Trying to resolve: {host}");
+
                     try
                     {
                         hostEntry = Dns.GetHostEntry(targetHost);

--- a/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Types/AddrInfo4.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Types/AddrInfo4.cs
@@ -21,9 +21,9 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Types
             Port    = port;
             Address = default;
 
-            address.GetAddressBytes().AsSpan().CopyTo(Address.ToSpan());
-
-            Address.ToSpan().Reverse();
+            Span<byte> outAddress = Address.ToSpan();
+            address.TryWriteBytes(outAddress, out _);
+            outAddress.Reverse();
         }
     }
 }

--- a/Ryujinx.HLE/Switch.cs
+++ b/Ryujinx.HLE/Switch.cs
@@ -49,7 +49,7 @@ namespace Ryujinx.HLE
                 throw new ArgumentNullException(nameof(configuration.AudioDeviceDriver));
             }
 
-            if (configuration.UserChannelPersistence== null)
+            if (configuration.UserChannelPersistence == null)
             {
                 throw new ArgumentNullException(nameof(configuration.UserChannelPersistence));
             }

--- a/Ryujinx.Headless.SDL2/Options.cs
+++ b/Ryujinx.Headless.SDL2/Options.cs
@@ -79,6 +79,9 @@ namespace Ryujinx.Headless.SDL2
         [Option("enable-ptc", Required = false, Default = true, HelpText = "Enables profiled translation cache persistency.")]
         public bool? EnablePtc { get; set; }
 
+        [Option("enable-internet-connection", Required = false, Default = false, HelpText = "Enables guest Internet connection.")]
+        public bool? EnableInternetAccess { get; set; }
+
         [Option("enable-fs-integrity-checks", Required = false, Default = true, HelpText = "Enables integrity checks on Game content files.")]
         public bool? EnableFsIntegrityChecks { get; set; }
 

--- a/Ryujinx.Headless.SDL2/Program.cs
+++ b/Ryujinx.Headless.SDL2/Program.cs
@@ -459,6 +459,7 @@ namespace Ryujinx.Headless.SDL2
                                                                   (bool)options.EnableVsync,
                                                                   (bool)options.EnableDockedMode,
                                                                   (bool)options.EnablePtc,
+                                                                  (bool)options.EnableInternetAccess,
                                                                   (bool)options.EnableFsIntegrityChecks ? LibHac.FsSystem.IntegrityCheckLevel.ErrorOnInvalid : LibHac.FsSystem.IntegrityCheckLevel.None,
                                                                   options.FsGlobalAccessLogMode,
                                                                   options.SystemTimeOffset,

--- a/Ryujinx/Configuration/ConfigurationFileFormat.cs
+++ b/Ryujinx/Configuration/ConfigurationFileFormat.cs
@@ -14,8 +14,11 @@ namespace Ryujinx.Configuration
         /// <summary>
         /// The current version of the file format
         /// </summary>
-        public const int CurrentVersion = 33;
+        public const int CurrentVersion = 34;
 
+        /// <summary>
+        /// Version of the configuration file format
+        /// </summary>
         public int Version { get; set; }
 
         /// <summary>
@@ -98,7 +101,6 @@ namespace Ryujinx.Configuration
         /// </summary>
         public GraphicsDebugLevel LoggingGraphicsDebugLevel { get; set; }
 
-
         /// <summary>
         /// Change System Language
         /// </summary>
@@ -155,14 +157,14 @@ namespace Ryujinx.Configuration
         public bool EnableShaderCache { get; set; }
 
         /// <summary>
-        /// Enables or disables multi-core scheduling of threads
-        /// </summary>
-        public bool EnableMulticoreScheduling { get; set; }
-
-        /// <summary>
         /// Enables or disables profiled translation cache persistency
         /// </summary>
         public bool EnablePtc { get; set; }
+
+        /// <summary>
+        /// Enables or disables guest Internet access
+        /// </summary>
+        public bool EnableInternetAccess { get; set; }
 
         /// <summary>
         /// Enables integrity checks on Game content files

--- a/Ryujinx/Configuration/ConfigurationState.cs
+++ b/Ryujinx/Configuration/ConfigurationState.cs
@@ -206,6 +206,11 @@ namespace Ryujinx.Configuration
             public ReactiveObject<bool> EnablePtc { get; private set; }
 
             /// <summary>
+            /// Enables or disables guest Internet access
+            /// </summary>
+            public ReactiveObject<bool> EnableInternetAccess { get; private set; }
+
+            /// <summary>
             /// Enables integrity checks on Game content files
             /// </summary>
             public ReactiveObject<bool> EnableFsIntegrityChecks { get; private set; }
@@ -250,6 +255,8 @@ namespace Ryujinx.Configuration
                 EnableDockedMode.Event        += static (sender, e) => LogValueChange(sender, e, nameof(EnableDockedMode));
                 EnablePtc                     = new ReactiveObject<bool>();
                 EnablePtc.Event               += static (sender, e) => LogValueChange(sender, e, nameof(EnablePtc));
+                EnableInternetAccess          = new ReactiveObject<bool>();
+                EnableInternetAccess.Event    += static (sender, e) => LogValueChange(sender, e, nameof(EnableInternetAccess));
                 EnableFsIntegrityChecks       = new ReactiveObject<bool>();
                 EnableFsIntegrityChecks.Event += static (sender, e) => LogValueChange(sender, e, nameof(EnableFsIntegrityChecks));
                 FsGlobalAccessLogMode         = new ReactiveObject<int>();
@@ -276,7 +283,7 @@ namespace Ryujinx.Configuration
             /// Enable or disable keyboard support (Independent from controllers binding)
             /// </summary>
             public ReactiveObject<bool> EnableKeyboard { get; private set; }
-            
+
             /// <summary>
             /// Enable or disable mouse support (Independent from controllers binding)
             /// </summary>
@@ -464,6 +471,7 @@ namespace Ryujinx.Configuration
                 EnableVsync               = Graphics.EnableVsync,
                 EnableShaderCache         = Graphics.EnableShaderCache,
                 EnablePtc                 = System.EnablePtc,
+                EnableInternetAccess      = System.EnableInternetAccess,
                 EnableFsIntegrityChecks   = System.EnableFsIntegrityChecks,
                 FsGlobalAccessLogMode     = System.FsGlobalAccessLogMode,
                 AudioBackend              = System.AudioBackend,
@@ -534,6 +542,7 @@ namespace Ryujinx.Configuration
             Graphics.EnableVsync.Value             = true;
             Graphics.EnableShaderCache.Value       = true;
             System.EnablePtc.Value                 = true;
+            System.EnableInternetAccess.Value      = false;
             System.EnableFsIntegrityChecks.Value   = true;
             System.FsGlobalAccessLogMode.Value     = 0;
             System.AudioBackend.Value              = AudioBackend.SDL2;
@@ -956,6 +965,15 @@ namespace Ryujinx.Configuration
                 configurationFileUpdated = true;
             }
 
+            if (configurationFileFormat.Version < 34)
+            {
+                Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 34.");
+
+                configurationFileFormat.EnableInternetAccess = false;
+
+                configurationFileUpdated = true;
+            }
+
             Logger.EnableFileLog.Value             = configurationFileFormat.EnableFileLog;
             Graphics.BackendThreading.Value        = configurationFileFormat.BackendThreading;
             Graphics.ResScale.Value                = configurationFileFormat.ResScale;
@@ -984,6 +1002,7 @@ namespace Ryujinx.Configuration
             Graphics.EnableVsync.Value             = configurationFileFormat.EnableVsync;
             Graphics.EnableShaderCache.Value       = configurationFileFormat.EnableShaderCache;
             System.EnablePtc.Value                 = configurationFileFormat.EnablePtc;
+            System.EnableInternetAccess.Value      = configurationFileFormat.EnableInternetAccess;
             System.EnableFsIntegrityChecks.Value   = configurationFileFormat.EnableFsIntegrityChecks;
             System.FsGlobalAccessLogMode.Value     = configurationFileFormat.FsGlobalAccessLogMode;
             System.AudioBackend.Value              = configurationFileFormat.AudioBackend;

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -206,7 +206,7 @@ namespace Ryujinx.Ui
             ConfigurationState.Instance.System.IgnoreMissingServices.Event += UpdateIgnoreMissingServicesState;
             ConfigurationState.Instance.Graphics.AspectRatio.Event         += UpdateAspectRatioState;
             ConfigurationState.Instance.System.EnableDockedMode.Event      += UpdateDockedModeState;
-            ConfigurationState.Instance.System.AudioVolume.Event           += UpdateAudioVolumeState; 
+            ConfigurationState.Instance.System.AudioVolume.Event           += UpdateAudioVolumeState;
 
             if (ConfigurationState.Instance.Ui.StartFullscreen)
             {
@@ -434,7 +434,7 @@ namespace Ryujinx.Ui
                 else
                 {
                     Logger.Warning?.Print(LogClass.Audio, "SDL2 is not supported, trying to fall back to OpenAL.");
-                
+
                     if (OpenALHardwareDeviceDriver.IsSupported)
                     {
                         Logger.Warning?.Print(LogClass.Audio, "Found OpenAL, changing configuration.");
@@ -447,7 +447,7 @@ namespace Ryujinx.Ui
                     else
                     {
                         Logger.Warning?.Print(LogClass.Audio, "OpenAL is not supported, trying to fall back to SoundIO.");
-                         
+
                         if (SoundIoHardwareDeviceDriver.IsSupported)
                         {
                             Logger.Warning?.Print(LogClass.Audio, "Found SoundIO, changing configuration.");
@@ -460,8 +460,8 @@ namespace Ryujinx.Ui
                         else
                         {
                             Logger.Warning?.Print(LogClass.Audio, "SoundIO is not supported, falling back to dummy audio out.");
-                        }           
-                    }   
+                        }
+                    }
                 }
             }
             else if (ConfigurationState.Instance.System.AudioBackend.Value == AudioBackend.SoundIo)
@@ -499,7 +499,7 @@ namespace Ryujinx.Ui
                         else
                         {
                             Logger.Warning?.Print(LogClass.Audio, "OpenAL is not supported, falling back to dummy audio out.");
-                        }           
+                        }
                     }
                 }
             }
@@ -525,7 +525,7 @@ namespace Ryujinx.Ui
                     else
                     {
                         Logger.Warning?.Print(LogClass.Audio, "SDL2 is not supported, trying to fall back to SoundIO.");
-                        
+
                         if (SoundIoHardwareDeviceDriver.IsSupported)
                         {
                             Logger.Warning?.Print(LogClass.Audio, "Found SoundIO, changing configuration.");
@@ -563,6 +563,7 @@ namespace Ryujinx.Ui
                                                                           ConfigurationState.Instance.Graphics.EnableVsync,
                                                                           ConfigurationState.Instance.System.EnableDockedMode,
                                                                           ConfigurationState.Instance.System.EnablePtc,
+                                                                          ConfigurationState.Instance.System.EnableInternetAccess,
                                                                           fsIntegrityCheckLevel,
                                                                           ConfigurationState.Instance.System.FsGlobalAccessLogMode,
                                                                           ConfigurationState.Instance.System.SystemTimeOffset,

--- a/Ryujinx/Ui/Windows/SettingsWindow.cs
+++ b/Ryujinx/Ui/Windows/SettingsWindow.cs
@@ -52,6 +52,7 @@ namespace Ryujinx.Ui.Windows
         [GUI] CheckButton     _vSyncToggle;
         [GUI] CheckButton     _shaderCacheToggle;
         [GUI] CheckButton     _ptcToggle;
+        [GUI] CheckButton     _internetToggle;
         [GUI] CheckButton     _fsicToggle;
         [GUI] RadioButton     _mmSoftware;
         [GUI] RadioButton     _mmHost;
@@ -224,6 +225,11 @@ namespace Ryujinx.Ui.Windows
             if (ConfigurationState.Instance.System.EnablePtc)
             {
                 _ptcToggle.Click();
+            }
+
+            if (ConfigurationState.Instance.System.EnableInternetAccess)
+            {
+                _internetToggle.Click();
             }
 
             if (ConfigurationState.Instance.System.EnableFsIntegrityChecks)
@@ -496,6 +502,7 @@ namespace Ryujinx.Ui.Windows
             ConfigurationState.Instance.Graphics.EnableVsync.Value             = _vSyncToggle.Active;
             ConfigurationState.Instance.Graphics.EnableShaderCache.Value       = _shaderCacheToggle.Active;
             ConfigurationState.Instance.System.EnablePtc.Value                 = _ptcToggle.Active;
+            ConfigurationState.Instance.System.EnableInternetAccess.Value      = _internetToggle.Active;
             ConfigurationState.Instance.System.EnableFsIntegrityChecks.Value   = _fsicToggle.Active;
             ConfigurationState.Instance.System.MemoryManagerMode.Value         = memoryMode;
             ConfigurationState.Instance.System.ExpandRam.Value                 = _expandRamToggle.Active;

--- a/Ryujinx/Ui/Windows/SettingsWindow.glade
+++ b/Ryujinx/Ui/Windows/SettingsWindow.glade
@@ -1508,6 +1508,24 @@
                                   </packing>
                                 </child>
                                 <child>
+                                  <object class="GtkCheckButton" id="_internetToggle">
+                                    <property name="label" translatable="yes">Enable guest Internet access</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Enables guest Internet access. If enabled, the application will behave as if the emulated Switch console was connected to the Internet. Note that in some cases, applications may still access the Internet even with this option disabled</property>
+                                    <property name="halign">start</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">7</property>
+                                  </packing>
+                                </child>
+                                <child>
                                   <object class="GtkCheckButton" id="_fsicToggle">
                                     <property name="label" translatable="yes">Enable FS Integrity Checks</property>
                                     <property name="visible">True</property>
@@ -1522,7 +1540,7 @@
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="fill">True</property>
-                                    <property name="position">7</property>
+                                    <property name="position">8</property>
                                   </packing>
                                 </child>
                               </object>


### PR DESCRIPTION
This fixes several issues related to the sockets implementation:
- `GetAddrInfoWIthOptions` was incorrect, as the output layout is different from `GetAddrInfo`. On the former, the `serializedSize` is actually the *first* field on the output, and not the last. Before any games trying to use this function would just not receive anything from SDK side, as it would think the serialized size is 0 and thus theres no data to be read. This has been fixed which allows DNS lookup to actually work.
- `Socket.Connect` would return the error `EAGAIN` if an attempt was made to connect with a non-blocking socket. That is because those will make an async connection, and Winsocks/the .NET wrapper returns `WSAEWOULDBLOCK` in this case, which is translated to the Linux error `EAGAIN`. But that is incorrect as the function is documented to return `EINPROGRESS` in this case.
- `Socket.GetSockOpt` and `Socket.SetSockOpt` would only allow the "Socket" level. I'm not sure why, but I have changed it to instead accept any level passed by the application.
- The `Socket.Send` and `Socket.Recv` function were limited to only support a small subset of flag values, and would return an error if any other was set, including some that are supposed to be supported on the Switch. I have made some changes here, first by adding the correct BSD enum instead of using the .NET one that does not match for all values, and then adding a new function that converts between enums, and warns but does not return an error for unsupported flags. In addition to that, a few more flags are supported (Trunc and CTrunc).
- NIFM's `IRequest.GetRequestState` was hardcoded to return 1, which makes the application believe there's no Internet connection. This has been changed to be configurable with a new "Enable guest Internet access" option on the settings system tab. It is disabled by default to match the old behaviour. When enabled, some applications will now try to access their servers.

Those changes allows the Youtube application to run (albeit in a very broken state, but those issues are related to other areas of the emulation).
![image](https://user-images.githubusercontent.com/5624669/147394840-be74fd9f-564b-4650-bfa1-5eb08eb421eb.png)
Running it requires the "Enable guest Internet access" option to be enabled, of course.
This might also help other games with network related issues (World War Z, maybe?)