### PR TITLE
Fix incorrect tessellation inputs/outputs

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 3697;
+        private const uint CodeGenVersion = 3728;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
@@ -28,33 +28,27 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
         private static Dictionary<int, BuiltInAttribute> _builtInAttributes = new Dictionary<int, BuiltInAttribute>()
         {
-            { AttributeConsts.TessLevelOuter0, new BuiltInAttribute("gl_TessLevelOuter[0]", VariableType.F32)  },
-            { AttributeConsts.TessLevelOuter1, new BuiltInAttribute("gl_TessLevelOuter[1]", VariableType.F32)  },
-            { AttributeConsts.TessLevelOuter2, new BuiltInAttribute("gl_TessLevelOuter[2]", VariableType.F32)  },
-            { AttributeConsts.TessLevelOuter3, new BuiltInAttribute("gl_TessLevelOuter[3]", VariableType.F32)  },
-            { AttributeConsts.TessLevelInner0, new BuiltInAttribute("gl_TessLevelInner[0]", VariableType.F32)  },
-            { AttributeConsts.TessLevelInner1, new BuiltInAttribute("gl_TessLevelInner[1]", VariableType.F32)  },
-            { AttributeConsts.Layer,           new BuiltInAttribute("gl_Layer",             VariableType.S32)  },
-            { AttributeConsts.PointSize,       new BuiltInAttribute("gl_PointSize",         VariableType.F32)  },
-            { AttributeConsts.PositionX,       new BuiltInAttribute("gl_Position.x",        VariableType.F32)  },
-            { AttributeConsts.PositionY,       new BuiltInAttribute("gl_Position.y",        VariableType.F32)  },
-            { AttributeConsts.PositionZ,       new BuiltInAttribute("gl_Position.z",        VariableType.F32)  },
-            { AttributeConsts.PositionW,       new BuiltInAttribute("gl_Position.w",        VariableType.F32)  },
-            { AttributeConsts.ClipDistance0,   new BuiltInAttribute("gl_ClipDistance[0]",   VariableType.F32)  },
-            { AttributeConsts.ClipDistance1,   new BuiltInAttribute("gl_ClipDistance[1]",   VariableType.F32)  },
-            { AttributeConsts.ClipDistance2,   new BuiltInAttribute("gl_ClipDistance[2]",   VariableType.F32)  },
-            { AttributeConsts.ClipDistance3,   new BuiltInAttribute("gl_ClipDistance[3]",   VariableType.F32)  },
-            { AttributeConsts.ClipDistance4,   new BuiltInAttribute("gl_ClipDistance[4]",   VariableType.F32)  },
-            { AttributeConsts.ClipDistance5,   new BuiltInAttribute("gl_ClipDistance[5]",   VariableType.F32)  },
-            { AttributeConsts.ClipDistance6,   new BuiltInAttribute("gl_ClipDistance[6]",   VariableType.F32)  },
-            { AttributeConsts.ClipDistance7,   new BuiltInAttribute("gl_ClipDistance[7]",   VariableType.F32)  },
-            { AttributeConsts.PointCoordX,     new BuiltInAttribute("gl_PointCoord.x",      VariableType.F32)  },
-            { AttributeConsts.PointCoordY,     new BuiltInAttribute("gl_PointCoord.y",      VariableType.F32)  },
-            { AttributeConsts.TessCoordX,      new BuiltInAttribute("gl_TessCoord.x",       VariableType.F32)  },
-            { AttributeConsts.TessCoordY,      new BuiltInAttribute("gl_TessCoord.y",       VariableType.F32)  },
-            { AttributeConsts.InstanceId,      new BuiltInAttribute("gl_InstanceID",        VariableType.S32)  },
-            { AttributeConsts.VertexId,        new BuiltInAttribute("gl_VertexID",          VariableType.S32)  },
-            { AttributeConsts.FrontFacing,     new BuiltInAttribute("gl_FrontFacing",       VariableType.Bool) },
+            { AttributeConsts.Layer,         new BuiltInAttribute("gl_Layer",           VariableType.S32)  },
+            { AttributeConsts.PointSize,     new BuiltInAttribute("gl_PointSize",       VariableType.F32)  },
+            { AttributeConsts.PositionX,     new BuiltInAttribute("gl_Position.x",      VariableType.F32)  },
+            { AttributeConsts.PositionY,     new BuiltInAttribute("gl_Position.y",      VariableType.F32)  },
+            { AttributeConsts.PositionZ,     new BuiltInAttribute("gl_Position.z",      VariableType.F32)  },
+            { AttributeConsts.PositionW,     new BuiltInAttribute("gl_Position.w",      VariableType.F32)  },
+            { AttributeConsts.ClipDistance0, new BuiltInAttribute("gl_ClipDistance[0]", VariableType.F32)  },
+            { AttributeConsts.ClipDistance1, new BuiltInAttribute("gl_ClipDistance[1]", VariableType.F32)  },
+            { AttributeConsts.ClipDistance2, new BuiltInAttribute("gl_ClipDistance[2]", VariableType.F32)  },
+            { AttributeConsts.ClipDistance3, new BuiltInAttribute("gl_ClipDistance[3]", VariableType.F32)  },
+            { AttributeConsts.ClipDistance4, new BuiltInAttribute("gl_ClipDistance[4]", VariableType.F32)  },
+            { AttributeConsts.ClipDistance5, new BuiltInAttribute("gl_ClipDistance[5]", VariableType.F32)  },
+            { AttributeConsts.ClipDistance6, new BuiltInAttribute("gl_ClipDistance[6]", VariableType.F32)  },
+            { AttributeConsts.ClipDistance7, new BuiltInAttribute("gl_ClipDistance[7]", VariableType.F32)  },
+            { AttributeConsts.PointCoordX,   new BuiltInAttribute("gl_PointCoord.x",    VariableType.F32)  },
+            { AttributeConsts.PointCoordY,   new BuiltInAttribute("gl_PointCoord.y",    VariableType.F32)  },
+            { AttributeConsts.TessCoordX,    new BuiltInAttribute("gl_TessCoord.x",     VariableType.F32)  },
+            { AttributeConsts.TessCoordY,    new BuiltInAttribute("gl_TessCoord.y",     VariableType.F32)  },
+            { AttributeConsts.InstanceId,    new BuiltInAttribute("gl_InstanceID",      VariableType.S32)  },
+            { AttributeConsts.VertexId,      new BuiltInAttribute("gl_VertexID",        VariableType.S32)  },
+            { AttributeConsts.FrontFacing,   new BuiltInAttribute("gl_FrontFacing",     VariableType.Bool) },
 
             // Special.
             { AttributeConsts.FragmentOutputDepth, new BuiltInAttribute("gl_FragDepth",           VariableType.F32)  },
@@ -170,7 +164,29 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
             value &= AttributeConsts.Mask & ~3;
             char swzMask = GetSwizzleMask((value >> 2) & 3);
 
-            if (value >= AttributeConsts.UserAttributeBase && value < AttributeConsts.UserAttributeEnd)
+            if (perPatch)
+            {
+                if (value >= AttributeConsts.UserAttributePerPatchBase && value < AttributeConsts.UserAttributePerPatchEnd)
+                {
+                    value -= AttributeConsts.UserAttributePerPatchBase;
+
+                    return $"{DefaultNames.PerPatchAttributePrefix}{(value >> 4)}.{swzMask}";
+                }
+                else if (value < AttributeConsts.UserAttributePerPatchBase)
+                {
+                    return value switch
+                    {
+                        AttributeConsts.TessLevelOuter0 => "gl_TessLevelOuter[0]",
+                        AttributeConsts.TessLevelOuter1 => "gl_TessLevelOuter[1]",
+                        AttributeConsts.TessLevelOuter2 => "gl_TessLevelOuter[2]",
+                        AttributeConsts.TessLevelOuter3 => "gl_TessLevelOuter[3]",
+                        AttributeConsts.TessLevelInner0 => "gl_TessLevelInner[0]",
+                        AttributeConsts.TessLevelInner1 => "gl_TessLevelInner[1]",
+                        _ => null
+                    };
+                }
+            }
+            else if (value >= AttributeConsts.UserAttributeBase && value < AttributeConsts.UserAttributeEnd)
             {
                 value -= AttributeConsts.UserAttributeBase;
 
@@ -179,11 +195,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
                     : DefaultNames.IAttributePrefix;
 
                 bool indexable = config.UsedFeatures.HasFlag(isOutAttr ? FeatureFlags.OaIndexing : FeatureFlags.IaIndexing);
-
-                if (!indexable && perPatch)
-                {
-                    prefix = DefaultNames.PerPatchAttributePrefix;
-                }
 
                 if (indexable)
                 {
@@ -202,7 +213,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
                 {
                     string name = $"{prefix}{(value >> 4)}_{swzMask}";
 
-                    if (!perPatch && AttributeInfo.IsArrayAttributeGlsl(config.Stage, isOutAttr))
+                    if (AttributeInfo.IsArrayAttributeGlsl(config.Stage, isOutAttr))
                     {
                         name += isOutAttr ? "[gl_InvocationID]" : $"[{indexExpr}]";
                     }
@@ -213,7 +224,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
                 {
                     string name = $"{prefix}{(value >> 4)}";
 
-                    if (!perPatch && AttributeInfo.IsArrayAttributeGlsl(config.Stage, isOutAttr))
+                    if (AttributeInfo.IsArrayAttributeGlsl(config.Stage, isOutAttr))
                     {
                         name += isOutAttr ? "[gl_InvocationID]" : $"[{indexExpr}]";
                     }
@@ -277,7 +288,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
                     string name = builtInAttr.Name;
 
-                    if (!perPatch && AttributeInfo.IsArrayAttributeGlsl(config.Stage, isOutAttr) && AttributeInfo.IsArrayBuiltIn(value))
+                    if (AttributeInfo.IsArrayAttributeGlsl(config.Stage, isOutAttr) && AttributeInfo.IsArrayBuiltIn(value))
                     {
                         name = isOutAttr ? $"gl_out[gl_InvocationID].{name}" : $"gl_in[{indexExpr}].{name}";
                     }

--- a/Ryujinx.Graphics.Shader/CodeGen/Spirv/CodeGenContext.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Spirv/CodeGenContext.cs
@@ -382,16 +382,12 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
         public Instruction GetAttributePerPatchElemPointer(int attr, bool isOutAttr, out AggregateType elemType)
         {
             var storageClass = isOutAttr ? StorageClass.Output : StorageClass.Input;
-            var attrInfo = AttributeInfo.From(Config, attr, isOutAttr);
+            var attrInfo = AttributeInfo.FromPatch(Config, attr, isOutAttr);
 
             int attrOffset = attrInfo.BaseValue;
-            Instruction ioVariable;
-
-            bool isUserAttr = attr >= AttributeConsts.UserAttributeBase && attr < AttributeConsts.UserAttributeEnd;
+            Instruction ioVariable = isOutAttr ? OutputsPerPatch[attrOffset] : InputsPerPatch[attrOffset];
 
             elemType = attrInfo.Type & AggregateType.ElementTypeMask;
-
-            ioVariable = isOutAttr ? OutputsPerPatch[attrOffset] : InputsPerPatch[attrOffset];
 
             if ((attrInfo.Type & (AggregateType.Array | AggregateType.Vector)) == 0)
             {
@@ -404,7 +400,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
 
         public Instruction GetAttributePerPatch(AggregateType type, int attr, bool isOutAttr)
         {
-            if (!AttributeInfo.Validate(Config, attr, isOutAttr: false))
+            if (!AttributeInfo.ValidatePerPatch(Config, attr, isOutAttr: false))
             {
                 return GetConstant(type, new AstOperand(IrOperandType.Constant, 0));
             }

--- a/Ryujinx.Graphics.Shader/CodeGen/Spirv/Instructions.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Spirv/Instructions.cs
@@ -882,7 +882,8 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
             if (src2 is AstOperand operand && operand.Type == OperandType.Constant)
             {
                 int attrOffset = (baseAttr.Value & AttributeConsts.Mask) + (operand.Value << 2);
-                return new OperationResult(resultType, context.GetAttribute(resultType, attrOffset, isOutAttr: false, index));
+                bool isOutAttr = (baseAttr.Value & AttributeConsts.LoadOutputMask) != 0;
+                return new OperationResult(resultType, context.GetAttribute(resultType, attrOffset, isOutAttr, index));
             }
             else
             {

--- a/Ryujinx.Graphics.Shader/CodeGen/Spirv/SpirvGenerator.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Spirv/SpirvGenerator.cs
@@ -191,7 +191,15 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
                             break;
                     }
 
-                    if (context.Config.GpuAccessor.QueryTessCw())
+                    bool tessCw = context.Config.GpuAccessor.QueryTessCw();
+
+                    if (context.Config.Options.TargetApi == TargetApi.Vulkan)
+                    {
+                        // We invert the front face on Vulkan backend, so we need to do that here aswell.
+                        tessCw = !tessCw;
+                    }
+
+                    if (tessCw)
                     {
                         context.AddExecutionMode(spvFunc, ExecutionMode.VertexOrderCw);
                     }
@@ -375,9 +383,10 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
                     }
                     else if (dest.Type == OperandType.Attribute || dest.Type == OperandType.AttributePerPatch)
                     {
-                        if (AttributeInfo.Validate(context.Config, dest.Value, isOutAttr: true))
+                        bool perPatch = dest.Type == OperandType.AttributePerPatch;
+
+                        if (AttributeInfo.Validate(context.Config, dest.Value, isOutAttr: true, perPatch))
                         {
-                            bool perPatch = dest.Type == OperandType.AttributePerPatch;
                             AggregateType elemType;
 
                             var elemPointer = perPatch

--- a/Ryujinx.Graphics.Shader/Decoders/Decoder.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/Decoder.cs
@@ -306,18 +306,36 @@ namespace Ryujinx.Graphics.Shader.Decoders
                 for (int elemIndex = 0; elemIndex < count; elemIndex++)
                 {
                     int attr = offset + elemIndex * 4;
-                    if (attr >= AttributeConsts.UserAttributeBase && attr < AttributeConsts.UserAttributeEnd)
+
+                    if (perPatch)
+                    {
+                        if (attr >= AttributeConsts.UserAttributePerPatchBase && attr < AttributeConsts.UserAttributePerPatchEnd)
+                        {
+                            int userAttr = attr - AttributeConsts.UserAttributePerPatchBase;
+                            int index = userAttr / 16;
+
+                            if (isStore)
+                            {
+                                config.SetOutputUserAttributePerPatch(index);
+                            }
+                            else
+                            {
+                                config.SetInputUserAttributePerPatch(index);
+                            }
+                        }
+                    }
+                    else if (attr >= AttributeConsts.UserAttributeBase && attr < AttributeConsts.UserAttributeEnd)
                     {
                         int userAttr = attr - AttributeConsts.UserAttributeBase;
                         int index = userAttr / 16;
 
                         if (isStore)
                         {
-                            config.SetOutputUserAttribute(index, perPatch);
+                            config.SetOutputUserAttribute(index);
                         }
                         else
                         {
-                            config.SetInputUserAttribute(index, (userAttr >> 2) & 3, perPatch);
+                            config.SetInputUserAttribute(index, (userAttr >> 2) & 3);
                         }
                     }
 

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitAttribute.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitAttribute.cs
@@ -46,7 +46,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
                     context.FlagAttributeRead(offset);
 
-                    if (op.O)
+                    if (op.O && CanLoadOutput(offset))
                     {
                         offset |= AttributeConsts.LoadOutputMask;
                     }
@@ -61,7 +61,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
                     context.FlagAttributeRead(offset);
 
-                    if (op.O)
+                    if (op.O && CanLoadOutput(offset))
                     {
                         offset |= AttributeConsts.LoadOutputMask;
                     }
@@ -239,6 +239,11 @@ namespace Ryujinx.Graphics.Shader.Instructions
             {
                 context.EndPrimitive();
             }
+        }
+
+        private static bool CanLoadOutput(int attr)
+        {
+            return attr != AttributeConsts.TessCoordX && attr != AttributeConsts.TessCoordY;
         }
 
         private static bool TryFixedFuncToUserAttributeIpa(EmitterContext context, int attr, out Operand selectedAttr)

--- a/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgram.cs
+++ b/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgram.cs
@@ -97,7 +97,15 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
                 if (src1.Type == OperandType.Constant && src2.Type == OperandType.Constant)
                 {
                     int attrOffset = (src1.Value & AttributeConsts.Mask) + (src2.Value << 2);
-                    context.Info.Inputs.Add(attrOffset);
+
+                    if ((src1.Value & AttributeConsts.LoadOutputMask) != 0)
+                    {
+                        context.Info.Outputs.Add(attrOffset);
+                    }
+                    else
+                    {
+                        context.Info.Inputs.Add(attrOffset);
+                    }
                 }
             }
 

--- a/Ryujinx.Graphics.Shader/Translation/AttributeConsts.cs
+++ b/Ryujinx.Graphics.Shader/Translation/AttributeConsts.cs
@@ -54,6 +54,9 @@ namespace Ryujinx.Graphics.Shader.Translation
         public const int UserAttributeBase   = 0x80;
         public const int UserAttributeEnd    = UserAttributeBase + UserAttributesCount * 16;
 
+        public const int UserAttributePerPatchBase = 0x18;
+        public const int UserAttributePerPatchEnd  = 0x200;
+
         public const int LoadOutputMask = 1 << 30;
         public const int Mask = 0x3fffffff;
 

--- a/Ryujinx.Graphics.Shader/Translation/AttributeInfo.cs
+++ b/Ryujinx.Graphics.Shader/Translation/AttributeInfo.cs
@@ -4,36 +4,30 @@ namespace Ryujinx.Graphics.Shader.Translation
 {
     struct AttributeInfo
     {
-        private static readonly Dictionary<int, AttributeInfo> BuiltInAttributes = new Dictionary<int, AttributeInfo>()
+        private static readonly Dictionary<int, AttributeInfo> _builtInAttributes = new Dictionary<int, AttributeInfo>()
         {
-            { AttributeConsts.TessLevelOuter0, new AttributeInfo(AttributeConsts.TessLevelOuter0, 0, 4, AggregateType.Array  | AggregateType.FP32) },
-            { AttributeConsts.TessLevelOuter1, new AttributeInfo(AttributeConsts.TessLevelOuter0, 1, 4, AggregateType.Array  | AggregateType.FP32) },
-            { AttributeConsts.TessLevelOuter2, new AttributeInfo(AttributeConsts.TessLevelOuter0, 2, 4, AggregateType.Array  | AggregateType.FP32) },
-            { AttributeConsts.TessLevelOuter3, new AttributeInfo(AttributeConsts.TessLevelOuter0, 3, 4, AggregateType.Array  | AggregateType.FP32) },
-            { AttributeConsts.TessLevelInner0, new AttributeInfo(AttributeConsts.TessLevelInner0, 0, 2, AggregateType.Array  | AggregateType.FP32) },
-            { AttributeConsts.TessLevelInner1, new AttributeInfo(AttributeConsts.TessLevelInner0, 1, 2, AggregateType.Array  | AggregateType.FP32) },
-            { AttributeConsts.Layer,           new AttributeInfo(AttributeConsts.Layer,           0, 1, AggregateType.S32) },
-            { AttributeConsts.ViewportIndex,   new AttributeInfo(AttributeConsts.ViewportIndex,   0, 1, AggregateType.S32) },
-            { AttributeConsts.PointSize,       new AttributeInfo(AttributeConsts.PointSize,       0, 1, AggregateType.FP32) },
-            { AttributeConsts.PositionX,       new AttributeInfo(AttributeConsts.PositionX,       0, 4, AggregateType.Vector | AggregateType.FP32) },
-            { AttributeConsts.PositionY,       new AttributeInfo(AttributeConsts.PositionX,       1, 4, AggregateType.Vector | AggregateType.FP32) },
-            { AttributeConsts.PositionZ,       new AttributeInfo(AttributeConsts.PositionX,       2, 4, AggregateType.Vector | AggregateType.FP32) },
-            { AttributeConsts.PositionW,       new AttributeInfo(AttributeConsts.PositionX,       3, 4, AggregateType.Vector | AggregateType.FP32) },
-            { AttributeConsts.ClipDistance0,   new AttributeInfo(AttributeConsts.ClipDistance0,   0, 8, AggregateType.Array  | AggregateType.FP32) },
-            { AttributeConsts.ClipDistance1,   new AttributeInfo(AttributeConsts.ClipDistance0,   1, 8, AggregateType.Array  | AggregateType.FP32) },
-            { AttributeConsts.ClipDistance2,   new AttributeInfo(AttributeConsts.ClipDistance0,   2, 8, AggregateType.Array  | AggregateType.FP32) },
-            { AttributeConsts.ClipDistance3,   new AttributeInfo(AttributeConsts.ClipDistance0,   3, 8, AggregateType.Array  | AggregateType.FP32) },
-            { AttributeConsts.ClipDistance4,   new AttributeInfo(AttributeConsts.ClipDistance0,   4, 8, AggregateType.Array  | AggregateType.FP32) },
-            { AttributeConsts.ClipDistance5,   new AttributeInfo(AttributeConsts.ClipDistance0,   5, 8, AggregateType.Array  | AggregateType.FP32) },
-            { AttributeConsts.ClipDistance6,   new AttributeInfo(AttributeConsts.ClipDistance0,   6, 8, AggregateType.Array  | AggregateType.FP32) },
-            { AttributeConsts.ClipDistance7,   new AttributeInfo(AttributeConsts.ClipDistance0,   7, 8, AggregateType.Array  | AggregateType.FP32) },
-            { AttributeConsts.PointCoordX,     new AttributeInfo(AttributeConsts.PointCoordX,     0, 2, AggregateType.Vector | AggregateType.FP32) },
-            { AttributeConsts.PointCoordY,     new AttributeInfo(AttributeConsts.PointCoordX,     1, 2, AggregateType.Vector | AggregateType.FP32) },
-            { AttributeConsts.TessCoordX,      new AttributeInfo(AttributeConsts.TessCoordX,      0, 2, AggregateType.Vector | AggregateType.FP32) },
-            { AttributeConsts.TessCoordY,      new AttributeInfo(AttributeConsts.TessCoordX,      1, 2, AggregateType.Vector | AggregateType.FP32) },
-            { AttributeConsts.InstanceId,      new AttributeInfo(AttributeConsts.InstanceId,      0, 1, AggregateType.S32) },
-            { AttributeConsts.VertexId,        new AttributeInfo(AttributeConsts.VertexId,        0, 1, AggregateType.S32) },
-            { AttributeConsts.FrontFacing,     new AttributeInfo(AttributeConsts.FrontFacing,     0, 1, AggregateType.Bool) },
+            { AttributeConsts.Layer,         new AttributeInfo(AttributeConsts.Layer,         0, 1, AggregateType.S32) },
+            { AttributeConsts.ViewportIndex, new AttributeInfo(AttributeConsts.ViewportIndex, 0, 1, AggregateType.S32) },
+            { AttributeConsts.PointSize,     new AttributeInfo(AttributeConsts.PointSize,     0, 1, AggregateType.FP32) },
+            { AttributeConsts.PositionX,     new AttributeInfo(AttributeConsts.PositionX,     0, 4, AggregateType.Vector | AggregateType.FP32) },
+            { AttributeConsts.PositionY,     new AttributeInfo(AttributeConsts.PositionX,     1, 4, AggregateType.Vector | AggregateType.FP32) },
+            { AttributeConsts.PositionZ,     new AttributeInfo(AttributeConsts.PositionX,     2, 4, AggregateType.Vector | AggregateType.FP32) },
+            { AttributeConsts.PositionW,     new AttributeInfo(AttributeConsts.PositionX,     3, 4, AggregateType.Vector | AggregateType.FP32) },
+            { AttributeConsts.ClipDistance0, new AttributeInfo(AttributeConsts.ClipDistance0, 0, 8, AggregateType.Array  | AggregateType.FP32) },
+            { AttributeConsts.ClipDistance1, new AttributeInfo(AttributeConsts.ClipDistance0, 1, 8, AggregateType.Array  | AggregateType.FP32) },
+            { AttributeConsts.ClipDistance2, new AttributeInfo(AttributeConsts.ClipDistance0, 2, 8, AggregateType.Array  | AggregateType.FP32) },
+            { AttributeConsts.ClipDistance3, new AttributeInfo(AttributeConsts.ClipDistance0, 3, 8, AggregateType.Array  | AggregateType.FP32) },
+            { AttributeConsts.ClipDistance4, new AttributeInfo(AttributeConsts.ClipDistance0, 4, 8, AggregateType.Array  | AggregateType.FP32) },
+            { AttributeConsts.ClipDistance5, new AttributeInfo(AttributeConsts.ClipDistance0, 5, 8, AggregateType.Array  | AggregateType.FP32) },
+            { AttributeConsts.ClipDistance6, new AttributeInfo(AttributeConsts.ClipDistance0, 6, 8, AggregateType.Array  | AggregateType.FP32) },
+            { AttributeConsts.ClipDistance7, new AttributeInfo(AttributeConsts.ClipDistance0, 7, 8, AggregateType.Array  | AggregateType.FP32) },
+            { AttributeConsts.PointCoordX,   new AttributeInfo(AttributeConsts.PointCoordX,   0, 2, AggregateType.Vector | AggregateType.FP32) },
+            { AttributeConsts.PointCoordY,   new AttributeInfo(AttributeConsts.PointCoordX,   1, 2, AggregateType.Vector | AggregateType.FP32) },
+            { AttributeConsts.TessCoordX,    new AttributeInfo(AttributeConsts.TessCoordX,    0, 3, AggregateType.Vector | AggregateType.FP32) },
+            { AttributeConsts.TessCoordY,    new AttributeInfo(AttributeConsts.TessCoordX,    1, 3, AggregateType.Vector | AggregateType.FP32) },
+            { AttributeConsts.InstanceId,    new AttributeInfo(AttributeConsts.InstanceId,    0, 1, AggregateType.S32) },
+            { AttributeConsts.VertexId,      new AttributeInfo(AttributeConsts.VertexId,      0, 1, AggregateType.S32) },
+            { AttributeConsts.FrontFacing,   new AttributeInfo(AttributeConsts.FrontFacing,   0, 1, AggregateType.Bool) },
 
             // Special.
             { AttributeConsts.FragmentOutputDepth, new AttributeInfo(AttributeConsts.FragmentOutputDepth, 0, 1, AggregateType.FP32) },
@@ -53,6 +47,16 @@ namespace Ryujinx.Graphics.Shader.Translation
             { AttributeConsts.GtMask,              new AttributeInfo(AttributeConsts.GtMask,              0, 4, AggregateType.Vector | AggregateType.U32) },
             { AttributeConsts.LeMask,              new AttributeInfo(AttributeConsts.LeMask,              0, 4, AggregateType.Vector | AggregateType.U32) },
             { AttributeConsts.LtMask,              new AttributeInfo(AttributeConsts.LtMask,              0, 4, AggregateType.Vector | AggregateType.U32) },
+        };
+
+        private static readonly Dictionary<int, AttributeInfo> _builtInAttributesPerPatch = new Dictionary<int, AttributeInfo>()
+        {
+            { AttributeConsts.TessLevelOuter0, new AttributeInfo(AttributeConsts.TessLevelOuter0, 0, 4, AggregateType.Array | AggregateType.FP32) },
+            { AttributeConsts.TessLevelOuter1, new AttributeInfo(AttributeConsts.TessLevelOuter0, 1, 4, AggregateType.Array | AggregateType.FP32) },
+            { AttributeConsts.TessLevelOuter2, new AttributeInfo(AttributeConsts.TessLevelOuter0, 2, 4, AggregateType.Array | AggregateType.FP32) },
+            { AttributeConsts.TessLevelOuter3, new AttributeInfo(AttributeConsts.TessLevelOuter0, 3, 4, AggregateType.Array | AggregateType.FP32) },
+            { AttributeConsts.TessLevelInner0, new AttributeInfo(AttributeConsts.TessLevelInner0, 0, 2, AggregateType.Array | AggregateType.FP32) },
+            { AttributeConsts.TessLevelInner1, new AttributeInfo(AttributeConsts.TessLevelInner0, 1, 2, AggregateType.Array | AggregateType.FP32) },
         };
 
         public int BaseValue { get; }
@@ -76,6 +80,11 @@ namespace Ryujinx.Graphics.Shader.Translation
             return (Value - BaseValue) / 4;
         }
 
+        public static bool Validate(ShaderConfig config, int value, bool isOutAttr, bool perPatch)
+        {
+            return perPatch ? ValidatePerPatch(config, value, isOutAttr) : Validate(config, value, isOutAttr);
+        }
+
         public static bool Validate(ShaderConfig config, int value, bool isOutAttr)
         {
             if (value == AttributeConsts.ViewportIndex && !config.GpuAccessor.QueryHostSupportsViewportIndex())
@@ -84,6 +93,11 @@ namespace Ryujinx.Graphics.Shader.Translation
             }
 
             return From(config, value, isOutAttr).IsValid;
+        }
+
+        public static bool ValidatePerPatch(ShaderConfig config, int value, bool isOutAttr)
+        {
+            return FromPatch(config, value, isOutAttr).IsValid;
         }
 
         public static AttributeInfo From(ShaderConfig config, int value, bool isOutAttr)
@@ -115,7 +129,24 @@ namespace Ryujinx.Graphics.Shader.Translation
             {
                 return new AttributeInfo(value, 0, 1, AggregateType.FP32);
             }
-            else if (BuiltInAttributes.TryGetValue(value, out AttributeInfo info))
+            else if (_builtInAttributes.TryGetValue(value, out AttributeInfo info))
+            {
+                return info;
+            }
+
+            return new AttributeInfo(value, 0, 0, AggregateType.Invalid);
+        }
+
+        public static AttributeInfo FromPatch(ShaderConfig config, int value, bool isOutAttr)
+        {
+            value &= ~3;
+
+            if (value >= AttributeConsts.UserAttributePerPatchBase && value < AttributeConsts.UserAttributePerPatchEnd)
+            {
+                int offset = (value - AttributeConsts.UserAttributePerPatchBase) & 0xf;
+                return new AttributeInfo(value - offset, offset >> 2, 4, AggregateType.Vector | AggregateType.FP32, false);
+            }
+            else if (_builtInAttributesPerPatch.TryGetValue(value, out AttributeInfo info))
             {
                 return info;
             }

--- a/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -261,7 +261,7 @@ namespace Ryujinx.Graphics.Shader.Translation
                         {
                             int index = BitOperations.TrailingZeroCount(passthroughAttributes);
                             WriteOutput(AttributeConsts.UserAttributeBase + index * 16, primIndex);
-                            Config.SetOutputUserAttribute(index, perPatch: false);
+                            Config.SetOutputUserAttribute(index);
                             passthroughAttributes &= ~(1 << index);
                         }
 
@@ -364,7 +364,7 @@ namespace Ryujinx.Graphics.Shader.Translation
                     bool targetEnabled = (Config.OmapTargets & (0xf << (rtIndex * 4))) != 0;
                     if (targetEnabled)
                     {
-                        Config.SetOutputUserAttribute(rtIndex, perPatch: false);
+                        Config.SetOutputUserAttribute(rtIndex);
                         regIndexBase += 4;
                     }
                 }

--- a/Ryujinx.Graphics.Shader/Translation/Translator.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Translator.cs
@@ -204,14 +204,12 @@ namespace Ryujinx.Graphics.Shader.Translation
                 InitializeOutputComponent(context, AttributeConsts.UserAttributeBase + index * 4, perPatch: false);
             }
 
-            UInt128 usedAttributesPerPatch = context.Config.NextInputAttributesPerPatchComponents;
-            while (usedAttributesPerPatch != UInt128.Zero)
+            if (context.Config.NextUsedInputAttributesPerPatch != null)
             {
-                int index = usedAttributesPerPatch.TrailingZeroCount();
-
-                InitializeOutputComponent(context, AttributeConsts.UserAttributeBase + index * 4, perPatch: true);
-
-                usedAttributesPerPatch &= ~UInt128.Pow2(index);
+                foreach (int vecIndex in context.Config.NextUsedInputAttributesPerPatch.OrderBy(x => x))
+                {
+                    InitializeOutput(context, AttributeConsts.UserAttributePerPatchBase + vecIndex * 16, perPatch: true);
+                }
             }
 
             if (config.NextUsesFixedFuncAttributes)
@@ -236,7 +234,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             for (int c = 0; c < 4; c++)
             {
                 int attrOffset = baseAttr + c * 4;
-                context.Copy(perPatch ? AttributePerPatch(attrOffset) : Attribute(attrOffset), ConstF(c == 3 ? 1f : 0f));
+                InitializeOutputComponent(context, attrOffset, perPatch);
             }
         }
 

--- a/Ryujinx.Graphics.Shader/Translation/TranslatorContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/TranslatorContext.cs
@@ -1,6 +1,7 @@
 ﻿using Ryujinx.Graphics.Shader.Decoders;
 using Ryujinx.Graphics.Shader.IntermediateRepresentation;
 using System.Collections.Generic;
+using System.Linq;
 
 using static Ryujinx.Graphics.Shader.IntermediateRepresentation.OperandHelper;
 using static Ryujinx.Graphics.Shader.Translation.Translator;
@@ -137,7 +138,7 @@ namespace Ryujinx.Graphics.Shader.Translation
 
             if (other != null)
             {
-                other._config.MergeOutputUserAttributes(_config.UsedOutputAttributes, 0);
+                other._config.MergeOutputUserAttributes(_config.UsedOutputAttributes, Enumerable.Empty<int>());
 
                 FunctionCode[] otherCode = EmitShader(other._program, other._config, initializeOutputs: true, out int aStart);
 


### PR DESCRIPTION
This is mainly fixing a wrong assumption that I made about tessellation per-patch input/output buffer. I assumed that it was the same as the regular attribute buffer, but it isn't really. The only offsets from the per-patch buffer that have a special meaning are the ones < 0x18. Those map to the TessOuterLevel and TessInnerLevel built-ins. The remaining space can be used for anything, so it's just generic storage. So this PR is changing the code including the GLSL and SPIR-V backends to account for this.

In addition to that, it fixes some existing issues that affects SPIR-V/Vulkan:
- On SPIR-V, the `LoadOutputMask` flag was being ignored for `LoadAttribute`, which could cause it to read from a input rather than output variable.
- `gl_TessCoord` was being declared with a vec2 type on SPIR-V, rather than a vec3 type.
- SPIR-V was using locations for per-patch inputs/outputs that overlaps with the regular inputs/outputs. This was not causing validation errors but it seems to cause issues on some drivers. Both GLSL and SPIR-V were changed to "allocate" locations from the unused locations, so that they never overlap.
- The winding order on the tessellation evaluation shader is now inverted when targeting Vulkan. This is required because it is also inverted on the backend (see `EnumConversion.Convert(this GAL.FrontFace frontFace)` on `Ryujinx.Graphics.Vulkan`).

This fixes rendering on The Legend of Heroes: Trails from Zero.
Before:
![image](https://user-images.githubusercontent.com/5624669/193142059-e8908a73-1d84-4329-aa4e-615c226c9868.png)
![image](https://user-images.githubusercontent.com/5624669/193142069-03a7840d-7bad-4851-974e-836dd73dc9fb.png)
After:
![image](https://user-images.githubusercontent.com/5624669/193142091-3abd6dea-62a8-4a49-a662-c99be29781e6.png)
![image](https://user-images.githubusercontent.com/5624669/193142111-d1052cb9-eac2-4923-af64-6e1cf5b633bc.png)
This affects both OpenGL and Vulkan, but the "before" images would be different from OpenGL (just a black background with text). That's because the shader fails to compile, while on Vulkan the behavior depends on the driver.

The change has also been tested on Intel (Windows). While it no longer crashes on Intel, tessellation is still not working correctly. I also tested GLSL + Vulkan on Intel, and it was also rendering incorrectly, so I don't think the SPIR-V code generation is the issue.

It might potentially affect The Witcher 3 on Vulkan, which I believe had missing ground or something like that on Vulkan? I don't have a save on that area to test.