### PR TITLE
CI: Add dependabot for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - "infra"
+    reviewers:
+      - marysaka
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
This PR adds `dependabot.yml` to automatically create PRs when a new version of an action gets released.
It's currently configured to only run weekly and adds the label `infra` for each PR that it creates.

I doubt that it will create more than 3 PRs at a time, but we could still limit the amount of open PRs from it, if you want.

---

Originally this was part of #3774 and is now it's own PR.