### PR TITLE
Vulkan: Fix vertex position Z conversion with geometry shader passthrough

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 3759;
+        private const uint CodeGenVersion = 3781;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -306,7 +306,10 @@ namespace Ryujinx.Graphics.Shader.Translation
                 config._perPatchAttributeLocations = locationsMap;
             }
 
-            if (config.Stage != ShaderStage.Fragment)
+            // We don't consider geometry shaders using the geometry shader passthrough feature
+            // as being the last because when this feature is used, it can't actually modify any of the outputs,
+            // so the stage that comes before it is the last one that can do modifications.
+            if (config.Stage != ShaderStage.Fragment && (config.Stage != ShaderStage.Geometry || !config.GpPassthrough))
             {
                 LastInVertexPipeline = false;
             }


### PR DESCRIPTION
Right now we do the Z value conversion for the -1 to 1 depth mode in the last vertex pipeline stage shader that is used. But because shaders using geometry shader passthrough don't (and can't) modify `gl_Position`, when those shaders are used, it wouldn't do the conversion at all. This fixes the issue by not considering geometry shader with passthrough as `LastInVertexPipeline`, so it will do the conversion in the previous stage instead, which can be vertex or tessellation control.

Fixes black screen in Game Builder Garage on Vulkan.
Before:
![image](https://user-images.githubusercontent.com/5624669/197097083-326fe7d5-c102-4457-8050-35cbdf0b7d93.png)
After:
![image](https://user-images.githubusercontent.com/5624669/197097109-5eeb8fd0-6703-4c4c-99bd-69d7fffaa2e4.png)
