### PR TITLE
Add short duration texture cache

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
@@ -169,18 +169,15 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>The texture if found, null otherwise</returns>
         public Texture FindShortCache(in TextureDescriptor descriptor)
         {
-            if (_shortCacheLookup.Count > 0)
+            if (_shortCacheLookup.Count > 0 && _shortCacheLookup.TryGetValue(descriptor, out var entry))
             {
-                if (_shortCacheLookup.TryGetValue(descriptor, out var entry))
+                if (entry.InvalidatedSequence == entry.Texture.InvalidatedSequence)
                 {
-                    if (entry.InvalidatedSequence == entry.Texture.InvalidatedSequence)
-                    {
-                        return entry.Texture;
-                    }
-                    else
-                    {
-                        _shortCacheLookup.Remove(descriptor);
-                    }
+                    return entry.Texture;
+                }
+                else
+                {
+                    _shortCacheLookup.Remove(descriptor);
                 }
             }
 

--- a/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
@@ -5,6 +5,28 @@ using System.Collections.Generic;
 namespace Ryujinx.Graphics.Gpu.Image
 {
     /// <summary>
+    /// An entry on the short duration texture cache.
+    /// </summary>
+    class ShortTextureCacheEntry
+    {
+        public readonly TextureDescriptor Descriptor;
+        public readonly int InvalidatedSequence;
+        public readonly Texture Texture;
+
+        /// <summary>
+        /// Create a new entry on the short duration texture cache.
+        /// </summary>
+        /// <param name="descriptor">Last descriptor that referenced the texture</param>
+        /// <param name="texture">The texture</param>
+        public ShortTextureCacheEntry(TextureDescriptor descriptor, Texture texture)
+        {
+            Descriptor = descriptor;
+            InvalidatedSequence = texture.InvalidatedSequence;
+            Texture = texture;
+        }
+    }
+
+    /// <summary>
     /// A texture cache that automatically removes older textures that are not used for some time.
     /// The cache works with a rotated list with a fixed size. When new textures are added, the
     /// old ones at the bottom of the list are deleted.
@@ -16,8 +38,10 @@ namespace Ryujinx.Graphics.Gpu.Image
         private readonly LinkedList<Texture> _textures;
         private readonly ConcurrentQueue<Texture> _deferredRemovals;
 
-        private HashSet<Texture> _shortCacheBuilder;
-        private HashSet<Texture> _shortCache;
+        private HashSet<ShortTextureCacheEntry> _shortCacheBuilder;
+        private HashSet<ShortTextureCacheEntry> _shortCache;
+
+        private Dictionary<TextureDescriptor, ShortTextureCacheEntry> _shortCacheLookup;
 
         /// <summary>
         /// Creates a new instance of the automatic deletion cache.
@@ -27,8 +51,10 @@ namespace Ryujinx.Graphics.Gpu.Image
             _textures = new LinkedList<Texture>();
             _deferredRemovals = new ConcurrentQueue<Texture>();
 
-            _shortCacheBuilder = new HashSet<Texture>();
-            _shortCache = new HashSet<Texture>();
+            _shortCacheBuilder = new HashSet<ShortTextureCacheEntry>();
+            _shortCache = new HashSet<ShortTextureCacheEntry>();
+
+            _shortCacheLookup = new Dictionary<TextureDescriptor, ShortTextureCacheEntry>();
         }
 
         /// <summary>
@@ -137,19 +163,45 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Attempt to find a texture on the short duration cache.
+        /// </summary>
+        /// <param name="descriptor">The texture descriptor</param>
+        /// <returns>The texture if found, null otherwise</returns>
+        public Texture FindShortCache(in TextureDescriptor descriptor)
+        {
+            if (_shortCacheLookup.Count > 0)
+            {
+                if (_shortCacheLookup.TryGetValue(descriptor, out var entry))
+                {
+                    if (entry.InvalidatedSequence == entry.Texture.InvalidatedSequence)
+                    {
+                        return entry.Texture;
+                    }
+                    else
+                    {
+                        _shortCacheLookup.Remove(descriptor);
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Removes a texture from the short duration cache.
         /// </summary>
         /// <param name="texture">Texture to remove from the short cache</param>
         public void RemoveShortCache(Texture texture)
         {
-            bool removed = _shortCache.Remove(texture);
-            removed |= _shortCacheBuilder.Remove(texture);
+            bool removed = _shortCache.Remove(texture.ShortCacheEntry);
+            removed |= _shortCacheBuilder.Remove(texture.ShortCacheEntry);
 
             if (removed)
             {
                 texture.DecrementReferenceCount();
 
-                texture.IsShortCached = false;
+                _shortCacheLookup.Remove(texture.ShortCacheEntry.Descriptor);
+                texture.ShortCacheEntry = null;
             }
         }
 
@@ -158,11 +210,15 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// It starts in the builder set, and it is moved into the deletion set on next process.
         /// </summary>
         /// <param name="texture">Texture to add to the short cache</param>
-        public void AddShortCache(Texture texture)
+        /// <param name="descriptor">Last used texture descriptor</param>
+        public void AddShortCache(Texture texture, ref TextureDescriptor descriptor)
         {
-            _shortCacheBuilder.Add(texture);
+            var entry = new ShortTextureCacheEntry(descriptor, texture);
 
-            texture.IsShortCached = true;
+            _shortCacheBuilder.Add(entry);
+            _shortCacheLookup.Add(entry.Descriptor, entry);
+
+            texture.ShortCacheEntry = entry;
 
             texture.IncrementReferenceCount();
         }
@@ -173,13 +229,14 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         public void ProcessShortCache()
         {
-            HashSet<Texture> toRemove = _shortCache;
+            HashSet<ShortTextureCacheEntry> toRemove = _shortCache;
 
-            foreach (var texture in toRemove)
+            foreach (var entry in toRemove)
             {
-                texture.DecrementReferenceCount();
+                entry.Texture.DecrementReferenceCount();
 
-                texture.IsShortCached = false;
+                _shortCacheLookup.Remove(entry.Descriptor);
+                entry.Texture.ShortCacheEntry = null;
             }
 
             toRemove.Clear();

--- a/Ryujinx.Graphics.Gpu/Image/Pool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Pool.cs
@@ -95,6 +95,16 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Gets a reference to the descriptor for a given address.
+        /// </summary>
+        /// <param name="address">Address of the descriptor</param>
+        /// <returns>A reference to the descriptor</returns>
+        public ref readonly T2 GetDescriptorRefAddress(ulong address)
+        {
+            return ref MemoryMarshal.Cast<byte, T2>(PhysicalMemory.GetSpan(address, DescriptorSize))[0];
+        }
+
+        /// <summary>
         /// Gets the GPU resource with the given ID.
         /// </summary>
         /// <param name="id">ID of the resource. This is effectively a zero-based index</param>

--- a/Ryujinx.Graphics.Gpu/Image/Pool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Pool.cs
@@ -91,7 +91,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>A reference to the descriptor</returns>
         public ref readonly T2 GetDescriptorRef(int id)
         {
-            return ref MemoryMarshal.Cast<byte, T2>(PhysicalMemory.GetSpan(Address + (ulong)id * DescriptorSize, DescriptorSize))[0];
+            return ref GetDescriptorRefAddress(Address + (ulong)id * DescriptorSize);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -138,9 +138,9 @@ namespace Ryujinx.Graphics.Gpu.Image
         public LinkedListNode<Texture> CacheNode { get; set; }
 
         /// <summary>
-        /// Indicator that this texture exists on the short cache.
+        /// Entry for this texture in the short duration cache, if present.
         /// </summary>
-        public bool IsShortCached { get; set; }
+        public ShortTextureCacheEntry ShortCacheEntry { get; set; }
 
         /// Physical memory ranges where the texture data is located.
         /// </summary>
@@ -1560,7 +1560,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             }
             _referenceCount++;
 
-            if (IsShortCached)
+            if (ShortCacheEntry != null)
             {
                 _physicalMemory.TextureCache.RemoveShortCache(this);
             }
@@ -1642,7 +1642,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 _poolOwners.Clear();
             }
 
-            if (IsShortCached && _context.IsGpuThread())
+            if (ShortCacheEntry != null && _context.IsGpuThread())
             {
                 // If this is called from another thread (unmapped), the short cache will
                 // have to remove this texture on a future tick.

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -138,6 +138,10 @@ namespace Ryujinx.Graphics.Gpu.Image
         public LinkedListNode<Texture> CacheNode { get; set; }
 
         /// <summary>
+        /// Indicator that this texture exists on the short cache.
+        /// </summary>
+        public bool IsShortCached { get; set; }
+
         /// Physical memory ranges where the texture data is located.
         /// </summary>
         public MultiRange Range { get; private set; }
@@ -1555,6 +1559,20 @@ namespace Ryujinx.Graphics.Gpu.Image
                 _poolOwners.Add(new TexturePoolOwner { Pool = pool, ID = id });
             }
             _referenceCount++;
+
+            if (IsShortCached)
+            {
+                _physicalMemory.TextureCache.RemoveShortCache(this);
+            }
+        }
+
+        /// <summary>
+        /// Indicates that the texture has one reference left, and will delete on reference decrement.
+        /// </summary>
+        /// <returns>True if there is one reference remaining, false otherwise</returns>
+        public bool HasOneReference()
+        {
+            return _referenceCount == 1;
         }
 
         /// <summary>
@@ -1622,6 +1640,14 @@ namespace Ryujinx.Graphics.Gpu.Image
                 }
 
                 _poolOwners.Clear();
+            }
+
+            if (IsShortCached && _context.IsGpuThread())
+            {
+                // If this is called from another thread (unmapped), the short cache will
+                // have to remove this texture on a future tick.
+
+                _physicalMemory.TextureCache.RemoveShortCache(this);
             }
 
             InvalidatedSequence++;

--- a/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -1179,6 +1179,32 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Adds a texture to the short duration cache. This typically keeps it alive for two ticks.
+        /// </summary>
+        /// <param name="texture">Texture to add to the short cache</param>
+        public void AddShortCache(Texture texture)
+        {
+            _cache.AddShortCache(texture);
+        }
+
+        /// <summary>
+        /// Removes a texture from the short duration cache.
+        /// </summary>
+        /// <param name="texture">Texture to remove from the short cache</param>
+        public void RemoveShortCache(Texture texture)
+        {
+            _cache.RemoveShortCache(texture);
+        }
+
+        /// <summary>
+        /// Ticks periodic elements of the texture cache.
+        /// </summary>
+        public void Tick()
+        {
+            _cache.ProcessShortCache();
+        }
+
+        /// <summary>
         /// Disposes all textures and samplers in the cache.
         /// It's an error to use the texture cache after disposal.
         /// </summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -895,6 +895,16 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Attempt to find a texture on the short duration cache.
+        /// </summary>
+        /// <param name="descriptor">The texture descriptor</param>
+        /// <returns>The texture if found, null otherwise</returns>
+        public Texture FindShortCache(in TextureDescriptor descriptor)
+        {
+            return _cache.FindShortCache(descriptor);
+        }
+
+        /// <summary>
         /// Tries to find an existing texture matching the given buffer copy destination. If none is found, returns null.
         /// </summary>
         /// <param name="memoryManager">GPU memory manager where the texture is mapped</param>
@@ -1182,9 +1192,10 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Adds a texture to the short duration cache. This typically keeps it alive for two ticks.
         /// </summary>
         /// <param name="texture">Texture to add to the short cache</param>
-        public void AddShortCache(Texture texture)
+        /// <param name="descriptor">Last used texture descriptor</param>
+        public void AddShortCache(Texture texture, ref TextureDescriptor descriptor)
         {
-            _cache.AddShortCache(texture);
+            _cache.AddShortCache(texture, ref descriptor);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureDescriptor.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureDescriptor.cs
@@ -258,7 +258,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>True if they are equal, false otherwise</returns>
         public bool Equals(TextureDescriptor other)
         {
-            return Unsafe.As<TextureDescriptor, Vector256<byte>>(ref this).Equals(Unsafe.As<TextureDescriptor, Vector256<byte>>(ref other));
+            return Equals(ref other);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureDescriptor.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureDescriptor.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 
@@ -6,7 +7,7 @@ namespace Ryujinx.Graphics.Gpu.Image
     /// <summary>
     /// Maxwell texture descriptor, as stored on the GPU texture pool memory region.
     /// </summary>
-    struct TextureDescriptor : ITextureDescriptor
+    struct TextureDescriptor : ITextureDescriptor, IEquatable<TextureDescriptor>
     {
 #pragma warning disable CS0649
         public uint Word0;
@@ -248,6 +249,25 @@ namespace Ryujinx.Graphics.Gpu.Image
         public bool Equals(ref TextureDescriptor other)
         {
             return Unsafe.As<TextureDescriptor, Vector256<byte>>(ref this).Equals(Unsafe.As<TextureDescriptor, Vector256<byte>>(ref other));
+        }
+
+        /// <summary>
+        /// Check if two descriptors are equal.
+        /// </summary>
+        /// <param name="other">The descriptor to compare against</param>
+        /// <returns>True if they are equal, false otherwise</returns>
+        public bool Equals(TextureDescriptor other)
+        {
+            return Unsafe.As<TextureDescriptor, Vector256<byte>>(ref this).Equals(Unsafe.As<TextureDescriptor, Vector256<byte>>(ref other));
+        }
+
+        /// <summary>
+        /// Gets a hashcode for this descriptor.
+        /// </summary>
+        /// <returns>The hash code for this descriptor.</returns>
+        public override int GetHashCode()
+        {
+            return Unsafe.As<TextureDescriptor, Vector256<byte>>(ref this).GetHashCode();
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Image/TextureDescriptor.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureDescriptor.cs
@@ -262,7 +262,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Gets a hashcode for this descriptor.
+        /// Gets a hash code for this descriptor.
         /// </summary>
         /// <returns>The hash code for this descriptor.</returns>
         public override int GetHashCode()

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -217,6 +217,11 @@ namespace Ryujinx.Graphics.Gpu.Image
                         continue;
                     }
 
+                    if (texture.HasOneReference())
+                    {
+                        _channel.MemoryManager.Physical.TextureCache.AddShortCache(texture);
+                    }
+
                     texture.DecrementReferenceCount(this, id);
 
                     Items[id] = null;

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -213,7 +213,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                     // If the descriptors are the same, the texture is the same,
                     // we don't need to remove as it was not modified. Just continue.
-                    if (descriptor.Equals(cachedDescriptor))
+                    if (descriptor.Equals(ref cachedDescriptor))
                     {
                         continue;
                     }

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -208,11 +208,12 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 if (texture != null)
                 {
-                    TextureDescriptor descriptor = PhysicalMemory.Read<TextureDescriptor>(address);
+                    ref TextureDescriptor cachedDescriptor = ref DescriptorCache[id];
+                    ref readonly TextureDescriptor descriptor = ref GetDescriptorRefAddress(address);
 
                     // If the descriptors are the same, the texture is the same,
                     // we don't need to remove as it was not modified. Just continue.
-                    if (descriptor.Equals(ref DescriptorCache[id]))
+                    if (descriptor.Equals(cachedDescriptor))
                     {
                         continue;
                     }

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -54,28 +54,19 @@ namespace Ryujinx.Graphics.Gpu.Image
             {
                 texture = PhysicalMemory.TextureCache.FindShortCache(descriptor);
 
-                if (texture != null)
-                {
-                    texture.IncrementReferenceCount(this, id);
-
-                    Items[id] = texture;
-
-                    DescriptorCache[id] = descriptor;
-                }
-            }
-
-            if (texture == null)
-            {
-                TextureInfo info = GetInfo(descriptor, out int layerSize);
-
-                ProcessDereferenceQueue();
-
-                texture = PhysicalMemory.TextureCache.FindOrCreateTexture(_channel.MemoryManager, TextureSearchFlags.ForSampler, info, layerSize);
-
-                // If this happens, then the texture address is invalid, we can't add it to the cache.
                 if (texture == null)
                 {
-                    return ref descriptor;
+                    TextureInfo info = GetInfo(descriptor, out int layerSize);
+
+                    ProcessDereferenceQueue();
+
+                    texture = PhysicalMemory.TextureCache.FindOrCreateTexture(_channel.MemoryManager, TextureSearchFlags.ForSampler, info, layerSize);
+
+                    // If this happens, then the texture address is invalid, we can't add it to the cache.
+                    if (texture == null)
+                    {
+                        return ref descriptor;
+                    }
                 }
 
                 texture.IncrementReferenceCount(this, id);

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -52,6 +52,20 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             if (texture == null)
             {
+                texture = PhysicalMemory.TextureCache.FindShortCache(descriptor);
+
+                if (texture != null)
+                {
+                    texture.IncrementReferenceCount(this, id);
+
+                    Items[id] = texture;
+
+                    DescriptorCache[id] = descriptor;
+                }
+            }
+
+            if (texture == null)
+            {
                 TextureInfo info = GetInfo(descriptor, out int layerSize);
 
                 ProcessDereferenceQueue();
@@ -220,7 +234,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                     if (texture.HasOneReference())
                     {
-                        _channel.MemoryManager.Physical.TextureCache.AddShortCache(texture);
+                        _channel.MemoryManager.Physical.TextureCache.AddShortCache(texture, ref cachedDescriptor);
                     }
 
                     texture.DecrementReferenceCount(this, id);

--- a/Ryujinx.Graphics.Gpu/Window.cs
+++ b/Ryujinx.Graphics.Gpu/Window.cs
@@ -204,6 +204,8 @@ namespace Ryujinx.Graphics.Gpu
 
                 Texture texture = pt.Cache.FindOrCreateTexture(null, TextureSearchFlags.WithUpscale, pt.Info, 0, null, pt.Range);
 
+                pt.Cache.Tick();
+
                 texture.SynchronizeMemory();
 
                 ImageCrop crop = pt.Crop;


### PR DESCRIPTION
Time for obscure edge case performance improvements.

This texture cache takes textures that lose their last pool reference and keeps them alive until the next frame, or until an incompatible overlap removes it. This is done since under certain circumstances, a texture's reference can be wiped from a pool despite it still being in use - though typically the reference will return when rendering the next frame.

This texture cache maintains a dictionary of TextureDescriptor to texture so that textures can be easily rediscovered if they are added to the pool shortly after.

While this may slightly increase texture memory usage when quickly going through a bunch of temporary textures, it's still bounded due to the overlap removal rule. This is an alternative to replacing the pool method of texture liveness checks entirely, as that could cause larger issues.

This greatly increases performance in Hyrule Warriors: Age of Calamity, which would slow to a crawl when too much happened at once. It may positively affect some UE4 games which dip framerate severely under certain circumstances.

### Hyrule Warriors: Age of Calamity

The game no longer becomes unplayable when dropping frames. This game used to run better, but that was before we started doing things correctly. This change does not reduce the accuracy of what is going on with the compute shaders and buffer flushes behind the scenes, it just brute forces past it.

#### Before (OGL)
https://cdn.discordapp.com/attachments/694459861190311957/1029424662523941024/before_ogl.mp4

#### After (OGL)
https://cdn.discordapp.com/attachments/694459861190311957/1029424661550878850/after_ogl.mp4

#### After (VK)
https://cdn.discordapp.com/attachments/694459861190311957/1029425850862534696/after_vk.mp4

This game typically performs better in Vulkan, but depending on your hardware you might need this branch to mitigate hardware issues (this branch's changes are already present):

https://github.com/riperiperi/Ryujinx/commits/feat/vk-buffer-migration

Maybe more comparisons to come. I would suggest trying areas in UE4 games that plummet FPS for no reason.

## Testing

Please test as many games as you can to verify that:
- No other games have worse performance
- No other games have texture issues
- No other games use an excessive amount of memory (at least, not more than they already do... looking at you FAST RMX)
