### PR TITLE
Fix shader textureSize with multisample and buffer textures

### DIFF
--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/CodeGenContext.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/CodeGenContext.cs
@@ -70,7 +70,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
             AppendLine("}" + suffix);
         }
 
-        public TextureDescriptor FindTextureDescriptor(AstTextureOperation texOp, out int descriptorIndex)
+        public (TextureDescriptor, int) FindTextureDescriptor(AstTextureOperation texOp)
         {
             TextureDescriptor[] descriptors = Config.GetTextureDescriptors();
 
@@ -82,13 +82,11 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
                     descriptor.HandleIndex == texOp.Handle &&
                     descriptor.Format == texOp.Format)
                 {
-                    descriptorIndex = i;
-                    return descriptor;
+                    return (descriptor, i);
                 }
             }
 
-            descriptorIndex = -1;
-            return default;
+            return (default, -1);
         }
 
         private static int FindDescriptorIndex(TextureDescriptor[] array, AstTextureOperation texOp)

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/CodeGenContext.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/CodeGenContext.cs
@@ -70,6 +70,27 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
             AppendLine("}" + suffix);
         }
 
+        public TextureDescriptor FindTextureDescriptor(AstTextureOperation texOp, out int descriptorIndex)
+        {
+            TextureDescriptor[] descriptors = Config.GetTextureDescriptors();
+
+            for (int i = 0; i < descriptors.Length; i++)
+            {
+                var descriptor = descriptors[i];
+
+                if (descriptor.CbufSlot == texOp.CbufSlot &&
+                    descriptor.HandleIndex == texOp.Handle &&
+                    descriptor.Format == texOp.Format)
+                {
+                    descriptorIndex = i;
+                    return descriptor;
+                }
+            }
+
+            descriptorIndex = -1;
+            return default;
+        }
+
         private static int FindDescriptorIndex(TextureDescriptor[] array, AstTextureOperation texOp)
         {
             for (int i = 0; i < array.Length; i++)

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
@@ -756,27 +756,34 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
 
             string samplerName = OperandManager.GetSamplerName(context.Config.Stage, texOp, indexExpr);
 
-            int lodSrcIndex = isBindless || isIndexed ? 1 : 0;
-
-            IAstNode lod = operation.GetSource(lodSrcIndex);
-
-            string lodExpr = GetSoureExpr(context, lod, GetSrcVarType(operation.Inst, lodSrcIndex));
-
             if (texOp.Index == 3)
             {
                 return $"textureQueryLevels({samplerName})";
             }
             else
             {
-                string texCall = $"textureSize({samplerName}, {lodExpr}){GetMask(texOp.Index)}";
+                SamplerType declarationType = context.FindTextureDescriptor(texOp, out int descriptorIndex).Type;
+                bool hasLod = !declarationType.HasFlag(SamplerType.Multisample) && declarationType != SamplerType.TextureBuffer;
+                string texCall;
+
+                if (hasLod)
+                {
+                    int lodSrcIndex = isBindless || isIndexed ? 1 : 0;
+                    IAstNode lod = operation.GetSource(lodSrcIndex);
+                    string lodExpr = GetSoureExpr(context, lod, GetSrcVarType(operation.Inst, lodSrcIndex));
+
+                    texCall = $"textureSize({samplerName}, {lodExpr}){GetMask(texOp.Index)}";
+                }
+                else
+                {
+                    texCall = $"textureSize({samplerName}){GetMask(texOp.Index)}";
+                }
 
                 if (context.Config.Stage.SupportsRenderScale() &&
                     !isBindless &&
                     !isIndexed)
                 {
-                    int index = context.FindTextureDescriptorIndex(texOp);
-
-                    texCall = "Helper_TextureSizeUnscale(" + texCall + ", " + index + ")";
+                    texCall = $"Helper_TextureSizeUnscale({texCall}, {descriptorIndex})";
                 }
 
                 return texCall;

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
@@ -762,8 +762,8 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
             }
             else
             {
-                SamplerType declarationType = context.FindTextureDescriptor(texOp, out int descriptorIndex).Type;
-                bool hasLod = !declarationType.HasFlag(SamplerType.Multisample) && declarationType != SamplerType.TextureBuffer;
+                (TextureDescriptor descriptor, int descriptorIndex) = context.FindTextureDescriptor(texOp);
+                bool hasLod = !descriptor.Type.HasFlag(SamplerType.Multisample) && descriptor.Type != SamplerType.TextureBuffer;
                 string texCall;
 
                 if (hasLod)


### PR DESCRIPTION
The multisample and buffer overloads does not take a lod parameter, because multisample and buffer textures can't have mipmaps. This removes the inexistent parameter from the GLSL code generation.

Fixes #3238.