### PR TITLE
Zero DMA region X/Y after copy

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -124,12 +124,10 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
         /// <summary>
         /// Performs a buffer to buffer, or buffer to texture copy.
         /// </summary>
-        /// <param name="argument">The LaunchDma call argument</param>
-        private void DmaCopy(int argument)
+        /// <param name="copyFlags">Flags passed on the DMA launch method</param>
+        private void DmaCopy(CopyFlags copyFlags)
         {
             var memoryManager = _channel.MemoryManager;
-
-            CopyFlags copyFlags = (CopyFlags)argument;
 
             bool srcLinear = copyFlags.HasFlag(CopyFlags.SrcLinear);
             bool dstLinear = copyFlags.HasFlag(CopyFlags.DstLinear);
@@ -329,8 +327,17 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
         /// <param name="argument">Method call argument</param>
         private void LaunchDma(int argument)
         {
-            DmaCopy(argument);
+            CopyFlags copyFlags = (CopyFlags)argument;
+
+            DmaCopy(copyFlags);
             ReleaseSemaphore(argument);
+
+            if (copyFlags.HasFlag(CopyFlags.MultiLineEnable))
+            {
+                // Some applications are not initializing the state and expects it to be zero.
+                _state.State.SetSrcOrigin = 0;
+                _state.State.SetDstOrigin = 0;
+            }
         }
     }
 }


### PR DESCRIPTION
River City Girls Zero is not writing to the destination region X/Y registers, and for this reason, they carry the previous value, however the game expects them to be zero.
This allow the game to get ingame, before it would crash after the manga style cutscene.
![image](https://user-images.githubusercontent.com/5624669/153975608-641a49b6-e325-4303-98a6-9ec18ab71fe8.png)
Still needs confirmation on hardware, so I have made it draft for now.