### PR TITLE
ffmpeg: Add extra checks and error messages

### DIFF
--- a/Ryujinx.Graphics.Nvdec.FFmpeg/FFmpegContext.cs
+++ b/Ryujinx.Graphics.Nvdec.FFmpeg/FFmpegContext.cs
@@ -20,7 +20,7 @@ namespace Ryujinx.Graphics.Nvdec.FFmpeg
             _codec = ffmpeg.avcodec_find_decoder(codecId);
             if (_codec == null)
             {
-                Logger.Error?.PrintMsg(LogClass.FFmpeg, $"Codec wasn't found. Make sure you have the {codecId} present in your FFmpeg installation.");
+                Logger.Error?.PrintMsg(LogClass.FFmpeg, $"Codec wasn't found. Make sure you have the {codecId} codec present in your FFmpeg installation.");
 
                 return;
             }

--- a/Ryujinx.Graphics.Nvdec.FFmpeg/FFmpegContext.cs
+++ b/Ryujinx.Graphics.Nvdec.FFmpeg/FFmpegContext.cs
@@ -18,11 +18,35 @@ namespace Ryujinx.Graphics.Nvdec.FFmpeg
         public FFmpegContext(AVCodecID codecId)
         {
             _codec = ffmpeg.avcodec_find_decoder(codecId);
-            _context = ffmpeg.avcodec_alloc_context3(_codec);
+            if (_codec == null)
+            {
+                Logger.Error?.PrintMsg(LogClass.FFmpeg, $"Codec wasn't found. Make sure you have the {codecId} present in your FFmpeg installation.");
 
-            ffmpeg.avcodec_open2(_context, _codec, null);
+                return;
+            }
+
+            _context = ffmpeg.avcodec_alloc_context3(_codec);
+            if (_context == null)
+            {
+                Logger.Error?.PrintMsg(LogClass.FFmpeg, "Codec context couldn't be allocated.");
+
+                return;
+            }
+
+            if (ffmpeg.avcodec_open2(_context, _codec, null) != 0)
+            {
+                Logger.Error?.PrintMsg(LogClass.FFmpeg, "Codec couldn't be opened.");
+
+                return;
+            }
 
             _packet = ffmpeg.av_packet_alloc();
+            if (_packet == null)
+            {
+                Logger.Error?.PrintMsg(LogClass.FFmpeg, "Packet couldn't be allocated.");
+
+                return;
+            }
 
             _decodeFrame = Marshal.GetDelegateForFunctionPointer<AVCodec_decode>(_codec->decode.Pointer);
         }


### PR DESCRIPTION
This PR adds some checks and logging error messages related to the ffmpeg context creation, that will prevent users to open issues because they don't have the correct packages installed.
Close #2762