### PR TITLE
Avalonia: Cleanup UserEditor a bit

### DIFF
--- a/Ryujinx.Ava/Assets/Locales/en_US.json
+++ b/Ryujinx.Ava/Assets/Locales/en_US.json
@@ -577,5 +577,7 @@
   "UserProfileNoImageError":  "Profile image must be set",
   "GameUpdateWindowHeading": "Updates Available for {0} [{1}]",
   "SettingsTabHotkeysResScaleUpHotkey": "Increase resolution:",
-  "SettingsTabHotkeysResScaleDownHotkey": "Decrease resolution:"
+  "SettingsTabHotkeysResScaleDownHotkey": "Decrease resolution:",
+  "UserProfilesName": "Name:",
+  "UserProfilesUserId" : "User Id:"
 }

--- a/Ryujinx.Ava/Ui/Controls/UserEditor.axaml
+++ b/Ryujinx.Ava/Ui/Controls/UserEditor.axaml
@@ -1,55 +1,87 @@
-<UserControl xmlns="https://github.com/avaloniaui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             mc:Ignorable="d" 
-             Padding="0"
-             Margin="0"
-             xmlns:Locale="clr-namespace:Ryujinx.Ava.Common.Locale"
-             xmlns:viewModels="clr-namespace:Ryujinx.Ava.Ui.ViewModels"
-             xmlns:models="clr-namespace:Ryujinx.Ava.Ui.Models"
-             xmlns:controls="clr-namespace:Ryujinx.Ava.Ui.Controls"
-             xmlns:ui="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
-             x:Class="Ryujinx.Ava.Ui.Controls.UserEditor">
+<UserControl
+    x:Class="Ryujinx.Ava.Ui.Controls.UserEditor"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:Locale="clr-namespace:Ryujinx.Ava.Common.Locale"
+    xmlns:controls="clr-namespace:Ryujinx.Ava.Ui.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="clr-namespace:Ryujinx.Ava.Ui.Models"
+    xmlns:ui="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
+    xmlns:viewModels="clr-namespace:Ryujinx.Ava.Ui.ViewModels"
+    Margin="0"
+    Padding="0"
+    mc:Ignorable="d">
     <UserControl.Resources>
         <controls:BitmapArrayValueConverter x:Key="ByteImage" />
     </UserControl.Resources>
     <Grid Margin="0">
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto"/>
-            <ColumnDefinition/>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition />
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
-            <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <StackPanel Orientation="Vertical" VerticalAlignment="Stretch" HorizontalAlignment="Left">
+        <StackPanel
+            HorizontalAlignment="Left"
+            VerticalAlignment="Stretch"
+            Orientation="Vertical">
             <Image
+                Name="ProfileImage"
+                Width="96"
+                Height="96"
                 Margin="0"
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Top"
-                Height="96" Width="96"
-                Name="ProfileImage"
                 Source="{Binding Image, Converter={StaticResource ByteImage}}" />
-            <Button Margin="5" Content="{Locale:Locale UserProfilesChangeProfileImage}"
-                    Name="ChangePictureButton"
-                    Click="ChangePictureButton_Click"
-                    HorizontalAlignment="Stretch"/>
-			<Button Margin="5" Content="{Locale:Locale UserProfilesSetProfileImage}"
-                    Name="AddPictureButton"
-                    Click="ChangePictureButton_Click"
-                    HorizontalAlignment="Stretch"/>
+            <Button
+                Name="ChangePictureButton"
+                Margin="5"
+                HorizontalAlignment="Stretch"
+                Click="ChangePictureButton_Click"
+                Content="{Locale:Locale UserProfilesChangeProfileImage}" />
+            <Button
+                Name="AddPictureButton"
+                Margin="5"
+                HorizontalAlignment="Stretch"
+                Click="ChangePictureButton_Click"
+                Content="{Locale:Locale UserProfilesSetProfileImage}" />
         </StackPanel>
-        <StackPanel Grid.Row="0" Orientation="Vertical" HorizontalAlignment="Stretch" Grid.Column="1" Spacing="10"
-                    Margin="5, 10">
-            <TextBox Name="NameBox" Width="300" Text="{Binding Name}" MaxLength="{Binding MaxProfileNameLength}"
-                     HorizontalAlignment="Stretch" />
-            <TextBlock Text="{Binding UserId}" Name="IdLabel" />
+        <StackPanel
+            Grid.Row="0"
+            Grid.Column="1"
+            Margin="5,10"
+            HorizontalAlignment="Stretch"
+            Orientation="Vertical"
+            Spacing="10">
+            <TextBlock Text="{Locale:Locale UserProfilesName}" />
+            <TextBox
+                Name="NameBox"
+                Width="300"
+                HorizontalAlignment="Stretch"
+                MaxLength="{Binding MaxProfileNameLength}"
+                Text="{Binding Name}" />
+            <TextBlock Text="{Locale:Locale UserProfilesUserId}" />
+            <TextBlock Name="IdLabel" Text="{Binding UserId}" />
         </StackPanel>
-        <StackPanel Grid.Column="0" Grid.ColumnSpan="2"  Grid.Row="1" Orientation="Horizontal" Spacing="10" HorizontalAlignment="Right">
-            <Button Content="{Locale:Locale Save}" Name="SaveButton" Click="SaveButton_Click"/>
-            <Button HorizontalAlignment="Right" Content="{Locale:Locale Discard}"
-                    Name="CloseButton" Click="CloseButton_Click"/>
+        <StackPanel
+            Grid.Row="1"
+            Grid.Column="0"
+            Grid.ColumnSpan="2"
+            HorizontalAlignment="Right"
+            Orientation="Horizontal"
+            Spacing="10">
+            <Button
+                Name="SaveButton"
+                Click="SaveButton_Click"
+                Content="{Locale:Locale Save}" />
+            <Button
+                Name="CloseButton"
+                HorizontalAlignment="Right"
+                Click="CloseButton_Click"
+                Content="{Locale:Locale Discard}" />
         </StackPanel>
     </Grid>
 </UserControl>

--- a/Ryujinx.Ava/Ui/Controls/UserEditor.axaml.cs
+++ b/Ryujinx.Ava/Ui/Controls/UserEditor.axaml.cs
@@ -63,7 +63,7 @@ namespace Ryujinx.Ava.Ui.Controls
             _parent?.GoBack();
         }
 
-        private void SaveButton_Click(object sender, RoutedEventArgs e)
+        private async void SaveButton_Click(object sender, RoutedEventArgs e)
         {
             DataValidationErrors.ClearErrors(NameBox);
             bool isInvalid = false;
@@ -77,7 +77,7 @@ namespace Ryujinx.Ava.Ui.Controls
 
             if (TempProfile.Image == null)
             {
-                ContentDialogHelper.CreateWarningDialog(LocaleManager.Instance["UserProfileNoImageError"], "");
+                await ContentDialogHelper.CreateWarningDialog(LocaleManager.Instance["UserProfileNoImageError"], "");
 
                 isInvalid = true;
             }

--- a/Ryujinx.Ava/Ui/Controls/UserSelector.axaml
+++ b/Ryujinx.Ava/Ui/Controls/UserSelector.axaml
@@ -1,29 +1,35 @@
-<UserControl xmlns="https://github.com/avaloniaui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:flex="clr-namespace:Avalonia.Flexbox;assembly=Avalonia.Flexbox"
-             xmlns:Locale="clr-namespace:Ryujinx.Ava.Common.Locale"
-             xmlns:viewModels="clr-namespace:Ryujinx.Ava.Ui.ViewModels"
-             xmlns:controls="clr-namespace:Ryujinx.Ava.Ui.Controls"
-             xmlns:ui="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
-             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-             x:Class="Ryujinx.Ava.Ui.Controls.UserSelector">
+<UserControl
+    x:Class="Ryujinx.Ava.Ui.Controls.UserSelector"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:Locale="clr-namespace:Ryujinx.Ava.Common.Locale"
+    xmlns:controls="clr-namespace:Ryujinx.Ava.Ui.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:flex="clr-namespace:Avalonia.Flexbox;assembly=Avalonia.Flexbox"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ui="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
+    xmlns:viewModels="clr-namespace:Ryujinx.Ava.Ui.ViewModels"
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    mc:Ignorable="d">
     <UserControl.Resources>
         <controls:BitmapArrayValueConverter x:Key="ByteImage" />
     </UserControl.Resources>
     <Design.DataContext>
         <viewModels:UserProfileViewModel />
     </Design.DataContext>
-    <Grid HorizontalAlignment="Stretch"
-          VerticalAlignment="Stretch">
+    <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
         <Grid.RowDefinitions>
             <RowDefinition />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <ListBox HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="5" Items="{Binding Profiles}"
-                 DoubleTapped="ProfilesList_DoubleTapped"
-                 SelectionChanged="SelectingItemsControl_SelectionChanged">
+        <ListBox
+            Margin="5"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Center"
+            DoubleTapped="ProfilesList_DoubleTapped"
+            Items="{Binding Profiles}"
+            SelectionChanged="SelectingItemsControl_SelectionChanged">
             <ListBox.ItemsPanel>
                 <ItemsPanelTemplate>
                     <flex:FlexPanel
@@ -49,10 +55,11 @@
                                 </Grid.RowDefinitions>
                                 <Image
                                     Grid.Row="0"
+                                    Width="96"
+                                    Height="96"
                                     Margin="0"
                                     HorizontalAlignment="Stretch"
                                     VerticalAlignment="Top"
-                                    Height="96" Width="96"
                                     Source="{Binding Image, Converter={StaticResource ByteImage}}" />
                                 <StackPanel
                                     Grid.Row="1"
@@ -68,23 +75,34 @@
                                 </StackPanel>
                             </Grid>
                         </Border>
-                        <Border HorizontalAlignment="Left" VerticalAlignment="Top"
-                                IsVisible="{Binding IsOpened}"
-                                Background="LimeGreen"
-                                Width="10"
-                                Height="10"
-                                Margin="5"
-                                CornerRadius="5" />
+                        <Border
+                            Width="10"
+                            Height="10"
+                            Margin="5"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Top"
+                            Background="LimeGreen"
+                            CornerRadius="5"
+                            IsVisible="{Binding IsOpened}" />
                     </Grid>
                 </DataTemplate>
             </ListBox.ItemTemplate>
         </ListBox>
-        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="10,0" Spacing="10" HorizontalAlignment="Center">
-            <Button Content="{Locale:Locale UserProfilesAddNewProfile}" Command="{Binding AddUser}" />
-            <Button IsEnabled="{Binding  IsSelectedProfiledEditable}"
-                    Content="{Locale:Locale UserProfilesEditProfile}" Command="{Binding EditUser}" />
-            <Button IsEnabled="{Binding IsSelectedProfileDeletable}"
-                    Content="{Locale:Locale UserProfilesDeleteSelectedProfile}" Command="{Binding DeleteUser}" />
+        <StackPanel
+            Grid.Row="1"
+            Margin="10,0"
+            HorizontalAlignment="Center"
+            Orientation="Horizontal"
+            Spacing="10">
+            <Button Command="{Binding AddUser}" Content="{Locale:Locale UserProfilesAddNewProfile}" />
+            <Button
+                Command="{Binding EditUser}"
+                Content="{Locale:Locale UserProfilesEditProfile}"
+                IsEnabled="{Binding IsSelectedProfiledEditable}" />
+            <Button
+                Command="{Binding DeleteUser}"
+                Content="{Locale:Locale UserProfilesDeleteSelectedProfile}"
+                IsEnabled="{Binding IsSelectedProfileDeletable}" />
         </StackPanel>
     </Grid>
 </UserControl>

--- a/Ryujinx.Ava/Ui/Controls/UserSelector.axaml.cs
+++ b/Ryujinx.Ava/Ui/Controls/UserSelector.axaml.cs
@@ -21,7 +21,7 @@ namespace Ryujinx.Ava.Ui.Controls
                 AddHandler(Frame.NavigatedToEvent, (s, e) =>
                 {
                     NavigatedTo(e);
-                }, Avalonia.Interactivity.RoutingStrategies.Direct);
+                }, RoutingStrategies.Direct);
             }
         }
 
@@ -29,12 +29,10 @@ namespace Ryujinx.Ava.Ui.Controls
         {
             if (Program.PreviewerDetached)
             {
-                switch (arg.NavigationMode)
+                if (arg.NavigationMode == NavigationMode.New)
                 {
-                    case NavigationMode.New:
-                        _parent = (NavigationDialogHost)arg.Parameter;
-                        ViewModel = _parent.ViewModel;
-                        break;
+                    _parent = (NavigationDialogHost)arg.Parameter;
+                    ViewModel = _parent.ViewModel;
                 }
 
                 DataContext = ViewModel;

--- a/Ryujinx.Ava/Ui/ViewModels/UserProfileViewModel.cs
+++ b/Ryujinx.Ava/Ui/ViewModels/UserProfileViewModel.cs
@@ -43,11 +43,9 @@ namespace Ryujinx.Ava.Ui.ViewModels
             }
         }
 
-        public bool IsHighlightedProfileEditable =>
-            _highlightedProfile != null;
+        public bool IsHighlightedProfileEditable => _highlightedProfile != null;
 
-        public bool IsHighlightedProfileDeletable =>
-            _highlightedProfile != null && _highlightedProfile.UserId != AccountManager.DefaultUserId;
+        public bool IsHighlightedProfileDeletable => _highlightedProfile != null && _highlightedProfile.UserId != AccountManager.DefaultUserId;
 
         public UserProfile HighlightedProfile
         {
@@ -62,16 +60,13 @@ namespace Ryujinx.Ava.Ui.ViewModels
             }
         }
 
-        public void Dispose()
-        {
-        }
+        public void Dispose() { }
 
         public void LoadProfiles()
         {
             Profiles.Clear();
 
-            var profiles = _owner.AccountManager.GetAllUsers()
-                .OrderByDescending(x => x.AccountState == AccountState.Open);
+            var profiles = _owner.AccountManager.GetAllUsers().OrderByDescending(x => x.AccountState == AccountState.Open);
 
             foreach (var profile in profiles)
             {
@@ -94,6 +89,7 @@ namespace Ryujinx.Ava.Ui.ViewModels
         public void AddUser()
         {
             UserProfile userProfile = null;
+
             _owner.Navigate(typeof(UserEditor), (this._owner, userProfile, true));
         }
 


### PR DESCRIPTION
This PR cleanup the UserEditor code a bit, 2 texts are added for "Name" and "User Id", because when you create a new profile, the textbox is empty without any hints. `axaml` files are autoformated too.