### PR TITLE
Scale SamplesPassed counter by RT scale on report

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Threed/SemaphoreUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/SemaphoreUpdater.cs
@@ -1,4 +1,5 @@
 ﻿using Ryujinx.Graphics.GAL;
+using System;
 
 namespace Ryujinx.Graphics.Gpu.Engine.Threed
 {
@@ -151,10 +152,21 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
             ulong ticks = _context.GetTimestamp();
 
+            float divisor = type switch
+            {
+                ReportCounterType.SamplesPassed => _channel.TextureManager.RenderTargetScale * _channel.TextureManager.RenderTargetScale,
+                _ => 1f
+            };
+
             ICounterEvent counter = null;
 
             void resultHandler(object evt, ulong result)
             {
+                if (divisor != 1f)
+                {
+                    result = (ulong)Math.Ceiling(result / divisor);
+                }
+
                 CounterData counterData = new CounterData
                 {
                     Counter = result,

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/SemaphoreUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/SemaphoreUpdater.cs
@@ -164,7 +164,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             {
                 if (divisor != 1f)
                 {
-                    result = (ulong)Math.Ceiling(result / divisor);
+                    result = (ulong)MathF.Ceiling(result / divisor);
                 }
 
                 CounterData counterData = new CounterData


### PR DESCRIPTION
Adds a scale factor for samples passed counter report based on the render target scale at the time. This ensures that when a game reads this counter, it appears similar to the result at 1x.

This doesn't cover cases where the the render target scale changes during the queried draws, though that might be better to handle along with other scope related issues in a future rework of counters. Games generally don't count for occlusion queries over render target changes anyways.

Fixes an issue in Splatoon 2 and the splatfest demo where the special charge would scale too quickly at high res, points at the end of the game would be broken (but still provide a correct winner), and playing at a low res would make it impossible to swim in ink.

Before (0.25x):
![image](https://user-images.githubusercontent.com/6294155/188755049-4cf92896-f4a5-4285-aac5-03aa54ac5856.png)

After (0.25x):
![image](https://user-images.githubusercontent.com/6294155/188755061-e37f0181-2054-456f-a6a7-d39dad3b204a.png)

Not that I'd recommend playing at this resolution, just demonstrates that it goes both ways. It might be better not to scale the ink surface, but this bug with samples passed is more apparent.

May also affect LOD scaling in The Witcher 3.