### PR TITLE
Vulkan: Use dynamic state for blend constants

### DIFF
--- a/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -535,10 +535,11 @@ namespace Ryujinx.Graphics.Vulkan
                 vkBlend = new PipelineColorBlendAttachmentState();
             }
 
-            _newState.BlendConstantR = blend.BlendConstant.Red;
-            _newState.BlendConstantG = blend.BlendConstant.Green;
-            _newState.BlendConstantB = blend.BlendConstant.Blue;
-            _newState.BlendConstantA = blend.BlendConstant.Alpha;
+            DynamicState.SetBlendConstants(
+                blend.BlendConstant.Red,
+                blend.BlendConstant.Green,
+                blend.BlendConstant.Blue,
+                blend.BlendConstant.Alpha);
 
             SignalStateChange();
         }

--- a/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
@@ -135,11 +135,6 @@ namespace Ryujinx.Graphics.Vulkan
 
             // It is assumed that Dynamic State is enabled when this conversion is used.
 
-            pipeline.BlendConstantA = state.BlendDescriptors[0].BlendConstant.Alpha;
-            pipeline.BlendConstantB = state.BlendDescriptors[0].BlendConstant.Blue;
-            pipeline.BlendConstantG = state.BlendDescriptors[0].BlendConstant.Green;
-            pipeline.BlendConstantR = state.BlendDescriptors[0].BlendConstant.Red;
-
             pipeline.CullMode = state.CullEnable ? state.CullMode.Convert() : CullModeFlags.CullModeNone;
 
             pipeline.DepthBoundsTestEnable = false; // Not implemented.

--- a/Ryujinx.Graphics.Vulkan/PipelineState.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineState.cs
@@ -499,7 +499,7 @@ namespace Ryujinx.Graphics.Vulkan
                 colorBlendState.BlendConstants[3] = BlendConstantA;
 
                 bool supportsExtDynamicState = gd.Capabilities.SupportsExtendedDynamicState;
-                int dynamicStatesCount = supportsExtDynamicState ? 8 : 7;
+                int dynamicStatesCount = supportsExtDynamicState ? 9 : 8;
 
                 DynamicState* dynamicStates = stackalloc DynamicState[dynamicStatesCount];
 
@@ -510,10 +510,11 @@ namespace Ryujinx.Graphics.Vulkan
                 dynamicStates[4] = DynamicState.StencilCompareMask;
                 dynamicStates[5] = DynamicState.StencilWriteMask;
                 dynamicStates[6] = DynamicState.StencilReference;
+                dynamicStates[7] = DynamicState.BlendConstants;
 
                 if (supportsExtDynamicState)
                 {
-                    dynamicStates[7] = DynamicState.VertexInputBindingStrideExt;
+                    dynamicStates[8] = DynamicState.VertexInputBindingStrideExt;
                 }
 
                 var pipelineDynamicStateCreateInfo = new PipelineDynamicStateCreateInfo()


### PR DESCRIPTION
Prevents Mario Kart 8 Deluxe from creating an unbounded number of graphics pipelines when using blend constants (it seems to blend between colours depending on progress through certain course sections). Of course, it's possible for other games to do this.

Should generally use less memory and speed up drivers where compiling pipeline variants is slower.