### PR TITLE
ptm: Stub GetTemperature

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Ptm/Ts/IMeasurementServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Ptm/Ts/IMeasurementServer.cs
@@ -6,9 +6,22 @@ namespace Ryujinx.HLE.HOS.Services.Ptm.Ts
     [Service("ts")]
     class IMeasurementServer : IpcService
     {
-        private const uint DefaultTemperature = 42000u;
+        private const uint DefaultTemperature = 42u;
 
         public IMeasurementServer(ServiceCtx context) { }
+
+        [CommandHipc(1)]
+        // GetTemperature(Location location) -> u32
+        public ResultCode GetTemperature(ServiceCtx context)
+        {
+            Location location = (Location)context.RequestData.ReadByte();
+
+            Logger.Stub?.PrintStub(LogClass.ServicePtm, new { location });
+
+            context.ResponseData.Write(DefaultTemperature);
+
+            return ResultCode.Success;
+        }
 
         [CommandHipc(3)]
         // GetTemperatureMilliC(Location location) -> u32
@@ -18,7 +31,7 @@ namespace Ryujinx.HLE.HOS.Services.Ptm.Ts
 
             Logger.Stub?.PrintStub(LogClass.ServicePtm, new { location });
 
-            context.ResponseData.Write(DefaultTemperature);
+            context.ResponseData.Write(DefaultTemperature * 1000);
 
             return ResultCode.Success;
         }


### PR DESCRIPTION
This stub GetTemperature of ptm service, needed by the latest version of Homebrew Menu. (Fixes #3422)

![image](https://user-images.githubusercontent.com/4905390/176272817-91f5a6a7-edaf-4e46-898d-35df73a1e927.png)
