### PR TITLE
Fix build id case issue for enabled cheats

### DIFF
--- a/Ryujinx/Ui/Windows/CheatWindow.cs
+++ b/Ryujinx/Ui/Windows/CheatWindow.cs
@@ -84,7 +84,7 @@ namespace Ryujinx.Ui.Windows
                     currentCheatFile = cheat.Path.FullName;
                     string parentPath = currentCheatFile.Replace(titleModsPath, "");
 
-                    buildId = System.IO.Path.GetFileNameWithoutExtension(currentCheatFile);
+                    buildId = System.IO.Path.GetFileNameWithoutExtension(currentCheatFile).ToUpper();
                     parentIter = ((TreeStore)_cheatTreeView.Model).AppendValues(false, buildId, parentPath, "");
                 }
 


### PR DESCRIPTION
Hot fix for issue with enabled cheats when cheat file is not in upper case.