### PR TITLE
Transform shader LDC into constant buffer access if offset is constant

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 3525;
+        private const uint CodeGenVersion = 3672;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/Ryujinx.Graphics.Shader/Translation/Optimizations/ConstantFolding.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Optimizations/ConstantFolding.cs
@@ -153,6 +153,10 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
                     EvaluateFPUnary(operation, (x) => float.IsNaN(x));
                     break;
 
+                case Instruction.LoadConstant:
+                    operation.TurnIntoCopy(Cbuf(operation.GetSource(0).Value, operation.GetSource(1).Value));
+                    break;
+
                 case Instruction.Maximum:
                     EvaluateBinary(operation, (x, y) => Math.Max(x, y));
                     break;


### PR DESCRIPTION
The `LoadConstant` IR operation is used for constant buffer loads with non-constant offset or constant buffer index. If both are constant, we can just use the regular "Cbuf" operand. Doing so allow bindless elimination to kick in on more cases (since it does not expect a `LoadConstant` operation, as those are usually used when the offset is not constant).

Improves rendering on Ys VIII: Lacrimosa of DANA:
Before:
![image](https://user-images.githubusercontent.com/5624669/188361482-0b6d8df3-2ea9-4735-9bac-1182af027558.png)
After:
![image](https://user-images.githubusercontent.com/5624669/188361497-22fdc028-c2a3-453e-9c57-231a0885b853.png)