### PR TITLE
CI: Fix windows builds missing SourceRevisionId

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Get git short hash
         id: git_short_hash
         run: echo "result=$(git rev-parse --short "${{ github.sha }}")" >> $GITHUB_OUTPUT
+        shell: bash
       - name: Clear
         run: dotnet clean && dotnet nuget locals all --clear
       - name: Build


### PR DESCRIPTION
Quick fix for the [issue](https://discordapp.com/channels/410208534861447168/410432399500115968/1035943546982768761) mentioned by mageven on discord.

Windows builds should now properly include the SourceRevisionId.

You can verify that this works in the following workflow run: https://github.com/TSRBerry/Ryujinx/actions/runs/3352123839/jobs/5554048680