### PR TITLE
Fix disposed textures being updated on TextureBindingsManager

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -138,9 +138,9 @@ namespace Ryujinx.Graphics.Gpu.Image
         public LinkedListNode<Texture> CacheNode { get; set; }
 
         /// <summary>
-        /// Event to fire when texture data is disposed.
+        /// True if the texture is disposed, false otherwise.
         /// </summary>
-        public event Action<Texture> Disposed;
+        public bool IsDisposed { get; private set; }
 
         /// <summary>
         /// Physical memory ranges where the texture data is located.
@@ -1635,9 +1635,9 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         public void Dispose()
         {
-            DisposeTextures();
+            IsDisposed = true;
 
-            Disposed?.Invoke(this);
+            DisposeTextures();
 
             if (Group.Storage == this)
             {

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -138,11 +138,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         public LinkedListNode<Texture> CacheNode { get; set; }
 
         /// <summary>
-        /// True if the texture is disposed, false otherwise.
-        /// </summary>
-        public bool IsDisposed { get; private set; }
-
-        /// <summary>
         /// Physical memory ranges where the texture data is located.
         /// </summary>
         public MultiRange Range { get; private set; }
@@ -1448,7 +1443,6 @@ namespace Ryujinx.Graphics.Gpu.Image
             DisposeTextures();
 
             HostTexture = hostTexture;
-            InvalidatedSequence++;
         }
 
         /// <summary>
@@ -1603,6 +1597,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         private void DisposeTextures()
         {
+            InvalidatedSequence++;
+
             _currentData = null;
             HostTexture.Release();
 
@@ -1635,8 +1631,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         public void Dispose()
         {
-            IsDisposed = true;
-
             DisposeTextures();
 
             if (Group.Storage == this)

--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -528,6 +528,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     state.TextureHandle == textureId &&
                     state.SamplerHandle == samplerId &&
                     state.CachedTexture != null &&
+                    !state.CachedTexture.IsDisposed &&
                     state.CachedTexture.InvalidatedSequence == state.InvalidatedSequence &&
                     state.CachedSampler?.IsDisposed != true)
                 {
@@ -651,6 +652,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 if (!poolModified &&
                     state.TextureHandle == textureId &&
                     state.CachedTexture != null &&
+                    !state.CachedTexture.IsDisposed &&
                     state.CachedTexture.InvalidatedSequence == state.InvalidatedSequence)
                 {
                     Texture cachedTexture = state.CachedTexture;

--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -528,7 +528,6 @@ namespace Ryujinx.Graphics.Gpu.Image
                     state.TextureHandle == textureId &&
                     state.SamplerHandle == samplerId &&
                     state.CachedTexture != null &&
-                    !state.CachedTexture.IsDisposed &&
                     state.CachedTexture.InvalidatedSequence == state.InvalidatedSequence &&
                     state.CachedSampler?.IsDisposed != true)
                 {
@@ -652,7 +651,6 @@ namespace Ryujinx.Graphics.Gpu.Image
                 if (!poolModified &&
                     state.TextureHandle == textureId &&
                     state.CachedTexture != null &&
-                    !state.CachedTexture.IsDisposed &&
                     state.CachedTexture.InvalidatedSequence == state.InvalidatedSequence)
                 {
                     Texture cachedTexture = state.CachedTexture;


### PR DESCRIPTION
It was checking if the sampler was disposed, but not the texture. This could cause an attempt to update the data of a texture that was already disposed, which causes access violation on Vulkan.

This fixes the following crash on Crash Team Racing when using Vulkan:
```
Fatal error. System.AccessViolationException: Attempted to read or write protected memory. This is often an indication that other memory is corrupt.
   at Ryujinx.Graphics.Vulkan.TextureView.CopyFromOrToBuffer(Silk.NET.Vulkan.CommandBuffer, Silk.NET.Vulkan.Buffer, Silk.NET.Vulkan.Image, Int32, Boolean, Int32, Int32, Int32, Int32, Boolean)
   at Ryujinx.Graphics.Vulkan.TextureView.SetData(System.ReadOnlySpan`1<Byte>, Int32, Int32, Int32, Int32, Boolean, System.Nullable`1<Ryujinx.Graphics.GAL.Rectangle`1<Int32>>)
   at Ryujinx.Graphics.Vulkan.TextureView.SetData(Ryujinx.Common.Memory.SpanOrArray`1<Byte>)
   at Ryujinx.Graphics.GAL.Multithreading.CommandHelper+<>c.<InitLookup>b__5_27(System.Span`1<Byte>, Ryujinx.Graphics.GAL.Multithreading.ThreadedRenderer, Ryujinx.Graphics.GAL.IRenderer)
   at Ryujinx.Graphics.GAL.Multithreading.ThreadedRenderer.RenderLoop()
   at Ryujinx.Graphics.GAL.Multithreading.ThreadedRenderer.RunLoop(System.Action)
   at Ryujinx.Ui.RendererWidgetBase.Render()
   at System.Threading.Thread.StartCallback()
```

The `Texture` had a `Disposed` event, but nothing was using it. Maybe it was added to allow the texture bindings manager to listen to it and maybe remove it from the cache if its disposed?