### PR TITLE
SPIR-V: Fix tessellation control shader output types

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 3781;
+        private const uint CodeGenVersion = 3807;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/Ryujinx.Graphics.Shader/CodeGen/Spirv/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Spirv/Declarations.cs
@@ -473,6 +473,11 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
                         var attrType = context.TypeVector(context.TypeFP32(), (LiteralInteger)4);
                         attrType = context.TypeArray(attrType, context.Constant(context.TypeU32(), (LiteralInteger)MaxAttributes));
 
+                        if (context.Config.Stage == ShaderStage.TessellationControl)
+                        {
+                            attrType = context.TypeArray(attrType, context.Constant(context.TypeU32(), context.Config.ThreadsPerInputPrimitive));
+                        }
+
                         var spvType = context.TypePointer(StorageClass.Output, attrType);
                         var spvVar = context.Variable(spvType, StorageClass.Output);
 
@@ -541,6 +546,11 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
                 {
                     builtInPassthrough = true;
                 }
+            }
+
+            if (context.Config.Stage == ShaderStage.TessellationControl && isOutAttr && !perPatch)
+            {
+                attrType = context.TypeArray(attrType, context.Constant(context.TypeU32(), context.Config.ThreadsPerInputPrimitive));
             }
 
             var spvType = context.TypePointer(storageClass, attrType);
@@ -632,6 +642,11 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
             {
                 int arraySize = context.Config.Stage == ShaderStage.Geometry ? context.InputVertices : 32;
                 attrType = context.TypeArray(attrType, context.Constant(context.TypeU32(), (LiteralInteger)arraySize));
+            }
+
+            if (context.Config.Stage == ShaderStage.TessellationControl && isOutAttr)
+            {
+                attrType = context.TypeArray(attrType, context.Constant(context.TypeU32(), context.Config.ThreadsPerInputPrimitive));
             }
 
             var spvType = context.TypePointer(storageClass, attrType);

--- a/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgramContext.cs
+++ b/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgramContext.cs
@@ -37,7 +37,12 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
 
             Config = config;
 
-            if (config.GpPassthrough)
+            if (config.Stage == ShaderStage.TessellationControl)
+            {
+                // Required to index outputs.
+                Info.Inputs.Add(AttributeConsts.InvocationId);
+            }
+            else if (config.GpPassthrough)
             {
                 int passthroughAttributes = config.PassthroughAttributes;
                 while (passthroughAttributes != 0)


### PR DESCRIPTION
GLSL requires that tessellation control shaders are indexed with `gl_InvocationID` built-in input. You can't actually use anything else as index, so this is effectively useless. On SPIR-V, this was not being done. This was not causing any validation errors, and most compilers did not complain about it, except AMD on Windows, where it would cause the compiler to crash. So to fix this, I have changed it to index outputs using `gl_InvocationID` on tessellation control shaders, which matches the GLSL compiler, and fixes the AMD crash.

Fixes crash on the following games on AMD Vulkan (Windows):
- Bayonetta 3 (chapter 1, after the cutscene).
- Luigi's Mansion 3 (right before the title screen).
- And likely any other game using tessellation (see list below, I did not test all of them).

Testing is welcome. Below is a list of games I know that uses tessellation (if you don't have AMD, they should be tested just to make sure they didn't break):
- Bayonetta 3 (only some areas, like the island (?) on chapter 1).
- Luigi's Mansion 3 (uses it right on the title screen, most visible on that sand room).
- The Witcher 3.
- The Legend of Heroes: Trails from Zero.
- Mario Golf: Super Rush.