### PR TITLE
Fix render target clear when sizes mismatch

### DIFF
--- a/Ryujinx.Graphics.GAL/IPipeline.cs
+++ b/Ryujinx.Graphics.GAL/IPipeline.cs
@@ -1,4 +1,3 @@
-using Ryujinx.Graphics.Shader;
 using System;
 
 namespace Ryujinx.Graphics.GAL
@@ -15,9 +14,9 @@ namespace Ryujinx.Graphics.GAL
 
         void ClearRenderTargetDepthStencil(
             float depthValue,
-            bool  depthMask,
-            int   stencilValue,
-            int   stencilMask);
+            bool depthMask,
+            int stencilValue,
+            int stencilMask);
 
         void CommandBufferBarrier();
 

--- a/Ryujinx.Graphics.GAL/RectangleF.cs
+++ b/Ryujinx.Graphics.GAL/RectangleF.cs
@@ -2,16 +2,16 @@ namespace Ryujinx.Graphics.GAL
 {
     public struct RectangleF
     {
-        public float X      { get; }
-        public float Y      { get; }
-        public float Width  { get; }
+        public float X { get; }
+        public float Y { get; }
+        public float Width { get; }
         public float Height { get; }
 
         public RectangleF(float x, float y, float width, float height)
         {
-            X      = x;
-            Y      = y;
-            Width  = width;
+            X = x;
+            Y = y;
+            Width = width;
             Height = height;
         }
     }

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
@@ -138,6 +138,14 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         }
 
         /// <summary>
+        /// Updates scissor based on current render target state.
+        /// </summary>
+        public void UpdateScissorState()
+        {
+            _stateUpdater.UpdateScissorState();
+        }
+
+        /// <summary>
         /// Marks the entire state as dirty, forcing a full host state update before the next draw.
         /// </summary>
         public void ForceStateDirty()

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClassState.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClassState.cs
@@ -754,7 +754,9 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         public int DrawTextureTextureId;
         public int DrawTextureSrcX;
         public int DrawTextureSrcY;
-        public fixed uint Reserved10B0[44];
+        public fixed uint Reserved10B0[18];
+        public uint ClearFlags;
+        public fixed uint Reserved10FC[25];
         public Array16<VertexAttribState> VertexAttribState;
         public fixed uint Reserved11A0[31];
         public RtControl RtControl;

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -48,6 +48,16 @@ namespace Ryujinx.Graphics.Gpu.Image
         public Target Target { get; private set; }
 
         /// <summary>
+        /// Texture width.
+        /// </summary>
+        public int Width { get; private set; }
+
+        /// <summary>
+        /// Texture height.
+        /// </summary>
+        public int Height { get; private set; }
+
+        /// <summary>
         /// Texture information.
         /// </summary>
         public TextureInfo Info { get; private set; }
@@ -926,7 +936,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 FlushTextureDataToGuest(tracked);
             }
         }
-        
+
         /// <summary>
         /// Gets a host texture to use for flushing the texture, at 1x resolution.
         /// If the HostTexture is already at 1x resolution, it is returned directly.
@@ -1322,6 +1332,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             Info = info;
             Target = info.Target;
+            Width = info.Width;
+            Height = info.Height;
             CanForceAnisotropy = CanTextureForceAnisotropy();
 
             _depth  = info.GetDepth();

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -6,7 +6,6 @@ using Ryujinx.Graphics.OpenGL.Queries;
 using Ryujinx.Graphics.Shader;
 using System;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 namespace Ryujinx.Graphics.OpenGL
 {
@@ -1058,14 +1057,17 @@ namespace Ryujinx.Graphics.OpenGL
 
                 _framebuffer.AttachColor(index, color);
 
-                int isBgra = color != null && color.Format.IsBgr() ? 1 : 0;
-
-                if (_fpIsBgra[index].X != isBgra)
+                if (color != null)
                 {
-                    _fpIsBgra[index].X = isBgra;
-                    isBgraChanged = true;
+                    int isBgra = color.Format.IsBgr() ? 1 : 0;
 
-                    RestoreComponentMask(index);
+                    if (_fpIsBgra[index].X != isBgra)
+                    {
+                        _fpIsBgra[index].X = isBgra;
+                        isBgraChanged = true;
+
+                        RestoreComponentMask(index);
+                    }
                 }
             }
 


### PR DESCRIPTION
On OpenGL (and Vulkan too iirc), when the bound render targets have different sizes, then it only render on the intersection of all their sizes. On the GPU, this clipping is controlled by the `ScreenScissorState` pair of registers. This register was being mostly ignored before, but for clears, that may cause issues if there are render targets of different sizes bound, and the game is trying to clear one of them, with a screen scissor size that matches the target being cleared. OpenGL would clip it to the smallest size and not clear the entire region.

This issue has been fixed by forcing all other render targets to be unbound, to avoid the host clipping, and then using a custom scissor region, calculated from the screen scissor and user scissor (0). Additionally, I also implemented the clear flags (that can be used to disable user scissor on stencil mask from affecting clear, but everything I tested so far always have both enabled). Also includes other minor improvements.

Fixes Pathway not having the screen entirely cleared.
Before:
![image](https://user-images.githubusercontent.com/5624669/148878934-60cee7d8-9ca9-41a4-8694-56aab4c99870.png)
After:
![image](https://user-images.githubusercontent.com/5624669/148878954-eb89a18b-4937-4672-af0e-e30173af2b42.png)
Fixes #2989
Testing is welcome (as always).