### PR TITLE
Bindless elimination for constant sampler handle

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -792,13 +792,23 @@ namespace Ryujinx.Graphics.Gpu.Image
             // turn that into a regular texture access and produce those special handles with values on the higher 16 bits.
             if (handleType != TextureHandleType.CombinedSampler)
             {
-                ulong samplerBufferAddress = _isCompute
-                    ? _channel.BufferManager.GetComputeUniformBufferAddress(samplerBufferIndex)
-                    : _channel.BufferManager.GetGraphicsUniformBufferAddress(stageIndex, samplerBufferIndex);
+                int samplerHandle;
 
-                int samplerHandle = _channel.MemoryManager.Physical.Read<int>(samplerBufferAddress + (uint)samplerWordOffset * 4);
+                if (handleType != TextureHandleType.SeparateConstantSamplerHandle)
+                {
+                    ulong samplerBufferAddress = _isCompute
+                        ? _channel.BufferManager.GetComputeUniformBufferAddress(samplerBufferIndex)
+                        : _channel.BufferManager.GetGraphicsUniformBufferAddress(stageIndex, samplerBufferIndex);
 
-                if (handleType == TextureHandleType.SeparateSamplerId)
+                    samplerHandle = _channel.MemoryManager.Physical.Read<int>(samplerBufferAddress + (uint)samplerWordOffset * 4);
+                }
+                else
+                {
+                    samplerHandle = samplerWordOffset;
+                }
+
+                if (handleType == TextureHandleType.SeparateSamplerId ||
+                    handleType == TextureHandleType.SeparateConstantSamplerHandle)
                 {
                     samplerHandle <<= 20;
                 }

--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -21,7 +21,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 1;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 1;
+        private const uint CodeGenVersion = 3424;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/Ryujinx.Graphics.Shader/IGpuAccessor.cs
+++ b/Ryujinx.Graphics.Shader/IGpuAccessor.cs
@@ -237,7 +237,7 @@ namespace Ryujinx.Graphics.Shader
         /// <returns>True if the coordinates are normalized, false otherwise</returns>
         bool QueryTextureCoordNormalized(int handle, int cbufSlot = -1)
         {
-            return false;
+            return true;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Shader/TextureHandle.cs
+++ b/Ryujinx.Graphics.Shader/TextureHandle.cs
@@ -98,9 +98,19 @@ namespace Ryujinx.Graphics.Shader
             // turn that into a regular texture access and produce those special handles with values on the higher 16 bits.
             if (handleType != TextureHandleType.CombinedSampler)
             {
-                int samplerHandle = cachedSamplerBuffer[samplerWordOffset];
+                int samplerHandle;
 
-                if (handleType == TextureHandleType.SeparateSamplerId)
+                if (handleType != TextureHandleType.SeparateConstantSamplerHandle)
+                {
+                    samplerHandle = cachedSamplerBuffer[samplerWordOffset];
+                }
+                else
+                {
+                    samplerHandle = samplerWordOffset;
+                }
+
+                if (handleType == TextureHandleType.SeparateSamplerId ||
+                    handleType == TextureHandleType.SeparateConstantSamplerHandle)
                 {
                     samplerHandle <<= 20;
                 }

--- a/Ryujinx.Graphics.Shader/TextureHandle.cs
+++ b/Ryujinx.Graphics.Shader/TextureHandle.cs
@@ -7,7 +7,8 @@ namespace Ryujinx.Graphics.Shader
     {
         CombinedSampler = 0, // Must be 0.
         SeparateSamplerHandle = 1,
-        SeparateSamplerId = 2
+        SeparateSamplerId = 2,
+        SeparateConstantSamplerHandle = 3
     }
 
     public static class TextureHandle


### PR DESCRIPTION
This is extending the shader bindless texture access elimination to also work on cases where the texture handle is being combined with a constant handle value using bitwise OR operation.

Doing so allows Monster Hunter Rise Sunbreak to render (it was just showing black screen before):
![image](https://user-images.githubusercontent.com/5624669/175863164-f3a65b33-c5e6-44d4-a646-b3a91fcd93ab.png)
Still does not reach the title screen due to other issues.

Testing is welcome. Probably a good idea to test The Witcher 3 and Hades since those two uses the other "odd" handle combinations.