### PR TITLE
Fix geometry shader passthrough fallback being used when feature is supported

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 14;
+        private const uint CodeGenVersion = 3525;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -248,7 +248,7 @@ namespace Ryujinx.Graphics.Shader.Translation
                     this.Copy(Attribute(index + 12), w);
                 }
 
-                if (Config.GpPassthrough)
+                if (Config.GpPassthrough && !Config.GpuAccessor.QueryHostSupportsGeometryShaderPassthrough())
                 {
                     int inputVertices = Config.GpuAccessor.QueryPrimitiveTopology().ToInputVertices();
 


### PR DESCRIPTION
#2518 introduced a regression on GPUs that supports geometry shader passthrough. The fallback was being used even if the feature is supported, that is invalid because you can't assign to passthrough inputs and causes compilation error on OpenGL. Might be causing issues on Vulkan too, but likely not as bad as OpenGL.

Fixes regression on Marvel Ultimate Alliance 3 on Maxwell and newer NVIDIA GPUs.
![image](https://user-images.githubusercontent.com/5624669/182224260-6944fbbb-8405-4c60-9488-897e1fc04159.png)
