### PR TITLE
Improve shader BRX instruction code generation

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 3732;
+        private const uint CodeGenVersion = 3759;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/Ryujinx.Graphics.Shader/Decoders/Decoder.cs
+++ b/Ryujinx.Graphics.Shader/Decoders/Decoder.cs
@@ -377,6 +377,8 @@ namespace Ryujinx.Graphics.Shader.Decoders
 
                 if (lastOp.Name == InstName.Brx && block.Successors.Count == (hasNext ? 1 : 0))
                 {
+                    HashSet<ulong> visited = new HashSet<ulong>();
+
                     InstBrx opBrx = new InstBrx(lastOp.RawOpCode);
                     ulong baseOffset = lastOp.GetAbsoluteAddress();
 
@@ -392,9 +394,14 @@ namespace Ryujinx.Graphics.Shader.Decoders
                     for (int i = 0; i < cbOffsetsCount; i++)
                     {
                         uint targetOffset = config.ConstantBuffer1Read(cbBaseOffset + i * 4);
-                        Block target = getBlock(baseOffset + targetOffset);
-                        target.Predecessors.Add(block);
-                        block.Successors.Add(target);
+                        ulong targetAddress = baseOffset + targetOffset;
+
+                        if (visited.Add(targetAddress))
+                        {
+                            Block target = getBlock(targetAddress);
+                            target.Predecessors.Add(block);
+                            block.Successors.Add(target);
+                        }
                     }
                 }
             }

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitFlowControl.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitFlowControl.cs
@@ -58,6 +58,14 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
             if (allTargetsSinglePred)
             {
+                // Chain blocks, each target block will check if the BRX target address
+                // matches its own address, if not, it jumps to the next target which will do the same check,
+                // until it reaches the last possible target, which executed unconditionally.
+                // We can only do this if the BRX block is the only predecessor of all target blocks.
+                // Additionally, this is not supported for blocks located before the current block,
+                // since it will be too late to insert a label, but this is something that can be improved
+                // in the future if necessary.
+
                 var sortedTargets = targets.OrderBy(x => x.Address);
 
                 Block currentTarget = null;
@@ -84,6 +92,9 @@ namespace Ryujinx.Graphics.Shader.Instructions
             }
             else
             {
+                // Emit the branches sequentially.
+                // This generates slightly worse code, but should work for all cases.
+
                 var sortedTargets = targets.OrderByDescending(x => x.Address);
                 ulong lastTargetAddress = ulong.MaxValue;
 

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitFlowControl.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitFlowControl.cs
@@ -41,24 +41,71 @@ namespace Ryujinx.Graphics.Shader.Instructions
 
             Operand address = context.IAdd(Register(op.SrcA, RegisterType.Gpr), Const(offset));
 
-            // Sorting the target addresses in descending order improves the code,
-            // since it will always check the most distant targets first, then the
-            // near ones. This can be easily transformed into if/else statements.
-            var sortedTargets = context.CurrBlock.Successors.Skip(startIndex).OrderByDescending(x => x.Address);
+            var targets = context.CurrBlock.Successors.Skip(startIndex);
 
-            Block lastTarget = sortedTargets.LastOrDefault();
+            bool allTargetsSinglePred = true;
+            int total = context.CurrBlock.Successors.Count - startIndex;
+            int count = 0;
 
-            foreach (Block possibleTarget in sortedTargets)
+            foreach (var target in targets.OrderBy(x => x.Address))
             {
-                Operand label = context.GetLabel(possibleTarget.Address);
-
-                if (possibleTarget != lastTarget)
+                if (++count < total && (target.Predecessors.Count > 1 || target.Address <= context.CurrBlock.Address))
                 {
-                    context.BranchIfTrue(label, context.ICompareEqual(address, Const((int)possibleTarget.Address)));
+                    allTargetsSinglePred = false;
+                    break;
                 }
-                else
+            }
+
+            if (allTargetsSinglePred)
+            {
+                var sortedTargets = targets.OrderBy(x => x.Address);
+
+                Block currentTarget = null;
+                ulong firstTargetAddress = 0;
+
+                foreach (Block nextTarget in sortedTargets)
                 {
-                    context.Branch(label);
+                    if (currentTarget != null)
+                    {
+                        if (currentTarget.Address != nextTarget.Address)
+                        {
+                            context.SetBrxTarget(currentTarget.Address, address, (int)currentTarget.Address, nextTarget.Address);
+                        }
+                    }
+                    else
+                    {
+                        firstTargetAddress = nextTarget.Address;
+                    }
+
+                    currentTarget = nextTarget;
+                }
+
+                context.Branch(context.GetLabel(firstTargetAddress));
+            }
+            else
+            {
+                var sortedTargets = targets.OrderByDescending(x => x.Address);
+                ulong lastTargetAddress = ulong.MaxValue;
+
+                count = 0;
+
+                foreach (Block target in sortedTargets)
+                {
+                    Operand label = context.GetLabel(target.Address);
+
+                    if (++count < total)
+                    {
+                        if (target.Address != lastTargetAddress)
+                        {
+                            context.BranchIfTrue(label, context.ICompareEqual(address, Const((int)target.Address)));
+                        }
+
+                        lastTargetAddress = target.Address;
+                    }
+                    else
+                    {
+                        context.Branch(label);
+                    }
                 }
             }
         }

--- a/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -21,8 +21,33 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public int OperationsCount => _operations.Count;
 
+        private struct BrxTarget
+        {
+            public readonly Operand Selector;
+            public readonly int ExpectedValue;
+            public readonly ulong NextTargetAddress;
+
+            public BrxTarget(Operand selector, int expectedValue, ulong nextTargetAddress)
+            {
+                Selector = selector;
+                ExpectedValue = expectedValue;
+                NextTargetAddress = nextTargetAddress;
+            }
+        }
+
+        private class BlockLabel
+        {
+            public readonly Operand Label;
+            public BrxTarget BrxTarget;
+
+            public BlockLabel(Operand label)
+            {
+                Label = label;
+            }
+        }
+
         private readonly List<Operation> _operations;
-        private readonly Dictionary<ulong, Operand> _labels;
+        private readonly Dictionary<ulong, BlockLabel> _labels;
 
         public EmitterContext(DecodedProgram program, ShaderConfig config, bool isNonMain)
         {
@@ -30,7 +55,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             Config = config;
             IsNonMain = isNonMain;
             _operations = new List<Operation>();
-            _labels = new Dictionary<ulong, Operand>();
+            _labels = new Dictionary<ulong, BlockLabel>();
 
             EmitStart();
         }
@@ -158,14 +183,38 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public Operand GetLabel(ulong address)
         {
-            if (!_labels.TryGetValue(address, out Operand label))
-            {
-                label = Label();
+            return EnsureBlockLabel(address).Label;
+        }
 
-                _labels.Add(address, label);
+        public void SetBrxTarget(ulong address, Operand selector, int targetValue, ulong nextTargetAddress)
+        {
+            EnsureBlockLabel(address).BrxTarget = new BrxTarget(selector, targetValue, nextTargetAddress);
+        }
+
+        public void EnterBlock(ulong address)
+        {
+            BlockLabel blockLabel = EnsureBlockLabel(address);
+
+            MarkLabel(blockLabel.Label);
+
+            BrxTarget brxTarget = blockLabel.BrxTarget;
+
+            if (brxTarget.Selector != null)
+            {
+                this.BranchIfFalse(GetLabel(brxTarget.NextTargetAddress), this.ICompareEqual(brxTarget.Selector, Const(brxTarget.ExpectedValue)));
+            }
+        }
+
+        private BlockLabel EnsureBlockLabel(ulong address)
+        {
+            if (!_labels.TryGetValue(address, out BlockLabel blockLabel))
+            {
+                blockLabel = new BlockLabel(Label());
+
+                _labels.Add(address, blockLabel);
             }
 
-            return label;
+            return blockLabel;
         }
 
         public void PrepareForVertexReturn()

--- a/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -188,7 +188,9 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public void SetBrxTarget(ulong address, Operand selector, int targetValue, ulong nextTargetAddress)
         {
-            EnsureBlockLabel(address).BrxTarget = new BrxTarget(selector, targetValue, nextTargetAddress);
+            BlockLabel blockLabel = EnsureBlockLabel(address);
+            Debug.Assert(blockLabel.BrxTarget.Selector == null);
+            blockLabel.BrxTarget = new BrxTarget(selector, targetValue, nextTargetAddress);
         }
 
         public void EnterBlock(ulong address)

--- a/Ryujinx.Graphics.Shader/Translation/Translator.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Translator.cs
@@ -162,7 +162,7 @@ namespace Ryujinx.Graphics.Shader.Translation
                 {
                     context.CurrBlock = block;
 
-                    context.MarkLabel(context.GetLabel(block.Address));
+                    context.EnterBlock(block.Address);
 
                     EmitOps(context, block);
                 }


### PR DESCRIPTION
This change improves the code generated for BRX instructions. This should help compilers produce slightly better code for those shaders, and make the output a bit easier to read aswell.

What this change does it basically chaining the blocks, where at the start, each block checks if the BRX target address matches the block address, and if not, it jumps to the next block which will do the same check, until it reaches the last possible BRX target block. Before, it would generate all the jumps sequentially at the point of the BRX instruction. The new approach is only used if all targets of the BRX instruction only have a single predecessor (which should be the block where the BRX is located), because otherwise the change wouldn't be valid. Failing to use the new approach, it will still use the old one.

On all games that I tested, all BRX targets (with the exception of the last one) have a single predecessor, so it can use the new approach on all of them.

Code generated before:
```glsl
        // 0x000D70: 0xE2500FFF28871A0F Brx
        temp_299 = floatBitsToInt(temp_298) == 0xE70;
        if (!temp_299)
        {
            temp_300 = floatBitsToInt(temp_298) == 0xDD8;
            if (!temp_300)
            {
                // 0x000D78: 0x4C59301009970404 Fadd
                temp_301 = 0.0 - temp_46;
                temp_302 = 0.0 - vp_c4_data[38].y;
                temp_303 = temp_301 + temp_302;
                // ...
                // 0x000DD0: 0xE24000000A07000F Bra
                temp_313 = true;
            }
            else
            {
                // 0x000DD8: 0x33A0063D80070505 Ffma
                temp_314 = fma(temp_59, -0.0625, 0.5);
                // ...
                // 0x000E68: 0xE24000000087000F Bra
                temp_313 = true;
            }
        }
        else
        {
            // 0x000E70: 0xEFF07F800DC7FFFF Ast
            out_attr5.w = 0.0;
        }
```
After:
```glsl
        // 0x000D70: 0xE2500FFF28871A0F Brx
        temp_299 = floatBitsToInt(temp_298) == 0xD78;
        if (temp_299)
        {
            // 0x000D78: 0x4C59301009970404 Fadd
            temp_300 = 0.0 - temp_46;
            temp_301 = 0.0 - vp_c4_data[38].y;
            temp_302 = temp_300 + temp_301;
            // ...
            // 0x000DD0: 0xE24000000A07000F Bra
            temp_312 = true;
        }
        else
        {
            temp_313 = floatBitsToInt(temp_298) == 0xDD8;
            if (temp_313)
            {
                // 0x000DD8: 0x33A0063D80070505 Ffma
                temp_314 = fma(temp_59, -0.0625, 0.5);
                // ...
                // 0x000E68: 0xE24000000087000F Bra
                temp_312 = true;
            }
            else
            {
                // 0x000E70: 0xEFF07F800DC7FFFF Ast
                out_attr5.w = 0.0;
            }
        }
```
Testing is welcome.