### PR TITLE
Allow bindless textures with handles from unbound constant buffer

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -806,7 +806,9 @@ namespace Ryujinx.Graphics.Gpu.Image
                 ? _channel.BufferManager.GetComputeUniformBufferAddress(textureBufferIndex)
                 : _channel.BufferManager.GetGraphicsUniformBufferAddress(stageIndex, textureBufferIndex);
 
-            int handle = _channel.MemoryManager.Physical.Read<int>(textureBufferAddress + (uint)textureWordOffset * 4);
+            int handle = textureBufferAddress != 0
+                ? _channel.MemoryManager.Physical.Read<int>(textureBufferAddress + (uint)textureWordOffset * 4)
+                : 0;
 
             // The "wordOffset" (which is really the immediate value used on texture instructions on the shader)
             // is a 13-bit value. However, in order to also support separate samplers and textures (which uses
@@ -824,7 +826,9 @@ namespace Ryujinx.Graphics.Gpu.Image
                         ? _channel.BufferManager.GetComputeUniformBufferAddress(samplerBufferIndex)
                         : _channel.BufferManager.GetGraphicsUniformBufferAddress(stageIndex, samplerBufferIndex);
 
-                    samplerHandle = _channel.MemoryManager.Physical.Read<int>(samplerBufferAddress + (uint)samplerWordOffset * 4);
+                    samplerHandle = samplerBufferAddress != 0
+                        ? _channel.MemoryManager.Physical.Read<int>(samplerBufferAddress + (uint)samplerWordOffset * 4)
+                        : 0;
                 }
                 else
                 {

--- a/Ryujinx.Graphics.Shader/TextureHandle.cs
+++ b/Ryujinx.Graphics.Shader/TextureHandle.cs
@@ -88,7 +88,7 @@ namespace Ryujinx.Graphics.Shader
         {
             (int textureWordOffset, int samplerWordOffset, TextureHandleType handleType) = UnpackOffsets(wordOffset);
 
-            int handle = cachedTextureBuffer[textureWordOffset];
+            int handle = cachedTextureBuffer.Length != 0 ? cachedTextureBuffer[textureWordOffset] : 0;
 
             // The "wordOffset" (which is really the immediate value used on texture instructions on the shader)
             // is a 13-bit value. However, in order to also support separate samplers and textures (which uses
@@ -102,7 +102,7 @@ namespace Ryujinx.Graphics.Shader
 
                 if (handleType != TextureHandleType.SeparateConstantSamplerHandle)
                 {
-                    samplerHandle = cachedSamplerBuffer[samplerWordOffset];
+                    samplerHandle = cachedSamplerBuffer.Length != 0 ? cachedSamplerBuffer[samplerWordOffset] : 0;
                 }
                 else
                 {


### PR DESCRIPTION
Currently, trying to read a handle that is used for bindless texture access from a constant buffer that is not bound will crash the emulator, because it tries to read from a unmapped address. This change has it assume that the handle value is 0 if the constant buffer is not bound. This is in-line with the sparse buffer behavior where out of bounds access read as 0 and does not write anywhere (although this is not really a sparse buffer, so not sure if it would apply here?).

This fixes a crash at launch on Sniper Elite 3 Ultimate Edition.