### PR TITLE
Fix deadlock in mouse input on Avalonia

### DIFF
--- a/Ryujinx.Ava/Input/AvaloniaMouseDriver.cs
+++ b/Ryujinx.Ava/Input/AvaloniaMouseDriver.cs
@@ -33,9 +33,7 @@ namespace Ryujinx.Ava.Input
             PressedButtons = new bool[(int)MouseButton.Count];
 
             _size = new Size((int)parent.Bounds.Width, (int)parent.Bounds.Height);
-            IObservable<Rect> resizeObservable = parent.GetObservable(Control.BoundsProperty);
-
-            resizeObservable.Subscribe(Resized);
+            parent.GetObservable(Control.BoundsProperty).Subscribe(Resized);
         }
 
         private void Resized(Rect rect)

--- a/Ryujinx.Ava/Input/AvaloniaMouseDriver.cs
+++ b/Ryujinx.Ava/Input/AvaloniaMouseDriver.cs
@@ -1,3 +1,4 @@
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Threading;
@@ -13,6 +14,7 @@ namespace Ryujinx.Ava.Input
     {
         private Control _widget;
         private bool _isDisposed;
+        private Size _size;
 
         public bool[] PressedButtons { get; }
 
@@ -29,6 +31,16 @@ namespace Ryujinx.Ava.Input
             _widget.PointerWheelChanged += Parent_ScrollEvent;
 
             PressedButtons = new bool[(int)MouseButton.Count];
+
+            _size = new Size((int)parent.Bounds.Width, (int)parent.Bounds.Height);
+            IObservable<Rect> resizeObservable = parent.GetObservable(Control.BoundsProperty);
+
+            resizeObservable.Subscribe(Resized);
+        }
+
+        private void Resized(Rect rect)
+        {
+            _size = new Size((int)rect.Width, (int)rect.Height);
         }
 
         private void Parent_ScrollEvent(object o, PointerWheelEventArgs args)
@@ -78,14 +90,7 @@ namespace Ryujinx.Ava.Input
 
         public Size GetClientSize()
         {
-            Size size = new();
-
-            Dispatcher.UIThread.InvokeAsync(() =>
-            {
-                size = new Size((int)_widget.Bounds.Width, (int)_widget.Bounds.Height);
-            }).Wait();
-
-            return size;
+            return _size;
         }
 
         public string DriverName => "Avalonia";


### PR DESCRIPTION
Fixes a deadlock that occurs if you open any window while direct mouse input is enabled.