### PR TITLE
Fix a potential GPFIFO submission race

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostChannel/NvHostChannelDeviceFile.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostChannel/NvHostChannelDeviceFile.cs
@@ -429,8 +429,6 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostChannel
                 Channel.PushHostCommandBuffer(CreateWaitCommandBuffer(header.Fence));
             }
 
-            Channel.PushEntries(entries);
-
             header.Fence.Id = _channelSyncpoint.Id;
 
             if (header.Flags.HasFlag(SubmitGpfifoFlags.FenceIncrement) || header.Flags.HasFlag(SubmitGpfifoFlags.IncrementWithValue))
@@ -448,6 +446,8 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostChannel
             {
                 header.Fence.Value = _device.System.HostSyncpoint.ReadSyncpointMaxValue(header.Fence.Id);
             }
+
+            Channel.PushEntries(entries);
 
             if (header.Flags.HasFlag(SubmitGpfifoFlags.FenceIncrement))
             {


### PR DESCRIPTION
The syncpoint maximum value represents the maximum possible syncpt value at a given time, however due to PBs being submitted before max was incremented, for a brief moment of time this is not the case which could lead to invalid behaviour if a game waits on the fence at that specific time.