### PR TITLE
Fix bindless 1D textures having a buffer type on the shader

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 3644;
+        private const uint CodeGenVersion = 3697;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitTexture.cs
@@ -16,7 +16,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
             { 0b0111, 0b1011, 0b1101, 0b1110, 0b1111, 0b0000, 0b0000, 0b0000 }
         };
 
-        private const bool Sample1DAs2D = true;
+        public const bool Sample1DAs2D = true;
 
         private enum TexsType
         {

--- a/Ryujinx.Graphics.Shader/IntermediateRepresentation/Operation.cs
+++ b/Ryujinx.Graphics.Shader/IntermediateRepresentation/Operation.cs
@@ -180,6 +180,18 @@ namespace Ryujinx.Graphics.Shader.IntermediateRepresentation
             _sources[index] = source;
         }
 
+        public void InsertSource(int index, Operand source)
+        {
+            Operand[] newSources = new Operand[_sources.Length + 1];
+
+            Array.Copy(_sources, 0, newSources, 0, index);
+            Array.Copy(_sources, index, newSources, index + 1, _sources.Length - index);
+
+            newSources[index] = source;
+
+            _sources = newSources;
+        }
+
         protected void RemoveSource(int index)
         {
             SetSource(index, null);

--- a/Ryujinx.Graphics.Shader/IntermediateRepresentation/TextureOperation.cs
+++ b/Ryujinx.Graphics.Shader/IntermediateRepresentation/TextureOperation.cs
@@ -60,5 +60,10 @@ namespace Ryujinx.Graphics.Shader.IntermediateRepresentation
             CbufSlot = cbufSlot;
             Handle = handle;
         }
+
+        public void SetLodLevelFlag()
+        {
+            Flags |= TextureFlags.LodLevel;
+        }
     }
 }


### PR DESCRIPTION
Because 1D and Buffer textures uses the same type on most texture instructions on the shader, it must get the actual texture type from GPU state. However, it was not doing that for bindless textures and assuming a buffer type, even if bindless elimination was successful. This change allows it to fix the type if bindless elimination is successful.

Fixes black screen on Prinny 2.
Master:
![image](https://user-images.githubusercontent.com/5624669/189583924-887a56ce-ecc0-408d-bd40-75479632dc84.png)
This PR:
![image](https://user-images.githubusercontent.com/5624669/189583884-72d802d5-bd15-4d18-9624-5db54e0ee142.png)
This PR + #3695:
![image](https://user-images.githubusercontent.com/5624669/189583864-83cd2cba-8f17-4975-97ea-8fb9bdcb0cf8.png)

Testing is welcome.
