### PR TITLE
Propagate Shader phi nodes with the same source value from all blocks

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -21,7 +21,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 1;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 3069;
+        private const uint CodeGenVersion = 3457;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/Ryujinx.Graphics.Shader/Translation/Optimizations/Optimizer.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Optimizations/Optimizer.cs
@@ -1,6 +1,4 @@
-using Ryujinx.Graphics.Shader.Decoders;
 using Ryujinx.Graphics.Shader.IntermediateRepresentation;
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/Ryujinx.Graphics.Shader/Translation/Optimizations/Optimizer.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Optimizations/Optimizer.cs
@@ -1,4 +1,6 @@
+using Ryujinx.Graphics.Shader.Decoders;
 using Ryujinx.Graphics.Shader.IntermediateRepresentation;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -45,6 +47,11 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
 
                         if (!(node.Value is Operation operation) || isUnused)
                         {
+                            if (node.Value is PhiNode phi && !isUnused)
+                            {
+                                isUnused = PropagatePhi(phi);
+                            }
+
                             if (isUnused)
                             {
                                 RemoveNode(block, node);
@@ -101,6 +108,7 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
         {
             // Propagate copy source operand to all uses of
             // the destination operand.
+
             Operand dest = copyOp.Dest;
             Operand src  = copyOp.GetSource(0);
 
@@ -116,6 +124,53 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
                     }
                 }
             }
+        }
+
+        private static bool PropagatePhi(PhiNode phi)
+        {
+            // If all phi sources are the same, we can propagate it and remove the phi.
+
+            Operand firstSrc = phi.GetSource(0);
+
+            for (int index = 1; index < phi.SourcesCount; index++)
+            {
+                if (!IsSameOperand(firstSrc, phi.GetSource(index)))
+                {
+                    return false;
+                }
+            }
+
+            // All sources are equal, we can propagate the value.
+
+            Operand dest = phi.Dest;
+
+            INode[] uses = dest.UseOps.ToArray();
+
+            foreach (INode useNode in uses)
+            {
+                for (int index = 0; index < useNode.SourcesCount; index++)
+                {
+                    if (useNode.GetSource(index) == dest)
+                    {
+                        useNode.SetSource(index, firstSrc);
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        private static bool IsSameOperand(Operand x, Operand y)
+        {
+            if (x.Type != y.Type || x.Value != y.Value)
+            {
+                return false;
+            }
+
+            return x.Type == OperandType.Attribute ||
+                   x.Type == OperandType.AttributePerPatch ||
+                   x.Type == OperandType.Constant ||
+                   x.Type == OperandType.ConstantBuffer;
         }
 
         private static bool PropagatePack(Operation packOp)


### PR DESCRIPTION
In order to ensure that all variables only have a single assignment to keep optimizations simple, we keep the IR in [SSA form](https://en.wikipedia.org/wiki/Static_single-assignment_form). It is possible for a variable to be set to the same value in multiple blocks, and currently the shader translator will insert a copy on each one of them. Since it does not know that the values are actually the same, it will insert a Phi on blocks with multiple predecessors where the value is used. But the Phi is not actually needed in this case, if the value is actually the same on all of them, it doesn't matter from where it comes from.

This change extends the optimizer to also propagate the Phi source values if the value is always the same, regardless of the incoming block. This makes the generated shader code smaller and better.

The main noticeable benefit here is that bindless elimination now works on more cases, which fixes the flickering that Monster Hunter Rise had with latest update and Sunbreak expansion.

**Note:** The game still needs the other fixes (#3431 and #3425) to actually run, of course.