### PR TITLE
Calculate vertex buffer size from index buffer type

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -35,6 +35,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
         private bool _prevDrawIndexed;
         private IndexType _prevIndexType;
+        private uint _prevFirstVertex;
         private bool _prevTfEnable;
 
         /// <summary>
@@ -195,14 +196,21 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             // method when doing indexed draws, so we need to make sure
             // to update the vertex buffers if we are doing a regular
             // draw after a indexed one and vice-versa.
-            // In some cases, the index type is also used to guess the
-            // vertex buffer size, so we must update it if the type changed too.
-            if ((_drawState.DrawIndexed != _prevDrawIndexed) ||
-                (_drawState.DrawIndexed && (_prevIndexType != _state.State.IndexBufferState.Type)))
+            if (_drawState.DrawIndexed != _prevDrawIndexed)
             {
                 _updateTracker.ForceDirty(VertexBufferStateIndex);
                 _prevDrawIndexed = _drawState.DrawIndexed;
+            }
+
+            // In some cases, the index type is also used to guess the
+            // vertex buffer size, so we must update it if the type changed too.
+            if (_drawState.DrawIndexed &&
+                (_prevIndexType != _state.State.IndexBufferState.Type ||
+                 _prevFirstVertex != _state.State.FirstVertex))
+            {
+                _updateTracker.ForceDirty(VertexBufferStateIndex);
                 _prevIndexType = _state.State.IndexBufferState.Type;
+                _prevFirstVertex = _state.State.FirstVertex;
             }
 
             bool tfEnable = _state.State.TfEnable;


### PR DESCRIPTION
This change aims to make the size of vertex buffers that are too large smaller.

First, I will describe an approach that I have tried on the past. Since on indexed draws, the vertex index comes from the index buffer, we can find an upper bound, that is, the maximum vertex index that can possibly be accessed by examining all entries on the index buffer. From that, we can calculate a maximum size by multiplying the value by the vertex buffer stride.
This has a few problems:
- We don't know if the index buffer was written from CPU or GPU. If it was written by the GPU, then it is most likely in GPU memory and we need to flush the data to examine it (which is expensive).
- Checking the entire index buffer to get the maximum index might not be exactly cheap depending on the index buffer size. So we might need to limit up to some index buffer size.
- In general, it's error prone as we need to re-calculate if for every index buffer or associated state change.

This is an alternative approach that avoids most of the issues above. First, this does **not** provide the same benefits of the approach above. So don't expect for example, Super Mario Galaxy getting faster with this, it won't. It also does not have the same goal of that change, which was improving performance. This one aims to make some games that are currently broken due to very, very high vertex buffer sizes (so high that they would cause out of memory errors and crashes) work. It works by defining a maximum range of vertices that it can possibly access from the index buffer *type*. If the type is a 16-bit integer, then we can only access up to 65536 vertices. If it's 8-bits, then we can only access 256. From that we can set an upper bound for the vertex buffer size, which might be less than the upper bound defined by the game.

This prevent out of memory errors and crashes on Super Mario 64 (on Super Mario 3D All-Stars) and Perky Little Things. Both still needs other fixes to actually render/work, so even with this change they are not really playable, but this is one of the fixes required so there's no reason for not getting it done now.

Sky Children of Light suffers from a similar issue, but unfortunately it uses 32-bit index buffer types, so this change doesn't really help it (as the upper bound would be still too high, as a 32-bit index means we can have up to 4294967296 vertices, which is still way, way too high. But the games requires an internet connection to boot anyway, so not really a big loss. We might want to consider a different or alternative approach to handle this case.

Testing is appreciated to ensure it did not cause regressions.