### PR TITLE
Don't force DPI aware on Avalonia

### DIFF
--- a/Ryujinx.Ava/Program.cs
+++ b/Ryujinx.Ava/Program.cs
@@ -137,7 +137,6 @@ namespace Ryujinx.Ava
             }
 
             // Make process DPI aware for proper window sizing on high-res screens.
-            ForceDpiAware.Windows();
             WindowScaleFactor = ForceDpiAware.GetWindowScaleFactor();
 
             // Delete backup files after updating.


### PR DESCRIPTION
Fixes an issue where per-monitor DPI was not working - it would just select the lowest DPI and scale the window surface up when moving to other monitors instead of switching application DPI. I guess avalonia already has this under control, so no need to tell windows any different. Makes things a little sharper on my 2nd screen.

It's worth noting that GTK doesn't support this at all.

Before:
![image](https://user-images.githubusercontent.com/6294155/169663830-3f10f141-2f55-4eec-bef1-a676f7537f20.png)

After:
![image](https://user-images.githubusercontent.com/6294155/169663838-47a021d2-0b79-4f9d-a336-4f46ba732e1b.png)