### PR TITLE
Remove AddProtection count > 0 assert

### DIFF
--- a/Ryujinx.Memory/WindowsShared/PlaceholderManager.cs
+++ b/Ryujinx.Memory/WindowsShared/PlaceholderManager.cs
@@ -469,13 +469,11 @@ namespace Ryujinx.Memory.WindowsShared
         {
             ulong endAddress = address + size;
             var overlaps = Array.Empty<IntervalTreeNode<ulong, MemoryPermission>>();
-            int count = 0;
+            int count;
 
             lock (_protections)
             {
                 count = _protections.Get(address, endAddress, ref overlaps);
-
-                Debug.Assert(count > 0);
 
                 if (count == 1 &&
                     overlaps[0].Start <= address &&
@@ -574,7 +572,7 @@ namespace Ryujinx.Memory.WindowsShared
         {
             ulong endAddress = address + size;
             var overlaps = Array.Empty<IntervalTreeNode<ulong, MemoryPermission>>();
-            int count = 0;
+            int count;
 
             lock (_protections)
             {


### PR DESCRIPTION
Removes the `count > 0` assert as it doesn't make sense, since count will be 0 if the protection didn't already exist before. Likely a leftover from one of my previous implementations before I arrived at the final version.

No impact on release builds, only impacts debug builds.