### PR TITLE
amadeus: Fix possible device sink input out of bound

### DIFF
--- a/Ryujinx.Audio/Renderer/Dsp/Command/DeviceSinkCommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/DeviceSinkCommand.cs
@@ -52,7 +52,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
             InputCount = sink.Parameter.InputCount;
             InputBufferIndices = new ushort[InputCount];
 
-            for (int i = 0; i < InputCount; i++)
+            for (int i = 0; i < Math.Min(InputCount, Constants.ChannelCountMax); i++)
             {
                 InputBufferIndices[i] = (ushort)(bufferOffset + sink.Parameter.Input[i]);
             }


### PR DESCRIPTION
This fix an out of bound when indexing inputs for games that uses unsupported input count. (8 here)

Death Coming now goes to menu but crash trying to contact online servers (even with guest internet disabled)

![image](https://user-images.githubusercontent.com/1760003/150699473-9e8656de-084a-4482-882c-84e90421b012.png)

Close #2724.