### PR TITLE
Optimize Texture Binding and Shader Specialization Checks

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Compute/ComputeClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Compute/ComputeClass.cs
@@ -237,7 +237,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Compute
 
             _channel.TextureManager.SetComputeMaxBindings(maxTextureBinding, maxImageBinding);
 
-            _channel.TextureManager.CommitComputeBindings(cs.SpecializationState); // Should be up to date, since the shader was fetched above.
+            // Should never return false for mismatching spec state, since the shader was fetched above.
+            _channel.TextureManager.CommitComputeBindings(cs.SpecializationState); 
             
             _channel.BufferManager.CommitComputeBindings();
 

--- a/Ryujinx.Graphics.Gpu/Engine/Compute/ComputeClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Compute/ComputeClass.cs
@@ -188,6 +188,9 @@ namespace Ryujinx.Graphics.Gpu.Engine.Compute
             _channel.BufferManager.SetComputeStorageBufferBindings(info.SBuffers);
             _channel.BufferManager.SetComputeUniformBufferBindings(info.CBuffers);
 
+            int maxTextureBinding = 0;
+            int maxImageBinding = 0;
+
             TextureBindingInfo[] textureBindings = _channel.TextureManager.RentComputeTextureBindings(info.Textures.Count);
 
             for (int index = 0; index < info.Textures.Count; index++)
@@ -202,6 +205,11 @@ namespace Ryujinx.Graphics.Gpu.Engine.Compute
                     descriptor.CbufSlot,
                     descriptor.HandleIndex,
                     descriptor.Flags);
+
+                if (descriptor.Binding > maxTextureBinding)
+                {
+                    maxTextureBinding = descriptor.Binding;
+                }
             }
 
             TextureBindingInfo[] imageBindings = _channel.TextureManager.RentComputeImageBindings(info.Images.Count);
@@ -220,9 +228,17 @@ namespace Ryujinx.Graphics.Gpu.Engine.Compute
                     descriptor.CbufSlot,
                     descriptor.HandleIndex,
                     descriptor.Flags);
+
+                if (descriptor.Binding > maxImageBinding)
+                {
+                    maxImageBinding = descriptor.Binding;
+                }
             }
 
-            _channel.TextureManager.CommitComputeBindings();
+            _channel.TextureManager.SetComputeMaxBindings(maxTextureBinding, maxImageBinding);
+
+            _channel.TextureManager.CommitComputeBindings(cs.SpecializationState); // Should be up to date, since the shader was fetched above.
+            
             _channel.BufferManager.CommitComputeBindings();
 
             _context.Renderer.Pipeline.DispatchCompute(qmd.CtaRasterWidth, qmd.CtaRasterHeight, qmd.CtaRasterDepth);

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -277,7 +277,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
             if (!_channel.TextureManager.CommitGraphicsBindings(_shaderSpecState))
             {
-                Logger.Error?.Print(LogClass.Gpu, "Oh my");
+                // Shader must be reloaded.
                 UpdateShaderState();
             }
 

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -201,7 +201,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             // of the shader for the new state.
             if (_shaderSpecState != null)
             {
-                if (!_shaderSpecState.MatchesGraphics(_channel, GetPoolState(), GetGraphicsState()))
+                if (!_shaderSpecState.MatchesGraphics(_channel, GetPoolState(), GetGraphicsState(), false))
                 {
                     ForceShaderUpdate();
                 }
@@ -275,7 +275,12 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         {
             UpdateStorageBuffers();
 
-            _channel.TextureManager.CommitGraphicsBindings();
+            if (!_channel.TextureManager.CommitGraphicsBindings(_shaderSpecState))
+            {
+                Logger.Error?.Print(LogClass.Gpu, "Oh my");
+                UpdateShaderState();
+            }
+
             _channel.BufferManager.CommitGraphicsBindings();
         }
 
@@ -1148,6 +1153,9 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 return;
             }
 
+            int maxTextureBinding = 0;
+            int maxImageBinding = 0;
+
             Span<TextureBindingInfo> textureBindings = _channel.TextureManager.RentGraphicsTextureBindings(stage, info.Textures.Count);
 
             if (info.UsesRtLayer)
@@ -1167,6 +1175,11 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                     descriptor.CbufSlot,
                     descriptor.HandleIndex,
                     descriptor.Flags);
+
+                if (descriptor.Binding > maxTextureBinding)
+                {
+                    maxTextureBinding = descriptor.Binding;
+                }
             }
 
             TextureBindingInfo[] imageBindings = _channel.TextureManager.RentGraphicsImageBindings(stage, info.Images.Count);
@@ -1185,7 +1198,14 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                     descriptor.CbufSlot,
                     descriptor.HandleIndex,
                     descriptor.Flags);
+
+                if (descriptor.Binding > maxImageBinding)
+                {
+                    maxImageBinding = descriptor.Binding;
+                }
             }
+
+            _channel.TextureManager.SetGraphicsMaxBindings(maxTextureBinding, maxImageBinding);
 
             _channel.BufferManager.SetGraphicsStorageBufferBindings(stage, info.SBuffers);
             _channel.BufferManager.SetGraphicsUniformBufferBindings(stage, info.CBuffers);

--- a/Ryujinx.Graphics.Gpu/Image/Sampler.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Sampler.cs
@@ -9,6 +9,11 @@ namespace Ryujinx.Graphics.Gpu.Image
     class Sampler : IDisposable
     {
         /// <summary>
+        /// True if the sampler is disposed, false otherwise.
+        /// </summary>
+        public bool IsDisposed { get; private set; }
+
+        /// <summary>
         /// Host sampler object.
         /// </summary>
         private readonly ISampler _hostSampler;
@@ -101,6 +106,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         public void Dispose()
         {
+            IsDisposed = true;
+
             _hostSampler.Dispose();
             _anisoSampler?.Dispose();
         }

--- a/Ryujinx.Graphics.Gpu/Image/SamplerPool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/SamplerPool.cs
@@ -8,7 +8,6 @@ namespace Ryujinx.Graphics.Gpu.Image
     class SamplerPool : Pool<Sampler, SamplerDescriptor>
     {
         private float _forcedAnisotropy;
-        private int _modifiedSequenceNumber;
 
         /// <summary>
         /// Constructs a new instance of the sampler pool.
@@ -53,10 +52,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 SequenceNumber = Context.SequenceNumber;
 
-                if (SynchronizeMemory())
-                {
-                    _modifiedSequenceNumber = SequenceNumber;
-                }
+                SynchronizeMemory();
             }
 
             Sampler sampler = Items[id];
@@ -78,7 +74,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <summary>
         /// Checks if the pool was modified, and returns the last sequence number where a modification was detected.
         /// </summary>
-        /// <returns>The last sequence number where a modification was detected</returns>
+        /// <returns>A number that increments each time a modification is detected</returns>
         public int CheckModified()
         {
             if (SequenceNumber != Context.SequenceNumber)
@@ -99,16 +95,13 @@ namespace Ryujinx.Graphics.Gpu.Image
                         }
                     }
 
-                    _modifiedSequenceNumber = SequenceNumber;
+                    UpdateModifiedSequence();
                 }
 
-                if (SynchronizeMemory())
-                {
-                    _modifiedSequenceNumber = SequenceNumber;
-                }
+                SynchronizeMemory();
             }
 
-            return _modifiedSequenceNumber;
+            return ModifiedSequenceNumber;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -100,6 +100,11 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         public bool AlwaysFlushOnOverlap { get; private set; }
 
+        /// <summary>
+        /// Increments when the host texture is swapped, or when the texture is removed from all pools.
+        /// </summary>
+        public int InvalidatedSequence { get; private set; }
+
         private int _depth;
         private int _layers;
         public int FirstLayer { get; private set; }
@@ -1407,6 +1412,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             DisposeTextures();
 
             HostTexture = hostTexture;
+            InvalidatedSequence++;
         }
 
         /// <summary>
@@ -1535,6 +1541,8 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 _poolOwners.Clear();
             }
+
+            InvalidatedSequence++;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -1,8 +1,12 @@
 using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Engine.Types;
+using Ryujinx.Graphics.Gpu.Memory;
+using Ryujinx.Graphics.Gpu.Shader;
 using Ryujinx.Graphics.Shader;
 using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace Ryujinx.Graphics.Gpu.Image
 {
@@ -11,7 +15,7 @@ namespace Ryujinx.Graphics.Gpu.Image
     /// </summary>
     class TextureBindingsManager : IDisposable
     {
-        private const int InitialTextureStateSize = 32;
+        private const int InitialTextureStateSize = 32; // Should match binding range for host.
         private const int InitialImageStateSize = 8;
 
         private readonly GpuContext _context;
@@ -35,17 +39,21 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             public ITexture Texture;
             public ISampler Sampler;
+
+            public int TextureHandle;
+            public int SamplerHandle;
+            public int InvalidatedSequence;
+            public Texture CachedTexture;
+            public Sampler CachedSampler;
         }
 
-        private readonly TextureStatePerStage[][] _textureState;
-        private readonly TextureStatePerStage[][] _imageState;
+        private TextureStatePerStage[] _textureState;
+        private TextureStatePerStage[] _imageState;
 
         private int[] _textureBindingsCount;
         private int[] _imageBindingsCount;
 
         private int _textureBufferIndex;
-
-        private bool _rebind;
 
         private readonly float[] _scales;
         private bool _scaleChanged;
@@ -72,8 +80,8 @@ namespace Ryujinx.Graphics.Gpu.Image
             _textureBindings = new TextureBindingInfo[stages][];
             _imageBindings   = new TextureBindingInfo[stages][];
 
-            _textureState = new TextureStatePerStage[stages][];
-            _imageState   = new TextureStatePerStage[stages][];
+            _textureState = new TextureStatePerStage[InitialTextureStateSize];
+            _imageState   = new TextureStatePerStage[InitialImageStateSize];
 
             _textureBindingsCount = new int[stages];
             _imageBindingsCount = new int[stages];
@@ -82,9 +90,6 @@ namespace Ryujinx.Graphics.Gpu.Image
             {
                 _textureBindings[stage] = new TextureBindingInfo[InitialTextureStateSize];
                 _imageBindings[stage] = new TextureBindingInfo[InitialImageStateSize];
-
-                _textureState[stage] = new TextureStatePerStage[InitialTextureStateSize];
-                _imageState[stage] = new TextureStatePerStage[InitialImageStateSize];
             }
         }
 
@@ -99,15 +104,6 @@ namespace Ryujinx.Graphics.Gpu.Image
             if (count > _textureBindings[stage].Length)
             {
                 Array.Resize(ref _textureBindings[stage], count);
-                Array.Resize(ref _textureState[stage], count);
-            }
-
-            int toClear = Math.Max(_textureBindingsCount[stage], count);
-            TextureStatePerStage[] state = _textureState[stage];
-
-            for (int i = 0; i < toClear; i++)
-            {
-                state[i] = new TextureStatePerStage();
             }
 
             _textureBindingsCount[stage] = count;
@@ -126,20 +122,29 @@ namespace Ryujinx.Graphics.Gpu.Image
             if (count > _imageBindings[stage].Length)
             {
                 Array.Resize(ref _imageBindings[stage], count);
-                Array.Resize(ref _imageState[stage], count);
-            }
-
-            int toClear = Math.Max(_imageBindingsCount[stage], count);
-            TextureStatePerStage[] state = _imageState[stage];
-
-            for (int i = 0; i < toClear; i++)
-            {
-                state[i] = new TextureStatePerStage();
             }
 
             _imageBindingsCount[stage] = count;
 
             return _imageBindings[stage];
+        }
+
+        /// <summary>
+        /// Sets the max binding indexes for textures and images.
+        /// </summary>
+        /// <param name="maxTextureBinding">The maximum texture binding</param>
+        /// <param name="maxImageBinding">The maximum image binding</param>
+        public void SetMaxBindings(int maxTextureBinding, int maxImageBinding)
+        {
+            if (maxTextureBinding >= _textureState.Length)
+            {
+                Array.Resize(ref _textureState, maxTextureBinding + 1);
+            }
+
+            if (maxImageBinding >= _imageState.Length)
+            {
+                Array.Resize(ref _imageState, maxImageBinding + 1);
+            }
         }
 
         /// <summary>
@@ -319,11 +324,16 @@ namespace Ryujinx.Graphics.Gpu.Image
             }
         }
 
+        private int _texturePoolSequence;
+        private int _samplerPoolSequence;
+
         /// <summary>
         /// Ensures that the bindings are visible to the host GPU.
         /// Note: this actually performs the binding using the host graphics API.
         /// </summary>
-        public void CommitBindings()
+        /// <param name="specState">Specialization state for the bound shader</param>
+        /// <returns>True if all bound textures match the current shader specialiation state, false otherwise</returns>
+        public bool CommitBindings(ShaderSpecializationState specState)
         {
             ulong texturePoolAddress = _texturePoolAddress;
 
@@ -331,10 +341,38 @@ namespace Ryujinx.Graphics.Gpu.Image
                 ? _texturePoolCache.FindOrCreate(_channel, texturePoolAddress, _texturePoolMaximumId)
                 : null;
 
+            // Check if the texture pool has been modified since bindings were last committed.
+            // If it wasn't, then it's possible to avoid looking up textures again when the handle remains the same.
+            bool poolModified = false;
+
+            if (texturePool != null)
+            {
+                int texturePoolSequence = texturePool.CheckModified();
+
+                if (_texturePoolSequence != texturePoolSequence)
+                {
+                    poolModified = true;
+                    _texturePoolSequence = texturePoolSequence;
+                }
+            }
+
+            if (_samplerPool != null)
+            {
+                int samplerPoolSequence = _samplerPool.CheckModified();
+
+                if (_samplerPoolSequence != samplerPoolSequence)
+                {
+                    poolModified = true;
+                    _samplerPoolSequence = samplerPoolSequence;
+                }
+            }
+
+            bool specStateMatches = true;
+
             if (_isCompute)
             {
-                CommitTextureBindings(texturePool, ShaderStage.Compute, 0);
-                CommitImageBindings  (texturePool, ShaderStage.Compute, 0);
+                specStateMatches &= CommitTextureBindings(texturePool, ShaderStage.Compute, 0, poolModified, specState);
+                specStateMatches &= CommitImageBindings(texturePool, ShaderStage.Compute, 0, poolModified, specState);
             }
             else
             {
@@ -342,14 +380,57 @@ namespace Ryujinx.Graphics.Gpu.Image
                 {
                     int stageIndex = (int)stage - 1;
 
-                    CommitTextureBindings(texturePool, stage, stageIndex);
-                    CommitImageBindings  (texturePool, stage, stageIndex);
+                    specStateMatches &= CommitTextureBindings(texturePool, stage, stageIndex, poolModified, specState);
+                    specStateMatches &= CommitImageBindings(texturePool, stage, stageIndex, poolModified, specState);
                 }
             }
 
             CommitRenderScale();
 
-            _rebind = false;
+            return specStateMatches;
+        }
+
+        /// <summary>
+        /// Fetch the constant buffers used for a texture to cache.
+        /// </summary>
+        /// <param name="stageIndex">Stage index of the constant buffer</param>
+        /// <param name="cachedTextureBufferIndex">The currently cached texture buffer index</param>
+        /// <param name="cachedSamplerBufferIndex">The currently cached sampler buffer index</param>
+        /// <param name="cachedTextureBuffer">The currently cached texture buffer data</param>
+        /// <param name="cachedSamplerBuffer">The currently cached sampler buffer data</param>
+        /// <param name="textureBufferIndex">The new texture buffer index</param>
+        /// <param name="samplerBufferIndex">The new sampler buffer index</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void UpdateCachedBuffer(
+            int stageIndex,
+            ref int cachedTextureBufferIndex,
+            ref int cachedSamplerBufferIndex,
+            ref ReadOnlySpan<int> cachedTextureBuffer,
+            ref ReadOnlySpan<int> cachedSamplerBuffer,
+            int textureBufferIndex,
+            int samplerBufferIndex)
+        {
+            if (textureBufferIndex != cachedTextureBufferIndex)
+            {
+                ref BufferBounds bounds = ref _channel.BufferManager.GetUniformBufferBounds(_isCompute, stageIndex, textureBufferIndex);
+
+                cachedTextureBuffer = MemoryMarshal.Cast<byte, int>(_channel.MemoryManager.Physical.GetSpan(bounds.Address, (int)bounds.Size));
+                cachedTextureBufferIndex = textureBufferIndex;
+
+                if (samplerBufferIndex == textureBufferIndex)
+                {
+                    cachedSamplerBuffer = cachedTextureBuffer;
+                    cachedSamplerBufferIndex = samplerBufferIndex;
+                }
+            }
+
+            if (cachedSamplerBufferIndex != samplerBufferIndex)
+            {
+                ref BufferBounds bounds = ref _channel.BufferManager.GetUniformBufferBounds(_isCompute, stageIndex, samplerBufferIndex);
+
+                cachedSamplerBuffer = MemoryMarshal.Cast<byte, int>(_channel.MemoryManager.Physical.GetSpan(bounds.Address, (int)bounds.Size));
+                cachedSamplerBufferIndex = samplerBufferIndex;
+            }
         }
 
         /// <summary>
@@ -358,13 +439,16 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         /// <param name="pool">The current texture pool</param>
         /// <param name="stage">The shader stage using the textures to be bound</param>
-        /// <param name="stageIndex">The stage number of the specified shader stage</param>
-        private void CommitTextureBindings(TexturePool pool, ShaderStage stage, int stageIndex)
+        /// <param name="stageIndex">The stage number of the specified shader stage</param
+        /// <param name="poolModified">True if either the texture or sampler pool was modified, false otherwise</param>
+        /// <param name="specState">Specialization state for the bound shader</param>
+        /// <returns>True if all bound textures match the current shader specialiation state, false otherwise</returns>
+        private bool CommitTextureBindings(TexturePool pool, ShaderStage stage, int stageIndex, bool poolModified, ShaderSpecializationState specState)
         {
             int textureCount = _textureBindingsCount[stageIndex];
             if (textureCount == 0)
             {
-                return;
+                return true;
             }
 
             var samplerPool = _samplerPool;
@@ -372,8 +456,15 @@ namespace Ryujinx.Graphics.Gpu.Image
             if (pool == null)
             {
                 Logger.Error?.Print(LogClass.Gpu, $"Shader stage \"{stage}\" uses textures, but texture pool was not set.");
-                return;
+                return true;
             }
+
+            bool specStateMatches = true;
+
+            int cachedTextureBufferIndex = -1;
+            int cachedSamplerBufferIndex = -1;
+            ReadOnlySpan<int> cachedTextureBuffer = Span<int>.Empty;
+            ReadOnlySpan<int> cachedSamplerBuffer = Span<int>.Empty;
 
             for (int index = 0; index < textureCount; index++)
             {
@@ -381,8 +472,10 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 (int textureBufferIndex, int samplerBufferIndex) = TextureHandle.UnpackSlots(bindingInfo.CbufSlot, _textureBufferIndex);
 
-                int packedId = ReadPackedId(stageIndex, bindingInfo.Handle, textureBufferIndex, samplerBufferIndex);
-                int textureId = UnpackTextureId(packedId);
+                UpdateCachedBuffer(stageIndex, ref cachedTextureBufferIndex, ref cachedSamplerBufferIndex, ref cachedTextureBuffer, ref cachedSamplerBuffer, textureBufferIndex, samplerBufferIndex);
+
+                int packedId = TextureHandle.ReadPackedId(bindingInfo.Handle, cachedTextureBuffer, cachedSamplerBuffer);
+                int textureId = TextureHandle.UnpackTextureId(packedId);
                 int samplerId;
 
                 if (_samplerIndex == SamplerIndex.ViaHeaderIndex)
@@ -394,7 +487,27 @@ namespace Ryujinx.Graphics.Gpu.Image
                     samplerId = UnpackSamplerId(packedId);
                 }
 
-                Texture texture = pool.Get(textureId);
+                ref TextureStatePerStage state = ref _textureState[bindingInfo.Binding];
+
+                if (!poolModified &&
+                    state.TextureHandle == textureId &&
+                    state.SamplerHandle == samplerId &&
+                    state.CachedTexture != null &&
+                    state.CachedTexture.InvalidatedSequence == state.InvalidatedSequence &&
+                    state.CachedSampler?.IsDisposed != true)
+                {
+                    // The texture is already bound.
+                    state.CachedTexture.SynchronizeMemory();
+
+                    continue;
+                }
+
+                state.TextureHandle = textureId;
+                state.SamplerHandle = samplerId;
+
+                ref readonly TextureDescriptor descriptor = ref pool.GetForBinding(textureId, out Texture texture);
+
+                specStateMatches &= specState.MatchesTexture(stage, index, descriptor);
 
                 ITexture hostTexture = texture?.GetTargetTexture(bindingInfo.Target);
 
@@ -407,30 +520,36 @@ namespace Ryujinx.Graphics.Gpu.Image
                 }
                 else
                 {
-                    if (_textureState[stageIndex][index].Texture != hostTexture || _rebind)
+                    if (state.Texture != hostTexture)
                     {
                         if (UpdateScale(texture, bindingInfo, index, stage))
                         {
                             hostTexture = texture?.GetTargetTexture(bindingInfo.Target);
                         }
 
-                        _textureState[stageIndex][index].Texture = hostTexture;
+                        state.Texture = hostTexture;
 
                         _context.Renderer.Pipeline.SetTexture(bindingInfo.Binding, hostTexture);
                     }
 
                     Sampler sampler = samplerPool?.Get(samplerId);
+                    state.CachedSampler = sampler;
 
                     ISampler hostSampler = sampler?.GetHostSampler(texture);
 
-                    if (_textureState[stageIndex][index].Sampler != hostSampler || _rebind)
+                    if (state.Sampler != hostSampler)
                     {
-                        _textureState[stageIndex][index].Sampler = hostSampler;
+                        state.Sampler = hostSampler;
 
                         _context.Renderer.Pipeline.SetSampler(bindingInfo.Binding, hostSampler);
                     }
+
+                    state.CachedTexture = texture;
+                    state.InvalidatedSequence = texture?.InvalidatedSequence ?? 0;
                 }
             }
+
+            return specStateMatches;
         }
 
         /// <summary>
@@ -440,22 +559,32 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="pool">The current texture pool</param>
         /// <param name="stage">The shader stage using the textures to be bound</param>
         /// <param name="stageIndex">The stage number of the specified shader stage</param>
-        private void CommitImageBindings(TexturePool pool, ShaderStage stage, int stageIndex)
+        /// <param name="poolModified">True if either the texture or sampler pool was modified, false otherwise</param>
+        /// <param name="specState">Specialization state for the bound shader</param>
+        /// <returns>True if all bound images match the current shader specialiation state, false otherwise</returns>
+        private bool CommitImageBindings(TexturePool pool, ShaderStage stage, int stageIndex, bool poolModified, ShaderSpecializationState specState)
         {
             int imageCount = _imageBindingsCount[stageIndex];
             if (imageCount == 0)
             {
-                return;
+                return true;
             }
 
             if (pool == null)
             {
                 Logger.Error?.Print(LogClass.Gpu, $"Shader stage \"{stage}\" uses images, but texture pool was not set.");
-                return;
+                return true;
             }
 
             // Scales for images appear after the texture ones.
             int baseScaleIndex = _textureBindingsCount[stageIndex];
+
+            int cachedTextureBufferIndex = -1;
+            int cachedSamplerBufferIndex = -1;
+            ReadOnlySpan<int> cachedTextureBuffer = Span<int>.Empty;
+            ReadOnlySpan<int> cachedSamplerBuffer = Span<int>.Empty;
+
+            bool specStateMatches = true;
 
             for (int index = 0; index < imageCount; index++)
             {
@@ -463,14 +592,38 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 (int textureBufferIndex, int samplerBufferIndex) = TextureHandle.UnpackSlots(bindingInfo.CbufSlot, _textureBufferIndex);
 
-                int packedId = ReadPackedId(stageIndex, bindingInfo.Handle, textureBufferIndex, samplerBufferIndex);
-                int textureId = UnpackTextureId(packedId);
+                UpdateCachedBuffer(stageIndex, ref cachedTextureBufferIndex, ref cachedSamplerBufferIndex, ref cachedTextureBuffer, ref cachedSamplerBuffer, textureBufferIndex, samplerBufferIndex);
 
-                Texture texture = pool.Get(textureId);
+                int packedId = TextureHandle.ReadPackedId(bindingInfo.Handle, cachedTextureBuffer, cachedSamplerBuffer);
+                int textureId = TextureHandle.UnpackTextureId(packedId);
 
-                ITexture hostTexture = texture?.GetTargetTexture(bindingInfo.Target);
+                ref TextureStatePerStage state = ref _imageState[bindingInfo.Binding];
 
                 bool isStore = bindingInfo.Flags.HasFlag(TextureUsageFlags.ImageStore);
+
+                if (!poolModified &&
+                    state.TextureHandle == textureId &&
+                    state.CachedTexture != null &&
+                    state.CachedTexture.InvalidatedSequence == state.InvalidatedSequence)
+                {
+                    // The texture is already bound.
+                    state.CachedTexture.SynchronizeMemory();
+
+                    if (isStore)
+                    {
+                        state.CachedTexture?.SignalModified();
+                    }
+
+                    continue;
+                }
+
+                state.TextureHandle = textureId;
+
+                ref readonly TextureDescriptor descriptor = ref pool.GetForBinding(textureId, out Texture texture);
+
+                specStateMatches &= specState.MatchesImage(stage, index, descriptor);
+
+                ITexture hostTexture = texture?.GetTargetTexture(bindingInfo.Target);
 
                 if (hostTexture != null && texture.Target == Target.TextureBuffer)
                 {
@@ -494,14 +647,14 @@ namespace Ryujinx.Graphics.Gpu.Image
                         texture?.SignalModified();
                     }
 
-                    if (_imageState[stageIndex][index].Texture != hostTexture || _rebind)
+                    if (state.Texture != hostTexture)
                     {
                         if (UpdateScale(texture, bindingInfo, baseScaleIndex + index, stage))
                         {
                             hostTexture = texture?.GetTargetTexture(bindingInfo.Target);
                         }
 
-                        _imageState[stageIndex][index].Texture = hostTexture;
+                        state.Texture = hostTexture;
 
                         Format format = bindingInfo.Format;
 
@@ -512,8 +665,13 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                         _context.Renderer.Pipeline.SetImage(bindingInfo.Binding, hostTexture, format);
                     }
+
+                    state.CachedTexture = texture;
+                    state.InvalidatedSequence = texture?.InvalidatedSequence ?? 0;
                 }
             }
+
+            return specStateMatches;
         }
 
         /// <summary>
@@ -537,7 +695,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             (int textureBufferIndex, int samplerBufferIndex) = TextureHandle.UnpackSlots(cbufSlot, bufferIndex);
 
             int packedId = ReadPackedId(stageIndex, handle, textureBufferIndex, samplerBufferIndex);
-            int textureId = UnpackTextureId(packedId);
+            int textureId = TextureHandle.UnpackTextureId(packedId);
 
             ulong poolAddress = _channel.MemoryManager.Translate(poolGpuVa);
 
@@ -555,13 +713,14 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="textureBufferIndex">Index of the constant buffer holding the texture handles</param>
         /// <param name="samplerBufferIndex">Index of the constant buffer holding the sampler handles</param>
         /// <returns>The packed texture and sampler ID (the real texture handle)</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private int ReadPackedId(int stageIndex, int wordOffset, int textureBufferIndex, int samplerBufferIndex)
         {
             (int textureWordOffset, int samplerWordOffset, TextureHandleType handleType) = TextureHandle.UnpackOffsets(wordOffset);
 
             ulong textureBufferAddress = _isCompute
-                ? _channel.BufferManager.GetComputeUniformBufferAddress(textureBufferIndex)
-                : _channel.BufferManager.GetGraphicsUniformBufferAddress(stageIndex, textureBufferIndex);
+                    ? _channel.BufferManager.GetComputeUniformBufferAddress(textureBufferIndex)
+                    : _channel.BufferManager.GetGraphicsUniformBufferAddress(stageIndex, textureBufferIndex);
 
             int handle = _channel.MemoryManager.Physical.Read<int>(textureBufferAddress + (uint)textureWordOffset * 4);
 
@@ -574,8 +733,8 @@ namespace Ryujinx.Graphics.Gpu.Image
             if (handleType != TextureHandleType.CombinedSampler)
             {
                 ulong samplerBufferAddress = _isCompute
-                    ? _channel.BufferManager.GetComputeUniformBufferAddress(samplerBufferIndex)
-                    : _channel.BufferManager.GetGraphicsUniformBufferAddress(stageIndex, samplerBufferIndex);
+                ? _channel.BufferManager.GetComputeUniformBufferAddress(samplerBufferIndex)
+                : _channel.BufferManager.GetGraphicsUniformBufferAddress(stageIndex, samplerBufferIndex);
 
                 int samplerHandle = _channel.MemoryManager.Physical.Read<int>(samplerBufferAddress + (uint)samplerWordOffset * 4);
 
@@ -588,16 +747,6 @@ namespace Ryujinx.Graphics.Gpu.Image
             }
 
             return handle;
-        }
-
-        /// <summary>
-        /// Unpacks the texture ID from the real texture handle.
-        /// </summary>
-        /// <param name="packedId">The real texture handle</param>
-        /// <returns>The texture ID</returns>
-        private static int UnpackTextureId(int packedId)
-        {
-            return (packedId >> 0) & 0xfffff;
         }
 
         /// <summary>
@@ -615,7 +764,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         public void Rebind()
         {
-            _rebind = true;
+            Array.Clear(_textureState);
+            Array.Clear(_imageState);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -1,5 +1,6 @@
 ﻿using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Engine.Types;
+using Ryujinx.Graphics.Gpu.Shader;
 using System;
 
 namespace Ryujinx.Graphics.Gpu.Image
@@ -10,9 +11,11 @@ namespace Ryujinx.Graphics.Gpu.Image
     class TextureManager : IDisposable
     {
         private readonly GpuContext _context;
+        private readonly GpuChannel _channel;
 
         private readonly TextureBindingsManager _cpBindingsManager;
         private readonly TextureBindingsManager _gpBindingsManager;
+        private readonly TexturePoolCache _texturePoolCache;
 
         private readonly Texture[] _rtColors;
         private readonly ITexture[] _rtHostColors;
@@ -35,6 +38,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         public TextureManager(GpuContext context, GpuChannel channel)
         {
             _context = context;
+            _channel = channel;
 
             TexturePoolCache texturePoolCache = new TexturePoolCache(context);
 
@@ -43,6 +47,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             _cpBindingsManager = new TextureBindingsManager(context, channel, texturePoolCache, scales, isCompute: true);
             _gpBindingsManager = new TextureBindingsManager(context, channel, texturePoolCache, scales, isCompute: false);
+            _texturePoolCache = texturePoolCache;
 
             _rtColors = new Texture[Constants.TotalRenderTargets];
             _rtHostColors = new ITexture[Constants.TotalRenderTargets];
@@ -100,12 +105,32 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Sets the max binding indexes on the compute pipeline.
+        /// </summary>
+        /// <param name="maxTextureBinding">The maximum texture binding</param>
+        /// <param name="maxImageBinding">The maximum image binding</param>
+        public void SetComputeMaxBindings(int maxTextureBinding, int maxImageBinding)
+        {
+            _cpBindingsManager.SetMaxBindings(maxTextureBinding, maxImageBinding);
+        }
+
+        /// <summary>
         /// Sets the texture constant buffer index on the graphics pipeline.
         /// </summary>
         /// <param name="index">The texture constant buffer index</param>
         public void SetGraphicsTextureBufferIndex(int index)
         {
             _gpBindingsManager.SetTextureBufferIndex(index);
+        }
+
+        /// <summary>
+        /// Sets the max binding indexes on the graphics pipeline.
+        /// </summary>
+        /// <param name="maxTextureBinding">The maximum texture binding</param>
+        /// <param name="maxImageBinding">The maximum image binding</param>
+        public void SetGraphicsMaxBindings(int maxTextureBinding, int maxImageBinding)
+        {
+            _gpBindingsManager.SetMaxBindings(maxTextureBinding, maxImageBinding);
         }
 
         /// <summary>
@@ -335,25 +360,48 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <summary>
         /// Commits bindings on the compute pipeline.
         /// </summary>
-        public void CommitComputeBindings()
+        /// <param name="specState">Specialization state for the bound shader</param>
+        /// <returns>True if all bound textures match the current shader specialiation state, false otherwise</returns>
+        public bool CommitComputeBindings(ShaderSpecializationState specState)
         {
             // Every time we switch between graphics and compute work,
             // we must rebind everything.
             // Since compute work happens less often, we always do that
             // before and after the compute dispatch.
             _cpBindingsManager.Rebind();
-            _cpBindingsManager.CommitBindings();
+            bool result = _cpBindingsManager.CommitBindings(specState);
             _gpBindingsManager.Rebind();
+
+            return result;
         }
 
         /// <summary>
         /// Commits bindings on the graphics pipeline.
         /// </summary>
-        public void CommitGraphicsBindings()
+        /// <param name="specState">Specialization state for the bound shader</param>
+        /// <returns>True if all bound textures match the current shader specialiation state, false otherwise</returns>
+        public bool CommitGraphicsBindings(ShaderSpecializationState specState)
         {
-            _gpBindingsManager.CommitBindings();
+            bool result = _gpBindingsManager.CommitBindings(specState);
 
             UpdateRenderTargets();
+
+            return result;
+        }
+
+        /// <summary>
+        /// Returns a texture pool from the cache, with the given address and maximum id.
+        /// </summary>
+        /// <param name="poolGpuVa">GPU virtual address of the texture pool</param>
+        /// <param name="maximumId">Maximum ID of the texture pool</param>
+        /// <returns>The texture pool</returns>
+        public TexturePool GetTexturePool(ulong poolGpuVa, int maximumId)
+        {
+            ulong poolAddress = _channel.MemoryManager.Translate(poolGpuVa);
+
+            TexturePool texturePool = _texturePoolCache.FindOrCreate(_channel, poolAddress, maximumId);
+
+            return texturePool;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -14,7 +14,6 @@ namespace Ryujinx.Graphics.Gpu.Image
     {
         private readonly GpuChannel _channel;
         private readonly ConcurrentQueue<Texture> _dereferenceQueue = new ConcurrentQueue<Texture>();
-        private int _modifiedSequenceNumber;
         private TextureDescriptor _defaultDescriptor;
 
         /// <summary>
@@ -106,10 +105,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             {
                 SequenceNumber = Context.SequenceNumber;
 
-                if (SynchronizeMemory())
-                {
-                    _modifiedSequenceNumber = SequenceNumber;
-                }
+                SynchronizeMemory();
             }
 
             GetInternal(id, out Texture texture);
@@ -142,20 +138,17 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <summary>
         /// Checks if the pool was modified, and returns the last sequence number where a modification was detected.
         /// </summary>
-        /// <returns>The last sequence number where a modifiaction was detected</returns>
+        /// <returns>A number that increments each time a modification is detected</returns>
         public int CheckModified()
         {
             if (SequenceNumber != Context.SequenceNumber)
             {
                 SequenceNumber = Context.SequenceNumber;
 
-                if (SynchronizeMemory())
-                {
-                    _modifiedSequenceNumber = SequenceNumber;
-                }
+                SynchronizeMemory();
             }
 
-            return _modifiedSequenceNumber;
+            return ModifiedSequenceNumber;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -379,6 +379,25 @@ namespace Ryujinx.Graphics.Gpu.Memory
         }
 
         /// <summary>
+        /// Gets the bounds of the compute uniform buffer currently bound at the given index.
+        /// </summary>
+        /// <param name="isCompute">Indicates whenever the uniform is requested by the 3D or compute engine</param>
+        /// <param name="stage">Index of the shader stage, if the uniform is for the 3D engine</param>
+        /// <param name="index">Index of the uniform buffer binding</param>
+        /// <returns>The uniform buffer bounds, or an undefined value if the buffer is not currently bound</returns>
+        public ref BufferBounds GetUniformBufferBounds(bool isCompute, int stage, int index)
+        {
+            if (isCompute)
+            {
+                return ref _cpUniformBuffers.Buffers[index];
+            }
+            else
+            {
+                return ref _gpUniformBuffers[stage].Buffers[index];
+            }
+        }
+
+        /// <summary>
         /// Ensures that the compute engine bindings are visible to the host GPU.
         /// Note: this actually performs the binding using the host graphics API.
         /// </summary>

--- a/Ryujinx.Graphics.Gpu/Shader/CachedShaderProgram.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/CachedShaderProgram.cs
@@ -35,6 +35,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
             HostProgram = hostProgram;
             SpecializationState = specializationState;
             Shaders = shaders;
+
+            SpecializationState.Prepare(shaders);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -418,7 +418,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         {
             if (IsShaderEqual(channel.MemoryManager, cpShader.Shaders[0], gpuVa))
             {
-                return cpShader.SpecializationState.MatchesCompute(channel, poolState);
+                return cpShader.SpecializationState.MatchesCompute(channel, poolState, true);
             }
 
             return false;
@@ -454,7 +454,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 }
             }
 
-            return gpShaders.SpecializationState.MatchesGraphics(channel, poolState, graphicsState);
+            return gpShaders.SpecializationState.MatchesGraphics(channel, poolState, graphicsState, true);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderSpecializationList.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderSpecializationList.cs
@@ -35,7 +35,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         {
             foreach (var entry in _entries)
             {
-                if (entry.SpecializationState.MatchesGraphics(channel, poolState, graphicsState))
+                if (entry.SpecializationState.MatchesGraphics(channel, poolState, graphicsState, true))
                 {
                     program = entry;
                     return true;
@@ -57,7 +57,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         {
             foreach (var entry in _entries)
             {
-                if (entry.SpecializationState.MatchesCompute(channel, poolState))
+                if (entry.SpecializationState.MatchesCompute(channel, poolState, true))
                 {
                     program = entry;
                     return true;

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderSpecializationState.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderSpecializationState.cs
@@ -469,7 +469,6 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// </summary>
         /// <param name="channel">GPU channel</param>
         /// <param name="isCompute">Indicates whenever the check is requested by the 3D or compute engine</param>
-        /// <param name="stageIndex">Stage index of the constant buffer</param>
         /// <param name="cachedTextureBufferIndex">The currently cached texture buffer index</param>
         /// <param name="cachedSamplerBufferIndex">The currently cached sampler buffer index</param>
         /// <param name="cachedTextureBuffer">The currently cached texture buffer data</param>
@@ -477,6 +476,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <param name="cachedStageIndex">The currently cached stage</param>
         /// <param name="textureBufferIndex">The new texture buffer index</param>
         /// <param name="samplerBufferIndex">The new sampler buffer index</param>
+        /// <param name="stageIndex">Stage index of the constant buffer</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void UpdateCachedBuffer(
             GpuChannel channel,
@@ -578,10 +578,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
 
                     ref readonly Image.TextureDescriptor descriptor = ref pool.GetDescriptorRef(textureId);
 
-                    Box<TextureSpecializationState> specializationState = kv.Value;
-
-                    if (specializationState.Value.QueriedFlags.HasFlag(QueriedTextureStateFlags.CoordNormalized) &&
-                        specializationState.Value.CoordNormalized != descriptor.UnpackTextureCoordNormalized())
+                    if (!MatchesTexture(kv.Value, descriptor))
                     {
                         return false;
                     }
@@ -597,6 +594,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <param name="specializationState">Texture specialization state</param>
         /// <param name="descriptor">Texture descriptor</param>
         /// <returns>True if the state matches, false otherwise</returns>
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool MatchesTexture(Box<TextureSpecializationState> specializationState, in Image.TextureDescriptor descriptor)
         {
             if (specializationState != null)

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderSpecializationState.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderSpecializationState.cs
@@ -1,9 +1,14 @@
 using Ryujinx.Common.Memory;
+using Ryujinx.Graphics.Gpu.Image;
+using Ryujinx.Graphics.Gpu.Memory;
 using Ryujinx.Graphics.Gpu.Shader.DiskCache;
 using Ryujinx.Graphics.Shader;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace Ryujinx.Graphics.Gpu.Shader
 {
@@ -158,6 +163,9 @@ namespace Ryujinx.Graphics.Gpu.Shader
         }
 
         private readonly Dictionary<TextureKey, Box<TextureSpecializationState>> _textureSpecialization;
+        private KeyValuePair<TextureKey, Box<TextureSpecializationState>>[] _allTextures;
+        private Box<TextureSpecializationState>[][] _textureByBinding;
+        private Box<TextureSpecializationState>[][] _imageByBinding;
 
         /// <summary>
         /// Creates a new instance of the shader specialization state.
@@ -191,6 +199,42 @@ namespace Ryujinx.Graphics.Gpu.Shader
             {
                 TransformFeedbackDescriptors = descriptors;
                 _queriedState |= QueriedStateFlags.TransformFeedback;
+            }
+        }
+
+        public void Prepare(CachedShaderStage[] stages)
+        {
+            _allTextures = _textureSpecialization.ToArray();
+
+            _textureByBinding = new Box<TextureSpecializationState>[stages.Length][];
+            _imageByBinding = new Box<TextureSpecializationState>[stages.Length][];
+
+            for (int i = 0; i < stages.Length; i++)
+            {
+                CachedShaderStage stage = stages[i];
+                if (stage != null)
+                {
+                    var textures = stage.Info.Textures;
+                    var images = stage.Info.Images;
+
+                    var texBindings = new Box<TextureSpecializationState>[textures.Count];
+                    var imageBindings = new Box<TextureSpecializationState>[images.Count];
+
+                    for (int j = 0; j < textures.Count; j++)
+                    {
+                        var texture = textures[j];
+                        texBindings[j] = GetTextureSpecState(i, texture.HandleIndex, texture.CbufSlot);
+                    }
+
+                    for (int j = 0; j < images.Count; j++)
+                    {
+                        var image = images[j];
+                        imageBindings[j] = GetTextureSpecState(i, image.HandleIndex, image.CbufSlot);
+                    }
+
+                    _textureByBinding[i] = texBindings;
+                    _imageByBinding[i] = imageBindings;
+                }
             }
         }
 
@@ -396,15 +440,16 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <param name="channel">GPU channel</param>
         /// <param name="poolState">Texture pool state</param>
         /// <param name="graphicsState">Graphics state</param>
+        /// <param name="checkTextures">Indicates whether texture descriptors should be checked</param>
         /// <returns>True if the state matches, false otherwise</returns>
-        public bool MatchesGraphics(GpuChannel channel, GpuChannelPoolState poolState, GpuChannelGraphicsState graphicsState)
+        public bool MatchesGraphics(GpuChannel channel, GpuChannelPoolState poolState, GpuChannelGraphicsState graphicsState, bool checkTextures)
         {
             if (graphicsState.ViewportTransformDisable != GraphicsState.ViewportTransformDisable)
             {
                 return false;
             }
 
-            return Matches(channel, poolState, isCompute: false);
+            return Matches(channel, poolState, checkTextures, isCompute: false);
         }
 
         /// <summary>
@@ -412,10 +457,64 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// </summary>
         /// <param name="channel">GPU channel</param>
         /// <param name="poolState">Texture pool state</param>
+        /// <param name="checkTextures">Indicates whether texture descriptors should be checked</param>
         /// <returns>True if the state matches, false otherwise</returns>
-        public bool MatchesCompute(GpuChannel channel, GpuChannelPoolState poolState)
+        public bool MatchesCompute(GpuChannel channel, GpuChannelPoolState poolState, bool checkTextures)
         {
-            return Matches(channel, poolState, isCompute: true);
+            return Matches(channel, poolState, checkTextures, isCompute: true);
+        }
+
+        /// <summary>
+        /// Fetch the constant buffers used for a texture to cache.
+        /// </summary>
+        /// <param name="channel">GPU channel</param>
+        /// <param name="isCompute">Indicates whenever the check is requested by the 3D or compute engine</param>
+        /// <param name="stageIndex">Stage index of the constant buffer</param>
+        /// <param name="cachedTextureBufferIndex">The currently cached texture buffer index</param>
+        /// <param name="cachedSamplerBufferIndex">The currently cached sampler buffer index</param>
+        /// <param name="cachedTextureBuffer">The currently cached texture buffer data</param>
+        /// <param name="cachedSamplerBuffer">The currently cached sampler buffer data</param>
+        /// <param name="cachedStageIndex">The currently cached stage</param>
+        /// <param name="textureBufferIndex">The new texture buffer index</param>
+        /// <param name="samplerBufferIndex">The new sampler buffer index</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void UpdateCachedBuffer(
+            GpuChannel channel,
+            bool isCompute,
+            ref int cachedTextureBufferIndex,
+            ref int cachedSamplerBufferIndex,
+            ref ReadOnlySpan<int> cachedTextureBuffer,
+            ref ReadOnlySpan<int> cachedSamplerBuffer,
+            ref int cachedStageIndex,
+            int textureBufferIndex,
+            int samplerBufferIndex,
+            int stageIndex)
+        {
+            bool stageChange = stageIndex != cachedStageIndex;
+
+            if (stageChange || textureBufferIndex != cachedTextureBufferIndex)
+            {
+                ref BufferBounds bounds = ref channel.BufferManager.GetUniformBufferBounds(isCompute, stageIndex, textureBufferIndex);
+
+                cachedTextureBuffer = MemoryMarshal.Cast<byte, int>(channel.MemoryManager.Physical.GetSpan(bounds.Address, (int)bounds.Size));
+                cachedTextureBufferIndex = textureBufferIndex;
+
+                if (samplerBufferIndex == textureBufferIndex)
+                {
+                    cachedSamplerBuffer = cachedTextureBuffer;
+                    cachedSamplerBufferIndex = samplerBufferIndex;
+                }
+            }
+
+            if (stageChange || cachedSamplerBufferIndex != samplerBufferIndex)
+            {
+                ref BufferBounds bounds = ref channel.BufferManager.GetUniformBufferBounds(isCompute, stageIndex, samplerBufferIndex);
+
+                cachedSamplerBuffer = MemoryMarshal.Cast<byte, int>(channel.MemoryManager.Physical.GetSpan(bounds.Address, (int)bounds.Size));
+                cachedSamplerBufferIndex = samplerBufferIndex;
+            }
+
+            cachedStageIndex = stageIndex;
         }
 
         /// <summary>
@@ -423,9 +522,10 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// </summary>
         /// <param name="channel">GPU channel</param>
         /// <param name="poolState">Texture pool state</param>
+        /// <param name="checkTextures">Indicates whether texture descriptors should be checked</param>
         /// <param name="isCompute">Indicates whenever the check is requested by the 3D or compute engine</param>
         /// <returns>True if the state matches, false otherwise</returns>
-        private bool Matches(GpuChannel channel, GpuChannelPoolState poolState, bool isCompute)
+        private bool Matches(GpuChannel channel, GpuChannelPoolState poolState, bool checkTextures, bool isCompute)
         {
             int constantBufferUsePerStageMask = _constantBufferUsePerStage;
 
@@ -445,55 +545,62 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 constantBufferUsePerStageMask &= ~(1 << index);
             }
 
-            foreach (var kv in _textureSpecialization)
+            if (checkTextures)
             {
-                TextureKey textureKey = kv.Key;
+                TexturePool pool = channel.TextureManager.GetTexturePool(poolState.TexturePoolGpuVa, poolState.TexturePoolMaximumId);
 
-                (int textureBufferIndex, int samplerBufferIndex) = TextureHandle.UnpackSlots(textureKey.CbufSlot, poolState.TextureBufferIndex);
+                int cachedTextureBufferIndex = -1;
+                int cachedSamplerBufferIndex = -1;
+                int cachedStageIndex = -1;
+                ReadOnlySpan<int> cachedTextureBuffer = Span<int>.Empty;
+                ReadOnlySpan<int> cachedSamplerBuffer = Span<int>.Empty;
 
-                ulong textureCbAddress;
-                ulong samplerCbAddress;
-
-                if (isCompute)
+                foreach (var kv in _allTextures)
                 {
-                    textureCbAddress = channel.BufferManager.GetComputeUniformBufferAddress(textureBufferIndex);
-                    samplerCbAddress = channel.BufferManager.GetComputeUniformBufferAddress(samplerBufferIndex);
-                }
-                else
-                {
-                    textureCbAddress = channel.BufferManager.GetGraphicsUniformBufferAddress(textureKey.StageIndex, textureBufferIndex);
-                    samplerCbAddress = channel.BufferManager.GetGraphicsUniformBufferAddress(textureKey.StageIndex, samplerBufferIndex);
-                }
+                    TextureKey textureKey = kv.Key;
 
-                if (!channel.MemoryManager.Physical.IsMapped(textureCbAddress) || !channel.MemoryManager.Physical.IsMapped(samplerCbAddress))
-                {
-                    continue;
+                    (int textureBufferIndex, int samplerBufferIndex) = TextureHandle.UnpackSlots(textureKey.CbufSlot, poolState.TextureBufferIndex);
+
+                    UpdateCachedBuffer(channel,
+                        isCompute,
+                        ref cachedTextureBufferIndex,
+                        ref cachedSamplerBufferIndex,
+                        ref cachedTextureBuffer,
+                        ref cachedSamplerBuffer,
+                        ref cachedStageIndex,
+                        textureBufferIndex,
+                        samplerBufferIndex,
+                        textureKey.StageIndex);
+
+                    int packedId = TextureHandle.ReadPackedId(textureKey.Handle, cachedTextureBuffer, cachedSamplerBuffer);
+
+                    int textureId = TextureHandle.UnpackTextureId(packedId);
+
+                    ref readonly Image.TextureDescriptor descriptor = ref pool.GetDescriptorRef(textureId);
+
+                    Box<TextureSpecializationState> specializationState = kv.Value;
+
+                    if (specializationState.Value.QueriedFlags.HasFlag(QueriedTextureStateFlags.CoordNormalized) &&
+                        specializationState.Value.CoordNormalized != descriptor.UnpackTextureCoordNormalized())
+                    {
+                        return false;
+                    }
                 }
+            }
 
-                Image.TextureDescriptor descriptor;
+            return true;
+        }
 
-                if (isCompute)
-                {
-                    descriptor = channel.TextureManager.GetComputeTextureDescriptor(
-                        poolState.TexturePoolGpuVa,
-                        poolState.TextureBufferIndex,
-                        poolState.TexturePoolMaximumId,
-                        textureKey.Handle,
-                        textureKey.CbufSlot);
-                }
-                else
-                {
-                    descriptor = channel.TextureManager.GetGraphicsTextureDescriptor(
-                        poolState.TexturePoolGpuVa,
-                        poolState.TextureBufferIndex,
-                        poolState.TexturePoolMaximumId,
-                        textureKey.StageIndex,
-                        textureKey.Handle,
-                        textureKey.CbufSlot);
-                }
-
-                Box<TextureSpecializationState> specializationState = kv.Value;
-
+        /// <summary>
+        /// Checks if the recorded texture state matches the given texture descriptor.
+        /// </summary>
+        /// <param name="specializationState">Texture specialization state</param>
+        /// <param name="descriptor">Texture descriptor</param>
+        /// <returns>True if the state matches, false otherwise</returns>
+        private bool MatchesTexture(Box<TextureSpecializationState> specializationState, in Image.TextureDescriptor descriptor)
+        {
+            if (specializationState != null)
+            {
                 if (specializationState.Value.QueriedFlags.HasFlag(QueriedTextureStateFlags.CoordNormalized) &&
                     specializationState.Value.CoordNormalized != descriptor.UnpackTextureCoordNormalized())
                 {
@@ -502,6 +609,34 @@ namespace Ryujinx.Graphics.Gpu.Shader
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Checks if the recorded texture state for a given texture binding matches a texture descriptor.
+        /// </summary>
+        /// <param name="stage">The shader stage</param>
+        /// <param name="index">The texture index</param>
+        /// <param name="descriptor">Texture descriptor</param>
+        /// <returns>True if the state matches, false otherwise</returns>
+        public bool MatchesTexture(ShaderStage stage, int index, in Image.TextureDescriptor descriptor)
+        {
+            Box<TextureSpecializationState> specializationState = _textureByBinding[(int)stage][index];
+
+            return MatchesTexture(specializationState, descriptor);
+        }
+
+        /// <summary>
+        /// Checks if the recorded texture state for a given image binding matches a texture descriptor.
+        /// </summary>
+        /// <param name="stage">The shader stage</param>
+        /// <param name="index">The texture index</param>
+        /// <param name="descriptor">Texture descriptor</param>
+        /// <returns>True if the state matches, false otherwise</returns>
+        public bool MatchesImage(ShaderStage stage, int index, in Image.TextureDescriptor descriptor)
+        {
+            Box<TextureSpecializationState> specializationState = _imageByBinding[(int)stage][index];
+
+            return MatchesTexture(specializationState, descriptor);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Shader/TextureHandle.cs
+++ b/Ryujinx.Graphics.Shader/TextureHandle.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.CompilerServices;
 
 namespace Ryujinx.Graphics.Shader
@@ -49,6 +50,48 @@ namespace Ryujinx.Graphics.Shader
         public static (int, int, TextureHandleType) UnpackOffsets(int handle)
         {
             return (handle & 0x3fff, (handle >> 14) & 0x3fff, (TextureHandleType)((uint)handle >> 28));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int UnpackTextureId(int packedId)
+        {
+            return (packedId >> 0) & 0xfffff;
+        }
+
+        /// <summary>
+        /// Reads a packed texture and sampler ID (basically, the real texture handle)
+        /// from a given texture/sampler constant buffer.
+        /// </summary>
+        /// <param name="wordOffset">A word offset of the handle on the buffer (the "fake" shader handle)</param>
+        /// <param name="cachedTextureBuffer">The constant buffer to fetch texture IDs from</param>
+        /// <param name="cachedSamplerBuffer">The constant buffer to fetch sampler IDs from</param>
+        /// <returns>The packed texture and sampler ID (the real texture handle)</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int ReadPackedId(int wordOffset, ReadOnlySpan<int> cachedTextureBuffer, ReadOnlySpan<int> cachedSamplerBuffer)
+        {
+            (int textureWordOffset, int samplerWordOffset, TextureHandleType handleType) = UnpackOffsets(wordOffset);
+
+            int handle = cachedTextureBuffer[textureWordOffset];
+
+            // The "wordOffset" (which is really the immediate value used on texture instructions on the shader)
+            // is a 13-bit value. However, in order to also support separate samplers and textures (which uses
+            // bindless textures on the shader), we extend it with another value on the higher 16 bits with
+            // another offset for the sampler.
+            // The shader translator has code to detect separate texture and sampler uses with a bindless texture,
+            // turn that into a regular texture access and produce those special handles with values on the higher 16 bits.
+            if (handleType != TextureHandleType.CombinedSampler)
+            {
+                int samplerHandle = cachedSamplerBuffer[samplerWordOffset];
+
+                if (handleType == TextureHandleType.SeparateSamplerId)
+                {
+                    samplerHandle <<= 20;
+                }
+
+                handle |= samplerHandle;
+            }
+
+            return handle;
         }
     }
 }


### PR DESCRIPTION
This PR aims to reverse a performance regression caused by the new shader cache. The main issue is that shader specialization state was being checked for every draw, which was taking a very large amount of time, and essentially ended up iterating the texture bindings for a draw twice. (and calculating offsets, loading handles from cb...)

This changes it so that specialization state for textures is only checked when selecting shader programs (on shader address change), and when the bindings change in the texture bindings manager. If the bindings change and the shader is no longer compatible, it will _force_ shader state to be updated mid-state-update, which should be fine as none of the bindings should change.

Texture binding has been changed significantly to gain more performance in general:
- The pools have been changed to synchronize their memory only once before binding, rather than repeatedly checking on each Get() call.
 - The pools maintain and return a "modified sequence number" that increments each time the pool makes a modification. This is checked against a stored number in users so that they can figure out if the pool was modified since the last time _they_ used it, which in the case of texture bindings forces a rebind.
- The constant buffers containing texture/sampler handles are cached on first access rather than performing individual reads.
  - This speeds up draws with many textures greatly, as reading handles past the first is as easy as indexing into a span, rather than calls to the memory manager.
- Texture/Image state is remembered in terms of [BindingId], rather than [Stage][Index], and is not cleared when programs change. This allows for textures to avoid rebinds even when the program changes.
  
There are some possible downsides, but I think they are mitigated by being infrequent:
- All accesses getting textures will get a reference to the descriptor, as it is needed for checking specialization state. This could slow down a case where the bound texture changes every draw, but in games with lots of draws it's usually batched so that similar things are drawn at the same time.
- When texture and sampler buffer are not the same for each binding, the cache will be refetched each time it changes.
  - I don't think this will happen, but the code can handle it. NVN games that use regular bindings seem to behave the same as ones with eliminated bindless, where the same cb contains all the texture handles.
- When the texture/sampler constant buffer is fragmented, a copy will occur when getting span. I think this is very unlikely to happen, but if it does happen I think it would be the most noticeable cost.

## Xenoblade Chronicles Definitive Edition
This game performs an incredibly large number of draws that should probably be instanced but aren't, so the bound textures tend to stay the same. Thus, the largest improvement.

Screenshots are at FPS high points.

### Before:
![image](https://user-images.githubusercontent.com/6294155/173263628-37737638-a9c4-43b8-9db6-f152de525b56.png)

### After:
![image](https://user-images.githubusercontent.com/6294155/173263421-d8390e6d-ea9a-4d17-95e5-ce44ecb42f5a.png)

## Super Mario Odyssey
It's always this game. Note that this game still performs better in Vulkan in certain spots, I think including this one, so benefits may be limited by backend performance. Similar "instanced-adjacent" behaviour where it draws the same thing with a different constant buffer bound.

### Before:
![image](https://user-images.githubusercontent.com/6294155/173264609-c38ce884-c26a-4bf4-8bfd-d5cad5d046d2.png)

### After:
![image](https://user-images.githubusercontent.com/6294155/173264155-39336d7f-de6d-4ee0-8294-49916b67174a.png)

## BOTW
This game is limited by other stuff, but there's a good case in the FIFO% lowering, as it has a lot of those similar draws like Xenoblade: (or it could just be this game being weird as usual)

### Before
![image](https://user-images.githubusercontent.com/6294155/173263778-3ba9e922-ff0f-4c19-9ce0-75acf6e8fd1a.png)

### After
![image](https://user-images.githubusercontent.com/6294155/173263832-fd042232-1742-42dd-9652-926d95d6ab7e.png)

## Notes

This changes a lot so it should be tested in a variety of games. It should especially be tested in games that shader specialization fixed in the first place, **_specifically issues involving rectangle textures._** I don't really have any.

I'll leave this draft til more testing is done.