### PR TITLE
Vulkan: Fix sampler custom border color

### DIFF
--- a/Ryujinx.Graphics.Vulkan/SamplerHolder.cs
+++ b/Ryujinx.Graphics.Vulkan/SamplerHolder.cs
@@ -64,6 +64,7 @@ namespace Ryujinx.Graphics.Vulkan
                 };
 
                 samplerCreateInfo.PNext = &customBorderColor;
+                samplerCreateInfo.BorderColor = BorderColor.FloatCustomExt;
             }
 
             gd.Api.CreateSampler(device, samplerCreateInfo, null, out var sampler).ThrowOnError();


### PR DESCRIPTION
We were passing the custom border color struct, but the border color was not being set to "custom" which means that the driver would just ignore it.

Fixes shadows in Xenoblade Chronicles 2 cutscenes.
Before:
![image](https://user-images.githubusercontent.com/5624669/194778394-ea636173-7dd7-4ab5-9a48-dd6032bb948d.png)
After:
![image](https://user-images.githubusercontent.com/5624669/194778396-3ed713d4-704e-4817-a75b-5940500304d2.png)
Obviously, it will continue being broken on drivers that does not support the `VK_EXT_custom_border_color` extension.