### PR TITLE
Fix calls passing V128 values on Linux

### DIFF
--- a/ARMeilleure/CodeGen/X86/PreAllocator.cs
+++ b/ARMeilleure/CodeGen/X86/PreAllocator.cs
@@ -796,6 +796,8 @@ namespace ARMeilleure.CodeGen.X86
                 }
             }
 
+            node.SetSources(sources.ToArray());
+
             if (dest != default)
             {
                 if (dest.Type == OperandType.V128)
@@ -822,9 +824,7 @@ namespace ARMeilleure.CodeGen.X86
 
                     node.Destination = retReg;
                 }
-            }
-
-            node.SetSources(sources.ToArray());
+            }            
         }
 
         private static void HandleTailcallSystemVAbi(IntrusiveList<Operation> nodes, StackAllocator stackAlloc, Operation node)

--- a/ARMeilleure/CodeGen/X86/PreAllocator.cs
+++ b/ARMeilleure/CodeGen/X86/PreAllocator.cs
@@ -824,7 +824,7 @@ namespace ARMeilleure.CodeGen.X86
 
                     node.Destination = retReg;
                 }
-            }            
+            }
         }
 
         private static void HandleTailcallSystemVAbi(IntrusiveList<Operation> nodes, StackAllocator stackAlloc, Operation node)

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -27,7 +27,7 @@ namespace ARMeilleure.Translation.PTC
         private const string OuterHeaderMagicString = "PTCohd\0\0";
         private const string InnerHeaderMagicString = "PTCihd\0\0";
 
-        private const uint InternalVersion = 3015; //! To be incremented manually for each change to the ARMeilleure project.
+        private const uint InternalVersion = 3034; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";


### PR DESCRIPTION
This fixes a regression introduced on #2515 where in some cases, during the pre-allocation stage, the new register operations would not be added to the call operation node. This would cause the register allocator to not keep track of the fixed registers (possibly overwriting the register values), and also to do register allocation for the operands passed on the call (which it should not, calls are supposed to be entirely handled by the pre-allocator, as the ABI requires each argument to be passed on a specific register or stack offset).

This only affects Linux, and mostly calls that passes V128 values (those are passed on a pair of 2 general purpose registers on Linux).

Fixes #2805, fixes #2864, fixes #3024 and fixes #3028.
Yes, that fixes the save file corrupted error on Pokémon Sword/Shield.
Testing is welcome.

Note for people testing this: Existing saves created on any version after the linked PR was merged are most likely actually corrupted, so you'll need to delete them. Saves created before the bug was introduced (or created on Windows) should be fine.