### PR TITLE
amadeus: Fix wrong Span usage in CopyHistories

### DIFF
--- a/Ryujinx.Audio/Renderer/Server/Performance/PerformanceManagerGeneric.cs
+++ b/Ryujinx.Audio/Renderer/Server/Performance/PerformanceManagerGeneric.cs
@@ -149,11 +149,21 @@ namespace Ryujinx.Audio.Renderer.Server.Performance
 
                 Span<byte> targetSpan = performanceOutput.Slice(nextOffset);
 
+                // NOTE: We check for the space for two headers for the final blank header.
+                int requiredSpace = Unsafe.SizeOf<THeader>() + Unsafe.SizeOf<TEntry>() * inputHeader.GetEntryCount()
+                                                             + Unsafe.SizeOf<TEntryDetail>() * inputHeader.GetEntryDetailCount()
+                                                             + Unsafe.SizeOf<THeader>();
+
+                if (targetSpan.Length < requiredSpace)
+                {
+                    break;
+                }
+
                 ref THeader outputHeader = ref MemoryMarshal.Cast<byte, THeader>(targetSpan)[0];
 
                 nextOffset += Unsafe.SizeOf<THeader>();
 
-                Span<TEntry> outputEntries = MemoryMarshal.Cast<byte, TEntry>(targetSpan.Slice(nextOffset));
+                Span<TEntry> outputEntries = MemoryMarshal.Cast<byte, TEntry>(performanceOutput.Slice(nextOffset));
 
                 int totalProcessingTime = 0;
 
@@ -175,7 +185,7 @@ namespace Ryujinx.Audio.Renderer.Server.Performance
                     }
                 }
 
-                Span<TEntryDetail> outputEntriesDetail = MemoryMarshal.Cast<byte, TEntryDetail>(targetSpan.Slice(nextOffset));
+                Span<TEntryDetail> outputEntriesDetail = MemoryMarshal.Cast<byte, TEntryDetail>(performanceOutput.Slice(nextOffset));
 
                 int effectiveEntryDetailCount = 0;
 


### PR DESCRIPTION
Fix a copypasta from the original Amadeus PR causing invalid CopyHistories output.

Also added a missing size check.

This fix a crash in [Mononoke Slashdown](https://github.com/Ryujinx/Ryujinx-Games-List/issues/3844) (now goes in-game)

![image](https://user-images.githubusercontent.com/1760003/156942244-15b24f5d-2495-4dec-b5db-12e3c4f318ff.png)
![image](https://user-images.githubusercontent.com/1760003/156942265-81d26c05-6808-44d0-9e80-64d57b9d8e74.png)
