### PR TITLE
Fix Fedora support

### DIFF
--- a/Ryujinx.Ava/Ryujinx.Ava.csproj
+++ b/Ryujinx.Ava/Ryujinx.Ava.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Silk.NET.Vulkan" Version="2.10.1" />
     <PackageReference Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.10.1" />
     <PackageReference Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.10.1" />
-    <PackageReference Include="SPB" Version="0.0.4-build27" />
+    <PackageReference Include="SPB" Version="0.0.4-build28" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
   </ItemGroup>

--- a/Ryujinx/Program.cs
+++ b/Ryujinx/Program.cs
@@ -29,13 +29,41 @@ namespace Ryujinx
 
         public static string ConfigurationPath { get; set; }
 
-        [DllImport("libX11")]
+        public static string CommandLineProfile { get; set; }
+
+        private const string X11LibraryName = "libX11";
+
+        [DllImport(X11LibraryName)]
         private extern static int XInitThreads();
 
         [DllImport("user32.dll", SetLastError = true)]
         public static extern int MessageBoxA(IntPtr hWnd, string text, string caption, uint type);
 
         private const uint MB_ICONWARNING = 0x30;
+
+        static Program()
+        {
+            if (OperatingSystem.IsLinux())
+            {
+                NativeLibrary.SetDllImportResolver(typeof(Program).Assembly, (name, assembly, path) =>
+                {
+                    if (name != X11LibraryName)
+                    {
+                        return IntPtr.Zero;
+                    }
+
+                    if (!NativeLibrary.TryLoad("libX11.so.6", assembly, path, out IntPtr result))
+                    {
+                        if (!NativeLibrary.TryLoad("libX11.so", assembly, path, out result))
+                        {
+                            return IntPtr.Zero;
+                        }
+                    }
+
+                    return result;
+                });
+            }
+        }
 
         static void Main(string[] args)
         {

--- a/Ryujinx/Ryujinx.csproj
+++ b/Ryujinx/Ryujinx.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Ryujinx.Graphics.Nvdec.Dependencies" Version="5.0.1-build10" Condition="'$(RuntimeIdentifier)' != 'linux-x64' AND '$(RuntimeIdentifier)' != 'osx-x64'" />
     <PackageReference Include="Ryujinx.Audio.OpenAL.Dependencies" Version="1.21.0.1" Condition="'$(RuntimeIdentifier)' != 'linux-x64' AND '$(RuntimeIdentifier)' != 'osx-x64'" />
     <PackageReference Include="OpenTK.Graphics" Version="4.7.2" />
-    <PackageReference Include="SPB" Version="0.0.4-build27" />
+    <PackageReference Include="SPB" Version="0.0.4-build28" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
   </ItemGroup>


### PR DESCRIPTION
For some reasons, my fresh installation of Fedora 36 (KDE) doesn't have a symlink for libX11.so.

This PR fixes this by trying to import the library with its major version or fallback to the normal way.

SPB was updated in consequence.