### PR TITLE
friend: Stub IsFriendListCacheAvailable and EnsureFriendListAvailable

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Friend/ServiceCreator/IFriendService.cs
+++ b/Ryujinx.HLE/HOS/Services/Friend/ServiceCreator/IFriendService.cs
@@ -133,7 +133,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
 
             // TODO: Service mount the friends:/ system savedata and try to load friend.cache file, returns true if exists, false otherwise. 
             // NOTE: If no cache is available, guest then calls nn::friends::EnsureFriendListAvailable, we can avoid that by faking the cache check.
-            context.ResponseData.Write(1);
+            context.ResponseData.Write(true);
 
             // TODO: Since we don't support friend features, it's fine to stub it for now.
             Logger.Stub?.PrintStub(LogClass.ServiceFriend, new { UserId = userId.ToString() });

--- a/Ryujinx.HLE/HOS/Services/Friend/ServiceCreator/IFriendService.cs
+++ b/Ryujinx.HLE/HOS/Services/Friend/ServiceCreator/IFriendService.cs
@@ -120,6 +120,45 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
             return ResultCode.Success;
         }
 
+        [CommandHipc(10120)]
+        // nn::friends::IsFriendListCacheAvailable(nn::account::Uid userId) -> bool
+        public ResultCode IsFriendListCacheAvailable(ServiceCtx context)
+        {
+            UserId userId = context.RequestData.ReadStruct<UserId>();
+
+            if (userId.IsNull)
+            {
+                return ResultCode.InvalidArgument;
+            }
+
+            // TODO: Service mount the friends:/ system savedata and try to load friend.cache file, returns true if exists, false instead. 
+            // NOTE: If no cache is available, guest then calls nn::friends::EnsureFriendListAvailable, we can avoid that by fake the cache check.
+            context.ResponseData.Write(true);
+
+            // TODO: Since we doesn't support friend features, it's fine to stub it for now.
+            Logger.Stub?.PrintStub(LogClass.ServiceFriend, new { UserId = userId.ToString() });
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(10121)]
+        // nn::friends::EnsureFriendListAvailable(nn::account::Uid userId)
+        public ResultCode EnsureFriendListAvailable(ServiceCtx context)
+        {
+            UserId userId = context.RequestData.ReadStruct<UserId>();
+
+            if (userId.IsNull)
+            {
+                return ResultCode.InvalidArgument;
+            }
+
+            // TODO: Service mount the friends:/ system savedata and create a friend.cache file for the given user id.
+            //       Since we doesn't support friend features, it's fine to stub it for now.
+            Logger.Stub?.PrintStub(LogClass.ServiceFriend, new { UserId = userId.ToString() });
+
+            return ResultCode.Success;
+        }
+
         [CommandHipc(10400)]
         // nn::friends::GetBlockedUserListIds(int offset, nn::account::Uid userId) -> (u32, buffer<nn::account::NetworkServiceAccountId, 0xa>)
         public ResultCode GetBlockedUserListIds(ServiceCtx context)

--- a/Ryujinx.HLE/HOS/Services/Friend/ServiceCreator/IFriendService.cs
+++ b/Ryujinx.HLE/HOS/Services/Friend/ServiceCreator/IFriendService.cs
@@ -120,7 +120,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
             return ResultCode.Success;
         }
 
-        [CommandHipc(10120)]
+        [CommandHipc(10120)] // 10.0.0+
         // nn::friends::IsFriendListCacheAvailable(nn::account::Uid userId) -> bool
         public ResultCode IsFriendListCacheAvailable(ServiceCtx context)
         {
@@ -141,7 +141,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
             return ResultCode.Success;
         }
 
-        [CommandHipc(10121)]
+        [CommandHipc(10121)] // 10.0.0+
         // nn::friends::EnsureFriendListAvailable(nn::account::Uid userId)
         public ResultCode EnsureFriendListAvailable(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Friend/ServiceCreator/IFriendService.cs
+++ b/Ryujinx.HLE/HOS/Services/Friend/ServiceCreator/IFriendService.cs
@@ -131,11 +131,11 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
                 return ResultCode.InvalidArgument;
             }
 
-            // TODO: Service mount the friends:/ system savedata and try to load friend.cache file, returns true if exists, false instead. 
-            // NOTE: If no cache is available, guest then calls nn::friends::EnsureFriendListAvailable, we can avoid that by fake the cache check.
-            context.ResponseData.Write(true);
+            // TODO: Service mount the friends:/ system savedata and try to load friend.cache file, returns true if exists, false otherwise. 
+            // NOTE: If no cache is available, guest then calls nn::friends::EnsureFriendListAvailable, we can avoid that by faking the cache check.
+            context.ResponseData.Write(1);
 
-            // TODO: Since we doesn't support friend features, it's fine to stub it for now.
+            // TODO: Since we don't support friend features, it's fine to stub it for now.
             Logger.Stub?.PrintStub(LogClass.ServiceFriend, new { UserId = userId.ToString() });
 
             return ResultCode.Success;
@@ -153,7 +153,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
             }
 
             // TODO: Service mount the friends:/ system savedata and create a friend.cache file for the given user id.
-            //       Since we doesn't support friend features, it's fine to stub it for now.
+            //       Since we don't support friend features, it's fine to stub it for now.
             Logger.Stub?.PrintStub(LogClass.ServiceFriend, new { UserId = userId.ToString() });
 
             return ResultCode.Success;


### PR DESCRIPTION
This PR stubs `IsFriendListCacheAvailable` and `EnsureFriendListAvailable` call of `friend` service, checked by RE, which close #2896.

Sadly, Super Bomberman R Online is still stuck on the loading screen and keep calling `TryPopFromFriendInvitationStorageChannel`, probably because another issue somewhere.