### PR TITLE
Fix instanced indexed inline draw index count

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Threed/IbStreamer.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/IbStreamer.cs
@@ -21,6 +21,11 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         public bool HasInlineIndexData => _inlineIndexCount != 0;
 
         /// <summary>
+        /// Total numbers of indices that have been pushed.
+        /// </summary>
+        public int InlineIndexCount => _inlineIndexCount;
+
+        /// <summary>
         /// Gets the handle for the host buffer currently holding the inline index buffer data.
         /// </summary>
         /// <returns>Host buffer handle</returns>


### PR DESCRIPTION
#3383 fixed the issue where the index buffer, count and potentially draw type would be incorrect. However, it still had one issue. The index count used on the draw would be the total index count for all instances, which causes it to overdraw. This fixes the issue now passing the count for a single instance.

For example, below you can see the counts before and after on RenderDoc:
Before:
![image](https://user-images.githubusercontent.com/5624669/172210760-caa51dc6-5bcc-416c-9450-b9a447b9f548.png)
After:
![image](https://user-images.githubusercontent.com/5624669/172210841-099b90a8-dd0a-417d-b626-7c9b90b0fbba.png)
On the games the original fix was targeting, this did not cause visual issues (which is why I didn't notice it was wrong), only performance issues from it drawing the same thing over and over. So now the game is a bit faster on those 3D sections.