### PR TITLE
Manage state of NfcManager

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Nfc/NfcManager/INfc.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/NfcManager/INfc.cs
@@ -5,33 +5,34 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.NfcManager
     class INfc : IpcService
     {
         private NfcPermissionLevel _permissionLevel;
-        private State _state = State.NonInitialized;
+        private State _state;
 
         public INfc(NfcPermissionLevel permissionLevel)
         {
             _permissionLevel = permissionLevel;
+            _state = State.NonInitialized;
         }
 
         [CommandHipc(0)]
         [CommandHipc(400)] // 4.0.0+
-        // Initialize()
+        // Initialize(u64, u64, pid, buffer<unknown, 5>)
         public ResultCode Initialize(ServiceCtx context)
         {
-            Logger.Stub?.PrintStub(LogClass.ServiceNfc, new { _permissionLevel });
-
             _state = State.Initialized;
+
+            Logger.Stub?.PrintStub(LogClass.ServiceNfc, new { _permissionLevel });
 
             return ResultCode.Success;
         }
 
         [CommandHipc(1)]
         [CommandHipc(401)] // 4.0.0+
-        // Initialize()
+        // Finalize()
         public ResultCode Finalize(ServiceCtx context)
         {
-            Logger.Stub?.PrintStub(LogClass.ServiceNfc, new { _permissionLevel });
-
             _state = State.NonInitialized;
+
+            Logger.Stub?.PrintStub(LogClass.ServiceNfc, new { _permissionLevel });
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Nfc/NfcManager/INfc.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/NfcManager/INfc.cs
@@ -5,6 +5,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.NfcManager
     class INfc : IpcService
     {
         private NfcPermissionLevel _permissionLevel;
+        private State _state = State.NonInitialized;
 
         public INfc(NfcPermissionLevel permissionLevel)
         {
@@ -17,6 +18,30 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.NfcManager
         public ResultCode Initialize(ServiceCtx context)
         {
             Logger.Stub?.PrintStub(LogClass.ServiceNfc, new { _permissionLevel });
+
+            _state = State.Initialized;
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(1)]
+        [CommandHipc(401)] // 4.0.0+
+        // Initialize()
+        public ResultCode Finalize(ServiceCtx context)
+        {
+            Logger.Stub?.PrintStub(LogClass.ServiceNfc, new { _permissionLevel });
+
+            _state = State.NonInitialized;
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(2)]
+        [CommandHipc(402)] // 4.0.0+
+        // GetState() -> u32
+        public ResultCode GetState(ServiceCtx context) 
+        {
+            context.ResponseData.Write((int)_state);
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Nfc/NfcManager/Types/State.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/NfcManager/Types/State.cs
@@ -2,7 +2,7 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.NfcManager
 {
     enum State
     {
-        NonInitialized = 0,
-        Initialized    = 1
+        NonInitialized,
+        Initialized
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Nfc/NfcManager/Types/State.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/NfcManager/Types/State.cs
@@ -1,0 +1,8 @@
+namespace Ryujinx.HLE.HOS.Services.Nfc.NfcManager
+{
+    enum State
+    {
+        NonInitialized = 0,
+        Initialized    = 1
+    }
+}


### PR DESCRIPTION
Very basic state management but works with Hyrule Warriors Definitive Edition. Partially fixes #2122.

An evolution since that issue, on master, that game now asked for `Ryujinx.HLE.HOS.Services.Nfc.NfcManager.INfc: 2` to be implemented. By implementing this basic state management, the game accepts Amiibo scans through the emulator and does not crash anymore.

Should I remove the Stub prints from `Initialize` and `Finalize`? I feel like I didn't really implement anything nor did any kind of reverse engineering to figure out what is supposed to happen here, except blindly setting the state.