### PR TITLE
Implement HwOpus multistream functions

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Audio/HardwareOpusDecoderManager/Decoder.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/HardwareOpusDecoderManager/Decoder.cs
@@ -1,0 +1,27 @@
+using Concentus.Structs;
+
+namespace Ryujinx.HLE.HOS.Services.Audio.HardwareOpusDecoderManager
+{
+    class Decoder : IDecoder
+    {
+        private readonly OpusDecoder _decoder;
+
+        public int SampleRate => _decoder.SampleRate;
+        public int ChannelsCount => _decoder.NumChannels;
+
+        public Decoder(int sampleRate, int channelsCount)
+        {
+            _decoder = new OpusDecoder(sampleRate, channelsCount);
+        }
+
+        public int Decode(byte[] inData, int inDataOffset, int len, short[] outPcm, int outPcmOffset, int frameSize)
+        {
+            return _decoder.Decode(inData, inDataOffset, len, outPcm, outPcmOffset, frameSize);
+        }
+
+        public void ResetState()
+        {
+            _decoder.ResetState();
+        }
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Audio/HardwareOpusDecoderManager/DecoderCommon.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/HardwareOpusDecoderManager/DecoderCommon.cs
@@ -1,0 +1,92 @@
+using Concentus;
+using Concentus.Enums;
+using Concentus.Structs;
+using Ryujinx.HLE.HOS.Services.Audio.Types;
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Ryujinx.HLE.HOS.Services.Audio.HardwareOpusDecoderManager
+{
+    static class DecoderCommon
+    {
+        private static ResultCode GetPacketNumSamples(this IDecoder decoder, out int numSamples, byte[] packet)
+        {
+            int result = OpusPacketInfo.GetNumSamples(packet, 0, packet.Length, decoder.SampleRate);
+
+            numSamples = result;
+
+            if (result == OpusError.OPUS_INVALID_PACKET)
+            {
+                return ResultCode.OpusInvalidInput;
+            }
+            else if (result == OpusError.OPUS_BAD_ARG)
+            {
+                return ResultCode.OpusInvalidInput;
+            }
+
+            return ResultCode.Success;
+        }
+
+        public static ResultCode DecodeInterleaved(
+            this IDecoder decoder,
+            bool reset,
+            ReadOnlySpan<byte> input,
+            out short[] outPcmData,
+            ulong outputSize,
+            out uint outConsumed,
+            out int outSamples)
+        {
+            outPcmData = null;
+            outConsumed = 0;
+            outSamples = 0;
+
+            int streamSize = input.Length;
+
+            if (streamSize < Unsafe.SizeOf<OpusPacketHeader>())
+            {
+                return ResultCode.OpusInvalidInput;
+            }
+
+            OpusPacketHeader header = OpusPacketHeader.FromSpan(input);
+            int headerSize = Unsafe.SizeOf<OpusPacketHeader>();
+            uint totalSize = header.length + (uint)headerSize;
+
+            if (totalSize > streamSize)
+            {
+                return ResultCode.OpusInvalidInput;
+            }
+
+            byte[] opusData = input.Slice(headerSize, (int)header.length).ToArray();
+
+            ResultCode result = decoder.GetPacketNumSamples(out int numSamples, opusData);
+
+            if (result == ResultCode.Success)
+            {
+                if ((uint)numSamples * (uint)decoder.ChannelsCount * sizeof(short) > outputSize)
+                {
+                    return ResultCode.OpusInvalidInput;
+                }
+
+                outPcmData = new short[numSamples * decoder.ChannelsCount];
+
+                if (reset)
+                {
+                    decoder.ResetState();
+                }
+
+                try
+                {
+                    outSamples = decoder.Decode(opusData, 0, opusData.Length, outPcmData, 0, outPcmData.Length / decoder.ChannelsCount);
+                    outConsumed = totalSize;
+                }
+                catch (OpusException)
+                {
+                    // TODO: as OpusException doesn't provide us the exact error code, this is kind of inaccurate in some cases...
+                    return ResultCode.OpusInvalidInput;
+                }
+            }
+
+            return ResultCode.Success;
+        }
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Audio/HardwareOpusDecoderManager/IDecoder.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/HardwareOpusDecoderManager/IDecoder.cs
@@ -1,0 +1,11 @@
+namespace Ryujinx.HLE.HOS.Services.Audio.HardwareOpusDecoderManager
+{
+    interface IDecoder
+    {
+        int SampleRate { get; }
+        int ChannelsCount { get; }
+
+        int Decode(byte[] inData, int inDataOffset, int len, short[] outPcm, int outPcmOffset, int frameSize);
+        void ResetState();
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Audio/HardwareOpusDecoderManager/IHardwareOpusDecoder.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/HardwareOpusDecoderManager/IHardwareOpusDecoder.cs
@@ -1,5 +1,6 @@
 using Ryujinx.HLE.HOS.Services.Audio.Types;
 using System;
+using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Audio.HardwareOpusDecoderManager
 {
@@ -97,9 +98,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.HardwareOpusDecoderManager
 
             if (result == ResultCode.Success)
             {
-                byte[] pcmDataBytes = new byte[outPcmData.Length * sizeof(short)];
-                Buffer.BlockCopy(outPcmData, 0, pcmDataBytes, 0, pcmDataBytes.Length);
-                context.Memory.Write(outputPosition, pcmDataBytes);
+                context.Memory.Write(outputPosition, MemoryMarshal.Cast<short, byte>(outPcmData.AsSpan()));
 
                 context.ResponseData.Write(outConsumed);
                 context.ResponseData.Write(outSamples);

--- a/Ryujinx.HLE/HOS/Services/Audio/HardwareOpusDecoderManager/IHardwareOpusDecoder.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/HardwareOpusDecoderManager/IHardwareOpusDecoder.cs
@@ -1,244 +1,113 @@
-using Concentus;
-using Concentus.Enums;
-using Concentus.Structs;
 using Ryujinx.HLE.HOS.Services.Audio.Types;
 using System;
-using System.IO;
-using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Audio.HardwareOpusDecoderManager
 {
     class IHardwareOpusDecoder : IpcService
     {
-        private int  _sampleRate;
-        private int  _channelsCount;
-        private bool _reset;
+        private readonly IDecoder _decoder;
+        private readonly OpusDecoderFlags _flags;
 
-        private OpusDecoder _decoder;
-
-        public IHardwareOpusDecoder(int sampleRate, int channelsCount)
+        public IHardwareOpusDecoder(int sampleRate, int channelsCount, OpusDecoderFlags flags)
         {
-            _sampleRate    = sampleRate;
-            _channelsCount = channelsCount;
-            _reset         = false;
-
-            _decoder = new OpusDecoder(sampleRate, channelsCount);
+            _decoder = new Decoder(sampleRate, channelsCount);
+            _flags = flags;
         }
 
-        private ResultCode GetPacketNumSamples(out int numSamples, byte[] packet)
+        public IHardwareOpusDecoder(int sampleRate, int channelsCount, int streams, int coupledStreams, OpusDecoderFlags flags, byte[] mapping)
         {
-            int result = OpusPacketInfo.GetNumSamples(_decoder, packet, 0, packet.Length);
-
-            numSamples = result;
-
-            if (result == OpusError.OPUS_INVALID_PACKET)
-            {
-                return ResultCode.OpusInvalidInput;
-            }
-            else if (result == OpusError.OPUS_BAD_ARG)
-            {
-                return ResultCode.OpusInvalidInput;
-            }
-
-            return ResultCode.Success;
-        }
-
-        private ResultCode DecodeInterleavedInternal(BinaryReader input, out short[] outPcmData, long outputSize, out uint outConsumed, out int outSamples)
-        {
-            outPcmData  = null;
-            outConsumed = 0;
-            outSamples  = 0;
-
-            long streamSize = input.BaseStream.Length;
-
-            if (streamSize < Marshal.SizeOf<OpusPacketHeader>())
-            {
-                return ResultCode.OpusInvalidInput;
-            }
-
-            OpusPacketHeader header = OpusPacketHeader.FromStream(input);
-
-            uint totalSize = header.length + (uint)Marshal.SizeOf<OpusPacketHeader>();
-
-            if (totalSize > streamSize)
-            {
-                return ResultCode.OpusInvalidInput;
-            }
-
-            byte[] opusData = input.ReadBytes((int)header.length);
-
-            ResultCode result = GetPacketNumSamples(out int numSamples, opusData);
-
-            if (result == ResultCode.Success)
-            {
-                if ((uint)numSamples * (uint)_channelsCount * sizeof(short) > outputSize)
-                {
-                    return ResultCode.OpusInvalidInput;
-                }
-
-                outPcmData = new short[numSamples * _channelsCount];
-
-                if (_reset)
-                {
-                    _reset = false;
-
-                    _decoder.ResetState();
-                }
-
-                try
-                {
-                    outSamples  = _decoder.Decode(opusData, 0, opusData.Length, outPcmData, 0, outPcmData.Length / _channelsCount);
-                    outConsumed = totalSize;
-                }
-                catch (OpusException)
-                {
-                    // TODO: as OpusException doesn't provide us the exact error code, this is kind of inaccurate in some cases...
-                    return ResultCode.OpusInvalidInput;
-                }
-            }
-
-            return ResultCode.Success;
+            _decoder = new MultiSampleDecoder(sampleRate, channelsCount, streams, coupledStreams, mapping);
+            _flags = flags;
         }
 
         [CommandHipc(0)]
-        // DecodeInterleaved(buffer<unknown, 5>) -> (u32, u32, buffer<unknown, 6>)
-        public ResultCode DecodeInterleavedOriginal(ServiceCtx context)
+        // DecodeInterleavedOld(buffer<unknown, 5>) -> (u32, u32, buffer<unknown, 6>)
+        public ResultCode DecodeInterleavedOld(ServiceCtx context)
         {
-            ResultCode result;
+            return DecodeInterleavedInternal(context, OpusDecoderFlags.None, reset: false, withPerf: false);
+        }
 
-            ulong inPosition     = context.Request.SendBuff[0].Position;
-            ulong inSize         = context.Request.SendBuff[0].Size;
-            ulong outputPosition = context.Request.ReceiveBuff[0].Position;
-            ulong outputSize     = context.Request.ReceiveBuff[0].Size;
-
-            byte[] buffer = new byte[inSize];
-
-            context.Memory.Read(inPosition, buffer);
-
-            using (BinaryReader inputStream = new BinaryReader(new MemoryStream(buffer)))
-            {
-                result = DecodeInterleavedInternal(inputStream, out short[] outPcmData, (long)outputSize, out uint outConsumed, out int outSamples);
-
-                if (result == ResultCode.Success)
-                {
-                    byte[] pcmDataBytes = new byte[outPcmData.Length * sizeof(short)];
-                    Buffer.BlockCopy(outPcmData, 0, pcmDataBytes, 0, pcmDataBytes.Length);
-                    context.Memory.Write(outputPosition, pcmDataBytes);
-
-                    context.ResponseData.Write(outConsumed);
-                    context.ResponseData.Write(outSamples);
-                }
-            }
-
-            return result;
+        [CommandHipc(2)]
+        // DecodeInterleavedForMultiStreamOld(buffer<unknown, 5>) -> (u32, u32, buffer<unknown, 6>)
+        public ResultCode DecodeInterleavedForMultiStreamOld(ServiceCtx context)
+        {
+            return DecodeInterleavedInternal(context, OpusDecoderFlags.None, reset: false, withPerf: false);
         }
 
         [CommandHipc(4)] // 6.0.0+
         // DecodeInterleavedWithPerfOld(buffer<unknown, 5>) -> (u32, u32, u64, buffer<unknown, 0x46>)
         public ResultCode DecodeInterleavedWithPerfOld(ServiceCtx context)
         {
-            ResultCode result;
+            return DecodeInterleavedInternal(context, OpusDecoderFlags.None, reset: false, withPerf: true);
+        }
 
-            ulong inPosition     = context.Request.SendBuff[0].Position;
-            ulong inSize         = context.Request.SendBuff[0].Size;
-            ulong outputPosition = context.Request.ReceiveBuff[0].Position;
-            ulong outputSize     = context.Request.ReceiveBuff[0].Size;
-
-            byte[] buffer = new byte[inSize];
-
-            context.Memory.Read(inPosition, buffer);
-
-            using (BinaryReader inputStream = new BinaryReader(new MemoryStream(buffer)))
-            {
-                result = DecodeInterleavedInternal(inputStream, out short[] outPcmData, (long)outputSize, out uint outConsumed, out int outSamples);
-
-                if (result == ResultCode.Success)
-                {
-                    byte[] pcmDataBytes = new byte[outPcmData.Length * sizeof(short)];
-                    Buffer.BlockCopy(outPcmData, 0, pcmDataBytes, 0, pcmDataBytes.Length);
-                    context.Memory.Write(outputPosition, pcmDataBytes);
-
-                    context.ResponseData.Write(outConsumed);
-                    context.ResponseData.Write(outSamples);
-
-                    // This is the time the DSP took to process the request, TODO: fill this.
-                    context.ResponseData.Write(0);
-                }
-            }
-
-            return result;
+        [CommandHipc(5)] // 6.0.0+
+        // DecodeInterleavedForMultiStreamWithPerfOld(buffer<unknown, 5>) -> (u32, u32, u64, buffer<unknown, 0x46>)
+        public ResultCode DecodeInterleavedForMultiStreamWithPerfOld(ServiceCtx context)
+        {
+            return DecodeInterleavedInternal(context, OpusDecoderFlags.None, reset: false, withPerf: true);
         }
 
         [CommandHipc(6)] // 6.0.0+
-        // DecodeInterleavedOld(bool reset, buffer<unknown, 5>) -> (u32, u32, u64, buffer<unknown, 0x46>)
-        public ResultCode DecodeInterleavedOld(ServiceCtx context)
+        // DecodeInterleavedWithPerfAndResetOld(bool reset, buffer<unknown, 5>) -> (u32, u32, u64, buffer<unknown, 0x46>)
+        public ResultCode DecodeInterleavedWithPerfAndResetOld(ServiceCtx context)
         {
-            ResultCode result;
+            bool reset = context.RequestData.ReadBoolean();
 
-            _reset = context.RequestData.ReadBoolean();
+            return DecodeInterleavedInternal(context, OpusDecoderFlags.None, reset, withPerf: true);
+        }
 
-            ulong inPosition     = context.Request.SendBuff[0].Position;
-            ulong inSize         = context.Request.SendBuff[0].Size;
-            ulong outputPosition = context.Request.ReceiveBuff[0].Position;
-            ulong outputSize     = context.Request.ReceiveBuff[0].Size;
+        [CommandHipc(7)] // 6.0.0+
+        // DecodeInterleavedForMultiStreamWithPerfAndResetOld(bool reset, buffer<unknown, 5>) -> (u32, u32, u64, buffer<unknown, 0x46>)
+        public ResultCode DecodeInterleavedForMultiStreamWithPerfAndResetOld(ServiceCtx context)
+        {
+            bool reset = context.RequestData.ReadBoolean();
 
-            byte[] buffer = new byte[inSize];
-
-            context.Memory.Read(inPosition, buffer);
-
-            using (BinaryReader inputStream = new BinaryReader(new MemoryStream(buffer)))
-            {
-                result = DecodeInterleavedInternal(inputStream, out short[] outPcmData, (long)outputSize, out uint outConsumed, out int outSamples);
-
-                if (result == ResultCode.Success)
-                {
-                    byte[] pcmDataBytes = new byte[outPcmData.Length * sizeof(short)];
-                    Buffer.BlockCopy(outPcmData, 0, pcmDataBytes, 0, pcmDataBytes.Length);
-                    context.Memory.Write(outputPosition, pcmDataBytes);
-
-                    context.ResponseData.Write(outConsumed);
-                    context.ResponseData.Write(outSamples);
-
-                    // This is the time the DSP took to process the request, TODO: fill this.
-                    context.ResponseData.Write(0);
-                }
-            }
-
-            return result;
+            return DecodeInterleavedInternal(context, OpusDecoderFlags.None, reset, withPerf: true);
         }
 
         [CommandHipc(8)] // 7.0.0+
         // DecodeInterleaved(bool reset, buffer<unknown, 0x45>) -> (u32, u32, u64, buffer<unknown, 0x46>)
         public ResultCode DecodeInterleaved(ServiceCtx context)
         {
-            ResultCode result;
+            bool reset = context.RequestData.ReadBoolean();
 
-            _reset = context.RequestData.ReadBoolean();
+            return DecodeInterleavedInternal(context, _flags, reset, withPerf: true);
+        }
 
+        [CommandHipc(9)] // 7.0.0+
+        // DecodeInterleavedForMultiStream(bool reset, buffer<unknown, 0x45>) -> (u32, u32, u64, buffer<unknown, 0x46>)
+        public ResultCode DecodeInterleavedForMultiStream(ServiceCtx context)
+        {
+            bool reset = context.RequestData.ReadBoolean();
+
+            return DecodeInterleavedInternal(context, _flags, reset, withPerf: true);
+        }
+
+        private ResultCode DecodeInterleavedInternal(ServiceCtx context, OpusDecoderFlags flags, bool reset, bool withPerf)
+        {
             ulong inPosition     = context.Request.SendBuff[0].Position;
             ulong inSize         = context.Request.SendBuff[0].Size;
             ulong outputPosition = context.Request.ReceiveBuff[0].Position;
             ulong outputSize     = context.Request.ReceiveBuff[0].Size;
 
-            byte[] buffer = new byte[inSize];
+            ReadOnlySpan<byte> input = context.Memory.GetSpan(inPosition, (int)inSize);
 
-            context.Memory.Read(inPosition, buffer);
+            ResultCode result = _decoder.DecodeInterleaved(reset, input, out short[] outPcmData, outputSize, out uint outConsumed, out int outSamples);
 
-            using (BinaryReader inputStream = new BinaryReader(new MemoryStream(buffer)))
+            if (result == ResultCode.Success)
             {
-                result = DecodeInterleavedInternal(inputStream, out short[] outPcmData, (long)outputSize, out uint outConsumed, out int outSamples);
+                byte[] pcmDataBytes = new byte[outPcmData.Length * sizeof(short)];
+                Buffer.BlockCopy(outPcmData, 0, pcmDataBytes, 0, pcmDataBytes.Length);
+                context.Memory.Write(outputPosition, pcmDataBytes);
 
-                if (result == ResultCode.Success)
+                context.ResponseData.Write(outConsumed);
+                context.ResponseData.Write(outSamples);
+
+                if (withPerf)
                 {
-                    byte[] pcmDataBytes = new byte[outPcmData.Length * sizeof(short)];
-                    Buffer.BlockCopy(outPcmData, 0, pcmDataBytes, 0, pcmDataBytes.Length);
-                    context.Memory.Write(outputPosition, pcmDataBytes);
-
-                    context.ResponseData.Write(outConsumed);
-                    context.ResponseData.Write(outSamples);
-
                     // This is the time the DSP took to process the request, TODO: fill this.
-                    context.ResponseData.Write(0);
+                    context.ResponseData.Write(0UL);
                 }
             }
 

--- a/Ryujinx.HLE/HOS/Services/Audio/HardwareOpusDecoderManager/MultiSampleDecoder.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/HardwareOpusDecoderManager/MultiSampleDecoder.cs
@@ -1,0 +1,28 @@
+using Concentus.Structs;
+
+namespace Ryujinx.HLE.HOS.Services.Audio.HardwareOpusDecoderManager
+{
+    class MultiSampleDecoder : IDecoder
+    {
+        private readonly OpusMSDecoder _decoder;
+
+        public int SampleRate => _decoder.SampleRate;
+        public int ChannelsCount { get; }
+
+        public MultiSampleDecoder(int sampleRate, int channelsCount, int streams, int coupledStreams, byte[] mapping)
+        {
+            ChannelsCount = channelsCount;
+            _decoder = new OpusMSDecoder(sampleRate, channelsCount, streams, coupledStreams, mapping);
+        }
+
+        public int Decode(byte[] inData, int inDataOffset, int len, short[] outPcm, int outPcmOffset, int frameSize)
+        {
+            return _decoder.DecodeMultistream(inData, inDataOffset, len, outPcm, outPcmOffset, frameSize, 0);
+        }
+
+        public void ResetState()
+        {
+            _decoder.ResetState();
+        }
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Audio/Types/OpusMultiStreamParameters.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/Types/OpusMultiStreamParameters.cs
@@ -1,0 +1,15 @@
+using Ryujinx.Common.Memory;
+using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Audio.Types
+{
+    [StructLayout(LayoutKind.Sequential, Size = 0x110)]
+    struct OpusMultiStreamParameters
+    {
+        public int SampleRate;
+        public int ChannelsCount;
+        public int NumberOfStreams;
+        public int NumberOfStereoStreams;
+        public Array64<uint> ChannelMappings;
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Audio/Types/OpusMultiStreamParametersEx.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/Types/OpusMultiStreamParametersEx.cs
@@ -1,0 +1,19 @@
+using Ryujinx.Common.Memory;
+using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Audio.Types
+{
+    [StructLayout(LayoutKind.Sequential, Size = 0x118)]
+    struct OpusMultiStreamParametersEx
+    {
+        public int SampleRate;
+        public int ChannelsCount;
+        public int NumberOfStreams;
+        public int NumberOfStereoStreams;
+        public OpusDecoderFlags Flags;
+
+        Array4<byte> Padding1;
+
+        public Array64<uint> ChannelMappings;
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Audio/Types/OpusPacketHeader.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/Types/OpusPacketHeader.cs
@@ -12,9 +12,9 @@ namespace Ryujinx.HLE.HOS.Services.Audio.Types
         public uint length;
         public uint finalRange;
 
-        public static OpusPacketHeader FromStream(BinaryReader reader)
+        public static OpusPacketHeader FromSpan(ReadOnlySpan<byte> data)
         {
-            OpusPacketHeader header = reader.ReadStruct<OpusPacketHeader>();
+            OpusPacketHeader header = MemoryMarshal.Cast<byte, OpusPacketHeader>(data)[0];
 
             header.length     = BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(header.length)     : header.length;
             header.finalRange = BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(header.finalRange) : header.finalRange;

--- a/Ryujinx.HLE/HOS/Services/Audio/Types/OpusParametersEx.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/Types/OpusParametersEx.cs
@@ -7,8 +7,8 @@ namespace Ryujinx.HLE.HOS.Services.Audio.Types
     struct OpusParametersEx
     {
         public int SampleRate;
-        public int ChannelCount;
-        public OpusDecoderFlags UseLargeFrameSize;
+        public int ChannelsCount;
+        public OpusDecoderFlags Flags;
 
         Array4<byte> Padding1;
     }


### PR DESCRIPTION
This PR mainly implements the multistream related Opus decoding functions, that are required by MLB The Show 22 and maybe other games. In addition to that, it does some small refactoring to avoid code duplication:
- Implementation of decoding moved to a single method to avoid code duplication.
- Decoding now uses spans rather than streams when possible. Unfortunately Concentus doesn't have overloads of the decoding functions that takes spans, so we still need to do some copies.
- GetWorkBufferSize functions were updated, before it was only taking the ADSP side into account and only calculating the size of the Opus decoder state. But the service also adds an extra size, so the code was updated to reflect that. This shouldn't have any consequence though as we don't really use the transfer memory passed by the game.

MLB The Show 22 still requires other services implemented to work, so it's not playable even with this change, but it's a step towards it.