### PR TITLE
gui: Fixes the games icon when there is an update 

### DIFF
--- a/Ryujinx/Ui/App/ApplicationLibrary.cs
+++ b/Ryujinx/Ui/App/ApplicationLibrary.cs
@@ -242,15 +242,20 @@ namespace Ryujinx.Ui.App
                                 }
                                 else
                                 {
-                                    // Store the ControlFS in variable called controlFs
                                     GetControlFsAndTitleId(pfs, out IFileSystem controlFs, out titleId);
+
+                                    // Check if there is an update available.
+                                    IsUpdateApplied(titleId, out IFileSystem updatedControlFs);
+
+                                    if (updatedControlFs != null)
+                                    {
+                                        // Replace the original ControlFs by the updated one.
+                                        controlFs = updatedControlFs;
+                                    }
 
                                     ReadControlData(controlFs, controlHolder.ByteSpan);
 
-                                    // Get the title name, title ID, developer name and version number from the NACP
-                                    version = IsUpdateApplied(titleId, out string updateVersion) ? updateVersion : controlHolder.Value.DisplayVersion.ToString();
-
-                                    GetNameIdDeveloper(ref controlHolder.Value, out titleName, out _, out developer);
+                                    GetGameInformation(ref controlHolder.Value, out titleName, out _, out developer, out version);
 
                                     // Read the icon from the ControlFS and store it as a byte array
                                     try
@@ -351,10 +356,7 @@ namespace Ryujinx.Ui.App
                                     // Read the NACP data
                                     Read(assetOffset + (int)nacpOffset, (int)nacpSize).AsSpan().CopyTo(controlHolder.ByteSpan);
 
-                                    // Get the title name, title ID, developer name and version number from the NACP
-                                    version = controlHolder.Value.DisplayVersion.ToString();
-
-                                    GetNameIdDeveloper(ref controlHolder.Value, out titleName, out titleId, out developer);
+                                    GetGameInformation(ref controlHolder.Value, out titleName, out titleId, out developer, out version);
                                 }
                                 else
                                 {
@@ -554,7 +556,7 @@ namespace Ryujinx.Ui.App
             return readableString;
         }
 
-        private void GetNameIdDeveloper(ref ApplicationControlProperty controlData, out string titleName, out string titleId, out string publisher)
+        private void GetGameInformation(ref ApplicationControlProperty controlData, out string titleName, out string titleId, out string publisher, out string version)
         {
             _ = Enum.TryParse(_desiredTitleLanguage.ToString(), out TitleLanguage desiredTitleLanguage);
 
@@ -611,10 +613,14 @@ namespace Ryujinx.Ui.App
             {
                 titleId = "0000000000000000";
             }
+
+            version = controlData.DisplayVersion.ToString();
         }
 
-        private bool IsUpdateApplied(string titleId, out string version)
+        private bool IsUpdateApplied(string titleId, out IFileSystem updatedControlFs)
         {
+            updatedControlFs = null;
+            
             string updatePath = "(unknown)";
 
             try
@@ -623,14 +629,7 @@ namespace Ryujinx.Ui.App
 
                 if (patchNca != null && controlNca != null)
                 {
-                    ApplicationControlProperty controlData = new ApplicationControlProperty();
-                    using var nacpFile = new UniqueRef<IFile>();
-
-                    controlNca.OpenFileSystem(NcaSectionType.Data, IntegrityCheckLevel.None).OpenFile(ref nacpFile.Ref(), "/control.nacp".ToU8Span(), OpenMode.Read).ThrowIfFailure();
-
-                    nacpFile.Get.Read(out _, 0, SpanHelpers.AsByteSpan(ref controlData), ReadOption.None).ThrowIfFailure();
-
-                    version = controlData.DisplayVersion.ToString();
+                    updatedControlFs = controlNca?.OpenFileSystem(NcaSectionType.Data, IntegrityCheckLevel.None);
 
                     return true;
                 }
@@ -644,8 +643,6 @@ namespace Ryujinx.Ui.App
             {
                 Logger.Warning?.Print(LogClass.Application, $"Your key set is missing a key with the name: {exception.Name}. Errored File: {updatePath}");
             }
-
-            version = "";
 
             return false;
         }

--- a/Ryujinx/Ui/App/ApplicationLibrary.cs
+++ b/Ryujinx/Ui/App/ApplicationLibrary.cs
@@ -245,9 +245,7 @@ namespace Ryujinx.Ui.App
                                     GetControlFsAndTitleId(pfs, out IFileSystem controlFs, out titleId);
 
                                     // Check if there is an update available.
-                                    IsUpdateApplied(titleId, out IFileSystem updatedControlFs);
-
-                                    if (updatedControlFs != null)
+                                    if (IsUpdateApplied(titleId, out IFileSystem updatedControlFs))
                                     {
                                         // Replace the original ControlFs by the updated one.
                                         controlFs = updatedControlFs;


### PR DESCRIPTION
Currently we just load the version of the update, instead of the whole NACP file. This PR fixes that. A little cleanup is made into the code to avoid duplicate things.
(Closes #3039)

Before:
![image](https://user-images.githubusercontent.com/4905390/154864937-10719be7-570b-41c2-aa60-4f0806c8b196.png)

After:
![image](https://user-images.githubusercontent.com/4905390/154864950-1414d6a3-1e9f-4e80-b3eb-4a2e066b5fa5.png)
