### PR TITLE
Less invasive fix for EventFd blocking operations

### DIFF
--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -309,7 +309,7 @@ namespace Ryujinx.HLE.HOS
             // only then doing connections to SM is safe.
             SmServer.InitDone.WaitOne();
 
-            BsdServer = new ServerBase(KernelContext, "BsdServer", null, 2);
+            BsdServer = new ServerBase(KernelContext, "BsdServer");
             AudRenServer = new ServerBase(KernelContext, "AudioRendererServer");
             AudOutServer = new ServerBase(KernelContext, "AudioOutServer");
             FsServer = new ServerBase(KernelContext, "FsServer");

--- a/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Impl/EventFileDescriptor.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Impl/EventFileDescriptor.cs
@@ -18,6 +18,11 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
 
         public EventFileDescriptor(ulong value, EventFdFlags flags)
         {
+            // FIXME: We should support blocking operations.
+            // Right now they can't be supported because it would cause the
+            // service to lock up as we only have one thread processing requests.
+            flags |= EventFdFlags.NonBlocking;
+
             _value = value;
             _flags = flags;
 


### PR DESCRIPTION
https://github.com/Ryujinx/Ryujinx/pull/3385 fixed a issue where blocking Read/Write operations would prevent all sockets requests from being processed, because only one thread was processing them. However, it introduced another issue. Since right now the IPC processing is not thread safe, it was breaking in some games that uses sockets. like Pokémon Sword/Shield, where the game would crash after a few seconds with the following exception:
```
Unhandled exception. System.NotImplementedException: HipcResponse
```
It seems to indicate one thread is trying to process TLS where a response was just written by another thread.
In order to fix this, I made it only use one thread for sockets again, and to avoid regressing Diablo 2 again I forced the non-blocking flag to prevent the thread from blocking. I tested and it is still working with this, while fixing the regression on Pokémon. Also added a comment since we need to address this limitation in the future, but it will be more complicated, hence why I decided to submit this quick fix.

Testing is welcome.