### PR TITLE
Add unsafe memory option for modded games

### DIFF
--- a/Ryujinx.Ava/AppHost.cs
+++ b/Ryujinx.Ava/AppHost.cs
@@ -747,7 +747,7 @@ namespace Ryujinx.Ava
                                                                           ConfigurationState.Instance.System.IgnoreMissingServices,
                                                                           ConfigurationState.Instance.Graphics.AspectRatio,
                                                                           ConfigurationState.Instance.System.AudioVolume,
-                                                                          ConfigurationState.Instance.System.UnsafeMem.Value);
+                                                                          ConfigurationState.Instance.System.allowJitCodeMem.Value);
 
             Device = new Switch(configuration);
         }

--- a/Ryujinx.Ava/AppHost.cs
+++ b/Ryujinx.Ava/AppHost.cs
@@ -746,7 +746,8 @@ namespace Ryujinx.Ava
                                                                           ConfigurationState.Instance.System.MemoryManagerMode,
                                                                           ConfigurationState.Instance.System.IgnoreMissingServices,
                                                                           ConfigurationState.Instance.Graphics.AspectRatio,
-                                                                          ConfigurationState.Instance.System.AudioVolume);
+                                                                          ConfigurationState.Instance.System.AudioVolume,
+                                                                          ConfigurationState.Instance.System.UnsafeMem.Value);
 
             Device = new Switch(configuration);
         }

--- a/Ryujinx.Ava/AppHost.cs
+++ b/Ryujinx.Ava/AppHost.cs
@@ -747,7 +747,7 @@ namespace Ryujinx.Ava
                                                                           ConfigurationState.Instance.System.IgnoreMissingServices,
                                                                           ConfigurationState.Instance.Graphics.AspectRatio,
                                                                           ConfigurationState.Instance.System.AudioVolume,
-                                                                          ConfigurationState.Instance.System.allowJitCodeMem.Value);
+                                                                          ConfigurationState.Instance.System.AllowJitCodeMem.Value);
 
             Device = new Switch(configuration);
         }

--- a/Ryujinx.HLE/HLEConfiguration.cs
+++ b/Ryujinx.HLE/HLEConfiguration.cs
@@ -158,13 +158,30 @@ namespace Ryujinx.HLE
         /// </summary>
         public Action RefreshInputConfig { internal get; set; }
 
-        public HLEConfiguration(VirtualFileSystem virtualFileSystem, LibHacHorizonManager libHacHorizonManager,
-            ContentManager contentManager, AccountManager accountManager, UserChannelPersistence userChannelPersistence,
-            IRenderer gpuRenderer, IHardwareDeviceDriver audioDeviceDriver, MemoryConfiguration memoryConfiguration,
-            IHostUiHandler hostUiHandler, SystemLanguage systemLanguage, RegionCode region, bool enableVsync,
-            bool enableDockedMode, bool enablePtc, bool enableInternetAccess, IntegrityCheckLevel fsIntegrityCheckLevel,
-            int fsGlobalAccessLogMode, long systemTimeOffset, string timeZone, MemoryManagerMode memoryManagerMode,
-            bool ignoreMissingServices, AspectRatio aspectRatio, float audioVolume, bool allowUnsafeMem)
+        public HLEConfiguration(VirtualFileSystem      virtualFileSystem,
+                                LibHacHorizonManager   libHacHorizonManager,
+                                ContentManager         contentManager,
+                                AccountManager         accountManager,
+                                UserChannelPersistence userChannelPersistence,
+                                IRenderer              gpuRenderer,
+                                IHardwareDeviceDriver  audioDeviceDriver,
+                                MemoryConfiguration    memoryConfiguration,
+                                IHostUiHandler         hostUiHandler,
+                                SystemLanguage         systemLanguage,
+                                RegionCode             region,
+                                bool                   enableVsync,
+                                bool                   enableDockedMode,
+                                bool                   enablePtc,
+                                bool                   enableInternetAccess,
+                                IntegrityCheckLevel    fsIntegrityCheckLevel,
+                                int                    fsGlobalAccessLogMode,
+                                long                   systemTimeOffset,
+                                string                 timeZone,
+                                MemoryManagerMode      memoryManagerMode,
+                                bool                   ignoreMissingServices,
+                                AspectRatio            aspectRatio,
+                                float                  audioVolume,
+                                bool                   allowUnsafeMem);
         {
             VirtualFileSystem      = virtualFileSystem;
             LibHacHorizonManager   = libHacHorizonManager;

--- a/Ryujinx.HLE/HLEConfiguration.cs
+++ b/Ryujinx.HLE/HLEConfiguration.cs
@@ -90,7 +90,7 @@ namespace Ryujinx.HLE
         /// <summary>
         /// Controls whether code can access normally restricted memory areas.
         /// </summary>
-        internal readonly bool allowJitCodeMem;
+        internal readonly bool AllowJitCodeMem;
         
         /// <summary>
         /// Control the initial state of the docked mode.
@@ -181,7 +181,7 @@ namespace Ryujinx.HLE
                                 bool                   ignoreMissingServices,
                                 AspectRatio            aspectRatio,
                                 float                  audioVolume,
-                                bool                   allowJitCodeMemOpt)
+                                bool                   AllowJitCodeMemOpt)
         {
             VirtualFileSystem      = virtualFileSystem;
             LibHacHorizonManager   = libHacHorizonManager;
@@ -206,7 +206,7 @@ namespace Ryujinx.HLE
             IgnoreMissingServices  = ignoreMissingServices;
             AspectRatio            = aspectRatio;
             AudioVolume            = audioVolume;
-            allowJitCodeMem        = allowJitCodeMemOpt;
+            AllowJitCodeMem        = AllowJitCodeMemOpt;
         }
     }
 }

--- a/Ryujinx.HLE/HLEConfiguration.cs
+++ b/Ryujinx.HLE/HLEConfiguration.cs
@@ -90,7 +90,7 @@ namespace Ryujinx.HLE
         /// <summary>
         /// Controls whether code can access normally restricted memory areas.
         /// </summary>
-        internal readonly bool UnsafeMem;
+        internal readonly bool allowJitCodeMem;
         
         /// <summary>
         /// Control the initial state of the docked mode.
@@ -181,7 +181,7 @@ namespace Ryujinx.HLE
                                 bool                   ignoreMissingServices,
                                 AspectRatio            aspectRatio,
                                 float                  audioVolume,
-                                bool                   allowUnsafeMem);
+                                bool                   allowJitCodeMemOpt)
         {
             VirtualFileSystem      = virtualFileSystem;
             LibHacHorizonManager   = libHacHorizonManager;
@@ -206,7 +206,7 @@ namespace Ryujinx.HLE
             IgnoreMissingServices  = ignoreMissingServices;
             AspectRatio            = aspectRatio;
             AudioVolume            = audioVolume;
-            UnsafeMem              = allowUnsafeMem;
+            allowJitCodeMem        = allowJitCodeMemOpt;
         }
     }
 }

--- a/Ryujinx.HLE/HLEConfiguration.cs
+++ b/Ryujinx.HLE/HLEConfiguration.cs
@@ -88,6 +88,11 @@ namespace Ryujinx.HLE
         internal readonly bool EnableVsync;
 
         /// <summary>
+        /// Controls whether code can access normally restricted memory areas.
+        /// </summary>
+        internal readonly bool UnsafeMem;
+        
+        /// <summary>
         /// Control the initial state of the docked mode.
         /// </summary>
         internal readonly bool EnableDockedMode;
@@ -153,29 +158,13 @@ namespace Ryujinx.HLE
         /// </summary>
         public Action RefreshInputConfig { internal get; set; }
 
-        public HLEConfiguration(VirtualFileSystem      virtualFileSystem,
-                                LibHacHorizonManager   libHacHorizonManager,
-                                ContentManager         contentManager,
-                                AccountManager         accountManager,
-                                UserChannelPersistence userChannelPersistence,
-                                IRenderer              gpuRenderer,
-                                IHardwareDeviceDriver  audioDeviceDriver,
-                                MemoryConfiguration    memoryConfiguration,
-                                IHostUiHandler         hostUiHandler,
-                                SystemLanguage         systemLanguage,
-                                RegionCode             region,
-                                bool                   enableVsync,
-                                bool                   enableDockedMode,
-                                bool                   enablePtc,
-                                bool                   enableInternetAccess,
-                                IntegrityCheckLevel    fsIntegrityCheckLevel,
-                                int                    fsGlobalAccessLogMode,
-                                long                   systemTimeOffset,
-                                string                 timeZone,
-                                MemoryManagerMode      memoryManagerMode,
-                                bool                   ignoreMissingServices,
-                                AspectRatio            aspectRatio,
-                                float                  audioVolume)
+        public HLEConfiguration(VirtualFileSystem virtualFileSystem, LibHacHorizonManager libHacHorizonManager,
+            ContentManager contentManager, AccountManager accountManager, UserChannelPersistence userChannelPersistence,
+            IRenderer gpuRenderer, IHardwareDeviceDriver audioDeviceDriver, MemoryConfiguration memoryConfiguration,
+            IHostUiHandler hostUiHandler, SystemLanguage systemLanguage, RegionCode region, bool enableVsync,
+            bool enableDockedMode, bool enablePtc, bool enableInternetAccess, IntegrityCheckLevel fsIntegrityCheckLevel,
+            int fsGlobalAccessLogMode, long systemTimeOffset, string timeZone, MemoryManagerMode memoryManagerMode,
+            bool ignoreMissingServices, AspectRatio aspectRatio, float audioVolume, bool allowUnsafeMem)
         {
             VirtualFileSystem      = virtualFileSystem;
             LibHacHorizonManager   = libHacHorizonManager;
@@ -200,6 +189,7 @@ namespace Ryujinx.HLE
             IgnoreMissingServices  = ignoreMissingServices;
             AspectRatio            = aspectRatio;
             AudioVolume            = audioVolume;
+            UnsafeMem              = allowUnsafeMem;
         }
     }
 }

--- a/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
@@ -13,1183 +13,1121 @@ using System.Threading;
 
 namespace Ryujinx.HLE.HOS.Kernel.Process
 {
-    class KProcess : KSynchronizationObject
+class KProcess : KSynchronizationObject
+{
+    public const int KernelVersionMajor = 10;
+    public const int KernelVersionMinor = 4;
+    public const int KernelVersionRevision = 0;
+
+    public const int KernelVersionPacked =
+        (KernelVersionMajor << 19) | (KernelVersionMinor << 15) | (KernelVersionRevision << 0);
+
+    public KPageTableBase MemoryManager { get; private set; }
+
+    private SortedDictionary<ulong, KTlsPageInfo> _fullTlsPages;
+    private SortedDictionary<ulong, KTlsPageInfo> _freeTlsPages;
+
+    public int DefaultCpuCore { get; set; }
+
+    public bool Debug { get; private set; }
+
+    public KResourceLimit ResourceLimit { get; private set; }
+
+    public ulong PersonalMmHeapPagesCount { get; private set; }
+
+    public ProcessState State { get; private set; }
+
+    private object _processLock;
+    private object _threadingLock;
+
+    public KAddressArbiter AddressArbiter { get; private set; }
+
+    public ulong[] RandomEntropy { get; private set; }
+    public KThread[] PinnedThreads { get; private set; }
+
+    private bool _signaled;
+
+    public string Name { get; private set; }
+
+    private int _threadCount;
+
+    public ProcessCreationFlags Flags { get; private set; }
+
+    private MemoryRegion _memRegion;
+
+    public KProcessCapabilities Capabilities { get; private set; }
+
+    public bool AllowCodeMemoryForJit { get; private set; }
+
+    public ulong TitleId { get; private set; }
+    public bool IsApplication { get; private set; }
+    public ulong Pid { get; private set; }
+
+    private long _creationTimestamp;
+    private ulong _entrypoint;
+    private ThreadStart _customThreadStart;
+    private ulong _imageSize;
+    private ulong _mainThreadStackSize;
+    private ulong _memoryUsageCapacity;
+    private int _version;
+
+    public KHandleTable HandleTable { get; private set; }
+
+    public ulong UserExceptionContextAddress { get; private set; }
+
+    private LinkedList<KThread> _threads;
+
+    public bool IsPaused { get; private set; }
+
+    private long _totalTimeRunning;
+
+    public long TotalTimeRunning => _totalTimeRunning;
+
+    private IProcessContextFactory _contextFactory;
+    public IProcessContext Context { get; private set; }
+    public IVirtualMemoryManager CpuMemory => Context.AddressSpace;
+
+    public HleProcessDebugger Debugger { get; private set; }
+
+    public KProcess(KernelContext context, bool allowCodeMemoryForJit = false) : base(context)
     {
-        public const int KernelVersionMajor = 10;
-        public const int KernelVersionMinor = 4;
-        public const int KernelVersionRevision = 0;
+        _processLock = new object();
+        _threadingLock = new object();
 
-        public const int KernelVersionPacked =
-            (KernelVersionMajor << 19) |
-            (KernelVersionMinor << 15) |
-            (KernelVersionRevision << 0);
+        AddressArbiter = new KAddressArbiter(context);
 
-        public KPageTableBase MemoryManager { get; private set; }
+        _fullTlsPages = new SortedDictionary<ulong, KTlsPageInfo>();
+        _freeTlsPages = new SortedDictionary<ulong, KTlsPageInfo>();
 
-        private SortedDictionary<ulong, KTlsPageInfo> _fullTlsPages;
-        private SortedDictionary<ulong, KTlsPageInfo> _freeTlsPages;
+        Capabilities = new KProcessCapabilities();
 
-        public int DefaultCpuCore { get; set; }
+        AllowCodeMemoryForJit = context.Device.Configuration.allowJitCodeMem;
 
-        public bool Debug { get; private set; }
+        RandomEntropy = new ulong[KScheduler.CpuCoresCount];
+        PinnedThreads = new KThread[KScheduler.CpuCoresCount];
 
-        public KResourceLimit ResourceLimit { get; private set; }
+        // TODO: Remove once we no longer need to initialize it externally.
+        HandleTable = new KHandleTable(context);
 
-        public ulong PersonalMmHeapPagesCount { get; private set; }
+        _threads = new LinkedList<KThread>();
 
-        public ProcessState State { get; private set; }
+        Debugger = new HleProcessDebugger(this);
+    }
 
-        private object _processLock;
-        private object _threadingLock;
+    public KernelResult InitializeKip(ProcessCreationInfo creationInfo, ReadOnlySpan<int> capabilities,
+        KPageList pageList, KResourceLimit resourceLimit, MemoryRegion memRegion, IProcessContextFactory contextFactory,
+        ThreadStart customThreadStart = null)
+    {
+        ResourceLimit = resourceLimit;
+        _memRegion = memRegion;
+        _contextFactory = contextFactory ?? new ProcessContextFactory();
+        _customThreadStart = customThreadStart;
 
-        public KAddressArbiter AddressArbiter { get; private set; }
+        AddressSpaceType addrSpaceType =
+            (AddressSpaceType)((int)(creationInfo.Flags & ProcessCreationFlags.AddressSpaceMask) >>
+                               (int)ProcessCreationFlags.AddressSpaceShift);
 
-        public ulong[] RandomEntropy { get; private set; }
-        public KThread[] PinnedThreads { get; private set; }
+        Pid = KernelContext.NewKipId();
 
-        private bool _signaled;
-
-        public string Name { get; private set; }
-
-        private int _threadCount;
-
-        public ProcessCreationFlags Flags { get; private set; }
-
-        private MemoryRegion _memRegion;
-
-        public KProcessCapabilities Capabilities { get; private set; }
-
-        public bool AllowCodeMemoryForJit { get; private set; }
-
-        public ulong TitleId { get; private set; }
-        public bool IsApplication { get; private set; }
-        public ulong Pid { get; private set; }
-
-        private long _creationTimestamp;
-        private ulong _entrypoint;
-        private ThreadStart _customThreadStart;
-        private ulong _imageSize;
-        private ulong _mainThreadStackSize;
-        private ulong _memoryUsageCapacity;
-        private int _version;
-
-        public KHandleTable HandleTable { get; private set; }
-
-        public ulong UserExceptionContextAddress { get; private set; }
-
-        private LinkedList<KThread> _threads;
-
-        public bool IsPaused { get; private set; }
-
-        private long _totalTimeRunning;
-
-        public long TotalTimeRunning => _totalTimeRunning;
-
-        private IProcessContextFactory _contextFactory;
-        public IProcessContext Context { get; private set; }
-        public IVirtualMemoryManager CpuMemory => Context.AddressSpace;
-
-        public HleProcessDebugger Debugger { get; private set; }
-
-        public KProcess(KernelContext context, bool allowCodeMemoryForJit = false) : base(context)
+        if (Pid == 0 || Pid >= KernelConstants.InitialProcessId)
         {
-            _processLock = new object();
-            _threadingLock = new object();
-
-            AddressArbiter = new KAddressArbiter(context);
-
-            _fullTlsPages = new SortedDictionary<ulong, KTlsPageInfo>();
-            _freeTlsPages = new SortedDictionary<ulong, KTlsPageInfo>();
-
-            Capabilities = new KProcessCapabilities();
-
-            AllowCodeMemoryForJit = allowCodeMemoryForJit;
-
-            RandomEntropy = new ulong[KScheduler.CpuCoresCount];
-            PinnedThreads = new KThread[KScheduler.CpuCoresCount];
-
-            // TODO: Remove once we no longer need to initialize it externally.
-            HandleTable = new KHandleTable(context);
-
-            _threads = new LinkedList<KThread>();
-
-            Debugger = new HleProcessDebugger(this);
+            throw new InvalidOperationException($"Invalid KIP Id {Pid}.");
         }
 
-        public KernelResult InitializeKip(
-            ProcessCreationInfo creationInfo,
-            ReadOnlySpan<int> capabilities,
-            KPageList pageList,
-            KResourceLimit resourceLimit,
-            MemoryRegion memRegion,
-            IProcessContextFactory contextFactory,
-            ThreadStart customThreadStart = null)
+        InitializeMemoryManager(creationInfo.Flags);
+
+        bool aslrEnabled = creationInfo.Flags.HasFlag(ProcessCreationFlags.EnableAslr);
+
+        ulong codeAddress = creationInfo.CodeAddress;
+
+        ulong codeSize = (ulong)creationInfo.CodePagesCount * KPageTableBase.PageSize;
+
+        KMemoryBlockSlabManager slabManager = creationInfo.Flags.HasFlag(ProcessCreationFlags.IsApplication)
+            ? KernelContext.LargeMemoryBlockSlabManager
+            : KernelContext.SmallMemoryBlockSlabManager;
+
+        KernelResult result = MemoryManager.InitializeForProcess(addrSpaceType, aslrEnabled, !aslrEnabled, memRegion,
+            codeAddress, codeSize, slabManager);
+
+        if (result != KernelResult.Success)
         {
-            ResourceLimit = resourceLimit;
-            _memRegion = memRegion;
-            _contextFactory = contextFactory ?? new ProcessContextFactory();
-            _customThreadStart = customThreadStart;
-
-            AddressSpaceType addrSpaceType = (AddressSpaceType)((int)(creationInfo.Flags & ProcessCreationFlags.AddressSpaceMask) >> (int)ProcessCreationFlags.AddressSpaceShift);
-
-            Pid = KernelContext.NewKipId();
-
-            if (Pid == 0 || Pid >= KernelConstants.InitialProcessId)
-            {
-                throw new InvalidOperationException($"Invalid KIP Id {Pid}.");
-            }
-
-            InitializeMemoryManager(creationInfo.Flags);
-
-            bool aslrEnabled = creationInfo.Flags.HasFlag(ProcessCreationFlags.EnableAslr);
-
-            ulong codeAddress = creationInfo.CodeAddress;
-
-            ulong codeSize = (ulong)creationInfo.CodePagesCount * KPageTableBase.PageSize;
-
-            KMemoryBlockSlabManager slabManager = creationInfo.Flags.HasFlag(ProcessCreationFlags.IsApplication)
-                ? KernelContext.LargeMemoryBlockSlabManager
-                : KernelContext.SmallMemoryBlockSlabManager;
-
-            KernelResult result = MemoryManager.InitializeForProcess(
-                addrSpaceType,
-                aslrEnabled,
-                !aslrEnabled,
-                memRegion,
-                codeAddress,
-                codeSize,
-                slabManager);
-
-            if (result != KernelResult.Success)
-            {
-                return result;
-            }
-
-            if (!MemoryManager.CanContain(codeAddress, codeSize, MemoryState.CodeStatic))
-            {
-                return KernelResult.InvalidMemRange;
-            }
-
-            result = MemoryManager.MapPages(codeAddress, pageList, MemoryState.CodeStatic, KMemoryPermission.None);
-
-            if (result != KernelResult.Success)
-            {
-                return result;
-            }
-
-            result = Capabilities.InitializeForKernel(capabilities, MemoryManager);
-
-            if (result != KernelResult.Success)
-            {
-                return result;
-            }
-
-            return ParseProcessInfo(creationInfo);
+            return result;
         }
 
-        public KernelResult Initialize(
-            ProcessCreationInfo creationInfo,
-            ReadOnlySpan<int> capabilities,
-            KResourceLimit resourceLimit,
-            MemoryRegion memRegion,
-            IProcessContextFactory contextFactory,
-            ThreadStart customThreadStart = null)
+        if (!MemoryManager.CanContain(codeAddress, codeSize, MemoryState.CodeStatic))
         {
-            ResourceLimit = resourceLimit;
-            _memRegion = memRegion;
-            _contextFactory = contextFactory ?? new ProcessContextFactory();
-            _customThreadStart = customThreadStart;
-            IsApplication = creationInfo.Flags.HasFlag(ProcessCreationFlags.IsApplication);
+            return KernelResult.InvalidMemRange;
+        }
 
-            ulong personalMmHeapSize = GetPersonalMmHeapSize((ulong)creationInfo.SystemResourcePagesCount, memRegion);
+        result = MemoryManager.MapPages(codeAddress, pageList, MemoryState.CodeStatic, KMemoryPermission.None);
 
-            ulong codePagesCount = (ulong)creationInfo.CodePagesCount;
+        if (result != KernelResult.Success)
+        {
+            return result;
+        }
 
-            ulong neededSizeForProcess = personalMmHeapSize + codePagesCount * KPageTableBase.PageSize;
+        result = Capabilities.InitializeForKernel(capabilities, MemoryManager);
 
+        if (result != KernelResult.Success)
+        {
+            return result;
+        }
+
+        return ParseProcessInfo(creationInfo);
+    }
+
+    public KernelResult Initialize(ProcessCreationInfo creationInfo, ReadOnlySpan<int> capabilities,
+        KResourceLimit resourceLimit, MemoryRegion memRegion, IProcessContextFactory contextFactory,
+        ThreadStart customThreadStart = null)
+    {
+        ResourceLimit = resourceLimit;
+        _memRegion = memRegion;
+        _contextFactory = contextFactory ?? new ProcessContextFactory();
+        _customThreadStart = customThreadStart;
+        IsApplication = creationInfo.Flags.HasFlag(ProcessCreationFlags.IsApplication);
+
+        ulong personalMmHeapSize = GetPersonalMmHeapSize((ulong)creationInfo.SystemResourcePagesCount, memRegion);
+
+        ulong codePagesCount = (ulong)creationInfo.CodePagesCount;
+
+        ulong neededSizeForProcess = personalMmHeapSize + codePagesCount * KPageTableBase.PageSize;
+
+        if (neededSizeForProcess != 0 && resourceLimit != null)
+        {
+            if (!resourceLimit.Reserve(LimitableResource.Memory, neededSizeForProcess))
+            {
+                return KernelResult.ResLimitExceeded;
+            }
+        }
+
+        void CleanUpForError()
+        {
             if (neededSizeForProcess != 0 && resourceLimit != null)
             {
-                if (!resourceLimit.Reserve(LimitableResource.Memory, neededSizeForProcess))
-                {
-                    return KernelResult.ResLimitExceeded;
-                }
+                resourceLimit.Release(LimitableResource.Memory, neededSizeForProcess);
             }
+        }
 
-            void CleanUpForError()
-            {
-                if (neededSizeForProcess != 0 && resourceLimit != null)
-                {
-                    resourceLimit.Release(LimitableResource.Memory, neededSizeForProcess);
-                }
-            }
+        PersonalMmHeapPagesCount = (ulong)creationInfo.SystemResourcePagesCount;
 
-            PersonalMmHeapPagesCount = (ulong)creationInfo.SystemResourcePagesCount;
+        KMemoryBlockSlabManager slabManager;
 
-            KMemoryBlockSlabManager slabManager;
+        if (PersonalMmHeapPagesCount != 0)
+        {
+            slabManager = new KMemoryBlockSlabManager(PersonalMmHeapPagesCount * KPageTableBase.PageSize);
+        }
+        else
+        {
+            slabManager = creationInfo.Flags.HasFlag(ProcessCreationFlags.IsApplication)
+                ? KernelContext.LargeMemoryBlockSlabManager
+                : KernelContext.SmallMemoryBlockSlabManager;
+        }
 
-            if (PersonalMmHeapPagesCount != 0)
-            {
-                slabManager = new KMemoryBlockSlabManager(PersonalMmHeapPagesCount * KPageTableBase.PageSize);
-            }
-            else
-            {
-                slabManager = creationInfo.Flags.HasFlag(ProcessCreationFlags.IsApplication)
-                    ? KernelContext.LargeMemoryBlockSlabManager
-                    : KernelContext.SmallMemoryBlockSlabManager;
-            }
+        AddressSpaceType addrSpaceType =
+            (AddressSpaceType)((int)(creationInfo.Flags & ProcessCreationFlags.AddressSpaceMask) >>
+                               (int)ProcessCreationFlags.AddressSpaceShift);
 
-            AddressSpaceType addrSpaceType = (AddressSpaceType)((int)(creationInfo.Flags & ProcessCreationFlags.AddressSpaceMask) >> (int)ProcessCreationFlags.AddressSpaceShift);
+        Pid = KernelContext.NewProcessId();
 
-            Pid = KernelContext.NewProcessId();
+        if (Pid == ulong.MaxValue || Pid < KernelConstants.InitialProcessId)
+        {
+            throw new InvalidOperationException($"Invalid Process Id {Pid}.");
+        }
 
-            if (Pid == ulong.MaxValue || Pid < KernelConstants.InitialProcessId)
-            {
-                throw new InvalidOperationException($"Invalid Process Id {Pid}.");
-            }
+        InitializeMemoryManager(creationInfo.Flags);
 
-            InitializeMemoryManager(creationInfo.Flags);
+        bool aslrEnabled = creationInfo.Flags.HasFlag(ProcessCreationFlags.EnableAslr);
 
-            bool aslrEnabled = creationInfo.Flags.HasFlag(ProcessCreationFlags.EnableAslr);
+        ulong codeAddress = creationInfo.CodeAddress;
 
-            ulong codeAddress = creationInfo.CodeAddress;
+        ulong codeSize = codePagesCount * KPageTableBase.PageSize;
 
-            ulong codeSize = codePagesCount * KPageTableBase.PageSize;
+        KernelResult result = MemoryManager.InitializeForProcess(addrSpaceType, aslrEnabled, !aslrEnabled, memRegion,
+            codeAddress, codeSize, slabManager);
 
-            KernelResult result = MemoryManager.InitializeForProcess(
-                addrSpaceType,
-                aslrEnabled,
-                !aslrEnabled,
-                memRegion,
-                codeAddress,
-                codeSize,
-                slabManager);
-
-            if (result != KernelResult.Success)
-            {
-                CleanUpForError();
-
-                return result;
-            }
-
-            if (!MemoryManager.CanContain(codeAddress, codeSize, MemoryState.CodeStatic))
-            {
-                CleanUpForError();
-
-                return KernelResult.InvalidMemRange;
-            }
-
-            result = MemoryManager.MapPages(
-                codeAddress,
-                codePagesCount,
-                MemoryState.CodeStatic,
-                KMemoryPermission.None);
-
-            if (result != KernelResult.Success)
-            {
-                CleanUpForError();
-
-                return result;
-            }
-
-            result = Capabilities.InitializeForUser(capabilities, MemoryManager);
-
-            if (result != KernelResult.Success)
-            {
-                CleanUpForError();
-
-                return result;
-            }
-
-            result = ParseProcessInfo(creationInfo);
-
-            if (result != KernelResult.Success)
-            {
-                CleanUpForError();
-            }
+        if (result != KernelResult.Success)
+        {
+            CleanUpForError();
 
             return result;
         }
 
-        private KernelResult ParseProcessInfo(ProcessCreationInfo creationInfo)
+        if (!MemoryManager.CanContain(codeAddress, codeSize, MemoryState.CodeStatic))
         {
-            // Ensure that the current kernel version is equal or above to the minimum required.
-            uint requiredKernelVersionMajor = (uint)Capabilities.KernelReleaseVersion >> 19;
-            uint requiredKernelVersionMinor = ((uint)Capabilities.KernelReleaseVersion >> 15) & 0xf;
+            CleanUpForError();
 
-            if (KernelContext.EnableVersionChecks)
-            {
-                if (requiredKernelVersionMajor > KernelVersionMajor)
-                {
-                    return KernelResult.InvalidCombination;
-                }
-
-                if (requiredKernelVersionMajor != KernelVersionMajor && requiredKernelVersionMajor < 3)
-                {
-                    return KernelResult.InvalidCombination;
-                }
-
-                if (requiredKernelVersionMinor > KernelVersionMinor)
-                {
-                    return KernelResult.InvalidCombination;
-                }
-            }
-
-            KernelResult result = AllocateThreadLocalStorage(out ulong userExceptionContextAddress);
-
-            if (result != KernelResult.Success)
-            {
-                return result;
-            }
-
-            UserExceptionContextAddress = userExceptionContextAddress;
-
-            MemoryHelper.FillWithZeros(CpuMemory, userExceptionContextAddress, KTlsPageInfo.TlsEntrySize);
-
-            Name = creationInfo.Name;
-
-            State = ProcessState.Created;
-
-            _creationTimestamp = PerformanceCounter.ElapsedMilliseconds;
-
-            Flags = creationInfo.Flags;
-            _version = creationInfo.Version;
-            TitleId = creationInfo.TitleId;
-            _entrypoint = creationInfo.CodeAddress;
-            _imageSize = (ulong)creationInfo.CodePagesCount * KPageTableBase.PageSize;
-
-            switch (Flags & ProcessCreationFlags.AddressSpaceMask)
-            {
-                case ProcessCreationFlags.AddressSpace32Bit:
-                case ProcessCreationFlags.AddressSpace64BitDeprecated:
-                case ProcessCreationFlags.AddressSpace64Bit:
-                    _memoryUsageCapacity = MemoryManager.HeapRegionEnd -
-                                           MemoryManager.HeapRegionStart;
-                    break;
-
-                case ProcessCreationFlags.AddressSpace32BitWithoutAlias:
-                    _memoryUsageCapacity = MemoryManager.HeapRegionEnd -
-                                           MemoryManager.HeapRegionStart +
-                                           MemoryManager.AliasRegionEnd -
-                                           MemoryManager.AliasRegionStart;
-                    break;
-
-                default: throw new InvalidOperationException($"Invalid MMU flags value 0x{Flags:x2}.");
-            }
-
-            GenerateRandomEntropy();
-
-            return KernelResult.Success;
+            return KernelResult.InvalidMemRange;
         }
 
-        public KernelResult AllocateThreadLocalStorage(out ulong address)
+        result = MemoryManager.MapPages(codeAddress, codePagesCount, MemoryState.CodeStatic, KMemoryPermission.None);
+
+        if (result != KernelResult.Success)
         {
-            KernelContext.CriticalSection.Enter();
+            CleanUpForError();
 
-            KernelResult result;
+            return result;
+        }
 
-            if (_freeTlsPages.Count > 0)
+        result = Capabilities.InitializeForUser(capabilities, MemoryManager);
+
+        if (result != KernelResult.Success)
+        {
+            CleanUpForError();
+
+            return result;
+        }
+
+        result = ParseProcessInfo(creationInfo);
+
+        if (result != KernelResult.Success)
+        {
+            CleanUpForError();
+        }
+
+        return result;
+    }
+
+    private KernelResult ParseProcessInfo(ProcessCreationInfo creationInfo)
+    {
+        // Ensure that the current kernel version is equal or above to the minimum required.
+        uint requiredKernelVersionMajor = (uint)Capabilities.KernelReleaseVersion >> 19;
+        uint requiredKernelVersionMinor = ((uint)Capabilities.KernelReleaseVersion >> 15) & 0xf;
+
+        if (KernelContext.EnableVersionChecks)
+        {
+            if (requiredKernelVersionMajor > KernelVersionMajor)
             {
-                // If we have free TLS pages available, just use the first one.
-                KTlsPageInfo pageInfo = _freeTlsPages.Values.First();
+                return KernelResult.InvalidCombination;
+            }
 
+            if (requiredKernelVersionMajor != KernelVersionMajor && requiredKernelVersionMajor < 3)
+            {
+                return KernelResult.InvalidCombination;
+            }
+
+            if (requiredKernelVersionMinor > KernelVersionMinor)
+            {
+                return KernelResult.InvalidCombination;
+            }
+        }
+
+        KernelResult result = AllocateThreadLocalStorage(out ulong userExceptionContextAddress);
+
+        if (result != KernelResult.Success)
+        {
+            return result;
+        }
+
+        UserExceptionContextAddress = userExceptionContextAddress;
+
+        MemoryHelper.FillWithZeros(CpuMemory, userExceptionContextAddress, KTlsPageInfo.TlsEntrySize);
+
+        Name = creationInfo.Name;
+
+        State = ProcessState.Created;
+
+        _creationTimestamp = PerformanceCounter.ElapsedMilliseconds;
+
+        Flags = creationInfo.Flags;
+        _version = creationInfo.Version;
+        TitleId = creationInfo.TitleId;
+        _entrypoint = creationInfo.CodeAddress;
+        _imageSize = (ulong)creationInfo.CodePagesCount * KPageTableBase.PageSize;
+
+        switch (Flags & ProcessCreationFlags.AddressSpaceMask)
+        {
+            case ProcessCreationFlags.AddressSpace32Bit:
+            case ProcessCreationFlags.AddressSpace64BitDeprecated:
+            case ProcessCreationFlags.AddressSpace64Bit:
+                _memoryUsageCapacity = MemoryManager.HeapRegionEnd - MemoryManager.HeapRegionStart;
+                break;
+
+            case ProcessCreationFlags.AddressSpace32BitWithoutAlias:
+                _memoryUsageCapacity = MemoryManager.HeapRegionEnd - MemoryManager.HeapRegionStart +
+                    MemoryManager.AliasRegionEnd - MemoryManager.AliasRegionStart;
+                break;
+
+            default: throw new InvalidOperationException($"Invalid MMU flags value 0x{Flags:x2}.");
+        }
+
+        GenerateRandomEntropy();
+
+        return KernelResult.Success;
+    }
+
+    public KernelResult AllocateThreadLocalStorage(out ulong address)
+    {
+        KernelContext.CriticalSection.Enter();
+
+        KernelResult result;
+
+        if (_freeTlsPages.Count > 0)
+        {
+            // If we have free TLS pages available, just use the first one.
+            KTlsPageInfo pageInfo = _freeTlsPages.Values.First();
+
+            if (!pageInfo.TryGetFreePage(out address))
+            {
+                throw new InvalidOperationException("Unexpected failure getting free TLS page!");
+            }
+
+            if (pageInfo.IsFull())
+            {
+                _freeTlsPages.Remove(pageInfo.PageVirtualAddress);
+
+                _fullTlsPages.Add(pageInfo.PageVirtualAddress, pageInfo);
+            }
+
+            result = KernelResult.Success;
+        }
+        else
+        {
+            // Otherwise, we need to create a new one.
+            result = AllocateTlsPage(out KTlsPageInfo pageInfo);
+
+            if (result == KernelResult.Success)
+            {
                 if (!pageInfo.TryGetFreePage(out address))
                 {
                     throw new InvalidOperationException("Unexpected failure getting free TLS page!");
                 }
 
-                if (pageInfo.IsFull())
-                {
-                    _freeTlsPages.Remove(pageInfo.PageVirtualAddress);
+                _freeTlsPages.Add(pageInfo.PageVirtualAddress, pageInfo);
+            }
+            else
+            {
+                address = 0;
+            }
+        }
 
-                    _fullTlsPages.Add(pageInfo.PageVirtualAddress, pageInfo);
+        KernelContext.CriticalSection.Leave();
+
+        return result;
+    }
+
+    private KernelResult AllocateTlsPage(out KTlsPageInfo pageInfo)
+    {
+        pageInfo = default;
+
+        if (!KernelContext.UserSlabHeapPages.TryGetItem(out ulong tlsPagePa))
+        {
+            return KernelResult.OutOfMemory;
+        }
+
+        ulong regionStart = MemoryManager.TlsIoRegionStart;
+        ulong regionSize = MemoryManager.TlsIoRegionEnd - regionStart;
+
+        ulong regionPagesCount = regionSize / KPageTableBase.PageSize;
+
+        KernelResult result = MemoryManager.MapPages(1, KPageTableBase.PageSize, tlsPagePa, true, regionStart,
+            regionPagesCount, MemoryState.ThreadLocal, KMemoryPermission.ReadAndWrite, out ulong tlsPageVa);
+
+        if (result != KernelResult.Success)
+        {
+            KernelContext.UserSlabHeapPages.Free(tlsPagePa);
+        }
+        else
+        {
+            pageInfo = new KTlsPageInfo(tlsPageVa, tlsPagePa);
+
+            MemoryHelper.FillWithZeros(CpuMemory, tlsPageVa, KPageTableBase.PageSize);
+        }
+
+        return result;
+    }
+
+    public KernelResult FreeThreadLocalStorage(ulong tlsSlotAddr)
+    {
+        ulong tlsPageAddr = BitUtils.AlignDown(tlsSlotAddr, KPageTableBase.PageSize);
+
+        KernelContext.CriticalSection.Enter();
+
+        KernelResult result = KernelResult.Success;
+
+        KTlsPageInfo pageInfo;
+
+        if (_fullTlsPages.TryGetValue(tlsPageAddr, out pageInfo))
+        {
+            // TLS page was full, free slot and move to free pages tree.
+            _fullTlsPages.Remove(tlsPageAddr);
+
+            _freeTlsPages.Add(tlsPageAddr, pageInfo);
+        }
+        else if (!_freeTlsPages.TryGetValue(tlsPageAddr, out pageInfo))
+        {
+            result = KernelResult.InvalidAddress;
+        }
+
+        if (pageInfo != null)
+        {
+            pageInfo.FreeTlsSlot(tlsSlotAddr);
+
+            if (pageInfo.IsEmpty())
+            {
+                // TLS page is now empty, we should ensure it is removed
+                // from all trees, and free the memory it was using.
+                _freeTlsPages.Remove(tlsPageAddr);
+
+                KernelContext.CriticalSection.Leave();
+
+                FreeTlsPage(pageInfo);
+
+                return KernelResult.Success;
+            }
+        }
+
+        KernelContext.CriticalSection.Leave();
+
+        return result;
+    }
+
+    private KernelResult FreeTlsPage(KTlsPageInfo pageInfo)
+    {
+        KernelResult result = MemoryManager.UnmapForKernel(pageInfo.PageVirtualAddress, 1, MemoryState.ThreadLocal);
+
+        if (result == KernelResult.Success)
+        {
+            KernelContext.UserSlabHeapPages.Free(pageInfo.PagePhysicalAddress);
+        }
+
+        return result;
+    }
+
+    private void GenerateRandomEntropy()
+    {
+        // TODO.
+    }
+
+    public KernelResult Start(int mainThreadPriority, ulong stackSize)
+    {
+        lock (_processLock)
+        {
+            if (State > ProcessState.CreatedAttached)
+            {
+                return KernelResult.InvalidState;
+            }
+
+            if (ResourceLimit != null && !ResourceLimit.Reserve(LimitableResource.Thread, 1))
+            {
+                return KernelResult.ResLimitExceeded;
+            }
+
+            KResourceLimit threadResourceLimit = ResourceLimit;
+            KResourceLimit memoryResourceLimit = null;
+
+            if (_mainThreadStackSize != 0)
+            {
+                throw new InvalidOperationException("Trying to start a process with a invalid state!");
+            }
+
+            ulong stackSizeRounded = BitUtils.AlignUp(stackSize, KPageTableBase.PageSize);
+
+            ulong neededSize = stackSizeRounded + _imageSize;
+
+            // Check if the needed size for the code and the stack will fit on the
+            // memory usage capacity of this Process. Also check for possible overflow
+            // on the above addition.
+            if (neededSize > _memoryUsageCapacity || neededSize < stackSizeRounded)
+            {
+                threadResourceLimit?.Release(LimitableResource.Thread, 1);
+
+                return KernelResult.OutOfMemory;
+            }
+
+            if (stackSizeRounded != 0 && ResourceLimit != null)
+            {
+                memoryResourceLimit = ResourceLimit;
+
+                if (!memoryResourceLimit.Reserve(LimitableResource.Memory, stackSizeRounded))
+                {
+                    threadResourceLimit?.Release(LimitableResource.Thread, 1);
+
+                    return KernelResult.ResLimitExceeded;
+                }
+            }
+
+            KernelResult result;
+
+            KThread mainThread = null;
+
+            ulong stackTop = 0;
+
+            void CleanUpForError()
+            {
+                HandleTable.Destroy();
+
+                mainThread?.DecrementReferenceCount();
+
+                if (_mainThreadStackSize != 0)
+                {
+                    ulong stackBottom = stackTop - _mainThreadStackSize;
+
+                    ulong stackPagesCount = _mainThreadStackSize / KPageTableBase.PageSize;
+
+                    MemoryManager.UnmapForKernel(stackBottom, stackPagesCount, MemoryState.Stack);
+
+                    _mainThreadStackSize = 0;
+                }
+
+                memoryResourceLimit?.Release(LimitableResource.Memory, stackSizeRounded);
+                threadResourceLimit?.Release(LimitableResource.Thread, 1);
+            }
+
+            if (stackSizeRounded != 0)
+            {
+                ulong stackPagesCount = stackSizeRounded / KPageTableBase.PageSize;
+
+                ulong regionStart = MemoryManager.StackRegionStart;
+                ulong regionSize = MemoryManager.StackRegionEnd - regionStart;
+
+                ulong regionPagesCount = regionSize / KPageTableBase.PageSize;
+
+                result = MemoryManager.MapPages(stackPagesCount, KPageTableBase.PageSize, 0, false, regionStart,
+                    regionPagesCount, MemoryState.Stack, KMemoryPermission.ReadAndWrite, out ulong stackBottom);
+
+                if (result != KernelResult.Success)
+                {
+                    CleanUpForError();
+
+                    return result;
+                }
+
+                _mainThreadStackSize += stackSizeRounded;
+
+                stackTop = stackBottom + stackSizeRounded;
+            }
+
+            ulong heapCapacity = _memoryUsageCapacity - _mainThreadStackSize - _imageSize;
+
+            result = MemoryManager.SetHeapCapacity(heapCapacity);
+
+            if (result != KernelResult.Success)
+            {
+                CleanUpForError();
+
+                return result;
+            }
+
+            HandleTable = new KHandleTable(KernelContext);
+
+            result = HandleTable.Initialize(Capabilities.HandleTableSize);
+
+            if (result != KernelResult.Success)
+            {
+                CleanUpForError();
+
+                return result;
+            }
+
+            mainThread = new KThread(KernelContext);
+
+            result = mainThread.Initialize(_entrypoint, 0, stackTop, mainThreadPriority, DefaultCpuCore, this,
+                ThreadType.User, _customThreadStart);
+
+            if (result != KernelResult.Success)
+            {
+                CleanUpForError();
+
+                return result;
+            }
+
+            result = HandleTable.GenerateHandle(mainThread, out int mainThreadHandle);
+
+            if (result != KernelResult.Success)
+            {
+                CleanUpForError();
+
+                return result;
+            }
+
+            mainThread.SetEntryArguments(0, mainThreadHandle);
+
+            ProcessState oldState = State;
+            ProcessState newState = State != ProcessState.Created ? ProcessState.Attached : ProcessState.Started;
+
+            SetState(newState);
+
+            result = mainThread.Start();
+
+            if (result != KernelResult.Success)
+            {
+                SetState(oldState);
+
+                CleanUpForError();
+            }
+
+            if (result == KernelResult.Success)
+            {
+                mainThread.IncrementReferenceCount();
+            }
+
+            mainThread.DecrementReferenceCount();
+
+            return result;
+        }
+    }
+
+    private void SetState(ProcessState newState)
+    {
+        if (State != newState)
+        {
+            State = newState;
+            _signaled = true;
+
+            Signal();
+        }
+    }
+
+    public KernelResult InitializeThread(KThread thread, ulong entrypoint, ulong argsPtr, ulong stackTop, int priority,
+        int cpuCore, ThreadStart customThreadStart = null)
+    {
+        lock (_processLock)
+        {
+            return thread.Initialize(entrypoint, argsPtr, stackTop, priority, cpuCore, this, ThreadType.User,
+                customThreadStart);
+        }
+    }
+
+    public IExecutionContext CreateExecutionContext()
+    {
+        return Context?.CreateExecutionContext(new ExceptionCallbacks(InterruptHandler, null,
+            KernelContext.SyscallHandler.SvcCall, UndefinedInstructionHandler));
+    }
+
+    private void InterruptHandler(IExecutionContext context)
+    {
+        KThread currentThread = KernelStatic.GetCurrentThread();
+
+        if (currentThread.Context.Running && currentThread.Owner != null && currentThread.GetUserDisableCount() != 0 &&
+            currentThread.Owner.PinnedThreads[currentThread.CurrentCore] == null)
+        {
+            KernelContext.CriticalSection.Enter();
+
+            currentThread.Owner.PinThread(currentThread);
+
+            currentThread.SetUserInterruptFlag();
+
+            KernelContext.CriticalSection.Leave();
+        }
+
+        if (currentThread.IsSchedulable)
+        {
+            KernelContext.Schedulers[currentThread.CurrentCore].Schedule();
+        }
+
+        currentThread.HandlePostSyscall();
+    }
+
+    public void IncrementThreadCount()
+    {
+        Interlocked.Increment(ref _threadCount);
+    }
+
+    public void DecrementThreadCountAndTerminateIfZero()
+    {
+        if (Interlocked.Decrement(ref _threadCount) == 0)
+        {
+            Terminate();
+        }
+    }
+
+    public void DecrementToZeroWhileTerminatingCurrent()
+    {
+        while (Interlocked.Decrement(ref _threadCount) != 0)
+        {
+            Destroy();
+            TerminateCurrentProcess();
+        }
+
+        // Nintendo panic here because if it reaches this point, the current thread should be already dead.
+        // As we handle the death of the thread in the post SVC handler and inside the CPU emulator, we don't panic here.
+    }
+
+    public ulong GetMemoryCapacity()
+    {
+        ulong totalCapacity = (ulong)ResourceLimit.GetRemainingValue(LimitableResource.Memory);
+
+        totalCapacity += MemoryManager.GetTotalHeapSize();
+
+        totalCapacity += GetPersonalMmHeapSize();
+
+        totalCapacity += _imageSize + _mainThreadStackSize;
+
+        if (totalCapacity <= _memoryUsageCapacity)
+        {
+            return totalCapacity;
+        }
+
+        return _memoryUsageCapacity;
+    }
+
+    public ulong GetMemoryUsage()
+    {
+        return _imageSize + _mainThreadStackSize + MemoryManager.GetTotalHeapSize() + GetPersonalMmHeapSize();
+    }
+
+    public ulong GetMemoryCapacityWithoutPersonalMmHeap()
+    {
+        return GetMemoryCapacity() - GetPersonalMmHeapSize();
+    }
+
+    public ulong GetMemoryUsageWithoutPersonalMmHeap()
+    {
+        return GetMemoryUsage() - GetPersonalMmHeapSize();
+    }
+
+    private ulong GetPersonalMmHeapSize()
+    {
+        return GetPersonalMmHeapSize(PersonalMmHeapPagesCount, _memRegion);
+    }
+
+    private static ulong GetPersonalMmHeapSize(ulong personalMmHeapPagesCount, MemoryRegion memRegion)
+    {
+        if (memRegion == MemoryRegion.Applet)
+        {
+            return 0;
+        }
+
+        return personalMmHeapPagesCount * KPageTableBase.PageSize;
+    }
+
+    public void AddCpuTime(long ticks)
+    {
+        Interlocked.Add(ref _totalTimeRunning, ticks);
+    }
+
+    public void AddThread(KThread thread)
+    {
+        lock (_threadingLock)
+        {
+            thread.ProcessListNode = _threads.AddLast(thread);
+        }
+    }
+
+    public void RemoveThread(KThread thread)
+    {
+        lock (_threadingLock)
+        {
+            _threads.Remove(thread.ProcessListNode);
+        }
+    }
+
+    public bool IsCpuCoreAllowed(int core)
+    {
+        return (Capabilities.AllowedCpuCoresMask & (1UL << core)) != 0;
+    }
+
+    public bool IsPriorityAllowed(int priority)
+    {
+        return (Capabilities.AllowedThreadPriosMask & (1UL << priority)) != 0;
+    }
+
+    public override bool IsSignaled()
+    {
+        return _signaled;
+    }
+
+    public KernelResult Terminate()
+    {
+        KernelResult result;
+
+        bool shallTerminate = false;
+
+        KernelContext.CriticalSection.Enter();
+
+        lock (_processLock)
+        {
+            if (State >= ProcessState.Started)
+            {
+                if (State == ProcessState.Started || State == ProcessState.Crashed || State == ProcessState.Attached ||
+                    State == ProcessState.DebugSuspended)
+                {
+                    SetState(ProcessState.Exiting);
+
+                    shallTerminate = true;
                 }
 
                 result = KernelResult.Success;
             }
             else
             {
-                // Otherwise, we need to create a new one.
-                result = AllocateTlsPage(out KTlsPageInfo pageInfo);
+                result = KernelResult.InvalidState;
+            }
+        }
 
-                if (result == KernelResult.Success)
+        KernelContext.CriticalSection.Leave();
+
+        if (shallTerminate)
+        {
+            UnpauseAndTerminateAllThreadsExcept(KernelStatic.GetCurrentThread());
+
+            HandleTable.Destroy();
+
+            SignalExitToDebugTerminated();
+            SignalExit();
+        }
+
+        return result;
+    }
+
+    public void TerminateCurrentProcess()
+    {
+        bool shallTerminate = false;
+
+        KernelContext.CriticalSection.Enter();
+
+        lock (_processLock)
+        {
+            if (State >= ProcessState.Started)
+            {
+                if (State == ProcessState.Started || State == ProcessState.Attached ||
+                    State == ProcessState.DebugSuspended)
                 {
-                    if (!pageInfo.TryGetFreePage(out address))
-                    {
-                        throw new InvalidOperationException("Unexpected failure getting free TLS page!");
-                    }
+                    SetState(ProcessState.Exiting);
 
-                    _freeTlsPages.Add(pageInfo.PageVirtualAddress, pageInfo);
+                    shallTerminate = true;
                 }
-                else
+            }
+        }
+
+        KernelContext.CriticalSection.Leave();
+
+        if (shallTerminate)
+        {
+            UnpauseAndTerminateAllThreadsExcept(KernelStatic.GetCurrentThread());
+
+            HandleTable.Destroy();
+
+            // NOTE: this is supposed to be called in receiving of the mailbox.
+            SignalExitToDebugExited();
+            SignalExit();
+        }
+
+        KernelStatic.GetCurrentThread().Exit();
+    }
+
+    private void UnpauseAndTerminateAllThreadsExcept(KThread currentThread)
+    {
+        lock (_threadingLock)
+        {
+            KernelContext.CriticalSection.Enter();
+
+            if (currentThread != null && PinnedThreads[currentThread.CurrentCore] == currentThread)
+            {
+                UnpinThread(currentThread);
+            }
+
+            foreach (KThread thread in _threads)
+            {
+                if (thread != currentThread && (thread.SchedFlags & ThreadSchedState.LowMask) !=
+                    ThreadSchedState.TerminationPending)
                 {
-                    address = 0;
+                    thread.PrepareForTermination();
                 }
             }
 
             KernelContext.CriticalSection.Leave();
-
-            return result;
         }
 
-        private KernelResult AllocateTlsPage(out KTlsPageInfo pageInfo)
+        while (true)
         {
-            pageInfo = default;
+            KThread blockedThread = null;
 
-            if (!KernelContext.UserSlabHeapPages.TryGetItem(out ulong tlsPagePa))
+            lock (_threadingLock)
             {
-                return KernelResult.OutOfMemory;
+                foreach (KThread thread in _threads)
+                {
+                    if (thread != currentThread && (thread.SchedFlags & ThreadSchedState.LowMask) !=
+                        ThreadSchedState.TerminationPending)
+                    {
+                        thread.IncrementReferenceCount();
+
+                        blockedThread = thread;
+                        break;
+                    }
+                }
             }
 
-            ulong regionStart = MemoryManager.TlsIoRegionStart;
-            ulong regionSize = MemoryManager.TlsIoRegionEnd - regionStart;
-
-            ulong regionPagesCount = regionSize / KPageTableBase.PageSize;
-
-            KernelResult result = MemoryManager.MapPages(
-                1,
-                KPageTableBase.PageSize,
-                tlsPagePa,
-                true,
-                regionStart,
-                regionPagesCount,
-                MemoryState.ThreadLocal,
-                KMemoryPermission.ReadAndWrite,
-                out ulong tlsPageVa);
-
-            if (result != KernelResult.Success)
+            if (blockedThread == null)
             {
-                KernelContext.UserSlabHeapPages.Free(tlsPagePa);
+                break;
+            }
+
+            blockedThread.Terminate();
+            blockedThread.DecrementReferenceCount();
+        }
+    }
+
+    private void SignalExitToDebugTerminated()
+    {
+        // TODO: Debug events.
+    }
+
+    private void SignalExitToDebugExited()
+    {
+        // TODO: Debug events.
+    }
+
+    private void SignalExit()
+    {
+        if (ResourceLimit != null)
+        {
+            ResourceLimit.Release(LimitableResource.Memory, GetMemoryUsage());
+        }
+
+        KernelContext.CriticalSection.Enter();
+
+        SetState(ProcessState.Exited);
+
+        KernelContext.CriticalSection.Leave();
+    }
+
+    public KernelResult ClearIfNotExited()
+    {
+        KernelResult result;
+
+        KernelContext.CriticalSection.Enter();
+
+        lock (_processLock)
+        {
+            if (State != ProcessState.Exited && _signaled)
+            {
+                _signaled = false;
+
+                result = KernelResult.Success;
             }
             else
             {
-                pageInfo = new KTlsPageInfo(tlsPageVa, tlsPagePa);
-
-                MemoryHelper.FillWithZeros(CpuMemory, tlsPageVa, KPageTableBase.PageSize);
+                result = KernelResult.InvalidState;
             }
-
-            return result;
         }
 
-        public KernelResult FreeThreadLocalStorage(ulong tlsSlotAddr)
+        KernelContext.CriticalSection.Leave();
+
+        return result;
+    }
+
+    private void InitializeMemoryManager(ProcessCreationFlags flags)
+    {
+        int addrSpaceBits = (flags & ProcessCreationFlags.AddressSpaceMask) switch
         {
-            ulong tlsPageAddr = BitUtils.AlignDown(tlsSlotAddr, KPageTableBase.PageSize);
+            ProcessCreationFlags.AddressSpace32Bit => 32,
+            ProcessCreationFlags.AddressSpace64BitDeprecated => 36,
+            ProcessCreationFlags.AddressSpace32BitWithoutAlias => 32,
+            ProcessCreationFlags.AddressSpace64Bit => 39,
+            _ => 39
+        };
 
-            KernelContext.CriticalSection.Enter();
+        bool for64Bit = flags.HasFlag(ProcessCreationFlags.Is64Bit);
 
-            KernelResult result = KernelResult.Success;
+        Context = _contextFactory.Create(KernelContext, Pid, 1UL << addrSpaceBits, InvalidAccessHandler, for64Bit);
 
-            KTlsPageInfo pageInfo;
+        MemoryManager = new KPageTable(KernelContext, CpuMemory);
+    }
 
-            if (_fullTlsPages.TryGetValue(tlsPageAddr, out pageInfo))
+    private bool InvalidAccessHandler(ulong va)
+    {
+        KernelStatic.GetCurrentThread()?.PrintGuestStackTrace();
+        KernelStatic.GetCurrentThread()?.PrintGuestRegisterPrintout();
+
+        Logger.Error?.Print(LogClass.Cpu, $"Invalid memory access at virtual address 0x{va:X16}.");
+
+        return false;
+    }
+
+    private void UndefinedInstructionHandler(IExecutionContext context, ulong address, int opCode)
+    {
+        KernelStatic.GetCurrentThread().PrintGuestStackTrace();
+        KernelStatic.GetCurrentThread()?.PrintGuestRegisterPrintout();
+
+        throw new UndefinedInstructionException(address, opCode);
+    }
+
+    protected override void Destroy() => Context.Dispose();
+
+    public KernelResult SetActivity(bool pause)
+    {
+        KernelContext.CriticalSection.Enter();
+
+        if (State != ProcessState.Exiting && State != ProcessState.Exited)
+        {
+            if (pause)
             {
-                // TLS page was full, free slot and move to free pages tree.
-                _fullTlsPages.Remove(tlsPageAddr);
-
-                _freeTlsPages.Add(tlsPageAddr, pageInfo);
-            }
-            else if (!_freeTlsPages.TryGetValue(tlsPageAddr, out pageInfo))
-            {
-                result = KernelResult.InvalidAddress;
-            }
-
-            if (pageInfo != null)
-            {
-                pageInfo.FreeTlsSlot(tlsSlotAddr);
-
-                if (pageInfo.IsEmpty())
+                if (IsPaused)
                 {
-                    // TLS page is now empty, we should ensure it is removed
-                    // from all trees, and free the memory it was using.
-                    _freeTlsPages.Remove(tlsPageAddr);
-
                     KernelContext.CriticalSection.Leave();
 
-                    FreeTlsPage(pageInfo);
-
-                    return KernelResult.Success;
-                }
-            }
-
-            KernelContext.CriticalSection.Leave();
-
-            return result;
-        }
-
-        private KernelResult FreeTlsPage(KTlsPageInfo pageInfo)
-        {
-            KernelResult result = MemoryManager.UnmapForKernel(pageInfo.PageVirtualAddress, 1, MemoryState.ThreadLocal);
-
-            if (result == KernelResult.Success)
-            {
-                KernelContext.UserSlabHeapPages.Free(pageInfo.PagePhysicalAddress);
-            }
-
-            return result;
-        }
-
-        private void GenerateRandomEntropy()
-        {
-            // TODO.
-        }
-
-        public KernelResult Start(int mainThreadPriority, ulong stackSize)
-        {
-            lock (_processLock)
-            {
-                if (State > ProcessState.CreatedAttached)
-                {
                     return KernelResult.InvalidState;
                 }
-
-                if (ResourceLimit != null && !ResourceLimit.Reserve(LimitableResource.Thread, 1))
-                {
-                    return KernelResult.ResLimitExceeded;
-                }
-
-                KResourceLimit threadResourceLimit = ResourceLimit;
-                KResourceLimit memoryResourceLimit = null;
-
-                if (_mainThreadStackSize != 0)
-                {
-                    throw new InvalidOperationException("Trying to start a process with a invalid state!");
-                }
-
-                ulong stackSizeRounded = BitUtils.AlignUp(stackSize, KPageTableBase.PageSize);
-
-                ulong neededSize = stackSizeRounded + _imageSize;
-
-                // Check if the needed size for the code and the stack will fit on the
-                // memory usage capacity of this Process. Also check for possible overflow
-                // on the above addition.
-                if (neededSize > _memoryUsageCapacity || neededSize < stackSizeRounded)
-                {
-                    threadResourceLimit?.Release(LimitableResource.Thread, 1);
-
-                    return KernelResult.OutOfMemory;
-                }
-
-                if (stackSizeRounded != 0 && ResourceLimit != null)
-                {
-                    memoryResourceLimit = ResourceLimit;
-
-                    if (!memoryResourceLimit.Reserve(LimitableResource.Memory, stackSizeRounded))
-                    {
-                        threadResourceLimit?.Release(LimitableResource.Thread, 1);
-
-                        return KernelResult.ResLimitExceeded;
-                    }
-                }
-
-                KernelResult result;
-
-                KThread mainThread = null;
-
-                ulong stackTop = 0;
-
-                void CleanUpForError()
-                {
-                    HandleTable.Destroy();
-
-                    mainThread?.DecrementReferenceCount();
-
-                    if (_mainThreadStackSize != 0)
-                    {
-                        ulong stackBottom = stackTop - _mainThreadStackSize;
-
-                        ulong stackPagesCount = _mainThreadStackSize / KPageTableBase.PageSize;
-
-                        MemoryManager.UnmapForKernel(stackBottom, stackPagesCount, MemoryState.Stack);
-
-                        _mainThreadStackSize = 0;
-                    }
-
-                    memoryResourceLimit?.Release(LimitableResource.Memory, stackSizeRounded);
-                    threadResourceLimit?.Release(LimitableResource.Thread, 1);
-                }
-
-                if (stackSizeRounded != 0)
-                {
-                    ulong stackPagesCount = stackSizeRounded / KPageTableBase.PageSize;
-
-                    ulong regionStart = MemoryManager.StackRegionStart;
-                    ulong regionSize = MemoryManager.StackRegionEnd - regionStart;
-
-                    ulong regionPagesCount = regionSize / KPageTableBase.PageSize;
-
-                    result = MemoryManager.MapPages(
-                        stackPagesCount,
-                        KPageTableBase.PageSize,
-                        0,
-                        false,
-                        regionStart,
-                        regionPagesCount,
-                        MemoryState.Stack,
-                        KMemoryPermission.ReadAndWrite,
-                        out ulong stackBottom);
-
-                    if (result != KernelResult.Success)
-                    {
-                        CleanUpForError();
-
-                        return result;
-                    }
-
-                    _mainThreadStackSize += stackSizeRounded;
-
-                    stackTop = stackBottom + stackSizeRounded;
-                }
-
-                ulong heapCapacity = _memoryUsageCapacity - _mainThreadStackSize - _imageSize;
-
-                result = MemoryManager.SetHeapCapacity(heapCapacity);
-
-                if (result != KernelResult.Success)
-                {
-                    CleanUpForError();
-
-                    return result;
-                }
-
-                HandleTable = new KHandleTable(KernelContext);
-
-                result = HandleTable.Initialize(Capabilities.HandleTableSize);
-
-                if (result != KernelResult.Success)
-                {
-                    CleanUpForError();
-
-                    return result;
-                }
-
-                mainThread = new KThread(KernelContext);
-
-                result = mainThread.Initialize(
-                    _entrypoint,
-                    0,
-                    stackTop,
-                    mainThreadPriority,
-                    DefaultCpuCore,
-                    this,
-                    ThreadType.User,
-                    _customThreadStart);
-
-                if (result != KernelResult.Success)
-                {
-                    CleanUpForError();
-
-                    return result;
-                }
-
-                result = HandleTable.GenerateHandle(mainThread, out int mainThreadHandle);
-
-                if (result != KernelResult.Success)
-                {
-                    CleanUpForError();
-
-                    return result;
-                }
-
-                mainThread.SetEntryArguments(0, mainThreadHandle);
-
-                ProcessState oldState = State;
-                ProcessState newState = State != ProcessState.Created
-                    ? ProcessState.Attached
-                    : ProcessState.Started;
-
-                SetState(newState);
-
-                result = mainThread.Start();
-
-                if (result != KernelResult.Success)
-                {
-                    SetState(oldState);
-
-                    CleanUpForError();
-                }
-
-                if (result == KernelResult.Success)
-                {
-                    mainThread.IncrementReferenceCount();
-                }
-
-                mainThread.DecrementReferenceCount();
-
-                return result;
-            }
-        }
-
-        private void SetState(ProcessState newState)
-        {
-            if (State != newState)
-            {
-                State = newState;
-                _signaled = true;
-
-                Signal();
-            }
-        }
-
-        public KernelResult InitializeThread(
-            KThread thread,
-            ulong entrypoint,
-            ulong argsPtr,
-            ulong stackTop,
-            int priority,
-            int cpuCore,
-            ThreadStart customThreadStart = null)
-        {
-            lock (_processLock)
-            {
-                return thread.Initialize(entrypoint, argsPtr, stackTop, priority, cpuCore, this, ThreadType.User, customThreadStart);
-            }
-        }
-
-        public IExecutionContext CreateExecutionContext()
-        {
-            return Context?.CreateExecutionContext(new ExceptionCallbacks(
-                InterruptHandler,
-                null,
-                KernelContext.SyscallHandler.SvcCall,
-                UndefinedInstructionHandler));
-        }
-
-        private void InterruptHandler(IExecutionContext context)
-        {
-            KThread currentThread = KernelStatic.GetCurrentThread();
-
-            if (currentThread.Context.Running &&
-                currentThread.Owner != null &&
-                currentThread.GetUserDisableCount() != 0 &&
-                currentThread.Owner.PinnedThreads[currentThread.CurrentCore] == null)
-            {
-                KernelContext.CriticalSection.Enter();
-
-                currentThread.Owner.PinThread(currentThread);
-
-                currentThread.SetUserInterruptFlag();
-
-                KernelContext.CriticalSection.Leave();
-            }
-
-            if (currentThread.IsSchedulable)
-            {
-                KernelContext.Schedulers[currentThread.CurrentCore].Schedule();
-            }
-
-            currentThread.HandlePostSyscall();
-        }
-
-        public void IncrementThreadCount()
-        {
-            Interlocked.Increment(ref _threadCount);
-        }
-
-        public void DecrementThreadCountAndTerminateIfZero()
-        {
-            if (Interlocked.Decrement(ref _threadCount) == 0)
-            {
-                Terminate();
-            }
-        }
-
-        public void DecrementToZeroWhileTerminatingCurrent()
-        {
-            while (Interlocked.Decrement(ref _threadCount) != 0)
-            {
-                Destroy();
-                TerminateCurrentProcess();
-            }
-
-            // Nintendo panic here because if it reaches this point, the current thread should be already dead.
-            // As we handle the death of the thread in the post SVC handler and inside the CPU emulator, we don't panic here.
-        }
-
-        public ulong GetMemoryCapacity()
-        {
-            ulong totalCapacity = (ulong)ResourceLimit.GetRemainingValue(LimitableResource.Memory);
-
-            totalCapacity += MemoryManager.GetTotalHeapSize();
-
-            totalCapacity += GetPersonalMmHeapSize();
-
-            totalCapacity += _imageSize + _mainThreadStackSize;
-
-            if (totalCapacity <= _memoryUsageCapacity)
-            {
-                return totalCapacity;
-            }
-
-            return _memoryUsageCapacity;
-        }
-
-        public ulong GetMemoryUsage()
-        {
-            return _imageSize + _mainThreadStackSize + MemoryManager.GetTotalHeapSize() + GetPersonalMmHeapSize();
-        }
-
-        public ulong GetMemoryCapacityWithoutPersonalMmHeap()
-        {
-            return GetMemoryCapacity() - GetPersonalMmHeapSize();
-        }
-
-        public ulong GetMemoryUsageWithoutPersonalMmHeap()
-        {
-            return GetMemoryUsage() - GetPersonalMmHeapSize();
-        }
-
-        private ulong GetPersonalMmHeapSize()
-        {
-            return GetPersonalMmHeapSize(PersonalMmHeapPagesCount, _memRegion);
-        }
-
-        private static ulong GetPersonalMmHeapSize(ulong personalMmHeapPagesCount, MemoryRegion memRegion)
-        {
-            if (memRegion == MemoryRegion.Applet)
-            {
-                return 0;
-            }
-
-            return personalMmHeapPagesCount * KPageTableBase.PageSize;
-        }
-
-        public void AddCpuTime(long ticks)
-        {
-            Interlocked.Add(ref _totalTimeRunning, ticks);
-        }
-
-        public void AddThread(KThread thread)
-        {
-            lock (_threadingLock)
-            {
-                thread.ProcessListNode = _threads.AddLast(thread);
-            }
-        }
-
-        public void RemoveThread(KThread thread)
-        {
-            lock (_threadingLock)
-            {
-                _threads.Remove(thread.ProcessListNode);
-            }
-        }
-
-        public bool IsCpuCoreAllowed(int core)
-        {
-            return (Capabilities.AllowedCpuCoresMask & (1UL << core)) != 0;
-        }
-
-        public bool IsPriorityAllowed(int priority)
-        {
-            return (Capabilities.AllowedThreadPriosMask & (1UL << priority)) != 0;
-        }
-
-        public override bool IsSignaled()
-        {
-            return _signaled;
-        }
-
-        public KernelResult Terminate()
-        {
-            KernelResult result;
-
-            bool shallTerminate = false;
-
-            KernelContext.CriticalSection.Enter();
-
-            lock (_processLock)
-            {
-                if (State >= ProcessState.Started)
-                {
-                    if (State == ProcessState.Started ||
-                        State == ProcessState.Crashed ||
-                        State == ProcessState.Attached ||
-                        State == ProcessState.DebugSuspended)
-                    {
-                        SetState(ProcessState.Exiting);
-
-                        shallTerminate = true;
-                    }
-
-                    result = KernelResult.Success;
-                }
-                else
-                {
-                    result = KernelResult.InvalidState;
-                }
-            }
-
-            KernelContext.CriticalSection.Leave();
-
-            if (shallTerminate)
-            {
-                UnpauseAndTerminateAllThreadsExcept(KernelStatic.GetCurrentThread());
-
-                HandleTable.Destroy();
-
-                SignalExitToDebugTerminated();
-                SignalExit();
-            }
-
-            return result;
-        }
-
-        public void TerminateCurrentProcess()
-        {
-            bool shallTerminate = false;
-
-            KernelContext.CriticalSection.Enter();
-
-            lock (_processLock)
-            {
-                if (State >= ProcessState.Started)
-                {
-                    if (State == ProcessState.Started ||
-                        State == ProcessState.Attached ||
-                        State == ProcessState.DebugSuspended)
-                    {
-                        SetState(ProcessState.Exiting);
-
-                        shallTerminate = true;
-                    }
-                }
-            }
-
-            KernelContext.CriticalSection.Leave();
-
-            if (shallTerminate)
-            {
-                UnpauseAndTerminateAllThreadsExcept(KernelStatic.GetCurrentThread());
-
-                HandleTable.Destroy();
-
-                // NOTE: this is supposed to be called in receiving of the mailbox.
-                SignalExitToDebugExited();
-                SignalExit();
-            }
-
-            KernelStatic.GetCurrentThread().Exit();
-        }
-
-        private void UnpauseAndTerminateAllThreadsExcept(KThread currentThread)
-        {
-            lock (_threadingLock)
-            {
-                KernelContext.CriticalSection.Enter();
-
-                if (currentThread != null && PinnedThreads[currentThread.CurrentCore] == currentThread)
-                {
-                    UnpinThread(currentThread);
-                }
-
-                foreach (KThread thread in _threads)
-                {
-                    if (thread != currentThread && (thread.SchedFlags & ThreadSchedState.LowMask) != ThreadSchedState.TerminationPending)
-                    {
-                        thread.PrepareForTermination();
-                    }
-                }
-
-                KernelContext.CriticalSection.Leave();
-            }
-
-            while (true)
-            {
-                KThread blockedThread = null;
 
                 lock (_threadingLock)
                 {
                     foreach (KThread thread in _threads)
                     {
-                        if (thread != currentThread && (thread.SchedFlags & ThreadSchedState.LowMask) != ThreadSchedState.TerminationPending)
-                        {
-                            thread.IncrementReferenceCount();
-
-                            blockedThread = thread;
-                            break;
-                        }
+                        thread.Suspend(ThreadSchedState.ProcessPauseFlag);
                     }
                 }
 
-                if (blockedThread == null)
-                {
-                    break;
-                }
-
-                blockedThread.Terminate();
-                blockedThread.DecrementReferenceCount();
+                IsPaused = true;
             }
-        }
-
-        private void SignalExitToDebugTerminated()
-        {
-            // TODO: Debug events.
-        }
-
-        private void SignalExitToDebugExited()
-        {
-            // TODO: Debug events.
-        }
-
-        private void SignalExit()
-        {
-            if (ResourceLimit != null)
+            else
             {
-                ResourceLimit.Release(LimitableResource.Memory, GetMemoryUsage());
-            }
-
-            KernelContext.CriticalSection.Enter();
-
-            SetState(ProcessState.Exited);
-
-            KernelContext.CriticalSection.Leave();
-        }
-
-        public KernelResult ClearIfNotExited()
-        {
-            KernelResult result;
-
-            KernelContext.CriticalSection.Enter();
-
-            lock (_processLock)
-            {
-                if (State != ProcessState.Exited && _signaled)
+                if (!IsPaused)
                 {
-                    _signaled = false;
+                    KernelContext.CriticalSection.Leave();
 
-                    result = KernelResult.Success;
+                    return KernelResult.InvalidState;
                 }
-                else
+
+                lock (_threadingLock)
                 {
-                    result = KernelResult.InvalidState;
+                    foreach (KThread thread in _threads)
+                    {
+                        thread.Resume(ThreadSchedState.ProcessPauseFlag);
+                    }
                 }
+
+                IsPaused = false;
             }
 
             KernelContext.CriticalSection.Leave();
 
-            return result;
+            return KernelResult.Success;
         }
 
-        private void InitializeMemoryManager(ProcessCreationFlags flags)
+        KernelContext.CriticalSection.Leave();
+
+        return KernelResult.InvalidState;
+    }
+
+    public void PinThread(KThread thread)
+    {
+        if (!thread.TerminationRequested)
         {
-            int addrSpaceBits = (flags & ProcessCreationFlags.AddressSpaceMask) switch
-            {
-                ProcessCreationFlags.AddressSpace32Bit => 32,
-                ProcessCreationFlags.AddressSpace64BitDeprecated => 36,
-                ProcessCreationFlags.AddressSpace32BitWithoutAlias => 32,
-                ProcessCreationFlags.AddressSpace64Bit => 39,
-                _ => 39
-            };
+            PinnedThreads[thread.CurrentCore] = thread;
 
-            bool for64Bit = flags.HasFlag(ProcessCreationFlags.Is64Bit);
+            thread.Pin();
 
-            Context = _contextFactory.Create(KernelContext, Pid, 1UL << addrSpaceBits, InvalidAccessHandler, for64Bit);
-
-            MemoryManager = new KPageTable(KernelContext, CpuMemory);
-        }
-
-        private bool InvalidAccessHandler(ulong va)
-        {
-            KernelStatic.GetCurrentThread()?.PrintGuestStackTrace();
-            KernelStatic.GetCurrentThread()?.PrintGuestRegisterPrintout();
-
-            Logger.Error?.Print(LogClass.Cpu, $"Invalid memory access at virtual address 0x{va:X16}.");
-
-            return false;
-        }
-
-        private void UndefinedInstructionHandler(IExecutionContext context, ulong address, int opCode)
-        {
-            KernelStatic.GetCurrentThread().PrintGuestStackTrace();
-            KernelStatic.GetCurrentThread()?.PrintGuestRegisterPrintout();
-
-            throw new UndefinedInstructionException(address, opCode);
-        }
-
-        protected override void Destroy() => Context.Dispose();
-
-        public KernelResult SetActivity(bool pause)
-        {
-            KernelContext.CriticalSection.Enter();
-
-            if (State != ProcessState.Exiting && State != ProcessState.Exited)
-            {
-                if (pause)
-                {
-                    if (IsPaused)
-                    {
-                        KernelContext.CriticalSection.Leave();
-
-                        return KernelResult.InvalidState;
-                    }
-
-                    lock (_threadingLock)
-                    {
-                        foreach (KThread thread in _threads)
-                        {
-                            thread.Suspend(ThreadSchedState.ProcessPauseFlag);
-                        }
-                    }
-
-                    IsPaused = true;
-                }
-                else
-                {
-                    if (!IsPaused)
-                    {
-                        KernelContext.CriticalSection.Leave();
-
-                        return KernelResult.InvalidState;
-                    }
-
-                    lock (_threadingLock)
-                    {
-                        foreach (KThread thread in _threads)
-                        {
-                            thread.Resume(ThreadSchedState.ProcessPauseFlag);
-                        }
-                    }
-
-                    IsPaused = false;
-                }
-
-                KernelContext.CriticalSection.Leave();
-
-                return KernelResult.Success;
-            }
-
-            KernelContext.CriticalSection.Leave();
-
-            return KernelResult.InvalidState;
-        }
-
-        public void PinThread(KThread thread)
-        {
-            if (!thread.TerminationRequested)
-            {
-                PinnedThreads[thread.CurrentCore] = thread;
-
-                thread.Pin();
-
-                KernelContext.ThreadReselectionRequested = true;
-            }
-        }
-
-        public void UnpinThread(KThread thread)
-        {
-            if (!thread.TerminationRequested)
-            {
-                thread.Unpin();
-
-                PinnedThreads[thread.CurrentCore] = null;
-
-                KernelContext.ThreadReselectionRequested = true;
-            }
-        }
-
-        public bool IsExceptionUserThread(KThread thread)
-        {
-            // TODO
-            return false;
+            KernelContext.ThreadReselectionRequested = true;
         }
     }
+
+    public void UnpinThread(KThread thread)
+    {
+        if (!thread.TerminationRequested)
+        {
+            thread.Unpin();
+
+            PinnedThreads[thread.CurrentCore] = null;
+
+            KernelContext.ThreadReselectionRequested = true;
+        }
+    }
+
+    public bool IsExceptionUserThread(KThread thread)
+    {
+        // TODO
+        return false;
+    }
+}
 }

--- a/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
@@ -13,577 +13,635 @@ using System.Threading;
 
 namespace Ryujinx.HLE.HOS.Kernel.Process
 {
-class KProcess : KSynchronizationObject
-{
-    public const int KernelVersionMajor = 10;
-    public const int KernelVersionMinor = 4;
-    public const int KernelVersionRevision = 0;
-
-    public const int KernelVersionPacked =
-        (KernelVersionMajor << 19) | (KernelVersionMinor << 15) | (KernelVersionRevision << 0);
-
-    public KPageTableBase MemoryManager { get; private set; }
-
-    private SortedDictionary<ulong, KTlsPageInfo> _fullTlsPages;
-    private SortedDictionary<ulong, KTlsPageInfo> _freeTlsPages;
-
-    public int DefaultCpuCore { get; set; }
-
-    public bool Debug { get; private set; }
-
-    public KResourceLimit ResourceLimit { get; private set; }
-
-    public ulong PersonalMmHeapPagesCount { get; private set; }
-
-    public ProcessState State { get; private set; }
-
-    private object _processLock;
-    private object _threadingLock;
-
-    public KAddressArbiter AddressArbiter { get; private set; }
-
-    public ulong[] RandomEntropy { get; private set; }
-    public KThread[] PinnedThreads { get; private set; }
-
-    private bool _signaled;
-
-    public string Name { get; private set; }
-
-    private int _threadCount;
-
-    public ProcessCreationFlags Flags { get; private set; }
-
-    private MemoryRegion _memRegion;
-
-    public KProcessCapabilities Capabilities { get; private set; }
-
-    public bool AllowCodeMemoryForJit { get; private set; }
-
-    public ulong TitleId { get; private set; }
-    public bool IsApplication { get; private set; }
-    public ulong Pid { get; private set; }
-
-    private long _creationTimestamp;
-    private ulong _entrypoint;
-    private ThreadStart _customThreadStart;
-    private ulong _imageSize;
-    private ulong _mainThreadStackSize;
-    private ulong _memoryUsageCapacity;
-    private int _version;
-
-    public KHandleTable HandleTable { get; private set; }
-
-    public ulong UserExceptionContextAddress { get; private set; }
-
-    private LinkedList<KThread> _threads;
-
-    public bool IsPaused { get; private set; }
-
-    private long _totalTimeRunning;
-
-    public long TotalTimeRunning => _totalTimeRunning;
-
-    private IProcessContextFactory _contextFactory;
-    public IProcessContext Context { get; private set; }
-    public IVirtualMemoryManager CpuMemory => Context.AddressSpace;
-
-    public HleProcessDebugger Debugger { get; private set; }
-
-    public KProcess(KernelContext context, bool allowCodeMemoryForJit = false) : base(context)
+    class KProcess : KSynchronizationObject
     {
-        _processLock = new object();
-        _threadingLock = new object();
+        public const int KernelVersionMajor = 10;
+        public const int KernelVersionMinor = 4;
+        public const int KernelVersionRevision = 0;
 
-        AddressArbiter = new KAddressArbiter(context);
+        public const int KernelVersionPacked =
+            (KernelVersionMajor << 19) |
+            (KernelVersionMinor << 15) |
+            (KernelVersionRevision << 0);
 
-        _fullTlsPages = new SortedDictionary<ulong, KTlsPageInfo>();
-        _freeTlsPages = new SortedDictionary<ulong, KTlsPageInfo>();
+        public KPageTableBase MemoryManager { get; private set; }
 
-        Capabilities = new KProcessCapabilities();
+        private SortedDictionary<ulong, KTlsPageInfo> _fullTlsPages;
+        private SortedDictionary<ulong, KTlsPageInfo> _freeTlsPages;
 
-        AllowCodeMemoryForJit = context.Device.Configuration.allowJitCodeMem;
+        public int DefaultCpuCore { get; set; }
 
-        RandomEntropy = new ulong[KScheduler.CpuCoresCount];
-        PinnedThreads = new KThread[KScheduler.CpuCoresCount];
+        public bool Debug { get; private set; }
 
-        // TODO: Remove once we no longer need to initialize it externally.
-        HandleTable = new KHandleTable(context);
+        public KResourceLimit ResourceLimit { get; private set; }
 
-        _threads = new LinkedList<KThread>();
+        public ulong PersonalMmHeapPagesCount { get; private set; }
 
-        Debugger = new HleProcessDebugger(this);
-    }
+        public ProcessState State { get; private set; }
 
-    public KernelResult InitializeKip(ProcessCreationInfo creationInfo, ReadOnlySpan<int> capabilities,
-        KPageList pageList, KResourceLimit resourceLimit, MemoryRegion memRegion, IProcessContextFactory contextFactory,
-        ThreadStart customThreadStart = null)
-    {
-        ResourceLimit = resourceLimit;
-        _memRegion = memRegion;
-        _contextFactory = contextFactory ?? new ProcessContextFactory();
-        _customThreadStart = customThreadStart;
+        private object _processLock;
+        private object _threadingLock;
 
-        AddressSpaceType addrSpaceType =
-            (AddressSpaceType)((int)(creationInfo.Flags & ProcessCreationFlags.AddressSpaceMask) >>
-                               (int)ProcessCreationFlags.AddressSpaceShift);
+        public KAddressArbiter AddressArbiter { get; private set; }
 
-        Pid = KernelContext.NewKipId();
+        public ulong[] RandomEntropy { get; private set; }
+        public KThread[] PinnedThreads { get; private set; }
 
-        if (Pid == 0 || Pid >= KernelConstants.InitialProcessId)
+        private bool _signaled;
+
+        public string Name { get; private set; }
+
+        private int _threadCount;
+
+        public ProcessCreationFlags Flags { get; private set; }
+
+        private MemoryRegion _memRegion;
+
+        public KProcessCapabilities Capabilities { get; private set; }
+
+        public bool AllowCodeMemoryForJit { get; private set; }
+
+        public ulong TitleId { get; private set; }
+        public bool IsApplication { get; private set; }
+        public ulong Pid { get; private set; }
+
+        private long _creationTimestamp;
+        private ulong _entrypoint;
+        private ThreadStart _customThreadStart;
+        private ulong _imageSize;
+        private ulong _mainThreadStackSize;
+        private ulong _memoryUsageCapacity;
+        private int _version;
+
+        public KHandleTable HandleTable { get; private set; }
+
+        public ulong UserExceptionContextAddress { get; private set; }
+
+        private LinkedList<KThread> _threads;
+
+        public bool IsPaused { get; private set; }
+
+        private long _totalTimeRunning;
+
+        public long TotalTimeRunning => _totalTimeRunning;
+
+        private IProcessContextFactory _contextFactory;
+        public IProcessContext Context { get; private set; }
+        public IVirtualMemoryManager CpuMemory => Context.AddressSpace;
+
+        public HleProcessDebugger Debugger { get; private set; }
+
+        public KProcess(KernelContext context, bool allowCodeMemoryForJit = false) : base(context)
         {
-            throw new InvalidOperationException($"Invalid KIP Id {Pid}.");
+            _processLock = new object();
+            _threadingLock = new object();
+
+            AddressArbiter = new KAddressArbiter(context);
+
+            _fullTlsPages = new SortedDictionary<ulong, KTlsPageInfo>();
+            _freeTlsPages = new SortedDictionary<ulong, KTlsPageInfo>();
+
+            Capabilities = new KProcessCapabilities();
+
+            AllowCodeMemoryForJit = context.Device.Configuration.allowJitCodeMem;
+
+            RandomEntropy = new ulong[KScheduler.CpuCoresCount];
+            PinnedThreads = new KThread[KScheduler.CpuCoresCount];
+
+            // TODO: Remove once we no longer need to initialize it externally.
+            HandleTable = new KHandleTable(context);
+
+            _threads = new LinkedList<KThread>();
+
+            Debugger = new HleProcessDebugger(this);
         }
 
-        InitializeMemoryManager(creationInfo.Flags);
-
-        bool aslrEnabled = creationInfo.Flags.HasFlag(ProcessCreationFlags.EnableAslr);
-
-        ulong codeAddress = creationInfo.CodeAddress;
-
-        ulong codeSize = (ulong)creationInfo.CodePagesCount * KPageTableBase.PageSize;
-
-        KMemoryBlockSlabManager slabManager = creationInfo.Flags.HasFlag(ProcessCreationFlags.IsApplication)
-            ? KernelContext.LargeMemoryBlockSlabManager
-            : KernelContext.SmallMemoryBlockSlabManager;
-
-        KernelResult result = MemoryManager.InitializeForProcess(addrSpaceType, aslrEnabled, !aslrEnabled, memRegion,
-            codeAddress, codeSize, slabManager);
-
-        if (result != KernelResult.Success)
+        public KernelResult InitializeKip(
+            ProcessCreationInfo creationInfo,
+            ReadOnlySpan<int> capabilities,
+            KPageList pageList,
+            KResourceLimit resourceLimit,
+            MemoryRegion memRegion,
+            IProcessContextFactory contextFactory,
+            ThreadStart customThreadStart = null)
         {
-            return result;
-        }
+            ResourceLimit = resourceLimit;
+            _memRegion = memRegion;
+            _contextFactory = contextFactory ?? new ProcessContextFactory();
+            _customThreadStart = customThreadStart;
 
-        if (!MemoryManager.CanContain(codeAddress, codeSize, MemoryState.CodeStatic))
-        {
-            return KernelResult.InvalidMemRange;
-        }
+            AddressSpaceType addrSpaceType = (AddressSpaceType)((int)(creationInfo.Flags & ProcessCreationFlags.AddressSpaceMask) >> (int)ProcessCreationFlags.AddressSpaceShift);
 
-        result = MemoryManager.MapPages(codeAddress, pageList, MemoryState.CodeStatic, KMemoryPermission.None);
+            Pid = KernelContext.NewKipId();
 
-        if (result != KernelResult.Success)
-        {
-            return result;
-        }
-
-        result = Capabilities.InitializeForKernel(capabilities, MemoryManager);
-
-        if (result != KernelResult.Success)
-        {
-            return result;
-        }
-
-        return ParseProcessInfo(creationInfo);
-    }
-
-    public KernelResult Initialize(ProcessCreationInfo creationInfo, ReadOnlySpan<int> capabilities,
-        KResourceLimit resourceLimit, MemoryRegion memRegion, IProcessContextFactory contextFactory,
-        ThreadStart customThreadStart = null)
-    {
-        ResourceLimit = resourceLimit;
-        _memRegion = memRegion;
-        _contextFactory = contextFactory ?? new ProcessContextFactory();
-        _customThreadStart = customThreadStart;
-        IsApplication = creationInfo.Flags.HasFlag(ProcessCreationFlags.IsApplication);
-
-        ulong personalMmHeapSize = GetPersonalMmHeapSize((ulong)creationInfo.SystemResourcePagesCount, memRegion);
-
-        ulong codePagesCount = (ulong)creationInfo.CodePagesCount;
-
-        ulong neededSizeForProcess = personalMmHeapSize + codePagesCount * KPageTableBase.PageSize;
-
-        if (neededSizeForProcess != 0 && resourceLimit != null)
-        {
-            if (!resourceLimit.Reserve(LimitableResource.Memory, neededSizeForProcess))
+            if (Pid == 0 || Pid >= KernelConstants.InitialProcessId)
             {
-                return KernelResult.ResLimitExceeded;
+                throw new InvalidOperationException($"Invalid KIP Id {Pid}.");
             }
-        }
 
-        void CleanUpForError()
-        {
-            if (neededSizeForProcess != 0 && resourceLimit != null)
-            {
-                resourceLimit.Release(LimitableResource.Memory, neededSizeForProcess);
-            }
-        }
+            InitializeMemoryManager(creationInfo.Flags);
 
-        PersonalMmHeapPagesCount = (ulong)creationInfo.SystemResourcePagesCount;
+            bool aslrEnabled = creationInfo.Flags.HasFlag(ProcessCreationFlags.EnableAslr);
 
-        KMemoryBlockSlabManager slabManager;
+            ulong codeAddress = creationInfo.CodeAddress;
 
-        if (PersonalMmHeapPagesCount != 0)
-        {
-            slabManager = new KMemoryBlockSlabManager(PersonalMmHeapPagesCount * KPageTableBase.PageSize);
-        }
-        else
-        {
-            slabManager = creationInfo.Flags.HasFlag(ProcessCreationFlags.IsApplication)
+            ulong codeSize = (ulong)creationInfo.CodePagesCount * KPageTableBase.PageSize;
+
+            KMemoryBlockSlabManager slabManager = creationInfo.Flags.HasFlag(ProcessCreationFlags.IsApplication)
                 ? KernelContext.LargeMemoryBlockSlabManager
                 : KernelContext.SmallMemoryBlockSlabManager;
+
+            KernelResult result = MemoryManager.InitializeForProcess(
+                addrSpaceType,
+                aslrEnabled,
+                !aslrEnabled,
+                memRegion,
+                codeAddress,
+                codeSize,
+                slabManager);
+
+            if (result != KernelResult.Success)
+            {
+                return result;
+            }
+
+            if (!MemoryManager.CanContain(codeAddress, codeSize, MemoryState.CodeStatic))
+            {
+                return KernelResult.InvalidMemRange;
+            }
+
+            result = MemoryManager.MapPages(codeAddress, pageList, MemoryState.CodeStatic, KMemoryPermission.None);
+
+            if (result != KernelResult.Success)
+            {
+                return result;
+            }
+
+            result = Capabilities.InitializeForKernel(capabilities, MemoryManager);
+
+            if (result != KernelResult.Success)
+            {
+                return result;
+            }
+
+            return ParseProcessInfo(creationInfo);
         }
 
-        AddressSpaceType addrSpaceType =
-            (AddressSpaceType)((int)(creationInfo.Flags & ProcessCreationFlags.AddressSpaceMask) >>
-                               (int)ProcessCreationFlags.AddressSpaceShift);
-
-        Pid = KernelContext.NewProcessId();
-
-        if (Pid == ulong.MaxValue || Pid < KernelConstants.InitialProcessId)
+        public KernelResult Initialize(
+            ProcessCreationInfo creationInfo,
+            ReadOnlySpan<int> capabilities,
+            KResourceLimit resourceLimit,
+            MemoryRegion memRegion,
+            IProcessContextFactory contextFactory,
+            ThreadStart customThreadStart = null)
         {
-            throw new InvalidOperationException($"Invalid Process Id {Pid}.");
-        }
+            ResourceLimit = resourceLimit;
+            _memRegion = memRegion;
+            _contextFactory = contextFactory ?? new ProcessContextFactory();
+            _customThreadStart = customThreadStart;
+            IsApplication = creationInfo.Flags.HasFlag(ProcessCreationFlags.IsApplication);
 
-        InitializeMemoryManager(creationInfo.Flags);
+            ulong personalMmHeapSize = GetPersonalMmHeapSize((ulong)creationInfo.SystemResourcePagesCount, memRegion);
 
-        bool aslrEnabled = creationInfo.Flags.HasFlag(ProcessCreationFlags.EnableAslr);
+            ulong codePagesCount = (ulong)creationInfo.CodePagesCount;
 
-        ulong codeAddress = creationInfo.CodeAddress;
+            ulong neededSizeForProcess = personalMmHeapSize + codePagesCount * KPageTableBase.PageSize;
 
-        ulong codeSize = codePagesCount * KPageTableBase.PageSize;
+            if (neededSizeForProcess != 0 && resourceLimit != null)
+            {
+                if (!resourceLimit.Reserve(LimitableResource.Memory, neededSizeForProcess))
+                {
+                    return KernelResult.ResLimitExceeded;
+                }
+            }
 
-        KernelResult result = MemoryManager.InitializeForProcess(addrSpaceType, aslrEnabled, !aslrEnabled, memRegion,
-            codeAddress, codeSize, slabManager);
+            void CleanUpForError()
+            {
+                if (neededSizeForProcess != 0 && resourceLimit != null)
+                {
+                    resourceLimit.Release(LimitableResource.Memory, neededSizeForProcess);
+                }
+            }
 
-        if (result != KernelResult.Success)
-        {
-            CleanUpForError();
+            PersonalMmHeapPagesCount = (ulong)creationInfo.SystemResourcePagesCount;
+
+            KMemoryBlockSlabManager slabManager;
+
+            if (PersonalMmHeapPagesCount != 0)
+            {
+                slabManager = new KMemoryBlockSlabManager(PersonalMmHeapPagesCount * KPageTableBase.PageSize);
+            }
+            else
+            {
+                slabManager = creationInfo.Flags.HasFlag(ProcessCreationFlags.IsApplication)
+                    ? KernelContext.LargeMemoryBlockSlabManager
+                    : KernelContext.SmallMemoryBlockSlabManager;
+            }
+
+            AddressSpaceType addrSpaceType = (AddressSpaceType)((int)(creationInfo.Flags & ProcessCreationFlags.AddressSpaceMask) >> (int)ProcessCreationFlags.AddressSpaceShift);
+
+            Pid = KernelContext.NewProcessId();
+
+            if (Pid == ulong.MaxValue || Pid < KernelConstants.InitialProcessId)
+            {
+                throw new InvalidOperationException($"Invalid Process Id {Pid}.");
+            }
+
+            InitializeMemoryManager(creationInfo.Flags);
+
+            bool aslrEnabled = creationInfo.Flags.HasFlag(ProcessCreationFlags.EnableAslr);
+
+            ulong codeAddress = creationInfo.CodeAddress;
+
+            ulong codeSize = codePagesCount * KPageTableBase.PageSize;
+
+            KernelResult result = MemoryManager.InitializeForProcess(
+                addrSpaceType,
+                aslrEnabled,
+                !aslrEnabled,
+                memRegion,
+                codeAddress,
+                codeSize,
+                slabManager);
+
+            if (result != KernelResult.Success)
+            {
+                CleanUpForError();
+
+                return result;
+            }
+
+            if (!MemoryManager.CanContain(codeAddress, codeSize, MemoryState.CodeStatic))
+            {
+                CleanUpForError();
+
+                return KernelResult.InvalidMemRange;
+            }
+
+            result = MemoryManager.MapPages(
+                codeAddress,
+                codePagesCount,
+                MemoryState.CodeStatic,
+                KMemoryPermission.None);
+
+            if (result != KernelResult.Success)
+            {
+                CleanUpForError();
+
+                return result;
+            }
+
+            result = Capabilities.InitializeForUser(capabilities, MemoryManager);
+
+            if (result != KernelResult.Success)
+            {
+                CleanUpForError();
+
+                return result;
+            }
+
+            result = ParseProcessInfo(creationInfo);
+
+            if (result != KernelResult.Success)
+            {
+                CleanUpForError();
+            }
 
             return result;
         }
 
-        if (!MemoryManager.CanContain(codeAddress, codeSize, MemoryState.CodeStatic))
+        private KernelResult ParseProcessInfo(ProcessCreationInfo creationInfo)
         {
-            CleanUpForError();
+            // Ensure that the current kernel version is equal or above to the minimum required.
+            uint requiredKernelVersionMajor = (uint)Capabilities.KernelReleaseVersion >> 19;
+            uint requiredKernelVersionMinor = ((uint)Capabilities.KernelReleaseVersion >> 15) & 0xf;
 
-            return KernelResult.InvalidMemRange;
-        }
-
-        result = MemoryManager.MapPages(codeAddress, codePagesCount, MemoryState.CodeStatic, KMemoryPermission.None);
-
-        if (result != KernelResult.Success)
-        {
-            CleanUpForError();
-
-            return result;
-        }
-
-        result = Capabilities.InitializeForUser(capabilities, MemoryManager);
-
-        if (result != KernelResult.Success)
-        {
-            CleanUpForError();
-
-            return result;
-        }
-
-        result = ParseProcessInfo(creationInfo);
-
-        if (result != KernelResult.Success)
-        {
-            CleanUpForError();
-        }
-
-        return result;
-    }
-
-    private KernelResult ParseProcessInfo(ProcessCreationInfo creationInfo)
-    {
-        // Ensure that the current kernel version is equal or above to the minimum required.
-        uint requiredKernelVersionMajor = (uint)Capabilities.KernelReleaseVersion >> 19;
-        uint requiredKernelVersionMinor = ((uint)Capabilities.KernelReleaseVersion >> 15) & 0xf;
-
-        if (KernelContext.EnableVersionChecks)
-        {
-            if (requiredKernelVersionMajor > KernelVersionMajor)
+            if (KernelContext.EnableVersionChecks)
             {
-                return KernelResult.InvalidCombination;
+                if (requiredKernelVersionMajor > KernelVersionMajor)
+                {
+                    return KernelResult.InvalidCombination;
+                }
+
+                if (requiredKernelVersionMajor != KernelVersionMajor && requiredKernelVersionMajor < 3)
+                {
+                    return KernelResult.InvalidCombination;
+                }
+
+                if (requiredKernelVersionMinor > KernelVersionMinor)
+                {
+                    return KernelResult.InvalidCombination;
+                }
             }
 
-            if (requiredKernelVersionMajor != KernelVersionMajor && requiredKernelVersionMajor < 3)
+            KernelResult result = AllocateThreadLocalStorage(out ulong userExceptionContextAddress);
+
+            if (result != KernelResult.Success)
             {
-                return KernelResult.InvalidCombination;
+                return result;
             }
 
-            if (requiredKernelVersionMinor > KernelVersionMinor)
+            UserExceptionContextAddress = userExceptionContextAddress;
+
+            MemoryHelper.FillWithZeros(CpuMemory, userExceptionContextAddress, KTlsPageInfo.TlsEntrySize);
+
+            Name = creationInfo.Name;
+
+            State = ProcessState.Created;
+
+            _creationTimestamp = PerformanceCounter.ElapsedMilliseconds;
+
+            Flags = creationInfo.Flags;
+            _version = creationInfo.Version;
+            TitleId = creationInfo.TitleId;
+            _entrypoint = creationInfo.CodeAddress;
+            _imageSize = (ulong)creationInfo.CodePagesCount * KPageTableBase.PageSize;
+
+            switch (Flags & ProcessCreationFlags.AddressSpaceMask)
             {
-                return KernelResult.InvalidCombination;
-            }
-        }
+                case ProcessCreationFlags.AddressSpace32Bit:
+                case ProcessCreationFlags.AddressSpace64BitDeprecated:
+                case ProcessCreationFlags.AddressSpace64Bit:
+                    _memoryUsageCapacity = MemoryManager.HeapRegionEnd -
+                                           MemoryManager.HeapRegionStart;
+                    break;
 
-        KernelResult result = AllocateThreadLocalStorage(out ulong userExceptionContextAddress);
+                case ProcessCreationFlags.AddressSpace32BitWithoutAlias:
+                    _memoryUsageCapacity = MemoryManager.HeapRegionEnd -
+                                           MemoryManager.HeapRegionStart +
+                                           MemoryManager.AliasRegionEnd -
+                                           MemoryManager.AliasRegionStart;
+                    break;
 
-        if (result != KernelResult.Success)
-        {
-            return result;
-        }
-
-        UserExceptionContextAddress = userExceptionContextAddress;
-
-        MemoryHelper.FillWithZeros(CpuMemory, userExceptionContextAddress, KTlsPageInfo.TlsEntrySize);
-
-        Name = creationInfo.Name;
-
-        State = ProcessState.Created;
-
-        _creationTimestamp = PerformanceCounter.ElapsedMilliseconds;
-
-        Flags = creationInfo.Flags;
-        _version = creationInfo.Version;
-        TitleId = creationInfo.TitleId;
-        _entrypoint = creationInfo.CodeAddress;
-        _imageSize = (ulong)creationInfo.CodePagesCount * KPageTableBase.PageSize;
-
-        switch (Flags & ProcessCreationFlags.AddressSpaceMask)
-        {
-            case ProcessCreationFlags.AddressSpace32Bit:
-            case ProcessCreationFlags.AddressSpace64BitDeprecated:
-            case ProcessCreationFlags.AddressSpace64Bit:
-                _memoryUsageCapacity = MemoryManager.HeapRegionEnd - MemoryManager.HeapRegionStart;
-                break;
-
-            case ProcessCreationFlags.AddressSpace32BitWithoutAlias:
-                _memoryUsageCapacity = MemoryManager.HeapRegionEnd - MemoryManager.HeapRegionStart +
-                    MemoryManager.AliasRegionEnd - MemoryManager.AliasRegionStart;
-                break;
-
-            default: throw new InvalidOperationException($"Invalid MMU flags value 0x{Flags:x2}.");
-        }
-
-        GenerateRandomEntropy();
-
-        return KernelResult.Success;
-    }
-
-    public KernelResult AllocateThreadLocalStorage(out ulong address)
-    {
-        KernelContext.CriticalSection.Enter();
-
-        KernelResult result;
-
-        if (_freeTlsPages.Count > 0)
-        {
-            // If we have free TLS pages available, just use the first one.
-            KTlsPageInfo pageInfo = _freeTlsPages.Values.First();
-
-            if (!pageInfo.TryGetFreePage(out address))
-            {
-                throw new InvalidOperationException("Unexpected failure getting free TLS page!");
+                default: throw new InvalidOperationException($"Invalid MMU flags value 0x{Flags:x2}.");
             }
 
-            if (pageInfo.IsFull())
-            {
-                _freeTlsPages.Remove(pageInfo.PageVirtualAddress);
+            GenerateRandomEntropy();
 
-                _fullTlsPages.Add(pageInfo.PageVirtualAddress, pageInfo);
-            }
-
-            result = KernelResult.Success;
+            return KernelResult.Success;
         }
-        else
-        {
-            // Otherwise, we need to create a new one.
-            result = AllocateTlsPage(out KTlsPageInfo pageInfo);
 
-            if (result == KernelResult.Success)
+        public KernelResult AllocateThreadLocalStorage(out ulong address)
+        {
+            KernelContext.CriticalSection.Enter();
+
+            KernelResult result;
+
+            if (_freeTlsPages.Count > 0)
             {
+                // If we have free TLS pages available, just use the first one.
+                KTlsPageInfo pageInfo = _freeTlsPages.Values.First();
+
                 if (!pageInfo.TryGetFreePage(out address))
                 {
                     throw new InvalidOperationException("Unexpected failure getting free TLS page!");
                 }
 
-                _freeTlsPages.Add(pageInfo.PageVirtualAddress, pageInfo);
+                if (pageInfo.IsFull())
+                {
+                    _freeTlsPages.Remove(pageInfo.PageVirtualAddress);
+
+                    _fullTlsPages.Add(pageInfo.PageVirtualAddress, pageInfo);
+                }
+
+                result = KernelResult.Success;
             }
             else
             {
-                address = 0;
-            }
-        }
+                // Otherwise, we need to create a new one.
+                result = AllocateTlsPage(out KTlsPageInfo pageInfo);
 
-        KernelContext.CriticalSection.Leave();
+                if (result == KernelResult.Success)
+                {
+                    if (!pageInfo.TryGetFreePage(out address))
+                    {
+                        throw new InvalidOperationException("Unexpected failure getting free TLS page!");
+                    }
 
-        return result;
-    }
-
-    private KernelResult AllocateTlsPage(out KTlsPageInfo pageInfo)
-    {
-        pageInfo = default;
-
-        if (!KernelContext.UserSlabHeapPages.TryGetItem(out ulong tlsPagePa))
-        {
-            return KernelResult.OutOfMemory;
-        }
-
-        ulong regionStart = MemoryManager.TlsIoRegionStart;
-        ulong regionSize = MemoryManager.TlsIoRegionEnd - regionStart;
-
-        ulong regionPagesCount = regionSize / KPageTableBase.PageSize;
-
-        KernelResult result = MemoryManager.MapPages(1, KPageTableBase.PageSize, tlsPagePa, true, regionStart,
-            regionPagesCount, MemoryState.ThreadLocal, KMemoryPermission.ReadAndWrite, out ulong tlsPageVa);
-
-        if (result != KernelResult.Success)
-        {
-            KernelContext.UserSlabHeapPages.Free(tlsPagePa);
-        }
-        else
-        {
-            pageInfo = new KTlsPageInfo(tlsPageVa, tlsPagePa);
-
-            MemoryHelper.FillWithZeros(CpuMemory, tlsPageVa, KPageTableBase.PageSize);
-        }
-
-        return result;
-    }
-
-    public KernelResult FreeThreadLocalStorage(ulong tlsSlotAddr)
-    {
-        ulong tlsPageAddr = BitUtils.AlignDown(tlsSlotAddr, KPageTableBase.PageSize);
-
-        KernelContext.CriticalSection.Enter();
-
-        KernelResult result = KernelResult.Success;
-
-        KTlsPageInfo pageInfo;
-
-        if (_fullTlsPages.TryGetValue(tlsPageAddr, out pageInfo))
-        {
-            // TLS page was full, free slot and move to free pages tree.
-            _fullTlsPages.Remove(tlsPageAddr);
-
-            _freeTlsPages.Add(tlsPageAddr, pageInfo);
-        }
-        else if (!_freeTlsPages.TryGetValue(tlsPageAddr, out pageInfo))
-        {
-            result = KernelResult.InvalidAddress;
-        }
-
-        if (pageInfo != null)
-        {
-            pageInfo.FreeTlsSlot(tlsSlotAddr);
-
-            if (pageInfo.IsEmpty())
-            {
-                // TLS page is now empty, we should ensure it is removed
-                // from all trees, and free the memory it was using.
-                _freeTlsPages.Remove(tlsPageAddr);
-
-                KernelContext.CriticalSection.Leave();
-
-                FreeTlsPage(pageInfo);
-
-                return KernelResult.Success;
-            }
-        }
-
-        KernelContext.CriticalSection.Leave();
-
-        return result;
-    }
-
-    private KernelResult FreeTlsPage(KTlsPageInfo pageInfo)
-    {
-        KernelResult result = MemoryManager.UnmapForKernel(pageInfo.PageVirtualAddress, 1, MemoryState.ThreadLocal);
-
-        if (result == KernelResult.Success)
-        {
-            KernelContext.UserSlabHeapPages.Free(pageInfo.PagePhysicalAddress);
-        }
-
-        return result;
-    }
-
-    private void GenerateRandomEntropy()
-    {
-        // TODO.
-    }
-
-    public KernelResult Start(int mainThreadPriority, ulong stackSize)
-    {
-        lock (_processLock)
-        {
-            if (State > ProcessState.CreatedAttached)
-            {
-                return KernelResult.InvalidState;
+                    _freeTlsPages.Add(pageInfo.PageVirtualAddress, pageInfo);
+                }
+                else
+                {
+                    address = 0;
+                }
             }
 
-            if (ResourceLimit != null && !ResourceLimit.Reserve(LimitableResource.Thread, 1))
+            KernelContext.CriticalSection.Leave();
+
+            return result;
+        }
+
+        private KernelResult AllocateTlsPage(out KTlsPageInfo pageInfo)
+        {
+            pageInfo = default;
+
+            if (!KernelContext.UserSlabHeapPages.TryGetItem(out ulong tlsPagePa))
             {
-                return KernelResult.ResLimitExceeded;
-            }
-
-            KResourceLimit threadResourceLimit = ResourceLimit;
-            KResourceLimit memoryResourceLimit = null;
-
-            if (_mainThreadStackSize != 0)
-            {
-                throw new InvalidOperationException("Trying to start a process with a invalid state!");
-            }
-
-            ulong stackSizeRounded = BitUtils.AlignUp(stackSize, KPageTableBase.PageSize);
-
-            ulong neededSize = stackSizeRounded + _imageSize;
-
-            // Check if the needed size for the code and the stack will fit on the
-            // memory usage capacity of this Process. Also check for possible overflow
-            // on the above addition.
-            if (neededSize > _memoryUsageCapacity || neededSize < stackSizeRounded)
-            {
-                threadResourceLimit?.Release(LimitableResource.Thread, 1);
-
                 return KernelResult.OutOfMemory;
             }
 
-            if (stackSizeRounded != 0 && ResourceLimit != null)
+            ulong regionStart = MemoryManager.TlsIoRegionStart;
+            ulong regionSize = MemoryManager.TlsIoRegionEnd - regionStart;
+
+            ulong regionPagesCount = regionSize / KPageTableBase.PageSize;
+
+            KernelResult result = MemoryManager.MapPages(
+                1,
+                KPageTableBase.PageSize,
+                tlsPagePa,
+                true,
+                regionStart,
+                regionPagesCount,
+                MemoryState.ThreadLocal,
+                KMemoryPermission.ReadAndWrite,
+                out ulong tlsPageVa);
+
+            if (result != KernelResult.Success)
             {
-                memoryResourceLimit = ResourceLimit;
+                KernelContext.UserSlabHeapPages.Free(tlsPagePa);
+            }
+            else
+            {
+                pageInfo = new KTlsPageInfo(tlsPageVa, tlsPagePa);
 
-                if (!memoryResourceLimit.Reserve(LimitableResource.Memory, stackSizeRounded))
+                MemoryHelper.FillWithZeros(CpuMemory, tlsPageVa, KPageTableBase.PageSize);
+            }
+
+            return result;
+        }
+
+        public KernelResult FreeThreadLocalStorage(ulong tlsSlotAddr)
+        {
+            ulong tlsPageAddr = BitUtils.AlignDown(tlsSlotAddr, KPageTableBase.PageSize);
+
+            KernelContext.CriticalSection.Enter();
+
+            KernelResult result = KernelResult.Success;
+
+            KTlsPageInfo pageInfo;
+
+            if (_fullTlsPages.TryGetValue(tlsPageAddr, out pageInfo))
+            {
+                // TLS page was full, free slot and move to free pages tree.
+                _fullTlsPages.Remove(tlsPageAddr);
+
+                _freeTlsPages.Add(tlsPageAddr, pageInfo);
+            }
+            else if (!_freeTlsPages.TryGetValue(tlsPageAddr, out pageInfo))
+            {
+                result = KernelResult.InvalidAddress;
+            }
+
+            if (pageInfo != null)
+            {
+                pageInfo.FreeTlsSlot(tlsSlotAddr);
+
+                if (pageInfo.IsEmpty())
                 {
-                    threadResourceLimit?.Release(LimitableResource.Thread, 1);
+                    // TLS page is now empty, we should ensure it is removed
+                    // from all trees, and free the memory it was using.
+                    _freeTlsPages.Remove(tlsPageAddr);
 
-                    return KernelResult.ResLimitExceeded;
+                    KernelContext.CriticalSection.Leave();
+
+                    FreeTlsPage(pageInfo);
+
+                    return KernelResult.Success;
                 }
             }
 
-            KernelResult result;
+            KernelContext.CriticalSection.Leave();
 
-            KThread mainThread = null;
+            return result;
+        }
 
-            ulong stackTop = 0;
+        private KernelResult FreeTlsPage(KTlsPageInfo pageInfo)
+        {
+            KernelResult result = MemoryManager.UnmapForKernel(pageInfo.PageVirtualAddress, 1, MemoryState.ThreadLocal);
 
-            void CleanUpForError()
+            if (result == KernelResult.Success)
             {
-                HandleTable.Destroy();
+                KernelContext.UserSlabHeapPages.Free(pageInfo.PagePhysicalAddress);
+            }
 
-                mainThread?.DecrementReferenceCount();
+            return result;
+        }
+
+        private void GenerateRandomEntropy()
+        {
+            // TODO.
+        }
+
+        public KernelResult Start(int mainThreadPriority, ulong stackSize)
+        {
+            lock (_processLock)
+            {
+                if (State > ProcessState.CreatedAttached)
+                {
+                    return KernelResult.InvalidState;
+                }
+
+                if (ResourceLimit != null && !ResourceLimit.Reserve(LimitableResource.Thread, 1))
+                {
+                    return KernelResult.ResLimitExceeded;
+                }
+
+                KResourceLimit threadResourceLimit = ResourceLimit;
+                KResourceLimit memoryResourceLimit = null;
 
                 if (_mainThreadStackSize != 0)
                 {
-                    ulong stackBottom = stackTop - _mainThreadStackSize;
-
-                    ulong stackPagesCount = _mainThreadStackSize / KPageTableBase.PageSize;
-
-                    MemoryManager.UnmapForKernel(stackBottom, stackPagesCount, MemoryState.Stack);
-
-                    _mainThreadStackSize = 0;
+                    throw new InvalidOperationException("Trying to start a process with a invalid state!");
                 }
 
-                memoryResourceLimit?.Release(LimitableResource.Memory, stackSizeRounded);
-                threadResourceLimit?.Release(LimitableResource.Thread, 1);
-            }
+                ulong stackSizeRounded = BitUtils.AlignUp(stackSize, KPageTableBase.PageSize);
 
-            if (stackSizeRounded != 0)
-            {
-                ulong stackPagesCount = stackSizeRounded / KPageTableBase.PageSize;
+                ulong neededSize = stackSizeRounded + _imageSize;
 
-                ulong regionStart = MemoryManager.StackRegionStart;
-                ulong regionSize = MemoryManager.StackRegionEnd - regionStart;
+                // Check if the needed size for the code and the stack will fit on the
+                // memory usage capacity of this Process. Also check for possible overflow
+                // on the above addition.
+                if (neededSize > _memoryUsageCapacity || neededSize < stackSizeRounded)
+                {
+                    threadResourceLimit?.Release(LimitableResource.Thread, 1);
 
-                ulong regionPagesCount = regionSize / KPageTableBase.PageSize;
+                    return KernelResult.OutOfMemory;
+                }
 
-                result = MemoryManager.MapPages(stackPagesCount, KPageTableBase.PageSize, 0, false, regionStart,
-                    regionPagesCount, MemoryState.Stack, KMemoryPermission.ReadAndWrite, out ulong stackBottom);
+                if (stackSizeRounded != 0 && ResourceLimit != null)
+                {
+                    memoryResourceLimit = ResourceLimit;
+
+                    if (!memoryResourceLimit.Reserve(LimitableResource.Memory, stackSizeRounded))
+                    {
+                        threadResourceLimit?.Release(LimitableResource.Thread, 1);
+
+                        return KernelResult.ResLimitExceeded;
+                    }
+                }
+
+                KernelResult result;
+
+                KThread mainThread = null;
+
+                ulong stackTop = 0;
+
+                void CleanUpForError()
+                {
+                    HandleTable.Destroy();
+
+                    mainThread?.DecrementReferenceCount();
+
+                    if (_mainThreadStackSize != 0)
+                    {
+                        ulong stackBottom = stackTop - _mainThreadStackSize;
+
+                        ulong stackPagesCount = _mainThreadStackSize / KPageTableBase.PageSize;
+
+                        MemoryManager.UnmapForKernel(stackBottom, stackPagesCount, MemoryState.Stack);
+
+                        _mainThreadStackSize = 0;
+                    }
+
+                    memoryResourceLimit?.Release(LimitableResource.Memory, stackSizeRounded);
+                    threadResourceLimit?.Release(LimitableResource.Thread, 1);
+                }
+
+                if (stackSizeRounded != 0)
+                {
+                    ulong stackPagesCount = stackSizeRounded / KPageTableBase.PageSize;
+
+                    ulong regionStart = MemoryManager.StackRegionStart;
+                    ulong regionSize = MemoryManager.StackRegionEnd - regionStart;
+
+                    ulong regionPagesCount = regionSize / KPageTableBase.PageSize;
+
+                    result = MemoryManager.MapPages(
+                        stackPagesCount,
+                        KPageTableBase.PageSize,
+                        0,
+                        false,
+                        regionStart,
+                        regionPagesCount,
+                        MemoryState.Stack,
+                        KMemoryPermission.ReadAndWrite,
+                        out ulong stackBottom);
+
+                    if (result != KernelResult.Success)
+                    {
+                        CleanUpForError();
+
+                        return result;
+                    }
+
+                    _mainThreadStackSize += stackSizeRounded;
+
+                    stackTop = stackBottom + stackSizeRounded;
+                }
+
+                ulong heapCapacity = _memoryUsageCapacity - _mainThreadStackSize - _imageSize;
+
+                result = MemoryManager.SetHeapCapacity(heapCapacity);
 
                 if (result != KernelResult.Success)
                 {
@@ -592,542 +650,546 @@ class KProcess : KSynchronizationObject
                     return result;
                 }
 
-                _mainThreadStackSize += stackSizeRounded;
+                HandleTable = new KHandleTable(KernelContext);
 
-                stackTop = stackBottom + stackSizeRounded;
-            }
+                result = HandleTable.Initialize(Capabilities.HandleTableSize);
 
-            ulong heapCapacity = _memoryUsageCapacity - _mainThreadStackSize - _imageSize;
+                if (result != KernelResult.Success)
+                {
+                    CleanUpForError();
 
-            result = MemoryManager.SetHeapCapacity(heapCapacity);
+                    return result;
+                }
 
-            if (result != KernelResult.Success)
-            {
-                CleanUpForError();
+                mainThread = new KThread(KernelContext);
+
+                result = mainThread.Initialize(
+                    _entrypoint,
+                    0,
+                    stackTop,
+                    mainThreadPriority,
+                    DefaultCpuCore,
+                    this,
+                    ThreadType.User,
+                    _customThreadStart);
+
+                if (result != KernelResult.Success)
+                {
+                    CleanUpForError();
+
+                    return result;
+                }
+
+                result = HandleTable.GenerateHandle(mainThread, out int mainThreadHandle);
+
+                if (result != KernelResult.Success)
+                {
+                    CleanUpForError();
+
+                    return result;
+                }
+
+                mainThread.SetEntryArguments(0, mainThreadHandle);
+
+                ProcessState oldState = State;
+                ProcessState newState = State != ProcessState.Created
+                    ? ProcessState.Attached
+                    : ProcessState.Started;
+
+                SetState(newState);
+
+                result = mainThread.Start();
+
+                if (result != KernelResult.Success)
+                {
+                    SetState(oldState);
+
+                    CleanUpForError();
+                }
+
+                if (result == KernelResult.Success)
+                {
+                    mainThread.IncrementReferenceCount();
+                }
+
+                mainThread.DecrementReferenceCount();
 
                 return result;
             }
+        }
 
-            HandleTable = new KHandleTable(KernelContext);
-
-            result = HandleTable.Initialize(Capabilities.HandleTableSize);
-
-            if (result != KernelResult.Success)
+        private void SetState(ProcessState newState)
+        {
+            if (State != newState)
             {
-                CleanUpForError();
+                State = newState;
+                _signaled = true;
 
-                return result;
+                Signal();
+            }
+        }
+
+        public KernelResult InitializeThread(
+            KThread thread,
+            ulong entrypoint,
+            ulong argsPtr,
+            ulong stackTop,
+            int priority,
+            int cpuCore,
+            ThreadStart customThreadStart = null)
+        {
+            lock (_processLock)
+            {
+                return thread.Initialize(entrypoint, argsPtr, stackTop, priority, cpuCore, this, ThreadType.User, customThreadStart);
+            }
+        }
+
+        public IExecutionContext CreateExecutionContext()
+        {
+            return Context?.CreateExecutionContext(new ExceptionCallbacks(
+                InterruptHandler,
+                null,
+                KernelContext.SyscallHandler.SvcCall,
+                UndefinedInstructionHandler));
+        }
+
+        private void InterruptHandler(IExecutionContext context)
+        {
+            KThread currentThread = KernelStatic.GetCurrentThread();
+
+            if (currentThread.Context.Running &&
+                currentThread.Owner != null &&
+                currentThread.GetUserDisableCount() != 0 &&
+                currentThread.Owner.PinnedThreads[currentThread.CurrentCore] == null)
+            {
+                KernelContext.CriticalSection.Enter();
+
+                currentThread.Owner.PinThread(currentThread);
+
+                currentThread.SetUserInterruptFlag();
+
+                KernelContext.CriticalSection.Leave();
             }
 
-            mainThread = new KThread(KernelContext);
-
-            result = mainThread.Initialize(_entrypoint, 0, stackTop, mainThreadPriority, DefaultCpuCore, this,
-                ThreadType.User, _customThreadStart);
-
-            if (result != KernelResult.Success)
+            if (currentThread.IsSchedulable)
             {
-                CleanUpForError();
-
-                return result;
+                KernelContext.Schedulers[currentThread.CurrentCore].Schedule();
             }
 
-            result = HandleTable.GenerateHandle(mainThread, out int mainThreadHandle);
+            currentThread.HandlePostSyscall();
+        }
 
-            if (result != KernelResult.Success)
+        public void IncrementThreadCount()
+        {
+            Interlocked.Increment(ref _threadCount);
+        }
+
+        public void DecrementThreadCountAndTerminateIfZero()
+        {
+            if (Interlocked.Decrement(ref _threadCount) == 0)
             {
-                CleanUpForError();
+                Terminate();
+            }
+        }
 
-                return result;
+        public void DecrementToZeroWhileTerminatingCurrent()
+        {
+            while (Interlocked.Decrement(ref _threadCount) != 0)
+            {
+                Destroy();
+                TerminateCurrentProcess();
             }
 
-            mainThread.SetEntryArguments(0, mainThreadHandle);
+            // Nintendo panic here because if it reaches this point, the current thread should be already dead.
+            // As we handle the death of the thread in the post SVC handler and inside the CPU emulator, we don't panic here.
+        }
 
-            ProcessState oldState = State;
-            ProcessState newState = State != ProcessState.Created ? ProcessState.Attached : ProcessState.Started;
+        public ulong GetMemoryCapacity()
+        {
+            ulong totalCapacity = (ulong)ResourceLimit.GetRemainingValue(LimitableResource.Memory);
 
-            SetState(newState);
+            totalCapacity += MemoryManager.GetTotalHeapSize();
 
-            result = mainThread.Start();
+            totalCapacity += GetPersonalMmHeapSize();
 
-            if (result != KernelResult.Success)
+            totalCapacity += _imageSize + _mainThreadStackSize;
+
+            if (totalCapacity <= _memoryUsageCapacity)
             {
-                SetState(oldState);
-
-                CleanUpForError();
+                return totalCapacity;
             }
 
-            if (result == KernelResult.Success)
+            return _memoryUsageCapacity;
+        }
+
+        public ulong GetMemoryUsage()
+        {
+            return _imageSize + _mainThreadStackSize + MemoryManager.GetTotalHeapSize() + GetPersonalMmHeapSize();
+        }
+
+        public ulong GetMemoryCapacityWithoutPersonalMmHeap()
+        {
+            return GetMemoryCapacity() - GetPersonalMmHeapSize();
+        }
+
+        public ulong GetMemoryUsageWithoutPersonalMmHeap()
+        {
+            return GetMemoryUsage() - GetPersonalMmHeapSize();
+        }
+
+        private ulong GetPersonalMmHeapSize()
+        {
+            return GetPersonalMmHeapSize(PersonalMmHeapPagesCount, _memRegion);
+        }
+
+        private static ulong GetPersonalMmHeapSize(ulong personalMmHeapPagesCount, MemoryRegion memRegion)
+        {
+            if (memRegion == MemoryRegion.Applet)
             {
-                mainThread.IncrementReferenceCount();
+                return 0;
             }
 
-            mainThread.DecrementReferenceCount();
+            return personalMmHeapPagesCount * KPageTableBase.PageSize;
+        }
+
+        public void AddCpuTime(long ticks)
+        {
+            Interlocked.Add(ref _totalTimeRunning, ticks);
+        }
+
+        public void AddThread(KThread thread)
+        {
+            lock (_threadingLock)
+            {
+                thread.ProcessListNode = _threads.AddLast(thread);
+            }
+        }
+
+        public void RemoveThread(KThread thread)
+        {
+            lock (_threadingLock)
+            {
+                _threads.Remove(thread.ProcessListNode);
+            }
+        }
+
+        public bool IsCpuCoreAllowed(int core)
+        {
+            return (Capabilities.AllowedCpuCoresMask & (1UL << core)) != 0;
+        }
+
+        public bool IsPriorityAllowed(int priority)
+        {
+            return (Capabilities.AllowedThreadPriosMask & (1UL << priority)) != 0;
+        }
+
+        public override bool IsSignaled()
+        {
+            return _signaled;
+        }
+
+        public KernelResult Terminate()
+        {
+            KernelResult result;
+
+            bool shallTerminate = false;
+
+            KernelContext.CriticalSection.Enter();
+
+            lock (_processLock)
+            {
+                if (State >= ProcessState.Started)
+                {
+                    if (State == ProcessState.Started ||
+                        State == ProcessState.Crashed ||
+                        State == ProcessState.Attached ||
+                        State == ProcessState.DebugSuspended)
+                    {
+                        SetState(ProcessState.Exiting);
+
+                        shallTerminate = true;
+                    }
+
+                    result = KernelResult.Success;
+                }
+                else
+                {
+                    result = KernelResult.InvalidState;
+                }
+            }
+
+            KernelContext.CriticalSection.Leave();
+
+            if (shallTerminate)
+            {
+                UnpauseAndTerminateAllThreadsExcept(KernelStatic.GetCurrentThread());
+
+                HandleTable.Destroy();
+
+                SignalExitToDebugTerminated();
+                SignalExit();
+            }
 
             return result;
         }
-    }
 
-    private void SetState(ProcessState newState)
-    {
-        if (State != newState)
+        public void TerminateCurrentProcess()
         {
-            State = newState;
-            _signaled = true;
+            bool shallTerminate = false;
 
-            Signal();
-        }
-    }
-
-    public KernelResult InitializeThread(KThread thread, ulong entrypoint, ulong argsPtr, ulong stackTop, int priority,
-        int cpuCore, ThreadStart customThreadStart = null)
-    {
-        lock (_processLock)
-        {
-            return thread.Initialize(entrypoint, argsPtr, stackTop, priority, cpuCore, this, ThreadType.User,
-                customThreadStart);
-        }
-    }
-
-    public IExecutionContext CreateExecutionContext()
-    {
-        return Context?.CreateExecutionContext(new ExceptionCallbacks(InterruptHandler, null,
-            KernelContext.SyscallHandler.SvcCall, UndefinedInstructionHandler));
-    }
-
-    private void InterruptHandler(IExecutionContext context)
-    {
-        KThread currentThread = KernelStatic.GetCurrentThread();
-
-        if (currentThread.Context.Running && currentThread.Owner != null && currentThread.GetUserDisableCount() != 0 &&
-            currentThread.Owner.PinnedThreads[currentThread.CurrentCore] == null)
-        {
             KernelContext.CriticalSection.Enter();
 
-            currentThread.Owner.PinThread(currentThread);
-
-            currentThread.SetUserInterruptFlag();
-
-            KernelContext.CriticalSection.Leave();
-        }
-
-        if (currentThread.IsSchedulable)
-        {
-            KernelContext.Schedulers[currentThread.CurrentCore].Schedule();
-        }
-
-        currentThread.HandlePostSyscall();
-    }
-
-    public void IncrementThreadCount()
-    {
-        Interlocked.Increment(ref _threadCount);
-    }
-
-    public void DecrementThreadCountAndTerminateIfZero()
-    {
-        if (Interlocked.Decrement(ref _threadCount) == 0)
-        {
-            Terminate();
-        }
-    }
-
-    public void DecrementToZeroWhileTerminatingCurrent()
-    {
-        while (Interlocked.Decrement(ref _threadCount) != 0)
-        {
-            Destroy();
-            TerminateCurrentProcess();
-        }
-
-        // Nintendo panic here because if it reaches this point, the current thread should be already dead.
-        // As we handle the death of the thread in the post SVC handler and inside the CPU emulator, we don't panic here.
-    }
-
-    public ulong GetMemoryCapacity()
-    {
-        ulong totalCapacity = (ulong)ResourceLimit.GetRemainingValue(LimitableResource.Memory);
-
-        totalCapacity += MemoryManager.GetTotalHeapSize();
-
-        totalCapacity += GetPersonalMmHeapSize();
-
-        totalCapacity += _imageSize + _mainThreadStackSize;
-
-        if (totalCapacity <= _memoryUsageCapacity)
-        {
-            return totalCapacity;
-        }
-
-        return _memoryUsageCapacity;
-    }
-
-    public ulong GetMemoryUsage()
-    {
-        return _imageSize + _mainThreadStackSize + MemoryManager.GetTotalHeapSize() + GetPersonalMmHeapSize();
-    }
-
-    public ulong GetMemoryCapacityWithoutPersonalMmHeap()
-    {
-        return GetMemoryCapacity() - GetPersonalMmHeapSize();
-    }
-
-    public ulong GetMemoryUsageWithoutPersonalMmHeap()
-    {
-        return GetMemoryUsage() - GetPersonalMmHeapSize();
-    }
-
-    private ulong GetPersonalMmHeapSize()
-    {
-        return GetPersonalMmHeapSize(PersonalMmHeapPagesCount, _memRegion);
-    }
-
-    private static ulong GetPersonalMmHeapSize(ulong personalMmHeapPagesCount, MemoryRegion memRegion)
-    {
-        if (memRegion == MemoryRegion.Applet)
-        {
-            return 0;
-        }
-
-        return personalMmHeapPagesCount * KPageTableBase.PageSize;
-    }
-
-    public void AddCpuTime(long ticks)
-    {
-        Interlocked.Add(ref _totalTimeRunning, ticks);
-    }
-
-    public void AddThread(KThread thread)
-    {
-        lock (_threadingLock)
-        {
-            thread.ProcessListNode = _threads.AddLast(thread);
-        }
-    }
-
-    public void RemoveThread(KThread thread)
-    {
-        lock (_threadingLock)
-        {
-            _threads.Remove(thread.ProcessListNode);
-        }
-    }
-
-    public bool IsCpuCoreAllowed(int core)
-    {
-        return (Capabilities.AllowedCpuCoresMask & (1UL << core)) != 0;
-    }
-
-    public bool IsPriorityAllowed(int priority)
-    {
-        return (Capabilities.AllowedThreadPriosMask & (1UL << priority)) != 0;
-    }
-
-    public override bool IsSignaled()
-    {
-        return _signaled;
-    }
-
-    public KernelResult Terminate()
-    {
-        KernelResult result;
-
-        bool shallTerminate = false;
-
-        KernelContext.CriticalSection.Enter();
-
-        lock (_processLock)
-        {
-            if (State >= ProcessState.Started)
+            lock (_processLock)
             {
-                if (State == ProcessState.Started || State == ProcessState.Crashed || State == ProcessState.Attached ||
-                    State == ProcessState.DebugSuspended)
+                if (State >= ProcessState.Started)
                 {
-                    SetState(ProcessState.Exiting);
+                    if (State == ProcessState.Started ||
+                        State == ProcessState.Attached ||
+                        State == ProcessState.DebugSuspended)
+                    {
+                        SetState(ProcessState.Exiting);
 
-                    shallTerminate = true;
-                }
-
-                result = KernelResult.Success;
-            }
-            else
-            {
-                result = KernelResult.InvalidState;
-            }
-        }
-
-        KernelContext.CriticalSection.Leave();
-
-        if (shallTerminate)
-        {
-            UnpauseAndTerminateAllThreadsExcept(KernelStatic.GetCurrentThread());
-
-            HandleTable.Destroy();
-
-            SignalExitToDebugTerminated();
-            SignalExit();
-        }
-
-        return result;
-    }
-
-    public void TerminateCurrentProcess()
-    {
-        bool shallTerminate = false;
-
-        KernelContext.CriticalSection.Enter();
-
-        lock (_processLock)
-        {
-            if (State >= ProcessState.Started)
-            {
-                if (State == ProcessState.Started || State == ProcessState.Attached ||
-                    State == ProcessState.DebugSuspended)
-                {
-                    SetState(ProcessState.Exiting);
-
-                    shallTerminate = true;
-                }
-            }
-        }
-
-        KernelContext.CriticalSection.Leave();
-
-        if (shallTerminate)
-        {
-            UnpauseAndTerminateAllThreadsExcept(KernelStatic.GetCurrentThread());
-
-            HandleTable.Destroy();
-
-            // NOTE: this is supposed to be called in receiving of the mailbox.
-            SignalExitToDebugExited();
-            SignalExit();
-        }
-
-        KernelStatic.GetCurrentThread().Exit();
-    }
-
-    private void UnpauseAndTerminateAllThreadsExcept(KThread currentThread)
-    {
-        lock (_threadingLock)
-        {
-            KernelContext.CriticalSection.Enter();
-
-            if (currentThread != null && PinnedThreads[currentThread.CurrentCore] == currentThread)
-            {
-                UnpinThread(currentThread);
-            }
-
-            foreach (KThread thread in _threads)
-            {
-                if (thread != currentThread && (thread.SchedFlags & ThreadSchedState.LowMask) !=
-                    ThreadSchedState.TerminationPending)
-                {
-                    thread.PrepareForTermination();
+                        shallTerminate = true;
+                    }
                 }
             }
 
             KernelContext.CriticalSection.Leave();
+
+            if (shallTerminate)
+            {
+                UnpauseAndTerminateAllThreadsExcept(KernelStatic.GetCurrentThread());
+
+                HandleTable.Destroy();
+
+                // NOTE: this is supposed to be called in receiving of the mailbox.
+                SignalExitToDebugExited();
+                SignalExit();
+            }
+
+            KernelStatic.GetCurrentThread().Exit();
         }
 
-        while (true)
+        private void UnpauseAndTerminateAllThreadsExcept(KThread currentThread)
         {
-            KThread blockedThread = null;
-
             lock (_threadingLock)
             {
+                KernelContext.CriticalSection.Enter();
+
+                if (currentThread != null && PinnedThreads[currentThread.CurrentCore] == currentThread)
+                {
+                    UnpinThread(currentThread);
+                }
+
                 foreach (KThread thread in _threads)
                 {
-                    if (thread != currentThread && (thread.SchedFlags & ThreadSchedState.LowMask) !=
-                        ThreadSchedState.TerminationPending)
+                    if (thread != currentThread && (thread.SchedFlags & ThreadSchedState.LowMask) != ThreadSchedState.TerminationPending)
                     {
-                        thread.IncrementReferenceCount();
-
-                        blockedThread = thread;
-                        break;
+                        thread.PrepareForTermination();
                     }
                 }
+
+                KernelContext.CriticalSection.Leave();
             }
 
-            if (blockedThread == null)
+            while (true)
             {
-                break;
-            }
-
-            blockedThread.Terminate();
-            blockedThread.DecrementReferenceCount();
-        }
-    }
-
-    private void SignalExitToDebugTerminated()
-    {
-        // TODO: Debug events.
-    }
-
-    private void SignalExitToDebugExited()
-    {
-        // TODO: Debug events.
-    }
-
-    private void SignalExit()
-    {
-        if (ResourceLimit != null)
-        {
-            ResourceLimit.Release(LimitableResource.Memory, GetMemoryUsage());
-        }
-
-        KernelContext.CriticalSection.Enter();
-
-        SetState(ProcessState.Exited);
-
-        KernelContext.CriticalSection.Leave();
-    }
-
-    public KernelResult ClearIfNotExited()
-    {
-        KernelResult result;
-
-        KernelContext.CriticalSection.Enter();
-
-        lock (_processLock)
-        {
-            if (State != ProcessState.Exited && _signaled)
-            {
-                _signaled = false;
-
-                result = KernelResult.Success;
-            }
-            else
-            {
-                result = KernelResult.InvalidState;
-            }
-        }
-
-        KernelContext.CriticalSection.Leave();
-
-        return result;
-    }
-
-    private void InitializeMemoryManager(ProcessCreationFlags flags)
-    {
-        int addrSpaceBits = (flags & ProcessCreationFlags.AddressSpaceMask) switch
-        {
-            ProcessCreationFlags.AddressSpace32Bit => 32,
-            ProcessCreationFlags.AddressSpace64BitDeprecated => 36,
-            ProcessCreationFlags.AddressSpace32BitWithoutAlias => 32,
-            ProcessCreationFlags.AddressSpace64Bit => 39,
-            _ => 39
-        };
-
-        bool for64Bit = flags.HasFlag(ProcessCreationFlags.Is64Bit);
-
-        Context = _contextFactory.Create(KernelContext, Pid, 1UL << addrSpaceBits, InvalidAccessHandler, for64Bit);
-
-        MemoryManager = new KPageTable(KernelContext, CpuMemory);
-    }
-
-    private bool InvalidAccessHandler(ulong va)
-    {
-        KernelStatic.GetCurrentThread()?.PrintGuestStackTrace();
-        KernelStatic.GetCurrentThread()?.PrintGuestRegisterPrintout();
-
-        Logger.Error?.Print(LogClass.Cpu, $"Invalid memory access at virtual address 0x{va:X16}.");
-
-        return false;
-    }
-
-    private void UndefinedInstructionHandler(IExecutionContext context, ulong address, int opCode)
-    {
-        KernelStatic.GetCurrentThread().PrintGuestStackTrace();
-        KernelStatic.GetCurrentThread()?.PrintGuestRegisterPrintout();
-
-        throw new UndefinedInstructionException(address, opCode);
-    }
-
-    protected override void Destroy() => Context.Dispose();
-
-    public KernelResult SetActivity(bool pause)
-    {
-        KernelContext.CriticalSection.Enter();
-
-        if (State != ProcessState.Exiting && State != ProcessState.Exited)
-        {
-            if (pause)
-            {
-                if (IsPaused)
-                {
-                    KernelContext.CriticalSection.Leave();
-
-                    return KernelResult.InvalidState;
-                }
+                KThread blockedThread = null;
 
                 lock (_threadingLock)
                 {
                     foreach (KThread thread in _threads)
                     {
-                        thread.Suspend(ThreadSchedState.ProcessPauseFlag);
+                        if (thread != currentThread && (thread.SchedFlags & ThreadSchedState.LowMask) != ThreadSchedState.TerminationPending)
+                        {
+                            thread.IncrementReferenceCount();
+
+                            blockedThread = thread;
+                            break;
+                        }
                     }
                 }
 
-                IsPaused = true;
+                if (blockedThread == null)
+                {
+                    break;
+                }
+
+                blockedThread.Terminate();
+                blockedThread.DecrementReferenceCount();
             }
-            else
+        }
+
+        private void SignalExitToDebugTerminated()
+        {
+            // TODO: Debug events.
+        }
+
+        private void SignalExitToDebugExited()
+        {
+            // TODO: Debug events.
+        }
+
+        private void SignalExit()
+        {
+            if (ResourceLimit != null)
             {
-                if (!IsPaused)
+                ResourceLimit.Release(LimitableResource.Memory, GetMemoryUsage());
+            }
+
+            KernelContext.CriticalSection.Enter();
+
+            SetState(ProcessState.Exited);
+
+            KernelContext.CriticalSection.Leave();
+        }
+
+        public KernelResult ClearIfNotExited()
+        {
+            KernelResult result;
+
+            KernelContext.CriticalSection.Enter();
+
+            lock (_processLock)
+            {
+                if (State != ProcessState.Exited && _signaled)
                 {
-                    KernelContext.CriticalSection.Leave();
+                    _signaled = false;
 
-                    return KernelResult.InvalidState;
+                    result = KernelResult.Success;
                 }
-
-                lock (_threadingLock)
+                else
                 {
-                    foreach (KThread thread in _threads)
-                    {
-                        thread.Resume(ThreadSchedState.ProcessPauseFlag);
-                    }
+                    result = KernelResult.InvalidState;
                 }
-
-                IsPaused = false;
             }
 
             KernelContext.CriticalSection.Leave();
 
-            return KernelResult.Success;
+            return result;
         }
 
-        KernelContext.CriticalSection.Leave();
-
-        return KernelResult.InvalidState;
-    }
-
-    public void PinThread(KThread thread)
-    {
-        if (!thread.TerminationRequested)
+        private void InitializeMemoryManager(ProcessCreationFlags flags)
         {
-            PinnedThreads[thread.CurrentCore] = thread;
+            int addrSpaceBits = (flags & ProcessCreationFlags.AddressSpaceMask) switch
+            {
+                ProcessCreationFlags.AddressSpace32Bit => 32,
+                ProcessCreationFlags.AddressSpace64BitDeprecated => 36,
+                ProcessCreationFlags.AddressSpace32BitWithoutAlias => 32,
+                ProcessCreationFlags.AddressSpace64Bit => 39,
+                _ => 39
+            };
 
-            thread.Pin();
+            bool for64Bit = flags.HasFlag(ProcessCreationFlags.Is64Bit);
 
-            KernelContext.ThreadReselectionRequested = true;
+            Context = _contextFactory.Create(KernelContext, Pid, 1UL << addrSpaceBits, InvalidAccessHandler, for64Bit);
+
+            MemoryManager = new KPageTable(KernelContext, CpuMemory);
         }
-    }
 
-    public void UnpinThread(KThread thread)
-    {
-        if (!thread.TerminationRequested)
+        private bool InvalidAccessHandler(ulong va)
         {
-            thread.Unpin();
+            KernelStatic.GetCurrentThread()?.PrintGuestStackTrace();
+            KernelStatic.GetCurrentThread()?.PrintGuestRegisterPrintout();
 
-            PinnedThreads[thread.CurrentCore] = null;
+            Logger.Error?.Print(LogClass.Cpu, $"Invalid memory access at virtual address 0x{va:X16}.");
 
-            KernelContext.ThreadReselectionRequested = true;
+            return false;
+        }
+
+        private void UndefinedInstructionHandler(IExecutionContext context, ulong address, int opCode)
+        {
+            KernelStatic.GetCurrentThread().PrintGuestStackTrace();
+            KernelStatic.GetCurrentThread()?.PrintGuestRegisterPrintout();
+
+            throw new UndefinedInstructionException(address, opCode);
+        }
+
+        protected override void Destroy() => Context.Dispose();
+
+        public KernelResult SetActivity(bool pause)
+        {
+            KernelContext.CriticalSection.Enter();
+
+            if (State != ProcessState.Exiting && State != ProcessState.Exited)
+            {
+                if (pause)
+                {
+                    if (IsPaused)
+                    {
+                        KernelContext.CriticalSection.Leave();
+
+                        return KernelResult.InvalidState;
+                    }
+
+                    lock (_threadingLock)
+                    {
+                        foreach (KThread thread in _threads)
+                        {
+                            thread.Suspend(ThreadSchedState.ProcessPauseFlag);
+                        }
+                    }
+
+                    IsPaused = true;
+                }
+                else
+                {
+                    if (!IsPaused)
+                    {
+                        KernelContext.CriticalSection.Leave();
+
+                        return KernelResult.InvalidState;
+                    }
+
+                    lock (_threadingLock)
+                    {
+                        foreach (KThread thread in _threads)
+                        {
+                            thread.Resume(ThreadSchedState.ProcessPauseFlag);
+                        }
+                    }
+
+                    IsPaused = false;
+                }
+
+                KernelContext.CriticalSection.Leave();
+
+                return KernelResult.Success;
+            }
+
+            KernelContext.CriticalSection.Leave();
+
+            return KernelResult.InvalidState;
+        }
+
+        public void PinThread(KThread thread)
+        {
+            if (!thread.TerminationRequested)
+            {
+                PinnedThreads[thread.CurrentCore] = thread;
+
+                thread.Pin();
+
+                KernelContext.ThreadReselectionRequested = true;
+            }
+        }
+
+        public void UnpinThread(KThread thread)
+        {
+            if (!thread.TerminationRequested)
+            {
+                thread.Unpin();
+
+                PinnedThreads[thread.CurrentCore] = null;
+
+                KernelContext.ThreadReselectionRequested = true;
+            }
+        }
+
+        public bool IsExceptionUserThread(KThread thread)
+        {
+            // TODO
+            return false;
         }
     }
-
-    public bool IsExceptionUserThread(KThread thread)
-    {
-        // TODO
-        return false;
-    }
-}
 }

--- a/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
@@ -103,7 +103,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
             Capabilities = new KProcessCapabilities();
 
-            AllowCodeMemoryForJit = context.Device.Configuration.allowJitCodeMem;
+            AllowCodeMemoryForJit = context.Device.Configuration.AllowJitCodeMem;
 
             RandomEntropy = new ulong[KScheduler.CpuCoresCount];
             PinnedThreads = new KThread[KScheduler.CpuCoresCount];

--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
@@ -8,13 +8,16 @@ using Ryujinx.HLE.HOS.Kernel.Memory;
 using Ryujinx.HLE.HOS.Kernel.Process;
 using Ryujinx.HLE.HOS.Kernel.Threading;
 using System;
+using System.Management;
 using System.Threading;
 
 namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
 {
-    [SvcImpl]
+[SvcImpl]
     class Syscall
     {
+        public static bool allowUnsafeMemAccess;    
+
         private readonly KernelContext _context;
 
         public Syscall(KernelContext context)
@@ -537,7 +540,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return ReplyAndReceive(out handleIndex, handles, replyTargetHandle, timeout);
         }
 
-        public KernelResult ReplyAndReceive(out int handleIndex, ReadOnlySpan<int> handles, int replyTargetHandle, long timeout)
+        public KernelResult ReplyAndReceive(out int handleIndex, int[] handles, int replyTargetHandle, long timeout)
         {
             handleIndex = 0;
 
@@ -1413,7 +1416,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             // Newer versions of the kernel also returns an error here if the owner and process
             // where the operation will happen are the same. We do not return an error here
             // for homebrew because some of them requires this to be patched out to work (for JIT).
-            if (codeMemory == null || (!currentProcess.AllowCodeMemoryForJit && codeMemory.Owner == currentProcess))
+            if ((codeMemory == null) || (!allowUnsafeMemAccess &&((!currentProcess.AllowCodeMemoryForJit && codeMemory.Owner == currentProcess))))
             {
                 return KernelResult.InvalidHandle;
             }

--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
@@ -1,4 +1,4 @@
-﻿using Ryujinx.Common;
+using Ryujinx.Common;
 using Ryujinx.Common.Logging;
 using Ryujinx.Cpu;
 using Ryujinx.HLE.Exceptions;
@@ -8,16 +8,13 @@ using Ryujinx.HLE.HOS.Kernel.Memory;
 using Ryujinx.HLE.HOS.Kernel.Process;
 using Ryujinx.HLE.HOS.Kernel.Threading;
 using System;
-using System.Management;
 using System.Threading;
 
 namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
 {
-[SvcImpl]
+    [SvcImpl]
     class Syscall
     {
-        public static bool allowUnsafeMemAccess;    
-
         private readonly KernelContext _context;
 
         public Syscall(KernelContext context)
@@ -540,7 +537,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             return ReplyAndReceive(out handleIndex, handles, replyTargetHandle, timeout);
         }
 
-        public KernelResult ReplyAndReceive(out int handleIndex, int[] handles, int replyTargetHandle, long timeout)
+        public KernelResult ReplyAndReceive(out int handleIndex, ReadOnlySpan<int> handles, int replyTargetHandle, long timeout)
         {
             handleIndex = 0;
 
@@ -1416,7 +1413,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
             // Newer versions of the kernel also returns an error here if the owner and process
             // where the operation will happen are the same. We do not return an error here
             // for homebrew because some of them requires this to be patched out to work (for JIT).
-            if ((codeMemory == null) || (!allowUnsafeMemAccess &&((!currentProcess.AllowCodeMemoryForJit && codeMemory.Owner == currentProcess))))
+            if (codeMemory == null || (!currentProcess.AllowCodeMemoryForJit && codeMemory.Owner == currentProcess))
             {
                 return KernelResult.InvalidHandle;
             }

--- a/Ryujinx.HLE/Switch.cs
+++ b/Ryujinx.HLE/Switch.cs
@@ -4,6 +4,7 @@ using Ryujinx.Common.Configuration;
 using Ryujinx.Graphics.Gpu;
 using Ryujinx.HLE.FileSystem;
 using Ryujinx.HLE.HOS;
+using Ryujinx.HLE.HOS.Kernel.SupervisorCall;
 using Ryujinx.HLE.HOS.Services.Apm;
 using Ryujinx.HLE.HOS.Services.Hid;
 using Ryujinx.HLE.Ui;
@@ -73,6 +74,7 @@ namespace Ryujinx.HLE
             System.EnablePtc                        = Configuration.EnablePtc;
             System.FsIntegrityCheckLevel            = Configuration.FsIntegrityCheckLevel;
             System.GlobalAccessLogMode              = Configuration.FsGlobalAccessLogMode;
+            Syscall.allowUnsafeMemAccess            = Configuration.UnsafeMem;
         }
 
         public void LoadCart(string exeFsDir, string romFsFile = null)

--- a/Ryujinx.HLE/Switch.cs
+++ b/Ryujinx.HLE/Switch.cs
@@ -74,7 +74,6 @@ namespace Ryujinx.HLE
             System.EnablePtc                        = Configuration.EnablePtc;
             System.FsIntegrityCheckLevel            = Configuration.FsIntegrityCheckLevel;
             System.GlobalAccessLogMode              = Configuration.FsGlobalAccessLogMode;
-            Syscall.allowUnsafeMemAccess            = Configuration.UnsafeMem;
         }
 
         public void LoadCart(string exeFsDir, string romFsFile = null)

--- a/Ryujinx.Headless.SDL2/Options.cs
+++ b/Ryujinx.Headless.SDL2/Options.cs
@@ -176,5 +176,8 @@ namespace Ryujinx.Headless.SDL2
 
         [Value(0, MetaName = "input", HelpText = "Input to load.", Required = true)]
         public string InputPath { get; set; }
+
+        [Option("allow-unsafe-mem", Required = false, Default = false, HelpText = "Allows games and mods to access RAM they may not normally have access to. Required by some homebrew and game mods.")]
+        public bool UnsafeMem { get; set; }
     }
 }

--- a/Ryujinx.Headless.SDL2/Options.cs
+++ b/Ryujinx.Headless.SDL2/Options.cs
@@ -177,7 +177,7 @@ namespace Ryujinx.Headless.SDL2
         [Value(0, MetaName = "input", HelpText = "Input to load.", Required = true)]
         public string InputPath { get; set; }
 
-        [Option("allow-unsafe-mem", Required = false, Default = false, HelpText = "Allows games and mods to access RAM they may not normally have access to. Required by some homebrew and game mods.")]
-        public bool UnsafeMem { get; set; }
+        [Option("allow-jit-code-mem", Required = false, Default = false, HelpText = "Allows mods to access areas of memory they normally shouldn't. Don't enable this setting unless a mod is crashing because it needs it.")]
+        public bool allowJitCodeMem { get; set; }
     }
 }

--- a/Ryujinx.Headless.SDL2/Options.cs
+++ b/Ryujinx.Headless.SDL2/Options.cs
@@ -178,6 +178,6 @@ namespace Ryujinx.Headless.SDL2
         public string InputPath { get; set; }
 
         [Option("allow-jit-code-mem", Required = false, Default = false, HelpText = "Allows mods to access areas of memory they normally shouldn't. Don't enable this setting unless a mod is crashing because it needs it.")]
-        public bool allowJitCodeMem { get; set; }
+        public bool AllowJitCodeMem { get; set; }
     }
 }

--- a/Ryujinx.Headless.SDL2/Program.cs
+++ b/Ryujinx.Headless.SDL2/Program.cs
@@ -485,7 +485,7 @@ namespace Ryujinx.Headless.SDL2
                                                                   (bool)options.IgnoreMissingServices,
                                                                   options.AspectRatio,
                                                                   options.AudioVolume,
-                                                                  options.allowJitCodeMem);
+                                                                  options.AllowJitCodeMem);
 
             return new Switch(configuration);
         }

--- a/Ryujinx.Headless.SDL2/Program.cs
+++ b/Ryujinx.Headless.SDL2/Program.cs
@@ -484,7 +484,7 @@ namespace Ryujinx.Headless.SDL2
                                                                   options.MemoryManagerMode,
                                                                   (bool)options.IgnoreMissingServices,
                                                                   options.AspectRatio,
-                                                                  options.AudioVolume);
+                                                                  options.AudioVolume, options.UnsafeMem);
 
             return new Switch(configuration);
         }

--- a/Ryujinx.Headless.SDL2/Program.cs
+++ b/Ryujinx.Headless.SDL2/Program.cs
@@ -485,7 +485,7 @@ namespace Ryujinx.Headless.SDL2
                                                                   (bool)options.IgnoreMissingServices,
                                                                   options.AspectRatio,
                                                                   options.AudioVolume,
-                                                                  options.UnsafeMem);
+                                                                  options.allowJitCodeMem);
 
             return new Switch(configuration);
         }

--- a/Ryujinx.Headless.SDL2/Program.cs
+++ b/Ryujinx.Headless.SDL2/Program.cs
@@ -484,7 +484,8 @@ namespace Ryujinx.Headless.SDL2
                                                                   options.MemoryManagerMode,
                                                                   (bool)options.IgnoreMissingServices,
                                                                   options.AspectRatio,
-                                                                  options.AudioVolume, options.UnsafeMem);
+                                                                  options.AudioVolume,
+                                                                  options.UnsafeMem);
 
             return new Switch(configuration);
         }

--- a/Ryujinx.Ui.Common/Configuration/ConfigurationFileFormat.cs
+++ b/Ryujinx.Ui.Common/Configuration/ConfigurationFileFormat.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.Ui.Common.Configuration
         /// <summary>
         /// The current version of the file format
         /// </summary>
-        public const int CurrentVersion = 38;
+        public const int CurrentVersion = 39;
 
         /// <summary>
         /// Version of the configuration file format
@@ -201,6 +201,11 @@ namespace Ryujinx.Ui.Common.Configuration
         /// </summary>
         public bool ExpandRam { get; set; }
 
+        /// <summary>
+        /// Controls whether code can access normally restricted memory areas.
+        /// </summary>
+        public bool UnsafeMem { get; set; }
+        
         /// <summary>
         /// Enable or disable ignoring missing services
         /// </summary>

--- a/Ryujinx.Ui.Common/Configuration/ConfigurationFileFormat.cs
+++ b/Ryujinx.Ui.Common/Configuration/ConfigurationFileFormat.cs
@@ -204,7 +204,7 @@ namespace Ryujinx.Ui.Common.Configuration
         /// <summary>
         /// Controls whether code can access normally restricted memory areas.
         /// </summary>
-        public bool allowJitCodeMem { get; set; }
+        public bool AllowJitCodeMem { get; set; }
         
         /// <summary>
         /// Enable or disable ignoring missing services

--- a/Ryujinx.Ui.Common/Configuration/ConfigurationFileFormat.cs
+++ b/Ryujinx.Ui.Common/Configuration/ConfigurationFileFormat.cs
@@ -204,7 +204,7 @@ namespace Ryujinx.Ui.Common.Configuration
         /// <summary>
         /// Controls whether code can access normally restricted memory areas.
         /// </summary>
-        public bool UnsafeMem { get; set; }
+        public bool allowJitCodeMem { get; set; }
         
         /// <summary>
         /// Enable or disable ignoring missing services

--- a/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
+++ b/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
@@ -297,6 +297,11 @@ namespace Ryujinx.Ui.Common.Configuration
             public ReactiveObject<bool> ExpandRam { get; private set; }
 
             /// <summary>
+            /// Controls whether code can access normally restricted memory areas.
+            /// </summary>
+            public ReactiveObject<bool> UnsafeMem { get; private set; }
+            
+            /// <summary>
             /// Enable or disable ignoring missing services
             /// </summary>
             public ReactiveObject<bool> IgnoreMissingServices { get; private set; }
@@ -323,6 +328,8 @@ namespace Ryujinx.Ui.Common.Configuration
                 MemoryManagerMode.Event       += static (sender, e) => LogValueChange(sender, e, nameof(MemoryManagerMode));
                 ExpandRam                     = new ReactiveObject<bool>();
                 ExpandRam.Event               += static (sender, e) => LogValueChange(sender, e, nameof(ExpandRam));
+                UnsafeMem                     = new ReactiveObject<bool>();
+                UnsafeMem.Event               += static (sender, e) => LogValueChange(sender, e, nameof(UnsafeMem));
                 IgnoreMissingServices         = new ReactiveObject<bool>();
                 IgnoreMissingServices.Event   += static (sender, e) => LogValueChange(sender, e, nameof(IgnoreMissingServices));
                 AudioVolume                   = new ReactiveObject<float>();
@@ -535,6 +542,7 @@ namespace Ryujinx.Ui.Common.Configuration
                 AudioVolume               = System.AudioVolume,
                 MemoryManagerMode         = System.MemoryManagerMode,
                 ExpandRam                 = System.ExpandRam,
+                UnsafeMem                 = System.UnsafeMem,
                 IgnoreMissingServices     = System.IgnoreMissingServices,
                 GuiColumns                = new GuiColumns
                 {
@@ -615,6 +623,7 @@ namespace Ryujinx.Ui.Common.Configuration
             System.AudioVolume.Value               = 1;
             System.MemoryManagerMode.Value         = MemoryManagerMode.HostMappedUnsafe;
             System.ExpandRam.Value                 = false;
+            System.UnsafeMem.Value                 = false;
             System.IgnoreMissingServices.Value     = false;
             Ui.GuiColumns.FavColumn.Value          = true;
             Ui.GuiColumns.IconColumn.Value         = true;
@@ -1132,6 +1141,7 @@ namespace Ryujinx.Ui.Common.Configuration
             System.AudioVolume.Value               = configurationFileFormat.AudioVolume;
             System.MemoryManagerMode.Value         = configurationFileFormat.MemoryManagerMode;
             System.ExpandRam.Value                 = configurationFileFormat.ExpandRam;
+            System.UnsafeMem.Value                 = configurationFileFormat.UnsafeMem;
             System.IgnoreMissingServices.Value     = configurationFileFormat.IgnoreMissingServices;
             Ui.GuiColumns.FavColumn.Value          = configurationFileFormat.GuiColumns.FavColumn;
             Ui.GuiColumns.IconColumn.Value         = configurationFileFormat.GuiColumns.IconColumn;

--- a/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
+++ b/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
@@ -299,7 +299,7 @@ namespace Ryujinx.Ui.Common.Configuration
             /// <summary>
             /// Controls whether code can access normally restricted memory areas.
             /// </summary>
-            public ReactiveObject<bool> allowJitCodeMem { get; private set; }
+            public ReactiveObject<bool> AllowJitCodeMem { get; private set; }
             
             /// <summary>
             /// Enable or disable ignoring missing services
@@ -328,8 +328,8 @@ namespace Ryujinx.Ui.Common.Configuration
                 MemoryManagerMode.Event       += static (sender, e) => LogValueChange(sender, e, nameof(MemoryManagerMode));
                 ExpandRam                     = new ReactiveObject<bool>();
                 ExpandRam.Event               += static (sender, e) => LogValueChange(sender, e, nameof(ExpandRam));
-                allowJitCodeMem                     = new ReactiveObject<bool>();
-                allowJitCodeMem.Event               += static (sender, e) => LogValueChange(sender, e, nameof(allowJitCodeMem));
+                AllowJitCodeMem                     = new ReactiveObject<bool>();
+                AllowJitCodeMem.Event               += static (sender, e) => LogValueChange(sender, e, nameof(AllowJitCodeMem));
                 IgnoreMissingServices         = new ReactiveObject<bool>();
                 IgnoreMissingServices.Event   += static (sender, e) => LogValueChange(sender, e, nameof(IgnoreMissingServices));
                 AudioVolume                   = new ReactiveObject<float>();
@@ -542,7 +542,7 @@ namespace Ryujinx.Ui.Common.Configuration
                 AudioVolume               = System.AudioVolume,
                 MemoryManagerMode         = System.MemoryManagerMode,
                 ExpandRam                 = System.ExpandRam,
-                allowJitCodeMem           = System.allowJitCodeMem,
+                AllowJitCodeMem           = System.AllowJitCodeMem,
                 IgnoreMissingServices     = System.IgnoreMissingServices,
                 GuiColumns                = new GuiColumns
                 {
@@ -623,7 +623,7 @@ namespace Ryujinx.Ui.Common.Configuration
             System.AudioVolume.Value               = 1;
             System.MemoryManagerMode.Value         = MemoryManagerMode.HostMappedUnsafe;
             System.ExpandRam.Value                 = false;
-            System.allowJitCodeMem.Value                 = false;
+            System.AllowJitCodeMem.Value                 = false;
             System.IgnoreMissingServices.Value     = false;
             Ui.GuiColumns.FavColumn.Value          = true;
             Ui.GuiColumns.IconColumn.Value         = true;
@@ -1141,7 +1141,7 @@ namespace Ryujinx.Ui.Common.Configuration
             System.AudioVolume.Value               = configurationFileFormat.AudioVolume;
             System.MemoryManagerMode.Value         = configurationFileFormat.MemoryManagerMode;
             System.ExpandRam.Value                 = configurationFileFormat.ExpandRam;
-            System.allowJitCodeMem.Value           = configurationFileFormat.allowJitCodeMem;
+            System.AllowJitCodeMem.Value           = configurationFileFormat.AllowJitCodeMem;
             System.IgnoreMissingServices.Value     = configurationFileFormat.IgnoreMissingServices;
             Ui.GuiColumns.FavColumn.Value          = configurationFileFormat.GuiColumns.FavColumn;
             Ui.GuiColumns.IconColumn.Value         = configurationFileFormat.GuiColumns.IconColumn;

--- a/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
+++ b/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
@@ -299,7 +299,7 @@ namespace Ryujinx.Ui.Common.Configuration
             /// <summary>
             /// Controls whether code can access normally restricted memory areas.
             /// </summary>
-            public ReactiveObject<bool> UnsafeMem { get; private set; }
+            public ReactiveObject<bool> allowJitCodeMem { get; private set; }
             
             /// <summary>
             /// Enable or disable ignoring missing services
@@ -328,8 +328,8 @@ namespace Ryujinx.Ui.Common.Configuration
                 MemoryManagerMode.Event       += static (sender, e) => LogValueChange(sender, e, nameof(MemoryManagerMode));
                 ExpandRam                     = new ReactiveObject<bool>();
                 ExpandRam.Event               += static (sender, e) => LogValueChange(sender, e, nameof(ExpandRam));
-                UnsafeMem                     = new ReactiveObject<bool>();
-                UnsafeMem.Event               += static (sender, e) => LogValueChange(sender, e, nameof(UnsafeMem));
+                allowJitCodeMem                     = new ReactiveObject<bool>();
+                allowJitCodeMem.Event               += static (sender, e) => LogValueChange(sender, e, nameof(allowJitCodeMem));
                 IgnoreMissingServices         = new ReactiveObject<bool>();
                 IgnoreMissingServices.Event   += static (sender, e) => LogValueChange(sender, e, nameof(IgnoreMissingServices));
                 AudioVolume                   = new ReactiveObject<float>();
@@ -542,7 +542,7 @@ namespace Ryujinx.Ui.Common.Configuration
                 AudioVolume               = System.AudioVolume,
                 MemoryManagerMode         = System.MemoryManagerMode,
                 ExpandRam                 = System.ExpandRam,
-                UnsafeMem                 = System.UnsafeMem,
+                allowJitCodeMem           = System.allowJitCodeMem,
                 IgnoreMissingServices     = System.IgnoreMissingServices,
                 GuiColumns                = new GuiColumns
                 {
@@ -623,7 +623,7 @@ namespace Ryujinx.Ui.Common.Configuration
             System.AudioVolume.Value               = 1;
             System.MemoryManagerMode.Value         = MemoryManagerMode.HostMappedUnsafe;
             System.ExpandRam.Value                 = false;
-            System.UnsafeMem.Value                 = false;
+            System.allowJitCodeMem.Value                 = false;
             System.IgnoreMissingServices.Value     = false;
             Ui.GuiColumns.FavColumn.Value          = true;
             Ui.GuiColumns.IconColumn.Value         = true;
@@ -1141,7 +1141,7 @@ namespace Ryujinx.Ui.Common.Configuration
             System.AudioVolume.Value               = configurationFileFormat.AudioVolume;
             System.MemoryManagerMode.Value         = configurationFileFormat.MemoryManagerMode;
             System.ExpandRam.Value                 = configurationFileFormat.ExpandRam;
-            System.UnsafeMem.Value                 = configurationFileFormat.UnsafeMem;
+            System.allowJitCodeMem.Value           = configurationFileFormat.allowJitCodeMem;
             System.IgnoreMissingServices.Value     = configurationFileFormat.IgnoreMissingServices;
             Ui.GuiColumns.FavColumn.Value          = configurationFileFormat.GuiColumns.FavColumn;
             Ui.GuiColumns.IconColumn.Value         = configurationFileFormat.GuiColumns.IconColumn;

--- a/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
+++ b/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
@@ -328,8 +328,8 @@ namespace Ryujinx.Ui.Common.Configuration
                 MemoryManagerMode.Event       += static (sender, e) => LogValueChange(sender, e, nameof(MemoryManagerMode));
                 ExpandRam                     = new ReactiveObject<bool>();
                 ExpandRam.Event               += static (sender, e) => LogValueChange(sender, e, nameof(ExpandRam));
-                AllowJitCodeMem                     = new ReactiveObject<bool>();
-                AllowJitCodeMem.Event               += static (sender, e) => LogValueChange(sender, e, nameof(AllowJitCodeMem));
+                AllowJitCodeMem               = new ReactiveObject<bool>();
+                AllowJitCodeMem.Event         += static (sender, e) => LogValueChange(sender, e, nameof(AllowJitCodeMem));
                 IgnoreMissingServices         = new ReactiveObject<bool>();
                 IgnoreMissingServices.Event   += static (sender, e) => LogValueChange(sender, e, nameof(IgnoreMissingServices));
                 AudioVolume                   = new ReactiveObject<float>();
@@ -623,7 +623,7 @@ namespace Ryujinx.Ui.Common.Configuration
             System.AudioVolume.Value               = 1;
             System.MemoryManagerMode.Value         = MemoryManagerMode.HostMappedUnsafe;
             System.ExpandRam.Value                 = false;
-            System.AllowJitCodeMem.Value                 = false;
+            System.AllowJitCodeMem.Value           = false;
             System.IgnoreMissingServices.Value     = false;
             Ui.GuiColumns.FavColumn.Value          = true;
             Ui.GuiColumns.IconColumn.Value         = true;

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -574,7 +574,8 @@ namespace Ryujinx.Ui
                                                                           ConfigurationState.Instance.System.MemoryManagerMode,
                                                                           ConfigurationState.Instance.System.IgnoreMissingServices,
                                                                           ConfigurationState.Instance.Graphics.AspectRatio,
-                                                                          ConfigurationState.Instance.System.AudioVolume, ConfigurationState.Instance.System.UnsafeMem.Value);
+                                                                          ConfigurationState.Instance.System.AudioVolume,
+                                                                          ConfigurationState.Instance.System.UnsafeMem.Value);
 
             _emulationContext = new HLE.Switch(configuration);
         }

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -575,7 +575,7 @@ namespace Ryujinx.Ui
                                                                           ConfigurationState.Instance.System.IgnoreMissingServices,
                                                                           ConfigurationState.Instance.Graphics.AspectRatio,
                                                                           ConfigurationState.Instance.System.AudioVolume,
-                                                                          ConfigurationState.Instance.System.allowJitCodeMem.Value);
+                                                                          ConfigurationState.Instance.System.AllowJitCodeMem.Value);
 
             _emulationContext = new HLE.Switch(configuration);
         }

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -574,7 +574,7 @@ namespace Ryujinx.Ui
                                                                           ConfigurationState.Instance.System.MemoryManagerMode,
                                                                           ConfigurationState.Instance.System.IgnoreMissingServices,
                                                                           ConfigurationState.Instance.Graphics.AspectRatio,
-                                                                          ConfigurationState.Instance.System.AudioVolume);
+                                                                          ConfigurationState.Instance.System.AudioVolume, ConfigurationState.Instance.System.UnsafeMem.Value);
 
             _emulationContext = new HLE.Switch(configuration);
         }

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -575,7 +575,7 @@ namespace Ryujinx.Ui
                                                                           ConfigurationState.Instance.System.IgnoreMissingServices,
                                                                           ConfigurationState.Instance.Graphics.AspectRatio,
                                                                           ConfigurationState.Instance.System.AudioVolume,
-                                                                          ConfigurationState.Instance.System.UnsafeMem.Value);
+                                                                          ConfigurationState.Instance.System.allowJitCodeMem.Value);
 
             _emulationContext = new HLE.Switch(configuration);
         }

--- a/Ryujinx/Ui/Windows/SettingsWindow.cs
+++ b/Ryujinx/Ui/Windows/SettingsWindow.cs
@@ -60,6 +60,7 @@ namespace Ryujinx.Ui.Windows
         [GUI] RadioButton     _mmHost;
         [GUI] RadioButton     _mmHostUnsafe;
         [GUI] CheckButton     _expandRamToggle;
+        [GUI] CheckButton     _unsafeMemToggle;
         [GUI] CheckButton     _ignoreToggle;
         [GUI] CheckButton     _directKeyboardAccess;
         [GUI] CheckButton     _directMouseAccess;
@@ -260,6 +261,10 @@ namespace Ryujinx.Ui.Windows
             if (ConfigurationState.Instance.System.ExpandRam)
             {
                 _expandRamToggle.Click();
+            }
+            if (ConfigurationState.Instance.System.UnsafeMem)
+            {
+                _unsafeMemToggle.Click();
             }
 
             if (ConfigurationState.Instance.System.IgnoreMissingServices)
@@ -514,6 +519,7 @@ namespace Ryujinx.Ui.Windows
             ConfigurationState.Instance.System.EnableFsIntegrityChecks.Value   = _fsicToggle.Active;
             ConfigurationState.Instance.System.MemoryManagerMode.Value         = memoryMode;
             ConfigurationState.Instance.System.ExpandRam.Value                 = _expandRamToggle.Active;
+            ConfigurationState.Instance.System.UnsafeMem.Value                 = _unsafeMemToggle.Active;
             ConfigurationState.Instance.System.IgnoreMissingServices.Value     = _ignoreToggle.Active;
             ConfigurationState.Instance.Hid.EnableKeyboard.Value               = _directKeyboardAccess.Active;
             ConfigurationState.Instance.Hid.EnableMouse.Value                  = _directMouseAccess.Active;

--- a/Ryujinx/Ui/Windows/SettingsWindow.cs
+++ b/Ryujinx/Ui/Windows/SettingsWindow.cs
@@ -262,7 +262,7 @@ namespace Ryujinx.Ui.Windows
             {
                 _expandRamToggle.Click();
             }
-            if (ConfigurationState.Instance.System.allowJitCodeMem)
+            if (ConfigurationState.Instance.System.AllowJitCodeMem)
             {
                 _allowJitCodeMemToggle.Click();
             }
@@ -519,7 +519,7 @@ namespace Ryujinx.Ui.Windows
             ConfigurationState.Instance.System.EnableFsIntegrityChecks.Value   = _fsicToggle.Active;
             ConfigurationState.Instance.System.MemoryManagerMode.Value         = memoryMode;
             ConfigurationState.Instance.System.ExpandRam.Value                 = _expandRamToggle.Active;
-            ConfigurationState.Instance.System.allowJitCodeMem.Value                 = _allowJitCodeMemToggle.Active;
+            ConfigurationState.Instance.System.AllowJitCodeMem.Value           = _allowJitCodeMemToggle.Active;
             ConfigurationState.Instance.System.IgnoreMissingServices.Value     = _ignoreToggle.Active;
             ConfigurationState.Instance.Hid.EnableKeyboard.Value               = _directKeyboardAccess.Active;
             ConfigurationState.Instance.Hid.EnableMouse.Value                  = _directMouseAccess.Active;

--- a/Ryujinx/Ui/Windows/SettingsWindow.cs
+++ b/Ryujinx/Ui/Windows/SettingsWindow.cs
@@ -60,7 +60,7 @@ namespace Ryujinx.Ui.Windows
         [GUI] RadioButton     _mmHost;
         [GUI] RadioButton     _mmHostUnsafe;
         [GUI] CheckButton     _expandRamToggle;
-        [GUI] CheckButton     _unsafeMemToggle;
+        [GUI] CheckButton     _allowJitCodeMemToggle;
         [GUI] CheckButton     _ignoreToggle;
         [GUI] CheckButton     _directKeyboardAccess;
         [GUI] CheckButton     _directMouseAccess;
@@ -262,9 +262,9 @@ namespace Ryujinx.Ui.Windows
             {
                 _expandRamToggle.Click();
             }
-            if (ConfigurationState.Instance.System.UnsafeMem)
+            if (ConfigurationState.Instance.System.allowJitCodeMem)
             {
-                _unsafeMemToggle.Click();
+                _allowJitCodeMemToggle.Click();
             }
 
             if (ConfigurationState.Instance.System.IgnoreMissingServices)
@@ -519,7 +519,7 @@ namespace Ryujinx.Ui.Windows
             ConfigurationState.Instance.System.EnableFsIntegrityChecks.Value   = _fsicToggle.Active;
             ConfigurationState.Instance.System.MemoryManagerMode.Value         = memoryMode;
             ConfigurationState.Instance.System.ExpandRam.Value                 = _expandRamToggle.Active;
-            ConfigurationState.Instance.System.UnsafeMem.Value                 = _unsafeMemToggle.Active;
+            ConfigurationState.Instance.System.allowJitCodeMem.Value                 = _allowJitCodeMemToggle.Active;
             ConfigurationState.Instance.System.IgnoreMissingServices.Value     = _ignoreToggle.Active;
             ConfigurationState.Instance.Hid.EnableKeyboard.Value               = _directKeyboardAccess.Active;
             ConfigurationState.Instance.Hid.EnableMouse.Value                  = _directMouseAccess.Active;

--- a/Ryujinx/Ui/Windows/SettingsWindow.glade
+++ b/Ryujinx/Ui/Windows/SettingsWindow.glade
@@ -1,2696 +1,2714 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.38.2 -->
 <interface>
-  <requires lib="gtk+" version="3.20"/>
-  <object class="GtkAdjustment" id="_fsLogSpinAdjustment">
-    <property name="upper">3</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
-  </object>
-  <object class="GtkAdjustment" id="_systemTimeDaySpinAdjustment">
-    <property name="lower">1</property>
-    <property name="upper">31</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">5</property>
-  </object>
-  <object class="GtkAdjustment" id="_systemTimeHourSpinAdjustment">
-    <property name="upper">23</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">5</property>
-  </object>
-  <object class="GtkAdjustment" id="_systemTimeMinuteSpinAdjustment">
-    <property name="upper">59</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">5</property>
-  </object>
-  <object class="GtkAdjustment" id="_systemTimeMonthSpinAdjustment">
-    <property name="lower">1</property>
-    <property name="upper">12</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">5</property>
-  </object>
-  <object class="GtkAdjustment" id="_systemTimeYearSpinAdjustment">
-    <property name="lower">2000</property>
-    <property name="upper">2060</property>
-    <property name="step-increment">1</property>
-    <property name="page-increment">10</property>
-  </object>
-  <object class="GtkEntryCompletion" id="_systemTimeZoneCompletion">
-    <property name="minimum-key-length">0</property>
-    <property name="inline-completion">True</property>
-    <property name="inline-selection">True</property>
-  </object>
-  <object class="GtkWindow" id="_settingsWin">
-    <property name="can-focus">False</property>
-    <property name="title" translatable="yes">Ryujinx - Settings</property>
-    <property name="modal">True</property>
-    <property name="window-position">center</property>
-    <property name="default-width">650</property>
-    <property name="default-height">650</property>
-    <child>
-      <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <property name="orientation">vertical</property>
-        <child>
-          <object class="GtkScrolledWindow">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="shadow-type">in</property>
-            <child>
-              <object class="GtkViewport">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <child>
-                  <object class="GtkNotebook">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <child>
-                      <object class="GtkBox" id="TabGeneral">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="margin-left">5</property>
-                        <property name="margin-right">10</property>
-                        <property name="margin-top">5</property>
-                        <property name="orientation">vertical</property>
-                        <child>
-                          <object class="GtkBox" id="CatGeneral">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="margin-left">5</property>
-                            <property name="margin-right">5</property>
-                            <property name="orientation">vertical</property>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="halign">start</property>
-                                <property name="margin-bottom">5</property>
-                                <property name="label" translatable="yes">General</property>
-                                <attributes>
-                                  <attribute name="weight" value="bold"/>
-                                </attributes>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox" id="General">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="margin-left">10</property>
-                                <property name="margin-right">10</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <object class="GtkCheckButton" id="_discordToggle">
-                                    <property name="label" translatable="yes">Enable Discord Rich Presence</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="tooltip-text" translatable="yes">Enables or disables Discord Rich Presence</property>
-                                    <property name="halign">start</property>
-                                    <property name="draw-indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="padding">5</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="_checkUpdatesToggle">
-                                    <property name="label" translatable="yes">Check for Updates on Launch</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="draw-indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="padding">5</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="_showConfirmExitToggle">
-                                    <property name="label" translatable="yes">Show "Confirm Exit" Dialog</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="draw-indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="padding">5</property>
-                                    <property name="position">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="_hideCursorOnIdleToggle">
-                                    <property name="label" translatable="yes">Hide Cursor On Idle</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="draw-indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="padding">5</property>
-                                    <property name="position">3</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="padding">5</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkSeparator">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="margin-left">5</property>
-                            <property name="margin-right">5</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="padding">5</property>
-                            <property name="position">2</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkBox" id="CatGameDir">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="margin-left">5</property>
-                            <property name="margin-right">5</property>
-                            <property name="orientation">vertical</property>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="halign">start</property>
-                                <property name="margin-bottom">5</property>
-                                <property name="label" translatable="yes">Game Directories</property>
-                                <attributes>
-                                  <attribute name="weight" value="bold"/>
-                                </attributes>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="margin-left">10</property>
-                                <property name="margin-right">10</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <object class="GtkScrolledWindow">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="margin-bottom">10</property>
-                                    <property name="shadow-type">in</property>
-                                    <child>
-                                      <object class="GtkTreeView" id="_gameDirsBox">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="headers-visible">False</property>
-                                        <property name="headers-clickable">False</property>
-                                        <child internal-child="selection">
-                                          <object class="GtkTreeSelection"/>
-                                        </child>
-                                      </object>
-                                    </child>
-                                    <style>
-                                      <class name="GameDir"/>
-                                    </style>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">True</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <child>
-                                      <object class="GtkEntry" id="_addGameDirBox">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="tooltip-text" translatable="yes">Enter a game directroy to add to the list</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">True</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkToggleButton" id="_addDir">
-                                        <property name="label" translatable="yes">Add</property>
-                                        <property name="width-request">80</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">True</property>
-                                        <property name="tooltip-text" translatable="yes"> Add a game directory to the list</property>
-                                        <property name="margin-left">5</property>
-                                        <signal name="toggled" handler="AddDir_Pressed" swapped="no"/>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">1</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkToggleButton" id="_removeDir">
-                                        <property name="label" translatable="yes">Remove</property>
-                                        <property name="width-request">80</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">True</property>
-                                        <property name="tooltip-text" translatable="yes">Remove selected game directory</property>
-                                        <property name="margin-left">5</property>
-                                        <signal name="toggled" handler="RemoveDir_Pressed" swapped="no"/>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">3</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="padding">5</property>
-                            <property name="position">4</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkSeparator">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="margin-left">5</property>
-                            <property name="margin-right">5</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="padding">5</property>
-                            <property name="position">5</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkBox" id="CatThemes">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="margin-left">5</property>
-                            <property name="margin-right">5</property>
-                            <property name="orientation">vertical</property>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="halign">start</property>
-                                <property name="margin-bottom">5</property>
-                                <property name="label" translatable="yes">Themes</property>
-                                <attributes>
-                                  <attribute name="weight" value="bold"/>
-                                </attributes>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="margin-left">10</property>
-                                <property name="margin-right">10</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <object class="GtkCheckButton" id="_custThemeToggle">
-                                    <property name="label" translatable="yes">Use Custom Theme</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="tooltip-text" translatable="yes">Enable or disable custom themes in the GUI</property>
-                                    <property name="halign">start</property>
-                                    <property name="draw-indicator">True</property>
-                                    <signal name="toggled" handler="CustThemeToggle_Activated" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="padding">5</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <child>
-                                      <object class="GtkLabel" id="_custThemePathLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Path to custom GUI theme</property>
-                                        <property name="label" translatable="yes">Custom Theme Path:</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="padding">5</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkEntry" id="_custThemePath">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="tooltip-text" translatable="yes">Path to custom GUI theme</property>
-                                        <property name="valign">center</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">True</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">1</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkToggleButton" id="_browseThemePath">
-                                        <property name="label" translatable="yes">Browse...</property>
-                                        <property name="width-request">80</property>
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="receives-default">True</property>
-                                        <property name="tooltip-text" translatable="yes">Browse for a custom GUI theme</property>
-                                        <property name="margin-left">5</property>
-                                        <signal name="toggled" handler="BrowseThemeDir_Pressed" swapped="no"/>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">2</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="padding">10</property>
-                                    <property name="position">2</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="padding">5</property>
-                            <property name="position">6</property>
-                          </packing>
-                        </child>
-                      </object>
-                    </child>
-                    <child type="tab">
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="label" translatable="yes">General</property>
-                      </object>
-                      <packing>
-                        <property name="tab-fill">False</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkBox" id="TabInput">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="margin-left">5</property>
-                        <property name="margin-right">10</property>
-                        <property name="margin-top">5</property>
-                        <property name="orientation">vertical</property>
-                        <child>
-                          <object class="GtkBox">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="margin-top">5</property>
-                            <property name="margin-bottom">5</property>
-                            <child>
-                              <object class="GtkCheckButton" id="_dockedModeToggle">
-                                <property name="label" translatable="yes">Enable Docked Mode</property>
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="receives-default">False</property>
-                                <property name="tooltip-text" translatable="yes">Enable or disable Docked Mode</property>
-                                <property name="draw-indicator">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="padding">10</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkCheckButton" id="_directKeyboardAccess">
-                                <property name="label" translatable="yes">Direct Keyboard Access</property>
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="receives-default">False</property>
-                                <property name="tooltip-text" translatable="yes">Enable or disable "direct keyboard access (HID) support" (Provides games access to your keyboard as a text entry device)</property>
-                                <property name="draw-indicator">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="padding">10</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkCheckButton" id="_directMouseAccess">
-                                <property name="label" translatable="yes">Direct Mouse Access</property>
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="receives-default">False</property>
-                                <property name="tooltip-text" translatable="yes">Enable or disable "direct mouse access (HID) support" (Provides games access to your mouse as a pointing device)</property>
-                                <property name="draw-indicator">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="padding">10</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="padding">5</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkSeparator">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <!-- n-columns=5 n-rows=5 -->
-                          <object class="GtkGrid" id="ControllerGrid">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="halign">center</property>
-                            <property name="valign">center</property>
-                            <property name="column-spacing">20</property>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-top">20</property>
-                                    <property name="margin-bottom">20</property>
-                                    <property name="label" translatable="yes">Player 1</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkToggleButton" id="_configureController1">
-                                    <property name="label" translatable="yes">Configure</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">True</property>
-                                    <property name="margin-left">20</property>
-                                    <property name="margin-right">20</property>
-                                    <property name="margin-top">20</property>
-                                    <property name="margin-bottom">20</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="left-attach">0</property>
-                                <property name="top-attach">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-top">20</property>
-                                    <property name="margin-bottom">20</property>
-                                    <property name="label" translatable="yes">Player 3</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkToggleButton" id="_configureController3">
-                                    <property name="label" translatable="yes">Configure</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">True</property>
-                                    <property name="margin-left">20</property>
-                                    <property name="margin-right">20</property>
-                                    <property name="margin-top">20</property>
-                                    <property name="margin-bottom">20</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="left-attach">4</property>
-                                <property name="top-attach">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-top">20</property>
-                                    <property name="margin-bottom">20</property>
-                                    <property name="label" translatable="yes">Player 2</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkToggleButton" id="_configureController2">
-                                    <property name="label" translatable="yes">Configure</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">True</property>
-                                    <property name="margin-left">20</property>
-                                    <property name="margin-right">20</property>
-                                    <property name="margin-top">20</property>
-                                    <property name="margin-bottom">20</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="left-attach">2</property>
-                                <property name="top-attach">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-top">20</property>
-                                    <property name="margin-bottom">20</property>
-                                    <property name="label" translatable="yes">Handheld</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkToggleButton" id="_configureControllerH">
-                                    <property name="label" translatable="yes">Configure</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">True</property>
-                                    <property name="margin-left">20</property>
-                                    <property name="margin-right">20</property>
-                                    <property name="margin-top">20</property>
-                                    <property name="margin-bottom">20</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="left-attach">4</property>
-                                <property name="top-attach">4</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-top">20</property>
-                                    <property name="margin-bottom">20</property>
-                                    <property name="label" translatable="yes">Player 6</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkToggleButton" id="_configureController6">
-                                    <property name="label" translatable="yes">Configure</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">True</property>
-                                    <property name="margin-left">20</property>
-                                    <property name="margin-right">20</property>
-                                    <property name="margin-top">20</property>
-                                    <property name="margin-bottom">20</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="left-attach">4</property>
-                                <property name="top-attach">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-top">20</property>
-                                    <property name="margin-bottom">20</property>
-                                    <property name="label" translatable="yes">Player 5</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkToggleButton" id="_configureController5">
-                                    <property name="label" translatable="yes">Configure</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">True</property>
-                                    <property name="margin-left">20</property>
-                                    <property name="margin-right">20</property>
-                                    <property name="margin-top">20</property>
-                                    <property name="margin-bottom">20</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="left-attach">2</property>
-                                <property name="top-attach">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-top">20</property>
-                                    <property name="margin-bottom">20</property>
-                                    <property name="label" translatable="yes">Player 7</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkToggleButton" id="_configureController7">
-                                    <property name="label" translatable="yes">Configure</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">True</property>
-                                    <property name="margin-left">20</property>
-                                    <property name="margin-right">20</property>
-                                    <property name="margin-top">20</property>
-                                    <property name="margin-bottom">20</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="left-attach">0</property>
-                                <property name="top-attach">4</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-top">20</property>
-                                    <property name="margin-bottom">20</property>
-                                    <property name="label" translatable="yes">Player 4</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkToggleButton" id="_configureController4">
-                                    <property name="label" translatable="yes">Configure</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">True</property>
-                                    <property name="margin-left">20</property>
-                                    <property name="margin-right">20</property>
-                                    <property name="margin-top">20</property>
-                                    <property name="margin-bottom">20</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="left-attach">0</property>
-                                <property name="top-attach">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-top">20</property>
-                                    <property name="margin-bottom">20</property>
-                                    <property name="label" translatable="yes">Player 8</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkToggleButton" id="_configureController8">
-                                    <property name="label" translatable="yes">Configure</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">True</property>
-                                    <property name="margin-left">20</property>
-                                    <property name="margin-right">20</property>
-                                    <property name="margin-top">20</property>
-                                    <property name="margin-bottom">20</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="left-attach">2</property>
-                                <property name="top-attach">4</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left-attach">1</property>
-                                <property name="top-attach">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left-attach">3</property>
-                                <property name="top-attach">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left-attach">3</property>
-                                <property name="top-attach">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left-attach">3</property>
-                                <property name="top-attach">4</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left-attach">1</property>
-                                <property name="top-attach">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left-attach">1</property>
-                                <property name="top-attach">4</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left-attach">1</property>
-                                <property name="top-attach">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left-attach">1</property>
-                                <property name="top-attach">3</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left-attach">3</property>
-                                <property name="top-attach">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left-attach">3</property>
-                                <property name="top-attach">3</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left-attach">0</property>
-                                <property name="top-attach">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left-attach">2</property>
-                                <property name="top-attach">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left-attach">4</property>
-                                <property name="top-attach">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left-attach">0</property>
-                                <property name="top-attach">3</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left-attach">2</property>
-                                <property name="top-attach">3</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkSeparator">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                              </object>
-                              <packing>
-                                <property name="left-attach">4</property>
-                                <property name="top-attach">3</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">2</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkSeparator">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">3</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child type="tab">
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="label" translatable="yes">Input</property>
-                      </object>
-                      <packing>
-                        <property name="position">1</property>
-                        <property name="tab-fill">False</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkBox" id="TabSystem">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="margin-left">5</property>
-                        <property name="margin-right">10</property>
-                        <property name="margin-top">5</property>
-                        <property name="orientation">vertical</property>
-                        <child>
-                          <object class="GtkBox" id="CatCore">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="valign">start</property>
-                            <property name="margin-left">5</property>
-                            <property name="margin-right">5</property>
-                            <property name="orientation">vertical</property>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="halign">start</property>
-                                <property name="margin-bottom">5</property>
-                                <property name="label" translatable="yes">Core</property>
-                                <attributes>
-                                  <attribute name="weight" value="bold"/>
-                                </attributes>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="margin-left">10</property>
-                                <property name="margin-right">10</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <object class="GtkBox" id="RegionBox">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <child>
-                                      <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Change System Region</property>
-                                        <property name="halign">end</property>
-                                        <property name="label" translatable="yes">System Region:</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="padding">5</property>
-                                        <property name="position">2</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkComboBoxText" id="_systemRegionSelect">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Change System Region</property>
-                                        <property name="margin-left">5</property>
-                                        <items>
-                                          <item id="Japan" translatable="yes">Japan</item>
-                                          <item id="USA" translatable="yes">USA</item>
-                                          <item id="Europe" translatable="yes">Europe</item>
-                                          <item id="Australia" translatable="yes">Australia</item>
-                                          <item id="China" translatable="yes">China</item>
-                                          <item id="Korea" translatable="yes">Korea</item>
-                                          <item id="Taiwan" translatable="yes">Taiwan</item>
-                                        </items>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">3</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="padding">5</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkBox" id="LanguageBox">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <child>
-                                      <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Change System Language</property>
-                                        <property name="halign">end</property>
-                                        <property name="label" translatable="yes">System Language:</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="padding">5</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkComboBoxText" id="_systemLanguageSelect">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Change System Language</property>
-                                        <items>
-                                          <item id="AmericanEnglish" translatable="yes">American English</item>
-                                          <item id="BritishEnglish" translatable="yes">British English</item>
-                                          <item id="CanadianFrench" translatable="yes">Canadian French</item>
-                                          <item id="Chinese" translatable="yes">Chinese</item>
-                                          <item id="Dutch" translatable="yes">Dutch</item>
-                                          <item id="French" translatable="yes">French</item>
-                                          <item id="German" translatable="yes">German</item>
-                                          <item id="Italian" translatable="yes">Italian</item>
-                                          <item id="Japanese" translatable="yes">Japanese</item>
-                                          <item id="Korean" translatable="yes">Korean</item>
-                                          <item id="LatinAmericanSpanish" translatable="yes">Latin American Spanish</item>
-                                          <item id="Portuguese" translatable="yes">Portuguese</item>
-                                          <item id="Russian" translatable="yes">Russian</item>
-                                          <item id="SimplifiedChinese" translatable="yes">Simplified Chinese</item>
-                                          <item id="Spanish" translatable="yes">Spanish</item>
-                                          <item id="Taiwanese" translatable="yes">Taiwanese</item>
-                                          <item id="TraditionalChinese" translatable="yes">Traditional Chinese</item>
-                                          <item id="BrazilianPortuguese" translatable="yes">Brazilian Portuguese</item>
-                                        </items>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">1</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="padding">5</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkBox" id="TimeZoneBox">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <child>
-                                      <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Change System TimeZone</property>
-                                        <property name="halign">end</property>
-                                        <property name="label" translatable="yes">System TimeZone:</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="padding">5</property>
-                                        <property name="position">1</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkEntry" id="_systemTimeZoneEntry">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="tooltip-text" translatable="yes">Change System TimeZone</property>
-                                        <property name="margin-left">5</property>
-                                        <property name="completion">_systemTimeZoneCompletion</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">2</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="padding">5</property>
-                                    <property name="position">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkBox" id="TimeBox">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <child>
-                                      <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Change System Time</property>
-                                        <property name="halign">end</property>
-                                        <property name="label" translatable="yes">System Time:</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="padding">5</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSpinButton" id="_systemTimeYearSpin">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="text" translatable="yes">2000</property>
-                                        <property name="orientation">vertical</property>
-                                        <property name="adjustment">_systemTimeYearSpinAdjustment</property>
-                                        <property name="wrap">True</property>
-                                        <property name="value">2000</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">1</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="halign">end</property>
-                                        <property name="label">-</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="padding">5</property>
-                                        <property name="position">2</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSpinButton" id="_systemTimeMonthSpin">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="text" translatable="yes">1</property>
-                                        <property name="orientation">vertical</property>
-                                        <property name="adjustment">_systemTimeMonthSpinAdjustment</property>
-                                        <property name="wrap">True</property>
-                                        <property name="value">1</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">3</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="halign">end</property>
-                                        <property name="label">-</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="padding">5</property>
-                                        <property name="position">4</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSpinButton" id="_systemTimeDaySpin">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="text" translatable="yes">1</property>
-                                        <property name="orientation">vertical</property>
-                                        <property name="adjustment">_systemTimeDaySpinAdjustment</property>
-                                        <property name="wrap">True</property>
-                                        <property name="value">1</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">5</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSpinButton" id="_systemTimeHourSpin">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="text" translatable="yes">0</property>
-                                        <property name="orientation">vertical</property>
-                                        <property name="adjustment">_systemTimeHourSpinAdjustment</property>
-                                        <property name="wrap">True</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">6</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="halign">end</property>
-                                        <property name="label">:</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="padding">5</property>
-                                        <property name="position">7</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSpinButton" id="_systemTimeMinuteSpin">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="text" translatable="yes">0</property>
-                                        <property name="orientation">vertical</property>
-                                        <property name="adjustment">_systemTimeMinuteSpinAdjustment</property>
-                                        <property name="wrap">True</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">8</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="padding">5</property>
-                                    <property name="position">3</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="_vSyncToggle">
-                                    <property name="label" translatable="yes">Enable VSync</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="tooltip-text" translatable="yes">Enables or disables Vertical Sync</property>
-                                    <property name="halign">start</property>
-                                    <property name="margin-top">5</property>
-                                    <property name="margin-bottom">5</property>
-                                    <property name="draw-indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">4</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="_ptcToggle">
-                                    <property name="label" translatable="yes">Enable PPTC (Profiled Persistent Translation Cache)</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="tooltip-text" translatable="yes">Enables or disables profiled translation cache persistency</property>
-                                    <property name="halign">start</property>
-                                    <property name="margin-top">5</property>
-                                    <property name="margin-bottom">5</property>
-                                    <property name="draw-indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">6</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="_internetToggle">
-                                    <property name="label" translatable="yes">Enable guest Internet access</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="tooltip-text" translatable="yes">Enables guest Internet access. If enabled, the application will behave as if the emulated Switch console was connected to the Internet. Note that in some cases, applications may still access the Internet even with this option disabled</property>
-                                    <property name="halign">start</property>
-                                    <property name="margin-top">5</property>
-                                    <property name="margin-bottom">5</property>
-                                    <property name="draw-indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">7</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="_fsicToggle">
-                                    <property name="label" translatable="yes">Enable FS Integrity Checks</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="tooltip-text" translatable="yes">Enables integrity checks on Game content files</property>
-                                    <property name="halign">start</property>
-                                    <property name="margin-top">5</property>
-                                    <property name="margin-bottom">5</property>
-                                    <property name="draw-indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">8</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox" id="_audioBackendBox">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="tooltip-text" translatable="yes">Change Audio Backend</property>
-                                    <property name="halign">end</property>
-                                    <property name="margin-right">5</property>
-                                    <property name="label" translatable="yes">Audio Backend: </property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="padding">5</property>
-                                    <property name="position">2</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="padding">5</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox" id="_memoryManagerBox">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="tooltip-text" translatable="yes">Change how guest memory is mapped and accessed. Greatly affects emulated CPU performance.</property>
-                                    <property name="halign">end</property>
-                                    <property name="margin-right">5</property>
-                                    <property name="label" translatable="yes">Memory Manager Mode: </property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="padding">5</property>
-                                    <property name="position">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkRadioButton" id="_mmSoftware">
-                                    <property name="label" translatable="yes">Software</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="tooltip-text" translatable="yes">Use a software page table for address translation. Highest accuracy but slowest performance.</property>
-                                    <property name="halign">start</property>
-                                    <property name="margin-top">5</property>
-                                    <property name="margin-bottom">5</property>
-                                    <property name="draw-indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">3</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkRadioButton" id="_mmHost">
-                                    <property name="label" translatable="yes">Host (fast)</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="tooltip-text" translatable="yes">Directly map memory in the host address space. Much faster JIT compilation and execution.</property>
-                                    <property name="halign">start</property>
-                                    <property name="margin-top">5</property>
-                                    <property name="margin-bottom">5</property>
-                                    <property name="draw-indicator">True</property>
-                                    <property name="group">_mmSoftware</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">4</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkRadioButton" id="_mmHostUnsafe">
-                                    <property name="label" translatable="yes">Host unchecked (fastest, unsafe)</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="tooltip-text" translatable="yes">Directly map memory, but do not mask the address within the guest address space before access. Faster, but at the cost of safety. The guest application can access memory from anywhere in Ryujinx, so only run programs you trust with this mode.</property>
-                                    <property name="halign">start</property>
-                                    <property name="margin-top">5</property>
-                                    <property name="margin-bottom">5</property>
-                                    <property name="draw-indicator">True</property>
-                                    <property name="group">_mmSoftware</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">5</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="padding">5</property>
-                                <property name="position">3</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="padding">5</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkSeparator">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="margin-left">5</property>
-                            <property name="margin-right">5</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="padding">5</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkBox" id="CatHacks">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="valign">start</property>
-                            <property name="margin-left">5</property>
-                            <property name="margin-right">5</property>
-                            <property name="orientation">vertical</property>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="margin-bottom">5</property>
-                                    <property name="label" translatable="yes">Hacks</property>
-                                    <attributes>
-                                      <attribute name="weight" value="bold"/>
-                                    </attributes>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="margin-bottom">5</property>
-                                    <property name="label" translatable="yes"> - These may cause instability</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="margin-left">10</property>
-                                <property name="margin-right">10</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <object class="GtkCheckButton" id="_expandRamToggle">
-                                    <property name="label" translatable="yes">Expand DRAM size to 6GB</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="tooltip-text" translatable="yes">Expands the amount of memory on the emulated system from 4GB to 6GB</property>
-                                    <property name="halign">start</property>
-                                    <property name="margin-top">5</property>
-                                    <property name="margin-bottom">5</property>
-                                    <property name="draw-indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="_ignoreToggle">
-                                    <property name="label" translatable="yes">Ignore Missing Services</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="tooltip-text" translatable="yes">Enable or disable ignoring missing services</property>
-                                    <property name="halign">start</property>
-                                    <property name="margin-top">5</property>
-                                    <property name="margin-bottom">5</property>
-                                    <property name="draw-indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="padding">5</property>
-                            <property name="position">4</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="position">2</property>
-                      </packing>
-                    </child>
-                    <child type="tab">
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="halign">end</property>
-                        <property name="label" translatable="yes">System</property>
-                      </object>
-                      <packing>
-                        <property name="position">2</property>
-                        <property name="tab-fill">False</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkBox" id="TabGraphics">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="margin-top">5</property>
-                        <property name="orientation">vertical</property>
-                        <child>
-                          <object class="GtkBox" id="CatFeatures">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="margin-left">5</property>
-                            <property name="margin-right">5</property>
-                            <property name="orientation">vertical</property>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="halign">start</property>
-                                <property name="margin-left">5</property>
-                                <property name="margin-right">5</property>
-                                <property name="margin-bottom">5</property>
-                                <property name="label" translatable="yes">Features</property>
-                                <attributes>
-                                  <attribute name="weight" value="bold"/>
-                                </attributes>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox" id="FeaturesOptions">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="margin-left">10</property>
-                                <property name="margin-right">10</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-top">5</property>
-                                    <property name="margin-bottom">5</property>
-                                    <child>
-                                      <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Enable Graphics Backend Multithreading</property>
-                                        <property name="label" translatable="yes">Graphics Backend Multithreading:</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="padding">5</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkComboBoxText" id="_galThreading">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Executes graphics backend commands on a second thread. Allows runtime multithreading of shader compilation, reduces stuttering, and improves performance on drivers without multithreading support of their own. Slightly varying peak performance on drivers with multithreading. Ryujinx may need to be restarted to correctly disable driver built-in multithreading, or you may need to do it manually to get the best performance.</property>
-                                        <property name="active-id">-1</property>
-                                        <items>
-                                          <item id="Auto" translatable="yes">Auto</item>
-                                          <item id="Off" translatable="yes">Off</item>
-                                          <item id="On" translatable="yes">On</item>
-                                        </items>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">1</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="padding">5</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="padding">5</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkBox" id="CatEnhancements">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="margin-left">5</property>
-                            <property name="margin-right">5</property>
-                            <property name="orientation">vertical</property>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="halign">start</property>
-                                <property name="margin-left">5</property>
-                                <property name="margin-right">5</property>
-                                <property name="margin-bottom">5</property>
-                                <property name="label" translatable="yes">Enhancements</property>
-                                <attributes>
-                                  <attribute name="weight" value="bold"/>
-                                </attributes>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox" id="EnhancementOptions">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="margin-left">10</property>
-                                <property name="margin-right">10</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <object class="GtkCheckButton" id="_shaderCacheToggle">
-                                    <property name="label" translatable="yes">Enable Shader Cache</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="tooltip-text" translatable="yes">Enables or disables Shader Cache</property>
-                                    <property name="halign">start</property>
-                                    <property name="margin-top">5</property>
-                                    <property name="margin-bottom">5</property>
-                                    <property name="draw-indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-top">5</property>
-                                    <property name="margin-bottom">5</property>
-                                    <child>
-                                      <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Resolution Scale applied to applicable render targets.</property>
-                                        <property name="label" translatable="yes">Resolution Scale:</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="padding">5</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkComboBoxText" id="_resScaleCombo">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Resolution Scale applied to applicable render targets.</property>
-                                        <property name="active-id">1</property>
-                                        <items>
-                                          <item id="1" translatable="yes">Native (720p/1080p)</item>
-                                          <item id="2" translatable="yes">2x (1440p/2160p)</item>
-                                          <item id="3" translatable="yes">3x (2160p/3240p)</item>
-                                          <item id="4" translatable="yes">4x (2880p/4320p)</item>
-                                          <item id="-1" translatable="yes">Custom (not recommended)</item>
-                                        </items>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">1</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkEntry" id="_resScaleText">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="tooltip-text" translatable="yes">Floating point resolution scale, such as 1.5. Non-integral scales are more likely to cause issues or crash.</property>
-                                        <property name="valign">center</property>
-                                        <property name="caps-lock-warning">False</property>
-                                        <property name="placeholder-text">1.0</property>
-                                        <property name="input-purpose">number</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">True</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">2</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="padding">5</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-top">5</property>
-                                    <property name="margin-bottom">5</property>
-                                    <child>
-                                      <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Level of Anisotropic Filtering (set to Auto to use the value requested by the game)</property>
-                                        <property name="label" translatable="yes">Anisotropic Filtering:</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="padding">5</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkComboBoxText" id="_anisotropy">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Level of Anisotropic Filtering (set to Auto to use the value requested by the game)</property>
-                                        <property name="active-id">-1</property>
-                                        <items>
-                                          <item id="-1" translatable="yes">Auto</item>
-                                          <item id="2" translatable="yes">2x</item>
-                                          <item id="4" translatable="yes">4x</item>
-                                          <item id="8" translatable="yes">8x</item>
-                                          <item id="16" translatable="yes">16x</item>
-                                        </items>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">1</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="padding">5</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-top">5</property>
-                                    <property name="margin-bottom">5</property>
-                                    <child>
-                                      <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Aspect Ratio applied to the renderer window.</property>
-                                        <property name="label" translatable="yes">Aspect Ratio:</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="padding">5</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkComboBoxText" id="_aspectRatio">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Aspect Ratio applied to the renderer window.</property>
-                                        <property name="active-id">1</property>
-                                        <items>
-                                          <item id="0" translatable="yes">4:3</item>
-                                          <item id="1" translatable="yes">16:9</item>
-                                          <item id="2" translatable="yes">16:10</item>
-                                          <item id="3" translatable="yes">21:9</item>
-                                          <item id="4" translatable="yes">32:9</item>
-                                          <item id="5" translatable="yes">Stretch to Fit Window</item>
-                                        </items>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">1</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="padding">5</property>
-                                    <property name="position">3</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="padding">5</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkSeparator">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="padding">5</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkBox" id="CatDev">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="margin-left">5</property>
-                            <property name="margin-right">5</property>
-                            <property name="orientation">vertical</property>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="halign">start</property>
-                                <property name="margin-left">5</property>
-                                <property name="margin-right">5</property>
-                                <property name="margin-bottom">5</property>
-                                <property name="label" translatable="yes">Developer Options</property>
-                                <attributes>
-                                  <attribute name="weight" value="bold"/>
-                                </attributes>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox" id="DevOptions">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="margin-left">10</property>
-                                <property name="margin-right">10</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-top">5</property>
-                                    <property name="margin-bottom">5</property>
-                                    <child>
-                                      <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Graphics Shaders Dump Path</property>
-                                        <property name="label" translatable="yes">Graphics Shaders Dump Path:</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="padding">5</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkEntry" id="_graphicsShadersDumpPath">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="tooltip-text" translatable="yes">Graphics Shaders Dump Path</property>
-                                        <property name="valign">center</property>
-                                        <property name="caps-lock-warning">False</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">True</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">1</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="padding">5</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="padding">5</property>
-                            <property name="position">4</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="position">3</property>
-                      </packing>
-                    </child>
-                    <child type="tab">
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="label" translatable="yes">Graphics</property>
-                      </object>
-                      <packing>
-                        <property name="position">3</property>
-                        <property name="tab-fill">False</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkBox" id="TabLogging">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="margin-left">5</property>
-                        <property name="margin-right">10</property>
-                        <property name="margin-top">5</property>
-                        <property name="orientation">vertical</property>
-                        <child>
-                          <object class="GtkBox" id="CatLogging">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="margin-left">5</property>
-                            <property name="margin-right">5</property>
-                            <property name="orientation">vertical</property>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="halign">start</property>
-                                <property name="margin-bottom">5</property>
-                                <property name="label" translatable="yes">Logging</property>
-                                <attributes>
-                                  <attribute name="weight" value="bold"/>
-                                </attributes>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox" id="LogggingOptions">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="valign">start</property>
-                                <property name="margin-left">10</property>
-                                <property name="margin-right">10</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <object class="GtkCheckButton" id="_fileLogToggle">
-                                    <property name="label" translatable="yes">Enable Logging to File</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="tooltip-text" translatable="yes">Enables or disables logging to a file on disk</property>
-                                    <property name="halign">start</property>
-                                    <property name="margin-top">5</property>
-                                    <property name="margin-bottom">5</property>
-                                    <property name="draw-indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="_stubLogToggle">
-                                    <property name="label" translatable="yes">Enable Stub Logs</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="tooltip-text" translatable="yes">Enables printing stub log messages</property>
-                                    <property name="halign">start</property>
-                                    <property name="margin-top">5</property>
-                                    <property name="margin-bottom">5</property>
-                                    <property name="draw-indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">3</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="_infoLogToggle">
-                                    <property name="label" translatable="yes">Enable Info Logs</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="tooltip-text" translatable="yes">Enables printing info log messages</property>
-                                    <property name="halign">start</property>
-                                    <property name="margin-top">5</property>
-                                    <property name="margin-bottom">5</property>
-                                    <property name="draw-indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">4</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="_warningLogToggle">
-                                    <property name="label" translatable="yes">Enable Warning Logs</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="tooltip-text" translatable="yes">Enables printing warning log messages</property>
-                                    <property name="halign">start</property>
-                                    <property name="margin-top">5</property>
-                                    <property name="margin-bottom">5</property>
-                                    <property name="draw-indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">5</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="_errorLogToggle">
-                                    <property name="label" translatable="yes">Enable Error Logs</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="tooltip-text" translatable="yes">Enables printing error log messages</property>
-                                    <property name="halign">start</property>
-                                    <property name="margin-top">5</property>
-                                    <property name="margin-bottom">5</property>
-                                    <property name="draw-indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">6</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="_guestLogToggle">
-                                    <property name="label" translatable="yes">Enable Guest Logs</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="tooltip-text" translatable="yes">Enables printing guest log messages</property>
-                                    <property name="halign">start</property>
-                                    <property name="margin-top">5</property>
-                                    <property name="margin-bottom">5</property>
-                                    <property name="draw-indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">7</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="_fsAccessLogToggle">
-                                    <property name="label" translatable="yes">Enable Fs Access Logs</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="tooltip-text" translatable="yes">Enables printing fs access log messages</property>
-                                    <property name="halign">start</property>
-                                    <property name="margin-top">5</property>
-                                    <property name="margin-bottom">5</property>
-                                    <property name="draw-indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">8</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <child>
-                                      <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Enables FS access log output to the console. Possible modes are 0-3</property>
-                                        <property name="label" translatable="yes">Fs Global Access Log Mode:</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="padding">5</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkSpinButton">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
-                                        <property name="tooltip-text" translatable="yes">Enables FS access log output to the console. Possible modes are 0-3</property>
-                                        <property name="text" translatable="yes">0</property>
-                                        <property name="adjustment">_fsLogSpinAdjustment</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">True</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">1</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="padding">5</property>
-                                    <property name="position">9</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="padding">5</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkBox" id="CatDevLogging">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="margin-left">5</property>
-                            <property name="margin-right">5</property>
-                            <property name="margin-top">10</property>
-                            <property name="orientation">vertical</property>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="tooltip-text" translatable="yes">Use with care</property>
-                                <property name="halign">start</property>
-                                <property name="margin-bottom">5</property>
-                                <property name="label" translatable="yes">Developer Options (WARNING: Will reduce performance)</property>
-                                <attributes>
-                                  <attribute name="weight" value="bold"/>
-                                </attributes>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox" id="DevLoggingOptions">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="valign">start</property>
-                                <property name="margin-left">10</property>
-                                <property name="margin-right">10</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <object class="GtkBox">
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-top">5</property>
-                                    <child>
-                                      <object class="GtkLabel">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Requires appropriate log levels enabled.</property>
-                                        <property name="label" translatable="yes">OpenGL Log Level</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="padding">5</property>
-                                        <property name="position">22</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkComboBoxText" id="_graphicsDebugLevel">
-                                        <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
-                                        <property name="tooltip-text" translatable="yes">Requires appropriate log levels enabled.</property>
-                                        <property name="margin-left">5</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">22</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="_debugLogToggle">
-                                    <property name="label" translatable="yes">Enable Debug Logs</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="tooltip-text" translatable="yes">Enables printing debug log messages</property>
-                                    <property name="halign">start</property>
-                                    <property name="margin-top">5</property>
-                                    <property name="margin-bottom">5</property>
-                                    <property name="draw-indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">21</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkCheckButton" id="_traceLogToggle">
-                                    <property name="label" translatable="yes">Enable Trace Logs</property>
-                                    <property name="visible">True</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="receives-default">False</property>
-                                    <property name="tooltip-text" translatable="yes">Enables printing trace log messages</property>
-                                    <property name="halign">start</property>
-                                    <property name="margin-top">5</property>
-                                    <property name="margin-bottom">5</property>
-                                    <property name="draw-indicator">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">22</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="padding">5</property>
-                            <property name="position">22</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="position">4</property>
-                      </packing>
-                    </child>
-                    <child type="tab">
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="label" translatable="yes">Logging</property>
-                      </object>
-                      <packing>
-                        <property name="position">4</property>
-                        <property name="tab-fill">False</property>
-                      </packing>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkButtonBox" id="_buttonBox">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="margin-right">5</property>
-            <property name="margin-top">3</property>
-            <property name="margin-bottom">3</property>
-            <property name="spacing">5</property>
-            <property name="layout-style">end</property>
-            <child>
-              <object class="GtkToggleButton" id="SaveToggle">
-                <property name="label" translatable="yes">Save</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
-                <signal name="toggled" handler="SaveToggle_Activated" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkToggleButton" id="CloseToggle">
-                <property name="label" translatable="yes">Close</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
-                <signal name="toggled" handler="CloseToggle_Activated" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton">
-                <property name="label" translatable="yes">Apply</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
-                <signal name="clicked" handler="ApplyToggle_Activated" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-      </object>
-    </child>
-  </object>
+	<requires lib="gtk+" version="3.20"/>
+	<object class="GtkAdjustment" id="_fsLogSpinAdjustment">
+		<property name="upper">3</property>
+		<property name="step-increment">1</property>
+		<property name="page-increment">10</property>
+	</object>
+	<object class="GtkAdjustment" id="_systemTimeDaySpinAdjustment">
+		<property name="lower">1</property>
+		<property name="upper">31</property>
+		<property name="step-increment">1</property>
+		<property name="page-increment">5</property>
+	</object>
+	<object class="GtkAdjustment" id="_systemTimeHourSpinAdjustment">
+		<property name="upper">23</property>
+		<property name="step-increment">1</property>
+		<property name="page-increment">5</property>
+	</object>
+	<object class="GtkAdjustment" id="_systemTimeMinuteSpinAdjustment">
+		<property name="upper">59</property>
+		<property name="step-increment">1</property>
+		<property name="page-increment">5</property>
+	</object>
+	<object class="GtkAdjustment" id="_systemTimeMonthSpinAdjustment">
+		<property name="lower">1</property>
+		<property name="upper">12</property>
+		<property name="step-increment">1</property>
+		<property name="page-increment">5</property>
+	</object>
+	<object class="GtkAdjustment" id="_systemTimeYearSpinAdjustment">
+		<property name="lower">2000</property>
+		<property name="upper">2060</property>
+		<property name="step-increment">1</property>
+		<property name="page-increment">10</property>
+	</object>
+	<object class="GtkEntryCompletion" id="_systemTimeZoneCompletion">
+		<property name="minimum-key-length">0</property>
+		<property name="inline-completion">True</property>
+		<property name="inline-selection">True</property>
+	</object>
+	<object class="GtkWindow" id="_settingsWin">
+		<property name="can-focus">False</property>
+		<property name="title" translatable="yes">Ryujinx - Settings</property>
+		<property name="modal">True</property>
+		<property name="window-position">center</property>
+		<property name="default-width">650</property>
+		<property name="default-height">650</property>
+		<child>
+			<object class="GtkBox">
+				<property name="visible">True</property>
+				<property name="can-focus">False</property>
+				<property name="orientation">vertical</property>
+				<child>
+					<object class="GtkScrolledWindow">
+						<property name="visible">True</property>
+						<property name="can-focus">True</property>
+						<property name="shadow-type">in</property>
+						<child>
+							<object class="GtkViewport">
+								<property name="visible">True</property>
+								<property name="can-focus">False</property>
+								<child>
+									<object class="GtkNotebook">
+										<property name="visible">True</property>
+										<property name="can-focus">True</property>
+										<child>
+											<object class="GtkBox" id="TabGeneral">
+												<property name="visible">True</property>
+												<property name="can-focus">False</property>
+												<property name="margin-left">5</property>
+												<property name="margin-right">10</property>
+												<property name="margin-top">5</property>
+												<property name="orientation">vertical</property>
+												<child>
+													<object class="GtkBox" id="CatGeneral">
+														<property name="visible">True</property>
+														<property name="can-focus">False</property>
+														<property name="margin-left">5</property>
+														<property name="margin-right">5</property>
+														<property name="orientation">vertical</property>
+														<child>
+															<object class="GtkLabel">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="halign">start</property>
+																<property name="margin-bottom">5</property>
+																<property name="label" translatable="yes">General</property>
+																<attributes>
+																	<attribute name="weight" value="bold"/>
+																</attributes>
+															</object>
+															<packing>
+																<property name="expand">False</property>
+																<property name="fill">True</property>
+																<property name="position">0</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkBox" id="General">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="margin-left">10</property>
+																<property name="margin-right">10</property>
+																<property name="orientation">vertical</property>
+																<child>
+																	<object class="GtkCheckButton" id="_discordToggle">
+																		<property name="label" translatable="yes">Enable Discord Rich Presence</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">False</property>
+																		<property name="tooltip-text" translatable="yes">Enables or disables Discord Rich Presence</property>
+																		<property name="halign">start</property>
+																		<property name="draw-indicator">True</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="padding">5</property>
+																		<property name="position">0</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkCheckButton" id="_checkUpdatesToggle">
+																		<property name="label" translatable="yes">Check for Updates on Launch</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">False</property>
+																		<property name="halign">start</property>
+																		<property name="draw-indicator">True</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="padding">5</property>
+																		<property name="position">1</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkCheckButton" id="_showConfirmExitToggle">
+																		<property name="label" translatable="yes">Show "Confirm Exit" Dialog</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">False</property>
+																		<property name="halign">start</property>
+																		<property name="draw-indicator">True</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="padding">5</property>
+																		<property name="position">2</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkCheckButton" id="_hideCursorOnIdleToggle">
+																		<property name="label" translatable="yes">Hide Cursor On Idle</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">False</property>
+																		<property name="halign">start</property>
+																		<property name="draw-indicator">True</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="padding">5</property>
+																		<property name="position">3</property>
+																	</packing>
+																</child>
+															</object>
+															<packing>
+																<property name="expand">True</property>
+																<property name="fill">True</property>
+																<property name="position">1</property>
+															</packing>
+														</child>
+													</object>
+													<packing>
+														<property name="expand">False</property>
+														<property name="fill">True</property>
+														<property name="padding">5</property>
+														<property name="position">1</property>
+													</packing>
+												</child>
+												<child>
+													<object class="GtkSeparator">
+														<property name="visible">True</property>
+														<property name="can-focus">False</property>
+														<property name="margin-left">5</property>
+														<property name="margin-right">5</property>
+													</object>
+													<packing>
+														<property name="expand">False</property>
+														<property name="fill">True</property>
+														<property name="padding">5</property>
+														<property name="position">2</property>
+													</packing>
+												</child>
+												<child>
+													<object class="GtkBox" id="CatGameDir">
+														<property name="visible">True</property>
+														<property name="can-focus">False</property>
+														<property name="margin-left">5</property>
+														<property name="margin-right">5</property>
+														<property name="orientation">vertical</property>
+														<child>
+															<object class="GtkLabel">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="halign">start</property>
+																<property name="margin-bottom">5</property>
+																<property name="label" translatable="yes">Game Directories</property>
+																<attributes>
+																	<attribute name="weight" value="bold"/>
+																</attributes>
+															</object>
+															<packing>
+																<property name="expand">False</property>
+																<property name="fill">True</property>
+																<property name="position">0</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkBox">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="margin-left">10</property>
+																<property name="margin-right">10</property>
+																<property name="orientation">vertical</property>
+																<child>
+																	<object class="GtkScrolledWindow">
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="margin-bottom">10</property>
+																		<property name="shadow-type">in</property>
+																		<child>
+																			<object class="GtkTreeView" id="_gameDirsBox">
+																				<property name="visible">True</property>
+																				<property name="can-focus">True</property>
+																				<property name="headers-visible">False</property>
+																				<property name="headers-clickable">False</property>
+																				<child internal-child="selection">
+																					<object class="GtkTreeSelection"/>
+																				</child>
+																			</object>
+																		</child>
+																		<style>
+																			<class name="GameDir"/>
+																		</style>
+																	</object>
+																	<packing>
+																		<property name="expand">True</property>
+																		<property name="fill">True</property>
+																		<property name="position">0</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkBox">
+																		<property name="visible">True</property>
+																		<property name="can-focus">False</property>
+																		<child>
+																			<object class="GtkEntry" id="_addGameDirBox">
+																				<property name="visible">True</property>
+																				<property name="can-focus">True</property>
+																				<property name="tooltip-text" translatable="yes">Enter a game directroy to add to the list</property>
+																			</object>
+																			<packing>
+																				<property name="expand">True</property>
+																				<property name="fill">True</property>
+																				<property name="position">0</property>
+																			</packing>
+																		</child>
+																		<child>
+																			<object class="GtkToggleButton" id="_addDir">
+																				<property name="label" translatable="yes">Add</property>
+																				<property name="width-request">80</property>
+																				<property name="visible">True</property>
+																				<property name="can-focus">True</property>
+																				<property name="receives-default">True</property>
+																				<property name="tooltip-text" translatable="yes"> Add a game directory to the list</property>
+																				<property name="margin-left">5</property>
+																				<signal name="toggled" handler="AddDir_Pressed" swapped="no"/>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="position">1</property>
+																			</packing>
+																		</child>
+																		<child>
+																			<object class="GtkToggleButton" id="_removeDir">
+																				<property name="label" translatable="yes">Remove</property>
+																				<property name="width-request">80</property>
+																				<property name="visible">True</property>
+																				<property name="can-focus">True</property>
+																				<property name="receives-default">True</property>
+																				<property name="tooltip-text" translatable="yes">Remove selected game directory</property>
+																				<property name="margin-left">5</property>
+																				<signal name="toggled" handler="RemoveDir_Pressed" swapped="no"/>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="position">3</property>
+																			</packing>
+																		</child>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">1</property>
+																	</packing>
+																</child>
+															</object>
+															<packing>
+																<property name="expand">True</property>
+																<property name="fill">True</property>
+																<property name="position">1</property>
+															</packing>
+														</child>
+													</object>
+													<packing>
+														<property name="expand">True</property>
+														<property name="fill">True</property>
+														<property name="padding">5</property>
+														<property name="position">4</property>
+													</packing>
+												</child>
+												<child>
+													<object class="GtkSeparator">
+														<property name="visible">True</property>
+														<property name="can-focus">False</property>
+														<property name="margin-left">5</property>
+														<property name="margin-right">5</property>
+													</object>
+													<packing>
+														<property name="expand">False</property>
+														<property name="fill">True</property>
+														<property name="padding">5</property>
+														<property name="position">5</property>
+													</packing>
+												</child>
+												<child>
+													<object class="GtkBox" id="CatThemes">
+														<property name="visible">True</property>
+														<property name="can-focus">False</property>
+														<property name="margin-left">5</property>
+														<property name="margin-right">5</property>
+														<property name="orientation">vertical</property>
+														<child>
+															<object class="GtkLabel">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="halign">start</property>
+																<property name="margin-bottom">5</property>
+																<property name="label" translatable="yes">Themes</property>
+																<attributes>
+																	<attribute name="weight" value="bold"/>
+																</attributes>
+															</object>
+															<packing>
+																<property name="expand">False</property>
+																<property name="fill">True</property>
+																<property name="position">0</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkBox">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="margin-left">10</property>
+																<property name="margin-right">10</property>
+																<property name="orientation">vertical</property>
+																<child>
+																	<object class="GtkCheckButton" id="_custThemeToggle">
+																		<property name="label" translatable="yes">Use Custom Theme</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">False</property>
+																		<property name="tooltip-text" translatable="yes">Enable or disable custom themes in the GUI</property>
+																		<property name="halign">start</property>
+																		<property name="draw-indicator">True</property>
+																		<signal name="toggled" handler="CustThemeToggle_Activated" swapped="no"/>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="padding">5</property>
+																		<property name="position">1</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkBox">
+																		<property name="visible">True</property>
+																		<property name="can-focus">False</property>
+																		<child>
+																			<object class="GtkLabel" id="_custThemePathLabel">
+																				<property name="visible">True</property>
+																				<property name="can-focus">False</property>
+																				<property name="tooltip-text" translatable="yes">Path to custom GUI theme</property>
+																				<property name="label" translatable="yes">Custom Theme Path:</property>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="padding">5</property>
+																				<property name="position">0</property>
+																			</packing>
+																		</child>
+																		<child>
+																			<object class="GtkEntry" id="_custThemePath">
+																				<property name="visible">True</property>
+																				<property name="can-focus">True</property>
+																				<property name="tooltip-text" translatable="yes">Path to custom GUI theme</property>
+																				<property name="valign">center</property>
+																			</object>
+																			<packing>
+																				<property name="expand">True</property>
+																				<property name="fill">True</property>
+																				<property name="position">1</property>
+																			</packing>
+																		</child>
+																		<child>
+																			<object class="GtkToggleButton" id="_browseThemePath">
+																				<property name="label" translatable="yes">Browse...</property>
+																				<property name="width-request">80</property>
+																				<property name="visible">True</property>
+																				<property name="can-focus">True</property>
+																				<property name="receives-default">True</property>
+																				<property name="tooltip-text" translatable="yes">Browse for a custom GUI theme</property>
+																				<property name="margin-left">5</property>
+																				<signal name="toggled" handler="BrowseThemeDir_Pressed" swapped="no"/>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="position">2</property>
+																			</packing>
+																		</child>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="padding">10</property>
+																		<property name="position">2</property>
+																	</packing>
+																</child>
+															</object>
+															<packing>
+																<property name="expand">False</property>
+																<property name="fill">True</property>
+																<property name="position">1</property>
+															</packing>
+														</child>
+													</object>
+													<packing>
+														<property name="expand">False</property>
+														<property name="fill">True</property>
+														<property name="padding">5</property>
+														<property name="position">6</property>
+													</packing>
+												</child>
+											</object>
+										</child>
+										<child type="tab">
+											<object class="GtkLabel">
+												<property name="visible">True</property>
+												<property name="can-focus">False</property>
+												<property name="label" translatable="yes">General</property>
+											</object>
+											<packing>
+												<property name="tab-fill">False</property>
+											</packing>
+										</child>
+										<child>
+											<object class="GtkBox" id="TabInput">
+												<property name="visible">True</property>
+												<property name="can-focus">False</property>
+												<property name="margin-left">5</property>
+												<property name="margin-right">10</property>
+												<property name="margin-top">5</property>
+												<property name="orientation">vertical</property>
+												<child>
+													<object class="GtkBox">
+														<property name="visible">True</property>
+														<property name="can-focus">False</property>
+														<property name="margin-top">5</property>
+														<property name="margin-bottom">5</property>
+														<child>
+															<object class="GtkCheckButton" id="_dockedModeToggle">
+																<property name="label" translatable="yes">Enable Docked Mode</property>
+																<property name="visible">True</property>
+																<property name="can-focus">True</property>
+																<property name="receives-default">False</property>
+																<property name="tooltip-text" translatable="yes">Enable or disable Docked Mode</property>
+																<property name="draw-indicator">True</property>
+															</object>
+															<packing>
+																<property name="expand">False</property>
+																<property name="fill">True</property>
+																<property name="padding">10</property>
+																<property name="position">0</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkCheckButton" id="_directKeyboardAccess">
+																<property name="label" translatable="yes">Direct Keyboard Access</property>
+																<property name="visible">True</property>
+																<property name="can-focus">True</property>
+																<property name="receives-default">False</property>
+																<property name="tooltip-text" translatable="yes">Enable or disable "direct keyboard access (HID) support" (Provides games access to your keyboard as a text entry device)</property>
+																<property name="draw-indicator">True</property>
+															</object>
+															<packing>
+																<property name="expand">False</property>
+																<property name="fill">False</property>
+																<property name="padding">10</property>
+																<property name="position">1</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkCheckButton" id="_directMouseAccess">
+																<property name="label" translatable="yes">Direct Mouse Access</property>
+																<property name="visible">True</property>
+																<property name="can-focus">True</property>
+																<property name="receives-default">False</property>
+																<property name="tooltip-text" translatable="yes">Enable or disable "direct mouse access (HID) support" (Provides games access to your mouse as a pointing device)</property>
+																<property name="draw-indicator">True</property>
+															</object>
+															<packing>
+																<property name="expand">False</property>
+																<property name="fill">False</property>
+																<property name="padding">10</property>
+																<property name="position">2</property>
+															</packing>
+														</child>
+													</object>
+													<packing>
+														<property name="expand">False</property>
+														<property name="fill">True</property>
+														<property name="padding">5</property>
+														<property name="position">0</property>
+													</packing>
+												</child>
+												<child>
+													<object class="GtkSeparator">
+														<property name="visible">True</property>
+														<property name="can-focus">False</property>
+													</object>
+													<packing>
+														<property name="expand">False</property>
+														<property name="fill">True</property>
+														<property name="position">1</property>
+													</packing>
+												</child>
+												<child>
+													<!-- n-columns=5 n-rows=5 -->
+													<object class="GtkGrid" id="ControllerGrid">
+														<property name="visible">True</property>
+														<property name="can-focus">False</property>
+														<property name="halign">center</property>
+														<property name="valign">center</property>
+														<property name="column-spacing">20</property>
+														<child>
+															<object class="GtkBox">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="orientation">vertical</property>
+																<child>
+																	<object class="GtkLabel">
+																		<property name="visible">True</property>
+																		<property name="can-focus">False</property>
+																		<property name="margin-top">20</property>
+																		<property name="margin-bottom">20</property>
+																		<property name="label" translatable="yes">Player 1</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">0</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkToggleButton" id="_configureController1">
+																		<property name="label" translatable="yes">Configure</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">True</property>
+																		<property name="margin-left">20</property>
+																		<property name="margin-right">20</property>
+																		<property name="margin-top">20</property>
+																		<property name="margin-bottom">20</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">1</property>
+																	</packing>
+																</child>
+															</object>
+															<packing>
+																<property name="left-attach">0</property>
+																<property name="top-attach">0</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkBox">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="orientation">vertical</property>
+																<child>
+																	<object class="GtkLabel">
+																		<property name="visible">True</property>
+																		<property name="can-focus">False</property>
+																		<property name="margin-top">20</property>
+																		<property name="margin-bottom">20</property>
+																		<property name="label" translatable="yes">Player 3</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">0</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkToggleButton" id="_configureController3">
+																		<property name="label" translatable="yes">Configure</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">True</property>
+																		<property name="margin-left">20</property>
+																		<property name="margin-right">20</property>
+																		<property name="margin-top">20</property>
+																		<property name="margin-bottom">20</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">1</property>
+																	</packing>
+																</child>
+															</object>
+															<packing>
+																<property name="left-attach">4</property>
+																<property name="top-attach">0</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkBox">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="orientation">vertical</property>
+																<child>
+																	<object class="GtkLabel">
+																		<property name="visible">True</property>
+																		<property name="can-focus">False</property>
+																		<property name="margin-top">20</property>
+																		<property name="margin-bottom">20</property>
+																		<property name="label" translatable="yes">Player 2</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">0</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkToggleButton" id="_configureController2">
+																		<property name="label" translatable="yes">Configure</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">True</property>
+																		<property name="margin-left">20</property>
+																		<property name="margin-right">20</property>
+																		<property name="margin-top">20</property>
+																		<property name="margin-bottom">20</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">1</property>
+																	</packing>
+																</child>
+															</object>
+															<packing>
+																<property name="left-attach">2</property>
+																<property name="top-attach">0</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkBox">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="orientation">vertical</property>
+																<child>
+																	<object class="GtkLabel">
+																		<property name="visible">True</property>
+																		<property name="can-focus">False</property>
+																		<property name="margin-top">20</property>
+																		<property name="margin-bottom">20</property>
+																		<property name="label" translatable="yes">Handheld</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">0</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkToggleButton" id="_configureControllerH">
+																		<property name="label" translatable="yes">Configure</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">True</property>
+																		<property name="margin-left">20</property>
+																		<property name="margin-right">20</property>
+																		<property name="margin-top">20</property>
+																		<property name="margin-bottom">20</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">1</property>
+																	</packing>
+																</child>
+															</object>
+															<packing>
+																<property name="left-attach">4</property>
+																<property name="top-attach">4</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkBox">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="orientation">vertical</property>
+																<child>
+																	<object class="GtkLabel">
+																		<property name="visible">True</property>
+																		<property name="can-focus">False</property>
+																		<property name="margin-top">20</property>
+																		<property name="margin-bottom">20</property>
+																		<property name="label" translatable="yes">Player 6</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">0</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkToggleButton" id="_configureController6">
+																		<property name="label" translatable="yes">Configure</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">True</property>
+																		<property name="margin-left">20</property>
+																		<property name="margin-right">20</property>
+																		<property name="margin-top">20</property>
+																		<property name="margin-bottom">20</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">1</property>
+																	</packing>
+																</child>
+															</object>
+															<packing>
+																<property name="left-attach">4</property>
+																<property name="top-attach">2</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkBox">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="orientation">vertical</property>
+																<child>
+																	<object class="GtkLabel">
+																		<property name="visible">True</property>
+																		<property name="can-focus">False</property>
+																		<property name="margin-top">20</property>
+																		<property name="margin-bottom">20</property>
+																		<property name="label" translatable="yes">Player 5</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">0</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkToggleButton" id="_configureController5">
+																		<property name="label" translatable="yes">Configure</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">True</property>
+																		<property name="margin-left">20</property>
+																		<property name="margin-right">20</property>
+																		<property name="margin-top">20</property>
+																		<property name="margin-bottom">20</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">1</property>
+																	</packing>
+																</child>
+															</object>
+															<packing>
+																<property name="left-attach">2</property>
+																<property name="top-attach">2</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkBox">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="orientation">vertical</property>
+																<child>
+																	<object class="GtkLabel">
+																		<property name="visible">True</property>
+																		<property name="can-focus">False</property>
+																		<property name="margin-top">20</property>
+																		<property name="margin-bottom">20</property>
+																		<property name="label" translatable="yes">Player 7</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">0</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkToggleButton" id="_configureController7">
+																		<property name="label" translatable="yes">Configure</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">True</property>
+																		<property name="margin-left">20</property>
+																		<property name="margin-right">20</property>
+																		<property name="margin-top">20</property>
+																		<property name="margin-bottom">20</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">1</property>
+																	</packing>
+																</child>
+															</object>
+															<packing>
+																<property name="left-attach">0</property>
+																<property name="top-attach">4</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkBox">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="orientation">vertical</property>
+																<child>
+																	<object class="GtkLabel">
+																		<property name="visible">True</property>
+																		<property name="can-focus">False</property>
+																		<property name="margin-top">20</property>
+																		<property name="margin-bottom">20</property>
+																		<property name="label" translatable="yes">Player 4</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">0</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkToggleButton" id="_configureController4">
+																		<property name="label" translatable="yes">Configure</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">True</property>
+																		<property name="margin-left">20</property>
+																		<property name="margin-right">20</property>
+																		<property name="margin-top">20</property>
+																		<property name="margin-bottom">20</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">1</property>
+																	</packing>
+																</child>
+															</object>
+															<packing>
+																<property name="left-attach">0</property>
+																<property name="top-attach">2</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkBox">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="orientation">vertical</property>
+																<child>
+																	<object class="GtkLabel">
+																		<property name="visible">True</property>
+																		<property name="can-focus">False</property>
+																		<property name="margin-top">20</property>
+																		<property name="margin-bottom">20</property>
+																		<property name="label" translatable="yes">Player 8</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">0</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkToggleButton" id="_configureController8">
+																		<property name="label" translatable="yes">Configure</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">True</property>
+																		<property name="margin-left">20</property>
+																		<property name="margin-right">20</property>
+																		<property name="margin-top">20</property>
+																		<property name="margin-bottom">20</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">1</property>
+																	</packing>
+																</child>
+															</object>
+															<packing>
+																<property name="left-attach">2</property>
+																<property name="top-attach">4</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkSeparator">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+															</object>
+															<packing>
+																<property name="left-attach">1</property>
+																<property name="top-attach">0</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkSeparator">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+															</object>
+															<packing>
+																<property name="left-attach">3</property>
+																<property name="top-attach">0</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkSeparator">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+															</object>
+															<packing>
+																<property name="left-attach">3</property>
+																<property name="top-attach">2</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkSeparator">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+															</object>
+															<packing>
+																<property name="left-attach">3</property>
+																<property name="top-attach">4</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkSeparator">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+															</object>
+															<packing>
+																<property name="left-attach">1</property>
+																<property name="top-attach">2</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkSeparator">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+															</object>
+															<packing>
+																<property name="left-attach">1</property>
+																<property name="top-attach">4</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkSeparator">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+															</object>
+															<packing>
+																<property name="left-attach">1</property>
+																<property name="top-attach">1</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkSeparator">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+															</object>
+															<packing>
+																<property name="left-attach">1</property>
+																<property name="top-attach">3</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkSeparator">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+															</object>
+															<packing>
+																<property name="left-attach">3</property>
+																<property name="top-attach">1</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkSeparator">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+															</object>
+															<packing>
+																<property name="left-attach">3</property>
+																<property name="top-attach">3</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkSeparator">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+															</object>
+															<packing>
+																<property name="left-attach">0</property>
+																<property name="top-attach">1</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkSeparator">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+															</object>
+															<packing>
+																<property name="left-attach">2</property>
+																<property name="top-attach">1</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkSeparator">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+															</object>
+															<packing>
+																<property name="left-attach">4</property>
+																<property name="top-attach">1</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkSeparator">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+															</object>
+															<packing>
+																<property name="left-attach">0</property>
+																<property name="top-attach">3</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkSeparator">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+															</object>
+															<packing>
+																<property name="left-attach">2</property>
+																<property name="top-attach">3</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkSeparator">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+															</object>
+															<packing>
+																<property name="left-attach">4</property>
+																<property name="top-attach">3</property>
+															</packing>
+														</child>
+													</object>
+													<packing>
+														<property name="expand">True</property>
+														<property name="fill">True</property>
+														<property name="position">2</property>
+													</packing>
+												</child>
+												<child>
+													<object class="GtkSeparator">
+														<property name="visible">True</property>
+														<property name="can-focus">False</property>
+													</object>
+													<packing>
+														<property name="expand">False</property>
+														<property name="fill">True</property>
+														<property name="position">3</property>
+													</packing>
+												</child>
+											</object>
+											<packing>
+												<property name="position">1</property>
+											</packing>
+										</child>
+										<child type="tab">
+											<object class="GtkLabel">
+												<property name="visible">True</property>
+												<property name="can-focus">False</property>
+												<property name="label" translatable="yes">Input</property>
+											</object>
+											<packing>
+												<property name="position">1</property>
+												<property name="tab-fill">False</property>
+											</packing>
+										</child>
+										<child>
+											<object class="GtkBox" id="TabSystem">
+												<property name="visible">True</property>
+												<property name="can-focus">False</property>
+												<property name="margin-left">5</property>
+												<property name="margin-right">10</property>
+												<property name="margin-top">5</property>
+												<property name="orientation">vertical</property>
+												<child>
+													<object class="GtkBox" id="CatCore">
+														<property name="visible">True</property>
+														<property name="can-focus">False</property>
+														<property name="valign">start</property>
+														<property name="margin-left">5</property>
+														<property name="margin-right">5</property>
+														<property name="orientation">vertical</property>
+														<child>
+															<object class="GtkLabel">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="halign">start</property>
+																<property name="margin-bottom">5</property>
+																<property name="label" translatable="yes">Core</property>
+																<attributes>
+																	<attribute name="weight" value="bold"/>
+																</attributes>
+															</object>
+															<packing>
+																<property name="expand">False</property>
+																<property name="fill">True</property>
+																<property name="position">0</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkBox">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="margin-left">10</property>
+																<property name="margin-right">10</property>
+																<property name="orientation">vertical</property>
+																<child>
+																	<object class="GtkBox" id="RegionBox">
+																		<property name="visible">True</property>
+																		<property name="can-focus">False</property>
+																		<child>
+																			<object class="GtkLabel">
+																				<property name="visible">True</property>
+																				<property name="can-focus">False</property>
+																				<property name="tooltip-text" translatable="yes">Change System Region</property>
+																				<property name="halign">end</property>
+																				<property name="label" translatable="yes">System Region:</property>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="padding">5</property>
+																				<property name="position">2</property>
+																			</packing>
+																		</child>
+																		<child>
+																			<object class="GtkComboBoxText" id="_systemRegionSelect">
+																				<property name="visible">True</property>
+																				<property name="can-focus">False</property>
+																				<property name="tooltip-text" translatable="yes">Change System Region</property>
+																				<property name="margin-left">5</property>
+																				<items>
+																					<item id="Japan" translatable="yes">Japan</item>
+																					<item id="USA" translatable="yes">USA</item>
+																					<item id="Europe" translatable="yes">Europe</item>
+																					<item id="Australia" translatable="yes">Australia</item>
+																					<item id="China" translatable="yes">China</item>
+																					<item id="Korea" translatable="yes">Korea</item>
+																					<item id="Taiwan" translatable="yes">Taiwan</item>
+																				</items>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="position">3</property>
+																			</packing>
+																		</child>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="padding">5</property>
+																		<property name="position">0</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkBox" id="LanguageBox">
+																		<property name="visible">True</property>
+																		<property name="can-focus">False</property>
+																		<child>
+																			<object class="GtkLabel">
+																				<property name="visible">True</property>
+																				<property name="can-focus">False</property>
+																				<property name="tooltip-text" translatable="yes">Change System Language</property>
+																				<property name="halign">end</property>
+																				<property name="label" translatable="yes">System Language:</property>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="padding">5</property>
+																				<property name="position">0</property>
+																			</packing>
+																		</child>
+																		<child>
+																			<object class="GtkComboBoxText" id="_systemLanguageSelect">
+																				<property name="visible">True</property>
+																				<property name="can-focus">False</property>
+																				<property name="tooltip-text" translatable="yes">Change System Language</property>
+																				<items>
+																					<item id="AmericanEnglish" translatable="yes">American English</item>
+																					<item id="BritishEnglish" translatable="yes">British English</item>
+																					<item id="CanadianFrench" translatable="yes">Canadian French</item>
+																					<item id="Chinese" translatable="yes">Chinese</item>
+																					<item id="Dutch" translatable="yes">Dutch</item>
+																					<item id="French" translatable="yes">French</item>
+																					<item id="German" translatable="yes">German</item>
+																					<item id="Italian" translatable="yes">Italian</item>
+																					<item id="Japanese" translatable="yes">Japanese</item>
+																					<item id="Korean" translatable="yes">Korean</item>
+																					<item id="LatinAmericanSpanish" translatable="yes">Latin American Spanish</item>
+																					<item id="Portuguese" translatable="yes">Portuguese</item>
+																					<item id="Russian" translatable="yes">Russian</item>
+																					<item id="SimplifiedChinese" translatable="yes">Simplified Chinese</item>
+																					<item id="Spanish" translatable="yes">Spanish</item>
+																					<item id="Taiwanese" translatable="yes">Taiwanese</item>
+																					<item id="TraditionalChinese" translatable="yes">Traditional Chinese</item>
+																					<item id="BrazilianPortuguese" translatable="yes">Brazilian Portuguese</item>
+																				</items>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="position">1</property>
+																			</packing>
+																		</child>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="padding">5</property>
+																		<property name="position">1</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkBox" id="TimeZoneBox">
+																		<property name="visible">True</property>
+																		<property name="can-focus">False</property>
+																		<child>
+																			<object class="GtkLabel">
+																				<property name="visible">True</property>
+																				<property name="can-focus">False</property>
+																				<property name="tooltip-text" translatable="yes">Change System TimeZone</property>
+																				<property name="halign">end</property>
+																				<property name="label" translatable="yes">System TimeZone:</property>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="padding">5</property>
+																				<property name="position">1</property>
+																			</packing>
+																		</child>
+																		<child>
+																			<object class="GtkEntry" id="_systemTimeZoneEntry">
+																				<property name="visible">True</property>
+																				<property name="can-focus">True</property>
+																				<property name="tooltip-text" translatable="yes">Change System TimeZone</property>
+																				<property name="margin-left">5</property>
+																				<property name="completion">_systemTimeZoneCompletion</property>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="position">2</property>
+																			</packing>
+																		</child>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="padding">5</property>
+																		<property name="position">2</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkBox" id="TimeBox">
+																		<property name="visible">True</property>
+																		<property name="can-focus">False</property>
+																		<child>
+																			<object class="GtkLabel">
+																				<property name="visible">True</property>
+																				<property name="can-focus">False</property>
+																				<property name="tooltip-text" translatable="yes">Change System Time</property>
+																				<property name="halign">end</property>
+																				<property name="label" translatable="yes">System Time:</property>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="padding">5</property>
+																				<property name="position">0</property>
+																			</packing>
+																		</child>
+																		<child>
+																			<object class="GtkSpinButton" id="_systemTimeYearSpin">
+																				<property name="visible">True</property>
+																				<property name="can-focus">True</property>
+																				<property name="text" translatable="yes">2000</property>
+																				<property name="orientation">vertical</property>
+																				<property name="adjustment">_systemTimeYearSpinAdjustment</property>
+																				<property name="wrap">True</property>
+																				<property name="value">2000</property>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="position">1</property>
+																			</packing>
+																		</child>
+																		<child>
+																			<object class="GtkLabel">
+																				<property name="visible">True</property>
+																				<property name="can-focus">False</property>
+																				<property name="halign">end</property>
+																				<property name="label">-</property>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="padding">5</property>
+																				<property name="position">2</property>
+																			</packing>
+																		</child>
+																		<child>
+																			<object class="GtkSpinButton" id="_systemTimeMonthSpin">
+																				<property name="visible">True</property>
+																				<property name="can-focus">True</property>
+																				<property name="text" translatable="yes">1</property>
+																				<property name="orientation">vertical</property>
+																				<property name="adjustment">_systemTimeMonthSpinAdjustment</property>
+																				<property name="wrap">True</property>
+																				<property name="value">1</property>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="position">3</property>
+																			</packing>
+																		</child>
+																		<child>
+																			<object class="GtkLabel">
+																				<property name="visible">True</property>
+																				<property name="can-focus">False</property>
+																				<property name="halign">end</property>
+																				<property name="label">-</property>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="padding">5</property>
+																				<property name="position">4</property>
+																			</packing>
+																		</child>
+																		<child>
+																			<object class="GtkSpinButton" id="_systemTimeDaySpin">
+																				<property name="visible">True</property>
+																				<property name="can-focus">True</property>
+																				<property name="text" translatable="yes">1</property>
+																				<property name="orientation">vertical</property>
+																				<property name="adjustment">_systemTimeDaySpinAdjustment</property>
+																				<property name="wrap">True</property>
+																				<property name="value">1</property>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="position">5</property>
+																			</packing>
+																		</child>
+																		<child>
+																			<object class="GtkSpinButton" id="_systemTimeHourSpin">
+																				<property name="visible">True</property>
+																				<property name="can-focus">True</property>
+																				<property name="text" translatable="yes">0</property>
+																				<property name="orientation">vertical</property>
+																				<property name="adjustment">_systemTimeHourSpinAdjustment</property>
+																				<property name="wrap">True</property>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="position">6</property>
+																			</packing>
+																		</child>
+																		<child>
+																			<object class="GtkLabel">
+																				<property name="visible">True</property>
+																				<property name="can-focus">False</property>
+																				<property name="halign">end</property>
+																				<property name="label">:</property>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="padding">5</property>
+																				<property name="position">7</property>
+																			</packing>
+																		</child>
+																		<child>
+																			<object class="GtkSpinButton" id="_systemTimeMinuteSpin">
+																				<property name="visible">True</property>
+																				<property name="can-focus">True</property>
+																				<property name="text" translatable="yes">0</property>
+																				<property name="orientation">vertical</property>
+																				<property name="adjustment">_systemTimeMinuteSpinAdjustment</property>
+																				<property name="wrap">True</property>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="position">8</property>
+																			</packing>
+																		</child>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="padding">5</property>
+																		<property name="position">3</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkCheckButton" id="_vSyncToggle">
+																		<property name="label" translatable="yes">Enable VSync</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">False</property>
+																		<property name="tooltip-text" translatable="yes">Enables or disables Vertical Sync</property>
+																		<property name="halign">start</property>
+																		<property name="margin-top">5</property>
+																		<property name="margin-bottom">5</property>
+																		<property name="draw-indicator">True</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">4</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkCheckButton" id="_ptcToggle">
+																		<property name="label" translatable="yes">Enable PPTC (Profiled Persistent Translation Cache)</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">False</property>
+																		<property name="tooltip-text" translatable="yes">Enables or disables profiled translation cache persistency</property>
+																		<property name="halign">start</property>
+																		<property name="margin-top">5</property>
+																		<property name="margin-bottom">5</property>
+																		<property name="draw-indicator">True</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">6</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkCheckButton" id="_internetToggle">
+																		<property name="label" translatable="yes">Enable guest Internet access</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">False</property>
+																		<property name="tooltip-text" translatable="yes">Enables guest Internet access. If enabled, the application will behave as if the emulated Switch console was connected to the Internet. Note that in some cases, applications may still access the Internet even with this option disabled</property>
+																		<property name="halign">start</property>
+																		<property name="margin-top">5</property>
+																		<property name="margin-bottom">5</property>
+																		<property name="draw-indicator">True</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">7</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkCheckButton" id="_fsicToggle">
+																		<property name="label" translatable="yes">Enable FS Integrity Checks</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">False</property>
+																		<property name="tooltip-text" translatable="yes">Enables integrity checks on Game content files</property>
+																		<property name="halign">start</property>
+																		<property name="margin-top">5</property>
+																		<property name="margin-bottom">5</property>
+																		<property name="draw-indicator">True</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">8</property>
+																	</packing>
+																</child>
+															</object>
+															<packing>
+																<property name="expand">True</property>
+																<property name="fill">True</property>
+																<property name="position">1</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkBox" id="_audioBackendBox">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<child>
+																	<placeholder/>
+																</child>
+																<child>
+																	<object class="GtkLabel">
+																		<property name="visible">True</property>
+																		<property name="can-focus">False</property>
+																		<property name="tooltip-text" translatable="yes">Change Audio Backend</property>
+																		<property name="halign">end</property>
+																		<property name="margin-right">5</property>
+																		<property name="label" translatable="yes">Audio Backend: </property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="padding">5</property>
+																		<property name="position">2</property>
+																	</packing>
+																</child>
+															</object>
+															<packing>
+																<property name="expand">False</property>
+																<property name="fill">True</property>
+																<property name="padding">5</property>
+																<property name="position">2</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkBox" id="_memoryManagerBox">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<child>
+																	<placeholder/>
+																</child>
+																<child>
+																	<object class="GtkLabel">
+																		<property name="visible">True</property>
+																		<property name="can-focus">False</property>
+																		<property name="tooltip-text" translatable="yes">Change how guest memory is mapped and accessed. Greatly affects emulated CPU performance.</property>
+																		<property name="halign">end</property>
+																		<property name="margin-right">5</property>
+																		<property name="label" translatable="yes">Memory Manager Mode: </property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="padding">5</property>
+																		<property name="position">2</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkRadioButton" id="_mmSoftware">
+																		<property name="label" translatable="yes">Software</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">False</property>
+																		<property name="tooltip-text" translatable="yes">Use a software page table for address translation. Highest accuracy but slowest performance.</property>
+																		<property name="halign">start</property>
+																		<property name="margin-top">5</property>
+																		<property name="margin-bottom">5</property>
+																		<property name="draw-indicator">True</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">3</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkRadioButton" id="_mmHost">
+																		<property name="label" translatable="yes">Host (fast)</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">False</property>
+																		<property name="tooltip-text" translatable="yes">Directly map memory in the host address space. Much faster JIT compilation and execution.</property>
+																		<property name="halign">start</property>
+																		<property name="margin-top">5</property>
+																		<property name="margin-bottom">5</property>
+																		<property name="draw-indicator">True</property>
+																		<property name="group">_mmSoftware</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">4</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkRadioButton" id="_mmHostUnsafe">
+																		<property name="label" translatable="yes">Host unchecked (fastest, unsafe)</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">False</property>
+																		<property name="tooltip-text" translatable="yes">Directly map memory, but do not mask the address within the guest address space before access. Faster, but at the cost of safety. The guest application can access memory from anywhere in Ryujinx, so only run programs you trust with this mode.</property>
+																		<property name="halign">start</property>
+																		<property name="margin-top">5</property>
+																		<property name="margin-bottom">5</property>
+																		<property name="draw-indicator">True</property>
+																		<property name="group">_mmSoftware</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">5</property>
+																	</packing>
+																</child>
+															</object>
+															<packing>
+																<property name="expand">False</property>
+																<property name="fill">True</property>
+																<property name="padding">5</property>
+																<property name="position">3</property>
+															</packing>
+														</child>
+													</object>
+													<packing>
+														<property name="expand">False</property>
+														<property name="fill">True</property>
+														<property name="padding">5</property>
+														<property name="position">0</property>
+													</packing>
+												</child>
+												<child>
+													<object class="GtkSeparator">
+														<property name="visible">True</property>
+														<property name="can-focus">False</property>
+														<property name="margin-left">5</property>
+														<property name="margin-right">5</property>
+													</object>
+													<packing>
+														<property name="expand">False</property>
+														<property name="fill">True</property>
+														<property name="padding">5</property>
+														<property name="position">1</property>
+													</packing>
+												</child>
+												<child>
+													<object class="GtkBox" id="CatHacks">
+														<property name="visible">True</property>
+														<property name="can-focus">False</property>
+														<property name="valign">start</property>
+														<property name="margin-left">5</property>
+														<property name="margin-right">5</property>
+														<property name="orientation">vertical</property>
+														<child>
+															<object class="GtkBox">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<child>
+																	<object class="GtkLabel">
+																		<property name="visible">True</property>
+																		<property name="can-focus">False</property>
+																		<property name="halign">start</property>
+																		<property name="margin-bottom">5</property>
+																		<property name="label" translatable="yes">Hacks</property>
+																		<attributes>
+																			<attribute name="weight" value="bold"/>
+																		</attributes>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">0</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkLabel">
+																		<property name="visible">True</property>
+																		<property name="can-focus">False</property>
+																		<property name="halign">start</property>
+																		<property name="margin-bottom">5</property>
+																		<property name="label" translatable="yes"> - These may cause instability</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">1</property>
+																	</packing>
+																</child>
+															</object>
+															<packing>
+																<property name="expand">False</property>
+																<property name="fill">True</property>
+																<property name="position">1</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkBox">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="margin-left">10</property>
+																<property name="margin-right">10</property>
+																<property name="orientation">vertical</property>
+																<child>
+																	<object class="GtkCheckButton" id="_expandRamToggle">
+																		<property name="label" translatable="yes">Expand DRAM size to 6GB</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">False</property>
+																		<property name="tooltip-text" translatable="yes">Expands the amount of memory on the emulated system from 4GB to 6GB</property>
+																		<property name="halign">start</property>
+																		<property name="margin-top">5</property>
+																		<property name="margin-bottom">5</property>
+																		<property name="draw-indicator">True</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">0</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkCheckButton" id="_unsafeMemToggle">
+																		<property name="label" translatable="yes">Allow unsafe memory access</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">False</property>
+																		<property name="tooltip-text" translatable="yes">Allows games and mods to access RAM they may not normally have access to. Required by some homebrew and game mods.</property>
+																		<property name="halign">start</property>
+																		<property name="margin-top">5</property>
+																		<property name="margin-bottom">5</property>
+																		<property name="draw-indicator">True</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">0</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkCheckButton" id="_ignoreToggle">
+																		<property name="label" translatable="yes">Ignore Missing Services</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">False</property>
+																		<property name="tooltip-text" translatable="yes">Enable or disable ignoring missing services</property>
+																		<property name="halign">start</property>
+																		<property name="margin-top">5</property>
+																		<property name="margin-bottom">5</property>
+																		<property name="draw-indicator">True</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">1</property>
+																	</packing>
+																</child>
+															</object>
+															<packing>
+																<property name="expand">True</property>
+																<property name="fill">True</property>
+																<property name="position">2</property>
+															</packing>
+														</child>
+													</object>
+													<packing>
+														<property name="expand">False</property>
+														<property name="fill">True</property>
+														<property name="padding">5</property>
+														<property name="position">4</property>
+													</packing>
+												</child>
+											</object>
+											<packing>
+												<property name="position">2</property>
+											</packing>
+										</child>
+										<child type="tab">
+											<object class="GtkLabel">
+												<property name="visible">True</property>
+												<property name="can-focus">False</property>
+												<property name="halign">end</property>
+												<property name="label" translatable="yes">System</property>
+											</object>
+											<packing>
+												<property name="position">2</property>
+												<property name="tab-fill">False</property>
+											</packing>
+										</child>
+										<child>
+											<object class="GtkBox" id="TabGraphics">
+												<property name="visible">True</property>
+												<property name="can-focus">False</property>
+												<property name="margin-top">5</property>
+												<property name="orientation">vertical</property>
+												<child>
+													<object class="GtkBox" id="CatFeatures">
+														<property name="visible">True</property>
+														<property name="can-focus">False</property>
+														<property name="margin-left">5</property>
+														<property name="margin-right">5</property>
+														<property name="orientation">vertical</property>
+														<child>
+															<object class="GtkLabel">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="halign">start</property>
+																<property name="margin-left">5</property>
+																<property name="margin-right">5</property>
+																<property name="margin-bottom">5</property>
+																<property name="label" translatable="yes">Features</property>
+																<attributes>
+																	<attribute name="weight" value="bold"/>
+																</attributes>
+															</object>
+															<packing>
+																<property name="expand">False</property>
+																<property name="fill">True</property>
+																<property name="position">0</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkBox" id="FeaturesOptions">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="margin-left">10</property>
+																<property name="margin-right">10</property>
+																<property name="orientation">vertical</property>
+																<child>
+																	<object class="GtkBox">
+																		<property name="visible">True</property>
+																		<property name="can-focus">False</property>
+																		<property name="margin-top">5</property>
+																		<property name="margin-bottom">5</property>
+																		<child>
+																			<object class="GtkLabel">
+																				<property name="visible">True</property>
+																				<property name="can-focus">False</property>
+																				<property name="tooltip-text" translatable="yes">Enable Graphics Backend Multithreading</property>
+																				<property name="label" translatable="yes">Graphics Backend Multithreading:</property>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="padding">5</property>
+																				<property name="position">0</property>
+																			</packing>
+																		</child>
+																		<child>
+																			<object class="GtkComboBoxText" id="_galThreading">
+																				<property name="visible">True</property>
+																				<property name="can-focus">False</property>
+																				<property name="tooltip-text" translatable="yes">Executes graphics backend commands on a second thread. Allows runtime multithreading of shader compilation, reduces stuttering, and improves performance on drivers without multithreading support of their own. Slightly varying peak performance on drivers with multithreading. Ryujinx may need to be restarted to correctly disable driver built-in multithreading, or you may need to do it manually to get the best performance.</property>
+																				<property name="active-id">-1</property>
+																				<items>
+																					<item id="Auto" translatable="yes">Auto</item>
+																					<item id="Off" translatable="yes">Off</item>
+																					<item id="On" translatable="yes">On</item>
+																				</items>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="position">1</property>
+																			</packing>
+																		</child>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="padding">5</property>
+																		<property name="position">1</property>
+																	</packing>
+																</child>
+															</object>
+															<packing>
+																<property name="expand">False</property>
+																<property name="fill">True</property>
+																<property name="position">2</property>
+															</packing>
+														</child>
+													</object>
+													<packing>
+														<property name="expand">False</property>
+														<property name="fill">True</property>
+														<property name="padding">5</property>
+														<property name="position">0</property>
+													</packing>
+												</child>
+												<child>
+													<object class="GtkBox" id="CatEnhancements">
+														<property name="visible">True</property>
+														<property name="can-focus">False</property>
+														<property name="margin-left">5</property>
+														<property name="margin-right">5</property>
+														<property name="orientation">vertical</property>
+														<child>
+															<object class="GtkLabel">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="halign">start</property>
+																<property name="margin-left">5</property>
+																<property name="margin-right">5</property>
+																<property name="margin-bottom">5</property>
+																<property name="label" translatable="yes">Enhancements</property>
+																<attributes>
+																	<attribute name="weight" value="bold"/>
+																</attributes>
+															</object>
+															<packing>
+																<property name="expand">False</property>
+																<property name="fill">True</property>
+																<property name="position">0</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkBox" id="EnhancementOptions">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="margin-left">10</property>
+																<property name="margin-right">10</property>
+																<property name="orientation">vertical</property>
+																<child>
+																	<object class="GtkCheckButton" id="_shaderCacheToggle">
+																		<property name="label" translatable="yes">Enable Shader Cache</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">False</property>
+																		<property name="tooltip-text" translatable="yes">Enables or disables Shader Cache</property>
+																		<property name="halign">start</property>
+																		<property name="margin-top">5</property>
+																		<property name="margin-bottom">5</property>
+																		<property name="draw-indicator">True</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">0</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkBox">
+																		<property name="visible">True</property>
+																		<property name="can-focus">False</property>
+																		<property name="margin-top">5</property>
+																		<property name="margin-bottom">5</property>
+																		<child>
+																			<object class="GtkLabel">
+																				<property name="visible">True</property>
+																				<property name="can-focus">False</property>
+																				<property name="tooltip-text" translatable="yes">Resolution Scale applied to applicable render targets.</property>
+																				<property name="label" translatable="yes">Resolution Scale:</property>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="padding">5</property>
+																				<property name="position">0</property>
+																			</packing>
+																		</child>
+																		<child>
+																			<object class="GtkComboBoxText" id="_resScaleCombo">
+																				<property name="visible">True</property>
+																				<property name="can-focus">False</property>
+																				<property name="tooltip-text" translatable="yes">Resolution Scale applied to applicable render targets.</property>
+																				<property name="active-id">1</property>
+																				<items>
+																					<item id="1" translatable="yes">Native (720p/1080p)</item>
+																					<item id="2" translatable="yes">2x (1440p/2160p)</item>
+																					<item id="3" translatable="yes">3x (2160p/3240p)</item>
+																					<item id="4" translatable="yes">4x (2880p/4320p)</item>
+																					<item id="-1" translatable="yes">Custom (not recommended)</item>
+																				</items>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="position">1</property>
+																			</packing>
+																		</child>
+																		<child>
+																			<object class="GtkEntry" id="_resScaleText">
+																				<property name="visible">True</property>
+																				<property name="can-focus">True</property>
+																				<property name="tooltip-text" translatable="yes">Floating point resolution scale, such as 1.5. Non-integral scales are more likely to cause issues or crash.</property>
+																				<property name="valign">center</property>
+																				<property name="caps-lock-warning">False</property>
+																				<property name="placeholder-text">1.0</property>
+																				<property name="input-purpose">number</property>
+																			</object>
+																			<packing>
+																				<property name="expand">True</property>
+																				<property name="fill">True</property>
+																				<property name="position">2</property>
+																			</packing>
+																		</child>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="padding">5</property>
+																		<property name="position">1</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkBox">
+																		<property name="visible">True</property>
+																		<property name="can-focus">False</property>
+																		<property name="margin-top">5</property>
+																		<property name="margin-bottom">5</property>
+																		<child>
+																			<object class="GtkLabel">
+																				<property name="visible">True</property>
+																				<property name="can-focus">False</property>
+																				<property name="tooltip-text" translatable="yes">Level of Anisotropic Filtering (set to Auto to use the value requested by the game)</property>
+																				<property name="label" translatable="yes">Anisotropic Filtering:</property>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="padding">5</property>
+																				<property name="position">0</property>
+																			</packing>
+																		</child>
+																		<child>
+																			<object class="GtkComboBoxText" id="_anisotropy">
+																				<property name="visible">True</property>
+																				<property name="can-focus">False</property>
+																				<property name="tooltip-text" translatable="yes">Level of Anisotropic Filtering (set to Auto to use the value requested by the game)</property>
+																				<property name="active-id">-1</property>
+																				<items>
+																					<item id="-1" translatable="yes">Auto</item>
+																					<item id="2" translatable="yes">2x</item>
+																					<item id="4" translatable="yes">4x</item>
+																					<item id="8" translatable="yes">8x</item>
+																					<item id="16" translatable="yes">16x</item>
+																				</items>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="position">1</property>
+																			</packing>
+																		</child>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="padding">5</property>
+																		<property name="position">1</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkBox">
+																		<property name="visible">True</property>
+																		<property name="can-focus">False</property>
+																		<property name="margin-top">5</property>
+																		<property name="margin-bottom">5</property>
+																		<child>
+																			<object class="GtkLabel">
+																				<property name="visible">True</property>
+																				<property name="can-focus">False</property>
+																				<property name="tooltip-text" translatable="yes">Aspect Ratio applied to the renderer window.</property>
+																				<property name="label" translatable="yes">Aspect Ratio:</property>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="padding">5</property>
+																				<property name="position">0</property>
+																			</packing>
+																		</child>
+																		<child>
+																			<object class="GtkComboBoxText" id="_aspectRatio">
+																				<property name="visible">True</property>
+																				<property name="can-focus">False</property>
+																				<property name="tooltip-text" translatable="yes">Aspect Ratio applied to the renderer window.</property>
+																				<property name="active-id">1</property>
+																				<items>
+																					<item id="0" translatable="yes">4:3</item>
+																					<item id="1" translatable="yes">16:9</item>
+																					<item id="2" translatable="yes">16:10</item>
+																					<item id="3" translatable="yes">21:9</item>
+																					<item id="4" translatable="yes">32:9</item>
+																					<item id="5" translatable="yes">Stretch to Fit Window</item>
+																				</items>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="position">1</property>
+																			</packing>
+																		</child>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="padding">5</property>
+																		<property name="position">3</property>
+																	</packing>
+																</child>
+															</object>
+															<packing>
+																<property name="expand">False</property>
+																<property name="fill">True</property>
+																<property name="position">2</property>
+															</packing>
+														</child>
+													</object>
+													<packing>
+														<property name="expand">False</property>
+														<property name="fill">True</property>
+														<property name="padding">5</property>
+														<property name="position">0</property>
+													</packing>
+												</child>
+												<child>
+													<object class="GtkSeparator">
+														<property name="visible">True</property>
+														<property name="can-focus">False</property>
+													</object>
+													<packing>
+														<property name="expand">False</property>
+														<property name="fill">True</property>
+														<property name="padding">5</property>
+														<property name="position">1</property>
+													</packing>
+												</child>
+												<child>
+													<object class="GtkBox" id="CatDev">
+														<property name="visible">True</property>
+														<property name="can-focus">False</property>
+														<property name="margin-left">5</property>
+														<property name="margin-right">5</property>
+														<property name="orientation">vertical</property>
+														<child>
+															<object class="GtkLabel">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="halign">start</property>
+																<property name="margin-left">5</property>
+																<property name="margin-right">5</property>
+																<property name="margin-bottom">5</property>
+																<property name="label" translatable="yes">Developer Options</property>
+																<attributes>
+																	<attribute name="weight" value="bold"/>
+																</attributes>
+															</object>
+															<packing>
+																<property name="expand">False</property>
+																<property name="fill">True</property>
+																<property name="position">0</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkBox" id="DevOptions">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="margin-left">10</property>
+																<property name="margin-right">10</property>
+																<property name="orientation">vertical</property>
+																<child>
+																	<object class="GtkBox">
+																		<property name="visible">True</property>
+																		<property name="can-focus">False</property>
+																		<property name="margin-top">5</property>
+																		<property name="margin-bottom">5</property>
+																		<child>
+																			<object class="GtkLabel">
+																				<property name="visible">True</property>
+																				<property name="can-focus">False</property>
+																				<property name="tooltip-text" translatable="yes">Graphics Shaders Dump Path</property>
+																				<property name="label" translatable="yes">Graphics Shaders Dump Path:</property>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="padding">5</property>
+																				<property name="position">0</property>
+																			</packing>
+																		</child>
+																		<child>
+																			<object class="GtkEntry" id="_graphicsShadersDumpPath">
+																				<property name="visible">True</property>
+																				<property name="can-focus">True</property>
+																				<property name="tooltip-text" translatable="yes">Graphics Shaders Dump Path</property>
+																				<property name="valign">center</property>
+																				<property name="caps-lock-warning">False</property>
+																			</object>
+																			<packing>
+																				<property name="expand">True</property>
+																				<property name="fill">True</property>
+																				<property name="position">1</property>
+																			</packing>
+																		</child>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="padding">5</property>
+																		<property name="position">0</property>
+																	</packing>
+																</child>
+															</object>
+															<packing>
+																<property name="expand">False</property>
+																<property name="fill">True</property>
+																<property name="position">1</property>
+															</packing>
+														</child>
+													</object>
+													<packing>
+														<property name="expand">False</property>
+														<property name="fill">True</property>
+														<property name="padding">5</property>
+														<property name="position">4</property>
+													</packing>
+												</child>
+											</object>
+											<packing>
+												<property name="position">3</property>
+											</packing>
+										</child>
+										<child type="tab">
+											<object class="GtkLabel">
+												<property name="visible">True</property>
+												<property name="can-focus">False</property>
+												<property name="label" translatable="yes">Graphics</property>
+											</object>
+											<packing>
+												<property name="position">3</property>
+												<property name="tab-fill">False</property>
+											</packing>
+										</child>
+										<child>
+											<object class="GtkBox" id="TabLogging">
+												<property name="visible">True</property>
+												<property name="can-focus">False</property>
+												<property name="margin-left">5</property>
+												<property name="margin-right">10</property>
+												<property name="margin-top">5</property>
+												<property name="orientation">vertical</property>
+												<child>
+													<object class="GtkBox" id="CatLogging">
+														<property name="visible">True</property>
+														<property name="can-focus">False</property>
+														<property name="margin-left">5</property>
+														<property name="margin-right">5</property>
+														<property name="orientation">vertical</property>
+														<child>
+															<object class="GtkLabel">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="halign">start</property>
+																<property name="margin-bottom">5</property>
+																<property name="label" translatable="yes">Logging</property>
+																<attributes>
+																	<attribute name="weight" value="bold"/>
+																</attributes>
+															</object>
+															<packing>
+																<property name="expand">False</property>
+																<property name="fill">True</property>
+																<property name="position">0</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkBox" id="LogggingOptions">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="valign">start</property>
+																<property name="margin-left">10</property>
+																<property name="margin-right">10</property>
+																<property name="orientation">vertical</property>
+																<child>
+																	<object class="GtkCheckButton" id="_fileLogToggle">
+																		<property name="label" translatable="yes">Enable Logging to File</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">False</property>
+																		<property name="tooltip-text" translatable="yes">Enables or disables logging to a file on disk</property>
+																		<property name="halign">start</property>
+																		<property name="margin-top">5</property>
+																		<property name="margin-bottom">5</property>
+																		<property name="draw-indicator">True</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">0</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkCheckButton" id="_stubLogToggle">
+																		<property name="label" translatable="yes">Enable Stub Logs</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">False</property>
+																		<property name="tooltip-text" translatable="yes">Enables printing stub log messages</property>
+																		<property name="halign">start</property>
+																		<property name="margin-top">5</property>
+																		<property name="margin-bottom">5</property>
+																		<property name="draw-indicator">True</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">3</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkCheckButton" id="_infoLogToggle">
+																		<property name="label" translatable="yes">Enable Info Logs</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">False</property>
+																		<property name="tooltip-text" translatable="yes">Enables printing info log messages</property>
+																		<property name="halign">start</property>
+																		<property name="margin-top">5</property>
+																		<property name="margin-bottom">5</property>
+																		<property name="draw-indicator">True</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">4</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkCheckButton" id="_warningLogToggle">
+																		<property name="label" translatable="yes">Enable Warning Logs</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">False</property>
+																		<property name="tooltip-text" translatable="yes">Enables printing warning log messages</property>
+																		<property name="halign">start</property>
+																		<property name="margin-top">5</property>
+																		<property name="margin-bottom">5</property>
+																		<property name="draw-indicator">True</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">5</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkCheckButton" id="_errorLogToggle">
+																		<property name="label" translatable="yes">Enable Error Logs</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">False</property>
+																		<property name="tooltip-text" translatable="yes">Enables printing error log messages</property>
+																		<property name="halign">start</property>
+																		<property name="margin-top">5</property>
+																		<property name="margin-bottom">5</property>
+																		<property name="draw-indicator">True</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">6</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkCheckButton" id="_guestLogToggle">
+																		<property name="label" translatable="yes">Enable Guest Logs</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">False</property>
+																		<property name="tooltip-text" translatable="yes">Enables printing guest log messages</property>
+																		<property name="halign">start</property>
+																		<property name="margin-top">5</property>
+																		<property name="margin-bottom">5</property>
+																		<property name="draw-indicator">True</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">7</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkCheckButton" id="_fsAccessLogToggle">
+																		<property name="label" translatable="yes">Enable Fs Access Logs</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">False</property>
+																		<property name="tooltip-text" translatable="yes">Enables printing fs access log messages</property>
+																		<property name="halign">start</property>
+																		<property name="margin-top">5</property>
+																		<property name="margin-bottom">5</property>
+																		<property name="draw-indicator">True</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">8</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkBox">
+																		<property name="visible">True</property>
+																		<property name="can-focus">False</property>
+																		<child>
+																			<object class="GtkLabel">
+																				<property name="visible">True</property>
+																				<property name="can-focus">False</property>
+																				<property name="tooltip-text" translatable="yes">Enables FS access log output to the console. Possible modes are 0-3</property>
+																				<property name="label" translatable="yes">Fs Global Access Log Mode:</property>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="padding">5</property>
+																				<property name="position">0</property>
+																			</packing>
+																		</child>
+																		<child>
+																			<object class="GtkSpinButton">
+																				<property name="visible">True</property>
+																				<property name="can-focus">True</property>
+																				<property name="tooltip-text" translatable="yes">Enables FS access log output to the console. Possible modes are 0-3</property>
+																				<property name="text" translatable="yes">0</property>
+																				<property name="adjustment">_fsLogSpinAdjustment</property>
+																			</object>
+																			<packing>
+																				<property name="expand">True</property>
+																				<property name="fill">True</property>
+																				<property name="position">1</property>
+																			</packing>
+																		</child>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="padding">5</property>
+																		<property name="position">9</property>
+																	</packing>
+																</child>
+															</object>
+															<packing>
+																<property name="expand">True</property>
+																<property name="fill">True</property>
+																<property name="position">1</property>
+															</packing>
+														</child>
+													</object>
+													<packing>
+														<property name="expand">False</property>
+														<property name="fill">True</property>
+														<property name="padding">5</property>
+														<property name="position">0</property>
+													</packing>
+												</child>
+												<child>
+													<object class="GtkBox" id="CatDevLogging">
+														<property name="visible">True</property>
+														<property name="can-focus">False</property>
+														<property name="margin-left">5</property>
+														<property name="margin-right">5</property>
+														<property name="margin-top">10</property>
+														<property name="orientation">vertical</property>
+														<child>
+															<object class="GtkLabel">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="tooltip-text" translatable="yes">Use with care</property>
+																<property name="halign">start</property>
+																<property name="margin-bottom">5</property>
+																<property name="label" translatable="yes">Developer Options (WARNING: Will reduce performance)</property>
+																<attributes>
+																	<attribute name="weight" value="bold"/>
+																</attributes>
+															</object>
+															<packing>
+																<property name="expand">False</property>
+																<property name="fill">True</property>
+																<property name="position">0</property>
+															</packing>
+														</child>
+														<child>
+															<object class="GtkBox" id="DevLoggingOptions">
+																<property name="visible">True</property>
+																<property name="can-focus">False</property>
+																<property name="valign">start</property>
+																<property name="margin-left">10</property>
+																<property name="margin-right">10</property>
+																<property name="orientation">vertical</property>
+																<child>
+																	<object class="GtkBox">
+																		<property name="visible">True</property>
+																		<property name="can-focus">False</property>
+																		<property name="margin-top">5</property>
+																		<child>
+																			<object class="GtkLabel">
+																				<property name="visible">True</property>
+																				<property name="can-focus">False</property>
+																				<property name="tooltip-text" translatable="yes">Requires appropriate log levels enabled.</property>
+																				<property name="label" translatable="yes">OpenGL Log Level</property>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="padding">5</property>
+																				<property name="position">22</property>
+																			</packing>
+																		</child>
+																		<child>
+																			<object class="GtkComboBoxText" id="_graphicsDebugLevel">
+																				<property name="visible">True</property>
+																				<property name="can-focus">False</property>
+																				<property name="tooltip-text" translatable="yes">Requires appropriate log levels enabled.</property>
+																				<property name="margin-left">5</property>
+																			</object>
+																			<packing>
+																				<property name="expand">False</property>
+																				<property name="fill">True</property>
+																				<property name="position">22</property>
+																			</packing>
+																		</child>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">1</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkCheckButton" id="_debugLogToggle">
+																		<property name="label" translatable="yes">Enable Debug Logs</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">False</property>
+																		<property name="tooltip-text" translatable="yes">Enables printing debug log messages</property>
+																		<property name="halign">start</property>
+																		<property name="margin-top">5</property>
+																		<property name="margin-bottom">5</property>
+																		<property name="draw-indicator">True</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">21</property>
+																	</packing>
+																</child>
+																<child>
+																	<object class="GtkCheckButton" id="_traceLogToggle">
+																		<property name="label" translatable="yes">Enable Trace Logs</property>
+																		<property name="visible">True</property>
+																		<property name="can-focus">True</property>
+																		<property name="receives-default">False</property>
+																		<property name="tooltip-text" translatable="yes">Enables printing trace log messages</property>
+																		<property name="halign">start</property>
+																		<property name="margin-top">5</property>
+																		<property name="margin-bottom">5</property>
+																		<property name="draw-indicator">True</property>
+																	</object>
+																	<packing>
+																		<property name="expand">False</property>
+																		<property name="fill">True</property>
+																		<property name="position">22</property>
+																	</packing>
+																</child>
+															</object>
+															<packing>
+																<property name="expand">False</property>
+																<property name="fill">True</property>
+																<property name="position">1</property>
+															</packing>
+														</child>
+													</object>
+													<packing>
+														<property name="expand">False</property>
+														<property name="fill">True</property>
+														<property name="padding">5</property>
+														<property name="position">22</property>
+													</packing>
+												</child>
+											</object>
+											<packing>
+												<property name="position">4</property>
+											</packing>
+										</child>
+										<child type="tab">
+											<object class="GtkLabel">
+												<property name="visible">True</property>
+												<property name="can-focus">False</property>
+												<property name="label" translatable="yes">Logging</property>
+											</object>
+											<packing>
+												<property name="position">4</property>
+												<property name="tab-fill">False</property>
+											</packing>
+										</child>
+									</object>
+								</child>
+							</object>
+						</child>
+					</object>
+					<packing>
+						<property name="expand">True</property>
+						<property name="fill">True</property>
+						<property name="position">0</property>
+					</packing>
+				</child>
+				<child>
+					<object class="GtkButtonBox" id="_buttonBox">
+						<property name="visible">True</property>
+						<property name="can-focus">False</property>
+						<property name="margin-right">5</property>
+						<property name="margin-top">3</property>
+						<property name="margin-bottom">3</property>
+						<property name="spacing">5</property>
+						<property name="layout-style">end</property>
+						<child>
+							<object class="GtkToggleButton" id="SaveToggle">
+								<property name="label" translatable="yes">Save</property>
+								<property name="visible">True</property>
+								<property name="can-focus">True</property>
+								<property name="receives-default">True</property>
+								<signal name="toggled" handler="SaveToggle_Activated" swapped="no"/>
+							</object>
+							<packing>
+								<property name="expand">False</property>
+								<property name="fill">False</property>
+								<property name="position">0</property>
+							</packing>
+						</child>
+						<child>
+							<object class="GtkToggleButton" id="CloseToggle">
+								<property name="label" translatable="yes">Close</property>
+								<property name="visible">True</property>
+								<property name="can-focus">True</property>
+								<property name="receives-default">True</property>
+								<signal name="toggled" handler="CloseToggle_Activated" swapped="no"/>
+							</object>
+							<packing>
+								<property name="expand">False</property>
+								<property name="fill">False</property>
+								<property name="position">1</property>
+							</packing>
+						</child>
+						<child>
+							<object class="GtkButton">
+								<property name="label" translatable="yes">Apply</property>
+								<property name="visible">True</property>
+								<property name="can-focus">True</property>
+								<property name="receives-default">True</property>
+								<signal name="clicked" handler="ApplyToggle_Activated" swapped="no"/>
+							</object>
+							<packing>
+								<property name="expand">True</property>
+								<property name="fill">True</property>
+								<property name="position">2</property>
+							</packing>
+						</child>
+					</object>
+					<packing>
+						<property name="expand">False</property>
+						<property name="fill">False</property>
+						<property name="position">1</property>
+					</packing>
+				</child>
+			</object>
+		</child>
+	</object>
 </interface>

--- a/Ryujinx/Ui/Windows/SettingsWindow.glade
+++ b/Ryujinx/Ui/Windows/SettingsWindow.glade
@@ -1,2714 +1,2714 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.38.2 -->
 <interface>
-	<requires lib="gtk+" version="3.20"/>
-	<object class="GtkAdjustment" id="_fsLogSpinAdjustment">
-		<property name="upper">3</property>
-		<property name="step-increment">1</property>
-		<property name="page-increment">10</property>
-	</object>
-	<object class="GtkAdjustment" id="_systemTimeDaySpinAdjustment">
-		<property name="lower">1</property>
-		<property name="upper">31</property>
-		<property name="step-increment">1</property>
-		<property name="page-increment">5</property>
-	</object>
-	<object class="GtkAdjustment" id="_systemTimeHourSpinAdjustment">
-		<property name="upper">23</property>
-		<property name="step-increment">1</property>
-		<property name="page-increment">5</property>
-	</object>
-	<object class="GtkAdjustment" id="_systemTimeMinuteSpinAdjustment">
-		<property name="upper">59</property>
-		<property name="step-increment">1</property>
-		<property name="page-increment">5</property>
-	</object>
-	<object class="GtkAdjustment" id="_systemTimeMonthSpinAdjustment">
-		<property name="lower">1</property>
-		<property name="upper">12</property>
-		<property name="step-increment">1</property>
-		<property name="page-increment">5</property>
-	</object>
-	<object class="GtkAdjustment" id="_systemTimeYearSpinAdjustment">
-		<property name="lower">2000</property>
-		<property name="upper">2060</property>
-		<property name="step-increment">1</property>
-		<property name="page-increment">10</property>
-	</object>
-	<object class="GtkEntryCompletion" id="_systemTimeZoneCompletion">
-		<property name="minimum-key-length">0</property>
-		<property name="inline-completion">True</property>
-		<property name="inline-selection">True</property>
-	</object>
-	<object class="GtkWindow" id="_settingsWin">
-		<property name="can-focus">False</property>
-		<property name="title" translatable="yes">Ryujinx - Settings</property>
-		<property name="modal">True</property>
-		<property name="window-position">center</property>
-		<property name="default-width">650</property>
-		<property name="default-height">650</property>
-		<child>
-			<object class="GtkBox">
-				<property name="visible">True</property>
-				<property name="can-focus">False</property>
-				<property name="orientation">vertical</property>
-				<child>
-					<object class="GtkScrolledWindow">
-						<property name="visible">True</property>
-						<property name="can-focus">True</property>
-						<property name="shadow-type">in</property>
-						<child>
-							<object class="GtkViewport">
-								<property name="visible">True</property>
-								<property name="can-focus">False</property>
-								<child>
-									<object class="GtkNotebook">
-										<property name="visible">True</property>
-										<property name="can-focus">True</property>
-										<child>
-											<object class="GtkBox" id="TabGeneral">
-												<property name="visible">True</property>
-												<property name="can-focus">False</property>
-												<property name="margin-left">5</property>
-												<property name="margin-right">10</property>
-												<property name="margin-top">5</property>
-												<property name="orientation">vertical</property>
-												<child>
-													<object class="GtkBox" id="CatGeneral">
-														<property name="visible">True</property>
-														<property name="can-focus">False</property>
-														<property name="margin-left">5</property>
-														<property name="margin-right">5</property>
-														<property name="orientation">vertical</property>
-														<child>
-															<object class="GtkLabel">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="halign">start</property>
-																<property name="margin-bottom">5</property>
-																<property name="label" translatable="yes">General</property>
-																<attributes>
-																	<attribute name="weight" value="bold"/>
-																</attributes>
-															</object>
-															<packing>
-																<property name="expand">False</property>
-																<property name="fill">True</property>
-																<property name="position">0</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkBox" id="General">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="margin-left">10</property>
-																<property name="margin-right">10</property>
-																<property name="orientation">vertical</property>
-																<child>
-																	<object class="GtkCheckButton" id="_discordToggle">
-																		<property name="label" translatable="yes">Enable Discord Rich Presence</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">False</property>
-																		<property name="tooltip-text" translatable="yes">Enables or disables Discord Rich Presence</property>
-																		<property name="halign">start</property>
-																		<property name="draw-indicator">True</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="padding">5</property>
-																		<property name="position">0</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkCheckButton" id="_checkUpdatesToggle">
-																		<property name="label" translatable="yes">Check for Updates on Launch</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">False</property>
-																		<property name="halign">start</property>
-																		<property name="draw-indicator">True</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="padding">5</property>
-																		<property name="position">1</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkCheckButton" id="_showConfirmExitToggle">
-																		<property name="label" translatable="yes">Show "Confirm Exit" Dialog</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">False</property>
-																		<property name="halign">start</property>
-																		<property name="draw-indicator">True</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="padding">5</property>
-																		<property name="position">2</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkCheckButton" id="_hideCursorOnIdleToggle">
-																		<property name="label" translatable="yes">Hide Cursor On Idle</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">False</property>
-																		<property name="halign">start</property>
-																		<property name="draw-indicator">True</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="padding">5</property>
-																		<property name="position">3</property>
-																	</packing>
-																</child>
-															</object>
-															<packing>
-																<property name="expand">True</property>
-																<property name="fill">True</property>
-																<property name="position">1</property>
-															</packing>
-														</child>
-													</object>
-													<packing>
-														<property name="expand">False</property>
-														<property name="fill">True</property>
-														<property name="padding">5</property>
-														<property name="position">1</property>
-													</packing>
-												</child>
-												<child>
-													<object class="GtkSeparator">
-														<property name="visible">True</property>
-														<property name="can-focus">False</property>
-														<property name="margin-left">5</property>
-														<property name="margin-right">5</property>
-													</object>
-													<packing>
-														<property name="expand">False</property>
-														<property name="fill">True</property>
-														<property name="padding">5</property>
-														<property name="position">2</property>
-													</packing>
-												</child>
-												<child>
-													<object class="GtkBox" id="CatGameDir">
-														<property name="visible">True</property>
-														<property name="can-focus">False</property>
-														<property name="margin-left">5</property>
-														<property name="margin-right">5</property>
-														<property name="orientation">vertical</property>
-														<child>
-															<object class="GtkLabel">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="halign">start</property>
-																<property name="margin-bottom">5</property>
-																<property name="label" translatable="yes">Game Directories</property>
-																<attributes>
-																	<attribute name="weight" value="bold"/>
-																</attributes>
-															</object>
-															<packing>
-																<property name="expand">False</property>
-																<property name="fill">True</property>
-																<property name="position">0</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkBox">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="margin-left">10</property>
-																<property name="margin-right">10</property>
-																<property name="orientation">vertical</property>
-																<child>
-																	<object class="GtkScrolledWindow">
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="margin-bottom">10</property>
-																		<property name="shadow-type">in</property>
-																		<child>
-																			<object class="GtkTreeView" id="_gameDirsBox">
-																				<property name="visible">True</property>
-																				<property name="can-focus">True</property>
-																				<property name="headers-visible">False</property>
-																				<property name="headers-clickable">False</property>
-																				<child internal-child="selection">
-																					<object class="GtkTreeSelection"/>
-																				</child>
-																			</object>
-																		</child>
-																		<style>
-																			<class name="GameDir"/>
-																		</style>
-																	</object>
-																	<packing>
-																		<property name="expand">True</property>
-																		<property name="fill">True</property>
-																		<property name="position">0</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkBox">
-																		<property name="visible">True</property>
-																		<property name="can-focus">False</property>
-																		<child>
-																			<object class="GtkEntry" id="_addGameDirBox">
-																				<property name="visible">True</property>
-																				<property name="can-focus">True</property>
-																				<property name="tooltip-text" translatable="yes">Enter a game directroy to add to the list</property>
-																			</object>
-																			<packing>
-																				<property name="expand">True</property>
-																				<property name="fill">True</property>
-																				<property name="position">0</property>
-																			</packing>
-																		</child>
-																		<child>
-																			<object class="GtkToggleButton" id="_addDir">
-																				<property name="label" translatable="yes">Add</property>
-																				<property name="width-request">80</property>
-																				<property name="visible">True</property>
-																				<property name="can-focus">True</property>
-																				<property name="receives-default">True</property>
-																				<property name="tooltip-text" translatable="yes"> Add a game directory to the list</property>
-																				<property name="margin-left">5</property>
-																				<signal name="toggled" handler="AddDir_Pressed" swapped="no"/>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="position">1</property>
-																			</packing>
-																		</child>
-																		<child>
-																			<object class="GtkToggleButton" id="_removeDir">
-																				<property name="label" translatable="yes">Remove</property>
-																				<property name="width-request">80</property>
-																				<property name="visible">True</property>
-																				<property name="can-focus">True</property>
-																				<property name="receives-default">True</property>
-																				<property name="tooltip-text" translatable="yes">Remove selected game directory</property>
-																				<property name="margin-left">5</property>
-																				<signal name="toggled" handler="RemoveDir_Pressed" swapped="no"/>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="position">3</property>
-																			</packing>
-																		</child>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">1</property>
-																	</packing>
-																</child>
-															</object>
-															<packing>
-																<property name="expand">True</property>
-																<property name="fill">True</property>
-																<property name="position">1</property>
-															</packing>
-														</child>
-													</object>
-													<packing>
-														<property name="expand">True</property>
-														<property name="fill">True</property>
-														<property name="padding">5</property>
-														<property name="position">4</property>
-													</packing>
-												</child>
-												<child>
-													<object class="GtkSeparator">
-														<property name="visible">True</property>
-														<property name="can-focus">False</property>
-														<property name="margin-left">5</property>
-														<property name="margin-right">5</property>
-													</object>
-													<packing>
-														<property name="expand">False</property>
-														<property name="fill">True</property>
-														<property name="padding">5</property>
-														<property name="position">5</property>
-													</packing>
-												</child>
-												<child>
-													<object class="GtkBox" id="CatThemes">
-														<property name="visible">True</property>
-														<property name="can-focus">False</property>
-														<property name="margin-left">5</property>
-														<property name="margin-right">5</property>
-														<property name="orientation">vertical</property>
-														<child>
-															<object class="GtkLabel">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="halign">start</property>
-																<property name="margin-bottom">5</property>
-																<property name="label" translatable="yes">Themes</property>
-																<attributes>
-																	<attribute name="weight" value="bold"/>
-																</attributes>
-															</object>
-															<packing>
-																<property name="expand">False</property>
-																<property name="fill">True</property>
-																<property name="position">0</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkBox">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="margin-left">10</property>
-																<property name="margin-right">10</property>
-																<property name="orientation">vertical</property>
-																<child>
-																	<object class="GtkCheckButton" id="_custThemeToggle">
-																		<property name="label" translatable="yes">Use Custom Theme</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">False</property>
-																		<property name="tooltip-text" translatable="yes">Enable or disable custom themes in the GUI</property>
-																		<property name="halign">start</property>
-																		<property name="draw-indicator">True</property>
-																		<signal name="toggled" handler="CustThemeToggle_Activated" swapped="no"/>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="padding">5</property>
-																		<property name="position">1</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkBox">
-																		<property name="visible">True</property>
-																		<property name="can-focus">False</property>
-																		<child>
-																			<object class="GtkLabel" id="_custThemePathLabel">
-																				<property name="visible">True</property>
-																				<property name="can-focus">False</property>
-																				<property name="tooltip-text" translatable="yes">Path to custom GUI theme</property>
-																				<property name="label" translatable="yes">Custom Theme Path:</property>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="padding">5</property>
-																				<property name="position">0</property>
-																			</packing>
-																		</child>
-																		<child>
-																			<object class="GtkEntry" id="_custThemePath">
-																				<property name="visible">True</property>
-																				<property name="can-focus">True</property>
-																				<property name="tooltip-text" translatable="yes">Path to custom GUI theme</property>
-																				<property name="valign">center</property>
-																			</object>
-																			<packing>
-																				<property name="expand">True</property>
-																				<property name="fill">True</property>
-																				<property name="position">1</property>
-																			</packing>
-																		</child>
-																		<child>
-																			<object class="GtkToggleButton" id="_browseThemePath">
-																				<property name="label" translatable="yes">Browse...</property>
-																				<property name="width-request">80</property>
-																				<property name="visible">True</property>
-																				<property name="can-focus">True</property>
-																				<property name="receives-default">True</property>
-																				<property name="tooltip-text" translatable="yes">Browse for a custom GUI theme</property>
-																				<property name="margin-left">5</property>
-																				<signal name="toggled" handler="BrowseThemeDir_Pressed" swapped="no"/>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="position">2</property>
-																			</packing>
-																		</child>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="padding">10</property>
-																		<property name="position">2</property>
-																	</packing>
-																</child>
-															</object>
-															<packing>
-																<property name="expand">False</property>
-																<property name="fill">True</property>
-																<property name="position">1</property>
-															</packing>
-														</child>
-													</object>
-													<packing>
-														<property name="expand">False</property>
-														<property name="fill">True</property>
-														<property name="padding">5</property>
-														<property name="position">6</property>
-													</packing>
-												</child>
-											</object>
-										</child>
-										<child type="tab">
-											<object class="GtkLabel">
-												<property name="visible">True</property>
-												<property name="can-focus">False</property>
-												<property name="label" translatable="yes">General</property>
-											</object>
-											<packing>
-												<property name="tab-fill">False</property>
-											</packing>
-										</child>
-										<child>
-											<object class="GtkBox" id="TabInput">
-												<property name="visible">True</property>
-												<property name="can-focus">False</property>
-												<property name="margin-left">5</property>
-												<property name="margin-right">10</property>
-												<property name="margin-top">5</property>
-												<property name="orientation">vertical</property>
-												<child>
-													<object class="GtkBox">
-														<property name="visible">True</property>
-														<property name="can-focus">False</property>
-														<property name="margin-top">5</property>
-														<property name="margin-bottom">5</property>
-														<child>
-															<object class="GtkCheckButton" id="_dockedModeToggle">
-																<property name="label" translatable="yes">Enable Docked Mode</property>
-																<property name="visible">True</property>
-																<property name="can-focus">True</property>
-																<property name="receives-default">False</property>
-																<property name="tooltip-text" translatable="yes">Enable or disable Docked Mode</property>
-																<property name="draw-indicator">True</property>
-															</object>
-															<packing>
-																<property name="expand">False</property>
-																<property name="fill">True</property>
-																<property name="padding">10</property>
-																<property name="position">0</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkCheckButton" id="_directKeyboardAccess">
-																<property name="label" translatable="yes">Direct Keyboard Access</property>
-																<property name="visible">True</property>
-																<property name="can-focus">True</property>
-																<property name="receives-default">False</property>
-																<property name="tooltip-text" translatable="yes">Enable or disable "direct keyboard access (HID) support" (Provides games access to your keyboard as a text entry device)</property>
-																<property name="draw-indicator">True</property>
-															</object>
-															<packing>
-																<property name="expand">False</property>
-																<property name="fill">False</property>
-																<property name="padding">10</property>
-																<property name="position">1</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkCheckButton" id="_directMouseAccess">
-																<property name="label" translatable="yes">Direct Mouse Access</property>
-																<property name="visible">True</property>
-																<property name="can-focus">True</property>
-																<property name="receives-default">False</property>
-																<property name="tooltip-text" translatable="yes">Enable or disable "direct mouse access (HID) support" (Provides games access to your mouse as a pointing device)</property>
-																<property name="draw-indicator">True</property>
-															</object>
-															<packing>
-																<property name="expand">False</property>
-																<property name="fill">False</property>
-																<property name="padding">10</property>
-																<property name="position">2</property>
-															</packing>
-														</child>
-													</object>
-													<packing>
-														<property name="expand">False</property>
-														<property name="fill">True</property>
-														<property name="padding">5</property>
-														<property name="position">0</property>
-													</packing>
-												</child>
-												<child>
-													<object class="GtkSeparator">
-														<property name="visible">True</property>
-														<property name="can-focus">False</property>
-													</object>
-													<packing>
-														<property name="expand">False</property>
-														<property name="fill">True</property>
-														<property name="position">1</property>
-													</packing>
-												</child>
-												<child>
-													<!-- n-columns=5 n-rows=5 -->
-													<object class="GtkGrid" id="ControllerGrid">
-														<property name="visible">True</property>
-														<property name="can-focus">False</property>
-														<property name="halign">center</property>
-														<property name="valign">center</property>
-														<property name="column-spacing">20</property>
-														<child>
-															<object class="GtkBox">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="orientation">vertical</property>
-																<child>
-																	<object class="GtkLabel">
-																		<property name="visible">True</property>
-																		<property name="can-focus">False</property>
-																		<property name="margin-top">20</property>
-																		<property name="margin-bottom">20</property>
-																		<property name="label" translatable="yes">Player 1</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">0</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkToggleButton" id="_configureController1">
-																		<property name="label" translatable="yes">Configure</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">True</property>
-																		<property name="margin-left">20</property>
-																		<property name="margin-right">20</property>
-																		<property name="margin-top">20</property>
-																		<property name="margin-bottom">20</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">1</property>
-																	</packing>
-																</child>
-															</object>
-															<packing>
-																<property name="left-attach">0</property>
-																<property name="top-attach">0</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkBox">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="orientation">vertical</property>
-																<child>
-																	<object class="GtkLabel">
-																		<property name="visible">True</property>
-																		<property name="can-focus">False</property>
-																		<property name="margin-top">20</property>
-																		<property name="margin-bottom">20</property>
-																		<property name="label" translatable="yes">Player 3</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">0</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkToggleButton" id="_configureController3">
-																		<property name="label" translatable="yes">Configure</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">True</property>
-																		<property name="margin-left">20</property>
-																		<property name="margin-right">20</property>
-																		<property name="margin-top">20</property>
-																		<property name="margin-bottom">20</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">1</property>
-																	</packing>
-																</child>
-															</object>
-															<packing>
-																<property name="left-attach">4</property>
-																<property name="top-attach">0</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkBox">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="orientation">vertical</property>
-																<child>
-																	<object class="GtkLabel">
-																		<property name="visible">True</property>
-																		<property name="can-focus">False</property>
-																		<property name="margin-top">20</property>
-																		<property name="margin-bottom">20</property>
-																		<property name="label" translatable="yes">Player 2</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">0</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkToggleButton" id="_configureController2">
-																		<property name="label" translatable="yes">Configure</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">True</property>
-																		<property name="margin-left">20</property>
-																		<property name="margin-right">20</property>
-																		<property name="margin-top">20</property>
-																		<property name="margin-bottom">20</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">1</property>
-																	</packing>
-																</child>
-															</object>
-															<packing>
-																<property name="left-attach">2</property>
-																<property name="top-attach">0</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkBox">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="orientation">vertical</property>
-																<child>
-																	<object class="GtkLabel">
-																		<property name="visible">True</property>
-																		<property name="can-focus">False</property>
-																		<property name="margin-top">20</property>
-																		<property name="margin-bottom">20</property>
-																		<property name="label" translatable="yes">Handheld</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">0</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkToggleButton" id="_configureControllerH">
-																		<property name="label" translatable="yes">Configure</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">True</property>
-																		<property name="margin-left">20</property>
-																		<property name="margin-right">20</property>
-																		<property name="margin-top">20</property>
-																		<property name="margin-bottom">20</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">1</property>
-																	</packing>
-																</child>
-															</object>
-															<packing>
-																<property name="left-attach">4</property>
-																<property name="top-attach">4</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkBox">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="orientation">vertical</property>
-																<child>
-																	<object class="GtkLabel">
-																		<property name="visible">True</property>
-																		<property name="can-focus">False</property>
-																		<property name="margin-top">20</property>
-																		<property name="margin-bottom">20</property>
-																		<property name="label" translatable="yes">Player 6</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">0</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkToggleButton" id="_configureController6">
-																		<property name="label" translatable="yes">Configure</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">True</property>
-																		<property name="margin-left">20</property>
-																		<property name="margin-right">20</property>
-																		<property name="margin-top">20</property>
-																		<property name="margin-bottom">20</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">1</property>
-																	</packing>
-																</child>
-															</object>
-															<packing>
-																<property name="left-attach">4</property>
-																<property name="top-attach">2</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkBox">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="orientation">vertical</property>
-																<child>
-																	<object class="GtkLabel">
-																		<property name="visible">True</property>
-																		<property name="can-focus">False</property>
-																		<property name="margin-top">20</property>
-																		<property name="margin-bottom">20</property>
-																		<property name="label" translatable="yes">Player 5</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">0</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkToggleButton" id="_configureController5">
-																		<property name="label" translatable="yes">Configure</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">True</property>
-																		<property name="margin-left">20</property>
-																		<property name="margin-right">20</property>
-																		<property name="margin-top">20</property>
-																		<property name="margin-bottom">20</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">1</property>
-																	</packing>
-																</child>
-															</object>
-															<packing>
-																<property name="left-attach">2</property>
-																<property name="top-attach">2</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkBox">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="orientation">vertical</property>
-																<child>
-																	<object class="GtkLabel">
-																		<property name="visible">True</property>
-																		<property name="can-focus">False</property>
-																		<property name="margin-top">20</property>
-																		<property name="margin-bottom">20</property>
-																		<property name="label" translatable="yes">Player 7</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">0</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkToggleButton" id="_configureController7">
-																		<property name="label" translatable="yes">Configure</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">True</property>
-																		<property name="margin-left">20</property>
-																		<property name="margin-right">20</property>
-																		<property name="margin-top">20</property>
-																		<property name="margin-bottom">20</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">1</property>
-																	</packing>
-																</child>
-															</object>
-															<packing>
-																<property name="left-attach">0</property>
-																<property name="top-attach">4</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkBox">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="orientation">vertical</property>
-																<child>
-																	<object class="GtkLabel">
-																		<property name="visible">True</property>
-																		<property name="can-focus">False</property>
-																		<property name="margin-top">20</property>
-																		<property name="margin-bottom">20</property>
-																		<property name="label" translatable="yes">Player 4</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">0</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkToggleButton" id="_configureController4">
-																		<property name="label" translatable="yes">Configure</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">True</property>
-																		<property name="margin-left">20</property>
-																		<property name="margin-right">20</property>
-																		<property name="margin-top">20</property>
-																		<property name="margin-bottom">20</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">1</property>
-																	</packing>
-																</child>
-															</object>
-															<packing>
-																<property name="left-attach">0</property>
-																<property name="top-attach">2</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkBox">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="orientation">vertical</property>
-																<child>
-																	<object class="GtkLabel">
-																		<property name="visible">True</property>
-																		<property name="can-focus">False</property>
-																		<property name="margin-top">20</property>
-																		<property name="margin-bottom">20</property>
-																		<property name="label" translatable="yes">Player 8</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">0</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkToggleButton" id="_configureController8">
-																		<property name="label" translatable="yes">Configure</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">True</property>
-																		<property name="margin-left">20</property>
-																		<property name="margin-right">20</property>
-																		<property name="margin-top">20</property>
-																		<property name="margin-bottom">20</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">1</property>
-																	</packing>
-																</child>
-															</object>
-															<packing>
-																<property name="left-attach">2</property>
-																<property name="top-attach">4</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkSeparator">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-															</object>
-															<packing>
-																<property name="left-attach">1</property>
-																<property name="top-attach">0</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkSeparator">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-															</object>
-															<packing>
-																<property name="left-attach">3</property>
-																<property name="top-attach">0</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkSeparator">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-															</object>
-															<packing>
-																<property name="left-attach">3</property>
-																<property name="top-attach">2</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkSeparator">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-															</object>
-															<packing>
-																<property name="left-attach">3</property>
-																<property name="top-attach">4</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkSeparator">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-															</object>
-															<packing>
-																<property name="left-attach">1</property>
-																<property name="top-attach">2</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkSeparator">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-															</object>
-															<packing>
-																<property name="left-attach">1</property>
-																<property name="top-attach">4</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkSeparator">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-															</object>
-															<packing>
-																<property name="left-attach">1</property>
-																<property name="top-attach">1</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkSeparator">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-															</object>
-															<packing>
-																<property name="left-attach">1</property>
-																<property name="top-attach">3</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkSeparator">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-															</object>
-															<packing>
-																<property name="left-attach">3</property>
-																<property name="top-attach">1</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkSeparator">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-															</object>
-															<packing>
-																<property name="left-attach">3</property>
-																<property name="top-attach">3</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkSeparator">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-															</object>
-															<packing>
-																<property name="left-attach">0</property>
-																<property name="top-attach">1</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkSeparator">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-															</object>
-															<packing>
-																<property name="left-attach">2</property>
-																<property name="top-attach">1</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkSeparator">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-															</object>
-															<packing>
-																<property name="left-attach">4</property>
-																<property name="top-attach">1</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkSeparator">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-															</object>
-															<packing>
-																<property name="left-attach">0</property>
-																<property name="top-attach">3</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkSeparator">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-															</object>
-															<packing>
-																<property name="left-attach">2</property>
-																<property name="top-attach">3</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkSeparator">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-															</object>
-															<packing>
-																<property name="left-attach">4</property>
-																<property name="top-attach">3</property>
-															</packing>
-														</child>
-													</object>
-													<packing>
-														<property name="expand">True</property>
-														<property name="fill">True</property>
-														<property name="position">2</property>
-													</packing>
-												</child>
-												<child>
-													<object class="GtkSeparator">
-														<property name="visible">True</property>
-														<property name="can-focus">False</property>
-													</object>
-													<packing>
-														<property name="expand">False</property>
-														<property name="fill">True</property>
-														<property name="position">3</property>
-													</packing>
-												</child>
-											</object>
-											<packing>
-												<property name="position">1</property>
-											</packing>
-										</child>
-										<child type="tab">
-											<object class="GtkLabel">
-												<property name="visible">True</property>
-												<property name="can-focus">False</property>
-												<property name="label" translatable="yes">Input</property>
-											</object>
-											<packing>
-												<property name="position">1</property>
-												<property name="tab-fill">False</property>
-											</packing>
-										</child>
-										<child>
-											<object class="GtkBox" id="TabSystem">
-												<property name="visible">True</property>
-												<property name="can-focus">False</property>
-												<property name="margin-left">5</property>
-												<property name="margin-right">10</property>
-												<property name="margin-top">5</property>
-												<property name="orientation">vertical</property>
-												<child>
-													<object class="GtkBox" id="CatCore">
-														<property name="visible">True</property>
-														<property name="can-focus">False</property>
-														<property name="valign">start</property>
-														<property name="margin-left">5</property>
-														<property name="margin-right">5</property>
-														<property name="orientation">vertical</property>
-														<child>
-															<object class="GtkLabel">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="halign">start</property>
-																<property name="margin-bottom">5</property>
-																<property name="label" translatable="yes">Core</property>
-																<attributes>
-																	<attribute name="weight" value="bold"/>
-																</attributes>
-															</object>
-															<packing>
-																<property name="expand">False</property>
-																<property name="fill">True</property>
-																<property name="position">0</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkBox">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="margin-left">10</property>
-																<property name="margin-right">10</property>
-																<property name="orientation">vertical</property>
-																<child>
-																	<object class="GtkBox" id="RegionBox">
-																		<property name="visible">True</property>
-																		<property name="can-focus">False</property>
-																		<child>
-																			<object class="GtkLabel">
-																				<property name="visible">True</property>
-																				<property name="can-focus">False</property>
-																				<property name="tooltip-text" translatable="yes">Change System Region</property>
-																				<property name="halign">end</property>
-																				<property name="label" translatable="yes">System Region:</property>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="padding">5</property>
-																				<property name="position">2</property>
-																			</packing>
-																		</child>
-																		<child>
-																			<object class="GtkComboBoxText" id="_systemRegionSelect">
-																				<property name="visible">True</property>
-																				<property name="can-focus">False</property>
-																				<property name="tooltip-text" translatable="yes">Change System Region</property>
-																				<property name="margin-left">5</property>
-																				<items>
-																					<item id="Japan" translatable="yes">Japan</item>
-																					<item id="USA" translatable="yes">USA</item>
-																					<item id="Europe" translatable="yes">Europe</item>
-																					<item id="Australia" translatable="yes">Australia</item>
-																					<item id="China" translatable="yes">China</item>
-																					<item id="Korea" translatable="yes">Korea</item>
-																					<item id="Taiwan" translatable="yes">Taiwan</item>
-																				</items>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="position">3</property>
-																			</packing>
-																		</child>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="padding">5</property>
-																		<property name="position">0</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkBox" id="LanguageBox">
-																		<property name="visible">True</property>
-																		<property name="can-focus">False</property>
-																		<child>
-																			<object class="GtkLabel">
-																				<property name="visible">True</property>
-																				<property name="can-focus">False</property>
-																				<property name="tooltip-text" translatable="yes">Change System Language</property>
-																				<property name="halign">end</property>
-																				<property name="label" translatable="yes">System Language:</property>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="padding">5</property>
-																				<property name="position">0</property>
-																			</packing>
-																		</child>
-																		<child>
-																			<object class="GtkComboBoxText" id="_systemLanguageSelect">
-																				<property name="visible">True</property>
-																				<property name="can-focus">False</property>
-																				<property name="tooltip-text" translatable="yes">Change System Language</property>
-																				<items>
-																					<item id="AmericanEnglish" translatable="yes">American English</item>
-																					<item id="BritishEnglish" translatable="yes">British English</item>
-																					<item id="CanadianFrench" translatable="yes">Canadian French</item>
-																					<item id="Chinese" translatable="yes">Chinese</item>
-																					<item id="Dutch" translatable="yes">Dutch</item>
-																					<item id="French" translatable="yes">French</item>
-																					<item id="German" translatable="yes">German</item>
-																					<item id="Italian" translatable="yes">Italian</item>
-																					<item id="Japanese" translatable="yes">Japanese</item>
-																					<item id="Korean" translatable="yes">Korean</item>
-																					<item id="LatinAmericanSpanish" translatable="yes">Latin American Spanish</item>
-																					<item id="Portuguese" translatable="yes">Portuguese</item>
-																					<item id="Russian" translatable="yes">Russian</item>
-																					<item id="SimplifiedChinese" translatable="yes">Simplified Chinese</item>
-																					<item id="Spanish" translatable="yes">Spanish</item>
-																					<item id="Taiwanese" translatable="yes">Taiwanese</item>
-																					<item id="TraditionalChinese" translatable="yes">Traditional Chinese</item>
-																					<item id="BrazilianPortuguese" translatable="yes">Brazilian Portuguese</item>
-																				</items>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="position">1</property>
-																			</packing>
-																		</child>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="padding">5</property>
-																		<property name="position">1</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkBox" id="TimeZoneBox">
-																		<property name="visible">True</property>
-																		<property name="can-focus">False</property>
-																		<child>
-																			<object class="GtkLabel">
-																				<property name="visible">True</property>
-																				<property name="can-focus">False</property>
-																				<property name="tooltip-text" translatable="yes">Change System TimeZone</property>
-																				<property name="halign">end</property>
-																				<property name="label" translatable="yes">System TimeZone:</property>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="padding">5</property>
-																				<property name="position">1</property>
-																			</packing>
-																		</child>
-																		<child>
-																			<object class="GtkEntry" id="_systemTimeZoneEntry">
-																				<property name="visible">True</property>
-																				<property name="can-focus">True</property>
-																				<property name="tooltip-text" translatable="yes">Change System TimeZone</property>
-																				<property name="margin-left">5</property>
-																				<property name="completion">_systemTimeZoneCompletion</property>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="position">2</property>
-																			</packing>
-																		</child>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="padding">5</property>
-																		<property name="position">2</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkBox" id="TimeBox">
-																		<property name="visible">True</property>
-																		<property name="can-focus">False</property>
-																		<child>
-																			<object class="GtkLabel">
-																				<property name="visible">True</property>
-																				<property name="can-focus">False</property>
-																				<property name="tooltip-text" translatable="yes">Change System Time</property>
-																				<property name="halign">end</property>
-																				<property name="label" translatable="yes">System Time:</property>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="padding">5</property>
-																				<property name="position">0</property>
-																			</packing>
-																		</child>
-																		<child>
-																			<object class="GtkSpinButton" id="_systemTimeYearSpin">
-																				<property name="visible">True</property>
-																				<property name="can-focus">True</property>
-																				<property name="text" translatable="yes">2000</property>
-																				<property name="orientation">vertical</property>
-																				<property name="adjustment">_systemTimeYearSpinAdjustment</property>
-																				<property name="wrap">True</property>
-																				<property name="value">2000</property>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="position">1</property>
-																			</packing>
-																		</child>
-																		<child>
-																			<object class="GtkLabel">
-																				<property name="visible">True</property>
-																				<property name="can-focus">False</property>
-																				<property name="halign">end</property>
-																				<property name="label">-</property>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="padding">5</property>
-																				<property name="position">2</property>
-																			</packing>
-																		</child>
-																		<child>
-																			<object class="GtkSpinButton" id="_systemTimeMonthSpin">
-																				<property name="visible">True</property>
-																				<property name="can-focus">True</property>
-																				<property name="text" translatable="yes">1</property>
-																				<property name="orientation">vertical</property>
-																				<property name="adjustment">_systemTimeMonthSpinAdjustment</property>
-																				<property name="wrap">True</property>
-																				<property name="value">1</property>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="position">3</property>
-																			</packing>
-																		</child>
-																		<child>
-																			<object class="GtkLabel">
-																				<property name="visible">True</property>
-																				<property name="can-focus">False</property>
-																				<property name="halign">end</property>
-																				<property name="label">-</property>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="padding">5</property>
-																				<property name="position">4</property>
-																			</packing>
-																		</child>
-																		<child>
-																			<object class="GtkSpinButton" id="_systemTimeDaySpin">
-																				<property name="visible">True</property>
-																				<property name="can-focus">True</property>
-																				<property name="text" translatable="yes">1</property>
-																				<property name="orientation">vertical</property>
-																				<property name="adjustment">_systemTimeDaySpinAdjustment</property>
-																				<property name="wrap">True</property>
-																				<property name="value">1</property>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="position">5</property>
-																			</packing>
-																		</child>
-																		<child>
-																			<object class="GtkSpinButton" id="_systemTimeHourSpin">
-																				<property name="visible">True</property>
-																				<property name="can-focus">True</property>
-																				<property name="text" translatable="yes">0</property>
-																				<property name="orientation">vertical</property>
-																				<property name="adjustment">_systemTimeHourSpinAdjustment</property>
-																				<property name="wrap">True</property>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="position">6</property>
-																			</packing>
-																		</child>
-																		<child>
-																			<object class="GtkLabel">
-																				<property name="visible">True</property>
-																				<property name="can-focus">False</property>
-																				<property name="halign">end</property>
-																				<property name="label">:</property>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="padding">5</property>
-																				<property name="position">7</property>
-																			</packing>
-																		</child>
-																		<child>
-																			<object class="GtkSpinButton" id="_systemTimeMinuteSpin">
-																				<property name="visible">True</property>
-																				<property name="can-focus">True</property>
-																				<property name="text" translatable="yes">0</property>
-																				<property name="orientation">vertical</property>
-																				<property name="adjustment">_systemTimeMinuteSpinAdjustment</property>
-																				<property name="wrap">True</property>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="position">8</property>
-																			</packing>
-																		</child>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="padding">5</property>
-																		<property name="position">3</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkCheckButton" id="_vSyncToggle">
-																		<property name="label" translatable="yes">Enable VSync</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">False</property>
-																		<property name="tooltip-text" translatable="yes">Enables or disables Vertical Sync</property>
-																		<property name="halign">start</property>
-																		<property name="margin-top">5</property>
-																		<property name="margin-bottom">5</property>
-																		<property name="draw-indicator">True</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">4</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkCheckButton" id="_ptcToggle">
-																		<property name="label" translatable="yes">Enable PPTC (Profiled Persistent Translation Cache)</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">False</property>
-																		<property name="tooltip-text" translatable="yes">Enables or disables profiled translation cache persistency</property>
-																		<property name="halign">start</property>
-																		<property name="margin-top">5</property>
-																		<property name="margin-bottom">5</property>
-																		<property name="draw-indicator">True</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">6</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkCheckButton" id="_internetToggle">
-																		<property name="label" translatable="yes">Enable guest Internet access</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">False</property>
-																		<property name="tooltip-text" translatable="yes">Enables guest Internet access. If enabled, the application will behave as if the emulated Switch console was connected to the Internet. Note that in some cases, applications may still access the Internet even with this option disabled</property>
-																		<property name="halign">start</property>
-																		<property name="margin-top">5</property>
-																		<property name="margin-bottom">5</property>
-																		<property name="draw-indicator">True</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">7</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkCheckButton" id="_fsicToggle">
-																		<property name="label" translatable="yes">Enable FS Integrity Checks</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">False</property>
-																		<property name="tooltip-text" translatable="yes">Enables integrity checks on Game content files</property>
-																		<property name="halign">start</property>
-																		<property name="margin-top">5</property>
-																		<property name="margin-bottom">5</property>
-																		<property name="draw-indicator">True</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">8</property>
-																	</packing>
-																</child>
-															</object>
-															<packing>
-																<property name="expand">True</property>
-																<property name="fill">True</property>
-																<property name="position">1</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkBox" id="_audioBackendBox">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<child>
-																	<placeholder/>
-																</child>
-																<child>
-																	<object class="GtkLabel">
-																		<property name="visible">True</property>
-																		<property name="can-focus">False</property>
-																		<property name="tooltip-text" translatable="yes">Change Audio Backend</property>
-																		<property name="halign">end</property>
-																		<property name="margin-right">5</property>
-																		<property name="label" translatable="yes">Audio Backend: </property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="padding">5</property>
-																		<property name="position">2</property>
-																	</packing>
-																</child>
-															</object>
-															<packing>
-																<property name="expand">False</property>
-																<property name="fill">True</property>
-																<property name="padding">5</property>
-																<property name="position">2</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkBox" id="_memoryManagerBox">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<child>
-																	<placeholder/>
-																</child>
-																<child>
-																	<object class="GtkLabel">
-																		<property name="visible">True</property>
-																		<property name="can-focus">False</property>
-																		<property name="tooltip-text" translatable="yes">Change how guest memory is mapped and accessed. Greatly affects emulated CPU performance.</property>
-																		<property name="halign">end</property>
-																		<property name="margin-right">5</property>
-																		<property name="label" translatable="yes">Memory Manager Mode: </property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="padding">5</property>
-																		<property name="position">2</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkRadioButton" id="_mmSoftware">
-																		<property name="label" translatable="yes">Software</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">False</property>
-																		<property name="tooltip-text" translatable="yes">Use a software page table for address translation. Highest accuracy but slowest performance.</property>
-																		<property name="halign">start</property>
-																		<property name="margin-top">5</property>
-																		<property name="margin-bottom">5</property>
-																		<property name="draw-indicator">True</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">3</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkRadioButton" id="_mmHost">
-																		<property name="label" translatable="yes">Host (fast)</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">False</property>
-																		<property name="tooltip-text" translatable="yes">Directly map memory in the host address space. Much faster JIT compilation and execution.</property>
-																		<property name="halign">start</property>
-																		<property name="margin-top">5</property>
-																		<property name="margin-bottom">5</property>
-																		<property name="draw-indicator">True</property>
-																		<property name="group">_mmSoftware</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">4</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkRadioButton" id="_mmHostUnsafe">
-																		<property name="label" translatable="yes">Host unchecked (fastest, unsafe)</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">False</property>
-																		<property name="tooltip-text" translatable="yes">Directly map memory, but do not mask the address within the guest address space before access. Faster, but at the cost of safety. The guest application can access memory from anywhere in Ryujinx, so only run programs you trust with this mode.</property>
-																		<property name="halign">start</property>
-																		<property name="margin-top">5</property>
-																		<property name="margin-bottom">5</property>
-																		<property name="draw-indicator">True</property>
-																		<property name="group">_mmSoftware</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">5</property>
-																	</packing>
-																</child>
-															</object>
-															<packing>
-																<property name="expand">False</property>
-																<property name="fill">True</property>
-																<property name="padding">5</property>
-																<property name="position">3</property>
-															</packing>
-														</child>
-													</object>
-													<packing>
-														<property name="expand">False</property>
-														<property name="fill">True</property>
-														<property name="padding">5</property>
-														<property name="position">0</property>
-													</packing>
-												</child>
-												<child>
-													<object class="GtkSeparator">
-														<property name="visible">True</property>
-														<property name="can-focus">False</property>
-														<property name="margin-left">5</property>
-														<property name="margin-right">5</property>
-													</object>
-													<packing>
-														<property name="expand">False</property>
-														<property name="fill">True</property>
-														<property name="padding">5</property>
-														<property name="position">1</property>
-													</packing>
-												</child>
-												<child>
-													<object class="GtkBox" id="CatHacks">
-														<property name="visible">True</property>
-														<property name="can-focus">False</property>
-														<property name="valign">start</property>
-														<property name="margin-left">5</property>
-														<property name="margin-right">5</property>
-														<property name="orientation">vertical</property>
-														<child>
-															<object class="GtkBox">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<child>
-																	<object class="GtkLabel">
-																		<property name="visible">True</property>
-																		<property name="can-focus">False</property>
-																		<property name="halign">start</property>
-																		<property name="margin-bottom">5</property>
-																		<property name="label" translatable="yes">Hacks</property>
-																		<attributes>
-																			<attribute name="weight" value="bold"/>
-																		</attributes>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">0</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkLabel">
-																		<property name="visible">True</property>
-																		<property name="can-focus">False</property>
-																		<property name="halign">start</property>
-																		<property name="margin-bottom">5</property>
-																		<property name="label" translatable="yes"> - These may cause instability</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">1</property>
-																	</packing>
-																</child>
-															</object>
-															<packing>
-																<property name="expand">False</property>
-																<property name="fill">True</property>
-																<property name="position">1</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkBox">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="margin-left">10</property>
-																<property name="margin-right">10</property>
-																<property name="orientation">vertical</property>
-																<child>
-																	<object class="GtkCheckButton" id="_expandRamToggle">
-																		<property name="label" translatable="yes">Expand DRAM size to 6GB</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">False</property>
-																		<property name="tooltip-text" translatable="yes">Expands the amount of memory on the emulated system from 4GB to 6GB</property>
-																		<property name="halign">start</property>
-																		<property name="margin-top">5</property>
-																		<property name="margin-bottom">5</property>
-																		<property name="draw-indicator">True</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">0</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkCheckButton" id="_unsafeMemToggle">
-																		<property name="label" translatable="yes">Allow unsafe memory access</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">False</property>
-																		<property name="tooltip-text" translatable="yes">Allows games and mods to access RAM they may not normally have access to. Required by some homebrew and game mods.</property>
-																		<property name="halign">start</property>
-																		<property name="margin-top">5</property>
-																		<property name="margin-bottom">5</property>
-																		<property name="draw-indicator">True</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">0</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkCheckButton" id="_ignoreToggle">
-																		<property name="label" translatable="yes">Ignore Missing Services</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">False</property>
-																		<property name="tooltip-text" translatable="yes">Enable or disable ignoring missing services</property>
-																		<property name="halign">start</property>
-																		<property name="margin-top">5</property>
-																		<property name="margin-bottom">5</property>
-																		<property name="draw-indicator">True</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">1</property>
-																	</packing>
-																</child>
-															</object>
-															<packing>
-																<property name="expand">True</property>
-																<property name="fill">True</property>
-																<property name="position">2</property>
-															</packing>
-														</child>
-													</object>
-													<packing>
-														<property name="expand">False</property>
-														<property name="fill">True</property>
-														<property name="padding">5</property>
-														<property name="position">4</property>
-													</packing>
-												</child>
-											</object>
-											<packing>
-												<property name="position">2</property>
-											</packing>
-										</child>
-										<child type="tab">
-											<object class="GtkLabel">
-												<property name="visible">True</property>
-												<property name="can-focus">False</property>
-												<property name="halign">end</property>
-												<property name="label" translatable="yes">System</property>
-											</object>
-											<packing>
-												<property name="position">2</property>
-												<property name="tab-fill">False</property>
-											</packing>
-										</child>
-										<child>
-											<object class="GtkBox" id="TabGraphics">
-												<property name="visible">True</property>
-												<property name="can-focus">False</property>
-												<property name="margin-top">5</property>
-												<property name="orientation">vertical</property>
-												<child>
-													<object class="GtkBox" id="CatFeatures">
-														<property name="visible">True</property>
-														<property name="can-focus">False</property>
-														<property name="margin-left">5</property>
-														<property name="margin-right">5</property>
-														<property name="orientation">vertical</property>
-														<child>
-															<object class="GtkLabel">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="halign">start</property>
-																<property name="margin-left">5</property>
-																<property name="margin-right">5</property>
-																<property name="margin-bottom">5</property>
-																<property name="label" translatable="yes">Features</property>
-																<attributes>
-																	<attribute name="weight" value="bold"/>
-																</attributes>
-															</object>
-															<packing>
-																<property name="expand">False</property>
-																<property name="fill">True</property>
-																<property name="position">0</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkBox" id="FeaturesOptions">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="margin-left">10</property>
-																<property name="margin-right">10</property>
-																<property name="orientation">vertical</property>
-																<child>
-																	<object class="GtkBox">
-																		<property name="visible">True</property>
-																		<property name="can-focus">False</property>
-																		<property name="margin-top">5</property>
-																		<property name="margin-bottom">5</property>
-																		<child>
-																			<object class="GtkLabel">
-																				<property name="visible">True</property>
-																				<property name="can-focus">False</property>
-																				<property name="tooltip-text" translatable="yes">Enable Graphics Backend Multithreading</property>
-																				<property name="label" translatable="yes">Graphics Backend Multithreading:</property>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="padding">5</property>
-																				<property name="position">0</property>
-																			</packing>
-																		</child>
-																		<child>
-																			<object class="GtkComboBoxText" id="_galThreading">
-																				<property name="visible">True</property>
-																				<property name="can-focus">False</property>
-																				<property name="tooltip-text" translatable="yes">Executes graphics backend commands on a second thread. Allows runtime multithreading of shader compilation, reduces stuttering, and improves performance on drivers without multithreading support of their own. Slightly varying peak performance on drivers with multithreading. Ryujinx may need to be restarted to correctly disable driver built-in multithreading, or you may need to do it manually to get the best performance.</property>
-																				<property name="active-id">-1</property>
-																				<items>
-																					<item id="Auto" translatable="yes">Auto</item>
-																					<item id="Off" translatable="yes">Off</item>
-																					<item id="On" translatable="yes">On</item>
-																				</items>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="position">1</property>
-																			</packing>
-																		</child>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="padding">5</property>
-																		<property name="position">1</property>
-																	</packing>
-																</child>
-															</object>
-															<packing>
-																<property name="expand">False</property>
-																<property name="fill">True</property>
-																<property name="position">2</property>
-															</packing>
-														</child>
-													</object>
-													<packing>
-														<property name="expand">False</property>
-														<property name="fill">True</property>
-														<property name="padding">5</property>
-														<property name="position">0</property>
-													</packing>
-												</child>
-												<child>
-													<object class="GtkBox" id="CatEnhancements">
-														<property name="visible">True</property>
-														<property name="can-focus">False</property>
-														<property name="margin-left">5</property>
-														<property name="margin-right">5</property>
-														<property name="orientation">vertical</property>
-														<child>
-															<object class="GtkLabel">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="halign">start</property>
-																<property name="margin-left">5</property>
-																<property name="margin-right">5</property>
-																<property name="margin-bottom">5</property>
-																<property name="label" translatable="yes">Enhancements</property>
-																<attributes>
-																	<attribute name="weight" value="bold"/>
-																</attributes>
-															</object>
-															<packing>
-																<property name="expand">False</property>
-																<property name="fill">True</property>
-																<property name="position">0</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkBox" id="EnhancementOptions">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="margin-left">10</property>
-																<property name="margin-right">10</property>
-																<property name="orientation">vertical</property>
-																<child>
-																	<object class="GtkCheckButton" id="_shaderCacheToggle">
-																		<property name="label" translatable="yes">Enable Shader Cache</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">False</property>
-																		<property name="tooltip-text" translatable="yes">Enables or disables Shader Cache</property>
-																		<property name="halign">start</property>
-																		<property name="margin-top">5</property>
-																		<property name="margin-bottom">5</property>
-																		<property name="draw-indicator">True</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">0</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkBox">
-																		<property name="visible">True</property>
-																		<property name="can-focus">False</property>
-																		<property name="margin-top">5</property>
-																		<property name="margin-bottom">5</property>
-																		<child>
-																			<object class="GtkLabel">
-																				<property name="visible">True</property>
-																				<property name="can-focus">False</property>
-																				<property name="tooltip-text" translatable="yes">Resolution Scale applied to applicable render targets.</property>
-																				<property name="label" translatable="yes">Resolution Scale:</property>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="padding">5</property>
-																				<property name="position">0</property>
-																			</packing>
-																		</child>
-																		<child>
-																			<object class="GtkComboBoxText" id="_resScaleCombo">
-																				<property name="visible">True</property>
-																				<property name="can-focus">False</property>
-																				<property name="tooltip-text" translatable="yes">Resolution Scale applied to applicable render targets.</property>
-																				<property name="active-id">1</property>
-																				<items>
-																					<item id="1" translatable="yes">Native (720p/1080p)</item>
-																					<item id="2" translatable="yes">2x (1440p/2160p)</item>
-																					<item id="3" translatable="yes">3x (2160p/3240p)</item>
-																					<item id="4" translatable="yes">4x (2880p/4320p)</item>
-																					<item id="-1" translatable="yes">Custom (not recommended)</item>
-																				</items>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="position">1</property>
-																			</packing>
-																		</child>
-																		<child>
-																			<object class="GtkEntry" id="_resScaleText">
-																				<property name="visible">True</property>
-																				<property name="can-focus">True</property>
-																				<property name="tooltip-text" translatable="yes">Floating point resolution scale, such as 1.5. Non-integral scales are more likely to cause issues or crash.</property>
-																				<property name="valign">center</property>
-																				<property name="caps-lock-warning">False</property>
-																				<property name="placeholder-text">1.0</property>
-																				<property name="input-purpose">number</property>
-																			</object>
-																			<packing>
-																				<property name="expand">True</property>
-																				<property name="fill">True</property>
-																				<property name="position">2</property>
-																			</packing>
-																		</child>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="padding">5</property>
-																		<property name="position">1</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkBox">
-																		<property name="visible">True</property>
-																		<property name="can-focus">False</property>
-																		<property name="margin-top">5</property>
-																		<property name="margin-bottom">5</property>
-																		<child>
-																			<object class="GtkLabel">
-																				<property name="visible">True</property>
-																				<property name="can-focus">False</property>
-																				<property name="tooltip-text" translatable="yes">Level of Anisotropic Filtering (set to Auto to use the value requested by the game)</property>
-																				<property name="label" translatable="yes">Anisotropic Filtering:</property>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="padding">5</property>
-																				<property name="position">0</property>
-																			</packing>
-																		</child>
-																		<child>
-																			<object class="GtkComboBoxText" id="_anisotropy">
-																				<property name="visible">True</property>
-																				<property name="can-focus">False</property>
-																				<property name="tooltip-text" translatable="yes">Level of Anisotropic Filtering (set to Auto to use the value requested by the game)</property>
-																				<property name="active-id">-1</property>
-																				<items>
-																					<item id="-1" translatable="yes">Auto</item>
-																					<item id="2" translatable="yes">2x</item>
-																					<item id="4" translatable="yes">4x</item>
-																					<item id="8" translatable="yes">8x</item>
-																					<item id="16" translatable="yes">16x</item>
-																				</items>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="position">1</property>
-																			</packing>
-																		</child>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="padding">5</property>
-																		<property name="position">1</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkBox">
-																		<property name="visible">True</property>
-																		<property name="can-focus">False</property>
-																		<property name="margin-top">5</property>
-																		<property name="margin-bottom">5</property>
-																		<child>
-																			<object class="GtkLabel">
-																				<property name="visible">True</property>
-																				<property name="can-focus">False</property>
-																				<property name="tooltip-text" translatable="yes">Aspect Ratio applied to the renderer window.</property>
-																				<property name="label" translatable="yes">Aspect Ratio:</property>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="padding">5</property>
-																				<property name="position">0</property>
-																			</packing>
-																		</child>
-																		<child>
-																			<object class="GtkComboBoxText" id="_aspectRatio">
-																				<property name="visible">True</property>
-																				<property name="can-focus">False</property>
-																				<property name="tooltip-text" translatable="yes">Aspect Ratio applied to the renderer window.</property>
-																				<property name="active-id">1</property>
-																				<items>
-																					<item id="0" translatable="yes">4:3</item>
-																					<item id="1" translatable="yes">16:9</item>
-																					<item id="2" translatable="yes">16:10</item>
-																					<item id="3" translatable="yes">21:9</item>
-																					<item id="4" translatable="yes">32:9</item>
-																					<item id="5" translatable="yes">Stretch to Fit Window</item>
-																				</items>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="position">1</property>
-																			</packing>
-																		</child>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="padding">5</property>
-																		<property name="position">3</property>
-																	</packing>
-																</child>
-															</object>
-															<packing>
-																<property name="expand">False</property>
-																<property name="fill">True</property>
-																<property name="position">2</property>
-															</packing>
-														</child>
-													</object>
-													<packing>
-														<property name="expand">False</property>
-														<property name="fill">True</property>
-														<property name="padding">5</property>
-														<property name="position">0</property>
-													</packing>
-												</child>
-												<child>
-													<object class="GtkSeparator">
-														<property name="visible">True</property>
-														<property name="can-focus">False</property>
-													</object>
-													<packing>
-														<property name="expand">False</property>
-														<property name="fill">True</property>
-														<property name="padding">5</property>
-														<property name="position">1</property>
-													</packing>
-												</child>
-												<child>
-													<object class="GtkBox" id="CatDev">
-														<property name="visible">True</property>
-														<property name="can-focus">False</property>
-														<property name="margin-left">5</property>
-														<property name="margin-right">5</property>
-														<property name="orientation">vertical</property>
-														<child>
-															<object class="GtkLabel">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="halign">start</property>
-																<property name="margin-left">5</property>
-																<property name="margin-right">5</property>
-																<property name="margin-bottom">5</property>
-																<property name="label" translatable="yes">Developer Options</property>
-																<attributes>
-																	<attribute name="weight" value="bold"/>
-																</attributes>
-															</object>
-															<packing>
-																<property name="expand">False</property>
-																<property name="fill">True</property>
-																<property name="position">0</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkBox" id="DevOptions">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="margin-left">10</property>
-																<property name="margin-right">10</property>
-																<property name="orientation">vertical</property>
-																<child>
-																	<object class="GtkBox">
-																		<property name="visible">True</property>
-																		<property name="can-focus">False</property>
-																		<property name="margin-top">5</property>
-																		<property name="margin-bottom">5</property>
-																		<child>
-																			<object class="GtkLabel">
-																				<property name="visible">True</property>
-																				<property name="can-focus">False</property>
-																				<property name="tooltip-text" translatable="yes">Graphics Shaders Dump Path</property>
-																				<property name="label" translatable="yes">Graphics Shaders Dump Path:</property>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="padding">5</property>
-																				<property name="position">0</property>
-																			</packing>
-																		</child>
-																		<child>
-																			<object class="GtkEntry" id="_graphicsShadersDumpPath">
-																				<property name="visible">True</property>
-																				<property name="can-focus">True</property>
-																				<property name="tooltip-text" translatable="yes">Graphics Shaders Dump Path</property>
-																				<property name="valign">center</property>
-																				<property name="caps-lock-warning">False</property>
-																			</object>
-																			<packing>
-																				<property name="expand">True</property>
-																				<property name="fill">True</property>
-																				<property name="position">1</property>
-																			</packing>
-																		</child>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="padding">5</property>
-																		<property name="position">0</property>
-																	</packing>
-																</child>
-															</object>
-															<packing>
-																<property name="expand">False</property>
-																<property name="fill">True</property>
-																<property name="position">1</property>
-															</packing>
-														</child>
-													</object>
-													<packing>
-														<property name="expand">False</property>
-														<property name="fill">True</property>
-														<property name="padding">5</property>
-														<property name="position">4</property>
-													</packing>
-												</child>
-											</object>
-											<packing>
-												<property name="position">3</property>
-											</packing>
-										</child>
-										<child type="tab">
-											<object class="GtkLabel">
-												<property name="visible">True</property>
-												<property name="can-focus">False</property>
-												<property name="label" translatable="yes">Graphics</property>
-											</object>
-											<packing>
-												<property name="position">3</property>
-												<property name="tab-fill">False</property>
-											</packing>
-										</child>
-										<child>
-											<object class="GtkBox" id="TabLogging">
-												<property name="visible">True</property>
-												<property name="can-focus">False</property>
-												<property name="margin-left">5</property>
-												<property name="margin-right">10</property>
-												<property name="margin-top">5</property>
-												<property name="orientation">vertical</property>
-												<child>
-													<object class="GtkBox" id="CatLogging">
-														<property name="visible">True</property>
-														<property name="can-focus">False</property>
-														<property name="margin-left">5</property>
-														<property name="margin-right">5</property>
-														<property name="orientation">vertical</property>
-														<child>
-															<object class="GtkLabel">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="halign">start</property>
-																<property name="margin-bottom">5</property>
-																<property name="label" translatable="yes">Logging</property>
-																<attributes>
-																	<attribute name="weight" value="bold"/>
-																</attributes>
-															</object>
-															<packing>
-																<property name="expand">False</property>
-																<property name="fill">True</property>
-																<property name="position">0</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkBox" id="LogggingOptions">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="valign">start</property>
-																<property name="margin-left">10</property>
-																<property name="margin-right">10</property>
-																<property name="orientation">vertical</property>
-																<child>
-																	<object class="GtkCheckButton" id="_fileLogToggle">
-																		<property name="label" translatable="yes">Enable Logging to File</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">False</property>
-																		<property name="tooltip-text" translatable="yes">Enables or disables logging to a file on disk</property>
-																		<property name="halign">start</property>
-																		<property name="margin-top">5</property>
-																		<property name="margin-bottom">5</property>
-																		<property name="draw-indicator">True</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">0</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkCheckButton" id="_stubLogToggle">
-																		<property name="label" translatable="yes">Enable Stub Logs</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">False</property>
-																		<property name="tooltip-text" translatable="yes">Enables printing stub log messages</property>
-																		<property name="halign">start</property>
-																		<property name="margin-top">5</property>
-																		<property name="margin-bottom">5</property>
-																		<property name="draw-indicator">True</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">3</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkCheckButton" id="_infoLogToggle">
-																		<property name="label" translatable="yes">Enable Info Logs</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">False</property>
-																		<property name="tooltip-text" translatable="yes">Enables printing info log messages</property>
-																		<property name="halign">start</property>
-																		<property name="margin-top">5</property>
-																		<property name="margin-bottom">5</property>
-																		<property name="draw-indicator">True</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">4</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkCheckButton" id="_warningLogToggle">
-																		<property name="label" translatable="yes">Enable Warning Logs</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">False</property>
-																		<property name="tooltip-text" translatable="yes">Enables printing warning log messages</property>
-																		<property name="halign">start</property>
-																		<property name="margin-top">5</property>
-																		<property name="margin-bottom">5</property>
-																		<property name="draw-indicator">True</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">5</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkCheckButton" id="_errorLogToggle">
-																		<property name="label" translatable="yes">Enable Error Logs</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">False</property>
-																		<property name="tooltip-text" translatable="yes">Enables printing error log messages</property>
-																		<property name="halign">start</property>
-																		<property name="margin-top">5</property>
-																		<property name="margin-bottom">5</property>
-																		<property name="draw-indicator">True</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">6</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkCheckButton" id="_guestLogToggle">
-																		<property name="label" translatable="yes">Enable Guest Logs</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">False</property>
-																		<property name="tooltip-text" translatable="yes">Enables printing guest log messages</property>
-																		<property name="halign">start</property>
-																		<property name="margin-top">5</property>
-																		<property name="margin-bottom">5</property>
-																		<property name="draw-indicator">True</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">7</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkCheckButton" id="_fsAccessLogToggle">
-																		<property name="label" translatable="yes">Enable Fs Access Logs</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">False</property>
-																		<property name="tooltip-text" translatable="yes">Enables printing fs access log messages</property>
-																		<property name="halign">start</property>
-																		<property name="margin-top">5</property>
-																		<property name="margin-bottom">5</property>
-																		<property name="draw-indicator">True</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">8</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkBox">
-																		<property name="visible">True</property>
-																		<property name="can-focus">False</property>
-																		<child>
-																			<object class="GtkLabel">
-																				<property name="visible">True</property>
-																				<property name="can-focus">False</property>
-																				<property name="tooltip-text" translatable="yes">Enables FS access log output to the console. Possible modes are 0-3</property>
-																				<property name="label" translatable="yes">Fs Global Access Log Mode:</property>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="padding">5</property>
-																				<property name="position">0</property>
-																			</packing>
-																		</child>
-																		<child>
-																			<object class="GtkSpinButton">
-																				<property name="visible">True</property>
-																				<property name="can-focus">True</property>
-																				<property name="tooltip-text" translatable="yes">Enables FS access log output to the console. Possible modes are 0-3</property>
-																				<property name="text" translatable="yes">0</property>
-																				<property name="adjustment">_fsLogSpinAdjustment</property>
-																			</object>
-																			<packing>
-																				<property name="expand">True</property>
-																				<property name="fill">True</property>
-																				<property name="position">1</property>
-																			</packing>
-																		</child>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="padding">5</property>
-																		<property name="position">9</property>
-																	</packing>
-																</child>
-															</object>
-															<packing>
-																<property name="expand">True</property>
-																<property name="fill">True</property>
-																<property name="position">1</property>
-															</packing>
-														</child>
-													</object>
-													<packing>
-														<property name="expand">False</property>
-														<property name="fill">True</property>
-														<property name="padding">5</property>
-														<property name="position">0</property>
-													</packing>
-												</child>
-												<child>
-													<object class="GtkBox" id="CatDevLogging">
-														<property name="visible">True</property>
-														<property name="can-focus">False</property>
-														<property name="margin-left">5</property>
-														<property name="margin-right">5</property>
-														<property name="margin-top">10</property>
-														<property name="orientation">vertical</property>
-														<child>
-															<object class="GtkLabel">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="tooltip-text" translatable="yes">Use with care</property>
-																<property name="halign">start</property>
-																<property name="margin-bottom">5</property>
-																<property name="label" translatable="yes">Developer Options (WARNING: Will reduce performance)</property>
-																<attributes>
-																	<attribute name="weight" value="bold"/>
-																</attributes>
-															</object>
-															<packing>
-																<property name="expand">False</property>
-																<property name="fill">True</property>
-																<property name="position">0</property>
-															</packing>
-														</child>
-														<child>
-															<object class="GtkBox" id="DevLoggingOptions">
-																<property name="visible">True</property>
-																<property name="can-focus">False</property>
-																<property name="valign">start</property>
-																<property name="margin-left">10</property>
-																<property name="margin-right">10</property>
-																<property name="orientation">vertical</property>
-																<child>
-																	<object class="GtkBox">
-																		<property name="visible">True</property>
-																		<property name="can-focus">False</property>
-																		<property name="margin-top">5</property>
-																		<child>
-																			<object class="GtkLabel">
-																				<property name="visible">True</property>
-																				<property name="can-focus">False</property>
-																				<property name="tooltip-text" translatable="yes">Requires appropriate log levels enabled.</property>
-																				<property name="label" translatable="yes">OpenGL Log Level</property>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="padding">5</property>
-																				<property name="position">22</property>
-																			</packing>
-																		</child>
-																		<child>
-																			<object class="GtkComboBoxText" id="_graphicsDebugLevel">
-																				<property name="visible">True</property>
-																				<property name="can-focus">False</property>
-																				<property name="tooltip-text" translatable="yes">Requires appropriate log levels enabled.</property>
-																				<property name="margin-left">5</property>
-																			</object>
-																			<packing>
-																				<property name="expand">False</property>
-																				<property name="fill">True</property>
-																				<property name="position">22</property>
-																			</packing>
-																		</child>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">1</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkCheckButton" id="_debugLogToggle">
-																		<property name="label" translatable="yes">Enable Debug Logs</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">False</property>
-																		<property name="tooltip-text" translatable="yes">Enables printing debug log messages</property>
-																		<property name="halign">start</property>
-																		<property name="margin-top">5</property>
-																		<property name="margin-bottom">5</property>
-																		<property name="draw-indicator">True</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">21</property>
-																	</packing>
-																</child>
-																<child>
-																	<object class="GtkCheckButton" id="_traceLogToggle">
-																		<property name="label" translatable="yes">Enable Trace Logs</property>
-																		<property name="visible">True</property>
-																		<property name="can-focus">True</property>
-																		<property name="receives-default">False</property>
-																		<property name="tooltip-text" translatable="yes">Enables printing trace log messages</property>
-																		<property name="halign">start</property>
-																		<property name="margin-top">5</property>
-																		<property name="margin-bottom">5</property>
-																		<property name="draw-indicator">True</property>
-																	</object>
-																	<packing>
-																		<property name="expand">False</property>
-																		<property name="fill">True</property>
-																		<property name="position">22</property>
-																	</packing>
-																</child>
-															</object>
-															<packing>
-																<property name="expand">False</property>
-																<property name="fill">True</property>
-																<property name="position">1</property>
-															</packing>
-														</child>
-													</object>
-													<packing>
-														<property name="expand">False</property>
-														<property name="fill">True</property>
-														<property name="padding">5</property>
-														<property name="position">22</property>
-													</packing>
-												</child>
-											</object>
-											<packing>
-												<property name="position">4</property>
-											</packing>
-										</child>
-										<child type="tab">
-											<object class="GtkLabel">
-												<property name="visible">True</property>
-												<property name="can-focus">False</property>
-												<property name="label" translatable="yes">Logging</property>
-											</object>
-											<packing>
-												<property name="position">4</property>
-												<property name="tab-fill">False</property>
-											</packing>
-										</child>
-									</object>
-								</child>
-							</object>
-						</child>
-					</object>
-					<packing>
-						<property name="expand">True</property>
-						<property name="fill">True</property>
-						<property name="position">0</property>
-					</packing>
-				</child>
-				<child>
-					<object class="GtkButtonBox" id="_buttonBox">
-						<property name="visible">True</property>
-						<property name="can-focus">False</property>
-						<property name="margin-right">5</property>
-						<property name="margin-top">3</property>
-						<property name="margin-bottom">3</property>
-						<property name="spacing">5</property>
-						<property name="layout-style">end</property>
-						<child>
-							<object class="GtkToggleButton" id="SaveToggle">
-								<property name="label" translatable="yes">Save</property>
-								<property name="visible">True</property>
-								<property name="can-focus">True</property>
-								<property name="receives-default">True</property>
-								<signal name="toggled" handler="SaveToggle_Activated" swapped="no"/>
-							</object>
-							<packing>
-								<property name="expand">False</property>
-								<property name="fill">False</property>
-								<property name="position">0</property>
-							</packing>
-						</child>
-						<child>
-							<object class="GtkToggleButton" id="CloseToggle">
-								<property name="label" translatable="yes">Close</property>
-								<property name="visible">True</property>
-								<property name="can-focus">True</property>
-								<property name="receives-default">True</property>
-								<signal name="toggled" handler="CloseToggle_Activated" swapped="no"/>
-							</object>
-							<packing>
-								<property name="expand">False</property>
-								<property name="fill">False</property>
-								<property name="position">1</property>
-							</packing>
-						</child>
-						<child>
-							<object class="GtkButton">
-								<property name="label" translatable="yes">Apply</property>
-								<property name="visible">True</property>
-								<property name="can-focus">True</property>
-								<property name="receives-default">True</property>
-								<signal name="clicked" handler="ApplyToggle_Activated" swapped="no"/>
-							</object>
-							<packing>
-								<property name="expand">True</property>
-								<property name="fill">True</property>
-								<property name="position">2</property>
-							</packing>
-						</child>
-					</object>
-					<packing>
-						<property name="expand">False</property>
-						<property name="fill">False</property>
-						<property name="position">1</property>
-					</packing>
-				</child>
-			</object>
-		</child>
-	</object>
+  <requires lib="gtk+" version="3.20"/>
+  <object class="GtkAdjustment" id="_fsLogSpinAdjustment">
+    <property name="upper">3</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="_systemTimeDaySpinAdjustment">
+    <property name="lower">1</property>
+    <property name="upper">31</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">5</property>
+  </object>
+  <object class="GtkAdjustment" id="_systemTimeHourSpinAdjustment">
+    <property name="upper">23</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">5</property>
+  </object>
+  <object class="GtkAdjustment" id="_systemTimeMinuteSpinAdjustment">
+    <property name="upper">59</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">5</property>
+  </object>
+  <object class="GtkAdjustment" id="_systemTimeMonthSpinAdjustment">
+    <property name="lower">1</property>
+    <property name="upper">12</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">5</property>
+  </object>
+  <object class="GtkAdjustment" id="_systemTimeYearSpinAdjustment">
+    <property name="lower">2000</property>
+    <property name="upper">2060</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
+  </object>
+  <object class="GtkEntryCompletion" id="_systemTimeZoneCompletion">
+    <property name="minimum-key-length">0</property>
+    <property name="inline-completion">True</property>
+    <property name="inline-selection">True</property>
+  </object>
+  <object class="GtkWindow" id="_settingsWin">
+    <property name="can-focus">False</property>
+    <property name="title" translatable="yes">Ryujinx - Settings</property>
+    <property name="modal">True</property>
+    <property name="window-position">center</property>
+    <property name="default-width">650</property>
+    <property name="default-height">650</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkScrolledWindow">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="shadow-type">in</property>
+            <child>
+              <object class="GtkViewport">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <child>
+                  <object class="GtkNotebook">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <child>
+                      <object class="GtkBox" id="TabGeneral">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-left">5</property>
+                        <property name="margin-right">10</property>
+                        <property name="margin-top">5</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <object class="GtkBox" id="CatGeneral">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="margin-left">5</property>
+                            <property name="margin-right">5</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="halign">start</property>
+                                <property name="margin-bottom">5</property>
+                                <property name="label" translatable="yes">General</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox" id="General">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="margin-left">10</property>
+                                <property name="margin-right">10</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkCheckButton" id="_discordToggle">
+                                    <property name="label" translatable="yes">Enable Discord Rich Presence</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Enables or disables Discord Rich Presence</property>
+                                    <property name="halign">start</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">5</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="_checkUpdatesToggle">
+                                    <property name="label" translatable="yes">Check for Updates on Launch</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">5</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="_showConfirmExitToggle">
+                                    <property name="label" translatable="yes">Show "Confirm Exit" Dialog</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">5</property>
+                                    <property name="position">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="_hideCursorOnIdleToggle">
+                                    <property name="label" translatable="yes">Hide Cursor On Idle</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">5</property>
+                                    <property name="position">3</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="padding">5</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSeparator">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="margin-left">5</property>
+                            <property name="margin-right">5</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="padding">5</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="CatGameDir">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="margin-left">5</property>
+                            <property name="margin-right">5</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="halign">start</property>
+                                <property name="margin-bottom">5</property>
+                                <property name="label" translatable="yes">Game Directories</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="margin-left">10</property>
+                                <property name="margin-right">10</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkScrolledWindow">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="margin-bottom">10</property>
+                                    <property name="shadow-type">in</property>
+                                    <child>
+                                      <object class="GtkTreeView" id="_gameDirsBox">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="headers-visible">False</property>
+                                        <property name="headers-clickable">False</property>
+                                        <child internal-child="selection">
+                                          <object class="GtkTreeSelection"/>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <style>
+                                      <class name="GameDir"/>
+                                    </style>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <child>
+                                      <object class="GtkEntry" id="_addGameDirBox">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="tooltip-text" translatable="yes">Enter a game directroy to add to the list</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkToggleButton" id="_addDir">
+                                        <property name="label" translatable="yes">Add</property>
+                                        <property name="width-request">80</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">True</property>
+                                        <property name="tooltip-text" translatable="yes"> Add a game directory to the list</property>
+                                        <property name="margin-left">5</property>
+                                        <signal name="toggled" handler="AddDir_Pressed" swapped="no"/>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkToggleButton" id="_removeDir">
+                                        <property name="label" translatable="yes">Remove</property>
+                                        <property name="width-request">80</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">True</property>
+                                        <property name="tooltip-text" translatable="yes">Remove selected game directory</property>
+                                        <property name="margin-left">5</property>
+                                        <signal name="toggled" handler="RemoveDir_Pressed" swapped="no"/>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">3</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="padding">5</property>
+                            <property name="position">4</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSeparator">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="margin-left">5</property>
+                            <property name="margin-right">5</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="padding">5</property>
+                            <property name="position">5</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="CatThemes">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="margin-left">5</property>
+                            <property name="margin-right">5</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="halign">start</property>
+                                <property name="margin-bottom">5</property>
+                                <property name="label" translatable="yes">Themes</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="margin-left">10</property>
+                                <property name="margin-right">10</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkCheckButton" id="_custThemeToggle">
+                                    <property name="label" translatable="yes">Use Custom Theme</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Enable or disable custom themes in the GUI</property>
+                                    <property name="halign">start</property>
+                                    <property name="draw-indicator">True</property>
+                                    <signal name="toggled" handler="CustThemeToggle_Activated" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">5</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <child>
+                                      <object class="GtkLabel" id="_custThemePathLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Path to custom GUI theme</property>
+                                        <property name="label" translatable="yes">Custom Theme Path:</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="padding">5</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkEntry" id="_custThemePath">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="tooltip-text" translatable="yes">Path to custom GUI theme</property>
+                                        <property name="valign">center</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkToggleButton" id="_browseThemePath">
+                                        <property name="label" translatable="yes">Browse...</property>
+                                        <property name="width-request">80</property>
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">True</property>
+                                        <property name="tooltip-text" translatable="yes">Browse for a custom GUI theme</property>
+                                        <property name="margin-left">5</property>
+                                        <signal name="toggled" handler="BrowseThemeDir_Pressed" swapped="no"/>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">10</property>
+                                    <property name="position">2</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="padding">5</property>
+                            <property name="position">6</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                    <child type="tab">
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">General</property>
+                      </object>
+                      <packing>
+                        <property name="tab-fill">False</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="TabInput">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-left">5</property>
+                        <property name="margin-right">10</property>
+                        <property name="margin-top">5</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="margin-top">5</property>
+                            <property name="margin-bottom">5</property>
+                            <child>
+                              <object class="GtkCheckButton" id="_dockedModeToggle">
+                                <property name="label" translatable="yes">Enable Docked Mode</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="tooltip-text" translatable="yes">Enable or disable Docked Mode</property>
+                                <property name="draw-indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="padding">10</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="_directKeyboardAccess">
+                                <property name="label" translatable="yes">Direct Keyboard Access</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="tooltip-text" translatable="yes">Enable or disable "direct keyboard access (HID) support" (Provides games access to your keyboard as a text entry device)</property>
+                                <property name="draw-indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="padding">10</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="_directMouseAccess">
+                                <property name="label" translatable="yes">Direct Mouse Access</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="tooltip-text" translatable="yes">Enable or disable "direct mouse access (HID) support" (Provides games access to your mouse as a pointing device)</property>
+                                <property name="draw-indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
+                                <property name="padding">10</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="padding">5</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSeparator">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <!-- n-columns=5 n-rows=5 -->
+                          <object class="GtkGrid" id="ControllerGrid">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="halign">center</property>
+                            <property name="valign">center</property>
+                            <property name="column-spacing">20</property>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="margin-top">20</property>
+                                    <property name="margin-bottom">20</property>
+                                    <property name="label" translatable="yes">Player 1</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkToggleButton" id="_configureController1">
+                                    <property name="label" translatable="yes">Configure</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">True</property>
+                                    <property name="margin-left">20</property>
+                                    <property name="margin-right">20</property>
+                                    <property name="margin-top">20</property>
+                                    <property name="margin-bottom">20</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="margin-top">20</property>
+                                    <property name="margin-bottom">20</property>
+                                    <property name="label" translatable="yes">Player 3</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkToggleButton" id="_configureController3">
+                                    <property name="label" translatable="yes">Configure</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">True</property>
+                                    <property name="margin-left">20</property>
+                                    <property name="margin-right">20</property>
+                                    <property name="margin-top">20</property>
+                                    <property name="margin-bottom">20</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left-attach">4</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="margin-top">20</property>
+                                    <property name="margin-bottom">20</property>
+                                    <property name="label" translatable="yes">Player 2</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkToggleButton" id="_configureController2">
+                                    <property name="label" translatable="yes">Configure</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">True</property>
+                                    <property name="margin-left">20</property>
+                                    <property name="margin-right">20</property>
+                                    <property name="margin-top">20</property>
+                                    <property name="margin-bottom">20</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left-attach">2</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="margin-top">20</property>
+                                    <property name="margin-bottom">20</property>
+                                    <property name="label" translatable="yes">Handheld</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkToggleButton" id="_configureControllerH">
+                                    <property name="label" translatable="yes">Configure</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">True</property>
+                                    <property name="margin-left">20</property>
+                                    <property name="margin-right">20</property>
+                                    <property name="margin-top">20</property>
+                                    <property name="margin-bottom">20</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left-attach">4</property>
+                                <property name="top-attach">4</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="margin-top">20</property>
+                                    <property name="margin-bottom">20</property>
+                                    <property name="label" translatable="yes">Player 6</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkToggleButton" id="_configureController6">
+                                    <property name="label" translatable="yes">Configure</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">True</property>
+                                    <property name="margin-left">20</property>
+                                    <property name="margin-right">20</property>
+                                    <property name="margin-top">20</property>
+                                    <property name="margin-bottom">20</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left-attach">4</property>
+                                <property name="top-attach">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="margin-top">20</property>
+                                    <property name="margin-bottom">20</property>
+                                    <property name="label" translatable="yes">Player 5</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkToggleButton" id="_configureController5">
+                                    <property name="label" translatable="yes">Configure</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">True</property>
+                                    <property name="margin-left">20</property>
+                                    <property name="margin-right">20</property>
+                                    <property name="margin-top">20</property>
+                                    <property name="margin-bottom">20</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left-attach">2</property>
+                                <property name="top-attach">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="margin-top">20</property>
+                                    <property name="margin-bottom">20</property>
+                                    <property name="label" translatable="yes">Player 7</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkToggleButton" id="_configureController7">
+                                    <property name="label" translatable="yes">Configure</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">True</property>
+                                    <property name="margin-left">20</property>
+                                    <property name="margin-right">20</property>
+                                    <property name="margin-top">20</property>
+                                    <property name="margin-bottom">20</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">4</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="margin-top">20</property>
+                                    <property name="margin-bottom">20</property>
+                                    <property name="label" translatable="yes">Player 4</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkToggleButton" id="_configureController4">
+                                    <property name="label" translatable="yes">Configure</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">True</property>
+                                    <property name="margin-left">20</property>
+                                    <property name="margin-right">20</property>
+                                    <property name="margin-top">20</property>
+                                    <property name="margin-bottom">20</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="margin-top">20</property>
+                                    <property name="margin-bottom">20</property>
+                                    <property name="label" translatable="yes">Player 8</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkToggleButton" id="_configureController8">
+                                    <property name="label" translatable="yes">Configure</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">True</property>
+                                    <property name="margin-left">20</property>
+                                    <property name="margin-right">20</property>
+                                    <property name="margin-top">20</property>
+                                    <property name="margin-bottom">20</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left-attach">2</property>
+                                <property name="top-attach">4</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSeparator">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">1</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSeparator">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">3</property>
+                                <property name="top-attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSeparator">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">3</property>
+                                <property name="top-attach">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSeparator">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">3</property>
+                                <property name="top-attach">4</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSeparator">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">1</property>
+                                <property name="top-attach">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSeparator">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">1</property>
+                                <property name="top-attach">4</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSeparator">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">1</property>
+                                <property name="top-attach">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSeparator">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">1</property>
+                                <property name="top-attach">3</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSeparator">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">3</property>
+                                <property name="top-attach">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSeparator">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">3</property>
+                                <property name="top-attach">3</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSeparator">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSeparator">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">2</property>
+                                <property name="top-attach">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSeparator">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">4</property>
+                                <property name="top-attach">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSeparator">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">3</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSeparator">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">2</property>
+                                <property name="top-attach">3</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkSeparator">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                              </object>
+                              <packing>
+                                <property name="left-attach">4</property>
+                                <property name="top-attach">3</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSeparator">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">3</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child type="tab">
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Input</property>
+                      </object>
+                      <packing>
+                        <property name="position">1</property>
+                        <property name="tab-fill">False</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="TabSystem">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-left">5</property>
+                        <property name="margin-right">10</property>
+                        <property name="margin-top">5</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <object class="GtkBox" id="CatCore">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="valign">start</property>
+                            <property name="margin-left">5</property>
+                            <property name="margin-right">5</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="halign">start</property>
+                                <property name="margin-bottom">5</property>
+                                <property name="label" translatable="yes">Core</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="margin-left">10</property>
+                                <property name="margin-right">10</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkBox" id="RegionBox">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Change System Region</property>
+                                        <property name="halign">end</property>
+                                        <property name="label" translatable="yes">System Region:</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="padding">5</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBoxText" id="_systemRegionSelect">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Change System Region</property>
+                                        <property name="margin-left">5</property>
+                                        <items>
+                                          <item id="Japan" translatable="yes">Japan</item>
+                                          <item id="USA" translatable="yes">USA</item>
+                                          <item id="Europe" translatable="yes">Europe</item>
+                                          <item id="Australia" translatable="yes">Australia</item>
+                                          <item id="China" translatable="yes">China</item>
+                                          <item id="Korea" translatable="yes">Korea</item>
+                                          <item id="Taiwan" translatable="yes">Taiwan</item>
+                                        </items>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">3</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">5</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox" id="LanguageBox">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Change System Language</property>
+                                        <property name="halign">end</property>
+                                        <property name="label" translatable="yes">System Language:</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="padding">5</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBoxText" id="_systemLanguageSelect">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Change System Language</property>
+                                        <items>
+                                          <item id="AmericanEnglish" translatable="yes">American English</item>
+                                          <item id="BritishEnglish" translatable="yes">British English</item>
+                                          <item id="CanadianFrench" translatable="yes">Canadian French</item>
+                                          <item id="Chinese" translatable="yes">Chinese</item>
+                                          <item id="Dutch" translatable="yes">Dutch</item>
+                                          <item id="French" translatable="yes">French</item>
+                                          <item id="German" translatable="yes">German</item>
+                                          <item id="Italian" translatable="yes">Italian</item>
+                                          <item id="Japanese" translatable="yes">Japanese</item>
+                                          <item id="Korean" translatable="yes">Korean</item>
+                                          <item id="LatinAmericanSpanish" translatable="yes">Latin American Spanish</item>
+                                          <item id="Portuguese" translatable="yes">Portuguese</item>
+                                          <item id="Russian" translatable="yes">Russian</item>
+                                          <item id="SimplifiedChinese" translatable="yes">Simplified Chinese</item>
+                                          <item id="Spanish" translatable="yes">Spanish</item>
+                                          <item id="Taiwanese" translatable="yes">Taiwanese</item>
+                                          <item id="TraditionalChinese" translatable="yes">Traditional Chinese</item>
+                                          <item id="BrazilianPortuguese" translatable="yes">Brazilian Portuguese</item>
+                                        </items>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">5</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox" id="TimeZoneBox">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Change System TimeZone</property>
+                                        <property name="halign">end</property>
+                                        <property name="label" translatable="yes">System TimeZone:</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="padding">5</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkEntry" id="_systemTimeZoneEntry">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="tooltip-text" translatable="yes">Change System TimeZone</property>
+                                        <property name="margin-left">5</property>
+                                        <property name="completion">_systemTimeZoneCompletion</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">5</property>
+                                    <property name="position">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox" id="TimeBox">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Change System Time</property>
+                                        <property name="halign">end</property>
+                                        <property name="label" translatable="yes">System Time:</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="padding">5</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="_systemTimeYearSpin">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="text" translatable="yes">2000</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="adjustment">_systemTimeYearSpinAdjustment</property>
+                                        <property name="wrap">True</property>
+                                        <property name="value">2000</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">end</property>
+                                        <property name="label">-</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="padding">5</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="_systemTimeMonthSpin">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="text" translatable="yes">1</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="adjustment">_systemTimeMonthSpinAdjustment</property>
+                                        <property name="wrap">True</property>
+                                        <property name="value">1</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">3</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">end</property>
+                                        <property name="label">-</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="padding">5</property>
+                                        <property name="position">4</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="_systemTimeDaySpin">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="text" translatable="yes">1</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="adjustment">_systemTimeDaySpinAdjustment</property>
+                                        <property name="wrap">True</property>
+                                        <property name="value">1</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">5</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="_systemTimeHourSpin">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="text" translatable="yes">0</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="adjustment">_systemTimeHourSpinAdjustment</property>
+                                        <property name="wrap">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">6</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="halign">end</property>
+                                        <property name="label">:</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="padding">5</property>
+                                        <property name="position">7</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="_systemTimeMinuteSpin">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="text" translatable="yes">0</property>
+                                        <property name="orientation">vertical</property>
+                                        <property name="adjustment">_systemTimeMinuteSpinAdjustment</property>
+                                        <property name="wrap">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">8</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">5</property>
+                                    <property name="position">3</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="_vSyncToggle">
+                                    <property name="label" translatable="yes">Enable VSync</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Enables or disables Vertical Sync</property>
+                                    <property name="halign">start</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">4</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="_ptcToggle">
+                                    <property name="label" translatable="yes">Enable PPTC (Profiled Persistent Translation Cache)</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Enables or disables profiled translation cache persistency</property>
+                                    <property name="halign">start</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">6</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="_internetToggle">
+                                    <property name="label" translatable="yes">Enable guest Internet access</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Enables guest Internet access. If enabled, the application will behave as if the emulated Switch console was connected to the Internet. Note that in some cases, applications may still access the Internet even with this option disabled</property>
+                                    <property name="halign">start</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">7</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="_fsicToggle">
+                                    <property name="label" translatable="yes">Enable FS Integrity Checks</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Enables integrity checks on Game content files</property>
+                                    <property name="halign">start</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">8</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox" id="_audioBackendBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="tooltip-text" translatable="yes">Change Audio Backend</property>
+                                    <property name="halign">end</property>
+                                    <property name="margin-right">5</property>
+                                    <property name="label" translatable="yes">Audio Backend: </property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">5</property>
+                                    <property name="position">2</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="padding">5</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox" id="_memoryManagerBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <child>
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="tooltip-text" translatable="yes">Change how guest memory is mapped and accessed. Greatly affects emulated CPU performance.</property>
+                                    <property name="halign">end</property>
+                                    <property name="margin-right">5</property>
+                                    <property name="label" translatable="yes">Memory Manager Mode: </property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">5</property>
+                                    <property name="position">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkRadioButton" id="_mmSoftware">
+                                    <property name="label" translatable="yes">Software</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Use a software page table for address translation. Highest accuracy but slowest performance.</property>
+                                    <property name="halign">start</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">3</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkRadioButton" id="_mmHost">
+                                    <property name="label" translatable="yes">Host (fast)</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Directly map memory in the host address space. Much faster JIT compilation and execution.</property>
+                                    <property name="halign">start</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="draw-indicator">True</property>
+                                    <property name="group">_mmSoftware</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">4</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkRadioButton" id="_mmHostUnsafe">
+                                    <property name="label" translatable="yes">Host unchecked (fastest, unsafe)</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Directly map memory, but do not mask the address within the guest address space before access. Faster, but at the cost of safety. The guest application can access memory from anywhere in Ryujinx, so only run programs you trust with this mode.</property>
+                                    <property name="halign">start</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="draw-indicator">True</property>
+                                    <property name="group">_mmSoftware</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">5</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="padding">5</property>
+                                <property name="position">3</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="padding">5</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSeparator">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="margin-left">5</property>
+                            <property name="margin-right">5</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="padding">5</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="CatHacks">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="valign">start</property>
+                            <property name="margin-left">5</property>
+                            <property name="margin-right">5</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="label" translatable="yes">Hacks</property>
+                                    <attributes>
+                                      <attribute name="weight" value="bold"/>
+                                    </attributes>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="label" translatable="yes"> - These may cause instability</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="margin-left">10</property>
+                                <property name="margin-right">10</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkCheckButton" id="_expandRamToggle">
+                                    <property name="label" translatable="yes">Expand DRAM size to 6GB</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Expands the amount of memory on the emulated system from 4GB to 6GB</property>
+                                    <property name="halign">start</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="_allowJitCodeMemToggle">
+                                    <property name="label" translatable="yes">Allow JIT kernel memory access</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Allows mods to access areas of memory they normally shouldn't. Don't enable this setting unless a mod is crashing because it needs it.</property>
+                                    <property name="halign">start</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="_ignoreToggle">
+                                    <property name="label" translatable="yes">Ignore Missing Services</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Enable or disable ignoring missing services</property>
+                                    <property name="halign">start</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="padding">5</property>
+                            <property name="position">4</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                    <child type="tab">
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">end</property>
+                        <property name="label" translatable="yes">System</property>
+                      </object>
+                      <packing>
+                        <property name="position">2</property>
+                        <property name="tab-fill">False</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="TabGraphics">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-top">5</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <object class="GtkBox" id="CatFeatures">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="margin-left">5</property>
+                            <property name="margin-right">5</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="halign">start</property>
+                                <property name="margin-left">5</property>
+                                <property name="margin-right">5</property>
+                                <property name="margin-bottom">5</property>
+                                <property name="label" translatable="yes">Features</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox" id="FeaturesOptions">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="margin-left">10</property>
+                                <property name="margin-right">10</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Enable Graphics Backend Multithreading</property>
+                                        <property name="label" translatable="yes">Graphics Backend Multithreading:</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="padding">5</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBoxText" id="_galThreading">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Executes graphics backend commands on a second thread. Allows runtime multithreading of shader compilation, reduces stuttering, and improves performance on drivers without multithreading support of their own. Slightly varying peak performance on drivers with multithreading. Ryujinx may need to be restarted to correctly disable driver built-in multithreading, or you may need to do it manually to get the best performance.</property>
+                                        <property name="active-id">-1</property>
+                                        <items>
+                                          <item id="Auto" translatable="yes">Auto</item>
+                                          <item id="Off" translatable="yes">Off</item>
+                                          <item id="On" translatable="yes">On</item>
+                                        </items>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">5</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="padding">5</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="CatEnhancements">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="margin-left">5</property>
+                            <property name="margin-right">5</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="halign">start</property>
+                                <property name="margin-left">5</property>
+                                <property name="margin-right">5</property>
+                                <property name="margin-bottom">5</property>
+                                <property name="label" translatable="yes">Enhancements</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox" id="EnhancementOptions">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="margin-left">10</property>
+                                <property name="margin-right">10</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkCheckButton" id="_shaderCacheToggle">
+                                    <property name="label" translatable="yes">Enable Shader Cache</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Enables or disables Shader Cache</property>
+                                    <property name="halign">start</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Resolution Scale applied to applicable render targets.</property>
+                                        <property name="label" translatable="yes">Resolution Scale:</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="padding">5</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBoxText" id="_resScaleCombo">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Resolution Scale applied to applicable render targets.</property>
+                                        <property name="active-id">1</property>
+                                        <items>
+                                          <item id="1" translatable="yes">Native (720p/1080p)</item>
+                                          <item id="2" translatable="yes">2x (1440p/2160p)</item>
+                                          <item id="3" translatable="yes">3x (2160p/3240p)</item>
+                                          <item id="4" translatable="yes">4x (2880p/4320p)</item>
+                                          <item id="-1" translatable="yes">Custom (not recommended)</item>
+                                        </items>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkEntry" id="_resScaleText">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="tooltip-text" translatable="yes">Floating point resolution scale, such as 1.5. Non-integral scales are more likely to cause issues or crash.</property>
+                                        <property name="valign">center</property>
+                                        <property name="caps-lock-warning">False</property>
+                                        <property name="placeholder-text">1.0</property>
+                                        <property name="input-purpose">number</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">5</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Level of Anisotropic Filtering (set to Auto to use the value requested by the game)</property>
+                                        <property name="label" translatable="yes">Anisotropic Filtering:</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="padding">5</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBoxText" id="_anisotropy">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Level of Anisotropic Filtering (set to Auto to use the value requested by the game)</property>
+                                        <property name="active-id">-1</property>
+                                        <items>
+                                          <item id="-1" translatable="yes">Auto</item>
+                                          <item id="2" translatable="yes">2x</item>
+                                          <item id="4" translatable="yes">4x</item>
+                                          <item id="8" translatable="yes">8x</item>
+                                          <item id="16" translatable="yes">16x</item>
+                                        </items>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">5</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Aspect Ratio applied to the renderer window.</property>
+                                        <property name="label" translatable="yes">Aspect Ratio:</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="padding">5</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBoxText" id="_aspectRatio">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Aspect Ratio applied to the renderer window.</property>
+                                        <property name="active-id">1</property>
+                                        <items>
+                                          <item id="0" translatable="yes">4:3</item>
+                                          <item id="1" translatable="yes">16:9</item>
+                                          <item id="2" translatable="yes">16:10</item>
+                                          <item id="3" translatable="yes">21:9</item>
+                                          <item id="4" translatable="yes">32:9</item>
+                                          <item id="5" translatable="yes">Stretch to Fit Window</item>
+                                        </items>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">5</property>
+                                    <property name="position">3</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="padding">5</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkSeparator">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="padding">5</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="CatDev">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="margin-left">5</property>
+                            <property name="margin-right">5</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="halign">start</property>
+                                <property name="margin-left">5</property>
+                                <property name="margin-right">5</property>
+                                <property name="margin-bottom">5</property>
+                                <property name="label" translatable="yes">Developer Options</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox" id="DevOptions">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="margin-left">10</property>
+                                <property name="margin-right">10</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Graphics Shaders Dump Path</property>
+                                        <property name="label" translatable="yes">Graphics Shaders Dump Path:</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="padding">5</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkEntry" id="_graphicsShadersDumpPath">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="tooltip-text" translatable="yes">Graphics Shaders Dump Path</property>
+                                        <property name="valign">center</property>
+                                        <property name="caps-lock-warning">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">5</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="padding">5</property>
+                            <property name="position">4</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="position">3</property>
+                      </packing>
+                    </child>
+                    <child type="tab">
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Graphics</property>
+                      </object>
+                      <packing>
+                        <property name="position">3</property>
+                        <property name="tab-fill">False</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="TabLogging">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-left">5</property>
+                        <property name="margin-right">10</property>
+                        <property name="margin-top">5</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <object class="GtkBox" id="CatLogging">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="margin-left">5</property>
+                            <property name="margin-right">5</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="halign">start</property>
+                                <property name="margin-bottom">5</property>
+                                <property name="label" translatable="yes">Logging</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox" id="LogggingOptions">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="valign">start</property>
+                                <property name="margin-left">10</property>
+                                <property name="margin-right">10</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkCheckButton" id="_fileLogToggle">
+                                    <property name="label" translatable="yes">Enable Logging to File</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Enables or disables logging to a file on disk</property>
+                                    <property name="halign">start</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="_stubLogToggle">
+                                    <property name="label" translatable="yes">Enable Stub Logs</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Enables printing stub log messages</property>
+                                    <property name="halign">start</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">3</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="_infoLogToggle">
+                                    <property name="label" translatable="yes">Enable Info Logs</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Enables printing info log messages</property>
+                                    <property name="halign">start</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">4</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="_warningLogToggle">
+                                    <property name="label" translatable="yes">Enable Warning Logs</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Enables printing warning log messages</property>
+                                    <property name="halign">start</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">5</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="_errorLogToggle">
+                                    <property name="label" translatable="yes">Enable Error Logs</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Enables printing error log messages</property>
+                                    <property name="halign">start</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">6</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="_guestLogToggle">
+                                    <property name="label" translatable="yes">Enable Guest Logs</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Enables printing guest log messages</property>
+                                    <property name="halign">start</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">7</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="_fsAccessLogToggle">
+                                    <property name="label" translatable="yes">Enable Fs Access Logs</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Enables printing fs access log messages</property>
+                                    <property name="halign">start</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">8</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Enables FS access log output to the console. Possible modes are 0-3</property>
+                                        <property name="label" translatable="yes">Fs Global Access Log Mode:</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="padding">5</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="tooltip-text" translatable="yes">Enables FS access log output to the console. Possible modes are 0-3</property>
+                                        <property name="text" translatable="yes">0</property>
+                                        <property name="adjustment">_fsLogSpinAdjustment</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="padding">5</property>
+                                    <property name="position">9</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="padding">5</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="CatDevLogging">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="margin-left">5</property>
+                            <property name="margin-right">5</property>
+                            <property name="margin-top">10</property>
+                            <property name="orientation">vertical</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="tooltip-text" translatable="yes">Use with care</property>
+                                <property name="halign">start</property>
+                                <property name="margin-bottom">5</property>
+                                <property name="label" translatable="yes">Developer Options (WARNING: Will reduce performance)</property>
+                                <attributes>
+                                  <attribute name="weight" value="bold"/>
+                                </attributes>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox" id="DevLoggingOptions">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="valign">start</property>
+                                <property name="margin-left">10</property>
+                                <property name="margin-right">10</property>
+                                <property name="orientation">vertical</property>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="margin-top">5</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Requires appropriate log levels enabled.</property>
+                                        <property name="label" translatable="yes">OpenGL Log Level</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="padding">5</property>
+                                        <property name="position">22</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkComboBoxText" id="_graphicsDebugLevel">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="tooltip-text" translatable="yes">Requires appropriate log levels enabled.</property>
+                                        <property name="margin-left">5</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">22</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="_debugLogToggle">
+                                    <property name="label" translatable="yes">Enable Debug Logs</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Enables printing debug log messages</property>
+                                    <property name="halign">start</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">21</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkCheckButton" id="_traceLogToggle">
+                                    <property name="label" translatable="yes">Enable Trace Logs</property>
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
+                                    <property name="tooltip-text" translatable="yes">Enables printing trace log messages</property>
+                                    <property name="halign">start</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="margin-bottom">5</property>
+                                    <property name="draw-indicator">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">22</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="padding">5</property>
+                            <property name="position">22</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="position">4</property>
+                      </packing>
+                    </child>
+                    <child type="tab">
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Logging</property>
+                      </object>
+                      <packing>
+                        <property name="position">4</property>
+                        <property name="tab-fill">False</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButtonBox" id="_buttonBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="margin-right">5</property>
+            <property name="margin-top">3</property>
+            <property name="margin-bottom">3</property>
+            <property name="spacing">5</property>
+            <property name="layout-style">end</property>
+            <child>
+              <object class="GtkToggleButton" id="SaveToggle">
+                <property name="label" translatable="yes">Save</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <signal name="toggled" handler="SaveToggle_Activated" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkToggleButton" id="CloseToggle">
+                <property name="label" translatable="yes">Close</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <signal name="toggled" handler="CloseToggle_Activated" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton">
+                <property name="label" translatable="yes">Apply</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <signal name="clicked" handler="ApplyToggle_Activated" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
 </interface>


### PR DESCRIPTION
Adds a setting that ignores memory permission checks, allowing certain homebrew and mod menus to function within Ryujinx like on actual hardware.