### PR TITLE
Fix DMA linear texture copy fast path

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -242,7 +242,6 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                         }
                         else
                         {
-
                             data = LayoutConverter.ConvertBlockLinearToLinear(
                                 src.Width,
                                 src.Height,

--- a/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -216,13 +216,14 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                 {
                     var target = memoryManager.Physical.TextureCache.FindTexture(
                         memoryManager,
-                        dst,
                         dstGpuVa,
                         dstBpp,
                         dstStride,
+                        dst.Height,
                         xCount,
                         yCount,
-                        dstLinear);
+                        dstLinear,
+                        dst.MemoryLayout);
 
                     if (target != null)
                     {
@@ -241,6 +242,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                         }
                         else
                         {
+
                             data = LayoutConverter.ConvertBlockLinearToLinear(
                                 src.Width,
                                 src.Height,


### PR DESCRIPTION
`FindTexture` tries to find an existing texture that matches the copy parameters, if found we try to write the data into the texture directly which is more efficient. However, `FindTexture` was also matching textures that have a height higher than the copy height. This causes problems because linear strided -> linear conversion expects data to be at least as large as the texture itself, and in this case it won't be causing an exception.

The fix here is making `FindTexture` only match linear textures with *exactly* the copy height. In addition to that, I removed the `RegionY` parameter because it is not used for linear copies, only block linear ones (that's an incorrect assumption that was made in the past and corrected, but I missed that code). Since after this only two fields from `DmaTexture` were accessed, I decided to stop passing the whole struct and just pass those 2 parameters to the function, which is more efficient.

Fixes crash in SD Gundam Battle Alliance Demo with the following exception:
```
Unhandled exception. System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
   at Ryujinx.Graphics.Texture.LayoutConverter.ConvertLinearStridedToLinear(Int32 width, Int32 height, Int32 blockWidth, Int32 blockHeight, Int32 lineSize, Int32 stride, Int32 bytesPerPixel, ReadOnlySpan`1 data) in F:\Ryujinx\Ryujinx.Graphics.Texture\LayoutConverter.cs:line 272
   at Ryujinx.Graphics.Gpu.Engine.Dma.DmaClass.DmaCopy(Int32 argument) in F:\Ryujinx\Ryujinx.Graphics.Gpu\Engine\Dma\DmaClass.cs:line 331
   at Ryujinx.Graphics.Gpu.Engine.Dma.DmaClass.LaunchDma(Int32 argument) in F:\Ryujinx\Ryujinx.Graphics.Gpu\Engine\Dma\DmaClass.cs:line 450
   at Ryujinx.Graphics.Gpu.Engine.GPFifo.GPFifoProcessor.Send(UInt64 gpuVa, Int32 offset, Int32 argument, Int32 subChannel, Boolean isLastCall) in F:\Ryujinx\Ryujinx.Graphics.Gpu\Engine\GPFifo\GPFifoProcessor.cs:line 213
   at Ryujinx.Graphics.Gpu.Engine.GPFifo.GPFifoProcessor.Process(UInt64 baseGpuVa, ReadOnlySpan`1 commandBuffer) in F:\Ryujinx\Ryujinx.Graphics.Gpu\Engine\GPFifo\GPFifoProcessor.cs:line 95
   at Ryujinx.Graphics.Gpu.Engine.GPFifo.GPFifoDevice.DispatchCalls() in F:\Ryujinx\Ryujinx.Graphics.Gpu\Engine\GPFifo\GPFifoDevice.cs:line 188
   at Ryujinx.Ui.RendererWidgetBase.<Render>b__71_0() in F:\Ryujinx\Ryujinx\Ui\RendererWidgetBase.cs:line 394
   at Ryujinx.Graphics.GAL.Multithreading.ThreadedRenderer.<>c__DisplayClass48_0.<RunLoop>b__0() in F:\Ryujinx\Ryujinx.Graphics.GAL\Multithreading\ThreadedRenderer.cs:line 100
   at System.Threading.Thread.StartCallback()
```
For the record, at that time it was trying to write 256x25 data into a 64x29 RGBA8Srgb texture. With this fix, it tries to write it into a 64x25 texture.

![image](https://user-images.githubusercontent.com/5624669/181432619-29c3f205-3ca1-4606-8369-d5f085c73546.png)