### PR TITLE
Use RGBA16 vertex format if RGB16 is not supported on Vulkan

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -1262,10 +1262,12 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
             for (int location = 0; location < attributeTypes.Length; location++)
             {
-                attributeTypes[location] = vertexAttribState[location].UnpackType() switch
+                VertexAttribType type = vertexAttribState[location].UnpackType();
+
+                attributeTypes[location] = type switch
                 {
-                    3 => AttributeType.Sint,
-                    4 => AttributeType.Uint,
+                    VertexAttribType.Sint => AttributeType.Sint,
+                    VertexAttribType.Uint => AttributeType.Uint,
                     _ => AttributeType.Float
                 };
             }

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClassState.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClassState.cs
@@ -268,6 +268,41 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
     }
 
     /// <summary>
+    /// Vertex attribute vector and component size.
+    /// </summary>
+    enum VertexAttribSize
+    {
+        Size32x4 = 1,
+        Size32x3 = 2,
+        Size16x4 = 3,
+        Size32x2 = 4,
+        Size16x3 = 5,
+        Size8x4 = 0xa,
+        Size16x2 = 0xf,
+        Size32 = 0x12,
+        Size8x3 = 0x13,
+        Size8x2 = 0x18,
+        Size16 = 0x1b,
+        Size8 = 0x1d,
+        Rgb10A2 = 0x30,
+        Rg11B10 = 0x31
+    }
+
+    /// <summary>
+    /// Vertex attribute component type.
+    /// </summary>
+    enum VertexAttribType
+    {
+        Snorm = 1,
+        Unorm = 2,
+        Sint = 3,
+        Uint = 4,
+        Uscaled = 5,
+        Sscaled = 6,
+        Float = 7
+    }
+
+    /// <summary>
     /// Vertex buffer attribute state.
     /// </summary>
     struct VertexAttribState
@@ -312,13 +347,22 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             return Attribute & 0x3fe00000;
         }
 
-         /// <summary>
+        /// <summary>
+        /// Unpacks the Maxwell attribute size.
+        /// </summary>
+        /// <returns>Attribute size</returns>
+        public VertexAttribSize UnpackSize()
+        {
+            return (VertexAttribSize)((Attribute >> 21) & 0x3f);
+        }
+
+        /// <summary>
         /// Unpacks the Maxwell attribute component type.
         /// </summary>
         /// <returns>Attribute component type</returns>
-        public uint UnpackType()
+        public VertexAttribType UnpackType()
         {
-            return (Attribute >> 27) & 7;
+            return (VertexAttribType)((Attribute >> 27) & 7);
         }
     }
 

--- a/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -82,7 +82,7 @@ namespace Ryujinx.Graphics.Gpu
         /// <summary>
         /// Host hardware capabilities.
         /// </summary>
-        internal Capabilities Capabilities { get; private set; }
+        internal Capabilities Capabilities;
 
         /// <summary>
         /// Event for signalling shader cache loading progress.

--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/ParallelDiskCacheLoader.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/ParallelDiskCacheLoader.cs
@@ -573,9 +573,9 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
                     RecompileGraphicsFromGuestCode(guestShaders, specState, programIndex);
                 }
             }
-            catch (DiskCacheLoadException diskCacheLoadException)
+            catch (Exception exception)
             {
-                Logger.Error?.Print(LogClass.Gpu, $"Error translating guest shader. {diskCacheLoadException.Message}");
+                Logger.Error?.Print(LogClass.Gpu, $"Error translating guest shader. {exception.Message}");
 
                 ErrorCount++;
                 SignalCompiled();

--- a/Ryujinx.Graphics.Shader/AttributeType.cs
+++ b/Ryujinx.Graphics.Shader/AttributeType.cs
@@ -1,9 +1,12 @@
+using Ryujinx.Graphics.Shader.StructuredIr;
+using Ryujinx.Graphics.Shader.Translation;
 using System;
 
 namespace Ryujinx.Graphics.Shader
 {
     public enum AttributeType : byte
     {
+        // Generic types.
         Float,
         Sint,
         Uint
@@ -11,24 +14,35 @@ namespace Ryujinx.Graphics.Shader
 
     static class AttributeTypeExtensions
     {
-        public static string GetScalarType(this AttributeType type)
-        {
-            return type switch
-            {
-                AttributeType.Float => "float",
-                AttributeType.Sint => "int",
-                AttributeType.Uint => "uint",
-                _ => throw new ArgumentException($"Invalid attribute type \"{type}\".")
-            };
-        }
-
-        public static string GetVec4Type(this AttributeType type)
+        public static string ToVec4Type(this AttributeType type)
         {
             return type switch
             {
                 AttributeType.Float => "vec4",
                 AttributeType.Sint => "ivec4",
                 AttributeType.Uint => "uvec4",
+                _ => throw new ArgumentException($"Invalid attribute type \"{type}\".")
+            };
+        }
+
+        public static VariableType ToVariableType(this AttributeType type)
+        {
+            return type switch
+            {
+                AttributeType.Float => VariableType.F32,
+                AttributeType.Sint => VariableType.S32,
+                AttributeType.Uint => VariableType.U32,
+                _ => throw new ArgumentException($"Invalid attribute type \"{type}\".")
+            };
+        }
+
+        public static AggregateType ToAggregateType(this AttributeType type)
+        {
+            return type switch
+            {
+                AttributeType.Float => AggregateType.FP32,
+                AttributeType.Sint => AggregateType.S32,
+                AttributeType.Uint => AggregateType.U32,
                 _ => throw new ArgumentException($"Invalid attribute type \"{type}\".")
             };
         }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
@@ -553,11 +553,11 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
                 if (context.Config.Stage == ShaderStage.Vertex)
                 {
-                    type = context.Config.GpuAccessor.QueryAttributeType(attr).GetVec4Type();
+                    type = context.Config.GpuAccessor.QueryAttributeType(attr).ToVec4Type();
                 }
                 else
                 {
-                    type = AttributeType.Float.GetVec4Type();
+                    type = AttributeType.Float.ToVec4Type();
                 }
 
                 context.AppendLine($"layout ({pass}location = {attr}) {iq}in {type} {name}{suffix};");

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
@@ -454,12 +454,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
                     AttributeType type = context.Config.GpuAccessor.QueryAttributeType(location);
 
-                    return type switch
-                    {
-                        AttributeType.Sint => VariableType.S32,
-                        AttributeType.Uint => VariableType.U32,
-                        _ => VariableType.F32
-                    };
+                    return type.ToVariableType();
                 }
             }
 

--- a/Ryujinx.Graphics.Shader/Translation/AttributeInfo.cs
+++ b/Ryujinx.Graphics.Shader/Translation/AttributeInfo.cs
@@ -93,12 +93,7 @@ namespace Ryujinx.Graphics.Shader.Translation
 
                 if (config.Stage == ShaderStage.Vertex && !isOutAttr)
                 {
-                    elemType = config.GpuAccessor.QueryAttributeType(location) switch
-                    {
-                        AttributeType.Sint => AggregateType.S32,
-                        AttributeType.Uint => AggregateType.U32,
-                        _ => AggregateType.FP32
-                    };
+                    elemType = config.GpuAccessor.QueryAttributeType(location).ToAggregateType();
                 }
                 else
                 {

--- a/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -730,6 +730,8 @@ namespace Ryujinx.Graphics.Vulkan
 
         public void SetVertexAttribs(ReadOnlySpan<VertexAttribDescriptor> vertexAttribs)
         {
+            var formatCapabilities = Gd.FormatCapabilities;
+
             int count = Math.Min(Constants.MaxVertexAttributes, vertexAttribs.Length);
 
             for (int i = 0; i < count; i++)
@@ -740,7 +742,7 @@ namespace Ryujinx.Graphics.Vulkan
                 _newState.Internal.VertexAttributeDescriptions[i] = new VertexInputAttributeDescription(
                     (uint)i,
                     (uint)bufferIndex,
-                    FormatTable.GetFormat(attribute.Format),
+                    formatCapabilities.ConvertToVertexVkFormat(attribute.Format),
                     (uint)attribute.Offset);
             }
 

--- a/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
@@ -211,7 +211,7 @@ namespace Ryujinx.Graphics.Vulkan
                 pipeline.Internal.VertexAttributeDescriptions[i] = new VertexInputAttributeDescription(
                     (uint)i,
                     (uint)bufferIndex,
-                    FormatTable.GetFormat(attribute.Format),
+                    gd.FormatCapabilities.ConvertToVertexVkFormat(attribute.Format),
                     (uint)attribute.Offset);
             }
 

--- a/Ryujinx.Graphics.Vulkan/TextureView.cs
+++ b/Ryujinx.Graphics.Vulkan/TextureView.cs
@@ -452,8 +452,8 @@ namespace Ryujinx.Graphics.Vulkan
 
                     return;
                 }
-                else if (_gd.FormatCapabilities.FormatSupports(FormatFeatureFlags.FormatFeatureBlitSrcBit, srcFormat) &&
-                         _gd.FormatCapabilities.FormatSupports(FormatFeatureFlags.FormatFeatureBlitDstBit, dstFormat))
+                else if (_gd.FormatCapabilities.OptimalFormatSupports(FormatFeatureFlags.FormatFeatureBlitSrcBit, srcFormat) &&
+                         _gd.FormatCapabilities.OptimalFormatSupports(FormatFeatureFlags.FormatFeatureBlitDstBit, dstFormat))
                 {
                     TextureCopy.Blit(
                         _gd.Api,
@@ -762,8 +762,8 @@ namespace Ryujinx.Graphics.Vulkan
         private bool SupportsBlitFromD32FS8ToD32FAndS8()
         {
             var formatFeatureFlags = FormatFeatureFlags.FormatFeatureBlitSrcBit | FormatFeatureFlags.FormatFeatureBlitDstBit;
-            return _gd.FormatCapabilities.FormatSupports(formatFeatureFlags, GAL.Format.D32Float)  &&
-                   _gd.FormatCapabilities.FormatSupports(formatFeatureFlags, GAL.Format.S8Uint);
+            return _gd.FormatCapabilities.OptimalFormatSupports(formatFeatureFlags, GAL.Format.D32Float)  &&
+                   _gd.FormatCapabilities.OptimalFormatSupports(formatFeatureFlags, GAL.Format.S8Uint);
         }
 
         public TextureView GetView(GAL.Format format)

--- a/Ryujinx.Graphics.Vulkan/VulkanConfiguration.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanConfiguration.cs
@@ -7,5 +7,6 @@
         public const bool UsePushDescriptors = false;
 
         public const bool ForceD24S8Unsupported = false;
+        public const bool ForceRGB16IntFloatUnsupported = false;
     }
 }

--- a/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -377,7 +377,7 @@ namespace Ryujinx.Graphics.Vulkan
                 FormatFeatureFlags.FormatFeatureTransferSrcBit |
                 FormatFeatureFlags.FormatFeatureTransferDstBit;
 
-            bool supportsBc123CompressionFormat = FormatCapabilities.FormatsSupports(compressedFormatFeatureFlags,
+            bool supportsBc123CompressionFormat = FormatCapabilities.OptimalFormatsSupport(compressedFormatFeatureFlags,
                 GAL.Format.Bc1RgbaSrgb,
                 GAL.Format.Bc1RgbaUnorm,
                 GAL.Format.Bc2Srgb,
@@ -385,13 +385,13 @@ namespace Ryujinx.Graphics.Vulkan
                 GAL.Format.Bc3Srgb,
                 GAL.Format.Bc3Unorm);
 
-            bool supportsBc45CompressionFormat = FormatCapabilities.FormatsSupports(compressedFormatFeatureFlags,
+            bool supportsBc45CompressionFormat = FormatCapabilities.OptimalFormatsSupport(compressedFormatFeatureFlags,
                 GAL.Format.Bc4Snorm,
                 GAL.Format.Bc4Unorm,
                 GAL.Format.Bc5Snorm,
                 GAL.Format.Bc5Unorm);
 
-            bool supportsBc67CompressionFormat = FormatCapabilities.FormatsSupports(compressedFormatFeatureFlags,
+            bool supportsBc67CompressionFormat = FormatCapabilities.OptimalFormatsSupport(compressedFormatFeatureFlags,
                 GAL.Format.Bc6HSfloat,
                 GAL.Format.Bc6HUfloat,
                 GAL.Format.Bc7Srgb,


### PR DESCRIPTION
This is an alternative to #3529. It solves the same problem, but using a different approach. Rather than using a format that has the same size but different type, this uses a format that has the same type but different size. The fact that it has the same type means that no conversion on the shader is required, but it brings other potential issues which is why I didn't want to use this approach before:
- The fact that this format is larger means that its size may be greater than offset + stride, which is invalid according to the spec.
- If the shader attempts to access the last component which should not exist, it will read garbage (the whatever is next in the vertex buffer) rather than 0.
- This can cause out of bounds access of the vertex buffer (by 2 bytes).

Puting this here for testing since we had a issue reported with the other approach.