### PR TITLE
Ignore ClipControl on draw texture fallback

### DIFF
--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -597,6 +597,8 @@ namespace Ryujinx.Graphics.OpenGL
                         GL.EndTransformFeedback();
                     }
 
+                    GL.ClipControl(ClipOrigin.UpperLeft, ClipDepthMode.NegativeOneToOne);
+
                     _drawTexture.Draw(
                         view,
                         samp,
@@ -627,6 +629,8 @@ namespace Ryujinx.Graphics.OpenGL
                     {
                         GL.BeginTransformFeedback(_tfTopology);
                     }
+
+                    RestoreClipControl();
                 }
             }
         }


### PR DESCRIPTION
When using the draw textures fallback (used when the NV_draw_texture extension is not supported), we should ignore current ClipControl settings, otherwise it can cause the viewport to be flipped. That was causing some games to be upside down on AMD and Intel, like Moero Chronicles and friends (fox example, see https://github.com/Ryujinx/Ryujinx-Games-List/issues/182#issuecomment-1147521009). NVIDIA is not affected because it supports the NV_draw_texture extension and ClipControl does not seem to affect DrawTexture.