### PR TITLE
PreAllocator: Check if instruction supports a Vex prefix in IsVexSameOperandDestSrc1

### DIFF
--- a/ARMeilleure/CodeGen/X86/AssemblerTable.cs
+++ b/ARMeilleure/CodeGen/X86/AssemblerTable.cs
@@ -4,6 +4,11 @@ namespace ARMeilleure.CodeGen.X86
 {
     partial class Assembler
     {
+        public static bool SupportsVexPrefix(X86Instruction inst)
+        {
+            return _instTable[(int)inst].Flags.HasFlag(InstructionFlags.Vex);
+        }
+
         private const int BadOp = 0;
 
         [Flags]

--- a/ARMeilleure/CodeGen/X86/PreAllocator.cs
+++ b/ARMeilleure/CodeGen/X86/PreAllocator.cs
@@ -1297,11 +1297,15 @@ namespace ARMeilleure.CodeGen.X86
         {
             if (IsIntrinsic(operation.Instruction))
             {
+                IntrinsicInfo info = IntrinsicTable.GetInfo(operation.Intrinsic);
+
+                bool hasVex = HardwareCapabilities.SupportsVexEncoding && Assembler.SupportsVexPrefix(info.Inst);
+
                 bool isUnary = operation.SourcesCount < 2;
 
                 bool hasVecDest = operation.Destination != default && operation.Destination.Type == OperandType.V128;
 
-                return !HardwareCapabilities.SupportsVexEncoding && !isUnary && hasVecDest;
+                return !hasVex && !isUnary && hasVecDest;
             }
 
             return false;


### PR DESCRIPTION
Don't assume all vector instructions have a vex encoding.

Not checking this causes invalid allocations on vector instructions that don't have a vex prefixed variant.