### PR TITLE
Fix R4G4B4A4 format on Vulkan

### DIFF
--- a/Ryujinx.Graphics.Vulkan/FormatCapabilities.cs
+++ b/Ryujinx.Graphics.Vulkan/FormatCapabilities.cs
@@ -108,6 +108,10 @@ namespace Ryujinx.Graphics.Vulkan
                 {
                     format = VkFormat.D32SfloatS8Uint;
                 }
+                else if (srcFormat == GAL.Format.R4G4B4A4Unorm)
+                {
+                    format = VkFormat.R4G4B4A4UnormPack16;
+                }
                 else
                 {
                     Logger.Error?.Print(LogClass.Gpu, $"Format {srcFormat} is not supported by the host.");

--- a/Ryujinx.Graphics.Vulkan/FormatTable.cs
+++ b/Ryujinx.Graphics.Vulkan/FormatTable.cs
@@ -6,11 +6,11 @@ namespace Ryujinx.Graphics.Vulkan
 {
     static class FormatTable
     {
-        private static readonly VkFormat[] Table;
+        private static readonly VkFormat[] _table;
 
         static FormatTable()
         {
-            Table = new VkFormat[Enum.GetNames(typeof(Format)).Length];
+            _table = new VkFormat[Enum.GetNames(typeof(Format)).Length];
 
             Add(Format.R8Unorm,             VkFormat.R8Unorm);
             Add(Format.R8Snorm,             VkFormat.R8SNorm);
@@ -68,7 +68,7 @@ namespace Ryujinx.Graphics.Vulkan
             Add(Format.D32FloatS8Uint,      VkFormat.D32SfloatS8Uint);
             Add(Format.R8G8B8A8Srgb,        VkFormat.R8G8B8A8Srgb);
             Add(Format.R4G4Unorm,           VkFormat.R4G4UnormPack8);
-            Add(Format.R4G4B4A4Unorm,       VkFormat.R4G4B4A4UnormPack16);
+            Add(Format.R4G4B4A4Unorm,       VkFormat.A4B4G4R4UnormPack16Ext);
             Add(Format.R5G5B5X1Unorm,       VkFormat.A1R5G5B5UnormPack16);
             Add(Format.R5G5B5A1Unorm,       VkFormat.A1R5G5B5UnormPack16);
             Add(Format.R5G6B5Unorm,         VkFormat.R5G6B5UnormPack16);
@@ -161,12 +161,12 @@ namespace Ryujinx.Graphics.Vulkan
 
         private static void Add(Format format, VkFormat vkFormat)
         {
-            Table[(int)format] = vkFormat;
+            _table[(int)format] = vkFormat;
         }
 
         public static VkFormat GetFormat(Format format)
         {
-            return Table[(int)format];
+            return _table[(int)format];
         }
     }
 }

--- a/Ryujinx.Graphics.Vulkan/TextureView.cs
+++ b/Ryujinx.Graphics.Vulkan/TextureView.cs
@@ -74,17 +74,7 @@ namespace Ryujinx.Graphics.Vulkan
                 swizzleR = swizzleB;
                 swizzleB = temp;
             }
-            else if (info.Format == GAL.Format.R4G4B4A4Unorm)
-            {
-                var tempG = swizzleG;
-                var tempB = swizzleB;
-
-                swizzleB = swizzleA;
-                swizzleG = swizzleR;
-                swizzleR = tempG;
-                swizzleA = tempB;
-            }
-            else if (info.Format == GAL.Format.A1B5G5R5Unorm)
+            else if (VkFormat == VkFormat.R4G4B4A4UnormPack16 || info.Format == GAL.Format.A1B5G5R5Unorm)
             {
                 var tempB = swizzleB;
                 var tempA = swizzleA;


### PR DESCRIPTION
The component order was wrong.
Since the correct format was introduced on a extension and not all GPUs supports it, it will continue using the RGBA4 format with a different swizzle. The new swizzle also works correctly on the games below, but will not work correctly if the texture is rendered from GPU. If the GPU does support the ABGR4 format, then all cases should work correctly.

Fixes text on a few games.

Ni no Kuni.
Before:
![image](https://user-images.githubusercontent.com/5624669/189565231-e4f535dd-5837-40b7-bd99-e119fe7d3b26.png)
After:
![image](https://user-images.githubusercontent.com/5624669/189565250-4aa1f756-26f7-4b67-b3a3-aa19f71c0ea6.png)
Ys VIII: Lacrimosa of Dana.
Before:
![image](https://user-images.githubusercontent.com/5624669/189565280-9b559225-3567-4473-9f32-e487453634de.png)
After:
![image](https://user-images.githubusercontent.com/5624669/189565301-994b76c0-ae5c-4b87-8c13-f13b89df688d.png)
Vroom in the night sky.
Before:
![image](https://user-images.githubusercontent.com/5624669/189565328-650b7262-9d1c-48c2-91c9-495e35781c99.png)
After:
![image](https://user-images.githubusercontent.com/5624669/189565361-6080950c-4b0d-4a41-abaf-573be080b662.png)
Might also fix #3545 but I don't have the game to test.
OpenGL is not affected.
