### PR TITLE
Use a SSBO for the shader support buffer, if using UBOs would be above limit

### DIFF
--- a/Ryujinx.Graphics.GAL/Capabilities.cs
+++ b/Ryujinx.Graphics.GAL/Capabilities.cs
@@ -19,7 +19,14 @@ namespace Ryujinx.Graphics.GAL
 
         public int MaximumComputeSharedMemorySize { get; }
         public float MaximumSupportedAnisotropy { get; }
+        public int MaximumSupportedComputeUniforms { get; }
+        public int MaximumSupportedVertexUniforms { get; }
+        public int MaximumSupportedTessControlUniforms { get; }
+        public int MaximumSupportedTessEvaluationUniforms { get; }
+        public int MaximumSupportedGeometryUniforms { get; }
+        public int MaximumSupportedFragmentUniforms { get; }
         public int StorageBufferOffsetAlignment { get; }
+
 
         public Capabilities(
             bool hasFrontFacingBug,
@@ -37,6 +44,12 @@ namespace Ryujinx.Graphics.GAL
             bool supportsIndirectParameters,
             int maximumComputeSharedMemorySize,
             float maximumSupportedAnisotropy,
+            int maximumSupportedComputeUniforms,
+            int maximumSupportedVertexUniforms,
+            int maximumSupportedTessControlUniforms,
+            int maximumSupportedTessEvaluationUniforms,
+            int maximumSupportedGeometryUniforms,
+            int maximumSupportedFragmentUniforms,
             int storageBufferOffsetAlignment)
         {
             HasFrontFacingBug = hasFrontFacingBug;
@@ -54,6 +67,12 @@ namespace Ryujinx.Graphics.GAL
             SupportsIndirectParameters = supportsIndirectParameters;
             MaximumComputeSharedMemorySize = maximumComputeSharedMemorySize;
             MaximumSupportedAnisotropy = maximumSupportedAnisotropy;
+            MaximumSupportedComputeUniforms = maximumSupportedComputeUniforms;
+            MaximumSupportedVertexUniforms = maximumSupportedVertexUniforms;
+            MaximumSupportedTessControlUniforms = maximumSupportedTessControlUniforms;
+            MaximumSupportedTessEvaluationUniforms = maximumSupportedTessEvaluationUniforms;
+            MaximumSupportedGeometryUniforms = maximumSupportedGeometryUniforms;
+            MaximumSupportedFragmentUniforms = maximumSupportedFragmentUniforms;
             StorageBufferOffsetAlignment = storageBufferOffsetAlignment;
         }
     }

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -40,7 +40,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 2972;
+        private const ulong ShaderCodeGenVersion = 3005;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Gpu/Shader/TextureDescriptorCapableGpuAccessor.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/TextureDescriptorCapableGpuAccessor.cs
@@ -37,6 +37,25 @@ namespace Ryujinx.Graphics.Gpu.Shader
         public int QueryHostStorageBufferOffsetAlignment() => _context.Capabilities.StorageBufferOffsetAlignment;
 
         /// <summary>
+        /// Queries host maximum number of uniform buffers for a given shader stage.
+        /// </summary>
+        /// <param name="stage">Shader stage</param>
+        /// <returns>The maximum number of uniform buffers the specified stage can use</returns>
+        public int QueryHostMaximumUniforms(ShaderStage stage)
+        {
+            return stage switch
+            {
+                ShaderStage.Compute => _context.Capabilities.MaximumSupportedComputeUniforms,
+                ShaderStage.Vertex => _context.Capabilities.MaximumSupportedVertexUniforms,
+                ShaderStage.TessellationControl => _context.Capabilities.MaximumSupportedTessControlUniforms,
+                ShaderStage.TessellationEvaluation => _context.Capabilities.MaximumSupportedTessEvaluationUniforms,
+                ShaderStage.Geometry => _context.Capabilities.MaximumSupportedGeometryUniforms,
+                ShaderStage.Fragment => _context.Capabilities.MaximumSupportedFragmentUniforms,
+                _ => throw new ArgumentException($"Invalid shader stage \"{stage}\".")
+            };
+        }
+
+        /// <summary>
         /// Queries host support for fragment shader ordering critical sections on the shader code.
         /// </summary>
         /// <returns>True if fragment shader interlock is supported, false otherwise</returns>

--- a/Ryujinx.Graphics.OpenGL/HwCapabilities.cs
+++ b/Ryujinx.Graphics.OpenGL/HwCapabilities.cs
@@ -21,6 +21,12 @@ namespace Ryujinx.Graphics.OpenGL
 
         private static readonly Lazy<int> _maximumComputeSharedMemorySize = new Lazy<int>(() => GetLimit(All.MaxComputeSharedMemorySize));
         private static readonly Lazy<int> _storageBufferOffsetAlignment   = new Lazy<int>(() => GetLimit(All.ShaderStorageBufferOffsetAlignment));
+        private static readonly Lazy<int> _maxComputeUniformBlocks        = new Lazy<int>(() => GetLimit(All.MaxComputeUniformBlocks));
+        private static readonly Lazy<int> _maxVertexUniformBlocks         = new Lazy<int>(() => GetLimit(All.MaxVertexUniformBlocks));
+        private static readonly Lazy<int> _maxTessControlUniformBlocks    = new Lazy<int>(() => GetLimit(All.MaxTessControlUniformBlocks));
+        private static readonly Lazy<int> _maxTessEvaluationUniformBlocks = new Lazy<int>(() => GetLimit(All.MaxTessEvaluationUniformBlocks));
+        private static readonly Lazy<int> _maxGeometryUniformBlocks       = new Lazy<int>(() => GetLimit(All.MaxGeometryUniformBlocks));
+        private static readonly Lazy<int> _maxFragmentUniformBlocks       = new Lazy<int>(() => GetLimit(All.MaxFragmentUniformBlocks));
 
         public enum GpuVendor
         {
@@ -63,6 +69,12 @@ namespace Ryujinx.Graphics.OpenGL
 
         public static int MaximumComputeSharedMemorySize => _maximumComputeSharedMemorySize.Value;
         public static int StorageBufferOffsetAlignment   => _storageBufferOffsetAlignment.Value;
+        public static int MaxComputeUniformBlocks        => _maxComputeUniformBlocks.Value;
+        public static int MaxVertexUniformBlocks         => _maxVertexUniformBlocks.Value;
+        public static int MaxTessControlUniformBlocks    => _maxTessControlUniformBlocks.Value;
+        public static int MaxTessEvaluationUniformBlocks => _maxTessEvaluationUniformBlocks.Value;
+        public static int MaxGeometryUniformBlocks       => _maxGeometryUniformBlocks.Value;
+        public static int MaxFragmentUniformBlocks       => _maxFragmentUniformBlocks.Value;
 
         public static float MaximumSupportedAnisotropy => _maxSupportedAnisotropy.Value;
 

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -91,6 +91,7 @@ namespace Ryujinx.Graphics.OpenGL
         {
             _supportBuffer = new SupportBufferUpdater(renderer);
             GL.BindBufferBase(BufferRangeTarget.UniformBuffer, 0, Unsafe.As<BufferHandle, int>(ref _supportBuffer.Handle));
+            GL.BindBufferBase(BufferRangeTarget.ShaderStorageBuffer, 0, Unsafe.As<BufferHandle, int>(ref _supportBuffer.Handle));
 
             _supportBuffer.UpdateFragmentIsBgra(_fpIsBgra, 0, SupportBuffer.FragmentIsBgraCount);
             _supportBuffer.UpdateRenderScale(_renderScale, 0, SupportBuffer.RenderScaleMaxCount);

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -116,6 +116,12 @@ namespace Ryujinx.Graphics.OpenGL
                 supportsIndirectParameters: HwCapabilities.SupportsIndirectParameters,
                 maximumComputeSharedMemorySize: HwCapabilities.MaximumComputeSharedMemorySize,
                 maximumSupportedAnisotropy: HwCapabilities.MaximumSupportedAnisotropy,
+                maximumSupportedComputeUniforms: HwCapabilities.MaxComputeUniformBlocks,
+                maximumSupportedVertexUniforms: HwCapabilities.MaxVertexUniformBlocks,
+                maximumSupportedTessControlUniforms: HwCapabilities.MaxTessControlUniformBlocks,
+                maximumSupportedTessEvaluationUniforms: HwCapabilities.MaxTessEvaluationUniformBlocks,
+                maximumSupportedGeometryUniforms: HwCapabilities.MaxGeometryUniformBlocks,
+                maximumSupportedFragmentUniforms: HwCapabilities.MaxFragmentUniformBlocks,
                 storageBufferOffsetAlignment: HwCapabilities.StorageBufferOffsetAlignment);
         }
 

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
@@ -599,7 +599,15 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
                 return;
             }
 
-            context.AppendLine($"layout (binding = 0, std140) uniform {DefaultNames.SupportBlockName}");
+            // Check if the total amount of uniform buffers we use (also including the support buffer)
+            // would be past the host limit. If so, use a storage buffer for the support buffer instead.
+            // This may allow the shader to be within the host limit.
+            int usedUniformBuffers = context.Config.GetConstantBufferDescriptors().Length + 1;
+            int maxUniformBuffers = context.Config.GpuAccessor.QueryHostMaximumUniforms(context.Config.Stage);
+            bool isPastUniformsLimit = usedUniformBuffers > maxUniformBuffers;
+            string bufferType = isPastUniformsLimit ? "buffer" : "uniform";
+
+            context.AppendLine($"layout (binding = 0, std140) {bufferType} {DefaultNames.SupportBlockName}");
             context.EnterScope();
 
             switch (stage)

--- a/Ryujinx.Graphics.Shader/IGpuAccessor.cs
+++ b/Ryujinx.Graphics.Shader/IGpuAccessor.cs
@@ -61,6 +61,11 @@ namespace Ryujinx.Graphics.Shader
             return 16;
         }
 
+        int QueryHostMaximumUniforms(ShaderStage stage)
+        {
+            return 18;
+        }
+
         bool QueryHostSupportsFragmentShaderInterlock()
         {
             return true;

--- a/Ryujinx.Graphics.Shader/Translation/TranslationCounts.cs
+++ b/Ryujinx.Graphics.Shader/Translation/TranslationCounts.cs
@@ -11,6 +11,7 @@ namespace Ryujinx.Graphics.Shader.Translation
         {
             // The first binding is reserved for the support buffer.
             UniformBuffersCount = 1;
+            StorageBuffersCount = 1;
         }
 
         internal int IncrementUniformBuffersCount()


### PR DESCRIPTION
APIs have a limit on the number of uniform buffers one can use on the shader. On NVIDIA OpenGL that is 14. The Switch GPU supports up to 18, but APIs actually exposes less than that to the user. The constant buffers that are not exposed to the user, are instead reserved by the driver and used to store constants and other data used by the shader.

There are some games getting past the host limit. For example, Beyond a Steel Sky has shaders using 14 uniform buffers. When you add the support buffer one, then it becomes 15, which is past the limit. This change addresses this case by instead using a storage buffer for the support buffer if it would be past the limit with a uniform. To make this work, now theres one storage binding reserved for the support buffer too, and it is also bound to the SSBO binding point 0.

Note that this does not address *all* possible cases. For example, if the shader uses 15 or more uniform buffers, it still won't be enough. In those cases, it should try converting some of those uniform buffers to storage buffers.

Also worth noting that Vulkan likely does not have the issue, as the limit on the number of uniform buffers per shaders is higher than OpenGL.

Fixes missing geometry in Beyond a Steel Sky.
Before:
![image](https://user-images.githubusercontent.com/5624669/149817253-1fd66f22-0350-42c7-846e-5aafb8819085.png)
After:
![image](https://user-images.githubusercontent.com/5624669/149817269-1bf7c602-c7ac-486e-a413-779cdaa0b770.png)
Closes #3003.