### PR TITLE
Avalonia - Make menuitems toggleable on textclick

### DIFF
--- a/Ryujinx.Ava/Ui/Windows/MainWindow.axaml
+++ b/Ryujinx.Ava/Ui/Windows/MainWindow.axaml
@@ -123,14 +123,20 @@
                                 Command="{ReflectionBinding ToggleFullscreen}"
                                 Header="{locale:Locale MenuBarOptionsToggleFullscreen}"
                                 InputGesture="F11" />
-                            <MenuItem Header="{locale:Locale MenuBarOptionsStartGamesInFullscreen}">
+                            <MenuItem>
                                 <MenuItem.Icon>
-                                    <CheckBox IsChecked="{Binding StartGamesInFullscreen, Mode=TwoWay}" />
+                                    <CheckBox IsChecked="{Binding StartGamesInFullscreen, Mode=TwoWay}"
+                                              MinWidth="250">
+                                        <TextBlock Text="{locale:Locale MenuBarOptionsStartGamesInFullscreen}"/>
+                                    </CheckBox>
                                 </MenuItem.Icon>
                             </MenuItem>
-                            <MenuItem Header="{locale:Locale MenuBarOptionsShowConsole}" IsVisible="{Binding ShowConsoleVisible}">
+                            <MenuItem IsVisible="{Binding ShowConsoleVisible}">
                                 <MenuItem.Icon>
-                                    <CheckBox IsChecked="{Binding ShowConsole, Mode=TwoWay}" />
+                                    <CheckBox IsChecked="{Binding ShowConsole, Mode=TwoWay}"
+                                              MinWidth="250">
+                                        <TextBlock Text="{locale:Locale MenuBarOptionsShowConsole}"/>
+                                    </CheckBox>
                                 </MenuItem.Icon>
                             </MenuItem>
                             <Separator />


### PR DESCRIPTION
Makes menuitem checkboxes behave in the same way as the settings menu checkboxes in that they are embedded textblocks within checkbox parents versus the current implementation where the menuitem is given the text and a checkbox is embedded inside.

Given them a static width of 250 as this is the current size of the drop-down so that anywhere clicked along the row (even outside the text itself) is clickable.