### PR TITLE
Use new LINQ Order() methods

### DIFF
--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
@@ -520,7 +520,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
         private static void DeclareInputAttributesPerPatch(CodeGenContext context, HashSet<int> attrs)
         {
-            foreach (int attr in attrs.OrderBy(x => x))
+            foreach (int attr in attrs.Order())
             {
                 DeclareInputAttributePerPatch(context, attr);
             }
@@ -653,7 +653,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
         private static void DeclareUsedOutputAttributesPerPatch(CodeGenContext context, HashSet<int> attrs)
         {
-            foreach (int attr in attrs.OrderBy(x => x))
+            foreach (int attr in attrs.Order())
             {
                 DeclareOutputAttributePerPatch(context, attr);
             }

--- a/Ryujinx.Graphics.Shader/Translation/Translator.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Translator.cs
@@ -206,7 +206,7 @@ namespace Ryujinx.Graphics.Shader.Translation
 
             if (context.Config.NextUsedInputAttributesPerPatch != null)
             {
-                foreach (int vecIndex in context.Config.NextUsedInputAttributesPerPatch.OrderBy(x => x))
+                foreach (int vecIndex in context.Config.NextUsedInputAttributesPerPatch.Order())
                 {
                     InitializeOutput(context, AttributeConsts.UserAttributePerPatchBase + vecIndex * 16, perPatch: true);
                 }


### PR DESCRIPTION
Replace usage of OrderBy(x => x) with Order()
[Introduced in .NET 7](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.order?view=net-7.0#system-linq-enumerable-order-1(system-collections-generic-ienumerable((-0))))
A bit faster and less allocations.