### PR TITLE
Bsd: Fix NullReferenceException in BsdSockAddr.FromIPEndPoint()

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
@@ -568,7 +568,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             LinuxError errno  = LinuxError.EBADF;
             ISocket    socket = _context.RetrieveSocket(socketFd);
 
-            if (socket != null)
+            if (socket != null && socket.RemoteEndPoint != null)
             {
                 errno = LinuxError.SUCCESS;
 

--- a/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
@@ -567,7 +567,6 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
 
             LinuxError errno  = LinuxError.EBADF;
             ISocket    socket = _context.RetrieveSocket(socketFd);
-            
             if (socket != null)
             {
                 errno = LinuxError.ENOTCONN;

--- a/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
@@ -567,14 +567,19 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
 
             LinuxError errno  = LinuxError.EBADF;
             ISocket    socket = _context.RetrieveSocket(socketFd);
-
-            if (socket != null && socket.RemoteEndPoint != null)
+            
+            if (socket != null)
             {
-                errno = LinuxError.SUCCESS;
+                errno = LinuxError.ENOTCONN;
 
-                WriteSockAddr(context, bufferPosition, socket, true);
-                WriteBsdResult(context, 0, errno);
-                context.ResponseData.Write(Unsafe.SizeOf<BsdSockAddr>());
+                if (socket.RemoteEndPoint != null)
+                {
+                    errno = LinuxError.SUCCESS;
+
+                    WriteSockAddr(context, bufferPosition, socket, true);
+                    WriteBsdResult(context, 0, errno);
+                    context.ResponseData.Write(Unsafe.SizeOf<BsdSockAddr>());
+                }
             }
 
             return WriteBsdResult(context, 0, errno);


### PR DESCRIPTION
This PR adds another check to prevent games from crashing with guest internet access enabled.

@EmulationFanatic sent me a log of "Victor Vran Overkill Edition" crashing on boot because a `System.NullReferenceException` was thrown inside of `BsdSockAddr.FromIPEndPoint()`. 
Following the stack trace I found a missing check for `socket.RemoteEndPoint` to ensure it's not null.

With this change "Victor Vran Overkill Edition" boots with guest internet access enabled, although it will still deadlock shortly after, but that's a different issue.

Thanks to @EmulationFanatic for confirming my fix works so quickly!