### PR TITLE
Add support for conditional (with CC) shader Exit instructions

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -21,7 +21,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 1;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 3470;
+        private const uint CodeGenVersion = 3469;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -21,7 +21,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 1;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 3472;
+        private const uint CodeGenVersion = 3470;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitFlowControl.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitFlowControl.cs
@@ -104,11 +104,16 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 return;
             }
 
-            // TODO: Figure out how this is supposed to work in the
-            // presence of other condition codes.
             if (op.Ccc == Ccc.T)
             {
                 context.Return();
+            }
+            else
+            {
+                Operand lblSkip = Label();
+                context.BranchIfFalse(lblSkip, GetCondition(context, op.Ccc));
+                context.Return();
+                context.MarkLabel(lblSkip);
             }
         }
 

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitFlowControl.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitFlowControl.cs
@@ -110,10 +110,16 @@ namespace Ryujinx.Graphics.Shader.Instructions
             }
             else
             {
-                Operand lblSkip = Label();
-                context.BranchIfFalse(lblSkip, GetCondition(context, op.Ccc));
-                context.Return();
-                context.MarkLabel(lblSkip);
+                Operand cond = GetCondition(context, op.Ccc, IrConsts.False);
+
+                // If the condition is always false, we don't need to do anything.
+                if (cond.Type != OperandType.Constant || cond.Value != IrConsts.False)
+                {
+                    Operand lblSkip = Label();
+                    context.BranchIfFalse(lblSkip, cond);
+                    context.Return();
+                    context.MarkLabel(lblSkip);
+                }
             }
         }
 
@@ -255,7 +261,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
             }
         }
 
-        private static Operand GetCondition(EmitterContext context, Ccc cond)
+        private static Operand GetCondition(EmitterContext context, Ccc cond, int defaultCond = IrConsts.True)
         {
             // TODO: More condition codes, figure out how they work.
             switch (cond)
@@ -268,7 +274,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
                     return context.BitwiseNot(GetZF());
             }
 
-            return Const(IrConsts.True);
+            return Const(defaultCond);
         }
     }
 }


### PR DESCRIPTION
This adds support for shader conditional exit, using the CC (Condition Code) register.
Fixes bloom in Tokyo Mirage Session (closes #3261).
Before:
![image](https://user-images.githubusercontent.com/5624669/179233637-8cd9bce3-7e68-454a-a9df-07b5cec9d47e.png)
After:
![image](https://user-images.githubusercontent.com/5624669/179233664-23938e4f-7774-459b-a956-d2bd3e4622ae.png)

Note that the CC register is written by previous instructions. Since it is not implemented in *all* shader instructions yet, there is a chance that this cause different, incorrect behavior if an EXIT.CC instruction that uses CC written by an instruction were the emulator does not support CC condition write yet. Of course, before that change, it would be also incorrect since EXIT.CC was not supported at all, but it's something to keep in mind since it can cause still incorrect but different behavior. This game uses ISET RZ.CC followed by EXIT.CC, so it is correct with this change.