### PR TITLE
Do not clamp SNorm outputs to the [0, 1] range on OpenGL

### DIFF
--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -155,6 +155,12 @@ namespace Ryujinx.Graphics.OpenGL
 
             _pipeline.Initialize(this);
             _counters.Initialize();
+
+            // This is required to disable [0, 1] clamping for SNorm outputs on compatibility profiles.
+            // This call is expected to fail if we're running with a core profile,
+            // as this clamp target was deprecated, but that's fine as a core profile
+            // should already have the desired behaviour were outputs are not clamped.
+            GL.ClampColor(ClampColorTarget.ClampFragmentColor, ClampColorMode.False);
         }
 
         private void PrintGpuInformation()


### PR DESCRIPTION
When using OpenGL compatibility profiles, fragment clamping behaviour is set to "FIXED_ONLY", which as per the spec:

> The default state for fragment clamping is "FIXED_ONLY", which
    has the behavior of clamping colors for fixed-point color buffers
    and not clamping colors for floating-pont color buffers.

and:

>   If fragment
    clamping is enabled, the final fragment color values or the final
    fragment data values written by a fragment shader are clamped to
    the range [0, 1] and then may be converted to fixed-point as
    described in section 2.14.9.  If fragment clamping is disabled,
    the final fragment color values or the final fragment data values
    are not modified.

This means that UNorm outputs are clamped to the [0, 1] range (which is fine, UNorm can't store values outside that range), but also means that SNorm values are clamped to [0, 1] (which is not fine, as the SNorm full range is [-1, 1]). This change explicitly disables this clamping of the fragment shader output, which avoids clamping negative values to 0 for SNorm outputs.

This fixes broken reflections and lighting on LEGO Star Wars: The Skywalker Saga, which was caused by negative normal (?) values being clamped to 0.
Before:

https://user-images.githubusercontent.com/5624669/161814031-3aae138b-7149-40e5-9280-519aa22e5c3a.mp4

After:

https://user-images.githubusercontent.com/5624669/161814105-773c3e5e-7c21-447f-b701-e531a89c1256.mp4

Note: This issue does not affect Vulkan. It already has the desired behaviour were the fragment outputs are not clamped. It should also not affect OpenGL when using core profiles (while also requesting a newer version on the context).
