### PR TITLE
Implement -p or --profile command line argument

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Account/Acc/AccountManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/AccountManager.cs
@@ -43,7 +43,28 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             }
             else
             {
-                OpenUser(_accountSaveDataManager.LastOpened);
+                UserId commandLineUserProfileOverride = default; 
+                var args = Environment.GetCommandLineArgs();
+                for (int i = 0; i < args.Length; ++i)
+                {
+                    string arg = args[i];
+
+                    if (arg == "-p" || arg == "--profile")
+                    {
+                        if (i + 1 >= args.Length)
+                        {
+                            Common.Logging.Logger.Error?.Print(Common.Logging.LogClass.Application, $"Invalid option '{arg}'");
+
+                            continue;
+                        }
+
+                        string profileName = args[++i];
+                        commandLineUserProfileOverride = _profiles.FirstOrDefault(x => x.Value.Name == profileName).Value?.UserId ?? default;
+                        if(commandLineUserProfileOverride.IsNull)
+                            Common.Logging.Logger.Warning?.Print(Common.Logging.LogClass.Application, $"The command line specified profile named '{profileName}' was not found");
+                    }
+                }
+                OpenUser(commandLineUserProfileOverride.IsNull ? _accountSaveDataManager.LastOpened : commandLineUserProfileOverride);
             }
         }
 

--- a/Ryujinx/Program.cs
+++ b/Ryujinx/Program.cs
@@ -51,6 +51,16 @@ namespace Ryujinx
 
                     baseDirPathArg = args[++i];
                 }
+                else if (arg == "-p" || arg == "--profile")
+                {
+                    if (i + 1 >= args.Length)
+                    {
+                        Logger.Error?.Print(LogClass.Application, $"Invalid option '{arg}'");
+
+                        continue;
+                    }
+                    i++;
+                }
                 else if (arg == "-f" || arg == "--fullscreen")
                 {
                     startFullscreenArg = true;


### PR DESCRIPTION
This PR implements a command line argument for specifying which profile to load, overriding the default behavior of loading the most recently used profile.

This functionality is useful for those who like to, for example, create individualize desktop shortcuts on a shared computer. Each profile user can launch ryujinx directly to their profile without having to visit the manage user profiles window.


Here is an example. The user would add `-p MyUserName` to the target line of the desktop shortcut. They would then do the same but with a different profile name with another shortcut for a different user.
![explorer_2021-12-26_23-56-54](https://user-images.githubusercontent.com/4522492/147443983-005f19ee-c666-4740-a786-25881e28e022.png)


I tried to follow existing examples of intended error levels and code styles, but I'm happy to change anything if needed. The somewhat duplicate code parsing the command line arguments was needed since the existing code seems to expect any parameters not captured to be a launch path.


I also feel that the <https://github.com/Ryujinx/Ryujinx/wiki/Ryujinx-Setup-&-Configuration-Guide> page needs a section outlining all existing command line arguments, it took me quite a while to determine from the wiki the available command line arguments. I would like to see if a parameter for launching a game directly would also be possible after this gets merged.