### PR TITLE
Vulkan: Fix indirect buffer barrier

### DIFF
--- a/Ryujinx.Graphics.Vulkan/BufferHolder.cs
+++ b/Ryujinx.Graphics.Vulkan/BufferHolder.cs
@@ -12,13 +12,12 @@ namespace Ryujinx.Graphics.Vulkan
         private const int MaxUpdateBufferSize = 0x10000;
 
         public const AccessFlags DefaultAccessFlags =
+            AccessFlags.AccessIndirectCommandReadBit |
             AccessFlags.AccessShaderReadBit |
             AccessFlags.AccessShaderWriteBit |
             AccessFlags.AccessTransferReadBit |
             AccessFlags.AccessTransferWriteBit |
-            AccessFlags.AccessUniformReadBit |
-            AccessFlags.AccessShaderReadBit |
-            AccessFlags.AccessShaderWriteBit;
+            AccessFlags.AccessUniformReadBit;
 
         private readonly VulkanRenderer _gd;
         private readonly Device _device;

--- a/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -228,10 +228,26 @@ namespace Ryujinx.Graphics.Vulkan
             Gd.Api.CmdClearAttachments(CommandBuffer, 1, &attachment, 1, &clearRect);
         }
 
-        public void CommandBufferBarrier()
+        public unsafe void CommandBufferBarrier()
         {
-            // TODO: More specific barrier?
-            Barrier();
+            MemoryBarrier memoryBarrier = new MemoryBarrier()
+            {
+                SType = StructureType.MemoryBarrier,
+                SrcAccessMask = BufferHolder.DefaultAccessFlags,
+                DstAccessMask = AccessFlags.AccessIndirectCommandReadBit
+            };
+
+            Gd.Api.CmdPipelineBarrier(
+                CommandBuffer,
+                PipelineStageFlags.PipelineStageAllCommandsBit,
+                PipelineStageFlags.PipelineStageDrawIndirectBit,
+                0,
+                1,
+                memoryBarrier,
+                0,
+                null,
+                0,
+                null);
         }
 
         public void CopyBuffer(BufferHandle source, BufferHandle destination, int srcOffset, int dstOffset, int size)
@@ -823,7 +839,7 @@ namespace Ryujinx.Graphics.Vulkan
 
                 if (range.Handle != BufferHandle.Null)
                 {
-                    _transformFeedbackBuffers[i] = 
+                    _transformFeedbackBuffers[i] =
                         new BufferState(Gd.BufferManager.GetBuffer(CommandBuffer, range.Handle, range.Offset, range.Size, true), range.Offset, range.Size);
                     _transformFeedbackBuffers[i].BindTransformFeedbackBuffer(Gd, Cbs, (uint)i);
                 }


### PR DESCRIPTION
This is basically extracting a fix from #3748 since I don't know when that PR is going to be merged. Right now, we are missing the `IndirectCommandRead` bit on buffer barriers, which might potentially cause parameters to be fetched before write to the buffer is complete and cause the draw to use incorrect parameters. This was causing some DeviceLost crashes on Monster Hunter Rise with latest NVIDIA drivers, and maybe the older ones aswell.