### PR TITLE
KThread: Fix GetPsr mask

### DIFF
--- a/ARMeilleure/State/ExecutionContext.cs
+++ b/ARMeilleure/State/ExecutionContext.cs
@@ -103,6 +103,24 @@ namespace ARMeilleure.State
         public bool GetPstateFlag(PState flag)             => _nativeContext.GetPstateFlag(flag);
         public void SetPstateFlag(PState flag, bool value) => _nativeContext.SetPstateFlag(flag, value);
 
+        public uint GetPstate()
+        {
+            uint value = 0;
+            for (int i = 0; i < RegisterConsts.FlagsCount; i++)
+            {
+                value |= GetPstateFlag((PState)i) ? 1u << i : 0u;
+            }
+            return value;
+        }
+        public void SetPstate(uint value)
+        {
+            for (int i = 0; i < RegisterConsts.FlagsCount; i++)
+            {
+                uint flag = 1u << i;
+                SetPstateFlag((PState)i, (value & flag) == flag);
+            }
+        }
+
         public bool GetFPstateFlag(FPState flag) => _nativeContext.GetFPStateFlag(flag);
         public void SetFPstateFlag(FPState flag, bool value) => _nativeContext.SetFPStateFlag(flag, value);
 

--- a/ARMeilleure/State/ExecutionContext.cs
+++ b/ARMeilleure/State/ExecutionContext.cs
@@ -43,6 +43,8 @@ namespace ARMeilleure.State
         public long TpidrEl0 { get; set; }
         public long Tpidr    { get; set; }
 
+        public uint Pstate { get => _nativeContext.GetPstate(); set => _nativeContext.SetPstate(value); }
+
         public FPCR Fpcr { get; set; }
         public FPSR Fpsr { get; set; }
         public FPCR StandardFpcrValue => (Fpcr & (FPCR.Ahp)) | FPCR.Dn | FPCR.Fz;
@@ -102,9 +104,6 @@ namespace ARMeilleure.State
 
         public bool GetPstateFlag(PState flag)             => _nativeContext.GetPstateFlag(flag);
         public void SetPstateFlag(PState flag, bool value) => _nativeContext.SetPstateFlag(flag, value);
-
-        public uint GetPstate()           => _nativeContext.GetPstate();
-        public void SetPstate(uint value) => _nativeContext.SetPstate(value);
 
         public bool GetFPstateFlag(FPState flag) => _nativeContext.GetFPStateFlag(flag);
         public void SetFPstateFlag(FPState flag, bool value) => _nativeContext.SetFPStateFlag(flag, value);

--- a/ARMeilleure/State/ExecutionContext.cs
+++ b/ARMeilleure/State/ExecutionContext.cs
@@ -103,23 +103,8 @@ namespace ARMeilleure.State
         public bool GetPstateFlag(PState flag)             => _nativeContext.GetPstateFlag(flag);
         public void SetPstateFlag(PState flag, bool value) => _nativeContext.SetPstateFlag(flag, value);
 
-        public uint GetPstate()
-        {
-            uint value = 0;
-            for (int i = 0; i < RegisterConsts.FlagsCount; i++)
-            {
-                value |= GetPstateFlag((PState)i) ? 1u << i : 0u;
-            }
-            return value;
-        }
-        public void SetPstate(uint value)
-        {
-            for (int i = 0; i < RegisterConsts.FlagsCount; i++)
-            {
-                uint flag = 1u << i;
-                SetPstateFlag((PState)i, (value & flag) == flag);
-            }
-        }
+        public uint GetPstate()           => _nativeContext.GetPstate();
+        public void SetPstate(uint value) => _nativeContext.SetPstate(value);
 
         public bool GetFPstateFlag(FPState flag) => _nativeContext.GetFPStateFlag(flag);
         public void SetFPstateFlag(FPState flag, bool value) => _nativeContext.SetFPStateFlag(flag, value);

--- a/ARMeilleure/State/ExecutionContext.cs
+++ b/ARMeilleure/State/ExecutionContext.cs
@@ -43,7 +43,11 @@ namespace ARMeilleure.State
         public long TpidrEl0 { get; set; }
         public long Tpidr    { get; set; }
 
-        public uint Pstate { get => _nativeContext.GetPstate(); set => _nativeContext.SetPstate(value); }
+        public uint Pstate
+        {
+            get => _nativeContext.GetPstate();
+            set => _nativeContext.SetPstate(value);
+        }
 
         public FPCR Fpcr { get; set; }
         public FPSR Fpsr { get; set; }

--- a/ARMeilleure/State/NativeContext.cs
+++ b/ARMeilleure/State/NativeContext.cs
@@ -95,6 +95,25 @@ namespace ARMeilleure.State
             GetStorage().Flags[(int)flag] = value ? 1u : 0u;
         }
 
+        public unsafe uint GetPstate()
+        {
+            uint value = 0;
+            for (int flag = 0; flag < RegisterConsts.FlagsCount; flag++)
+            {
+                value |= GetStorage().Flags[flag] != 0 ? 1u << flag : 0u;
+            }
+            return value;
+        }
+
+        public unsafe void SetPstate(uint value)
+        {
+            for (int flag = 0; flag < RegisterConsts.FlagsCount; flag++)
+            {
+                uint bit = 1u << flag;
+                GetStorage().Flags[flag] = (value & bit) == bit ? 1u : 0u;
+            }
+        }
+
         public unsafe bool GetFPStateFlag(FPState flag)
         {
             if ((uint)flag >= RegisterConsts.FpFlagsCount)

--- a/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
@@ -658,7 +658,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
 
         private static uint GetPsr(ARMeilleure.State.ExecutionContext context)
         {
-            return context.GetPstate() & 0xFF0FFE20;
+            return context.Pstate & 0xFF0FFE20;
         }
 
         private ThreadContext GetCurrentContext()

--- a/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
@@ -658,7 +658,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
 
         private static uint GetPsr(ARMeilleure.State.ExecutionContext context)
         {
-            return context.GetPstate() & 0xF0000000;
+            return context.GetPstate() & 0xFF0FFE20;
         }
 
         private ThreadContext GetCurrentContext()

--- a/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
@@ -658,10 +658,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
 
         private static uint GetPsr(ARMeilleure.State.ExecutionContext context)
         {
-            return (context.GetPstateFlag(ARMeilleure.State.PState.NFlag) ? (1U << (int)ARMeilleure.State.PState.NFlag) : 0U) |
-                   (context.GetPstateFlag(ARMeilleure.State.PState.ZFlag) ? (1U << (int)ARMeilleure.State.PState.ZFlag) : 0U) |
-                   (context.GetPstateFlag(ARMeilleure.State.PState.CFlag) ? (1U << (int)ARMeilleure.State.PState.CFlag) : 0U) |
-                   (context.GetPstateFlag(ARMeilleure.State.PState.VFlag) ? (1U << (int)ARMeilleure.State.PState.VFlag) : 0U);
+            return context.GetPstate() & 0xF0000000;
         }
 
         private ThreadContext GetCurrentContext()
@@ -1371,7 +1368,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
 
             PreferredCore = _originalPreferredCore;
             AffinityMask = _originalAffinityMask;
-            
+
             if (AffinityMask != affinityMask)
             {
                 if ((AffinityMask & 1UL << ActiveCore) != 0)

--- a/Ryujinx.Tests/Cpu/CpuTest32.cs
+++ b/Ryujinx.Tests/Cpu/CpuTest32.cs
@@ -283,10 +283,7 @@ namespace Ryujinx.Tests.Cpu
             }
 
             uint finalCpsr = test.FinalRegs[15];
-            for (int i = 0; i < 32; i++)
-            {
-                Assert.That(GetContext().GetPstateFlag((PState)i), Is.EqualTo((finalCpsr & (1u << i)) != 0));
-            }
+            Assert.That(GetContext().GetPstate(), Is.EqualTo(finalCpsr));
         }
 
         protected void SetWorkingMemory(uint offset, byte[] data)

--- a/Ryujinx.Tests/Cpu/CpuTest32.cs
+++ b/Ryujinx.Tests/Cpu/CpuTest32.cs
@@ -283,7 +283,7 @@ namespace Ryujinx.Tests.Cpu
             }
 
             uint finalCpsr = test.FinalRegs[15];
-            Assert.That(GetContext().GetPstate(), Is.EqualTo(finalCpsr));
+            Assert.That(GetContext().Pstate, Is.EqualTo(finalCpsr));
         }
 
         protected void SetWorkingMemory(uint offset, byte[] data)


### PR DESCRIPTION
Very minor PR for ease of review. Forked off from #3101.

Provide helper functions for getting a uint value instead of having to construct from flags.

Also fix GetPsr in KThread while we're here. See [Atmosphere reference](https://github.com/Atmosphere-NX/Atmosphere/blob/96f95b9f95988bd30c3dcac6c2bbabf573a23bb5/libraries/libmesosphere/source/arch/arm64/kern_k_thread_context.cpp#L43).