### PR TITLE
Fix ThreadingLock deadlock on invalid access and ExitProcess

### DIFF
--- a/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
@@ -966,6 +966,8 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
                 SignalExitToDebugExited();
                 SignalExit();
             }
+
+            KernelStatic.GetCurrentThread().Exit();
         }
 
         private void UnpauseAndTerminateAllThreadsExcept(KThread currentThread)
@@ -981,7 +983,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
                 foreach (KThread thread in _threads)
                 {
-                    if ((thread.SchedFlags & ThreadSchedState.LowMask) != ThreadSchedState.TerminationPending)
+                    if (thread != currentThread && (thread.SchedFlags & ThreadSchedState.LowMask) != ThreadSchedState.TerminationPending)
                     {
                         thread.PrepareForTermination();
                     }

--- a/Ryujinx.Memory/Tracking/MemoryTracking.cs
+++ b/Ryujinx.Memory/Tracking/MemoryTracking.cs
@@ -227,6 +227,8 @@ namespace Ryujinx.Memory.Tracking
             // Look up the virtual region using the region list.
             // Signal up the chain to relevant handles.
 
+            bool shouldThrow = false;
+
             lock (TrackingLock)
             {
                 ref var overlaps = ref ThreadStaticArray<VirtualRegion>.Get();
@@ -235,32 +237,41 @@ namespace Ryujinx.Memory.Tracking
 
                 if (count == 0 && !precise)
                 {
-                    if (!_memoryManager.IsMapped(address))
+                    if (_memoryManager.IsMapped(address))
                     {
-                        _invalidAccessHandler?.Invoke(address);
-
-                        // We can't continue - it's impossible to remove protection from the page.
-                        // Even if the access handler wants us to continue, we wouldn't be able to.
-                        throw new InvalidMemoryRegionException();
-                    }
-
-                    _memoryManager.TrackingReprotect(address & ~(ulong)(_pageSize - 1), (ulong)_pageSize, MemoryPermission.ReadAndWrite);
-                    return false; // We can't handle this - it's probably a real invalid access.
-                }
-
-                for (int i = 0; i < count; i++)
-                {
-                    VirtualRegion region = overlaps[i];
-
-                    if (precise)
-                    {
-                        region.SignalPrecise(address, size, write);
+                        _memoryManager.TrackingReprotect(address & ~(ulong)(_pageSize - 1), (ulong)_pageSize, MemoryPermission.ReadAndWrite);
+                        return false; // We can't handle this - it's probably a real invalid access.
                     }
                     else
                     {
-                        region.Signal(address, size, write);
+                        shouldThrow = true;
                     }
                 }
+                else
+                {
+                    for (int i = 0; i < count; i++)
+                    {
+                        VirtualRegion region = overlaps[i];
+
+                        if (precise)
+                        {
+                            region.SignalPrecise(address, size, write);
+                        }
+                        else
+                        {
+                            region.Signal(address, size, write);
+                        }
+                    }
+                }
+            }
+
+            if (shouldThrow)
+            {
+                _invalidAccessHandler?.Invoke(address);
+
+                // We can't continue - it's impossible to remove protection from the page.
+                // Even if the access handler wants us to continue, we wouldn't be able to.
+                throw new InvalidMemoryRegionException();
             }
 
             return true;


### PR DESCRIPTION
This fixes two issues. The first issue is that `VirtualMemoryEvent` will call `_invalidAccessHandler` on invalid access, but it does so holding the `ThreadingLock`. Because the current invalid access handler prints the guest stack trace, it calls the HLE kernel `QueryMemory` function that will take memory manager locks. Since the memory manager calls CPU map/unmap methods which calls Tracking map/unmap methods, and those methods will also try to acquire the `TrackingLock`, this can cause deadlock if the invalid access happens when a guest memory mapping operation is in progress. This was fixed by calling it after releasing the lock.

The second issue was in kernel, when `TerminateProcess` is called, it will attempt to terminate all running threads, but it also requests the termination of the thread that triggered the process termination. Doing that prevents the termination thread from being unscheduled, which in turn prevents the thread that should be terminated to be scheduled if they are on the same guest core, which causes a infinite loop. This was fixed by not requesting the termination of the current thread which is the correct behaviour. This only affects termination triggered by the game, as a separate thread is used for emulator triggered termination.

Note that none of the above actually "fix" any game, as those paths are only taken when something else is wrong, games should not terminate themselves or perform invalid access under normal circumstances. The effect of those bugs is that the emulator would freeze if any of them happened. With the fix it no longer freezes and can be closed normally. It does *not* fix all "freeze when closing" issues, only this specific case.