### PR TITLE
Avalonia - Ensure mouse cursor is only hidden when mouse is in renderer

### DIFF
--- a/Ryujinx.Ava/Ui/Windows/MainWindow.axaml.cs
+++ b/Ryujinx.Ava/Ui/Windows/MainWindow.axaml.cs
@@ -376,6 +376,7 @@ namespace Ryujinx.Ava.Ui.Windows
                 ViewModel.ShowContent = true;
                 ViewModel.ShowLoadProgress = false;
                 ViewModel.IsLoadingIndeterminate = false;
+                Cursor = Cursor.Default;
 
                 AppHost = null;
 


### PR DESCRIPTION
Fixes a bug in the hide cursor feature.
The mouse cursor isn't restored  when it's hidden by an option and moves outside the game, but not the window, or if the game exits to menu. 