### PR TITLE
Limit number of events that can be retrieved from GetDisplayVSyncEvent

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Vi/IApplicationRootService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/IApplicationRootService.cs
@@ -16,7 +16,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi
 
             if (serviceType != ViServiceType.Application)
             {
-                return ResultCode.InvalidRange;
+                return ResultCode.PermissionDenied;
             }
 
             MakeObject(context, new IApplicationDisplayService(serviceType));

--- a/Ryujinx.HLE/HOS/Services/Vi/IManagerRootService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/IManagerRootService.cs
@@ -17,7 +17,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi
 
             if (serviceType != ViServiceType.Manager)
             {
-                return ResultCode.InvalidRange;
+                return ResultCode.PermissionDenied;
             }
 
             MakeObject(context, new IApplicationDisplayService(serviceType));

--- a/Ryujinx.HLE/HOS/Services/Vi/ISystemRootService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/ISystemRootService.cs
@@ -17,7 +17,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi
 
             if (serviceType != ViServiceType.System)
             {
-                return ResultCode.InvalidRange;
+                return ResultCode.PermissionDenied;
             }
 
             MakeObject(context, new IApplicationDisplayService(serviceType));

--- a/Ryujinx.HLE/HOS/Services/Vi/ResultCode.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/ResultCode.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi
 
         InvalidArguments   = (1 << ErrorCodeShift) | ModuleId,
         InvalidLayerSize   = (4 << ErrorCodeShift) | ModuleId,
-        InvalidRange       = (5 << ErrorCodeShift) | ModuleId,
+        PermissionDenied   = (5 << ErrorCodeShift) | ModuleId,
         InvalidScalingMode = (6 << ErrorCodeShift) | ModuleId,
         InvalidValue       = (7 << ErrorCodeShift) | ModuleId,
         AlreadyOpened      = (9 << ErrorCodeShift) | ModuleId

--- a/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
@@ -27,15 +27,15 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
         }
 
         private readonly List<DisplayInfo>               _displayInfo;
-        private readonly Dictionary<ulong, DisplayState> _openDisplayInfo;
+        private readonly Dictionary<ulong, DisplayState> _openDisplays;
 
         private int _vsyncEventHandle;
 
         public IApplicationDisplayService(ViServiceType serviceType)
         {
-            _serviceType     = serviceType;
-            _displayInfo     = new List<DisplayInfo>();
-            _openDisplayInfo = new Dictionary<ulong, DisplayState>();
+            _serviceType  = serviceType;
+            _displayInfo  = new List<DisplayInfo>();
+            _openDisplays = new Dictionary<ulong, DisplayState>();
 
             void AddDisplayInfo(string name, bool layerLimitEnabled, ulong layerLimitMax, ulong width, ulong height)
             {
@@ -178,7 +178,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
                 return ResultCode.InvalidValue;
             }
 
-            if (!_openDisplayInfo.TryAdd((ulong)displayId, new DisplayState()))
+            if (!_openDisplays.TryAdd((ulong)displayId, new DisplayState()))
             {
                 return ResultCode.AlreadyOpened;
             }
@@ -194,7 +194,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
         {
             ulong displayId = context.RequestData.ReadUInt64();
 
-            if (!_openDisplayInfo.Remove(displayId))
+            if (!_openDisplays.Remove(displayId))
             {
                 return ResultCode.InvalidValue;
             }
@@ -458,7 +458,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
         {
             ulong displayId = context.RequestData.ReadUInt64();
 
-            if (!_openDisplayInfo.TryGetValue(displayId, out DisplayState displayState))
+            if (!_openDisplays.TryGetValue(displayId, out DisplayState displayState))
             {
                 return ResultCode.InvalidValue;
             }

--- a/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
@@ -1,7 +1,6 @@
 using Ryujinx.Common;
 using Ryujinx.Common.Logging;
 using Ryujinx.Common.Memory;
-using Ryujinx.Cpu;
 using Ryujinx.HLE.HOS.Applets;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Kernel.Common;


### PR DESCRIPTION
It is only possible to get an event once per display with `GetDisplayVSyncEvent`, but the emulator implementation had no such limit. This updates the implementation to return an error if an event was already returned. Based on RE.

Fixes `WaitSyncrhonization` `InvalidHandle` error spam on .hack//G.U. Last Recode, also making the game playable with logs enabled.
![image](https://user-images.githubusercontent.com/5624669/157907844-3902dc4a-9402-4c79-a7b0-df58a97d5fc4.png)
![image](https://user-images.githubusercontent.com/5624669/157907869-e3721182-ba1a-41e7-bb5d-d0f288a08aba.png)
Testing is appreciated to ensure there's no regressions.