### PR TITLE
Fix A1B5G5R5 texture format

### DIFF
--- a/Ryujinx.Graphics.OpenGL/FormatTable.cs
+++ b/Ryujinx.Graphics.OpenGL/FormatTable.cs
@@ -171,7 +171,7 @@ namespace Ryujinx.Graphics.OpenGL
             Add(Format.B5G6R5Unorm,         new FormatInfo(3, true,  false, All.Rgb565,            PixelFormat.Rgb,            PixelType.UnsignedShort565Reversed));
             Add(Format.B5G5R5X1Unorm,       new FormatInfo(4, true,  false, All.Rgb5,              PixelFormat.Rgba,           PixelType.UnsignedShort1555Reversed));
             Add(Format.B5G5R5A1Unorm,       new FormatInfo(4, true,  false, All.Rgb5A1,            PixelFormat.Rgba,           PixelType.UnsignedShort1555Reversed));
-            Add(Format.A1B5G5R5Unorm,       new FormatInfo(4, true,  false, All.Rgb5A1,            PixelFormat.Bgra,           PixelType.UnsignedShort1555Reversed));
+            Add(Format.A1B5G5R5Unorm,       new FormatInfo(4, true,  false, All.Rgb5A1,            PixelFormat.Rgba,           PixelType.UnsignedShort5551));
             Add(Format.B8G8R8X8Unorm,       new FormatInfo(4, true,  false, All.Rgba8,             PixelFormat.Rgba,           PixelType.UnsignedByte));
             Add(Format.B8G8R8A8Unorm,       new FormatInfo(4, true,  false, All.Rgba8,             PixelFormat.Rgba,           PixelType.UnsignedByte));
             Add(Format.B8G8R8X8Srgb,        new FormatInfo(4, false, false, All.Srgb8,             PixelFormat.Rgba,           PixelType.UnsignedByte));

--- a/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
@@ -72,7 +72,16 @@ namespace Ryujinx.Graphics.OpenGL.Image
                 (int)Info.SwizzleA.Convert()
             };
 
-            if (Info.Format.IsBgr())
+            if (Info.Format == Format.A1B5G5R5Unorm)
+            {
+                int temp = swizzleRgba[0];
+                int temp2 = swizzleRgba[1];
+                swizzleRgba[0] = swizzleRgba[3];
+                swizzleRgba[1] = swizzleRgba[2];
+                swizzleRgba[2] = temp2;
+                swizzleRgba[3] = temp;
+            }
+            else if (Info.Format.IsBgr())
             {
                 // Swap B <-> R for BGRA formats, as OpenGL has no support for them
                 // and we need to manually swap the components on read/write on the GPU.


### PR DESCRIPTION
The format had the wrong order before, resulting in graphical glitches in at least one title (NSO Nintendo 64 emulator).
This emulator does not work on master due to other components that are not implemented yet, so I have tested it on a private branch, and I'm providing those screenshots only to illustrate what was fixed.

Before:
![image](https://user-images.githubusercontent.com/5624669/147715568-2e8b2745-ce24-4d30-a80b-a94f37556263.png)
After:
![image](https://user-images.githubusercontent.com/5624669/147715580-f1970c5a-e768-4d23-8626-5b5acc4efc8a.png)