### PR TITLE
Fix primitive count calculation for topology conversion

### DIFF
--- a/Ryujinx.Graphics.Vulkan/IndexBufferPattern.cs
+++ b/Ryujinx.Graphics.Vulkan/IndexBufferPattern.cs
@@ -38,7 +38,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         public int GetPrimitiveCount(int vertexCount)
         {
-            return Math.Max(0, ((vertexCount - BaseIndex) + IndexStride - 1) / IndexStride);
+            return Math.Max(0, (vertexCount - BaseIndex) / IndexStride);
         }
 
         public int GetConvertedCount(int indexCount)


### PR DESCRIPTION
Luigi's Mansion 3 performs a few non-index quads draws with 6 vertices for the mini map. It's meant to ignore the last two, but the index pattern's primitive count calculation was rounding up and drawing two quads instead of one.

https://user-images.githubusercontent.com/6294155/196014080-7f74a3be-265a-4f1e-a2e7-45ea30ee72f9.mp4

No idea why the game does this but this should fix random triangles in the map.

This is a recent regression from #3715. Feel free to make sure other stuff hasn't broken.