### PR TITLE
amadeus: Fix limiter correctness

### DIFF
--- a/Ryujinx.Audio/Renderer/Dsp/Command/LimiterCommandVersion1.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/LimiterCommandVersion1.cs
@@ -100,9 +100,11 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
                 {
                     for (int sampleIndex = 0; sampleIndex < context.SampleCount; sampleIndex++)
                     {
-                        float inputSample = *((float*)inputBuffers[channelIndex] + sampleIndex);
+                        float rawInputSample = *((float*)inputBuffers[channelIndex] + sampleIndex);
 
-                        float sampleInputMax = Math.Abs(inputSample * Parameter.InputGain);
+                        float inputSample = (rawInputSample / short.MaxValue) * Parameter.InputGain;
+
+                        float sampleInputMax = Math.Abs(inputSample);
 
                         float inputCoefficient = Parameter.ReleaseCoefficient;
 
@@ -131,7 +133,9 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
                         ref float delayedSample = ref state.DelayedSampleBuffer[channelIndex * Parameter.DelayBufferSampleCountMax + state.DelayedSampleBufferPosition[channelIndex]];
 
-                        *((float*)outputBuffers[channelIndex] + sampleIndex) = delayedSample * state.CompressionGain[channelIndex] * Parameter.OutputGain;
+                        float outputSample = delayedSample * state.CompressionGain[channelIndex] * Parameter.OutputGain;
+
+                        *((float*)outputBuffers[channelIndex] + sampleIndex) = outputSample * short.MaxValue;
 
                         delayedSample = inputSample;
 

--- a/Ryujinx.Audio/Renderer/Dsp/Command/LimiterCommandVersion2.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/LimiterCommandVersion2.cs
@@ -111,9 +111,11 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
                 {
                     for (int sampleIndex = 0; sampleIndex < context.SampleCount; sampleIndex++)
                     {
-                        float inputSample = *((float*)inputBuffers[channelIndex] + sampleIndex);
+                        float rawInputSample = *((float*)inputBuffers[channelIndex] + sampleIndex);
 
-                        float sampleInputMax = Math.Abs(inputSample * Parameter.InputGain);
+                        float inputSample = (rawInputSample / short.MaxValue) * Parameter.InputGain;
+
+                        float sampleInputMax = Math.Abs(inputSample);
 
                         float inputCoefficient = Parameter.ReleaseCoefficient;
 
@@ -142,7 +144,9 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
                         ref float delayedSample = ref state.DelayedSampleBuffer[channelIndex * Parameter.DelayBufferSampleCountMax + state.DelayedSampleBufferPosition[channelIndex]];
 
-                        *((float*)outputBuffers[channelIndex] + sampleIndex) = delayedSample * state.CompressionGain[channelIndex] * Parameter.OutputGain;
+                        float outputSample = delayedSample * state.CompressionGain[channelIndex] * Parameter.OutputGain;
+
+                        *((float*)outputBuffers[channelIndex] + sampleIndex) = outputSample * short.MaxValue;
 
                         delayedSample = inputSample;
 

--- a/Ryujinx.Audio/Renderer/Dsp/State/LimiterState.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/State/LimiterState.cs
@@ -37,6 +37,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.State
             DectectorAverage.AsSpan().Fill(0.0f);
             CompressionGain.AsSpan().Fill(1.0f);
             DelayedSampleBufferPosition.AsSpan().Fill(0);
+            DelayedSampleBuffer.AsSpan().Fill(0.0f);
 
             UpdateParameter(ref parameter);
         }

--- a/Ryujinx.Audio/Renderer/Server/CommandGenerator.cs
+++ b/Ryujinx.Audio/Renderer/Server/CommandGenerator.cs
@@ -558,7 +558,16 @@ namespace Ryujinx.Audio.Renderer.Server
 
             if (_rendererContext.BehaviourContext.IsEffectInfoVersion2Supported())
             {
-                Memory<EffectResultState> dspResultState = _effectContext.GetDspStateMemory(effectId);
+                Memory<EffectResultState> dspResultState;
+
+                if (effect.Parameter.StatisticsEnabled)
+                {
+                    dspResultState = _effectContext.GetDspStateMemory(effectId);
+                }
+                else
+                {
+                    dspResultState = Memory<EffectResultState>.Empty;
+                }
 
                 _commandBuffer.GenerateLimiterEffectVersion2(bufferOffset, effect.Parameter, effect.State, dspResultState, effect.IsEnabled, workBuffer, nodeId);
             }


### PR DESCRIPTION
There was multiple inconsistencies on the implementation as it was left untested back then.

The following fixes were made:
- Statistics are now not reported when explicitly disabled by a game.
- The buffer for delayed samples is now explicitly initialized. (for correctness)
- Fix input gain not being applied for delayed samples.
- Fix missing input and output conversion. (Nintendo map to PcmFloat where we map to PcmInt16 with float)

This fixes missing audio on Nintendo Switch Sports Online Play Test.

Closes #3125.