### PR TITLE
Texture Sync, incompatible overlap handling, data flush improvements.

### DIFF
--- a/Ryujinx.Graphics.GAL/ITexture.cs
+++ b/Ryujinx.Graphics.GAL/ITexture.cs
@@ -15,6 +15,7 @@ namespace Ryujinx.Graphics.GAL
         ITexture CreateView(TextureCreateInfo info, int firstLayer, int firstLevel);
 
         ReadOnlySpan<byte> GetData();
+        ReadOnlySpan<byte> GetData(int layer, int level);
 
         void SetData(ReadOnlySpan<byte> data);
         void SetData(ReadOnlySpan<byte> data, int layer, int level);

--- a/Ryujinx.Graphics.GAL/Multithreading/CommandHelper.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/CommandHelper.cs
@@ -111,6 +111,8 @@ namespace Ryujinx.Graphics.GAL.Multithreading
                 TextureCreateViewCommand.Run(ref GetCommand<TextureCreateViewCommand>(memory), threaded, renderer);
             _lookup[(int)CommandType.TextureGetData] = (Span<byte> memory, ThreadedRenderer threaded, IRenderer renderer) =>
                 TextureGetDataCommand.Run(ref GetCommand<TextureGetDataCommand>(memory), threaded, renderer);
+            _lookup[(int)CommandType.TextureGetDataSlice] = (Span<byte> memory, ThreadedRenderer threaded, IRenderer renderer) =>
+                TextureGetDataSliceCommand.Run(ref GetCommand<TextureGetDataSliceCommand>(memory), threaded, renderer);
             _lookup[(int)CommandType.TextureRelease] = (Span<byte> memory, ThreadedRenderer threaded, IRenderer renderer) =>
                 TextureReleaseCommand.Run(ref GetCommand<TextureReleaseCommand>(memory), threaded, renderer);
             _lookup[(int)CommandType.TextureSetData] = (Span<byte> memory, ThreadedRenderer threaded, IRenderer renderer) =>

--- a/Ryujinx.Graphics.GAL/Multithreading/CommandType.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/CommandType.cs
@@ -36,6 +36,7 @@
         TextureCopyToSlice,
         TextureCreateView,
         TextureGetData,
+        TextureGetDataSlice,
         TextureRelease,
         TextureSetData,
         TextureSetDataSlice,

--- a/Ryujinx.Graphics.GAL/Multithreading/Commands/Texture/TextureGetDataSliceCommand.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/Commands/Texture/TextureGetDataSliceCommand.cs
@@ -1,0 +1,30 @@
+﻿using Ryujinx.Graphics.GAL.Multithreading.Model;
+using Ryujinx.Graphics.GAL.Multithreading.Resources;
+using System;
+
+namespace Ryujinx.Graphics.GAL.Multithreading.Commands.Texture
+{
+    struct TextureGetDataSliceCommand : IGALCommand
+    {
+        public CommandType CommandType => CommandType.TextureGetDataSlice;
+        private TableRef<ThreadedTexture> _texture;
+        private TableRef<ResultBox<PinnedSpan<byte>>> _result;
+        private int _layer;
+        private int _level;
+
+        public void Set(TableRef<ThreadedTexture> texture, TableRef<ResultBox<PinnedSpan<byte>>> result, int layer, int level)
+        {
+            _texture = texture;
+            _result = result;
+            _layer = layer;
+            _level = level;
+        }
+
+        public static void Run(ref TextureGetDataSliceCommand command, ThreadedRenderer threaded, IRenderer renderer)
+        {
+            ReadOnlySpan<byte> result = command._texture.Get(threaded).Base.GetData(command._layer, command._level);
+
+            command._result.Get(threaded).Result = new PinnedSpan<byte>(result);
+        }
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -212,7 +212,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                         yCount,
                         dstLinear);
 
-                    if (target != null && !target.Group.HasIncompatibleOverlaps)
+                    if (target != null)
                     {
                         ReadOnlySpan<byte> data;
                         if (srcLinear)

--- a/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -212,7 +212,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                         yCount,
                         dstLinear);
 
-                    if (target != null)
+                    if (target != null && !target.Group.HasIncompatibleOverlaps)
                     {
                         ReadOnlySpan<byte> data;
                         if (srcLinear)
@@ -245,6 +245,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                                 srcSpan);
                         }
 
+                        target.SynchronizeMemory();
                         target.SetData(data);
                         target.SignalModified();
 

--- a/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -234,7 +234,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                                 src.Height,
                                 src.Depth,
                                 1,
-                                target.Info.Levels,
+                                1,
                                 1,
                                 1,
                                 1,

--- a/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -232,6 +232,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                             data = LayoutConverter.ConvertBlockLinearToLinear(
                                 src.Width,
                                 src.Height,
+                                src.Depth,
                                 1,
                                 target.Info.Levels,
                                 1,

--- a/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoClass.cs
@@ -136,7 +136,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
             }
             else if (operation == SyncpointbOperation.Incr)
             {
-                _context.CreateHostSyncIfNeeded();
+                _context.CreateHostSyncIfNeeded(true);
                 _context.Synchronization.IncrementSyncpoint(syncpointId);
             }
 
@@ -152,7 +152,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
             _parent.PerformDeferredDraws();
             _context.Renderer.Pipeline.Barrier();
 
-            _context.CreateHostSyncIfNeeded();
+            _context.CreateHostSyncIfNeeded(false);
         }
 
         /// <summary>
@@ -163,7 +163,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
         {
             _context.Renderer.Pipeline.CommandBufferBarrier();
 
-            _context.CreateHostSyncIfNeeded();
+            _context.CreateHostSyncIfNeeded(false);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
@@ -224,7 +224,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             uint syncpointId = (uint)argument & 0xFFFF;
 
             _context.AdvanceSequence();
-            _context.CreateHostSyncIfNeeded();
+            _context.CreateHostSyncIfNeeded(true);
             _context.Renderer.UpdateCounters(); // Poll the query counters, the game may want an updated result.
             _context.Synchronization.IncrementSyncpoint(syncpointId);
         }

--- a/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -52,11 +52,18 @@ namespace Ryujinx.Graphics.Gpu
         internal ulong SyncNumber { get; private set; }
 
         /// <summary>
-        /// Actions to be performed when a CPU waiting sync point is triggered.
+        /// Actions to be performed when a CPU waiting syncpoint or barrier is triggered.
         /// If there are more than 0 items when this happens, a host sync object will be generated for the given <see cref="SyncNumber"/>,
         /// and the SyncNumber will be incremented.
         /// </summary>
         internal List<Action> SyncActions { get; }
+
+        /// <summary>
+        /// Actions to be performed when a CPU waiting sync point is triggered.
+        /// If there are more than 0 items when this happens, a host sync object will be generated for the given <see cref="SyncNumber"/>,
+        /// and the SyncNumber will be incremented.
+        /// </summary>
+        internal List<Action> SyncpointActions { get; }
 
         /// <summary>
         /// Queue with deferred actions that must run on the render thread.
@@ -79,6 +86,7 @@ namespace Ryujinx.Graphics.Gpu
         public event Action<ShaderCacheState, int, int> ShaderCacheStateChanged;
 
         private readonly Lazy<Capabilities> _caps;
+        private Thread _gpuThread;
 
         /// <summary>
         /// Creates a new instance of the GPU emulation context.
@@ -97,6 +105,7 @@ namespace Ryujinx.Graphics.Gpu
             HostInitalized = new ManualResetEvent(false);
 
             SyncActions = new List<Action>();
+            SyncpointActions = new List<Action>();
 
             DeferredActions = new Queue<Action>();
 
@@ -184,6 +193,20 @@ namespace Ryujinx.Graphics.Gpu
             }
         }
 
+        public void SetGpuThread()
+        {
+            _gpuThread = Thread.CurrentThread;
+        }
+
+        /// <summary>
+        /// Checks if the current thread is the GPU thread.
+        /// </summary>
+        /// <returns>True if the thread is the GPU thread, false otherwise</returns>
+        public bool IsGpuThread()
+        {
+            return _gpuThread == Thread.CurrentThread;
+        }
+
         /// <summary>
         /// Processes the queue of shaders that must save their binaries to the disk cache.
         /// </summary>
@@ -209,18 +232,26 @@ namespace Ryujinx.Graphics.Gpu
         /// This will also ensure a host sync object is created, and <see cref="SyncNumber"/> is incremented.
         /// </summary>
         /// <param name="action">The action to be performed on sync object creation</param>
-        public void RegisterSyncAction(Action action)
+        /// <param name="syncpointOnly">True if the sync action should only run when syncpoints are incremented</param>
+        public void RegisterSyncAction(Action action, bool syncpointOnly = false)
         {
-            SyncActions.Add(action);
+            if (syncpointOnly)
+            {
+                SyncpointActions.Add(action);
+            }
+            else
+            {
+                SyncActions.Add(action);
+            }
         }
 
         /// <summary>
         /// Creates a host sync object if there are any pending sync actions. The actions will then be called.
         /// If no actions are present, a host sync object is not created.
         /// </summary>
-        public void CreateHostSyncIfNeeded()
+        public void CreateHostSyncIfNeeded(bool syncpoint)
         {
-            if (SyncActions.Count > 0)
+            if (SyncActions.Count > 0 || (syncpoint && SyncpointActions.Count > 0))
             {
                 Renderer.CreateSync(SyncNumber);
 
@@ -231,7 +262,13 @@ namespace Ryujinx.Graphics.Gpu
                     action();
                 }
 
+                foreach (Action action in SyncpointActions)
+                {
+                    action();
+                }
+
                 SyncActions.Clear();
+                SyncpointActions.Clear();
             }
         }
 

--- a/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -59,7 +59,7 @@ namespace Ryujinx.Graphics.Gpu
         internal List<Action> SyncActions { get; }
 
         /// <summary>
-        /// Actions to be performed when a CPU waiting sync point is triggered.
+        /// Actions to be performed when a CPU waiting syncpoint is triggered.
         /// If there are more than 0 items when this happens, a host sync object will be generated for the given <see cref="SyncNumber"/>,
         /// and the SyncNumber will be incremented.
         /// </summary>
@@ -193,6 +193,9 @@ namespace Ryujinx.Graphics.Gpu
             }
         }
 
+        /// <summary>
+        /// Sets the current thread as the main GPU thread.
+        /// </summary>
         public void SetGpuThread()
         {
             _gpuThread = Thread.CurrentThread;
@@ -249,6 +252,7 @@ namespace Ryujinx.Graphics.Gpu
         /// Creates a host sync object if there are any pending sync actions. The actions will then be called.
         /// If no actions are present, a host sync object is not created.
         /// </summary>
+        /// <param name="syncpoint">True if host sync is being created by a syncpoint</param>
         public void CreateHostSyncIfNeeded(bool syncpoint)
         {
             if (SyncActions.Count > 0 || (syncpoint && SyncpointActions.Count > 0))

--- a/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
@@ -41,14 +41,14 @@ namespace Ryujinx.Graphics.Gpu.Image
             {
                 Texture oldestTexture = _textures.First.Value;
 
-                if (oldestTexture.IsModified && !oldestTexture.CheckModified(false))
+                if (!oldestTexture.CheckModified(false)) //todo: check modified before sync dependents?
                 {
                     // The texture must be flushed if it falls out of the auto delete cache.
                     // Flushes out of the auto delete cache do not trigger write tracking,
                     // as it is expected that other overlapping textures exist that have more up-to-date contents.
 
                     oldestTexture.Group.SynchronizeDependents(oldestTexture);
-                    oldestTexture.Flush(false);
+                    oldestTexture.FlushModified(false);
                 }
 
                 _textures.RemoveFirst();
@@ -93,9 +93,9 @@ namespace Ryujinx.Graphics.Gpu.Image
             }
 
             // Remove our reference to this texture.
-            if (flush && texture.IsModified)
+            if (flush)
             {
-                texture.Flush(false);
+                texture.FlushModified(false);
             }
 
             _textures.Remove(texture.CacheNode);

--- a/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
@@ -41,7 +41,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             {
                 Texture oldestTexture = _textures.First.Value;
 
-                if (!oldestTexture.CheckModified(false)) //todo: check modified before sync dependents?
+                if (!oldestTexture.CheckModified(false))
                 {
                     // The texture must be flushed if it falls out of the auto delete cache.
                     // Flushes out of the auto delete cache do not trigger write tracking,

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -244,6 +244,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="withData">True if the texture is to be initialized with data</param>
         public void InitializeData(bool isView, bool withData = false)
         {
+            withData |= Group != null && Group.FlushIncompatibleOverlapsIfNeeded();
+
             if (withData)
             {
                 Debug.Assert(!isView);
@@ -840,9 +842,10 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// This may cause data corruption if the memory is already being used for something else on the CPU side.
         /// </summary>
         /// <param name="tracked">Whether or not the flush triggers write tracking. If it doesn't, the texture will not be blacklisted for scaling either.</param>
-        public void FlushModified(bool tracked = true)
+        /// <returns>True if data was flushed, false otherwise</returns>
+        public bool FlushModified(bool tracked = true)
         {
-            Group.FlushModified(this, tracked);
+            return Group.FlushModified(this, tracked);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -1006,7 +1006,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Gets data from the host GPU.
+        /// Gets data from the host GPU for a single slice.
         /// </summary>
         /// <remarks>
         /// This method should be used to retrieve data that was modified by the host GPU.
@@ -1021,8 +1021,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         public ReadOnlySpan<byte> GetTextureDataSliceFromGpu(Span<byte> output, int layer, int level, bool blacklist, ITexture texture = null)
         {
             ReadOnlySpan<byte> data;
-
-            //Logger.Error?.Print(LogClass.Gpu, $"{Info.Target} {Info.FormatInfo.Format} {Info.Width}x{Info.Height}x{Info.DepthOrLayers} {layer} {level}");
 
             if (texture != null)
             {

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -1535,6 +1535,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Called when the memory for this texture has been unmapped.
         /// Calls are from non-gpu threads.
         /// </summary>
+        /// <param name="unmapRange">The range of memory being unmapped</param>
         public void Unmapped(MultiRange unmapRange)
         {
             ChangedMapping = true;

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -1381,29 +1381,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Determine if any of our child textures are compaible as views of the given texture.
-        /// </summary>
-        /// <param name="texture">The texture to check against</param>
-        /// <returns>True if any child is view compatible, false otherwise</returns>
-        public bool HasViewCompatibleChild(Texture texture)
-        {
-            if (_viewStorage != this || _views.Count == 0)
-            {
-                return false;
-            }
-
-            foreach (Texture view in _views)
-            {
-                if (texture.IsViewCompatible(view.Info, view.Range, view.LayerSize, _context.Capabilities, out _, out _) > TextureViewCompatibility.LayoutIncompatible)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        /// <summary>
         /// Determine if any of this texture's data overlaps with another.
         /// </summary>
         /// <param name="texture">The texture to check against</param>

--- a/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -682,15 +682,13 @@ namespace Ryujinx.Graphics.Gpu.Image
                             }
 
                             // The overlap texture is going to contain garbage data after we draw, or is generally incompatible.
-                            // If the texture cannot be entirely contained in the new address space, and one of its view children is compatible with us,
-                            // it must be flushed before removal, so that the data is not lost.
+                            // The texture group will obtain copy dependencies for any subresources that are compatible between the two textures,
+                            // but sometimes its data must be flushed regardless.
 
                             // If the texture was modified since its last use, then that data is probably meant to go into this texture.
                             // If the data has been modified by the CPU, then it also shouldn't be flushed.
 
-                            bool viewCompatibleChild = overlap.HasViewCompatibleChild(texture);
-
-                            bool flush = overlapInCache && !modified && (overlap.AlwaysFlushOnOverlap || (!texture.Range.Contains(overlap.Range) && viewCompatibleChild));
+                            bool flush = overlapInCache && !modified && overlap.AlwaysFlushOnOverlap;
 
                             setData |= modified || flush;
 
@@ -699,7 +697,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                                 _cache.Remove(overlap, flush);
                             }
 
-                            removeOverlap = modified && !viewCompatibleChild;
+                            removeOverlap = modified;
                         }
                         else
                         {

--- a/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -658,7 +658,8 @@ namespace Ryujinx.Graphics.Gpu.Image
                     else
                     {
                         bool dataOverlaps = texture.DataOverlaps(overlap);
-                        if (!overlap.IsView && dataOverlaps && incompatibleOverlaps.FindIndex(incompatible => incompatible.Group == overlap.Group) == -1)
+                        
+                        if (!overlap.IsView && dataOverlaps && !incompatibleOverlaps.Exists(incompatible => incompatible.Group == overlap.Group))
                         {
                             incompatibleOverlaps.Add(new TextureIncompatibleOverlap(overlap.Group, compatibility));
                         }

--- a/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -23,7 +23,23 @@ namespace Ryujinx.Graphics.Gpu.Image
             Bc4,
             Bc5,
             Bc6,
-            Bc7
+            Bc7,
+            Etc2Rgb,
+            Etc2Rgba,
+            Astc4x4,
+            Astc5x4,
+            Astc5x5,
+            Astc6x5,
+            Astc6x6,
+            Astc8x5,
+            Astc8x6,
+            Astc8x8,
+            Astc10x5,
+            Astc10x6,
+            Astc10x8,
+            Astc10x10,
+            Astc12x10,
+            Astc12x12
         }
 
         /// <summary>
@@ -497,7 +513,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             if (rhs.IsLinear)
             {
                 int stride = Math.Max(1, lhs.Stride >> level);
-                stride = BitUtils.AlignUp(stride, 32);
+                stride = BitUtils.AlignUp(stride, Constants.StrideAlignment);
 
                 return stride == rhs.Stride;
             }
@@ -540,10 +556,10 @@ namespace Ryujinx.Graphics.Gpu.Image
             if (rhs.IsLinear)
             {
                 int lhsStride = Math.Max(1, lhs.Stride >> lhsLevel);
-                lhsStride = BitUtils.AlignUp(lhsStride, 32);
+                lhsStride = BitUtils.AlignUp(lhsStride, Constants.StrideAlignment);
 
                 int rhsStride = Math.Max(1, rhs.Stride >> rhsLevel);
-                rhsStride = BitUtils.AlignUp(rhsStride, 32);
+                rhsStride = BitUtils.AlignUp(rhsStride, Constants.StrideAlignment);
 
                 return lhsStride == rhsStride;
             }
@@ -757,6 +773,54 @@ namespace Ryujinx.Graphics.Gpu.Image
                 case Format.Bc7Srgb:
                 case Format.Bc7Unorm:
                     return FormatClass.Bc7;
+                case Format.Etc2RgbSrgb:
+                case Format.Etc2RgbUnorm:
+                    return FormatClass.Etc2Rgb;
+                case Format.Etc2RgbaSrgb:
+                case Format.Etc2RgbaUnorm:
+                    return FormatClass.Etc2Rgba;
+                case Format.Astc4x4Srgb:
+                case Format.Astc4x4Unorm:
+                    return FormatClass.Astc4x4;
+                case Format.Astc5x4Srgb:
+                case Format.Astc5x4Unorm:
+                    return FormatClass.Astc5x4;
+                case Format.Astc5x5Srgb:
+                case Format.Astc5x5Unorm:
+                    return FormatClass.Astc5x5;
+                case Format.Astc6x5Srgb:
+                case Format.Astc6x5Unorm:
+                    return FormatClass.Astc6x5;
+                case Format.Astc6x6Srgb:
+                case Format.Astc6x6Unorm:
+                    return FormatClass.Astc6x6;
+                case Format.Astc8x5Srgb:
+                case Format.Astc8x5Unorm:
+                    return FormatClass.Astc8x5;
+                case Format.Astc8x6Srgb:
+                case Format.Astc8x6Unorm:
+                    return FormatClass.Astc8x6;
+                case Format.Astc8x8Srgb:
+                case Format.Astc8x8Unorm:
+                    return FormatClass.Astc8x8;
+                case Format.Astc10x5Srgb:
+                case Format.Astc10x5Unorm:
+                    return FormatClass.Astc10x5;
+                case Format.Astc10x6Srgb:
+                case Format.Astc10x6Unorm:
+                    return FormatClass.Astc10x6;
+                case Format.Astc10x8Srgb:
+                case Format.Astc10x8Unorm:
+                    return FormatClass.Astc10x8;
+                case Format.Astc10x10Srgb:
+                case Format.Astc10x10Unorm:
+                    return FormatClass.Astc10x10;
+                case Format.Astc12x10Srgb:
+                case Format.Astc12x10Unorm:
+                    return FormatClass.Astc12x10;
+                case Format.Astc12x12Srgb:
+                case Format.Astc12x12Unorm:
+                    return FormatClass.Astc12x12;
             }
 
             return FormatClass.Unclassified;

--- a/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -94,6 +94,28 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Determines whether a texture can flush its data back to guest memory.
+        /// </summary>
+        /// <param name="info">Texture information</param>
+        /// <param name="caps">Host GPU Capabilities</param>
+        /// <returns>True if the texture can flush, false otherwise</returns>
+        public static bool CanTextureFlush(TextureInfo info, Capabilities caps)
+        {
+            if (IsFormatHostIncompatible(info, caps))
+            {
+                return false; // Flushing this format is not supported, as it may have been converted to another host format.
+            }
+
+            if (info.Target == Target.Texture2DMultisample ||
+                info.Target == Target.Texture2DMultisampleArray)
+            {
+                return false; // Flushing multisample textures is not supported, the host does not allow getting their data.
+            }
+
+            return true;
+        }
+
+        /// <summary>
         /// Checks if two formats are compatible, according to the host API copy format compatibility rules.
         /// </summary>
         /// <param name="lhsFormat">First comparand</param>

--- a/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -312,15 +312,6 @@ namespace Ryujinx.Graphics.Gpu.Image
                     {
                         result = TextureViewCompatibility.CopyOnly;
                     }
-                    else
-                    {
-                        int levels = Math.Max(32 - BitOperations.LeadingZeroCount((uint)mip0SizeLhs.Width), 32 - BitOperations.LeadingZeroCount((uint)mip0SizeLhs.Height));
-                        int newLevels = Math.Max(32 - BitOperations.LeadingZeroCount((uint)mip0SizeRhs.Width), 32 - BitOperations.LeadingZeroCount((uint)mip0SizeRhs.Height));
-                        if (newLevels != levels)
-                        {
-
-                        }
-                    }
                 }
 
                 return result;
@@ -406,18 +397,9 @@ namespace Ryujinx.Graphics.Gpu.Image
                 Size size0 = GetLargestAlignedSize(lhs, lhsLevel);
                 Size size1 = GetLargestAlignedSize(rhs, lhsLevel);
 
-                bool test = size0.Width  == size1.Width &&
+                return size0.Width  == size1.Width &&
                        size0.Height == size1.Height &&
                        size0.Depth  == size1.Depth;
-
-                int levels = Math.Max(32 - BitOperations.LeadingZeroCount((uint)size0.Width), 32 - BitOperations.LeadingZeroCount((uint)size0.Height));
-                int newLevels = Math.Max(32 - BitOperations.LeadingZeroCount((uint)size1.Width), 32 - BitOperations.LeadingZeroCount((uint)size1.Height));
-                if (newLevels != levels && levels == lhs.Levels)
-                {
-
-                }
-
-                return test;
             }
             else
             {

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -294,7 +294,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                     if (group.Modified)
                     {
-                        if (endOffset != group.Offset)
+                        if (endOffset < group.Offset)
                         {
                             if (endOffset > offset)
                             {

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -964,10 +964,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="relativeOffset">The offset of the old handles in relation to the new ones</param>
         private void InheritHandles(TextureGroupHandle[] oldHandles, TextureGroupHandle[] handles, int relativeOffset)
         {
-            if (relativeOffset == -1)
-            {
-                throw new Exception("oops!!");
-            }
             foreach (var group in handles)
             {
                 foreach (var handle in group.Handles)

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -112,6 +112,10 @@ namespace Ryujinx.Graphics.Gpu.Image
             RecalculateHandleRegions();
         }
 
+        /// <summary>
+        /// Initialize all incompatible overlaps in the list, registering them with the other texture groups
+        /// and creating copy dependencies when partially compatible.
+        /// </summary>
         public void InitializeOverlaps()
         {
             foreach (TextureIncompatibleOverlap overlap in _incompatibleOverlaps)
@@ -383,7 +387,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Gets data from the host GPU, and flushes it all to guest memory.
+        /// Gets data from the host GPU, and flushes a slice to guest memory.
         /// </summary>
         /// <remarks>
         /// This method should be used to retrieve data that was modified by the host GPU.
@@ -406,6 +410,13 @@ namespace Ryujinx.Graphics.Gpu.Image
             Storage.GetTextureDataSliceFromGpu(region.Memory.Span, layer, level, tracked, texture);
         }
 
+        /// <summary>
+        /// Gets and flushes a number of slices of the storage texture to guest memory.
+        /// </summary>
+        /// <param name="tracked">True if writing the texture data is tracked, false otherwise</param>
+        /// <param name="sliceStart">The first slice to flush</param>
+        /// <param name="sliceEnd">The slice to finish flushing on (exclusive)</param>
+        /// <param name="texture">The specific host texture to flush. Defaults to the storage texture</param>
         private void FlushSliceRange(bool tracked, int sliceStart, int sliceEnd, ITexture texture = null)
         {
             for (int i = sliceStart; i < sliceEnd; i++)

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -10,11 +10,19 @@ using System.Runtime.CompilerServices;
 
 namespace Ryujinx.Graphics.Gpu.Image
 {
+    /// <summary>
+    /// An overlapping texture group with a given view compatibility.
+    /// </summary>
     struct TextureIncompatibleOverlap
     {
-        public TextureGroup Group;
-        public TextureViewCompatibility Compatibility;
+        public readonly TextureGroup Group;
+        public readonly TextureViewCompatibility Compatibility;
 
+        /// <summary>
+        /// Create a new texture incompatible overlap.
+        /// </summary>
+        /// <param name="group">The group that is incompatible</param>
+        /// <param name="compatibility">The view compatibility for the group</param>
         public TextureIncompatibleOverlap(TextureGroup group, TextureViewCompatibility compatibility)
         {
             Group = group;
@@ -1303,9 +1311,10 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Registers another texture group as an incompatible overlap, if not already registered.
         /// </summary>
         /// <param name="other">The texture group to add to the incompatible overlaps list</param>
+        /// <param name="copy">True if the overlap should register copy dependencies</param>
         public void RegisterIncompatibleOverlap(TextureIncompatibleOverlap other, bool copy)
         {
-            if (_incompatibleOverlaps.FindIndex(overlap => overlap.Group == other.Group) == -1)
+            if (!_incompatibleOverlaps.Exists(overlap => overlap.Group == other.Group))
             {
                 if (copy && other.Compatibility == TextureViewCompatibility.LayoutIncompatible)
                 {

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
@@ -239,7 +239,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             }
         }
 
-    private void SyncAction()
+        private void SyncAction()
         {
             // Register region tracking for CPU? (again)
             _registeredSync = _modifiedSync;
@@ -408,6 +408,24 @@ namespace Ryujinx.Graphics.Gpu.Image
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Check if this handle has a dependency to a given texture group.
+        /// </summary>
+        /// <param name="group">The texture group to check for</param>
+        /// <returns>True if there is a dependency, false otherwise</returns>
+        public bool HasDependencyTo(TextureGroup group)
+        {
+            foreach (TextureDependency dep in Dependencies)
+            {
+                if (dep.Other.Handle._group == group)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
@@ -432,21 +432,25 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Inherit modified flags and dependencies from another texture handle.
         /// </summary>
         /// <param name="old">The texture handle to inherit from</param>
-        public void Inherit(TextureGroupHandle old)
+        /// <param name="withCopies">Whether the handle should inherit copy dependencies or not</param>
+        public void Inherit(TextureGroupHandle old, bool withCopies)
         {
             Modified |= old.Modified;
 
-            foreach (TextureDependency dependency in old.Dependencies.ToArray())
+            if (withCopies)
             {
-                CreateCopyDependency(dependency.Other.Handle);
-
-                if (dependency.Other.Handle.DeferredCopy == old)
+                foreach (TextureDependency dependency in old.Dependencies.ToArray())
                 {
-                    dependency.Other.Handle.DeferredCopy = this;
-                }
-            }
+                    CreateCopyDependency(dependency.Other.Handle);
 
-            DeferredCopy = old.DeferredCopy;
+                    if (dependency.Other.Handle.DeferredCopy == old)
+                    {
+                        dependency.Other.Handle.DeferredCopy = this;
+                    }
+                }
+
+                DeferredCopy = old.DeferredCopy;
+            }
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
@@ -53,6 +53,16 @@ namespace Ryujinx.Graphics.Gpu.Image
         public int Size { get; }
 
         /// <summary>
+        /// The base slice index for this handle.
+        /// </summary>
+        public int BaseSlice { get; }
+
+        /// <summary>
+        /// The number of slices covered by this handle.
+        /// </summary>
+        public int SliceCount { get; }
+
+        /// <summary>
         /// The textures which this handle overlaps with.
         /// </summary>
         public List<Texture> Overlaps { get; }
@@ -91,8 +101,18 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="views">All views of the storage texture, used to calculate overlaps</param>
         /// <param name="firstLayer">The first layer of this handle in the storage texture</param>
         /// <param name="firstLevel">The first level of this handle in the storage texture</param>
+        /// <param name="baseSlice">The base slice index of this handle</param>
+        /// <param name="sliceCount">The number of slices this handle covers</param>
         /// <param name="handles">The memory tracking handles that cover this handle</param>
-        public TextureGroupHandle(TextureGroup group, int offset, ulong size, List<Texture> views, int firstLayer, int firstLevel, CpuRegionHandle[] handles)
+        public TextureGroupHandle(TextureGroup group,
+                                  int offset,
+                                  ulong size,
+                                  List<Texture> views,
+                                  int firstLayer,
+                                  int firstLevel,
+                                  int baseSlice,
+                                  int sliceCount,
+                                  CpuRegionHandle[] handles)
         {
             _group = group;
             _firstLayer = firstLayer;
@@ -102,6 +122,9 @@ namespace Ryujinx.Graphics.Gpu.Image
             Size = (int)size;
             Overlaps = new List<Texture>();
             Dependencies = new List<TextureDependency>();
+
+            BaseSlice = baseSlice;
+            SliceCount = sliceCount;
 
             if (views != null)
             {

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
@@ -1,5 +1,4 @@
-﻿using Ryujinx.Common.Logging;
-using Ryujinx.Cpu.Tracking;
+﻿using Ryujinx.Cpu.Tracking;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -227,9 +226,10 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// 
+        /// Wait for the latest sync number that the texture handle was written to,
+        /// removing the modified flag if it was reached, or leaving it set if it has not yet been created.
         /// </summary>
-        /// <param name="context"></param>
+        /// <param name="context">The GPU context used to wait for sync</param>
         public void Sync(GpuContext context)
         {
             _actionRegistered = false;
@@ -262,6 +262,10 @@ namespace Ryujinx.Graphics.Gpu.Image
             }
         }
 
+        /// <summary>
+        /// Action to perform when a sync number is registered after modification.
+        /// This action will register a read tracking action on the memory tracking handle so that a flush from CPU can happen.
+        /// </summary>
         private void SyncAction()
         {
             // Register region tracking for CPU? (again)
@@ -369,6 +373,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <summary>
         /// Perform a copy from the provided handle to this one, or perform a deferred copy if none is provided.
         /// </summary>
+        /// <param name="context">GPU context to register sync for modified handles</param>
         /// <param name="fromHandle">The handle to copy from. If not provided, this method will copy from and clear the deferred copy instead</param>
         /// <returns>True if the copy was performed, false otherwise</returns>
         public bool Copy(GpuContext context, TextureGroupHandle fromHandle = null)
@@ -487,6 +492,9 @@ namespace Ryujinx.Graphics.Gpu.Image
             return Offset < offset + size && offset < Offset + Size;
         }
 
+        /// <summary>
+        /// Dispose this texture group handle, removing all its dependencies and disposing its memory tracking handles.
+        /// </summary>
         public void Dispose()
         {
             foreach (CpuRegionHandle handle in Handles)

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
@@ -201,6 +201,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Signal that this handle has either started or ended being modified.
         /// </summary>
         /// <param name="bound">True if this handle is being bound, false if unbound</param>
+        /// <param name="context">The GPU context to register a sync action on</param>
         public void SignalModifying(bool bound, GpuContext context)
         {
             SignalModified(context);
@@ -388,7 +389,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 if (fromHandle != null)
                 {
                     // Only copy if the copy texture is still modified.
-                    // It will be set as unmodified if new data is written from cpu, as the data previously in the texture will flush.
+                    // It will be set as unmodified if new data is written from CPU, as the data previously in the texture will flush.
                     // It will also set as unmodified if a copy is deferred to it.
 
                     shouldCopy = fromHandle.Modified;

--- a/Ryujinx.Graphics.Gpu/Image/TextureViewCompatibility.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureViewCompatibility.cs
@@ -7,6 +7,7 @@
     enum TextureViewCompatibility
     {
         Incompatible = 0,
+        LayoutIncompatible,
         CopyOnly,
         Full
     }

--- a/Ryujinx.Graphics.Gpu/Memory/MultiRangeWritableBlock.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MultiRangeWritableBlock.cs
@@ -1,0 +1,58 @@
+﻿using Ryujinx.Memory;
+using Ryujinx.Memory.Range;
+using System;
+
+namespace Ryujinx.Graphics.Gpu.Memory
+{
+    /// <summary>
+    /// A writable block that targets a given MultiRange within a PhysicalMemory instance.
+    /// </summary>
+    internal class MultiRangeWritableBlock : IWritableBlock
+    {
+        private MultiRange _range;
+        private PhysicalMemory _physicalMemory;
+
+        /// <summary>
+        /// Creates a new MultiRangeWritableBlock.
+        /// </summary>
+        /// <param name="range">The MultiRange to write to</param>
+        /// <param name="physicalMemory">The PhysicalMemory the given MultiRange addresses</param>
+        public MultiRangeWritableBlock(MultiRange range, PhysicalMemory physicalMemory)
+        {
+            _range = range;
+            _physicalMemory = physicalMemory;
+        }
+
+        /// <summary>
+        /// Write data to the MultiRange.
+        /// </summary>
+        /// <param name="va">Offset address</param>
+        /// <param name="data">Data to write</param>
+        /// <exception cref="ArgumentException">Throw when a non-zero offset is given</exception>
+        public void Write(ulong va, ReadOnlySpan<byte> data)
+        {
+            if (va != 0)
+            {
+                throw new ArgumentException($"{nameof(va)} cannot be non-zero for {nameof(MultiRangeWritableBlock)}.");
+            }
+
+            _physicalMemory.Write(_range, data);
+        }
+
+        /// <summary>
+        /// Write data to the MultiRange, without tracking.
+        /// </summary>
+        /// <param name="va">Offset address</param>
+        /// <param name="data">Data to write</param>
+        /// <exception cref="ArgumentException">Throw when a non-zero offset is given</exception>
+        public void WriteUntracked(ulong va, ReadOnlySpan<byte> data)
+        {
+            if (va != 0)
+            {
+                throw new ArgumentException($"{nameof(va)} cannot be non-zero for {nameof(MultiRangeWritableBlock)}.");
+            }
+
+            _physicalMemory.WriteUntracked(_range, data);
+        }
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Memory/MultiRangeWritableBlock.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MultiRangeWritableBlock.cs
@@ -9,8 +9,8 @@ namespace Ryujinx.Graphics.Gpu.Memory
     /// </summary>
     internal class MultiRangeWritableBlock : IWritableBlock
     {
-        private MultiRange _range;
-        private PhysicalMemory _physicalMemory;
+        private readonly MultiRange _range;
+        private readonly PhysicalMemory _physicalMemory;
 
         /// <summary>
         /// Creates a new MultiRangeWritableBlock.

--- a/Ryujinx.Graphics.OpenGL/Image/TextureBuffer.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureBuffer.cs
@@ -43,6 +43,11 @@ namespace Ryujinx.Graphics.OpenGL.Image
             return Buffer.GetData(_renderer, _buffer, _bufferOffset, _bufferSize);
         }
 
+        public ReadOnlySpan<byte> GetData(int layer, int level)
+        {
+            return GetData();
+        }
+
         public void SetData(ReadOnlySpan<byte> data)
         {
             Buffer.SetData(_buffer, _bufferOffset, data.Slice(0, Math.Min(data.Length, _bufferSize)));

--- a/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
@@ -168,7 +168,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
 
                 int offset = WriteTo2D(target, layer, level);
 
-                return new ReadOnlySpan<byte>(IntPtr.Add(target, offset).ToPointer(), size - offset);
+                return new ReadOnlySpan<byte>(target.ToPointer(), size).Slice(offset);
             }
         }
 

--- a/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
@@ -200,31 +200,31 @@ namespace Ryujinx.Graphics.OpenGL.Image
 
             int mipSize = Info.GetMipSize2D(level);
 
-            // The GL function returns all layers. Must return the offset of the layer we're interested in.
-            int resultOffset = target switch
-            {
-                TextureTarget.TextureCubeMapArray => (layer / 6) * mipSize,
-                TextureTarget.Texture1DArray => layer * mipSize,
-                TextureTarget.Texture2DArray => layer * mipSize,
-                _ => 0
-            };
-
             if (format.IsCompressed)
             {
-                GL.GetCompressedTexImage(target, level, data);
+                GL.GetCompressedTextureSubImage(Handle, level, 0, 0, layer, Math.Max(1, Info.Width >> level), Math.Max(1, Info.Height >> level), 1, mipSize, data);
             }
             else if (format.PixelFormat != PixelFormat.DepthStencil)
             {
                 GL.GetTextureSubImage(Handle, level, 0, 0, layer, Math.Max(1, Info.Width >> level), Math.Max(1, Info.Height >> level), 1, pixelFormat, pixelType, mipSize, data);
-
-                return 0;
             }
             else
             {
+                // The GL function returns all layers. Must return the offset of the layer we're interested in.
+                int resultOffset = target switch
+                {
+                    TextureTarget.TextureCubeMapArray => (layer / 6) * mipSize,
+                    TextureTarget.Texture1DArray => layer * mipSize,
+                    TextureTarget.Texture2DArray => layer * mipSize,
+                    _ => 0
+                };
+
                 GL.GetTexImage(target, level, pixelFormat, pixelType, data);
+
+                return resultOffset;
             }
 
-            return resultOffset;
+            return 0;
         }
 
         private void WriteTo(IntPtr data, bool forceBgra = false)

--- a/Ryujinx.Graphics.OpenGL/PersistentBuffers.cs
+++ b/Ryujinx.Graphics.OpenGL/PersistentBuffers.cs
@@ -100,13 +100,13 @@ namespace Ryujinx.Graphics.OpenGL
 
             GL.BindBuffer(BufferTarget.PixelPackBuffer, _copyBufferHandle);
 
-            view.WriteToPbo2D(0, layer, level);
+            int offset = view.WriteToPbo2D(0, layer, level);
 
             GL.BindBuffer(BufferTarget.PixelPackBuffer, 0);
 
             Sync();
 
-            return new ReadOnlySpan<byte>(_bufferMap.ToPointer(), size);
+            return new ReadOnlySpan<byte>(IntPtr.Add(_bufferMap, offset).ToPointer(), size - offset);
         }
 
         public unsafe ReadOnlySpan<byte> GetBufferData(BufferHandle buffer, int offset, int size)

--- a/Ryujinx.Graphics.OpenGL/PersistentBuffers.cs
+++ b/Ryujinx.Graphics.OpenGL/PersistentBuffers.cs
@@ -106,7 +106,7 @@ namespace Ryujinx.Graphics.OpenGL
 
             Sync();
 
-            return new ReadOnlySpan<byte>(IntPtr.Add(_bufferMap, offset).ToPointer(), size - offset);
+            return new ReadOnlySpan<byte>(_bufferMap.ToPointer(), size).Slice(offset);
         }
 
         public unsafe ReadOnlySpan<byte> GetBufferData(BufferHandle buffer, int offset, int size)

--- a/Ryujinx.Graphics.OpenGL/PersistentBuffers.cs
+++ b/Ryujinx.Graphics.OpenGL/PersistentBuffers.cs
@@ -94,6 +94,21 @@ namespace Ryujinx.Graphics.OpenGL
             return new ReadOnlySpan<byte>(_bufferMap.ToPointer(), size);
         }
 
+        public unsafe ReadOnlySpan<byte> GetTextureData(TextureView view, int size, int layer, int level)
+        {
+            EnsureBuffer(size);
+
+            GL.BindBuffer(BufferTarget.PixelPackBuffer, _copyBufferHandle);
+
+            view.WriteToPbo2D(0, layer, level);
+
+            GL.BindBuffer(BufferTarget.PixelPackBuffer, 0);
+
+            Sync();
+
+            return new ReadOnlySpan<byte>(_bufferMap.ToPointer(), size);
+        }
+
         public unsafe ReadOnlySpan<byte> GetBufferData(BufferHandle buffer, int offset, int size)
         {
             EnsureBuffer(size);

--- a/Ryujinx.Graphics.Texture/LayoutConverter.cs
+++ b/Ryujinx.Graphics.Texture/LayoutConverter.cs
@@ -97,6 +97,7 @@ namespace Ryujinx.Graphics.Texture
             int width,
             int height,
             int depth,
+            int sliceDepth,
             int levels,
             int layers,
             int blockWidth,
@@ -172,6 +173,8 @@ namespace Ryujinx.Graphics.Texture
                     mipGobBlocksInZ,
                     bytesPerPixel);
 
+                int sd = Math.Max(1, sliceDepth >> level);
+
                 unsafe bool Convert<T>(Span<byte> output, ReadOnlySpan<byte> data) where T : unmanaged
                 {
                     fixed (byte* outputPtr = output, dataPtr = data)
@@ -181,7 +184,7 @@ namespace Ryujinx.Graphics.Texture
                         {
                             byte* inBaseOffset = dataPtr + (layer * sizeInfo.LayerSize + sizeInfo.GetMipOffset(level));
 
-                            for (int z = 0; z < d; z++)
+                            for (int z = 0; z < sd; z++)
                             {
                                 layoutConverter.SetZ(z);
                                 for (int y = 0; y < h; y++)
@@ -364,6 +367,7 @@ namespace Ryujinx.Graphics.Texture
             int width,
             int height,
             int depth,
+            int sliceDepth,
             int levels,
             int layers,
             int blockWidth,
@@ -432,6 +436,8 @@ namespace Ryujinx.Graphics.Texture
                     mipGobBlocksInZ,
                     bytesPerPixel);
 
+                int sd = Math.Max(1, sliceDepth >> level);
+
                 unsafe bool Convert<T>(Span<byte> output, ReadOnlySpan<byte> data) where T : unmanaged
                 {
                     fixed (byte* outputPtr = output, dataPtr = data)
@@ -441,7 +447,7 @@ namespace Ryujinx.Graphics.Texture
                         {
                             byte* outBaseOffset = outputPtr + (layer * sizeInfo.LayerSize + sizeInfo.GetMipOffset(level));
 
-                            for (int z = 0; z < d; z++)
+                            for (int z = 0; z < sd; z++)
                             {
                                 layoutConverter.SetZ(z);
                                 for (int y = 0; y < h; y++)

--- a/Ryujinx.Graphics.Texture/SizeCalculator.cs
+++ b/Ryujinx.Graphics.Texture/SizeCalculator.cs
@@ -43,6 +43,7 @@ namespace Ryujinx.Graphics.Texture
             int[] allOffsets = new int[is3D ? Calculate3DOffsetCount(levels, depth) : levels * layers * depth];
             int[] mipOffsets = new int[levels];
             int[] sliceSizes = new int[levels];
+            int[] levelSizes = new int[levels];
 
             int mipGobBlocksInY = gobBlocksInY;
             int mipGobBlocksInZ = gobBlocksInZ;
@@ -108,8 +109,9 @@ namespace Ryujinx.Graphics.Texture
 
                 mipOffsets[level] = layerSize;
                 sliceSizes[level] = totalBlocksOfGobsInY * robSize;
+                levelSizes[level] = totalBlocksOfGobsInZ * sliceSizes[level];
 
-                layerSize += totalBlocksOfGobsInZ * sliceSizes[level];
+                layerSize += levelSizes[level];
 
                 depthLevelOffset += d;
             }
@@ -152,7 +154,7 @@ namespace Ryujinx.Graphics.Texture
                 }
             }
 
-            return new SizeInfo(mipOffsets, allOffsets, sliceSizes, depth, levels, layerSize, totalSize, is3D);
+            return new SizeInfo(mipOffsets, allOffsets, sliceSizes, levelSizes, depth, levels, layerSize, totalSize, is3D);
         }
 
         public static SizeInfo GetLinearTextureSize(int stride, int height, int blockHeight)

--- a/Ryujinx.Graphics.Texture/SizeInfo.cs
+++ b/Ryujinx.Graphics.Texture/SizeInfo.cs
@@ -99,7 +99,8 @@ namespace Ryujinx.Graphics.Texture
             {
                 for (int i = 0; i < _mipOffsets.Length; i++)
                 {
-                    yield return new Region(_mipOffsets[i], SliceSizes[i]);
+                    int maxSize = TotalSize - _mipOffsets[i];
+                    yield return new Region(_mipOffsets[i], Math.Min(maxSize, SliceSizes[i]));
                 }
             }
             else

--- a/Ryujinx.Graphics.Texture/SizeInfo.cs
+++ b/Ryujinx.Graphics.Texture/SizeInfo.cs
@@ -13,6 +13,7 @@ namespace Ryujinx.Graphics.Texture
 
         public readonly int[] AllOffsets;
         public readonly int[] SliceSizes;
+        public readonly int[] LevelSizes;
         public int LayerSize { get; }
         public int TotalSize { get; }
 
@@ -21,6 +22,7 @@ namespace Ryujinx.Graphics.Texture
             _mipOffsets = new int[] { 0 };
             AllOffsets  = new int[] { 0 };
             SliceSizes  = new int[] { size };
+            LevelSizes  = new int[] { size };
             _depth      = 1;
             _levels     = 1;
             LayerSize   = size;
@@ -32,6 +34,7 @@ namespace Ryujinx.Graphics.Texture
             int[] mipOffsets,
             int[] allOffsets,
             int[] sliceSizes,
+            int[] levelSizes,
             int   depth,
             int   levels,
             int   layerSize,
@@ -41,6 +44,7 @@ namespace Ryujinx.Graphics.Texture
             _mipOffsets = mipOffsets;
             AllOffsets  = allOffsets;
             SliceSizes  = sliceSizes;
+            LevelSizes  = levelSizes;
             _depth      = depth;
             _levels     = levels;
             LayerSize   = layerSize;
@@ -100,7 +104,7 @@ namespace Ryujinx.Graphics.Texture
                 for (int i = 0; i < _mipOffsets.Length; i++)
                 {
                     int maxSize = TotalSize - _mipOffsets[i];
-                    yield return new Region(_mipOffsets[i], Math.Min(maxSize, SliceSizes[i]));
+                    yield return new Region(_mipOffsets[i], Math.Min(maxSize, LevelSizes[i]));
                 }
             }
             else

--- a/Ryujinx.Memory/Range/MultiRange.cs
+++ b/Ryujinx.Memory/Range/MultiRange.cs
@@ -284,6 +284,11 @@ namespace Ryujinx.Memory.Range
         /// <returns>Total size in bytes</returns>
         public ulong GetSize()
         {
+            if (HasSingleRange)
+            {
+                return _singleRange.Size;
+            }
+
             ulong sum = 0;
 
             foreach (MemoryRange range in _ranges)

--- a/Ryujinx/Ui/RendererWidgetBase.cs
+++ b/Ryujinx/Ui/RendererWidgetBase.cs
@@ -386,6 +386,7 @@ namespace Ryujinx.Ui
 
             Device.Gpu.Renderer.RunLoop(() =>
             {
+                Device.Gpu.SetGpuThread();
                 Device.Gpu.InitializeShaderCache();
                 Translator.IsReadyForTranslation.Set();
 


### PR DESCRIPTION
This PR aims to solve a bunch of issues caused by texture modification and data flushing, by primarily handling data flush on a per-handle instead of per-view basis, and synchronizing flushes with syncpoint increments.

This introduces a new backend method, so it's not currently compatible with Vulkan (though the benefits are more important there)

# Part 1: Syncing Texture Flush

This one has been a while coming. When texture flush via memory tracking was first added, our CPU and various other components were considerably slower. The GPU was so tight with the CPU as a result of both this and the lack of backend multithreading, so when the game tried to access the data it was almost certain that the draw would have completed and the data would be there, just by chance.

This did not last. Over time people started encountering various issues where textures would flush _before_ their data was fully ready, causing white water in BOTW and rainbow lighting in Splatoon. This is compounded a lot by the addition of Background Multithreading and Vulkan, so much that people thought there was a regression. There wasn't, the texture flush was just behaving as it always did.

The new flushing mechanism is similar to the method we use for buffers, which has proven speedy and always gets the data in place by the time the CPU wants it. There is one key difference - texture data is only synced at syncpoint increment, rather than every WaitForIdle. This is mostly a limitation of buffer flush that can be fixed later, but it means that adding these syncpoints for texture flush should not cost anything at all comparatively.

But things are not as simple as shoving the buffer syncaction logic onto textures, as there is another hurdle that could affect games that write into complex texture view layouts.

## Modified Flags move to the Texture Group
Texture groups are a useful abstraction for keeping track of each subimage's memory tracking within a storage texture, and is shared across all views of a texture. Before now, this was _not used_ for texture flush, and each texture view could have its own modified flag and flush action... these views could also overlap. While this has the benefit of fetching the data for modified views in one chunk, it doesn't bode well for tracking rules that use the gpu modified state of each subimage, as they are decoupled from the texture group and might flush at the wrong time.

Now, the modified flag and flush action have been moved to the texture group, and are tracked for each handle individually. Each handle can also have its own sync numbers for determining which sync object to wait on, or if it should even wait at all (more on this later)

## Flushing by slice, rather than by view
Since modified flags are now owned by texture group handles, rather than texture views, they must be able to flush at a granularity smaller than a view. I've added methods on the backend to allow this, though cases which would flush the whole storage texture will still try to do that. These methods will also use the OGL 4.5 methods for flushing texture sub data, rather than flushing an entire level (all layers) and picking out of that. This has potential to be a little faster or slower depending on the game. Hopefully no drivers complain about this.

## Flushing data that isn't ready
When a game flushes texture data, it's a reasonable assumption that the guest must have waited on some synchronization so that it could be sure that the data was actually there. If not, then they're leaving things up to chance, and they've essentially caused a race. This is undefined behaviour, so if texture data is accessed before its syncpoint is incremented, we flush the data regardless of whether it is ready or not (but wait on the _last_ syncpoint that the guest did acknowledge, if possible).

This is the best of both worlds - we ensure data that's appropriately waited on becomes available, don't waste time waiting on accidental flushes that happen after an unrelated gpu write or other textures that share pages.

When one of these undefined flushes happens, the Modified flag is not cleared. The tracking action is re-added when the sync for the texture _is_ actually reached, in case the game wants to access the up to date data later on. CPU writes during this state are considered to be racing with the GPU, so this is also treated specially.

When the modified flag remains set on a texture handle, data is ignored from the CPU. One possible case is that data is written to one mip level of a texture, but another mip level of the same texture remains untouched and contains data modified by the GPU (and is not flushed due to sync rules). Both are on the same page, so both recieve the same dirty flag from write tracking... but one contains data that is unflushed or flushed out of date. It would be invalid to overwrite that unflushed data from CPU if it truly was not touched, so tracking dirty flags are consumed and ignored in this state. Given a race, we therefore say that the GPU _always wins_.

Finally, it's important to note that accesses from the GPU thread do not follow these rules at all. The GPU's own engines and methods must have the texture data at the latest point in time. Thankfully, flushing from the main GPU thread in our backends guarantees this, so sync is skipped and the data is accessed "immediately". Buffers, conversely, must wait right now.

# Part 2: Flush ordering for incompatible data
As of right now, Ryujinx follows a core assumption with the texture cache, where a use of any given texture should be valid in its own layout+format. If this is the case, then any previously cached textures overlapping the same memory that do _not_ share the layout and format are tharefore invalid - they will contain garbage data. This core assumption keeps important texture data alive while saving time by not flushing or loading data that would be "garbage" in the new format/layout.

This rule wasn't fully established before. Incompatible textures only have the _potential_ to be deleted when a new overlap appears over them, and any checks only happened when the texture was created. If both textures existed in the cache at the same point, they would be disjoint, and could flush separately... in any order. This meant that old texture data could flush over new texture data - not ideal for games with complex streaming behaviour.

This is where the new incompatible overlap rules come into play. To put it simply, if a texture is written to and one or more other incompatible textures overlap its memory, their data is considered _invalid_ and their modified flags are immediately cleared. This means that only one can live at a time, and therefore when data flushes, it will always be the latest. Problem solved! Note that these rules were already in place before, they were just enforced _on creation_, rather than on each use.

This is a large sweeping change that affects every game, so testing would be appreciated to see if everything is still holding up.

# Part 3: Flushing host incompatible formats

Occasionally, a texture format or relationship is used which isn't fully supported on the host. Two such examples are:

- ASTC compressed textures, which are not supported on desktop GPUs. 
- BCn compressed 3D textures, which are not supported by OpenGL (but can be supported by Vulkan)

Ryujinx supports these formats by decompressing them to a supported, uncompressed format on the CPU. But, this means that data cannot be copied to/from these textures on the gpu due to using the replacement format, so they are ineligible for texture copy dependencies and views. This causes problems when certain games draw or copy data to these formats by aliasing them as some other data format:

- Life is Strange: True Colors, and potentially other UE4 games (dungeon defenders?) use ASTC textures for characters and environments. UE4 moves texture data around by aliasing levels of textures as a data format such as R32G32Float, and copying them with a blit. Before, this moved data would be lost, as there was no relationship between the copy target and the ASTC texture.
- BOTW draws into a compressed 3D BCn texture to use for the blue dissolve teleportation animation. The texture contains some perlin noise generated and compressed by the GPU. Before, link would just disappear immediately as ryu could not move the data for this texture.

The changes to add incompatible overlaps allowed me to add an additional case for these textures - the ability to force overlaps of these host incompatible format textures to flush their data back to the CPU before it can be used. This is not the fastest, but it is fully compatible and allows us to cover cases which were completely broken before.

This path is essentially the "slow path" for this kind of relationship, and will allow us to support rendered compressed textures on platforms that don't support BCn like mobile hardware. In time, we can introduce compute shader paths that will allow copy dependencies between data textures and "emulated" compressed textures to be done without any data flushing at all, which will further improve performance.

# Potential issues with buffer/texture flush as it stands
One tracking structure is shared between all users of the same address space - they all see and signal the same tracked handles. However, there might be times where we want to sync on GPU, but the sync should not be visible on CPU yet. On top of this, a sync from CPU could remove tracking without sync flushing, but the GPU might try to use that handle immediately after for something like a UBO/I2M write and expect to get the latest data.

This last case can happen with buffers and textures. Not that it couldn't happen before, but it's important to bring up as potential future work. I have not seen it happen in practice.

# Fixes

**1:**
- Weird issues with BOTW regarding link sinking into the ground and water colour (potentially other minor effects)
  - Before: https://cdn.discordapp.com/attachments/410208534861447170/918516347779026984/unknown.png
  - After: https://cdn.discordapp.com/attachments/728011297857339422/919229695780855848/unknown.png
- Splatoon 2 world lighting being a very solid colour or rainbow after a loading screen.
  - Before: https://cdn.discordapp.com/attachments/728011297857339422/916816387673034752/unknown.png
  - After: https://cdn.discordapp.com/attachments/728011297857339422/919231358981800056/unknown.png
- Saved MK8D replay thumbnails occasionally being from the previous race or black.
- More "random chance" visual issues?

**2:**
- Texture streaming issues in UE3/UE4 games (mostly)
  - There are still some small issues in A Hat in Time, but they are greatly reduced. These are being investigated.

**3:**
- Blue dissolve teleportation animation in BOTW. https://gyazo.com/d57a3827ce137f21b852596fc6101447
- UE4 games that stream ASTC format textures, such as Life is Strange: True Colors. (not perfect, same as UE3/4 in general, but vastly better)
  - Before: https://user-images.githubusercontent.com/2002038/146266301-10db3ce5-9e50-44bc-8bfc-99fd43ef3ccf.PNG
  - After: https://cdn.discordapp.com/attachments/787101806085406724/923630179966918706/unknown.png
 
I also fixed an issue with partial 3D texture DMA/load/flush that caused the gob size in z to be incorrect. Not sure what this fixes, but it might improve some issues with lighting in UE4 games a little.

Some things have been fixed regarding the DmaClass fast path used for videos. It won't try to copy to compressed textures directly now, and is aware of its 1 layer limitation.

Testing would be greately appreciated, to ensure that nothing is broken and that performance is similar.

Specifically, AMD/Intel Windows and Linux should be tested to make sure they don't have any weird issues with `glGetTextureSubImage`, as it's technially a DSA method and these drivers are pretty terrible at that.
