### PR TITLE
Implement rotate stick 90 degrees clockwise

### DIFF
--- a/Ryujinx.Common/Configuration/Hid/Controller/JoyconConfigControllerStick.cs
+++ b/Ryujinx.Common/Configuration/Hid/Controller/JoyconConfigControllerStick.cs
@@ -5,7 +5,7 @@
         public Stick Joystick { get; set; }
         public bool InvertStickX { get; set; }
         public bool InvertStickY { get; set; }
-        public bool SwapSticks { get; set; }
+        public bool Rotate90CW { get; set; }
         public Button StickButton { get; set; }
     }
 }

--- a/Ryujinx.Common/Configuration/Hid/Controller/JoyconConfigControllerStick.cs
+++ b/Ryujinx.Common/Configuration/Hid/Controller/JoyconConfigControllerStick.cs
@@ -5,6 +5,7 @@
         public Stick Joystick { get; set; }
         public bool InvertStickX { get; set; }
         public bool InvertStickY { get; set; }
+        public bool SwapSticks { get; set; }
         public Button StickButton { get; set; }
     }
 }

--- a/Ryujinx.Headless.SDL2/Program.cs
+++ b/Ryujinx.Headless.SDL2/Program.cs
@@ -220,7 +220,7 @@ namespace Ryujinx.Headless.SDL2
                             StickButton  = ConfigGamepadInputId.LeftStick,
                             InvertStickX = false,
                             InvertStickY = false,
-                            SwapSticks   = false,
+                            Rotate90CW   = false,
                         },
 
                         RightJoycon = new RightJoyconCommonConfig<ConfigGamepadInputId>
@@ -242,7 +242,7 @@ namespace Ryujinx.Headless.SDL2
                             StickButton  = ConfigGamepadInputId.RightStick,
                             InvertStickX = false,
                             InvertStickY = false,
-                            SwapSticks   = false,
+                            Rotate90CW   = false,
                         },
 
                         Motion = new StandardMotionConfigController

--- a/Ryujinx.Headless.SDL2/Program.cs
+++ b/Ryujinx.Headless.SDL2/Program.cs
@@ -220,6 +220,7 @@ namespace Ryujinx.Headless.SDL2
                             StickButton  = ConfigGamepadInputId.LeftStick,
                             InvertStickX = false,
                             InvertStickY = false,
+                            SwapSticks   = false,
                         },
 
                         RightJoycon = new RightJoyconCommonConfig<ConfigGamepadInputId>
@@ -241,6 +242,7 @@ namespace Ryujinx.Headless.SDL2
                             StickButton  = ConfigGamepadInputId.RightStick,
                             InvertStickX = false,
                             InvertStickY = false,
+                            SwapSticks   = false,
                         },
 
                         Motion = new StandardMotionConfigController

--- a/Ryujinx.Input.SDL2/SDL2Gamepad.cs
+++ b/Ryujinx.Input.SDL2/SDL2Gamepad.cs
@@ -350,6 +350,14 @@ namespace Ryujinx.Input.SDL2
                 {
                     resultY = -resultY;
                 }
+
+                if ((inputId == StickInputId.Left && _configuration.LeftJoyconStick.SwapSticks) ||
+                    (inputId == StickInputId.Right && _configuration.RightJoyconStick.SwapSticks))
+                {
+                    float temp = resultX;
+                    resultX = resultY;
+                    resultY = temp;
+                }
             }
 
             return (resultX, resultY);

--- a/Ryujinx.Input.SDL2/SDL2Gamepad.cs
+++ b/Ryujinx.Input.SDL2/SDL2Gamepad.cs
@@ -351,12 +351,12 @@ namespace Ryujinx.Input.SDL2
                     resultY = -resultY;
                 }
 
-                if ((inputId == StickInputId.Left && _configuration.LeftJoyconStick.SwapSticks) ||
-                    (inputId == StickInputId.Right && _configuration.RightJoyconStick.SwapSticks))
+                if ((inputId == StickInputId.Left && _configuration.LeftJoyconStick.Rotate90CW) ||
+                    (inputId == StickInputId.Right && _configuration.RightJoyconStick.Rotate90CW))
                 {
                     float temp = resultX;
                     resultX = resultY;
-                    resultY = temp;
+                    resultY = -temp;
                 }
             }
 

--- a/Ryujinx/Ui/Windows/ControllerWindow.cs
+++ b/Ryujinx/Ui/Windows/ControllerWindow.cs
@@ -73,6 +73,7 @@ namespace Ryujinx.Ui.Windows
         [GUI] ToggleButton _lStick;
         [GUI] CheckButton  _invertLStickX;
         [GUI] CheckButton  _invertLStickY;
+        [GUI] CheckButton  _swapLSticks;
         [GUI] ToggleButton _lStickUp;
         [GUI] ToggleButton _lStickDown;
         [GUI] ToggleButton _lStickLeft;
@@ -88,6 +89,7 @@ namespace Ryujinx.Ui.Windows
         [GUI] ToggleButton _rStick;
         [GUI] CheckButton  _invertRStickX;
         [GUI] CheckButton  _invertRStickY;
+        [GUI] CheckButton  _swapRSticks;
         [GUI] ToggleButton _rStickUp;
         [GUI] ToggleButton _rStickDown;
         [GUI] ToggleButton _rStickLeft;
@@ -490,6 +492,7 @@ namespace Ryujinx.Ui.Windows
                     _lStick.Label                     = controllerConfig.LeftJoyconStick.Joystick.ToString();
                     _invertLStickX.Active             = controllerConfig.LeftJoyconStick.InvertStickX;
                     _invertLStickY.Active             = controllerConfig.LeftJoyconStick.InvertStickY;
+                    _swapLSticks.Active               = controllerConfig.LeftJoyconStick.SwapSticks;
                     _lStickButton.Label               = controllerConfig.LeftJoyconStick.StickButton.ToString();
                     _dpadUp.Label                     = controllerConfig.LeftJoycon.DpadUp.ToString();
                     _dpadDown.Label                   = controllerConfig.LeftJoycon.DpadDown.ToString();
@@ -503,6 +506,7 @@ namespace Ryujinx.Ui.Windows
                     _rStick.Label                     = controllerConfig.RightJoyconStick.Joystick.ToString();
                     _invertRStickX.Active             = controllerConfig.RightJoyconStick.InvertStickX;
                     _invertRStickY.Active             = controllerConfig.RightJoyconStick.InvertStickY;
+                    _swapRSticks.Active               = controllerConfig.RightJoyconStick.SwapSticks;
                     _rStickButton.Label               = controllerConfig.RightJoyconStick.StickButton.ToString();
                     _a.Label                          = controllerConfig.RightJoycon.ButtonA.ToString();
                     _b.Label                          = controllerConfig.RightJoycon.ButtonB.ToString();
@@ -718,6 +722,7 @@ namespace Ryujinx.Ui.Windows
                         Joystick     = lStick,
                         InvertStickY = _invertLStickY.Active,
                         StickButton  = lStickButton,
+                        SwapSticks   = _swapLSticks.Active,
                     },
                     RightJoycon      = new RightJoyconCommonConfig<ConfigGamepadInputId>
                     {
@@ -737,6 +742,7 @@ namespace Ryujinx.Ui.Windows
                         Joystick     = rStick,
                         InvertStickY = _invertRStickY.Active,
                         StickButton  = rStickButton,
+                        SwapSticks   = _swapRSticks.Active,
                     },
                     Motion           = motionConfig,
                     Rumble           = new RumbleConfigController
@@ -1056,6 +1062,7 @@ namespace Ryujinx.Ui.Windows
                             StickButton  = ConfigGamepadInputId.LeftStick,
                             InvertStickX = false,
                             InvertStickY = false,
+                            SwapSticks   = false,
                         },
 
                         RightJoycon = new RightJoyconCommonConfig<ConfigGamepadInputId>
@@ -1077,6 +1084,7 @@ namespace Ryujinx.Ui.Windows
                             StickButton  = ConfigGamepadInputId.RightStick,
                             InvertStickX = false,
                             InvertStickY = false,
+                            SwapSticks   = false,
                         },
 
                         Motion = new StandardMotionConfigController

--- a/Ryujinx/Ui/Windows/ControllerWindow.cs
+++ b/Ryujinx/Ui/Windows/ControllerWindow.cs
@@ -73,7 +73,7 @@ namespace Ryujinx.Ui.Windows
         [GUI] ToggleButton _lStick;
         [GUI] CheckButton  _invertLStickX;
         [GUI] CheckButton  _invertLStickY;
-        [GUI] CheckButton  _swapLSticks;
+        [GUI] CheckButton  _rotateL90CW;
         [GUI] ToggleButton _lStickUp;
         [GUI] ToggleButton _lStickDown;
         [GUI] ToggleButton _lStickLeft;
@@ -89,7 +89,7 @@ namespace Ryujinx.Ui.Windows
         [GUI] ToggleButton _rStick;
         [GUI] CheckButton  _invertRStickX;
         [GUI] CheckButton  _invertRStickY;
-        [GUI] CheckButton  _swapRSticks;
+        [GUI] CheckButton  _rotateR90CW;
         [GUI] ToggleButton _rStickUp;
         [GUI] ToggleButton _rStickDown;
         [GUI] ToggleButton _rStickLeft;
@@ -492,7 +492,7 @@ namespace Ryujinx.Ui.Windows
                     _lStick.Label                     = controllerConfig.LeftJoyconStick.Joystick.ToString();
                     _invertLStickX.Active             = controllerConfig.LeftJoyconStick.InvertStickX;
                     _invertLStickY.Active             = controllerConfig.LeftJoyconStick.InvertStickY;
-                    _swapLSticks.Active               = controllerConfig.LeftJoyconStick.SwapSticks;
+                    _rotateL90CW.Active               = controllerConfig.LeftJoyconStick.Rotate90CW;
                     _lStickButton.Label               = controllerConfig.LeftJoyconStick.StickButton.ToString();
                     _dpadUp.Label                     = controllerConfig.LeftJoycon.DpadUp.ToString();
                     _dpadDown.Label                   = controllerConfig.LeftJoycon.DpadDown.ToString();
@@ -506,7 +506,7 @@ namespace Ryujinx.Ui.Windows
                     _rStick.Label                     = controllerConfig.RightJoyconStick.Joystick.ToString();
                     _invertRStickX.Active             = controllerConfig.RightJoyconStick.InvertStickX;
                     _invertRStickY.Active             = controllerConfig.RightJoyconStick.InvertStickY;
-                    _swapRSticks.Active               = controllerConfig.RightJoyconStick.SwapSticks;
+                    _rotateR90CW.Active               = controllerConfig.RightJoyconStick.Rotate90CW;
                     _rStickButton.Label               = controllerConfig.RightJoyconStick.StickButton.ToString();
                     _a.Label                          = controllerConfig.RightJoycon.ButtonA.ToString();
                     _b.Label                          = controllerConfig.RightJoycon.ButtonB.ToString();
@@ -722,7 +722,7 @@ namespace Ryujinx.Ui.Windows
                         Joystick     = lStick,
                         InvertStickY = _invertLStickY.Active,
                         StickButton  = lStickButton,
-                        SwapSticks   = _swapLSticks.Active,
+                        Rotate90CW   = _rotateL90CW.Active,
                     },
                     RightJoycon      = new RightJoyconCommonConfig<ConfigGamepadInputId>
                     {
@@ -742,7 +742,7 @@ namespace Ryujinx.Ui.Windows
                         Joystick     = rStick,
                         InvertStickY = _invertRStickY.Active,
                         StickButton  = rStickButton,
-                        SwapSticks   = _swapRSticks.Active,
+                        Rotate90CW   = _rotateR90CW.Active,
                     },
                     Motion           = motionConfig,
                     Rumble           = new RumbleConfigController
@@ -1062,7 +1062,7 @@ namespace Ryujinx.Ui.Windows
                             StickButton  = ConfigGamepadInputId.LeftStick,
                             InvertStickX = false,
                             InvertStickY = false,
-                            SwapSticks   = false,
+                            Rotate90CW   = false,
                         },
 
                         RightJoycon = new RightJoyconCommonConfig<ConfigGamepadInputId>
@@ -1084,7 +1084,7 @@ namespace Ryujinx.Ui.Windows
                             StickButton  = ConfigGamepadInputId.RightStick,
                             InvertStickX = false,
                             InvertStickY = false,
-                            SwapSticks   = false,
+                            Rotate90CW   = false,
                         },
 
                         Motion = new StandardMotionConfigController

--- a/Ryujinx/Ui/Windows/ControllerWindow.glade
+++ b/Ryujinx/Ui/Windows/ControllerWindow.glade
@@ -740,6 +740,19 @@
                                             <property name="top_attach">1</property>
                                           </packing>
                                         </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="_swapLSticks">
+                                            <property name="label" translatable="yes">Swap Sticks</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">2</property>
+                                            <property name="top_attach">2</property>
+                                          </packing>
+                                        </child>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -1695,6 +1708,19 @@
                                           <packing>
                                             <property name="left_attach">2</property>
                                             <property name="top_attach">1</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="_swapRSticks">
+                                            <property name="label" translatable="yes">Swap Sticks</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">2</property>
+                                            <property name="top_attach">2</property>
                                           </packing>
                                         </child>
                                       </object>

--- a/Ryujinx/Ui/Windows/ControllerWindow.glade
+++ b/Ryujinx/Ui/Windows/ControllerWindow.glade
@@ -741,8 +741,8 @@
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkCheckButton" id="_swapLSticks">
-                                            <property name="label" translatable="yes">Swap Sticks</property>
+                                          <object class="GtkCheckButton" id="_rotateL90CW">
+                                            <property name="label" translatable="yes">Rotate 90° Clockwise</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="receives_default">False</property>
@@ -1711,8 +1711,8 @@
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkCheckButton" id="_swapRSticks">
-                                            <property name="label" translatable="yes">Swap Sticks</property>
+                                          <object class="GtkCheckButton" id="_rotateR90CW">
+                                            <property name="label" translatable="yes">Rotate 90° Clockwise</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
                                             <property name="receives_default">False</property>


### PR DESCRIPTION
One solution to feature request #2287
Instead of mapping axes independently I added simple option to swap X/Y sticks.

NOTE: I encountered an issue that probably needs fixing. Inverting axes options work properly if we select Pro Controller or Joycon Pair for controller type, but if we select Joycon Right, invert options for left sticks are actually used for right stick.