### PR TITLE
Fix adjacent 3d texture slices being detected as Incompatible Overlaps

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -1382,9 +1382,16 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Determine if any of this texture's data overlaps with another.
         /// </summary>
         /// <param name="texture">The texture to check against</param>
+        /// <param name="compatibility">The view compatibility of the two textures</param>
         /// <returns>True if any slice of the textures overlap, false otherwise</returns>
-        public bool DataOverlaps(Texture texture)
+        public bool DataOverlaps(Texture texture, TextureViewCompatibility compatibility)
         {
+            if (compatibility == TextureViewCompatibility.LayoutIncompatible && Info.GobBlocksInZ > 1 && Info.GobBlocksInZ == texture.Info.GobBlocksInZ)
+            {
+                // Allow overlapping slices of layout compatible 3D textures with matching GobBlocksInZ, as they are interleaved.
+                return false;
+            }
+
             if (texture._sizeInfo.AllOffsets.Length == 1 && _sizeInfo.AllOffsets.Length == 1)
             {
                 return Range.OverlapsWith(texture.Range);

--- a/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -582,7 +582,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                     if (oInfo.Compatibility <= TextureViewCompatibility.LayoutIncompatible)
                     {
-                        if (!overlap.IsView && texture.DataOverlaps(overlap))
+                        if (!overlap.IsView && texture.DataOverlaps(overlap, oInfo.Compatibility))
                         {
                             texture.Group.RegisterIncompatibleOverlap(new TextureIncompatibleOverlap(overlap.Group, oInfo.Compatibility), true);
                         }
@@ -657,7 +657,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     }
                     else
                     {
-                        bool dataOverlaps = texture.DataOverlaps(overlap);
+                        bool dataOverlaps = texture.DataOverlaps(overlap, compatibility);
                         
                         if (!overlap.IsView && dataOverlaps && !incompatibleOverlaps.Exists(incompatible => incompatible.Group == overlap.Group))
                         {
@@ -673,12 +673,6 @@ namespace Ryujinx.Graphics.Gpu.Image
                             {
                                 // Allow textures to overlap if their data does not actually overlap.
                                 // This typically happens when mip level subranges of a layered texture are used. (each texture fills the gaps of the others)
-                                continue;
-                            }
-
-                            if (info.GobBlocksInZ > 1 && info.GobBlocksInZ == overlap.Info.GobBlocksInZ)
-                            {
-                                // Allow overlapping slices of 3D textures. Could be improved in future by making sure the textures don't overlap.
                                 continue;
                             }
 


### PR DESCRIPTION
This fixes some regressions caused by #2971 which caused rendered 3D texture data to be lost for most slices. Fixes issues with Xenoblade 2's colour grading, probably a ton of other games.

This also removes the check from TextureCache, making it the tiniest bit smaller (any win is a win here).