### PR TITLE
Avalonia: Fix About window not displaying translated window titles

### DIFF
--- a/Ryujinx.Ava/Ui/Windows/AboutWindow.axaml
+++ b/Ryujinx.Ava/Ui/Windows/AboutWindow.axaml
@@ -6,7 +6,6 @@
     xmlns:locale="clr-namespace:Ryujinx.Ava.Common.Locale"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:window="clr-namespace:Ryujinx.Ava.Ui.Windows"
-    Title="Ryujinx - About"
     Width="850"
     Height="550"
     MinWidth="500"


### PR DESCRIPTION
It seems at some point someone had done the work to make it so that the about window titlebar would show translated names but never removed the hardcoded english "Ryujinx - About" from the main .axaml.

Removing it seems to make it work as expected without issues.