### PR TITLE
Avalonia - Use loaded config when assigning controller input

### DIFF
--- a/Ryujinx.Ava/Ui/Windows/ControllerSettingsWindow.axaml.cs
+++ b/Ryujinx.Ava/Ui/Windows/ControllerSettingsWindow.axaml.cs
@@ -8,6 +8,7 @@ using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Ryujinx.Ava.Common.Locale;
 using Ryujinx.Ava.Ui.Controls;
+using Ryujinx.Ava.Ui.Models;
 using Ryujinx.Ava.Ui.ViewModels;
 using Ryujinx.Common.Configuration.Hid;
 using Ryujinx.Common.Configuration.Hid.Controller;
@@ -182,8 +183,8 @@ namespace Ryujinx.Ava.Ui.Windows
 
                 if (e.AddedItems.Count > 0)
                 {
-                    (PlayerIndex key, _) = (KeyValuePair<PlayerIndex, string>)e.AddedItems[0];
-                    ViewModel.PlayerId = key;
+                    var player = (PlayerModel)e.AddedItems[0];
+                    ViewModel.PlayerId = player.Id;
                 }
             }
         }

--- a/Ryujinx.Ava/Ui/Windows/ControllerSettingsWindow.axaml.cs
+++ b/Ryujinx.Ava/Ui/Windows/ControllerSettingsWindow.axaml.cs
@@ -127,9 +127,7 @@ namespace Ryujinx.Ava.Ui.Windows
             }
             else if (device.Type == Models.DeviceType.Controller)
             {
-                InputConfig config = ConfigurationState.Instance.Hid.InputConfig.Value.Find(inputConfig => inputConfig.Id == ViewModel.SelectedGamepad.Id);
-
-                assigner = new GamepadButtonAssigner(ViewModel.SelectedGamepad, (config as StandardControllerInputConfig).TriggerThreshold, forStick);
+                assigner = new GamepadButtonAssigner(ViewModel.SelectedGamepad, (ViewModel.Config as StandardControllerInputConfig).TriggerThreshold, forStick);
             }
             else
             {


### PR DESCRIPTION
Should fix the crash that occurs when mapping controller input and a config hasn't been saved for that controller