### PR TITLE
Fix texture bindings using wrong sampler pool in some cases

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -553,7 +553,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 specStateMatches &= specState.MatchesTexture(stage, index, descriptor);
 
-                Sampler sampler = _samplerPool?.Get(samplerId);
+                Sampler sampler = samplerPool?.Get(samplerId);
 
                 ITexture hostTexture = texture?.GetTargetTexture(bindingInfo.Target);
                 ISampler hostSampler = sampler?.GetHostSampler(texture);


### PR DESCRIPTION
This was an oversight during Vulkan rebase. Since #3487 added a sampler pool cache, it should use the sampler pool passed as argument rather than the one on `_samplerPool` field.

Thanks to Leischii for finding this issue.

Closes #3561