### PR TITLE
Ship SoundIO library only for the specified runtime

### DIFF
--- a/Ryujinx.Audio.Backends.SoundIo/Ryujinx.Audio.Backends.SoundIo.csproj
+++ b/Ryujinx.Audio.Backends.SoundIo/Ryujinx.Audio.Backends.SoundIo.csproj
@@ -3,9 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <RuntimeIdentifiers>linux-x64</RuntimeIdentifiers>
-    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
-    <RuntimeIdentifiers>osx-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Ryujinx.Audio.Backends.SoundIo/Ryujinx.Audio.Backends.SoundIo.csproj
+++ b/Ryujinx.Audio.Backends.SoundIo/Ryujinx.Audio.Backends.SoundIo.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RuntimeIdentifiers>linux-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
On the project file for the project ```Ryujinx.Audio.Backends.SoundIo``` we specify which SoundIO library will be published depending on the RuntimeIdentifier property; if it isn't linux-x64 or osx-64 it is Windows therefore it gets a .dll, if it isn't linux-x64 or win-x64 then it's OS X so it gets a .dylib and if it isn't win-x64 or osx-64 it has to be Linux so it gets a .so file. And these checks work fine when building the project as an individual project. So if you do for example ```dotnet build Ryujinx.Audio.Backends.SoundIo/Ryujinx.Audio.Backends.SoundIo.csproj -o soundio -r osx-x64``` the generated soundio folder will contain a .dylib but not a .dll or .so file as it should. However, when building Ryujinx as a whole and ```Ryujinx.Audio.Backends.SoundIo``` is built as a subproject the property isn't passed to MSBuild. In order for it to work we have to add the supported RuntimeIdentifiers on the PropertyGroup.

Closes #2399 