### PR TITLE
Add supported languages to UI

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
@@ -174,7 +174,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
 
             return ResultCode.Success;
         }
-        
+
         [CommandHipc(22)]
         // SetTerminateResult(u32)
         public ResultCode SetTerminateResult(ServiceCtx context)

--- a/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
@@ -148,12 +148,10 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             // TODO: When above calls are implemented, switch to using ns:am
 
             long desiredLanguageCode = context.Device.System.State.DesiredLanguageCode;
-            int desiredTitleLanguage = (int)context.Device.System.State.DesiredTitleLanguage;
-            int  supportedLanguages  = (int)context.Device.Application.ControlData.Value.SupportedLanguageFlag;
-            int  firstSupported      = BitOperations.TrailingZeroCount(supportedLanguages);
-            int numberOfCurrentlyDefinedLanguages = Enum.GetNames(typeof(TitleLanguage)).Length - 1;
+            int supportedLanguages = (int)context.Device.Application.ControlData.Value.SupportedLanguageFlag;
+            int firstSupported = BitOperations.TrailingZeroCount(supportedLanguages);
 
-            if (firstSupported > numberOfCurrentlyDefinedLanguages)
+            if (firstSupported > (int)SystemState.TitleLanguage.BrazilianPortuguese)
             {
                 Logger.Warning?.Print(LogClass.ServiceAm, "Application has zero supported languages");
 
@@ -164,9 +162,9 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
 
             // If desired language is not supported by application, use first supported language from TitleLanguage.
             // TODO: In the future, a GUI could enable user-specified search priority
-            if ((supportedLanguages & 1 << desiredTitleLanguage) != 1 << desiredTitleLanguage)
+            if (((1 << (int)context.Device.System.State.DesiredTitleLanguage) & supportedLanguages) == 0)
             {
-                SystemLanguage newLanguage = Enum.Parse<SystemLanguage>(Enum.GetName(typeof(TitleLanguage), firstSupported));
+                SystemLanguage newLanguage = Enum.Parse<SystemLanguage>(Enum.GetName(typeof(SystemState.TitleLanguage), firstSupported));
                 desiredLanguageCode = SystemStateMgr.GetLanguageCode((int)newLanguage);
 
                 Logger.Info?.Print(LogClass.ServiceAm, $"Application doesn't support configured language. Using {newLanguage}");
@@ -176,7 +174,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
 
             return ResultCode.Success;
         }
-
+        
         [CommandHipc(22)]
         // SetTerminateResult(u32)
         public ResultCode SetTerminateResult(ServiceCtx context)

--- a/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
@@ -148,10 +148,12 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
             // TODO: When above calls are implemented, switch to using ns:am
 
             long desiredLanguageCode = context.Device.System.State.DesiredLanguageCode;
+            int desiredTitleLanguage = (int)context.Device.System.State.DesiredTitleLanguage;
             int  supportedLanguages  = (int)context.Device.Application.ControlData.Value.SupportedLanguageFlag;
             int  firstSupported      = BitOperations.TrailingZeroCount(supportedLanguages);
+            int numberOfCurrentlyDefinedLanguages = Enum.GetNames(typeof(TitleLanguage)).Length - 1;
 
-            if (firstSupported > (int)SystemState.TitleLanguage.BrazilianPortuguese)
+            if (firstSupported > numberOfCurrentlyDefinedLanguages)
             {
                 Logger.Warning?.Print(LogClass.ServiceAm, "Application has zero supported languages");
 
@@ -162,9 +164,9 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
 
             // If desired language is not supported by application, use first supported language from TitleLanguage.
             // TODO: In the future, a GUI could enable user-specified search priority
-            if (((1 << (int)context.Device.System.State.DesiredTitleLanguage) & supportedLanguages) == 0)
+            if ((supportedLanguages & 1 << desiredTitleLanguage) != 1 << desiredTitleLanguage)
             {
-                SystemLanguage newLanguage = Enum.Parse<SystemLanguage>(Enum.GetName(typeof(SystemState.TitleLanguage), firstSupported));
+                SystemLanguage newLanguage = Enum.Parse<SystemLanguage>(Enum.GetName(typeof(TitleLanguage), firstSupported));
                 desiredLanguageCode = SystemStateMgr.GetLanguageCode((int)newLanguage);
 
                 Logger.Info?.Print(LogClass.ServiceAm, $"Application doesn't support configured language. Using {newLanguage}");

--- a/Ryujinx/Configuration/ConfigurationFileFormat.cs
+++ b/Ryujinx/Configuration/ConfigurationFileFormat.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.Configuration
         /// <summary>
         /// The current version of the file format
         /// </summary>
-        public const int CurrentVersion = 37;
+        public const int CurrentVersion = 38;
 
         /// <summary>
         /// Version of the configuration file format

--- a/Ryujinx/Configuration/ConfigurationState.cs
+++ b/Ryujinx/Configuration/ConfigurationState.cs
@@ -26,6 +26,7 @@ namespace Ryujinx.Configuration
                 public ReactiveObject<bool> AppColumn        { get; private set; }
                 public ReactiveObject<bool> DevColumn        { get; private set; }
                 public ReactiveObject<bool> VersionColumn    { get; private set; }
+                public ReactiveObject<bool> SupportedLanguagesColumn { get; private set; }
                 public ReactiveObject<bool> TimePlayedColumn { get; private set; }
                 public ReactiveObject<bool> LastPlayedColumn { get; private set; }
                 public ReactiveObject<bool> FileExtColumn    { get; private set; }
@@ -39,6 +40,7 @@ namespace Ryujinx.Configuration
                     AppColumn        = new ReactiveObject<bool>();
                     DevColumn        = new ReactiveObject<bool>();
                     VersionColumn    = new ReactiveObject<bool>();
+                    SupportedLanguagesColumn = new ReactiveObject<bool>();
                     TimePlayedColumn = new ReactiveObject<bool>();
                     LastPlayedColumn = new ReactiveObject<bool>();
                     FileExtColumn    = new ReactiveObject<bool>();
@@ -456,51 +458,52 @@ namespace Ryujinx.Configuration
         {
             ConfigurationFileFormat configurationFile = new ConfigurationFileFormat
             {
-                Version                   = ConfigurationFileFormat.CurrentVersion,
-                EnableFileLog             = Logger.EnableFileLog,
-                BackendThreading          = Graphics.BackendThreading,
-                ResScale                  = Graphics.ResScale,
-                ResScaleCustom            = Graphics.ResScaleCustom,
-                MaxAnisotropy             = Graphics.MaxAnisotropy,
-                AspectRatio               = Graphics.AspectRatio,
-                GraphicsShadersDumpPath   = Graphics.ShadersDumpPath,
-                LoggingEnableDebug        = Logger.EnableDebug,
-                LoggingEnableStub         = Logger.EnableStub,
-                LoggingEnableInfo         = Logger.EnableInfo,
-                LoggingEnableWarn         = Logger.EnableWarn,
-                LoggingEnableError        = Logger.EnableError,
-                LoggingEnableTrace        = Logger.EnableTrace,
-                LoggingEnableGuest        = Logger.EnableGuest,
-                LoggingEnableFsAccessLog  = Logger.EnableFsAccessLog,
-                LoggingFilteredClasses    = Logger.FilteredClasses,
+                Version = ConfigurationFileFormat.CurrentVersion,
+                EnableFileLog = Logger.EnableFileLog,
+                BackendThreading = Graphics.BackendThreading,
+                ResScale = Graphics.ResScale,
+                ResScaleCustom = Graphics.ResScaleCustom,
+                MaxAnisotropy = Graphics.MaxAnisotropy,
+                AspectRatio = Graphics.AspectRatio,
+                GraphicsShadersDumpPath = Graphics.ShadersDumpPath,
+                LoggingEnableDebug = Logger.EnableDebug,
+                LoggingEnableStub = Logger.EnableStub,
+                LoggingEnableInfo = Logger.EnableInfo,
+                LoggingEnableWarn = Logger.EnableWarn,
+                LoggingEnableError = Logger.EnableError,
+                LoggingEnableTrace = Logger.EnableTrace,
+                LoggingEnableGuest = Logger.EnableGuest,
+                LoggingEnableFsAccessLog = Logger.EnableFsAccessLog,
+                LoggingFilteredClasses = Logger.FilteredClasses,
                 LoggingGraphicsDebugLevel = Logger.GraphicsDebugLevel,
-                SystemLanguage            = System.Language,
-                SystemRegion              = System.Region,
-                SystemTimeZone            = System.TimeZone,
-                SystemTimeOffset          = System.SystemTimeOffset,
-                DockedMode                = System.EnableDockedMode,
-                EnableDiscordIntegration  = EnableDiscordIntegration,
-                CheckUpdatesOnStart       = CheckUpdatesOnStart,
-                ShowConfirmExit           = ShowConfirmExit,
-                HideCursorOnIdle          = HideCursorOnIdle,
-                EnableVsync               = Graphics.EnableVsync,
-                EnableShaderCache         = Graphics.EnableShaderCache,
-                EnablePtc                 = System.EnablePtc,
-                EnableInternetAccess      = System.EnableInternetAccess,
-                EnableFsIntegrityChecks   = System.EnableFsIntegrityChecks,
-                FsGlobalAccessLogMode     = System.FsGlobalAccessLogMode,
-                AudioBackend              = System.AudioBackend,
-                AudioVolume               = System.AudioVolume,
-                MemoryManagerMode         = System.MemoryManagerMode,
-                ExpandRam                 = System.ExpandRam,
-                IgnoreMissingServices     = System.IgnoreMissingServices,
-                GuiColumns                = new GuiColumns
+                SystemLanguage = System.Language,
+                SystemRegion = System.Region,
+                SystemTimeZone = System.TimeZone,
+                SystemTimeOffset = System.SystemTimeOffset,
+                DockedMode = System.EnableDockedMode,
+                EnableDiscordIntegration = EnableDiscordIntegration,
+                CheckUpdatesOnStart = CheckUpdatesOnStart,
+                ShowConfirmExit = ShowConfirmExit,
+                HideCursorOnIdle = HideCursorOnIdle,
+                EnableVsync = Graphics.EnableVsync,
+                EnableShaderCache = Graphics.EnableShaderCache,
+                EnablePtc = System.EnablePtc,
+                EnableInternetAccess = System.EnableInternetAccess,
+                EnableFsIntegrityChecks = System.EnableFsIntegrityChecks,
+                FsGlobalAccessLogMode = System.FsGlobalAccessLogMode,
+                AudioBackend = System.AudioBackend,
+                AudioVolume = System.AudioVolume,
+                MemoryManagerMode = System.MemoryManagerMode,
+                ExpandRam = System.ExpandRam,
+                IgnoreMissingServices = System.IgnoreMissingServices,
+                GuiColumns = new GuiColumns
                 {
-                    FavColumn        = Ui.GuiColumns.FavColumn,
-                    IconColumn       = Ui.GuiColumns.IconColumn,
-                    AppColumn        = Ui.GuiColumns.AppColumn,
-                    DevColumn        = Ui.GuiColumns.DevColumn,
-                    VersionColumn    = Ui.GuiColumns.VersionColumn,
+                    FavColumn = Ui.GuiColumns.FavColumn,
+                    IconColumn = Ui.GuiColumns.IconColumn,
+                    AppColumn = Ui.GuiColumns.AppColumn,
+                    DevColumn = Ui.GuiColumns.DevColumn,
+                    VersionColumn = Ui.GuiColumns.VersionColumn,
+                    SupportedLanguagesColumn = Ui.GuiColumns.SupportedLanguagesColumn,
                     TimePlayedColumn = Ui.GuiColumns.TimePlayedColumn,
                     LastPlayedColumn = Ui.GuiColumns.LastPlayedColumn,
                     FileExtColumn    = Ui.GuiColumns.FileExtColumn,
@@ -572,6 +575,7 @@ namespace Ryujinx.Configuration
             Ui.GuiColumns.AppColumn.Value          = true;
             Ui.GuiColumns.DevColumn.Value          = true;
             Ui.GuiColumns.VersionColumn.Value      = true;
+            Ui.GuiColumns.SupportedLanguagesColumn.Value = true;
             Ui.GuiColumns.TimePlayedColumn.Value   = true;
             Ui.GuiColumns.LastPlayedColumn.Value   = true;
             Ui.GuiColumns.FileExtColumn.Value      = true;
@@ -1027,6 +1031,28 @@ namespace Ryujinx.Configuration
                 configurationFileUpdated = true;
             }
 
+            if (configurationFileFormat.Version < 38)
+            {
+                Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 38.");
+
+                configurationFileFormat.GuiColumns = new GuiColumns
+                {
+                    FavColumn = configurationFileFormat.GuiColumns.FavColumn,
+                    IconColumn = configurationFileFormat.GuiColumns.IconColumn,
+                    AppColumn = configurationFileFormat.GuiColumns.AppColumn,
+                    DevColumn = configurationFileFormat.GuiColumns.DevColumn,
+                    VersionColumn = configurationFileFormat.GuiColumns.VersionColumn,
+                    SupportedLanguagesColumn = true,
+                    TimePlayedColumn = configurationFileFormat.GuiColumns.TimePlayedColumn,
+                    LastPlayedColumn = configurationFileFormat.GuiColumns.LastPlayedColumn,
+                    FileExtColumn = configurationFileFormat.GuiColumns.FileExtColumn,
+                    FileSizeColumn = configurationFileFormat.GuiColumns.FileSizeColumn,
+                    PathColumn = configurationFileFormat.GuiColumns.PathColumn
+                };
+
+                configurationFileUpdated = true;
+            }
+
             Logger.EnableFileLog.Value             = configurationFileFormat.EnableFileLog;
             Graphics.BackendThreading.Value        = configurationFileFormat.BackendThreading;
             Graphics.ResScale.Value                = configurationFileFormat.ResScale;
@@ -1069,6 +1095,7 @@ namespace Ryujinx.Configuration
             Ui.GuiColumns.AppColumn.Value          = configurationFileFormat.GuiColumns.AppColumn;
             Ui.GuiColumns.DevColumn.Value          = configurationFileFormat.GuiColumns.DevColumn;
             Ui.GuiColumns.VersionColumn.Value      = configurationFileFormat.GuiColumns.VersionColumn;
+            Ui.GuiColumns.SupportedLanguagesColumn.Value = configurationFileFormat.GuiColumns.SupportedLanguagesColumn;
             Ui.GuiColumns.TimePlayedColumn.Value   = configurationFileFormat.GuiColumns.TimePlayedColumn;
             Ui.GuiColumns.LastPlayedColumn.Value   = configurationFileFormat.GuiColumns.LastPlayedColumn;
             Ui.GuiColumns.FileExtColumn.Value      = configurationFileFormat.GuiColumns.FileExtColumn;

--- a/Ryujinx/Configuration/Ui/GuiColumns.cs
+++ b/Ryujinx/Configuration/Ui/GuiColumns.cs
@@ -7,6 +7,7 @@
         public bool AppColumn        { get; set; }
         public bool DevColumn        { get; set; }
         public bool VersionColumn    { get; set; }
+        public bool SupportedLanguagesColumn { get; set; }
         public bool TimePlayedColumn { get; set; }
         public bool LastPlayedColumn { get; set; }
         public bool FileExtColumn    { get; set; }

--- a/Ryujinx/Ui/App/ApplicationData.cs
+++ b/Ryujinx/Ui/App/ApplicationData.cs
@@ -1,5 +1,6 @@
 ﻿using LibHac.Common;
 using LibHac.Ns;
+using System.Collections.Generic;
 
 namespace Ryujinx.Ui.App
 {
@@ -11,6 +12,7 @@ namespace Ryujinx.Ui.App
         public string TitleId       { get; set; }
         public string Developer     { get; set; }
         public string Version       { get; set; }
+        public string SupportedLanguages { get; set; }
         public string TimePlayed    { get; set; }
         public string LastPlayed    { get; set; }
         public string FileExtension { get; set; }

--- a/Ryujinx/Ui/App/ApplicationLibrary.cs
+++ b/Ryujinx/Ui/App/ApplicationLibrary.cs
@@ -602,7 +602,7 @@ namespace Ryujinx.Ui.App
             List<string> supportedLanguagesList = new List<string>();
             for (int i = 0; i < Enum.GetNames(typeof(TitleLanguage)).Length; i++)
             {
-                if ((controlData.SupportedLanguageFlag & 1 << i) == 1 << i) {
+                if ((1 << i & controlData.SupportedLanguageFlag) != 0) {
                     var languageToAdd = Enum.GetNames(typeof(TitleLanguage))[i];
                     var formattedLanguageToAdd = Regex.Replace(languageToAdd, "([A-Z])", " $1").Trim();
                     supportedLanguagesList.Add(formattedLanguageToAdd);

--- a/Ryujinx/Ui/App/ApplicationLibrary.cs
+++ b/Ryujinx/Ui/App/ApplicationLibrary.cs
@@ -591,7 +591,7 @@ namespace Ryujinx.Ui.App
                 {
                     if (!controlTitle.PublisherString.IsEmpty())
                     {
-                        publisher = controlTitle.ToString();
+                        publisher = controlTitle.PublisherString.ToString();
 
                         break;
                     }

--- a/Ryujinx/Ui/App/ApplicationLibrary.cs
+++ b/Ryujinx/Ui/App/ApplicationLibrary.cs
@@ -599,7 +599,7 @@ namespace Ryujinx.Ui.App
             }
 
             supportedLanguages = string.Empty;
-            var supportedLanguagesList = new List<string>();
+            List<string> supportedLanguagesList = new List<string>();
             for (int i = 0; i < Enum.GetNames(typeof(TitleLanguage)).Length; i++)
             {
                 if ((controlData.SupportedLanguageFlag & 1 << i) == 1 << i) {

--- a/Ryujinx/Ui/Helper/SortHelper.cs
+++ b/Ryujinx/Ui/Helper/SortHelper.cs
@@ -7,8 +7,8 @@ namespace Ryujinx.Ui.Helper
     {
         public static int TimePlayedSort(ITreeModel model, TreeIter a, TreeIter b)
         {
-            string aValue = model.GetValue(a, 5).ToString();
-            string bValue = model.GetValue(b, 5).ToString();
+            string aValue = model.GetValue(a, 6).ToString();
+            string bValue = model.GetValue(b, 6).ToString();
 
             if (aValue.Length > 4 && aValue[^4..] == "mins")
             {
@@ -60,8 +60,8 @@ namespace Ryujinx.Ui.Helper
 
         public static int LastPlayedSort(ITreeModel model, TreeIter a, TreeIter b)
         {
-            string aValue = model.GetValue(a, 6).ToString();
-            string bValue = model.GetValue(b, 6).ToString();
+            string aValue = model.GetValue(a, 7).ToString();
+            string bValue = model.GetValue(b, 7).ToString();
 
             if (aValue == "Never")
             {
@@ -78,8 +78,8 @@ namespace Ryujinx.Ui.Helper
 
         public static int FileSizeSort(ITreeModel model, TreeIter a, TreeIter b)
         {
-            string aValue = model.GetValue(a, 8).ToString();
-            string bValue = model.GetValue(b, 8).ToString();
+            string aValue = model.GetValue(a, 9).ToString();
+            string bValue = model.GetValue(b, 9).ToString();
 
             if (aValue[^2..] == "GB")
             {

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -113,6 +113,7 @@ namespace Ryujinx.Ui
         [GUI] CheckMenuItem   _appToggle;
         [GUI] CheckMenuItem   _timePlayedToggle;
         [GUI] CheckMenuItem   _versionToggle;
+        [GUI] CheckMenuItem   _supportedLanguagesToggle;
         [GUI] CheckMenuItem   _lastPlayedToggle;
         [GUI] CheckMenuItem   _fileExtToggle;
         [GUI] CheckMenuItem   _pathToggle;
@@ -222,6 +223,7 @@ namespace Ryujinx.Ui
             if (ConfigurationState.Instance.Ui.GuiColumns.AppColumn)        _appToggle.Active        = true;
             if (ConfigurationState.Instance.Ui.GuiColumns.DevColumn)        _developerToggle.Active  = true;
             if (ConfigurationState.Instance.Ui.GuiColumns.VersionColumn)    _versionToggle.Active    = true;
+            if (ConfigurationState.Instance.Ui.GuiColumns.SupportedLanguagesColumn) _supportedLanguagesToggle.Active = true;
             if (ConfigurationState.Instance.Ui.GuiColumns.TimePlayedColumn) _timePlayedToggle.Active = true;
             if (ConfigurationState.Instance.Ui.GuiColumns.LastPlayedColumn) _lastPlayedToggle.Active = true;
             if (ConfigurationState.Instance.Ui.GuiColumns.FileExtColumn)    _fileExtToggle.Active    = true;
@@ -233,6 +235,7 @@ namespace Ryujinx.Ui
             _appToggle.Toggled        += App_Toggled;
             _developerToggle.Toggled  += Developer_Toggled;
             _versionToggle.Toggled    += Version_Toggled;
+            _supportedLanguagesToggle.Toggled += SupportedLanguages_Toggled;
             _timePlayedToggle.Toggled += TimePlayed_Toggled;
             _lastPlayedToggle.Toggled += LastPlayed_Toggled;
             _fileExtToggle.Toggled    += FileExt_Toggled;
@@ -250,11 +253,12 @@ namespace Ryujinx.Ui
                 typeof(string),
                 typeof(string),
                 typeof(string),
+                typeof(string),
                 typeof(BlitStruct<ApplicationControlProperty>));
 
-            _tableStore.SetSortFunc(5, SortHelper.TimePlayedSort);
-            _tableStore.SetSortFunc(6, SortHelper.LastPlayedSort);
-            _tableStore.SetSortFunc(8, SortHelper.FileSizeSort);
+            _tableStore.SetSortFunc(6, SortHelper.TimePlayedSort);
+            _tableStore.SetSortFunc(7, SortHelper.LastPlayedSort);
+            _tableStore.SetSortFunc(9, SortHelper.FileSizeSort);
 
             int  columnId  = ConfigurationState.Instance.Ui.ColumnSort.SortColumnId;
             bool ascending = ConfigurationState.Instance.Ui.ColumnSort.SortAscending;
@@ -342,11 +346,12 @@ namespace Ryujinx.Ui
             if (ConfigurationState.Instance.Ui.GuiColumns.AppColumn)        _gameTable.AppendColumn("Application", new CellRendererText(),   "text",   2);
             if (ConfigurationState.Instance.Ui.GuiColumns.DevColumn)        _gameTable.AppendColumn("Developer",   new CellRendererText(),   "text",   3);
             if (ConfigurationState.Instance.Ui.GuiColumns.VersionColumn)    _gameTable.AppendColumn("Version",     new CellRendererText(),   "text",   4);
-            if (ConfigurationState.Instance.Ui.GuiColumns.TimePlayedColumn) _gameTable.AppendColumn("Time Played", new CellRendererText(),   "text",   5);
-            if (ConfigurationState.Instance.Ui.GuiColumns.LastPlayedColumn) _gameTable.AppendColumn("Last Played", new CellRendererText(),   "text",   6);
-            if (ConfigurationState.Instance.Ui.GuiColumns.FileExtColumn)    _gameTable.AppendColumn("File Ext",    new CellRendererText(),   "text",   7);
-            if (ConfigurationState.Instance.Ui.GuiColumns.FileSizeColumn)   _gameTable.AppendColumn("File Size",   new CellRendererText(),   "text",   8);
-            if (ConfigurationState.Instance.Ui.GuiColumns.PathColumn)       _gameTable.AppendColumn("Path",        new CellRendererText(),   "text",   9);
+            if (ConfigurationState.Instance.Ui.GuiColumns.SupportedLanguagesColumn) _gameTable.AppendColumn("Supported Languages", new CellRendererText(), "text", 5);
+            if (ConfigurationState.Instance.Ui.GuiColumns.TimePlayedColumn) _gameTable.AppendColumn("Time Played", new CellRendererText(),   "text",   6);
+            if (ConfigurationState.Instance.Ui.GuiColumns.LastPlayedColumn) _gameTable.AppendColumn("Last Played", new CellRendererText(),   "text",   7);
+            if (ConfigurationState.Instance.Ui.GuiColumns.FileExtColumn)    _gameTable.AppendColumn("File Ext",    new CellRendererText(),   "text",   8);
+            if (ConfigurationState.Instance.Ui.GuiColumns.FileSizeColumn)   _gameTable.AppendColumn("File Size",   new CellRendererText(),   "text",   9);
+            if (ConfigurationState.Instance.Ui.GuiColumns.PathColumn)       _gameTable.AppendColumn("Path",        new CellRendererText(),   "text",   10);
 
             foreach (TreeViewColumn column in _gameTable.Columns)
             {
@@ -368,24 +373,28 @@ namespace Ryujinx.Ui
                         column.SortColumnId = 4;
                         column.Clicked += Column_Clicked;
                         break;
-                    case "Time Played":
+                    case "Supported Languages":
                         column.SortColumnId = 5;
                         column.Clicked += Column_Clicked;
                         break;
-                    case "Last Played":
+                    case "Time Played":
                         column.SortColumnId = 6;
                         column.Clicked += Column_Clicked;
                         break;
-                    case "File Ext":
+                    case "Last Played":
                         column.SortColumnId = 7;
                         column.Clicked += Column_Clicked;
                         break;
-                    case "File Size":
+                    case "File Ext":
                         column.SortColumnId = 8;
                         column.Clicked += Column_Clicked;
                         break;
-                    case "Path":
+                    case "File Size":
                         column.SortColumnId = 9;
+                        column.Clicked += Column_Clicked;
+                        break;
+                    case "Path":
+                        column.SortColumnId = 10;
                         column.Clicked += Column_Clicked;
                         break;
                 }
@@ -1082,6 +1091,7 @@ namespace Ryujinx.Ui
                     $"{args.AppData.TitleName}\n{args.AppData.TitleId.ToUpper()}",
                     args.AppData.Developer,
                     args.AppData.Version,
+                    args.AppData.SupportedLanguages,
                     args.AppData.TimePlayed,
                     args.AppData.LastPlayed,
                     args.AppData.FileExtension,
@@ -1166,7 +1176,7 @@ namespace Ryujinx.Ui
         {
             _gameTableSelection.GetSelected(out TreeIter treeIter);
 
-            string path = (string)_tableStore.GetValue(treeIter, 9);
+            string path = (string)_tableStore.GetValue(treeIter, 10);
 
             LoadApplication(path);
         }
@@ -1226,11 +1236,11 @@ namespace Ryujinx.Ui
                 return;
             }
 
-            string titleFilePath = _tableStore.GetValue(treeIter, 9).ToString();
+            string titleFilePath = _tableStore.GetValue(treeIter, 10).ToString();
             string titleName     = _tableStore.GetValue(treeIter, 2).ToString().Split("\n")[0];
             string titleId       = _tableStore.GetValue(treeIter, 2).ToString().Split("\n")[1].ToLower();
 
-            BlitStruct<ApplicationControlProperty> controlData = (BlitStruct<ApplicationControlProperty>)_tableStore.GetValue(treeIter, 10);
+            BlitStruct<ApplicationControlProperty> controlData = (BlitStruct<ApplicationControlProperty>)_tableStore.GetValue(treeIter, 11);
 
             _ = new GameTableContextMenu(this, _virtualFileSystem, _accountManager, _libHacHorizonManager.RyujinxClient, titleFilePath, titleName, titleId, controlData);
         }
@@ -1691,6 +1701,14 @@ namespace Ryujinx.Ui
         private void Version_Toggled(object sender, EventArgs args)
         {
             ConfigurationState.Instance.Ui.GuiColumns.VersionColumn.Value = _versionToggle.Active;
+
+            SaveConfig();
+            UpdateColumns();
+        }
+
+        private void SupportedLanguages_Toggled(object sender, EventArgs args)
+        {
+            ConfigurationState.Instance.Ui.GuiColumns.SupportedLanguagesColumn.Value = _supportedLanguagesToggle.Active;
 
             SaveConfig();
             UpdateColumns();

--- a/Ryujinx/Ui/MainWindow.glade
+++ b/Ryujinx/Ui/MainWindow.glade
@@ -214,14 +214,14 @@
                               </object>
                             </child>
                             <child>
-	                          <object class="GtkCheckMenuItem" id="_supportedLanguagesToggle">
-	                           <property name="visible">True</property>
-	                           <property name="can_focus">False</property>
-	                           <property name="tooltip_text" translatable="yes">Enable or Disable Supported Languages in the game list</property>
-	                           <property name="label" translatable="yes">Enable Supported Languages Column</property>
-	                           <property name="use_underline">True</property>
-	                          </object>
-                            </child>  
+                              <object class="GtkCheckMenuItem" id="_supportedLanguagesToggle">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="tooltip_text" translatable="yes">Enable or Disable Supported Languages in the game list</property>
+                                <property name="label" translatable="yes">Enable Supported Languages Column</property>
+                                <property name="use_underline">True</property>
+                              </object>
+                            </child>
                             <child>
                               <object class="GtkCheckMenuItem" id="_timePlayedToggle">
                                 <property name="visible">True</property>

--- a/Ryujinx/Ui/MainWindow.glade
+++ b/Ryujinx/Ui/MainWindow.glade
@@ -213,15 +213,15 @@
                                 <property name="use_underline">True</property>
                               </object>
                             </child>
-							<child>
-							  <object class="GtkCheckMenuItem" id="_supportedLanguagesToggle">
-							    <property name="visible">True</property>
-							    <property name="can_focus">False</property>
-								<property name="tooltip_text" translatable="yes">Enable or Disable Supported Languages in the game list</property>
-								<property name="label" translatable="yes">Enable Supported Languages Column</property>
-								<property name="use_underline">True</property>
-							  </object>
-							</child>  
+                            <child>
+	                            <object class="GtkCheckMenuItem" id="_supportedLanguagesToggle">
+	                            <property name="visible">True</property>
+	                            <property name="can_focus">False</property>
+	                            <property name="tooltip_text" translatable="yes">Enable or Disable Supported Languages in the game list</property>
+	                            <property name="label" translatable="yes">Enable Supported Languages Column</property>
+	                            <property name="use_underline">True</property>
+	                            </object>
+                            </child>  
                             <child>
                               <object class="GtkCheckMenuItem" id="_timePlayedToggle">
                                 <property name="visible">True</property>

--- a/Ryujinx/Ui/MainWindow.glade
+++ b/Ryujinx/Ui/MainWindow.glade
@@ -214,13 +214,13 @@
                               </object>
                             </child>
                             <child>
-	                            <object class="GtkCheckMenuItem" id="_supportedLanguagesToggle">
-	                            <property name="visible">True</property>
-	                            <property name="can_focus">False</property>
-	                            <property name="tooltip_text" translatable="yes">Enable or Disable Supported Languages in the game list</property>
-	                            <property name="label" translatable="yes">Enable Supported Languages Column</property>
-	                            <property name="use_underline">True</property>
-	                            </object>
+	                          <object class="GtkCheckMenuItem" id="_supportedLanguagesToggle">
+	                           <property name="visible">True</property>
+	                           <property name="can_focus">False</property>
+	                           <property name="tooltip_text" translatable="yes">Enable or Disable Supported Languages in the game list</property>
+	                           <property name="label" translatable="yes">Enable Supported Languages Column</property>
+	                           <property name="use_underline">True</property>
+	                          </object>
                             </child>  
                             <child>
                               <object class="GtkCheckMenuItem" id="_timePlayedToggle">

--- a/Ryujinx/Ui/MainWindow.glade
+++ b/Ryujinx/Ui/MainWindow.glade
@@ -213,6 +213,15 @@
                                 <property name="use_underline">True</property>
                               </object>
                             </child>
+							<child>
+							  <object class="GtkCheckMenuItem" id="_supportedLanguagesToggle">
+							    <property name="visible">True</property>
+							    <property name="can_focus">False</property>
+								<property name="tooltip_text" translatable="yes">Enable or Disable Supported Languages in the game list</property>
+								<property name="label" translatable="yes">Enable Supported Languages Column</property>
+								<property name="use_underline">True</property>
+							  </object>
+							</child>  
                             <child>
                               <object class="GtkCheckMenuItem" id="_timePlayedToggle">
                                 <property name="visible">True</property>


### PR DESCRIPTION
Hi,

First contribution here.

I thought it would be useful if supported languages for games was visible in the UI so I have added that as part of this PR.

![image](https://user-images.githubusercontent.com/25060863/165479054-708384c6-ad13-4b8d-8fdd-fa773c351af7.png)

Background on this is #3287 where the user most likely selected Spanish instead of Latin American Spanish and because Spanish was unsupported the game defaulted back to English.

Sometimes the language shown in-game can be misleading to what is actually needed i.e. in Sword Art Online the select language screen specifies Canadian French. However, it is actually only specifically French that is supported.
