### PR TITLE
Mod loading from atmosphere SD directories

### DIFF
--- a/Ryujinx.Common/Configuration/AppDataManager.cs
+++ b/Ryujinx.Common/Configuration/AppDataManager.cs
@@ -34,6 +34,7 @@ namespace Ryujinx.Common.Configuration
         private const string DefaultModsDir = "mods";
 
         public static string CustomModsPath { get; set; }
+        public static string CustomSdModsPath {get; set; }
         public static string CustomNandPath { get; set; } // TODO: Actually implement this into VFS
         public static string CustomSdCardPath { get; set; } // TODO: Actually implement this into VFS
 
@@ -85,5 +86,6 @@ namespace Ryujinx.Common.Configuration
         }
 
         public static string GetModsPath() => CustomModsPath ?? Directory.CreateDirectory(Path.Combine(BaseDirPath, DefaultModsDir)).FullName;
+        public static string GetSdModsPath() => CustomSdModsPath ?? Directory.CreateDirectory(Path.Combine(BaseDirPath, DefaultSdcardDir, "atmosphere")).FullName;
     }
 }

--- a/Ryujinx.Common/Configuration/AppDataManager.cs
+++ b/Ryujinx.Common/Configuration/AppDataManager.cs
@@ -85,7 +85,7 @@ namespace Ryujinx.Common.Configuration
             Directory.CreateDirectory(KeysDirPath = Path.Combine(BaseDirPath, KeysDir));
         }
 
-        public static string GetModsPath() => CustomModsPath ?? Directory.CreateDirectory(Path.Combine(BaseDirPath, DefaultModsDir)).FullName;
+        public static string GetModsPath()   => CustomModsPath ?? Directory.CreateDirectory(Path.Combine(BaseDirPath, DefaultModsDir)).FullName;
         public static string GetSdModsPath() => CustomSdModsPath ?? Directory.CreateDirectory(Path.Combine(BaseDirPath, DefaultSdcardDir, "atmosphere")).FullName;
     }
 }

--- a/Ryujinx.HLE/HOS/ApplicationLoader.cs
+++ b/Ryujinx.HLE/HOS/ApplicationLoader.cs
@@ -84,7 +84,7 @@ namespace Ryujinx.HLE.HOS
 
             MetaLoader metaData = ReadNpdm(codeFs);
 
-            _device.Configuration.VirtualFileSystem.ModLoader.CollectMods(new[] { TitleId }, _device.Configuration.VirtualFileSystem.ModLoader.GetModsBasePath());
+            _device.Configuration.VirtualFileSystem.ModLoader.CollectMods(new[] { TitleId }, _device.Configuration.VirtualFileSystem.ModLoader.GetModsBasePath(), _device.Configuration.VirtualFileSystem.ModLoader.GetSdModsBasePath());
 
             if (TitleId != 0)
             {
@@ -388,7 +388,7 @@ namespace Ryujinx.HLE.HOS
 
             MetaLoader metaData = ReadNpdm(codeFs);
 
-            _device.Configuration.VirtualFileSystem.ModLoader.CollectMods(_device.Configuration.ContentManager.GetAocTitleIds().Prepend(TitleId), _device.Configuration.VirtualFileSystem.ModLoader.GetModsBasePath());
+            _device.Configuration.VirtualFileSystem.ModLoader.CollectMods(_device.Configuration.ContentManager.GetAocTitleIds().Prepend(TitleId), _device.Configuration.VirtualFileSystem.ModLoader.GetModsBasePath(), _device.Configuration.VirtualFileSystem.ModLoader.GetSdModsBasePath());
 
             if (controlNca != null)
             {

--- a/Ryujinx.HLE/HOS/ApplicationLoader.cs
+++ b/Ryujinx.HLE/HOS/ApplicationLoader.cs
@@ -84,7 +84,10 @@ namespace Ryujinx.HLE.HOS
 
             MetaLoader metaData = ReadNpdm(codeFs);
 
-            _device.Configuration.VirtualFileSystem.ModLoader.CollectMods(new[] { TitleId }, _device.Configuration.VirtualFileSystem.ModLoader.GetModsBasePath(), _device.Configuration.VirtualFileSystem.ModLoader.GetSdModsBasePath());
+            _device.Configuration.VirtualFileSystem.ModLoader.CollectMods(
+                new[] { TitleId }, 
+                _device.Configuration.VirtualFileSystem.ModLoader.GetModsBasePath(), 
+                _device.Configuration.VirtualFileSystem.ModLoader.GetSdModsBasePath());
 
             if (TitleId != 0)
             {
@@ -388,7 +391,10 @@ namespace Ryujinx.HLE.HOS
 
             MetaLoader metaData = ReadNpdm(codeFs);
 
-            _device.Configuration.VirtualFileSystem.ModLoader.CollectMods(_device.Configuration.ContentManager.GetAocTitleIds().Prepend(TitleId), _device.Configuration.VirtualFileSystem.ModLoader.GetModsBasePath(), _device.Configuration.VirtualFileSystem.ModLoader.GetSdModsBasePath());
+            _device.Configuration.VirtualFileSystem.ModLoader.CollectMods(
+                _device.Configuration.ContentManager.GetAocTitleIds().Prepend(TitleId), 
+                _device.Configuration.VirtualFileSystem.ModLoader.GetModsBasePath(), 
+                _device.Configuration.VirtualFileSystem.ModLoader.GetSdModsBasePath());
 
             if (controlNca != null)
             {

--- a/Ryujinx.HLE/HOS/ModLoader.cs
+++ b/Ryujinx.HLE/HOS/ModLoader.cs
@@ -136,7 +136,7 @@ namespace Ryujinx.HLE.HOS
 
         private static bool StrEquals(string s1, string s2) => string.Equals(s1, s2, StringComparison.OrdinalIgnoreCase);
 
-        public string GetModsBasePath() => EnsureBaseDirStructure(AppDataManager.GetModsPath());
+        public string GetModsBasePath()   => EnsureBaseDirStructure(AppDataManager.GetModsPath());
         public string GetSdModsBasePath() => EnsureBaseDirStructure(AppDataManager.GetSdModsPath());
 
         private string EnsureBaseDirStructure(string modsBasePath)

--- a/Ryujinx.HLE/HOS/ModLoader.cs
+++ b/Ryujinx.HLE/HOS/ModLoader.cs
@@ -137,6 +137,7 @@ namespace Ryujinx.HLE.HOS
         private static bool StrEquals(string s1, string s2) => string.Equals(s1, s2, StringComparison.OrdinalIgnoreCase);
 
         public string GetModsBasePath() => EnsureBaseDirStructure(AppDataManager.GetModsPath());
+        public string GetSdModsBasePath() => EnsureBaseDirStructure(AppDataManager.GetSdModsPath());
 
         private string EnsureBaseDirStructure(string modsBasePath)
         {

--- a/Ryujinx/Ui/Widgets/GameTableContextMenu.Designer.cs
+++ b/Ryujinx/Ui/Widgets/GameTableContextMenu.Designer.cs
@@ -92,7 +92,7 @@ namespace Ryujinx.Ui.Widgets
             //
             // _openTitleSdModDirMenuItem
             //
-            _openTitleSdModDirMenuItem = new MenuItem("Open SD Atmosphere Mods Directory")
+            _openTitleSdModDirMenuItem = new MenuItem("Open Atmosphere Mods Directory")
             {
                 TooltipText = "Open the alternative SD card atmosphere directory which contains the Application's Mods."
             };

--- a/Ryujinx/Ui/Widgets/GameTableContextMenu.Designer.cs
+++ b/Ryujinx/Ui/Widgets/GameTableContextMenu.Designer.cs
@@ -11,6 +11,7 @@ namespace Ryujinx.Ui.Widgets
         private MenuItem _manageDlcMenuItem;
         private MenuItem _manageCheatMenuItem;
         private MenuItem _openTitleModDirMenuItem;
+        private MenuItem _openTitleSdModDirMenuItem;
         private Menu     _extractSubMenu;
         private MenuItem _extractMenuItem;
         private MenuItem _extractRomFsMenuItem;
@@ -87,6 +88,15 @@ namespace Ryujinx.Ui.Widgets
                 TooltipText = "Open the directory which contains Application's Mods."
             };
             _openTitleModDirMenuItem.Activated += OpenTitleModDir_Clicked;
+
+            //
+            // _openTitleSdModDirMenuItem
+            //
+            _openTitleSdModDirMenuItem = new MenuItem("Open SD Atmosphere Mods Directory")
+            {
+                TooltipText = "Open the alternative SD card atmosphere directory which contains the Application's Mods."
+            };
+            _openTitleSdModDirMenuItem.Activated += OpenTitleSdModDir_Clicked;
 
             //
             // _extractSubMenu
@@ -199,6 +209,7 @@ namespace Ryujinx.Ui.Widgets
             Add(_manageDlcMenuItem);
             Add(_manageCheatMenuItem);
             Add(_openTitleModDirMenuItem);
+            Add(_openTitleSdModDirMenuItem);
             Add(new SeparatorMenuItem());
             Add(_manageCacheMenuItem);
             Add(_extractMenuItem);

--- a/Ryujinx/Ui/Widgets/GameTableContextMenu.cs
+++ b/Ryujinx/Ui/Widgets/GameTableContextMenu.cs
@@ -477,6 +477,14 @@ namespace Ryujinx.Ui.Widgets
             OpenHelper.OpenFolder(titleModsPath);
         }
 
+        private void OpenTitleSdModDir_Clicked(object sender, EventArgs args)
+        {
+            string sdModsBasePath  = _virtualFileSystem.ModLoader.GetSdModsBasePath();
+            string titleModsPath   = _virtualFileSystem.ModLoader.GetTitleDir(sdModsBasePath, _titleIdText);
+
+            OpenHelper.OpenFolder(titleModsPath);
+        }
+
         private void ExtractRomFs_Clicked(object sender, EventArgs args)
         {
             ExtractSection(NcaSectionType.Data);


### PR DESCRIPTION
Implements addition of SD paths into the ModLoader so that standard atmosphere/hardware directory set up mods can be used semi-seamlessly. GUI context menu addition to open the directory is also added.

![image](https://user-images.githubusercontent.com/44103205/156784628-b0392ddf-3f30-491c-bc28-b18ed78af9d4.png)
![image](https://user-images.githubusercontent.com/44103205/156784683-3ae5ee1c-9491-4bba-8db9-2dbea68ba6f0.png)
![image](https://user-images.githubusercontent.com/44103205/156784747-87407a01-c103-4b0c-bb38-72bd5dd76ebd.png)

Closes #3174 