### PR TITLE
Fix OpenGL issues with RTSS overlays and OBS Game Capture

### DIFF
--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -1478,6 +1478,11 @@ namespace Ryujinx.Graphics.OpenGL
             _currentComponentMasks |= componentMaskAtIndex;
         }
 
+        public void RestoreClipControl()
+        {
+            GL.ClipControl(_clipOrigin, _clipDepthMode);
+        }
+
         public void RestoreScissor0Enable()
         {
             if ((_scissorEnables & 1u) != 0)
@@ -1492,6 +1497,11 @@ namespace Ryujinx.Graphics.OpenGL
             {
                 GL.Enable(EnableCap.RasterizerDiscard);
             }
+        }
+
+        public void RestoreViewport0()
+        {
+            GL.ViewportArray(0, 1, _viewportArray);
         }
 
         public bool TryHostConditionalRendering(ICounterEvent value, ulong compare, bool isEqual)


### PR DESCRIPTION
OpenGL game overlays and hooks tend to make a lot of assumptions about how games present frames to the screen, since presentation in OpenGL kind of sucks and they would like to have info such as the size of the screen, or if the contents are SRGB rather than linear.

There are two ways of getting this. OBS hooks swap buffers to get a frame for video capture, but it actually checks the bound framebuffer at the time. I made sure that this matches the output framebuffer (the window) so that the output matches the size. RTSS checks the viewport size by default, but this was actually set to the last used viewport by the game, causing the OSD to fly all across the screen depending on how it was used (or res scale). The viewport is now manually set to match the output framebuffer size.

In the case of RTSS, it also loads its resources by destructively setting a pixel pack parameter without regard to what it was set to by the guest application. OpenGL state can be set for a long period of time and is not expected to be set before each call to a method, so randomly changing it isn't great practice. To fix this, I've added a line to set the pixel unpack alignment back to 4 after presentation, which should cover RTSS loading its incredibly ugly font.

- RTSS and overlays that use it should no longer cause certain textures to load incorrectly. (mario kart 8, pokemon legends arceus)
- OBS Game Capture should no longer crop the game output incorrectly, flicker randomly, or capture with incorrect gamma.

This doesn't fix issues with how RTSS reports our frame timings.

Closes https://github.com/Ryujinx/Ryujinx/issues/3021