### PR TITLE
vk: Workaround XCB not availaible on FlatHub build

### DIFF
--- a/Ryujinx.Ava/Ryujinx.Ava.csproj
+++ b/Ryujinx.Ava/Ryujinx.Ava.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Silk.NET.Vulkan" Version="2.10.1" />
     <PackageReference Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.10.1" />
     <PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.10.1" />
-    <PackageReference Include="SPB" Version="0.0.4-build17" />
+    <PackageReference Include="SPB" Version="0.0.4-build24" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
   </ItemGroup>

--- a/Ryujinx/Ryujinx.csproj
+++ b/Ryujinx/Ryujinx.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Ryujinx.Graphics.Nvdec.Dependencies" Version="5.0.1-build10" Condition="'$(RuntimeIdentifier)' != 'linux-x64' AND '$(RuntimeIdentifier)' != 'osx-x64'" />
     <PackageReference Include="Ryujinx.Audio.OpenAL.Dependencies" Version="1.21.0.1" Condition="'$(RuntimeIdentifier)' != 'linux-x64' AND '$(RuntimeIdentifier)' != 'osx-x64'" />
     <PackageReference Include="OpenTK.Graphics" Version="4.7.2" />
-    <PackageReference Include="SPB" Version="0.0.4-build17" />
+    <PackageReference Include="SPB" Version="0.0.4-build24" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
   </ItemGroup>


### PR DESCRIPTION
Update SPB to 0.0.4-build24 which fix the issue by checking libX11-xcb presence.

Fix https://github.com/flathub/org.ryujinx.Ryujinx/issues/4.