### PR TITLE
Perform unscaled 2d engine copy on CPU if source texture isn't in cache.

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Twod/TwodClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Twod/TwodClass.cs
@@ -1,8 +1,10 @@
-﻿using Ryujinx.Graphics.Device;
+﻿using Ryujinx.Common;
+using Ryujinx.Graphics.Device;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Engine.Types;
 using Ryujinx.Graphics.Gpu.Image;
 using Ryujinx.Graphics.Texture;
+using Ryujinx.Memory;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
@@ -43,6 +45,144 @@ namespace Ryujinx.Graphics.Gpu.Engine.Twod
         /// <param name="offset">Register byte offset</param>
         /// <param name="data">Data to be written</param>
         public void Write(int offset, int data) => _state.Write(offset, data);
+
+        /// <summary>
+        /// Determines if data is compatible between the source and destination texture.
+        /// The two textures must have the same size, layout, and bytes per pixel.
+        /// </summary>
+        /// <param name="lhs">Info for the first texture</param>
+        /// <param name="rhs">Info for the second texture</param>
+        /// <param name="lhsFormat">Format of the first texture</param>
+        /// <param name="rhsFormat">Format of the second texture</param>
+        /// <returns>True if the data is compatible, false otherwise</returns>
+        private bool IsDataCompatible(TwodTexture lhs, TwodTexture rhs, FormatInfo lhsFormat, FormatInfo rhsFormat)
+        {
+            if (lhsFormat.BytesPerPixel != rhsFormat.BytesPerPixel ||
+                lhs.Height != rhs.Height ||
+                lhs.Depth != rhs.Depth ||
+                lhs.LinearLayout != rhs.LinearLayout ||
+                lhs.MemoryLayout.Packed != rhs.MemoryLayout.Packed)
+            {
+                return false;
+            }
+
+            if (lhs.LinearLayout)
+            {
+                return lhs.Stride == rhs.Stride;
+            }
+            else
+            {
+                return lhs.Width == rhs.Width;
+            }
+        }
+
+        /// <summary>
+        /// Determine if the given region covers the full texture, also considering width alignment.
+        /// </summary>
+        /// <param name="texture"></param>
+        /// <param name="formatInfo"></param>
+        /// <param name="x1"></param>
+        /// <param name="y1"></param>
+        /// <param name="x2"></param>
+        /// <param name="y2"></param>
+        /// <returns>True if the region covers the full texture, false otherwise</returns>
+        private bool IsCopyRegionComplete(TwodTexture texture, FormatInfo formatInfo, int x1, int y1, int x2, int y2)
+        {
+            if (x1 != 0 || y1 != 0 || y2 != texture.Height)
+            {
+                return false;
+            }
+
+            int width;
+            int widthAlignment;
+
+            if (texture.LinearLayout)
+            {
+                widthAlignment = 1;
+                width = texture.Stride / formatInfo.BytesPerPixel;
+            }
+            else
+            {
+                widthAlignment = Constants.GobAlignment / formatInfo.BytesPerPixel;
+                width = texture.Width;
+            }
+
+            return width == BitUtils.AlignUp(x2, widthAlignment);
+        }
+
+        /// <summary>
+        /// Performs a full data copy between two textures, reading and writing directly from guest memory.
+        /// The textures must have a matching layout, size, and bytes per pixel.
+        /// </summary>
+        /// <param name="src">The source texture</param>
+        /// <param name="dst">The destination texture</param>
+        /// <param name="w">Copy width</param>
+        /// <param name="h">Copy height</param>
+        /// <param name="bpp">Bytes per pixel</param>
+        private void UnscaledFullCopy(TwodTexture src, TwodTexture dst, int w, int h, int bpp)
+        {
+            var srcCalculator = new OffsetCalculator(
+                w,
+                h,
+                src.Stride,
+                src.LinearLayout,
+                src.MemoryLayout.UnpackGobBlocksInY(),
+                src.MemoryLayout.UnpackGobBlocksInZ(),
+                bpp);
+
+            (int _, int srcSize) = srcCalculator.GetRectangleRange(0, 0, w, h);
+
+            var memoryManager = _channel.MemoryManager;
+
+            ulong srcGpuVa = src.Address.Pack();
+            ulong dstGpuVa = dst.Address.Pack();
+
+            ReadOnlySpan<byte> srcSpan = memoryManager.GetSpan(srcGpuVa, srcSize, true);
+
+            int width;
+            int height = src.Height;
+            if (src.LinearLayout)
+            {
+                width = src.Stride / bpp;
+            }
+            else
+            {
+                width = src.Width;
+            }
+
+            // If the copy is not equal to the width and height of the texture, we will need to copy partially.
+            // It's worth noting that it has already been established that the src and dst are the same size.
+            if (w == width && h == height)
+            {
+                memoryManager.Write(dstGpuVa, srcSpan);
+            }
+            else
+            {
+                using WritableRegion dstRegion = memoryManager.GetWritableRegion(dstGpuVa, srcSize, true);
+                Span<byte> dstSpan = dstRegion.Memory.Span;
+
+                if (src.LinearLayout)
+                {
+                    int stride = src.Stride;
+                    int offset = 0;
+                    int lineSize = width * bpp;
+
+                    for (int y = 0; y < height; y++)
+                    {
+                        srcSpan.Slice(offset, lineSize).CopyTo(dstSpan.Slice(offset));
+
+                        offset += src.Stride;
+                    }
+                }
+                else
+                {
+                    // Copy as many blocks as possible, then individual pixels near the edges.
+
+                    // TODO
+                    srcSpan.CopyTo(dstSpan);
+                }
+            }
+        }
 
         /// <summary>
         /// Performs the blit operation, triggered by the register write.
@@ -114,25 +254,43 @@ namespace Ryujinx.Graphics.Gpu.Engine.Twod
                 srcX1 = 0;
             }
 
+            FormatInfo dstCopyTextureFormat = dstCopyTexture.Format.Convert();
+
+            bool canDirectCopy = GraphicsConfig.Fast2DCopy &&
+                srcX2 == dstX2 && srcY2 == dstY2 &&
+                IsDataCompatible(srcCopyTexture, dstCopyTexture, srcCopyTextureFormat, dstCopyTextureFormat) &&
+                IsCopyRegionComplete(srcCopyTexture, srcCopyTextureFormat, srcX1, srcY1, srcX2, srcY2) &&
+                IsCopyRegionComplete(dstCopyTexture, dstCopyTextureFormat, dstX1, dstY1, dstX2, dstY2);
+
+
             var srcTexture = memoryManager.Physical.TextureCache.FindOrCreateTexture(
                 memoryManager,
                 srcCopyTexture,
                 offset,
                 srcCopyTextureFormat,
+                !canDirectCopy,
                 false,
                 srcHint);
 
             if (srcTexture == null)
             {
+                if (canDirectCopy)
+                {
+                    // Directly copy the data on CPU.
+                    Common.Logging.Logger.Warning?.Print(Common.Logging.LogClass.Gpu, $"Fast Copy {srcX2} {srcY2} {srcCopyTexture.Format}");
+                    UnscaledFullCopy(srcCopyTexture, dstCopyTexture, srcX2, srcY2, srcCopyTextureFormat.BytesPerPixel);
+                }
+
                 return;
             }
 
+            if (srcCopyTexture.Format == ColorFormat.R16G16B16A16Float) { }
+            Common.Logging.Logger.Error?.Print(Common.Logging.LogClass.Gpu, $"Slow Copy {srcX2} {srcY2} {srcCopyTexture.Format}");
             memoryManager.Physical.TextureCache.Lift(srcTexture);
 
             // When the source texture that was found has a depth format,
             // we must enforce the target texture also has a depth format,
             // as copies between depth and color formats are not allowed.
-            FormatInfo dstCopyTextureFormat;
 
             if (srcTexture.Format.IsDepthOrStencil())
             {
@@ -148,6 +306,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Twod
                 dstCopyTexture,
                 0,
                 dstCopyTextureFormat,
+                true,
                 srcTexture.ScaleMode == TextureScaleMode.Scaled,
                 dstHint);
 

--- a/Ryujinx.Graphics.Gpu/Engine/Twod/TwodClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Twod/TwodClass.cs
@@ -174,7 +174,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Twod
                     {
                         srcSpan.Slice(offset, lineSize).CopyTo(dstSpan.Slice(offset));
 
-                        offset += src.Stride;
+                        offset += stride;
                     }
                 }
                 else

--- a/Ryujinx.Graphics.Gpu/GraphicsConfig.cs
+++ b/Ryujinx.Graphics.Gpu/GraphicsConfig.cs
@@ -29,6 +29,14 @@ namespace Ryujinx.Graphics.Gpu
         public static bool FastGpuTime = true;
 
         /// <summary>
+        /// Enables or disables fast 2d engine texture copies entirely on CPU when possible.
+        /// Reduces stuttering and # of textures in games that copy textures around for streaming, 
+        /// as textures will not need to be created for the copy, and the data does not need to be 
+        /// flushed from GPU.
+        /// </summary>
+        public static bool Fast2DCopy = true;
+
+        /// <summary>
         /// Enables or disables the Just-in-Time compiler for GPU Macro code.
         /// </summary>
         public static bool EnableMacroJit = true;

--- a/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -194,6 +194,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             TwodTexture copyTexture,
             ulong offset,
             FormatInfo formatInfo,
+            bool shouldCreate,
             bool preferScaling = true,
             Size? sizeHint = null)
         {
@@ -232,6 +233,11 @@ namespace Ryujinx.Graphics.Gpu.Image
             if (preferScaling)
             {
                 flags |= TextureSearchFlags.WithUpscale;
+            }
+
+            if (!shouldCreate)
+            {
+                flags |= TextureSearchFlags.NoCreate;
             }
 
             Texture texture = FindOrCreateTexture(memoryManager, flags, info, 0, sizeHint);
@@ -479,6 +485,10 @@ namespace Ryujinx.Graphics.Gpu.Image
                 texture.SynchronizeMemory();
 
                 return texture;
+            }
+            else if (flags.HasFlag(TextureSearchFlags.NoCreate))
+            {
+                return null;
             }
 
             // Calculate texture sizes, used to find all overlapping textures.

--- a/Ryujinx.Graphics.Gpu/Image/TextureSearchFlags.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureSearchFlags.cs
@@ -12,6 +12,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         Strict      = 1 << 0,
         ForSampler  = 1 << 1,
         ForCopy     = 1 << 2,
-        WithUpscale = 1 << 3
+        WithUpscale = 1 << 3,
+        NoCreate    = 1 << 4
     }
 }

--- a/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
@@ -154,14 +154,15 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <summary>
         /// Gets a writable region from GPU mapped memory.
         /// </summary>
-        /// <param name="address">Start address of the range</param>
+        /// <param name="va">Start address of the range</param>
         /// <param name="size">Size in bytes to be range</param>
+        /// <param name="tracked">True if write tracking is triggered on the span</param>
         /// <returns>A writable region with the data at the specified memory location</returns>
-        public WritableRegion GetWritableRegion(ulong va, int size)
+        public WritableRegion GetWritableRegion(ulong va, int size, bool tracked = false)
         {
             if (IsContiguous(va, size))
             {
-                return Physical.GetWritableRegion(Translate(va), size);
+                return Physical.GetWritableRegion(Translate(va), size, tracked);
             }
             else
             {
@@ -169,7 +170,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
                 GetSpan(va, size).CopyTo(memory.Span);
 
-                return new WritableRegion(this, va, memory);
+                return new WritableRegion(this, va, memory, tracked);
             }
         }
 


### PR DESCRIPTION
Unreal Engine games tend to move texture data directly into levels of a texture via DMA. This is all well and good, but if the game is using _texture streaming_, then it will move this data between a pool of storage textures by **blitting** individual levels. This causes a number of problems for us, as People Who Want to Emulate Video Games:

- To copy a single level of a mipmapped texture to another, we need to create a view for the source and destination, which takes time and clutters up the texture cache.
- Blitting compressed texture data is done by aliasing the src/dst textures as another format... which is not supported in OpenGL, so we need to perform additional copies between the "data" representation and the "compressed" one, which is used for rendering.
  - Copy dependencies aren't perfect, so have historically caused bugs when complicated dependencies between textures are present.
- Similar to draws, blits add textures to the auto delete cache, which quickly fills up. When the auto delete cache fills up, this _forces_ the data to be flushed back to the guest memory, which forces a wait on the GPU and lengthy data conversion/copy.
- Blits count as a GPU side modification, so we need to register write tracking on textures. Write tracking costs a little to activate, but the main issue is that the data must be flushed if it is read/written on the CPU side.
  - This is especially bad given how unreal engine loads textures with DMA - the DMA transfer triggers the read tracking for textures, and forces a flush, causing a massive stutter.

This PR adds an additional path for the 2d engine copy (blit) that directly copies the data on the CPU, given a number of conditions:
- The copy regions match. (unscaled copy)
- The two textures are "data compatible" (matching dimensions, layout, bytes per pixel)
- The copy regions start at (0, 0) and align up to the texture dimensions.
- The source texture does not already exist in the cache.
  
This greatly reduces stuttering in A Hat in Time (UE3), as well as fixing any remaining texture issues with it. It will improve stuttering in UE4 games that use texture streaming (for example, if they had random graphical issues fixed by my earlier texture PRs) such as Yoshi's Crafted World. This PR does not fix stuttering in UE4 games due to bindless not working with the shader cache or file access. Really depends on the game.

I'd recommend testing some Unreal Engine games, and other stuff for regressions.

It might be a good idea to also do this copy if the source texture exists, but does not have a gpu modified flag. I'll think about it.