### PR TITLE
Do not allow render targets not explicitly written by the fragment shader to be modified

### DIFF
--- a/Ryujinx.Graphics.GAL/IRenderer.cs
+++ b/Ryujinx.Graphics.GAL/IRenderer.cs
@@ -20,7 +20,7 @@ namespace Ryujinx.Graphics.GAL
 
         BufferHandle CreateBuffer(int size);
 
-        IProgram CreateProgram(IShader[] shaders);
+        IProgram CreateProgram(IShader[] shaders, ShaderInfo info);
 
         ISampler CreateSampler(SamplerCreateInfo info);
         ITexture CreateTexture(TextureCreateInfo info, float scale);
@@ -33,7 +33,7 @@ namespace Ryujinx.Graphics.GAL
 
         Capabilities GetCapabilities();
 
-        IProgram LoadProgramBinary(byte[] programBinary);
+        IProgram LoadProgramBinary(byte[] programBinary, bool hasFragmentShader, ShaderInfo info);
 
         void SetBufferData(BufferHandle buffer, int offset, ReadOnlySpan<byte> data);
 

--- a/Ryujinx.Graphics.GAL/Multithreading/Resources/Programs/BinaryProgramRequest.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/Resources/Programs/BinaryProgramRequest.cs
@@ -5,17 +5,21 @@
         public ThreadedProgram Threaded { get; set; }
 
         private byte[] _data;
+        private bool _hasFragmentShader;
+        private ShaderInfo _info;
 
-        public BinaryProgramRequest(ThreadedProgram program, byte[] data)
+        public BinaryProgramRequest(ThreadedProgram program, byte[] data, bool hasFragmentShader, ShaderInfo info)
         {
             Threaded = program;
 
             _data = data;
+            _hasFragmentShader = hasFragmentShader;
+            _info = info;
         }
 
         public IProgram Create(IRenderer renderer)
         {
-            return renderer.LoadProgramBinary(_data);
+            return renderer.LoadProgramBinary(_data, _hasFragmentShader, _info);
         }
     }
 }

--- a/Ryujinx.Graphics.GAL/Multithreading/Resources/Programs/SourceProgramRequest.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/Resources/Programs/SourceProgramRequest.cs
@@ -7,12 +7,14 @@ namespace Ryujinx.Graphics.GAL.Multithreading.Resources.Programs
         public ThreadedProgram Threaded { get; set; }
 
         private IShader[] _shaders;
+        private ShaderInfo _info;
 
-        public SourceProgramRequest(ThreadedProgram program, IShader[] shaders)
+        public SourceProgramRequest(ThreadedProgram program, IShader[] shaders, ShaderInfo info)
         {
             Threaded = program;
 
             _shaders = shaders;
+            _info = info;
         }
 
         public IProgram Create(IRenderer renderer)
@@ -24,7 +26,7 @@ namespace Ryujinx.Graphics.GAL.Multithreading.Resources.Programs
                 return threaded?.Base;
             }).ToArray();
 
-            return renderer.CreateProgram(shaders);
+            return renderer.CreateProgram(shaders, _info);
         }
     }
 }

--- a/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
@@ -268,10 +268,10 @@ namespace Ryujinx.Graphics.GAL.Multithreading
             return handle;
         }
 
-        public IProgram CreateProgram(IShader[] shaders)
+        public IProgram CreateProgram(IShader[] shaders, ShaderInfo info)
         {
             var program = new ThreadedProgram(this);
-            SourceProgramRequest request = new SourceProgramRequest(program, shaders);
+            SourceProgramRequest request = new SourceProgramRequest(program, shaders, info);
             Programs.Add(request);
 
             New<CreateProgramCommand>().Set(Ref((IProgramRequest)request));
@@ -355,11 +355,11 @@ namespace Ryujinx.Graphics.GAL.Multithreading
             _baseRenderer.Initialize(logLevel);
         }
 
-        public IProgram LoadProgramBinary(byte[] programBinary)
+        public IProgram LoadProgramBinary(byte[] programBinary, bool hasFragmentShader, ShaderInfo info)
         {
             var program = new ThreadedProgram(this);
 
-            BinaryProgramRequest request = new BinaryProgramRequest(program, programBinary);
+            BinaryProgramRequest request = new BinaryProgramRequest(program, programBinary, hasFragmentShader, info);
             Programs.Add(request);
 
             New<CreateProgramCommand>().Set(Ref((IProgramRequest)request));

--- a/Ryujinx.Graphics.GAL/ShaderInfo.cs
+++ b/Ryujinx.Graphics.GAL/ShaderInfo.cs
@@ -1,0 +1,12 @@
+namespace Ryujinx.Graphics.GAL
+{
+    public struct ShaderInfo
+    {
+        public int FragmentOutputMap { get; }
+
+        public ShaderInfo(int fragmentOutputMap)
+        {
+            FragmentOutputMap = fragmentOutputMap;
+        }
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Shader/Cache/Definition/HostShaderCacheEntry.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/Cache/Definition/HostShaderCacheEntry.cs
@@ -77,7 +77,8 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache.Definition
                                                     programInfo.Images.Count,
                                                     programInfo.UsesInstanceId,
                                                     programInfo.UsesRtLayer,
-                                                    programInfo.ClipDistancesWritten);
+                                                    programInfo.ClipDistancesWritten,
+                                                    programInfo.FragmentOutputMap);
             CBuffers = programInfo.CBuffers.ToArray();
             SBuffers = programInfo.SBuffers.ToArray();
             Textures = programInfo.Textures.ToArray();
@@ -97,7 +98,8 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache.Definition
                 Images,
                 Header.UseFlags.HasFlag(UseFlags.InstanceId),
                 Header.UseFlags.HasFlag(UseFlags.RtLayer),
-                Header.ClipDistancesWritten);
+                Header.ClipDistancesWritten,
+                Header.FragmentOutputMap);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Shader/Cache/Definition/HostShaderCacheEntryHeader.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/Cache/Definition/HostShaderCacheEntryHeader.cs
@@ -26,7 +26,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache.Definition
     /// <summary>
     /// Host shader entry header used for binding information.
     /// </summary>
-    [StructLayout(LayoutKind.Sequential, Pack = 1, Size = 0x14)]
+    [StructLayout(LayoutKind.Sequential, Pack = 1, Size = 0x18)]
     struct HostShaderCacheEntryHeader
     {
         /// <summary>
@@ -71,6 +71,11 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache.Definition
         public byte Reserved;
 
         /// <summary>
+        /// Mask of components written by the fragment shader stage.
+        /// </summary>
+        public int FragmentOutputMap;
+
+        /// <summary>
         /// Create a new host shader cache entry header.
         /// </summary>
         /// <param name="cBuffersCount">Count of constant buffer descriptors</param>
@@ -78,6 +83,8 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache.Definition
         /// <param name="texturesCount">Count of texture descriptors</param>
         /// <param name="imagesCount">Count of image descriptors</param>
         /// <param name="usesInstanceId">Set to true if the shader uses instance id</param>
+        /// <param name="clipDistancesWritten">Mask of clip distances that are written to on the shader</param>
+        /// <param name="fragmentOutputMap">Mask of components written by the fragment shader stage</param>
         public HostShaderCacheEntryHeader(
             int cBuffersCount,
             int sBuffersCount,
@@ -85,13 +92,15 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache.Definition
             int imagesCount,
             bool usesInstanceId,
             bool usesRtLayer,
-            byte clipDistancesWritten) : this()
+            byte clipDistancesWritten,
+            int fragmentOutputMap) : this()
         {
             CBuffersCount        = cBuffersCount;
             SBuffersCount        = sBuffersCount;
             TexturesCount        = texturesCount;
             ImagesCount          = imagesCount;
             ClipDistancesWritten = clipDistancesWritten;
+            FragmentOutputMap    = fragmentOutputMap;
             InUse                = true;
 
             UseFlags = usesInstanceId ? UseFlags.InstanceId : UseFlags.None;

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -40,7 +40,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 1234;
+        private const ulong ShaderCodeGenVersion = 3063;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -756,8 +756,6 @@ namespace Ryujinx.Graphics.Gpu.Shader
                     shaders[stageIndex] = TranslateShader(_dumper, channel.MemoryManager, shaderContexts, stageIndex + 1);
                 }
 
-
-
                 List<IShader> hostShaders = new List<IShader>();
 
                 for (int stage = 0; stage < Constants.ShaderStages; stage++)

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -308,7 +308,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
                                 int fragmentOutputMap = -1;
                                 int fragmentIndex = (int)ShaderStage.Fragment - 1;
 
-                                if (hostShaderEntries[fragmentIndex].Header.InUse)
+                                if (hostShaderEntries[fragmentIndex] != null && hostShaderEntries[fragmentIndex].Header.InUse)
                                 {
                                     hasFragmentShader = true;
                                     fragmentOutputMap = hostShaderEntries[fragmentIndex].Header.FragmentOutputMap;

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -40,7 +40,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 3106;
+        private const ulong ShaderCodeGenVersion = 1234;
 
         // Progress reporting helpers
         private volatile int _shaderCount;
@@ -188,7 +188,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
                             {
                                 hostShaderEntries = HostShaderCacheEntry.Parse(hostProgramBinary, out ReadOnlySpan<byte> hostProgramBinarySpan);
                                 hostProgramBinary = hostProgramBinarySpan.ToArray();
-                                hostProgram = _context.Renderer.LoadProgramBinary(hostProgramBinary);
+                                hostProgram = _context.Renderer.LoadProgramBinary(hostProgramBinary, false, new ShaderInfo(-1));
                             }
 
                             ShaderCompileTask task = new ShaderCompileTask(taskDoneEvent);
@@ -252,7 +252,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
 
                                         // Compile shader and create program as the shader program binary got invalidated.
                                         shader.HostShader = _context.Renderer.CompileShader(ShaderStage.Compute, program.Code);
-                                        hostProgram = _context.Renderer.CreateProgram(new IShader[] { shader.HostShader });
+                                        hostProgram = _context.Renderer.CreateProgram(new IShader[] { shader.HostShader }, new ShaderInfo(-1));
 
                                         task.OnCompiled(hostProgram, (bool isNewProgramValid, ShaderCompileTask task) =>
                                         {
@@ -303,7 +303,18 @@ namespace Ryujinx.Graphics.Gpu.Shader
                             {
                                 hostShaderEntries = HostShaderCacheEntry.Parse(hostProgramBinary, out ReadOnlySpan<byte> hostProgramBinarySpan);
                                 hostProgramBinary = hostProgramBinarySpan.ToArray();
-                                hostProgram = _context.Renderer.LoadProgramBinary(hostProgramBinary);
+
+                                bool hasFragmentShader = false;
+                                int fragmentOutputMap = -1;
+                                int fragmentIndex = (int)ShaderStage.Fragment - 1;
+
+                                if (hostShaderEntries[fragmentIndex].Header.InUse)
+                                {
+                                    hasFragmentShader = true;
+                                    fragmentOutputMap = hostShaderEntries[fragmentIndex].Header.FragmentOutputMap;
+                                }
+
+                                hostProgram = _context.Renderer.LoadProgramBinary(hostProgramBinary, hasFragmentShader, new ShaderInfo(fragmentOutputMap));
                             }
 
                             ShaderCompileTask task = new ShaderCompileTask(taskDoneEvent);
@@ -426,7 +437,15 @@ namespace Ryujinx.Graphics.Gpu.Shader
                                             hostShaders.Add(hostShader);
                                         }
 
-                                        hostProgram = _context.Renderer.CreateProgram(hostShaders.ToArray());
+                                        int fragmentIndex = (int)ShaderStage.Fragment - 1;
+                                        int fragmentOutputMap = -1;
+
+                                        if (shaders[fragmentIndex] != null)
+                                        {
+                                            fragmentOutputMap = shaders[fragmentIndex].Info.FragmentOutputMap;
+                                        }
+
+                                        hostProgram = _context.Renderer.CreateProgram(hostShaders.ToArray(), new ShaderInfo(fragmentOutputMap));
 
                                         task.OnCompiled(hostProgram, (bool isNewProgramValid, ShaderCompileTask task) =>
                                         {
@@ -617,7 +636,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
 
                 shader.HostShader = _context.Renderer.CompileShader(ShaderStage.Compute, shader.Program.Code);
 
-                IProgram hostProgram = _context.Renderer.CreateProgram(new IShader[] { shader.HostShader });
+                IProgram hostProgram = _context.Renderer.CreateProgram(new IShader[] { shader.HostShader }, new ShaderInfo(-1));
 
                 cpShader = new ShaderBundle(hostProgram, shader);
 
@@ -737,6 +756,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
                     shaders[stageIndex] = TranslateShader(_dumper, channel.MemoryManager, shaderContexts, stageIndex + 1);
                 }
 
+
+
                 List<IShader> hostShaders = new List<IShader>();
 
                 for (int stage = 0; stage < Constants.ShaderStages; stage++)
@@ -755,7 +776,15 @@ namespace Ryujinx.Graphics.Gpu.Shader
                     hostShaders.Add(hostShader);
                 }
 
-                IProgram hostProgram = _context.Renderer.CreateProgram(hostShaders.ToArray());
+                int fragmentIndex = (int)ShaderStage.Fragment - 1;
+                int fragmentOutputMap = -1;
+
+                if (shaders[fragmentIndex] != null)
+                {
+                    fragmentOutputMap = shaders[fragmentIndex].Info.FragmentOutputMap;
+                }
+
+                IProgram hostProgram = _context.Renderer.CreateProgram(hostShaders.ToArray(), new ShaderInfo(fragmentOutputMap));
 
                 gpShaders = new ShaderBundle(hostProgram, shaders);
 

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -1016,7 +1016,7 @@ namespace Ryujinx.Graphics.OpenGL
                 prg.Bind();
             }
 
-            if (prg.HasFragmentShader)
+            if (prg.HasFragmentShader && _fragmentOutputMap != prg.FragmentOutputMap)
             {
                 _fragmentOutputMap = prg.FragmentOutputMap;
 

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -54,8 +54,8 @@ namespace Ryujinx.Graphics.OpenGL
         private ClipDepthMode _clipDepthMode;
 
         private uint _fragmentOutputMap;
-        private uint _componentMask;
-        private uint _currentComponentMask;
+        private uint _componentMasks;
+        private uint _currentComponentMasks;
 
         private uint _scissorEnables;
 
@@ -76,7 +76,7 @@ namespace Ryujinx.Graphics.OpenGL
             _clipDepthMode = ClipDepthMode.NegativeOneToOne;
 
             _fragmentOutputMap = uint.MaxValue;
-            _componentMask = uint.MaxValue;
+            _componentMasks = uint.MaxValue;
 
             var defaultScale = new Vector4<float> { X = 1f, Y = 0f, Z = 0f, W = 0f };
             new Span<Vector4<float>>(_renderScale).Fill(defaultScale);
@@ -1047,11 +1047,11 @@ namespace Ryujinx.Graphics.OpenGL
 
         public void SetRenderTargetColorMasks(ReadOnlySpan<uint> componentMasks)
         {
-            _componentMask = 0;
+            _componentMasks = 0;
 
             for (int index = 0; index < componentMasks.Length; index++)
             {
-                _componentMask |= componentMasks[index] << (index * 4);
+                _componentMasks |= componentMasks[index] << (index * 4);
 
                 RestoreComponentMask(index, force: false);
             }
@@ -1455,10 +1455,10 @@ namespace Ryujinx.Graphics.OpenGL
             uint blueMask = _fpIsBgra[index].X == 0 ? 4u : 1u;
 
             int shift = index * 4;
-            uint componentMask = _componentMask & _fragmentOutputMap;
+            uint componentMask = _componentMasks & _fragmentOutputMap;
             uint checkMask = 0xfu << shift;
 
-            if (!force && (componentMask & checkMask) == (_currentComponentMask & checkMask))
+            if (!force && (componentMask & checkMask) == (_currentComponentMasks & checkMask))
             {
                 return;
             }
@@ -1473,8 +1473,8 @@ namespace Ryujinx.Graphics.OpenGL
                 (componentMask & blueMask) != 0,
                 (componentMask & 8u) != 0);
 
-            _currentComponentMask &= ~checkMask;
-            _currentComponentMask |= componentMask;
+            _currentComponentMasks &= ~checkMask;
+            _currentComponentMasks |= componentMask;
         }
 
         public void RestoreScissor0Enable()

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -1457,8 +1457,9 @@ namespace Ryujinx.Graphics.OpenGL
             int shift = index * 4;
             uint componentMask = _componentMasks & _fragmentOutputMap;
             uint checkMask = 0xfu << shift;
+            uint componentMaskAtIndex = componentMask & checkMask;
 
-            if (!force && (componentMask & checkMask) == (_currentComponentMasks & checkMask))
+            if (!force && componentMaskAtIndex == (_currentComponentMasks & checkMask))
             {
                 return;
             }
@@ -1474,7 +1475,7 @@ namespace Ryujinx.Graphics.OpenGL
                 (componentMask & 8u) != 0);
 
             _currentComponentMasks &= ~checkMask;
-            _currentComponentMasks |= componentMask << shift;
+            _currentComponentMasks |= componentMaskAtIndex;
         }
 
         public void RestoreScissor0Enable()

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -1474,7 +1474,7 @@ namespace Ryujinx.Graphics.OpenGL
                 (componentMask & 8u) != 0);
 
             _currentComponentMasks &= ~checkMask;
-            _currentComponentMasks |= componentMask;
+            _currentComponentMasks |= componentMask << shift;
         }
 
         public void RestoreScissor0Enable()

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -66,9 +66,9 @@ namespace Ryujinx.Graphics.OpenGL
             return Buffer.Create(size);
         }
 
-        public IProgram CreateProgram(IShader[] shaders)
+        public IProgram CreateProgram(IShader[] shaders, ShaderInfo info)
         {
-            return new Program(shaders);
+            return new Program(shaders, info.FragmentOutputMap);
         }
 
         public ISampler CreateSampler(SamplerCreateInfo info)
@@ -202,9 +202,9 @@ namespace Ryujinx.Graphics.OpenGL
             _sync.Dispose();
         }
 
-        public IProgram LoadProgramBinary(byte[] programBinary)
+        public IProgram LoadProgramBinary(byte[] programBinary, bool hasFragmentShader, ShaderInfo info)
         {
-            return new Program(programBinary);
+            return new Program(programBinary, hasFragmentShader, info.FragmentOutputMap);
         }
 
         public void CreateSync(ulong id)

--- a/Ryujinx.Graphics.OpenGL/Shader.cs
+++ b/Ryujinx.Graphics.OpenGL/Shader.cs
@@ -7,6 +7,7 @@ namespace Ryujinx.Graphics.OpenGL
     class Shader : IShader
     {
         public int Handle { get; private set; }
+        public bool IsFragment { get; }
 
         public Shader(ShaderStage stage, string code)
         {
@@ -22,6 +23,7 @@ namespace Ryujinx.Graphics.OpenGL
             };
 
             Handle = GL.CreateShader(type);
+            IsFragment = stage == ShaderStage.Fragment;
 
             GL.ShaderSource(Handle, code);
             GL.CompileShader(Handle);

--- a/Ryujinx.Graphics.Shader/ShaderProgramInfo.cs
+++ b/Ryujinx.Graphics.Shader/ShaderProgramInfo.cs
@@ -5,32 +5,35 @@ namespace Ryujinx.Graphics.Shader
 {
     public class ShaderProgramInfo
     {
-        public ReadOnlyCollection<BufferDescriptor>  CBuffers { get; }
-        public ReadOnlyCollection<BufferDescriptor>  SBuffers { get; }
+        public ReadOnlyCollection<BufferDescriptor> CBuffers { get; }
+        public ReadOnlyCollection<BufferDescriptor> SBuffers { get; }
         public ReadOnlyCollection<TextureDescriptor> Textures { get; }
-        public ReadOnlyCollection<TextureDescriptor> Images   { get; }
+        public ReadOnlyCollection<TextureDescriptor> Images { get; }
 
         public bool UsesInstanceId { get; }
         public bool UsesRtLayer { get; }
         public byte ClipDistancesWritten { get; }
+        public int FragmentOutputMap { get; }
 
         public ShaderProgramInfo(
-            BufferDescriptor[]  cBuffers,
-            BufferDescriptor[]  sBuffers,
+            BufferDescriptor[] cBuffers,
+            BufferDescriptor[] sBuffers,
             TextureDescriptor[] textures,
             TextureDescriptor[] images,
-            bool                usesInstanceId,
-            bool                usesRtLayer,
-            byte                clipDistancesWritten)
+            bool usesInstanceId,
+            bool usesRtLayer,
+            byte clipDistancesWritten,
+            int fragmentOutputMap)
         {
             CBuffers = Array.AsReadOnly(cBuffers);
             SBuffers = Array.AsReadOnly(sBuffers);
             Textures = Array.AsReadOnly(textures);
-            Images   = Array.AsReadOnly(images);
+            Images = Array.AsReadOnly(images);
 
             UsesInstanceId = usesInstanceId;
             UsesRtLayer = usesRtLayer;
             ClipDistancesWritten = clipDistancesWritten;
+            FragmentOutputMap = fragmentOutputMap;
         }
     }
 }

--- a/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -172,11 +172,10 @@ namespace Ryujinx.Graphics.Shader.Translation
 
                 for (int rtIndex = 0; rtIndex < 8; rtIndex++)
                 {
-                    OmapTarget target = Config.OmapTargets[rtIndex];
-
                     for (int component = 0; component < 4; component++)
                     {
-                        if (!target.ComponentEnabled(component))
+                        bool componentEnabled = (Config.OmapTargets & (1 << (rtIndex * 4 + component))) != 0;
+                        if (!componentEnabled)
                         {
                             continue;
                         }
@@ -210,7 +209,8 @@ namespace Ryujinx.Graphics.Shader.Translation
                         }
                     }
 
-                    if (target.Enabled)
+                    bool targetEnabled = (Config.OmapTargets & (0xf << (rtIndex * 4))) != 0;
+                    if (targetEnabled)
                     {
                         Config.SetOutputUserAttribute(rtIndex, perPatch: false);
                         regIndexBase += 4;

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -25,9 +25,9 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public ImapPixelType[] ImapTypes { get; }
 
-        public OmapTarget[] OmapTargets    { get; }
-        public bool         OmapSampleMask { get; }
-        public bool         OmapDepth      { get; }
+        public int OmapTargets { get; }
+        public bool OmapSampleMask { get; }
+        public bool OmapDepth { get; }
 
         public IGpuAccessor GpuAccessor { get; }
 
@@ -135,21 +135,8 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public int GetDepthRegister()
         {
-            int count = 0;
-
-            for (int index = 0; index < OmapTargets.Length; index++)
-            {
-                for (int component = 0; component < 4; component++)
-                {
-                    if (OmapTargets[index].ComponentEnabled(component))
-                    {
-                        count++;
-                    }
-                }
-            }
-
             // The depth register is always two registers after the last color output.
-            return count + 1;
+            return BitOperations.PopCount((uint)OmapTargets) + 1;
         }
 
         public TextureFormat GetTextureFormat(int handle, int cbufSlot = -1)

--- a/Ryujinx.Graphics.Shader/Translation/ShaderHeader.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderHeader.cs
@@ -36,37 +36,6 @@ namespace Ryujinx.Graphics.Shader.Translation
         }
     }
 
-    struct OmapTarget
-    {
-        public bool Red   { get; }
-        public bool Green { get; }
-        public bool Blue  { get; }
-        public bool Alpha { get; }
-
-        public bool Enabled => Red || Green || Blue || Alpha;
-
-        public OmapTarget(bool red, bool green, bool blue, bool alpha)
-        {
-            Red   = red;
-            Green = green;
-            Blue  = blue;
-            Alpha = alpha;
-        }
-
-        public bool ComponentEnabled(int component)
-        {
-            switch (component)
-            {
-                case 0: return Red;
-                case 1: return Green;
-                case 2: return Blue;
-                case 3: return Alpha;
-            }
-
-            throw new ArgumentOutOfRangeException(nameof(component));
-        }
-    }
-
     class ShaderHeader
     {
         public int SphType { get; }
@@ -85,7 +54,7 @@ namespace Ryujinx.Graphics.Shader.Translation
         public bool GpPassthrough { get; }
 
         public bool DoesLoadOrStore { get; }
-        public bool DoesFp64        { get; }
+        public bool DoesFp64 { get; }
 
         public int StreamOutMask { get; }
 
@@ -104,13 +73,13 @@ namespace Ryujinx.Graphics.Shader.Translation
         public int MaxOutputVertexCount { get; }
 
         public int StoreReqStart { get; }
-        public int StoreReqEnd   { get; }
+        public int StoreReqEnd { get; }
 
         public ImapPixelType[] ImapTypes { get; }
 
-        public OmapTarget[] OmapTargets    { get; }
-        public bool         OmapSampleMask { get; }
-        public bool         OmapDepth      { get; }
+        public int OmapTargets { get; }
+        public bool OmapSampleMask { get; }
+        public bool OmapDepth { get; }
 
         public ShaderHeader(IGpuAccessor gpuAccessor, ulong address)
         {
@@ -144,7 +113,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             GpPassthrough = commonWord0.Extract(24);
 
             DoesLoadOrStore = commonWord0.Extract(26);
-            DoesFp64        = commonWord0.Extract(27);
+            DoesFp64 = commonWord0.Extract(27);
 
             StreamOutMask = commonWord0.Extract(28, 4);
 
@@ -163,7 +132,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             MaxOutputVertexCount = commonWord4.Extract(0, 12);
 
             StoreReqStart = commonWord4.Extract(12, 8);
-            StoreReqEnd   = commonWord4.Extract(24, 8);
+            StoreReqEnd = commonWord4.Extract(24, 8);
 
             ImapTypes = new ImapPixelType[32];
 
@@ -179,21 +148,11 @@ namespace Ryujinx.Graphics.Shader.Translation
             }
 
             int type2OmapTarget = header[18];
-            int type2Omap       = header[19];
+            int type2Omap = header[19];
 
-            OmapTargets = new OmapTarget[8];
-
-            for (int offset = 0; offset < OmapTargets.Length * 4; offset += 4)
-            {
-                OmapTargets[offset >> 2] = new OmapTarget(
-                    type2OmapTarget.Extract(offset + 0),
-                    type2OmapTarget.Extract(offset + 1),
-                    type2OmapTarget.Extract(offset + 2),
-                    type2OmapTarget.Extract(offset + 3));
-            }
-
+            OmapTargets = type2OmapTarget;
             OmapSampleMask = type2Omap.Extract(0);
-            OmapDepth      = type2Omap.Extract(1);
+            OmapDepth = type2Omap.Extract(1);
         }
     }
 }

--- a/Ryujinx.Graphics.Shader/Translation/Translator.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Translator.cs
@@ -105,7 +105,8 @@ namespace Ryujinx.Graphics.Shader.Translation
                 config.GetImageDescriptors(),
                 config.UsedFeatures.HasFlag(FeatureFlags.InstanceId),
                 config.UsedFeatures.HasFlag(FeatureFlags.RtLayer),
-                config.ClipDistancesWritten);
+                config.ClipDistancesWritten,
+                config.OmapTargets);
 
             return program;
         }


### PR DESCRIPTION
On OpenGL, if you have multiple render targets, but the fragment shader only writes one output, it still writes that output to all bound render targets. This does not match hardware behaviour, which is not writing those render targets. I fixed by forcing the color mask to be disabled for the components that the fragment shader does not write. For this, a new `ShaderInfo` struct is passed to the shader compilation functions on the backend. The struct was added because we will likely need to pass more information in the future (it already does on the Vulkan branch).

The output map handling was simplified on the shader translator. Instead of extracting each bit into a struct with 4 bools, it just stores and use the bitmask directly. This is also more efficient.

Fixes cave in Pokémon Legends Arceus.
Before:
![image](https://user-images.githubusercontent.com/5624669/151684973-ba6b2d0f-d10a-4b90-b690-e17710fd66d2.png)
After:
![image](https://user-images.githubusercontent.com/5624669/151684974-d16282d7-cd1a-463e-bfa3-29c169b8bb72.png)
(Thanks to Muffin for the save).
Also fixes black water on Paper Mario: Origami King. Lines on Pokémon Sword/Shield might be fixed too, but I did not test this one.

Testing is welcome (to ensure nothing regressed etc).