### PR TITLE
Fix SSL GetCertificates with certificate ID set to All

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Ssl/ISslService.cs
+++ b/Ryujinx.HLE/HOS/Services/Ssl/ISslService.cs
@@ -29,42 +29,40 @@ namespace Ryujinx.HLE.HOS.Services.Ssl
             return ResultCode.Success;
         }
 
-        private uint ComputeCertificateBufferSizeRequired(ReadOnlySpan<BuiltInCertificateManager.CertStoreEntry> entries)
-        {
-            uint totalSize = 0;
-
-            for (int i = 0; i < entries.Length; i++)
-            {
-                totalSize += (uint)Unsafe.SizeOf<BuiltInCertificateInfo>();
-                totalSize += (uint)entries[i].Data.Length;
-            }
-
-            return totalSize;
-        }
-
         [CommandHipc(2)]
         // GetCertificates(buffer<CaCertificateId, 5> ids) -> (u32 certificates_count, buffer<bytes, 6> certificates)
         public ResultCode GetCertificates(ServiceCtx context)
         {
             ReadOnlySpan<CaCertificateId> ids = MemoryMarshal.Cast<byte, CaCertificateId>(context.Memory.GetSpan(context.Request.SendBuff[0].Position, (int)context.Request.SendBuff[0].Size));
 
-            if (!BuiltInCertificateManager.Instance.TryGetCertificates(ids, out BuiltInCertificateManager.CertStoreEntry[] entries))
+            if (!BuiltInCertificateManager.Instance.TryGetCertificates(
+                ids,
+                out BuiltInCertificateManager.CertStoreEntry[] entries,
+                out bool hasAllCertificates,
+                out int requiredSize))
             {
                 throw new InvalidOperationException();
             }
 
-            if (ComputeCertificateBufferSizeRequired(entries) > context.Request.ReceiveBuff[0].Size)
+            if ((uint)requiredSize > (uint)context.Request.ReceiveBuff[0].Size)
             {
                 return ResultCode.InvalidCertBufSize;
+            }
+
+            int infosCount = entries.Length;
+
+            if (hasAllCertificates)
+            {
+                infosCount++;
             }
 
             using (WritableRegion region = context.Memory.GetWritableRegion(context.Request.ReceiveBuff[0].Position, (int)context.Request.ReceiveBuff[0].Size))
             {
                 Span<byte> rawData = region.Memory.Span;
-                Span<BuiltInCertificateInfo> infos = MemoryMarshal.Cast<byte, BuiltInCertificateInfo>(rawData)[..entries.Length];
-                Span<byte> certificatesData = rawData[(Unsafe.SizeOf<BuiltInCertificateInfo>() * entries.Length)..];
+                Span<BuiltInCertificateInfo> infos = MemoryMarshal.Cast<byte, BuiltInCertificateInfo>(rawData)[..infosCount];
+                Span<byte> certificatesData = rawData[(Unsafe.SizeOf<BuiltInCertificateInfo>() * infosCount)..];
 
-                for (int i = 0; i < infos.Length; i++)
+                for (int i = 0; i < entries.Length; i++)
                 {
                     entries[i].Data.CopyTo(certificatesData);
 
@@ -77,6 +75,17 @@ namespace Ryujinx.HLE.HOS.Services.Ssl
                     };
 
                     certificatesData = certificatesData[entries[i].Data.Length..];
+                }
+
+                if (hasAllCertificates)
+                {
+                    infos[entries.Length] = new BuiltInCertificateInfo
+                    {
+                        Id = CaCertificateId.All,
+                        Status = TrustedCertStatus.Removed,
+                        CertificateDataSize = 0,
+                        CertificateDataOffset = 0
+                    };
                 }
             }
 
@@ -91,12 +100,12 @@ namespace Ryujinx.HLE.HOS.Services.Ssl
         {
             ReadOnlySpan<CaCertificateId> ids = MemoryMarshal.Cast<byte, CaCertificateId>(context.Memory.GetSpan(context.Request.SendBuff[0].Position, (int)context.Request.SendBuff[0].Size));
 
-            if (!BuiltInCertificateManager.Instance.TryGetCertificates(ids, out BuiltInCertificateManager.CertStoreEntry[] entries))
+            if (!BuiltInCertificateManager.Instance.TryGetCertificates(ids, out _, out _, out int requiredSize))
             {
                 throw new InvalidOperationException();
             }
 
-            context.ResponseData.Write(ComputeCertificateBufferSizeRequired(entries));
+            context.ResponseData.Write(requiredSize);
 
             return ResultCode.Success;
         }


### PR DESCRIPTION
When `CaCertificateId` is set to `All`, the SSL `GetCertificates` function returns all the certificates. However, it also sets the last entry of the output array to `All` when it does that, in addition to setting the other fields to 0. That was not being done in our implementation, and was causing crashes since some  games uses this special value to know where the array ends, without the value to indicate that it would keep reading forever and eventually access out of bounds memory and crash.

Fixes crash on launch on Life is Strange Remastered.
![image](https://user-images.githubusercontent.com/5624669/192909180-19950766-15e9-4644-822d-fa3ac4d10549.png)