### PR TITLE
Avoid lookup of invalid textures if pool did not change

### DIFF
--- a/Ryujinx.Common/Collections/BitMap.cs
+++ b/Ryujinx.Common/Collections/BitMap.cs
@@ -1,0 +1,226 @@
+namespace Ryujinx.Common.Collections
+{
+    /// <summary>
+    /// Represents a collection that can store 1 bit values.
+    /// </summary>
+    public struct BitMap
+    {
+        /// <summary>
+        /// Size in bits of the integer used internally for the groups of bits.
+        /// </summary>
+        public const int IntSize = 64;
+
+        private const int IntShift = 6;
+        private const int IntMask = IntSize - 1;
+
+        private readonly long[] _masks;
+
+        /// <summary>
+        /// Gets or sets the value of a bit.
+        /// </summary>
+        /// <param name="bit">Bit to access</param>
+        /// <returns>Bit value</returns>
+        public bool this[int bit]
+        {
+            get => IsSet(bit);
+            set
+            {
+                if (value)
+                {
+                    Set(bit);
+                }
+                else
+                {
+                    Clear(bit);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates a new bitmap.
+        /// </summary>
+        /// <param name="count">Total number of bits</param>
+        public BitMap(int count)
+        {
+            _masks = new long[(count + IntMask) / IntSize];
+        }
+
+        /// <summary>
+        /// Checks if any bit is set.
+        /// </summary>
+        /// <returns>True if any bit is set, false otherwise</returns>
+        public bool AnySet()
+        {
+            for (int i = 0; i < _masks.Length; i++)
+            {
+                if (_masks[i] != 0)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks if a specific bit is set.
+        /// </summary>
+        /// <param name="bit">Bit to be checked</param>
+        /// <returns>True if set, false otherwise</returns>
+        public bool IsSet(int bit)
+        {
+            int wordIndex = bit >> IntShift;
+            int wordBit = bit & IntMask;
+
+            long wordMask = 1L << wordBit;
+
+            return (_masks[wordIndex] & wordMask) != 0;
+        }
+
+        /// <summary>
+        /// Checks if any bit inside a given range of bits is set.
+        /// </summary>
+        /// <param name="start">Start bit of the range</param>
+        /// <param name="end">End bit of the range (inclusive)</param>
+        /// <returns>True if any bit is set, false otherwise</returns>
+        public bool IsSet(int start, int end)
+        {
+            if (start == end)
+            {
+                return IsSet(start);
+            }
+
+            int startIndex = start >> IntShift;
+            int startBit = start & IntMask;
+            long startMask = -1L << startBit;
+
+            int endIndex = end >> IntShift;
+            int endBit = end & IntMask;
+            long endMask = (long)(ulong.MaxValue >> (IntMask - endBit));
+
+            if (startIndex == endIndex)
+            {
+                return (_masks[startIndex] & startMask & endMask) != 0;
+            }
+
+            if ((_masks[startIndex] & startMask) != 0)
+            {
+                return true;
+            }
+
+            for (int i = startIndex + 1; i < endIndex; i++)
+            {
+                if (_masks[i] != 0)
+                {
+                    return true;
+                }
+            }
+
+            if ((_masks[endIndex] & endMask) != 0)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Sets the value of a bit to 1.
+        /// </summary>
+        /// <param name="bit">Bit to be set</param>
+        /// <returns>True if the bit was 0 and then changed to 1, false if it was already 1</returns>
+        public bool Set(int bit)
+        {
+            int wordIndex = bit >> IntShift;
+            int wordBit = bit & IntMask;
+
+            long wordMask = 1L << wordBit;
+
+            if ((_masks[wordIndex] & wordMask) != 0)
+            {
+                return false;
+            }
+
+            _masks[wordIndex] |= wordMask;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Sets a given range of bits to 1.
+        /// </summary>
+        /// <param name="start">Start bit of the range</param>
+        /// <param name="end">End bit of the range (inclusive)</param>
+        public void SetRange(int start, int end)
+        {
+            if (start == end)
+            {
+                Set(start);
+                return;
+            }
+
+            int startIndex = start >> IntShift;
+            int startBit = start & IntMask;
+            long startMask = -1L << startBit;
+
+            int endIndex = end >> IntShift;
+            int endBit = end & IntMask;
+            long endMask = (long)(ulong.MaxValue >> (IntMask - endBit));
+
+            if (startIndex == endIndex)
+            {
+                _masks[startIndex] |= startMask & endMask;
+            }
+            else
+            {
+                _masks[startIndex] |= startMask;
+
+                for (int i = startIndex + 1; i < endIndex; i++)
+                {
+                    _masks[i] |= -1;
+                }
+
+                _masks[endIndex] |= endMask;
+            }
+        }
+
+        /// <summary>
+        /// Sets a given bit to 0.
+        /// </summary>
+        /// <param name="bit">Bit to be cleared</param>
+        public void Clear(int bit)
+        {
+            int wordIndex = bit >> IntShift;
+            int wordBit   = bit & IntMask;
+
+            long wordMask = 1L << wordBit;
+
+            _masks[wordIndex] &= ~wordMask;
+        }
+
+        /// <summary>
+        /// Sets all bits to 0.
+        /// </summary>
+        public void Clear()
+        {
+            for (int i = 0; i < _masks.Length; i++)
+            {
+                _masks[i] = 0;
+            }
+        }
+
+        /// <summary>
+        /// Sets one or more groups of bits to 0.
+        /// See <see cref="IntSize"/> for how many bits are inside each group.
+        /// </summary>
+        /// <param name="start">Start index of the group</param>
+        /// <param name="end">End index of the group (inclusive)</param>
+        public void ClearInt(int start, int end)
+        {
+            for (int i = start; i <= end; i++)
+            {
+                _masks[i] = 0;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Currently, the cache returns null for invalid textures. Because we also use null to indicate that the texture is not "cached" on the pool, this results in the `TextureDescriptor` -> `TextureInfo` logic and lookup running over and over if there is an invalid texture on the pool. In some cases, this manifests as a "Invalid texture format" error being printed over and over in the log.

In order to prevent that from happening, I added a bitmap where we set the bit to 1 if the texture at the respective index is invalid. Then on a future call to the `Get` method in the pool, it will not attempt to look it up again and just return the descriptor and null texture directly. Should save a little bit of time in those cases, and prevent the "Invalid texture format" log spam (now the error is only printed once).

This has a little bit of cost (the additional bitmap check, which should be pretty cheap, and I don't believe that the `texture == null` path is common anyway, and a few KB of memory for the bitmap storage), but I believe it's worth it.

I noticed the error being printed on Shin Megami Tensei V. Now it's only printed once.