### PR TITLE
Support use of buffer ranges with size 0

### DIFF
--- a/Ryujinx.Graphics.Vulkan/BufferUsageBitmap.cs
+++ b/Ryujinx.Graphics.Vulkan/BufferUsageBitmap.cs
@@ -24,6 +24,11 @@
 
         public void Add(int cbIndex, int offset, int size)
         {
+            if (size == 0)
+            {
+                return;
+            }
+
             // Some usages can be out of bounds (vertex buffer on amd), so bound if necessary.
             if (offset + size > _size)
             {
@@ -39,6 +44,11 @@
 
         public bool OverlapsWith(int cbIndex, int offset, int size)
         {
+            if (size == 0)
+            {
+                return false;
+            }
+
             int cbBase = cbIndex * _bitsPerCb;
             int start = cbBase + offset / _granularity;
             int end = cbBase + (offset + size - 1) / _granularity;


### PR DESCRIPTION
`BufferUsageBitmap` calculates a inclusive end address as `offset + size - 1`, however, if size is 0, it will result in a invalid offset that is less than the start. `BitMap.SetRange` is not prepared to handle this and will throw `IndexOutOfRangeException` if such ranges are passed. This started happening after #3715 because some games draws quads with a vertex count of 0. The fix here explicitly returns in `BufferUsageBitmap` when the size is 0 since there's nothing to be done in this case.

Fixes #3734.