### PR TITLE
kernel: Fix deadlock when pinning in interrupt handler

### DIFF
--- a/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
@@ -762,13 +762,9 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
                 currentThread.SetUserInterruptFlag();
 
                 KernelContext.CriticalSection.Leave();
-
-                if (currentThread.IsSchedulable)
-                {
-                    KernelContext.Schedulers[currentThread.CurrentCore].Schedule();
-                }
             }
-            else if (currentThread.IsSchedulable)
+
+            if (currentThread.IsSchedulable)
             {
                 KernelContext.Schedulers[currentThread.CurrentCore].Schedule();
             }

--- a/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
@@ -761,12 +761,12 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
                 currentThread.SetUserInterruptFlag();
 
+                KernelContext.CriticalSection.Leave();
+
                 if (currentThread.IsSchedulable)
                 {
                     KernelContext.Schedulers[currentThread.CurrentCore].Schedule();
                 }
-
-                KernelContext.CriticalSection.Leave();
             }
             else if (currentThread.IsSchedulable)
             {


### PR DESCRIPTION
This fix a misplace critical section leave.
This fix a deadlock on DoDonPachi Resurrection when starting a new game and possibly other games.