### PR TITLE
Fix tail merge from block with conditional jump to multiple returns

### DIFF
--- a/ARMeilleure/CodeGen/Optimizations/TailMerge.cs
+++ b/ARMeilleure/CodeGen/Optimizations/TailMerge.cs
@@ -59,7 +59,7 @@ namespace ARMeilleure.CodeGen.Optimizations
             BasicBlock fromPred = from.Predecessors.Count == 1 ? from.Predecessors[0] : null;
 
             // If the block is empty, we can try to append to the predecessor and avoid unnecessary jumps.
-            if (from.Operations.Count == 0 && fromPred != null)
+            if (from.Operations.Count == 0 && fromPred != null && fromPred.SuccessorsCount == 1)
             {
                 for (int i = 0; i < fromPred.SuccessorsCount; i++)
                 {

--- a/ARMeilleure/Signal/NativeSignalHandler.cs
+++ b/ARMeilleure/Signal/NativeSignalHandler.cs
@@ -191,7 +191,7 @@ namespace ARMeilleure.Signal
                 // Is the fault address within this tracked region?
                 Operand inRange = context.BitwiseAnd(
                     context.ICompare(faultAddress, rangeAddress, Comparison.GreaterOrEqualUI),
-                    context.ICompare(faultAddress, rangeEndAddress, Comparison.Less)
+                    context.ICompare(faultAddress, rangeEndAddress, Comparison.LessUI)
                     );
 
                 // Only call tracking if in range.

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -27,7 +27,7 @@ namespace ARMeilleure.Translation.PTC
         private const string OuterHeaderMagicString = "PTCohd\0\0";
         private const string InnerHeaderMagicString = "PTCihd\0\0";
 
-        private const uint InternalVersion = 3193; //! To be incremented manually for each change to the ARMeilleure project.
+        private const uint InternalVersion = 3267; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";


### PR DESCRIPTION
This fixes two issues.

First, it fixes a regression from the tail merge optimization (#2721). This optimization can make multiple blocks that end with a return instruction instead jump to a single return block. This has the advantage of reducing code size as we only need to emit the epilogue for one block instead of several blocks. Additionally, this optimization also tries to remove blocks if, for example, the only instruction on a block is a return. However, there was one case where this was producing incorrect code. Consider the following IR:
```
 block0 (block1, block2):
  i64 %0 = LoadArgument i32 0x0
  i64 %1 = Load i64 %0
  i32 %2 = Load i64 %1
  BranchIf i32 %2, i32 0xC0000005, Equal
 block1:
  Return i32 0x0
 block2 (block3, block4):
  i32 %3 = Load i64 0x22D7B2D5BE0
  i32 %4 = Load i64 0x22D7B2D5BE4
  i64 %5 = ZeroExtend32 i32 %3
  i64 %6 = Add i64 %1, i64 %5
  i64 %7 = Load i64 %6
  i64 %8 = ZeroExtend32 i32 %4
  i64 %9 = Add i64 %1, i64 %8
  i64 %10 = Load i64 %9
  i32 %11 = Compare i64 %10, i64 0x0, NotEqual
  BranchIf i32 0x0, i32 0x0, NotEqual
 block3:
  Return i32 0x0
 block4:
  Return i32 0xFFFFFFFF
```
After tail merge, we get:
```
 block0 (block2, block1):
  i64 %0 = LoadArgument i32 0x0
  i64 %1 = Load i64 %0
  i32 %2 = Load i64 %1
  i32 %3 = Copy i32 0x0
  BranchIf i32 %2, i32 0xC0000005, Equal
 block1 (block2, block2):
  i32 %4 = Load i64 0x22D7B2D5BE0
  i32 %5 = Load i64 0x22D7B2D5BE4
  i64 %6 = ZeroExtend32 i32 %4
  i64 %7 = Add i64 %1, i64 %6
  i64 %8 = Load i64 %7
  i64 %9 = ZeroExtend32 i32 %5
  i64 %10 = Add i64 %1, i64 %9
  i64 %11 = Load i64 %10
  i32 %12 = Compare i64 %11, i64 0x0, NotEqual
  i32 %3 = Copy i32 0x0
  i32 %3 = Copy i32 0xFFFFFFFF
  BranchIf i32 0x0, i32 0x0, NotEqual
 block2 cold:
  Return i32 %3
```
This is not correct because the values from both return were moved into two sequential copies:
```
  i32 %3 = Copy i32 0x0
  i32 %3 = Copy i32 0xFFFFFFFF
```
The problem here is that we can't merge the blocks if the jump is conditional, because it's possible that the block we're merging was not supposed to be executed. It's quite possible that this fix is too conservative, so I'm open to ideas with better ways to do it.

The second issue that it fixes is a wrong comparison on the native exception handler used for write tracking. It was using signed less than comparison rather than ungined to check if the exceptionAddress is less than the tracked range address. This means that it would handle some out of range addresses as if it was in range. For example, any negative long value could trigger this. To test this you can just do `Marshal.WriteInt32((IntPtr)ulong.MaxValue, 0);` after the exception handler has been registered. Rather than an `AccessViolation`, it will either call `VirtualMemoryEvent` or crash with `Fatal error. Invalid Program: attempted to call a UnmanagedCallersOnly method from managed code.`.

This also fixes `NullReferenceException` and `AccessViolationException` causing the thread to hang. This was happening because of the tail merge bug mentioned before. It would merge the two blocks and generate:
```nasm
  16:   31 c0                   xor    eax,eax
  18:   c7 c1 ff ff ff ff       mov    ecx,0xffffffff
```
Which would cause the exception handler to return `EXCEPTION_CONTINUE_EXECUTION` rather than `EXCEPTION_CONTINUE_SEARCH`. So the thread would just continue and fault forever (on Windows).

Closes #3241.