### PR TITLE
Only initialize shader outputs that are actually used on the next stage

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -40,7 +40,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 3132;
+        private const ulong ShaderCodeGenVersion = 3054;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Shader/Decoders/Decoder.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/Decoder.cs
@@ -308,7 +308,8 @@ namespace Ryujinx.Graphics.Shader.Decoders
                     int attr = offset + elemIndex * 4;
                     if (attr >= AttributeConsts.UserAttributeBase && attr < AttributeConsts.UserAttributeEnd)
                     {
-                        int index = (attr - AttributeConsts.UserAttributeBase) / 16;
+                        int userAttr = attr - AttributeConsts.UserAttributeBase;
+                        int index = userAttr / 16;
 
                         if (isStore)
                         {
@@ -316,7 +317,7 @@ namespace Ryujinx.Graphics.Shader.Decoders
                         }
                         else
                         {
-                            config.SetInputUserAttribute(index, perPatch);
+                            config.SetInputUserAttribute(index, (userAttr >> 2) & 3, perPatch);
                         }
                     }
 

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -54,6 +54,11 @@ namespace Ryujinx.Graphics.Shader.Translation
         private int _nextUsedInputAttributes;
         private int _thisUsedInputAttributes;
 
+        public UInt128 NextInputAttributesComponents { get; private set; }
+        public UInt128 ThisInputAttributesComponents { get; private set; }
+        public UInt128 NextInputAttributesPerPatchComponents { get; private set; }
+        public UInt128 ThisInputAttributesPerPatchComponents { get; private set; }
+
         private int _usedConstantBuffers;
         private int _usedStorageBuffers;
         private int _usedStorageBuffersWrite;
@@ -227,11 +232,12 @@ namespace Ryujinx.Graphics.Shader.Translation
             UsedOutputAttributes |= 1 << index;
         }
 
-        public void SetInputUserAttribute(int index, bool perPatch)
+        public void SetInputUserAttribute(int index, int component, bool perPatch)
         {
             if (perPatch)
             {
                 UsedInputAttributesPerPatch |= 1 << index;
+                ThisInputAttributesPerPatchComponents |= UInt128.Pow2(index * 4 + component);
             }
             else
             {
@@ -239,6 +245,7 @@ namespace Ryujinx.Graphics.Shader.Translation
 
                 UsedInputAttributes |= mask;
                 _thisUsedInputAttributes |= mask;
+                ThisInputAttributesComponents |= UInt128.Pow2(index * 4 + component);
             }
         }
 
@@ -256,6 +263,8 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public void MergeFromtNextStage(ShaderConfig config)
         {
+            NextInputAttributesComponents = config.ThisInputAttributesComponents;
+            NextInputAttributesPerPatchComponents = config.ThisInputAttributesPerPatchComponents;
             NextUsesFixedFuncAttributes = config.UsedFeatures.HasFlag(FeatureFlags.FixedFuncAttr);
             MergeOutputUserAttributes(config.UsedInputAttributes, config.UsedInputAttributesPerPatch);
         }

--- a/Ryujinx.Graphics.Shader/Translation/UInt128.cs
+++ b/Ryujinx.Graphics.Shader/Translation/UInt128.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Numerics;
+
+namespace Ryujinx.Graphics.Shader.Translation
+{
+    struct UInt128 : IEquatable<UInt128>
+    {
+        public static UInt128 Zero => new UInt128() { _v0 = 0, _v1 = 0 };
+
+        private ulong _v0;
+        private ulong _v1;
+
+        public int TrailingZeroCount()
+        {
+            int count = BitOperations.TrailingZeroCount(_v0);
+            if (count == 64)
+            {
+                count += BitOperations.TrailingZeroCount(_v1);
+            }
+
+            return count;
+        }
+
+        public static UInt128 Pow2(int x)
+        {
+            if (x >= 64)
+            {
+                return new UInt128() { _v0 = 0, _v1 = 1UL << (x - 64 ) };
+            }
+
+            return new UInt128() { _v0 = 1UL << x, _v1 = 0 };
+        }
+
+        public static UInt128 operator ~(UInt128 x)
+        {
+            return new UInt128() { _v0 = ~x._v0, _v1 = ~x._v1 };
+        }
+
+        public static UInt128 operator &(UInt128 x, UInt128 y)
+        {
+            return new UInt128() { _v0 = x._v0 & y._v0, _v1 = x._v1 & y._v1 };
+        }
+
+        public static UInt128 operator |(UInt128 x, UInt128 y)
+        {
+            return new UInt128() { _v0 = x._v0 | y._v0, _v1 = x._v1 | y._v1 };
+        }
+
+        public static bool operator ==(UInt128 x, UInt128 y)
+        {
+            return x.Equals(y);
+        }
+
+        public static bool operator !=(UInt128 x, UInt128 y)
+        {
+            return !x.Equals(y);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is UInt128 other && Equals(other);
+        }
+
+        public bool Equals(UInt128 other)
+        {
+            return _v0 == other._v0 && _v1 == other._v1;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(_v0, _v1);
+        }
+    }
+}


### PR DESCRIPTION
If one shader stage reads an input that is not written by the previous stage, as per the spec, the contents are undefined. This is not a problem on NVIDIA as the contents are actually consistent for those uninitialized values, but it does cause issues for Intel and AMD. So to fix that, the shader translator adds code to explicitly initialize outputs that are used by the next stage, but might not be written on the current one.

Right now it initialize some outputs that don't need to be initialized, for one of those two reasons:
- The specific component is not accessed on the next stage. Right now it only keeps track of the entire vec4 input that is consumed on the next stage. It does not keep track of the individual XYZW float components.
- The output might not be used on the next stage at all. Right now it initializes both outputs written on the current stage *and* inputs consumed on the next one.

This change addresses both of the above cases. First, a new `UInt128` type was added. It is used to keep track of individual components that are used on the next stage, per input. Since there is a maximum of 32, and each one has 4 components (XYZW), 32 * 4 = 128 bits. Now, it will only initialize the specific components that are used on the next stage. Second, it now only initializes the outputs that are consumed on the next stage.

This should make the shader code a bit smaller as it removes those redundant operations, but there is another benefit here. On Pokémon Legends Arceus, the AMD OpenGL driver on Windows complains that some shader uses too many outputs. I'm not sure why it does that, one of the shader where it does this only has 12 outputs on the vertex shader, but anyway, this change also happens to fix this shader compilation error, and allows the models to render on OpenGL:
![image](https://user-images.githubusercontent.com/5624669/151566505-9004d1fb-520a-4cf9-bb44-902ca95815a2.png)

Testing is welcome (to ensure we have no regressions here), especially on Intel and AMD where the initialization is more important.
Here's some games I know that depends on it to render properly:
- Zelda Link's Awakening.
- Monster Hunter Stores 2: Wings of Ruin.
- Hatsune Miku Project DIVA MEGA 39's.
- Luigi's Mansion 3.
- Pokémon Legends Arceus.

I'm also interested in how Pokémon Legends Arceus is running on AMD OpenGL on Windows.