### PR TITLE
Fix audio error on Linux when playing Paper Mario: Origami King

### DIFF
--- a/Ryujinx.Audio/Renderer/Dsp/AdpcmHelper.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/AdpcmHelper.cs
@@ -1,5 +1,4 @@
 using Ryujinx.Audio.Renderer.Dsp.State;
-using Ryujinx.Common.Logging;
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;

--- a/Ryujinx.Audio/Renderer/Dsp/AdpcmHelper.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/AdpcmHelper.cs
@@ -1,4 +1,5 @@
 using Ryujinx.Audio.Renderer.Dsp.State;
+using Ryujinx.Common.Logging;
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -108,9 +109,24 @@ namespace Ryujinx.Audio.Renderer.Dsp
                     scale = (byte)(predScale & 0xF);
 
                     coefficientIndex = (byte)((predScale >> 4) & 0xF);
+                    int multiplyTwo = (coefficientIndex * 2);
+                    int plusOne = (multiplyTwo + 1);
 
-                    coefficient0 = coefficients[coefficientIndex * 2 + 0];
-                    coefficient1 = coefficients[coefficientIndex * 2 + 1];
+                    try
+                    {
+                        coefficient0 = coefficients[multiplyTwo]; // Somehow out of bounds?
+                        coefficient1 = coefficients[plusOne]; // Will also be out of bounds if 115 is out of bounds.
+                    }
+                    catch (System.IndexOutOfRangeException ex)
+                    {
+
+                        Logger.Info?.Print(LogClass.AudioRenderer, $"Coefficients Length: " + coefficients.Length);
+                        Logger.Info?.Print(LogClass.AudioRenderer, $"Coefficients Index: " + coefficientIndex);
+                        Logger.Info?.Print(LogClass.AudioRenderer, $"Coefficients Multiply Two: " + multiplyTwo);
+                        Logger.Info?.Print(LogClass.AudioRenderer, $"Coefficients Multiply Two Add One: " + plusOne);
+                        Logger.Error?.Print(LogClass.AudioRenderer, $"Index error in audio decode " + ex.ToString());
+                        return 0;
+                    }
 
                     nibbles += 2;
 

--- a/Ryujinx.Audio/Renderer/Dsp/AdpcmHelper.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/AdpcmHelper.cs
@@ -82,7 +82,8 @@ namespace Ryujinx.Audio.Renderer.Dsp
 
             byte predScale = (byte)loopContext.PredScale;
             byte scale = (byte)(predScale & 0xF);
-            byte coefficientIndex = (byte)((predScale >> 4) & 0xF);
+            // byte coefficientIndex = (byte)((predScale >> 4) & 0xF);
+            byte coefficientIndex = (byte)((predScale >> 4) & 0x7);
             short history0 = loopContext.History0;
             short history1 = loopContext.History1;
             short coefficient0 = coefficients[coefficientIndex * 2 + 0];
@@ -108,25 +109,10 @@ namespace Ryujinx.Audio.Renderer.Dsp
 
                     scale = (byte)(predScale & 0xF);
 
-                    coefficientIndex = (byte)((predScale >> 4) & 0xF);
-                    int multiplyTwo = (coefficientIndex * 2);
-                    int plusOne = (multiplyTwo + 1);
+                    coefficientIndex = (byte)((predScale >> 4) & 0x7);
 
-                    try
-                    {
-                        coefficient0 = coefficients[multiplyTwo]; // Somehow out of bounds?
-                        coefficient1 = coefficients[plusOne]; // Will also be out of bounds if 115 is out of bounds.
-                    }
-                    catch (System.IndexOutOfRangeException ex)
-                    {
-
-                        Logger.Info?.Print(LogClass.AudioRenderer, $"Coefficients Length: " + coefficients.Length);
-                        Logger.Info?.Print(LogClass.AudioRenderer, $"Coefficients Index: " + coefficientIndex);
-                        Logger.Info?.Print(LogClass.AudioRenderer, $"Coefficients Multiply Two: " + multiplyTwo);
-                        Logger.Info?.Print(LogClass.AudioRenderer, $"Coefficients Multiply Two Add One: " + plusOne);
-                        Logger.Error?.Print(LogClass.AudioRenderer, $"Index error in audio decode " + ex.ToString());
-                        return 0;
-                    }
+                    coefficient0 = coefficients[coefficientIndex * 2 + 0];
+                    coefficient1 = coefficients[coefficientIndex * 2 + 1];
 
                     nibbles += 2;
 

--- a/Ryujinx.Audio/Renderer/Dsp/AdpcmHelper.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/AdpcmHelper.cs
@@ -81,7 +81,6 @@ namespace Ryujinx.Audio.Renderer.Dsp
 
             byte predScale = (byte)loopContext.PredScale;
             byte scale = (byte)(predScale & 0xF);
-            // byte coefficientIndex = (byte)((predScale >> 4) & 0xF);
             byte coefficientIndex = (byte)((predScale >> 4) & 0x7);
             short history0 = loopContext.History0;
             short history1 = loopContext.History1;

--- a/Ryujinx.Audio/Renderer/Dsp/DataSourceHelper.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/DataSourceHelper.cs
@@ -139,15 +139,7 @@ namespace Ryujinx.Audio.Renderer.Dsp
                                 }
 
                                 ReadOnlySpan<short> coefficients = MemoryMarshal.Cast<byte, short>(memoryManager.GetSpan(info.ExtraParameter, (int)info.ExtraParameterSize));
-                                try
-                                {
-                                    decodedSampleCount = AdpcmHelper.Decode(tempSpan, waveBufferAdpcm, targetSampleStartOffset, targetSampleEndOffset, offset, sampleCountToDecode - y, coefficients, ref voiceState.LoopContext);
-                                }
-                                catch (System.IndexOutOfRangeException ex)
-                                {
-                                    Logger.Error?.Print(LogClass.AudioRenderer, $"Index error in audio decode " + ex.ToString());
-                                    decodedSampleCount = 0;
-                                }
+                                decodedSampleCount = AdpcmHelper.Decode(tempSpan, waveBufferAdpcm, targetSampleStartOffset, targetSampleEndOffset, offset, sampleCountToDecode - y, coefficients, ref voiceState.LoopContext);
                                 break;
                             case SampleFormat.PcmInt16:
                                 ReadOnlySpan<short> waveBufferPcm16 = ReadOnlySpan<short>.Empty;

--- a/Ryujinx.Audio/Renderer/Dsp/DataSourceHelper.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/DataSourceHelper.cs
@@ -139,7 +139,15 @@ namespace Ryujinx.Audio.Renderer.Dsp
                                 }
 
                                 ReadOnlySpan<short> coefficients = MemoryMarshal.Cast<byte, short>(memoryManager.GetSpan(info.ExtraParameter, (int)info.ExtraParameterSize));
-                                decodedSampleCount = AdpcmHelper.Decode(tempSpan, waveBufferAdpcm, targetSampleStartOffset, targetSampleEndOffset, offset, sampleCountToDecode - y, coefficients, ref voiceState.LoopContext);
+                                try
+                                {
+                                    decodedSampleCount = AdpcmHelper.Decode(tempSpan, waveBufferAdpcm, targetSampleStartOffset, targetSampleEndOffset, offset, sampleCountToDecode - y, coefficients, ref voiceState.LoopContext);
+                                }
+                                catch (System.IndexOutOfRangeException ex)
+                                {
+                                    Logger.Error?.Print(LogClass.AudioRenderer, $"Index error in audio decode " + ex.ToString());
+                                    decodedSampleCount = 0;
+                                }
                                 break;
                             case SampleFormat.PcmInt16:
                                 ReadOnlySpan<short> waveBufferPcm16 = ReadOnlySpan<short>.Empty;


### PR DESCRIPTION
Whenever I was trying to get through the spa area with Kamek, Bowser Jr, and the multiple folded enemies battling the normal paper minions, Ryujinx would crash.

By enabling log files and compiling a debug version of Ryujinx, I traced the issue to the audio render.
Here are the relevant audio logs with me trying multiple audio systems.
```
SDL2:
https://cdn.discordapp.com/attachments/410208610455519243/1014263116273569842/Ryujinx_1.1.243_2022-08-30_15-54-20.log

SoundIO:
https://cdn.discordapp.com/attachments/410208610455519243/1014265886267428904/Ryujinx_1.1.243_2022-08-30_16-09-07.log

OpenAL:
https://cdn.discordapp.com/attachments/410208610455519243/1014266172151173202/Ryujinx_1.1.243_2022-08-30_16-04-52.log
```

So far I've been able to catch the exception, but I'm not sure how to fix the actual problem. At the minimum, I've made it so that the emulator no longer crashes.

Here is an example log of the caught exceptions:
```
00:01:43.331 |W| HLE.OsThread.10 ServiceNv Wait: GPU processing thread is too slow, waiting on CPU...
00:02:23.927 |I| AudioProcessor.Worker AudioRenderer Decode: Coefficients Length: 16
00:02:23.927 |I| AudioProcessor.Worker AudioRenderer Decode: Coefficients Index: 8
00:02:23.927 |I| AudioProcessor.Worker AudioRenderer Decode: Coefficients Multiply Two: 16
00:02:23.927 |I| AudioProcessor.Worker AudioRenderer Decode: Coefficients Multiply Two Add One: 17
00:02:23.979 |E| AudioProcessor.Worker AudioRenderer Decode: Index error in audio decode System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at Ryujinx.Audio.Renderer.Dsp.AdpcmHelper.Decode(Span`1 output, ReadOnlySpan`1 input, Int32 startSampleOffset, Int32 endSampleOffset, Int32 offset, Int32 count, ReadOnlySpan`1 coefficients, AdpcmLoopContext& loopContext) in C:\Users\SirBlobman\source\repos\Ryujinx\Ryujinx.Audio\Renderer\Dsp\AdpcmHelper.cs:line 117
00:02:23.982 |I| AudioProcessor.Worker AudioRenderer Decode: Coefficients Length: 16
00:02:23.982 |I| AudioProcessor.Worker AudioRenderer Decode: Coefficients Index: 10
00:02:23.982 |I| AudioProcessor.Worker AudioRenderer Decode: Coefficients Multiply Two: 20
00:02:23.982 |I| AudioProcessor.Worker AudioRenderer Decode: Coefficients Multiply Two Add One: 21
00:02:23.982 |E| AudioProcessor.Worker AudioRenderer Decode: Index error in audio decode System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at Ryujinx.Audio.Renderer.Dsp.AdpcmHelper.Decode(Span`1 output, ReadOnlySpan`1 input, Int32 startSampleOffset, Int32 endSampleOffset, Int32 offset, Int32 count, ReadOnlySpan`1 coefficients, AdpcmLoopContext& loopContext) in C:\Users\SirBlobman\source\repos\Ryujinx\Ryujinx.Audio\Renderer\Dsp\AdpcmHelper.cs:line 117
00:02:26.305 |I| AudioProcessor.Worker AudioRenderer Decode: Coefficients Length: 16
00:02:26.305 |I| AudioProcessor.Worker AudioRenderer Decode: Coefficients Index: 11
00:02:26.305 |I| AudioProcessor.Worker AudioRenderer Decode: Coefficients Multiply Two: 22
00:02:26.305 |I| AudioProcessor.Worker AudioRenderer Decode: Coefficients Multiply Two Add One: 23
00:02:26.305 |E| AudioProcessor.Worker AudioRenderer Decode: Index error in audio decode System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at Ryujinx.Audio.Renderer.Dsp.AdpcmHelper.Decode(Span`1 output, ReadOnlySpan`1 input, Int32 startSampleOffset, Int32 endSampleOffset, Int32 offset, Int32 count, ReadOnlySpan`1 coefficients, AdpcmLoopContext& loopContext) in C:\Users\SirBlobman\source\repos\Ryujinx\Ryujinx.Audio\Renderer\Dsp\AdpcmHelper.cs:line 117
```

Hopefully someone can help out with fixing this. Normally I'm a Java developer, so C# and audio systems are out of my scope.