### PR TITLE
UI - Scale end framebuffer blit

### DIFF
--- a/Ryujinx.Ava/AppHost.cs
+++ b/Ryujinx.Ava/AppHost.cs
@@ -177,7 +177,7 @@ namespace Ryujinx.Ava
         {
             if (_renderer != null)
             {
-                double scale = Program.WindowScaleFactor;
+                double scale = _parent.PlatformImpl.RenderScaling;
                 _renderer.Window.SetSize((int)(size.Width * scale), (int)(size.Height * scale));
             }
         }
@@ -809,7 +809,7 @@ namespace Ryujinx.Ava
             Width = (int)Renderer.Bounds.Width;
             Height = (int)Renderer.Bounds.Height;
 
-            _renderer.Window.SetSize((int)(Width * Program.WindowScaleFactor), (int)(Height * Program.WindowScaleFactor));
+            _renderer.Window.SetSize((int)(Width * _parent.PlatformImpl.RenderScaling), (int)(Height * _parent.PlatformImpl.RenderScaling));
 
             Device.Gpu.Renderer.RunLoop(() =>
             {

--- a/Ryujinx.Ava/Ui/Controls/RendererControl.cs
+++ b/Ryujinx.Ava/Ui/Controls/RendererControl.cs
@@ -73,10 +73,13 @@ namespace Ryujinx.Ava.Ui.Controls
         {
             SizeChanged?.Invoke(this, rect.Size);
 
-            RenderSize = rect.Size * Program.WindowScaleFactor;
+            if (!rect.IsEmpty)
+            {
+                RenderSize = rect.Size * VisualRoot.RenderScaling;
 
-            _glDrawOperation?.Dispose();
-            _glDrawOperation = new GlDrawOperation(this);
+                _glDrawOperation?.Dispose();
+                _glDrawOperation = new GlDrawOperation(this);
+            }
         }
 
         public override void Render(DrawingContext context)

--- a/Ryujinx.Ava/Ui/Windows/MainWindow.axaml.cs
+++ b/Ryujinx.Ava/Ui/Windows/MainWindow.axaml.cs
@@ -123,10 +123,6 @@ namespace Ryujinx.Ava.Ui.Windows
                 CheckLaunchState();
             }
 
-            if (OperatingSystem.IsLinux())
-            {
-                Program.WindowScaleFactor = this.PlatformImpl.RenderScaling;
-            }
             _rendererWaitEvent = new AutoResetEvent(false);
         }
 

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -114,12 +114,12 @@ namespace Ryujinx.Ui
 
                 GL.BlitFramebuffer(0,
                     0,
-                    AllocatedWidth,
-                    AllocatedHeight,
+                    (int)(AllocatedWidth * Program.WindowScaleFactor),
+                    (int)(AllocatedHeight * Program.WindowScaleFactor),
                     0,
                     0,
-                    AllocatedWidth,
-                    AllocatedHeight,
+                    (int)(AllocatedWidth * Program.WindowScaleFactor),
+                    (int)(AllocatedHeight * Program.WindowScaleFactor),
                     ClearBufferMask.ColorBufferBit,
                     BlitFramebufferFilter.Linear);
             }

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -118,8 +118,8 @@ namespace Ryujinx.Ui
                     (int)(AllocatedHeight * Program.WindowScaleFactor),
                     0,
                     0,
-                    (int)(AllocatedWidth * Program.WindowScaleFactor),
-                    (int)(AllocatedHeight * Program.WindowScaleFactor),
+                    WindowWidth,
+                    WindowHeight,
                     ClearBufferMask.ColorBufferBit,
                     BlitFramebufferFilter.Linear);
             }

--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -114,8 +114,8 @@ namespace Ryujinx.Ui
 
                 GL.BlitFramebuffer(0,
                     0,
-                    (int)(AllocatedWidth * Program.WindowScaleFactor),
-                    (int)(AllocatedHeight * Program.WindowScaleFactor),
+                    WindowWidth,
+                    WindowHeight,
                     0,
                     0,
                     WindowWidth,

--- a/Ryujinx/Ui/RendererWidgetBase.cs
+++ b/Ryujinx/Ui/RendererWidgetBase.cs
@@ -41,6 +41,8 @@ namespace Ryujinx.Ui
         public IRenderer Renderer { get; private set; }
 
         public bool ScreenshotRequested { get; set; }
+        protected int WindowWidth { get; private set; }
+        protected int WindowHeight { get; private set; }
 
         public static event EventHandler<StatusUpdatedEventArgs> StatusUpdatedEvent;
 
@@ -71,9 +73,6 @@ namespace Ryujinx.Ui
         private IKeyboard _keyboardInterface;
         private GraphicsDebugLevel _glLogLevel;
         private string _gpuVendorName;
-
-        private int _windowHeight;
-        private int _windowWidth;
         private bool _isMouseInClient;
 
         public RendererWidgetBase(InputManager inputManager, GraphicsDebugLevel glLogLevel)
@@ -223,10 +222,10 @@ namespace Ryujinx.Ui
 
             Gdk.Monitor monitor = Display.GetMonitorAtWindow(Window);
 
-            _windowWidth = evnt.Width * monitor.ScaleFactor;
-            _windowHeight = evnt.Height * monitor.ScaleFactor;
+            WindowWidth = evnt.Width * monitor.ScaleFactor;
+            WindowHeight = evnt.Height * monitor.ScaleFactor;
 
-            Renderer?.Window.SetSize(_windowWidth, _windowHeight);
+            Renderer?.Window.SetSize(WindowWidth, WindowHeight);
 
             return result;
         }
@@ -307,7 +306,7 @@ namespace Ryujinx.Ui
             }
 
             Renderer = renderer;
-            Renderer?.Window.SetSize(_windowWidth, _windowHeight);
+            Renderer?.Window.SetSize(WindowWidth, WindowHeight);
 
             if (Renderer != null)
             {


### PR DESCRIPTION
Scales the blit to the window's framebuffer. Should fix rendering when desktop scaling is over 150%