### PR TITLE
A32: Fix ALU immediate instructions

### DIFF
--- a/ARMeilleure/Instructions/InstEmitAluHelper.cs
+++ b/ARMeilleure/Instructions/InstEmitAluHelper.cs
@@ -197,7 +197,7 @@ namespace ARMeilleure.Instructions
                 // ARM32.
                 case IOpCode32AluImm op:
                 {
-                    if (ShouldSetFlags(context) && op.IsRotated)
+                    if (ShouldSetFlags(context) && op.IsRotated && setCarry)
                     {
                         SetFlag(context, PState.CFlag, Const((uint)op.Immediate >> 31));
                     }

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -27,7 +27,7 @@ namespace ARMeilleure.Translation.PTC
         private const string OuterHeaderMagicString = "PTCohd\0\0";
         private const string InnerHeaderMagicString = "PTCihd\0\0";
 
-        private const uint InternalVersion = 3138; //! To be incremented manually for each change to the ARMeilleure project.
+        private const uint InternalVersion = 3179; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";

--- a/Ryujinx.Tests/Cpu/CpuTestAluImm32.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestAluImm32.cs
@@ -11,16 +11,24 @@ namespace Ryujinx.Tests.Cpu
 #if AluRs32
 
 #region "ValueSource (Opcodes)"
-        private static uint[] _Adc_Adcs_Rsc_Rscs_Sbc_Sbcs_()
+        private static uint[] _opcodes()
         {
             return new uint[]
             {
                 0xe2a00000u, // ADC R0, R0, #0
                 0xe2b00000u, // ADCS R0, R0, #0
+                0xe2800000u, // ADD R0, R0, #0
+                0xe2900000u, // ADDS R0, R0, #0
+                0xe3c00000u, // BIC R0, R0, #0
+                0xe3d00000u, // BICS R0, R0, #0
+                0xe2600000u, // RSB R0, R0, #0
+                0xe2700000u, // RSBS R0, R0, #0
                 0xe2e00000u, // RSC R0, R0, #0
                 0xe2f00000u, // RSCS R0, R0, #0
                 0xe2c00000u, // SBC R0, R0, #0
-                0xe2d00000u  // SBCS R0, R0, #0
+                0xe2d00000u, // SBCS R0, R0, #0
+                0xe2400000u, // SUB R0, R0, #0
+                0xe2500000u, // SUBS R0, R0, #0
             };
         }
 #endregion
@@ -29,12 +37,12 @@ namespace Ryujinx.Tests.Cpu
         private const int RndCntAmount = 2;
 
         [Test, Pairwise]
-        public void Adc_Adcs_Rsc_Rscs_Sbc_Sbcs([ValueSource("_Adc_Adcs_Rsc_Rscs_Sbc_Sbcs_")] uint opcode,
-                                               [Values(0u, 13u)] uint rd,
-                                               [Values(1u, 13u)] uint rn,
-                                               [Random(RndCnt)] uint imm,
-                                               [Random(RndCnt)] uint wn,
-                                               [Values(true, false)] bool carryIn)
+        public void TestCpuTestAluImm32([ValueSource("_opcodes")] uint opcode,
+                                        [Values(0u, 13u)] uint rd,
+                                        [Values(1u, 13u)] uint rn,
+                                        [Random(RndCnt)] uint imm,
+                                        [Random(RndCnt)] uint wn,
+                                        [Values(true, false)] bool carryIn)
         {
             opcode |= ((imm & 0xfff) << 0) | ((rn & 15) << 16) | ((rd & 15) << 12);
 

--- a/Ryujinx.Tests/Cpu/CpuTestAluImm32.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestAluImm32.cs
@@ -1,0 +1,49 @@
+#define AluRs32
+
+using NUnit.Framework;
+using System.Runtime.CompilerServices;
+
+namespace Ryujinx.Tests.Cpu
+{
+    [Category("AluImm32")]
+    public sealed class CpuTestAluImm32 : CpuTest32
+    {
+#if AluRs32
+
+#region "ValueSource (Opcodes)"
+        private static uint[] _Adc_Adcs_Rsc_Rscs_Sbc_Sbcs_()
+        {
+            return new uint[]
+            {
+                0xe2a00000u, // ADC R0, R0, #0
+                0xe2b00000u, // ADCS R0, R0, #0
+                0xe2e00000u, // RSC R0, R0, #0
+                0xe2f00000u, // RSCS R0, R0, #0
+                0xe2c00000u, // SBC R0, R0, #0
+                0xe2d00000u  // SBCS R0, R0, #0
+            };
+        }
+#endregion
+
+        private const int RndCnt = 2;
+        private const int RndCntAmount = 2;
+
+        [Test, Pairwise]
+        public void Adc_Adcs_Rsc_Rscs_Sbc_Sbcs([ValueSource("_Adc_Adcs_Rsc_Rscs_Sbc_Sbcs_")] uint opcode,
+                                               [Values(0u, 13u)] uint rd,
+                                               [Values(1u, 13u)] uint rn,
+                                               [Random(RndCnt)] uint imm,
+                                               [Random(RndCnt)] uint wn,
+                                               [Values(true, false)] bool carryIn)
+        {
+            opcode |= ((imm & 0xfff) << 0) | ((rn & 15) << 16) | ((rd & 15) << 12);
+
+            uint sp = TestContext.CurrentContext.Random.NextUInt();
+
+            SingleOpcode(opcode, r1: wn, sp: sp, carry: carryIn);
+
+            CompareAgainstUnicorn();
+        }
+#endif
+    }
+}


### PR DESCRIPTION
Add a test for some of these arm32 instructions. This reveals an existing bug. Fix this bug.

Bug occurs because carry flag is overwritten before it can be used in the calculation which is incorrect behaviour.

