### PR TITLE
Fix DMA copy fast path line size when xCount < stride

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -222,6 +222,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                                 target.Info.Height,
                                 1,
                                 1,
+                                xCount * srcBpp,
                                 srcStride,
                                 target.Info.FormatInfo.BytesPerPixel,
                                 srcSpan);

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -760,6 +760,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     Info.FormatInfo.BlockWidth,
                     Info.FormatInfo.BlockHeight,
                     Info.Stride,
+                    Info.Stride,
                     Info.FormatInfo.BytesPerPixel,
                     data);
             }

--- a/Ryujinx.Graphics.Texture/LayoutConverter.cs
+++ b/Ryujinx.Graphics.Texture/LayoutConverter.cs
@@ -248,6 +248,7 @@ namespace Ryujinx.Graphics.Texture
             int height,
             int blockWidth,
             int blockHeight,
+            int lineSize,
             int stride,
             int bytesPerPixel,
             ReadOnlySpan<byte> data)
@@ -256,7 +257,7 @@ namespace Ryujinx.Graphics.Texture
             int h = BitUtils.DivRoundUp(height, blockHeight);
 
             int outStride = BitUtils.AlignUp(w * bytesPerPixel, HostStrideAlignment);
-            int lineSize = Math.Min(stride, outStride);
+            lineSize = Math.Min(lineSize, outStride);
 
             Span<byte> output = new byte[h * outStride];
 


### PR DESCRIPTION
The copy could be out of bounds before if `xCount` was less than stride, as the span size is calculated based on the stride and `xCount` (so it could be missing a few bytes at the end). This change makes it not copy any more than `xCount`. I'm not sure if the fast path should be used in this case though, as technically the data of the few missing pixels would be just 0.

This fixes some random crashes in the Youtube app and maybe some other games that does DMA copy with linear source textures.

Testing to ensure that it did not regress any game is welcome.