### PR TITLE
Stop Emulation UI clean-up + fixes

### DIFF
--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -1320,14 +1320,13 @@ namespace Ryujinx.Ui
 
         private void StopEmulation_Pressed(object sender, EventArgs args)
         {
-            if (_emulationContext != null)
+            if (!_gameLoaded || !ConfigurationState.Instance.ShowConfirmExit || GtkDialog.CreateEndDialog())
             {
                 UpdateGameMetadata(_emulationContext.Application.TitleIdText);
+                _pauseEmulation.Sensitive = false;
+                _resumeEmulation.Sensitive = false;
+                RendererWidget?.Exit();
             }
-
-            _pauseEmulation.Sensitive = false;
-            _resumeEmulation.Sensitive = false;
-            RendererWidget?.Exit();
         }
 
         private void PauseEmulation_Pressed(object sender, EventArgs args)

--- a/Ryujinx/Ui/RendererWidgetBase.cs
+++ b/Ryujinx/Ui/RendererWidgetBase.cs
@@ -250,7 +250,7 @@ namespace Ryujinx.Ui
                     {
                         if (keyboard.IsPressed(Key.Escape))
                         {
-                            if (!ConfigurationState.Instance.ShowConfirmExit || GtkDialog.CreateExitDialog())
+                            if (!ConfigurationState.Instance.ShowConfirmExit || GtkDialog.CreateEndDialog())
                             {
                                 Exit();
                             }

--- a/Ryujinx/Ui/Widgets/GtkDialog.cs
+++ b/Ryujinx/Ui/Widgets/GtkDialog.cs
@@ -109,5 +109,10 @@ namespace Ryujinx.Ui.Widgets
         {
             return CreateChoiceDialog("Ryujinx - Exit", "Are you sure you want to close Ryujinx?", "All unsaved data will be lost!");
         }
+
+        internal static bool CreateEndDialog()
+        {
+            return CreateChoiceDialog("Ryujinx - End Emulation", "Are you sure you want to end emulation?", "All unsaved data will be lost!");
+        }
     }
 }


### PR DESCRIPTION
Fixes the following bugs/inconsistencies:

- Clicking "Stop Emulation" now brings up the dialog box when the show confirmation setting is ticked. A custom dialog was also created instead of re-using the dialog for exiting the entire emulator as this would be misleading and inconsistent.
- Ending emulation when not in full screen with escape now also uses this new dialog box as before it used the program ending dialog.

Remaining bugs:
- [ ] Ending emulation with Escape when not in full screen will cause the same window to appear when a new game is booted. This is both an annoyance and game-breaking when combined with toggling the confirm prompt. This combination of events causes the launched game to end instantly.

Closes #2975 