### PR TITLE
fix: Support FFmpeg 5.1.x for decoding

### DIFF
--- a/Ryujinx.Graphics.Nvdec.FFmpeg/Native/AVCodec.cs
+++ b/Ryujinx.Graphics.Nvdec.FFmpeg/Native/AVCodec.cs
@@ -20,6 +20,7 @@ namespace Ryujinx.Graphics.Nvdec.FFmpeg.Native
         public unsafe IntPtr PrivClass;
         public IntPtr Profiles;
         public unsafe byte* WrapperName;
+        public IntPtr ChLayouts;
 #pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Nvdec.FFmpeg/Native/AVCodec501.cs
+++ b/Ryujinx.Graphics.Nvdec.FFmpeg/Native/AVCodec501.cs
@@ -2,7 +2,7 @@
 
 namespace Ryujinx.Graphics.Nvdec.FFmpeg.Native
 {
-    struct AVCodecLegacy
+    struct AVCodec501
     {
 #pragma warning disable CS0649
         public unsafe byte* Name;
@@ -20,7 +20,6 @@ namespace Ryujinx.Graphics.Nvdec.FFmpeg.Native
         public unsafe IntPtr PrivClass;
         public IntPtr Profiles;
         public unsafe byte* WrapperName;
-        public IntPtr ChLayouts;
 #pragma warning restore CS0649
     }
 }

--- a/Ryujinx.Graphics.Nvdec.FFmpeg/Native/AVCodecContext.cs
+++ b/Ryujinx.Graphics.Nvdec.FFmpeg/Native/AVCodecContext.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Graphics.Nvdec.FFmpeg.Native
         public unsafe IntPtr AvClass;
         public int LogLevelOffset;
         public int CodecType;
-        public unsafe AVCodecLegacy* Codec;
+        public unsafe AVCodec* Codec;
         public AVCodecID CodecId;
         public uint CodecTag;
         public IntPtr PrivData;

--- a/Ryujinx.Graphics.Nvdec.FFmpeg/Native/FFCodec.cs
+++ b/Ryujinx.Graphics.Nvdec.FFmpeg/Native/FFCodec.cs
@@ -2,12 +2,10 @@
 
 namespace Ryujinx.Graphics.Nvdec.FFmpeg.Native
 {
-    struct FFCodec
+    struct FFCodec<T> where T: struct
     {
-        public unsafe delegate int AVCodec_decode(AVCodecContext* avctx, void* outdata, int* got_frame_ptr, AVPacket* avpkt);
-
 #pragma warning disable CS0649
-        public AVCodec Base;
+        public T Base;
         public int CapsInternalOrCbType;
         public int PrivDataSize;
         public IntPtr UpdateThreadContext;


### PR DESCRIPTION
For some reason FFmpeg 5.1.x reverted part of the changes made in 5.0.x on AVCodec.

This fix decoding issues with it.

Close #3645