### PR TITLE
Avoid allocating unmanaged string per shader

### DIFF
--- a/Ryujinx.Graphics.Vulkan/Shader.cs
+++ b/Ryujinx.Graphics.Vulkan/Shader.cs
@@ -15,16 +15,7 @@ namespace Ryujinx.Graphics.Vulkan
         // Take this lock when using them.
         private static object _shaderOptionsLock = new object();
 
-        private static ReadOnlySpan<byte> MainEntryPointName => new byte[] { (byte)'m', (byte)'a', (byte)'i', (byte)'n', 0 };
-        private static readonly IntPtr PtrMainEntryPointName;
-
-        unsafe static Shader()
-        {
-            fixed (byte* ptr = MainEntryPointName)
-            {
-                PtrMainEntryPointName = (IntPtr)ptr;
-            }
-        }
+        private static readonly IntPtr _ptrMainEntryPointName = Marshal.StringToHGlobalAnsi("main");
 
         private readonly Vk _api;
         private readonly Device _device;
@@ -156,7 +147,7 @@ namespace Ryujinx.Graphics.Vulkan
                 SType = StructureType.PipelineShaderStageCreateInfo,
                 Stage = _stage,
                 Module = _module,
-                PName = (byte*)PtrMainEntryPointName
+                PName = (byte*)_ptrMainEntryPointName
             };
         }
 

--- a/Ryujinx.Graphics.Vulkan/Shader.cs
+++ b/Ryujinx.Graphics.Vulkan/Shader.cs
@@ -21,7 +21,7 @@ namespace Ryujinx.Graphics.Vulkan
         private readonly Device _device;
         private readonly ShaderStageFlags _stage;
 
-        private bool _active;
+        private bool _disposed;
         private ShaderModule _module;
 
         public ShaderStageFlags StageFlags => _stage;
@@ -41,7 +41,6 @@ namespace Ryujinx.Graphics.Vulkan
             CompileStatus = ProgramLinkStatus.Incomplete;
 
             _stage = shaderSource.Stage.Convert();
-            _active = true;
 
             CompileTask = Task.Run(() =>
             {
@@ -158,10 +157,10 @@ namespace Ryujinx.Graphics.Vulkan
 
         public unsafe void Dispose()
         {
-            if (_active)
+            if (!_disposed)
             {
                 _api.DestroyShaderModule(_device, _module, null);
-                _active = false;
+                _disposed = true;
             }
         }
     }


### PR DESCRIPTION
Implemented in a fun way for zero allocations (like C string literals). If this is too hacky, I'll replace it with a static `AllocHGlobal`, it should clean up properly without a free. 

Not sure why there's a condition for disposing but I kept it (afaik it's not even referenced outside of `ShaderCollection`). Let me know if it can be removed too. 

Also added missing `IDisposable` for clarity.