### PR TITLE
Add updates for nuget packages to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,15 @@ updates:
       - marysaka
     commit-message:
       prefix: "ci"
+
+  - package-ecosystem: nuget
+    directory: /
+    open-pull-requests-limit: 5
+    schedule:
+      interval: daily
+    labels:
+      - "infra"
+    reviewers:
+      - marysaka
+    commit-message:
+      prefix: nuget


### PR DESCRIPTION
@marysaka was looking to add this to dependabot too, so I quickly added it here.

For nuget packages dependabot will check for updates every day, add the label `infra` to PRs and prefix them with `nuget`.

I was looking at other PRs updating nuget packages before and wasn't sure which prefix to pick. The most common ones are `misc` and `infra`, so please tell me if you want the prefix changed.

(Sorry for creating so many small PRs, my next PR won't be something CI related and probably not as small.)