### PR TITLE
Minor GTK & Avalonia UI verbiage/case fixes

### DIFF
--- a/Ryujinx.Ava/Assets/Locales/en_US.json
+++ b/Ryujinx.Ava/Assets/Locales/en_US.json
@@ -118,7 +118,7 @@
   "SettingsTabSystemAudioBackendSoundIO": "SoundIO",
   "SettingsTabSystemAudioBackendSDL2": "SDL2",
   "SettingsTabSystemHacks": "Hacks",
-  "SettingsTabSystemHacksNote": " - These may cause instabilities",
+  "SettingsTabSystemHacksNote": " (may cause instability)",
   "SettingsTabSystemExpandDramSize": "Expand DRAM Size to 6GB",
   "SettingsTabSystemIgnoreMissingServices": "Ignore Missing Services",
   "SettingsTabGraphics": "Graphics",

--- a/Ryujinx/Ui/Windows/SettingsWindow.glade
+++ b/Ryujinx/Ui/Windows/SettingsWindow.glade
@@ -1509,7 +1509,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkCheckButton" id="_internetToggle">
-                                    <property name="label" translatable="yes">Enable guest Internet access</property>
+                                    <property name="label" translatable="yes">Enable Guest Internet Access</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">False</property>
@@ -1643,7 +1643,7 @@
                                 </child>
                                 <child>
                                   <object class="GtkRadioButton" id="_mmHostUnsafe">
-                                    <property name="label" translatable="yes">Host unchecked (fastest, unsafe)</property>
+                                    <property name="label" translatable="yes">Host Unchecked (fastest, unsafe)</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">False</property>
@@ -1725,7 +1725,7 @@
                                     <property name="can-focus">False</property>
                                     <property name="halign">start</property>
                                     <property name="margin-bottom">5</property>
-                                    <property name="label" translatable="yes"> - These may cause instability</property>
+                                    <property name="label" translatable="yes"> (may cause instability)</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -1749,7 +1749,7 @@
                                 <property name="orientation">vertical</property>
                                 <child>
                                   <object class="GtkCheckButton" id="_expandRamToggle">
-                                    <property name="label" translatable="yes">Expand DRAM size to 6GB</property>
+                                    <property name="label" translatable="yes">Expand DRAM Size to 6GB</property>
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="receives-default">False</property>


### PR DESCRIPTION
This PR aims to standardize title case practices in the GTK settings window, as well as adjust the Hacks hint/description in both GTK and Avalonia to appear more consistently with the rest of the hints in their respective UIs.

GTK Before:
![2022-07-21 06_28_07-Ryujinx - Settings](https://user-images.githubusercontent.com/62343878/180258151-5f56f93e-1d42-4bbd-89b7-81bc82b1db16.png)

GTK After:
![2022-07-21 06_54_45-Ryujinx - Settings](https://user-images.githubusercontent.com/62343878/180258159-c6056f96-11f3-4cf3-a657-d3cbba18dbeb.png)

Avalonia Before:
![2022-07-21 08_47_52-Ryujinx 1 1 182 - Settings](https://user-images.githubusercontent.com/62343878/180258612-6913beb1-f978-4c72-9742-2e0950e04466.png)

Avalonia After:
![2022-07-21 08_47_04-Ryujinx 1 0 0-dirty - Settings](https://user-images.githubusercontent.com/62343878/180258508-1787d43f-f660-47b2-ae27-6bd21c3d093e.png)

