### PR TITLE
ControllerApplet: Override player counts when SingleMode is set

### DIFF
--- a/Ryujinx.HLE/HOS/Applets/Controller/ControllerApplet.cs
+++ b/Ryujinx.HLE/HOS/Applets/Controller/ControllerApplet.cs
@@ -72,8 +72,15 @@ namespace Ryujinx.HLE.HOS.Applets
 
             int playerMin = argHeader.PlayerCountMin;
             int playerMax = argHeader.PlayerCountMax;
+            bool singleMode = argHeader.EnableSingleMode != 0;
 
             Logger.Stub?.PrintStub(LogClass.ServiceHid, $"ControllerApplet Arg {playerMin} {playerMax} {argHeader.EnableTakeOverConnection} {argHeader.EnableSingleMode}");
+
+            if (singleMode)
+            {
+                // Applications can set an arbitrary player range even with SingleMode, so clamp it
+                playerMin = playerMax = 1;
+            }
 
             int configuredCount = 0;
             PlayerIndex primaryIndex = PlayerIndex.Unknown;


### PR DESCRIPTION
This strictly bandaid fix (as in it'll work until HID is properly reversed) stops ControllerApplet spam seen in Splatoon 2, Xenoblade Chronicles 3 and other single-player games which don't play well with multiple inputs configured/enabled. Instead the usual "Controller Applet" message dialog pops up requesting "exactly 1 player". 

The spam eventually caused crashes like `InvalidOperationException: Out of handles` or `InvalidMemoryAccess` in Splatoon 2 or very weird behavior such as bad/no audio, erratic character movement and eventual crashes(?) in Xenoblade 3. 

This oversight was originally fixed in the now abandoned #1523. Relevant excerpt-
> Also, I noticed there was some talk about a crash in Splatoon 2 related to multiple configured controllers while playing with the new local wireless feature. This one crash is because controller applet was being silently spammed. The underlying reason was that the applet didn't consider EnableSingleMode and so thought the configuration was valid (it wasn't). This has also been fixed.

**Note:** This change is only relevant if you see ControllerApplet spam in the logs and is ineffective otherwise. 
Apologies to the team for such long-term inconvenience. Better late than never I guess.