### PR TITLE
Decoders: Add IOpCode32HasSetFlags

### DIFF
--- a/ARMeilleure/Decoders/IOpCode32Alu.cs
+++ b/ARMeilleure/Decoders/IOpCode32Alu.cs
@@ -1,10 +1,8 @@
 namespace ARMeilleure.Decoders
 {
-    interface IOpCode32Alu : IOpCode32
+    interface IOpCode32Alu : IOpCode32, IOpCode32HasSetFlags
     {
         int Rd { get; }
         int Rn { get; }
-
-        bool? SetFlags { get; }
     }
 }

--- a/ARMeilleure/Decoders/IOpCode32HasSetFlags.cs
+++ b/ARMeilleure/Decoders/IOpCode32HasSetFlags.cs
@@ -1,0 +1,7 @@
+﻿namespace ARMeilleure.Decoders
+{
+    interface IOpCode32HasSetFlags
+    {
+        bool? SetFlags { get; }
+    }
+}

--- a/ARMeilleure/Decoders/OpCode32AluUmull.cs
+++ b/ARMeilleure/Decoders/OpCode32AluUmull.cs
@@ -1,6 +1,6 @@
 ﻿namespace ARMeilleure.Decoders
 {
-    class OpCode32AluUmull : OpCode32
+    class OpCode32AluUmull : OpCode32, IOpCode32HasSetFlags
     {
         public int RdLo { get; }
         public int RdHi { get; }

--- a/ARMeilleure/Instructions/InstEmitAluHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitAluHelper.cs
@@ -14,7 +14,7 @@ namespace ARMeilleure.Instructions
     {
         public static bool ShouldSetFlags(ArmEmitterContext context)
         {
-            IOpCode32Alu op = (IOpCode32Alu)context.CurrOp;
+            IOpCode32HasSetFlags op = (IOpCode32HasSetFlags)context.CurrOp;
 
             if (op.SetFlags == null)
             {


### PR DESCRIPTION
Bugfix.

`OpCode32AluUmull` does not derive from `IOpCode32Alu`, so introduce a new interface.
