### PR TITLE
Fix deadlock for GPU counter report when 0 draws are done

### DIFF
--- a/Ryujinx.Graphics.OpenGL/Queries/BufferedQuery.cs
+++ b/Ryujinx.Graphics.OpenGL/Queries/BufferedQuery.cs
@@ -56,6 +56,11 @@ namespace Ryujinx.Graphics.OpenGL.Queries
                 GL.GetQueryObject(Query, GetQueryObjectParam.QueryResult, (long*)0);
                 GL.MemoryBarrier(MemoryBarrierFlags.QueryBufferBarrierBit | MemoryBarrierFlags.ClientMappedBufferBarrierBit);
             }
+            else
+            {
+                // Dummy result, just return 0.
+                Marshal.WriteInt64(_bufferMap, 0L);
+            }
         }
 
         public bool TryGetResult(out long result)

--- a/Ryujinx.Graphics.OpenGL/Queries/CounterQueue.cs
+++ b/Ryujinx.Graphics.OpenGL/Queries/CounterQueue.cs
@@ -119,19 +119,10 @@ namespace Ryujinx.Graphics.OpenGL.Queries
                     _current.ReserveForHostAccess();
                 }
 
-                if (draws > 0)
-                {
-                    _current.Complete(true);
-                    _events.Enqueue(_current);
+                _current.Complete(draws > 0);
+                _events.Enqueue(_current);
 
-                    _current.OnResult += resultHandler;
-                }
-                else
-                {
-                    _current.Complete(false);
-                    _current.Dispose();
-                    resultHandler(_current, 0);
-                }
+                _current.OnResult += resultHandler;
 
                 result = _current;
 


### PR DESCRIPTION
This fixes a rare bug where reporting a counter for a region containing 0 draws could deadlock the GPU. If this write overlaps with a tracking action, then the GPU could end up waiting on something that it's meant to do in the future, so it would just get stuck.

Before, this reported immediately and wrote the result to guest memory (tracked) from the backend thread. The backend thread cannot be allowed to trigger read actions that wait on the GPU when backend threading is enabled, as it can end up waiting on itself, and never advancing. This is the only case that does this...

In the case of backend multithreading's `SyncMap`, it would try to wait for a backend sync object that does not yet fully exist, as the sync object would exist according to the GPU and tracking, but it has not yet been created by the backend (and never will be, since it's stuck).

The fix is to queue the 0 draw event just like any other, its _bufferMap value is just forced to 0, and it will be flushed with other events on the counter queue.

This affects games that use Conditional Rendering: SMO, MK8, Splatoon 2, at least one of the Yokai Watch games, though it is very uncommon as it require a written buffer sharing a page with a counter report address, and a 0 draw report. Was generally indicated by a red message in log saying that the _query result timed out after 5000 tries_, but not always the cause. These games should be tested to make sure there's no regression.