### PR TITLE
fix: Ensure to load latest version of ffmpeg libraries first

### DIFF
--- a/Ryujinx.Graphics.Nvdec.FFmpeg/Native/FFmpegApi.cs
+++ b/Ryujinx.Graphics.Nvdec.FFmpeg/Native/FFmpegApi.cs
@@ -45,7 +45,7 @@ namespace Ryujinx.Graphics.Nvdec.FFmpeg.Native
             {
                 (int minVersion, int maxVersion) = value;
 
-                for (int version = minVersion; version <= maxVersion; version++)
+                for (int version = maxVersion; version >= minVersion; version--)
                 {
                     if (NativeLibrary.TryLoad(FormatLibraryNameForCurrentOs(libraryName, version), assembly, searchPath, out handle))
                     {


### PR DESCRIPTION
Fix a possible crash related to older version of ffmpeg being loaded
instead of the one shipped with the emulator.