### PR TITLE
Vulkan: Clear dummy texture to (0,0,0,0) on creation

### DIFF
--- a/Ryujinx.Graphics.Vulkan/DescriptorSetUpdater.cs
+++ b/Ryujinx.Graphics.Vulkan/DescriptorSetUpdater.cs
@@ -130,6 +130,12 @@ namespace Ryujinx.Graphics.Vulkan
                 1f));
         }
 
+        public void Initialize()
+        {
+            Span<byte> dummyTextureData = stackalloc byte[4];
+            _dummyTexture.SetData(dummyTextureData);
+        }
+
         public void SetProgram(ShaderCollection program)
         {
             _program = program;

--- a/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -114,6 +114,8 @@ namespace Ryujinx.Graphics.Vulkan
 
         public void Initialize()
         {
+            _descriptorSetUpdater.Initialize();
+
             SupportBufferUpdater = new SupportBufferUpdater(Gd);
             SupportBufferUpdater.UpdateRenderScale(_renderScale, 0, SupportBuffer.RenderScaleMaxCount);
 


### PR DESCRIPTION
This might fix an issue with AMD gpus on linux where the data could contain random garbage. On the switch, it always samples as 0.

Or so I think. Needs testing.