### PR TITLE
Skipped over the last "Count" key explicitly

### DIFF
--- a/Ryujinx/Input/GTK3/GTK3MappingHelper.cs
+++ b/Ryujinx/Input/GTK3/GTK3MappingHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using GtkKey = Gdk.Key;
 
@@ -150,22 +151,15 @@ namespace Ryujinx.Input.GTK3
 
         static GTK3MappingHelper()
         {
-            var inputKeys = Enum.GetValues<Key>();
+            var inputKeys = Enum.GetValues<Key>().SkipLast(1);
 
             // GtkKey is not contiguous and quite large, so use a dictionary instead of an array.
             _gtkKeyMapping = new Dictionary<GtkKey, Key>();
 
             foreach (var key in inputKeys)
             {
-                try
-                {
-                    var index = ToGtkKey((Key)key);
-                    _gtkKeyMapping[index] = (Key)key;
-                }
-                catch
-                {
-                    // Skip invalid mappings.
-                }
+                var index = ToGtkKey(key);
+                _gtkKeyMapping[index] = key;
             }
         }
 


### PR DESCRIPTION
Skipped over the last "Count" key explicitly, instead of relying on an exception.

Previously, the code included all values, and just blindly swallowed exceptions.
Now, we just skip the last (Count) key.