### PR TITLE
Prefer texture over textureSize for sampler type

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -40,7 +40,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Version of the codegen (to be changed when codegen or guest format change).
         /// </summary>
-        private const ulong ShaderCodeGenVersion = 3063;
+        private const ulong ShaderCodeGenVersion = 3132;
 
         // Progress reporting helpers
         private volatile int _shaderCount;

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -369,7 +369,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             inst &= Instruction.Mask;
             bool isImage = inst == Instruction.ImageLoad || inst == Instruction.ImageStore || inst == Instruction.ImageAtomic;
             bool isWrite = inst == Instruction.ImageStore || inst == Instruction.ImageAtomic;
-            bool accurateType = inst != Instruction.Lod;
+            bool accurateType = inst != Instruction.Lod && inst != Instruction.TextureSize;
             bool coherent = flags.HasFlag(TextureFlags.Coherent);
 
             if (isImage)


### PR DESCRIPTION
Fix one case of shader failing to compile. `textureSize` sampler type is sourced from the texture pool since the GPU instruction does not specify the type. However, the type may still not be ideal in a few cases:
- Texture is sampled with depth compare later on. In this case the type should be `sampler*Shadow` and not just `sampler*`.
- Texture pool type does not match sampled type. For example, texture pool could have Texture2D while it samples as Texture2DArray.

To handle those cases, if there is more than one use of the texture, one by `textureSize` and another by regular `texture` sample operations, it prefers the type from the `texture` sample operation, as this instruction actually specifies the type and it is accurate.

I did find shaders failing to compile on games due to this, but I'm not aware of any game where it causes a visible difference.