### PR TITLE
ForceDpiAware: X11 implementation

### DIFF
--- a/Ryujinx.Common/System/ForceDpiAware.cs
+++ b/Ryujinx.Common/System/ForceDpiAware.cs
@@ -12,20 +12,22 @@ namespace Ryujinx.Common.System
         [DllImport("user32.dll")]
         private static extern bool SetProcessDPIAware();
 
-        [DllImport("libX11.so.6")]
-        public static extern IntPtr XOpenDisplay(string display);
+        private const string X11LibraryName = "libX11.so.6";
 
-        [DllImport("libX11.so.6")]
-        public static extern IntPtr XGetDefault(IntPtr display, string program, string option);
+        [DllImport(X11LibraryName)]
+        private static extern IntPtr XOpenDisplay(string display);
 
-        [DllImport("libX11.so.6")]
-        public static extern int XDisplayWidth(IntPtr display, int screenNumber);
+        [DllImport(X11LibraryName)]
+        private static extern IntPtr XGetDefault(IntPtr display, string program, string option);
 
-        [DllImport("libX11.so.6")]
-        public static extern int XDisplayWidthMM(IntPtr display, int screenNumber);
+        [DllImport(X11LibraryName)]
+        private static extern int XDisplayWidth(IntPtr display, int screenNumber);
 
-        [DllImport("libX11.so.6")]
-        public static extern int XCloseDisplay(IntPtr display);
+        [DllImport(X11LibraryName)]
+        private static extern int XDisplayWidthMM(IntPtr display, int screenNumber);
+
+        [DllImport(X11LibraryName)]
+        private static extern int XCloseDisplay(IntPtr display);
 
         private static readonly double _standardDpiScale = 96.0;
         private static readonly double _maxScaleFactor   = 1.25;
@@ -54,7 +56,7 @@ namespace Ryujinx.Common.System
                 }
                 else if (OperatingSystem.IsLinux())
                 {
-                    string xdgSessionType = Environment.GetEnvironmentVariable("XDG_SESSION_TYPE");
+                    string xdgSessionType = Environment.GetEnvironmentVariable("XDG_SESSION_TYPE")?.ToLower();
 
                     if (xdgSessionType == null || xdgSessionType == "x11")
                     {
@@ -69,6 +71,7 @@ namespace Ryujinx.Common.System
                     else if (xdgSessionType == "wayland")
                     {
                         // TODO
+                        Logger.Warning?.Print(LogClass.Application, $"Couldn't determine monitor DPI: Wayland not yet supported");
                     }
                     else
                     {

--- a/Ryujinx.Common/System/ForceDpiAware.cs
+++ b/Ryujinx.Common/System/ForceDpiAware.cs
@@ -1,6 +1,7 @@
 ﻿using Ryujinx.Common.Logging;
 using System;
 using System.Drawing;
+using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 
@@ -10,6 +11,21 @@ namespace Ryujinx.Common.System
     {
         [DllImport("user32.dll")]
         private static extern bool SetProcessDPIAware();
+
+        [DllImport("libX11.so.6")]
+        public static extern IntPtr XOpenDisplay(string display);
+
+        [DllImport("libX11.so.6")]
+        public static extern IntPtr XGetDefault(IntPtr display, string program, string option);
+
+        [DllImport("libX11.so.6")]
+        public static extern int XDisplayWidth(IntPtr display, int screenNumber);
+
+        [DllImport("libX11.so.6")]
+        public static extern int XDisplayWidthMM(IntPtr display, int screenNumber);
+
+        [DllImport("libX11.so.6")]
+        public static extern int XCloseDisplay(IntPtr display);
 
         private static readonly double _standardDpiScale = 96.0;
         private static readonly double _maxScaleFactor   = 1.25;
@@ -36,9 +52,28 @@ namespace Ryujinx.Common.System
                 {
                     userDpiScale = Graphics.FromHwnd(IntPtr.Zero).DpiX;
                 }
-                else
+                else if (OperatingSystem.IsLinux())
                 {
-                    // TODO: Linux support
+                    string xdgSessionType = Environment.GetEnvironmentVariable("XDG_SESSION_TYPE");
+
+                    if (xdgSessionType == null || xdgSessionType == "x11")
+                    {
+                        IntPtr display = XOpenDisplay(null);
+                        string dpiString = Marshal.PtrToStringAnsi(XGetDefault(display, "Xft", "dpi"));
+                        if (dpiString == null || !double.TryParse(dpiString, NumberStyles.Any, CultureInfo.InvariantCulture, out userDpiScale))
+                        {
+                            userDpiScale = (double)XDisplayWidth(display, 0) * 25.4 / (double)XDisplayWidthMM(display, 0);
+                        }
+                        XCloseDisplay(display);
+                    }
+                    else if (xdgSessionType == "wayland")
+                    {
+                        // TODO
+                    }
+                    else
+                    {
+                        Logger.Warning?.Print(LogClass.Application, $"Couldn't determine monitor DPI: Unrecognised XDG_SESSION_TYPE: {xdgSessionType}");
+                    }
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
Detect dpi based on screen dimensions provided by X server. As is standard expected behavior of a Linux application, this can be overridden by the user's Xft.dpi setting.