### PR TITLE
Fix sampled multisample texture size

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -196,6 +196,13 @@ namespace Ryujinx.Graphics.Gpu.Image
             int width = target == Target.TextureBuffer ? descriptor.UnpackBufferTextureWidth() : descriptor.UnpackWidth();
             int height = descriptor.UnpackHeight();
 
+            if (target == Target.Texture2DMultisample || target == Target.Texture2DMultisampleArray)
+            {
+                // This is divided back before the backend texture is created.
+                width *= samplesInX;
+                height *= samplesInY;
+            }
+
             // We use 2D targets for 1D textures as that makes texture cache
             // management easier. We don't know the target for render target
             // and copies, so those would normally use 2D targets, which are


### PR DESCRIPTION
The width/height of render target and copy textures is already pre-multiplied by the driver for multisample textures. For shader sampled textures that are on the pool, they are not pre-multiplied. This changes multiply their size by the multisample size, in order to allow them to match existing textures on the cache, in addition to allowing the texture to have the correct size (as the `TextureCreateInfo` that is passed to the backend has the width and height divided by the amount of samples).

Fixes rendering on Okami HD.
Before (from gamedb):
![image](https://user-images.githubusercontent.com/62343878/88603613-aa295880-d032-11ea-9456-b62388ef030c.png)
![image](https://user-images.githubusercontent.com/62343878/88603617-abf31c00-d032-11ea-98a1-13022796c497.png)
PR:
![image](https://user-images.githubusercontent.com/5624669/148668204-638877bb-9f66-4965-b46b-e15efd52793d.png)
![image](https://user-images.githubusercontent.com/5624669/148668207-5c9b52ce-f68c-4ddd-a1c0-77e85a9b2fcd.png)

Might also fix broken fight effects on Rune Factory 5.
Testing on games using multisampling is appreciated.
