### PR TITLE
ARMeilleure: Implement single stepping

### DIFF
--- a/ARMeilleure/Decoders/Decoder.cs
+++ b/ARMeilleure/Decoders/Decoder.cs
@@ -38,7 +38,7 @@ namespace ARMeilleure.Decoders
                 {
                     block = new Block(blkAddress);
 
-                    if ((dMode != DecoderMode.Normal && visited.Count >= 1) || opsCount > instructionLimit || !memory.IsMapped(blkAddress))
+                    if ((dMode != DecoderMode.MultipleBlocks && visited.Count >= 1) || opsCount > instructionLimit || !memory.IsMapped(blkAddress))
                     {
                         block.Exit = true;
                         block.EndAddress = blkAddress;
@@ -149,7 +149,7 @@ namespace ARMeilleure.Decoders
                 throw new InvalidOperationException($"Decoded a single empty exit block. Entry point = 0x{address:X}.");
             }
 
-            if (dMode == DecoderMode.Normal)
+            if (dMode == DecoderMode.MultipleBlocks)
             {
                 return TailCallRemover.RunPass(address, blocks);
             }

--- a/ARMeilleure/Decoders/Decoder.cs
+++ b/ARMeilleure/Decoders/Decoder.cs
@@ -18,7 +18,7 @@ namespace ARMeilleure.Decoders
         // For lower code quality translation, we set a lower limit since we're blocking execution.
         private const int MaxInstsPerFunctionLowCq = 500;
 
-        public static Block[] Decode(IMemoryManager memory, ulong address, ExecutionMode mode, bool highCq, bool singleBlock)
+        public static Block[] Decode(IMemoryManager memory, ulong address, ExecutionMode mode, bool highCq, DecoderMode dMode)
         {
             List<Block> blocks = new List<Block>();
 
@@ -38,7 +38,7 @@ namespace ARMeilleure.Decoders
                 {
                     block = new Block(blkAddress);
 
-                    if ((singleBlock && visited.Count >= 1) || opsCount > instructionLimit || !memory.IsMapped(blkAddress))
+                    if ((dMode != DecoderMode.Normal && visited.Count >= 1) || opsCount > instructionLimit || !memory.IsMapped(blkAddress))
                     {
                         block.Exit = true;
                         block.EndAddress = blkAddress;
@@ -96,6 +96,12 @@ namespace ARMeilleure.Decoders
                         }
                     }
 
+                    if (dMode == DecoderMode.SingleInstruction)
+                    {
+                        // Only read at most one instruction
+                        limitAddress = currBlock.Address + 1;
+                    }
+
                     FillBlock(memory, mode, currBlock, limitAddress);
 
                     opsCount += currBlock.OpCodes.Count;
@@ -143,7 +149,7 @@ namespace ARMeilleure.Decoders
                 throw new InvalidOperationException($"Decoded a single empty exit block. Entry point = 0x{address:X}.");
             }
 
-            if (!singleBlock)
+            if (dMode == DecoderMode.Normal)
             {
                 return TailCallRemover.RunPass(address, blocks);
             }

--- a/ARMeilleure/Decoders/DecoderMode.cs
+++ b/ARMeilleure/Decoders/DecoderMode.cs
@@ -2,7 +2,7 @@
 {
     enum DecoderMode
     {
-        Normal,
+        MultipleBlocks,
         SingleBlock,
         SingleInstruction,
     }

--- a/ARMeilleure/Decoders/DecoderMode.cs
+++ b/ARMeilleure/Decoders/DecoderMode.cs
@@ -1,0 +1,9 @@
+﻿namespace ARMeilleure.Decoders
+{
+    enum DecoderMode
+    {
+        Normal,
+        SingleBlock,
+        SingleInstruction,
+    }
+}

--- a/ARMeilleure/Translation/Translator.cs
+++ b/ARMeilleure/Translation/Translator.cs
@@ -266,7 +266,7 @@ namespace ARMeilleure.Translation
 
             Logger.StartPass(PassName.Decoding);
 
-            Block[] blocks = Decoder.Decode(Memory, address, mode, highCq, singleStep ? DecoderMode.SingleInstruction : DecoderMode.Normal);
+            Block[] blocks = Decoder.Decode(Memory, address, mode, highCq, singleStep ? DecoderMode.SingleInstruction : DecoderMode.MultipleBlocks);
 
             Logger.EndPass(PassName.Decoding);
 

--- a/ARMeilleure/Translation/Translator.cs
+++ b/ARMeilleure/Translation/Translator.cs
@@ -255,7 +255,7 @@ namespace ARMeilleure.Translation
 
             Logger.StartPass(PassName.Decoding);
 
-            Block[] blocks = Decoder.Decode(Memory, address, mode, highCq, singleBlock: false);
+            Block[] blocks = Decoder.Decode(Memory, address, mode, highCq, DecoderMode.Normal);
 
             Logger.EndPass(PassName.Decoding);
 

--- a/ARMeilleure/Translation/Translator.cs
+++ b/ARMeilleure/Translation/Translator.cs
@@ -209,6 +209,17 @@ namespace ARMeilleure.Translation
             return nextAddr;
         }
 
+        public ulong Step(State.ExecutionContext context, ulong address)
+        {
+            TranslatedFunction func = Translate(address, context.ExecutionMode, highCq: false, singleStep: true);
+
+            address = func.Execute(context);
+
+            EnqueueForDeletion(address, func);
+
+            return address;
+        }
+
         internal TranslatedFunction GetOrTranslate(ulong address, ExecutionMode mode)
         {
             if (!Functions.TryGetValue(address, out TranslatedFunction func))
@@ -242,7 +253,7 @@ namespace ARMeilleure.Translation
             }
         }
 
-        internal TranslatedFunction Translate(ulong address, ExecutionMode mode, bool highCq)
+        internal TranslatedFunction Translate(ulong address, ExecutionMode mode, bool highCq, bool singleStep = false)
         {
             var context = new ArmEmitterContext(
                 Memory,
@@ -255,7 +266,7 @@ namespace ARMeilleure.Translation
 
             Logger.StartPass(PassName.Decoding);
 
-            Block[] blocks = Decoder.Decode(Memory, address, mode, highCq, DecoderMode.Normal);
+            Block[] blocks = Decoder.Decode(Memory, address, mode, highCq, singleStep ? DecoderMode.SingleInstruction : DecoderMode.Normal);
 
             Logger.EndPass(PassName.Decoding);
 
@@ -285,14 +296,14 @@ namespace ARMeilleure.Translation
 
             var options = highCq ? CompilerOptions.HighCq : CompilerOptions.None;
 
-            if (context.HasPtc)
+            if (context.HasPtc && !singleStep)
             {
                 options |= CompilerOptions.Relocatable;
             }
 
             CompiledFunction compiledFunc = Compiler.Compile(cfg, argTypes, retType, options);
 
-            if (context.HasPtc)
+            if (context.HasPtc && !singleStep)
             {
                 Hash128 hash = Ptc.ComputeHash(Memory, address, funcSize);
 


### PR DESCRIPTION
Allow for single stepping of instructions.

This is forked off #3101 for ease of review. Note however, this PR was implemented [slightly differently](https://github.com/Ryujinx/Ryujinx/pull/3101/files#diff-82cd0b0f0bc66b6bc9dddb35b31c72707554587253f7a5de9f4602766383c6baR99) to allow for the existence of IT blocks introduced by the thumb PR. (i.e. We step over an IT block as a monolithic unit.)

Resolving the above IT block situation is not really considered a priority given it's unlikely to crop up much in the real world use case, thus the additional complexity is unlikely to be worth it. Will revisit if this turns out to be an issue.