### PR TITLE
Unsubscribe MemoryUnmappedHandler even when GPU channel is destroyed

### DIFF
--- a/Ryujinx.Graphics.Gpu/GpuChannel.cs
+++ b/Ryujinx.Graphics.Gpu/GpuChannel.cs
@@ -133,6 +133,7 @@ namespace Ryujinx.Graphics.Gpu
             {
                 oldMemoryManager.Physical.BufferCache.NotifyBuffersModified -= BufferManager.Rebind;
                 oldMemoryManager.Physical.DecrementReferenceCount();
+                oldMemoryManager.MemoryUnmapped -= MemoryUnmappedHandler;
             }
         }
     }


### PR DESCRIPTION
Event was not being unsubscribed which was causing NRE if any map or unmap operation was done after the GPU channel is destroyed since #3862. Only affects games that uses multiple GPU channels. Should fix #3871 but I did not test this particular game, so would be nice to get tests on this game.