### PR TITLE
Flip scissor box when the YNegate bit is set

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -436,7 +436,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
                         if (y < 0)
                         {
-                            height -= Math.Abs(y);
+                            height += y;
                             y = 0;
                         }
                     }


### PR DESCRIPTION
It should be flipped when this bit is set, required by OpenGL games.
Fixes menus being cut off in the Youtube app.
Before:
![image](https://user-images.githubusercontent.com/5624669/147400921-9c152007-9d50-4ed2-9694-6524b36f9f8b.png)
After:
![image](https://user-images.githubusercontent.com/5624669/147400926-4432a707-f636-4179-9c5e-3d7c2760d47b.png)

Testing to ensure there's no regressions on games is welcome.