### PR TITLE
Fix ListOpenContextStoredUsers and stub LoadOpenContext

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Account/Acc/AccountManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/AccountManager.cs
@@ -22,7 +22,8 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
         // outside of the AccountManager.
         private readonly HorizonClient _horizonClient;
 
-        private ConcurrentDictionary<string, UserProfile> _profiles;
+        private readonly ConcurrentDictionary<string, UserProfile> _profiles;
+        private UserProfile[] _storedOpenedUsers;
 
         public UserProfile LastOpenedUser { get; private set; }
 
@@ -31,6 +32,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             _horizonClient = horizonClient;
 
             _profiles = new ConcurrentDictionary<string, UserProfile>();
+            _storedOpenedUsers = Array.Empty<UserProfile>();
 
             _accountSaveDataManager = new AccountSaveDataManager(_profiles);
 
@@ -44,9 +46,9 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             }
             else
             {
-                UserId commandLineUserProfileOverride = default; 
+                UserId commandLineUserProfileOverride = default;
                 if (!string.IsNullOrEmpty(initialProfileName))
-                { 
+                {
                     commandLineUserProfileOverride = _profiles.Values.FirstOrDefault(x => x.Name == initialProfileName)?.UserId ?? default;
                     if (commandLineUserProfileOverride.IsNull)
                         Logger.Warning?.Print(LogClass.Application, $"The command line specified profile named '{initialProfileName}' was not found");
@@ -219,6 +221,16 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
         internal IEnumerable<UserProfile> GetOpenedUsers()
         {
             return _profiles.Values.Where(x => x.AccountState == AccountState.Open);
+        }
+
+        internal IEnumerable<UserProfile> GetStoredOpenedUsers()
+        {
+            return _storedOpenedUsers;
+        }
+
+        internal void StoreOpenedUsers()
+        {
+            _storedOpenedUsers = _profiles.Values.Where(x => x.AccountState == AccountState.Open).ToArray();
         }
 
         internal UserProfile GetFirst()

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/AccountService/ManagerServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/AccountService/ManagerServer.cs
@@ -162,7 +162,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc.AccountService
 
         public ResultCode StoreOpenContext(ServiceCtx context)
         {
-            Logger.Stub?.PrintStub(LogClass.ServiceAcc);
+            context.Device.System.AccountManager.StoreOpenedUsers();
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/ApplicationServiceServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/ApplicationServiceServer.cs
@@ -201,6 +201,13 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             return ResultCode.Success;
         }
 
+        public ResultCode ListOpenContextStoredUsers(ServiceCtx context)
+        {
+            // TODO: Determine how users are "qualified". We assume all users are "qualified" for now.
+
+            return WriteUserList(context, context.Device.System.AccountManager.GetStoredOpenedUsers());
+        }
+
         public ResultCode ListQualifiedUsers(ServiceCtx context)
         {
             // TODO: Determine how users are "qualified". We assume all users are "qualified" for now.

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/ApplicationServiceServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/ApplicationServiceServer.cs
@@ -203,8 +203,6 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
 
         public ResultCode ListOpenContextStoredUsers(ServiceCtx context)
         {
-            // TODO: Determine how users are "qualified". We assume all users are "qualified" for now.
-
             return WriteUserList(context, context.Device.System.AccountManager.GetStoredOpenedUsers());
         }
 

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
@@ -1,5 +1,4 @@
 using Ryujinx.Common.Logging;
-using Ryujinx.Cpu;
 using Ryujinx.HLE.HOS.Services.Account.Acc.AccountService;
 using Ryujinx.HLE.HOS.Services.Arp;
 
@@ -139,20 +138,21 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             return _applicationServiceServer.ClearSaveDataThumbnail(context);
         }
 
+        [CommandHipc(130)] // 5.0.0+
+        // LoadOpenContext(nn::account::Uid)
+        public ResultCode LoadOpenContext(ServiceCtx context)
+        {
+            Logger.Stub?.PrintStub(LogClass.ServiceAcc);
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(60)] // 5.0.0-5.1.0
         [CommandHipc(131)] // 6.0.0+
         // ListOpenContextStoredUsers() -> array<nn::account::Uid, 0xa>
         public ResultCode ListOpenContextStoredUsers(ServiceCtx context)
         {
-            ulong outputPosition = context.Request.RecvListBuff[0].Position;
-            ulong outputSize     = context.Request.RecvListBuff[0].Size;
-
-            MemoryHelper.FillWithZeros(context.Memory, outputPosition, (int)outputSize);
-
-            // TODO: This seems to write stored userids of the OpenContext in the buffer. We needs to determine them.
-            
-            Logger.Stub?.PrintStub(LogClass.ServiceAcc);
-
-            return ResultCode.Success;
+            return _applicationServiceServer.ListOpenContextStoredUsers(context);
         }
 
         [CommandHipc(141)] // 6.0.0+


### PR DESCRIPTION
`StoreOpenContext` can be used to save the current list of open users, while `ListOpenContextStoredUsers` can be used to retrieve the list that was saved. This is useful in multi-program applications because the previous program can save the open users and then the next one can retrieve the list, however on master this was stubbed and would always return an empty list. This change makes it save the open profiles and return them on the next program.

Additionally stub `LoadOpenContext`. This started being called after I made `ListOpenContextStoredUsers` behave correctly.

Fixes crash when launching the games in Prinny Presents NIS Classics Volume 3: La Pucelle: Ragnarok / Rhapsody: A Musical Adventure. This is a collection with 2 games, and the crash was caused because it was trying to mount save data with an invalid UserId. The UserId was from `ListOpenContextStoredUsers` which was not returning anything.
![image](https://user-images.githubusercontent.com/5624669/191338195-e930bdeb-48c8-4b01-b438-6bb42aa23975.png)
![image](https://user-images.githubusercontent.com/5624669/191338214-a807ba81-0129-494d-be9b-8ada4e22c400.png)
Rhapsody also confirmed to be playable form start to end with this PR:
![image](https://user-images.githubusercontent.com/5624669/191824587-9c99891f-22c1-406d-b262-76ffdabd16d4.png)