### PR TITLE
OpenGL: Fix clear of unbound color targets

### DIFF
--- a/Ryujinx.Graphics.OpenGL/Framebuffer.cs
+++ b/Ryujinx.Graphics.OpenGL/Framebuffer.cs
@@ -147,7 +147,7 @@ namespace Ryujinx.Graphics.OpenGL
 
         public int GetColorLayerCount(int index)
         {
-            return _colors[index].Info.GetDepthOrLayers();
+            return _colors[index]?.Info.GetDepthOrLayers() ?? 0;
         }
 
         public int GetDepthStencilLayerCount()

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -112,6 +112,8 @@ namespace Ryujinx.Graphics.OpenGL
 
         public void ClearRenderTargetColor(int index, int layer, int layerCount, uint componentMask, ColorF color)
         {
+            EnsureFramebuffer();
+
             GL.ColorMask(
                 index,
                 (componentMask & 1) != 0,
@@ -142,6 +144,8 @@ namespace Ryujinx.Graphics.OpenGL
 
         public void ClearRenderTargetDepthStencil(int layer, int layerCount, float depthValue, bool depthMask, int stencilValue, int stencilMask)
         {
+            EnsureFramebuffer();
+
             bool stencilMaskChanged =
                 stencilMask != 0 &&
                 stencilMask != _stencilFrontMask;


### PR DESCRIPTION
There was a regression (likely from #3400) causing New Super Mario Bros U Deluxe (or any game that tries to clear unbound color targets) to crash with NullReferenceException. This change fixes the issue by making sure that the framebuffer exists and that we don't try to get the layer count from inexistent textures.