### PR TITLE
Fix memory corruption in BCAT and FS Read methods when buffer is larger than needed

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Bcat/ServiceCreator/IDeliveryCacheStorageService.cs
+++ b/Ryujinx.HLE/HOS/Services/Bcat/ServiceCreator/IDeliveryCacheStorageService.cs
@@ -50,18 +50,17 @@ namespace Ryujinx.HLE.HOS.Services.Bcat.ServiceCreator
         // EnumerateDeliveryCacheDirectory() -> (u32, buffer<nn::bcat::DirectoryName, 6>)
         public ResultCode EnumerateDeliveryCacheDirectory(ServiceCtx context)
         {
-            ulong position = context.Request.ReceiveBuff[0].Position;
-            ulong size = context.Request.ReceiveBuff[0].Size;
+            ulong bufferAddress = context.Request.ReceiveBuff[0].Position;
+            ulong bufferLen = context.Request.ReceiveBuff[0].Size;
 
-            byte[] data = new byte[size];
+            using (var region = context.Memory.GetWritableRegion(bufferAddress, (int)bufferLen, true))
+            {
+                Result result = _base.Get.EnumerateDeliveryCacheDirectory(out int count, MemoryMarshal.Cast<byte, DirectoryName>(region.Memory.Span));
 
-            Result result = _base.Get.EnumerateDeliveryCacheDirectory(out int count, MemoryMarshal.Cast<byte, DirectoryName>(data));
+                context.ResponseData.Write(count);
 
-            context.Memory.Write(position, data);
-
-            context.ResponseData.Write(count);
-
-            return (ResultCode)result.Value;
+                return (ResultCode)result.Value;
+            }
         }
 
         protected override void Dispose(bool isDisposing)

--- a/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IDirectory.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IDirectory.cs
@@ -17,17 +17,17 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
         // Read() -> (u64 count, buffer<nn::fssrv::sf::IDirectoryEntry, 6, 0> entries)
         public ResultCode Read(ServiceCtx context)
         {
-            ulong bufferPosition = context.Request.ReceiveBuff[0].Position;
+            ulong bufferAddress = context.Request.ReceiveBuff[0].Position;
             ulong bufferLen = context.Request.ReceiveBuff[0].Size;
 
-            byte[] entryBuffer = new byte[bufferLen];
+            using (var region = context.Memory.GetWritableRegion(bufferAddress, (int)bufferLen))
+            {
+                Result result = _baseDirectory.Get.Read(out long entriesRead, new OutBuffer(region.Memory.Span));
 
-            Result result = _baseDirectory.Get.Read(out long entriesRead, new OutBuffer(entryBuffer));
+                context.ResponseData.Write(entriesRead);
 
-            context.Memory.Write(bufferPosition, entryBuffer);
-            context.ResponseData.Write(entriesRead);
-
-            return (ResultCode)result.Value;
+                return (ResultCode)result.Value;
+            }
         }
 
         [CommandHipc(1)]

--- a/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IDirectory.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IDirectory.cs
@@ -20,7 +20,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
             ulong bufferAddress = context.Request.ReceiveBuff[0].Position;
             ulong bufferLen = context.Request.ReceiveBuff[0].Size;
 
-            using (var region = context.Memory.GetWritableRegion(bufferAddress, (int)bufferLen))
+            using (var region = context.Memory.GetWritableRegion(bufferAddress, (int)bufferLen, true))
             {
                 Result result = _baseDirectory.Get.Read(out long entriesRead, new OutBuffer(region.Memory.Span));
 

--- a/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IFile.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IFile.cs
@@ -19,14 +19,14 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
         // Read(u32 readOption, u64 offset, u64 size) -> (u64 out_size, buffer<u8, 0x46, 0> out_buf)
         public ResultCode Read(ServiceCtx context)
         {
+            ulong bufferAddress = context.Request.ReceiveBuff[0].Position;
+            ulong bufferLen = context.Request.ReceiveBuff[0].Size;
+
             ReadOption readOption = context.RequestData.ReadStruct<ReadOption>();
             context.RequestData.BaseStream.Position += 4;
 
             long offset = context.RequestData.ReadInt64();
             long size   = context.RequestData.ReadInt64();
-
-            ulong bufferAddress = context.Request.ReceiveBuff[0].Position;
-            ulong bufferLen = context.Request.ReceiveBuff[0].Size;
 
             using (var region = context.Memory.GetWritableRegion(bufferAddress, (int)bufferLen, true))
             {

--- a/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IFile.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IFile.cs
@@ -19,7 +19,8 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
         // Read(u32 readOption, u64 offset, u64 size) -> (u64 out_size, buffer<u8, 0x46, 0> out_buf)
         public ResultCode Read(ServiceCtx context)
         {
-            ulong position = context.Request.ReceiveBuff[0].Position;
+            ulong bufferAddress = context.Request.ReceiveBuff[0].Position;
+            ulong bufferLen = context.Request.ReceiveBuff[0].Size;
 
             ReadOption readOption = context.RequestData.ReadStruct<ReadOption>();
             context.RequestData.BaseStream.Position += 4;
@@ -27,15 +28,14 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
             long offset = context.RequestData.ReadInt64();
             long size   = context.RequestData.ReadInt64();
 
-            byte[] data = new byte[context.Request.ReceiveBuff[0].Size];
+            using (var region = context.Memory.GetWritableRegion(bufferAddress, (int)bufferLen))
+            {
+                Result result = _baseFile.Get.Read(out long bytesRead, offset, new OutBuffer(region.Memory.Span), size, readOption);
 
-            Result result = _baseFile.Get.Read(out long bytesRead, offset, new OutBuffer(data), size, readOption);
+                context.ResponseData.Write(bytesRead);
 
-            context.Memory.Write(position, data);
-
-            context.ResponseData.Write(bytesRead);
-
-            return (ResultCode)result.Value;
+                return (ResultCode)result.Value;
+            }
         }
 
         [CommandHipc(1)]

--- a/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IFile.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IFile.cs
@@ -19,16 +19,16 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
         // Read(u32 readOption, u64 offset, u64 size) -> (u64 out_size, buffer<u8, 0x46, 0> out_buf)
         public ResultCode Read(ServiceCtx context)
         {
-            ulong bufferAddress = context.Request.ReceiveBuff[0].Position;
-            ulong bufferLen = context.Request.ReceiveBuff[0].Size;
-
             ReadOption readOption = context.RequestData.ReadStruct<ReadOption>();
             context.RequestData.BaseStream.Position += 4;
 
             long offset = context.RequestData.ReadInt64();
             long size   = context.RequestData.ReadInt64();
 
-            using (var region = context.Memory.GetWritableRegion(bufferAddress, (int)bufferLen))
+            ulong bufferAddress = context.Request.ReceiveBuff[0].Position;
+            ulong bufferLen = context.Request.ReceiveBuff[0].Size;
+
+            using (var region = context.Memory.GetWritableRegion(bufferAddress, (int)bufferLen, true))
             {
                 Result result = _baseFile.Get.Read(out long bytesRead, offset, new OutBuffer(region.Memory.Span), size, readOption);
 

--- a/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IFileSystem.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/FileSystemProxy/IFileSystem.cs
@@ -197,13 +197,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy
             context.ResponseData.Write(timestamp.Created);
             context.ResponseData.Write(timestamp.Modified);
             context.ResponseData.Write(timestamp.Accessed);
-
-            byte[] data = new byte[8];
-
-            // is valid?
-            data[0] = 1;
-
-            context.ResponseData.Write(data);
+            context.ResponseData.Write(1L); // Is valid?
 
             return (ResultCode)result.Value;
         }

--- a/Ryujinx.HLE/HOS/Services/Fs/ISaveDataInfoReader.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/ISaveDataInfoReader.cs
@@ -17,17 +17,17 @@ namespace Ryujinx.HLE.HOS.Services.Fs
         // ReadSaveDataInfo() -> (u64, buffer<unknown, 6>)
         public ResultCode ReadSaveDataInfo(ServiceCtx context)
         {
-            ulong bufferPosition = context.Request.ReceiveBuff[0].Position;
+            ulong bufferAddress = context.Request.ReceiveBuff[0].Position;
             ulong bufferLen = context.Request.ReceiveBuff[0].Size;
 
-            byte[] infoBuffer = new byte[bufferLen];
+            using (var region = context.Memory.GetWritableRegion(bufferAddress, (int)bufferLen, true))
+            {
+                Result result = _baseReader.Get.Read(out long readCount, new OutBuffer(region.Memory.Span));
 
-            Result result = _baseReader.Get.Read(out long readCount, new OutBuffer(infoBuffer));
+                context.ResponseData.Write(readCount);
 
-            context.Memory.Write(bufferPosition, infoBuffer);
-            context.ResponseData.Write(readCount);
-
-            return (ResultCode)result.Value;
+                return (ResultCode)result.Value;
+            }
         }
 
         protected override void Dispose(bool isDisposing)

--- a/Ryujinx.HLE/HOS/Services/Ssl/SslService/ISslConnection.cs
+++ b/Ryujinx.HLE/HOS/Services/Ssl/SslService/ISslConnection.cs
@@ -142,14 +142,13 @@ namespace Ryujinx.HLE.HOS.Services.Ssl.SslService
         // GetHostName(buffer<bytes, 6>) -> u32
         public ResultCode GetHostName(ServiceCtx context)
         {
-            ulong hostNameDataPosition = context.Request.ReceiveBuff[0].Position;
-            ulong hostNameDataSize = context.Request.ReceiveBuff[0].Size;
+            ulong bufferAddress = context.Request.ReceiveBuff[0].Position;
+            ulong bufferLen = context.Request.ReceiveBuff[0].Size;
 
-            byte[] hostNameData = new byte[hostNameDataSize];
-
-            Encoding.ASCII.GetBytes(_hostName, hostNameData);
-
-            context.Memory.Write(hostNameDataPosition, hostNameData);
+            using (var region = context.Memory.GetWritableRegion(bufferAddress, (int)bufferLen, true))
+            {
+                Encoding.ASCII.GetBytes(_hostName, region.Memory.Span);
+            }
 
             context.ResponseData.Write((uint)_hostName.Length);
 


### PR DESCRIPTION
Right now, the FS Read methods allocates an array without any regard for existing memory contents, reads the data from the file (or directory entries for `IDirectory.Read`) and then writes the buffer in memory. In most cases this does not cause issues because the application  usually doesn't care about the existing memory contents, but in some cases, applications might pass a buffer that is large and exposes other data to the service. In those cases, since it allocates a new array for the buffer and does not read existing memory contents, such values would be zeroed.

This was causing a crash on the title screen of SWORD ART ONLINE: Alicization Lycoris, because part of the buffer used on `IDirectory.Read` contained data for a `FiberType` struct, and since the method would zero out the struct, the game would skip a step where it frees the fiber and removes it from a internal list. Since the fiber was not removed from the list, it would later try to use it and cause a crash because it had already exited and was not usable anymore.

The title mentioned above can now go ingame:
![image](https://user-images.githubusercontent.com/5624669/193716136-47d2e92a-6336-45fa-bcfc-bb55238bf5ba.png)

This change uses `GetWritableRegion`, which will automatically copy the existing memory contents if needed, and just return a span of the memory directly if possible, avoiding the issue.

The change on `IFile.Read` is just to be on the safe side, but SWORD ART ONLINE seems to work even without that change.

Testing is welcome.