### PR TITLE
Fix doubling of detected gamepads (sometimes the connected event is fired when the app starts even though the pad was connected for some time now).

### DIFF
--- a/Ryujinx.Input.SDL2/SDL2GamepadDriver.cs
+++ b/Ryujinx.Input.SDL2/SDL2GamepadDriver.cs
@@ -79,6 +79,11 @@ namespace Ryujinx.Input.SDL2
                     return;
                 }
 
+                // sometimes a JoyStick connected event fires after the app starts even though it was connected before
+                // so it is rejected to avoid doubling the entries
+                if (_gamepadsIds.Contains(id))
+                    return;
+
                 if (_gamepadsInstanceIdsMapping.TryAdd(joystickInstanceId, id))
                 {
                     _gamepadsIds.Add(id);


### PR DESCRIPTION
The fix rejects the gamepad if one with the same ID is already present.

Here is a screenshot of the issue in action:
![image](https://user-images.githubusercontent.com/11345822/173246159-0a674a90-bf5d-4b91-b201-da305a481426.png)

