### PR TITLE
Implement OpenDataStorageWithProgramIndex partially

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
@@ -550,7 +550,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
 
         [CommandHipc(123)] // 5.0.0+
         // GetPreviousProgramIndex() -> s32 program_index
-        public ResultCode GetPreviousProgramIndex(ServiceCtx context)
+        public ResultCode GetPrevious(ServiceCtx context)
         {
             int previousProgramIndex = context.Device.Configuration.UserChannelPersistence.PreviousIndex;
 

--- a/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
+++ b/Ryujinx.HLE/HOS/Services/Am/AppletOE/ApplicationProxyService/ApplicationProxy/IApplicationFunctions.cs
@@ -550,7 +550,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletOE.ApplicationProxyService.Applicati
 
         [CommandHipc(123)] // 5.0.0+
         // GetPreviousProgramIndex() -> s32 program_index
-        public ResultCode GetPrevious(ServiceCtx context)
+        public ResultCode GetPreviousProgramIndex(ServiceCtx context)
         {
             int previousProgramIndex = context.Device.Configuration.UserChannelPersistence.PreviousIndex;
 

--- a/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
@@ -789,14 +789,14 @@ namespace Ryujinx.HLE.HOS.Services.Fs
         }
 
         [CommandHipc(205)]
-        // OpenDataStorageWithProgramIndex(u8) -> object<nn::fssrv::sf::IStorage>
+        // OpenDataStorageWithProgramIndex(u8 program_index) -> object<nn::fssrv::sf::IStorage>
         public ResultCode OpenDataStorageWithProgramIndex(ServiceCtx context)
         {
             byte programIndex = context.RequestData.ReadByte();
 
             if ((context.Device.Application.TitleId & 0xf) != programIndex)
             {
-                throw new NotImplementedException($"Reading storage from other programs is not supported (program index = {programIndex}).");
+                throw new NotImplementedException($"Accessing storage from other programs is not supported (program index = {programIndex}).");
             }
 
             var storage = context.Device.FileSystem.RomFs.AsStorage(true);

--- a/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
@@ -12,6 +12,7 @@ using LibHac.Tools.FsSystem.NcaUtils;
 using Ryujinx.Common;
 using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Services.Fs.FileSystemProxy;
+using System;
 using System.IO;
 
 using static Ryujinx.HLE.Utilities.StringUtils;
@@ -778,6 +779,26 @@ namespace Ryujinx.HLE.HOS.Services.Fs
         // OpenPatchDataStorageByCurrentProcess() -> object<nn::fssrv::sf::IStorage>
         public ResultCode OpenPatchDataStorageByCurrentProcess(ServiceCtx context)
         {
+            var storage = context.Device.FileSystem.RomFs.AsStorage(true);
+            using var sharedStorage = new SharedRef<LibHac.Fs.IStorage>(storage);
+            using var sfStorage = new SharedRef<IStorage>(new StorageInterfaceAdapter(ref sharedStorage.Ref()));
+
+            MakeObject(context, new FileSystemProxy.IStorage(ref sfStorage.Ref()));
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(205)]
+        // OpenDataStorageWithProgramIndex(u8) -> object<nn::fssrv::sf::IStorage>
+        public ResultCode OpenDataStorageWithProgramIndex(ServiceCtx context)
+        {
+            byte programIndex = context.RequestData.ReadByte();
+
+            if ((context.Device.Application.TitleId & 0xf) != programIndex)
+            {
+                throw new NotImplementedException($"Reading storage from other programs is not supported (program index = {programIndex}).");
+            }
+
             var storage = context.Device.FileSystem.RomFs.AsStorage(true);
             using var sharedStorage = new SharedRef<LibHac.Fs.IStorage>(storage);
             using var sfStorage = new SharedRef<IStorage>(new StorageInterfaceAdapter(ref sharedStorage.Ref()));


### PR DESCRIPTION
This implements `OpenDataStorageWithProgramIndex`. This implementation only supports accessing the storage if the program index is the same as the current program index. It doesn't look like the emulator has any infrastructure right now to access data from other NCAs from the game. The current content manager only "installs" firmware NCAs, so only those are accessible.

If an attempt is made to access the storage of another program, it will throw `NotImplementedException`.
This is enough for all games that I have that requires this functionality.

RollerCoaster Tycoon 3:
![image](https://user-images.githubusercontent.com/5624669/196085568-778acb9d-a7a3-4fa2-b093-1f7e10c06317.png)
MLB The Show 22:
![image](https://user-images.githubusercontent.com/5624669/196085594-91898969-dcdf-4668-9870-063ca122af41.png)
This one has quite a few issues. It runs very slow and crashes on Vulkan due the local size being above the limit of 1024 on my graphics card (although it seems that Pascal and older have a higher limit of 1536, so maybe it will work on those cards on Vulkan?)

I believe it fixes #1596, but we might need to revisit this if a game has multi-program and needs to access the storage of the other programs.