### PR TITLE
Allow copy texture views to have mismatching multisample state

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -513,7 +513,14 @@ namespace Ryujinx.Graphics.Gpu.Image
             for (int index = 0; index < overlapsCount; index++)
             {
                 Texture overlap = _textureOverlaps[index];
-                TextureViewCompatibility overlapCompatibility = overlap.IsViewCompatible(info, range.Value, sizeInfo.LayerSize, _context.Capabilities, out int firstLayer, out int firstLevel);
+                TextureViewCompatibility overlapCompatibility = overlap.IsViewCompatible(
+                    info,
+                    range.Value,
+                    sizeInfo.LayerSize,
+                    _context.Capabilities,
+                    flags.HasFlag(TextureSearchFlags.ForCopy),
+                    out int firstLayer,
+                    out int firstLevel);
 
                 if (overlapCompatibility == TextureViewCompatibility.Full)
                 {
@@ -621,7 +628,14 @@ namespace Ryujinx.Graphics.Gpu.Image
                     Texture overlap = _textureOverlaps[index];
                     bool overlapInCache = overlap.CacheNode != null;
 
-                    TextureViewCompatibility compatibility = texture.IsViewCompatible(overlap.Info, overlap.Range, overlap.LayerSize, _context.Capabilities, out int firstLayer, out int firstLevel);
+                    TextureViewCompatibility compatibility = texture.IsViewCompatible(
+                        overlap.Info,
+                        overlap.Range,
+                        overlap.LayerSize,
+                        _context.Capabilities,
+                        false,
+                        out int firstLayer,
+                        out int firstLevel);
 
                     if (overlap.IsView && compatibility == TextureViewCompatibility.Full)
                     {
@@ -658,7 +672,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     else
                     {
                         bool dataOverlaps = texture.DataOverlaps(overlap, compatibility);
-                        
+
                         if (!overlap.IsView && dataOverlaps && !incompatibleOverlaps.Exists(incompatible => incompatible.Group == overlap.Group))
                         {
                             incompatibleOverlaps.Add(new TextureIncompatibleOverlap(overlap.Group, compatibility));
@@ -963,20 +977,34 @@ namespace Ryujinx.Graphics.Gpu.Image
                 depthOrLayers = info.DepthOrLayers;
             }
 
+            // 2D and 2D multisample textures are not considered compatible.
+            // This specific case is required for copies, where the source texture might be multisample.
+            // In this case, we inherit the parent texture multisample state.
+            Target target = info.Target;
+            int samplesInX = info.SamplesInX;
+            int samplesInY = info.SamplesInY;
+
+            if (target == Target.Texture2D && parent.Target == Target.Texture2DMultisample)
+            {
+                target = Target.Texture2DMultisample;
+                samplesInX = parent.Info.SamplesInX;
+                samplesInY = parent.Info.SamplesInY;
+            }
+
             return new TextureInfo(
                 info.GpuAddress,
                 width,
                 height,
                 depthOrLayers,
                 info.Levels,
-                info.SamplesInX,
-                info.SamplesInY,
+                samplesInX,
+                samplesInY,
                 info.Stride,
                 info.IsLinear,
                 info.GobBlocksInY,
                 info.GobBlocksInZ,
                 info.GobBlocksInTileX,
-                info.Target,
+                target,
                 info.FormatInfo,
                 info.DepthStencilMode,
                 info.SwizzleR,


### PR DESCRIPTION
We have no way to know if textures are multisampled on the 2D engine for copies. Currently, this is handled by allowing the matched texture to be multisampled, even if we are looking for a non-multisample 2D texture for copies. The problem is that right now, this is only allowed for *exact* matches, which means that if the copy texture is slightly different from the one in the cache (for example, the format is different, such as render target texture being Unorm and copy one being Srgb), exact match will fail and it will try to create a view instead, or new texture if that fails too.

This case is happening on Pinball FX3 with the update. Render target is Unorm, copy is Srgb, exact match fails, view match fails because the target is different (render target is 2DMultisample, copy is just 2D), and then it is forced to create a new texture, and the copy is broken as it doesn't have the render target data.

This change fixes this by also allowing multisample state to not match for views when looking for copy textures. The `AdjustSizes` method was also changed to propagate the multisample state from the view parent in this case. This fixes the black screen issue on the game, see screenshots below for comparison.

Before:
![image](https://user-images.githubusercontent.com/5624669/155052799-7aff3346-acf2-412d-9e32-711cef5ca201.png)
After:
![image](https://user-images.githubusercontent.com/5624669/155052819-249bee1d-e1a2-411e-900e-5645d04031aa.png)
![image](https://user-images.githubusercontent.com/5624669/155052836-d9bcddc6-5a3a-4029-93c8-ddb29f189eb0.png)

I recommend reviewing the changes carefully as I don't touch the texture cache in a long time, and it used to be pretty easy to break.