### PR TITLE
Decoder: Exit on trapping instructions, and resume execution at trapping instruction

### DIFF
--- a/ARMeilleure/Decoders/Decoder.cs
+++ b/ARMeilleure/Decoders/Decoder.cs
@@ -32,13 +32,13 @@ namespace ARMeilleure.Decoders
 
             int instructionLimit = highCq ? MaxInstsPerFunction : MaxInstsPerFunctionLowCq;
 
-            Block GetBlock(ulong blkAddress, bool mustExit = false)
+            Block GetBlock(ulong blkAddress)
             {
                 if (!visited.TryGetValue(blkAddress, out Block block))
                 {
                     block = new Block(blkAddress);
 
-                    if (mustExit || (dMode != DecoderMode.MultipleBlocks && visited.Count >= 1) || opsCount > instructionLimit || !memory.IsMapped(blkAddress))
+                    if ((dMode != DecoderMode.MultipleBlocks && visited.Count >= 1) || opsCount > instructionLimit || !memory.IsMapped(blkAddress))
                     {
                         block.Exit = true;
                         block.EndAddress = blkAddress;

--- a/ARMeilleure/Decoders/Decoder.cs
+++ b/ARMeilleure/Decoders/Decoder.cs
@@ -121,12 +121,7 @@ namespace ARMeilleure.Decoders
                             currBlock.Branch = GetBlock((ulong)op.Immediate);
                         }
 
-                        if (IsTrap(lastOp))
-                        {
-                            // On reentry, resume execution at the address of the trapping instruction.
-                            currBlock.Next = GetBlock(lastOp.Address, mustExit: true);
-                        }
-                        else if (!IsUnconditionalBranch(lastOp) || isCall)
+                        if (isCall || !(IsUnconditionalBranch(lastOp) || IsTrap(lastOp)))
                         {
                             currBlock.Next = GetBlock(currBlock.EndAddress);
                         }

--- a/ARMeilleure/Instructions/InstEmitException.cs
+++ b/ARMeilleure/Instructions/InstEmitException.cs
@@ -9,17 +9,24 @@ namespace ARMeilleure.Instructions
     {
         public static void Brk(ArmEmitterContext context)
         {
-            EmitExceptionCall(context, nameof(NativeInterface.Break));
+            OpCodeException op = (OpCodeException)context.CurrOp;
+
+            string name = nameof(NativeInterface.Break);
+
+            context.StoreToContext();
+
+            context.Call(typeof(NativeInterface).GetMethod(name), Const(op.Address), Const(op.Id));
+
+            context.LoadFromContext();
+
+            context.Return(Const(op.Address));
         }
 
         public static void Svc(ArmEmitterContext context)
         {
-            EmitExceptionCall(context, nameof(NativeInterface.SupervisorCall));
-        }
-
-        private static void EmitExceptionCall(ArmEmitterContext context, string name)
-        {
             OpCodeException op = (OpCodeException)context.CurrOp;
+
+            string name = nameof(NativeInterface.SupervisorCall);
 
             context.StoreToContext();
 
@@ -41,6 +48,8 @@ namespace ARMeilleure.Instructions
             context.Call(typeof(NativeInterface).GetMethod(name), Const(op.Address), Const(op.RawOpCode));
 
             context.LoadFromContext();
+
+            context.Return(Const(op.Address));
         }
     }
 }

--- a/ARMeilleure/Instructions/InstEmitException32.cs
+++ b/ARMeilleure/Instructions/InstEmitException32.cs
@@ -10,17 +10,9 @@ namespace ARMeilleure.Instructions
     {
         public static void Svc(ArmEmitterContext context)
         {
-            EmitExceptionCall(context, nameof(NativeInterface.SupervisorCall));
-        }
-
-        public static void Trap(ArmEmitterContext context)
-        {
-            EmitExceptionCall(context, nameof(NativeInterface.Break));
-        }
-
-        private static void EmitExceptionCall(ArmEmitterContext context, string name)
-        {
             IOpCode32Exception op = (IOpCode32Exception)context.CurrOp;
+
+            string name = nameof(NativeInterface.SupervisorCall);
 
             context.StoreToContext();
 
@@ -29,6 +21,21 @@ namespace ARMeilleure.Instructions
             context.LoadFromContext();
 
             Translator.EmitSynchronization(context);
+        }
+
+        public static void Trap(ArmEmitterContext context)
+        {
+            IOpCode32Exception op = (IOpCode32Exception)context.CurrOp;
+
+            string name = nameof(NativeInterface.Break);
+
+            context.StoreToContext();
+
+            context.Call(typeof(NativeInterface).GetMethod(name), Const(((IOpCode)op).Address), Const(op.Id));
+
+            context.LoadFromContext();
+
+            context.Return(Const(context.CurrOp.Address));
         }
     }
 }


### PR DESCRIPTION
Exiting when encountering a trapping instruction is important for ensuring correct behavior, because further code beyond the trapping instruction should not execute. This allows for the opportunity for a debugger (e.g. gdbstub) that has taken over the dispatch loop to redirect the program counter appropriately.

If an instruction is a trap, we expect execution to normally resume at the trapping instruction itself. The common usecase for this is when a BRK instruction is inserted as a software breakpoint, and execution is expected to resume at that location once the original instruction has been replaced.