### PR TITLE
InstEmitMemory32: Literal loads always have word-aligned PC

### DIFF
--- a/ARMeilleure/Instructions/InstEmitHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitHelper.cs
@@ -47,6 +47,20 @@ namespace ARMeilleure.Instructions
             }
         }
 
+        public static Operand GetIntA32AlignedPC(ArmEmitterContext context, int regIndex)
+        {
+            if (regIndex == RegisterAlias.Aarch32Pc)
+            {
+                OpCode32 op = (OpCode32)context.CurrOp;
+
+                return Const((int)(op.GetPc() & 0xfffffffc));
+            }
+            else
+            {
+                return Register(GetRegisterAlias(context.Mode, regIndex), RegisterType.Integer, OperandType.I32);
+            }
+        }
+
         public static Operand GetVecA32(int regIndex)
         {
             return Register(regIndex, RegisterType.Vector, OperandType.V128);

--- a/ARMeilleure/Instructions/InstEmitMemory32.cs
+++ b/ARMeilleure/Instructions/InstEmitMemory32.cs
@@ -153,7 +153,7 @@ namespace ARMeilleure.Instructions
         {
             OpCode32Mem op = (OpCode32Mem)context.CurrOp;
 
-            Operand n = context.Copy(GetIntA32(context, op.Rn));
+            Operand n = context.Copy(GetIntA32AlignedPC(context, op.Rn));
             Operand m = GetMemM(context, setCarry: false);
 
             Operand temp = default;


### PR DESCRIPTION
There are a few times when reading from R15 is very slightly different from normal and returns a word-aligned PC instead:

1. During a literal load.
2. During a two-word thumb BLX instruction.
3. During an ADR instruction.
4. During a literal store (the only one which isn't UNPREDICTABLE is a VFP store, afaik.)

Thus for the above special cases we need to have a different register read function.

The reason this is an issue is because the value of PC which is exposed to the memory addressing circuitry is always word aligned.

The effect of this change will only be noticeable once thumb support is implemented.