### PR TITLE
Avoid adding shader buffer descriptors for constant buffers that are not used

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -21,7 +21,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 1;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 3457;
+        private const uint CodeGenVersion = 3478;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitHelper.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitHelper.cs
@@ -45,12 +45,12 @@ namespace Ryujinx.Graphics.Shader.Instructions
             if (isFP64)
             {
                 return context.PackDouble2x32(
-                    context.Config.CreateCbuf(cbufSlot, cbufOffset),
-                    context.Config.CreateCbuf(cbufSlot, cbufOffset + 1));
+                    Cbuf(cbufSlot, cbufOffset),
+                    Cbuf(cbufSlot, cbufOffset + 1));
             }
             else
             {
-                return context.Config.CreateCbuf(cbufSlot, cbufOffset);
+                return Cbuf(cbufSlot, cbufOffset);
             }
         }
 

--- a/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgramContext.cs
+++ b/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgramContext.cs
@@ -300,6 +300,11 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
 
             if (operand.Type != OperandType.LocalVariable)
             {
+                if (operand.Type == OperandType.ConstantBuffer)
+                {
+                    Config.SetUsedConstantBuffer(operand.GetCbufSlot());
+                }
+
                 return new AstOperand(operand);
             }
 

--- a/Ryujinx.Graphics.Shader/Translation/Optimizations/GlobalToStorage.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Optimizations/GlobalToStorage.cs
@@ -68,7 +68,7 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
             {
                 Operand addrLow = operation.GetSource(0);
 
-                Operand baseAddrLow = config.CreateCbuf(0, GetStorageCbOffset(config.Stage, storageIndex));
+                Operand baseAddrLow = Cbuf(0, GetStorageCbOffset(config.Stage, storageIndex));
 
                 Operand baseAddrTrunc = Local();
 
@@ -152,7 +152,7 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
             {
                 Operand addrLow = operation.GetSource(0);
 
-                Operand baseAddrLow = config.CreateCbuf(0, UbeBaseOffset + storageIndex * StorageDescSize);
+                Operand baseAddrLow = Cbuf(0, UbeBaseOffset + storageIndex * StorageDescSize);
 
                 Operand baseAddrTrunc = Local();
 

--- a/Ryujinx.Graphics.Shader/Translation/Rewriter.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Rewriter.cs
@@ -75,9 +75,9 @@ namespace Ryujinx.Graphics.Shader.Translation
 
                 int cbOffset = GetStorageCbOffset(config.Stage, slot);
 
-                Operand baseAddrLow  = config.CreateCbuf(0, cbOffset);
-                Operand baseAddrHigh = config.CreateCbuf(0, cbOffset + 1);
-                Operand size         = config.CreateCbuf(0, cbOffset + 2);
+                Operand baseAddrLow  = Cbuf(0, cbOffset);
+                Operand baseAddrHigh = Cbuf(0, cbOffset + 1);
+                Operand size         = Cbuf(0, cbOffset + 2);
 
                 Operand offset = PrependOperation(Instruction.Subtract,       addrLow, baseAddrLow);
                 Operand borrow = PrependOperation(Instruction.CompareLessU32, addrLow, baseAddrLow);

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -360,12 +360,6 @@ namespace Ryujinx.Graphics.Shader.Translation
             UsedFeatures |= flags;
         }
 
-        public Operand CreateCbuf(int slot, int offset)
-        {
-            SetUsedConstantBuffer(slot);
-            return OperandHelper.Cbuf(slot, offset);
-        }
-
         public void SetUsedConstantBuffer(int slot)
         {
             _usedConstantBuffers |= 1 << slot;


### PR DESCRIPTION
Currently it sets all the constant buffer used on the shader as "used". However some later passes may make them unused (for example, texture handles are read from constant buffer 2, but bindless elimination might be able to find that out and remove the constant buffer access and replace it with a non-bindless texture access). With this change, constant buffer use is set much later, after all optimizations and eliminations. This prevents the emulator from creating and sending data for buffers that are not actually used by the shader. This can have a very minor performance benefit, I would expect Vulkan to benefit more from this since we usually need to end the current render pass to perform inline buffer updates.