### PR TITLE
Add X86 support to build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,11 @@ jobs:
           OS_NAME: Windows x64
           DOTNET_RUNTIME_IDENTIFIER: win-x64
           RELEASE_ZIP_OS_NAME: win_x64
+          
+        - os: windows-latest
+          OS_NAME: Windows x86
+          DOTNET_RUNTIME_IDENTIFIER: win-x86
+          RELEASE_ZIP_OS_NAME: win_x86
 
       fail-fast: false
     env:


### PR DESCRIPTION
I stuck on Windows 10 X86 without USB stick, but I think Windows 10 X86 will work with this emulator.
I can't understand why there's no X86 support.