### PR TITLE
Support Array/3D depth-stencil render target, and single layer clears

### DIFF
--- a/Ryujinx.Graphics.GAL/IPipeline.cs
+++ b/Ryujinx.Graphics.GAL/IPipeline.cs
@@ -10,9 +10,10 @@ namespace Ryujinx.Graphics.GAL
 
         void ClearBuffer(BufferHandle destination, int offset, int size, uint value);
 
-        void ClearRenderTargetColor(int index, uint componentMask, ColorF color);
+        void ClearRenderTargetColor(int index, int layer, uint componentMask, ColorF color);
 
         void ClearRenderTargetDepthStencil(
+            int layer,
             float depthValue,
             bool depthMask,
             int stencilValue,

--- a/Ryujinx.Graphics.GAL/Multithreading/Commands/ClearRenderTargetColorCommand.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/Commands/ClearRenderTargetColorCommand.cs
@@ -4,19 +4,21 @@
     {
         public CommandType CommandType => CommandType.ClearRenderTargetColor;
         private int _index;
+        private int _layer;
         private uint _componentMask;
         private ColorF _color;
 
-        public void Set(int index, uint componentMask, ColorF color)
+        public void Set(int index, int layer, uint componentMask, ColorF color)
         {
             _index = index;
+            _layer = layer;
             _componentMask = componentMask;
             _color = color;
         }
 
         public static void Run(ref ClearRenderTargetColorCommand command, ThreadedRenderer threaded, IRenderer renderer)
         {
-            renderer.Pipeline.ClearRenderTargetColor(command._index, command._componentMask, command._color);
+            renderer.Pipeline.ClearRenderTargetColor(command._index, command._layer, command._componentMask, command._color);
         }
     }
 }

--- a/Ryujinx.Graphics.GAL/Multithreading/Commands/ClearRenderTargetDepthStencilCommand.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/Commands/ClearRenderTargetDepthStencilCommand.cs
@@ -3,13 +3,15 @@
     struct ClearRenderTargetDepthStencilCommand : IGALCommand
     {
         public CommandType CommandType => CommandType.ClearRenderTargetDepthStencil;
+        private int _layer;
         private float _depthValue;
         private bool _depthMask;
         private int _stencilValue;
         private int _stencilMask;
 
-        public void Set(float depthValue, bool depthMask, int stencilValue, int stencilMask)
+        public void Set(int layer, float depthValue, bool depthMask, int stencilValue, int stencilMask)
         {
+            _layer = layer;
             _depthValue = depthValue;
             _depthMask = depthMask;
             _stencilValue = stencilValue;
@@ -18,7 +20,7 @@
 
         public static void Run(ref ClearRenderTargetDepthStencilCommand command, ThreadedRenderer threaded, IRenderer renderer)
         {
-            renderer.Pipeline.ClearRenderTargetDepthStencil(command._depthValue, command._depthMask, command._stencilValue, command._stencilMask);
+            renderer.Pipeline.ClearRenderTargetDepthStencil(command._layer, command._depthValue, command._depthMask, command._stencilValue, command._stencilMask);
         }
     }
 }

--- a/Ryujinx.Graphics.GAL/Multithreading/ThreadedPipeline.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/ThreadedPipeline.cs
@@ -40,15 +40,15 @@ namespace Ryujinx.Graphics.GAL.Multithreading
             _renderer.QueueCommand();
         }
 
-        public void ClearRenderTargetColor(int index, uint componentMask, ColorF color)
+        public void ClearRenderTargetColor(int index, int layer, uint componentMask, ColorF color)
         {
-            _renderer.New<ClearRenderTargetColorCommand>().Set(index, componentMask, color);
+            _renderer.New<ClearRenderTargetColorCommand>().Set(index, layer, componentMask, color);
             _renderer.QueueCommand();
         }
 
-        public void ClearRenderTargetDepthStencil(float depthValue, bool depthMask, int stencilValue, int stencilMask)
+        public void ClearRenderTargetDepthStencil(int layer, float depthValue, bool depthMask, int stencilValue, int stencilMask)
         {
-            _renderer.New<ClearRenderTargetDepthStencilCommand>().Set(depthValue, depthMask, stencilValue, stencilMask);
+            _renderer.New<ClearRenderTargetDepthStencilCommand>().Set(layer, depthValue, depthMask, stencilValue, stencilMask);
             _renderer.QueueCommand();
         }
 

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
@@ -505,8 +505,9 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             }
 
             int index = (argument >> 6) & 0xf;
+            int layer = (argument >> 10) & 0x3ff;
 
-            engine.UpdateRenderTargetState(useControl: false, singleUse: index);
+            engine.UpdateRenderTargetState(useControl: false, layered: layer != 0, singleUse: index);
 
             // If there is a mismatch on the host clip region and the one explicitly defined by the guest
             // on the screen scissor state, then we need to force only one texture to be bound to avoid
@@ -581,7 +582,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
                 ColorF color = new ColorF(clearColor.Red, clearColor.Green, clearColor.Blue, clearColor.Alpha);
 
-                _context.Renderer.Pipeline.ClearRenderTargetColor(index, componentMask, color);
+                _context.Renderer.Pipeline.ClearRenderTargetColor(index, layer, componentMask, color);
             }
 
             if (clearDepth || clearStencil)
@@ -602,6 +603,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 }
 
                 _context.Renderer.Pipeline.ClearRenderTargetDepthStencil(
+                    layer,
                     depthValue,
                     clearDepth,
                     stencilValue,

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -362,8 +362,9 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         /// Updates render targets (color and depth-stencil buffers) based on current render target state.
         /// </summary>
         /// <param name="useControl">Use draw buffers information from render target control register</param>
+        /// <param name="layered">Indicates if the texture is layered</param>
         /// <param name="singleUse">If this is not -1, it indicates that only the given indexed target will be used.</param>
-        public void UpdateRenderTargetState(bool useControl, int singleUse = -1)
+        public void UpdateRenderTargetState(bool useControl, bool layered = false, int singleUse = -1)
         {
             var memoryManager = _channel.MemoryManager;
             var rtControl = _state.State.RtControl;
@@ -399,7 +400,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 Image.Texture color = memoryManager.Physical.TextureCache.FindOrCreateTexture(
                     memoryManager,
                     colorState,
-                    _vtgWritesRtLayer,
+                    _vtgWritesRtLayer || layered,
                     samplesInX,
                     samplesInY,
                     sizeHint);
@@ -433,6 +434,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                     memoryManager,
                     dsState,
                     dsSize,
+                    _vtgWritesRtLayer || layered,
                     samplesInX,
                     samplesInY,
                     sizeHint);

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
@@ -131,10 +131,11 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         /// Updates render targets (color and depth-stencil buffers) based on current render target state.
         /// </summary>
         /// <param name="useControl">Use draw buffers information from render target control register</param>
+        /// <param name="layered">Indicates if the texture is layered</param>
         /// <param name="singleUse">If this is not -1, it indicates that only the given indexed target will be used.</param>
-        public void UpdateRenderTargetState(bool useControl, int singleUse = -1)
+        public void UpdateRenderTargetState(bool useControl, bool layered = false, int singleUse = -1)
         {
-            _stateUpdater.UpdateRenderTargetState(useControl, singleUse);
+            _stateUpdater.UpdateRenderTargetState(useControl, layered, singleUse);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.OpenGL/Framebuffer.cs
+++ b/Ryujinx.Graphics.OpenGL/Framebuffer.cs
@@ -9,10 +9,13 @@ namespace Ryujinx.Graphics.OpenGL
     class Framebuffer : IDisposable
     {
         public int Handle { get; private set; }
+        private int _clearFbHandle;
+        private bool _clearFbInitialized;
 
         private FramebufferAttachment _lastDsAttachment;
 
         private readonly TextureView[] _colors;
+        private TextureView _depthStencil;
 
         private int _colorsCount;
         private bool _dualSourceBlend;
@@ -20,6 +23,7 @@ namespace Ryujinx.Graphics.OpenGL
         public Framebuffer()
         {
             Handle = GL.GenFramebuffer();
+            _clearFbHandle = GL.GenFramebuffer();
 
             _colors = new TextureView[8];
         }
@@ -55,20 +59,7 @@ namespace Ryujinx.Graphics.OpenGL
 
             if (depthStencil != null)
             {
-                FramebufferAttachment attachment;
-
-                if (IsPackedDepthStencilFormat(depthStencil.Format))
-                {
-                    attachment = FramebufferAttachment.DepthStencilAttachment;
-                }
-                else if (IsDepthOnlyFormat(depthStencil.Format))
-                {
-                    attachment = FramebufferAttachment.DepthAttachment;
-                }
-                else
-                {
-                    attachment = FramebufferAttachment.StencilAttachment;
-                }
+                FramebufferAttachment attachment = GetAttachment(depthStencil.Format);
 
                 GL.FramebufferTexture(
                     FramebufferTarget.Framebuffer,
@@ -82,6 +73,8 @@ namespace Ryujinx.Graphics.OpenGL
             {
                 _lastDsAttachment = 0;
             }
+
+            _depthStencil = depthStencil;
         }
 
         public void SetDualSourceBlend(bool enable)
@@ -124,6 +117,22 @@ namespace Ryujinx.Graphics.OpenGL
             GL.DrawBuffers(colorsCount, drawBuffers);
         }
 
+        private static FramebufferAttachment GetAttachment(Format format)
+        {
+            if (IsPackedDepthStencilFormat(format))
+            {
+                return FramebufferAttachment.DepthStencilAttachment;
+            }
+            else if (IsDepthOnlyFormat(format))
+            {
+                return FramebufferAttachment.DepthAttachment;
+            }
+            else
+            {
+                return FramebufferAttachment.StencilAttachment;
+            }
+        }
+
         private static bool IsPackedDepthStencilFormat(Format format)
         {
             return format == Format.D24UnormS8Uint ||
@@ -136,6 +145,78 @@ namespace Ryujinx.Graphics.OpenGL
             return format == Format.D16Unorm || format == Format.D32Float;
         }
 
+        public void AttachColorLayerForClear(int index, int layer)
+        {
+            TextureView color = _colors[index];
+
+            if (!IsLayered(color))
+            {
+                return;
+            }
+
+            BindClearFb();
+            GL.FramebufferTextureLayer(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0 + index, color.Handle, 0, layer);
+        }
+
+        public void DetachColorLayerForClear(int index)
+        {
+            TextureView color = _colors[index];
+
+            if (!IsLayered(color))
+            {
+                return;
+            }
+
+            GL.FramebufferTexture(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0 + index, 0, 0);
+            Bind();
+        }
+
+        public void AttachDepthStencilLayerForClear(int layer)
+        {
+            TextureView depthStencil = _depthStencil;
+
+            if (!IsLayered(depthStencil))
+            {
+                return;
+            }
+
+            BindClearFb();
+            GL.FramebufferTextureLayer(FramebufferTarget.Framebuffer, GetAttachment(depthStencil.Format), depthStencil.Handle, 0, layer);
+        }
+
+        public void DetachDepthStencilLayerForClear()
+        {
+            TextureView depthStencil = _depthStencil;
+
+            if (!IsLayered(depthStencil))
+            {
+                return;
+            }
+
+            GL.FramebufferTexture(FramebufferTarget.Framebuffer, GetAttachment(depthStencil.Format), 0, 0);
+            Bind();
+        }
+
+        private void BindClearFb()
+        {
+            GL.BindFramebuffer(FramebufferTarget.Framebuffer, _clearFbHandle);
+
+            if (!_clearFbInitialized)
+            {
+                SetDrawBuffersImpl(Constants.MaxRenderTargets);
+                _clearFbInitialized = true;
+            }
+        }
+
+        private static bool IsLayered(TextureView view)
+        {
+            return view != null &&
+                    view.Target != Target.Texture1D &&
+                    view.Target != Target.Texture2D &&
+                    view.Target != Target.Texture2DMultisample &&
+                    view.Target != Target.TextureBuffer;
+        }
+
         public void Dispose()
         {
             if (Handle != 0)
@@ -143,6 +224,13 @@ namespace Ryujinx.Graphics.OpenGL
                 GL.DeleteFramebuffer(Handle);
 
                 Handle = 0;
+            }
+
+            if (_clearFbHandle != 0)
+            {
+                GL.DeleteFramebuffer(_clearFbHandle);
+
+                _clearFbHandle = 0;
             }
         }
     }

--- a/Ryujinx.Graphics.OpenGL/Framebuffer.cs
+++ b/Ryujinx.Graphics.OpenGL/Framebuffer.cs
@@ -211,10 +211,10 @@ namespace Ryujinx.Graphics.OpenGL
         private static bool IsLayered(TextureView view)
         {
             return view != null &&
-                    view.Target != Target.Texture1D &&
-                    view.Target != Target.Texture2D &&
-                    view.Target != Target.Texture2DMultisample &&
-                    view.Target != Target.TextureBuffer;
+                   view.Target != Target.Texture1D &&
+                   view.Target != Target.Texture2D &&
+                   view.Target != Target.Texture2DMultisample &&
+                   view.Target != Target.TextureBuffer;
         }
 
         public void Dispose()

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -110,7 +110,7 @@ namespace Ryujinx.Graphics.OpenGL
             Buffer.Clear(destination, offset, size, value);
         }
 
-        public void ClearRenderTargetColor(int index, uint componentMask, ColorF color)
+        public void ClearRenderTargetColor(int index, int layer, uint componentMask, ColorF color)
         {
             GL.ColorMask(
                 index,
@@ -119,14 +119,18 @@ namespace Ryujinx.Graphics.OpenGL
                 (componentMask & 4) != 0,
                 (componentMask & 8) != 0);
 
+            _framebuffer.AttachColorLayerForClear(index, layer);
+
             float[] colors = new float[] { color.Red, color.Green, color.Blue, color.Alpha };
 
             GL.ClearBuffer(OpenTK.Graphics.OpenGL.ClearBuffer.Color, index, colors);
 
+            _framebuffer.DetachColorLayerForClear(index);
+
             RestoreComponentMask(index);
         }
 
-        public void ClearRenderTargetDepthStencil(float depthValue, bool depthMask, int stencilValue, int stencilMask)
+        public void ClearRenderTargetDepthStencil(int layer, float depthValue, bool depthMask, int stencilValue, int stencilMask)
         {
             bool stencilMaskChanged =
                 stencilMask != 0 &&
@@ -144,6 +148,8 @@ namespace Ryujinx.Graphics.OpenGL
                 GL.DepthMask(depthMask);
             }
 
+            _framebuffer.AttachDepthStencilLayerForClear(layer);
+
             if (depthMask && stencilMask != 0)
             {
                 GL.ClearBuffer(ClearBufferCombined.DepthStencil, 0, depthValue, stencilValue);
@@ -156,6 +162,8 @@ namespace Ryujinx.Graphics.OpenGL
             {
                 GL.ClearBuffer(OpenTK.Graphics.OpenGL.ClearBuffer.Stencil, 0, ref stencilValue);
             }
+
+            _framebuffer.DetachDepthStencilLayerForClear();
 
             if (stencilMaskChanged)
             {


### PR DESCRIPTION
This fixes two issues.

First, it adds support for array and 3D textures to depth-stencil render targets. Before, only the color render targets had support for this, and in cases where an Array render target was used with a depth buffer for example, it would cause a framebuffer completness error on OpenGL and not draw anything.

The second and more problematic issue is that render target clears takes a layer parameter, but it was being ignored. What is worse is that it decides if the render target is layered or not based on shader state, and since the shader state is not updated for clears, it might not consider the texture layered at all. This means that often only the first layer would be cleared. To fix this, first I made it force the texture to be considered layered if the clear layer is > 0. The second part of the fix was adding a new `layer` parameter to the backend clear methods, were the layer is passed. Since OpenGL does not have a simple way to clear a single layer, I also had to add another framebuffer and attach the single layer with `glFramebufferTextureLayer` just for the clear.

This fixes missing crowd on Mario Strikers.
Before:
![image](https://user-images.githubusercontent.com/5624669/173267910-e8e4802e-6e5e-410c-a29e-14e61fa58288.png)
After:
![image](https://user-images.githubusercontent.com/5624669/173267928-5ae9b8f6-dbfb-4e61-a84e-59db5c12e218.png)

Testing is welcome, to ensure this or other games did not regress.