### PR TITLE
Global memory emulation using NV_shader_buffer_store and DrawElementsIndirect macro HLE

### DIFF
--- a/Ryujinx.Graphics.GAL/IPipeline.cs
+++ b/Ryujinx.Graphics.GAL/IPipeline.cs
@@ -25,12 +25,15 @@ namespace Ryujinx.Graphics.GAL
         void DispatchCompute(int groupsX, int groupsY, int groupsZ);
 
         void Draw(int vertexCount, int instanceCount, int firstVertex, int firstInstance);
+        void DrawIndirect(BufferRange indirectBuffer);
         void DrawIndexed(
             int indexCount,
             int instanceCount,
             int firstIndex,
             int firstVertex,
             int firstInstance);
+        void DrawIndexedIndirect(BufferRange indirectBuffer);
+
         void DrawTexture(ITexture texture, ISampler sampler, Extents2DF srcRegion, Extents2DF dstRegion);
 
         void EndTransformFeedback();

--- a/Ryujinx.Graphics.GAL/IRenderer.cs
+++ b/Ryujinx.Graphics.GAL/IRenderer.cs
@@ -28,6 +28,7 @@ namespace Ryujinx.Graphics.GAL
         void DeleteBuffer(BufferHandle buffer);
 
         ReadOnlySpan<byte> GetBufferData(BufferHandle buffer, int offset, int size);
+        ulong GetBufferGpuAddress(BufferHandle buffer);
 
         Capabilities GetCapabilities();
 

--- a/Ryujinx.Graphics.GAL/Multithreading/CommandHelper.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/CommandHelper.cs
@@ -77,6 +77,8 @@ namespace Ryujinx.Graphics.GAL.Multithreading
                 BufferDisposeCommand.Run(ref GetCommand<BufferDisposeCommand>(memory), threaded, renderer);
             _lookup[(int)CommandType.BufferGetData] = (Span<byte> memory, ThreadedRenderer threaded, IRenderer renderer) =>
                 BufferGetDataCommand.Run(ref GetCommand<BufferGetDataCommand>(memory), threaded, renderer);
+            _lookup[(int)CommandType.BufferGetGpuAddress] = (Span<byte> memory, ThreadedRenderer threaded, IRenderer renderer) =>
+                BufferGetGpuAddressCommand.Run(ref GetCommand<BufferGetGpuAddressCommand>(memory), threaded, renderer);
             _lookup[(int)CommandType.BufferSetData] = (Span<byte> memory, ThreadedRenderer threaded, IRenderer renderer) =>
                 BufferSetDataCommand.Run(ref GetCommand<BufferSetDataCommand>(memory), threaded, renderer);
 
@@ -137,8 +139,12 @@ namespace Ryujinx.Graphics.GAL.Multithreading
                 DispatchComputeCommand.Run(ref GetCommand<DispatchComputeCommand>(memory), threaded, renderer);
             _lookup[(int)CommandType.Draw] = (Span<byte> memory, ThreadedRenderer threaded, IRenderer renderer) =>
                 DrawCommand.Run(ref GetCommand<DrawCommand>(memory), threaded, renderer);
+            _lookup[(int)CommandType.DrawIndirect] = (Span<byte> memory, ThreadedRenderer threaded, IRenderer renderer) =>
+                DrawIndirectCommand.Run(ref GetCommand<DrawIndirectCommand>(memory), threaded, renderer);
             _lookup[(int)CommandType.DrawIndexed] = (Span<byte> memory, ThreadedRenderer threaded, IRenderer renderer) =>
                 DrawIndexedCommand.Run(ref GetCommand<DrawIndexedCommand>(memory), threaded, renderer);
+            _lookup[(int)CommandType.DrawIndexedIndirect] = (Span<byte> memory, ThreadedRenderer threaded, IRenderer renderer) =>
+                DrawIndexedIndirectCommand.Run(ref GetCommand<DrawIndexedIndirectCommand>(memory), threaded, renderer);
             _lookup[(int)CommandType.DrawTexture] = (Span<byte> memory, ThreadedRenderer threaded, IRenderer renderer) =>
                 DrawTextureCommand.Run(ref GetCommand<DrawTextureCommand>(memory), threaded, renderer);
             _lookup[(int)CommandType.EndHostConditionalRendering] = (Span<byte> memory, ThreadedRenderer threaded, IRenderer renderer) =>

--- a/Ryujinx.Graphics.GAL/Multithreading/CommandType.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/CommandType.cs
@@ -17,6 +17,7 @@
 
         BufferDispose,
         BufferGetData,
+        BufferGetGpuAddress,
         BufferSetData,
 
         CounterEventDispose,
@@ -50,7 +51,9 @@
         CopyBuffer,
         DispatchCompute,
         Draw,
+        DrawIndirect,
         DrawIndexed,
+        DrawIndexedIndirect,
         DrawTexture,
         EndHostConditionalRendering,
         EndTransformFeedback,

--- a/Ryujinx.Graphics.GAL/Multithreading/Commands/Buffer/BufferGetGpuAddressCommand.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/Commands/Buffer/BufferGetGpuAddressCommand.cs
@@ -1,0 +1,24 @@
+using Ryujinx.Graphics.GAL.Multithreading.Model;
+
+namespace Ryujinx.Graphics.GAL.Multithreading.Commands.Buffer
+{
+    struct BufferGetGpuAddressCommand : IGALCommand
+    {
+        public CommandType CommandType => CommandType.BufferGetGpuAddress;
+        private BufferHandle _buffer;
+        private TableRef<ResultBox<ulong>> _result;
+
+        public void Set(BufferHandle buffer, TableRef<ResultBox<ulong>> result)
+        {
+            _buffer = buffer;
+            _result = result;
+        }
+
+        public static void Run(ref BufferGetGpuAddressCommand command, ThreadedRenderer threaded, IRenderer renderer)
+        {
+            ulong result = renderer.GetBufferGpuAddress(threaded.Buffers.MapBuffer(command._buffer));
+
+            command._result.Get(threaded).Result = result;
+        }
+    }
+}

--- a/Ryujinx.Graphics.GAL/Multithreading/Commands/DrawIndexedIndirectCommand.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/Commands/DrawIndexedIndirectCommand.cs
@@ -1,0 +1,18 @@
+namespace Ryujinx.Graphics.GAL.Multithreading.Commands
+{
+    struct DrawIndexedIndirectCommand : IGALCommand
+    {
+        public CommandType CommandType => CommandType.DrawIndexedIndirect;
+        private BufferRange _indirectBuffer;
+
+        public void Set(BufferRange indirectBuffer)
+        {
+            _indirectBuffer = indirectBuffer;
+        }
+
+        public static void Run(ref DrawIndexedIndirectCommand command, ThreadedRenderer threaded, IRenderer renderer)
+        {
+            renderer.Pipeline.DrawIndexedIndirect(threaded.Buffers.MapBufferRange(command._indirectBuffer));
+        }
+    }
+}

--- a/Ryujinx.Graphics.GAL/Multithreading/Commands/DrawIndirectCommand.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/Commands/DrawIndirectCommand.cs
@@ -1,0 +1,18 @@
+namespace Ryujinx.Graphics.GAL.Multithreading.Commands
+{
+    struct DrawIndirectCommand : IGALCommand
+    {
+        public CommandType CommandType => CommandType.DrawIndirect;
+        private BufferRange _indirectBuffer;
+
+        public void Set(BufferRange indirectBuffer)
+        {
+            _indirectBuffer = indirectBuffer;
+        }
+
+        public static void Run(ref DrawIndirectCommand command, ThreadedRenderer threaded, IRenderer renderer)
+        {
+            renderer.Pipeline.DrawIndirect(threaded.Buffers.MapBufferRange(command._indirectBuffer));
+        }
+    }
+}

--- a/Ryujinx.Graphics.GAL/Multithreading/ThreadedPipeline.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/ThreadedPipeline.cs
@@ -76,9 +76,21 @@ namespace Ryujinx.Graphics.GAL.Multithreading
             _renderer.QueueCommand();
         }
 
+        public void DrawIndirect(BufferRange indirectBuffer)
+        {
+            _renderer.New<DrawIndirectCommand>().Set(indirectBuffer);
+            _renderer.QueueCommand();
+        }
+
         public void DrawIndexed(int indexCount, int instanceCount, int firstIndex, int firstVertex, int firstInstance)
         {
             _renderer.New<DrawIndexedCommand>().Set(indexCount, instanceCount, firstIndex, firstVertex, firstInstance);
+            _renderer.QueueCommand();
+        }
+
+        public void DrawIndexedIndirect(BufferRange indirectBuffer)
+        {
+            _renderer.New<DrawIndexedIndirectCommand>().Set(indirectBuffer);
             _renderer.QueueCommand();
         }
 

--- a/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
@@ -328,6 +328,22 @@ namespace Ryujinx.Graphics.GAL.Multithreading
             }
         }
 
+        public ulong GetBufferGpuAddress(BufferHandle buffer)
+        {
+            if (IsGpuThread())
+            {
+                ResultBox<ulong> box = new ResultBox<ulong>();
+                New<BufferGetGpuAddressCommand>().Set(buffer, Ref(box));
+                InvokeCommand();
+
+                return box.Result;
+            }
+            else
+            {
+                return _baseRenderer.GetBufferGpuAddress(Buffers.MapBufferBlocking(buffer));
+            }
+        }
+
         public Capabilities GetCapabilities()
         {
             ResultBox<Capabilities> box = new ResultBox<Capabilities>();

--- a/Ryujinx.Graphics.Gpu/Engine/Compute/ComputeClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Compute/ComputeClass.cs
@@ -222,6 +222,11 @@ namespace Ryujinx.Graphics.Gpu.Engine.Compute
                     descriptor.Flags);
             }
 
+            if (info.UsesGlobalMemory)
+            {
+                _channel.BufferManager.SyncAllBuffers();
+            }
+
             _channel.TextureManager.CommitComputeBindings();
             _channel.BufferManager.CommitComputeBindings();
 

--- a/Ryujinx.Graphics.Gpu/Engine/MME/Macro.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MME/Macro.cs
@@ -1,6 +1,5 @@
 ﻿using Ryujinx.Graphics.Device;
 using Ryujinx.Graphics.Gpu.Engine.GPFifo;
-using Ryujinx.Graphics.Gpu.Memory;
 using System;
 
 namespace Ryujinx.Graphics.Gpu.Engine.MME
@@ -63,10 +62,14 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
                 }
             }
 
-            if (_hleFunction == MacroHLEFunctionName.MultiDrawElementsIndirectCount)
+            // We don't consume the parameter buffer value, so we don't need to flush it.
+            // Doing so improves performance if the value was written by a GPU shader.
+            if (_hleFunction == MacroHLEFunctionName.DrawElementsIndirect)
             {
-                // We don't consume the parameter buffer value, so we don't need to flush it.
-                // Doing so improves performance if the value was written by a GPU shader.
+                context.GPFifo.SetFlushSkips(1);
+            }
+            else if (_hleFunction == MacroHLEFunctionName.MultiDrawElementsIndirectCount)
+            {
                 context.GPFifo.SetFlushSkips(2);
             }
         }

--- a/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLE.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLE.cs
@@ -74,9 +74,9 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
 
             var bufferCache = _processor.MemoryManager.Physical.BufferCache;
 
-            var indirectBuffer = bufferCache.GetGpuBufferRange(_processor.MemoryManager, indirectBufferGpuVa, 0x14);
+            ulong indirectBufferAddress = bufferCache.TranslateAndCreateBuffer(_processor.MemoryManager, indirectBufferGpuVa, 0x14);
 
-            _processor.ThreedClass.DrawIndirect(indexCount, topology, indirectBuffer);
+            _processor.ThreedClass.DrawIndirect(indexCount, topology, indirectBufferAddress);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLEFunctionName.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLEFunctionName.cs
@@ -6,6 +6,7 @@
     enum MacroHLEFunctionName
     {
         None,
+        DrawElementsIndirect,
         MultiDrawElementsIndirectCount
     }
 }

--- a/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLETable.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLETable.cs
@@ -46,12 +46,17 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
 
         private static readonly TableEntry[] Table = new TableEntry[]
         {
+            new TableEntry(MacroHLEFunctionName.DrawElementsIndirect, new Hash128(0x86A3E8E903AF8F45, 0xD35BBA07C23860A4), 0x7c),
             new TableEntry(MacroHLEFunctionName.MultiDrawElementsIndirectCount, new Hash128(0x890AF57ED3FB1C37, 0x35D0C95C61F5386F), 0x19C)
         };
 
         private static bool IsMacroHLESupported(Capabilities caps, MacroHLEFunctionName name)
         {
-            if (name == MacroHLEFunctionName.MultiDrawElementsIndirectCount)
+            if (name == MacroHLEFunctionName.DrawElementsIndirect)
+            {
+                return true;
+            }
+            else if (name == MacroHLEFunctionName.MultiDrawElementsIndirectCount)
             {
                 return caps.SupportsIndirectParameters;
             }

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
@@ -379,7 +379,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 new Extents2DF(dstX0, dstY0, dstX1, dstY1));
         }
 
-        public void DrawIndirect(ThreedClass engine, int indexCount, PrimitiveTopology topology, BufferRange indirectBuffer)
+        public void DrawIndirect(ThreedClass engine, int indexCount, PrimitiveTopology topology, ulong indirectBufferAddress)
         {
             engine.Write(IndexBufferCountMethodOffset * 4, indexCount);
 
@@ -403,6 +403,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             _drawState.IndexCount = indexCount;
 
             engine.UpdateState();
+
+            var indirectBuffer = _channel.MemoryManager.Physical.BufferCache.GetBufferRange(indirectBufferAddress, 0x14);
 
             if (_drawState.DrawIndexed)
             {

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
@@ -379,6 +379,48 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 new Extents2DF(dstX0, dstY0, dstX1, dstY1));
         }
 
+        public void DrawIndirect(ThreedClass engine, int indexCount, PrimitiveTopology topology, BufferRange indirectBuffer)
+        {
+            engine.Write(IndexBufferCountMethodOffset * 4, indexCount);
+
+            _context.Renderer.Pipeline.SetPrimitiveTopology(topology);
+            _drawState.Topology = topology;
+            _topologySet = true;
+
+            ConditionalRenderEnabled renderEnable = ConditionalRendering.GetRenderEnable(
+                _context,
+                _channel.MemoryManager,
+                _state.State.RenderEnableAddress,
+                _state.State.RenderEnableCondition);
+
+            if (renderEnable == ConditionalRenderEnabled.False)
+            {
+                _drawState.DrawIndexed = false;
+                return;
+            }
+
+            _drawState.FirstIndex = _state.State.IndexBufferState.First;
+            _drawState.IndexCount = indexCount;
+
+            engine.UpdateState();
+
+            if (_drawState.DrawIndexed)
+            {
+                _context.Renderer.Pipeline.DrawIndexedIndirect(indirectBuffer);
+            }
+            else
+            {
+                _context.Renderer.Pipeline.DrawIndirect(indirectBuffer);
+            }
+
+            _drawState.DrawIndexed = false;
+
+            if (renderEnable == ConditionalRenderEnabled.Host)
+            {
+                _context.Renderer.Pipeline.EndHostConditionalRendering();
+            }
+        }
+
         /// <summary>
         /// Performs a indirect multi-draw, with parameters from a GPU buffer.
         /// </summary>

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
@@ -484,9 +484,9 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             return 0;
         }
 
-        public void DrawIndirect(int indexCount, PrimitiveTopology topology, BufferRange indirectBuffer)
+        public void DrawIndirect(int indexCount, PrimitiveTopology topology, ulong indirectBufferAddress)
         {
-            _drawManager.DrawIndirect(this, indexCount, topology, indirectBuffer);
+            _drawManager.DrawIndirect(this, indexCount, topology, indirectBufferAddress);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
@@ -484,6 +484,11 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             return 0;
         }
 
+        public void DrawIndirect(int indexCount, PrimitiveTopology topology, BufferRange indirectBuffer)
+        {
+            _drawManager.DrawIndirect(this, indexCount, topology, indirectBuffer);
+        }
+
         /// <summary>
         /// Performs a indirect multi-draw, with parameters from a GPU buffer.
         /// </summary>

--- a/Ryujinx.Graphics.Gpu/GraphicsConfig.cs
+++ b/Ryujinx.Graphics.Gpu/GraphicsConfig.cs
@@ -30,8 +30,8 @@ namespace Ryujinx.Graphics.Gpu
 
         /// <summary>
         /// Enables or disables fast 2d engine texture copies entirely on CPU when possible.
-        /// Reduces stuttering and # of textures in games that copy textures around for streaming, 
-        /// as textures will not need to be created for the copy, and the data does not need to be 
+        /// Reduces stuttering and # of textures in games that copy textures around for streaming,
+        /// as textures will not need to be created for the copy, and the data does not need to be
         /// flushed from GPU.
         /// </summary>
         public static bool Fast2DCopy = true;

--- a/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
@@ -66,6 +66,8 @@ namespace Ryujinx.Graphics.Gpu.Memory
         private bool _useGranular;
         private bool _syncActionRegistered;
 
+        private ulong _hostGpuAddress;
+
         /// <summary>
         /// Creates a new instance of the buffer.
         /// </summary>
@@ -164,6 +166,16 @@ namespace Ryujinx.Graphics.Gpu.Memory
             int offset = (int)(address - Address);
 
             return new BufferRange(Handle, offset, (int)size);
+        }
+
+        public ulong GetHostGpuAddress(ulong address)
+        {
+            if (_hostGpuAddress == 0)
+            {
+                _hostGpuAddress = _context.Renderer.GetBufferGpuAddress(Handle);
+            }
+
+            return _hostGpuAddress + (address - Address);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Memory/BufferCache.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferCache.cs
@@ -23,7 +23,6 @@ namespace Ryujinx.Graphics.Gpu.Memory
         private readonly PhysicalMemory _physicalMemory;
 
         private readonly RangeList<Buffer> _buffers;
-
         private Buffer[] _bufferOverlaps;
 
         private readonly Dictionary<ulong, BufferCacheEntry> _dirtyCache;
@@ -360,6 +359,11 @@ namespace Ryujinx.Graphics.Gpu.Memory
         public BufferRange GetBufferRange(ulong address, ulong size, bool write = false)
         {
             return GetBuffer(address, size, write).GetRange(address, size);
+        }
+
+        public ulong GetBufferHostGpuAddress(ulong address, ulong size, bool write = false)
+        {
+            return GetBuffer(address, size, write).GetHostGpuAddress(address);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Memory/Mapping.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/Mapping.cs
@@ -1,0 +1,22 @@
+using Ryujinx.Memory.Range;
+
+namespace Ryujinx.Graphics.Gpu.Memory
+{
+    struct Mapping : IRange
+    {
+        public ulong Address { get; }
+        public ulong Size { get; }
+        public ulong EndAddress => Address + Size;
+
+        public bool OverlapsWith(ulong address, ulong size)
+        {
+            return Address < address + size && address < EndAddress;
+        }
+
+        public Mapping(ulong address, ulong size)
+        {
+            Address = address;
+            Size = size;
+        }
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Shader/Cache/Definition/HostShaderCacheEntry.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/Cache/Definition/HostShaderCacheEntry.cs
@@ -97,6 +97,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache.Definition
                 Textures,
                 Images,
                 default,
+                false,
                 Header.UseFlags.HasFlag(UseFlags.InstanceId),
                 Header.UseFlags.HasFlag(UseFlags.RtLayer),
                 Header.ClipDistancesWritten,

--- a/Ryujinx.Graphics.Gpu/Shader/Cache/Migration.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/Cache/Migration.cs
@@ -95,6 +95,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache
                             ShaderStage.Compute,
                             false,
                             false,
+                            false,
                             0,
                             0);
 
@@ -205,6 +206,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.Cache
                                 Array.Empty<TextureDescriptor>(),
                                 Array.Empty<TextureDescriptor>(),
                                 (ShaderStage)(i + 1),
+                                false,
                                 false,
                                 false,
                                 0,

--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -21,7 +21,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 1;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 0;
+        private const uint CodeGenVersion = 10;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";
@@ -133,6 +133,8 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
             /// Shader stage.
             /// </summary>
             public ShaderStage Stage;
+
+            public bool UsesGlobalMemory;
 
             /// <summary>
             /// Indicates if the shader accesses the Instance ID built-in variable.
@@ -703,6 +705,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
                 textures,
                 images,
                 dataInfo.Stage,
+                dataInfo.UsesGlobalMemory,
                 dataInfo.UsesInstanceId,
                 dataInfo.UsesRtLayer,
                 dataInfo.ClipDistancesWritten,
@@ -728,6 +731,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
             dataInfo.TexturesCount = (ushort)info.Textures.Count;
             dataInfo.ImagesCount = (ushort)info.Images.Count;
             dataInfo.Stage = info.Stage;
+            dataInfo.UsesGlobalMemory = info.UsesGlobalMemory;
             dataInfo.UsesInstanceId = info.UsesInstanceId;
             dataInfo.UsesRtLayer = info.UsesRtLayer;
             dataInfo.ClipDistancesWritten = info.ClipDistancesWritten;

--- a/Ryujinx.Graphics.Gpu/Shader/ResourceCounts.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ResourceCounts.cs
@@ -31,6 +31,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         public ResourceCounts()
         {
             UniformBuffersCount = 1; // The first binding is reserved for the support buffer.
+            StorageBuffersCount = 1; // The first binding is reserved for the buffer mappings table for GPU address translation.
         }
     }
 }

--- a/Ryujinx.Graphics.OpenGL/Buffer.cs
+++ b/Ryujinx.Graphics.OpenGL/Buffer.cs
@@ -73,6 +73,14 @@ namespace Ryujinx.Graphics.OpenGL
             }
         }
 
+        public static ulong GetGpuAddress(BufferHandle handle)
+        {
+            GL.BindBuffer(BufferTarget.CopyWriteBuffer, handle.ToInt32());
+            GL.NV.MakeBufferResident((NvShaderBufferLoad)BufferTarget.CopyWriteBuffer, (NvShaderBufferLoad)All.ReadWrite);
+            GL.NV.GetBufferParameter(BufferTargetArb.CopyWriteBuffer, NvShaderBufferLoad.BufferGpuAddressNv, out ulong gpuAddress);
+            return gpuAddress;
+        }
+
         public static void Resize(BufferHandle handle, int size)
         {
             GL.BindBuffer(BufferTarget.CopyWriteBuffer, handle.ToInt32());

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -217,6 +217,23 @@ namespace Ryujinx.Graphics.OpenGL
             PostDraw();
         }
 
+        public void DrawIndirect(BufferRange indirectBuffer)
+        {
+            if (!_program.IsLinked)
+            {
+                Logger.Debug?.Print(LogClass.Gpu, "Draw error, shader not linked.");
+                return;
+            }
+
+            PreDraw();
+
+            GL.BindBuffer((BufferTarget)All.DrawIndirectBuffer, indirectBuffer.Handle.ToInt32());
+
+            GL.DrawArraysIndirect(_primitiveType, (IntPtr)indirectBuffer.Offset);
+
+            PostDraw();
+        }
+
         private void DrawQuadsImpl(
             int vertexCount,
             int instanceCount,
@@ -542,6 +559,27 @@ namespace Ryujinx.Graphics.OpenGL
                     firstVertex,
                     firstInstance);
             }
+        }
+
+        public void DrawIndexedIndirect(BufferRange indirectBuffer)
+        {
+            if (!_program.IsLinked)
+            {
+                Logger.Debug?.Print(LogClass.Gpu, "Draw error, shader not linked.");
+                return;
+            }
+
+            PreDraw();
+
+            _vertexArray.SetRangeOfIndexBuffer();
+
+            GL.BindBuffer((BufferTarget)All.DrawIndirectBuffer, indirectBuffer.Handle.ToInt32());
+
+            GL.DrawElementsIndirect(_primitiveType, _elementsType, (IntPtr)indirectBuffer.Offset);
+
+            _vertexArray.RestoreIndexBuffer();
+
+            PostDraw();
         }
 
         public void DrawTexture(ITexture texture, ISampler sampler, Extents2DF srcRegion, Extents2DF dstRegion)

--- a/Ryujinx.Graphics.OpenGL/Renderer.cs
+++ b/Ryujinx.Graphics.OpenGL/Renderer.cs
@@ -92,6 +92,11 @@ namespace Ryujinx.Graphics.OpenGL
             return Buffer.GetData(this, buffer, offset, size);
         }
 
+        public ulong GetBufferGpuAddress(BufferHandle buffer)
+        {
+            return Buffer.GetGpuAddress(buffer);
+        }
+
         public Capabilities GetCapabilities()
         {
             return new Capabilities(

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
@@ -27,6 +27,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
             context.AppendLine("#extension GL_ARB_shader_group_vote : enable");
             context.AppendLine("#extension GL_EXT_shader_image_load_formatted : enable");
             context.AppendLine("#extension GL_EXT_texture_shadow_lod : enable");
+            context.AppendLine("#extension GL_NV_shader_buffer_load : enable");
 
             if (context.Config.Stage == ShaderStage.Compute)
             {
@@ -263,6 +264,11 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
             if ((info.HelperFunctionsMask & HelperFunctionsMask.AtomicMinMaxS32Storage) != 0)
             {
                 AppendHelperFunction(context, "Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/AtomicMinMaxS32Storage.glsl");
+            }
+
+            if ((info.HelperFunctionsMask & HelperFunctionsMask.GlobalMemory) != 0)
+            {
+                AppendHelperFunction(context, "Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/GlobalMemory.glsl");
             }
 
             if ((info.HelperFunctionsMask & HelperFunctionsMask.MultiplyHighS32) != 0)

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/GlobalMemory.glsl
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/GlobalMemory.glsl
@@ -1,0 +1,39 @@
+layout (binding = 0, std430) buffer buffer_regions_block
+{
+    uvec4 buffer_regions[];
+};
+
+uvec2 Helper_TranslateAddress(uvec2 address)
+{
+    uint64_t address64 = packUint2x32(address);
+    uint count = buffer_regions[0].x;
+    uint left = 0;
+    uint right = count;
+
+    while (left != right)
+    {
+        uint middle = left + ((right - left) >> 1);
+        uint offset = middle * 2;
+        uvec4 guest_info = buffer_regions[1 + offset];
+        uvec4 host_info = buffer_regions[2 + offset];
+
+        uint64_t start_address = packUint2x32(guest_info.xy);
+        uint64_t end_address = packUint2x32(guest_info.zw);
+        if (address64 >= start_address && address64 < end_address)
+        {
+            uint64_t host_address = packUint2x32(host_info.xy);
+            return unpackUint2x32((address64 - start_address) + host_address);
+        }
+
+        if (address64 < start_address)
+        {
+            right = middle;
+        }
+        else
+        {
+            left = middle + 1;
+        }
+    }
+
+    return uvec2(0, 0);
+}

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/HelperFunctionNames.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/HelperFunctionNames.cs
@@ -18,5 +18,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
         public static string StoreShared8   = "Helper_StoreShared8";
         public static string StoreStorage16 = "Helper_StoreStorage16";
         public static string StoreStorage8  = "Helper_StoreStorage8";
+
+        public static string TranslateAddress = "Helper_TranslateAddress";
     }
 }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGen.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGen.cs
@@ -170,6 +170,9 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
                     case Instruction.LoadConstant:
                         return LoadConstant(context, operation);
 
+                    case Instruction.LoadGlobal:
+                        return LoadGlobal(context, operation);
+
                     case Instruction.LoadLocal:
                         return LoadLocal(context, operation);
 
@@ -193,6 +196,9 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
 
                     case Instruction.StoreAttribute:
                         return StoreAttribute(context, operation);
+
+                    case Instruction.StoreGlobal:
+                        return StoreGlobal(context, operation);
 
                     case Instruction.StoreLocal:
                         return StoreLocal(context, operation);

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenHelper.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenHelper.cs
@@ -83,6 +83,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
             Add(Instruction.IsNan,                    InstType.CallUnary,      "isnan");
             Add(Instruction.LoadAttribute,            InstType.Special);
             Add(Instruction.LoadConstant,             InstType.Special);
+            Add(Instruction.LoadGlobal,               InstType.Special);
             Add(Instruction.LoadLocal,                InstType.Special);
             Add(Instruction.LoadShared,               InstType.Special);
             Add(Instruction.LoadStorage,              InstType.Special);
@@ -118,6 +119,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
             Add(Instruction.Sine,                     InstType.CallUnary,      "sin");
             Add(Instruction.SquareRoot,               InstType.CallUnary,      "sqrt");
             Add(Instruction.StoreAttribute,           InstType.Special);
+            Add(Instruction.StoreGlobal,              InstType.Special);
             Add(Instruction.StoreLocal,               InstType.Special);
             Add(Instruction.StoreShared,              InstType.Special);
             Add(Instruction.StoreShared16,            InstType.Special);

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
@@ -238,6 +238,17 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
             }
         }
 
+        public static string LoadGlobal(CodeGenContext context, AstOperation operation)
+        {
+            IAstNode src1 = operation.GetSource(0);
+            IAstNode src2 = operation.GetSource(1);
+
+            string addressLowExpr  = GetSoureExpr(context, src1, GetSrcVarType(operation.Inst, 0));
+            string addressHighExpr = GetSoureExpr(context, src2, GetSrcVarType(operation.Inst, 1));
+
+            return $"*(uint*)packPtr({HelperFunctionNames.TranslateAddress}(uvec2({addressLowExpr}, {addressHighExpr})))";
+        }
+
         public static string LoadLocal(CodeGenContext context, AstOperation operation)
         {
             return LoadLocalOrShared(context, operation, DefaultNames.LocalMemoryName);
@@ -343,6 +354,22 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
 
             string value = GetSoureExpr(context, src3, GetSrcVarType(operation.Inst, 2));
             return $"{attrName} = {value}";
+        }
+
+        public static string StoreGlobal(CodeGenContext context, AstOperation operation)
+        {
+            IAstNode src1 = operation.GetSource(0);
+            IAstNode src2 = operation.GetSource(1);
+            IAstNode src3 = operation.GetSource(2);
+
+            string addressLowExpr  = GetSoureExpr(context, src1, GetSrcVarType(operation.Inst, 0));
+            string addressHighExpr = GetSoureExpr(context, src2, GetSrcVarType(operation.Inst, 1));
+
+            VariableType srcType = OperandManager.GetNodeDestType(context, src3);
+
+            string src = TypeConversion.ReinterpretCast(context, src3, srcType, VariableType.U32);
+
+            return $"*(uint*)packPtr({HelperFunctionNames.TranslateAddress}(uvec2({addressLowExpr}, {addressHighExpr}))) = {src}";
         }
 
         public static string StoreLocal(CodeGenContext context, AstOperation operation)

--- a/Ryujinx.Graphics.Shader/Decoders/Decoder.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/Decoder.cs
@@ -234,11 +234,6 @@ namespace Ryujinx.Graphics.Shader.Decoders
 
                 op = InstTable.GetOp(address, opCode);
 
-                if (op.Props.HasFlag(InstProps.TexB))
-                {
-                    config.SetUsedFeature(FeatureFlags.Bindless);
-                }
-
                 if (op.Name == InstName.Ald || op.Name == InstName.Ast || op.Name == InstName.Ipa)
                 {
                     SetUserAttributeUses(config, op.Name, opCode);

--- a/Ryujinx.Graphics.Shader/Ryujinx.Graphics.Shader.csproj
+++ b/Ryujinx.Graphics.Shader/Ryujinx.Graphics.Shader.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\AtomicMinMaxS32Shared.glsl" />
     <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\AtomicMinMaxS32Storage.glsl" />
+    <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\GlobalMemory.glsl" />
     <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\MultiplyHighS32.glsl" />
     <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\MultiplyHighU32.glsl" />
     <EmbeddedResource Include="CodeGen\Glsl\HelperFunctions\Shuffle.glsl" />

--- a/Ryujinx.Graphics.Shader/ShaderProgramInfo.cs
+++ b/Ryujinx.Graphics.Shader/ShaderProgramInfo.cs
@@ -11,6 +11,7 @@ namespace Ryujinx.Graphics.Shader
         public ReadOnlyCollection<TextureDescriptor> Images { get; }
 
         public ShaderStage Stage { get; }
+        public bool UsesGlobalMemory { get; }
         public bool UsesInstanceId { get; }
         public bool UsesRtLayer { get; }
         public byte ClipDistancesWritten { get; }
@@ -22,6 +23,7 @@ namespace Ryujinx.Graphics.Shader
             TextureDescriptor[] textures,
             TextureDescriptor[] images,
             ShaderStage stage,
+            bool usesGlobalMemory,
             bool usesInstanceId,
             bool usesRtLayer,
             byte clipDistancesWritten,
@@ -33,6 +35,7 @@ namespace Ryujinx.Graphics.Shader
             Images = Array.AsReadOnly(images);
 
             Stage = stage;
+            UsesGlobalMemory = usesGlobalMemory;
             UsesInstanceId = usesInstanceId;
             UsesRtLayer = usesRtLayer;
             ClipDistancesWritten = clipDistancesWritten;

--- a/Ryujinx.Graphics.Shader/StructuredIr/HelperFunctionsMask.cs
+++ b/Ryujinx.Graphics.Shader/StructuredIr/HelperFunctionsMask.cs
@@ -7,14 +7,15 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
     {
         AtomicMinMaxS32Shared  = 1 << 0,
         AtomicMinMaxS32Storage = 1 << 1,
-        MultiplyHighS32        = 1 << 2,
-        MultiplyHighU32        = 1 << 3,
-        Shuffle                = 1 << 4,
-        ShuffleDown            = 1 << 5,
-        ShuffleUp              = 1 << 6,
-        ShuffleXor             = 1 << 7,
-        StoreSharedSmallInt    = 1 << 8,
-        StoreStorageSmallInt   = 1 << 9,
-        SwizzleAdd             = 1 << 10
+        GlobalMemory           = 1 << 2,
+        MultiplyHighS32        = 1 << 3,
+        MultiplyHighU32        = 1 << 4,
+        Shuffle                = 1 << 5,
+        ShuffleDown            = 1 << 6,
+        ShuffleUp              = 1 << 7,
+        ShuffleXor             = 1 << 8,
+        StoreSharedSmallInt    = 1 << 9,
+        StoreStorageSmallInt   = 1 << 10,
+        SwizzleAdd             = 1 << 11
     }
 }

--- a/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgram.cs
+++ b/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgram.cs
@@ -203,6 +203,13 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
                 case Instruction.AtomicMinS32 | Instruction.MrStorage:
                     context.Info.HelperFunctionsMask |= HelperFunctionsMask.AtomicMinMaxS32Storage;
                     break;
+                case Instruction.LoadGlobal:
+                case Instruction.StoreGlobal:
+                case Instruction.StoreGlobal16:
+                case Instruction.StoreGlobal8:
+                    context.Config.SetUsedFeature(FeatureFlags.GlobalMemory);
+                    context.Info.HelperFunctionsMask |= HelperFunctionsMask.GlobalMemory;
+                    break;
                 case Instruction.MultiplyHighS32:
                     context.Info.HelperFunctionsMask |= HelperFunctionsMask.MultiplyHighS32;
                     break;

--- a/Ryujinx.Graphics.Shader/Translation/FeatureFlags.cs
+++ b/Ryujinx.Graphics.Shader/Translation/FeatureFlags.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.Graphics.Shader.Translation
         IntegerSampling = 1 << 0,
         FragCoordXY     = 1 << 1,
 
-        Bindless = 1 << 2,
+        GlobalMemory = 1 << 2,
         InstanceId = 1 << 3,
         RtLayer = 1 << 4,
         CbIndexing = 1 << 5,

--- a/Ryujinx.Graphics.Shader/Translation/Rewriter.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Rewriter.cs
@@ -23,10 +23,10 @@ namespace Ryujinx.Graphics.Shader.Translation
                         continue;
                     }
 
-                    if (UsesGlobalMemory(operation.Inst))
+                    /* if (UsesGlobalMemory(operation.Inst))
                     {
                         node = RewriteGlobalAccess(node, config);
-                    }
+                    } */
 
                     if (operation is TextureOperation texOp)
                     {

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -273,7 +273,15 @@ namespace Ryujinx.Graphics.Shader.Translation
             NextInputAttributesComponents = config.ThisInputAttributesComponents;
             NextInputAttributesPerPatchComponents = config.ThisInputAttributesPerPatchComponents;
             NextUsesFixedFuncAttributes = config.UsedFeatures.HasFlag(FeatureFlags.FixedFuncAttr);
-            MergeOutputUserAttributes(config.UsedInputAttributes, config.UsedInputAttributesPerPatch);
+            MergeOutputUserAttributes(config.UsedInputAttributes | config.PassthroughAttributes, config.UsedInputAttributesPerPatch);
+
+            int passthroughAttributes = config.PassthroughAttributes;
+            while (passthroughAttributes != 0)
+            {
+                int bit = BitOperations.TrailingZeroCount(passthroughAttributes);
+                NextInputAttributesComponents |= new UInt128(0xf, 0) << (bit * 4);
+                passthroughAttributes &= ~(1 << bit);
+            }
         }
 
         public void MergeOutputUserAttributes(int mask, int maskPerPatch)

--- a/Ryujinx.Graphics.Shader/Translation/Translator.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Translator.cs
@@ -87,6 +87,7 @@ namespace Ryujinx.Graphics.Shader.Translation
                 config.GetTextureDescriptors(),
                 config.GetImageDescriptors(),
                 config.Stage,
+                config.UsedFeatures.HasFlag(FeatureFlags.GlobalMemory),
                 config.UsedFeatures.HasFlag(FeatureFlags.InstanceId),
                 config.UsedFeatures.HasFlag(FeatureFlags.RtLayer),
                 config.ClipDistancesWritten,

--- a/Ryujinx.Memory/Range/RangeList.cs
+++ b/Ryujinx.Memory/Range/RangeList.cs
@@ -427,6 +427,18 @@ namespace Ryujinx.Memory.Range
             return ~left;
         }
 
+        public T[] ToArray()
+        {
+            T[] output = new T[Count];
+
+            for (int i = 0; i < output.Length; i++)
+            {
+                output[i] = _items[i].Value;
+            }
+
+            return output;
+        }
+
         public IEnumerator<T> GetEnumerator()
         {
             for (int i = 0; i < Count; i++)


### PR DESCRIPTION
This is mostly a bunch of changes/fixes to get Nintendo Switch Sports working. I don't plan to get this specific PR merged, instead each change should be PRed and tested individually later.

This includes the following changes:
- New approach for global memory emulation. This approach works for games that passes GPU pointers to the shader and access them directly. It requires `NV_shader_buffer_store` OpenGL extension that is only supported by NVIDIA, so it *won't work on other vendors*.
- HLE macro for `DrawElementsIndirect`. Not necessary to make it work, but it improves the performance.
- Some shader fixes related to geometry shader passthrough.

This change allows the game to go in-game on NVIDIA as you can see on the screenshots below.
![image](https://user-images.githubusercontent.com/5624669/166009362-69848cc0-a2a9-4b94-94ca-7bd499f3c61c.png)
![image](https://user-images.githubusercontent.com/5624669/166009375-454045b7-5706-4ba4-8d5e-3e3f11b9e2dc.png)
![image](https://user-images.githubusercontent.com/5624669/166009390-dd97c125-f38e-4f31-942b-d481c1c9fac7.png)