### PR TITLE
Avalonia: Line up volume status bar item

### DIFF
--- a/Ryujinx.Ava/Ui/ViewModels/MainWindowViewModel.cs
+++ b/Ryujinx.Ava/Ui/ViewModels/MainWindowViewModel.cs
@@ -387,9 +387,7 @@ namespace Ryujinx.Ava.Ui.ViewModels
         {
             get
             {
-                string icon = Volume == 0 ? "🔇" : "🔊";
-
-                return $"{icon} {(int)(Volume * 100)}%";
+                return $"Vol: {(int)(Volume * 100)}%";
             }
         }
 

--- a/Ryujinx.Ava/Ui/Windows/MainWindow.axaml
+++ b/Ryujinx.Ava/Ui/Windows/MainWindow.axaml
@@ -661,12 +661,13 @@
                         IsVisible="{Binding !ShowLoadProgress}" />
                     <ui:ToggleSplitButton
                         Name="VolumeStatus"
-                        Margin="-2,0,-3,0"
-                        Padding="5,0,0,5"
+                        Margin="5,0,5,0"
+                        Padding="0"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
+                        VerticalContentAlignment="Center"
                         Background="{DynamicResource ThemeContentBackgroundColor}"
-                        BorderBrush="{DynamicResource ThemeContentBackgroundColor}"
+                        BorderThickness="0"
                         Content="{Binding VolumeStatusText}"
                         IsChecked="{Binding VolumeMuted}"
                         IsVisible="{Binding !ShowLoadProgress}">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8682882/189771970-7bfe262c-12f8-453b-9307-13c2c71f5748.png)

Issue with alignment had to do with use of iconography. The simplest fix was to remove this.