### PR TITLE
Fix missing geometry shader passthrough inputs

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -40,7 +40,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 3012;
+        private const ulong ShaderCodeGenVersion = 3106;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
@@ -490,7 +490,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
             }
             else
             {
-                int usedAttributes = context.Config.UsedInputAttributes;
+                int usedAttributes = context.Config.UsedInputAttributes | context.Config.PassthroughAttributes;
                 while (usedAttributes != 0)
                 {
                     int index = BitOperations.TrailingZeroCount(usedAttributes);


### PR DESCRIPTION
When using geometry shader passthrough, ensure that the inputs consumed by the next stage are passed on the geometry shader stage.
This fixes a regression on Game Builder Garage, but I'm not sure which specific PR caused the regression.
master (solid black characters):
![image](https://user-images.githubusercontent.com/5624669/153532011-e5797ba5-91fb-45a1-9c68-13dd3576d632.png)
PR:
![image](https://user-images.githubusercontent.com/5624669/153532019-2e8b4ecd-09cd-43e0-895e-133ca854ab60.png)