### PR TITLE
Add capability for BGRA formats

### DIFF
--- a/Ryujinx.Graphics.GAL/Capabilities.cs
+++ b/Ryujinx.Graphics.GAL/Capabilities.cs
@@ -6,6 +6,7 @@ namespace Ryujinx.Graphics.GAL
         public bool HasVectorIndexingBug { get; }
 
         public bool SupportsAstcCompression { get; }
+        public bool SupportsBgraFormat { get; }
         public bool SupportsR4G4Format { get; }
         public bool SupportsFragmentShaderInterlock { get; }
         public bool SupportsFragmentShaderOrderingIntel { get; }
@@ -25,6 +26,7 @@ namespace Ryujinx.Graphics.GAL
             bool hasFrontFacingBug,
             bool hasVectorIndexingBug,
             bool supportsAstcCompression,
+            bool supportsBgraFormat,
             bool supportsR4G4Format,
             bool supportsFragmentShaderInterlock,
             bool supportsFragmentShaderOrderingIntel,
@@ -42,6 +44,7 @@ namespace Ryujinx.Graphics.GAL
             HasFrontFacingBug = hasFrontFacingBug;
             HasVectorIndexingBug = hasVectorIndexingBug;
             SupportsAstcCompression = supportsAstcCompression;
+            SupportsBgraFormat = supportsBgraFormat;
             SupportsR4G4Format = supportsR4G4Format;
             SupportsFragmentShaderInterlock = supportsFragmentShaderInterlock;
             SupportsFragmentShaderOrderingIntel = supportsFragmentShaderOrderingIntel;

--- a/Ryujinx.Graphics.Gpu/Shader/TextureDescriptorCapableGpuAccessor.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/TextureDescriptorCapableGpuAccessor.cs
@@ -37,6 +37,12 @@ namespace Ryujinx.Graphics.Gpu.Shader
         public int QueryHostStorageBufferOffsetAlignment() => _context.Capabilities.StorageBufferOffsetAlignment;
 
         /// <summary>
+        /// Queries host support for texture formats with BGRA component order (such as BGRA8).
+        /// </summary>
+        /// <returns>True if BGRA formats are supported, false otherwise</returns>
+        public bool QueryHostSupportsBgraFormat() => _context.Capabilities.SupportsBgraFormat;
+
+        /// <summary>
         /// Queries host support for fragment shader ordering critical sections on the shader code.
         /// </summary>
         /// <returns>True if fragment shader interlock is supported, false otherwise</returns>

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -104,6 +104,7 @@ namespace Ryujinx.Graphics.OpenGL
                 hasFrontFacingBug: HwCapabilities.Vendor == HwCapabilities.GpuVendor.IntelWindows,
                 hasVectorIndexingBug: HwCapabilities.Vendor == HwCapabilities.GpuVendor.AmdWindows,
                 supportsAstcCompression: HwCapabilities.SupportsAstcCompression,
+                supportsBgraFormat: false,
                 supportsR4G4Format: false,
                 supportsFragmentShaderInterlock: HwCapabilities.SupportsFragmentShaderInterlock,
                 supportsFragmentShaderOrderingIntel: HwCapabilities.SupportsFragmentShaderOrdering,

--- a/Ryujinx.Graphics.Shader/IGpuAccessor.cs
+++ b/Ryujinx.Graphics.Shader/IGpuAccessor.cs
@@ -61,6 +61,11 @@ namespace Ryujinx.Graphics.Shader
             return 16;
         }
 
+        bool QueryHostSupportsBgraFormat()
+        {
+            return true;
+        }
+
         bool QueryHostSupportsFragmentShaderInterlock()
         {
             return true;

--- a/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -167,6 +167,7 @@ namespace Ryujinx.Graphics.Shader.Translation
                     this.Copy(dest, src);
                 }
 
+                bool supportsBgra = Config.GpuAccessor.QueryHostSupportsBgraFormat();
                 int regIndexBase = 0;
 
                 for (int rtIndex = 0; rtIndex < 8; rtIndex++)
@@ -185,7 +186,7 @@ namespace Ryujinx.Graphics.Shader.Translation
                         Operand src = Register(regIndexBase + component, RegisterType.Gpr);
 
                         // Perform B <-> R swap if needed, for BGRA formats (not supported on OpenGL).
-                        if (component == 0 || component == 2)
+                        if (!supportsBgra && (component == 0 || component == 2))
                         {
                             Operand isBgra = Attribute(AttributeConsts.FragmentOutputIsBgraBase + rtIndex * 4);
 


### PR DESCRIPTION
This adds a new capability, `SupportsBgraFormat`. On OpenGL, it is always false as this API has no support for BGRA texture formats. However, it will be set to true on Vulkan, which allows us to use those formats there, without needing to swap the components ourselves on the fragment shader output.

Main benefit here is reducing the diff with the Vulkan branch and making review easier. Should not cause any changes on games.