### PR TITLE
Handle the case where byte size option values are sent to BSD

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Impl/ManagedSocket.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Impl/ManagedSocket.cs
@@ -304,7 +304,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                     return LinuxError.EOPNOTSUPP;
                 }
 
-                int value = MemoryMarshal.Read<int>(optionValue);
+                int value = optionValue.Length >= 4 ? MemoryMarshal.Read<int>(optionValue) : MemoryMarshal.Read<byte>(optionValue);
 
                 if (option == BsdSocketOption.SoLinger)
                 {


### PR DESCRIPTION
Some games and the Super Mario Odyssey Multiplayer Mod do this.

The SMO multiplayer mod also needs you to revert #3394 as it uses a blocking socket to receive (which hangs), and it doesn't seem to like being forced as non-blocking.

May fix some of the other games listed in #3236.