### PR TITLE
Allow concurrent BSD EventFd read/write

### DIFF
--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -309,7 +309,7 @@ namespace Ryujinx.HLE.HOS
             // only then doing connections to SM is safe.
             SmServer.InitDone.WaitOne();
 
-            BsdServer = new ServerBase(KernelContext, "BsdServer");
+            BsdServer = new ServerBase(KernelContext, "BsdServer", null, 2);
             AudRenServer = new ServerBase(KernelContext, "AudioRendererServer");
             AudOutServer = new ServerBase(KernelContext, "AudioOutServer");
             FsServer = new ServerBase(KernelContext, "FsServer");

--- a/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
@@ -735,11 +735,12 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
             ulong argsPtr,
             ulong stackTop,
             int priority,
-            int cpuCore)
+            int cpuCore,
+            ThreadStart customThreadStart = null)
         {
             lock (_processLock)
             {
-                return thread.Initialize(entrypoint, argsPtr, stackTop, priority, cpuCore, this, ThreadType.User, null);
+                return thread.Initialize(entrypoint, argsPtr, stackTop, priority, cpuCore, this, ThreadType.User, customThreadStart);
             }
         }
 

--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
@@ -2351,6 +2351,18 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             int priority,
             int cpuCore)
         {
+            return CreateThread(out handle, entrypoint, argsPtr, stackTop, priority, cpuCore, null);
+        }
+
+        public KernelResult CreateThread(
+            out int handle,
+            ulong entrypoint,
+            ulong argsPtr,
+            ulong stackTop,
+            int priority,
+            int cpuCore,
+            ThreadStart customThreadStart)
+        {
             handle = 0;
 
             KProcess currentProcess = KernelStatic.GetCurrentProcess();
@@ -2386,7 +2398,8 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
                 argsPtr,
                 stackTop,
                 priority,
-                cpuCore);
+                cpuCore,
+                customThreadStart);
 
             if (result == KernelResult.Success)
             {

--- a/Ryujinx.HLE/HOS/Services/ServerBase.cs
+++ b/Ryujinx.HLE/HOS/Services/ServerBase.cs
@@ -1,3 +1,4 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Ipc;
 using Ryujinx.HLE.HOS.Kernel;
 using Ryujinx.HLE.HOS.Kernel.Common;
@@ -38,15 +39,18 @@ namespace Ryujinx.HLE.HOS.Services
         private readonly Dictionary<int, Func<IpcService>> _ports = new Dictionary<int, Func<IpcService>>();
 
         public ManualResetEvent InitDone { get; }
-        public Func<IpcService> SmObjectFactory { get; }
         public string Name { get; }
+        public Func<IpcService> SmObjectFactory { get; }
 
-        public ServerBase(KernelContext context, string name, Func<IpcService> smObjectFactory = null)
+        private int _threadCount;
+
+        public ServerBase(KernelContext context, string name, Func<IpcService> smObjectFactory = null, int threadCount = 1)
         {
             InitDone = new ManualResetEvent(false);
+            _context = context;
             Name = name;
             SmObjectFactory = smObjectFactory;
-            _context = context;
+            _threadCount = threadCount;
 
             const ProcessCreationFlags flags =
                 ProcessCreationFlags.EnableAslr |
@@ -56,7 +60,7 @@ namespace Ryujinx.HLE.HOS.Services
 
             ProcessCreationInfo creationInfo = new ProcessCreationInfo("Service", 1, 0, 0x8000000, 1, flags, 0, 0);
 
-            KernelStatic.StartInitialProcess(context, creationInfo, DefaultCapabilities, 44, ServerLoop);
+            KernelStatic.StartInitialProcess(context, creationInfo, DefaultCapabilities, 44, Main);
         }
 
         private void AddPort(int serverPortHandle, Func<IpcService> objectFactory)
@@ -78,6 +82,32 @@ namespace Ryujinx.HLE.HOS.Services
         {
             _sessionHandles.Add(serverSessionHandle);
             _sessions.Add(serverSessionHandle, obj);
+        }
+
+        private void Main()
+        {
+            for (int i = 1; i < _threadCount; i++)
+            {
+                KernelResult result = _context.Syscall.CreateThread(out int threadHandle, 0UL, 0UL, 0UL, 44, 3, ServerLoop);
+
+                if (result == KernelResult.Success)
+                {
+                    result = _context.Syscall.StartThread(threadHandle);
+
+                    if (result != KernelResult.Success)
+                    {
+                        Logger.Error?.Print(LogClass.Service, $"Failed to start thread on {Name}: {result}");
+                    }
+
+                    _context.Syscall.CloseHandle(threadHandle);
+                }
+                else
+                {
+                    Logger.Error?.Print(LogClass.Service, $"Failed to create thread on {Name}: {result}");
+                }
+            }
+
+            ServerLoop();
         }
 
         private void ServerLoop()

--- a/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Impl/EventFileDescriptor.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Impl/EventFileDescriptor.cs
@@ -8,7 +8,6 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
     {
         private ulong _value;
         private readonly EventFdFlags _flags;
-        private AutoResetEvent _event;
 
         private object _lock = new object();
 
@@ -21,7 +20,6 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
         {
             _value = value;
             _flags = flags;
-            _event = new AutoResetEvent(false);
 
             WriteEvent = new ManualResetEvent(true);
             ReadEvent = new ManualResetEvent(true);
@@ -31,7 +29,6 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
 
         public void Dispose()
         {
-            _event.Dispose();
             WriteEvent.Dispose();
             ReadEvent.Dispose();
         }
@@ -57,7 +54,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                     {
                         while (_value == 0)
                         {
-                            _event.WaitOne();
+                            Monitor.Wait(_lock);
                         }
                     }
                     else
@@ -106,7 +103,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                 {
                     if (Blocking)
                     {
-                        _event.WaitOne();
+                        Monitor.Wait(_lock);
                     }
                     else
                     {
@@ -119,7 +116,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                 writeSize = sizeof(ulong);
 
                 _value += count;
-                _event.Set();
+                Monitor.Pulse(_lock);
 
                 WriteEvent.Set();
 


### PR DESCRIPTION
The `Read` and `Write` methods are supposed to be called from different threads, but there are two issues that prevents it from working in some cases:
- Currently only one thread is processing BSD IPC requests. So if any of the methods blocks, it will be unable to process requests submitted from other guest threads. This means that if one thread calls blocking `Read` and another calls `Write` after, the `Write` request will never be processed because it will be blocked on `Read`.
- Both `Read` and `Write` methods are taking the same lock. So even if the issue above didn't exist, calling both methods would result in a deadlock.

To fix the first issue I have changed `ServerBase` and added a new optional argument that allows one to specify a thread count, which defaults to 1. This thread count is the number of threads used to service requests for that service. With that implemented, I changed BSD to now use 2 threads for processing requests

For the second issue, I removed the event that it waits on and replaced the event wait and set calls with `Monitor.Wait` and `Monitor.Pulse`. `Monitor.Wait` atomically releases the lock, wait until the object is signaled, and then tries to re-acquire the lock, so it does not cause deadlock because while it is waiting, the lock is released.

This fixes a regression in Diablo 2 where the game would just hang on a black screen on boot. It was likely introduced on #2960 since that's when this code was added, but I did not test it to confirm.
![image](https://user-images.githubusercontent.com/5624669/172069439-c74a19a9-c0f9-4f6e-b3b9-bee9fb8ba0f4.png)