### PR TITLE
GTK: It's REE-YOU-JINX

### DIFF
--- a/Ryujinx/Ui/Windows/AboutWindow.Designer.cs
+++ b/Ryujinx/Ui/Windows/AboutWindow.Designer.cs
@@ -113,7 +113,7 @@ namespace Ryujinx.Ui.Windows
             //
             // _ryujinxPhoneticLabel
             //
-            _ryujinxPhoneticLabel = new Label("(REE-YOU-JI-NX)")
+            _ryujinxPhoneticLabel = new Label("(REE-YOU-JINX)")
             {
                 Justify = Justification.Center
             };


### PR DESCRIPTION
Avalonia's _About_ section and the main website already list the phonetically recommended pronunciation of Ryujinx to be REE-YOU-JINX. GTK still has the old and busted REE-YOU-JI-NX (whose pronunciation is anyone's guess).

This PR aligns GTK with reality.

Before:
![image](https://user-images.githubusercontent.com/62343878/201447233-1feea90e-dfa7-4345-bfdc-e9ad29f4a012.png)


After:
![image](https://user-images.githubusercontent.com/62343878/201447209-d253723c-6c0c-4f1d-8f52-45b353f074cd.png)

