### PR TITLE
Try to ensure save data always has a valid owner ID

### DIFF
--- a/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
+++ b/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
@@ -505,7 +505,9 @@ namespace Ryujinx.HLE.FileSystem
 
             bool canFixBySaveDataId = extraData.Attribute.StaticSaveDataId == 0 && info.StaticSaveDataId != 0;
 
-            if (!canFixByProgramId && !canFixBySaveDataId)
+            bool hasEmptyOwnerId = extraData.OwnerId == 0 && info.Type != LibHac.Fs.SaveDataType.System;
+
+            if (!canFixByProgramId && !canFixBySaveDataId && !hasEmptyOwnerId)
             {
                 wasFixNeeded = false;
                 return Result.Success;

--- a/Ryujinx.HLE/HOS/ApplicationLoader.cs
+++ b/Ryujinx.HLE/HOS/ApplicationLoader.cs
@@ -776,6 +776,7 @@ namespace Ryujinx.HLE.HOS
                 // The set sizes don't actually matter as long as they're non-zero because we use directory savedata.
                 control.UserAccountSaveDataSize = 0x4000;
                 control.UserAccountSaveDataJournalSize = 0x4000;
+                control.SaveDataOwnerId = applicationId;
 
                 Logger.Warning?.Print(LogClass.Application,
                     "No control file was found for this game. Using a dummy one instead. This may cause inaccuracies in some games.");


### PR DESCRIPTION
- Run the extra data fix in FixExtraData on non-system saves that have no owner ID.
- Set the owner ID in the dummy application control property if an application doesn't have a proper one available.

This fixes programs giving PermissionDenied in most, if not all situations when mounting their save data