### PR TITLE
sfdnsres: Implement NSD resolution

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Sockets/Nsd/IManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Nsd/IManager.cs
@@ -13,12 +13,19 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
     [Service("nsd:u")] // Max sessions: 20
     class IManager : IpcService
     {
-        private readonly NsdSettings  _nsdSettings;
+        public static readonly NsdSettings NsdSettings;
         private readonly FqdnResolver _fqdnResolver;
 
         private bool _isInitialized = false;
 
         public IManager(ServiceCtx context)
+        {
+            _fqdnResolver = new FqdnResolver();
+
+            _isInitialized = true;
+        }
+
+        static IManager()
         {
             // TODO: Load nsd settings through the savedata 0x80000000000000B0 (nsdsave:/).
 
@@ -32,16 +39,12 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
                 // return ResultCode.InvalidSettingsValue;
             }
 
-            _nsdSettings = new NsdSettings
+            NsdSettings = new NsdSettings
             {
                 Initialized = true,
-                TestMode    = (bool)testMode,
+                TestMode = (bool)testMode,
                 Environment = (string)environmentIdentifier
             };
-
-            _fqdnResolver = new FqdnResolver(_nsdSettings);
-
-            _isInitialized = true;
         }
 
         [CommandHipc(5)] // 11.0.0+
@@ -107,7 +110,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
             {
                 NxSettings.Settings.TryGetValue("nsd!environment_identifier", out object environmentIdentifier);
 
-                if ((string)environmentIdentifier == _nsdSettings.Environment)
+                if ((string)environmentIdentifier == NsdSettings.Environment)
                 {
                     // TODO: Call nn::fs::DeleteSystemFile() to delete the savedata file and return ResultCode.
                 }
@@ -298,7 +301,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
                 }
             */
 
-            if (!_nsdSettings.TestMode)
+            if (!NsdSettings.TestMode)
             {
                 return ResultCode.InvalidSettingsValue;
             }
@@ -327,7 +330,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd
                 }
             */
 
-            if (!_nsdSettings.TestMode)
+            if (!NsdSettings.TestMode)
             {
                 return ResultCode.InvalidSettingsValue;
             }

--- a/Ryujinx.HLE/HOS/Services/Sockets/Nsd/Manager/FqdnResolver.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Nsd/Manager/FqdnResolver.cs
@@ -6,16 +6,9 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd.Manager
     {
         private const string _dummyAddress = "unknown.dummy.nintendo.net";
 
-        private NsdSettings _nsdSettings;
-
-        public FqdnResolver(NsdSettings nsdSettings)
-        {
-            _nsdSettings = nsdSettings;
-        }
-
         public ResultCode GetEnvironmentIdentifier(out string identifier)
         {
-            if (_nsdSettings.TestMode)
+            if (IManager.NsdSettings.TestMode)
             {
                 identifier = "err";
 
@@ -23,13 +16,13 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd.Manager
             }
             else
             {
-                identifier = _nsdSettings.Environment;
+                identifier = IManager.NsdSettings.Environment;
             }
 
             return ResultCode.Success;
         }
 
-        public ResultCode Resolve(ServiceCtx context, string address, out string resolvedAddress)
+        public static ResultCode Resolve(string address, out string resolvedAddress)
         {
             if (address == "api.sect.srv.nintendo.net"     ||
                 address == "ctest.cdn.nintendo.net"        ||
@@ -41,16 +34,16 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd.Manager
             else
             {
                 // TODO: Load Environment from the savedata.
-                address = address.Replace("%", _nsdSettings.Environment);
+                address = address.Replace("%", IManager.NsdSettings.Environment);
 
                 resolvedAddress = "";
 
-                if (_nsdSettings == null)
+                if (IManager.NsdSettings == null)
                 {
                     return ResultCode.SettingsNotInitialized;
                 }
 
-                if (!_nsdSettings.Initialized)
+                if (!IManager.NsdSettings.Initialized)
                 {
                     return ResultCode.SettingsNotLoaded;
                 }
@@ -84,14 +77,14 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Nsd.Manager
 
             string address = Encoding.UTF8.GetString(addressBuffer).TrimEnd('\0');
 
-            resultCode = Resolve(context, address, out resolvedAddress);
+            resultCode = Resolve(address, out resolvedAddress);
 
             if (resultCode != ResultCode.Success)
             {
                 resolvedAddress = _dummyAddress;
             }
 
-            if (_nsdSettings.TestMode)
+            if (IManager.NsdSettings.TestMode)
             {
                 return ResultCode.Success;
             }


### PR DESCRIPTION
This fix a missing implementation usage of NSD on IResolver when requested on ``GetAddrInfoRequest*`` and ``GetHostByNameRequest*``.