### PR TITLE
Add alternative "GL" enum values for StencilOp

### DIFF
--- a/Ryujinx.Graphics.GAL/StencilOp.cs
+++ b/Ryujinx.Graphics.GAL/StencilOp.cs
@@ -9,6 +9,15 @@ namespace Ryujinx.Graphics.GAL
         DecrementAndClamp,
         Invert,
         IncrementAndWrap,
-        DecrementAndWrap
+        DecrementAndWrap,
+
+        ZeroGl              = 0x0,
+        InvertGl            = 0x150a,
+        KeepGl              = 0x1e00,
+        ReplaceGl           = 0x1e01,
+        IncrementAndClampGl = 0x1e02,
+        DecrementAndClampGl = 0x1e03,
+        IncrementAndWrapGl  = 0x8507,
+        DecrementAndWrapGl  = 0x8508
     }
 }

--- a/Ryujinx.Graphics.OpenGL/EnumConversion.cs
+++ b/Ryujinx.Graphics.OpenGL/EnumConversion.cs
@@ -379,20 +379,28 @@ namespace Ryujinx.Graphics.OpenGL
             switch (op)
             {
                 case GAL.StencilOp.Keep:
+                case GAL.StencilOp.KeepGl:
                     return OpenTK.Graphics.OpenGL.StencilOp.Keep;
                 case GAL.StencilOp.Zero:
+                case GAL.StencilOp.ZeroGl:
                     return OpenTK.Graphics.OpenGL.StencilOp.Zero;
                 case GAL.StencilOp.Replace:
+                case GAL.StencilOp.ReplaceGl:
                     return OpenTK.Graphics.OpenGL.StencilOp.Replace;
                 case GAL.StencilOp.IncrementAndClamp:
+                case GAL.StencilOp.IncrementAndClampGl:
                     return OpenTK.Graphics.OpenGL.StencilOp.Incr;
                 case GAL.StencilOp.DecrementAndClamp:
+                case GAL.StencilOp.DecrementAndClampGl:
                     return OpenTK.Graphics.OpenGL.StencilOp.Decr;
                 case GAL.StencilOp.Invert:
+                case GAL.StencilOp.InvertGl:
                     return OpenTK.Graphics.OpenGL.StencilOp.Invert;
                 case GAL.StencilOp.IncrementAndWrap:
+                case GAL.StencilOp.IncrementAndWrapGl:
                     return OpenTK.Graphics.OpenGL.StencilOp.IncrWrap;
                 case GAL.StencilOp.DecrementAndWrap:
+                case GAL.StencilOp.DecrementAndWrapGl:
                     return OpenTK.Graphics.OpenGL.StencilOp.DecrWrap;
             }
 


### PR DESCRIPTION
This PR adds the alternative enum values for StencilOp. Similar to the other enums, I added these with the same names but with Gl added to the end. These are used by homebrew using Nouveau, though they might be used by games with the official Vulkan driver.

Reference for the values from envytools:

https://github.com/envytools/envytools/blob/39d90be897f41434d67277ebdf244d6bd419ecd9/rnndb/graph/nv_3ddefs.xml#L77

Fixes some broken graphics in the Citra RetroArch core, such as missing shadows in Mario Kart 7. Likely fixes other homebrew.

Before:
![image](https://user-images.githubusercontent.com/6294155/166990025-a93a850a-0ec7-4ae3-8410-639901190c3e.png)

After:
![image](https://user-images.githubusercontent.com/6294155/166987632-3285be86-d120-4bae-89be-be3f300ba7f1.png)
