### PR TITLE
Fix GetUserDisableCount NRE

### DIFF
--- a/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
@@ -751,7 +751,8 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
         {
             KThread currentThread = KernelStatic.GetCurrentThread();
 
-            if (currentThread.Owner != null &&
+            if (currentThread.Context.Running &&
+                currentThread.Owner != null &&
                 currentThread.GetUserDisableCount() != 0 &&
                 currentThread.Owner.PinnedThreads[currentThread.CurrentCore] == null)
             {


### PR DESCRIPTION
This fixes a `NullReferenceException` that could happen when closing the emulator or stopping emulation. The problem is that `GetUserDisableCount` reads guest memory, however the memory manager is disposed as soon as all guest threads exit (well, what is really disposed is the ArmProcessContext, but that will decrement the memory manager reference count and set the instance to null). "Exiting" here happens when `KThread.Exit` is called, and at this point `StopRunning` is called, which will set the `Running` property to false and force a interrupt. The interrupt will happen *after* `StopRunning` is called, which might trigger the exception if the memory manager was already disposed. This doesn't always happen because the memory manager is disposed only after all threads exit, and it is disposed a bit later on the `KProcess.Destroy` method, so if the guest threads are fast enough, the memory manager will be still accessible.

This is fixed here by checking if the guest thread is still `Running` before trying to access the user disable count. There's no risk of race here because the `Exit` and `InterruptHandler` calls happens from the same thread.