### PR TITLE
Fix shader cache on Vulkan when geometry shaders are inserted

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 3866;
+        private const uint CodeGenVersion = 3868;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";
@@ -379,7 +379,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
 
                             if (context.Capabilities.Api == TargetApi.Vulkan)
                             {
-                                ShaderSource[] shaderSources = ShaderBinarySerializer.Unpack(shaders, hostCode, isCompute);
+                                ShaderSource[] shaderSources = ShaderBinarySerializer.Unpack(shaders, hostCode);
 
                                 hostProgram = context.Renderer.CreateProgram(shaderSources, shaderInfo);
                             }


### PR DESCRIPTION
This is a continuation of #3866, which added a workaround for `gl_Layer` on Vulkan for older GPUs, but it has one issue when loading the shader cache, because right now the shader cache assumes that there will be one SPIR-V shader for each guest shader stage, however this is not the case with the workaround since we need to insert a geometry shader  that didn't originally exist. This PR modifies the host shader save/load to take that into account. It now saves the shader stage type and stages count aswell, instead of assuming its the same as the guest code.

Fixes a crash when loading the shader cache on Vulkan on the affected GPUs on Pokémon Scarlet/Violet.

This is a general change on the shader cache so testing on any GPU is appreciated to ensure there's no regressions on Vulkan. OpenGL should be unaffected.