### PR TITLE
Change vsync signal to happen at 60hz, regardless of swap interval

### DIFF
--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
@@ -328,7 +328,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
                             Compose();
 
                             // When a frame is presented, delay the next one by its swap interval value.
-                            _swapIntervalDelay = _swapInterval - 1;
+                            _swapIntervalDelay = Math.Max(0, _swapInterval - 1);
                         }
 
                         _device.System?.SignalVsync();

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
@@ -92,7 +92,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
             }
             else
             {
-                _ticksPerFrame = Stopwatch.Frequency / (TargetFps);
+                _ticksPerFrame = Stopwatch.Frequency / TargetFps;
             }
         }
 

--- a/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
+++ b/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
@@ -35,6 +35,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
         private long _1msTicks;
 
         private int _swapInterval;
+        private int _swapIntervalDelay;
 
         private readonly object Lock = new object();
 
@@ -91,7 +92,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
             }
             else
             {
-                _ticksPerFrame = Stopwatch.Frequency / (TargetFps / _swapInterval);
+                _ticksPerFrame = Stopwatch.Frequency / (TargetFps);
             }
         }
 
@@ -322,7 +323,13 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
                     if (_ticks >= _ticksPerFrame)
                     {
-                        Compose();
+                        if (_swapIntervalDelay-- == 0)
+                        {
+                            Compose();
+
+                            // When a frame is presented, delay the next one by its swap interval value.
+                            _swapIntervalDelay = _swapInterval - 1;
+                        }
 
                         _device.System?.SignalVsync();
 


### PR DESCRIPTION
The vsync signal was signalling out at the swap interval, rather than every 16.667ms. Most games don't care about this, but there are a select few that do read the signal. This PR changes it to signal at 60hz regardless, and now swap interval is handled by setting a delay to the next frame when a present happens.

Fixes cutscene issues in [Tokyo Mirage Sessions #FE](https://github.com/Ryujinx/Ryujinx/issues/2914). The events within the cutscene relied on the vsync timer being at 60hz, whereas the animations relied on the actual presentation rate being 30hz. Having both run at the same speed caused interesting issues, but mostly just the voice lines playing at increasingly long delays.

This might also fix some weird game speed issues in The Legend of Zelda: Link's Awakening, and Breath of the Wild.

Games that run at 30fps should be tested to make sure that nothing breaks.