### PR TITLE
Fix buffer texture bindings on buffer resize

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -504,6 +504,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     state.TextureHandle == textureId &&
                     state.SamplerHandle == samplerId &&
                     state.CachedTexture != null &&
+                    state.CachedTexture.Target != Target.TextureBuffer &&
                     state.CachedTexture.InvalidatedSequence == state.InvalidatedSequence &&
                     state.CachedSampler?.IsDisposed != true)
                 {
@@ -631,6 +632,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 if (!poolModified &&
                     state.TextureHandle == textureId &&
                     state.CachedTexture != null &&
+                    state.CachedTexture.Target != Target.TextureBuffer &&
                     state.CachedTexture.InvalidatedSequence == state.InvalidatedSequence)
                 {
                     Texture cachedTexture = state.CachedTexture;


### PR DESCRIPTION
Fixes a potential regression from #3399. Since buffer textures might be resized on the buffer cache, we might need to rebind it even if the bindings did not change otherwise, so that optimization is not safe for those. This change disables it for buffer textures.