### PR TITLE
Add timestamp to 16-byte/4-word semaphore releases.

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -115,8 +115,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                 }
                 else /* if (type == LaunchDmaSemaphoreType.ReleaseFourWordSemaphore) */
                 {
-                    _channel.MemoryManager.Write(address, (ulong)_state.State.SetSemaphorePayload);
                     _channel.MemoryManager.Write(address + 8, _context.GetTimestamp());
+                    _channel.MemoryManager.Write(address, (ulong)_state.State.SetSemaphorePayload);
                 }
             }
         }

--- a/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -115,7 +115,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                 }
                 else /* if (type == LaunchDmaSemaphoreType.ReleaseFourWordSemaphore) */
                 {
-                    Logger.Warning?.Print(LogClass.Gpu, "DMA semaphore type ReleaseFourWordSemaphore was used, but is not currently implemented.");
+                    _channel.MemoryManager.Write(address, _state.State.SetSemaphorePayload);
+                    _channel.MemoryManager.Write(address + 8, _context.GetTimestamp());
                 }
             }
         }

--- a/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -115,7 +115,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                 }
                 else /* if (type == LaunchDmaSemaphoreType.ReleaseFourWordSemaphore) */
                 {
-                    _channel.MemoryManager.Write(address, _state.State.SetSemaphorePayload);
+                    _channel.MemoryManager.Write(address, (ulong)_state.State.SetSemaphorePayload);
                     _channel.MemoryManager.Write(address + 8, _context.GetTimestamp());
                 }
             }

--- a/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoClass.cs
@@ -75,6 +75,12 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
 
             SemaphoredOperation operation = _state.State.SemaphoredOperation;
 
+            if (_state.State.SemaphoredReleaseSize == SemaphoredReleaseSize.SixteenBytes)
+            {
+                _parent.MemoryManager.Write(address + 4, 0);
+                _parent.MemoryManager.Write(address + 8, _context.GetTimestamp());
+            }
+
             // TODO: Acquire operations (Wait), interrupts for invalid combinations.
             if (operation == SemaphoredOperation.Release)
             {

--- a/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -1,3 +1,4 @@
+using Ryujinx.Common;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Engine.GPFifo;
 using Ryujinx.Graphics.Gpu.Memory;
@@ -15,6 +16,9 @@ namespace Ryujinx.Graphics.Gpu
     /// </summary>
     public sealed class GpuContext : IDisposable
     {
+        private const int NsToTicksFractionNumerator = 384;
+        private const int NsToTicksFractionDenominator = 625;
+
         /// <summary>
         /// Event signaled when the host emulation context is ready to be used by the gpu context.
         /// </summary>
@@ -178,6 +182,46 @@ namespace Ryujinx.Graphics.Gpu
                 physicalMemory.ShaderCache.ShaderCacheStateChanged -= ShaderCacheStateUpdate;
                 physicalMemory.Dispose();
             }
+        }
+
+        /// <summary>
+        /// Converts a nanoseconds timestamp value to Maxwell time ticks.
+        /// </summary>
+        /// <remarks>
+        /// The frequency is 614400000 Hz.
+        /// </remarks>
+        /// <param name="nanoseconds">Timestamp in nanoseconds</param>
+        /// <returns>Maxwell ticks</returns>
+        private static ulong ConvertNanosecondsToTicks(ulong nanoseconds)
+        {
+            // We need to divide first to avoid overflows.
+            // We fix up the result later by calculating the difference and adding
+            // that to the result.
+            ulong divided = nanoseconds / NsToTicksFractionDenominator;
+
+            ulong rounded = divided * NsToTicksFractionDenominator;
+
+            ulong errorBias = (nanoseconds - rounded) * NsToTicksFractionNumerator / NsToTicksFractionDenominator;
+
+            return divided * NsToTicksFractionNumerator + errorBias;
+        }
+
+        /// <summary>
+        /// Gets the value of the GPU timer.
+        /// </summary>
+        /// <returns>The current GPU timestamp</returns>
+        public ulong GetTimestamp()
+        {
+            ulong ticks = ConvertNanosecondsToTicks((ulong)PerformanceCounter.ElapsedNanoseconds);
+
+            if (GraphicsConfig.FastGpuTime)
+            {
+                // Divide by some amount to report time as if operations were performed faster than they really are.
+                // This can prevent some games from switching to a lower resolution because rendering is too slow.
+                ticks /= 256;
+            }
+
+            return ticks;
         }
 
         /// <summary>


### PR DESCRIPTION
BOTW was reading a ulong 8 bytes after a semaphore release. Turns out this is the timestamp it was trying to do performance calculation with, so I've made it write when necessary. This fixes BOTW being capped at 20fps all the time. (now it only does this when the game runs too slowly)

![image](https://user-images.githubusercontent.com/6294155/151426492-e82dd4c6-9c3f-496c-b98a-d3b1b92ade5b.png)

This mode was also added to the DMA semaphore I added recently, as it is required by a few games. (i think quake?)

The timestamp code has been moved to GPU context. Check other games with an unusually low framerate cap or dynamic resolution to see if they have improved.