### PR TITLE
Protect against stack overflow caused by deep recursive calls

### DIFF
--- a/ARMeilleure/Instructions/InstEmitException.cs
+++ b/ARMeilleure/Instructions/InstEmitException.cs
@@ -19,7 +19,7 @@ namespace ARMeilleure.Instructions
 
             context.LoadFromContext();
 
-            context.Return(Const(op.Address));
+            InstEmitFlowHelper.EmitReturn(context, Const(op.Address));
         }
 
         public static void Svc(ArmEmitterContext context)
@@ -49,7 +49,7 @@ namespace ARMeilleure.Instructions
 
             context.LoadFromContext();
 
-            context.Return(Const(op.Address));
+            InstEmitFlowHelper.EmitReturn(context, Const(op.Address));
         }
     }
 }

--- a/ARMeilleure/Instructions/InstEmitException32.cs
+++ b/ARMeilleure/Instructions/InstEmitException32.cs
@@ -35,7 +35,7 @@ namespace ARMeilleure.Instructions
 
             context.LoadFromContext();
 
-            context.Return(Const(context.CurrOp.Address));
+            InstEmitFlowHelper.EmitReturn(context, Const(context.CurrOp.Address));
         }
     }
 }

--- a/ARMeilleure/Instructions/InstEmitFlow.cs
+++ b/ARMeilleure/Instructions/InstEmitFlow.cs
@@ -66,7 +66,7 @@ namespace ARMeilleure.Instructions
         {
             OpCodeBReg op = (OpCodeBReg)context.CurrOp;
 
-            context.Return(GetIntOrZR(context, op.Rn));
+            EmitReturn(context, GetIntOrZR(context, op.Rn));
         }
 
         public static void Tbnz(ArmEmitterContext context) => EmitTb(context, onNotZero: true);

--- a/ARMeilleure/Optimizations.cs
+++ b/ARMeilleure/Optimizations.cs
@@ -6,8 +6,9 @@ namespace ARMeilleure
     {
         public static bool FastFP { get; set; } = true;
 
-        public static bool AllowLcqInFunctionTable  { get; set; } = true;
+        public static bool AllowLcqInFunctionTable { get; set; } = true;
         public static bool UseUnmanagedDispatchLoop { get; set; } = true;
+        public static bool EnableDeepCallRecursionProtection { get; set; } = true;
 
         public static bool UseSseIfAvailable       { get; set; } = true;
         public static bool UseSse2IfAvailable      { get; set; } = true;

--- a/ARMeilleure/State/NativeContext.cs
+++ b/ARMeilleure/State/NativeContext.cs
@@ -19,6 +19,7 @@ namespace ARMeilleure.State
             public ulong ExclusiveValueLow;
             public ulong ExclusiveValueHigh;
             public int Running;
+            public int CallDepth;
         }
 
         private static NativeCtxStorage _dummyStorage = new NativeCtxStorage();
@@ -209,6 +210,11 @@ namespace ARMeilleure.State
         public static int GetRunningOffset()
         {
             return StorageOffset(ref _dummyStorage, ref _dummyStorage.Running);
+        }
+
+        public static int GetCallDepthOffset()
+        {
+            return StorageOffset(ref _dummyStorage, ref _dummyStorage.CallDepth);
         }
 
         private static int StorageOffset<T>(ref NativeCtxStorage storage, ref T target)

--- a/ARMeilleure/Translation/TranslatorStubs.cs
+++ b/ARMeilleure/Translation/TranslatorStubs.cs
@@ -227,8 +227,16 @@ namespace ARMeilleure.Translation
 
             Operand runningAddress = context.Add(nativeContext, Const((ulong)NativeContext.GetRunningOffset()));
             Operand dispatchAddress = context.Add(nativeContext, Const((ulong)NativeContext.GetDispatchAddressOffset()));
+            Operand callDepthAddress = context.Add(nativeContext, Const((ulong)NativeContext.GetCallDepthOffset()));
 
             context.MarkLabel(beginLbl);
+
+            if (Optimizations.EnableDeepCallRecursionProtection)
+            {
+                // Reset the call depth counter, since this is our first guest function call.
+                context.Store(callDepthAddress, Const(1));
+            }
+
             context.Store(dispatchAddress, guestAddress);
             context.Copy(guestAddress, context.Call(Const((ulong)DispatchStub), OperandType.I64, nativeContext));
             context.BranchIfFalse(endLbl, guestAddress);


### PR DESCRIPTION
On some games, the call stack might get deep, and this is problematic because it can consume a lot of stack space and eventually cause a overflow, which will cause the emulator to crash. This is possible because the CPU emulator implement guest function calls and function calls on the host too, as an optimization. In order to protect against this scenario, I have added a new `CallDepth` counter which keeps track of how deep it is on the call stack. Once it hits a given value, it will stop calling directly and return to the dispatcher. Doing so completely unwinds the stack.

This change might have a minor performance impact since we now need to do more work before each guest call, so I would recommend the following while testing:
- That there was no performance degradation.
- No noticeable increase in PPTC recompilation time.
- No large increase in the PPTC cache file size.

This fixes a crash that happens right after the first screen on Monster Hunter Rise with update 10.0.2. It should also fix a crash on the base game while looking at pictures taken with the camera on the game, but I did not check that one.