### PR TITLE
Ryujinx.Tests: Replace unicorn with dynarmic for A32 tests

### DIFF
--- a/Ryujinx.Tests/Cpu/CpuTest32.cs
+++ b/Ryujinx.Tests/Cpu/CpuTest32.cs
@@ -185,7 +185,7 @@ namespace Ryujinx.Tests.Cpu
             _dynarmic.Fpscr = (uint)fpscr;
         }
 
-        protected void ExecuteOpcodes(bool runUnicorn = true)
+        protected void ExecuteOpcodes()
         {
             _cpuContext.Execute(_context, CodeBaseAddress);
 
@@ -213,13 +213,12 @@ namespace Ryujinx.Tests.Cpu
                                                 bool carry = false,
                                                 bool zero = false,
                                                 bool negative = false,
-                                                int fpscr = 0,
-                                                bool runUnicorn = true)
+                                                int fpscr = 0)
         {
             Opcode(opcode);
             Opcode(0xE12FFF1E); // BX LR
             SetContext(r0, r1, r2, r3, sp, v0, v1, v2, v3, v4, v5, v14, v15, saturation, overflow, carry, zero, negative, fpscr);
-            ExecuteOpcodes(runUnicorn);
+            ExecuteOpcodes();
 
             return GetContext();
         }
@@ -392,9 +391,9 @@ namespace Ryujinx.Tests.Cpu
             if (_usingMemory)
             {
                 byte[] mem = _memory.GetSpan(DataBaseAddress, (int)Size).ToArray();
-                byte[] unicornMem = new Span<byte>(_dynarmicMemory, (int)DataBaseAddress, (int)Size).ToArray();
+                byte[] dynarmicMem = new Span<byte>(_dynarmicMemory, (int)DataBaseAddress, (int)Size).ToArray();
 
-                Assert.That(mem, Is.EqualTo(unicornMem), "Data");
+                Assert.That(mem, Is.EqualTo(dynarmicMem), "Data");
             }
         }
 

--- a/Ryujinx.Tests/Cpu/CpuTest32.cs
+++ b/Ryujinx.Tests/Cpu/CpuTest32.cs
@@ -97,15 +97,13 @@ namespace Ryujinx.Tests.Cpu
         {
             _memory.Write(_currAddress, opcode);
 
-            if (_unicornAvailable)
-            {
-                _unicornEmu.MemoryWrite16(_currAddress, opcode);
-            }
+            _dynarmicEnv.MemoryWrite16(_currAddress, opcode);
 
             _currAddress += 2;
         }
 
         protected ExecutionContext GetContext() => _context;
+        protected Dynarmic.Net.A32Jit GetDynarmic() => _dynarmic;
 
         protected void SetContext(uint r0 = 0,
                                   uint r1 = 0,
@@ -234,13 +232,12 @@ namespace Ryujinx.Tests.Cpu
                                                      bool carry = false,
                                                      bool zero = false,
                                                      bool negative = false,
-                                                     int fpscr = 0,
-                                                     bool runUnicorn = true)
+                                                     int fpscr = 0)
         {
             ThumbOpcode(opcode);
             ThumbOpcode(0x4770); // BX LR
             SetContext(r0, r1, r2, r3, sp, default, default, default, default, default, default, default, default, saturation, overflow, carry, zero, negative, fpscr, thumb: true);
-            ExecuteOpcodes(runUnicorn);
+            ExecuteOpcodes();
 
             return GetContext();
         }

--- a/Ryujinx.Tests/Cpu/CpuTestAlu32.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestAlu32.cs
@@ -58,7 +58,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r1: wn, sp: w31);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise]
@@ -74,7 +74,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r1: shiftValue, r2: (uint)shiftAmount);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise]
@@ -93,7 +93,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r0: w0, r1: w1, r2: w2, sp: sp);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise]
@@ -112,7 +112,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r0: w0, r1: w1, r2: w2, sp: sp);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise]
@@ -130,7 +130,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r1: wn, sp: w31);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise]
@@ -147,7 +147,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r1: wn, sp: w31);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise]
@@ -166,7 +166,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r0: w0, r1: w1, r2: w2, sp: sp);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise]
@@ -185,7 +185,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r0: w0, r1: w1, r2: w2, sp: sp);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 #endif
     }

--- a/Ryujinx.Tests/Cpu/CpuTestAluBinary32.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestAluBinary32.cs
@@ -85,7 +85,7 @@ namespace Ryujinx.Tests.Cpu
 
             uint sp = TestContext.CurrentContext.Random.NextUInt();
 
-            SingleOpcode(opcode, r1: test.Crc, r2: test.Value, sp: sp, runUnicorn: false);
+            SingleOpcode(opcode, r1: test.Crc, r2: test.Value, sp: sp);
 
             ExecutionContext context = GetContext();
             ulong result = context.GetX((int)rd);

--- a/Ryujinx.Tests/Cpu/CpuTestAluRs32.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestAluRs32.cs
@@ -55,7 +55,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r1: wn, r2: wm, sp: sp, carry: carryIn);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise]
@@ -77,7 +77,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r1: wn, r2: wm, sp: sp);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 #endif
     }

--- a/Ryujinx.Tests/Cpu/CpuTestBf32.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestBf32.cs
@@ -29,7 +29,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r0: wd, sp: sp);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("BFI <Rd>, <Rn>, #<lsb>, #<width>")]
@@ -51,7 +51,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r0: wd, r1: wn, sp: sp);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("UBFX <Rd>, <Rn>, #<lsb>, #<width>")]
@@ -76,7 +76,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r0: wd, r1: wn, sp: sp);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("SBFX <Rd>, <Rn>, #<lsb>, #<width>")]
@@ -101,7 +101,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r0: wd, r1: wn, sp: sp);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 #endif
     }

--- a/Ryujinx.Tests/Cpu/CpuTestMisc32.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestMisc32.cs
@@ -106,7 +106,7 @@ namespace Ryujinx.Tests.Cpu
 
             ExecuteOpcodes();
 
-            CompareAgainstUnicorn(fpsrMask: Fpsr.Nzcv);
+            CompareAgainstDynarmic(fpsrMask: Fpsr.Nzcv);
         }
 #endif
     }

--- a/Ryujinx.Tests/Cpu/CpuTestMul32.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestMul32.cs
@@ -73,7 +73,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r0: wn, r1: wm, r2: wa, sp: w31);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("SMLAW<x> <Rd>, <Rn>, <Rm>, <Ra>")]
@@ -95,7 +95,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r0: wn, r1: wm, r2: wa, sp: w31);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("SMUL<x><y> <Rd>, <Rn>, <Rm>")]
@@ -114,7 +114,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r0: wn, r1: wm, sp: w31);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("SMULW<x> <Rd>, <Rn>, <Rm>")]
@@ -133,7 +133,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r0: wn, r1: wm, sp: w31);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 #endif
     }

--- a/Ryujinx.Tests/Cpu/CpuTestSimd32.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestSimd32.cs
@@ -224,7 +224,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, v1: v1);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VCNT.8 D0, D0 | VCNT.8 Q0, Q0")]
@@ -252,7 +252,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 #endif
     }

--- a/Ryujinx.Tests/Cpu/CpuTestSimdCrypto32.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestSimdCrypto32.cs
@@ -38,8 +38,7 @@ namespace Ryujinx.Tests.Cpu
                 Assert.That(GetVectorE1(context.GetV(1)), Is.EqualTo(roundKeyH));
             });
 
-            // Unicorn does not yet support crypto instructions in A32.
-            // CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Description("AESE.8 <Qd>, <Qm>")]
@@ -72,8 +71,7 @@ namespace Ryujinx.Tests.Cpu
                 Assert.That(GetVectorE1(context.GetV(1)), Is.EqualTo(roundKeyH));
             });
 
-            // Unicorn does not yet support crypto instructions in A32.
-            // CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Description("AESIMC.8 <Qd>, <Qm>")]
@@ -110,8 +108,7 @@ namespace Ryujinx.Tests.Cpu
                 });
             }
 
-            // Unicorn does not yet support crypto instructions in A32.
-            // CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Description("AESMC.8 <Qd>, <Qm>")]
@@ -148,8 +145,7 @@ namespace Ryujinx.Tests.Cpu
                 });
             }
 
-            // Unicorn does not yet support crypto instructions in A32.
-            // CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
     }
 }

--- a/Ryujinx.Tests/Cpu/CpuTestSimdCrypto32.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestSimdCrypto32.cs
@@ -25,7 +25,7 @@ namespace Ryujinx.Tests.Cpu
             V128 v0 = MakeVectorE0E1(roundKeyL ^ valueL, roundKeyH ^ valueH);
             V128 v1 = MakeVectorE0E1(roundKeyL, roundKeyH);
 
-            ExecutionContext context = SingleOpcode(opcode, v0: v0, v1: v1, runUnicorn: false);
+            ExecutionContext context = SingleOpcode(opcode, v0: v0, v1: v1);
 
             Assert.Multiple(() =>
             {
@@ -58,7 +58,7 @@ namespace Ryujinx.Tests.Cpu
             V128 v0 = MakeVectorE0E1(roundKeyL ^ valueL, roundKeyH ^ valueH);
             V128 v1 = MakeVectorE0E1(roundKeyL, roundKeyH);
 
-            ExecutionContext context = SingleOpcode(opcode, v0: v0, v1: v1, runUnicorn: false);
+            ExecutionContext context = SingleOpcode(opcode, v0: v0, v1: v1);
 
             Assert.Multiple(() =>
             {
@@ -91,8 +91,7 @@ namespace Ryujinx.Tests.Cpu
             ExecutionContext context = SingleOpcode(
                 opcode,
                 v0: rm == 0u ? v : default(V128),
-                v1: rm == 2u ? v : default(V128),
-                runUnicorn: false);
+                v1: rm == 2u ? v : default(V128));
 
             Assert.Multiple(() =>
             {
@@ -128,8 +127,7 @@ namespace Ryujinx.Tests.Cpu
             ExecutionContext context = SingleOpcode(
                 opcode,
                 v0: rm == 0u ? v : default(V128),
-                v1: rm == 2u ? v : default(V128),
-                runUnicorn: false);
+                v1: rm == 2u ? v : default(V128));
 
             Assert.Multiple(() =>
             {

--- a/Ryujinx.Tests/Cpu/CpuTestSimdCvt32.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestSimdCvt32.cs
@@ -136,7 +136,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Explicit]
@@ -161,7 +161,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Explicit]
@@ -191,7 +191,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, fpscr: fpscr);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Explicit]
@@ -221,7 +221,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, fpscr: fpscr);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VRINTX.F<size> <Sd>, <Sm>")]
@@ -257,7 +257,7 @@ namespace Ryujinx.Tests.Cpu
             int fpscr = (int)rMode << (int)Fpcr.RMode;
             SingleOpcode(opcode, v0: v0, v1: v1, v2: v2, fpscr: fpscr);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 #endif
     }

--- a/Ryujinx.Tests/Cpu/CpuTestSimdLogical32.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestSimdLogical32.cs
@@ -80,7 +80,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, v1: v1, v2: v2);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise]
@@ -113,7 +113,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VTST.<dt> <Vd>, <Vn>, <Vm>")]
@@ -149,7 +149,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, v1: v1, v2: v2);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 #endif
     }

--- a/Ryujinx.Tests/Cpu/CpuTestSimdMemory32.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestSimdMemory32.cs
@@ -61,7 +61,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r0: 0x2500, r1: offset, sp: 0x2500);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VLDn.<size> <list>, [<Rn> {:<align>}]{ /!/, <Rm>} (all lanes)")]
@@ -88,7 +88,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r0: 0x2500, r1: offset, sp: 0x2500);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VLDn.<size> <list>, [<Rn> {:<align>}]{ /!/, <Rm>} (multiple n element structures)")]
@@ -111,7 +111,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r0: 0x2500, r1: offset, sp: 0x2500);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VSTn.<size> <list>, [<Rn> {:<align>}]{ /!/, <Rm>} (single n element structure)")]
@@ -143,7 +143,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r0: 0x2500, r1: offset, v1: vec1, v2: vec2, v3: vec3, v4: vec4, sp: 0x2500);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VSTn.<size> <list>, [<Rn> {:<align>}]{ /!/, <Rm>} (multiple n element structures)")]
@@ -168,7 +168,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r0: 0x2500, r1: offset, v1: vec1, v2: vec2, v3: vec3, v4: vec4, sp: 0x2500);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VLDM.<size> <Rn>{!}, <d/sreglist>")]
@@ -215,7 +215,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r0: 0x2500, sp: 0x2500);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VLDR.<size> <Sd>, [<Rn> {, #{+/-}<imm>}]")]
@@ -250,7 +250,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r0: 0x2500);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VSTR.<size> <Sd>, [<Rn> {, #{+/-}<imm>}]")]
@@ -287,7 +287,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r0: 0x2500, v0: vec1, v1: vec2);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         private (V128, V128, V128, V128) GenerateTestVectors()

--- a/Ryujinx.Tests/Cpu/CpuTestSimdMov32.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestSimdMov32.cs
@@ -57,7 +57,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VMOV.F<size> <Sd>, #<imm>")]
@@ -82,7 +82,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VMOV <Rd>, <Sd>")]
@@ -102,7 +102,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r0: valueRn, r1: valueRn, r2: valueRn, r3: valueRn, v0: new V128(valueVn1, valueVn2));
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VMOV.<size> <Rt>, <Dn[x]>")]
@@ -149,7 +149,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r0: valueRn, r1: valueRn, r2: valueRn, r3: valueRn, v0: new V128(valueVn1, valueVn2), v1: new V128(valueVn2, valueVn1));
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("(VMOV <Rt>, <Rt2>, <Dm>), (VMOV <Dm>, <Rt>, <Rt2>)")]
@@ -171,11 +171,16 @@ namespace Ryujinx.Tests.Cpu
             if (op)
             {
                 opcode |= 1 << 20;
+
+                if (rt == rt2)
+                {
+                    return; // Unpredictable instruction
+                }
             }
 
             SingleOpcode(opcode, r0: valueRt1, r1: valueRt2, r2: valueRt1, r3: valueRt2, v0: new V128(valueVn1, valueVn2));
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("(VMOV <Rt>, <Rt2>, <Sm>, <Sm1>), (VMOV <Sm>, <Sm1>, <Rt>, <Rt2>)")]
@@ -197,11 +202,16 @@ namespace Ryujinx.Tests.Cpu
             if (op)
             {
                 opcode |= 1 << 20;
+
+                if (rt == rt2)
+                {
+                    return; // Unpredictable instruction
+                }
             }
 
             SingleOpcode(opcode, r0: valueRt1, r1: valueRt2, r2: valueRt1, r3: valueRt2, v0: new V128(valueVn1, valueVn2), v1: new V128(valueVn2, valueVn1));
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VMOVN.<size> <Dt>, <Qm>")]
@@ -225,7 +235,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, v1: v1, v2: v2, v3: v3);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VMOVL.<size> <Qd>, <Dm>")]
@@ -255,7 +265,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, v1: v1, v2: v2, v3: v3);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VMVN.<size> <Vt>, <Vm>")]
@@ -287,7 +297,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, v1: v1, v2: v2, v3: v3);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VMVN.I<size> <Dd/Qd>, #<imm>")]
@@ -331,7 +341,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VTRN.<size> <Vd>, <Vm>")]
@@ -364,7 +374,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, v1: v1, v2: v2, v3: v3);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VZIP.<size> <Vd>, <Vm>")]
@@ -397,7 +407,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, v1: v1, v2: v2, v3: v3);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VUZP.<size> <Vd>, <Vm>")]
@@ -430,7 +440,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, v1: v1, v2: v2, v3: v3);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VTBL.8 <Dd>, {list}, <Dm>")]
@@ -479,7 +489,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, v1: v1, v2: v2, v3: v3, v4: v4, v5: v5);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VEXT.8 {<Vd>,} <Vn>, <Vm>, #<imm>")]
@@ -515,7 +525,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, v1: v1, v2: v2, v3: v3);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VDUP.<size> <Vd>, <Rt>")]
@@ -546,7 +556,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, r0: valueRn, r1: valueRn, r2: valueRn, r3: valueRn, v0: new V128(valueVn1, valueVn2), v1: v1);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VDUP.<size> <Vd>, <Dm[x]>")]
@@ -593,7 +603,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: new V128(valueVn1, valueVn2), v1: v1, v2: v2, v3: v3);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 #endif
     }

--- a/Ryujinx.Tests/Cpu/CpuTestSimdReg32.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestSimdReg32.cs
@@ -279,7 +279,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, v1: v1, v2: v2);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise]
@@ -313,7 +313,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, v1: v1, v2: v2);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VCMP.f<size> Vd, Vm")]
@@ -350,7 +350,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v1: v1, v2: v2, fpscr: fpscr);
 
-            CompareAgainstUnicorn(fpsrMask: Fpsr.Nzcv);
+            CompareAgainstDynarmic(fpsrMask: Fpsr.Nzcv);
         }
 
         [Test, Pairwise] [Explicit] // Fused.
@@ -371,7 +371,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise] [Explicit] // Fused.
@@ -390,7 +390,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise] [Explicit] // Fused.
@@ -422,7 +422,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, v1: v1);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise] [Explicit]
@@ -443,7 +443,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise] [Explicit]
@@ -462,7 +462,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VMLSL.<type><size> <Vd>, <Vn>, <Vm>")]
@@ -494,7 +494,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, v1: v1, v2: v2);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VMULL.<size> <Vd>, <Vn>, <Vm>")]
@@ -534,7 +534,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, v1: v1, v2: v2);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VMULL.<P8, P64> <Qd>, <Dn>, <Dm>")]
@@ -564,7 +564,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VSHL.<size> {<Vd>}, <Vm>, <Vn>")]
@@ -604,7 +604,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, v1: v1, v2: v2);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Explicit]
@@ -631,7 +631,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, v1: v1, v2: v2);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise]
@@ -662,7 +662,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, v1: v1, v2: v2);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 #endif
     }

--- a/Ryujinx.Tests/Cpu/CpuTestSimdRegElem32.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestSimdRegElem32.cs
@@ -42,7 +42,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, v1: v1, v2: v2);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VMULL.<size> <Vd>, <Vn>, <Vm>[<index>]")]
@@ -74,7 +74,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, v1: v1, v2: v2);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 #endif
     }

--- a/Ryujinx.Tests/Cpu/CpuTestSimdShImm32.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestSimdShImm32.cs
@@ -166,7 +166,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, v1: v1);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VSHL.<size> {<Vd>}, <Vm>, #<imm>")]
@@ -200,7 +200,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, v1: v1, v2: v2);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VSHRN.<size> <Vd>, <Vm>, #<imm>")]
@@ -227,7 +227,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, v1: v1, v2: v2);
 
-            CompareAgainstUnicorn();
+            CompareAgainstDynarmic();
         }
 
         [Test, Pairwise, Description("VQRSHRN.<type><size> <Vd>, <Vm>, #<imm>")]
@@ -262,7 +262,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, v1: v1, v2: v2, fpscr: fpscr);
 
-            CompareAgainstUnicorn(fpsrMask: Fpsr.Qc);
+            CompareAgainstDynarmic(fpsrMask: Fpsr.Qc);
         }
 
         [Test, Pairwise, Description("VQRSHRUN.<type><size> <Vd>, <Vm>, #<imm>")]
@@ -291,7 +291,7 @@ namespace Ryujinx.Tests.Cpu
 
             SingleOpcode(opcode, v0: v0, v1: v1, v2: v2, fpscr: fpscr);
 
-            CompareAgainstUnicorn(fpsrMask: Fpsr.Qc);
+            CompareAgainstDynarmic(fpsrMask: Fpsr.Qc);
         }
 #endif
     }

--- a/Ryujinx.Tests/Ryujinx.Tests.csproj
+++ b/Ryujinx.Tests/Ryujinx.Tests.csproj
@@ -17,6 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Dynarmic.Net" Version="1.0.0-build4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />


### PR DESCRIPTION
Self-explanatory: Unicorn does not implement all userspace A32 instructions available on v8.0.

Also enabled some previously disabled tests.