### PR TITLE
Fix resolution scale values not being updated

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -50,8 +50,6 @@ namespace Ryujinx.Graphics.Gpu.Image
             public int InvalidatedSequence;
             public Texture CachedTexture;
             public Sampler CachedSampler;
-            public int ScaleIndex;
-            public TextureUsageFlags UsageFlags;
         }
 
         private TextureState[] _textureState;
@@ -535,14 +533,12 @@ namespace Ryujinx.Graphics.Gpu.Image
                     // The texture is already bound.
                     state.CachedTexture.SynchronizeMemory();
 
-                    if ((state.ScaleIndex != index || state.UsageFlags != usageFlags) &&
+                    if ((usageFlags & TextureUsageFlags.NeedsScaleValue) != 0 &&
                         UpdateScale(state.CachedTexture, usageFlags, index, stage))
                     {
                         ITexture hostTextureRebind = state.CachedTexture.GetTargetTexture(bindingInfo.Target);
 
                         state.Texture = hostTextureRebind;
-                        state.ScaleIndex = index;
-                        state.UsageFlags = usageFlags;
 
                         _context.Renderer.Pipeline.SetTextureAndSampler(stage, bindingInfo.Binding, hostTextureRebind, state.Sampler);
                     }
@@ -573,7 +569,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 {
                     bool textureOrSamplerChanged = state.Texture != hostTexture || state.Sampler != hostSampler;
 
-                    if ((state.ScaleIndex != index || state.UsageFlags != usageFlags || textureOrSamplerChanged) &&
+                    if ((usageFlags & TextureUsageFlags.NeedsScaleValue) != 0 &&
                         UpdateScale(texture, usageFlags, index, stage))
                     {
                         hostTexture = texture?.GetTargetTexture(bindingInfo.Target);
@@ -583,9 +579,6 @@ namespace Ryujinx.Graphics.Gpu.Image
                     if (textureOrSamplerChanged)
                     {
                         state.Texture = hostTexture;
-                        state.ScaleIndex = index;
-                        state.UsageFlags = usageFlags;
-
                         state.Sampler = hostSampler;
 
                         _context.Renderer.Pipeline.SetTextureAndSampler(stage, bindingInfo.Binding, hostTexture, hostSampler);
@@ -666,7 +659,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                         cachedTexture?.SignalModified();
                     }
 
-                    if ((state.ScaleIndex != scaleIndex || state.UsageFlags != usageFlags) &&
+                    if ((usageFlags & TextureUsageFlags.NeedsScaleValue) != 0 &&
                         UpdateScale(state.CachedTexture, usageFlags, scaleIndex, stage))
                     {
                         ITexture hostTextureRebind = state.CachedTexture.GetTargetTexture(bindingInfo.Target);
@@ -674,8 +667,6 @@ namespace Ryujinx.Graphics.Gpu.Image
                         Format format = bindingInfo.Format == 0 ? cachedTexture.Format : bindingInfo.Format;
 
                         state.Texture = hostTextureRebind;
-                        state.ScaleIndex = scaleIndex;
-                        state.UsageFlags = usageFlags;
 
                         _context.Renderer.Pipeline.SetImage(bindingInfo.Binding, hostTextureRebind, format);
                     }
@@ -713,7 +704,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                         texture?.SignalModified();
                     }
 
-                    if ((state.ScaleIndex != scaleIndex || state.UsageFlags != usageFlags || state.Texture != hostTexture) &&
+                    if ((usageFlags & TextureUsageFlags.NeedsScaleValue) != 0 &&
                         UpdateScale(texture, usageFlags, scaleIndex, stage))
                     {
                         hostTexture = texture?.GetTargetTexture(bindingInfo.Target);
@@ -722,8 +713,6 @@ namespace Ryujinx.Graphics.Gpu.Image
                     if (state.Texture != hostTexture)
                     {
                         state.Texture = hostTexture;
-                        state.ScaleIndex = scaleIndex;
-                        state.UsageFlags = usageFlags;
 
                         Format format = bindingInfo.Format;
 


### PR DESCRIPTION
#3399 introduced some regressions on resolution scaling that #3403 attempted to fix, however even with this fix some issues remained. I attempted to fix some of the remaining issues on #2518 because it was reported that resolution scaling was broken on Atelier Ryza and other games from the series. However, this introduced yet another issue on Xenoblade Chronicles Definitive Edition.

The problem seems to be caused by the interaction between textures and images. The scales for both is stored on  the same buffer and same array, yet on the texture bindings manager their state is separate. Right now, the only things that forces an update is the scale index, usage flags or the texture itself changing. One simple scenario where this could break is a game using a image that is scaled on a single draw. None of that state would change, yet any other texture using the same scale index on a past or future draw would overwrite the scale value, which would require an update when the image is used, but that doesn't happen right now.

I have fixed this by removing the optimization. In order to avoid calling the `UpdateScale` function for every single texture, I have added a check to call it only if a scale is needed.

Fixes regression when scaling Xenoblade Chronicles Definitive Edition.
Before:
![image](https://user-images.githubusercontent.com/5624669/182057630-508e4248-b08d-406e-a97a-82c3e3d7f764.png)
After:
![image](https://user-images.githubusercontent.com/5624669/182057643-b7f6c785-d9c2-4aab-a4ca-6f1e815f99b1.png)

Testing is welcome, would be also nice to get confirmation that performance was not affected. Also worth testing on other games since I think there were some weird resolution scale issues on other games that didn't happen before?