### PR TITLE
Make sure mesa_glthread gets a lowercase string

### DIFF
--- a/Ryujinx.Common/GraphicsDriver/DriverUtilities.cs
+++ b/Ryujinx.Common/GraphicsDriver/DriverUtilities.cs
@@ -6,7 +6,7 @@ namespace Ryujinx.Common.GraphicsDriver
     {
         public static void ToggleOGLThreading(bool enabled)
         {
-            Environment.SetEnvironmentVariable("mesa_glthread", enabled.ToString());
+            Environment.SetEnvironmentVariable("mesa_glthread", enabled.ToString().ToLower());
             Environment.SetEnvironmentVariable("__GL_THREADED_OPTIMIZATIONS", enabled ? "1" : "0");
 
             try


### PR DESCRIPTION
Ryujinx tries to enable threaded optimizations when threaded gal (Graphics Backend Multithreading) is Off, on Linux this is done by settings environmental variables. Since threaded gal conflicts with them Ryujinx also tries to force them off when it's on On or Auto (ATM Auto == On). The function ToggleOGLThreading takes a bool as input and the environmental variable that toggles this on MESA is mesa_glthread which takes true or false as arguments, so we convert the bool to a string using dotnet's ToString. The problem with ToString is that it converts to True or False which MESA doesn't accept and results in `illegal environment value for mesa_glthread: "False".  Ignoring.` So we have to convert it to lowercase using ToLower after it resulting in `ATTENTION: default value of option mesa_glthread overridden by environment.` as it should instead.

Interesting thing to note here, this env is applied when restarting Ryujinx after an update but not when running it manually so that's another bug to fix.