### PR TITLE
Add dedicated ServerBase for FileSystem services

### DIFF
--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -76,6 +76,7 @@ namespace Ryujinx.HLE.HOS
         internal ServerBase BsdServer { get; private set; }
         internal ServerBase AudRenServer { get; private set; }
         internal ServerBase AudOutServer { get; private set; }
+        internal ServerBase FsServer { get; private set; }
         internal ServerBase HidServer { get; private set; }
         internal ServerBase NvDrvServer { get; private set; }
         internal ServerBase TimeServer { get; private set; }
@@ -298,6 +299,7 @@ namespace Ryujinx.HLE.HOS
             BsdServer = new ServerBase(KernelContext, "BsdServer");
             AudRenServer = new ServerBase(KernelContext, "AudioRendererServer");
             AudOutServer = new ServerBase(KernelContext, "AudioOutServer");
+            FsServer = new ServerBase(KernelContext, "FsServer");
             HidServer = new ServerBase(KernelContext, "HidServer");
             NvDrvServer = new ServerBase(KernelContext, "NvservicesServer");
             TimeServer = new ServerBase(KernelContext, "TimeServer");

--- a/Ryujinx.HLE/HOS/Services/DisposableIpcService.cs
+++ b/Ryujinx.HLE/HOS/Services/DisposableIpcService.cs
@@ -7,6 +7,8 @@ namespace Ryujinx.HLE.HOS.Services
     {
         private int _disposeState;
 
+        public DisposableIpcService(ServerBase server = null) : base(server) { }
+
         protected abstract void Dispose(bool isDisposing);
 
         public void Dispose()

--- a/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
@@ -28,7 +28,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
     {
         private SharedRef<LibHac.FsSrv.Sf.IFileSystemProxy> _baseFileSystemProxy;
 
-        public IFileSystemProxy(ServiceCtx context)
+        public IFileSystemProxy(ServiceCtx context) : base(context.Device.System.FsServer)
         {
             var applicationClient = context.Device.System.LibHacHorizonManager.ApplicationClient;
             _baseFileSystemProxy = applicationClient.Fs.Impl.GetFileSystemProxyServiceObject();


### PR DESCRIPTION
This should prevent filesystem services from blocking other services that don't have their own ServerBase. May improve filesystem related stutters in certain titles, generally indicated by getting better on a second run (not shader related) or being worse on network/HDD vs SSD.

Improves button advanced cutscenes such as Miqol's Request in Xenoblade: DE when the game is on a network share (used to stutter when voice lines played).

Should probably be tested to make sure no mysterious bugs have been unearthed, and to see if any other filesystem related perf issues are improved.