### PR TITLE
Account for pool change on texture bindings cache

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -43,6 +43,8 @@ namespace Ryujinx.Graphics.Gpu.Image
             public int TextureHandle;
             public int SamplerHandle;
             public int InvalidatedSequence;
+            public TexturePool CachedTexturePool;
+            public SamplerPool CachedSamplerPool;
             public Texture CachedTexture;
             public Sampler CachedSampler;
             public int ScaleIndex;
@@ -493,6 +495,8 @@ namespace Ryujinx.Graphics.Gpu.Image
                 ref TextureState state = ref _textureState[bindingInfo.Binding];
 
                 if (!poolModified &&
+                    state.CachedTexturePool == pool &&
+                    state.CachedSamplerPool == samplerPool &&
                     state.TextureHandle == textureId &&
                     state.SamplerHandle == samplerId &&
                     state.CachedTexture != null &&
@@ -517,6 +521,8 @@ namespace Ryujinx.Graphics.Gpu.Image
                     continue;
                 }
 
+                state.CachedTexturePool = pool;
+                state.CachedSamplerPool = samplerPool;
                 state.TextureHandle = textureId;
                 state.SamplerHandle = samplerId;
 


### PR DESCRIPTION
#3399 tries to avoid texture binding updates if the state does not change, however it has one flaw, it checks if the texture and sampler IDs changed, and checks if the pool contents changed, but it does not check if the pool itself changed. This causes issues for games that changes the pools but keeps the same bindings. This seems pretty rare so I believe the number of games affected by the regression is low.

Fixes regression on Super Zangyura.
Before:
![image](https://user-images.githubusercontent.com/5624669/175754767-3d400354-b27e-4c00-9e4b-1c20195bf310.png)
After:
![image](https://user-images.githubusercontent.com/5624669/175754774-a3cf4372-3c95-4c44-8a90-bfc570bcebfd.png)

Closes #3419.