### PR TITLE
Add host CPU memory barriers for DMB/DSB and ordered load/store

### DIFF
--- a/ARMeilleure/CodeGen/X86/Assembler.cs
+++ b/ARMeilleure/CodeGen/X86/Assembler.cs
@@ -358,6 +358,12 @@ namespace ARMeilleure.CodeGen.X86
             WriteInstruction(dest, source, type, X86Instruction.Lea);
         }
 
+        public void LockOr(Operand dest, Operand source, OperandType type)
+        {
+            WriteByte(LockPrefix);
+            WriteInstruction(dest, source, type, X86Instruction.Or);
+        }
+
         public void Mov(Operand dest, Operand source, OperandType type)
         {
             WriteInstruction(dest, source, type, X86Instruction.Mov);

--- a/ARMeilleure/CodeGen/X86/CodeGenerator.cs
+++ b/ARMeilleure/CodeGen/X86/CodeGenerator.cs
@@ -49,6 +49,7 @@ namespace ARMeilleure.CodeGen.X86
             Add(Instruction.Load,                    GenerateLoad);
             Add(Instruction.Load16,                  GenerateLoad16);
             Add(Instruction.Load8,                   GenerateLoad8);
+            Add(Instruction.MemoryBarrier,           GenerateMemoryBarrier);
             Add(Instruction.Multiply,                GenerateMultiply);
             Add(Instruction.Multiply64HighSI,        GenerateMultiply64HighSI);
             Add(Instruction.Multiply64HighUI,        GenerateMultiply64HighUI);
@@ -538,7 +539,7 @@ namespace ARMeilleure.CodeGen.X86
                     context.Assembler.Lea(dest, memOp, dest.Type);
                 }
             }
-            else 
+            else
             {
                 ValidateBinOp(dest, src1, src2);
 
@@ -974,6 +975,11 @@ namespace ARMeilleure.CodeGen.X86
             Debug.Assert(value.Type.IsInteger());
 
             context.Assembler.Movzx8(value, address, value.Type);
+        }
+
+        private static void GenerateMemoryBarrier(CodeGenContext context, Operation operation)
+        {
+            context.Assembler.LockOr(MemoryOp(OperandType.I64, Register(X86Register.Rsp)), Const(0), OperandType.I32);
         }
 
         private static void GenerateMultiply(CodeGenContext context, Operation operation)

--- a/ARMeilleure/Instructions/InstEmitMemoryEx.cs
+++ b/ARMeilleure/Instructions/InstEmitMemoryEx.cs
@@ -52,11 +52,6 @@ namespace ARMeilleure.Instructions
             bool ordered   = (accType & AccessType.Ordered)   != 0;
             bool exclusive = (accType & AccessType.Exclusive) != 0;
 
-            if (ordered)
-            {
-                EmitBarrier(context);
-            }
-
             Operand address = context.Copy(GetIntOrSP(context, op.Rn));
 
             if (pair)
@@ -100,6 +95,12 @@ namespace ARMeilleure.Instructions
 
                 SetIntOrZR(context, op.Rt, value);
             }
+
+            if (ordered)
+            {
+                // Memory operations after this load may be only executed after the load completes.
+                EmitBarrier(context);
+            }
         }
 
         public static void Prfm(ArmEmitterContext context)
@@ -132,6 +133,7 @@ namespace ARMeilleure.Instructions
 
             if (ordered)
             {
+                // Memory operations before this store must have completed before the store is executed.
                 EmitBarrier(context);
             }
 
@@ -167,9 +169,7 @@ namespace ARMeilleure.Instructions
 
         private static void EmitBarrier(ArmEmitterContext context)
         {
-            // Note: This barrier is most likely not necessary, and probably
-            // doesn't make any difference since we need to do a ton of stuff
-            // (software MMU emulation) to read or write anything anyway.
+            context.MemoryBarrier();
         }
     }
 }

--- a/ARMeilleure/Instructions/InstEmitMemoryEx.cs
+++ b/ARMeilleure/Instructions/InstEmitMemoryEx.cs
@@ -52,6 +52,11 @@ namespace ARMeilleure.Instructions
             bool ordered   = (accType & AccessType.Ordered)   != 0;
             bool exclusive = (accType & AccessType.Exclusive) != 0;
 
+            if (ordered)
+            {
+                EmitBarrier(context);
+            }
+
             Operand address = context.Copy(GetIntOrSP(context, op.Rn));
 
             if (pair)
@@ -95,12 +100,6 @@ namespace ARMeilleure.Instructions
 
                 SetIntOrZR(context, op.Rt, value);
             }
-
-            if (ordered)
-            {
-                // Memory operations after this load may be only executed after the load completes.
-                EmitBarrier(context);
-            }
         }
 
         public static void Prfm(ArmEmitterContext context)
@@ -133,7 +132,6 @@ namespace ARMeilleure.Instructions
 
             if (ordered)
             {
-                // Memory operations before this store must have completed before the store is executed.
                 EmitBarrier(context);
             }
 

--- a/ARMeilleure/IntermediateRepresentation/Instruction.cs
+++ b/ARMeilleure/IntermediateRepresentation/Instruction.cs
@@ -26,6 +26,7 @@ namespace ARMeilleure.IntermediateRepresentation
         Load16,
         Load8,
         LoadArgument,
+        MemoryBarrier,
         Multiply,
         Multiply64HighSI,
         Multiply64HighUI,

--- a/ARMeilleure/Translation/EmitterContext.cs
+++ b/ARMeilleure/Translation/EmitterContext.cs
@@ -325,6 +325,11 @@ namespace ARMeilleure.Translation
             Add(Instruction.LoadFromContext);
         }
 
+        public void MemoryBarrier()
+        {
+            Add(Instruction.MemoryBarrier);
+        }
+
         public Operand Multiply(Operand op1, Operand op2)
         {
             return Add(Instruction.Multiply, Local(op1.Type), op1, op2);

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -27,7 +27,7 @@ namespace ARMeilleure.Translation.PTC
         private const string OuterHeaderMagicString = "PTCohd\0\0";
         private const string InnerHeaderMagicString = "PTCihd\0\0";
 
-        private const uint InternalVersion = 2953; //! To be incremented manually for each change to the ARMeilleure project.
+        private const uint InternalVersion = 123; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -27,7 +27,7 @@ namespace ARMeilleure.Translation.PTC
         private const string OuterHeaderMagicString = "PTCohd\0\0";
         private const string InnerHeaderMagicString = "PTCihd\0\0";
 
-        private const uint InternalVersion = 123; //! To be incremented manually for each change to the ARMeilleure project.
+        private const uint InternalVersion = 3015; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";


### PR DESCRIPTION
This just adds a memory barrier for the guest barrier instructions on the CPU. Before we had "host mapped memory" (the POWER PR), this was not *as* important because software memory emulation had to do address translation and validation, which would generate a large number of instructions per memory access, which makes memory reordering across separate guest memory accesses less likely. With the change it becomes a bigger problem because guest memory access can compile to a single host instruction.

Should fix softlocks on those games:
- Pokémon Mystery Dungeon DX (would sometimes get stuck on a black screen right before the title screen).
- Pokémon Brilliant Diamond/Shining Pearl (usually entering or exiting buildings, or changing areas in general).
Potentially also affected:
- Pokémon Sword/Shield? I know it has softlocks but I'm not familiarized with this one.
- YUME NIKKI Dream Diary (also before fully showing the title screen and Press Start button).
- Likely others?

Would appreciate testing for some of the games above, since due to the nature of this issue (happening completely randomly or not at all, depending on CPU vendor and model etc). Also would be nice to get confirmation that it's not causing any noticeable performance regression, or other issues that didn't exist before in general.

Closes #2719