### PR TITLE
Add a sampler pool cache and improve texture pool cache

### DIFF
--- a/Ryujinx.Graphics.Gpu/GpuChannel.cs
+++ b/Ryujinx.Graphics.Gpu/GpuChannel.cs
@@ -59,9 +59,24 @@ namespace Ryujinx.Graphics.Gpu
             {
                 oldMemoryManager.Physical.BufferCache.NotifyBuffersModified -= BufferManager.Rebind;
                 oldMemoryManager.Physical.DecrementReferenceCount();
+                oldMemoryManager.MemoryUnmapped -= MemoryUnmappedHandler;
             }
 
             memoryManager.Physical.BufferCache.NotifyBuffersModified += BufferManager.Rebind;
+            memoryManager.MemoryUnmapped += MemoryUnmappedHandler;
+
+            // Since the memory manager changed, make sure we will get pools from addresses of the new memory manager.
+            TextureManager.ReloadPools();
+        }
+
+        /// <summary>
+        /// Memory mappings change event handler.
+        /// </summary>
+        /// <param name="sender">Memory manager where the mappings changed</param>
+        /// <param name="e">Information about the region that is being changed</param>
+        private void MemoryUnmappedHandler(object sender, UnmapEventArgs e)
+        {
+            TextureManager.ReloadPools();
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/PoolCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/PoolCache.cs
@@ -32,7 +32,7 @@ namespace Ryujinx.Graphics.Gpu.Image
     class PoolCache<T> : IDisposable where T : IPool<T>, IDisposable
     {
         private const int MaxCapacity = 2;
-        private const ulong MinDeltaForRemoval = 5000;
+        private const ulong MinDeltaForRemoval = 20000;
 
         private readonly GpuContext _context;
         private readonly Func<GpuContext, GpuChannel, ulong, int, T> _factory;

--- a/Ryujinx.Graphics.Gpu/Image/PoolCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/PoolCache.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         ulong Address { get; }
 
         /// <summary>
-        /// Intrusive linked list node used on the texture pool cache.
+        /// Linked list node used on the texture pool cache.
         /// </summary>
         LinkedListNode<T> CacheNode { get; set; }
 

--- a/Ryujinx.Graphics.Gpu/Image/PoolCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/PoolCache.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+
+namespace Ryujinx.Graphics.Gpu.Image
+{
+    /// <summary>
+    /// Resource pool interface.
+    /// </summary>
+    /// <typeparam name="T">Resource pool type</typeparam>
+    interface IPool<T>
+    {
+        /// <summary>
+        /// Start address of the pool in memory.
+        /// </summary>
+        ulong Address { get; }
+
+        /// <summary>
+        /// Intrusive linked list node used on the texture pool cache.
+        /// </summary>
+        LinkedListNode<T> CacheNode { get; set; }
+
+        /// <summary>
+        /// Timestamp set on the last use of the pool by the cache.
+        /// </summary>
+        ulong CacheTimestamp { get; set; }
+    }
+
+    /// <summary>
+    /// Pool cache.
+    /// This can keep multiple pools, and return the current one as needed.
+    /// </summary>
+    class PoolCache<T> : IDisposable where T : IPool<T>, IDisposable
+    {
+        private const int MaxCapacity = 2;
+        private const ulong MinDeltaForRemoval = 5000;
+
+        private readonly GpuContext _context;
+        private readonly Func<GpuContext, GpuChannel, ulong, int, T> _factory;
+        private readonly LinkedList<T> _pools;
+        private ulong _currentTimestamp;
+
+        /// <summary>
+        /// Constructs a new instance of the pool.
+        /// </summary>
+        /// <param name="context">GPU context that the texture pool belongs to</param>
+        /// <param name="factory">Method used to create a new pool instance</param>
+        public PoolCache(GpuContext context, Func<GpuContext, GpuChannel, ulong, int, T> factory)
+        {
+            _context = context;
+            _factory = factory;
+            _pools = new LinkedList<T>();
+        }
+
+        /// <summary>
+        /// Increments the internal timestamp of the cache that is used to decide when old resources will be deleted.
+        /// </summary>
+        public void Tick()
+        {
+            _currentTimestamp++;
+        }
+
+        /// <summary>
+        /// Finds a cache texture pool, or creates a new one if not found.
+        /// </summary>
+        /// <param name="channel">GPU channel that the texture pool cache belongs to</param>
+        /// <param name="address">Start address of the texture pool</param>
+        /// <param name="maximumId">Maximum ID of the texture pool</param>
+        /// <returns>The found or newly created texture pool</returns>
+        public T FindOrCreate(GpuChannel channel, ulong address, int maximumId)
+        {
+            // Remove old entries from the cache, if possible.
+            while (_pools.Count > MaxCapacity && (_currentTimestamp - _pools.First.Value.CacheTimestamp) >= MinDeltaForRemoval)
+            {
+                T oldestPool = _pools.First.Value;
+
+                _pools.RemoveFirst();
+                oldestPool.Dispose();
+                oldestPool.CacheNode = null;
+            }
+
+            T pool;
+
+            // Try to find the pool on the cache.
+            for (LinkedListNode<T> node = _pools.First; node != null; node = node.Next)
+            {
+                pool = node.Value;
+
+                if (pool.Address == address)
+                {
+                    if (pool.CacheNode != _pools.Last)
+                    {
+                        _pools.Remove(pool.CacheNode);
+
+                        pool.CacheNode = _pools.AddLast(pool);
+                    }
+
+                    pool.CacheTimestamp = _currentTimestamp;
+
+                    return pool;
+                }
+            }
+
+            // If not found, create a new one.
+            pool = _factory(_context, channel, address, maximumId);
+
+            pool.CacheNode = _pools.AddLast(pool);
+            pool.CacheTimestamp = _currentTimestamp;
+
+            return pool;
+        }
+
+        public void Dispose()
+        {
+            foreach (T pool in _pools)
+            {
+                pool.Dispose();
+                pool.CacheNode = null;
+            }
+
+            _pools.Clear();
+        }
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Image/SamplerPool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/SamplerPool.cs
@@ -1,16 +1,27 @@
 using Ryujinx.Graphics.Gpu.Memory;
+using System.Collections.Generic;
 
 namespace Ryujinx.Graphics.Gpu.Image
 {
     /// <summary>
     /// Sampler pool.
     /// </summary>
-    class SamplerPool : Pool<Sampler, SamplerDescriptor>
+    class SamplerPool : Pool<Sampler, SamplerDescriptor>, IPool<SamplerPool>
     {
         private float _forcedAnisotropy;
 
         /// <summary>
-        /// Constructs a new instance of the sampler pool.
+        /// Intrusive linked list node used on the sampler pool cache.
+        /// </summary>
+        public LinkedListNode<SamplerPool> CacheNode { get; set; }
+
+        /// <summary>
+        /// Timestamp used by the sampler pool cache, updated on every use of this sampler pool.
+        /// </summary>
+        public ulong CacheTimestamp { get; set; }
+
+        /// <summary>
+        /// Creates a new instance of the sampler pool.
         /// </summary>
         /// <param name="context">GPU context that the sampler pool belongs to</param>
         /// <param name="physicalMemory">Physical memory where the sampler descriptors are mapped</param>

--- a/Ryujinx.Graphics.Gpu/Image/SamplerPool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/SamplerPool.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         private float _forcedAnisotropy;
 
         /// <summary>
-        /// Intrusive linked list node used on the sampler pool cache.
+        /// Linked list node used on the sampler pool cache.
         /// </summary>
         public LinkedListNode<SamplerPool> CacheNode { get; set; }
 

--- a/Ryujinx.Graphics.Gpu/Image/SamplerPoolCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/SamplerPoolCache.cs
@@ -1,0 +1,31 @@
+namespace Ryujinx.Graphics.Gpu.Image
+{
+    /// <summary>
+    /// Sampler pool cache.
+    /// This can keep multiple sampler pools, and return the current one as needed.
+    /// It is useful for applications that uses multiple sampler pools.
+    /// </summary>
+    class SamplerPoolCache : PoolCache<SamplerPool>
+    {
+        /// <summary>
+        /// Constructs a new instance of the texture pool.
+        /// </summary>
+        /// <param name="context">GPU context that the texture pool belongs to</param>
+        public SamplerPoolCache(GpuContext context) : base(context, CreateSamplerPool)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the sampler pool.
+        /// </summary>
+        /// <param name="context">GPU context that the sampler pool belongs to</param>
+        /// <param name="channel">GPU channel that the texture pool belongs to</param>
+        /// <param name="address">Address of the sampler pool in guest memory</param>
+        /// <param name="maximumId">Maximum sampler ID of the sampler pool (equal to maximum samplers minus one)</param>
+        private static SamplerPool CreateSamplerPool(GpuContext context, GpuChannel channel, ulong address, int maximumId)
+        {
+            return new SamplerPool(context, channel.MemoryManager.Physical, address, maximumId);
+        }
+
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Image/SamplerPoolCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/SamplerPoolCache.cs
@@ -26,6 +26,5 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             return new SamplerPool(context, channel.MemoryManager.Physical, address, maximumId);
         }
-
     }
 }

--- a/Ryujinx.Graphics.Gpu/Image/SamplerPoolCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/SamplerPoolCache.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Constructs a new instance of the texture pool.
         /// </summary>
         /// <param name="context">GPU context that the texture pool belongs to</param>
-        public SamplerPoolCache(GpuContext context) : base(context, CreateSamplerPool)
+        public SamplerPoolCache(GpuContext context) : base(context)
         {
         }
 
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="channel">GPU channel that the texture pool belongs to</param>
         /// <param name="address">Address of the sampler pool in guest memory</param>
         /// <param name="maximumId">Maximum sampler ID of the sampler pool (equal to maximum samplers minus one)</param>
-        private static SamplerPool CreateSamplerPool(GpuContext context, GpuChannel channel, ulong address, int maximumId)
+        protected override SamplerPool CreatePool(GpuContext context, GpuChannel channel, ulong address, int maximumId)
         {
             return new SamplerPool(context, channel.MemoryManager.Physical, address, maximumId);
         }

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -17,10 +17,13 @@ namespace Ryujinx.Graphics.Gpu.Image
         private TextureDescriptor _defaultDescriptor;
 
         /// <summary>
-        /// Intrusive linked list node used on the texture pool cache.
+        /// Linked list node used on the texture pool cache.
         /// </summary>
         public LinkedListNode<TexturePool> CacheNode { get; set; }
 
+        /// <summary>
+        /// Timestamp used by the texture pool cache, updated on every use of this texture pool.
+        /// </summary>
         public ulong CacheTimestamp { get; set; }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -10,7 +10,7 @@ namespace Ryujinx.Graphics.Gpu.Image
     /// <summary>
     /// Texture pool.
     /// </summary>
-    class TexturePool : Pool<Texture, TextureDescriptor>
+    class TexturePool : Pool<Texture, TextureDescriptor>, IPool<TexturePool>
     {
         private readonly GpuChannel _channel;
         private readonly ConcurrentQueue<Texture> _dereferenceQueue = new ConcurrentQueue<Texture>();
@@ -21,8 +21,10 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         public LinkedListNode<TexturePool> CacheNode { get; set; }
 
+        public ulong CacheTimestamp { get; set; }
+
         /// <summary>
-        /// Constructs a new instance of the texture pool.
+        /// Creates a new instance of the texture pool.
         /// </summary>
         /// <param name="context">GPU context that the texture pool belongs to</param>
         /// <param name="channel">GPU channel that the texture pool belongs to</param>

--- a/Ryujinx.Graphics.Gpu/Image/TexturePoolCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePoolCache.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-
 namespace Ryujinx.Graphics.Gpu.Image
 {
     /// <summary>
@@ -8,69 +5,26 @@ namespace Ryujinx.Graphics.Gpu.Image
     /// This can keep multiple texture pools, and return the current one as needed.
     /// It is useful for applications that uses multiple texture pools.
     /// </summary>
-    class TexturePoolCache
+    class TexturePoolCache : PoolCache<TexturePool>
     {
-        private const int MaxCapacity = 4;
-
-        private readonly GpuContext _context;
-        private readonly LinkedList<TexturePool> _pools;
-
         /// <summary>
         /// Constructs a new instance of the texture pool.
         /// </summary>
         /// <param name="context">GPU context that the texture pool belongs to</param>
-        public TexturePoolCache(GpuContext context)
+        public TexturePoolCache(GpuContext context) : base(context, CreateTexturePool)
         {
-            _context = context;
-            _pools = new LinkedList<TexturePool>();
         }
 
         /// <summary>
-        /// Finds a cache texture pool, or creates a new one if not found.
+        /// Creates a new instance of the texture pool.
         /// </summary>
-        /// <param name="channel">GPU channel that the texture pool cache belongs to</param>
-        /// <param name="address">Start address of the texture pool</param>
-        /// <param name="maximumId">Maximum ID of the texture pool</param>
-        /// <returns>The found or newly created texture pool</returns>
-        public TexturePool FindOrCreate(GpuChannel channel, ulong address, int maximumId)
+        /// <param name="context">GPU context that the texture pool belongs to</param>
+        /// <param name="channel">GPU channel that the texture pool belongs to</param>
+        /// <param name="address">Address of the texture pool in guest memory</param>
+        /// <param name="maximumId">Maximum texture ID of the texture pool (equal to maximum textures minus one)</param>
+        private static TexturePool CreateTexturePool(GpuContext context, GpuChannel channel, ulong address, int maximumId)
         {
-            TexturePool pool;
-
-            // First we try to find the pool.
-            for (LinkedListNode<TexturePool> node = _pools.First; node != null; node = node.Next)
-            {
-                pool = node.Value;
-
-                if (pool.Address == address)
-                {
-                    if (pool.CacheNode != _pools.Last)
-                    {
-                        _pools.Remove(pool.CacheNode);
-
-                        pool.CacheNode = _pools.AddLast(pool);
-                    }
-
-                    return pool;
-                }
-            }
-
-            // If not found, create a new one.
-            pool = new TexturePool(_context, channel, address, maximumId);
-
-            pool.CacheNode = _pools.AddLast(pool);
-
-            if (_pools.Count > MaxCapacity)
-            {
-                TexturePool oldestPool = _pools.First.Value;
-
-                _pools.RemoveFirst();
-
-                oldestPool.Dispose();
-
-                oldestPool.CacheNode = null;
-            }
-
-            return pool;
+            return new TexturePool(context, channel, address, maximumId);
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Image/TexturePoolCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePoolCache.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Constructs a new instance of the texture pool.
         /// </summary>
         /// <param name="context">GPU context that the texture pool belongs to</param>
-        public TexturePoolCache(GpuContext context) : base(context, CreateTexturePool)
+        public TexturePoolCache(GpuContext context) : base(context)
         {
         }
 
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="channel">GPU channel that the texture pool belongs to</param>
         /// <param name="address">Address of the texture pool in guest memory</param>
         /// <param name="maximumId">Maximum texture ID of the texture pool (equal to maximum textures minus one)</param>
-        private static TexturePool CreateTexturePool(GpuContext context, GpuChannel channel, ulong address, int maximumId)
+        protected override TexturePool CreatePool(GpuContext context, GpuChannel channel, ulong address, int maximumId)
         {
             return new TexturePool(context, channel, address, maximumId);
         }


### PR DESCRIPTION
Currently, the texture pool cache has a hard limit of 4 pools. If a game is actively using more than that, then the least recently used one is removed. This is not good for performance as we will need to re-create the pool (and possibly the textures) again later. In addition to that, there is no sampler pool cache, so the emulator needs to re-create the pool and all samplers every time the sampler pool changes (which may or may not happen frequently, most games only uses one pool, so there's no problem there).

To address those issues, this change takes a new factor into account before deleting pools. It only deletes pools that have not been used for some time. In order to avoid introducing non-deterministic behavior, it does not actually use time, rather it uses a "timestamp" that is incremented on every draw/dispatch. The pool capacity has been reduced from 4 to 2, since they are only removed if it is old enough now, so for actively used pools, the cache is capacity is basically unlimited.

A sampler pool cache has been added, it behaves exactly the same as the texture pool cache.

This improves performance on Super Zangyura.
Before:

https://user-images.githubusercontent.com/5624669/180701274-aac03efc-cd5a-44b7-8913-afb13cd160d0.mp4

After:

https://user-images.githubusercontent.com/5624669/180701320-74a02299-d86f-429a-a0ba-6eebcbf1028a.mp4

Note that most games won't show any performance improvement because they only use one pool. Only games that uses multiple pools are improved.
Testing is welcome.
