### PR TITLE
Use minimum stream sample count on SDL2 audio backend

### DIFF
--- a/Ryujinx.Audio.Backends.SDL2/SDL2HardwareDeviceSession.cs
+++ b/Ryujinx.Audio.Backends.SDL2/SDL2HardwareDeviceSession.cs
@@ -42,11 +42,13 @@ namespace Ryujinx.Audio.Backends.SDL2
 
         private void EnsureAudioStreamSetup(AudioBuffer buffer)
         {
-            bool needAudioSetup = _outputStream == 0 || ((uint)GetSampleCount(buffer) % _sampleCount) != 0;
+            uint bufferSampleCount = (uint)GetSampleCount(buffer);
+            bool needAudioSetup = _outputStream == 0 ||
+                (bufferSampleCount >= Constants.TargetSampleCount && bufferSampleCount < _sampleCount);
 
             if (needAudioSetup)
             {
-                _sampleCount = Math.Max(Constants.TargetSampleCount, (uint)GetSampleCount(buffer));
+                _sampleCount = Math.Max(Constants.TargetSampleCount, bufferSampleCount);
 
                 uint newOutputStream = SDL2HardwareDeviceDriver.OpenStream(RequestedSampleFormat, RequestedSampleRate, RequestedChannelCount, _sampleCount, _callbackDelegate);
 


### PR DESCRIPTION
Instead of recreating the stream every time the buffer sample count is not a multiple of the current sample count, just use the minimum sample count of all buffers ever submited to the audio stream.  This shoulld fix the "New audio stream setup with a sample count of ..." log spam followed by massive slowdown in some games, such as Final Fantasy VII, when using the SDL2 audio backend.