### PR TITLE
Add volume control when scrolling over volume in status bar

### DIFF
--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -1205,6 +1205,21 @@ namespace Ryujinx.Ui
             }
         }
 
+        private void VolumeStatus_Scroll(object sender, ScrollEventArgs args)
+        {
+            if (_emulationContext != null)
+            {
+                if (args.Event.Direction == Gdk.ScrollDirection.Up)
+                {
+                    _emulationContext.SetVolume(MathF.Round(MathF.Min(1.0f, _emulationContext.GetVolume() + 0.1f), 1));
+                }
+                else if (args.Event.Direction == Gdk.ScrollDirection.Down)
+                {
+                    _emulationContext.SetVolume(MathF.Round(MathF.Max(0.0f, _emulationContext.GetVolume() - 0.1f), 1));
+                }
+            }
+        }
+
         private void AspectRatio_Clicked(object sender, ButtonReleaseEventArgs args)
         {
             AspectRatio aspectRatio = ConfigurationState.Instance.Graphics.AspectRatio.Value;

--- a/Ryujinx/Ui/MainWindow.glade
+++ b/Ryujinx/Ui/MainWindow.glade
@@ -664,7 +664,9 @@
                       <object class="GtkEventBox">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="events">GDK_SCROLL_MASK</property>
                         <signal name="button-release-event" handler="VolumeStatus_Clicked" swapped="no"/>
+                        <signal name="scroll-event" handler="VolumeStatus_Scroll" swapped="no"/>
                         <child>
                           <object class="GtkLabel" id="_volumeStatus">
                             <property name="visible">True</property>


### PR DESCRIPTION
This augments the volume display in the status bar to allow users to {inc/de}crement the audio volume by scrolling the mousewheel while hovering over the display segment.

In terms of implementation this mirrors the existing click-to-mute functionality in that it's completely transient - any adjustment made will not carry over to subsequent launches or even running a new game, nor will it be reflected in the settings window. As with mute, I think this is reasonable behaviour. Movements are 10% per 'click' of the wheel, and the `else if` is needed because scroll events can also be generated horizontally by trackpads. `Round` is needed as you'll start to see `59%` etc. in the UI if you scroll back and forward enough without it.