### PR TITLE
bsd: improve socket poll

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Impl/ManagedSocketPollManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Impl/ManagedSocketPollManager.cs
@@ -38,12 +38,13 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             {
                 ManagedSocket socket = (ManagedSocket)evnt.FileDescriptor;
 
-                bool isValidEvent = false;
+                bool isValidEvent = evnt.Data.InputEvents == 0;
+
+                errorEvents.Add(socket.Socket);
 
                 if ((evnt.Data.InputEvents & PollEventTypeMask.Input) != 0)
                 {
                     readEvents.Add(socket.Socket);
-                    errorEvents.Add(socket.Socket);
 
                     isValidEvent = true;
                 }
@@ -51,7 +52,6 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                 if ((evnt.Data.InputEvents & PollEventTypeMask.UrgentInput) != 0)
                 {
                     readEvents.Add(socket.Socket);
-                    errorEvents.Add(socket.Socket);
 
                     isValidEvent = true;
                 }
@@ -59,14 +59,6 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                 if ((evnt.Data.InputEvents & PollEventTypeMask.Output) != 0)
                 {
                     writeEvents.Add(socket.Socket);
-                    errorEvents.Add(socket.Socket);
-
-                    isValidEvent = true;
-                }
-
-                if ((evnt.Data.InputEvents & PollEventTypeMask.Error) != 0)
-                {
-                    errorEvents.Add(socket.Socket);
 
                     isValidEvent = true;
                 }
@@ -93,7 +85,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
             {
                 Socket socket = ((ManagedSocket)evnt.FileDescriptor).Socket;
 
-                PollEventTypeMask outputEvents = 0;
+                PollEventTypeMask outputEvents = evnt.Data.OutputEvents & ~evnt.Data.InputEvents;
 
                 if (errorEvents.Contains(socket))
                 {


### PR DESCRIPTION
We should report errors even when not requested.
This also ensure we only clear the bits that were requested on the output.
Finally, this should fix when input events is 0.
