### PR TITLE
ThreadedRenderer: Remove check for _dispose

### DIFF
--- a/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
@@ -112,7 +112,7 @@ namespace Ryujinx.Graphics.GAL.Multithreading
         {
             // Power through the render queue until the Gpu thread work is done.
 
-            while (_running && !_disposed)
+            while (_running)
             {
                 _galWorkAvailable.Wait();
                 _galWorkAvailable.Reset();


### PR DESCRIPTION
This check is unnecessary and causes command consumption to end too early.

_running is set to false when gpuLoop terminates, which would allow the command loop to terminate.