### PR TITLE
Fix broken motion controls when using SDL2.

### DIFF
--- a/Ryujinx.Input/HLE/NpadController.cs
+++ b/Ryujinx.Input/HLE/NpadController.cs
@@ -302,7 +302,7 @@ namespace Ryujinx.Input.HLE
                             Vector3 gyroscope = _gamepad.GetMotionData(MotionInputId.Gyroscope);
 
                             accelerometer = new Vector3(accelerometer.X, -accelerometer.Z, accelerometer.Y);
-                            gyroscope = new Vector3(gyroscope.X, gyroscope.Z, gyroscope.Y);
+                            gyroscope = new Vector3(gyroscope.X, -gyroscope.Z, gyroscope.Y);
 
                             _leftMotionInput.Update(accelerometer, gyroscope, (ulong)PerformanceCounter.ElapsedNanoseconds / 1000, controllerConfig.Motion.Sensitivity, (float)controllerConfig.Motion.GyroDeadzone);
 


### PR DESCRIPTION
Right now on Master, when using motion controls with SDL2 (the default option), multiple games suffer from completely broken motion controls making them unplayable when the option is used.
Some games such as Kirby and the Forgotten Land require motion controls to complete them at 100%.

This was due to a missing `-` in front of `gyroscope.Z` in the controller config file.
This PR fixes that.

I tested Mario Kart 8 Deluxe and The Legend of Zelda: Breath of the Wild and in both cases it fixed the issues reported by users and myself, this PR should also fix most of the other issues reported as they were all the same issue.

Needs testing on multiple games to make sure nothing broke and needs testing on different controllers such as DS4 and DS5 just to be sure. I tested on the Pro Controller and Joycon where it worked fine.

Some footage:

Master:

https://user-images.githubusercontent.com/53187465/164028119-969a32fa-f81d-4358-999f-1dd560e1f61f.mp4


PR:

https://user-images.githubusercontent.com/53187465/164027698-0f61811d-e50f-404d-bfe3-a2ef5adb8f6e.mp4


Thanks to @Thog for finding the issue!

Closes #2480 