### PR TITLE
Force crop when presentation cached texture size mismatches

### DIFF
--- a/Ryujinx.Graphics.GAL/ImageCrop.cs
+++ b/Ryujinx.Graphics.GAL/ImageCrop.cs
@@ -21,8 +21,7 @@ namespace Ryujinx.Graphics.GAL
             bool  flipY,
             bool  isStretched,
             float aspectRatioX,
-            float aspectRatioY
-            )
+            float aspectRatioY)
         {
             Left         = left;
             Right        = right;

--- a/Ryujinx.Graphics.Gpu/Window.cs
+++ b/Ryujinx.Graphics.Gpu/Window.cs
@@ -201,7 +201,29 @@ namespace Ryujinx.Graphics.Gpu
 
                 texture.SynchronizeMemory();
 
-                _context.Renderer.Window.Present(texture.HostTexture, pt.Crop, swapBuffersCallback);
+                ImageCrop crop = pt.Crop;
+
+                if (texture.Info.Width > pt.Info.Width || texture.Info.Height > pt.Info.Height)
+                {
+                    int top = crop.Top;
+                    int bottom = crop.Bottom;
+                    int left = crop.Left;
+                    int right = crop.Right;
+
+                    if (top == 0 && bottom == 0)
+                    {
+                        bottom = Math.Min(texture.Info.Height, pt.Info.Height);
+                    }
+
+                    if (left == 0 && right == 0)
+                    {
+                        right = Math.Min(texture.Info.Width, pt.Info.Width);
+                    }
+
+                    crop = new ImageCrop(left, right, top, bottom, crop.FlipX, crop.FlipY, crop.IsStretched, crop.AspectRatioX, crop.AspectRatioY);
+                }
+
+                _context.Renderer.Window.Present(texture.HostTexture, crop, swapBuffersCallback);
 
                 pt.ReleaseCallback(pt.UserObj);
             }


### PR DESCRIPTION
Right now, the presentation texture size is used to find a matching texture on the cache, but after that is not used anymore, instead it uses the cached texture size. The problem is that due to size alignment, the cached texture might be actually larger than the texture size, leading to gaps when the texture is presented.

This has been fixed here by forcing the extra size to be cropped before presentation, using the crop rectangle that was already being passed from surface flinger.

Before:
![image](https://user-images.githubusercontent.com/5624669/147722198-224ecf20-c1f9-47ae-8763-e8f4b430809d.png)
After:
![image](https://user-images.githubusercontent.com/5624669/147722203-c9a3a442-2bf6-4411-9345-18cfb79c2b8e.png)

Should fix a similar issue on Hades aswell, but I did not test this one.