### PR TITLE
Adjusting how deadzones are calculated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,9 @@ _TeamCity*
 # DotCover is a Code Coverage Tool
 *.dotCover
 
+# Rider is a Visual Studio alternative
+.idea/*
+
 # NCrunch
 *.ncrunch*
 .*crunch*.local.xml

--- a/Ryujinx.Input/HLE/NpadController.cs
+++ b/Ryujinx.Input/HLE/NpadController.cs
@@ -391,10 +391,15 @@ namespace Ryujinx.Input.HLE
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static JoystickPosition ApplyDeadzone(float x, float y, float deadzone)
         {
-            return new JoystickPosition
+            float magnitudeClamped = Math.Clamp(MathF.Sqrt(x * x + y * y), -1f, 1f);
+            if (magnitudeClamped < deadzone) return new JoystickPosition()
             {
-                Dx = ClampAxis(MathF.Abs(x) > deadzone ? x : 0.0f),
-                Dy = ClampAxis(MathF.Abs(y) > deadzone ? y : 0.0f)
+                Dx = 0, Dy = 0
+            };
+            return new JoystickPosition()
+            {
+                Dx = ClampAxis((x / (magnitudeClamped)) * ((magnitudeClamped - deadzone) / (1 - deadzone))),
+                Dy = ClampAxis((y / (magnitudeClamped)) * ((magnitudeClamped - deadzone) / (1 - deadzone)))
             };
         }
 

--- a/Ryujinx.Input/HLE/NpadController.cs
+++ b/Ryujinx.Input/HLE/NpadController.cs
@@ -392,10 +392,12 @@ namespace Ryujinx.Input.HLE
         private static JoystickPosition ApplyDeadzone(float x, float y, float deadzone)
         {
             float magnitudeClamped = Math.Clamp(MathF.Sqrt(x * x + y * y), -1f, 1f);
-            if (magnitudeClamped <= deadzone) return new JoystickPosition()
+            
+            if (magnitudeClamped <= deadzone)
             {
-                Dx = 0, Dy = 0
-            };
+                return new JoystickPosition() {Dx = 0, Dy = 0};
+            }
+            
             return new JoystickPosition()
             {
                 Dx = ClampAxis((x / magnitudeClamped) * ((magnitudeClamped - deadzone) / (1 - deadzone))),

--- a/Ryujinx.Input/HLE/NpadController.cs
+++ b/Ryujinx.Input/HLE/NpadController.cs
@@ -392,14 +392,14 @@ namespace Ryujinx.Input.HLE
         private static JoystickPosition ApplyDeadzone(float x, float y, float deadzone)
         {
             float magnitudeClamped = Math.Clamp(MathF.Sqrt(x * x + y * y), -1f, 1f);
-            if (magnitudeClamped < deadzone) return new JoystickPosition()
+            if (magnitudeClamped <= deadzone) return new JoystickPosition()
             {
                 Dx = 0, Dy = 0
             };
             return new JoystickPosition()
             {
-                Dx = ClampAxis((x / (magnitudeClamped)) * ((magnitudeClamped - deadzone) / (1 - deadzone))),
-                Dy = ClampAxis((y / (magnitudeClamped)) * ((magnitudeClamped - deadzone) / (1 - deadzone)))
+                Dx = ClampAxis((x / magnitudeClamped) * ((magnitudeClamped - deadzone) / (1 - deadzone))),
+                Dy = ClampAxis((y / magnitudeClamped) * ((magnitudeClamped - deadzone) / (1 - deadzone)))
             };
         }
 

--- a/Ryujinx.Input/HLE/NpadController.cs
+++ b/Ryujinx.Input/HLE/NpadController.cs
@@ -391,7 +391,7 @@ namespace Ryujinx.Input.HLE
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static JoystickPosition ApplyDeadzone(float x, float y, float deadzone)
         {
-            float magnitudeClamped = Math.Clamp(MathF.Sqrt(x * x + y * y), -1f, 1f);
+            float magnitudeClamped = Math.Min(MathF.Sqrt(x * x + y * y), 1f);
             
             if (magnitudeClamped <= deadzone)
             {
@@ -408,14 +408,12 @@ namespace Ryujinx.Input.HLE
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static short ClampAxis(float value)
         {
-            if (value <= -short.MaxValue)
+            if (Math.Sign(value) < 0)
             {
-                return -short.MaxValue;
+                return (short)Math.Max(value * -short.MinValue, short.MinValue);
             }
-            else
-            {
-                return (short)(value * short.MaxValue);
-            }
+
+            return (short)Math.Min(value * short.MaxValue, short.MaxValue);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Previously, the way that deadzones were calculated was that if the x axis is smaller than the set value of the deadzone, then X would be 0. same goes for Y. This works for a select few games, but say for example, in some game you're moving forward with the stick pressed all the way forward. if you wanted to turn say 5 degrees to the right, then it wouldn't be possible, as the deadzone would entirely prevent small adjustments on the edge of another axis. With this new implementation, it creates what is essentially a dead circle in the centre, and then smooths the edges from there. This both allows for small adjustments at the extreme ends of a specific axis, but also prevents the problem of a sudden burst of movement once you're past the deadzone, because of there being no "sharp" edges.

Also added .idea/* to the gitignore because I'm sure more than just me uses rider for development, and it makes life easier if it's just there.

Should fix #3074 