### PR TITLE
Improve raw NCA handling

### DIFF
--- a/Ryujinx.HLE/HOS/ApplicationLoader.cs
+++ b/Ryujinx.HLE/HOS/ApplicationLoader.cs
@@ -512,9 +512,7 @@ namespace Ryujinx.HLE.HOS
             // Don't create save data for system programs.
             if (TitleId != 0 && (TitleId < SystemProgramId.Start.Value || TitleId > SystemAppletId.End.Value))
             {
-                // Multi-program applications can technically use any program ID for the main program, but in practice they always use 0 in the low nibble.
-                // We'll know if this changes in the future because stuff will get errors when trying to mount the correct save.
-                EnsureSaveData(new ApplicationId(TitleId & ~0xFul));
+                EnsureSaveData(new ApplicationId(TitleId));
             }
 
             LoadExeFs(codeFs, metaData);

--- a/Ryujinx.Ui.Common/App/ApplicationLibrary.cs
+++ b/Ryujinx.Ui.Common/App/ApplicationLibrary.cs
@@ -410,6 +410,8 @@ namespace Ryujinx.Ui.App.Common
 
                                         continue;
                                     }
+
+                                    titleId = nca.Header.TitleId.ToString("x16");
                                 }
                                 catch (InvalidDataException)
                                 {


### PR DESCRIPTION
This improves the handling of raw NCAs in two ways:
- Allows save data persistence to correctly function when booting the raw NCAs extracted from multiprogram applications. This avoids a crash when attempting to actually boot the game.
- Allows the actual TitleId of the NCA to appear in the main games list.

This allows conveniently booting the individual games from e.g. Super Mario 3D All-Stars, without having to go through the launcher title.