### PR TITLE
Better formatted Date and Time

### DIFF
--- a/Ryujinx/Ui/Windows/SettingsWindow.glade
+++ b/Ryujinx/Ui/Windows/SettingsWindow.glade
@@ -1332,9 +1332,9 @@
                                       <object class="GtkLabel">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Change System Time</property>
+                                        <property name="tooltip-text" translatable="yes">Change System Date</property>
                                         <property name="halign">end</property>
-                                        <property name="label" translatable="yes">System Time:</property>
+                                        <property name="label" translatable="yes">System Date:</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -1420,6 +1420,21 @@
                                       </packing>
                                     </child>
                                     <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Change System Time</property>
+                                        <property name="halign">end</property>
+                                        <property name="label" translatable="yes">System Time:</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="padding">5</property>
+                                        <property name="position">6</property>
+                                      </packing>
+                                    </child>
+                                    <child>
                                       <object class="GtkSpinButton" id="_systemTimeHourSpin">
                                         <property name="visible">True</property>
                                         <property name="can-focus">True</property>
@@ -1431,7 +1446,7 @@
                                       <packing>
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
-                                        <property name="position">6</property>
+                                        <property name="position">7</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -1445,7 +1460,7 @@
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
                                         <property name="padding">5</property>
-                                        <property name="position">7</property>
+                                        <property name="position">8</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -1460,7 +1475,7 @@
                                       <packing>
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
-                                        <property name="position">8</property>
+                                        <property name="position">9</property>
                                       </packing>
                                     </child>
                                   </object>

--- a/Ryujinx/Ui/Windows/SettingsWindow.glade
+++ b/Ryujinx/Ui/Windows/SettingsWindow.glade
@@ -1332,7 +1332,7 @@
                                       <object class="GtkLabel">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Change System Date</property>
+                                        <property name="tooltip-text" translatable="yes">Change System Date (YYYY/DD/MM)</property>
                                         <property name="halign">end</property>
                                         <property name="label" translatable="yes">System Date:</property>
                                       </object>
@@ -1340,7 +1340,7 @@
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
                                         <property name="padding">5</property>
-                                        <property name="position">0</property>
+                                        <property name="position">6</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -1356,7 +1356,7 @@
                                       <packing>
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
-                                        <property name="position">1</property>
+                                        <property name="position">5</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -1370,7 +1370,7 @@
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
                                         <property name="padding">5</property>
-                                        <property name="position">2</property>
+                                        <property name="position">6</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -1386,7 +1386,7 @@
                                       <packing>
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
-                                        <property name="position">3</property>
+                                        <property name="position">7</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -1400,7 +1400,7 @@
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
                                         <property name="padding">5</property>
-                                        <property name="position">4</property>
+                                        <property name="position">8</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -1411,19 +1411,19 @@
                                         <property name="orientation">vertical</property>
                                         <property name="adjustment">_systemTimeDaySpinAdjustment</property>
                                         <property name="wrap">True</property>
-                                        <property name="value">1</property>
+                                        <property name="value">4</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
-                                        <property name="position">5</property>
+                                        <property name="position">9</property>
                                       </packing>
                                     </child>
                                     <child>
                                       <object class="GtkLabel">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Change System Time</property>
+                                        <property name="tooltip-text" translatable="yes">Change System Time (HH/MM)</property>
                                         <property name="halign">end</property>
                                         <property name="label" translatable="yes">System Time:</property>
                                       </object>
@@ -1431,7 +1431,7 @@
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
                                         <property name="padding">5</property>
-                                        <property name="position">6</property>
+                                        <property name="position">0</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -1446,7 +1446,7 @@
                                       <packing>
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
-                                        <property name="position">7</property>
+                                        <property name="position">1</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -1460,7 +1460,7 @@
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
                                         <property name="padding">5</property>
-                                        <property name="position">8</property>
+                                        <property name="position">2</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -1475,7 +1475,7 @@
                                       <packing>
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
-                                        <property name="position">9</property>
+                                        <property name="position">3</property>
                                       </packing>
                                     </child>
                                   </object>

--- a/Ryujinx/Ui/Windows/SettingsWindow.glade
+++ b/Ryujinx/Ui/Windows/SettingsWindow.glade
@@ -1342,7 +1342,7 @@
                                         <property name="padding">5</property>
                                         <property name="position">6</property>
                                       </packing>
-                                    </child> # year spinner
+                                    </child>
                                     <child>
                                       <object class="GtkSpinButton" id="_systemTimeYearSpin">
                                         <property name="visible">True</property>
@@ -1402,7 +1402,7 @@
                                         <property name="padding">5</property>
                                         <property name="position">7</property>
                                       </packing>
-                                    </child> # day spinner
+                                    </child>
                                     <child>
                                       <object class="GtkSpinButton" id="_systemTimeDaySpin">
                                         <property name="visible">True</property>

--- a/Ryujinx/Ui/Windows/SettingsWindow.glade
+++ b/Ryujinx/Ui/Windows/SettingsWindow.glade
@@ -1332,7 +1332,7 @@
                                       <object class="GtkLabel">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Change System Date (YYYY/DD/MM)</property>
+                                        <property name="tooltip-text" translatable="yes">Change System Date (YYYY/MM/DD)</property>
                                         <property name="halign">end</property>
                                         <property name="label" translatable="yes">System Date:</property>
                                       </object>
@@ -1342,7 +1342,7 @@
                                         <property name="padding">5</property>
                                         <property name="position">6</property>
                                       </packing>
-                                    </child>
+                                    </child> # year spinner
                                     <child>
                                       <object class="GtkSpinButton" id="_systemTimeYearSpin">
                                         <property name="visible">True</property>
@@ -1356,7 +1356,7 @@
                                       <packing>
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
-                                        <property name="position">5</property>
+                                        <property name="position">4</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -1370,7 +1370,7 @@
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
                                         <property name="padding">5</property>
-                                        <property name="position">6</property>
+                                        <property name="position">5</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -1386,7 +1386,7 @@
                                       <packing>
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
-                                        <property name="position">7</property>
+                                        <property name="position">6</property>
                                       </packing>
                                     </child>
                                     <child>
@@ -1400,9 +1400,9 @@
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
                                         <property name="padding">5</property>
-                                        <property name="position">8</property>
+                                        <property name="position">7</property>
                                       </packing>
-                                    </child>
+                                    </child> # day spinner
                                     <child>
                                       <object class="GtkSpinButton" id="_systemTimeDaySpin">
                                         <property name="visible">True</property>
@@ -1416,7 +1416,7 @@
                                       <packing>
                                         <property name="expand">False</property>
                                         <property name="fill">True</property>
-                                        <property name="position">9</property>
+                                        <property name="position">8</property>
                                       </packing>
                                     </child>
                                     <child>

--- a/Ryujinx/Ui/Windows/SettingsWindow.glade
+++ b/Ryujinx/Ui/Windows/SettingsWindow.glade
@@ -1332,7 +1332,7 @@
                                       <object class="GtkLabel">
                                         <property name="visible">True</property>
                                         <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Change System Date (YYYY/MM/DD)</property>
+                                        <property name="tooltip-text" translatable="yes">Change System Date (DD/MM/YYYY)</property>
                                         <property name="halign">end</property>
                                         <property name="label" translatable="yes">System Date:</property>
                                       </object>
@@ -1344,14 +1344,14 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkSpinButton" id="_systemTimeYearSpin">
+                                      <object class="GtkSpinButton" id="_systemTimeDaySpin">
                                         <property name="visible">True</property>
                                         <property name="can-focus">True</property>
-                                        <property name="text" translatable="yes">2000</property>
+                                        <property name="text" translatable="yes">1</property>
                                         <property name="orientation">vertical</property>
-                                        <property name="adjustment">_systemTimeYearSpinAdjustment</property>
+                                        <property name="adjustment">_systemTimeDaySpinAdjustment</property>
                                         <property name="wrap">True</property>
-                                        <property name="value">2000</property>
+                                        <property name="value">4</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>
@@ -1404,14 +1404,14 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkSpinButton" id="_systemTimeDaySpin">
+                                      <object class="GtkSpinButton" id="_systemTimeYearSpin">
                                         <property name="visible">True</property>
                                         <property name="can-focus">True</property>
-                                        <property name="text" translatable="yes">1</property>
+                                        <property name="text" translatable="yes">2000</property>
                                         <property name="orientation">vertical</property>
-                                        <property name="adjustment">_systemTimeDaySpinAdjustment</property>
+                                        <property name="adjustment">_systemTimeYearSpinAdjustment</property>
                                         <property name="wrap">True</property>
-                                        <property name="value">4</property>
+                                        <property name="value">2000</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>


### PR DESCRIPTION
This is a pretty simple change

Before:
![btw_i_use_arch_2022-04-03_08_31](https://user-images.githubusercontent.com/100526773/161444817-8c3cda8d-8b05-4ac1-a7ca-8110e80f98cc.png)


After:
![btw_i_use_arch_2022-04-03_08_3](https://user-images.githubusercontent.com/100526773/161444801-4953b673-99a0-4624-813c-4cb55428d4cb.png)

