### PR TITLE
Initialize indexed inputs used on next shader stage

### DIFF
--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -328,6 +328,7 @@ namespace Ryujinx.Graphics.Shader.Translation
         public void SetAllInputUserAttributes()
         {
             UsedInputAttributes |= Constants.AllAttributesMask;
+            ThisInputAttributesComponents |= ~UInt128.Zero >> (128 - Constants.MaxAttributes * 4);
         }
 
         public void SetAllOutputUserAttributes()

--- a/Ryujinx.Graphics.Shader/Translation/UInt128.cs
+++ b/Ryujinx.Graphics.Shader/Translation/UInt128.cs
@@ -10,6 +10,12 @@ namespace Ryujinx.Graphics.Shader.Translation
         private ulong _v0;
         private ulong _v1;
 
+        public UInt128(ulong low, ulong high)
+        {
+            _v0 = low;
+            _v1 = high;
+        }
+
         public int TrailingZeroCount()
         {
             int count = BitOperations.TrailingZeroCount(_v0);
@@ -25,25 +31,57 @@ namespace Ryujinx.Graphics.Shader.Translation
         {
             if (x >= 64)
             {
-                return new UInt128() { _v0 = 0, _v1 = 1UL << (x - 64 ) };
+                return new UInt128(0, 1UL << (x - 64));
             }
 
-            return new UInt128() { _v0 = 1UL << x, _v1 = 0 };
+            return new UInt128(1UL << x, 0);
         }
 
         public static UInt128 operator ~(UInt128 x)
         {
-            return new UInt128() { _v0 = ~x._v0, _v1 = ~x._v1 };
+            return new UInt128(~x._v0, ~x._v1);
         }
 
         public static UInt128 operator &(UInt128 x, UInt128 y)
         {
-            return new UInt128() { _v0 = x._v0 & y._v0, _v1 = x._v1 & y._v1 };
+            return new UInt128(x._v0 & y._v0, x._v1 & y._v1);
         }
 
         public static UInt128 operator |(UInt128 x, UInt128 y)
         {
-            return new UInt128() { _v0 = x._v0 | y._v0, _v1 = x._v1 | y._v1 };
+            return new UInt128(x._v0 | y._v0, x._v1 | y._v1);
+        }
+
+        public static UInt128 operator <<(UInt128 x, int shift)
+        {
+            if (shift == 0)
+            {
+                return new UInt128(x._v0, x._v1);
+            }
+            else if (shift >= 64)
+            {
+                return new UInt128(0, x._v0 << (shift - 64));
+            }
+
+            ulong shiftOut = x._v0 >> (64 - shift);
+
+            return new UInt128(x._v0 << shift, (x._v1 << shift) | shiftOut);
+        }
+
+        public static UInt128 operator >>(UInt128 x, int shift)
+        {
+            if (shift == 0)
+            {
+                return new UInt128(x._v0, x._v1);
+            }
+            else if (shift >= 64)
+            {
+                return new UInt128(x._v1 >> (shift - 64), 0);
+            }
+
+            ulong shiftOut = x._v1 & ((1UL << shift) - 1);
+
+            return new UInt128((x._v0 >> shift) | (shiftOut << (64 - shift)), x._v1 >> shift);
         }
 
         public static bool operator ==(UInt128 x, UInt128 y)


### PR DESCRIPTION
Fixes another regression from https://github.com/Ryujinx/Ryujinx/pull/3054, this time making sure that *indexed* inputs are intialized. Since it can't guess which output the next stage might access when they are indexed, it just initializes all of them.

Fixes a regression that would cause shaders to fail to compile on WarioWare: Get It Together! and probably other games using indexed attributes.
![image](https://user-images.githubusercontent.com/5624669/158091116-5671f694-660d-4dc9-8950-8f7cdbeeb522.png)
(GIft was not showing before here).