### PR TITLE
Fix bug causing an audio buffer to be enqueued more than once

### DIFF
--- a/Ryujinx.Audio/Common/AudioDeviceSession.cs
+++ b/Ryujinx.Audio/Common/AudioDeviceSession.cs
@@ -175,7 +175,7 @@ namespace Ryujinx.Audio.Common
 
             for (int i = 0; i < buffersToFlush.Length; i++)
             {
-                buffersToFlush[i] = _buffers[_hardwareBufferIndex];
+                buffersToFlush[i] = _buffers[hardwareBufferIndex];
 
                 _bufferAppendedCount--;
                 _bufferRegisteredCount++;


### PR DESCRIPTION
Fixes what I assume to be an oversight that caused buffers to be enqueued (and played) more than once, if the game appended them fast enough.
Fixes audio in the Youtube app. Might potentially fix games with broken audio too.