### PR TITLE
Do not force scissor on clear if scissor is disabled

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
@@ -525,7 +525,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 int scissorW = screenScissorState.Width;
                 int scissorH = screenScissorState.Height;
 
-                if (clearAffectedByScissor)
+                if (clearAffectedByScissor && _state.State.ScissorState[0].Enable)
                 {
                     ref var scissorState = ref _state.State.ScissorState[0];
 


### PR DESCRIPTION
We should not force a scissor on clears if the respective scissor is disabled.
This fixes some glitckes on Kirby and the Forgotten Land and maybe other titles caused by textures not being fully cleared, and "garbage" data from previous textures being carried over.
Before:
![image](https://user-images.githubusercontent.com/5624669/161591059-a8cc2c03-a1f2-45e5-b154-757c9cb3dcd5.png)
After:
![image](https://user-images.githubusercontent.com/5624669/161591080-fc3fa011-8b7e-42af-bc0f-514bd324df08.png)
