### PR TITLE
Fix VertexId and InstanceId on Vulkan

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 3807;
+        private const uint CodeGenVersion = 3833;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
@@ -48,6 +48,10 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
             { AttributeConsts.TessCoordY,    new BuiltInAttribute("gl_TessCoord.y",     VariableType.F32)  },
             { AttributeConsts.InstanceId,    new BuiltInAttribute("gl_InstanceID",      VariableType.S32)  },
             { AttributeConsts.VertexId,      new BuiltInAttribute("gl_VertexID",        VariableType.S32)  },
+            { AttributeConsts.BaseInstance,  new BuiltInAttribute("gl_BaseInstance",    VariableType.S32)  },
+            { AttributeConsts.BaseVertex,    new BuiltInAttribute("gl_BaseVertex",      VariableType.S32)  },
+            { AttributeConsts.InstanceIndex, new BuiltInAttribute("gl_InstanceIndex",   VariableType.S32)  },
+            { AttributeConsts.VertexIndex,   new BuiltInAttribute("gl_VertexIndex",     VariableType.S32)  },
             { AttributeConsts.FrontFacing,   new BuiltInAttribute("gl_FrontFacing",     VariableType.Bool) },
 
             // Special.

--- a/Ryujinx.Graphics.Shader/CodeGen/Spirv/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Spirv/Declarations.cs
@@ -704,8 +704,12 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
                 AttributeConsts.ClipDistance0 => BuiltIn.ClipDistance,
                 AttributeConsts.PointCoordX => BuiltIn.PointCoord,
                 AttributeConsts.TessCoordX => BuiltIn.TessCoord,
-                AttributeConsts.InstanceId => BuiltIn.InstanceId, // FIXME: Invalid
-                AttributeConsts.VertexId => BuiltIn.VertexId, // FIXME: Invalid
+                AttributeConsts.InstanceId => BuiltIn.InstanceId,
+                AttributeConsts.VertexId => BuiltIn.VertexId,
+                AttributeConsts.BaseInstance => BuiltIn.BaseInstance,
+                AttributeConsts.BaseVertex => BuiltIn.BaseVertex,
+                AttributeConsts.InstanceIndex => BuiltIn.InstanceIndex,
+                AttributeConsts.VertexIndex => BuiltIn.VertexIndex,
                 AttributeConsts.FrontFacing => BuiltIn.FrontFacing,
                 AttributeConsts.FragmentOutputDepth => BuiltIn.FragDepth,
                 AttributeConsts.ThreadKill => BuiltIn.HelperInvocation,

--- a/Ryujinx.Graphics.Shader/Instructions/InstEmitAttribute.cs
+++ b/Ryujinx.Graphics.Shader/Instructions/InstEmitAttribute.cs
@@ -51,7 +51,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
                         offset |= AttributeConsts.LoadOutputMask;
                     }
 
-                    Operand src = op.P ? AttributePerPatch(offset) : Attribute(offset);
+                    Operand src = op.P ? AttributePerPatch(offset) : CreateInputAttribute(context, offset);
 
                     context.Copy(Register(rd), src);
                 }
@@ -311,6 +311,23 @@ namespace Ryujinx.Graphics.Shader.Instructions
             }
 
             return attr;
+        }
+
+        private static Operand CreateInputAttribute(EmitterContext context, int attr)
+        {
+            if (context.Config.Options.TargetApi == TargetApi.Vulkan)
+            {
+                if (attr == AttributeConsts.InstanceId)
+                {
+                    return context.ISubtract(Attribute(AttributeConsts.InstanceIndex), Attribute(AttributeConsts.BaseInstance));
+                }
+                else if (attr == AttributeConsts.VertexId)
+                {
+                    return Attribute(AttributeConsts.VertexIndex);
+                }
+            }
+
+            return Attribute(attr);
         }
     }
 }

--- a/Ryujinx.Graphics.Shader/Translation/AttributeConsts.cs
+++ b/Ryujinx.Graphics.Shader/Translation/AttributeConsts.cs
@@ -95,5 +95,10 @@ namespace Ryujinx.Graphics.Shader.Translation
         public const int LtMask = 0x2000040;
 
         public const int ThreadKill = 0x2000044;
+
+        public const int BaseInstance = 0x2000050;
+        public const int BaseVertex = 0x2000054;
+        public const int InstanceIndex = 0x2000058;
+        public const int VertexIndex = 0x200005c;
     }
 }

--- a/Ryujinx.Graphics.Shader/Translation/AttributeInfo.cs
+++ b/Ryujinx.Graphics.Shader/Translation/AttributeInfo.cs
@@ -27,6 +27,10 @@ namespace Ryujinx.Graphics.Shader.Translation
             { AttributeConsts.TessCoordY,    new AttributeInfo(AttributeConsts.TessCoordX,    1, 3, AggregateType.Vector | AggregateType.FP32) },
             { AttributeConsts.InstanceId,    new AttributeInfo(AttributeConsts.InstanceId,    0, 1, AggregateType.S32) },
             { AttributeConsts.VertexId,      new AttributeInfo(AttributeConsts.VertexId,      0, 1, AggregateType.S32) },
+            { AttributeConsts.BaseInstance,  new AttributeInfo(AttributeConsts.BaseInstance,  0, 1, AggregateType.S32) },
+            { AttributeConsts.BaseVertex,    new AttributeInfo(AttributeConsts.BaseVertex,    0, 1, AggregateType.S32) },
+            { AttributeConsts.InstanceIndex, new AttributeInfo(AttributeConsts.InstanceIndex, 0, 1, AggregateType.S32) },
+            { AttributeConsts.VertexIndex,   new AttributeInfo(AttributeConsts.VertexIndex,   0, 1, AggregateType.S32) },
             { AttributeConsts.FrontFacing,   new AttributeInfo(AttributeConsts.FrontFacing,   0, 1, AggregateType.Bool) },
 
             // Special.


### PR DESCRIPTION
`gl_VertexId`  and `gl_InstanceID` are only valid on OpenGL. On Vulkan, `gl_InstanceIndex` should be used instead. However, there's a difference between the two. `gl_InstanceIndex` includes the `gl_BaseInstance` while `gl_InstanceID` doesn't. So this code replaces `gl_InstanceID` with `gl_InstanceID - gl_BaseInstance`, and `gl_VertexID` with `gl_VertexIndex` (the two should be equivalent).

The old approach was already working fine on NVIDIA, but not Intel.
Fixes incorrect rendering on games using `gl_InstanceID` on the shader and instanced draw with non-zero base instance on Intel.
Before:
![image](https://user-images.githubusercontent.com/5624669/201275349-524d331c-49a1-4e7f-832b-7ef5058ae4f7.png)
After:
![image](https://user-images.githubusercontent.com/5624669/201275367-a70c2498-6ae3-48c3-9812-f9395fcee552.png)

Other games that are likely affected are Sniper Elite 3, Metro 2033 Redux, and others, but I didn't test those.
I don't know if the issue affects AMD.
Testing is welcome.