### PR TITLE
Collapse AsSpan().Slice(..) calls into AsSpan(..)

### DIFF
--- a/ARMeilleure/Translation/SsaConstruction.cs
+++ b/ARMeilleure/Translation/SsaConstruction.cs
@@ -113,7 +113,7 @@ namespace ARMeilleure.Translation
                     }
                 }
 
-                Array.Clear(localDefs, 0, localDefs.Length);
+                Array.Clear(localDefs);
             }
 
             // Second pass, rename variables with definitions on different blocks.

--- a/Ryujinx.Audio/Renderer/Dsp/State/ReverbState.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/State/ReverbState.cs
@@ -112,12 +112,12 @@ namespace Ryujinx.Audio.Renderer.Dsp.State
 
         private ReadOnlySpan<float> GetFdnDelayTimesByLateMode(ReverbLateMode lateMode)
         {
-            return FdnDelayTimes.AsSpan().Slice((int)lateMode * 4, 4);
+            return FdnDelayTimes.AsSpan((int)lateMode * 4, 4);
         }
 
         private ReadOnlySpan<float> GetDecayDelayTimesByLateMode(ReverbLateMode lateMode)
         {
-            return DecayDelayTimes.AsSpan().Slice((int)lateMode * 4, 4);
+            return DecayDelayTimes.AsSpan((int)lateMode * 4, 4);
         }
 
         public ReverbState(ref ReverbParameter parameter, ulong workBuffer, bool isLongSizePreDelaySupported)

--- a/Ryujinx.Audio/Renderer/Server/Voice/VoiceState.cs
+++ b/Ryujinx.Audio/Renderer/Server/Voice/VoiceState.cs
@@ -459,7 +459,7 @@ namespace Ryujinx.Audio.Renderer.Server.Voice
 
             for (int i = 0; i < Constants.VoiceWaveBufferCount; i++)
             {
-                UpdateWaveBuffer(errorInfos.AsSpan().Slice(i * 2, 2), ref WaveBuffers[i], ref parameter.WaveBuffers[i], parameter.SampleFormat, voiceUpdateState.IsWaveBufferValid[i], ref mapper, ref behaviourContext);
+                UpdateWaveBuffer(errorInfos.AsSpan(i * 2, 2), ref WaveBuffers[i], ref parameter.WaveBuffers[i], parameter.SampleFormat, voiceUpdateState.IsWaveBufferValid[i], ref mapper, ref behaviourContext);
             }
         }
 

--- a/Ryujinx.Graphics.Gpu/Shader/Cache/CacheHelper.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/Cache/CacheHelper.cs
@@ -113,7 +113,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache
                 dataSpan[i++] = hash;
             }
 
-            manifestHeader.UpdateChecksum(data.AsSpan().Slice(Unsafe.SizeOf<CacheManifestHeader>()));
+            manifestHeader.UpdateChecksum(data.AsSpan(Unsafe.SizeOf<CacheManifestHeader>()));
 
             MemoryMarshal.Write(data, ref manifestHeader);
 
@@ -447,12 +447,12 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache
 
                 if (cb1DataAddress != 0 && cb1DataSize != 0)
                 {
-                    memoryManager.Physical.GetSpan(cb1DataAddress, cb1DataSize).CopyTo(code.AsSpan().Slice(size, cb1DataSize));
+                    memoryManager.Physical.GetSpan(cb1DataAddress, cb1DataSize).CopyTo(code.AsSpan(size, cb1DataSize));
                 }
 
                 if (translatorContext2 != null)
                 {
-                    memoryManager.GetSpan(translatorContext2.Address, sizeA).CopyTo(code.AsSpan().Slice(size + cb1DataSize, sizeA));
+                    memoryManager.GetSpan(translatorContext2.Address, sizeA).CopyTo(code.AsSpan(size + cb1DataSize, sizeA));
                 }
 
                 GuestGpuAccessorHeader gpuAccessorHeader = CreateGuestGpuAccessorCache(context.GpuAccessor);

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -206,7 +206,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
                                     program = new ShaderProgram(entry.Header.Stage, "");
                                     shaderProgramInfo = hostShaderEntries[0].ToShaderProgramInfo();
 
-                                    byte[] code = entry.Code.AsSpan().Slice(0, entry.Header.Size - entry.Header.Cb1DataSize).ToArray();
+                                    byte[] code = entry.Code.AsSpan(0, entry.Header.Size - entry.Header.Cb1DataSize).ToArray();
 
                                     ShaderCodeHolder shader = new ShaderCodeHolder(program, shaderProgramInfo, code);
 
@@ -244,7 +244,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
                                             return true; // Exit early, the decoding step failed.
                                         }
 
-                                        byte[] code = entry.Code.AsSpan().Slice(0, entry.Header.Size - entry.Header.Cb1DataSize).ToArray();
+                                        byte[] code = entry.Code.AsSpan(0, entry.Header.Size - entry.Header.Cb1DataSize).ToArray();
 
                                         ShaderCodeHolder shader = new ShaderCodeHolder(program, shaderProgramInfo, code);
 
@@ -394,8 +394,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
                                         }
 
                                         // NOTE: Vertex B comes first in the shader cache.
-                                        byte[] code = entry.Code.AsSpan().Slice(0, entry.Header.Size - entry.Header.Cb1DataSize).ToArray();
-                                        byte[] code2 = entry.Header.SizeA != 0 ? entry.Code.AsSpan().Slice(entry.Header.Size, entry.Header.SizeA).ToArray() : null;
+                                        byte[] code = entry.Code.AsSpan(0, entry.Header.Size - entry.Header.Cb1DataSize).ToArray();
+                                        byte[] code2 = entry.Header.SizeA != 0 ? entry.Code.AsSpan(entry.Header.Size, entry.Header.SizeA).ToArray() : null;
 
                                         shaders[i] = new ShaderCodeHolder(program, shaderProgramInfo, code, code2);
 

--- a/Ryujinx.Graphics.OpenGL/Program.cs
+++ b/Ryujinx.Graphics.OpenGL/Program.cs
@@ -124,7 +124,7 @@ namespace Ryujinx.Graphics.OpenGL
 
             GL.GetProgramBinary(Handle, size, out _, out BinaryFormat binFormat, data);
 
-            BinaryPrimitives.WriteInt32LittleEndian(data.AsSpan().Slice(size, 4), (int)binFormat);
+            BinaryPrimitives.WriteInt32LittleEndian(data.AsSpan(size, 4), (int)binFormat);
 
             return data;
         }

--- a/Ryujinx.HLE/HOS/Services/ServerBase.cs
+++ b/Ryujinx.HLE/HOS/Services/ServerBase.cs
@@ -185,7 +185,7 @@ namespace Ryujinx.HLE.HOS.Services
             {
                 for (int i = 0; i < request.RecvListBuff.Count; i++)
                 {
-                    ulong size = (ulong)BinaryPrimitives.ReadInt16LittleEndian(request.RawData.AsSpan().Slice(sizesOffset + i * 2, 2));
+                    ulong size = (ulong)BinaryPrimitives.ReadInt16LittleEndian(request.RawData.AsSpan(sizesOffset + i * 2, 2));
 
                     response.PtrBuff.Add(new IpcPtrBuffDesc(tempAddr, (uint)i, size));
 

--- a/Ryujinx.HLE/Loaders/Executables/KipExecutable.cs
+++ b/Ryujinx.HLE/Loaders/Executables/KipExecutable.cs
@@ -8,9 +8,9 @@ namespace Ryujinx.HLE.Loaders.Executables
     class KipExecutable : IExecutable
     {
         public byte[] Program { get; }
-        public Span<byte> Text => Program.AsSpan().Slice((int)TextOffset, (int)TextSize);
-        public Span<byte> Ro   => Program.AsSpan().Slice((int)RoOffset,   (int)RoSize);
-        public Span<byte> Data => Program.AsSpan().Slice((int)DataOffset, (int)DataSize);
+        public Span<byte> Text => Program.AsSpan((int)TextOffset, (int)TextSize);
+        public Span<byte> Ro   => Program.AsSpan((int)RoOffset,   (int)RoSize);
+        public Span<byte> Data => Program.AsSpan((int)DataOffset, (int)DataSize);
 
         public uint TextOffset { get; }
         public uint RoOffset   { get; }
@@ -76,7 +76,7 @@ namespace Ryujinx.HLE.Loaders.Executables
         {
             reader.GetSegmentSize(segmentType, out int uncompressedSize).ThrowIfFailure();
 
-            var span = program.AsSpan().Slice((int)offset, uncompressedSize);
+            var span = program.AsSpan((int)offset, uncompressedSize);
 
             reader.ReadSegment(segmentType, span).ThrowIfFailure();
 

--- a/Ryujinx.HLE/Loaders/Executables/NroExecutable.cs
+++ b/Ryujinx.HLE/Loaders/Executables/NroExecutable.cs
@@ -7,9 +7,9 @@ namespace Ryujinx.HLE.Loaders.Executables
     class NroExecutable : Nro, IExecutable
     {
         public byte[] Program { get; }
-        public Span<byte> Text => Program.AsSpan().Slice((int)TextOffset, (int)Header.NroSegments[0].Size);
-        public Span<byte> Ro   => Program.AsSpan().Slice((int)RoOffset,   (int)Header.NroSegments[1].Size);
-        public Span<byte> Data => Program.AsSpan().Slice((int)DataOffset, (int)Header.NroSegments[2].Size);
+        public Span<byte> Text => Program.AsSpan((int)TextOffset, (int)Header.NroSegments[0].Size);
+        public Span<byte> Ro   => Program.AsSpan((int)RoOffset,   (int)Header.NroSegments[1].Size);
+        public Span<byte> Data => Program.AsSpan((int)DataOffset, (int)Header.NroSegments[2].Size);
 
         public uint TextOffset => Header.NroSegments[0].FileOffset;
         public uint RoOffset   => Header.NroSegments[1].FileOffset;

--- a/Ryujinx.HLE/Loaders/Executables/NsoExecutable.cs
+++ b/Ryujinx.HLE/Loaders/Executables/NsoExecutable.cs
@@ -12,9 +12,9 @@ namespace Ryujinx.HLE.Loaders.Executables
     class NsoExecutable : IExecutable
     {
         public byte[] Program { get; }
-        public Span<byte> Text => Program.AsSpan().Slice((int)TextOffset, (int)TextSize);
-        public Span<byte> Ro   => Program.AsSpan().Slice((int)RoOffset,   (int)RoSize);
-        public Span<byte> Data => Program.AsSpan().Slice((int)DataOffset, (int)DataSize);
+        public Span<byte> Text => Program.AsSpan((int)TextOffset, (int)TextSize);
+        public Span<byte> Ro   => Program.AsSpan((int)RoOffset,   (int)RoSize);
+        public Span<byte> Data => Program.AsSpan((int)DataOffset, (int)DataSize);
 
         public uint TextOffset { get; }
         public uint RoOffset   { get; }
@@ -58,7 +58,7 @@ namespace Ryujinx.HLE.Loaders.Executables
         {
             reader.GetSegmentSize(segmentType, out uint uncompressedSize).ThrowIfFailure();
 
-            var span = Program.AsSpan().Slice((int)offset, (int)uncompressedSize);
+            var span = Program.AsSpan((int)offset, (int)uncompressedSize);
 
             reader.ReadSegment(segmentType, span).ThrowIfFailure();
 

--- a/Ryujinx.HLE/Loaders/Mods/MemPatch.cs
+++ b/Ryujinx.HLE/Loaders/Mods/MemPatch.cs
@@ -85,7 +85,7 @@ namespace Ryujinx.HLE.Loaders.Mods
 
                 Logger.Info?.Print(LogClass.ModLoader, $"Patching address offset {patchOffset:x} <= {BitConverter.ToString(patch).Replace('-', ' ')} len={patchSize}");
 
-                patch.AsSpan().Slice(0, patchSize).CopyTo(memory.Slice(patchOffset, patchSize));
+                patch.AsSpan(0, patchSize).CopyTo(memory.Slice(patchOffset, patchSize));
 
                 count++;
             }


### PR DESCRIPTION
And collapse one Array.Clear(array, 0, array.Length) to just Array.Clear(array)

Less code and a bit faster.
