### PR TITLE
service: hid: Signal event on AcquireNpadStyleSetUpdateEventHandle

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
@@ -767,6 +767,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid
                 throw new InvalidOperationException("Out of handles!");
             }
 
+            // Games expect this event to be signaled after calling this function
+            evnt.ReadableEvent.Signal();
+
             context.Response.HandleDesc = IpcHandleDesc.MakeCopy(handle);
 
             Logger.Stub?.PrintStub(LogClass.ServiceHid, new { appletResourceUserId, npadId, npadStyleSet });


### PR DESCRIPTION
HW signals this event after `AcquireNpadStyleSetUpdateEventHandle` is called regardless of the controller status. Fixes random controller disconnects on Flip Wars