### PR TITLE
sfdsnres: fix endianess issue for port serialisation

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Types/AddrInfo4.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Types/AddrInfo4.cs
@@ -19,7 +19,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Types
         {
             Length  = (byte)Unsafe.SizeOf<Array4<byte>>();
             Family  = (byte)AddressFamily.InterNetwork;
-            Port    = port;
+            Port    = IPAddress.HostToNetworkOrder(port);
             Address = new Array4<byte>();
 
             address.TryWriteBytes(Address.AsSpan(), out _);


### PR DESCRIPTION
The port should be in network endianess when replying.