### PR TITLE
Fix missing default value of audio volume.

### DIFF
--- a/Ryujinx/Configuration/ConfigurationState.cs
+++ b/Ryujinx/Configuration/ConfigurationState.cs
@@ -537,6 +537,7 @@ namespace Ryujinx.Configuration
             System.EnableFsIntegrityChecks.Value   = true;
             System.FsGlobalAccessLogMode.Value     = 0;
             System.AudioBackend.Value              = AudioBackend.SDL2;
+            System.AudioVolume.Value               = 1;
             System.MemoryManagerMode.Value         = MemoryManagerMode.HostMappedUnsafe;
             System.ExpandRam.Value                 = false;
             System.IgnoreMissingServices.Value     = false;


### PR DESCRIPTION
The default configuration was missing the audio volume setting, causing updated config files to have their volume level set to 0. This PR sets the default volume level to 1 (100%) as it should have been when volume PR was created.