### PR TITLE
Check if game directories have been updated before refreshing GUI

### DIFF
--- a/Ryujinx.Ava/Ui/ViewModels/SettingsViewModel.cs
+++ b/Ryujinx.Ava/Ui/ViewModels/SettingsViewModel.cs
@@ -49,6 +49,7 @@ namespace Ryujinx.Ava.Ui.ViewModels
         private float _previousVolumeLevel;
         private float _volume;
         private bool _isVulkanAvailable = true;
+        private bool _directoryChanged = false;
         private List<string> _gpuIds = new List<string>();
         private KeyboardHotkeys _keyboardHotkeys;
         private int _graphicsBackendIndex;
@@ -107,6 +108,17 @@ namespace Ryujinx.Ava.Ui.ViewModels
             set
             {
                 _isVulkanAvailable = value;
+
+                OnPropertyChanged();
+            }
+        }
+
+        public bool DirectoryChanged
+        {
+            get => _directoryChanged;
+            set
+            {
+                _directoryChanged = value;
 
                 OnPropertyChanged();
             }
@@ -397,9 +409,15 @@ namespace Ryujinx.Ava.Ui.ViewModels
 
         public async Task SaveSettings()
         {
-            List<string> gameDirs = new List<string>(GameDirectories);
-
             ConfigurationState config = ConfigurationState.Instance;
+
+            if (_directoryChanged)
+            {
+                List<string> gameDirs = new List<string>(GameDirectories);
+                config.Ui.GameDirs.Value = gameDirs;
+
+                _directoryChanged = false;
+            }
 
             if (_validTzRegions.Contains(TimeZone))
             {
@@ -465,7 +483,6 @@ namespace Ryujinx.Ava.Ui.ViewModels
 
             config.System.SystemTimeOffset.Value = systemTimeOffset.Seconds;
             config.Graphics.ShadersDumpPath.Value = ShaderDumpPath;
-            config.Ui.GameDirs.Value = gameDirs;
             config.System.FsGlobalAccessLogMode.Value = FsGlobalAccessLogMode;
             config.System.MemoryManagerMode.Value = (MemoryManagerMode)MemoryMode;
 

--- a/Ryujinx.Ava/Ui/ViewModels/SettingsViewModel.cs
+++ b/Ryujinx.Ava/Ui/ViewModels/SettingsViewModel.cs
@@ -415,8 +415,6 @@ namespace Ryujinx.Ava.Ui.ViewModels
             {
                 List<string> gameDirs = new List<string>(GameDirectories);
                 config.Ui.GameDirs.Value = gameDirs;
-
-                _directoryChanged = false;
             }
 
             if (_validTzRegions.Contains(TimeZone))

--- a/Ryujinx.Ava/Ui/Windows/SettingsWindow.axaml.cs
+++ b/Ryujinx.Ava/Ui/Windows/SettingsWindow.axaml.cs
@@ -162,6 +162,7 @@ namespace Ryujinx.Ava.Ui.Windows
             if (!string.IsNullOrWhiteSpace(path) && Directory.Exists(path) && !ViewModel.GameDirectories.Contains(path))
             {
                 ViewModel.GameDirectories.Add(path);
+                ViewModel.DirectoryChanged = true;
             }
             else
             {
@@ -170,6 +171,7 @@ namespace Ryujinx.Ava.Ui.Windows
                 if (!string.IsNullOrWhiteSpace(path))
                 {
                     ViewModel.GameDirectories.Add(path);
+                    ViewModel.DirectoryChanged = true;
                 }
             }
         }
@@ -181,6 +183,7 @@ namespace Ryujinx.Ava.Ui.Windows
             foreach (string path in selected)
             {
                 ViewModel.GameDirectories.Remove(path);
+                ViewModel.DirectoryChanged = true;
             }
         }
 
@@ -232,7 +235,7 @@ namespace Ryujinx.Ava.Ui.Windows
 
             ControllerSettings?.SaveCurrentProfile();
 
-            if (Owner is MainWindow window)
+            if (Owner is MainWindow window && ViewModel.DirectoryChanged)
             {
                 window.ViewModel.LoadApplications();
             }

--- a/Ryujinx.Ava/Ui/Windows/SettingsWindow.axaml.cs
+++ b/Ryujinx.Ava/Ui/Windows/SettingsWindow.axaml.cs
@@ -239,6 +239,8 @@ namespace Ryujinx.Ava.Ui.Windows
             {
                 window.ViewModel.LoadApplications();
             }
+
+            ViewModel.DirectoryChanged = false;
         }
 
         protected override void OnClosed(EventArgs e)

--- a/Ryujinx/Ui/Windows/SettingsWindow.cs
+++ b/Ryujinx/Ui/Windows/SettingsWindow.cs
@@ -34,7 +34,7 @@ namespace Ryujinx.Ui.Windows
 
         private long  _systemTimeOffset;
         private float _previousVolumeLevel;
-        private bool directoryChanged = false;
+        private bool _directoryChanged = false;
 
 #pragma warning disable CS0649, IDE0044
         [GUI] CheckButton     _traceLogToggle;
@@ -502,7 +502,7 @@ namespace Ryujinx.Ui.Windows
 
         private void SaveSettings()
         {
-            if (directoryChanged)
+            if (_directoryChanged)
             {
                 List<string> gameDirs = new List<string>();
 
@@ -516,6 +516,8 @@ namespace Ryujinx.Ui.Windows
                 }
 
                 ConfigurationState.Instance.Ui.GameDirs.Value = gameDirs;
+
+                _directoryChanged = false;
             }
 
             if (!float.TryParse(_resScaleText.Buffer.Text, out float resScaleCustom) || resScaleCustom <= 0.0f)
@@ -669,18 +671,19 @@ namespace Ryujinx.Ui.Windows
                             {
                                 if (directory.Equals((string)_gameDirsBoxStore.GetValue(treeIter, 0)))
                                 {
+                                    _directoryChanged = true;
                                     break;
                                 }
                             } while(_gameDirsBoxStore.IterNext(ref treeIter));
                         }
 
-                        if (!directoryChanged)
+                        if (!_directoryChanged)
                         {
                             _gameDirsBoxStore.AppendValues(directory);
                         }
                     }
 
-                    directoryChanged = true;
+                    _directoryChanged = true;
                 }
 
                 fileChooser.Dispose();
@@ -699,7 +702,7 @@ namespace Ryujinx.Ui.Windows
             {
                 _gameDirsBoxStore.Remove(ref treeIter);
 
-                directoryChanged = true;
+                _directoryChanged = true;
             }
 
             ((ToggleButton)sender).SetStateFlags(StateFlags.Normal, true);

--- a/Ryujinx/Ui/Windows/SettingsWindow.cs
+++ b/Ryujinx/Ui/Windows/SettingsWindow.cs
@@ -663,6 +663,7 @@ namespace Ryujinx.Ui.Windows
 
                 if (fileChooser.Run() == (int)ResponseType.Accept)
                 {
+                    _directoryChanged = false;
                     foreach (string directory in fileChooser.Filenames)
                     {
                         if (_gameDirsBoxStore.GetIterFirst(out TreeIter treeIter))
@@ -671,7 +672,6 @@ namespace Ryujinx.Ui.Windows
                             {
                                 if (directory.Equals((string)_gameDirsBoxStore.GetValue(treeIter, 0)))
                                 {
-                                    _directoryChanged = true;
                                     break;
                                 }
                             } while(_gameDirsBoxStore.IterNext(ref treeIter));

--- a/Ryujinx/Ui/Windows/SettingsWindow.cs
+++ b/Ryujinx/Ui/Windows/SettingsWindow.cs
@@ -34,9 +34,7 @@ namespace Ryujinx.Ui.Windows
 
         private long  _systemTimeOffset;
         private float _previousVolumeLevel;
-
         private bool directoryChanged = false;
-
 
 #pragma warning disable CS0649, IDE0044
         [GUI] CheckButton     _traceLogToggle;


### PR DESCRIPTION
Previously no matter what setting was changed the GUI directory page would refresh and reload the entire game list. For larger libraries this can take an extremely long time and can make changing any settings quite painful for those users. 

This change adds a new variable that tracks if the game directories have been modified and will only force a refresh on save/apply if there have actually been valid changes made within the functions.