### PR TITLE
Fix audio renderer error message result code base

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/AudioRendererServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/AudioRendererServer.cs
@@ -83,7 +83,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             }
             else
             {
-                Logger.Error?.Print(LogClass.ServiceAudio, $"Error while processing renderer update: 0x{result}");
+                Logger.Error?.Print(LogClass.ServiceAudio, $"Error while processing renderer update: 0x{(int)result:X}");
             }
 
             return result;


### PR DESCRIPTION
The error message has a `0x` prefix which leads one to believe that the number of hexadecimal, but since there's no specifier for the number base it will just print as decimal, or in some cases it will just display 0x followed by the result name, if it's on the result code enum. Fix this by casting the result to integer and using the `:X` specifier to print as hex.

This just changes how the error is printed on the log/console, should have no other effect.