### PR TITLE
Fix I2M texture copies when line length is not a multiple of 4

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
@@ -171,7 +171,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.InlineToMemory
 
             if (_isLinear && _lineCount == 1)
             {
-                memoryManager.WriteTrackedResource(_dstGpuVa, data);
+                memoryManager.WriteTrackedResource(_dstGpuVa, data.Slice(0, _lineLengthIn));
                 _context.AdvanceSequence();
             }
             else

--- a/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
@@ -176,8 +176,6 @@ namespace Ryujinx.Graphics.Gpu.Engine.InlineToMemory
             }
             else
             {
-                int srcOffset = 0;
-
                 var dstCalculator = new OffsetCalculator(
                     _dstWidth,
                     _dstHeight,
@@ -185,6 +183,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.InlineToMemory
                     _isLinear,
                     _dstGobBlocksInY,
                     1);
+
+                int srcOffset = 0;
 
                 for (int y = _dstY; y < _dstY + _lineCount; y++)
                 {


### PR DESCRIPTION
Data can only be pushed 4 bytes at a time, so for this reason, the data for each line must be aligned to 4 bytes on submission, even if the line length is not a multiple of 4 (as is the case for < 4 bpp formats for example). This was not being taken into account, which caused the padding bytes to be copied into the next lines.

This fixes some texture corruption on OpenGL games (only OpenGL games will be affected, NVN does not use this at all).
Fixes subtitle text in Cat Girl Without Salad:
Before:
![image](https://user-images.githubusercontent.com/5624669/147398075-e10e66b0-f05d-4530-850d-1b458236fee7.png)
After:
![image](https://user-images.githubusercontent.com/5624669/147398079-2fa56c9f-d032-4cc8-96de-ee55d2ffd93a.png)
Also fixes a similar issue on the Youtube app.