### PR TITLE
Avoid allocations in .Parse methods

### DIFF
--- a/Ryujinx.Common/Utilities/EmbeddedResources.cs
+++ b/Ryujinx.Common/Utilities/EmbeddedResources.cs
@@ -129,7 +129,7 @@ namespace Ryujinx.Common
 
         private static (Assembly, string) ResolveManifestPath(string filename)
         {
-            var segments = filename.Split(new[] { '/' }, 2, StringSplitOptions.RemoveEmptyEntries);
+            var segments = filename.Split('/', 2, StringSplitOptions.RemoveEmptyEntries);
 
             if (segments.Length >= 2)
             {

--- a/Ryujinx.HLE/HOS/Diagnostics/Demangler/Demangler.cs
+++ b/Ryujinx.HLE/HOS/Diagnostics/Demangler/Demangler.cs
@@ -918,7 +918,7 @@ namespace Ryujinx.HLE.HOS.Diagnostics.Demangler
                 return -1;
             }
 
-            return int.Parse(part.Substring(0, numberLength));
+            return int.Parse(part.AsSpan(0, numberLength));
         }
 
         private string ParseNumber(bool isSigned = false)

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/INfp.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/INfp.cs
@@ -816,11 +816,11 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
                                 Reserved = new Array57<byte>()
                             };
 
-                            modelInfo.CharacterId      = BinaryPrimitives.ReverseEndianness(ushort.Parse(context.Device.System.NfpDevices[i].AmiiboId.Substring(0, 4), NumberStyles.HexNumber));
-                            modelInfo.CharacterVariant = byte.Parse(context.Device.System.NfpDevices[i].AmiiboId.Substring(4, 2), NumberStyles.HexNumber);
-                            modelInfo.Series           = byte.Parse(context.Device.System.NfpDevices[i].AmiiboId.Substring(12, 2), NumberStyles.HexNumber);
-                            modelInfo.ModelNumber      = ushort.Parse(context.Device.System.NfpDevices[i].AmiiboId.Substring(8, 4), NumberStyles.HexNumber);
-                            modelInfo.Type             = byte.Parse(context.Device.System.NfpDevices[i].AmiiboId.Substring(6, 2), NumberStyles.HexNumber);
+                            modelInfo.CharacterId      = BinaryPrimitives.ReverseEndianness(ushort.Parse(context.Device.System.NfpDevices[i].AmiiboId.AsSpan(0, 4), NumberStyles.HexNumber));
+                            modelInfo.CharacterVariant = byte.Parse(context.Device.System.NfpDevices[i].AmiiboId.AsSpan(4, 2), NumberStyles.HexNumber);
+                            modelInfo.Series           = byte.Parse(context.Device.System.NfpDevices[i].AmiiboId.AsSpan(12, 2), NumberStyles.HexNumber);
+                            modelInfo.ModelNumber      = ushort.Parse(context.Device.System.NfpDevices[i].AmiiboId.AsSpan(8, 4), NumberStyles.HexNumber);
+                            modelInfo.Type             = byte.Parse(context.Device.System.NfpDevices[i].AmiiboId.AsSpan(6, 2), NumberStyles.HexNumber);
 
                             context.Memory.Write(outputPosition, modelInfo);
 

--- a/Ryujinx.HLE/HOS/Tamper/InstructionHelper.cs
+++ b/Ryujinx.HLE/HOS/Tamper/InstructionHelper.cs
@@ -122,9 +122,8 @@ namespace Ryujinx.HLE.HOS.Tamper
                 for (int nybbleIndex = 0; nybbleIndex < wordSize; nybbleIndex++)
                 {
                     int index = wordIndex * wordSize + nybbleIndex;
-                    string byteData = word.Substring(nybbleIndex, 1);
 
-                    instruction[index] = byte.Parse(byteData, NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+                    instruction[index] = byte.Parse(word.AsSpan(nybbleIndex, 1), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
                 }
             }
 

--- a/Ryujinx.HLE/Loaders/Mods/IPSwitchPatcher.cs
+++ b/Ryujinx.HLE/Loaders/Mods/IPSwitchPatcher.cs
@@ -132,7 +132,7 @@ namespace Ryujinx.HLE.Loaders.Mods
         {
             if (str[0] == '0' && (str[1] == 'x' || str[1] == 'X'))
             {
-                return int.TryParse(str.Substring(2), System.Globalization.NumberStyles.HexNumber, null, out value);
+                return int.TryParse(str.AsSpan(2), System.Globalization.NumberStyles.HexNumber, null, out value);
             }
             else
             {

--- a/Ryujinx.HLE/Utilities/StringUtils.cs
+++ b/Ryujinx.HLE/Utilities/StringUtils.cs
@@ -54,7 +54,7 @@ namespace Ryujinx.HLE.Utilities
 
             for (int index = 0; index < bytesInHex; index++)
             {
-                output[index] = byte.Parse(hexString.Substring(index * 2, 2), NumberStyles.HexNumber);
+                output[index] = byte.Parse(hexString.AsSpan(index * 2, 2), NumberStyles.HexNumber);
             }
 
             return output;


### PR DESCRIPTION
Use the Span overloads of the Parse methods when possible to avoid string allocations and remove one unnecessarry array allocation