### PR TITLE
Fix kernel VA allocation when random allocation fails

### DIFF
--- a/Ryujinx.HLE/HOS/Kernel/Memory/KPageTableBase.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Memory/KPageTableBase.cs
@@ -2603,7 +2603,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
 
             ulong totalNeededSize = reservedSize + neededPagesCount * PageSize;
 
-            ulong regionEndAddr = regionStart + regionPagesCount * PageSize;
+            ulong regionEndAddr = (regionStart + regionPagesCount * PageSize) - 1;
 
             KMemoryBlock currBlock = _blockManager.FindBlock(regionStart);
 

--- a/Ryujinx.HLE/HOS/Kernel/Memory/KPageTableBase.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Memory/KPageTableBase.cs
@@ -2540,11 +2540,10 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
 
                 for (int attempt = 0; attempt < 8; attempt++)
                 {
-                    address = BitUtils.AlignDown(regionStart + GetRandomValue(0, aslrMaxOffset) * (ulong)alignment, alignment);
+                    ulong aslrAddress = BitUtils.AlignDown(regionStart + GetRandomValue(0, aslrMaxOffset) * (ulong)alignment, alignment);
+                    ulong aslrEndAddr = aslrAddress + totalNeededSize;
 
-                    ulong endAddr = address + totalNeededSize;
-
-                    KMemoryInfo info = _blockManager.FindBlock(address).GetInfo();
+                    KMemoryInfo info = _blockManager.FindBlock(aslrAddress).GetInfo();
 
                     if (info.State != MemoryState.Unmapped)
                     {
@@ -2554,11 +2553,12 @@ namespace Ryujinx.HLE.HOS.Kernel.Memory
                     ulong currBaseAddr = info.Address + reservedPagesCount * PageSize;
                     ulong currEndAddr = info.Address + info.Size;
 
-                    if (address >= regionStart &&
-                        address >= currBaseAddr &&
-                        endAddr - 1 <= regionEndAddr - 1 &&
-                        endAddr - 1 <= currEndAddr - 1)
+                    if (aslrAddress >= regionStart &&
+                        aslrAddress >= currBaseAddr &&
+                        aslrEndAddr - 1 <= regionEndAddr - 1 &&
+                        aslrEndAddr - 1 <= currEndAddr - 1)
                     {
+                        address = aslrAddress;
                         break;
                     }
                 }


### PR DESCRIPTION
The current kernel implementation first tries to allocate at a random location on the address space, and if that fails, it tries a linear allocation. But due to an oversight, it was using the `address` variable as temporary storage for the random region it was checking inside the loop. Since it expects the `address` to be 0 if the random allocation failed, and it is used a temporary, it will never actually be 0 when allocation fails, which might cause it to incorrectly return an address of memory already in use.

This is fixed here by introducing a new, separate `aslrAddress` variable to store the temporary value for the random allocation attempts.

In practice, it's very unlikely for the random allocation to fail, so I believe not many games are affected by this issue. It is much more common on 32-bit games due to the fact they have a smaller address space. I found this issue happening on the game DoDonPachi Resurrection, but did not notice any difference on the game (it was already working fine on master here, but I only played a little).

Here's a screenshot anyway.
![image](https://user-images.githubusercontent.com/5624669/195210983-81e35f66-6b2e-4169-b00b-eb6bc92eecc3.png)