### PR TITLE
Vulkan: Don't create preload command buffer outside a render pass

### DIFF
--- a/Ryujinx.Graphics.Vulkan/BufferHolder.cs
+++ b/Ryujinx.Graphics.Vulkan/BufferHolder.cs
@@ -210,7 +210,7 @@ namespace Ryujinx.Graphics.Vulkan
                 }
             }
 
-            if (cbs != null && !(_buffer.HasCommandBufferDependency(cbs.Value) && _waitable.IsBufferRangeInUse(cbs.Value.CommandBufferIndex, offset, dataSize)))
+            if (cbs != null && _gd.PipelineInternal.RenderPassActive && !(_buffer.HasCommandBufferDependency(cbs.Value) && _waitable.IsBufferRangeInUse(cbs.Value.CommandBufferIndex, offset, dataSize)))
             {
                 // If the buffer hasn't been used on the command buffer yet, try to preload the data.
                 // This avoids ending and beginning render passes on each buffer data upload.

--- a/Ryujinx.Graphics.Vulkan/BufferHolder.cs
+++ b/Ryujinx.Graphics.Vulkan/BufferHolder.cs
@@ -210,7 +210,10 @@ namespace Ryujinx.Graphics.Vulkan
                 }
             }
 
-            if (cbs != null && _gd.PipelineInternal.RenderPassActive && !(_buffer.HasCommandBufferDependency(cbs.Value) && _waitable.IsBufferRangeInUse(cbs.Value.CommandBufferIndex, offset, dataSize)))
+            if (cbs != null &&
+                _gd.PipelineInternal.RenderPassActive &&
+                !(_buffer.HasCommandBufferDependency(cbs.Value) &&
+                _waitable.IsBufferRangeInUse(cbs.Value.CommandBufferIndex, offset, dataSize)))
             {
                 // If the buffer hasn't been used on the command buffer yet, try to preload the data.
                 // This avoids ending and beginning render passes on each buffer data upload.

--- a/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
+++ b/Ryujinx.Graphics.Vulkan/ShaderCollection.cs
@@ -19,6 +19,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         public bool HasMinimalLayout { get; }
         public bool UsePushDescriptors { get; }
+        public bool IsCompute { get; }
 
         public uint Stages { get; }
 
@@ -47,7 +48,6 @@ namespace Ryujinx.Graphics.Vulkan
         private VulkanRenderer _gd;
         private Device _device;
         private bool _initialized;
-        private bool _isCompute;
 
         private ProgramPipelineState _state;
         private DisposableRenderPass _dummyRenderPass;
@@ -91,7 +91,7 @@ namespace Ryujinx.Graphics.Vulkan
 
                 if (shader.StageFlags == ShaderStageFlags.ShaderStageComputeBit)
                 {
-                    _isCompute = true;
+                    IsCompute = true;
                 }
 
                 internalShaders[i] = shader;
@@ -163,7 +163,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             try
             {
-                if (_isCompute)
+                if (IsCompute)
                 {
                     CreateBackgroundComputePipeline();
                 }


### PR DESCRIPTION
The preload command buffer is used to avoid render pass splits and barriers when updating buffer data. However, when a render pass is not active (for example, at the start of a command buffer, or during compute invocations) buffer uploads can be performed at any time, so the optimization isn't as useful.

This PR makes it so that the preload command buffer is only used for buffer updates outside of a render pass. It's still used for textures as I don't want to shake things up right now regarding how the preload buffer is obtained before some other changes, and texture updates are a lot rarer anyways.

This also immediately ends the render pass when switching to a compute shader.

Improves performance slightly in Pokemon Scarlet/Violet (43 -> 48), as it was switching to compute, writing a bunch of buffers inline, then dispatching, then flushing commands... It uses 1 command buffer instead of 2 every time it does this now. Maybe it would be nice to find a faster way to sync without creating so many command buffers in a short period of time.