### PR TITLE
InstEmitMemoryEx: Barrier after write on ordered store

### DIFF
--- a/ARMeilleure/Instructions/InstEmitMemoryEx.cs
+++ b/ARMeilleure/Instructions/InstEmitMemoryEx.cs
@@ -130,11 +130,6 @@ namespace ARMeilleure.Instructions
             bool ordered   = (accType & AccessType.Ordered)   != 0;
             bool exclusive = (accType & AccessType.Exclusive) != 0;
 
-            if (ordered)
-            {
-                EmitBarrier(context);
-            }
-
             Operand address = context.Copy(GetIntOrSP(context, op.Rn));
 
             Operand t = GetIntOrZR(context, op.Rt);
@@ -162,6 +157,11 @@ namespace ARMeilleure.Instructions
             else
             {
                 EmitStoreExclusive(context, address, t, exclusive, op.Size, op.Rs, a32: false);
+            }
+
+            if (ordered)
+            {
+                EmitBarrier(context);
             }
         }
 

--- a/ARMeilleure/Instructions/InstEmitMemoryEx32.cs
+++ b/ARMeilleure/Instructions/InstEmitMemoryEx32.cs
@@ -146,13 +146,13 @@ namespace ARMeilleure.Instructions
             var exclusive = (accType & AccessType.Exclusive) != 0;
             var ordered = (accType & AccessType.Ordered) != 0;
 
-            if (ordered)
-            {
-                EmitBarrier(context);
-            }
-
             if ((accType & AccessType.Load) != 0)
             {
+                if (ordered)
+                {
+                    EmitBarrier(context);
+                }
+
                 if (size == DWordSizeLog2)
                 {
                     // Keep loads atomic - make the call to get the whole region and then decompose it into parts
@@ -218,6 +218,11 @@ namespace ARMeilleure.Instructions
                 {
                     Operand value = context.ZeroExtend32(OperandType.I64, GetIntA32(context, op.Rt));
                     EmitStoreExclusive(context, address, value, exclusive, size, op.Rd, a32: true);
+                }
+
+                if (ordered)
+                {
+                    EmitBarrier(context);
                 }
             }
         }

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -27,7 +27,7 @@ namespace ARMeilleure.Translation.PTC
         private const string OuterHeaderMagicString = "PTCohd\0\0";
         private const string InnerHeaderMagicString = "PTCihd\0\0";
 
-        private const uint InternalVersion = 3179; //! To be incremented manually for each change to the ARMeilleure project.
+        private const uint InternalVersion = 3193; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";


### PR DESCRIPTION
In theory, mfence should be after a write.

Games that would likely be affected by this and would require testing:

* Pokémon Mystery Dungeon (boot) 
* Pokémon Brilliant Diamond/Shining Pearl (entering/exiting buildings)
* Pokémon Legends Arceus (anywhere)


Please note an alternative to this is to just implement an ordered write as a single instruction (`lock xchg`) which has a built-in memory fence.