### PR TITLE
timezone: Fix regression caused by #3361

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Time/TimeZone/Types/TimeTypeInfo.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/TimeZone/Types/TimeTypeInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Ryujinx.HLE.HOS.Services.Time.TimeZone
 {
     [StructLayout(LayoutKind.Sequential, Size = Size, Pack = 4)]
-    struct TimeTypeInfo
+    public struct TimeTypeInfo
     {
         public const int Size = 0x10;
 

--- a/Ryujinx.HLE/HOS/Services/Time/TimeZone/Types/TimeZoneRule.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/TimeZone/Types/TimeZoneRule.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 namespace Ryujinx.HLE.HOS.Services.Time.TimeZone
 {
     [StructLayout(LayoutKind.Sequential, Pack = 4, Size = 0x4000, CharSet = CharSet.Ansi)]
-    struct TimeZoneRule
+    public struct TimeZoneRule
     {
         public const int TzMaxTypes = 128;
         public const int TzMaxChars = 50;
@@ -25,20 +25,20 @@ namespace Ryujinx.HLE.HOS.Services.Time.TimeZone
         public bool GoAhead;
 
         [StructLayout(LayoutKind.Sequential, Size = sizeof(long) * TzMaxTimes)]
-        private struct AtsStorageStruct {}
+        private struct AtsStorageStruct { }
 
         private AtsStorageStruct _ats;
 
         public Span<long> Ats => SpanHelpers.AsSpan<AtsStorageStruct, long>(ref _ats);
 
         [StructLayout(LayoutKind.Sequential, Size = sizeof(byte) * TzMaxTimes)]
-        private struct TypesStorageStruct {}
+        private struct TypesStorageStruct { }
 
         private TypesStorageStruct _types;
 
-        public Span<byte> Types => SpanHelpers.AsByteSpan<TypesStorageStruct>(ref _types);
+        public Span<byte> Types => SpanHelpers.AsByteSpan(ref _types);
 
-        [StructLayout(LayoutKind.Sequential, Size = TimeTypeInfo.Size * TzMaxTimes)]
+        [StructLayout(LayoutKind.Sequential, Size = TimeTypeInfo.Size * TzMaxTypes)]
         private struct TimeTypeInfoStorageStruct { }
 
         private TimeTypeInfoStorageStruct _ttis;
@@ -46,7 +46,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.TimeZone
         public Span<TimeTypeInfo> Ttis => SpanHelpers.AsSpan<TimeTypeInfoStorageStruct, TimeTypeInfo>(ref _ttis);
 
         [StructLayout(LayoutKind.Sequential, Size = sizeof(byte) * TzCharsArraySize)]
-        private struct CharsStorageStruct {}
+        private struct CharsStorageStruct { }
 
         private CharsStorageStruct _chars;
         public Span<byte> Chars => SpanHelpers.AsByteSpan(ref _chars);

--- a/Ryujinx.Tests/Ryujinx.Tests.csproj
+++ b/Ryujinx.Tests/Ryujinx.Tests.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Ryujinx.Audio\Ryujinx.Audio.csproj" />
     <ProjectReference Include="..\Ryujinx.Cpu\Ryujinx.Cpu.csproj" />
+    <ProjectReference Include="..\Ryujinx.HLE\Ryujinx.HLE.csproj" />
     <ProjectReference Include="..\Ryujinx.Memory\Ryujinx.Memory.csproj" />
     <ProjectReference Include="..\Ryujinx.Tests.Unicorn\Ryujinx.Tests.Unicorn.csproj" />
     <ProjectReference Include="..\ARMeilleure\ARMeilleure.csproj" />

--- a/Ryujinx.Tests/Time/TimeZoneRuleTests.cs
+++ b/Ryujinx.Tests/Time/TimeZoneRuleTests.cs
@@ -1,0 +1,18 @@
+﻿using NUnit.Framework;
+using Ryujinx.HLE.HOS.Services.Time.TimeZone;
+using System.Runtime.CompilerServices;
+
+namespace Ryujinx.Tests.Time
+{
+    internal class TimeZoneRuleTests
+    {
+        class EffectInfoParameterTests
+        {
+            [Test]
+            public void EnsureTypeSize()
+            {
+                Assert.AreEqual(0x4000, Unsafe.SizeOf<TimeZoneRule>());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Because of that PR, TimeZoneRule was bigger than 0x4000 thanks to a
misuse of a constant.

This PR address this issue and add a new unit test to ensure the size of
TimeZoneRule is 0x4000 bytes.

Also address suggestions that were lost on the original PR.

Close https://github.com/Ryujinx/Ryujinx/issues/3417