### PR TITLE
am: Stub SetMediaPlaybackStateForApplication

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
@@ -330,6 +330,19 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             return ResultCode.Success;
         }
 
+        [CommandHipc(60)] // 2.0.0+
+        // SetMediaPlaybackStateForApplication(bool enabled)
+        public ResultCode SetMediaPlaybackStateForApplication(ServiceCtx context)
+        {
+            bool enabled = context.RequestData.ReadBoolean();
+
+            // NOTE: Service stores the "enabled" value in a private field, when enabled is false, it stores nn::os::GetSystemTick() too.
+
+            Logger.Stub?.PrintStub(LogClass.ServiceAm, new { enabled });
+
+            return ResultCode.Success;
+        }
+
         [CommandHipc(66)] // 3.0.0+
         // InitializeGamePlayRecording(u64, handle<copy>)
         public ResultCode InitializeGamePlayRecording(ServiceCtx context)


### PR DESCRIPTION
This PR stub `SetMediaPlaybackStateForApplication` of the am service. Accordingly to gdkchan it's needed by the Youtube app. This is checked by RE aswell.