### PR TITLE
Bsd: Fix ArgumentOutOfRangeException in SetSocketOption

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Impl/ManagedSocket.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Impl/ManagedSocket.cs
@@ -325,7 +325,12 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
 
                 if (option == BsdSocketOption.SoLinger)
                 {
-                    int value2 = MemoryMarshal.Read<int>(optionValue[4..]);
+                    int value2 = 0;
+                    
+                    if (optionValue.Length >= 8)
+                    {
+                        value2 = MemoryMarshal.Read<int>(optionValue[4..]);
+                    }
 
                     Socket.SetSocketOption(level, SocketOptionName.Linger, new LingerOption(value != 0, value2));
                 }

--- a/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Impl/ManagedSocket.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Impl/ManagedSocket.cs
@@ -323,10 +323,10 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
 
                 int value = optionValue.Length >= 4 ? MemoryMarshal.Read<int>(optionValue) : MemoryMarshal.Read<byte>(optionValue);
 
-                if (option == BsdSocketOption.SoLinger)
+                if (level == SocketOptionLevel.Socket && option == BsdSocketOption.SoLinger)
                 {
                     int value2 = 0;
-                    
+
                     if (optionValue.Length >= 8)
                     {
                         value2 = MemoryMarshal.Read<int>(optionValue[4..]);


### PR DESCRIPTION
This PR adds a length check for `optionValue` before trying to read bytes that could possibly be out of range for this array.

Adding this check allows Minecraft to boot and play properly when "Enable guest internet access" is left unchecked.
Enabling that option will still cause the game to hang on boot and even disabled it will still hang when trying to stop emulation.
Although I have no idea why that happens, my blind guess would be that this is related to blocking sockets somehow?

Related issue: #3236

---

Also I want to add that I'm a bit confused about why these changes fix this issue.
When logging the values I noticed that nothing should have fulfilled [this if-condition](https://github.com/Ryujinx/Ryujinx/blob/6922862db8677fb8067a3e35d2433b1f12f8329c/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Impl/ManagedSocket.cs#L326), since the option `BsdSocketOption.SoLinger` was never logged. 

Here is my log file: [Ryujinx_1.0.0-dirty_2022-08-27_02-04-36.log](https://github.com/Ryujinx/Ryujinx/files/9437001/Ryujinx_1.0.0-dirty_2022-08-27_02-04-36.log)

As you can see, the option that fulfills the if-condition in this case is `BsdSocketOption.TcpKeepInit`.