### PR TITLE
Ensure texture ID is valid before getting texture descriptor

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/Pool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Pool.cs
@@ -102,6 +102,16 @@ namespace Ryujinx.Graphics.Gpu.Image
         public abstract T1 Get(int id);
 
         /// <summary>
+        /// Checks if a given ID is valid and inside the range of the pool.
+        /// </summary>
+        /// <param name="id">ID of the descriptor. This is effectively a zero-based index</param>
+        /// <returns>True if the specified ID is valid, false otherwise</returns>
+        public bool IsValidId(int id)
+        {
+            return (uint)id <= MaximumId;
+        }
+
+        /// <summary>
         /// Synchronizes host memory with guest memory.
         /// This causes invalidation of pool entries,
         /// if a modification of entries by the CPU is detected.

--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -738,7 +738,22 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             TexturePool texturePool = _texturePoolCache.FindOrCreate(_channel, poolAddress, maximumId);
 
-            return texturePool.GetDescriptor(textureId);
+            TextureDescriptor descriptor;
+
+            if (texturePool.IsValidId(textureId))
+            {
+                descriptor = texturePool.GetDescriptor(textureId);
+            }
+            else
+            {
+                // If the ID is not valid, we just return a default descriptor with the most common state.
+                // Since this is used for shader specialization, doing so might avoid the need for recompilations.
+                descriptor = new TextureDescriptor();
+                descriptor.Word4 |= (uint)TextureTarget.Texture2D << 23;
+                descriptor.Word5 |= 1u << 31; // Coords normalized.
+            }
+
+            return descriptor;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureDescriptor.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureDescriptor.cs
@@ -242,25 +242,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Create the equivalent of this TextureDescriptor for the shader cache.
-        /// </summary>
-        /// <returns>The equivalent of this TextureDescriptor for the shader cache.</returns>
-        public GuestTextureDescriptor ToCache()
-        {
-            GuestTextureDescriptor result = new GuestTextureDescriptor
-            {
-                Handle = uint.MaxValue,
-                Format = UnpackFormat(),
-                Target = UnpackTextureTarget(),
-                IsSrgb = UnpackSrgb(),
-                IsTextureCoordNormalized = UnpackTextureCoordNormalized(),
-
-            };
-
-            return result;
-        }
-
-        /// <summary>
         /// Check if two descriptors are equal.
         /// </summary>
         /// <param name="other">The descriptor to compare against</param>

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderSpecializationState.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderSpecializationState.cs
@@ -579,14 +579,16 @@ namespace Ryujinx.Graphics.Gpu.Shader
                         textureKey.StageIndex);
 
                     int packedId = TextureHandle.ReadPackedId(textureKey.Handle, cachedTextureBuffer, cachedSamplerBuffer);
-
                     int textureId = TextureHandle.UnpackTextureId(packedId);
 
-                    ref readonly Image.TextureDescriptor descriptor = ref pool.GetDescriptorRef(textureId);
-
-                    if (!MatchesTexture(kv.Value, descriptor))
+                    if (pool.IsValidId(textureId))
                     {
-                        return false;
+                        ref readonly Image.TextureDescriptor descriptor = ref pool.GetDescriptorRef(textureId);
+
+                        if (!MatchesTexture(kv.Value, descriptor))
+                        {
+                            return false;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The texture ID might not be valid at the time the shader is compiled or specialization check (perhaps because the game did not bind the texture yet, either due to a bug or because the shader accesses it conditionally and the path were it is accessed is not supposed to be taken), so be must not try to read the descriptor in those cases as it could access unmapped memory and crash.

This adds an additional check before doing the access. If not valid, it will use a texture descriptor with the most common state. Doing so might avoid future shader recompilation due to state changes (in the case the texture is actually bound later).

This was causing a crash on A Hat in Time before reaching the title screen after progressing at a certain point in the game.
Fixes #3390.