### PR TITLE
Fast path for Inline-to-Memory texture data transfers

### DIFF
--- a/Ryujinx.Graphics.GAL/ITexture.cs
+++ b/Ryujinx.Graphics.GAL/ITexture.cs
@@ -19,6 +19,7 @@ namespace Ryujinx.Graphics.GAL
 
         void SetData(ReadOnlySpan<byte> data);
         void SetData(ReadOnlySpan<byte> data, int layer, int level);
+        void SetData(ReadOnlySpan<byte> data, int layer, int level, Rectangle<int> region);
         void SetStorage(BufferRange buffer);
         void Release();
     }

--- a/Ryujinx.Graphics.GAL/Multithreading/CommandHelper.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/CommandHelper.cs
@@ -113,6 +113,8 @@ namespace Ryujinx.Graphics.GAL.Multithreading
                 TextureSetDataCommand.Run(ref GetCommand<TextureSetDataCommand>(memory), threaded, renderer);
             _lookup[(int)CommandType.TextureSetDataSlice] = (Span<byte> memory, ThreadedRenderer threaded, IRenderer renderer) =>
                 TextureSetDataSliceCommand.Run(ref GetCommand<TextureSetDataSliceCommand>(memory), threaded, renderer);
+            _lookup[(int)CommandType.TextureSetDataSliceRegion] = (Span<byte> memory, ThreadedRenderer threaded, IRenderer renderer) =>
+                TextureSetDataSliceRegionCommand.Run(ref GetCommand<TextureSetDataSliceRegionCommand>(memory), threaded, renderer);
             _lookup[(int)CommandType.TextureSetStorage] = (Span<byte> memory, ThreadedRenderer threaded, IRenderer renderer) =>
                 TextureSetStorageCommand.Run(ref GetCommand<TextureSetStorageCommand>(memory), threaded, renderer);
 

--- a/Ryujinx.Graphics.GAL/Multithreading/CommandType.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/CommandType.cs
@@ -37,6 +37,7 @@
         TextureRelease,
         TextureSetData,
         TextureSetDataSlice,
+        TextureSetDataSliceRegion,
         TextureSetStorage,
 
         WindowPresent,

--- a/Ryujinx.Graphics.GAL/Multithreading/Commands/Texture/TextureSetDataSliceRegionCommand.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/Commands/Texture/TextureSetDataSliceRegionCommand.cs
@@ -1,0 +1,31 @@
+using Ryujinx.Graphics.GAL.Multithreading.Model;
+using Ryujinx.Graphics.GAL.Multithreading.Resources;
+using System;
+
+namespace Ryujinx.Graphics.GAL.Multithreading.Commands.Texture
+{
+    struct TextureSetDataSliceRegionCommand : IGALCommand
+    {
+        public CommandType CommandType => CommandType.TextureSetDataSliceRegion;
+        private TableRef<ThreadedTexture> _texture;
+        private TableRef<byte[]> _data;
+        private int _layer;
+        private int _level;
+        private Rectangle<int> _region;
+
+        public void Set(TableRef<ThreadedTexture> texture, TableRef<byte[]> data, int layer, int level, Rectangle<int> region)
+        {
+            _texture = texture;
+            _data = data;
+            _layer = layer;
+            _level = level;
+            _region = region;
+        }
+
+        public static void Run(ref TextureSetDataSliceRegionCommand command, ThreadedRenderer threaded, IRenderer renderer)
+        {
+            ThreadedTexture texture = command._texture.Get(threaded);
+            texture.Base.SetData(new ReadOnlySpan<byte>(command._data.Get(threaded)), command._layer, command._level, command._region);
+        }
+    }
+}

--- a/Ryujinx.Graphics.GAL/Multithreading/Resources/ThreadedTexture.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/Resources/ThreadedTexture.cs
@@ -119,6 +119,12 @@ namespace Ryujinx.Graphics.GAL.Multithreading.Resources
             _renderer.QueueCommand();
         }
 
+        public void SetData(ReadOnlySpan<byte> data, int layer, int level, Rectangle<int> region)
+        {
+            _renderer.New<TextureSetDataSliceRegionCommand>().Set(Ref(this), Ref(data.ToArray()), layer, level, region);
+            _renderer.QueueCommand();
+        }
+
         public void SetStorage(BufferRange buffer)
         {
             _renderer.New<TextureSetStorageCommand>().Set(Ref(this), buffer);

--- a/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -224,7 +224,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                         xCount,
                         yCount,
                         dstLinear,
-                        dst.MemoryLayout);
+                        dst.MemoryLayout.UnpackGobBlocksInY(),
+                        dst.MemoryLayout.UnpackGobBlocksInZ());
 
                     if (target != null)
                     {

--- a/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
@@ -29,6 +29,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.InlineToMemory
         private int _dstHeight;
         private int _dstStride;
         private int _dstGobBlocksInY;
+        private int _dstGobBlocksInZ;
         private int _lineLengthIn;
         private int _lineCount;
 
@@ -117,6 +118,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.InlineToMemory
             _dstHeight = (int)state.SetDstHeight;
             _dstStride = (int)state.PitchOut;
             _dstGobBlocksInY = 1 << (int)state.SetDstBlockSizeHeight;
+            _dstGobBlocksInZ = 1 << (int)state.SetDstBlockSizeDepth;
             _lineLengthIn = (int)state.LineLengthIn;
             _lineCount = (int)state.LineCount;
 
@@ -176,6 +178,25 @@ namespace Ryujinx.Graphics.Gpu.Engine.InlineToMemory
             }
             else
             {
+                var target = memoryManager.Physical.TextureCache.FindTexture(
+                    memoryManager,
+                    _dstGpuVa,
+                    1,
+                    _dstStride,
+                    _dstHeight,
+                    _lineLengthIn,
+                    _lineCount,
+                    _isLinear,
+                    _dstGobBlocksInY,
+                    _dstGobBlocksInZ);
+
+                if (target != null)
+                {
+                    target.SetData(data, 0, 0, new GAL.Rectangle<int>(_dstX, _dstY, _lineLengthIn / target.Info.FormatInfo.BytesPerPixel, _lineCount));
+
+                    return;
+                }
+
                 var dstCalculator = new OffsetCalculator(
                     _dstWidth,
                     _dstHeight,

--- a/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
@@ -178,23 +178,29 @@ namespace Ryujinx.Graphics.Gpu.Engine.InlineToMemory
             }
             else
             {
-                var target = memoryManager.Physical.TextureCache.FindTexture(
-                    memoryManager,
-                    _dstGpuVa,
-                    1,
-                    _dstStride,
-                    _dstHeight,
-                    _lineLengthIn,
-                    _lineCount,
-                    _isLinear,
-                    _dstGobBlocksInY,
-                    _dstGobBlocksInZ);
-
-                if (target != null)
+                // TODO: Verify if the destination X/Y and width/height are taken into account
+                // for linear texture transfers. If not, we can use the fast path for that aswell.
+                // Right now the copy code at the bottom assumes that it is used on both which might be incorrect.
+                if (!_isLinear)
                 {
-                    target.SetData(data, 0, 0, new GAL.Rectangle<int>(_dstX, _dstY, _lineLengthIn / target.Info.FormatInfo.BytesPerPixel, _lineCount));
+                    var target = memoryManager.Physical.TextureCache.FindTexture(
+                        memoryManager,
+                        _dstGpuVa,
+                        1,
+                        _dstStride,
+                        _dstHeight,
+                        _lineLengthIn,
+                        _lineCount,
+                        _isLinear,
+                        _dstGobBlocksInY,
+                        _dstGobBlocksInZ);
 
-                    return;
+                    if (target != null)
+                    {
+                        target.SetData(data, 0, 0, new GAL.Rectangle<int>(_dstX, _dstY, _lineLengthIn / target.Info.FormatInfo.BytesPerPixel, _lineCount));
+
+                        return;
+                    }
                 }
 
                 var dstCalculator = new OffsetCalculator(

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -762,6 +762,24 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Uploads new texture data to the host GPU for a specific layer/level and 2D sub-region.
+        /// </summary>
+        /// <param name="data">New data</param>
+        /// <param name="layer">Target layer</param>
+        /// <param name="level">Target level</param>
+        /// <param name="region">Target sub-region of the texture to update</param>
+        public void SetData(ReadOnlySpan<byte> data, int layer, int level, Rectangle<int> region)
+        {
+            BlacklistScale();
+
+            HostTexture.SetData(data, layer, level, region);
+
+            _currentData = null;
+
+            _hasData = true;
+        }
+
+        /// <summary>
         /// Converts texture data to a format and layout that is supported by the host GPU.
         /// </summary>
         /// <param name="data">Data to be converted</param>

--- a/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -905,7 +905,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="xCount">Number of pixels to be copied per line</param>
         /// <param name="yCount">Number of lines to be copied</param>
         /// <param name="linear">True if the texture has a linear layout, false otherwise</param>
-        /// <param name="memoryLayout">If <paramref name="linear"/> is false, should have the memory layout, otherwise ignored</param>
+        /// <param name="gobBlocksInY">If <paramref name="linear"/> is false, the amount of GOB blocks in the Y axis</param>
+        /// <param name="gobBlocksInZ">If <paramref name="linear"/> is false, the amount of GOB blocks in the Z axis</param>
         /// <returns>A matching texture, or null if there is no match</returns>
         public Texture FindTexture(
             MemoryManager memoryManager,
@@ -916,7 +917,8 @@ namespace Ryujinx.Graphics.Gpu.Image
             int xCount,
             int yCount,
             bool linear,
-            MemoryLayout memoryLayout)
+            int gobBlocksInY,
+            int gobBlocksInZ)
         {
             ulong address = memoryManager.Translate(gpuVa);
 
@@ -955,8 +957,8 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                     bool sizeMatch = xCount * bpp == texture.Info.Width * format.BytesPerPixel && height == texture.Info.Height;
                     bool formatMatch = !texture.Info.IsLinear &&
-                                        texture.Info.GobBlocksInY == memoryLayout.UnpackGobBlocksInY() &&
-                                        texture.Info.GobBlocksInZ == memoryLayout.UnpackGobBlocksInZ();
+                                        texture.Info.GobBlocksInY == gobBlocksInY &&
+                                        texture.Info.GobBlocksInZ == gobBlocksInZ;
 
                     match = sizeMatch && formatMatch;
                 }

--- a/Ryujinx.Graphics.OpenGL/Image/TextureBuffer.cs
+++ b/Ryujinx.Graphics.OpenGL/Image/TextureBuffer.cs
@@ -58,6 +58,11 @@ namespace Ryujinx.Graphics.OpenGL.Image
             throw new NotSupportedException();
         }
 
+        public void SetData(ReadOnlySpan<byte> data, int layer, int level, Rectangle<int> region)
+        {
+            throw new NotSupportedException();
+        }
+
         public void SetStorage(BufferRange buffer)
         {
             if (_buffer != BufferHandle.Null &&

--- a/Ryujinx.Graphics.Vulkan/TextureBuffer.cs
+++ b/Ryujinx.Graphics.Vulkan/TextureBuffer.cs
@@ -98,6 +98,11 @@ namespace Ryujinx.Graphics.Vulkan
             throw new NotSupportedException();
         }
 
+        public void SetData(ReadOnlySpan<byte> data, int layer, int level, Rectangle<int> region)
+        {
+            throw new NotSupportedException();
+        }
+
         public void SetStorage(BufferRange buffer)
         {
             if (_bufferHandle == buffer.Handle &&


### PR DESCRIPTION
This adds a fast path for Inline-to-memory texture data transfers, similar to what's done on DMA engine. This one has the difference that it can transfer to the sub-region of a texture. Normally, since OpenGL games transfer part of the texture using 2D engine and the remaining using Inline-to-memory, we do a GPU side blit, and then immediately after flush the texture to write the remaining data on CPU. This is not only very inefficient, but also a source of bugs. Due to the flush issue that I attempted to fix in #3481, it can actually break those textures.

This approach simply submits the remaining data to GPU directly if the texture is already in the cache, which does not require flush and is much more efficient, and also fixes some texture corruption on OpenGL games.

For example, on Digimon Cyber Sleuth.
Before:
![image](https://user-images.githubusercontent.com/5624669/185763684-6d470676-d0ec-450e-9393-ac44844ca7e6.png)
After:
![image](https://user-images.githubusercontent.com/5624669/185763690-14ab17c5-ffff-41d8-9b3a-72dec3070834.png)

Still, I believe we should get the flush working properly because the fast path but not be taken in all cases (for example, when there are multiple matches).

Testing in welcome, should only affect OpenGL *games* (it affects both the Vulkan and OpenGL backend on the emulator).
