### PR TITLE
Avalonia - Remove on property changed call in Time Zone validation

### DIFF
--- a/Ryujinx.Ava/Ui/ViewModels/SettingsViewModel.cs
+++ b/Ryujinx.Ava/Ui/ViewModels/SettingsViewModel.cs
@@ -295,8 +295,6 @@ namespace Ryujinx.Ava.Ui.ViewModels
             if (_validTzRegions.Contains(location))
             {
                 TimeZone = location;
-
-                OnPropertyChanged(nameof(TimeZone));
             }
         }
 

--- a/Ryujinx.Ava/Ui/Windows/SettingsWindow.axaml.cs
+++ b/Ryujinx.Ava/Ui/Windows/SettingsWindow.axaml.cs
@@ -37,7 +37,7 @@ namespace Ryujinx.Ava.Ui.Windows
             InitializeComponent();
             Load();
 
-            FuncMultiValueConverter<string, string> converter = new(parts => string.Format("{0}  {1}   {2}", parts.ToArray()));
+            FuncMultiValueConverter<string, string> converter = new(parts => string.Format("{0}  {1}   {2}", parts.ToArray()).Trim());
             MultiBinding tzMultiBinding = new() { Converter = converter };
             tzMultiBinding.Bindings.Add(new Binding("UtcDifference"));
             tzMultiBinding.Bindings.Add(new Binding("Location"));


### PR DESCRIPTION
The timezone box was setting the query and requesting the suggestion search be done when text or selection changes. This resets the suggestion list with new values, instead of keeping the current list when you navigate the box. The control already does a search when text changes. Forcing the text box be the selected value from the viewmodel is the cause of the issue.

Fixes #3662 time zone issue