### PR TITLE
Fix increment on Arm32 NEON VLDn/VSTn instructions with regs > 1

### DIFF
--- a/ARMeilleure/Decoders/OpCode32SimdMemPair.cs
+++ b/ARMeilleure/Decoders/OpCode32SimdMemPair.cs
@@ -1,11 +1,10 @@
 ﻿using ARMeilleure.State;
-using System;
 
 namespace ARMeilleure.Decoders
 {
     class OpCode32SimdMemPair : OpCode32, IOpCode32Simd
     {
-        private static int[] RegsMap =
+        private static int[] _regsMap =
         {
             1, 1, 4, 2,
             1, 1, 3, 1,
@@ -40,9 +39,9 @@ namespace ARMeilleure.Decoders
             WBack = Rm != RegisterAlias.Aarch32Pc;
             RegisterIndex = Rm != RegisterAlias.Aarch32Pc && Rm != RegisterAlias.Aarch32Sp;
 
-            Regs = RegsMap[(opCode >> 8) & 0xf];
+            Regs = _regsMap[(opCode >> 8) & 0xf];
 
-            Increment = Math.Min(Regs, ((opCode >> 8) & 0x1) + 1);
+            Increment = ((opCode >> 8) & 0x1) + 1;
         }
     }
 }

--- a/ARMeilleure/Decoders/OpCodeTable.cs
+++ b/ARMeilleure/Decoders/OpCodeTable.cs
@@ -888,18 +888,31 @@ namespace ARMeilleure.Decoders
             SetA32("111100100x00xxxxxxxx1100xxx1xxxx", InstName.Vfma,        InstEmit32.Vfma_V,      OpCode32SimdReg.Create);
             SetA32("111100100x10xxxxxxxx1100xxx1xxxx", InstName.Vfms,        InstEmit32.Vfms_V,      OpCode32SimdReg.Create);
             SetA32("1111001x0x<<xxxxxxxx0000xxx0xxxx", InstName.Vhadd,       InstEmit32.Vhadd,       OpCode32SimdReg.Create);
-            SetA32("111101001x10xxxxxxxxxx00xxxxxxxx", InstName.Vld1,        InstEmit32.Vld1,        OpCode32SimdMemSingle.Create);
-            SetA32("111101000x10xxxxxxxx0111xxxxxxxx", InstName.Vld1,        InstEmit32.Vld1,        OpCode32SimdMemPair.Create); // Regs = 1.
-            SetA32("111101000x10xxxxxxxx1010xxxxxxxx", InstName.Vld1,        InstEmit32.Vld1,        OpCode32SimdMemPair.Create); // Regs = 2.
-            SetA32("111101000x10xxxxxxxx0110xxxxxxxx", InstName.Vld1,        InstEmit32.Vld1,        OpCode32SimdMemPair.Create); // Regs = 3.
+            SetA32("111101001x10xxxxxxxx0000xxx0xxxx", InstName.Vld1,        InstEmit32.Vld1,        OpCode32SimdMemSingle.Create);
+            SetA32("111101001x10xxxxxxxx0100xx0xxxxx", InstName.Vld1,        InstEmit32.Vld1,        OpCode32SimdMemSingle.Create);
+            SetA32("111101001x10xxxxxxxx1000x000xxxx", InstName.Vld1,        InstEmit32.Vld1,        OpCode32SimdMemSingle.Create);
+            SetA32("111101001x10xxxxxxxx1000x011xxxx", InstName.Vld1,        InstEmit32.Vld1,        OpCode32SimdMemSingle.Create);
+            SetA32("111101001x10xxxxxxxx110000x0xxxx", InstName.Vld1,        InstEmit32.Vld1,        OpCode32SimdMemSingle.Create);
+            SetA32("111101001x10xxxxxxxx110001xxxxxx", InstName.Vld1,        InstEmit32.Vld1,        OpCode32SimdMemSingle.Create);
+            SetA32("111101001x10xxxxxxxx110010xxxxxx", InstName.Vld1,        InstEmit32.Vld1,        OpCode32SimdMemSingle.Create);
+            SetA32("111101000x10xxxxxxxx0111xx0xxxxx", InstName.Vld1,        InstEmit32.Vld1,        OpCode32SimdMemPair.Create); // Regs = 1.
+            SetA32("111101000x10xxxxxxxx1010xx<<xxxx", InstName.Vld1,        InstEmit32.Vld1,        OpCode32SimdMemPair.Create); // Regs = 2.
+            SetA32("111101000x10xxxxxxxx0110xx0xxxxx", InstName.Vld1,        InstEmit32.Vld1,        OpCode32SimdMemPair.Create); // Regs = 3.
             SetA32("111101000x10xxxxxxxx0010xxxxxxxx", InstName.Vld1,        InstEmit32.Vld1,        OpCode32SimdMemPair.Create); // Regs = 4.
-            SetA32("111101001x10xxxxxxxxxx01xxxxxxxx", InstName.Vld2,        InstEmit32.Vld2,        OpCode32SimdMemSingle.Create);
-            SetA32("111101000x10xxxxxxxx100xxxxxxxxx", InstName.Vld2,        InstEmit32.Vld2,        OpCode32SimdMemPair.Create); // Regs = 1, inc = 1/2 (itype).
-            SetA32("111101000x10xxxxxxxx0011xxxxxxxx", InstName.Vld2,        InstEmit32.Vld2,        OpCode32SimdMemPair.Create); // Regs = 2, inc = 2.
-            SetA32("111101001x10xxxxxxxxxx10xxxxxxxx", InstName.Vld3,        InstEmit32.Vld3,        OpCode32SimdMemSingle.Create);
-            SetA32("111101000x10xxxxxxxx010xxxxxxxxx", InstName.Vld3,        InstEmit32.Vld3,        OpCode32SimdMemPair.Create); // Inc = 1/2 (itype).
-            SetA32("111101001x10xxxxxxxxxx11xxxxxxxx", InstName.Vld4,        InstEmit32.Vld4,        OpCode32SimdMemSingle.Create);
-            SetA32("111101000x10xxxxxxxx000xxxxxxxxx", InstName.Vld4,        InstEmit32.Vld4,        OpCode32SimdMemPair.Create); // Inc = 1/2 (itype).
+            SetA32("111101001x10xxxxxxxx0x01xxxxxxxx", InstName.Vld2,        InstEmit32.Vld2,        OpCode32SimdMemSingle.Create);
+            SetA32("111101001x10xxxxxxxx1001xx0xxxxx", InstName.Vld2,        InstEmit32.Vld2,        OpCode32SimdMemSingle.Create);
+            SetA32("111101001x10xxxxxxxx1101<<xxxxxx", InstName.Vld2,        InstEmit32.Vld2,        OpCode32SimdMemSingle.Create);
+            SetA32("111101000x10xxxxxxxx100x<<0xxxxx", InstName.Vld2,        InstEmit32.Vld2,        OpCode32SimdMemPair.Create); // Regs = 1, inc = 1/2 (itype).
+            SetA32("111101000x10xxxxxxxx100x<<10xxxx", InstName.Vld2,        InstEmit32.Vld2,        OpCode32SimdMemPair.Create); // Regs = 1, inc = 1/2 (itype).
+            SetA32("111101000x10xxxxxxxx0011<<xxxxxx", InstName.Vld2,        InstEmit32.Vld2,        OpCode32SimdMemPair.Create); // Regs = 2, inc = 2.
+            SetA32("111101001x10xxxxxxxx0x10xxx0xxxx", InstName.Vld3,        InstEmit32.Vld3,        OpCode32SimdMemSingle.Create);
+            SetA32("111101001x10xxxxxxxx1010xx00xxxx", InstName.Vld3,        InstEmit32.Vld3,        OpCode32SimdMemSingle.Create);
+            SetA32("111101001x10xxxxxxxx1110<<x0xxxx", InstName.Vld3,        InstEmit32.Vld3,        OpCode32SimdMemSingle.Create);
+            SetA32("111101000x10xxxxxxxx010x<<0xxxxx", InstName.Vld3,        InstEmit32.Vld3,        OpCode32SimdMemPair.Create); // Inc = 1/2 (itype).
+            SetA32("111101001x10xxxxxxxx0x11xxxxxxxx", InstName.Vld4,        InstEmit32.Vld4,        OpCode32SimdMemSingle.Create);
+            SetA32("111101001x10xxxxxxxx1011xx<<xxxx", InstName.Vld4,        InstEmit32.Vld4,        OpCode32SimdMemSingle.Create);
+            SetA32("111101001x10xxxxxxxx1111<<x>xxxx", InstName.Vld4,        InstEmit32.Vld4,        OpCode32SimdMemSingle.Create);
+            SetA32("111101000x10xxxxxxxx000x<<xxxxxx", InstName.Vld4,        InstEmit32.Vld4,        OpCode32SimdMemPair.Create); // Inc = 1/2 (itype).
             SetA32("1111001x0x<<xxxxxxxx0110xxx0xxxx", InstName.Vmax,        InstEmit32.Vmax_I,      OpCode32SimdReg.Create);
             SetA32("111100100x00xxxxxxxx1111xxx0xxxx", InstName.Vmax,        InstEmit32.Vmax_V,      OpCode32SimdReg.Create);
             SetA32("1111001x0x<<xxxxxxxx0110xxx1xxxx", InstName.Vmin,        InstEmit32.Vmin_I,      OpCode32SimdReg.Create);
@@ -974,18 +987,25 @@ namespace ARMeilleure.Decoders
             SetA32("1111001x1x>>>xxxxxxx0000>xx1xxxx", InstName.Vshr,        InstEmit32.Vshr,        OpCode32SimdShImm.Create);
             SetA32("111100101x>>>xxxxxxx100000x1xxx0", InstName.Vshrn,       InstEmit32.Vshrn,       OpCode32SimdShImmNarrow.Create);
             SetA32("1111001x1x>>>xxxxxxx0001>xx1xxxx", InstName.Vsra,        InstEmit32.Vsra,        OpCode32SimdShImm.Create);
-            SetA32("111101001x00xxxxxxxx<<00xxxxxxxx", InstName.Vst1,        InstEmit32.Vst1,        OpCode32SimdMemSingle.Create);
-            SetA32("111101000x00xxxxxxxx0111xxxxxxxx", InstName.Vst1,        InstEmit32.Vst1,        OpCode32SimdMemPair.Create); // Regs = 1.
-            SetA32("111101000x00xxxxxxxx1010xxxxxxxx", InstName.Vst1,        InstEmit32.Vst1,        OpCode32SimdMemPair.Create); // Regs = 2.
-            SetA32("111101000x00xxxxxxxx0110xxxxxxxx", InstName.Vst1,        InstEmit32.Vst1,        OpCode32SimdMemPair.Create); // Regs = 3.
+            SetA32("111101001x00xxxxxxxx0000xxx0xxxx", InstName.Vst1,        InstEmit32.Vst1,        OpCode32SimdMemSingle.Create);
+            SetA32("111101001x00xxxxxxxx0100xx0xxxxx", InstName.Vst1,        InstEmit32.Vst1,        OpCode32SimdMemSingle.Create);
+            SetA32("111101001x00xxxxxxxx1000x000xxxx", InstName.Vst1,        InstEmit32.Vst1,        OpCode32SimdMemSingle.Create);
+            SetA32("111101001x00xxxxxxxx1000x011xxxx", InstName.Vst1,        InstEmit32.Vst1,        OpCode32SimdMemSingle.Create);
+            SetA32("111101000x00xxxxxxxx0111xx0xxxxx", InstName.Vst1,        InstEmit32.Vst1,        OpCode32SimdMemPair.Create); // Regs = 1.
+            SetA32("111101000x00xxxxxxxx1010xx<<xxxx", InstName.Vst1,        InstEmit32.Vst1,        OpCode32SimdMemPair.Create); // Regs = 2.
+            SetA32("111101000x00xxxxxxxx0110xx0xxxxx", InstName.Vst1,        InstEmit32.Vst1,        OpCode32SimdMemPair.Create); // Regs = 3.
             SetA32("111101000x00xxxxxxxx0010xxxxxxxx", InstName.Vst1,        InstEmit32.Vst1,        OpCode32SimdMemPair.Create); // Regs = 4.
-            SetA32("111101001x00xxxxxxxx<<01xxxxxxxx", InstName.Vst2,        InstEmit32.Vst2,        OpCode32SimdMemSingle.Create);
-            SetA32("111101000x00xxxxxxxx100xxxxxxxxx", InstName.Vst2,        InstEmit32.Vst2,        OpCode32SimdMemPair.Create); // Regs = 1, inc = 1/2 (itype).
-            SetA32("111101000x00xxxxxxxx0011xxxxxxxx", InstName.Vst2,        InstEmit32.Vst2,        OpCode32SimdMemPair.Create); // Regs = 2, inc = 2.
-            SetA32("111101001x00xxxxxxxx<<10xxxxxxxx", InstName.Vst3,        InstEmit32.Vst3,        OpCode32SimdMemSingle.Create);
-            SetA32("111101000x00xxxxxxxx010xxxxxxxxx", InstName.Vst3,        InstEmit32.Vst3,        OpCode32SimdMemPair.Create); // Inc = 1/2 (itype).
-            SetA32("111101001x00xxxxxxxx<<11xxxxxxxx", InstName.Vst4,        InstEmit32.Vst4,        OpCode32SimdMemSingle.Create);
-            SetA32("111101000x00xxxxxxxx000xxxxxxxxx", InstName.Vst4,        InstEmit32.Vst4,        OpCode32SimdMemPair.Create); // Inc = 1/2 (itype).
+            SetA32("111101001x00xxxxxxxx0x01xxxxxxxx", InstName.Vst2,        InstEmit32.Vst2,        OpCode32SimdMemSingle.Create);
+            SetA32("111101001x00xxxxxxxx1001xx0xxxxx", InstName.Vst2,        InstEmit32.Vst2,        OpCode32SimdMemSingle.Create);
+            SetA32("111101000x00xxxxxxxx100x<<0xxxxx", InstName.Vst2,        InstEmit32.Vst2,        OpCode32SimdMemPair.Create); // Regs = 1, inc = 1/2 (itype).
+            SetA32("111101000x00xxxxxxxx100x<<10xxxx", InstName.Vst2,        InstEmit32.Vst2,        OpCode32SimdMemPair.Create); // Regs = 1, inc = 1/2 (itype).
+            SetA32("111101000x00xxxxxxxx0011<<xxxxxx", InstName.Vst2,        InstEmit32.Vst2,        OpCode32SimdMemPair.Create); // Regs = 2, inc = 2.
+            SetA32("111101001x00xxxxxxxx0x10xxx0xxxx", InstName.Vst3,        InstEmit32.Vst3,        OpCode32SimdMemSingle.Create);
+            SetA32("111101001x00xxxxxxxx1010xx00xxxx", InstName.Vst3,        InstEmit32.Vst3,        OpCode32SimdMemSingle.Create);
+            SetA32("111101000x00xxxxxxxx010x<<0xxxxx", InstName.Vst3,        InstEmit32.Vst3,        OpCode32SimdMemPair.Create); // Inc = 1/2 (itype).
+            SetA32("111101001x00xxxxxxxx0x11xxxxxxxx", InstName.Vst4,        InstEmit32.Vst4,        OpCode32SimdMemSingle.Create);
+            SetA32("111101001x00xxxxxxxx1011xx<<xxxx", InstName.Vst4,        InstEmit32.Vst4,        OpCode32SimdMemSingle.Create);
+            SetA32("111101000x00xxxxxxxx000x<<xxxxxx", InstName.Vst4,        InstEmit32.Vst4,        OpCode32SimdMemPair.Create); // Inc = 1/2 (itype).
             SetA32("111100110xxxxxxxxxxx1000xxx0xxxx", InstName.Vsub,        InstEmit32.Vsub_I,      OpCode32SimdReg.Create);
             SetA32("111100100x10xxxxxxxx1101xxx0xxxx", InstName.Vsub,        InstEmit32.Vsub_V,      OpCode32SimdReg.Create);
             SetA32("1111001x1x<<xxxxxxx00010x0x0xxxx", InstName.Vsubl,       InstEmit32.Vsubl_I,     OpCode32SimdRegLong.Create);

--- a/ARMeilleure/Instructions/InstEmitSimdMemory32.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdMemory32.cs
@@ -67,7 +67,7 @@ namespace ARMeilleure.Instructions
 
                 for (int i = 0; i < count; i++)
                 {
-                    // Read an element from a double simd register.
+                    // Accesses an element from a double simd register.
                     Operand address = context.Add(n, Const(offset));
                     if (eBytes == 8)
                     {
@@ -145,7 +145,7 @@ namespace ARMeilleure.Instructions
                         int elemD = d + reg;
                         for (int i = 0; i < count; i++)
                         {
-                            // Write an element from a double simd register,
+                            // Accesses an element from a double simd register,
                             // add ebytes for each element.
                             Operand address = context.Add(n, Const(offset));
                             int index = ((elemD & 1) << (3 - op.Size)) + elem;

--- a/ARMeilleure/Instructions/InstEmitSimdMemory32.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdMemory32.cs
@@ -67,7 +67,7 @@ namespace ARMeilleure.Instructions
 
                 for (int i = 0; i < count; i++)
                 {
-                    // Write an element from a double simd register.
+                    // Read an element from a double simd register.
                     Operand address = context.Add(n, Const(offset));
                     if (eBytes == 8)
                     {
@@ -131,6 +131,7 @@ namespace ARMeilleure.Instructions
             {
                 OpCode32SimdMemPair op = (OpCode32SimdMemPair)context.CurrOp;
 
+                int increment = count > 1 ? op.Increment : 1;
                 int eBytes = 1 << op.Size;
 
                 Operand n = context.Copy(GetIntA32(context, op.Rn));
@@ -144,7 +145,7 @@ namespace ARMeilleure.Instructions
                         int elemD = d + reg;
                         for (int i = 0; i < count; i++)
                         {
-                            // Write an element from a double simd register
+                            // Write an element from a double simd register,
                             // add ebytes for each element.
                             Operand address = context.Add(n, Const(offset));
                             int index = ((elemD & 1) << (3 - op.Size)) + elem;
@@ -161,7 +162,6 @@ namespace ARMeilleure.Instructions
                             }
                             else
                             {
-
                                 if (load)
                                 {
                                     EmitLoadSimd(context, address, GetVecA32(elemD >> 1), elemD >> 1, index, op.Size);
@@ -173,7 +173,7 @@ namespace ARMeilleure.Instructions
                             }
 
                             offset += eBytes;
-                            elemD += op.Increment;
+                            elemD += increment;
                         }
                     }
                 }

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -27,7 +27,7 @@ namespace ARMeilleure.Translation.PTC
         private const string OuterHeaderMagicString = "PTCohd\0\0";
         private const string InnerHeaderMagicString = "PTCihd\0\0";
 
-        private const uint InternalVersion = 3683; //! To be incremented manually for each change to the ARMeilleure project.
+        private const uint InternalVersion = 3695; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";


### PR DESCRIPTION
Due to what appears to be an oversight, not all "modes" were being tested on the VLDn/VSTn (pair) tests. Only VLD1 and VST1 was being tested. Fixing that revealed several failures caused by an incorrect register increment value, which caused some of those instructions to get or put the value on the wrong register.

This change fixes the above issues, and additionally updates the `OpCodeTable` to account for several "Undefined" encoding, which were considered valid before.

Fixes black screen on No More Heroes 2.
Before:
![image](https://user-images.githubusercontent.com/5624669/189557209-73ff3220-6c9f-4b15-b579-1b712c92bc04.png)
After:
![image](https://user-images.githubusercontent.com/5624669/189557221-7f07ff88-f980-45ba-a45f-2fb95c2c8b66.png)
Fixes several missing effects on Pikmin 3 Deluxe.
Before (pay attention to the antenna above the main character head):
![image](https://user-images.githubusercontent.com/5624669/189557275-42717496-d26c-4272-95ad-1d466ca44e03.png)
After:
![image](https://user-images.githubusercontent.com/5624669/189557279-41ebadc2-3feb-4fee-83e4-0ea4e969f330.png)
Fixes the main character falling below the ground on Sphinx the Cursed Mummy.
Before:

https://user-images.githubusercontent.com/5624669/189557314-6fc81fed-efc4-49a2-993f-eac3016088d5.mp4

After:

https://user-images.githubusercontent.com/5624669/189557325-64246fcb-bc37-4846-81c7-5d60811ac66c.mp4

This also fixes bad voice audio quality on Ni no Kuni.