### PR TITLE
Avoid scaling 2d textures that could be used as “3d“

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -174,6 +174,14 @@ namespace Ryujinx.Graphics.Gpu.Image
                 }
             }
 
+            if (info.Width == info.Height * info.Height)
+            {
+                // Possibly used for a "3D texture" drawn onto a 2D surface.
+                // Some games do this to generate a tone mapping LUT without rendering into 3D texture slices.
+
+                return false;
+            }
+
             return true;
         }
 


### PR DESCRIPTION
This PR adds another “safe mode” toggle for scaling that disables it for 2d textures that might be used as 3D. These textures essentially have a line of “slices” stacked in the x direction, rather than using a real 3d texture, as it is easier to render into. Games that dynamically update a 3D look-up-table to do tone mapping might do this. If that texture were scaled, the slices would blend into each other, causing black to appear as red, and bright red to darken too.

Some notes about the rules:
- It is assumed that the slices are stacked in the x-direction.
- It is assumed that the “slice” count is the same as the height, so the width is the height squared.
- Due to other rules, minimum affected texture size is 64x8

Hopefully this should fix issue #3456 , but all those games are on different engines so it does need tested.