### PR TITLE
GPU: Don't trigger uploads for redundant buffer updates

### DIFF
--- a/Ryujinx.Cpu/Jit/MemoryManagerHostMapped.cs
+++ b/Ryujinx.Cpu/Jit/MemoryManagerHostMapped.cs
@@ -308,6 +308,34 @@ namespace Ryujinx.Cpu.Jit
         }
 
         /// <inheritdoc/>
+        public bool WriteWithRedundancyCheck(ulong va, ReadOnlySpan<byte> data)
+        {
+            try
+            {
+                SignalMemoryTracking(va, (ulong)data.Length, false);
+
+                Span<byte> target = _addressSpaceMirror.GetSpan(va, data.Length);
+                bool changed = !data.SequenceEqual(target);
+
+                if (changed)
+                {
+                    data.CopyTo(target);
+                }
+
+                return changed;
+            }
+            catch (InvalidMemoryRegionException)
+            {
+                if (_invalidAccessHandler == null || !_invalidAccessHandler(va))
+                {
+                    throw;
+                }
+
+                return true;
+            }
+        }
+
+        /// <inheritdoc/>
         public ReadOnlySpan<byte> GetSpan(ulong va, int size, bool tracked = false)
         {
             if (tracked)

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/ConstantBufferUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/ConstantBufferUpdater.cs
@@ -112,9 +112,13 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             if (_ubFollowUpAddress != 0)
             {
                 var memoryManager = _channel.MemoryManager;
-                memoryManager.Physical.BufferCache.ForceDirty(memoryManager, _ubFollowUpAddress - _ubByteCount, _ubByteCount);
 
-                memoryManager.Physical.Write(_ubBeginCpuAddress, MemoryMarshal.Cast<int, byte>(_ubData.AsSpan(0, (int)(_ubByteCount / 4))));
+                Span<byte> data = MemoryMarshal.Cast<int, byte>(_ubData.AsSpan(0, (int)(_ubByteCount / 4)));
+
+                if (memoryManager.Physical.WriteWithRedundancyCheck(_ubBeginCpuAddress, data))
+                {
+                    memoryManager.Physical.BufferCache.ForceDirty(memoryManager, _ubFollowUpAddress - _ubByteCount, _ubByteCount);
+                }
 
                 _ubFollowUpAddress = 0;
                 _ubIndex = 0;

--- a/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/PhysicalMemory.cs
@@ -242,6 +242,19 @@ namespace Ryujinx.Graphics.Gpu.Memory
             WriteImpl(range, data, _cpuMemory.WriteUntracked);
         }
 
+        /// <summary>
+        /// Writes data to the application process, returning false if the data was not changed.
+        /// This triggers read memory tracking, as a redundancy check would be useless if the data is not up to date.
+        /// </summary>
+        /// <remarks>The memory manager can return that memory has changed when it hasn't to avoid expensive data copies.</remarks>
+        /// <param name="address">Address to write into</param>
+        /// <param name="data">Data to be written</param>
+        /// <returns>True if the data was changed, false otherwise</returns>
+        public bool WriteWithRedundancyCheck(ulong address, ReadOnlySpan<byte> data)
+        {
+            return _cpuMemory.WriteWithRedundancyCheck(address, data);
+        }
+
         private delegate void WriteCallback(ulong address, ReadOnlySpan<byte> data);
 
         /// <summary>

--- a/Ryujinx.Memory.Tests/MockVirtualMemoryManager.cs
+++ b/Ryujinx.Memory.Tests/MockVirtualMemoryManager.cs
@@ -44,6 +44,11 @@ namespace Ryujinx.Memory.Tests
             throw new NotImplementedException();
         }
 
+        public bool WriteWithRedundancyCheck(ulong va, ReadOnlySpan<byte> data)
+        {
+            throw new NotImplementedException();
+        }
+
         public ReadOnlySpan<byte> GetSpan(ulong va, int size, bool tracked = false)
         {
             throw new NotImplementedException();

--- a/Ryujinx.Memory/AddressSpaceManager.cs
+++ b/Ryujinx.Memory/AddressSpaceManager.cs
@@ -137,6 +137,14 @@ namespace Ryujinx.Memory
         }
 
         /// <inheritdoc/>
+        public bool WriteWithRedundancyCheck(ulong va, ReadOnlySpan<byte> data)
+        {
+            Write(va, data);
+
+            return true;
+        }
+
+        /// <inheritdoc/>
         public ReadOnlySpan<byte> GetSpan(ulong va, int size, bool tracked = false)
         {
             if (size == 0)

--- a/Ryujinx.Memory/IVirtualMemoryManager.cs
+++ b/Ryujinx.Memory/IVirtualMemoryManager.cs
@@ -58,6 +58,16 @@ namespace Ryujinx.Memory
         /// <exception cref="InvalidMemoryRegionException">Throw for unhandled invalid or unmapped memory accesses</exception>
         void Write(ulong va, ReadOnlySpan<byte> data);
 
+        /// <summary>
+        /// Writes data to the application process, returning false if the data was not changed.
+        /// This triggers read memory tracking, as a redundancy check would be useless if the data is not up to date.
+        /// </summary>
+        /// <param name="va">Virtual address to write the data into</param>
+        /// <param name="data">Data to be written</param>
+        /// <exception cref="InvalidMemoryRegionException">Throw for unhandled invalid or unmapped memory accesses</exception>
+        /// <returns>True if the data was changed, false otherwise</returns>
+        bool WriteWithRedundancyCheck(ulong va, ReadOnlySpan<byte> data);
+
         void Fill(ulong va, ulong size, byte value)
         {
             const int MaxChunkSize = 1 << 24;

--- a/Ryujinx.Memory/IVirtualMemoryManager.cs
+++ b/Ryujinx.Memory/IVirtualMemoryManager.cs
@@ -62,6 +62,7 @@ namespace Ryujinx.Memory
         /// Writes data to the application process, returning false if the data was not changed.
         /// This triggers read memory tracking, as a redundancy check would be useless if the data is not up to date.
         /// </summary>
+        /// <remarks>The memory manager can return that memory has changed when it hasn't to avoid expensive data copies.</remarks>
         /// <param name="va">Virtual address to write the data into</param>
         /// <param name="data">Data to be written</param>
         /// <exception cref="InvalidMemoryRegionException">Throw for unhandled invalid or unmapped memory accesses</exception>


### PR DESCRIPTION
Benefits:
- Reduces number of buffer uploads greatly in certain games (4096 byte cost each time)
- Avoids splitting render pass on Vulkan (cost depends on GPU driver)
- Batches adjacent ConstantBufferUpdater (CBU) writes into one access, reduces number of memory manager calls.

Downsides:
- Check/triggers read tracking for upload regions (slightly slower)
- Can be slow in software memory if range is non-contigous (forces redundant update anyways)
  - The redundancy check method says that it can return true if checking would be too slow, and that's what it does in this case. Allocating and filling an array with the non-contiguous regions would be a lot slower than just saying the write happened.
- Upload must be flushed by potential users (could be buggy if a case is missed)

This has a lot of potential to break things since it moves the actual data upload to the flush method. This is to avoid performing the redundancy check per-integer for certain uploads. Hopefully we should flush before everything that can reasonably read CBU output.

Improves performance in Xenoblade Chronicles: Definitive Edition (Vulkan, note there is another issue here) and Link's Awakening. May very slightly reduce performance in games that do CBU that is not redundant, and are pegged at 99% FIFO.

This one is dangerous, so check with as many games and different engines as you can.