### PR TITLE
Return error on DNS resolution when guest internet access is disabled

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/IResolver.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/IResolver.cs
@@ -243,14 +243,16 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
             ulong optionsBufferPosition,
             ulong optionsBufferSize)
         {
+            string host = MemoryHelper.ReadAsciiString(context.Memory, inputBufferPosition, (int)inputBufferSize);
+
             if (!context.Device.Configuration.EnableInternetAccess)
             {
+                Logger.Info?.Print(LogClass.ServiceSfdnsres, $"Guest network access disabled, DNS Blocked: {host}");
+
                 WriteResponse(context, withOptions, 0, GaiError.NoData, NetDbError.HostNotFound);
 
                 return ResultCode.Success;
             }
-
-            string host = MemoryHelper.ReadAsciiString(context.Memory, inputBufferPosition, (int)inputBufferSize);
 
             // TODO: Use params.
             bool  enableNsdResolve = (context.RequestData.ReadInt32() & 1) != 0;
@@ -340,6 +342,8 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
         {
             if (!context.Device.Configuration.EnableInternetAccess)
             {
+                Logger.Info?.Print(LogClass.ServiceSfdnsres, $"Guest network access disabled, DNS Blocked.");
+
                 WriteResponse(context, withOptions, 0, GaiError.NoData, NetDbError.HostNotFound);
 
                 return ResultCode.Success;
@@ -450,18 +454,20 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
             ulong optionsBufferPosition,
             ulong optionsBufferSize)
         {
-            if (!context.Device.Configuration.EnableInternetAccess)
-            {
-                WriteResponse(context, withOptions, 0, GaiError.NoData, NetDbError.HostNotFound);
-
-                return ResultCode.Success;
-            }
-
             bool enableNsdResolve = (context.RequestData.ReadInt32() & 1) != 0;
             uint cancelHandle     = context.RequestData.ReadUInt32();
 
             string host    = MemoryHelper.ReadAsciiString(context.Memory, context.Request.SendBuff[0].Position, (long)context.Request.SendBuff[0].Size);
             string service = MemoryHelper.ReadAsciiString(context.Memory, context.Request.SendBuff[1].Position, (long)context.Request.SendBuff[1].Size);
+
+            if (!context.Device.Configuration.EnableInternetAccess)
+            {
+                Logger.Info?.Print(LogClass.ServiceSfdnsres, $"Guest network access disabled, DNS Blocked: {host}");
+
+                WriteResponse(context, withOptions, 0, GaiError.NoData, NetDbError.HostNotFound);
+
+                return ResultCode.Success;
+            }
 
             // NOTE: We ignore hints for now.
             DeserializeAddrInfos(context.Memory, (ulong)context.Request.SendBuff[2].Position, (ulong)context.Request.SendBuff[2].Size);

--- a/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/IResolver.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/IResolver.cs
@@ -243,6 +243,13 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
             ulong optionsBufferPosition,
             ulong optionsBufferSize)
         {
+            if (!context.Device.Configuration.EnableInternetAccess)
+            {
+                WriteResponse(context, withOptions, 0, GaiError.NoData, NetDbError.HostNotFound);
+
+                return ResultCode.Success;
+            }
+
             string host = MemoryHelper.ReadAsciiString(context.Memory, inputBufferPosition, (int)inputBufferSize);
 
             // TODO: Use params.
@@ -331,6 +338,13 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
             ulong optionsBufferPosition,
             ulong optionsBufferSize)
         {
+            if (!context.Device.Configuration.EnableInternetAccess)
+            {
+                WriteResponse(context, withOptions, 0, GaiError.NoData, NetDbError.HostNotFound);
+
+                return ResultCode.Success;
+            }
+
             byte[] rawIp = new byte[inputBufferSize];
 
             context.Memory.Read(inputBufferPosition, rawIp);
@@ -436,6 +450,13 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
             ulong optionsBufferPosition,
             ulong optionsBufferSize)
         {
+            if (!context.Device.Configuration.EnableInternetAccess)
+            {
+                WriteResponse(context, withOptions, 0, GaiError.NoData, NetDbError.HostNotFound);
+
+                return ResultCode.Success;
+            }
+
             bool enableNsdResolve = (context.RequestData.ReadInt32() & 1) != 0;
             uint cancelHandle     = context.RequestData.ReadUInt32();
 


### PR DESCRIPTION
The title says it all, if guest internet access is disabled, no DNS lookup is performed and it returns an error immediately. If the guest internet access is disabled, it doesn't make sense that we allow the servers to be reached.

This fixes a regression introduced by #2936 that made Crash Bandicoot 4 crash early on boot after trying to connect to some server. Note that the game will still crash with guest internet access enabled, that should be fixed separately.

The regression likely comes from the fact that before the fix on the linked PR, it was returning a serialized size of 0 which made the applications assume nothing was actually returned. This change should make it behave in a similar way to the old behaviour, except we return an actual error code now.

Thanks to Muffin for finding the change that caused the regression.