### PR TITLE
Remove save data creation prompt

### DIFF
--- a/Ryujinx.HLE/HOS/ModLoader.cs
+++ b/Ryujinx.HLE/HOS/ModLoader.cs
@@ -161,7 +161,7 @@ namespace Ryujinx.HLE.HOS
 
             if (titleModsPath == null)
             {
-                Logger.Info?.Print(LogClass.ModLoader, $"Creating mods dir for Title {titleId.ToUpper()}");
+                Logger.Info?.Print(LogClass.ModLoader, $"Creating mods directory for Title {titleId.ToUpper()}");
                 titleModsPath = contentsDir.CreateSubdirectory(titleId);
             }
 

--- a/Ryujinx/Ui/Widgets/GameTableContextMenu.cs
+++ b/Ryujinx/Ui/Widgets/GameTableContextMenu.cs
@@ -81,14 +81,14 @@ namespace Ryujinx.Ui.Widgets
         private bool TryFindSaveData(string titleName, ulong titleId, BlitStruct<ApplicationControlProperty> controlHolder, in SaveDataFilter filter, out ulong saveDataId)
         {
             saveDataId = default;
-            
+
             Result result = _horizonClient.Fs.FindSaveDataWithFilter(out SaveDataInfo saveDataInfo, SaveDataSpaceId.User, in filter);
 
             if (ResultFs.TargetNotFound.Includes(result))
             {
                 ref ApplicationControlProperty control = ref controlHolder.Value;
 
-                Logger.Info?.Print(LogClass.Application, $"Creating save dir for Title: {titleName} [{titleId:x16}]");
+                Logger.Info?.Print(LogClass.Application, $"Creating save directory for Title: {titleName} [{titleId:x16}]");
 
                 if (Utilities.IsZeros(controlHolder.ByteSpan))
                 {

--- a/Ryujinx/Ui/Widgets/GameTableContextMenu.cs
+++ b/Ryujinx/Ui/Widgets/GameTableContextMenu.cs
@@ -81,27 +81,14 @@ namespace Ryujinx.Ui.Widgets
         private bool TryFindSaveData(string titleName, ulong titleId, BlitStruct<ApplicationControlProperty> controlHolder, in SaveDataFilter filter, out ulong saveDataId)
         {
             saveDataId = default;
-
+            
             Result result = _horizonClient.Fs.FindSaveDataWithFilter(out SaveDataInfo saveDataInfo, SaveDataSpaceId.User, in filter);
 
             if (ResultFs.TargetNotFound.Includes(result))
             {
-                // Savedata was not found. Ask the user if they want to create it
-                using MessageDialog messageDialog = new MessageDialog(null, DialogFlags.Modal, MessageType.Question, ButtonsType.YesNo, null)
-                {
-                    Title          = "Ryujinx",
-                    Icon           = new Gdk.Pixbuf(Assembly.GetExecutingAssembly(), "Ryujinx.Ui.Resources.Logo_Ryujinx.png"),
-                    Text           = $"There is no savedata for {titleName} [{titleId:x16}]",
-                    SecondaryText  = "Would you like to create savedata for this game?",
-                    WindowPosition = WindowPosition.Center
-                };
-
-                if (messageDialog.Run() != (int)ResponseType.Yes)
-                {
-                    return false;
-                }
-
                 ref ApplicationControlProperty control = ref controlHolder.Value;
+
+                Logger.Info?.Print(LogClass.Application, $"Creating save dir for Title: {titleName} [{titleId:x16}]");
 
                 if (Utilities.IsZeros(controlHolder.ByteSpan))
                 {


### PR DESCRIPTION
This prompt was fairly redundant and was just another box to click. 
Creation of mod directories do not require this extra step and it seems weird to keep this one. If there is a particular reason to keep this around then I'm all ears but I currently can't see a scenario where a user wishes to open a directory... then says "No" when asked to create one.

The logger now simply reads when a directory has been created instead.