### PR TITLE
Fix: Arguments Break when Updating

### DIFF
--- a/Ryujinx.Ava/Modules/Updater/Updater.cs
+++ b/Ryujinx.Ava/Modules/Updater/Updater.cs
@@ -278,7 +278,7 @@ namespace Ryujinx.Modules
                 {
                     string ryuName = Path.GetFileName(Environment.ProcessPath);
                     string ryuExe = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ryuName);
-                    string ryuArg = string.Join(" ", Environment.GetCommandLineArgs().Skip(1).Select(s => '"' + s + '"'));
+                    string[] ryuArg = Environment.GetCommandLineArgs().Skip(1).ToArray();
 
                     if (!OperatingSystem.IsWindows())
                     {

--- a/Ryujinx.Ava/Modules/Updater/Updater.cs
+++ b/Ryujinx.Ava/Modules/Updater/Updater.cs
@@ -278,7 +278,7 @@ namespace Ryujinx.Modules
                 {
                     string ryuName = Path.GetFileName(Environment.ProcessPath);
                     string ryuExe = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ryuName);
-                    string ryuArg = string.Join(" ", Environment.GetCommandLineArgs().Skip(1).ToArray());
+                    string ryuArg = string.Join(" ", Environment.GetCommandLineArgs().Skip(1).Select(s => '"' + s + '"'));
 
                     if (!OperatingSystem.IsWindows())
                     {

--- a/Ryujinx.Ava/Modules/Updater/Updater.cs
+++ b/Ryujinx.Ava/Modules/Updater/Updater.cs
@@ -278,7 +278,7 @@ namespace Ryujinx.Modules
                 {
                     string ryuName = Path.GetFileName(Environment.ProcessPath);
                     string ryuExe = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ryuName);
-                    string[] ryuArg = Environment.GetCommandLineArgs().Skip(1).ToArray();
+                    var ryuArg = Environment.GetCommandLineArgs().Skip(1);
 
                     if (!OperatingSystem.IsWindows())
                     {

--- a/Ryujinx/Modules/Updater/UpdateDialog.cs
+++ b/Ryujinx/Modules/Updater/UpdateDialog.cs
@@ -48,7 +48,7 @@ namespace Ryujinx.Modules
             {
                 string ryuName = OperatingSystem.IsWindows() ? "Ryujinx.exe" : "Ryujinx";
                 string ryuExe  = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ryuName);
-                string[] ryuArg  = Environment.GetCommandLineArgs().AsEnumerable().Skip(1).ToArray();
+                var ryuArg  = Environment.GetCommandLineArgs().AsEnumerable().Skip(1);
 
                 Process.Start(ryuExe, ryuArg);
 

--- a/Ryujinx/Modules/Updater/UpdateDialog.cs
+++ b/Ryujinx/Modules/Updater/UpdateDialog.cs
@@ -48,7 +48,7 @@ namespace Ryujinx.Modules
             {
                 string ryuName = OperatingSystem.IsWindows() ? "Ryujinx.exe" : "Ryujinx";
                 string ryuExe  = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ryuName);
-                string ryuArg  = string.Join(" ", Environment.GetCommandLineArgs().AsEnumerable().Skip(1).ToArray());
+                string ryuArg  = string.Join(" ", Environment.GetCommandLineArgs().AsEnumerable().Skip(1).Select(s => '"' + s + '"'));
 
                 Process.Start(ryuExe, ryuArg);
 

--- a/Ryujinx/Modules/Updater/UpdateDialog.cs
+++ b/Ryujinx/Modules/Updater/UpdateDialog.cs
@@ -48,7 +48,7 @@ namespace Ryujinx.Modules
             {
                 string ryuName = OperatingSystem.IsWindows() ? "Ryujinx.exe" : "Ryujinx";
                 string ryuExe  = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ryuName);
-                string ryuArg  = string.Join(" ", Environment.GetCommandLineArgs().AsEnumerable().Skip(1).Select(s => '"' + s + '"'));
+                string[] ryuArg  = Environment.GetCommandLineArgs().AsEnumerable().Skip(1).ToArray();
 
                 Process.Start(ryuExe, ryuArg);
 


### PR DESCRIPTION
Edit: The method is slightly changed now. But the outcome is still the same. (https://github.com/Ryujinx/Ryujinx/pull/3744#issuecomment-1271276850)

Original Post:
Ryujinx updates fail to load any arguments that have spaces in them.

Example, loading Ryujinx with command line arguments:
````
-r "D:/Custom Ryujinx Folder"
arg[0] = "-r"
arg[1] = "D:/Custom Ryujinx Folder"
````
Will restart after updates with:
````
-r D:/Custom Ryujinx Folder
arg[0] = "-r"
arg[1] = "D:/Custom"
arg[2] = "Ryujinx"
arg[3] = "Folder"
````

This now wraps all arguments in quotes, resulting in:
````
"-r" "D:/Custom Ryujinx Folder"
arg[0] = "-r"
arg[1] = "D:/Custom Ryujinx Folder"
````

The quotes around each of the args gets ignored when run (eg. "-r" still works fine).

edit:
I should note that this was tested in windows. I have not tested it under Ubuntu. It's a small edit, though. Should be easy to get it working for Ubuntu if this fails and I'd be glad to try figuring that out if it needs worked on.
Edit2:
~Wasn't able to quickly figure out how to fake an update to fully test before getting busy today. But I was able to confirm that the ryuArg string does show as described, and I was able to start Ryujinx(windows) successfully with the string formatted as such.~ Got around to faking the update routine. Got a "Would you like to update...", clicked yes, watched dialog happen and Ryujinx successfully restart with the desired effect. Logs below.

