### PR TITLE
Fix: Autoupdater doesn't set the correct permissions on Linux/Unix

### DIFF
--- a/Ryujinx/Modules/Updater/Updater.cs
+++ b/Ryujinx/Modules/Updater/Updater.cs
@@ -396,7 +396,7 @@ namespace Ryujinx.Modules
 
             if (!OperatingSystem.IsWindows())
             {
-                chmod(ryuBin, 0777);
+                chmod(ryuBin, 493);
             }
         }
 


### PR DESCRIPTION
After downloading the latest release from GitHub actions which doesn't have executable rights we call chmod from the binding to libc that we have created. While the chmod command accepts permissions in Symbolic Mode (for example +x for executable rights) or Octal Mode (for example 755), the libc api accepts permissions in Decimal Mode. The 0 preceding 777 in the code suggests that its an octal number in a language like C however such thing does not exist in C# therefore we need to convert it to Decimal. The reason 755 is chosen instead of 777 this time is because these are the default permissions dotnet gives the binary and when converted in decimal the equivalent is 493.

Closes #2497