### PR TITLE
Add InfoType.MesosphereCurrentProcess

### DIFF
--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/InfoType.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/InfoType.cs
@@ -28,6 +28,7 @@
         UsedNonSystemMemorySize,
         IsApplication,
         FreeThreadCount,
-        ThreadTickCount
+        ThreadTickCount,
+        MesosphereCurrentProcess = 65001
     }
 }

--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
@@ -2107,6 +2107,34 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
                         break;
                     }
 
+                case InfoType.MesosphereCurrentProcess:
+                    {
+                        if (handle != 0)
+                        {
+                            return KernelResult.InvalidHandle;
+                        }
+
+                        if ((ulong)subId != 0)
+                        {
+                            return KernelResult.InvalidCombination;
+                        }
+
+                        KProcess currentProcess = KernelStatic.GetCurrentProcess();
+                        KHandleTable handleTable = currentProcess.HandleTable;
+                        int outHandle = 0;
+
+                        KernelResult result = handleTable.GenerateHandle(currentProcess, out outHandle);
+
+                        if (result != KernelResult.Success)
+                        {
+                            return result;
+                        }                        
+
+                        value = (ulong)outHandle;
+
+                        break;
+                    }
+
                 default: return KernelResult.InvalidEnumValue;
             }
 

--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
@@ -2121,9 +2121,8 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
 
                         KProcess currentProcess = KernelStatic.GetCurrentProcess();
                         KHandleTable handleTable = currentProcess.HandleTable;
-                        int outHandle = 0;
 
-                        KernelResult result = handleTable.GenerateHandle(currentProcess, out outHandle);
+                        KernelResult result = handleTable.GenerateHandle(currentProcess, out int outHandle);
 
                         if (result != KernelResult.Success)
                         {


### PR DESCRIPTION
Add's InfoType.MesosphereCurrentProcess to enum InfoType. 
It allows exefs replacements and homebrew to easily get their own process handle for use with certain SVCs, such as MapProcessMemory.

This isn't vanilla HOS behaviour but rather an extension added by Atmosphere, so I am not sure if this is fitting for Ryujinx. It is possible to get the process handle with a hacky method involving an IPC trick, but this is not exactly desirable.