### PR TITLE
Fix various issues with texture sync

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -1393,6 +1393,12 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="size">The size of the flushing memory access</param>
         public void FlushAction(TextureGroupHandle handle, ulong address, ulong size)
         {
+            // There is a small gap here where the action is removed but _actionRegistered is still 1.
+            // In this case it will skip registering the action, but here we are already handling it,
+            // so there shouldn't be any issue as it's the same handler for all actions.
+
+            handle.ClearActionRegistered();
+
             if (!handle.Modified)
             {
                 return;

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
@@ -172,7 +172,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 _syncActionRegistered = true;
             }
 
-            if (Interlocked.CompareExchange(ref _actionRegistered, 1, 0) == 0)
+            if (Interlocked.Exchange(ref _actionRegistered, 1) == 0)
             {
                 _group.RegisterAction(this);
             }
@@ -290,7 +290,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             _registeredSync = _modifiedSync;
             _syncActionRegistered = false;
 
-            if (Interlocked.CompareExchange(ref _actionRegistered, 1, 0) == 0)
+            if (Interlocked.Exchange(ref _actionRegistered, 1) == 0)
             {
                 _group.RegisterAction(this);
             }

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace Ryujinx.Graphics.Gpu.Image
 {
@@ -32,9 +33,9 @@ namespace Ryujinx.Graphics.Gpu.Image
         private ulong _modifiedSync;
 
         /// <summary>
-        /// Whether a tracking action is currently registered or not.
+        /// Whether a tracking action is currently registered or not. (0/1)
         /// </summary>
-        private bool _actionRegistered;
+        private int _actionRegistered;
 
         /// <summary>
         /// Whether a sync action is currently registered or not.
@@ -171,11 +172,9 @@ namespace Ryujinx.Graphics.Gpu.Image
                 _syncActionRegistered = true;
             }
 
-            if (!_actionRegistered)
+            if (Interlocked.CompareExchange(ref _actionRegistered, 1, 0) == 0)
             {
                 _group.RegisterAction(this);
-
-                _actionRegistered = true;
             }
         }
 
@@ -233,8 +232,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="context">The GPU context used to wait for sync</param>
         public void Sync(GpuContext context)
         {
-            _actionRegistered = false;
-
             bool needsSync = !context.IsGpuThread();
 
             if (needsSync)
@@ -264,20 +261,38 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Clears the action registered variable, indicating that the tracking action should be
+        /// re-registered on the next modification.
+        /// </summary>
+        public void ClearActionRegistered()
+        {
+            Interlocked.Exchange(ref _actionRegistered, 0);
+        }
+
+        /// <summary>
         /// Action to perform when a sync number is registered after modification.
         /// This action will register a read tracking action on the memory tracking handle so that a flush from CPU can happen.
         /// </summary>
         private void SyncAction()
         {
+            // The storage will need to signal modified again to update the sync number in future.
+            _group.Storage.SignalModifiedDirty();
+
+            lock (Overlaps)
+            {
+                foreach (Texture texture in Overlaps)
+                {
+                    texture.SignalModifiedDirty();
+                }
+            }
+
             // Register region tracking for CPU? (again)
             _registeredSync = _modifiedSync;
             _syncActionRegistered = false;
 
-            if (!_actionRegistered)
+            if (Interlocked.CompareExchange(ref _actionRegistered, 1, 0) == 0)
             {
                 _group.RegisterAction(this);
-
-                _actionRegistered = true;
             }
         }
 

--- a/Ryujinx.Memory/Tracking/RegionHandle.cs
+++ b/Ryujinx.Memory/Tracking/RegionHandle.cs
@@ -144,9 +144,9 @@ namespace Ryujinx.Memory.Tracking
                 {
                     lock (_preActionLock)
                     {
-                        _preAction?.Invoke(address, size);
+                        RegionSignal action = Interlocked.Exchange(ref _preAction, null);
 
-                        _preAction = null;
+                        action?.Invoke(address, size);
                     }
                 }
                 finally
@@ -252,8 +252,7 @@ namespace Ryujinx.Memory.Tracking
 
             lock (_preActionLock)
             {
-                RegionSignal lastAction = _preAction;
-                _preAction = action;
+                RegionSignal lastAction = Interlocked.Exchange(ref _preAction, action);
 
                 if (lastAction == null && action != lastAction)
                 {


### PR DESCRIPTION
A variable called _actionRegistered is used to keep track of whether a tracking action has been registered for a given texture group handle. This variable is set when the action is registered, and should be unset when it is consumed. This is used to skip registering the tracking action if it's already registered, saving some time for render targets that are modified very often.

There were two issues with this. The worst issue was that the tracking action handler exits early if the handle's modified flag is false... which means that it never reset _actionRegistered, as that was done within the Sync() method called later. The second issue was that this variable was set true after the sync action was registered, so it was technically possible for the action to run immediately, set the flag to false, then set it to true.

Both situations would lead to the action never being registered again, as the texture group handle would be sure the action is already registered. This breaks the texture for the remaining runtime, or until it is disposed.

It was also possible for a texture to register sync once, then on future frames the last modified sync number did not update. This may have caused some more minor issues.

I've also used `Interlocked` in a few additional places just to ensure coherent access for things accessed from multiple threads.

Seems to fix the Xenoblade flashing bug. Obviously this needs a lot of testing, since it was random chance. I typically had the most luck getting it to happen by switching time of day on the event theatre screen for a while, then entering the equipment screen by pressing X on an event.

May also fix weird things like random chance air swimming in BOTW, maybe a few texture streaming bugs.