### PR TITLE
Allocate work buffer for audio renderer instead of using guest supplied memory

### DIFF
--- a/Ryujinx.Audio/Renderer/Server/AudioRendererManager.cs
+++ b/Ryujinx.Audio/Renderer/Server/AudioRendererManager.cs
@@ -305,13 +305,34 @@ namespace Ryujinx.Audio.Renderer.Server
         /// <param name="workBufferSize">The guest work buffer size.</param>
         /// <param name="processHandle">The process handle of the application.</param>
         /// <returns>A <see cref="ResultCode"/> reporting an error or a success.</returns>
-        public ResultCode OpenAudioRenderer(out AudioRenderSystem renderer, IVirtualMemoryManager memoryManager, ref AudioRendererConfiguration parameter, ulong appletResourceUserId, ulong workBufferAddress, ulong workBufferSize, uint processHandle, float volume)
+        public ResultCode OpenAudioRenderer(
+            out AudioRenderSystem renderer,
+            IVirtualMemoryManager memoryManager,
+            ref AudioRendererConfiguration parameter,
+            ulong appletResourceUserId,
+            ulong workBufferAddress,
+            ulong workBufferSize,
+            uint processHandle,
+            float volume)
         {
             int sessionId = AcquireSessionId();
 
             AudioRenderSystem audioRenderer = new AudioRenderSystem(this, _sessionsSystemEvent[sessionId]);
 
-            ResultCode result = audioRenderer.Initialize(ref parameter, processHandle, workBufferAddress, workBufferSize, sessionId, appletResourceUserId, memoryManager);
+            // TODO: Eventually, we should try to use the guest supplised work buffer instead of allocating
+            // our own. However, it was causing problems on some applications that would unmap the memory
+            // before the audio renderer was fully disposed.
+            Memory<byte> workBufferMemory = new byte[workBufferSize];
+
+            ResultCode result = audioRenderer.Initialize(
+                ref parameter,
+                processHandle,
+                workBufferMemory,
+                workBufferAddress,
+                workBufferSize,
+                sessionId,
+                appletResourceUserId,
+                memoryManager);
 
             if (result == ResultCode.Success)
             {

--- a/Ryujinx.Audio/Renderer/Server/AudioRendererManager.cs
+++ b/Ryujinx.Audio/Renderer/Server/AudioRendererManager.cs
@@ -322,7 +322,7 @@ namespace Ryujinx.Audio.Renderer.Server
             // TODO: Eventually, we should try to use the guest supplied work buffer instead of allocating
             // our own. However, it was causing problems on some applications that would unmap the memory
             // before the audio renderer was fully disposed.
-            Memory<byte> workBufferMemory = new byte[workBufferSize];
+            Memory<byte> workBufferMemory = GC.AllocateArray<byte>((int)workBufferSize, pinned: true);
 
             ResultCode result = audioRenderer.Initialize(
                 ref parameter,

--- a/Ryujinx.Audio/Renderer/Server/AudioRendererManager.cs
+++ b/Ryujinx.Audio/Renderer/Server/AudioRendererManager.cs
@@ -319,7 +319,7 @@ namespace Ryujinx.Audio.Renderer.Server
 
             AudioRenderSystem audioRenderer = new AudioRenderSystem(this, _sessionsSystemEvent[sessionId]);
 
-            // TODO: Eventually, we should try to use the guest supplised work buffer instead of allocating
+            // TODO: Eventually, we should try to use the guest supplied work buffer instead of allocating
             // our own. However, it was causing problems on some applications that would unmap the memory
             // before the audio renderer was fully disposed.
             Memory<byte> workBufferMemory = new byte[workBufferSize];

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioRendererManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioRendererManager.cs
@@ -31,11 +31,26 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             return AudioRendererManagerImpl.GetWorkBufferSize(ref parameter);
         }
 
-        public ResultCode OpenAudioRenderer(ServiceCtx context, out IAudioRenderer obj, ref AudioRendererConfiguration parameter, ulong workBufferSize, ulong appletResourceUserId, KTransferMemory workBufferTransferMemory, uint processHandle)
+        public ResultCode OpenAudioRenderer(
+            ServiceCtx context,
+            out IAudioRenderer obj,
+            ref AudioRendererConfiguration parameter,
+            ulong workBufferSize,
+            ulong appletResourceUserId,
+            KTransferMemory workBufferTransferMemory,
+            uint processHandle)
         {
             var memoryManager = context.Process.HandleTable.GetKProcess((int)processHandle).CpuMemory;
 
-            ResultCode result = (ResultCode)_impl.OpenAudioRenderer(out AudioRenderSystem renderer, memoryManager, ref parameter, appletResourceUserId, workBufferTransferMemory.Address, workBufferTransferMemory.Size, processHandle, context.Device.Configuration.AudioVolume);
+            ResultCode result = (ResultCode)_impl.OpenAudioRenderer(
+                out AudioRenderSystem renderer,
+                memoryManager,
+                ref parameter,
+                appletResourceUserId,
+                workBufferTransferMemory.Address,
+                workBufferTransferMemory.Size,
+                processHandle,
+                context.Device.Configuration.AudioVolume);
 
             if (result == ResultCode.Success)
             {

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioRendererManagerServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioRendererManagerServer.cs
@@ -34,7 +34,14 @@ namespace Ryujinx.HLE.HOS.Services.Audio
             KTransferMemory workBufferTransferMemory = context.Process.HandleTable.GetObject<KTransferMemory>(transferMemoryHandle);
             uint processHandle = (uint)context.Request.HandleDesc.ToCopy[1];
 
-            ResultCode result = _impl.OpenAudioRenderer(context, out IAudioRenderer renderer, ref parameter, workBufferSize, appletResourceUserId, workBufferTransferMemory, processHandle);
+            ResultCode result = _impl.OpenAudioRenderer(
+                context,
+                out IAudioRenderer renderer,
+                ref parameter,
+                workBufferSize,
+                appletResourceUserId,
+                workBufferTransferMemory,
+                processHandle);
 
             if (result == ResultCode.Success)
             {


### PR DESCRIPTION
Right now we use the memory supplied by the guest when possible (when it is contiguous etc, which should be always the case with host memory manager modes) to store audio renderer state. While this is correct, there are some cases where the game unmaps the memory before the audio renderer is fully disposed. This can cause the audio renderer to try accessing the memory and cause an access violation because it was already unmapped.

This change fixes it by allocating our own memory to be used to store audio renderer state. Fixes an access violation crash on Urban Trial Tricky that started happening after #3267 (since before that change, access violation would cause the thread to just retry forever, which was probably masking the error).

Personally I'm not a fan of this change and I'm open to suggestions. I'm also not sure if pinning the array for a long time is a good idea, I heard it impacts GC negatively.