### PR TITLE
Do not update shader state for DrawTextures

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
@@ -372,7 +372,9 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             float srcX1 = ((float)_state.State.DrawTextureDuDx / (1UL << 32)) * dstWidth + srcX0;
             float srcY1 = ((float)_state.State.DrawTextureDvDy / (1UL << 32)) * dstHeight + srcY0;
 
-            engine.UpdateState();
+            engine.UpdateState(ulong.MaxValue & ~(1UL << StateUpdater.ShaderStateIndex));
+
+            _channel.TextureManager.UpdateRenderTargets();
 
             int textureId = _state.State.DrawTextureTextureId;
             int samplerId = _state.State.DrawTextureSamplerId;


### PR DESCRIPTION
`DrawTextures` is a bit weird because it behaves like a draw, but it's actually more like a blit. It does not use any shader, so we don't need to update the shader state for this operation. Updating shader state was causing problems because it could be in a invalid state, which would cause exceptions on the shader translator when processing the shader (as it would be working with a completely invalid shader).

This fixes a crash in A Hat in Time depending on where you are in the game. I'm not sure if the crash happens on OpenGL since it's possible that the translator would just generate a broken GLSL shader without throwing. But I can confirm the issue on Vulkan (`System.ArgumentException: Invalid shader stage "15".`), which is fixed by this PR.