### PR TITLE
Support NVDEC H264 interlaced video decoding and VIC deinterlacing

### DIFF
--- a/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
@@ -341,6 +341,16 @@ namespace Ryujinx.Graphics.Gpu.Memory
         }
 
         /// <summary>
+        /// Checks if the page at a given address is mapped on CPU memory.
+        /// </summary>
+        /// <param name="address">CPU virtual address of the page to check</param>
+        /// <returns>True if mapped, false otherwise</returns>
+        public bool IsMapped(ulong address)
+        {
+            return _cpuMemory.IsMapped(address);
+        }
+
+        /// <summary>
         /// Release our reference to the CPU memory manager.
         /// </summary>
         public void Dispose()

--- a/Ryujinx.Graphics.Nvdec.FFmpeg/Surface.cs
+++ b/Ryujinx.Graphics.Nvdec.FFmpeg/Surface.cs
@@ -15,11 +15,13 @@ namespace Ryujinx.Graphics.Nvdec.FFmpeg
         public Plane UPlane => new Plane((IntPtr)Frame->data[1], UvStride * UvHeight);
         public Plane VPlane => new Plane((IntPtr)Frame->data[2], UvStride * UvHeight);
 
+        public FrameField Field => Frame->interlaced_frame != 0 ? FrameField.Interlaced : FrameField.Progressive;
+
         public int Width => Frame->width;
         public int Height => Frame->height;
         public int Stride => Frame->linesize[0];
-        public int UvWidth => (Frame->width + 1) >> 1;
-        public int UvHeight => (Frame->height + 1) >> 1;
+        public int UvWidth => (Width + 1) >> 1;
+        public int UvHeight => (Height + 1) >> 1;
         public int UvStride => Frame->linesize[1];
 
         public Surface(int width, int height)

--- a/Ryujinx.Graphics.Nvdec.Vp9/Dsp/InvTxfm.cs
+++ b/Ryujinx.Graphics.Nvdec.Vp9/Dsp/InvTxfm.cs
@@ -486,8 +486,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
                 Idct8(tempIn, tempOut);
                 for (j = 0; j < 8; ++j)
                 {
-                    dest[j * stride + i] = ClipPixelAdd(dest[j * stride + i],
-                                                          BitUtils.RoundPowerOfTwo(tempOut[j], 5));
+                    dest[j * stride + i] = ClipPixelAdd(dest[j * stride + i], BitUtils.RoundPowerOfTwo(tempOut[j], 5));
                 }
             }
         }

--- a/Ryujinx.Graphics.Nvdec.Vp9/Types/Surface.cs
+++ b/Ryujinx.Graphics.Nvdec.Vp9/Types/Surface.cs
@@ -15,6 +15,8 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Types
         public unsafe Plane UPlane => new Plane((IntPtr)UBuffer.ToPointer(), UBuffer.Length);
         public unsafe Plane VPlane => new Plane((IntPtr)VBuffer.ToPointer(), VBuffer.Length);
 
+        public FrameField Field => FrameField.Progressive;
+
         public int Width { get; }
         public int Height { get; }
         public int AlignedWidth { get; }

--- a/Ryujinx.Graphics.Nvdec/H264Decoder.cs
+++ b/Ryujinx.Graphics.Nvdec/H264Decoder.cs
@@ -31,7 +31,24 @@ namespace Ryujinx.Graphics.Nvdec
 
             if (decoder.Decode(ref info, outputSurface, bitstream))
             {
-                SurfaceWriter.Write(rm.Gmm, outputSurface, lumaOffset, chromaOffset);
+                if (outputSurface.Field == FrameField.Progressive)
+                {
+                    SurfaceWriter.Write(
+                        rm.Gmm,
+                        outputSurface,
+                        lumaOffset   + pictureInfo.LumaFrameOffset,
+                        chromaOffset + pictureInfo.ChromaFrameOffset);
+                }
+                else
+                {
+                    SurfaceWriter.WriteInterlaced(
+                        rm.Gmm,
+                        outputSurface,
+                        lumaOffset   + pictureInfo.LumaTopFieldOffset,
+                        chromaOffset + pictureInfo.ChromaTopFieldOffset,
+                        lumaOffset   + pictureInfo.LumaBottomFieldOffset,
+                        chromaOffset + pictureInfo.ChromaBottomFieldOffset);
+                }
             }
 
             rm.Cache.Put(outputSurface);

--- a/Ryujinx.Graphics.Nvdec/Types/H264/PictureInfo.cs
+++ b/Ryujinx.Graphics.Nvdec/Types/H264/PictureInfo.cs
@@ -26,10 +26,10 @@ namespace Ryujinx.Graphics.Nvdec.Types.H264
         public uint Transform8x8ModeFlag;
         public uint LumaPitch;
         public uint ChromaPitch;
-        public uint LumaTopOffset;
-        public uint LumaBottomOffset;
+        public uint LumaTopFieldOffset;
+        public uint LumaBottomFieldOffset;
         public uint LumaFrameOffset;
-        public uint ChromaTopOffset;
+        public uint ChromaTopFieldOffset;
         public uint ChromaBottomFieldOffset;
         public uint ChromaFrameOffset;
         public uint HistBufferSize;

--- a/Ryujinx.Graphics.Vic/Blender.cs
+++ b/Ryujinx.Graphics.Vic/Blender.cs
@@ -48,38 +48,10 @@ namespace Ryujinx.Graphics.Vic
 
             int one = 1 << (mtx.MatrixRShift + 8);
 
-
-            // NOTE: This is buggy on .NET 5.0.100, we use a workaround for now (see https://github.com/dotnet/runtime/issues/44704)
-            // TODO: Uncomment this when fixed.
-            //Vector128<int> col1 = Vector128.Create(mtx.MatrixCoeff00, mtx.MatrixCoeff10, mtx.MatrixCoeff20, 0);
-            //Vector128<int> col2 = Vector128.Create(mtx.MatrixCoeff01, mtx.MatrixCoeff11, mtx.MatrixCoeff21, 0);
-            //Vector128<int> col3 = Vector128.Create(mtx.MatrixCoeff02, mtx.MatrixCoeff12, mtx.MatrixCoeff22, one);
-            //Vector128<int> col4 = Vector128.Create(mtx.MatrixCoeff03, mtx.MatrixCoeff13, mtx.MatrixCoeff23, 0);
-
-            Vector128<int> col1 = new Vector128<int>();
-            Vector128<int> col2 = new Vector128<int>();
-            Vector128<int> col3 = new Vector128<int>();
-            Vector128<int> col4 = new Vector128<int>();
-
-            col1 = Sse41.Insert(col1, mtx.MatrixCoeff00, 0);
-            col1 = Sse41.Insert(col1, mtx.MatrixCoeff10, 1);
-            col1 = Sse41.Insert(col1, mtx.MatrixCoeff20, 2);
-            col1 = Sse41.Insert(col1, 0, 3);
-
-            col2 = Sse41.Insert(col2, mtx.MatrixCoeff01, 0);
-            col2 = Sse41.Insert(col2, mtx.MatrixCoeff11, 1);
-            col2 = Sse41.Insert(col2, mtx.MatrixCoeff21, 2);
-            col2 = Sse41.Insert(col2, 0, 3);
-
-            col3 = Sse41.Insert(col3, mtx.MatrixCoeff02, 0);
-            col3 = Sse41.Insert(col3, mtx.MatrixCoeff12, 1);
-            col3 = Sse41.Insert(col3, mtx.MatrixCoeff22, 2);
-            col3 = Sse41.Insert(col3, one, 3);
-
-            col4 = Sse41.Insert(col4, mtx.MatrixCoeff03, 0);
-            col4 = Sse41.Insert(col4, mtx.MatrixCoeff13, 1);
-            col4 = Sse41.Insert(col4, mtx.MatrixCoeff23, 2);
-            col4 = Sse41.Insert(col4, 0, 3);
+            Vector128<int> col1 = Vector128.Create(mtx.MatrixCoeff00, mtx.MatrixCoeff10, mtx.MatrixCoeff20, 0);
+            Vector128<int> col2 = Vector128.Create(mtx.MatrixCoeff01, mtx.MatrixCoeff11, mtx.MatrixCoeff21, 0);
+            Vector128<int> col3 = Vector128.Create(mtx.MatrixCoeff02, mtx.MatrixCoeff12, mtx.MatrixCoeff22, one);
+            Vector128<int> col4 = Vector128.Create(mtx.MatrixCoeff03, mtx.MatrixCoeff13, mtx.MatrixCoeff23, 0);
 
             Vector128<int> rShift = Vector128.CreateScalar(mtx.MatrixRShift);
             Vector128<ushort> clMin = Vector128.Create((ushort)slot.SlotConfig.SoftClampLow);

--- a/Ryujinx.Graphics.Vic/Image/BufferPool.cs
+++ b/Ryujinx.Graphics.Vic/Image/BufferPool.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.Graphics.Vic.Image
         /// If the required buffer is larger than this, it won't be
         /// added to the pool to avoid long term high memory usage.
         /// </summary>
-        private const int MaxBufferSize = 2048 * 1280;
+        private const int MaxBufferSize = 2048 * 2048;
 
         private struct PoolItem
         {

--- a/Ryujinx.Graphics.Vic/Image/InputSurface.cs
+++ b/Ryujinx.Graphics.Vic/Image/InputSurface.cs
@@ -2,16 +2,85 @@
 
 namespace Ryujinx.Graphics.Vic.Image
 {
+    ref struct RentedBuffer
+    {
+        public static RentedBuffer Empty => new RentedBuffer(Span<byte>.Empty, -1);
+
+        public Span<byte> Data;
+        public int Index;
+
+        public RentedBuffer(Span<byte> data, int index)
+        {
+            Data = data;
+            Index = index;
+        }
+
+        public void Return(BufferPool<byte> pool)
+        {
+            if (Index != -1)
+            {
+                pool.Return(Index);
+            }
+        }
+    }
+
     ref struct InputSurface
     {
         public ReadOnlySpan<byte> Buffer0;
         public ReadOnlySpan<byte> Buffer1;
         public ReadOnlySpan<byte> Buffer2;
 
+        public int Buffer0Index;
+        public int Buffer1Index;
+        public int Buffer2Index;
+
         public int Width;
         public int Height;
 
         public int UvWidth;
         public int UvHeight;
+
+        public void Initialize()
+        {
+            Buffer0Index = -1;
+            Buffer1Index = -1;
+            Buffer2Index = -1;
+        }
+
+        public void SetBuffer0(RentedBuffer buffer)
+        {
+            Buffer0 = buffer.Data;
+            Buffer0Index = buffer.Index;
+        }
+
+        public void SetBuffer1(RentedBuffer buffer)
+        {
+            Buffer1 = buffer.Data;
+            Buffer1Index = buffer.Index;
+        }
+
+        public void SetBuffer2(RentedBuffer buffer)
+        {
+            Buffer2 = buffer.Data;
+            Buffer2Index = buffer.Index;
+        }
+
+        public void Return(BufferPool<byte> pool)
+        {
+            if (Buffer0Index != -1)
+            {
+                pool.Return(Buffer0Index);
+            }
+
+            if (Buffer1Index != -1)
+            {
+                pool.Return(Buffer1Index);
+            }
+
+            if (Buffer2Index != -1)
+            {
+                pool.Return(Buffer2Index);
+            }
+        }
     }
 }

--- a/Ryujinx.Graphics.Vic/Image/SurfaceWriter.cs
+++ b/Ryujinx.Graphics.Vic/Image/SurfaceWriter.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.Graphics.Vic.Image
             switch (config.OutPixelFormat)
             {
                 case PixelFormat.A8B8G8R8:
-                case PixelFormat.X8B8G8R8:    
+                case PixelFormat.X8B8G8R8:
                     WriteA8B8G8R8(rm, input, ref config, ref offsets);
                     break;
                 case PixelFormat.A8R8G8B8:
@@ -433,7 +433,7 @@ namespace Ryujinx.Graphics.Vic.Image
         {
             if (linear)
             {
-                rm.Gmm.Write(ExtendOffset(offset), src);
+                rm.Gmm.WriteMapped(ExtendOffset(offset), src);
                 return;
             }
 
@@ -456,7 +456,7 @@ namespace Ryujinx.Graphics.Vic.Image
 
             LayoutConverter.ConvertLinearToBlockLinear(dst, width, height, dstStride, bytesPerPixel, gobBlocksInY, src);
 
-            rm.Gmm.Write(ExtendOffset(offset), dst);
+            rm.Gmm.WriteMapped(ExtendOffset(offset), dst);
 
             rm.BufferPool.Return(dstIndex);
         }

--- a/Ryujinx.Graphics.Vic/Scaler.cs
+++ b/Ryujinx.Graphics.Vic/Scaler.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+namespace Ryujinx.Graphics.Vic
+{
+    static class Scaler
+    {
+        public static void DeinterlaceWeave(Span<byte> data, ReadOnlySpan<byte> prevData, int width, int fieldSize, bool isTopField)
+        {
+            // Prev I    Curr I    Curr P
+            // TTTTTTTT  BBBBBBBB  TTTTTTTT
+            // --------  --------  BBBBBBBB
+
+            if (isTopField)
+            {
+                for (int offset = 0; offset < data.Length; offset += fieldSize * 2)
+                {
+                    prevData.Slice(offset >> 1, width).CopyTo(data.Slice(offset + fieldSize, width));
+                }
+            }
+            else
+            {
+                for (int offset = 0; offset < data.Length; offset += fieldSize * 2)
+                {
+                    prevData.Slice(offset >> 1, width).CopyTo(data.Slice(offset, width));
+                }
+            }
+        }
+
+        public static void DeinterlaceBob(Span<byte> data, int width, int fieldSize, bool isTopField)
+        {
+            // Curr I    Curr P
+            // TTTTTTTT  TTTTTTTT
+            // --------  TTTTTTTT
+
+            if (isTopField)
+            {
+                for (int offset = 0; offset < data.Length; offset += fieldSize * 2)
+                {
+                    data.Slice(offset, width).CopyTo(data.Slice(offset + fieldSize, width));
+                }
+            }
+            else
+            {
+                for (int offset = 0; offset < data.Length; offset += fieldSize * 2)
+                {
+                    data.Slice(offset + fieldSize, width).CopyTo(data.Slice(offset, width));
+                }
+            }
+        }
+
+        public unsafe static void DeinterlaceMotionAdaptive(
+            Span<byte> data,
+            ReadOnlySpan<byte> prevData,
+            ReadOnlySpan<byte> nextData,
+            int width,
+            int fieldSize,
+            bool isTopField)
+        {
+            // Very simple motion adaptive algorithm.
+            // If the pixel changed between previous and next frame, use Bob, otherwise use Weave.
+            //
+            // Example pseudo code:
+            // C_even = (P_even == N_even) ? P_even : C_odd
+            // Where: C is current frame, P is previous frame and N is next frame, and even/odd are the fields.
+            //
+            // Note: This does not fully match the hardware algorithm.
+            // The motion adaptive deinterlacing implemented on hardware is considerably more complex,
+            // and hard to implement accurately without proper documentation as for example, the
+            // method used for motion estimation is unknown.
+
+            int start = isTopField ? fieldSize : 0;
+            int otherFieldOffset = isTopField ? -fieldSize : fieldSize;
+
+            fixed (byte* pData = data, pPrevData = prevData, pNextData = nextData)
+            {
+                for (int offset = start; offset < data.Length; offset += fieldSize * 2)
+                {
+                    int refOffset = (offset - start) >> 1;
+                    int x = 0;
+
+                    if (Avx2.IsSupported)
+                    {
+                        for (; x < (width & ~0x1f); x += 32)
+                        {
+                            Vector256<byte> prevPixels = Avx.LoadVector256(pPrevData + refOffset + x);
+                            Vector256<byte> nextPixels = Avx.LoadVector256(pNextData + refOffset + x);
+                            Vector256<byte> bob = Avx.LoadVector256(pData + offset + otherFieldOffset + x);
+                            Vector256<byte> diff = Avx2.CompareEqual(prevPixels, nextPixels);
+                            Avx.Store(pData + offset + x, Avx2.BlendVariable(bob, prevPixels, diff));
+                        }
+                    }
+                    else if (Sse41.IsSupported)
+                    {
+                        for (; x < (width & ~0xf); x += 16)
+                        {
+                            Vector128<byte> prevPixels = Sse2.LoadVector128(pPrevData + refOffset + x);
+                            Vector128<byte> nextPixels = Sse2.LoadVector128(pNextData + refOffset + x);
+                            Vector128<byte> bob = Sse2.LoadVector128(pData + offset + otherFieldOffset + x);
+                            Vector128<byte> diff = Sse2.CompareEqual(prevPixels, nextPixels);
+                            Sse2.Store(pData + offset + x, Sse41.BlendVariable(bob, prevPixels, diff));
+                        }
+                    }
+
+                    for (; x < width; x++)
+                    {
+                        byte prevPixel = prevData[refOffset + x];
+                        byte nextPixel = nextData[refOffset + x];
+
+                        if (nextPixel != prevPixel)
+                        {
+                            data[offset + x] = data[offset + otherFieldOffset + x];
+                        }
+                        else
+                        {
+                            data[offset + x] = prevPixel;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Ryujinx.Graphics.Vic/Types/DeinterlaceMode.cs
+++ b/Ryujinx.Graphics.Vic/Types/DeinterlaceMode.cs
@@ -1,0 +1,12 @@
+namespace Ryujinx.Graphics.Vic.Types
+{
+    enum DeinterlaceMode
+    {
+        Weave,
+        BobField,
+        Bob,
+        NewBob,
+        Disi1,
+        WeaveLumaBobFieldChroma
+    }
+}

--- a/Ryujinx.Graphics.Vic/Types/FrameFormat.cs
+++ b/Ryujinx.Graphics.Vic/Types/FrameFormat.cs
@@ -1,0 +1,79 @@
+namespace Ryujinx.Graphics.Vic.Types
+{
+    enum FrameFormat
+    {
+        Progressive,
+        InterlacedTopFieldFirst,
+        InterlacedBottomFieldFirst,
+        TopField,
+        BottomField,
+        SubPicProgressive,
+        SubPicInterlacedTopFieldFirst,
+        SubPicInterlacedBottomFieldFirst,
+        SubPicTopField,
+        SubPicBottomField,
+        TopFieldChromaBottom,
+        BottomFieldChromaTop,
+        SubPicTopFieldChromaBottom,
+        SubPicBottomFieldChromaTop
+    }
+
+    static class FrameFormatExtensions
+    {
+        public static bool IsField(this FrameFormat frameFormat)
+        {
+            switch (frameFormat)
+            {
+                case FrameFormat.TopField:
+                case FrameFormat.BottomField:
+                case FrameFormat.SubPicTopField:
+                case FrameFormat.SubPicBottomField:
+                case FrameFormat.TopFieldChromaBottom:
+                case FrameFormat.BottomFieldChromaTop:
+                case FrameFormat.SubPicTopFieldChromaBottom:
+                case FrameFormat.SubPicBottomFieldChromaTop:
+                    return true;
+            }
+
+            return false;
+        }
+
+        public static bool IsInterlaced(this FrameFormat frameFormat)
+        {
+            switch (frameFormat)
+            {
+                case FrameFormat.InterlacedTopFieldFirst:
+                case FrameFormat.InterlacedBottomFieldFirst:
+                case FrameFormat.SubPicInterlacedTopFieldFirst:
+                case FrameFormat.SubPicInterlacedBottomFieldFirst:
+                    return true;
+            }
+
+            return false;
+        }
+
+        public static bool IsInterlacedBottomFirst(this FrameFormat frameFormat)
+        {
+            return frameFormat == FrameFormat.InterlacedBottomFieldFirst ||
+                   frameFormat == FrameFormat.SubPicInterlacedBottomFieldFirst;
+        }
+
+        public static bool IsTopField(this FrameFormat frameFormat, bool isLuma)
+        {
+            switch (frameFormat)
+            {
+                case FrameFormat.TopField:
+                case FrameFormat.SubPicTopField:
+                    return true;
+                case FrameFormat.TopFieldChromaBottom:
+                case FrameFormat.SubPicTopFieldChromaBottom:
+                    return isLuma;
+                case FrameFormat.BottomFieldChromaTop:
+                case FrameFormat.SubPicBottomFieldChromaTop:
+                    return !isLuma;
+            }
+
+            return false;
+        }
+    }
+}

--- a/Ryujinx.Graphics.Vic/Types/SlotConfig.cs
+++ b/Ryujinx.Graphics.Vic/Types/SlotConfig.cs
@@ -27,7 +27,7 @@
         public bool PrevMotionFieldEnable => _word0.Extract(13);
         public bool PpMotionFieldEnable => _word0.Extract(14);
         public bool CombMotionFieldEnable => _word0.Extract(15);
-        public int FrameFormat => _word0.Extract(16, 4);
+        public FrameFormat FrameFormat => (FrameFormat)_word0.Extract(16, 4);
         public int FilterLengthY => _word0.Extract(20, 2);
         public int FilterLengthX => _word0.Extract(22, 2);
         public int Panoramic => _word0.Extract(24, 12);
@@ -36,7 +36,7 @@
         public int FilterDetail => _word1.Extract(74, 10);
         public int ChromaNoise => _word1.Extract(84, 10);
         public int ChromaDetail => _word1.Extract(94, 10);
-        public int DeinterlaceMode => _word1.Extract(104, 4);
+        public DeinterlaceMode DeinterlaceMode => (DeinterlaceMode)_word1.Extract(104, 4);
         public int MotionAccumWeight => _word1.Extract(108, 3);
         public int NoiseIir => _word1.Extract(111, 11);
         public int LightLevel => _word1.Extract(122, 4);

--- a/Ryujinx.Graphics.Vic/VicDevice.cs
+++ b/Ryujinx.Graphics.Vic/VicDevice.cs
@@ -43,9 +43,9 @@ namespace Ryujinx.Graphics.Vic
                     continue;
                 }
 
-                var offsets = _state.State.SetSurfacexSlotx[i][0];
+                ref var offsets = ref _state.State.SetSurfacexSlotx[i];
 
-                using Surface src = SurfaceReader.Read(_rm, ref slot.SlotSurfaceConfig, ref offsets);
+                using Surface src = SurfaceReader.Read(_rm, ref slot.SlotConfig, ref slot.SlotSurfaceConfig, ref offsets);
 
                 Blender.BlendOne(output, src, ref slot);
             }

--- a/Ryujinx.Graphics.Video/FrameField.cs
+++ b/Ryujinx.Graphics.Video/FrameField.cs
@@ -1,0 +1,8 @@
+namespace Ryujinx.Graphics.Video
+{
+    public enum FrameField
+    {
+        Progressive,
+        Interlaced
+    }
+}

--- a/Ryujinx.Graphics.Video/ISurface.cs
+++ b/Ryujinx.Graphics.Video/ISurface.cs
@@ -8,6 +8,8 @@ namespace Ryujinx.Graphics.Video
         Plane UPlane { get; }
         Plane VPlane { get; }
 
+        FrameField Field { get; }
+
         int Width { get; }
         int Height { get; }
         int Stride { get; }


### PR DESCRIPTION
## Background

Video interlacing is the process where a full video frame (called progressive frame) is halved vertically, keeping either the odd or even lines. Whenever the even or odd lines are used is alternated on each frame. That is, if the first interlaced frame consists of even lines, the second one will have only odd lines, and the third will have even lines again, etc.

Example (image not mine):
![image](https://user-images.githubusercontent.com/5624669/159542196-9840aa2c-3b8e-46ce-82a8-5e776557152e.png)

## NVDEC interlacing support

The NVDEC implementation on the emulator had no support for interlaced video decoding. While we use FFMPEG for H264 decoding, and FFMPEG does support interlaced video, the frame that it returns is not exactly what NVDEC would. NVDEC essentially writes 2 frames, each one with half the height of the full progressive frame. The first one contains even fields, while the second one contains odd fields. Meanwhile, FFMPEG returns a full progressive frame. So we need to extract the even fields of the FFMPEG frame, and then write it as the first frame, then extract the odd fields and write it as the second frame.

## VIC deinterlacing support

VIC also supports deinterlacing, but such support was not implemented on the emulator. This PR also implements that part. There are several deinterlacing modes that are supported by VIC:

### BOB

This is a very simple method that simple doubles the lines on each interlaced frame. This way one can re-create the full frame, but some vertical resolution is lost as you have duplicate lines. On static scenes, this creates a very noticeable effect where the lines appear to "jump" up and down, because the fields on each frame are alternating, that is, one is even and the other is the odd line, so they are not from the exact same position of the scene. This makes thing shift up and down by 1 pixel. On high movement scenes, this effect is not noticeable because everything is already moving anyway.

Example of line "jumping" caused by BOB deinterlacing:

https://user-images.githubusercontent.com/5624669/159551909-ecea6672-01f5-4eb0-9f70-61607cbce988.mp4

### Weave

This method fills the missing fields on the frame with the ones from the previous frame. On static scenes, this can re-create a perfect image since nothing is moving. However, on high movement scenes it creates very noticeable artifacts, where objects on every even or odd line appears displaced. That is because the two frame are from different points in time, so the lines that were copied from the previous frame might have objects at slightly different positions than the current frame.

Example of artifacts caused by Weave method:
![image](https://user-images.githubusercontent.com/5624669/159551379-fad9f4d2-7679-4f3f-a8b0-fdf46e5368ff.png)

### Motion adaptive (New BOB, DiSi1)

You may have noticed that the two methods above have opposite results. One is good for static scenes but not moving ones, while the other is good for high movement scenes but not static ones. Motion adaptive methods tries to get the "best of both worlds" by choosing which method to use based on the amount of movement for a given pixel. If the pixel did not move, then it uses Weave method, since it results in a perfect image for static scenes, and it does not create the "jump" effect on alternating frames. If the pixel did move, then it uses BOB method, as it does not introduce the artifacts that Weave does on high movement scenes.

Those motion adaptive methods works by first estimating the motion of the pixel between two frames (part and future frames, that are supplied to VIC), and then calculates a movement vector for each pixel based on that. The final output is then an interpolation of the Weave and BOB outputs, were the "weight" is defined by the movement vector magnitude.

The emulator implementation for this mode was simplified, and might not fully match hardware. That is because the exact algorithm that it uses for motion estimation, interpolation, etc, are unknown. So instead I implemented a deinterlacer that just picks BOB or Weave output based on whenever the pixels on past and future frames match or not. From my tests, it produces very good results, even without the more sophisticated approaches.

## What does it affect?

The only game that is know to use interlaced videos is Layton's Mystery Journey (and from what I was told, apparently the Japanese version is not using interlaced videos).

The first problem was that, since there was no deinterlacing, the input frame on VIC only had half the length. This caused a crash on the blend step as it would try to read out of bounds. The second problem was that the output surface is slightly larger than the region of memory mapped. The driver allocates enough memory for a 2048x1080 frame while the output frame size is 2048x1088 (note that the real size is 1920x1080, the 2048 is due to VIC required pitch alignment of 256 bytes, and 1088 is due to H264 required width/height alignment of 16, since the macro block size is 16x16). I tried looking at the VIC structures and documentation to try finding something that could cause the output to be cropped to 1080, but found nothing that would apply in this case, so I have added a new write method that skips unmapped regions, and started using it on VIC. This is making an assumption that this is a "bug" on the driver's end, and that unmapped memory access from VIC does not cause failures.

Of course, even with this fixed, it would be pointless without deinterlace support and NVDEC writing the output correctly, so that's mostly what this PR does.

As a result, videos on this game now works, rather than crashing instantly:
![image](https://user-images.githubusercontent.com/5624669/159549946-33ca4d9e-0c20-42c5-9d86-ff7e5fbf48c5.png)
