### PR TITLE
Enable JIT service LLE

### DIFF
--- a/Ryujinx.HLE/HOS/ApplicationLoader.cs
+++ b/Ryujinx.HLE/HOS/ApplicationLoader.cs
@@ -311,6 +311,12 @@ namespace Ryujinx.HLE.HOS
 
         public void LoadServiceNca(string ncaFile)
         {
+            // Disable PPTC here as it does not support multiple processes running.
+            // TODO: This should be eventually removed and it should stop using global state and
+            // instead manage the cache per process.
+            Ptc.Close();
+            PtcProfiler.Stop();
+
             FileStream file = new FileStream(ncaFile, FileMode.Open, FileAccess.Read);
             Nca mainNca = new Nca(_device.Configuration.VirtualFileSystem.KeySet, file.AsStorage(false));
 

--- a/Ryujinx.HLE/HOS/ApplicationLoader.cs
+++ b/Ryujinx.HLE/HOS/ApplicationLoader.cs
@@ -363,7 +363,7 @@ namespace Ryujinx.HLE.HOS
 
                 if (!codeFs.FileExists($"/{name}"))
                 {
-                    continue; // file doesn't exist, skip
+                    continue; // File doesn't exist, skip.
                 }
 
                 Logger.Info?.Print(LogClass.Loader, $"Loading {name}...");
@@ -375,7 +375,7 @@ namespace Ryujinx.HLE.HOS
                 nsos[i] = new NsoExecutable(nsoFile.Release().AsStorage(), name);
             }
 
-            // collect the nsos, ignoring ones that aren't used
+            // Collect the nsos, ignoring ones that aren't used.
             NsoExecutable[] programs = nsos.Where(x => x != null).ToArray();
 
             MemoryManagerMode memoryManagerMode = _device.Configuration.MemoryManagerMode;
@@ -597,7 +597,7 @@ namespace Ryujinx.HLE.HOS
         {
             if (_device.Configuration.VirtualFileSystem.ModLoader.ReplaceExefsPartition(TitleId, ref codeFs))
             {
-                metaData = null; //TODO: Check if we should retain old npdm
+                metaData = null; // TODO: Check if we should retain old npdm.
             }
 
             metaData ??= ReadNpdm(codeFs);
@@ -610,7 +610,7 @@ namespace Ryujinx.HLE.HOS
 
                 if (!codeFs.FileExists($"/{name}"))
                 {
-                    continue; // file doesn't exist, skip
+                    continue; // File doesn't exist, skip.
                 }
 
                 Logger.Info?.Print(LogClass.Loader, $"Loading {name}...");
@@ -622,13 +622,13 @@ namespace Ryujinx.HLE.HOS
                 nsos[i] = new NsoExecutable(nsoFile.Release().AsStorage(), name);
             }
 
-            // ExeFs file replacements
+            // ExeFs file replacements.
             ModLoadResult modLoadResult = _device.Configuration.VirtualFileSystem.ModLoader.ApplyExefsMods(TitleId, nsos);
 
-            // collect the nsos, ignoring ones that aren't used
+            // Collect the nsos, ignoring ones that aren't used.
             NsoExecutable[] programs = nsos.Where(x => x != null).ToArray();
 
-            // take the npdm from mods if present
+            // Take the npdm from mods if present.
             if (modLoadResult.Npdm != null)
             {
                 metaData = modLoadResult.Npdm;
@@ -687,7 +687,7 @@ namespace Ryujinx.HLE.HOS
 
                 executable = obj;
 
-                // homebrew NRO can actually have some data after the actual NRO
+                // Homebrew NRO can actually have some data after the actual NRO.
                 if (input.Length > obj.FileSize)
                 {
                     input.Position = obj.FileSize;
@@ -766,7 +766,7 @@ namespace Ryujinx.HLE.HOS
             TitleIs64Bit = (npdm.Meta.Value.Flags & 1) != 0;
             _device.System.LibHacHorizonManager.ArpIReader.ApplicationId = new LibHac.ApplicationId(TitleId);
 
-            // Explicitly null titleid to disable the shader cache
+            // Explicitly null titleid to disable the shader cache.
             Graphics.Gpu.GraphicsConfig.TitleId = null;
             _device.Gpu.HostInitalized.Set();
 

--- a/Ryujinx.HLE/HOS/ApplicationLoader.cs
+++ b/Ryujinx.HLE/HOS/ApplicationLoader.cs
@@ -386,7 +386,8 @@ namespace Ryujinx.HLE.HOS
             }
 
             metaData.GetNpdm(out Npdm npdm).ThrowIfFailure();
-            ProgramLoader.LoadNsos(_device.System.KernelContext, out _, metaData, new ProgramInfo(in npdm), executables: programs);
+            ProgramInfo programInfo = new ProgramInfo(in npdm, allowCodeMemoryForJit: false);
+            ProgramLoader.LoadNsos(_device.System.KernelContext, out _, metaData, programInfo, executables: programs);
 
             string titleIdText = npdm.Aci.Value.ProgramId.Value.ToString("x16");
             bool titleIs64Bit = (npdm.Meta.Value.Flags & 1) != 0;

--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -72,6 +72,8 @@ namespace Ryujinx.HLE.HOS
 
         internal List<NfpDevice> NfpDevices { get; private set; }
 
+        internal SmRegistry SmRegistry { get; private set; }
+
         internal ServerBase SmServer { get; private set; }
         internal ServerBase BsdServer { get; private set; }
         internal ServerBase AudRenServer { get; private set; }
@@ -291,7 +293,8 @@ namespace Ryujinx.HLE.HOS
 
         private void InitializeServices()
         {
-            SmServer = new ServerBase(KernelContext, "SmServer", () => new IUserInterface(KernelContext));
+            SmRegistry = new SmRegistry();
+            SmServer = new ServerBase(KernelContext, "SmServer", () => new IUserInterface(KernelContext, SmRegistry));
 
             // Wait until SM server thread is done with initialization,
             // only then doing connections to SM is safe.
@@ -468,7 +471,7 @@ namespace Ryujinx.HLE.HOS
                 AudioRendererManager.Dispose();
 
                 LibHacHorizonManager.PmClient.Fs.UnregisterProgram(LibHacHorizonManager.ApplicationClient.Os.GetCurrentProcessId().Value).ThrowIfFailure();
-                
+
                 KernelContext.Dispose();
             }
         }

--- a/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
@@ -2,9 +2,12 @@ using LibHac;
 using LibHac.Account;
 using LibHac.Common;
 using LibHac.Fs;
+using LibHac.FsSystem;
+using LibHac.Ncm;
 using LibHac.Ns;
 using Ryujinx.Common;
 using Ryujinx.Common.Logging;
+using Ryujinx.HLE.Exceptions;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Kernel.Common;
 using Ryujinx.HLE.HOS.Kernel.Memory;
@@ -12,9 +15,11 @@ using Ryujinx.HLE.HOS.Kernel.Threading;
 using Ryujinx.HLE.HOS.Services.Am.AppletAE.Storage;
 using Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.ApplicationProxy.Types;
 using Ryujinx.HLE.HOS.Services.Sdb.Pdm.QueryService;
+using Ryujinx.HLE.HOS.Services.Sm;
 using Ryujinx.HLE.HOS.SystemState;
 using System;
 using System.Numerics;
+using System.Threading;
 
 using static LibHac.Fs.ApplicationSaveDataManagement;
 using AccountUid    = Ryujinx.HLE.HOS.Services.Account.Acc.UserId;
@@ -36,6 +41,8 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
         private int _friendInvitationStorageChannelEventHandle;
         private int _notificationStorageChannelEventHandle;
         private int _healthWarningDisappearedSystemEventHandle;
+
+        private int _jitLoaded;
 
         private HorizonClient _horizon;
 
@@ -628,6 +635,32 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             }
 
             context.Response.HandleDesc = IpcHandleDesc.MakeCopy(_healthWarningDisappearedSystemEventHandle);
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(1001)] // 10.0.0+
+        // PrepareForJit()
+        public ResultCode PrepareForJit(ServiceCtx context)
+        {
+            if (Interlocked.Exchange(ref _jitLoaded, 1) == 0)
+            {
+                string jitPath = context.Device.System.ContentManager.GetInstalledContentPath(0x010000000000003B, StorageId.BuiltInSystem, NcaContentType.Program);
+                string filePath = context.Device.FileSystem.SwitchPathToSystemPath(jitPath);
+
+                if (string.IsNullOrWhiteSpace(filePath))
+                {
+                    throw new InvalidSystemResourceException($"JIT (010000000000003B) system title not found! The JIT will not work, provide the system archive to fix this error. (See https://github.com/Ryujinx/Ryujinx#requirements for more information)");
+                }
+
+                context.Device.Application.LoadServiceNca(filePath);
+
+                // FIXME: Most likely not how this should be done?
+                while (!IUserInterface.IsServiceRegistered("jit:u"))
+                {
+                    IUserInterface.WaitForServiceRegistration();
+                }
+            }
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
@@ -656,9 +656,9 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
                 context.Device.Application.LoadServiceNca(filePath);
 
                 // FIXME: Most likely not how this should be done?
-                while (!IUserInterface.IsServiceRegistered("jit:u"))
+                while (!context.Device.System.SmRegistry.IsServiceRegistered("jit:u"))
                 {
-                    IUserInterface.WaitForServiceRegistration();
+                    context.Device.System.SmRegistry.WaitForServiceRegistration();
                 }
             }
 

--- a/Ryujinx.HLE/HOS/Services/Ro/IRoInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Ro/IRoInterface.cs
@@ -579,6 +579,15 @@ namespace Ryujinx.HLE.HOS.Services.Ro
             return ResultCode.Success;
         }
 
+        [CommandHipc(10)]
+        // LoadNrr2(u64, u64, u64, pid)
+        public ResultCode LoadNrr2(ServiceCtx context)
+        {
+            context.Device.System.KernelContext.Syscall.CloseHandle(context.Request.HandleDesc.ToCopy[0]);
+
+            return LoadNrr(context);
+        }
+
         protected override void Dispose(bool isDisposing)
         {
             if (isDisposing)

--- a/Ryujinx.HLE/HOS/Services/ServerBase.cs
+++ b/Ryujinx.HLE/HOS/Services/ServerBase.cs
@@ -4,7 +4,6 @@ using Ryujinx.HLE.HOS.Kernel.Common;
 using Ryujinx.HLE.HOS.Kernel.Ipc;
 using Ryujinx.HLE.HOS.Kernel.Process;
 using Ryujinx.HLE.HOS.Kernel.Threading;
-using Ryujinx.HLE.HOS.Services.Sm;
 using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;

--- a/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Settings/ISystemSettingsServer.cs
@@ -222,12 +222,23 @@ namespace Ryujinx.HLE.HOS.Services.Settings
             return ResultCode.Success;
         }
 
-       [CommandHipc(60)]
+        [CommandHipc(60)]
         // IsUserSystemClockAutomaticCorrectionEnabled() -> bool
         public ResultCode IsUserSystemClockAutomaticCorrectionEnabled(ServiceCtx context)
         {
             // NOTE: When set to true, is automatically synced with the internet.
             context.ResponseData.Write(true);
+
+            Logger.Stub?.PrintStub(LogClass.ServiceSet);
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(62)]
+        // GetDebugModeFlag() -> bool
+        public ResultCode GetDebugModeFlag(ServiceCtx context)
+        {
+            context.ResponseData.Write(false);
 
             Logger.Stub?.PrintStub(LogClass.ServiceSet);
 

--- a/Ryujinx.HLE/HOS/Services/Sm/IUserInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Sm/IUserInterface.cs
@@ -1,16 +1,13 @@
 using Ryujinx.Common.Logging;
-using Ryujinx.HLE.Exceptions;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Kernel;
 using Ryujinx.HLE.HOS.Kernel.Common;
 using Ryujinx.HLE.HOS.Kernel.Ipc;
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Threading;
 
 namespace Ryujinx.HLE.HOS.Services.Sm
 {
@@ -18,23 +15,19 @@ namespace Ryujinx.HLE.HOS.Services.Sm
     {
         private static Dictionary<string, Type> _services;
 
-        private static readonly ConcurrentDictionary<string, KPort> _registeredServices;
-        private static readonly AutoResetEvent _serviceRegistrationEvent;
-
+        private readonly SmRegistry _registry;
         private readonly ServerBase _commonServer;
 
         private bool _isInitialized;
 
-        public IUserInterface(KernelContext context)
+        public IUserInterface(KernelContext context, SmRegistry registry)
         {
             _commonServer = new ServerBase(context, "CommonServer");
+            _registry = registry;
         }
 
         static IUserInterface()
         {
-            _registeredServices = new ConcurrentDictionary<string, KPort>();
-            _serviceRegistrationEvent = new AutoResetEvent(false);
-
             _services = Assembly.GetExecutingAssembly().GetTypes()
                 .SelectMany(type => type.GetCustomAttributes(typeof(ServiceAttribute), true)
                 .Select(service => (((ServiceAttribute)service).Name, type)))
@@ -77,7 +70,7 @@ namespace Ryujinx.HLE.HOS.Services.Sm
 
             KSession session = new KSession(context.Device.System.KernelContext);
 
-            if (_registeredServices.TryGetValue(name, out KPort port))
+            if (_registry.TryGetService(name, out KPort port))
             {
                 KernelResult result = port.EnqueueIncomingSession(session.ServerSession);
 
@@ -191,7 +184,7 @@ namespace Ryujinx.HLE.HOS.Services.Sm
 
             KPort port = new KPort(context.Device.System.KernelContext, maxSessions, isLight, 0);
 
-            if (!_registeredServices.TryAdd(name, port))
+            if (!_registry.TryRegister(name, port))
             {
                 return ResultCode.AlreadyRegistered;
             }
@@ -202,8 +195,6 @@ namespace Ryujinx.HLE.HOS.Services.Sm
             }
 
             context.Response.HandleDesc = IpcHandleDesc.MakeMove(handle);
-
-            _serviceRegistrationEvent.Set();
 
             return ResultCode.Success;
         }
@@ -233,22 +224,12 @@ namespace Ryujinx.HLE.HOS.Services.Sm
                 return ResultCode.InvalidName;
             }
 
-            if (!_registeredServices.TryRemove(name, out _))
+            if (!_registry.Unregister(name))
             {
                 return ResultCode.NotRegistered;
             }
 
             return ResultCode.Success;
-        }
-
-        public static bool IsServiceRegistered(string name)
-        {
-            return _registeredServices.TryGetValue(name, out _);
-        }
-
-        public static void WaitForServiceRegistration()
-        {
-            _serviceRegistrationEvent.WaitOne();
         }
 
         private static string ReadName(ServiceCtx context)

--- a/Ryujinx.HLE/HOS/Services/Sm/SmRegistry.cs
+++ b/Ryujinx.HLE/HOS/Services/Sm/SmRegistry.cs
@@ -1,0 +1,49 @@
+using Ryujinx.HLE.HOS.Kernel.Ipc;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace Ryujinx.HLE.HOS.Services.Sm
+{
+    class SmRegistry
+    {
+        private readonly ConcurrentDictionary<string, KPort> _registeredServices;
+        private readonly AutoResetEvent _serviceRegistrationEvent;
+
+        public SmRegistry()
+        {
+            _registeredServices = new ConcurrentDictionary<string, KPort>();
+            _serviceRegistrationEvent = new AutoResetEvent(false);
+        }
+
+        public bool TryGetService(string name, out KPort port)
+        {
+            return _registeredServices.TryGetValue(name, out port);
+        }
+
+        public bool TryRegister(string name, KPort port)
+        {
+            if (_registeredServices.TryAdd(name, port))
+            {
+                _serviceRegistrationEvent.Set();
+                return true;
+            }
+
+            return false;
+        }
+
+        public bool Unregister(string name)
+        {
+            return _registeredServices.TryRemove(name, out _);
+        }
+
+        public bool IsServiceRegistered(string name)
+        {
+            return _registeredServices.TryGetValue(name, out _);
+        }
+
+        public void WaitForServiceRegistration()
+        {
+            _serviceRegistrationEvent.WaitOne();
+        }
+    }
+}


### PR DESCRIPTION
This change allows the JIT service, required by the NSO N64 emulator and Super Mario 3D All Stars (for Super Mario 64), to run. It is not an actual service implementation, rather it runs the service on the firmware, so this is an "LLE" approach as opposed to the usual HLE approach where we re-implement the service on the emulator. There are a few reason for using this approach here:
- The JIT service needs to call an (Arm) user supplied function, which would be very complicated to do from a HLE service.
- Unlike other services, this one is initialized on-demand (when PrepareForJit is called), which means we don't need to initialize it for games that does not require it, minimizing the impact of those changes.
- The service has few dependencies, so it's easy to get it running.

Notes:
- Requires at least firmware 10.0.0. The service did not exist in retail before that version.
- I made it disable PPTC when the JIT service is used, since it does not support multiple processes running at once.

Screenshots:
![image](https://user-images.githubusercontent.com/5624669/166817917-275cfa5c-c6f8-4c98-a753-f009dbeccaa8.png)
![image](https://user-images.githubusercontent.com/5624669/166817930-97178c8c-26a8-4c20-9e90-dfd9067cb69d.png)
![image](https://user-images.githubusercontent.com/5624669/166817937-24245df6-c311-4979-8949-a1aa41607e20.png)

Closes #2042