### PR TITLE
Rename ToSpan to AsSpan

### DIFF
--- a/Ryujinx.Audio/Renderer/Dsp/DataSourceHelper.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/DataSourceHelper.cs
@@ -76,7 +76,7 @@ namespace Ryujinx.Audio.Renderer.Dsp
 
                     if (!info.DecodingBehaviour.HasFlag(DecodingBehaviour.SkipPitchAndSampleRateConversion))
                     {
-                        voiceState.Pitch.ToSpan().Slice(0, pitchMaxLength).CopyTo(tempBuffer);
+                        voiceState.Pitch.AsSpan().Slice(0, pitchMaxLength).CopyTo(tempBuffer);
                         tempBufferIndex += pitchMaxLength;
                     }
 
@@ -239,7 +239,7 @@ namespace Ryujinx.Audio.Renderer.Dsp
 
                         ResamplerHelper.Resample(outputBuffer, tempBuffer, sampleRateRatio, ref fraction, sampleCountToProcess, info.SrcQuality, y != sourceSampleCountToProcess || info.Pitch != 1.0f);
 
-                        tempBuffer.Slice(sampleCountToDecode, pitchMaxLength).CopyTo(voiceState.Pitch.ToSpan());
+                        tempBuffer.Slice(sampleCountToDecode, pitchMaxLength).CopyTo(voiceState.Pitch.AsSpan());
                     }
 
                     i += sampleCountToProcess;

--- a/Ryujinx.Audio/Renderer/Parameter/Effect/LimiterStatistics.cs
+++ b/Ryujinx.Audio/Renderer/Parameter/Effect/LimiterStatistics.cs
@@ -24,8 +24,8 @@ namespace Ryujinx.Audio.Renderer.Parameter.Effect
         /// </summary>
         public void Reset()
         {
-            InputMax.ToSpan().Fill(0.0f);
-            CompressionGainMin.ToSpan().Fill(1.0f);
+            InputMax.AsSpan().Fill(0.0f);
+            CompressionGainMin.AsSpan().Fill(1.0f);
         }
     }
 }

--- a/Ryujinx.Audio/Renderer/Server/CommandGenerator.cs
+++ b/Ryujinx.Audio/Renderer/Server/CommandGenerator.cs
@@ -141,7 +141,7 @@ namespace Ryujinx.Audio.Renderer.Server
                 Memory<byte> biquadStateRawMemory = SpanMemoryManager<byte>.Cast(state).Slice(VoiceUpdateState.BiquadStateOffset, VoiceUpdateState.BiquadStateSize * Constants.VoiceBiquadFilterCount);
                 Memory<BiquadFilterState> stateMemory = SpanMemoryManager<BiquadFilterState>.Cast(biquadStateRawMemory);
 
-                _commandBuffer.GenerateGroupedBiquadFilter(baseIndex, voiceState.BiquadFilters.ToSpan(), stateMemory, bufferOffset, bufferOffset, voiceState.BiquadFilterNeedInitialization, nodeId);
+                _commandBuffer.GenerateGroupedBiquadFilter(baseIndex, voiceState.BiquadFilters.AsSpan(), stateMemory, bufferOffset, bufferOffset, voiceState.BiquadFilterNeedInitialization, nodeId);
             }
             else
             {
@@ -337,8 +337,8 @@ namespace Ryujinx.Audio.Renderer.Server
                             GeneratePerformance(ref performanceEntry, PerformanceCommand.Type.Start, nodeId);
                         }
 
-                        GenerateVoiceMix(channelResource.Mix.ToSpan(),
-                                         channelResource.PreviousMix.ToSpan(),
+                        GenerateVoiceMix(channelResource.Mix.AsSpan(),
+                                         channelResource.PreviousMix.AsSpan(),
                                          dspStateMemory,
                                          mix.BufferOffset,
                                          mix.BufferCount,
@@ -505,8 +505,8 @@ namespace Ryujinx.Audio.Renderer.Server
                 BiquadFilterParameter parameter = new BiquadFilterParameter();
 
                 parameter.Enable = true;
-                effect.Parameter.Denominator.ToSpan().CopyTo(parameter.Denominator.ToSpan());
-                effect.Parameter.Numerator.ToSpan().CopyTo(parameter.Numerator.ToSpan());
+                effect.Parameter.Denominator.AsSpan().CopyTo(parameter.Denominator.AsSpan());
+                effect.Parameter.Numerator.AsSpan().CopyTo(parameter.Numerator.AsSpan());
 
                 for (int i = 0; i < effect.Parameter.ChannelCount; i++)
                 {
@@ -923,8 +923,8 @@ namespace Ryujinx.Audio.Renderer.Server
             if (useCustomDownMixingCommand)
             {
                 _commandBuffer.GenerateDownMixSurroundToStereo(finalMix.BufferOffset,
-                                                               sink.Parameter.Input.ToSpan(),
-                                                               sink.Parameter.Input.ToSpan(),
+                                                               sink.Parameter.Input.AsSpan(),
+                                                               sink.Parameter.Input.AsSpan(),
                                                                sink.DownMixCoefficients,
                                                                Constants.InvalidNodeId);
             }
@@ -932,8 +932,8 @@ namespace Ryujinx.Audio.Renderer.Server
             else if (_rendererContext.ChannelCount == 2 && sink.Parameter.InputCount == 6)
             {
                 _commandBuffer.GenerateDownMixSurroundToStereo(finalMix.BufferOffset,
-                                                               sink.Parameter.Input.ToSpan(),
-                                                               sink.Parameter.Input.ToSpan(),
+                                                               sink.Parameter.Input.AsSpan(),
+                                                               sink.Parameter.Input.AsSpan(),
                                                                Constants.DefaultSurroundToStereoCoefficients,
                                                                Constants.InvalidNodeId);
             }
@@ -945,7 +945,7 @@ namespace Ryujinx.Audio.Renderer.Server
                 _commandBuffer.GenerateUpsample(finalMix.BufferOffset,
                                                 sink.UpsamplerState,
                                                 sink.Parameter.InputCount,
-                                                sink.Parameter.Input.ToSpan(),
+                                                sink.Parameter.Input.AsSpan(),
                                                 commandList.BufferCount,
                                                 commandList.SampleCount,
                                                 commandList.SampleRate,

--- a/Ryujinx.Audio/Renderer/Server/Sink/DeviceSink.cs
+++ b/Ryujinx.Audio/Renderer/Server/Sink/DeviceSink.cs
@@ -63,10 +63,10 @@ namespace Ryujinx.Audio.Renderer.Server.Sink
             else
             {
                 Parameter.DownMixParameterEnabled = inputDeviceParameter.DownMixParameterEnabled;
-                inputDeviceParameter.DownMixParameter.ToSpan().CopyTo(Parameter.DownMixParameter.ToSpan());
+                inputDeviceParameter.DownMixParameter.AsSpan().CopyTo(Parameter.DownMixParameter.AsSpan());
             }
 
-            Parameter.DownMixParameter.ToSpan().CopyTo(DownMixCoefficients.AsSpan());
+            Parameter.DownMixParameter.AsSpan().CopyTo(DownMixCoefficients.AsSpan());
 
             errorInfo = new BehaviourParameter.ErrorInfo();
             outStatus = new SinkOutStatus();

--- a/Ryujinx.Audio/Renderer/Server/StateUpdater.cs
+++ b/Ryujinx.Audio/Renderer/Server/StateUpdater.cs
@@ -119,7 +119,7 @@ namespace Ryujinx.Audio.Renderer.Server
                 ref VoiceChannelResource resource = ref context.GetChannelResource(i);
 
                 resource.Id = parameter.Id;
-                parameter.Mix.ToSpan().CopyTo(resource.Mix.ToSpan());
+                parameter.Mix.AsSpan().CopyTo(resource.Mix.AsSpan());
                 resource.IsUsed = parameter.IsUsed;
             }
 
@@ -587,7 +587,7 @@ namespace Ryujinx.Audio.Renderer.Server
         {
             ref BehaviourErrorInfoOutStatus outStatus = ref SpanIOHelper.GetWriteRef<BehaviourErrorInfoOutStatus>(ref _output)[0];
 
-            _behaviourContext.CopyErrorInfo(outStatus.ErrorInfos.ToSpan(), out outStatus.ErrorInfosCount);
+            _behaviourContext.CopyErrorInfo(outStatus.ErrorInfos.AsSpan(), out outStatus.ErrorInfosCount);
 
             OutputHeader.BehaviourSize = (uint)Unsafe.SizeOf<BehaviourErrorInfoOutStatus>();
             OutputHeader.TotalSize += OutputHeader.BehaviourSize;

--- a/Ryujinx.Audio/Renderer/Server/Voice/VoiceChannelResource.cs
+++ b/Ryujinx.Audio/Renderer/Server/Voice/VoiceChannelResource.cs
@@ -34,7 +34,7 @@ namespace Ryujinx.Audio.Renderer.Server.Voice
 
         public void UpdateState()
         {
-            Mix.ToSpan().CopyTo(PreviousMix.ToSpan());
+            Mix.AsSpan().CopyTo(PreviousMix.AsSpan());
         }
     }
 }

--- a/Ryujinx.Audio/Renderer/Server/Voice/VoiceState.cs
+++ b/Ryujinx.Audio/Renderer/Server/Voice/VoiceState.cs
@@ -202,7 +202,7 @@ namespace Ryujinx.Audio.Renderer.Server.Voice
             Pitch = 0.0f;
             Volume = 0.0f;
             PreviousVolume = 0.0f;
-            BiquadFilters.ToSpan().Fill(new BiquadFilterParameter());
+            BiquadFilters.AsSpan().Fill(new BiquadFilterParameter());
             WaveBuffersCount = 0;
             WaveBuffersIndex = 0;
             MixId = Constants.UnusedMixId;
@@ -288,7 +288,7 @@ namespace Ryujinx.Audio.Renderer.Server.Voice
             ChannelsCount = parameter.ChannelCount;
             Pitch = parameter.Pitch;
             Volume = parameter.Volume;
-            parameter.BiquadFilters.ToSpan().CopyTo(BiquadFilters.ToSpan());
+            parameter.BiquadFilters.AsSpan().CopyTo(BiquadFilters.AsSpan());
             WaveBuffersCount = parameter.WaveBuffersCount;
             WaveBuffersIndex = parameter.WaveBuffersIndex;
 
@@ -308,7 +308,7 @@ namespace Ryujinx.Audio.Renderer.Server.Voice
                 SplitterId = Constants.UnusedSplitterId;
             }
 
-            parameter.ChannelResourceIds.ToSpan().CopyTo(ChannelResourceIds.ToSpan());
+            parameter.ChannelResourceIds.AsSpan().CopyTo(ChannelResourceIds.AsSpan());
 
             DecodingBehaviour behaviour = DecodingBehaviour.Default;
 
@@ -638,7 +638,7 @@ namespace Ryujinx.Audio.Renderer.Server.Voice
 
                         voiceUpdateState.Offset = 0;
                         voiceUpdateState.PlayedSampleCount = 0;
-                        voiceUpdateState.Pitch.ToSpan().Fill(0);
+                        voiceUpdateState.Pitch.AsSpan().Fill(0);
                         voiceUpdateState.Fraction = 0;
                         voiceUpdateState.LoopContext = new Dsp.State.AdpcmLoopContext();
                     }
@@ -650,7 +650,7 @@ namespace Ryujinx.Audio.Renderer.Server.Voice
 
                 case Types.PlayState.Stopped:
                 case Types.PlayState.Paused:
-                    foreach (ref WaveBuffer wavebuffer in WaveBuffers.ToSpan())
+                    foreach (ref WaveBuffer wavebuffer in WaveBuffers.AsSpan())
                     {
                         wavebuffer.BufferAddressInfo.GetReference(true);
                         wavebuffer.ContextAddressInfo.GetReference(true);

--- a/Ryujinx.Common/Memory/ArrayPtr.cs
+++ b/Ryujinx.Common/Memory/ArrayPtr.cs
@@ -87,7 +87,7 @@ namespace Ryujinx.Common.Memory
         /// Gets a span from the array.
         /// </summary>
         /// <returns>Span of the array</returns>
-        public Span<T> ToSpan() => Length == 0 ? Span<T>.Empty : MemoryMarshal.CreateSpan(ref this[0], Length);
+        public Span<T> AsSpan() => Length == 0 ? Span<T>.Empty : MemoryMarshal.CreateSpan(ref this[0], Length);
 
         /// <summary>
         /// Gets the array base pointer.

--- a/Ryujinx.Common/Memory/PartialUnmaps/PartialUnmapState.cs
+++ b/Ryujinx.Common/Memory/PartialUnmaps/PartialUnmapState.cs
@@ -83,7 +83,7 @@ namespace Ryujinx.Common.Memory.PartialUnmaps
         /// memory might be accessed but is unmapped. Users of the API must compensate for that by catching the
         /// access violation and retrying if it happened between the unmap and remap operation.
         /// This method can be used to decide if retrying in such cases is necessary or not.
-        /// 
+        ///
         /// This version of the function is not used, but serves as a reference for the native
         /// implementation in ARMeilleure.
         /// </remarks>
@@ -128,12 +128,12 @@ namespace Ryujinx.Common.Memory.PartialUnmaps
             const uint ExitCodeStillActive = 259;
             const int ThreadQueryInformation = 0x40;
 
-            Span<int> ids = LocalCounts.ThreadIds.ToSpan();
+            Span<int> ids = LocalCounts.ThreadIds.AsSpan();
 
             for (int i = 0; i < ids.Length; i++)
             {
                 int id = ids[i];
-                
+
                 if (id != 0)
                 {
                     IntPtr handle = OpenThread(ThreadQueryInformation, false, (uint)id);

--- a/Ryujinx.Common/Memory/StructArrayHelpers.cs
+++ b/Ryujinx.Common/Memory/StructArrayHelpers.cs
@@ -7,8 +7,8 @@ namespace Ryujinx.Common.Memory
     {
         T _e0;
         public int Length => 1;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 1);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 1);
     }
     public struct Array2<T> : IArray<T> where T : unmanaged
     {
@@ -17,8 +17,8 @@ namespace Ryujinx.Common.Memory
         Array1<T> _other;
 #pragma warning restore CS0169
         public int Length => 2;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 2);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 2);
     }
     public struct Array3<T> : IArray<T> where T : unmanaged
     {
@@ -27,8 +27,8 @@ namespace Ryujinx.Common.Memory
         Array2<T> _other;
 #pragma warning restore CS0169
         public int Length => 3;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 3);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 3);
     }
     public struct Array4<T> : IArray<T> where T : unmanaged
     {
@@ -37,8 +37,8 @@ namespace Ryujinx.Common.Memory
         Array3<T> _other;
 #pragma warning restore CS0169
         public int Length => 4;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 4);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 4);
     }
     public struct Array5<T> : IArray<T> where T : unmanaged
     {
@@ -47,8 +47,8 @@ namespace Ryujinx.Common.Memory
         Array4<T> _other;
 #pragma warning restore CS0169
         public int Length => 5;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 5);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 5);
     }
     public struct Array6<T> : IArray<T> where T : unmanaged
     {
@@ -57,8 +57,8 @@ namespace Ryujinx.Common.Memory
         Array5<T> _other;
 #pragma warning restore CS0169
         public int Length => 6;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 6);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 6);
     }
     public struct Array7<T> : IArray<T> where T : unmanaged
     {
@@ -67,8 +67,8 @@ namespace Ryujinx.Common.Memory
         Array6<T> _other;
 #pragma warning restore CS0169
         public int Length => 7;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 7);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 7);
     }
     public struct Array8<T> : IArray<T> where T : unmanaged
     {
@@ -77,8 +77,8 @@ namespace Ryujinx.Common.Memory
         Array7<T> _other;
 #pragma warning restore CS0169
         public int Length => 8;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 8);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 8);
     }
     public struct Array9<T> : IArray<T> where T : unmanaged
     {
@@ -87,8 +87,8 @@ namespace Ryujinx.Common.Memory
         Array8<T> _other;
 #pragma warning restore CS0169
         public int Length => 9;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 9);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 9);
     }
     public struct Array10<T> : IArray<T> where T : unmanaged
     {
@@ -97,8 +97,8 @@ namespace Ryujinx.Common.Memory
         Array9<T> _other;
 #pragma warning restore CS0169
         public int Length => 10;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 10);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 10);
     }
     public struct Array11<T> : IArray<T> where T : unmanaged
     {
@@ -107,8 +107,8 @@ namespace Ryujinx.Common.Memory
         Array10<T> _other;
 #pragma warning restore CS0169
         public int Length => 11;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 11);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 11);
     }
     public struct Array12<T> : IArray<T> where T : unmanaged
     {
@@ -117,8 +117,8 @@ namespace Ryujinx.Common.Memory
         Array11<T> _other;
 #pragma warning restore CS0169
         public int Length => 12;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 12);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 12);
     }
     public struct Array13<T> : IArray<T> where T : unmanaged
     {
@@ -127,8 +127,8 @@ namespace Ryujinx.Common.Memory
         Array12<T> _other;
 #pragma warning restore CS0169
         public int Length => 13;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 13);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 13);
     }
     public struct Array14<T> : IArray<T> where T : unmanaged
     {
@@ -137,8 +137,8 @@ namespace Ryujinx.Common.Memory
         Array13<T> _other;
 #pragma warning restore CS0169
         public int Length => 14;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 14);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 14);
     }
     public struct Array15<T> : IArray<T> where T : unmanaged
     {
@@ -147,8 +147,8 @@ namespace Ryujinx.Common.Memory
         Array14<T> _other;
 #pragma warning restore CS0169
         public int Length => 15;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 15);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 15);
     }
     public struct Array16<T> : IArray<T> where T : unmanaged
     {
@@ -157,8 +157,8 @@ namespace Ryujinx.Common.Memory
         Array15<T> _other;
 #pragma warning restore CS0169
         public int Length => 16;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 16);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 16);
     }
     public struct Array17<T> : IArray<T> where T : unmanaged
     {
@@ -167,8 +167,8 @@ namespace Ryujinx.Common.Memory
         Array16<T> _other;
 #pragma warning restore CS0169
         public int Length => 17;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 17);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 17);
     }
     public struct Array18<T> : IArray<T> where T : unmanaged
     {
@@ -177,8 +177,8 @@ namespace Ryujinx.Common.Memory
         Array17<T> _other;
 #pragma warning restore CS0169
         public int Length => 18;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 18);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 18);
     }
     public struct Array19<T> : IArray<T> where T : unmanaged
     {
@@ -187,8 +187,8 @@ namespace Ryujinx.Common.Memory
         Array18<T> _other;
 #pragma warning restore CS0169
         public int Length => 19;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 19);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 19);
     }
     public struct Array20<T> : IArray<T> where T : unmanaged
     {
@@ -197,8 +197,8 @@ namespace Ryujinx.Common.Memory
         Array19<T> _other;
 #pragma warning restore CS0169
         public int Length => 20;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 20);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 20);
     }
     public struct Array21<T> : IArray<T> where T : unmanaged
     {
@@ -207,8 +207,8 @@ namespace Ryujinx.Common.Memory
         Array20<T> _other;
 #pragma warning restore CS0169
         public int Length => 21;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 21);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 21);
     }
     public struct Array22<T> : IArray<T> where T : unmanaged
     {
@@ -217,8 +217,8 @@ namespace Ryujinx.Common.Memory
         Array21<T> _other;
 #pragma warning restore CS0169
         public int Length => 22;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 22);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 22);
     }
     public struct Array23<T> : IArray<T> where T : unmanaged
     {
@@ -227,8 +227,8 @@ namespace Ryujinx.Common.Memory
         Array22<T> _other;
 #pragma warning restore CS0169
         public int Length => 23;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 23);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 23);
     }
     public struct Array24<T> : IArray<T> where T : unmanaged
     {
@@ -237,8 +237,8 @@ namespace Ryujinx.Common.Memory
         Array23<T> _other;
 #pragma warning restore CS0169
         public int Length => 24;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 24);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 24);
     }
     public struct Array25<T> : IArray<T> where T : unmanaged
     {
@@ -247,8 +247,8 @@ namespace Ryujinx.Common.Memory
         Array24<T> _other;
 #pragma warning restore CS0169
         public int Length => 25;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 25);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 25);
     }
     public struct Array26<T> : IArray<T> where T : unmanaged
     {
@@ -257,8 +257,8 @@ namespace Ryujinx.Common.Memory
         Array25<T> _other;
 #pragma warning restore CS0169
         public int Length => 26;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 26);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 26);
     }
     public struct Array27<T> : IArray<T> where T : unmanaged
     {
@@ -267,8 +267,8 @@ namespace Ryujinx.Common.Memory
         Array26<T> _other;
 #pragma warning restore CS0169
         public int Length => 27;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 27);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 27);
     }
     public struct Array28<T> : IArray<T> where T : unmanaged
     {
@@ -277,8 +277,8 @@ namespace Ryujinx.Common.Memory
         Array27<T> _other;
 #pragma warning restore CS0169
         public int Length => 28;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 28);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 28);
     }
     public struct Array29<T> : IArray<T> where T : unmanaged
     {
@@ -287,8 +287,8 @@ namespace Ryujinx.Common.Memory
         Array28<T> _other;
 #pragma warning restore CS0169
         public int Length => 29;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 29);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 29);
     }
     public struct Array30<T> : IArray<T> where T : unmanaged
     {
@@ -297,8 +297,8 @@ namespace Ryujinx.Common.Memory
         Array29<T> _other;
 #pragma warning restore CS0169
         public int Length => 30;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 30);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 30);
     }
     public struct Array31<T> : IArray<T> where T : unmanaged
     {
@@ -307,8 +307,8 @@ namespace Ryujinx.Common.Memory
         Array30<T> _other;
 #pragma warning restore CS0169
         public int Length => 31;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 31);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 31);
     }
     public struct Array32<T> : IArray<T> where T : unmanaged
     {
@@ -317,8 +317,8 @@ namespace Ryujinx.Common.Memory
         Array31<T> _other;
 #pragma warning restore CS0169
         public int Length => 32;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 32);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 32);
     }
     public struct Array33<T> : IArray<T> where T : unmanaged
     {
@@ -327,8 +327,8 @@ namespace Ryujinx.Common.Memory
         Array32<T> _other;
 #pragma warning restore CS0169
         public int Length => 33;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 33);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 33);
     }
     public struct Array34<T> : IArray<T> where T : unmanaged
     {
@@ -337,8 +337,8 @@ namespace Ryujinx.Common.Memory
         Array33<T> _other;
 #pragma warning restore CS0169
         public int Length => 34;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 34);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 34);
     }
     public struct Array35<T> : IArray<T> where T : unmanaged
     {
@@ -347,8 +347,8 @@ namespace Ryujinx.Common.Memory
         Array34<T> _other;
 #pragma warning restore CS0169
         public int Length => 35;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 35);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 35);
     }
     public struct Array36<T> : IArray<T> where T : unmanaged
     {
@@ -357,8 +357,8 @@ namespace Ryujinx.Common.Memory
         Array35<T> _other;
 #pragma warning restore CS0169
         public int Length => 36;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 36);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 36);
     }
     public struct Array37<T> : IArray<T> where T : unmanaged
     {
@@ -367,8 +367,8 @@ namespace Ryujinx.Common.Memory
         Array36<T> _other;
 #pragma warning restore CS0169
         public int Length => 37;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 37);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 37);
     }
     public struct Array38<T> : IArray<T> where T : unmanaged
     {
@@ -377,8 +377,8 @@ namespace Ryujinx.Common.Memory
         Array37<T> _other;
 #pragma warning restore CS0169
         public int Length => 38;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 38);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 38);
     }
     public struct Array39<T> : IArray<T> where T : unmanaged
     {
@@ -387,8 +387,8 @@ namespace Ryujinx.Common.Memory
         Array38<T> _other;
 #pragma warning restore CS0169
         public int Length => 39;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 39);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 39);
     }
     public struct Array40<T> : IArray<T> where T : unmanaged
     {
@@ -397,8 +397,8 @@ namespace Ryujinx.Common.Memory
         Array39<T> _other;
 #pragma warning restore CS0169
         public int Length => 40;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 40);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 40);
     }
     public struct Array41<T> : IArray<T> where T : unmanaged
     {
@@ -407,8 +407,8 @@ namespace Ryujinx.Common.Memory
         Array40<T> _other;
 #pragma warning restore CS0169
         public int Length => 41;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 41);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 41);
     }
     public struct Array42<T> : IArray<T> where T : unmanaged
     {
@@ -417,8 +417,8 @@ namespace Ryujinx.Common.Memory
         Array41<T> _other;
 #pragma warning restore CS0169
         public int Length => 42;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 42);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 42);
     }
     public struct Array43<T> : IArray<T> where T : unmanaged
     {
@@ -427,8 +427,8 @@ namespace Ryujinx.Common.Memory
         Array42<T> _other;
 #pragma warning restore CS0169
         public int Length => 43;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 43);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 43);
     }
     public struct Array44<T> : IArray<T> where T : unmanaged
     {
@@ -437,8 +437,8 @@ namespace Ryujinx.Common.Memory
         Array43<T> _other;
 #pragma warning restore CS0169
         public int Length => 44;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 44);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 44);
     }
     public struct Array45<T> : IArray<T> where T : unmanaged
     {
@@ -447,8 +447,8 @@ namespace Ryujinx.Common.Memory
         Array44<T> _other;
 #pragma warning restore CS0169
         public int Length => 45;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 45);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 45);
     }
     public struct Array46<T> : IArray<T> where T : unmanaged
     {
@@ -457,8 +457,8 @@ namespace Ryujinx.Common.Memory
         Array45<T> _other;
 #pragma warning restore CS0169
         public int Length => 46;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 46);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 46);
     }
     public struct Array47<T> : IArray<T> where T : unmanaged
     {
@@ -467,8 +467,8 @@ namespace Ryujinx.Common.Memory
         Array46<T> _other;
 #pragma warning restore CS0169
         public int Length => 47;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 47);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 47);
     }
     public struct Array48<T> : IArray<T> where T : unmanaged
     {
@@ -477,8 +477,8 @@ namespace Ryujinx.Common.Memory
         Array47<T> _other;
 #pragma warning restore CS0169
         public int Length => 48;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 48);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 48);
     }
     public struct Array49<T> : IArray<T> where T : unmanaged
     {
@@ -487,8 +487,8 @@ namespace Ryujinx.Common.Memory
         Array48<T> _other;
 #pragma warning restore CS0169
         public int Length => 49;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 49);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 49);
     }
     public struct Array50<T> : IArray<T> where T : unmanaged
     {
@@ -497,8 +497,8 @@ namespace Ryujinx.Common.Memory
         Array49<T> _other;
 #pragma warning restore CS0169
         public int Length => 50;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 50);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 50);
     }
     public struct Array51<T> : IArray<T> where T : unmanaged
     {
@@ -507,8 +507,8 @@ namespace Ryujinx.Common.Memory
         Array50<T> _other;
 #pragma warning restore CS0169
         public int Length => 51;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 51);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 51);
     }
     public struct Array52<T> : IArray<T> where T : unmanaged
     {
@@ -517,8 +517,8 @@ namespace Ryujinx.Common.Memory
         Array51<T> _other;
 #pragma warning restore CS0169
         public int Length => 52;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 52);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 52);
     }
     public struct Array53<T> : IArray<T> where T : unmanaged
     {
@@ -527,8 +527,8 @@ namespace Ryujinx.Common.Memory
         Array52<T> _other;
 #pragma warning restore CS0169
         public int Length => 53;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 53);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 53);
     }
     public struct Array54<T> : IArray<T> where T : unmanaged
     {
@@ -537,8 +537,8 @@ namespace Ryujinx.Common.Memory
         Array53<T> _other;
 #pragma warning restore CS0169
         public int Length => 54;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 54);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 54);
     }
     public struct Array55<T> : IArray<T> where T : unmanaged
     {
@@ -547,8 +547,8 @@ namespace Ryujinx.Common.Memory
         Array54<T> _other;
 #pragma warning restore CS0169
         public int Length => 55;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 55);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 55);
     }
     public struct Array56<T> : IArray<T> where T : unmanaged
     {
@@ -557,8 +557,8 @@ namespace Ryujinx.Common.Memory
         Array55<T> _other;
 #pragma warning restore CS0169
         public int Length => 56;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 56);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 56);
     }
     public struct Array57<T> : IArray<T> where T : unmanaged
     {
@@ -567,8 +567,8 @@ namespace Ryujinx.Common.Memory
         Array56<T> _other;
 #pragma warning restore CS0169
         public int Length => 57;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 57);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 57);
     }
     public struct Array58<T> : IArray<T> where T : unmanaged
     {
@@ -577,8 +577,8 @@ namespace Ryujinx.Common.Memory
         Array57<T> _other;
 #pragma warning restore CS0169
         public int Length => 58;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 58);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 58);
     }
     public struct Array59<T> : IArray<T> where T : unmanaged
     {
@@ -587,8 +587,8 @@ namespace Ryujinx.Common.Memory
         Array58<T> _other;
 #pragma warning restore CS0169
         public int Length => 59;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 59);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 59);
     }
     public struct Array60<T> : IArray<T> where T : unmanaged
     {
@@ -597,8 +597,8 @@ namespace Ryujinx.Common.Memory
         Array59<T> _other;
 #pragma warning restore CS0169
         public int Length => 60;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 60);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 60);
     }
     public struct Array61<T> : IArray<T> where T : unmanaged
     {
@@ -607,8 +607,8 @@ namespace Ryujinx.Common.Memory
         Array60<T> _other;
 #pragma warning restore CS0169
         public int Length => 61;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 61);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 61);
     }
     public struct Array62<T> : IArray<T> where T : unmanaged
     {
@@ -617,8 +617,8 @@ namespace Ryujinx.Common.Memory
         Array61<T> _other;
 #pragma warning restore CS0169
         public int Length => 62;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 62);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 62);
     }
     public struct Array63<T> : IArray<T> where T : unmanaged
     {
@@ -627,8 +627,8 @@ namespace Ryujinx.Common.Memory
         Array62<T> _other;
 #pragma warning restore CS0169
         public int Length => 63;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 63);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 63);
     }
     public struct Array64<T> : IArray<T> where T : unmanaged
     {
@@ -637,8 +637,8 @@ namespace Ryujinx.Common.Memory
         Array63<T> _other;
 #pragma warning restore CS0169
         public int Length => 64;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 64);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 64);
     }
     public struct Array73<T> : IArray<T> where T : unmanaged
     {
@@ -648,7 +648,7 @@ namespace Ryujinx.Common.Memory
         Array8<T> _other2;
 #pragma warning restore CS0169
         public int Length => 73;
-        public ref T this[int index] => ref ToSpan()[index];
-        public Span<T> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 73);
+        public ref T this[int index] => ref AsSpan()[index];
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 73);
     }
 }

--- a/Ryujinx.Common/Memory/StructByteArrayHelpers.cs
+++ b/Ryujinx.Common/Memory/StructByteArrayHelpers.cs
@@ -11,8 +11,8 @@ namespace Ryujinx.Common.Memory
         byte _element;
 
         public int Length => Size;
-        public ref byte this[int index] => ref ToSpan()[index];
-        public Span<byte> ToSpan() => MemoryMarshal.CreateSpan(ref _element, Size);
+        public ref byte this[int index] => ref AsSpan()[index];
+        public Span<byte> AsSpan() => MemoryMarshal.CreateSpan(ref _element, Size);
     }
 
     [StructLayout(LayoutKind.Sequential, Size = Size, Pack = 1)]
@@ -23,8 +23,8 @@ namespace Ryujinx.Common.Memory
         byte _element;
 
         public int Length => Size;
-        public ref byte this[int index] => ref ToSpan()[index];
-        public Span<byte> ToSpan() => MemoryMarshal.CreateSpan(ref _element, Size);
+        public ref byte this[int index] => ref AsSpan()[index];
+        public Span<byte> AsSpan() => MemoryMarshal.CreateSpan(ref _element, Size);
     }
 
     [StructLayout(LayoutKind.Sequential, Size = Size, Pack = 1)]
@@ -35,8 +35,8 @@ namespace Ryujinx.Common.Memory
         byte _element;
 
         public int Length => Size;
-        public ref byte this[int index] => ref ToSpan()[index];
-        public Span<byte> ToSpan() => MemoryMarshal.CreateSpan(ref _element, Size);
+        public ref byte this[int index] => ref AsSpan()[index];
+        public Span<byte> AsSpan() => MemoryMarshal.CreateSpan(ref _element, Size);
     }
 
     [StructLayout(LayoutKind.Sequential, Size = Size, Pack = 1)]
@@ -47,8 +47,8 @@ namespace Ryujinx.Common.Memory
         byte _element;
 
         public int Length => Size;
-        public ref byte this[int index] => ref ToSpan()[index];
-        public Span<byte> ToSpan() => MemoryMarshal.CreateSpan(ref _element, Size);
+        public ref byte this[int index] => ref AsSpan()[index];
+        public Span<byte> AsSpan() => MemoryMarshal.CreateSpan(ref _element, Size);
     }
 
     [StructLayout(LayoutKind.Sequential, Size = Size, Pack = 1)]
@@ -59,8 +59,8 @@ namespace Ryujinx.Common.Memory
         byte _element;
 
         public int Length => Size;
-        public ref byte this[int index] => ref ToSpan()[index];
-        public Span<byte> ToSpan() => MemoryMarshal.CreateSpan(ref _element, Size);
+        public ref byte this[int index] => ref AsSpan()[index];
+        public Span<byte> AsSpan() => MemoryMarshal.CreateSpan(ref _element, Size);
     }
 
     [StructLayout(LayoutKind.Sequential, Size = Size, Pack = 1)]
@@ -71,7 +71,7 @@ namespace Ryujinx.Common.Memory
         byte _element;
 
         public int Length => Size;
-        public ref byte this[int index] => ref ToSpan()[index];
-        public Span<byte> ToSpan() => MemoryMarshal.CreateSpan(ref _element, Size);
+        public ref byte this[int index] => ref AsSpan()[index];
+        public Span<byte> AsSpan() => MemoryMarshal.CreateSpan(ref _element, Size);
     }
 }

--- a/Ryujinx.Graphics.GAL/Multithreading/Commands/SetPatchParametersCommand.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/Commands/SetPatchParametersCommand.cs
@@ -13,13 +13,13 @@ namespace Ryujinx.Graphics.GAL.Multithreading.Commands
         public void Set(int vertices, ReadOnlySpan<float> defaultOuterLevel, ReadOnlySpan<float> defaultInnerLevel)
         {
             _vertices = vertices;
-            defaultOuterLevel.CopyTo(_defaultOuterLevel.ToSpan());
-            defaultInnerLevel.CopyTo(_defaultInnerLevel.ToSpan());
+            defaultOuterLevel.CopyTo(_defaultOuterLevel.AsSpan());
+            defaultInnerLevel.CopyTo(_defaultInnerLevel.AsSpan());
         }
 
         public static void Run(ref SetPatchParametersCommand command, ThreadedRenderer threaded, IRenderer renderer)
         {
-            renderer.Pipeline.SetPatchParameters(command._vertices, command._defaultOuterLevel.ToSpan(), command._defaultInnerLevel.ToSpan());
+            renderer.Pipeline.SetPatchParameters(command._vertices, command._defaultOuterLevel.AsSpan(), command._defaultInnerLevel.AsSpan());
         }
     }
 }

--- a/Ryujinx.Graphics.GAL/ProgramPipelineState.cs
+++ b/Ryujinx.Graphics.GAL/ProgramPipelineState.cs
@@ -66,7 +66,7 @@ namespace Ryujinx.Graphics.GAL
         public void SetVertexAttribs(ReadOnlySpan<VertexAttribDescriptor> vertexAttribs)
         {
             VertexAttribCount = vertexAttribs.Length;
-            vertexAttribs.CopyTo(VertexAttribs.ToSpan());
+            vertexAttribs.CopyTo(VertexAttribs.AsSpan());
         }
 
         public void SetLogicOpState(bool enable, LogicalOp op)

--- a/Ryujinx.Graphics.GAL/SupportBufferUpdater.cs
+++ b/Ryujinx.Graphics.GAL/SupportBufferUpdater.cs
@@ -65,12 +65,12 @@ namespace Ryujinx.Graphics.GAL
 
         public void UpdateRenderScale(ReadOnlySpan<Vector4<float>> data, int offset, int count)
         {
-            UpdateGenericField(SupportBuffer.GraphicsRenderScaleOffset, data, Data.RenderScale.ToSpan(), offset, count);
+            UpdateGenericField(SupportBuffer.GraphicsRenderScaleOffset, data, Data.RenderScale.AsSpan(), offset, count);
         }
 
         public void UpdateFragmentIsBgra(ReadOnlySpan<Vector4<int>> data, int offset, int count)
         {
-            UpdateGenericField(SupportBuffer.FragmentIsBgraOffset, data, Data.FragmentIsBgra.ToSpan(), offset, count);
+            UpdateGenericField(SupportBuffer.FragmentIsBgraOffset, data, Data.FragmentIsBgra.AsSpan(), offset, count);
         }
 
         public void UpdateViewportInverse(Vector4<float> data)

--- a/Ryujinx.Graphics.Gpu/Engine/MmeShadowScratch.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MmeShadowScratch.cs
@@ -12,7 +12,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
 #pragma warning disable CS0169
         private uint _e0;
 #pragma warning restore CS0169
-        public ref uint this[int index] => ref ToSpan()[index];
-        public Span<uint> ToSpan() => MemoryMarshal.CreateSpan(ref _e0, 256);
+        public ref uint this[int index] => ref AsSpan()[index];
+        public Span<uint> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, 256);
     }
 }

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -331,8 +331,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
             _context.Renderer.Pipeline.SetPatchParameters(
                 _state.State.PatchVertices,
-                _state.State.TessOuterLevel.ToSpan(),
-                _state.State.TessInnerLevel.ToSpan());
+                _state.State.TessOuterLevel.AsSpan(),
+                _state.State.TessInnerLevel.AsSpan());
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderSpecializationState.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderSpecializationState.cs
@@ -515,7 +515,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 return false;
             }
 
-            if (!graphicsState.AttributeTypes.ToSpan().SequenceEqual(GraphicsState.AttributeTypes.ToSpan()))
+            if (!graphicsState.AttributeTypes.AsSpan().SequenceEqual(GraphicsState.AttributeTypes.AsSpan()))
             {
                 return false;
             }

--- a/Ryujinx.Graphics.Gpu/Shader/TransformFeedbackDescriptor.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/TransformFeedbackDescriptor.cs
@@ -52,7 +52,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <returns>Span of varying locations</returns>
         public ReadOnlySpan<byte> AsSpan()
         {
-            return MemoryMarshal.Cast<uint, byte>(VaryingLocations.ToSpan()).Slice(0, Math.Min(128, VaryingCount));
+            return MemoryMarshal.Cast<uint, byte>(VaryingLocations.AsSpan()).Slice(0, Math.Min(128, VaryingCount));
         }
     }
 }

--- a/Ryujinx.Graphics.Nvdec.Vp9/DecodeFrame.cs
+++ b/Ryujinx.Graphics.Nvdec.Vp9/DecodeFrame.cs
@@ -30,23 +30,23 @@ namespace Ryujinx.Graphics.Nvdec.Vp9
                 Span<ushort> dst16 = MemoryMarshal.Cast<byte, ushort>(dst);
                 if (xd.Lossless)
                 {
-                    Idct.HighbdIwht4x4Add(dqcoeff.ToSpan(), dst16, stride, eob, xd.Bd);
+                    Idct.HighbdIwht4x4Add(dqcoeff.AsSpan(), dst16, stride, eob, xd.Bd);
                 }
                 else
                 {
                     switch (txSize)
                     {
                         case TxSize.Tx4x4:
-                            Idct.HighbdIdct4x4Add(dqcoeff.ToSpan(), dst16, stride, eob, xd.Bd);
+                            Idct.HighbdIdct4x4Add(dqcoeff.AsSpan(), dst16, stride, eob, xd.Bd);
                             break;
                         case TxSize.Tx8x8:
-                            Idct.HighbdIdct8x8Add(dqcoeff.ToSpan(), dst16, stride, eob, xd.Bd);
+                            Idct.HighbdIdct8x8Add(dqcoeff.AsSpan(), dst16, stride, eob, xd.Bd);
                             break;
                         case TxSize.Tx16x16:
-                            Idct.HighbdIdct16x16Add(dqcoeff.ToSpan(), dst16, stride, eob, xd.Bd);
+                            Idct.HighbdIdct16x16Add(dqcoeff.AsSpan(), dst16, stride, eob, xd.Bd);
                             break;
                         case TxSize.Tx32x32:
-                            Idct.HighbdIdct32x32Add(dqcoeff.ToSpan(), dst16, stride, eob, xd.Bd);
+                            Idct.HighbdIdct32x32Add(dqcoeff.AsSpan(), dst16, stride, eob, xd.Bd);
                             break;
                         default: Debug.Assert(false, "Invalid transform size"); break;
                     }
@@ -56,16 +56,16 @@ namespace Ryujinx.Graphics.Nvdec.Vp9
             {
                 if (xd.Lossless)
                 {
-                    Idct.Iwht4x4Add(dqcoeff.ToSpan(), dst, stride, eob);
+                    Idct.Iwht4x4Add(dqcoeff.AsSpan(), dst, stride, eob);
                 }
                 else
                 {
                     switch (txSize)
                     {
-                        case TxSize.Tx4x4: Idct.Idct4x4Add(dqcoeff.ToSpan(), dst, stride, eob); break;
-                        case TxSize.Tx8x8: Idct.Idct8x8Add(dqcoeff.ToSpan(), dst, stride, eob); break;
-                        case TxSize.Tx16x16: Idct.Idct16x16Add(dqcoeff.ToSpan(), dst, stride, eob); break;
-                        case TxSize.Tx32x32: Idct.Idct32x32Add(dqcoeff.ToSpan(), dst, stride, eob); break;
+                        case TxSize.Tx4x4: Idct.Idct4x4Add(dqcoeff.AsSpan(), dst, stride, eob); break;
+                        case TxSize.Tx8x8: Idct.Idct8x8Add(dqcoeff.AsSpan(), dst, stride, eob); break;
+                        case TxSize.Tx16x16: Idct.Idct16x16Add(dqcoeff.AsSpan(), dst, stride, eob); break;
+                        case TxSize.Tx32x32: Idct.Idct32x32Add(dqcoeff.AsSpan(), dst, stride, eob); break;
                         default: Debug.Assert(false, "Invalid transform size"); return;
                     }
                 }
@@ -73,21 +73,21 @@ namespace Ryujinx.Graphics.Nvdec.Vp9
 
             if (eob == 1)
             {
-                dqcoeff.ToSpan()[0] = 0;
+                dqcoeff.AsSpan()[0] = 0;
             }
             else
             {
                 if (txSize <= TxSize.Tx16x16 && eob <= 10)
                 {
-                    dqcoeff.ToSpan().Slice(0, 4 * (4 << (int)txSize)).Fill(0);
+                    dqcoeff.AsSpan().Slice(0, 4 * (4 << (int)txSize)).Fill(0);
                 }
                 else if (txSize == TxSize.Tx32x32 && eob <= 34)
                 {
-                    dqcoeff.ToSpan().Slice(0, 256).Fill(0);
+                    dqcoeff.AsSpan().Slice(0, 256).Fill(0);
                 }
                 else
                 {
-                    dqcoeff.ToSpan().Slice(0, 16 << ((int)txSize << 1)).Fill(0);
+                    dqcoeff.AsSpan().Slice(0, 16 << ((int)txSize << 1)).Fill(0);
                 }
             }
         }
@@ -109,23 +109,23 @@ namespace Ryujinx.Graphics.Nvdec.Vp9
                 Span<ushort> dst16 = MemoryMarshal.Cast<byte, ushort>(dst);
                 if (xd.Lossless)
                 {
-                    Idct.HighbdIwht4x4Add(dqcoeff.ToSpan(), dst16, stride, eob, xd.Bd);
+                    Idct.HighbdIwht4x4Add(dqcoeff.AsSpan(), dst16, stride, eob, xd.Bd);
                 }
                 else
                 {
                     switch (txSize)
                     {
                         case TxSize.Tx4x4:
-                            Idct.HighbdIht4x4Add(txType, dqcoeff.ToSpan(), dst16, stride, eob, xd.Bd);
+                            Idct.HighbdIht4x4Add(txType, dqcoeff.AsSpan(), dst16, stride, eob, xd.Bd);
                             break;
                         case TxSize.Tx8x8:
-                            Idct.HighbdIht8x8Add(txType, dqcoeff.ToSpan(), dst16, stride, eob, xd.Bd);
+                            Idct.HighbdIht8x8Add(txType, dqcoeff.AsSpan(), dst16, stride, eob, xd.Bd);
                             break;
                         case TxSize.Tx16x16:
-                            Idct.HighbdIht16x16Add(txType, dqcoeff.ToSpan(), dst16, stride, eob, xd.Bd);
+                            Idct.HighbdIht16x16Add(txType, dqcoeff.AsSpan(), dst16, stride, eob, xd.Bd);
                             break;
                         case TxSize.Tx32x32:
-                            Idct.HighbdIdct32x32Add(dqcoeff.ToSpan(), dst16, stride, eob, xd.Bd);
+                            Idct.HighbdIdct32x32Add(dqcoeff.AsSpan(), dst16, stride, eob, xd.Bd);
                             break;
                         default: Debug.Assert(false, "Invalid transform size"); break;
                     }
@@ -135,16 +135,16 @@ namespace Ryujinx.Graphics.Nvdec.Vp9
             {
                 if (xd.Lossless)
                 {
-                    Idct.Iwht4x4Add(dqcoeff.ToSpan(), dst, stride, eob);
+                    Idct.Iwht4x4Add(dqcoeff.AsSpan(), dst, stride, eob);
                 }
                 else
                 {
                     switch (txSize)
                     {
-                        case TxSize.Tx4x4: Idct.Iht4x4Add(txType, dqcoeff.ToSpan(), dst, stride, eob); break;
-                        case TxSize.Tx8x8: Idct.Iht8x8Add(txType, dqcoeff.ToSpan(), dst, stride, eob); break;
-                        case TxSize.Tx16x16: Idct.Iht16x16Add(txType, dqcoeff.ToSpan(), dst, stride, eob); break;
-                        case TxSize.Tx32x32: Idct.Idct32x32Add(dqcoeff.ToSpan(), dst, stride, eob); break;
+                        case TxSize.Tx4x4: Idct.Iht4x4Add(txType, dqcoeff.AsSpan(), dst, stride, eob); break;
+                        case TxSize.Tx8x8: Idct.Iht8x8Add(txType, dqcoeff.AsSpan(), dst, stride, eob); break;
+                        case TxSize.Tx16x16: Idct.Iht16x16Add(txType, dqcoeff.AsSpan(), dst, stride, eob); break;
+                        case TxSize.Tx32x32: Idct.Idct32x32Add(dqcoeff.AsSpan(), dst, stride, eob); break;
                         default: Debug.Assert(false, "Invalid transform size"); return;
                     }
                 }
@@ -152,21 +152,21 @@ namespace Ryujinx.Graphics.Nvdec.Vp9
 
             if (eob == 1)
             {
-                dqcoeff.ToSpan()[0] = 0;
+                dqcoeff.AsSpan()[0] = 0;
             }
             else
             {
                 if (txType == TxType.DctDct && txSize <= TxSize.Tx16x16 && eob <= 10)
                 {
-                    dqcoeff.ToSpan().Slice(0, 4 * (4 << (int)txSize)).Fill(0);
+                    dqcoeff.AsSpan().Slice(0, 4 * (4 << (int)txSize)).Fill(0);
                 }
                 else if (txSize == TxSize.Tx32x32 && eob <= 34)
                 {
-                    dqcoeff.ToSpan().Slice(0, 256).Fill(0);
+                    dqcoeff.AsSpan().Slice(0, 256).Fill(0);
                 }
                 else
                 {
-                    dqcoeff.ToSpan().Slice(0, 16 << ((int)txSize << 1)).Fill(0);
+                    dqcoeff.AsSpan().Slice(0, 16 << ((int)txSize << 1)).Fill(0);
                 }
             }
         }
@@ -184,7 +184,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9
             PredictionMode mode = (plane == 0) ? mi.Mode : mi.UvMode;
             int dstOffset = 4 * row * pd.Dst.Stride + 4 * col;
             byte* dst = &pd.Dst.Buf.ToPointer()[dstOffset];
-            Span<byte> dstSpan = pd.Dst.Buf.ToSpan().Slice(dstOffset);
+            Span<byte> dstSpan = pd.Dst.Buf.AsSpan().Slice(dstOffset);
 
             if (mi.SbType < BlockSize.Block8x8)
             {
@@ -223,7 +223,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9
             ref MacroBlockDPlane pd = ref xd.Plane[plane];
             var sc = Luts.Vp9DefaultScanOrders[(int)txSize];
             int eob = Detokenize.DecodeBlockTokens(ref twd, plane, sc, col, row, txSize, mi.SegmentId);
-            Span<byte> dst = pd.Dst.Buf.ToSpan().Slice(4 * row * pd.Dst.Stride + 4 * col);
+            Span<byte> dst = pd.Dst.Buf.AsSpan().Slice(4 * row * pd.Dst.Stride + 4 * col);
 
             if (eob > 0)
             {
@@ -922,7 +922,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9
             BlockSize subsize,
             int bw)
         {
-            Span<sbyte> aboveCtx = twd.Xd.AboveSegContext.Slice(miCol).ToSpan();
+            Span<sbyte> aboveCtx = twd.Xd.AboveSegContext.Slice(miCol).AsSpan();
             Span<sbyte> leftCtx = MemoryMarshal.CreateSpan(ref twd.Xd.LeftSegContext[miRow & Constants.MiMask], 8 - (miRow & Constants.MiMask));
 
             // Update the partition context at the end notes. Set partition bits
@@ -1077,7 +1077,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9
                     errorInfo.InternalError(CodecErr.CodecCorruptFrame, "Truncated packet or corrupt tile length");
                 }
 
-                size = BinaryPrimitives.ReadInt32BigEndian(data.ToSpan());
+                size = BinaryPrimitives.ReadInt32BigEndian(data.AsSpan());
                 data = data.Slice(4);
 
                 if (size > data.Length)
@@ -1250,8 +1250,8 @@ namespace Ryujinx.Graphics.Nvdec.Vp9
             Debug.Assert(tileCols <= (1 << 6));
             Debug.Assert(tileRows == 1);
 
-            cm.AboveContext.ToSpan().Fill(0);
-            cm.AboveSegContext.ToSpan().Fill(0);
+            cm.AboveContext.AsSpan().Fill(0);
+            cm.AboveSegContext.AsSpan().Fill(0);
 
             for (n = 0; n < numWorkers; ++n)
             {
@@ -1266,12 +1266,12 @@ namespace Ryujinx.Graphics.Nvdec.Vp9
 
             GetTileBuffers(ref cm, data, tileCols, ref tileBuffers);
 
-            tileBuffers.ToSpan().Slice(0, tileCols).Sort(CompareTileBuffers);
+            tileBuffers.AsSpan().Slice(0, tileCols).Sort(CompareTileBuffers);
 
             if (numWorkers == tileCols)
             {
                 TileBuffer largest = tileBuffers[0];
-                Span<TileBuffer> buffers = tileBuffers.ToSpan();
+                Span<TileBuffer> buffers = tileBuffers.AsSpan();
                 buffers.Slice(1).CopyTo(buffers.Slice(0, tileBuffers.Length - 1));
                 tileBuffers[tileCols - 1] = largest;
             }

--- a/Ryujinx.Graphics.Nvdec.Vp9/Detokenize.cs
+++ b/Ryujinx.Graphics.Nvdec.Vp9/Detokenize.cs
@@ -236,8 +236,8 @@ namespace Ryujinx.Graphics.Nvdec.Vp9
             ref MacroBlockDPlane pd = ref xd.Plane[plane];
             ref Array2<short> dequant = ref pd.SegDequant[segId];
             int eob;
-            Span<sbyte> a = pd.AboveContext.ToSpan().Slice(x);
-            Span<sbyte> l = pd.LeftContext.ToSpan().Slice(y);
+            Span<sbyte> a = pd.AboveContext.AsSpan().Slice(x);
+            Span<sbyte> l = pd.LeftContext.AsSpan().Slice(y);
             int ctx;
             int ctxShiftA = 0;
             int ctxShiftL = 0;
@@ -250,7 +250,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9
                     eob = DecodeCoefs(
                         ref xd,
                         GetPlaneType(plane),
-                        pd.DqCoeff.ToSpan(),
+                        pd.DqCoeff.AsSpan(),
                         txSize,
                         ref dequant,
                         ctx,
@@ -266,7 +266,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9
                     eob = DecodeCoefs(
                         ref xd,
                         GetPlaneType(plane),
-                        pd.DqCoeff.ToSpan(),
+                        pd.DqCoeff.AsSpan(),
                         txSize,
                         ref dequant,
                         ctx,
@@ -283,7 +283,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9
                     eob = DecodeCoefs(
                         ref xd,
                         GetPlaneType(plane),
-                        pd.DqCoeff.ToSpan(),
+                        pd.DqCoeff.AsSpan(),
                         txSize,
                         ref dequant,
                         ctx,
@@ -303,7 +303,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9
                     eob = DecodeCoefs(
                         ref xd,
                         GetPlaneType(plane),
-                        pd.DqCoeff.ToSpan(),
+                        pd.DqCoeff.AsSpan(),
                         txSize,
                         ref dequant,
                         ctx,

--- a/Ryujinx.Graphics.Nvdec.Vp9/Dsp/Reader.cs
+++ b/Ryujinx.Graphics.Nvdec.Vp9/Dsp/Reader.cs
@@ -50,7 +50,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9.Dsp
 
         private void Fill()
         {
-            ReadOnlySpan<byte> buffer = _buffer.ToSpan();
+            ReadOnlySpan<byte> buffer = _buffer.AsSpan();
             ReadOnlySpan<byte> bufferStart = buffer;
             ulong value = Value;
             int count = Count;

--- a/Ryujinx.Graphics.Nvdec.Vp9/LoopFilter.cs
+++ b/Ryujinx.Graphics.Nvdec.Vp9/LoopFilter.cs
@@ -359,8 +359,8 @@ namespace Ryujinx.Graphics.Nvdec.Vp9
                     blockInsideLimit = 1;
                 }
 
-                lfi.Lfthr[lvl].Lim.ToSpan().Fill((byte)blockInsideLimit);
-                lfi.Lfthr[lvl].Mblim.ToSpan().Fill((byte)(2 * (lvl + 2) + blockInsideLimit));
+                lfi.Lfthr[lvl].Lim.AsSpan().Fill((byte)blockInsideLimit);
+                lfi.Lfthr[lvl].Mblim.AsSpan().Fill((byte)(2 * (lvl + 2) + blockInsideLimit));
             }
         }
 
@@ -395,7 +395,7 @@ namespace Ryujinx.Graphics.Nvdec.Vp9
                 {
                     // We could get rid of this if we assume that deltas are set to
                     // zero when not in use; encoder always uses deltas
-                    MemoryMarshal.Cast<Array2<byte>, byte>(lfi.Lvl[segId].ToSpan()).Fill((byte)lvlSeg);
+                    MemoryMarshal.Cast<Array2<byte>, byte>(lfi.Lvl[segId].AsSpan()).Fill((byte)lvlSeg);
                 }
                 else
                 {

--- a/Ryujinx.Graphics.Vulkan/NativeArray.cs
+++ b/Ryujinx.Graphics.Vulkan/NativeArray.cs
@@ -31,7 +31,7 @@ namespace Ryujinx.Graphics.Vulkan
             Length = length;
         }
 
-        public Span<T> ToSpan()
+        public Span<T> AsSpan()
         {
             return new Span<T>(Pointer, Length);
         }

--- a/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -582,7 +582,7 @@ namespace Ryujinx.Graphics.Vulkan
             _newState.PipelineLayout = internalProgram.PipelineLayout;
             _newState.StagesCount = (uint)stages.Length;
 
-            stages.CopyTo(_newState.Stages.ToSpan().Slice(0, stages.Length));
+            stages.CopyTo(_newState.Stages.AsSpan().Slice(0, stages.Length));
 
             SignalStateChange();
         }
@@ -921,7 +921,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         protected void UpdatePipelineAttachmentFormats()
         {
-            var dstAttachmentFormats = _newState.Internal.AttachmentFormats.ToSpan();
+            var dstAttachmentFormats = _newState.Internal.AttachmentFormats.AsSpan();
             FramebufferParams.AttachmentFormats.CopyTo(dstAttachmentFormats);
 
             int maxAttachmentIndex = FramebufferParams.MaxColorAttachmentIndex + (FramebufferParams.HasDepthStencil ? 1 : 0);

--- a/Ryujinx.Graphics.Vulkan/PipelineDynamicState.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineDynamicState.cs
@@ -117,7 +117,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         private void RecordScissor(Vk api, CommandBuffer commandBuffer)
         {
-            api.CmdSetScissor(commandBuffer, 0, (uint)ScissorsCount, _scissors.ToSpan());
+            api.CmdSetScissor(commandBuffer, 0, (uint)ScissorsCount, _scissors.AsSpan());
         }
 
         private void RecordStencilMasks(Vk api, CommandBuffer commandBuffer)
@@ -132,7 +132,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         private void RecordViewport(Vk api, CommandBuffer commandBuffer)
         {
-            api.CmdSetViewport(commandBuffer, 0, (uint)ViewportsCount, Viewports.ToSpan());
+            api.CmdSetViewport(commandBuffer, 0, (uint)ViewportsCount, Viewports.AsSpan());
         }
     }
 }

--- a/Ryujinx.Graphics.Vulkan/PipelineUid.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineUid.cs
@@ -52,22 +52,22 @@ namespace Ryujinx.Graphics.Vulkan
                 return false;
             }
 
-            if (!SequenceEqual<VertexInputAttributeDescription>(VertexAttributeDescriptions.ToSpan(), other.VertexAttributeDescriptions.ToSpan(), VertexAttributeDescriptionsCount))
+            if (!SequenceEqual<VertexInputAttributeDescription>(VertexAttributeDescriptions.AsSpan(), other.VertexAttributeDescriptions.AsSpan(), VertexAttributeDescriptionsCount))
             {
                 return false;
             }
 
-            if (!SequenceEqual<VertexInputBindingDescription>(VertexBindingDescriptions.ToSpan(), other.VertexBindingDescriptions.ToSpan(), VertexBindingDescriptionsCount))
+            if (!SequenceEqual<VertexInputBindingDescription>(VertexBindingDescriptions.AsSpan(), other.VertexBindingDescriptions.AsSpan(), VertexBindingDescriptionsCount))
             {
                 return false;
             }
 
-            if (!SequenceEqual<PipelineColorBlendAttachmentState>(ColorBlendAttachmentState.ToSpan(), other.ColorBlendAttachmentState.ToSpan(), ColorBlendAttachmentStateCount))
+            if (!SequenceEqual<PipelineColorBlendAttachmentState>(ColorBlendAttachmentState.AsSpan(), other.ColorBlendAttachmentState.AsSpan(), ColorBlendAttachmentStateCount))
             {
                 return false;
             }
 
-            if (!SequenceEqual<Format>(AttachmentFormats.ToSpan(), other.AttachmentFormats.ToSpan(), ColorBlendAttachmentStateCount + (HasDepthStencil ? 1u : 0u)))
+            if (!SequenceEqual<Format>(AttachmentFormats.AsSpan(), other.AttachmentFormats.AsSpan(), ColorBlendAttachmentStateCount + (HasDepthStencil ? 1u : 0u)))
             {
                 return false;
             }

--- a/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
+++ b/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
@@ -245,7 +245,7 @@ namespace Ryujinx.Graphics.Vulkan
             PipelineState pipeline = _state.ToVulkanPipelineState(_gd);
 
             // Copy the shader stage info to the pipeline.
-            var stages = pipeline.Stages.ToSpan();
+            var stages = pipeline.Stages.AsSpan();
 
             for (int i = 0; i < _shaders.Length; i++)
             {

--- a/Ryujinx.HLE/HOS/Applets/Controller/ControllerSupportArgV7.cs
+++ b/Ryujinx.HLE/HOS/Applets/Controller/ControllerSupportArgV7.cs
@@ -19,7 +19,7 @@ namespace Ryujinx.HLE.HOS.Applets
         {
             private byte element;
 
-            public Span<byte> ToSpan() => MemoryMarshal.CreateSpan(ref element, 8 * 0x81);
+            public Span<byte> AsSpan() => MemoryMarshal.CreateSpan(ref element, 8 * 0x81);
         }
     }
 #pragma warning restore CS0649

--- a/Ryujinx.HLE/HOS/Applets/Controller/ControllerSupportArgVPre7.cs
+++ b/Ryujinx.HLE/HOS/Applets/Controller/ControllerSupportArgVPre7.cs
@@ -19,7 +19,7 @@ namespace Ryujinx.HLE.HOS.Applets
         {
             private byte element;
 
-            public Span<byte> ToSpan() => MemoryMarshal.CreateSpan(ref element, 4 * 0x81);
+            public Span<byte> AsSpan() => MemoryMarshal.CreateSpan(ref element, 4 * 0x81);
         }
     }
 #pragma warning restore CS0649

--- a/Ryujinx.HLE/HOS/Applets/Error/ErrorApplet.cs
+++ b/Ryujinx.HLE/HOS/Applets/Error/ErrorApplet.cs
@@ -179,8 +179,8 @@ namespace Ryujinx.HLE.HOS.Applets.Error
             byte[] messageTextBuffer = new byte[0x800];
             byte[] detailsTextBuffer = new byte[0x800];
 
-            applicationErrorArg.MessageText.ToSpan().CopyTo(messageTextBuffer);
-            applicationErrorArg.DetailsText.ToSpan().CopyTo(detailsTextBuffer);
+            applicationErrorArg.MessageText.AsSpan().CopyTo(messageTextBuffer);
+            applicationErrorArg.DetailsText.AsSpan().CopyTo(detailsTextBuffer);
 
             string messageText = Encoding.ASCII.GetString(messageTextBuffer.TakeWhile(b => !b.Equals(0)).ToArray());
             string detailsText = Encoding.ASCII.GetString(detailsTextBuffer.TakeWhile(b => !b.Equals(0)).ToArray());

--- a/Ryujinx.HLE/HOS/Services/Audio/IHardwareOpusDecoderManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/IHardwareOpusDecoderManager.cs
@@ -117,7 +117,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio
 
             OpusMultiStreamParametersEx parameters = context.Memory.Read<OpusMultiStreamParametersEx>(parametersAddress);
 
-            byte[] mappings = MemoryMarshal.Cast<uint, byte>(parameters.ChannelMappings.ToSpan()).ToArray();
+            byte[] mappings = MemoryMarshal.Cast<uint, byte>(parameters.ChannelMappings.AsSpan()).ToArray();
 
             // UseLargeFrameSize can be ignored due to not relying on fixed size buffers for storing the decoded result.
             MakeObject(context, new IHardwareOpusDecoder(

--- a/Ryujinx.HLE/HOS/Services/Friend/ServiceCreator/IFriendService.cs
+++ b/Ryujinx.HLE/HOS/Services/Friend/ServiceCreator/IFriendService.cs
@@ -131,7 +131,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
                 return ResultCode.InvalidArgument;
             }
 
-            // TODO: Service mount the friends:/ system savedata and try to load friend.cache file, returns true if exists, false otherwise. 
+            // TODO: Service mount the friends:/ system savedata and try to load friend.cache file, returns true if exists, false otherwise.
             // NOTE: If no cache is available, guest then calls nn::friends::EnsureFriendListAvailable, we can avoid that by faking the cache check.
             context.ResponseData.Write(true);
 
@@ -190,7 +190,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
             }
 
             context.Device.System.AccountManager.OpenUserOnlinePlay(userId);
-            
+
             Logger.Stub?.PrintStub(LogClass.ServiceFriend, new { UserId = userId.ToString() });
 
             return ResultCode.Success;
@@ -277,7 +277,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
 
             Array16<byte> randomGuid = new Array16<byte>();
 
-            Guid.NewGuid().ToByteArray().AsSpan().CopyTo(randomGuid.ToSpan());
+            Guid.NewGuid().ToByteArray().AsSpan().CopyTo(randomGuid.AsSpan());
 
             PlayHistoryRegistrationKey playHistoryRegistrationKey = new PlayHistoryRegistrationKey
             {

--- a/Ryujinx.HLE/HOS/Services/Hid/HidDevices/KeyboardDevice.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/HidDevices/KeyboardDevice.cs
@@ -26,7 +26,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
                 SamplingNumber = previousEntry.SamplingNumber + 1,
             };
 
-            keyState.Keys.AsSpan().CopyTo(newState.Keys.RawData.ToSpan());
+            keyState.Keys.AsSpan().CopyTo(newState.Keys.RawData.AsSpan());
             newState.Modifiers = (KeyboardModifier)keyState.Modifier;
 
             lifo.Write(ref newState);

--- a/Ryujinx.HLE/HOS/Services/Hid/HidDevices/NpadDevices.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/HidDevices/NpadDevices.cs
@@ -543,7 +543,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
                 Attributes      = SixAxisSensorAttribute.IsConnected
             };
 
-            state.Orientation.AsSpan().CopyTo(newState.Direction.ToSpan());
+            state.Orientation.AsSpan().CopyTo(newState.Direction.AsSpan());
 
             ref RingLifo<SixAxisSensorState> lifo = ref GetSixAxisSensorLifo(ref currentNpad, isRightPair);
 

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/INfp.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/INfp.cs
@@ -628,7 +628,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
                                 Reserved2  = new Array6<byte>()
                             };
 
-                            Uuid.CopyTo(tagInfo.Uuid.ToSpan());
+                            Uuid.CopyTo(tagInfo.Uuid.AsSpan());
 
                             context.Memory.Write(outputPosition, tagInfo);
 

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/VirtualAmiibo.cs
@@ -85,7 +85,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
                 Reserved1       = new Array64<byte>(),
                 Reserved2       = new Array58<byte>()
             };
-            Encoding.ASCII.GetBytes("Ryujinx").CopyTo(registerInfo.Nickname.ToSpan());
+            Encoding.ASCII.GetBytes("Ryujinx").CopyTo(registerInfo.Nickname.AsSpan());
 
             return registerInfo;
         }

--- a/Ryujinx.HLE/HOS/Services/Nifm/StaticService/IGeneralService.cs
+++ b/Ryujinx.HLE/HOS/Services/Nifm/StaticService/IGeneralService.cs
@@ -84,7 +84,7 @@ namespace Ryujinx.HLE.HOS.Services.Nifm.StaticService
             networkProfile.IpSettingData.IpAddressSetting = new IpAddressSetting(interfaceProperties, unicastAddress);
             networkProfile.IpSettingData.DnsSetting       = new DnsSetting(interfaceProperties);
 
-            Encoding.ASCII.GetBytes("RyujinxNetwork").CopyTo(networkProfile.Name.ToSpan());
+            Encoding.ASCII.GetBytes("RyujinxNetwork").CopyTo(networkProfile.Name.AsSpan());
 
             context.Memory.Write(networkProfileDataPosition, networkProfile);
 

--- a/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Types/BsdSockAddr.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Types/BsdSockAddr.cs
@@ -16,7 +16,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
 
         public IPEndPoint ToIPEndPoint()
         {
-            IPAddress address = new IPAddress(Address.ToSpan());
+            IPAddress address = new IPAddress(Address.AsSpan());
             int port = (ushort)IPAddress.NetworkToHostOrder((short)Port);
 
             return new IPEndPoint(address, port);
@@ -31,7 +31,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                 Port = (ushort)IPAddress.HostToNetworkOrder((short)endpoint.Port)
             };
 
-            endpoint.Address.GetAddressBytes().AsSpan().CopyTo(result.Address.ToSpan());
+            endpoint.Address.GetAddressBytes().AsSpan().CopyTo(result.Address.AsSpan());
 
             return result;
         }

--- a/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Types/AddrInfo4.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Types/AddrInfo4.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Types
             Port    = port;
             Address = new Array4<byte>();
 
-            address.TryWriteBytes(Address.ToSpan(), out _);
+            address.TryWriteBytes(Address.AsSpan(), out _);
         }
 
         public void ToNetworkOrder()
@@ -43,7 +43,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Types
         {
             if (BitConverter.IsLittleEndian)
             {
-                address.ToSpan().Reverse();
+                address.AsSpan().Reverse();
             }
         }
     }

--- a/Ryujinx.HLE/HOS/Services/Time/TimeZone/TimeZone.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/TimeZone/TimeZone.cs
@@ -1440,7 +1440,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.TimeZone
 
                 int timeZoneSize = Math.Min(StringUtils.LengthCstr(timeZoneAbbreviation), 8);
 
-                timeZoneAbbreviation[..timeZoneSize].CopyTo(calendarAdditionalInfo.TimezoneName.ToSpan());
+                timeZoneAbbreviation[..timeZoneSize].CopyTo(calendarAdditionalInfo.TimezoneName.AsSpan());
             }
 
             return result;

--- a/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
+++ b/Ryujinx.HLE/HOS/Services/Vi/RootService/IApplicationDisplayService.cs
@@ -49,7 +49,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
                     Height            = height
                 };
 
-                Encoding.ASCII.GetBytes(name).AsSpan().CopyTo(displayInfo.Name.ToSpan());
+                Encoding.ASCII.GetBytes(name).AsSpan().CopyTo(displayInfo.Name.AsSpan());
 
                 _displayInfo.Add(displayInfo);
             }
@@ -171,7 +171,7 @@ namespace Ryujinx.HLE.HOS.Services.Vi.RootService
                 return ResultCode.InvalidValue;
             }
 
-            int displayId = _displayInfo.FindIndex(display => Encoding.ASCII.GetString(display.Name.ToSpan()).Trim('\0') == name);
+            int displayId = _displayInfo.FindIndex(display => Encoding.ASCII.GetString(display.Name.AsSpan()).Trim('\0') == name);
 
             if (displayId == -1)
             {

--- a/Spv.Generator/Instruction.cs
+++ b/Spv.Generator/Instruction.cs
@@ -46,7 +46,7 @@ namespace Spv.Generator
                 result += _resultType.WordCount;
             }
 
-            Span<Operand> operands = _operands.ToSpan();
+            Span<Operand> operands = _operands.AsSpan();
             for (int i = 0; i < operands.Length; i++)
             {
                 result += operands[i].WordCount;
@@ -120,7 +120,7 @@ namespace Spv.Generator
                 writer.Write(Id);
             }
 
-            Span<Operand> operands = _operands.ToSpan();
+            Span<Operand> operands = _operands.AsSpan();
             for (int i = 0; i < operands.Length; i++)
             {
                 operands[i].WriteOperand(writer);
@@ -185,8 +185,8 @@ namespace Spv.Generator
 
         public bool EqualsContent(Instruction cmpObj)
         {
-            Span<Operand> thisOperands = _operands.ToSpan();
-            Span<Operand> cmpOperands = cmpObj._operands.ToSpan();
+            Span<Operand> thisOperands = _operands.AsSpan();
+            Span<Operand> cmpOperands = cmpObj._operands.AsSpan();
 
             if (thisOperands.Length != cmpOperands.Length)
             {
@@ -211,7 +211,7 @@ namespace Spv.Generator
 
         public int GetHashCodeContent()
         {
-            return DeterministicHashCode.Combine<Operand>(_operands.ToSpan());
+            return DeterministicHashCode.Combine<Operand>(_operands.AsSpan());
         }
 
         public int GetHashCodeResultType()
@@ -221,7 +221,7 @@ namespace Spv.Generator
 
         public override int GetHashCode()
         {
-            return DeterministicHashCode.Combine(Opcode, Id, _resultType, DeterministicHashCode.Combine<Operand>(_operands.ToSpan()));
+            return DeterministicHashCode.Combine(Opcode, Id, _resultType, DeterministicHashCode.Combine<Operand>(_operands.AsSpan()));
         }
 
         public bool Equals(Operand obj)

--- a/Spv.Generator/InstructionOperands.cs
+++ b/Spv.Generator/InstructionOperands.cs
@@ -15,7 +15,7 @@ namespace Spv.Generator
         public Operand Operand5;
         public Operand[] Overflow;
 
-        public Span<Operand> ToSpan()
+        public Span<Operand> AsSpan()
         {
             if (Count > InternalCount)
             {


### PR DESCRIPTION
For consistency with .NET/other libraries. Those methods are returning a "view" of existing memory, rather than converting (which "To..." methods implies).