### PR TITLE
InstEmitSimdHelper: Add SSE2 impl of saturate float to 32-bit int

### DIFF
--- a/ARMeilleure/CodeGen/X86/AssemblerTable.cs
+++ b/ARMeilleure/CodeGen/X86/AssemblerTable.cs
@@ -103,6 +103,7 @@ namespace ARMeilleure.CodeGen.X86
             Add(X86Instruction.Cvtsi2ss,     new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x00000f2a, InstructionFlags.Vex | InstructionFlags.PrefixF3));
             Add(X86Instruction.Cvtss2sd,     new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x00000f5a, InstructionFlags.Vex | InstructionFlags.PrefixF3));
             Add(X86Instruction.Cvtss2si,     new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x00000f2d, InstructionFlags.Vex | InstructionFlags.PrefixF3));
+            Add(X86Instruction.Cvttsd2si,    new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x00000f2c, InstructionFlags.Vex | InstructionFlags.PrefixF2));
             Add(X86Instruction.Div,          new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x060000f7, InstructionFlags.None));
             Add(X86Instruction.Divpd,        new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x00000f5e, InstructionFlags.Vex | InstructionFlags.Prefix66));
             Add(X86Instruction.Divps,        new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x00000f5e, InstructionFlags.Vex));

--- a/ARMeilleure/CodeGen/X86/IntrinsicTable.cs
+++ b/ARMeilleure/CodeGen/X86/IntrinsicTable.cs
@@ -54,6 +54,7 @@ namespace ARMeilleure.CodeGen.X86
             Add(Intrinsic.X86Cvtsi2ss,     new IntrinsicInfo(X86Instruction.Cvtsi2ss,     IntrinsicType.BinaryGpr));
             Add(Intrinsic.X86Cvtss2sd,     new IntrinsicInfo(X86Instruction.Cvtss2sd,     IntrinsicType.Binary));
             Add(Intrinsic.X86Cvtss2si,     new IntrinsicInfo(X86Instruction.Cvtss2si,     IntrinsicType.UnaryToGpr));
+            Add(Intrinsic.X86Cvttsd2si,    new IntrinsicInfo(X86Instruction.Cvttsd2si,    IntrinsicType.UnaryToGpr));
             Add(Intrinsic.X86Divpd,        new IntrinsicInfo(X86Instruction.Divpd,        IntrinsicType.Binary));
             Add(Intrinsic.X86Divps,        new IntrinsicInfo(X86Instruction.Divps,        IntrinsicType.Binary));
             Add(Intrinsic.X86Divsd,        new IntrinsicInfo(X86Instruction.Divsd,        IntrinsicType.Binary));

--- a/ARMeilleure/CodeGen/X86/X86Instruction.cs
+++ b/ARMeilleure/CodeGen/X86/X86Instruction.cs
@@ -49,6 +49,7 @@ namespace ARMeilleure.CodeGen.X86
         Cvtsi2ss,
         Cvtss2sd,
         Cvtss2si,
+        Cvttsd2si,
         Div,
         Divpd,
         Divps,

--- a/ARMeilleure/Instructions/InstEmitSimdCvt.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdCvt.cs
@@ -695,21 +695,13 @@ namespace ARMeilleure.Instructions
 
                 if (sizeF == 0)
                 {
-                    MethodInfo info = signed
-                        ? typeof(SoftFallback).GetMethod(nameof(SoftFallback.SatF32ToS32))
-                        : typeof(SoftFallback).GetMethod(nameof(SoftFallback.SatF32ToU32));
-
-                    e = context.Call(info, e);
+                    e = EmitSaturateFloatToInt32(context, e, isF64: false, unsigned: !signed);
 
                     e = context.ZeroExtend32(OperandType.I64, e);
                 }
                 else /* if (sizeF == 1) */
                 {
-                    MethodInfo info = signed
-                        ? typeof(SoftFallback).GetMethod(nameof(SoftFallback.SatF64ToS64))
-                        : typeof(SoftFallback).GetMethod(nameof(SoftFallback.SatF64ToU64));
-
-                    e = context.Call(info, e);
+                    e = EmitSaturateFloatToInt64(context, e, isF64: true, unsigned: !signed);
                 }
 
                 res = EmitVectorInsert(context, res, e, index, sizeI);
@@ -743,21 +735,13 @@ namespace ARMeilleure.Instructions
 
                 if (sizeF == 0)
                 {
-                    MethodInfo info = signed
-                        ? typeof(SoftFallback).GetMethod(nameof(SoftFallback.SatF32ToS32))
-                        : typeof(SoftFallback).GetMethod(nameof(SoftFallback.SatF32ToU32));
-
-                    e = context.Call(info, e);
+                    e = EmitSaturateFloatToInt32(context, e, isF64: false, unsigned: !signed);
 
                     e = context.ZeroExtend32(OperandType.I64, e);
                 }
                 else /* if (sizeF == 1) */
                 {
-                    MethodInfo info = signed
-                        ? typeof(SoftFallback).GetMethod(nameof(SoftFallback.SatF64ToS64))
-                        : typeof(SoftFallback).GetMethod(nameof(SoftFallback.SatF64ToU64));
-
-                    e = context.Call(info, e);
+                    e = EmitSaturateFloatToInt64(context, e, isF64: true, unsigned: !signed);
                 }
 
                 res = EmitVectorInsert(context, res, e, index, sizeI);
@@ -876,22 +860,14 @@ namespace ARMeilleure.Instructions
 
             value = EmitF2iFBitsMul(context, value, fBits);
 
-            MethodInfo info;
-
             if (context.CurrOp.RegisterSize == RegisterSize.Int32)
             {
-                info = value.Type == OperandType.FP32
-                    ? typeof(SoftFallback).GetMethod(nameof(SoftFallback.SatF32ToS32))
-                    : typeof(SoftFallback).GetMethod(nameof(SoftFallback.SatF64ToS32));
+                return EmitSaturateFloatToInt32(context, value, value.Type == OperandType.FP64, unsigned: false);
             }
             else
             {
-                info = value.Type == OperandType.FP32
-                    ? typeof(SoftFallback).GetMethod(nameof(SoftFallback.SatF32ToS64))
-                    : typeof(SoftFallback).GetMethod(nameof(SoftFallback.SatF64ToS64));
+                return EmitSaturateFloatToInt64(context, value, value.Type == OperandType.FP64, unsigned: false);
             }
-
-            return context.Call(info, value);
         }
 
         private static Operand EmitScalarFcvtu(ArmEmitterContext context, Operand value, int fBits)
@@ -900,22 +876,14 @@ namespace ARMeilleure.Instructions
 
             value = EmitF2iFBitsMul(context, value, fBits);
 
-            MethodInfo info;
-
             if (context.CurrOp.RegisterSize == RegisterSize.Int32)
             {
-                info = value.Type == OperandType.FP32
-                    ? typeof(SoftFallback).GetMethod(nameof(SoftFallback.SatF32ToU32))
-                    : typeof(SoftFallback).GetMethod(nameof(SoftFallback.SatF64ToU32));
+                return EmitSaturateFloatToInt32(context, value, value.Type == OperandType.FP64, unsigned: true);
             }
             else
             {
-                info = value.Type == OperandType.FP32
-                    ? typeof(SoftFallback).GetMethod(nameof(SoftFallback.SatF32ToU64))
-                    : typeof(SoftFallback).GetMethod(nameof(SoftFallback.SatF64ToU64));
+                return EmitSaturateFloatToInt64(context, value, value.Type == OperandType.FP64, unsigned: true);
             }
-
-            return context.Call(info, value);
         }
 
         private static Operand EmitF2iFBitsMul(ArmEmitterContext context, Operand value, int fBits)

--- a/ARMeilleure/Instructions/InstEmitSimdHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdHelper.cs
@@ -1613,6 +1613,46 @@ namespace ARMeilleure.Instructions
             return context.AddIntrinsic(single ? Intrinsic.X86Andnps : Intrinsic.X86Andnpd, mask, value);
         }
 
+        public static Operand EmitSaturateFloatToInt32(ArmEmitterContext context, Operand value, bool isF64, bool unsigned)
+        {
+            MethodInfo info;
+
+            if (isF64)
+            {
+                info = unsigned
+                    ? typeof(SoftFallback).GetMethod(nameof(SoftFallback.SatF64ToU32))
+                    : typeof(SoftFallback).GetMethod(nameof(SoftFallback.SatF64ToS32));
+            }
+            else
+            {
+                info = unsigned
+                    ? typeof(SoftFallback).GetMethod(nameof(SoftFallback.SatF32ToU32))
+                    : typeof(SoftFallback).GetMethod(nameof(SoftFallback.SatF32ToS32));
+            }
+
+            return context.Call(info, value);
+        }
+
+        public static Operand EmitSaturateFloatToInt64(ArmEmitterContext context, Operand value, bool isF64, bool unsigned)
+        {
+            MethodInfo info;
+
+            if (value.Type == OperandType.FP64)
+            {
+                info = unsigned
+                    ? typeof(SoftFallback).GetMethod(nameof(SoftFallback.SatF64ToU64))
+                    : typeof(SoftFallback).GetMethod(nameof(SoftFallback.SatF64ToS64));
+            }
+            else
+            {
+                info = unsigned
+                    ? typeof(SoftFallback).GetMethod(nameof(SoftFallback.SatF32ToU64))
+                    : typeof(SoftFallback).GetMethod(nameof(SoftFallback.SatF32ToS64));
+            }
+
+            return context.Call(info, value);
+        }
+
         public static Operand EmitVectorExtractSx(ArmEmitterContext context, int reg, int index, int size)
         {
             return EmitVectorExtract(context, reg, index, size, true);

--- a/ARMeilleure/IntermediateRepresentation/Intrinsic.cs
+++ b/ARMeilleure/IntermediateRepresentation/Intrinsic.cs
@@ -43,6 +43,7 @@ namespace ARMeilleure.IntermediateRepresentation
         X86Cvtsi2ss,
         X86Cvtss2sd,
         X86Cvtss2si,
+        X86Cvttsd2si,
         X86Divpd,
         X86Divps,
         X86Divsd,


### PR DESCRIPTION
Self explanatory. Requires tests for completness.

32-bit version only currently, because writing a 64-bit implementation is [not entirely trivial](https://github.com/merryhime/dynarmic/blob/76ec1afdad3835ad6e87e6b711663a5aaf2c1939/src/dynarmic/backend/x64/emit_x64_floating_point.cpp#L1500-L1528).