### PR TITLE
Prefetch capabilities before spawning translation threads.

### DIFF
--- a/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -82,19 +82,7 @@ namespace Ryujinx.Graphics.Gpu
         /// <summary>
         /// Host hardware capabilities.
         /// </summary>
-        internal ref Capabilities Capabilities
-        {
-            get
-            {
-                if (!_capsLoaded)
-                {
-                    _caps = Renderer.GetCapabilities();
-                    _capsLoaded = true;
-                }
-
-                return ref _caps;
-            }
-        }
+        internal ref Capabilities Capabilities => ref _caps;
 
         /// <summary>
         /// Event for signalling shader cache loading progress.
@@ -254,6 +242,8 @@ namespace Ryujinx.Graphics.Gpu
         public void SetGpuThread()
         {
             _gpuThread = Thread.CurrentThread;
+
+            _caps = Renderer.GetCapabilities();
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -82,15 +82,13 @@ namespace Ryujinx.Graphics.Gpu
         /// <summary>
         /// Host hardware capabilities.
         /// </summary>
-        internal ref Capabilities Capabilities => ref _caps;
+        internal Capabilities Capabilities { get; private set; }
 
         /// <summary>
         /// Event for signalling shader cache loading progress.
         /// </summary>
         public event Action<ShaderCacheState, int, int> ShaderCacheStateChanged;
 
-        private bool _capsLoaded;
-        private Capabilities _caps;
         private Thread _gpuThread;
 
         /// <summary>
@@ -243,7 +241,7 @@ namespace Ryujinx.Graphics.Gpu
         {
             _gpuThread = Thread.CurrentThread;
 
-            _caps = Renderer.GetCapabilities();
+            Capabilities = Renderer.GetCapabilities();
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/ParallelDiskCacheLoader.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/ParallelDiskCacheLoader.cs
@@ -231,6 +231,9 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         {
             Thread[] workThreads = new Thread[ThreadCount];
 
+            // Prefetch the capabilities, so that the async translation threads don't all try to fetch them at the same time.
+            Capabilities capabilities = _context.Capabilities;
+
             for (int index = 0; index < ThreadCount; index++)
             {
                 workThreads[index] = new Thread(ProcessAsyncQueue)

--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/ParallelDiskCacheLoader.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/ParallelDiskCacheLoader.cs
@@ -231,9 +231,6 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         {
             Thread[] workThreads = new Thread[ThreadCount];
 
-            // Prefetch the capabilities, so that the async translation threads don't all try to fetch them at the same time.
-            Capabilities capabilities = _context.Capabilities;
-
             for (int index = 0; index < ThreadCount; index++)
             {
                 workThreads[index] = new Thread(ProcessAsyncQueue)

--- a/Ryujinx.Headless.SDL2/WindowBase.cs
+++ b/Ryujinx.Headless.SDL2/WindowBase.cs
@@ -164,6 +164,7 @@ namespace Ryujinx.Headless.SDL2
 
             Device.Gpu.Renderer.RunLoop(() =>
             {
+                Device.Gpu.SetGpuThread();
                 Device.Gpu.InitializeShaderCache(_gpuCancellationTokenSource.Token);
                 Translator.IsReadyForTranslation.Set();
 


### PR DESCRIPTION
The Backend Multithreading only expects one thread to submit commands at a time. When compiling shaders, the translator may request the host GPU capabilities from the backend. It's possible for a bunch of translators to do this at the same time.

There's a caching mechanism in place so that the capabilities are only fetched once. By triggering this before spawning the thread, the async translation threads no longer try to queue onto the backend queue all at the same time.

The Capabilities do need to be checked from the GPU thread, due to OpenGL needing a context to check them, so it's not possible to call the underlying backend directly.