### PR TITLE
Fix SpirV parse failure

### DIFF
--- a/Ryujinx.Graphics.Shader/CodeGen/Spirv/CodeGenContext.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Spirv/CodeGenContext.cs
@@ -244,7 +244,8 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
 
         private Instruction GetUndefined(AggregateType type)
         {
-            return type switch {
+            return type switch
+            {
                 AggregateType.Bool => ConstantFalse(TypeBool()),
                 AggregateType.FP32 => Constant(TypeFP32(), 0f),
                 _ => Constant(GetType(type), 0)

--- a/Ryujinx.Graphics.Shader/CodeGen/Spirv/CodeGenContext.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Spirv/CodeGenContext.cs
@@ -234,12 +234,21 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
                     IrOperandType.Constant => GetConstant(type, operand),
                     IrOperandType.ConstantBuffer => GetConstantBuffer(type, operand),
                     IrOperandType.LocalVariable => GetLocal(type, operand),
-                    IrOperandType.Undefined => Constant(GetType(type), 0),
+                    IrOperandType.Undefined => GetUndefined(type),
                     _ => throw new ArgumentException($"Invalid operand type \"{operand.Type}\".")
                 };
             }
 
             throw new NotImplementedException(node.GetType().Name);
+        }
+
+        private Instruction GetUndefined(AggregateType type)
+        {
+            return type switch {
+                AggregateType.Bool => ConstantFalse(TypeBool()),
+                AggregateType.FP32 => Constant(TypeFP32(), 0f),
+                _ => Constant(GetType(type), 0)
+            };
         }
 
         public Instruction GetAttributeElemPointer(int attr, bool isOutAttr, Instruction index, out AggregateType elemType)

--- a/Ryujinx.Graphics.Shader/CodeGen/Spirv/CodeGenContext.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Spirv/CodeGenContext.cs
@@ -248,6 +248,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
             {
                 AggregateType.Bool => ConstantFalse(TypeBool()),
                 AggregateType.FP32 => Constant(TypeFP32(), 0f),
+                AggregateType.FP64 => Constant(TypeFP64(), 0d),
                 _ => Constant(GetType(type), 0)
             };
         }

--- a/Ryujinx.sln.DotSettings
+++ b/Ryujinx.sln.DotSettings
@@ -15,6 +15,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Ryujinx/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Sint/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Snorm/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Spirv/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Srgb/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unorm/@EntryIndexedValue">True</s:Boolean>
 </wpf:ResourceDictionary>

--- a/Spv.Generator/Instruction.cs
+++ b/Spv.Generator/Instruction.cs
@@ -234,7 +234,7 @@ namespace Spv.Generator
         {
             var operandLabels = new Dictionary<Specification.Op, string[]>
             {
-                {Specification.Op.OpConstant, new []{"Value"}},
+                { Specification.Op.OpConstant, new [] { "Value" } },
                 {Specification.Op.OpTypeInt, new []{"Width", "Signed"}},
                 {Specification.Op.OpTypeFloat, new []{"Width"}}
             };

--- a/Spv.Generator/Instruction.cs
+++ b/Spv.Generator/Instruction.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 
@@ -227,6 +228,19 @@ namespace Spv.Generator
         public bool Equals(Operand obj)
         {
             return obj is Instruction instruction && Equals(instruction);
+        }
+
+        public override string ToString()
+        {
+            var operandLabels = new Dictionary<Specification.Op, string[]>
+            {
+                {Specification.Op.OpConstant, new []{"Value"}},
+                {Specification.Op.OpTypeInt, new []{"Width", "Signed"}},
+                {Specification.Op.OpTypeFloat, new []{"Width"}}
+            };
+            var labels = operandLabels.ContainsKey(Opcode) ? operandLabels[Opcode] : Array.Empty<string>();
+            var result = _resultType == null ? string.Empty : $"{_resultType} ";
+            return $"{result}{Opcode}{_operands.ToString(labels)}";
         }
     }
 }

--- a/Spv.Generator/Instruction.cs
+++ b/Spv.Generator/Instruction.cs
@@ -229,16 +229,17 @@ namespace Spv.Generator
         {
             return obj is Instruction instruction && Equals(instruction);
         }
+        
+        private static readonly Dictionary<Specification.Op, string[]> _operandLabels = new()
+        {
+            { Specification.Op.OpConstant, new [] { "Value" } },
+            { Specification.Op.OpTypeInt, new [] { "Width", "Signed" } },
+            { Specification.Op.OpTypeFloat, new [] { "Width" } }
+        };
 
         public override string ToString()
         {
-            var operandLabels = new Dictionary<Specification.Op, string[]>
-            {
-                { Specification.Op.OpConstant, new [] { "Value" } },
-                { Specification.Op.OpTypeInt, new [] { "Width", "Signed" } },
-                { Specification.Op.OpTypeFloat, new [] { "Width" } }
-            };
-            var labels = operandLabels.ContainsKey(Opcode) ? operandLabels[Opcode] : Array.Empty<string>();
+            var labels = _operandLabels.TryGetValue(Opcode, out var opLabels) ? opLabels : Array.Empty<string>();
             var result = _resultType == null ? string.Empty : $"{_resultType} ";
             return $"{result}{Opcode}{_operands.ToString(labels)}";
         }

--- a/Spv.Generator/Instruction.cs
+++ b/Spv.Generator/Instruction.cs
@@ -235,8 +235,8 @@ namespace Spv.Generator
             var operandLabels = new Dictionary<Specification.Op, string[]>
             {
                 { Specification.Op.OpConstant, new [] { "Value" } },
-                {Specification.Op.OpTypeInt, new []{"Width", "Signed"}},
-                {Specification.Op.OpTypeFloat, new []{"Width"}}
+                { Specification.Op.OpTypeInt, new [] { "Width", "Signed" } },
+                { Specification.Op.OpTypeFloat, new [] { "Width" } }
             };
             var labels = operandLabels.ContainsKey(Opcode) ? operandLabels[Opcode] : Array.Empty<string>();
             var result = _resultType == null ? string.Empty : $"{_resultType} ";

--- a/Spv.Generator/InstructionOperands.cs
+++ b/Spv.Generator/InstructionOperands.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 
 namespace Spv.Generator
@@ -48,6 +50,22 @@ namespace Spv.Generator
 
                 Overflow[Count++] = operand;
             }
+        }
+
+        private IEnumerable<Operand> AllOperands => new[] { Operand1, Operand2, Operand3, Operand4, Operand5 }
+            .Concat(Overflow ?? Array.Empty<Operand>())
+            .Take(Count);
+        public override string ToString()
+        {
+            return $"({string.Join(", ", AllOperands)})";
+        }
+
+        public string ToString(string[] labels)
+        {
+            var labeledParams = AllOperands.Zip(labels, (op, label) => $"{label}: {op}");
+            var unlabeledParams = AllOperands.Skip(labels.Length).Select(op => op.ToString());
+            var paramsToPrint = labeledParams.Concat(unlabeledParams);
+            return $"({string.Join(", ", paramsToPrint)})";
         }
     }
 }

--- a/Spv.Generator/InstructionOperands.cs
+++ b/Spv.Generator/InstructionOperands.cs
@@ -55,6 +55,7 @@ namespace Spv.Generator
         private IEnumerable<Operand> AllOperands => new[] { Operand1, Operand2, Operand3, Operand4, Operand5 }
             .Concat(Overflow ?? Array.Empty<Operand>())
             .Take(Count);
+
         public override string ToString()
         {
             return $"({string.Join(", ", AllOperands)})";

--- a/Spv.Generator/LiteralInteger.cs
+++ b/Spv.Generator/LiteralInteger.cs
@@ -99,5 +99,7 @@ namespace Spv.Generator
         {
             return obj is LiteralInteger literalInteger && Equals(literalInteger);
         }
+
+        public override string ToString() => $"{_integerType} {_data}";
     }
 }

--- a/Spv.Generator/LiteralString.cs
+++ b/Spv.Generator/LiteralString.cs
@@ -48,5 +48,7 @@ namespace Spv.Generator
         {
             return obj is LiteralString literalString && Equals(literalString);
         }
+
+        public override string ToString() => _value;
     }
 }


### PR DESCRIPTION
When running the Mii Editor, I was getting the following error:
```
00:00:03.926 |E| .NET ThreadPool Worker Gpu DebugReport: SPIR-V offset 10180: SPIR-V parsing FAILED:
    Unsupported SpvOpConstant bit size: 1
    10180 bytes into the SPIR-V binary
00:00:03.926 |E| .NET ThreadPool Worker Gpu : Background Compilation failed: Unexpected API error "ErrorUnknown".
```
This prevented me from seeing the colored squares when picking my favorite color.
![image](https://user-images.githubusercontent.com/2948533/184786670-d5a3d486-a808-4d82-b78a-ef65102c9bc5.png)
With this change, the issue is fixed:
![image](https://user-images.githubusercontent.com/2948533/184787596-619345f7-54ac-4f9f-b3be-bb05a7968403.png)

The issue was that we were making invalid constants. The type was "bool" which is one bit, but we assigned it an int32. Instead, I changed it to just a constant false. We were doing something similar with floating points (assigning int32 to a float32).

~This _MAY_ also have been the cause of the crash for #3566, and it should be retested (I can't reproduce OPs specific crash).~
Fixes #3566

Lastly, this change introduces some `.ToString()` implementations for a few SpirV related classes. This was instrumental in helping me diagnose the issue (so I could easily inspect the values in my debugger, as well as Console.WriteLine any suspicious constant creations).
A preview of the `.ToString()` results looks something like this:
```
OpTypeFloat(Width: Int32 32) OpConstant(Value: Int32 0)
OpTypeInt(Width: Int32 32, Signed: Int32 1) OpConstant(Value: Int32 0)
OpTypeBool() OpConstant(Value: Int32 0)
```