### PR TITLE
sfdnsres: Block communication attempt with NPLN servers

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsBlacklist.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsBlacklist.cs
@@ -9,6 +9,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Proxy
         private static readonly Regex[] BlockedHosts = new Regex[]
         {
             new Regex(@"^(.*)\-lp1\.(n|s)\.n\.srv\.nintendo\.net$", RegexOpts),
+            new Regex(@"^(.*)\-lp1\.lp1\.t\.npln\.srv\.nintendo\.net$", RegexOpts),
             new Regex(@"^(.*)\-lp1\.(znc|p)\.srv\.nintendo\.net$", RegexOpts),
             new Regex(@"^(.*)\-sb\-api\.accounts\.nintendo\.com$", RegexOpts),
             new Regex(@"^(.*)\-sb\.accounts\.nintendo\.com$", RegexOpts),


### PR DESCRIPTION
Seen on Monster Hunter Rise.