### PR TITLE
Do not output ViewportIndex on SPIR-V if GPU does not support it

### DIFF
--- a/Ryujinx.Graphics.GAL/Capabilities.cs
+++ b/Ryujinx.Graphics.GAL/Capabilities.cs
@@ -26,6 +26,7 @@ namespace Ryujinx.Graphics.GAL
         public readonly bool SupportsNonConstantTextureOffset;
         public readonly bool SupportsShaderBallot;
         public readonly bool SupportsTextureShadowLod;
+        public readonly bool SupportsViewportIndex;
         public readonly bool SupportsViewportSwizzle;
         public readonly bool SupportsIndirectParameters;
 
@@ -59,6 +60,7 @@ namespace Ryujinx.Graphics.GAL
             bool supportsNonConstantTextureOffset,
             bool supportsShaderBallot,
             bool supportsTextureShadowLod,
+            bool supportsViewportIndex,
             bool supportsViewportSwizzle,
             bool supportsIndirectParameters,
             uint maximumUniformBuffersPerStage,
@@ -89,6 +91,7 @@ namespace Ryujinx.Graphics.GAL
             SupportsNonConstantTextureOffset = supportsNonConstantTextureOffset;
             SupportsShaderBallot = supportsShaderBallot;
             SupportsTextureShadowLod = supportsTextureShadowLod;
+            SupportsViewportIndex = supportsViewportIndex;
             SupportsViewportSwizzle = supportsViewportSwizzle;
             SupportsIndirectParameters = supportsIndirectParameters;
             MaximumUniformBuffersPerStage = maximumUniformBuffersPerStage;

--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 3672;
+        private const uint CodeGenVersion = 3644;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/Ryujinx.Graphics.Gpu/Shader/GpuAccessorBase.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/GpuAccessorBase.cs
@@ -134,6 +134,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
 
         public bool QueryHostSupportsTextureShadowLod() => _context.Capabilities.SupportsTextureShadowLod;
 
+        public bool QueryHostSupportsViewportIndex() => _context.Capabilities.SupportsViewportIndex;
+
         /// <summary>
         /// Converts a packed Maxwell texture format to the shader translator texture format.
         /// </summary>

--- a/Ryujinx.Graphics.OpenGL/OpenGLRenderer.cs
+++ b/Ryujinx.Graphics.OpenGL/OpenGLRenderer.cs
@@ -120,6 +120,7 @@ namespace Ryujinx.Graphics.OpenGL
                 supportsNonConstantTextureOffset: HwCapabilities.SupportsNonConstantTextureOffset,
                 supportsShaderBallot: HwCapabilities.SupportsShaderBallot,
                 supportsTextureShadowLod: HwCapabilities.SupportsTextureShadowLod,
+                supportsViewportIndex: true,
                 supportsViewportSwizzle: HwCapabilities.SupportsViewportSwizzle,
                 supportsIndirectParameters: HwCapabilities.SupportsIndirectParameters,
                 maximumUniformBuffersPerStage: 13, // TODO: Avoid hardcoding those limits here and get from driver?

--- a/Ryujinx.Graphics.Shader/IGpuAccessor.cs
+++ b/Ryujinx.Graphics.Shader/IGpuAccessor.cs
@@ -268,6 +268,15 @@ namespace Ryujinx.Graphics.Shader
         }
 
         /// <summary>
+        /// Queries host GPU shader viewport index output support.
+        /// </summary>
+        /// <returns>True if the GPU and driver supports shader viewport index output, false otherwise</returns>
+        bool QueryHostSupportsViewportIndex()
+        {
+            return true;
+        }
+
+        /// <summary>
         /// Queries the point size from the GPU state, used when it is not explicitly set on the shader.
         /// </summary>
         /// <returns>Current point size</returns>

--- a/Ryujinx.Graphics.Shader/Translation/AttributeInfo.cs
+++ b/Ryujinx.Graphics.Shader/Translation/AttributeInfo.cs
@@ -78,6 +78,11 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public static bool Validate(ShaderConfig config, int value, bool isOutAttr)
         {
+            if (value == AttributeConsts.ViewportIndex && !config.GpuAccessor.QueryHostSupportsViewportIndex())
+            {
+                return false;
+            }
+
             return From(config, value, isOutAttr).IsValid;
         }
 

--- a/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -380,7 +380,7 @@ namespace Ryujinx.Graphics.Vulkan
             return BufferManager.GetData(buffer, offset, size);
         }
 
-        public Capabilities GetCapabilities()
+        public unsafe Capabilities GetCapabilities()
         {
             FormatFeatureFlags compressedFormatFeatureFlags =
                 FormatFeatureFlags.FormatFeatureSampledImageBit |
@@ -409,7 +409,19 @@ namespace Ryujinx.Graphics.Vulkan
                 GAL.Format.Bc7Srgb,
                 GAL.Format.Bc7Unorm);
 
-            Api.GetPhysicalDeviceFeatures(_physicalDevice, out var features);
+
+            PhysicalDeviceVulkan12Features featuresVk12 = new PhysicalDeviceVulkan12Features()
+            {
+                SType = StructureType.PhysicalDeviceVulkan12Features
+            };
+
+            PhysicalDeviceFeatures2 features2 = new PhysicalDeviceFeatures2()
+            {
+                SType = StructureType.PhysicalDeviceFeatures2,
+                PNext = &featuresVk12
+            };
+
+            Api.GetPhysicalDeviceFeatures2(_physicalDevice, &features2);
             Api.GetPhysicalDeviceProperties(_physicalDevice, out var properties);
 
             var limits = properties.Limits;
@@ -419,7 +431,7 @@ namespace Ryujinx.Graphics.Vulkan
                 GpuVendor,
                 hasFrontFacingBug: IsIntelWindows,
                 hasVectorIndexingBug: Vendor == Vendor.Qualcomm,
-                supportsAstcCompression: features.TextureCompressionAstcLdr,
+                supportsAstcCompression: features2.Features.TextureCompressionAstcLdr,
                 supportsBc123Compression: supportsBc123CompressionFormat,
                 supportsBc45Compression: supportsBc45CompressionFormat,
                 supportsBc67Compression: supportsBc67CompressionFormat,
@@ -429,12 +441,13 @@ namespace Ryujinx.Graphics.Vulkan
                 supportsFragmentShaderInterlock: Capabilities.SupportsFragmentShaderInterlock,
                 supportsFragmentShaderOrderingIntel: false,
                 supportsGeometryShaderPassthrough: Capabilities.SupportsGeometryShaderPassthrough,
-                supportsImageLoadFormatted: features.ShaderStorageImageReadWithoutFormat,
+                supportsImageLoadFormatted: features2.Features.ShaderStorageImageReadWithoutFormat,
                 supportsMismatchingViewFormat: true,
                 supportsCubemapView: !IsAmdGcn,
                 supportsNonConstantTextureOffset: false,
                 supportsShaderBallot: false,
                 supportsTextureShadowLod: false,
+                supportsViewportIndex: featuresVk12.ShaderOutputViewportIndex,
                 supportsViewportSwizzle: false,
                 supportsIndirectParameters: Capabilities.SupportsIndirectParameters,
                 maximumUniformBuffersPerStage: Constants.MaxUniformBuffersPerStage,


### PR DESCRIPTION
This change remove SPIR-V `ViewportIndex` outputs if the GPU does not support it, in an attempt to support older GPUs. Nothing should change for OpenGL as it does not currently output `gl_ViewportIndex` in GLSL.

Testing is welcome, it should not affect newer GPUs (for NVIDIA, it should not affect Maxwell 2nd gen and newer).