### PR TITLE
Periodically Flush Commands for Vulkan

### DIFF
--- a/Ryujinx.Graphics.Vulkan/AutoFlushCounter.cs
+++ b/Ryujinx.Graphics.Vulkan/AutoFlushCounter.cs
@@ -1,0 +1,78 @@
+﻿using System.Diagnostics;
+
+namespace Ryujinx.Graphics.Vulkan
+{
+    internal class AutoFlushCounter
+    {
+        /** How often to flush on framebuffer change. */
+        private readonly static long FramebufferFlushTimer = Stopwatch.Frequency / 1000;
+
+        private const int MinDrawCountForFlush = 10;
+        private const int InitialQueryCountForFlush = 32;
+
+        private long _lastFlush;
+        private ulong _lastDrawCount;
+        private bool _hasPendingQuery;
+        private int _queryCount;
+
+        public void RegisterFlush(ulong drawCount)
+        {
+            _lastFlush = Stopwatch.GetTimestamp();
+            _lastDrawCount = drawCount;
+
+            _hasPendingQuery = false;
+        }
+
+        public void RegisterPendingQuery()
+        {
+            _hasPendingQuery = true;
+        }
+
+        public bool ShouldFlushQuery()
+        {
+            return _hasPendingQuery;
+        }
+
+        public bool ShouldFlushDraw()
+        {
+            // Interrupt render passes to flush queries, so that early results arrive sooner.
+            if (_hasPendingQuery)
+            {
+                if (++_queryCount == InitialQueryCountForFlush)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public bool ShouldFlush(ulong drawCount)
+        {
+            _queryCount = 0;
+
+            if (_hasPendingQuery)
+            {
+                return true;
+            }
+
+            long draws = (long)(drawCount - _lastDrawCount);
+
+            if (draws < MinDrawCountForFlush)
+            {
+                if (draws == 0)
+                {
+                    _lastFlush = Stopwatch.GetTimestamp();
+                }
+
+                return false;
+            }
+
+            long flushTimeout = FramebufferFlushTimer;
+
+            long now = Stopwatch.GetTimestamp();
+
+            return now > _lastFlush + flushTimeout;
+        }
+    }
+}

--- a/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -1122,11 +1122,6 @@ namespace Ryujinx.Graphics.Vulkan
 
         private void RecreatePipelineIfNeeded(PipelineBindPoint pbp)
         {
-            if (AutoFlush.ShouldFlushDraw())
-            {
-                Gd.FlushAllCommands();
-            }
-
             _dynamicState.ReplayIfDirty(Gd.Api, CommandBuffer);
 
             // Commit changes to the support buffer before drawing.

--- a/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -19,6 +19,8 @@ namespace Ryujinx.Graphics.Vulkan
         protected readonly Device Device;
         public readonly PipelineCache PipelineCache;
 
+        protected readonly AutoFlushCounter AutoFlush;
+
         private PipelineDynamicState _dynamicState;
         private PipelineState _newState;
         private bool _stateDirty;
@@ -69,6 +71,8 @@ namespace Ryujinx.Graphics.Vulkan
         {
             Gd = gd;
             Device = device;
+
+            AutoFlush = new AutoFlushCounter();
 
             var pipelineCacheCreateInfo = new PipelineCacheCreateInfo()
             {
@@ -1118,6 +1122,11 @@ namespace Ryujinx.Graphics.Vulkan
 
         private void RecreatePipelineIfNeeded(PipelineBindPoint pbp)
         {
+            if (AutoFlush.ShouldFlushDraw())
+            {
+                Gd.FlushAllCommands();
+            }
+
             _dynamicState.ReplayIfDirty(Gd.Api, CommandBuffer);
 
             // Commit changes to the support buffer before drawing.

--- a/Ryujinx.Graphics.Vulkan/PipelineFull.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineFull.cs
@@ -275,7 +275,10 @@ namespace Ryujinx.Graphics.Vulkan
         {
             _pendingQueryCopies.Add(query);
 
-            AutoFlush.RegisterPendingQuery();
+            if (AutoFlush.RegisterPendingQuery())
+            {
+                FlushCommandsImpl();
+            }
         }
 
         protected override void SignalAttachmentChange()

--- a/Ryujinx.Graphics.Vulkan/PipelineFull.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineFull.cs
@@ -10,8 +10,6 @@ namespace Ryujinx.Graphics.Vulkan
     {
         private const ulong MinByteWeightForFlush = 256 * 1024 * 1024; // MB
 
-        private bool _hasPendingQuery;
-
         private readonly List<QueryPool> _activeQueries;
         private CounterQueueEvent _activeConditionalRender;
 

--- a/Ryujinx.Graphics.Vulkan/PipelineFull.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineFull.cs
@@ -158,9 +158,8 @@ namespace Ryujinx.Graphics.Vulkan
 
         private void FlushPendingQuery()
         {
-            if (_hasPendingQuery)
+            if (AutoFlush.ShouldFlushQuery())
             {
-                _hasPendingQuery = false;
                 FlushCommandsImpl();
             }
         }
@@ -211,6 +210,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         public void FlushCommandsImpl()
         {
+            AutoFlush.RegisterFlush(DrawCount);
             EndRenderPass();
 
             foreach (var queryPool in _activeQueries)
@@ -277,12 +277,15 @@ namespace Ryujinx.Graphics.Vulkan
         {
             _pendingQueryCopies.Add(query);
 
-            _hasPendingQuery = true;
+            AutoFlush.RegisterPendingQuery();
         }
 
         protected override void SignalAttachmentChange()
         {
-            FlushPendingQuery();
+            if (AutoFlush.ShouldFlush(DrawCount))
+            {
+                FlushCommandsImpl();
+            }
         }
 
         protected override void SignalRenderPassEnd()


### PR DESCRIPTION
NVIDIA's OpenGL driver has a built-in mechanism to automatically flush commands to GPU when a lot have been queued. It's also pretty inconsistent, but we'll ignore that for now.

Our Vulkan implementation only submits a command buffer (flush equivalent) when it needs to. This is typically when another command buffer needs to be sequenced after it, presenting a frame, or an edge case where we flush around GPU queries to get results sooner.

This difference in flush behaviour causes a notable difference between Vulkan and OpenGL when we have to wait for commands. In the worst case, we will wait for a sync point that has just been created. In Vulkan, this sync point is created by flushing the command buffer, and storing a waitable fence that signals its completion. Our command buffer contains _every command that we queued since the last submit_, which could be an entire frame's worth of draws.

This has a huge effect on CPU <-> GPU latency. The more commands in a command buffer, the longer we have to wait for it to complete, which results in wasted time. Because we don't know when the guest will force us to wait, we always want the smallest possible latency.

By periodically flushing commands, we ensure that each command buffer takes a more consistent, smaller amount of time to execute, and that the back of the GPU queue isn't as far away when we need to wait for something to happen. This also might reduce time that the GPU is left inactive while commands are being built.

This PR adds a class to keep track of time spent writing commands since the last flush, and flush commands on attachment change (when render pass will be ended). Flushing for query results has been integrated into this new class and tweaked a bit.

## Improvements:

The main affected game is Pokemon Sword, which got significantly faster in overworld areas due to reduced waiting time when it flushes a shadow map from the main GPU thread.

These screenshots have additional performance counters. GpuWait is time spent waiting on the GPU from guest threads, GpuInvoke is time spent waiting on the GPU from the main GPU thread.

### Before:
![image](https://user-images.githubusercontent.com/6294155/189492289-d2b0a601-69bf-45d2-bf5d-13544fa5147e.png)

### After
![image](https://user-images.githubusercontent.com/6294155/189492294-ecfbc1e9-1d57-4843-8b42-89927b1a9917.png)

This one is weird in that a lot of its cost lies in layout conversion rather than waiting for texture flush. This can be improved in the future. On a weaker system (steam deck) this goes from around 22FPS -> 25FPS, though the layout conversion is likely hitting hardest here.

Another affected game is BOTW, which gets faster depending on the area. This game flushes textures/buffers from its game thread, which is the bottleneck. The effect is smaller, and this could be improved further by pre-emptively flushing textures that are flushed often.

### Before:
![image](https://user-images.githubusercontent.com/6294155/189492369-7beadce7-3536-4a2c-9e78-1935a2fae536.png)

### After:
![image](https://user-images.githubusercontent.com/6294155/189492736-a33e83b5-a0c1-4883-8ee5-e4ab3a366435.png)

## Testing:

Flush latency and throughput may be improved on other games that are inexplicably slower than OpenGL. It's possible that certain games could have their performance _decreased_ slightly due to command buffer submit not being free, but it is unlikely.

Also, flushing to get query results sooner has been tweaked to improve the number of full draw skips that can be done. (tested in SMO)

This does not affect Xenoblade DE being slower in some areas.