### PR TITLE
Standardise GPU naming convention on the UI

### DIFF
--- a/Ryujinx.Ava/AppHost.cs
+++ b/Ryujinx.Ava/AppHost.cs
@@ -196,7 +196,7 @@ namespace Ryujinx.Ava
                 return (AmdVendor);
 
                 default:
-                return _renderer.GetHardwareInfo().GpuVendor;
+                return vendor;
             }
         }
 

--- a/Ryujinx.Ava/AppHost.cs
+++ b/Ryujinx.Ava/AppHost.cs
@@ -78,8 +78,6 @@ namespace Ryujinx.Ava
         private bool _isActive;
         private long _lastCursorMoveTime;
 
-        private string _gpuVendorName;
-
         private KeyboardHotkeyState _prevHotkeyState;
 
         private IRenderer _renderer;
@@ -895,7 +893,6 @@ namespace Ryujinx.Ava
             // Run a status update only when a frame is to be drawn. This prevents from updating the ui and wasting a render when no frame is queued
             string dockedMode = ConfigurationState.Instance.System.EnableDockedMode ? LocaleManager.Instance["Docked"] : LocaleManager.Instance["Handheld"];
             float scale = GraphicsConfig.ResScale;
-            _gpuVendorName = GetGpuVendorName();
 
             if (scale != 1)
             {
@@ -910,7 +907,7 @@ namespace Ryujinx.Ava
                 ConfigurationState.Instance.Graphics.AspectRatio.Value.ToText(),
                 LocaleManager.Instance["Game"] + $": {Device.Statistics.GetGameFrameRate():00.00} FPS ({Device.Statistics.GetGameFrameTime():00.00} ms)",
                 $"FIFO: {Device.Statistics.GetFifoPercent():00.00} %",
-                $"GPU: {_gpuVendorName}"));
+                $"GPU: {GetGpuVendorName()}"));
 
             Renderer.Present(image);
         }

--- a/Ryujinx.Ava/AppHost.cs
+++ b/Ryujinx.Ava/AppHost.cs
@@ -78,6 +78,8 @@ namespace Ryujinx.Ava
         private bool _isActive;
         private long _lastCursorMoveTime;
 
+        private string _gpuVendorName;
+
         private KeyboardHotkeyState _prevHotkeyState;
 
         private IRenderer _renderer;
@@ -893,6 +895,7 @@ namespace Ryujinx.Ava
             // Run a status update only when a frame is to be drawn. This prevents from updating the ui and wasting a render when no frame is queued
             string dockedMode = ConfigurationState.Instance.System.EnableDockedMode ? LocaleManager.Instance["Docked"] : LocaleManager.Instance["Handheld"];
             float scale = GraphicsConfig.ResScale;
+            _gpuVendorName = GetGpuVendorName();
 
             if (scale != 1)
             {
@@ -907,7 +910,7 @@ namespace Ryujinx.Ava
                 ConfigurationState.Instance.Graphics.AspectRatio.Value.ToText(),
                 LocaleManager.Instance["Game"] + $": {Device.Statistics.GetGameFrameRate():00.00} FPS ({Device.Statistics.GetGameFrameTime():00.00} ms)",
                 $"FIFO: {Device.Statistics.GetFifoPercent():00.00} %",
-                $"GPU: {GetGpuVendorName()}"));
+                $"GPU: {_gpuVendorName}"));
 
             Renderer.Present(image);
         }

--- a/Ryujinx.Ava/AppHost.cs
+++ b/Ryujinx.Ava/AppHost.cs
@@ -57,6 +57,8 @@ namespace Ryujinx.Ava
     {
         private const int CursorHideIdleTime = 8; // Hide Cursor seconds
         private const float MaxResolutionScale = 4.0f; // Max resolution hotkeys can scale to before wrapping.
+        private const string NvidiaVendor = "NVIDIA";
+        private const string AmdVendor = "AMD";
 
         private static readonly Cursor InvisibleCursor = new Cursor(StandardCursorType.None);
 
@@ -177,6 +179,24 @@ namespace Ryujinx.Ava
             {
                 double scale = _parent.PlatformImpl.RenderScaling;
                 _renderer.Window.SetSize((int)(size.Width * scale), (int)(size.Height * scale));
+            }
+        }
+
+        private string GetGpuVendorName()
+        {
+            string vendor = _renderer.GetHardwareInfo().GpuVendor;
+
+            switch (vendor.ToLower())
+            {
+                case ("nvidia corporation"):
+                return (NvidiaVendor);
+
+                case ("ati technologies inc."):
+                case ("advanced micro devices, inc."):
+                return (AmdVendor);
+
+                default:
+                return _renderer.GetHardwareInfo().GpuVendor;
             }
         }
 
@@ -887,7 +907,7 @@ namespace Ryujinx.Ava
                 ConfigurationState.Instance.Graphics.AspectRatio.Value.ToText(),
                 LocaleManager.Instance["Game"] + $": {Device.Statistics.GetGameFrameRate():00.00} FPS ({Device.Statistics.GetGameFrameTime():00.00} ms)",
                 $"FIFO: {Device.Statistics.GetFifoPercent():00.00} %",
-                $"GPU: {_renderer.GetHardwareInfo().GpuVendor}"));
+                $"GPU: {GetGpuVendorName()}"));
 
             Renderer.Present(image);
         }

--- a/Ryujinx/Ui/RendererWidgetBase.cs
+++ b/Ryujinx/Ui/RendererWidgetBase.cs
@@ -138,7 +138,7 @@ namespace Ryujinx.Ui
                 return (AmdVendor);
 
                 default:
-                return Renderer.GetHardwareInfo().GpuVendor;
+                return vendor;
             }
 
         }

--- a/Ryujinx/Ui/RendererWidgetBase.cs
+++ b/Ryujinx/Ui/RendererWidgetBase.cs
@@ -35,6 +35,8 @@ namespace Ryujinx.Ui
         private const int SwitchPanelHeight = 720;
         private const int TargetFps = 60;
         private const float MaxResolutionScale = 4.0f; // Max resolution hotkeys can scale to before wrapping.
+        private const string NvidiaVendor = "NVIDIA";
+        private const string AmdVendor = "AMD";
 
         public ManualResetEvent WaitEvent { get; set; }
         public NpadManager NpadManager { get; }
@@ -125,7 +127,21 @@ namespace Ryujinx.Ui
 
         private string GetGpuVendorName()
         {
-            return Renderer.GetHardwareInfo().GpuVendor;
+            string vendor = Renderer.GetHardwareInfo().GpuVendor;
+
+            switch (vendor.ToLower())
+            {
+                case ("nvidia corporation"):
+                return (NvidiaVendor);
+
+                case ("ati technologies inc."):
+                case ("advanced micro devices, inc."):
+                return (AmdVendor);
+
+                default:
+                return Renderer.GetHardwareInfo().GpuVendor;
+            }
+
         }
 
         private void HideCursorStateChanged(object sender, ReactiveEventArgs<bool> state)

--- a/Ryujinx/Ui/RendererWidgetBase.cs
+++ b/Ryujinx/Ui/RendererWidgetBase.cs
@@ -77,7 +77,6 @@ namespace Ryujinx.Ui
         private IKeyboard _keyboardInterface;
         private GraphicsDebugLevel _glLogLevel;
         private string _gpuBackendName;
-        private string _gpuVendorName;
         private bool _isMouseInClient;
 
         public RendererWidgetBase(InputManager inputManager, GraphicsDebugLevel glLogLevel)
@@ -410,7 +409,6 @@ namespace Ryujinx.Ui
             Device.Gpu.Renderer.Initialize(_glLogLevel);
 
             _gpuBackendName = GetGpuBackendName();
-            _gpuVendorName = GetGpuVendorName();
 
             Device.Gpu.Renderer.RunLoop(() =>
             {
@@ -460,7 +458,7 @@ namespace Ryujinx.Ui
                             ConfigurationState.Instance.Graphics.AspectRatio.Value.ToText(),
                             $"Game: {Device.Statistics.GetGameFrameRate():00.00} FPS ({Device.Statistics.GetGameFrameTime():00.00} ms)",
                             $"FIFO: {Device.Statistics.GetFifoPercent():0.00} %",
-                            $"GPU: {_gpuVendorName}"));
+                            $"GPU: {GetGpuVendorName()}"));
 
                         _ticks = Math.Min(_ticks - _ticksPerFrame, _ticksPerFrame);
                     }


### PR DESCRIPTION
Currently OpenGL and Vulkan return different strings for the GPU vendor section of the UI. 
![image](https://user-images.githubusercontent.com/44103205/182180238-032a70e4-2888-409e-b637-a6f30510fa75.png)
![image](https://user-images.githubusercontent.com/44103205/182180302-b55cf6fc-b75d-4449-9a11-748248b35343.png)

This is more annoying for AMD GPU's as their OpenGL designation is actually still "ATI technologies inc." which is a very legacy name and has confused some users in the past. Intel is the same in both APIs so no issues there.
This change makes the vendor title for OpenGL equal to the Vulkan titles. Also took the chance to remove a couple of redundant strings in the GTK render bar, calling the function directly is what Avalonia does and seems more intuitive.

![image](https://user-images.githubusercontent.com/44103205/182181241-c49fc05e-a355-444b-9d0f-ef0efe8c2f59.png)
