### PR TITLE
bsd: Check if socket is bound before calling RecvFrom()

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Impl/ManagedSocket.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Impl/ManagedSocket.cs
@@ -235,6 +235,13 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                     shouldBlockAfterOperation = true;
                 }
 
+                if (!Socket.IsBound)
+                {
+                    receiveSize = -1;
+
+                    return LinuxError.EOPNOTSUPP;
+                }
+
                 receiveSize = Socket.ReceiveFrom(buffer[..size], ConvertBsdSocketFlags(flags), ref temp);
 
                 remoteEndPoint = (IPEndPoint)temp;


### PR DESCRIPTION
This small PR fixes the `InvalidOperationException` that would be thrown if `RecvFrom()` gets called without calling `Bind()` first.
I'm not really sure about the return value, but couldn't find a better fit. Since I don't have bsdsockets RE'd enough to look this up, I decided to leave it like that and hope someone knows the correct return value to use here.

---

This fixes the crash Overpass experienced when selecting the career mode.

Thanks to @EmulationFanatic for sending me the crash log and testing my patch.