### PR TITLE
Fix mapping leaks caused by UnmapView not working on Linux

### DIFF
--- a/Ryujinx.Memory/MemoryManagementUnix.cs
+++ b/Ryujinx.Memory/MemoryManagementUnix.cs
@@ -177,12 +177,7 @@ namespace Ryujinx.Memory
 
         public static void UnmapView(IntPtr location, ulong size)
         {
-            IntPtr ptr = mmap(location, size, MmapProts.PROT_NONE, MmapFlags.MAP_FIXED | MmapFlags.MAP_PRIVATE | MmapFlags.MAP_ANONYMOUS | MmapFlags.MAP_NORESERVE, -1, 0);
-
-            if (ptr == new IntPtr(-1L))
-            {
-                throw new Exception("UnmapView failed");
-            }
+            mmap(location, size, MmapProts.PROT_NONE, MmapFlags.MAP_FIXED | MmapFlags.MAP_PRIVATE | MmapFlags.MAP_ANONYMOUS | MmapFlags.MAP_NORESERVE, -1, 0);
         }
     }
 }

--- a/Ryujinx.Memory/MemoryManagementUnix.cs
+++ b/Ryujinx.Memory/MemoryManagementUnix.cs
@@ -177,7 +177,12 @@ namespace Ryujinx.Memory
 
         public static void UnmapView(IntPtr location, ulong size)
         {
-            mmap(location, size, MmapProts.PROT_NONE, MmapFlags.MAP_FIXED, -1, 0);
+            IntPtr ptr = mmap(location, size, MmapProts.PROT_NONE, MmapFlags.MAP_FIXED, -1, 0);
+
+            if (ptr == new IntPtr(-1L))
+            {
+                throw new Exception("UnmapView failed");
+            }
         }
     }
 }

--- a/Ryujinx.Memory/MemoryManagementUnix.cs
+++ b/Ryujinx.Memory/MemoryManagementUnix.cs
@@ -177,7 +177,7 @@ namespace Ryujinx.Memory
 
         public static void UnmapView(IntPtr location, ulong size)
         {
-            IntPtr ptr = mmap(location, size, MmapProts.PROT_NONE, MmapFlags.MAP_FIXED, -1, 0);
+            IntPtr ptr = mmap(location, size, MmapProts.PROT_NONE, MmapFlags.MAP_FIXED | MmapFlags.MAP_PRIVATE | MmapFlags.MAP_ANONYMOUS | MmapFlags.MAP_NORESERVE, -1, 0);
 
             if (ptr == new IntPtr(-1L))
             {


### PR DESCRIPTION
This fixes an issue where UnmapView was failing on Linux because the flags combination being passed was invalid.
Needs to be tested on Linux, would be nice to know if it fixes #3372.