### PR TITLE
Fix small precision error on CPU reciprocal estimate instructions

### DIFF
--- a/ARMeilleure/Instructions/InstEmitSimdArithmetic.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdArithmetic.cs
@@ -3613,7 +3613,7 @@ namespace ARMeilleure.Instructions
             Operand masked = context.AddIntrinsic(Intrinsic.X86Pand, value, expMask);
             Operand isNaNInf = context.AddIntrinsic(Intrinsic.X86Pcmpeqd, masked, expMask);
 
-            value = context.AddIntrinsic(Intrinsic.X86Paddw, value, roundMask);
+            value = context.AddIntrinsic(Intrinsic.X86Paddd, value, roundMask);
             value = context.AddIntrinsic(Intrinsic.X86Pand, value, truncMask);
 
             return context.AddIntrinsic(Intrinsic.X86Blendvps, value, oValue, isNaNInf);

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -27,7 +27,7 @@ namespace ARMeilleure.Translation.PTC
         private const string OuterHeaderMagicString = "PTCohd\0\0";
         private const string InnerHeaderMagicString = "PTCihd\0\0";
 
-        private const uint InternalVersion = 3034; //! To be incremented manually for each change to the ARMeilleure project.
+        private const uint InternalVersion = 3061; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";


### PR DESCRIPTION
This just fixes a small oversight that I was already aware of for a while. The operation there is supposed to reduce the precision of the reciprocal instruction result, this is not necessary because *Intel* CPUs have more preicision than Arm CPUs for the reciprocal estimate instruction. The operation is supposed to round the value by adding a constant and then masking. However the instruction used was PADDW, which adds *words* (16-bits), when it should be using PADDD, which adds *double-words* (32-bits). This small bug could cause the lower bits of the float value to overflow, in some cases causing a small precision error in the mantissa field of the float value.

This should fix the "twitching" on some animations in Pokémon Legends Arceus.

Before (pay attention to the left arm):

https://user-images.githubusercontent.com/5624669/151679058-fc206649-ff95-461d-b64a-e24f67c8a946.mp4

After:

https://user-images.githubusercontent.com/5624669/151679063-39e83655-1a12-496d-89d6-4ad982d8b6a7.mp4

Testing is welcome.
