### PR TITLE
Fix bug that could cause depth buffer to be missing after clear

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -369,14 +369,14 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
                 if (color != null)
                 {
-                    if (clipRegionWidth > color.Width)
+                    if (clipRegionWidth > color.Width / samplesInX)
                     {
-                        clipRegionWidth = color.Width;
+                        clipRegionWidth = color.Width / samplesInX;
                     }
 
-                    if (clipRegionHeight > color.Height)
+                    if (clipRegionHeight > color.Height / samplesInY)
                     {
-                        clipRegionHeight = color.Height;
+                        clipRegionHeight = color.Height / samplesInY;
                     }
                 }
             }
@@ -400,14 +400,14 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
                 if (depthStencil != null)
                 {
-                    if (clipRegionWidth > depthStencil.Width)
+                    if (clipRegionWidth > depthStencil.Width / samplesInX)
                     {
-                        clipRegionWidth = depthStencil.Width;
+                        clipRegionWidth = depthStencil.Width / samplesInX;
                     }
 
-                    if (clipRegionHeight > depthStencil.Height)
+                    if (clipRegionHeight > depthStencil.Height / samplesInY)
                     {
-                        clipRegionHeight = depthStencil.Height;
+                        clipRegionHeight = depthStencil.Height / samplesInY;
                     }
                 }
             }

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -434,6 +434,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             new Span<ITexture>(_rtHostColors).Fill(null);
             _rtHostColors[index] = _rtColors[index]?.HostTexture;
+            _rtHostDs = null;
 
             _context.Renderer.Pipeline.SetRenderTargets(_rtHostColors, null);
         }


### PR DESCRIPTION
Fixes a regression introduced on #2994 that could cause the depth buffer to not be bound after a clear. The issue would happen if the game clears the color buffer after depth, and `clipSizeMismatch` is true. Additionally, make the clip region size take multisampled textures into account. Before, the size was incorrect for multisample textures, which would cause it to detect false mismatches.

Fixes regression where models would not be draw on Sonic Colors Ultimate. Thanks to Muffin for finding the regression.