### PR TITLE
Fix shared memory leak on Windows

### DIFF
--- a/Ryujinx.Memory/MemoryBlock.cs
+++ b/Ryujinx.Memory/MemoryBlock.cs
@@ -48,7 +48,7 @@ namespace Ryujinx.Memory
             {
                 _viewCompatible = flags.HasFlag(MemoryAllocationFlags.ViewCompatible);
                 _forceWindows4KBView = flags.HasFlag(MemoryAllocationFlags.ForceWindows4KBViewMapping);
-                _pointer = MemoryManagement.Reserve(size, _viewCompatible);
+                _pointer = MemoryManagement.Reserve(size, _viewCompatible, _forceWindows4KBView);
             }
             else
             {
@@ -404,7 +404,7 @@ namespace Ryujinx.Memory
                 }
                 else
                 {
-                    MemoryManagement.Free(ptr);
+                    MemoryManagement.Free(ptr, Size, _forceWindows4KBView);
                 }
 
                 foreach (MemoryBlock viewStorage in _viewStorages.Keys)

--- a/Ryujinx.Memory/MemoryManagement.cs
+++ b/Ryujinx.Memory/MemoryManagement.cs
@@ -8,9 +8,7 @@ namespace Ryujinx.Memory
         {
             if (OperatingSystem.IsWindows())
             {
-                IntPtr sizeNint = new IntPtr((long)size);
-
-                return MemoryManagementWindows.Allocate(sizeNint);
+                return MemoryManagementWindows.Allocate((IntPtr)size);
             }
             else if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
             {
@@ -22,13 +20,11 @@ namespace Ryujinx.Memory
             }
         }
 
-        public static IntPtr Reserve(ulong size, bool viewCompatible)
+        public static IntPtr Reserve(ulong size, bool viewCompatible, bool force4KBMap)
         {
             if (OperatingSystem.IsWindows())
             {
-                IntPtr sizeNint = new IntPtr((long)size);
-
-                return MemoryManagementWindows.Reserve(sizeNint, viewCompatible);
+                return MemoryManagementWindows.Reserve((IntPtr)size, viewCompatible, force4KBMap);
             }
             else if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
             {
@@ -44,9 +40,7 @@ namespace Ryujinx.Memory
         {
             if (OperatingSystem.IsWindows())
             {
-                IntPtr sizeNint = new IntPtr((long)size);
-
-                return MemoryManagementWindows.Commit(address, sizeNint);
+                return MemoryManagementWindows.Commit(address, (IntPtr)size);
             }
             else if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
             {
@@ -62,9 +56,7 @@ namespace Ryujinx.Memory
         {
             if (OperatingSystem.IsWindows())
             {
-                IntPtr sizeNint = new IntPtr((long)size);
-
-                return MemoryManagementWindows.Decommit(address, sizeNint);
+                return MemoryManagementWindows.Decommit(address, (IntPtr)size);
             }
             else if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
             {
@@ -80,15 +72,13 @@ namespace Ryujinx.Memory
         {
             if (OperatingSystem.IsWindows())
             {
-                IntPtr sizeNint = new IntPtr((long)size);
-
                 if (force4KBMap)
                 {
-                    MemoryManagementWindows.MapView4KB(sharedMemory, srcOffset, address, sizeNint);
+                    MemoryManagementWindows.MapView4KB(sharedMemory, srcOffset, address, (IntPtr)size);
                 }
                 else
                 {
-                    MemoryManagementWindows.MapView(sharedMemory, srcOffset, address, sizeNint);
+                    MemoryManagementWindows.MapView(sharedMemory, srcOffset, address, (IntPtr)size);
                 }
             }
             else if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
@@ -105,15 +95,13 @@ namespace Ryujinx.Memory
         {
             if (OperatingSystem.IsWindows())
             {
-                IntPtr sizeNint = new IntPtr((long)size);
-
                 if (force4KBMap)
                 {
-                    MemoryManagementWindows.UnmapView4KB(address, sizeNint);
+                    MemoryManagementWindows.UnmapView4KB(address, (IntPtr)size);
                 }
                 else
                 {
-                    MemoryManagementWindows.UnmapView(sharedMemory, address, sizeNint);
+                    MemoryManagementWindows.UnmapView(sharedMemory, address, (IntPtr)size);
                 }
             }
             else if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
@@ -132,15 +120,13 @@ namespace Ryujinx.Memory
 
             if (OperatingSystem.IsWindows())
             {
-                IntPtr sizeNint = new IntPtr((long)size);
-
                 if (forView && force4KBMap)
                 {
-                    result = MemoryManagementWindows.Reprotect4KB(address, sizeNint, permission, forView);
+                    result = MemoryManagementWindows.Reprotect4KB(address, (IntPtr)size, permission, forView);
                 }
                 else
                 {
-                    result = MemoryManagementWindows.Reprotect(address, sizeNint, permission, forView);
+                    result = MemoryManagementWindows.Reprotect(address, (IntPtr)size, permission, forView);
                 }
             }
             else if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
@@ -158,11 +144,11 @@ namespace Ryujinx.Memory
             }
         }
 
-        public static bool Free(IntPtr address)
+        public static bool Free(IntPtr address, ulong size, bool force4KBMap)
         {
             if (OperatingSystem.IsWindows())
             {
-                return MemoryManagementWindows.Free(address);
+                return MemoryManagementWindows.Free(address, (IntPtr)size, force4KBMap);
             }
             else if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
             {
@@ -178,9 +164,7 @@ namespace Ryujinx.Memory
         {
             if (OperatingSystem.IsWindows())
             {
-                IntPtr sizeNint = new IntPtr((long)size);
-
-                return MemoryManagementWindows.CreateSharedMemory(sizeNint, reserve);
+                return MemoryManagementWindows.CreateSharedMemory((IntPtr)size, reserve);
             }
             else if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
             {

--- a/Ryujinx.Memory/WindowsShared/PlaceholderManager.cs
+++ b/Ryujinx.Memory/WindowsShared/PlaceholderManager.cs
@@ -205,7 +205,7 @@ namespace Ryujinx.Memory.WindowsShared
             ulong endAddress = startAddress + unmapSize;
 
             var overlaps = Array.Empty<IntervalTreeNode<ulong, ulong>>();
-            int count = 0;
+            int count;
 
             lock (_mappings)
             {
@@ -369,7 +369,7 @@ namespace Ryujinx.Memory.WindowsShared
             ulong endAddress = reprotectAddress + reprotectSize;
 
             var overlaps = Array.Empty<IntervalTreeNode<ulong, ulong>>();
-            int count = 0;
+            int count;
 
             lock (_mappings)
             {
@@ -474,13 +474,11 @@ namespace Ryujinx.Memory.WindowsShared
         {
             ulong endAddress = address + size;
             var overlaps = Array.Empty<IntervalTreeNode<ulong, MemoryPermission>>();
-            int count = 0;
+            int count;
 
             lock (_protections)
             {
                 count = _protections.Get(address, endAddress, ref overlaps);
-
-                Debug.Assert(count > 0);
 
                 if (count == 1 &&
                     overlaps[0].Start <= address &&
@@ -541,7 +539,7 @@ namespace Ryujinx.Memory.WindowsShared
         {
             ulong endAddress = address + size;
             var overlaps = Array.Empty<IntervalTreeNode<ulong, MemoryPermission>>();
-            int count = 0;
+            int count;
 
             lock (_protections)
             {
@@ -579,7 +577,7 @@ namespace Ryujinx.Memory.WindowsShared
         {
             ulong endAddress = address + size;
             var overlaps = Array.Empty<IntervalTreeNode<ulong, MemoryPermission>>();
-            int count = 0;
+            int count;
 
             lock (_protections)
             {

--- a/Ryujinx.Memory/WindowsShared/PlaceholderManager4KB.cs
+++ b/Ryujinx.Memory/WindowsShared/PlaceholderManager4KB.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Runtime.Versioning;
+
+namespace Ryujinx.Memory.WindowsShared
+{
+    /// <summary>
+    /// Windows 4KB memory placeholder manager.
+    /// </summary>
+    [SupportedOSPlatform("windows")]
+    class PlaceholderManager4KB
+    {
+        private const int PageSize = MemoryManagementWindows.PageSize;
+
+        private readonly IntervalTree<ulong, byte> _mappings;
+
+        /// <summary>
+        /// Creates a new instance of the Windows 4KB memory placeholder manager.
+        /// </summary>
+        public PlaceholderManager4KB()
+        {
+            _mappings = new IntervalTree<ulong, byte>();
+        }
+
+        /// <summary>
+        /// Unmaps the specified range of memory and marks it as mapped internally.
+        /// </summary>
+        /// <remarks>
+        /// Since this marks the range as mapped, the expectation is that the range will be mapped after calling this method.
+        /// </remarks>
+        /// <param name="location">Memory address to unmap and mark as mapped</param>
+        /// <param name="size">Size of the range in bytes</param>
+        public void UnmapAndMarkRangeAsMapped(IntPtr location, IntPtr size)
+        {
+            ulong startAddress = (ulong)location;
+            ulong unmapSize = (ulong)size;
+            ulong endAddress = startAddress + unmapSize;
+
+            var overlaps = Array.Empty<IntervalTreeNode<ulong, byte>>();
+            int count = 0;
+
+            lock (_mappings)
+            {
+                count = _mappings.Get(startAddress, endAddress, ref overlaps);
+            }
+
+            for (int index = 0; index < count; index++)
+            {
+                var overlap = overlaps[index];
+
+                // Tree operations might modify the node start/end values, so save a copy before we modify the tree.
+                ulong overlapStart = overlap.Start;
+                ulong overlapEnd = overlap.End;
+                ulong overlapValue = overlap.Value;
+
+                _mappings.Remove(overlap);
+
+                ulong unmapStart = Math.Max(overlapStart, startAddress);
+                ulong unmapEnd = Math.Min(overlapEnd, endAddress);
+
+                if (overlapStart < startAddress)
+                {
+                    startAddress = overlapStart;
+                }
+
+                if (overlapEnd > endAddress)
+                {
+                    endAddress = overlapEnd;
+                }
+
+                ulong currentAddress = unmapStart;
+                while (currentAddress < unmapEnd)
+                {
+                    WindowsApi.UnmapViewOfFile2(WindowsApi.CurrentProcessHandle, (IntPtr)currentAddress, 2);
+                    currentAddress += PageSize;
+                }
+            }
+
+            _mappings.Add(startAddress, endAddress, 0);
+        }
+
+        /// <summary>
+        /// Unmaps views at the specified memory range.
+        /// </summary>
+        /// <param name="location">Address of the range</param>
+        /// <param name="size">Size of the range in bytes</param>
+        public void UnmapView(IntPtr location, IntPtr size)
+        {
+            ulong startAddress = (ulong)location;
+            ulong unmapSize = (ulong)size;
+            ulong endAddress = startAddress + unmapSize;
+
+            var overlaps = Array.Empty<IntervalTreeNode<ulong, byte>>();
+            int count = 0;
+
+            lock (_mappings)
+            {
+                count = _mappings.Get(startAddress, endAddress, ref overlaps);
+            }
+
+            for (int index = 0; index < count; index++)
+            {
+                var overlap = overlaps[index];
+
+                // Tree operations might modify the node start/end values, so save a copy before we modify the tree.
+                ulong overlapStart = overlap.Start;
+                ulong overlapEnd = overlap.End;
+
+                _mappings.Remove(overlap);
+
+                if (overlapStart < startAddress)
+                {
+                    _mappings.Add(overlapStart, startAddress, 0);
+                }
+
+                if (overlapEnd > endAddress)
+                {
+                    _mappings.Add(endAddress, overlapEnd, 0);
+                }
+
+                ulong unmapStart = Math.Max(overlapStart, startAddress);
+                ulong unmapEnd = Math.Min(overlapEnd, endAddress);
+
+                ulong currentAddress = unmapStart;
+                while (currentAddress < unmapEnd)
+                {
+                    WindowsApi.UnmapViewOfFile2(WindowsApi.CurrentProcessHandle, (IntPtr)currentAddress, 2);
+                    currentAddress += PageSize;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Unmaps mapped memory at a given range.
+        /// </summary>
+        /// <param name="location">Address of the range</param>
+        /// <param name="size">Size of the range in bytes</param>
+        public void UnmapRange(IntPtr location, IntPtr size)
+        {
+            ulong startAddress = (ulong)location;
+            ulong unmapSize = (ulong)size;
+            ulong endAddress = startAddress + unmapSize;
+
+            var overlaps = Array.Empty<IntervalTreeNode<ulong, byte>>();
+            int count = 0;
+
+            lock (_mappings)
+            {
+                count = _mappings.Get(startAddress, endAddress, ref overlaps);
+            }
+
+            for (int index = 0; index < count; index++)
+            {
+                var overlap = overlaps[index];
+
+                // Tree operations might modify the node start/end values, so save a copy before we modify the tree.
+                ulong unmapStart = Math.Max(overlap.Start, startAddress);
+                ulong unmapEnd = Math.Min(overlap.End, endAddress);
+
+                _mappings.Remove(overlap);
+
+                ulong currentAddress = unmapStart;
+                while (currentAddress < unmapEnd)
+                {
+                    WindowsApi.UnmapViewOfFile2(WindowsApi.CurrentProcessHandle, (IntPtr)currentAddress, 2);
+                    currentAddress += PageSize;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes the following issues:
- Windows requires all view mappings to be unmapped to release the memory. Just closing the file mapping handle is not enough. This was not being done which caused several GBs of memory to leak after the emulation was stopped (or on multi-title games, after switching from one title to the other).
- When using forced 4KB view mapping, if the mapping was done on memory that was already mapped, it would fail. Now it unmaps the memory before mapping in this case. This matches the other implementation that does not work page-by-pagee.
- When using forced 4KB view mappings, if there was a region in memory adjacent with the regular mapping, it would try to coalesce the two which might be invalid as the placeholder manager does not keep track of those 4KB mappings. This was fixed by not reserving the range on the placeholder manager for those regions.
- `UnmapView` was updating the tree outside of the lock, which makes the code not thread safe, it could lead to corruption of the tree if two threads tried to unmap memory at the same time.
- The RO service session incrementss the memory manager reference count, and decrements it when the session is closed. But it was possible for it to not be decremeented if the `ArmProcessContext` was disposed before the session object was disposed. This is because the memory manager instance is set to null. This was fixed by storing the memory manager instance on the RO object.

The first 3 issues were validated with the following test (which is not included as it allocates 1GB of memory in the loop to ensure there's no memory leak, and I think this might be too high for a general test):
```cs
        [Test, Explicit]
        public void Test_AliasLeak()
        {
            for (int i = 0; i < 2000; i++)
            {
                using MemoryBlock backing = new MemoryBlock(0x40000000, MemoryAllocationFlags.Mirrorable);
                using MemoryBlock toAlias = new MemoryBlock(0x10000, MemoryAllocationFlags.Reserve | MemoryAllocationFlags.ViewCompatible);
                using MemoryBlock toAlias2 = new MemoryBlock(0x10000, MemoryAllocationFlags.Reserve | MemoryAllocationFlags.ViewCompatible | MemoryAllocationFlags.ForceWindows4KBViewMapping);

                toAlias.MapView(backing, 0x1000, 0, 0x4000);
                toAlias.MapView(backing, 0x1000, 0x2000, 0x4000);
                toAlias.MapView(backing, 0x1000, 0x4000, 0x4000);
                toAlias.MapView(backing, 0x9000, 0x8000, 0x4000);
                toAlias.UnmapView(backing, 0x3000, 0x1000);

                toAlias2.MapView(backing, 0x1000, 0, 0x4000);
                toAlias2.MapView(backing, 0x1000, 0x2000, 0x4000);
                toAlias2.MapView(backing, 0x1000, 0x4000, 0x4000);
                toAlias2.MapView(backing, 0x9000, 0x8000, 0x4000);
                toAlias2.UnmapView(backing, 0x3000, 0x1000);

                toAlias.Write(4, 0xcafe);
                toAlias2.Write(0, 0xbadc0de);
                Assert.AreEqual(Marshal.ReadInt32(backing.Pointer, 0x1004), 0xcafe);
                Assert.AreEqual(Marshal.ReadInt32(backing.Pointer, 0x1000), 0xbadc0de);
            }
        }
```
And the last fix was validated on Super Mario 64 from Super Mario 3D All Stars.
All these issues were introduced on #2954, although its possible that the memory leak already existed (I did not test if versions prior to that leaked when stopping and restarting emulation).
Testing is welcome as always.