### PR TITLE
Ensure all pending draws are done before compute dispatch

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Compute/ComputeClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Compute/ComputeClass.cs
@@ -94,6 +94,10 @@ namespace Ryujinx.Graphics.Gpu.Engine.Compute
         {
             var memoryManager = _channel.MemoryManager;
 
+            // Since we're going to change the state, make sure any pending instanced draws are done.
+            _3dEngine.PerformDeferredDraws();
+
+            // Make sure all pending uniform buffer data is written to memory.
             _3dEngine.FlushUboDirty();
 
             uint qmdAddress = _state.State.SendPcasA;


### PR DESCRIPTION
Since instanced draws does one call per instance, we currently use an approach were the draw is deferred until we get the total instance count. In some rare circumstances, it was possible for a compute dispatch to be done while the draw was still pending, but then later it would do the pending draw, but at this point the state is already wrong, and since a compute shader is bound for the compute dispatch, it would try to draw with a compute shader which is invalid. This was causing crashes on Vulkan on the game Nights of Azure 2: Bride of the New Moon.

This change is basically just making sure all pending draws are done before the compute dispatch operation.
With this change, the aforementioned game now works on Vulkan.
![image](https://user-images.githubusercontent.com/5624669/199847044-babf7e52-1fb0-46e4-a393-c663af098f89.png)
