### PR TITLE
Capitalization to be consistent

### DIFF
--- a/Ryujinx.Cpu/IExecutionContext.cs
+++ b/Ryujinx.Cpu/IExecutionContext.cs
@@ -27,7 +27,7 @@ namespace Ryujinx.Cpu
         long TpidrroEl0 { get; set; }
 
         /// <summary>
-        /// Processor State register.
+        /// Processor State Register.
         /// </summary>
         uint Pstate { get; set; }
 


### PR DESCRIPTION
Thread ID Register, Floating-point Control Register, and Floating-point Status Register all had Register capitalized, so the Register in Processor State register should be capitalized.