### PR TITLE
TamperMachine: Fix input mask check

### DIFF
--- a/Ryujinx.HLE/HOS/Tamper/Conditions/InputMask.cs
+++ b/Ryujinx.HLE/HOS/Tamper/Conditions/InputMask.cs
@@ -13,7 +13,7 @@ namespace Ryujinx.HLE.HOS.Tamper.Conditions
 
         public bool Evaluate()
         {
-            return (_input.Value & _mask) != 0;
+            return (_input.Value & _mask) == _mask;
         }
     }
 }


### PR DESCRIPTION
I noticed a report that cheats with conditional inputs don't work and scanning through just code, found this logic error. Please test if this fixes the problem as I pretty much never use cheats.

I would've preferred `(_input.Value ^ _mask) == 0` but original implementation uses this check-
https://github.com/Atmosphere-NX/Atmosphere/blob/master/stratosphere/dmnt/source/cheat/impl/dmnt_cheat_vm.cpp#L976