### PR TITLE
Update VSync message

### DIFF
--- a/Ryujinx/Ui/Windows/SettingsWindow.glade
+++ b/Ryujinx/Ui/Windows/SettingsWindow.glade
@@ -1477,7 +1477,7 @@
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">False</property>
-                                    <property name="tooltip-text" translatable="yes">Enables or disables Vertical Sync</property>
+                                    <property name="tooltip-text" translatable="yes">Enables or disables guest Vertical Sync. This may speed up the game beyond what was intended or increase loading times.</property>
                                     <property name="halign">start</property>
                                     <property name="margin-top">5</property>
                                     <property name="margin-bottom">5</property>

--- a/Ryujinx/Ui/Windows/SettingsWindow.glade
+++ b/Ryujinx/Ui/Windows/SettingsWindow.glade
@@ -1477,7 +1477,7 @@
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">False</property>
-                                    <property name="tooltip-text" translatable="yes">Enables or disables guest Vertical Sync. This may speed up the game beyond what was intended or increase loading times.</property>
+                                    <property name="tooltip-text" translatable="yes">Enables or disables guest Vertical Sync. Disabling VSync may speed up the game beyond what was intended or increase loading times.</property>
                                     <property name="halign">start</property>
                                     <property name="margin-top">5</property>
                                     <property name="margin-bottom">5</property>


### PR DESCRIPTION
Lets the end user know that the VSync option is controlling the guest VSync, not the host. With a message saying that the game may be sped up if if is disabled. I see this being a common issue with people in the Discord and hopefully at least one person doesn't make the mistake thanks to this change aha