### PR TITLE
amadeus: Fix PCMFloat datasource command v1

### DIFF
--- a/Ryujinx.Audio/Renderer/Dsp/Command/PcmFloatDataSourceCommandVersion1.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/PcmFloatDataSourceCommandVersion1.cs
@@ -76,7 +76,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
             DataSourceHelper.WaveBufferInformation info = new DataSourceHelper.WaveBufferInformation
             {
                 SourceSampleRate = SampleRate,
-                SampleFormat = SampleFormat.PcmInt16,
+                SampleFormat = SampleFormat.PcmFloat,
                 Pitch = Pitch,
                 DecodingBehaviour = DecodingBehaviour,
                 ExtraParameter = 0,


### PR DESCRIPTION
Really simple copy pasta error here.

Shouldn't affect anything as float support was added at the same REV as datasource command v2.