### PR TITLE
Add DRAM expansion launch warning

### DIFF
--- a/Ryujinx.Ava/Assets/Locales/en_US.json
+++ b/Ryujinx.Ava/Assets/Locales/en_US.json
@@ -596,5 +596,5 @@
   "SettingsEnableMacroHLE": "Enable Macro HLE",
   "SettingsEnableMacroHLETooltip": "High-level emulation of GPU Macro code.\n\nImproves performance, but may cause graphical glitches in some games.\n\nLeave ON if unsure.",
   "DialogPerformanceCheckExpandDramEnabledMessage": "You have DRAM expansion enabled, which is designed to be used for 4K game-mods ONLY.",
-  "DialogPerformanceCheckExpandDramEnabledConfirmMessage": "This setting is known to cause crashes and instability. If you are unsure if you need this, then you don't. Would you like to disable DRAM expansion now?"
+  "DialogPerformanceCheckExpandDramEnabledConfirmMessage": "This setting, when enabled, is currently known to cause crashes and instability in some games. If you are unsure whether you need this option, leave it disabled. Disable DRAM expansion now?"
 }

--- a/Ryujinx.Ava/Assets/Locales/en_US.json
+++ b/Ryujinx.Ava/Assets/Locales/en_US.json
@@ -594,5 +594,7 @@
   "SettingsTabHotkeysVolumeDownHotkey": "Decrease Volume:",
   "VolumeShort": "Vol",
   "SettingsEnableMacroHLE": "Enable Macro HLE",
-  "SettingsEnableMacroHLETooltip": "High-level emulation of GPU Macro code.\n\nImproves performance, but may cause graphical glitches in some games.\n\nLeave ON if unsure."
+  "SettingsEnableMacroHLETooltip": "High-level emulation of GPU Macro code.\n\nImproves performance, but may cause graphical glitches in some games.\n\nLeave ON if unsure.",
+  "DialogPerformanceCheckExpandDramEnabledMessage": "You have DRAM expansion enabled, which is designed to be used for 4K game-mods ONLY.",
+  "DialogPerformanceCheckExpandDramEnabledConfirmMessage": "This setting is known to cause crashes and instability. If you are unsure if you need this, then you don't. Would you like to disable DRAM expansion now?"
 }

--- a/Ryujinx.Ava/Ui/ViewModels/SettingsViewModel.cs
+++ b/Ryujinx.Ava/Ui/ViewModels/SettingsViewModel.cs
@@ -132,6 +132,7 @@ namespace Ryujinx.Ava.Ui.ViewModels
         public bool EnableFsIntegrityChecks { get; set; }
         public bool IgnoreMissingServices { get; set; }
         public bool ExpandDramSize { get; set; }
+        public bool ConfirmedDramWarning { get; set; }
         public bool EnableShaderCache { get; set; }
         public bool EnableTextureRecompression { get; set; }
         public bool EnableMacroHLE { get; set; }
@@ -334,6 +335,7 @@ namespace Ryujinx.Ava.Ui.ViewModels
             EnableFsIntegrityChecks = config.System.EnableFsIntegrityChecks;
             IgnoreMissingServices = config.System.IgnoreMissingServices;
             ExpandDramSize = config.System.ExpandRam;
+            ConfirmedDramWarning = config.System.ConfirmedDramWarning;
             EnableShaderCache = config.Graphics.EnableShaderCache;
             EnableTextureRecompression = config.Graphics.EnableTextureRecompression;
             EnableMacroHLE = config.Graphics.EnableMacroHLE;
@@ -427,6 +429,7 @@ namespace Ryujinx.Ava.Ui.ViewModels
             config.System.EnableFsIntegrityChecks.Value = EnableFsIntegrityChecks;
             config.System.IgnoreMissingServices.Value = IgnoreMissingServices;
             config.System.ExpandRam.Value = ExpandDramSize;
+            config.System.ConfirmedDramWarning.Value = ConfirmedDramWarning;
             config.Hid.EnableKeyboard.Value = EnableKeyboard;
             config.Hid.EnableMouse.Value = EnableMouse;
             config.Ui.CustomThemePath.Value = CustomThemePath;

--- a/Ryujinx.Ava/Ui/Windows/MainWindow.axaml.cs
+++ b/Ryujinx.Ava/Ui/Windows/MainWindow.axaml.cs
@@ -199,6 +199,23 @@ namespace Ryujinx.Ava.Ui.Windows
                     SaveConfig();
                 }
             }
+
+            if (ConfigurationState.Instance.System.ExpandRam.Value)
+            {
+                string mainMessage = LocaleManager.Instance["DialogPerformanceCheckExpandDramEnabledMessage"];
+                string secondaryMessage = LocaleManager.Instance["DialogPerformanceCheckExpandDramEnabledConfirmMessage"];
+
+                UserResult result = await ContentDialogHelper.CreateConfirmationDialog(mainMessage, secondaryMessage,
+                    LocaleManager.Instance["InputDialogYes"], LocaleManager.Instance["InputDialogNo"],
+                    LocaleManager.Instance["RyujinxConfirm"]);
+
+                if (result != UserResult.No)
+                {
+                    ConfigurationState.Instance.System.ExpandRam.Value = false;
+
+                    SaveConfig();
+                }
+            }
         }
 
         internal static void DeferLoadApplication(string launchPathArg, bool startFullscreenArg)

--- a/Ryujinx.Ava/Ui/Windows/MainWindow.axaml.cs
+++ b/Ryujinx.Ava/Ui/Windows/MainWindow.axaml.cs
@@ -200,7 +200,7 @@ namespace Ryujinx.Ava.Ui.Windows
                 }
             }
 
-            if (ConfigurationState.Instance.System.ExpandRam.Value)
+            if (ConfigurationState.Instance.System.ExpandRam.Value && !ConfigurationState.Instance.System.ConfirmedDramWarning.Value)
             {
                 string mainMessage = LocaleManager.Instance["DialogPerformanceCheckExpandDramEnabledMessage"];
                 string secondaryMessage = LocaleManager.Instance["DialogPerformanceCheckExpandDramEnabledConfirmMessage"];
@@ -212,6 +212,12 @@ namespace Ryujinx.Ava.Ui.Windows
                 if (result != UserResult.No)
                 {
                     ConfigurationState.Instance.System.ExpandRam.Value = false;
+
+                    SaveConfig();
+                }
+                else
+                {
+                    ConfigurationState.Instance.System.ConfirmedDramWarning.Value = true;
 
                     SaveConfig();
                 }

--- a/Ryujinx.Ui.Common/Configuration/ConfigurationFileFormat.cs
+++ b/Ryujinx.Ui.Common/Configuration/ConfigurationFileFormat.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.Ui.Common.Configuration
         /// <summary>
         /// The current version of the file format
         /// </summary>
-        public const int CurrentVersion = 42;
+        public const int CurrentVersion = 43;
 
         /// <summary>
         /// Version of the configuration file format
@@ -210,6 +210,11 @@ namespace Ryujinx.Ui.Common.Configuration
         /// Expands the RAM amount on the emulated system from 4GiB to 6GiB
         /// </summary>
         public bool ExpandRam { get; set; }
+
+        /// <summary>
+        /// Used to check if the user has previously ignored the DRAM warning
+        /// </summary>
+        public bool ConfirmedDramWarning { get; set; }
 
         /// <summary>
         /// Enable or disable ignoring missing services

--- a/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
+++ b/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
@@ -297,6 +297,11 @@ namespace Ryujinx.Ui.Common.Configuration
             public ReactiveObject<bool> ExpandRam { get; private set; }
 
             /// <summary>
+            /// Used to check if the user has previously ignored the DRAM warning
+            /// </summary>
+            public ReactiveObject<bool> ConfirmedDramWarning { get; private set; }
+
+            /// <summary>
             /// Enable or disable ignoring missing services
             /// </summary>
             public ReactiveObject<bool> IgnoreMissingServices { get; private set; }
@@ -323,6 +328,8 @@ namespace Ryujinx.Ui.Common.Configuration
                 MemoryManagerMode.Event       += static (sender, e) => LogValueChange(sender, e, nameof(MemoryManagerMode));
                 ExpandRam                     = new ReactiveObject<bool>();
                 ExpandRam.Event               += static (sender, e) => LogValueChange(sender, e, nameof(ExpandRam));
+                ConfirmedDramWarning          = new ReactiveObject<bool>();
+                ConfirmedDramWarning.Event    += static (sender, e) => LogValueChange(sender, e, nameof(ConfirmedDramWarning));
                 IgnoreMissingServices         = new ReactiveObject<bool>();
                 IgnoreMissingServices.Event   += static (sender, e) => LogValueChange(sender, e, nameof(IgnoreMissingServices));
                 AudioVolume                   = new ReactiveObject<float>();
@@ -565,6 +572,7 @@ namespace Ryujinx.Ui.Common.Configuration
                 AudioVolume                = System.AudioVolume,
                 MemoryManagerMode          = System.MemoryManagerMode,
                 ExpandRam                  = System.ExpandRam,
+                ConfirmedDramWarning       = System.ConfirmedDramWarning,
                 IgnoreMissingServices      = System.IgnoreMissingServices,
                 GuiColumns                 = new GuiColumns
                 {
@@ -651,6 +659,7 @@ namespace Ryujinx.Ui.Common.Configuration
             System.AudioVolume.Value                  = 1;
             System.MemoryManagerMode.Value            = MemoryManagerMode.HostMappedUnsafe;
             System.ExpandRam.Value                    = false;
+            System.ConfirmedDramWarning.Value         = false;
             System.IgnoreMissingServices.Value        = false;
             Ui.GuiColumns.FavColumn.Value             = true;
             Ui.GuiColumns.IconColumn.Value            = true;
@@ -1192,6 +1201,14 @@ namespace Ryujinx.Ui.Common.Configuration
                 configurationFileFormat.EnableMacroHLE = true;
             }
 
+            if (configurationFileFormat.Version < 43)
+            {
+                Ryujinx.Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 43.");
+
+                configurationFileFormat.ExpandRam = false;
+                configurationFileFormat.ConfirmedDramWarning = false;
+            }
+
             Logger.EnableFileLog.Value                = configurationFileFormat.EnableFileLog;
             Graphics.ResScale.Value                   = configurationFileFormat.ResScale;
             Graphics.ResScaleCustom.Value             = configurationFileFormat.ResScaleCustom;
@@ -1232,6 +1249,7 @@ namespace Ryujinx.Ui.Common.Configuration
             System.AudioVolume.Value                  = configurationFileFormat.AudioVolume;
             System.MemoryManagerMode.Value            = configurationFileFormat.MemoryManagerMode;
             System.ExpandRam.Value                    = configurationFileFormat.ExpandRam;
+            System.ConfirmedDramWarning.Value         = configurationFileFormat.ConfirmedDramWarning;
             System.IgnoreMissingServices.Value        = configurationFileFormat.IgnoreMissingServices;
             Ui.GuiColumns.FavColumn.Value             = configurationFileFormat.GuiColumns.FavColumn;
             Ui.GuiColumns.IconColumn.Value            = configurationFileFormat.GuiColumns.IconColumn;

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -684,7 +684,7 @@ namespace Ryujinx.Ui
                 shadersDumpWarningDialog.Dispose();
             }
 
-            if (ConfigurationState.Instance.System.ExpandRam.Value)
+            if (ConfigurationState.Instance.System.ExpandRam.Value && !ConfigurationState.Instance.System.ConfirmedDramWarning.Value)
             {
                 MessageDialog dramWarningDialog = new MessageDialog(this, DialogFlags.Modal, MessageType.Warning, ButtonsType.YesNo, null)
                 {
@@ -696,6 +696,11 @@ namespace Ryujinx.Ui
                 if (dramWarningDialog.Run() == (int)ResponseType.Yes)
                 {
                     ConfigurationState.Instance.System.ExpandRam.Value = false;
+                    SaveConfig();
+                }
+                else
+                {
+                    ConfigurationState.Instance.System.ConfirmedDramWarning.Value = true;
                     SaveConfig();
                 }
 

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -683,6 +683,24 @@ namespace Ryujinx.Ui
 
                 shadersDumpWarningDialog.Dispose();
             }
+
+            if (ConfigurationState.Instance.System.ExpandRam.Value)
+            {
+                MessageDialog dramWarningDialog = new MessageDialog(this, DialogFlags.Modal, MessageType.Warning, ButtonsType.YesNo, null)
+                {
+                    Title         = "Ryujinx - Warning",
+                    Text          = "You have DRAM expansion enabled, which is designed to be used for 4K game-mods ONLY.",
+                    SecondaryText = "This setting is known to cause crashes and instability. If you are unsure if you need this, then you don't. Would you like to disable DRAM expansion now?"
+                };
+
+                if (dramWarningDialog.Run() == (int)ResponseType.Yes)
+                {
+                    ConfigurationState.Instance.System.ExpandRam.Value = false;
+                    SaveConfig();
+                }
+
+                dramWarningDialog.Dispose();
+            }
         }
 
         public void LoadApplication(string path, bool startFullscreen = false)

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -690,7 +690,7 @@ namespace Ryujinx.Ui
                 {
                     Title         = "Ryujinx - Warning",
                     Text          = "You have DRAM expansion enabled, which is designed to be used for 4K game-mods ONLY.",
-                    SecondaryText = "This setting is known to cause crashes and instability. If you are unsure if you need this, then you don't. Would you like to disable DRAM expansion now?"
+                    SecondaryText = "This setting, when enabled, is currently known to cause crashes and instability in some games. If you are unsure whether you need this option, leave it disabled. Disable DRAM expansion now?"
                 };
 
                 if (dramWarningDialog.Run() == (int)ResponseType.Yes)


### PR DESCRIPTION
Self-explanatory. Setting currently causes some titles to crash on launch, causing a lot of un-needed support requests.
Can potentially be reverted when #3314 is resolved.
![image](https://user-images.githubusercontent.com/44103205/202858079-0eb024ba-441c-45ee-b9e0-23c03c8468c7.png)
