### PR TITLE
 Avalonia: Update Polish Translation

### DIFF
--- a/Ryujinx.Ava/Assets/Locales/pl_PL.json
+++ b/Ryujinx.Ava/Assets/Locales/pl_PL.json
@@ -589,5 +589,7 @@
   "SettingsAppRequiredRestartMessage": "Wymagane Zrestartowanie Ryujinx",
   "SettingsGpuBackendRestartMessage": "Zmieniono ustawienia Backendu Graficznego lub GPU. Będzie to wymagało ponownego uruchomienia",
   "SettingsGpuBackendRestartSubMessage": "Czy chcesz zrestartować teraz?",
+  "SettingsTabHotkeysVolumeUpHotkey": "Zwiększ Głośność:",
+  "SettingsTabHotkeysVolumeDownHotkey": "Zmniejsz Głośność:",
   "VolumeShort": "Głoś"
 }

--- a/Ryujinx.Ava/Assets/Locales/pl_PL.json
+++ b/Ryujinx.Ava/Assets/Locales/pl_PL.json
@@ -588,5 +588,6 @@
   "SettingsTabGraphicsPreferredGpuTooltip": "Wybierz kartę graficzną, która będzie używana z backendem graficznym Vulkan.\n\nNie wpływa na GPU używane przez OpenGL.\n\nW razie wątpliwości ustaw flagę GPU jako \"dGPU\". Jeśli żadnej nie ma, pozostaw nietknięte.",
   "SettingsAppRequiredRestartMessage": "Wymagane Zrestartowanie Ryujinx",
   "SettingsGpuBackendRestartMessage": "Zmieniono ustawienia Backendu Graficznego lub GPU. Będzie to wymagało ponownego uruchomienia",
-  "SettingsGpuBackendRestartSubMessage": "Czy chcesz zrestartować teraz?"
+  "SettingsGpuBackendRestartSubMessage": "Czy chcesz zrestartować teraz?",
+  "VolumeShort": "Głoś."
 }

--- a/Ryujinx.Ava/Assets/Locales/pl_PL.json
+++ b/Ryujinx.Ava/Assets/Locales/pl_PL.json
@@ -589,5 +589,5 @@
   "SettingsAppRequiredRestartMessage": "Wymagane Zrestartowanie Ryujinx",
   "SettingsGpuBackendRestartMessage": "Zmieniono ustawienia Backendu Graficznego lub GPU. Będzie to wymagało ponownego uruchomienia",
   "SettingsGpuBackendRestartSubMessage": "Czy chcesz zrestartować teraz?",
-  "VolumeShort": "Głoś."
+  "VolumeShort": "Głoś"
 }

--- a/Ryujinx.Ava/Assets/Locales/pl_PL.json
+++ b/Ryujinx.Ava/Assets/Locales/pl_PL.json
@@ -589,6 +589,7 @@
   "SettingsAppRequiredRestartMessage": "Wymagane Zrestartowanie Ryujinx",
   "SettingsGpuBackendRestartMessage": "Zmieniono ustawienia Backendu Graficznego lub GPU. Będzie to wymagało ponownego uruchomienia",
   "SettingsGpuBackendRestartSubMessage": "Czy chcesz zrestartować teraz?",
+  "RyujinxUpdaterMessage": "Czy chcesz zaktualizować Ryujinx do najnowszej wersji?",
   "SettingsTabHotkeysVolumeUpHotkey": "Zwiększ Głośność:",
   "SettingsTabHotkeysVolumeDownHotkey": "Zmniejsz Głośność:",
   "VolumeShort": "Głoś"

--- a/Ryujinx.Ava/Ui/Windows/MainWindow.axaml
+++ b/Ryujinx.Ava/Ui/Windows/MainWindow.axaml
@@ -164,7 +164,7 @@
                                 <MenuItem
                                     Command="{ReflectionBinding ChangeLanguage}"
                                     CommandParameter="pl_PL"
-                                    Header="Polish" />
+                                    Header="Polski" />
                                 <MenuItem
                                     Command="{ReflectionBinding ChangeLanguage}"
                                     CommandParameter="ru_RU"


### PR DESCRIPTION
Adding the new shortened "volume" string from the recent updates to Avalonia.

You need the period there otherwise it could be read as "Głoś" -> "Preach".