### PR TITLE
Vulkan: Fix buffer texture storage not being updated on buffer handle reuse

### DIFF
--- a/Ryujinx.Graphics.Vulkan/BufferManager.cs
+++ b/Ryujinx.Graphics.Vulkan/BufferManager.cs
@@ -38,6 +38,8 @@ namespace Ryujinx.Graphics.Vulkan
 
         private readonly IdList<BufferHolder> _buffers;
 
+        public int BufferCount { get; private set; }
+
         public StagingBuffer StagingBuffer { get; }
 
         public BufferManager(VulkanRenderer gd, PhysicalDevice physicalDevice, Device device)
@@ -55,6 +57,8 @@ namespace Ryujinx.Graphics.Vulkan
             {
                 return BufferHandle.Null;
             }
+
+            BufferCount++;
 
             ulong handle64 = (uint)_buffers.Add(holder);
 

--- a/Ryujinx.Graphics.Vulkan/TextureBuffer.cs
+++ b/Ryujinx.Graphics.Vulkan/TextureBuffer.cs
@@ -16,6 +16,8 @@ namespace Ryujinx.Graphics.Vulkan
         private Auto<DisposableBufferView> _bufferView;
         private Dictionary<GAL.Format, Auto<DisposableBufferView>> _selfManagedViews;
 
+        private int _bufferCount;
+
         public int Width { get; }
         public int Height { get; }
 
@@ -107,7 +109,8 @@ namespace Ryujinx.Graphics.Vulkan
         {
             if (_bufferHandle == buffer.Handle &&
                 _offset == buffer.Offset &&
-                _size == buffer.Size)
+                _size == buffer.Size &&
+                _bufferCount == _gd.BufferManager.BufferCount)
             {
                 return;
             }
@@ -115,6 +118,7 @@ namespace Ryujinx.Graphics.Vulkan
             _bufferHandle = buffer.Handle;
             _offset = buffer.Offset;
             _size = buffer.Size;
+            _bufferCount = _gd.BufferManager.BufferCount;
 
             ReleaseImpl();
         }


### PR DESCRIPTION
Because buffer handles can be re-used (when the old buffer is deleted and a new one created), it is possible that the same handle will actually refer to different buffers. So skipping the update if the handle is the same as the old one is not correct. To fix this, it also forces an update if new buffers were created since the last update. We're currently doing the same thing on OpenGL. This was not always a problem on Vulkan, as buffer handles were not reused, but at some point I added the `IdList` which allows reuse of handles.

This is a tentative fix for the weird issue were models constantly swap back to a very old animation frame on UE4 games. It's hard to confirm if this change actually fixes the issue due to its random nature though. Testing is welcome. 