### PR TITLE
Restrict cases where vertex buffer size from index buffer type is used

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -928,7 +928,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
                     size = endAddress.Pack() - address + 1;
 
-                    if (stride > 0 && indexTypeSmall)
+                    if (stride > 0 && indexTypeSmall && _drawState.DrawIndexed && !instanced)
                     {
                         // If the index type is a small integer type, then we might be still able
                         // to reduce the vertex buffer size based on the maximum possible index value.


### PR DESCRIPTION
This fixes some regression introduced by #3253, like some glitches on Xenoblade Chronicles 2 blade awakening cutscenes. First, we can't guess the vertex buffer size from the index buffer type when the draw is not indexed, as in those cases the index buffer type is completely meaningless. This also does not allow it for instanced vertex buffers as I believe it might be possible to access vertices outside of the range in those cases (due to vertex being incremented per instance, might be wrong though). I have verified that it still works for Perky Little Things and Super Mario 64, which is what the previous PR fixed.