### PR TITLE
SDL2Driver: Invoke dispatcher on main thread

### DIFF
--- a/Ryujinx.Ava/Program.cs
+++ b/Ryujinx.Ava/Program.cs
@@ -11,6 +11,7 @@ using Ryujinx.Common.Logging;
 using Ryujinx.Common.System;
 using Ryujinx.Common.SystemInfo;
 using Ryujinx.Modules;
+using Ryujinx.SDL2.Common;
 using Ryujinx.Ui.Common;
 using Ryujinx.Ui.Common.Configuration;
 using Ryujinx.Ui.Common.Helper;
@@ -109,6 +110,9 @@ namespace Ryujinx.Ava
 
             // Initialize Discord integration.
             DiscordIntegrationModule.Initialize();
+
+            // Initialize SDL2 driver
+            SDL2Driver.MainThreadDispatcher = action => Dispatcher.UIThread.InvokeAsync(action, DispatcherPriority.Input);
 
             ReloadConfig();
 

--- a/Ryujinx.Headless.SDL2/Program.cs
+++ b/Ryujinx.Headless.SDL2/Program.cs
@@ -638,16 +638,7 @@ namespace Ryujinx.Headless.SDL2
 
             Translator.IsReadyForTranslation.Reset();
 
-            Thread windowThread = new Thread(() =>
-            {
-                ExecutionEntrypoint();
-            })
-            {
-                Name = "GUI.WindowThread"
-            };
-
-            windowThread.Start();
-            windowThread.Join();
+            ExecutionEntrypoint();
 
             return true;
         }

--- a/Ryujinx.Headless.SDL2/WindowBase.cs
+++ b/Ryujinx.Headless.SDL2/WindowBase.cs
@@ -168,14 +168,6 @@ namespace Ryujinx.Headless.SDL2
 
         public void Render()
         {
-            InitializeWindowRenderer();
-
-            Device.Gpu.Renderer.Initialize(_glLogLevel);
-
-            InitializeRenderer();
-
-            _gpuVendorName = GetGpuVendorName();
-
             Device.Gpu.Renderer.RunLoop(() =>
             {
                 Device.Gpu.SetGpuThread();
@@ -322,6 +314,14 @@ namespace Ryujinx.Headless.SDL2
             _isActive = true;
 
             InitializeWindow();
+
+            InitializeWindowRenderer();
+
+            Device.Gpu.Renderer.Initialize(_glLogLevel);
+
+            InitializeRenderer();
+
+            _gpuVendorName = GetGpuVendorName();
 
             Thread renderLoopThread = new Thread(Render)
             {

--- a/Ryujinx.SDL2.Common/SDL2Driver.cs
+++ b/Ryujinx.SDL2.Common/SDL2Driver.cs
@@ -28,6 +28,8 @@ namespace Ryujinx.SDL2.Common
             }
         }
 
+        public static Action<Action> MainThreadDispatcher { get; set; }
+
         private const uint SdlInitFlags = SDL_INIT_EVENTS | SDL_INIT_GAMECONTROLLER | SDL_INIT_JOYSTICK | SDL_INIT_AUDIO | SDL_INIT_VIDEO;
 
         private bool _isRunning;
@@ -154,10 +156,13 @@ namespace Ryujinx.SDL2.Common
 
             while (_isRunning)
             {
-                while (SDL_PollEvent(out SDL_Event evnt) != 0)
+                MainThreadDispatcher?.Invoke(() =>
                 {
-                    HandleSDLEvent(ref evnt);
-                }
+                    while (SDL_PollEvent(out SDL_Event evnt) != 0)
+                    {
+                        HandleSDLEvent(ref evnt);
+                    }
+                });
 
                 waitHandle.Wait(WaitTimeMs);
             }

--- a/Ryujinx/Program.cs
+++ b/Ryujinx/Program.cs
@@ -7,6 +7,7 @@ using Ryujinx.Common.Logging;
 using Ryujinx.Common.System;
 using Ryujinx.Common.SystemInfo;
 using Ryujinx.Modules;
+using Ryujinx.SDL2.Common;
 using Ryujinx.Ui;
 using Ryujinx.Ui.Common;
 using Ryujinx.Ui.Common.Configuration;
@@ -110,6 +111,15 @@ namespace Ryujinx
 
             // Initialize Discord integration.
             DiscordIntegrationModule.Initialize();
+
+            // Initialize SDL2 driver
+            SDL2Driver.MainThreadDispatcher = action =>
+            {
+                Gtk.Application.Invoke(delegate
+                {
+                    action();
+                });
+            };
 
             // Sets ImageSharp Jpeg Encoder Quality.
             SixLabors.ImageSharp.Configuration.Default.ImageFormatsManager.SetEncoder(JpegFormat.Instance, new JpegEncoder()


### PR DESCRIPTION
Executes `SDL_PumpEvents` on main thread.

I note the SDL2 frontend already manually calls `SDL_PumpEvents` in its main loop.

macOS enforces the need for events pumped on the main thread.