### PR TITLE
Coalesce Fpsr implementation

### DIFF
--- a/ARMeilleure/Instructions/InstEmitSimdShift32.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdShift32.cs
@@ -1,5 +1,6 @@
 ﻿using ARMeilleure.Decoders;
 using ARMeilleure.IntermediateRepresentation;
+using ARMeilleure.State;
 using ARMeilleure.Translation;
 using System;
 using System.Diagnostics;
@@ -330,7 +331,7 @@ namespace ARMeilleure.Instructions
 
             context.BranchIfFalse(lblNoSat, context.BitwiseOr(gt, lt));
 
-            context.Call(typeof(NativeInterface).GetMethod(nameof(NativeInterface.SetFpsrQc)));
+            SetFpFlag(context, FPState.QcFlag, Const(1));
 
             context.MarkLabel(lblNoSat);
 

--- a/ARMeilleure/Instructions/NativeInterface.cs
+++ b/ARMeilleure/Instructions/NativeInterface.cs
@@ -93,8 +93,7 @@ namespace ARMeilleure.Instructions
         {
             ExecutionContext context = GetContext();
 
-            return (uint)(context.Fpsr & FPSR.A32Mask & ~FPSR.Nzcv) |
-                   (uint)(context.Fpcr & FPCR.A32Mask);
+            return (uint)(context.Fpsr & FPSR.A32Mask) | (uint)(context.Fpcr & FPCR.A32Mask);
         }
 
         public static ulong GetTpidrEl0()
@@ -140,11 +139,6 @@ namespace ARMeilleure.Instructions
         public static void SetFpsr(ulong value)
         {
             GetContext().Fpsr = (FPSR)value;
-        }
-
-        public static void SetFpsrQc()
-        {
-            GetContext().Fpsr |= FPSR.Qc;
         }
 
         public static void SetFpscr(uint fpscr)

--- a/ARMeilleure/Instructions/SoftFallback.cs
+++ b/ARMeilleure/Instructions/SoftFallback.cs
@@ -253,13 +253,13 @@ namespace ARMeilleure.Instructions
 
             if (op > 0L)
             {
-                context.Fpsr |= FPSR.Qc;
+                context.SetFPstateFlag(FPState.QcFlag, true);
 
                 return tMaxValue;
             }
             else if (op < 0L)
             {
-                context.Fpsr |= FPSR.Qc;
+                context.SetFPstateFlag(FPState.QcFlag, true);
 
                 return tMinValue;
             }
@@ -275,7 +275,7 @@ namespace ARMeilleure.Instructions
 
             if (op > 0UL)
             {
-                context.Fpsr |= FPSR.Qc;
+                context.SetFPstateFlag(FPState.QcFlag, true);
 
                 return tMaxValue;
             }
@@ -520,13 +520,13 @@ namespace ARMeilleure.Instructions
 
             if (op > tMaxValue)
             {
-                context.Fpsr |= FPSR.Qc;
+                context.SetFPstateFlag(FPState.QcFlag, true);
 
                 return tMaxValue;
             }
             else if (op < tMinValue)
             {
-                context.Fpsr |= FPSR.Qc;
+                context.SetFPstateFlag(FPState.QcFlag, true);
 
                 return tMinValue;
             }
@@ -547,13 +547,13 @@ namespace ARMeilleure.Instructions
 
             if (op > (long)tMaxValue)
             {
-                context.Fpsr |= FPSR.Qc;
+                context.SetFPstateFlag(FPState.QcFlag, true);
 
                 return tMaxValue;
             }
             else if (op < (long)tMinValue)
             {
-                context.Fpsr |= FPSR.Qc;
+                context.SetFPstateFlag(FPState.QcFlag, true);
 
                 return tMinValue;
             }
@@ -573,7 +573,7 @@ namespace ARMeilleure.Instructions
 
             if (op > (ulong)tMaxValue)
             {
-                context.Fpsr |= FPSR.Qc;
+                context.SetFPstateFlag(FPState.QcFlag, true);
 
                 return tMaxValue;
             }
@@ -593,7 +593,7 @@ namespace ARMeilleure.Instructions
 
             if (op > tMaxValue)
             {
-                context.Fpsr |= FPSR.Qc;
+                context.SetFPstateFlag(FPState.QcFlag, true);
 
                 return tMaxValue;
             }
@@ -609,7 +609,7 @@ namespace ARMeilleure.Instructions
 
             if (op == long.MinValue)
             {
-                context.Fpsr |= FPSR.Qc;
+                context.SetFPstateFlag(FPState.QcFlag, true);
 
                 return long.MaxValue;
             }
@@ -627,7 +627,7 @@ namespace ARMeilleure.Instructions
 
             if ((~(op1 ^ op2) & (op1 ^ add)) < 0L)
             {
-                context.Fpsr |= FPSR.Qc;
+                context.SetFPstateFlag(FPState.QcFlag, true);
 
                 if (op1 < 0L)
                 {
@@ -652,7 +652,7 @@ namespace ARMeilleure.Instructions
 
             if ((add < op1) && (add < op2))
             {
-                context.Fpsr |= FPSR.Qc;
+                context.SetFPstateFlag(FPState.QcFlag, true);
 
                 return ulong.MaxValue;
             }
@@ -670,7 +670,7 @@ namespace ARMeilleure.Instructions
 
             if (((op1 ^ op2) & (op1 ^ sub)) < 0L)
             {
-                context.Fpsr |= FPSR.Qc;
+                context.SetFPstateFlag(FPState.QcFlag, true);
 
                 if (op1 < 0L)
                 {
@@ -695,7 +695,7 @@ namespace ARMeilleure.Instructions
 
             if (op1 < op2)
             {
-                context.Fpsr |= FPSR.Qc;
+                context.SetFPstateFlag(FPState.QcFlag, true);
 
                 return ulong.MinValue;
             }
@@ -718,7 +718,7 @@ namespace ARMeilleure.Instructions
 
                 if ((~op2 & add) < 0L)
                 {
-                    context.Fpsr |= FPSR.Qc;
+                    context.SetFPstateFlag(FPState.QcFlag, true);
 
                     return long.MaxValue;
                 }
@@ -732,7 +732,7 @@ namespace ARMeilleure.Instructions
                 // op1 from (ulong)long.MaxValue + 1UL to ulong.MaxValue
                 // op2 from (long)ulong.MinValue to long.MaxValue
 
-                context.Fpsr |= FPSR.Qc;
+                context.SetFPstateFlag(FPState.QcFlag, true);
 
                 return long.MaxValue;
             }
@@ -745,7 +745,7 @@ namespace ARMeilleure.Instructions
 
                 if (add > (ulong)long.MaxValue)
                 {
-                    context.Fpsr |= FPSR.Qc;
+                    context.SetFPstateFlag(FPState.QcFlag, true);
 
                     return long.MaxValue;
                 }
@@ -769,7 +769,7 @@ namespace ARMeilleure.Instructions
 
                 if ((add < (ulong)op1) && (add < op2))
                 {
-                    context.Fpsr |= FPSR.Qc;
+                    context.SetFPstateFlag(FPState.QcFlag, true);
 
                     return ulong.MaxValue;
                 }
@@ -794,7 +794,7 @@ namespace ARMeilleure.Instructions
 
                 if (add < (long)ulong.MinValue)
                 {
-                    context.Fpsr |= FPSR.Qc;
+                    context.SetFPstateFlag(FPState.QcFlag, true);
 
                     return ulong.MinValue;
                 }

--- a/ARMeilleure/Instructions/SoftFloat.cs
+++ b/ARMeilleure/Instructions/SoftFloat.cs
@@ -224,7 +224,7 @@ namespace ARMeilleure.Instructions
 
             if ((context.Fpcr & FPCR.Fz) != 0 && exponent < minimumExp)
             {
-                context.Fpsr |= FPSR.Ufc;
+                context.SetFPstateFlag(FPState.UfcFlag, true);
 
                 return FPZero(sign);
             }
@@ -327,7 +327,7 @@ namespace ARMeilleure.Instructions
             }
             else
             {
-                context.Fpsr |= (FPSR)(1 << (int)exc);
+                context.SetFPstateFlag((FPState)exc, true);
             }
         }
     }
@@ -614,7 +614,7 @@ namespace ARMeilleure.Instructions
             }
             else
             {
-                context.Fpsr |= (FPSR)(1 << (int)exc);
+                context.SetFPstateFlag((FPState)exc, true);
             }
         }
     }
@@ -665,7 +665,7 @@ namespace ARMeilleure.Instructions
 
                     if ((fpcr & FPCR.Fz) != 0 && float.IsSubnormal(result))
                     {
-                        context.Fpsr |= FPSR.Ufc;
+                        context.SetFPstateFlag(FPState.UfcFlag, true);
 
                         result = FPZero(result < 0f);
                     }
@@ -863,7 +863,7 @@ namespace ARMeilleure.Instructions
 
                     if ((fpcr & FPCR.Fz) != 0 && float.IsSubnormal(result))
                     {
-                        context.Fpsr |= FPSR.Ufc;
+                        context.SetFPstateFlag(FPState.UfcFlag, true);
 
                         result = FPZero(result < 0f);
                     }
@@ -906,7 +906,7 @@ namespace ARMeilleure.Instructions
 
                         if ((fpcr & FPCR.Fz) != 0 && float.IsSubnormal(result))
                         {
-                            context.Fpsr |= FPSR.Ufc;
+                            context.SetFPstateFlag(FPState.UfcFlag, true);
 
                             result = FPZero(result < 0f);
                         }
@@ -928,7 +928,7 @@ namespace ARMeilleure.Instructions
 
                         if ((fpcr & FPCR.Fz) != 0 && float.IsSubnormal(result))
                         {
-                            context.Fpsr |= FPSR.Ufc;
+                            context.SetFPstateFlag(FPState.UfcFlag, true);
 
                             result = FPZero(result < 0f);
                         }
@@ -997,7 +997,7 @@ namespace ARMeilleure.Instructions
 
                         if ((fpcr & FPCR.Fz) != 0 && float.IsSubnormal(result))
                         {
-                            context.Fpsr |= FPSR.Ufc;
+                            context.SetFPstateFlag(FPState.UfcFlag, true);
 
                             result = FPZero(result < 0f);
                         }
@@ -1019,7 +1019,7 @@ namespace ARMeilleure.Instructions
 
                         if ((fpcr & FPCR.Fz) != 0 && float.IsSubnormal(result))
                         {
-                            context.Fpsr |= FPSR.Ufc;
+                            context.SetFPstateFlag(FPState.UfcFlag, true);
 
                             result = FPZero(result < 0f);
                         }
@@ -1095,7 +1095,7 @@ namespace ARMeilleure.Instructions
 
                     if ((fpcr & FPCR.Fz) != 0 && float.IsSubnormal(result))
                     {
-                        context.Fpsr |= FPSR.Ufc;
+                        context.SetFPstateFlag(FPState.UfcFlag, true);
 
                         result = FPZero(result < 0f);
                     }
@@ -1163,7 +1163,7 @@ namespace ARMeilleure.Instructions
 
                     if ((fpcr & FPCR.Fz) != 0 && float.IsSubnormal(result))
                     {
-                        context.Fpsr |= FPSR.Ufc;
+                        context.SetFPstateFlag(FPState.UfcFlag, true);
 
                         result = FPZero(result < 0f);
                     }
@@ -1220,7 +1220,7 @@ namespace ARMeilleure.Instructions
 
                     if ((fpcr & FPCR.Fz) != 0 && float.IsSubnormal(result))
                     {
-                        context.Fpsr |= FPSR.Ufc;
+                        context.SetFPstateFlag(FPState.UfcFlag, true);
 
                         result = FPZero(result < 0f);
                     }
@@ -1295,7 +1295,7 @@ namespace ARMeilleure.Instructions
             {
                 result = FPZero(sign);
 
-                context.Fpsr |= FPSR.Ufc;
+                context.SetFPstateFlag(FPState.UfcFlag, true);
             }
             else
             {
@@ -1403,7 +1403,7 @@ namespace ARMeilleure.Instructions
 
                     if ((fpcr & FPCR.Fz) != 0 && float.IsSubnormal(result))
                     {
-                        context.Fpsr |= FPSR.Ufc;
+                        context.SetFPstateFlag(FPState.UfcFlag, true);
 
                         result = FPZero(result < 0f);
                     }
@@ -1545,7 +1545,7 @@ namespace ARMeilleure.Instructions
 
                     if ((fpcr & FPCR.Fz) != 0 && float.IsSubnormal(result))
                     {
-                        context.Fpsr |= FPSR.Ufc;
+                        context.SetFPstateFlag(FPState.UfcFlag, true);
 
                         result = FPZero(result < 0f);
                     }
@@ -1580,7 +1580,7 @@ namespace ARMeilleure.Instructions
                 {
                     product = FPMulFpscr(value1, value2, true);
                 }
-                
+
                 result = FPHalvedSub(FPThree(false), product, context, fpcr);
             }
 
@@ -1618,7 +1618,7 @@ namespace ARMeilleure.Instructions
 
                     if ((fpcr & FPCR.Fz) != 0 && float.IsSubnormal(result))
                     {
-                        context.Fpsr |= FPSR.Ufc;
+                        context.SetFPstateFlag(FPState.UfcFlag, true);
 
                         result = FPZero(result < 0f);
                     }
@@ -1661,7 +1661,7 @@ namespace ARMeilleure.Instructions
 
                 if ((fpcr & FPCR.Fz) != 0 && float.IsSubnormal(result))
                 {
-                    context.Fpsr |= FPSR.Ufc;
+                    context.SetFPstateFlag(FPState.UfcFlag, true);
 
                     result = FPZero(result < 0f);
                 }
@@ -1714,7 +1714,7 @@ namespace ARMeilleure.Instructions
 
                     if ((fpcr & FPCR.Fz) != 0 && float.IsSubnormal(result))
                     {
-                        context.Fpsr |= FPSR.Ufc;
+                        context.SetFPstateFlag(FPState.UfcFlag, true);
 
                         result = FPZero(result < 0f);
                     }
@@ -1921,7 +1921,7 @@ namespace ARMeilleure.Instructions
             }
             else
             {
-                context.Fpsr |= (FPSR)(1 << (int)exc);
+                context.SetFPstateFlag((FPState)exc, true);
             }
         }
     }
@@ -1972,7 +1972,7 @@ namespace ARMeilleure.Instructions
 
                     if ((fpcr & FPCR.Fz) != 0 && double.IsSubnormal(result))
                     {
-                        context.Fpsr |= FPSR.Ufc;
+                        context.SetFPstateFlag(FPState.UfcFlag, true);
 
                         result = FPZero(result < 0d);
                     }
@@ -2170,7 +2170,7 @@ namespace ARMeilleure.Instructions
 
                     if ((fpcr & FPCR.Fz) != 0 && double.IsSubnormal(result))
                     {
-                        context.Fpsr |= FPSR.Ufc;
+                        context.SetFPstateFlag(FPState.UfcFlag, true);
 
                         result = FPZero(result < 0d);
                     }
@@ -2213,7 +2213,7 @@ namespace ARMeilleure.Instructions
 
                         if ((fpcr & FPCR.Fz) != 0 && double.IsSubnormal(result))
                         {
-                            context.Fpsr |= FPSR.Ufc;
+                            context.SetFPstateFlag(FPState.UfcFlag, true);
 
                             result = FPZero(result < 0d);
                         }
@@ -2235,7 +2235,7 @@ namespace ARMeilleure.Instructions
 
                         if ((fpcr & FPCR.Fz) != 0 && double.IsSubnormal(result))
                         {
-                            context.Fpsr |= FPSR.Ufc;
+                            context.SetFPstateFlag(FPState.UfcFlag, true);
 
                             result = FPZero(result < 0d);
                         }
@@ -2304,7 +2304,7 @@ namespace ARMeilleure.Instructions
 
                         if ((fpcr & FPCR.Fz) != 0 && double.IsSubnormal(result))
                         {
-                            context.Fpsr |= FPSR.Ufc;
+                            context.SetFPstateFlag(FPState.UfcFlag, true);
 
                             result = FPZero(result < 0d);
                         }
@@ -2326,7 +2326,7 @@ namespace ARMeilleure.Instructions
 
                         if ((fpcr & FPCR.Fz) != 0 && double.IsSubnormal(result))
                         {
-                            context.Fpsr |= FPSR.Ufc;
+                            context.SetFPstateFlag(FPState.UfcFlag, true);
 
                             result = FPZero(result < 0d);
                         }
@@ -2402,7 +2402,7 @@ namespace ARMeilleure.Instructions
 
                     if ((fpcr & FPCR.Fz) != 0 && double.IsSubnormal(result))
                     {
-                        context.Fpsr |= FPSR.Ufc;
+                        context.SetFPstateFlag(FPState.UfcFlag, true);
 
                         result = FPZero(result < 0d);
                     }
@@ -2470,7 +2470,7 @@ namespace ARMeilleure.Instructions
 
                     if ((fpcr & FPCR.Fz) != 0 && double.IsSubnormal(result))
                     {
-                        context.Fpsr |= FPSR.Ufc;
+                        context.SetFPstateFlag(FPState.UfcFlag, true);
 
                         result = FPZero(result < 0d);
                     }
@@ -2527,7 +2527,7 @@ namespace ARMeilleure.Instructions
 
                     if ((fpcr & FPCR.Fz) != 0 && double.IsSubnormal(result))
                     {
-                        context.Fpsr |= FPSR.Ufc;
+                        context.SetFPstateFlag(FPState.UfcFlag, true);
 
                         result = FPZero(result < 0d);
                     }
@@ -2602,7 +2602,7 @@ namespace ARMeilleure.Instructions
             {
                 result = FPZero(sign);
 
-                context.Fpsr |= FPSR.Ufc;
+                context.SetFPstateFlag(FPState.UfcFlag, true);
             }
             else
             {
@@ -2710,7 +2710,7 @@ namespace ARMeilleure.Instructions
 
                     if ((fpcr & FPCR.Fz) != 0 && double.IsSubnormal(result))
                     {
-                        context.Fpsr |= FPSR.Ufc;
+                        context.SetFPstateFlag(FPState.UfcFlag, true);
 
                         result = FPZero(result < 0d);
                     }
@@ -2852,7 +2852,7 @@ namespace ARMeilleure.Instructions
 
                     if ((fpcr & FPCR.Fz) != 0 && double.IsSubnormal(result))
                     {
-                        context.Fpsr |= FPSR.Ufc;
+                        context.SetFPstateFlag(FPState.UfcFlag, true);
 
                         result = FPZero(result < 0d);
                     }
@@ -2925,7 +2925,7 @@ namespace ARMeilleure.Instructions
 
                     if ((fpcr & FPCR.Fz) != 0 && double.IsSubnormal(result))
                     {
-                        context.Fpsr |= FPSR.Ufc;
+                        context.SetFPstateFlag(FPState.UfcFlag, true);
 
                         result = FPZero(result < 0d);
                     }
@@ -2968,7 +2968,7 @@ namespace ARMeilleure.Instructions
 
                 if ((fpcr & FPCR.Fz) != 0 && double.IsSubnormal(result))
                 {
-                    context.Fpsr |= FPSR.Ufc;
+                    context.SetFPstateFlag(FPState.UfcFlag, true);
 
                     result = FPZero(result < 0d);
                 }
@@ -3021,7 +3021,7 @@ namespace ARMeilleure.Instructions
 
                     if ((fpcr & FPCR.Fz) != 0 && double.IsSubnormal(result))
                     {
-                        context.Fpsr |= FPSR.Ufc;
+                        context.SetFPstateFlag(FPState.UfcFlag, true);
 
                         result = FPZero(result < 0d);
                     }
@@ -3228,7 +3228,7 @@ namespace ARMeilleure.Instructions
             }
             else
             {
-                context.Fpsr |= (FPSR)(1 << (int)exc);
+                context.SetFPstateFlag((FPState)exc, true);
             }
         }
     }

--- a/ARMeilleure/State/ExecutionContext.cs
+++ b/ARMeilleure/State/ExecutionContext.cs
@@ -44,8 +44,13 @@ namespace ARMeilleure.State
         public long Tpidr    { get; set; }
 
         public FPCR Fpcr { get; set; }
-        public FPSR Fpsr { get; set; }
         public FPCR StandardFpcrValue => (Fpcr & (FPCR.Ahp)) | FPCR.Dn | FPCR.Fz;
+
+        public FPSR Fpsr
+        {
+            get => (FPSR)_nativeContext.GetFpsr();
+            set => _nativeContext.SetFpsr((uint)value);
+        }
 
         public bool IsAarch32 { get; set; }
 
@@ -103,7 +108,7 @@ namespace ARMeilleure.State
         public bool GetPstateFlag(PState flag)             => _nativeContext.GetPstateFlag(flag);
         public void SetPstateFlag(PState flag, bool value) => _nativeContext.SetPstateFlag(flag, value);
 
-        public bool GetFPstateFlag(FPState flag) => _nativeContext.GetFPStateFlag(flag);
+        public bool GetFPstateFlag(FPState flag)             => _nativeContext.GetFPStateFlag(flag);
         public void SetFPstateFlag(FPState flag, bool value) => _nativeContext.SetFPStateFlag(flag, value);
 
         internal void CheckInterrupt()

--- a/ARMeilleure/State/FPState.cs
+++ b/ARMeilleure/State/FPState.cs
@@ -5,6 +5,8 @@
         VFlag = 28,
         CFlag = 29,
         ZFlag = 30,
-        NFlag = 31
+        NFlag = 31,
+        QcFlag = 27,
+        UfcFlag = 3,
     }
 }

--- a/ARMeilleure/State/NativeContext.cs
+++ b/ARMeilleure/State/NativeContext.cs
@@ -115,6 +115,25 @@ namespace ARMeilleure.State
             GetStorage().FpFlags[(int)flag] = value ? 1u : 0u;
         }
 
+        public unsafe uint GetFpsr()
+        {
+            uint value = 0;
+            for (int flag = 0; flag < RegisterConsts.FpFlagsCount; flag++)
+            {
+                value |= GetStorage().FpFlags[flag] != 0 ? 1u << flag : 0u;
+            }
+            return value;
+        }
+
+        public unsafe void SetFpsr(uint value)
+        {
+            for (int flag = 0; flag < RegisterConsts.FpFlagsCount; flag++)
+            {
+                uint bit = 1u << flag;
+                GetStorage().FpFlags[flag] = (value & bit) == bit ? 1u : 0u;
+            }
+        }
+
         public int GetCounter() => GetStorage().Counter;
         public void SetCounter(int value) => GetStorage().Counter = value;
 

--- a/ARMeilleure/Translation/Delegates.cs
+++ b/ARMeilleure/Translation/Delegates.cs
@@ -127,7 +127,6 @@ namespace ARMeilleure.Translation
             SetDelegateInfo(typeof(NativeInterface).GetMethod(nameof(NativeInterface.SetFpcr)));
             SetDelegateInfo(typeof(NativeInterface).GetMethod(nameof(NativeInterface.SetFpscr))); // A32 only.
             SetDelegateInfo(typeof(NativeInterface).GetMethod(nameof(NativeInterface.SetFpsr)));
-            SetDelegateInfo(typeof(NativeInterface).GetMethod(nameof(NativeInterface.SetFpsrQc))); // A32 only.
             SetDelegateInfo(typeof(NativeInterface).GetMethod(nameof(NativeInterface.SetTpidrEl0)));
             SetDelegateInfo(typeof(NativeInterface).GetMethod(nameof(NativeInterface.SetTpidrEl032))); // A32 only.
             SetDelegateInfo(typeof(NativeInterface).GetMethod(nameof(NativeInterface.SignalMemoryTracking)));

--- a/Ryujinx.Tests/Cpu/CpuTest32.cs
+++ b/Ryujinx.Tests/Cpu/CpuTest32.cs
@@ -623,25 +623,13 @@ namespace Ryujinx.Tests.Cpu
 
         private uint GetFpscr()
         {
-            uint fpscr = (uint)(_context.Fpsr & FPSR.A32Mask & ~FPSR.Nzcv) | (uint)(_context.Fpcr & FPCR.A32Mask);
-
-            fpscr |= _context.GetFPstateFlag(FPState.NFlag) ? (1u << (int)FPState.NFlag) : 0;
-            fpscr |= _context.GetFPstateFlag(FPState.ZFlag) ? (1u << (int)FPState.ZFlag) : 0;
-            fpscr |= _context.GetFPstateFlag(FPState.CFlag) ? (1u << (int)FPState.CFlag) : 0;
-            fpscr |= _context.GetFPstateFlag(FPState.VFlag) ? (1u << (int)FPState.VFlag) : 0;
-
-            return fpscr;
+            return (uint)(_context.Fpsr & FPSR.A32Mask) | (uint)(_context.Fpcr & FPCR.A32Mask);
         }
 
         private void SetFpscr(uint fpscr)
         {
             _context.Fpsr = FPSR.A32Mask & (FPSR)fpscr;
             _context.Fpcr = FPCR.A32Mask & (FPCR)fpscr;
-
-            _context.SetFPstateFlag(FPState.NFlag, (fpscr & (1u << (int)FPState.NFlag)) != 0);
-            _context.SetFPstateFlag(FPState.ZFlag, (fpscr & (1u << (int)FPState.ZFlag)) != 0);
-            _context.SetFPstateFlag(FPState.CFlag, (fpscr & (1u << (int)FPState.CFlag)) != 0);
-            _context.SetFPstateFlag(FPState.VFlag, (fpscr & (1u << (int)FPState.VFlag)) != 0);
         }
     }
 }


### PR DESCRIPTION
There existed an `Fpsr` property in `ExecutionContext` as well as `FpFlags` in `NativeContext`. 

* This is unnecessary duplication of state. Merge the two and have `NativeContext` be ground truth.
* Fix some what-looks-like buggy code related to this. (Notably, fpscr in A32 did not include nzcv!!)
* Remove `NativeInterface.SetFpsrQc` because calling a function for this is kind of silly.