### PR TITLE
oslc: Fix condition in GetSaveDataBackupSetting

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Olsc/IOlscServiceForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Olsc/IOlscServiceForApplication.cs
@@ -45,7 +45,7 @@ namespace Ryujinx.HLE.HOS.Services.Olsc
                 return ResultCode.NullArgument;
             }
 
-            if (_saveDataBackupSettingDatabase[userId])
+            if (_saveDataBackupSettingDatabase.ContainsKey(userId) && _saveDataBackupSettingDatabase[userId])
             {
                 context.ResponseData.Write((byte)1); // TODO: Determine value.
             }

--- a/Ryujinx.HLE/HOS/Services/Olsc/IOlscServiceForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Olsc/IOlscServiceForApplication.cs
@@ -45,7 +45,7 @@ namespace Ryujinx.HLE.HOS.Services.Olsc
                 return ResultCode.NullArgument;
             }
 
-            if (_saveDataBackupSettingDatabase.ContainsKey(userId) && _saveDataBackupSettingDatabase[userId])
+            if (_saveDataBackupSettingDatabase.TryGetValue(userId, out bool enabled) && enabled)
             {
                 context.ResponseData.Write((byte)1); // TODO: Determine value.
             }


### PR DESCRIPTION
This PR fixes a condition previously implemented in #3190 where ACNH can't be booted without an existing savedata.
Closes #3206