### PR TITLE
Fix return type mismatch on 32-bit titles

### DIFF
--- a/ARMeilleure/Instructions/InstEmitFlowHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitFlowHelper.cs
@@ -163,6 +163,11 @@ namespace ARMeilleure.Instructions
         {
             if (isReturn)
             {
+                if (target.Type == OperandType.I32)
+                {
+                    target = context.ZeroExtend32(OperandType.I64, target);
+                }
+
                 context.Return(target);
             }
             else

--- a/ARMeilleure/Instructions/InstEmitMemory.cs
+++ b/ARMeilleure/Instructions/InstEmitMemory.cs
@@ -101,7 +101,7 @@ namespace ARMeilleure.Instructions
 
             Operand address = GetAddress(context);
 
-            InstEmitMemoryHelper.EmitStore(context, address, op.Rt, op.Size);
+            EmitStore(context, address, op.Rt, op.Size);
 
             EmitWBackIfNeeded(context, address);
         }
@@ -113,8 +113,8 @@ namespace ARMeilleure.Instructions
             Operand address = GetAddress(context);
             Operand address2 = GetAddress(context, 1L << op.Size);
 
-            InstEmitMemoryHelper.EmitStore(context, address,  op.Rt,  op.Size);
-            InstEmitMemoryHelper.EmitStore(context, address2, op.Rt2, op.Size);
+            EmitStore(context, address,  op.Rt,  op.Size);
+            EmitStore(context, address2, op.Rt2, op.Size);
 
             EmitWBackIfNeeded(context, address);
         }


### PR DESCRIPTION
Fixes an assert that was caused by the return type not matching the actual return type of the functoin, due to the address bein 32-bits. Usually this does not cause asserts, but when combined with the tail merge optimization, it could store 32-bit to 64-bit copies due to the mismatch of the different return types, which would later cause an assert on the copy.

I think this is otherwise harmless, since on x86, 32-bit operations will zero the upper 32-bits of the register, so the zero extension is technically not needed in this case.