### PR TITLE
olsc: Implement GetSaveDataBackupSetting

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Olsc/IOlscServiceForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Olsc/IOlscServiceForApplication.cs
@@ -18,7 +18,7 @@ namespace Ryujinx.HLE.HOS.Services.Olsc
         public ResultCode Initialize(ServiceCtx context)
         {
             // NOTE: Service call arp:r GetApplicationInstanceUnregistrationNotifier with the pid and initialize some internal struct.
-            //       Since we will not support online savedata backup. It's fine to stub it for now.
+            //       Since we will not support online savedata backup, it's fine to stub it for now.
 
             _saveDataBackupSettingDatabase = new Dictionary<UserId, bool>();
 
@@ -54,7 +54,7 @@ namespace Ryujinx.HLE.HOS.Services.Olsc
                 context.ResponseData.Write((byte)2); // TODO: Determine value.
             }
 
-            // NOTE: Since we will not support online savedata backup. It's fine to stub it for now.
+            // NOTE: Since we will not support online savedata backup, it's fine to stub it for now.
 
             Logger.Stub?.PrintStub(LogClass.ServiceOlsc, new { userId });
 
@@ -80,7 +80,7 @@ namespace Ryujinx.HLE.HOS.Services.Olsc
 
             _saveDataBackupSettingDatabase[userId] = saveDataBackupSettingEnabled;
 
-            // NOTE: Since we will not support online savedata backup. It's fine to stub it for now.
+            // NOTE: Since we will not support online savedata backup, it's fine to stub it for now.
 
             Logger.Stub?.PrintStub(LogClass.ServiceOlsc, new { userId, saveDataBackupSettingEnabled });
 

--- a/Ryujinx.HLE/HOS/Services/Olsc/IOlscServiceForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Olsc/IOlscServiceForApplication.cs
@@ -1,13 +1,15 @@
 ﻿using Ryujinx.Common;
 using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Services.Account.Acc;
+using System.Collections.Generic;
 
 namespace Ryujinx.HLE.HOS.Services.Olsc
 {
     [Service("olsc:u")] // 10.0.0+
     class IOlscServiceForApplication : IpcService
     {
-        private bool _initialized;
+        private bool                     _initialized;
+        private Dictionary<UserId, bool> _saveDataBackupSettingDatabase;
 
         public IOlscServiceForApplication(ServiceCtx context) { }
 
@@ -18,6 +20,8 @@ namespace Ryujinx.HLE.HOS.Services.Olsc
             // NOTE: Service call arp:r GetApplicationInstanceUnregistrationNotifier with the pid and initialize some internal struct.
             //       Since we will not support online savedata backup. It's fine to stub it for now.
 
+            _saveDataBackupSettingDatabase = new Dictionary<UserId, bool>();
+
             _initialized = true;
 
             Logger.Stub?.PrintStub(LogClass.ServiceOlsc);
@@ -25,12 +29,11 @@ namespace Ryujinx.HLE.HOS.Services.Olsc
             return ResultCode.Success;
         }
 
-        [CommandHipc(14)]
-        // SetSaveDataBackupSettingEnabled(nn::account::Uid, bool)
-        public ResultCode SetSaveDataBackupSettingEnabled(ServiceCtx context)
+        [CommandHipc(13)]
+        // GetSaveDataBackupSetting(nn::account::Uid) -> u8
+        public ResultCode GetSaveDataBackupSetting(ServiceCtx context)
         {
-            UserId userId                       = context.RequestData.ReadStruct<UserId>();
-            ulong  saveDataBackupSettingEnabled = context.RequestData.ReadUInt64();
+            UserId userId = context.RequestData.ReadStruct<UserId>();
 
             if (!_initialized)
             {
@@ -42,8 +45,42 @@ namespace Ryujinx.HLE.HOS.Services.Olsc
                 return ResultCode.NullArgument;
             }
 
-            // NOTE: Service store the UserId and the boolean in an internal SaveDataBackupSettingDatabase object.
-            //       Since we will not support online savedata backup. It's fine to stub it for now.
+            if (_saveDataBackupSettingDatabase[userId])
+            {
+                context.ResponseData.Write((byte)1); // TODO: Determine value.
+            }
+            else
+            {
+                context.ResponseData.Write((byte)2); // TODO: Determine value.
+            }
+
+            // NOTE: Since we will not support online savedata backup. It's fine to stub it for now.
+
+            Logger.Stub?.PrintStub(LogClass.ServiceOlsc, new { userId });
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(14)]
+        // SetSaveDataBackupSettingEnabled(nn::account::Uid, bool)
+        public ResultCode SetSaveDataBackupSettingEnabled(ServiceCtx context)
+        {
+            bool   saveDataBackupSettingEnabled = context.RequestData.ReadUInt64() != 0;
+            UserId userId                       = context.RequestData.ReadStruct<UserId>();
+
+            if (!_initialized)
+            {
+                return ResultCode.NotInitialized;
+            }
+
+            if (userId.IsNull)
+            {
+                return ResultCode.NullArgument;
+            }
+
+            _saveDataBackupSettingDatabase[userId] = saveDataBackupSettingEnabled;
+
+            // NOTE: Since we will not support online savedata backup. It's fine to stub it for now.
 
             Logger.Stub?.PrintStub(LogClass.ServiceOlsc, new { userId, saveDataBackupSettingEnabled });
 


### PR DESCRIPTION
This PR implement `GetSaveDataBackupSetting` of OLSC service which is now needed by ACNH 2.0.5.
The game is playable as usual if you use the same user profile as the original save file (I don't know if it was the case before), everything is checked by RE. (Closes #3140)

![image](https://user-images.githubusercontent.com/4905390/158024260-83d29767-c3f9-4dfe-b24f-7f20db942686.png)
