### PR TITLE
Scale scissor used for clears

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
@@ -535,6 +535,15 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                     scissorH = Math.Min(scissorH, scissorState.Y2 - scissorState.Y1);
                 }
 
+                float scale = _channel.TextureManager.RenderTargetScale;
+                if (scale != 1f)
+                {
+                    scissorX = (int)(scissorX * scale);
+                    scissorY = (int)(scissorY * scale);
+                    scissorW = (int)MathF.Ceiling(scissorW * scale);
+                    scissorH = (int)MathF.Ceiling(scissorH * scale);
+                }
+
                 _context.Renderer.Pipeline.SetScissor(0, true, scissorX, scissorY, scissorW, scissorH);
             }
 

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -477,8 +477,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                     {
                         x = (int)(x * scale);
                         y = (int)(y * scale);
-                        width = (int)Math.Ceiling(width * scale);
-                        height = (int)Math.Ceiling(height * scale);
+                        width = (int)MathF.Ceiling(width * scale);
+                        height = (int)MathF.Ceiling(height * scale);
                     }
 
                     _context.Renderer.Pipeline.SetScissor(index, true, x, y, width, height);


### PR DESCRIPTION
Fixes a regression introduced on #2994 that would cause the screen to "flicker" in some games with resolution scale other than native. Affected games includes Luigi's Mansion 3.

Also changes `Math.Ceiling` to `MathF.Ceiling` to avoid an implicit cast to double (plus, float operations are generally faster than double ones).