### PR TITLE
Fix decoding of block after shader BRA.CC instructions without predicate

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -21,7 +21,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 1;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 3478;
+        private const uint CodeGenVersion = 3472;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/Ryujinx.Graphics.Shader/Decoders/Block.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/Block.cs
@@ -92,7 +92,11 @@ namespace Ryujinx.Graphics.Shader.Decoders
                 pushOpInfo.Consumers.Add(rightBlock, local);
             }
 
-            rightBlock.SyncTargets.Union(SyncTargets);
+            foreach ((ulong  key, SyncTarget value) in SyncTargets)
+            {
+                rightBlock.SyncTargets.Add(key, value);
+            }
+
             SyncTargets.Clear();
 
             // Move push ops.

--- a/Ryujinx.Graphics.Shader/Decoders/Decoder.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/Decoder.cs
@@ -340,7 +340,7 @@ namespace Ryujinx.Graphics.Shader.Decoders
         {
             InstConditional condOp = new InstConditional(op.RawOpCode);
 
-            if (op.Name == InstName.Exit && condOp.Ccc != Ccc.T)
+            if ((op.Name == InstName.Bra || op.Name == InstName.Exit) && condOp.Ccc != Ccc.T)
             {
                 return false;
             }
@@ -672,6 +672,7 @@ namespace Ryujinx.Graphics.Shader.Decoders
                     // Make sure we found the correct address,
                     // the push and pop instruction types must match, so:
                     // - BRK can only consume addresses pushed by PBK.
+                    // - CONT can only consume addresses pushed by PCNT.
                     // - SYNC can only consume addresses pushed by SSY.
                     if (found)
                     {

--- a/Ryujinx.Graphics.Shader/Translation/Rewriter.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Rewriter.cs
@@ -164,7 +164,7 @@ namespace Ryujinx.Graphics.Shader.Translation
 
             bool isBindless = (texOp.Flags & TextureFlags.Bindless) != 0;
 
-            bool isCoordNormalized = !isBindless && config.GpuAccessor.QueryTextureCoordNormalized(texOp.Handle, texOp.CbufSlot);
+            bool isCoordNormalized = isBindless || config.GpuAccessor.QueryTextureCoordNormalized(texOp.Handle, texOp.CbufSlot);
 
             if (!hasInvalidOffset && isCoordNormalized)
             {


### PR DESCRIPTION
Because the decoder did not consider branch instructions that uses the CC register as conditional, it would skip blocks right after the branch instruction and only visit the branch target address. This causes some code to be missing from the shader.

Fixes "green lights" on JUMP FORCE Deluxe.
Before:
![image](https://user-images.githubusercontent.com/5624669/179324596-6d57ce7a-f501-4eaa-8880-77eedcecf6ef.png)
After:
![image](https://user-images.githubusercontent.com/5624669/179324601-ca8fe499-1b79-4229-8666-714529ddf169.png)
Closes #2760.

Note that the shader is still not entirely correct on this game. It has a bindless texture instruction using a handle that is the output from a shuffle instruction. The bindless elimination pass can't handle this. This is likely some compiler generated pattern that we will need to recognize and transform into the proper texture operation.

This also fixes a minor issue introduced by #3194, bindless textures were considered to have non-normalized coordinates, which caused it to generate the code to normalize them and would also add a bogus texture descriptor with a handle of 0, which later would cause the texture to be accessed from the pool and generate an error spam in the log about invalid texture formats. The fix is considering bindless textures as always being normalized, since we can't read the texture pool as the handle is unknown at compile time.
