### PR TITLE
Add RGB16 float and int vertex formats fallback

### DIFF
--- a/Ryujinx.Graphics.GAL/Capabilities.cs
+++ b/Ryujinx.Graphics.GAL/Capabilities.cs
@@ -17,6 +17,7 @@ namespace Ryujinx.Graphics.GAL
         public readonly bool Supports3DTextureCompression;
         public readonly bool SupportsBgraFormat;
         public readonly bool SupportsR4G4Format;
+        public readonly bool SupportsR16G16B16FloatIntVertexFormat;
         public readonly bool SupportsFragmentShaderInterlock;
         public readonly bool SupportsFragmentShaderOrderingIntel;
         public readonly bool SupportsGeometryShaderPassthrough;
@@ -50,6 +51,7 @@ namespace Ryujinx.Graphics.GAL
             bool supports3DTextureCompression,
             bool supportsBgraFormat,
             bool supportsR4G4Format,
+            bool supportsR16G16B16FloatIntVertexFormat,
             bool supportsFragmentShaderInterlock,
             bool supportsFragmentShaderOrderingIntel,
             bool supportsGeometryShaderPassthrough,
@@ -80,6 +82,7 @@ namespace Ryujinx.Graphics.GAL
             Supports3DTextureCompression = supports3DTextureCompression;
             SupportsBgraFormat = supportsBgraFormat;
             SupportsR4G4Format = supportsR4G4Format;
+            SupportsR16G16B16FloatIntVertexFormat = supportsR16G16B16FloatIntVertexFormat;
             SupportsFragmentShaderInterlock = supportsFragmentShaderInterlock;
             SupportsFragmentShaderOrderingIntel = supportsFragmentShaderOrderingIntel;
             SupportsGeometryShaderPassthrough = supportsGeometryShaderPassthrough;

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClassState.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClassState.cs
@@ -268,6 +268,41 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
     }
 
     /// <summary>
+    /// Vertex attribute vector and component size.
+    /// </summary>
+    enum VertexAttribSize
+    {
+        Size32x4 = 1,
+        Size32x3 = 2,
+        Size16x4 = 3,
+        Size32x2 = 4,
+        Size16x3 = 5,
+        Size8x4 = 0xa,
+        Size16x2 = 0xf,
+        Size32 = 0x12,
+        Size8x3 = 0x13,
+        Size8x2 = 0x18,
+        Size16 = 0x1b,
+        Size8 = 0x1d,
+        Rgb10A2 = 0x30,
+        Rg11B10 = 0x31
+    }
+
+    /// <summary>
+    /// Vertex attribute component type.
+    /// </summary>
+    enum VertexAttribType
+    {
+        Snorm = 1,
+        Unorm = 2,
+        Sint = 3,
+        Uint = 4,
+        Uscaled = 5,
+        Sscaled = 6,
+        Float = 7
+    }
+
+    /// <summary>
     /// Vertex buffer attribute state.
     /// </summary>
     struct VertexAttribState
@@ -312,13 +347,22 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             return Attribute & 0x3fe00000;
         }
 
-         /// <summary>
+        /// <summary>
+        /// Unpacks the Maxwell attribute size.
+        /// </summary>
+        /// <returns>Attribute size</returns>
+        public VertexAttribSize UnpackSize()
+        {
+            return (VertexAttribSize)((Attribute >> 21) & 0x3f);
+        }
+
+        /// <summary>
         /// Unpacks the Maxwell attribute component type.
         /// </summary>
         /// <returns>Attribute component type</returns>
-        public uint UnpackType()
+        public VertexAttribType UnpackType()
         {
-            return (Attribute >> 27) & 7;
+            return (VertexAttribType)((Attribute >> 27) & 7);
         }
     }
 

--- a/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -82,7 +82,7 @@ namespace Ryujinx.Graphics.Gpu
         /// <summary>
         /// Host hardware capabilities.
         /// </summary>
-        internal Capabilities Capabilities { get; private set; }
+        internal Capabilities Capabilities;
 
         /// <summary>
         /// Event for signalling shader cache loading progress.

--- a/Ryujinx.Graphics.OpenGL/OpenGLRenderer.cs
+++ b/Ryujinx.Graphics.OpenGL/OpenGLRenderer.cs
@@ -111,6 +111,7 @@ namespace Ryujinx.Graphics.OpenGL
                 supports3DTextureCompression: false,
                 supportsBgraFormat: false,
                 supportsR4G4Format: false,
+                supportsR16G16B16FloatIntVertexFormat: true,
                 supportsFragmentShaderInterlock: HwCapabilities.SupportsFragmentShaderInterlock,
                 supportsFragmentShaderOrderingIntel: HwCapabilities.SupportsFragmentShaderOrdering,
                 supportsGeometryShaderPassthrough: HwCapabilities.SupportsGeometryShaderPassthrough,

--- a/Ryujinx.Graphics.Shader/AttributeType.cs
+++ b/Ryujinx.Graphics.Shader/AttributeType.cs
@@ -1,34 +1,67 @@
+using Ryujinx.Graphics.Shader.StructuredIr;
+using Ryujinx.Graphics.Shader.Translation;
 using System;
 
 namespace Ryujinx.Graphics.Shader
 {
     public enum AttributeType : byte
     {
+        // Generic types.
         Float,
         Sint,
-        Uint
+        Uint,
+
+        // Specific formats for conversion.
+        Rgb16f,
+        Rgb16Si,
+        Rgb16Ui
     }
 
     static class AttributeTypeExtensions
     {
-        public static string GetScalarType(this AttributeType type)
+        public static bool HasFormatForConversion(this AttributeType type)
         {
-            return type switch
-            {
-                AttributeType.Float => "float",
-                AttributeType.Sint => "int",
-                AttributeType.Uint => "uint",
-                _ => throw new ArgumentException($"Invalid attribute type \"{type}\".")
-            };
+            return type >= AttributeType.Rgb16f;
         }
 
-        public static string GetVec4Type(this AttributeType type)
+        public static string ToVec4Type(this AttributeType type)
         {
             return type switch
             {
                 AttributeType.Float => "vec4",
                 AttributeType.Sint => "ivec4",
                 AttributeType.Uint => "uvec4",
+                AttributeType.Rgb16f or
+                AttributeType.Rgb16Si or
+                AttributeType.Rgb16Ui => "vec4",
+                _ => throw new ArgumentException($"Invalid attribute type \"{type}\".")
+            };
+        }
+
+        public static VariableType ToVariableType(this AttributeType type)
+        {
+            return type switch
+            {
+                AttributeType.Float => VariableType.F32,
+                AttributeType.Sint => VariableType.S32,
+                AttributeType.Uint => VariableType.U32,
+                AttributeType.Rgb16f or
+                AttributeType.Rgb16Si or
+                AttributeType.Rgb16Ui => VariableType.F32,
+                _ => throw new ArgumentException($"Invalid attribute type \"{type}\".")
+            };
+        }
+
+        public static AggregateType ToAggregateType(this AttributeType type)
+        {
+            return type switch
+            {
+                AttributeType.Float => AggregateType.FP32,
+                AttributeType.Sint => AggregateType.S32,
+                AttributeType.Uint => AggregateType.U32,
+                AttributeType.Rgb16f or
+                AttributeType.Rgb16Si or
+                AttributeType.Rgb16Ui => AggregateType.FP32,
                 _ => throw new ArgumentException($"Invalid attribute type \"{type}\".")
             };
         }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
@@ -553,11 +553,11 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
                 if (context.Config.Stage == ShaderStage.Vertex)
                 {
-                    type = context.Config.GpuAccessor.QueryAttributeType(attr).GetVec4Type();
+                    type = context.Config.GpuAccessor.QueryAttributeType(attr).ToVec4Type();
                 }
                 else
                 {
-                    type = AttributeType.Float.GetVec4Type();
+                    type = AttributeType.Float.ToVec4Type();
                 }
 
                 context.AppendLine($"layout ({pass}location = {attr}) {iq}in {type} {name}{suffix};");

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
@@ -454,12 +454,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
                     AttributeType type = context.Config.GpuAccessor.QueryAttributeType(location);
 
-                    return type switch
-                    {
-                        AttributeType.Sint => VariableType.S32,
-                        AttributeType.Uint => VariableType.U32,
-                        _ => VariableType.F32
-                    };
+                    return type.ToVariableType();
                 }
             }
 

--- a/Ryujinx.Graphics.Shader/Translation/AttributeInfo.cs
+++ b/Ryujinx.Graphics.Shader/Translation/AttributeInfo.cs
@@ -93,12 +93,7 @@ namespace Ryujinx.Graphics.Shader.Translation
 
                 if (config.Stage == ShaderStage.Vertex && !isOutAttr)
                 {
-                    elemType = config.GpuAccessor.QueryAttributeType(location) switch
-                    {
-                        AttributeType.Sint => AggregateType.S32,
-                        AttributeType.Uint => AggregateType.U32,
-                        _ => AggregateType.FP32
-                    };
+                    elemType = config.GpuAccessor.QueryAttributeType(location).ToAggregateType();
                 }
                 else
                 {

--- a/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
@@ -208,6 +208,13 @@ namespace Ryujinx.Graphics.Vulkan
                 var attribute = state.VertexAttribs[i];
                 var bufferIndex = attribute.IsZero ? 0 : attribute.BufferIndex + 1;
 
+                if (!gd.FormatCapabilities.BufferFormatSupports(FormatFeatureFlags.FormatFeatureVertexBufferBit, attribute.Format))
+                {
+                    // Not really a Vulkan exception, but we want to stop pipeline creation as attempting to create
+                    // a pipeline with an unsupported format might crash the driver.
+                    throw new VulkanException($"Attribute format \"{attribute.Format}\" is not supported by the host.");
+                }
+
                 pipeline.Internal.VertexAttributeDescriptions[i] = new VertexInputAttributeDescription(
                     (uint)i,
                     (uint)bufferIndex,

--- a/Ryujinx.Graphics.Vulkan/TextureView.cs
+++ b/Ryujinx.Graphics.Vulkan/TextureView.cs
@@ -452,8 +452,8 @@ namespace Ryujinx.Graphics.Vulkan
 
                     return;
                 }
-                else if (_gd.FormatCapabilities.FormatSupports(FormatFeatureFlags.FormatFeatureBlitSrcBit, srcFormat) &&
-                         _gd.FormatCapabilities.FormatSupports(FormatFeatureFlags.FormatFeatureBlitDstBit, dstFormat))
+                else if (_gd.FormatCapabilities.OptimalFormatSupports(FormatFeatureFlags.FormatFeatureBlitSrcBit, srcFormat) &&
+                         _gd.FormatCapabilities.OptimalFormatSupports(FormatFeatureFlags.FormatFeatureBlitDstBit, dstFormat))
                 {
                     TextureCopy.Blit(
                         _gd.Api,
@@ -762,8 +762,8 @@ namespace Ryujinx.Graphics.Vulkan
         private bool SupportsBlitFromD32FS8ToD32FAndS8()
         {
             var formatFeatureFlags = FormatFeatureFlags.FormatFeatureBlitSrcBit | FormatFeatureFlags.FormatFeatureBlitDstBit;
-            return _gd.FormatCapabilities.FormatSupports(formatFeatureFlags, GAL.Format.D32Float)  &&
-                   _gd.FormatCapabilities.FormatSupports(formatFeatureFlags, GAL.Format.S8Uint);
+            return _gd.FormatCapabilities.OptimalFormatSupports(formatFeatureFlags, GAL.Format.D32Float)  &&
+                   _gd.FormatCapabilities.OptimalFormatSupports(formatFeatureFlags, GAL.Format.S8Uint);
         }
 
         public TextureView GetView(GAL.Format format)

--- a/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -377,7 +377,7 @@ namespace Ryujinx.Graphics.Vulkan
                 FormatFeatureFlags.FormatFeatureTransferSrcBit |
                 FormatFeatureFlags.FormatFeatureTransferDstBit;
 
-            bool supportsBc123CompressionFormat = FormatCapabilities.FormatsSupports(compressedFormatFeatureFlags,
+            bool supportsBc123CompressionFormat = FormatCapabilities.OptimalFormatsSupport(compressedFormatFeatureFlags,
                 GAL.Format.Bc1RgbaSrgb,
                 GAL.Format.Bc1RgbaUnorm,
                 GAL.Format.Bc2Srgb,
@@ -385,17 +385,22 @@ namespace Ryujinx.Graphics.Vulkan
                 GAL.Format.Bc3Srgb,
                 GAL.Format.Bc3Unorm);
 
-            bool supportsBc45CompressionFormat = FormatCapabilities.FormatsSupports(compressedFormatFeatureFlags,
+            bool supportsBc45CompressionFormat = FormatCapabilities.OptimalFormatsSupport(compressedFormatFeatureFlags,
                 GAL.Format.Bc4Snorm,
                 GAL.Format.Bc4Unorm,
                 GAL.Format.Bc5Snorm,
                 GAL.Format.Bc5Unorm);
 
-            bool supportsBc67CompressionFormat = FormatCapabilities.FormatsSupports(compressedFormatFeatureFlags,
+            bool supportsBc67CompressionFormat = FormatCapabilities.OptimalFormatsSupport(compressedFormatFeatureFlags,
                 GAL.Format.Bc6HSfloat,
                 GAL.Format.Bc6HUfloat,
                 GAL.Format.Bc7Srgb,
                 GAL.Format.Bc7Unorm);
+
+            bool supportsRgb16FloatIntVertexFormat = FormatCapabilities.BufferFormatsSupport(FormatFeatureFlags.FormatFeatureVertexBufferBit,
+                GAL.Format.R16G16B16Float,
+                GAL.Format.R16G16B16Sint,
+                GAL.Format.R16G16B16Uint);
 
             Api.GetPhysicalDeviceFeatures(_physicalDevice, out var features);
             Api.GetPhysicalDeviceProperties(_physicalDevice, out var properties);
@@ -414,6 +419,7 @@ namespace Ryujinx.Graphics.Vulkan
                 supports3DTextureCompression: true,
                 supportsBgraFormat: true,
                 supportsR4G4Format: false,
+                supportsR16G16B16FloatIntVertexFormat: supportsRgb16FloatIntVertexFormat,
                 supportsFragmentShaderInterlock: Capabilities.SupportsFragmentShaderInterlock,
                 supportsFragmentShaderOrderingIntel: false,
                 supportsGeometryShaderPassthrough: Capabilities.SupportsGeometryShaderPassthrough,


### PR DESCRIPTION
AMD does not support the RGB16 Float, Uint and Sint vertex formats on Vulkan, so we need some way to emulate them. There are multiple ways to do this, but what I decided to do is use the Uscaled and Sscaled formats that are supported. Since Uscaled is just a unsigned integer converted to float, we can convert it back to integer for the Uint and Sint formats, and for the Float format, we can reinterpret as float in addition to converting to integer.

This fixes a crash when trying to create a graphics pipeline on Xenoblade Chronicles 3.
Also depends/includes #3528 since there was a driver (?) bug causing it to crash when trying to clear individual slices of a 3D texture.

I made it throw when a unsupported vertex format is found to avoid trying to create a pipeline with the invalid format, which might cause crashes that we can't catch on the driver. This is required to avoid crashes loading a shader cache with the unsupported format.

Also changed `Capabilities` from a property to a field, because it being a property means that every access will copy the struct, which is not great if its accessed on a hot path.

Testing is welcome.
Closes #3513.