### PR TITLE
Implement primitive restart draw arrays properly on OpenGL

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClassState.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClassState.cs
@@ -730,7 +730,9 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         public int PatchVertices;
         public fixed uint ReservedDD0[4];
         public uint TextureBarrier;
-        public fixed uint ReservedDE4[7];
+        public uint WatchdogTimer;
+        public Boolean32 PrimitiveRestartDrawArrays;
+        public fixed uint ReservedDEC[5];
         public Array16<ScissorState> ScissorState;
         public fixed uint ReservedF00[21];
         public StencilBackMasks StencilBackMasks;


### PR DESCRIPTION
Primitive restart is a feature that allows "spliting" the vertex stream when a special index value (called primitive restart index) is read from the index buffer. However, on OpenGL it also applies to non-indexed draws. In that case, it will split the stream after "primitive restart index" vertices. Vulkan does not have this behaviour, and the spec explicitly calls out that it only applies to indexed draws:
> primitiveRestartEnable controls whether a special vertex index value is treated as restarting the assembly of primitives. This enable only applies to indexed draws ([vkCmdDrawIndexed](https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdDrawIndexed.html), [vkCmdDrawMultiIndexedEXT](https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdDrawMultiIndexedEXT.html), and [vkCmdDrawIndexedIndirect](https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/vkCmdDrawIndexedIndirect.html))

The GPU actually has a register that controlls this behaviour. This change fixes the behaviour on OpenGL. If the "PrimitiveRestartDrawArrays" register is false, then it disables the primitive restart for non-indexed draws (regardless of the primitive restart enable register value). If that value is true, then it keeps the current behaviour (primitive restart enable on the backend always matches the GPU register value).

On OpenGL, that should make it behave like the hardware does. On Vulkan, primitive restart has no effect on non-indexed draws, so there's not much we can do here, however since Vulkan matches NVN behaviour, it is "fine" (that is, NVN games that depend on this behaviour were already correct on Vulkan, they were broken only on OpenGL).

This fixes white lines on sky on a few Hatsune Miku clips.
Before:
![image](https://user-images.githubusercontent.com/5624669/161564990-dfb6e5bb-bbb8-4a36-9aad-2a7ee98a9a75.png)
After:
![image](https://user-images.githubusercontent.com/5624669/161565043-f57daf05-5aa9-4972-9e5d-37399c20ef94.png)
Might also fix other glitches that happens on OpenGL but not Vulkan.