### PR TITLE
Update to LibHac 0.17.0

### DIFF
--- a/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
+++ b/Ryujinx.HLE/FileSystem/VirtualFileSystem.cs
@@ -172,9 +172,11 @@ namespace Ryujinx.HLE.FileSystem
             fsServerClient = horizon.CreatePrivilegedHorizonClient();
             var fsServer = new FileSystemServer(fsServerClient);
 
-            DefaultFsServerObjects fsServerObjects = DefaultFsServerObjects.GetDefaultEmulatedCreators(serverBaseFs, KeySet, fsServer);
+            RandomDataGenerator randomGenerator = buffer => Random.Shared.NextBytes(buffer);
 
-            // Use our own encrypted fs creator that always uses all-zero keys
+            DefaultFsServerObjects fsServerObjects = DefaultFsServerObjects.GetDefaultEmulatedCreators(serverBaseFs, KeySet, fsServer, randomGenerator);
+
+            // Use our own encrypted fs creator that doesn't actually do any encryption
             fsServerObjects.FsCreators.EncryptedFileSystemCreator = new EncryptedFileSystemCreator();
 
             GameCard = fsServerObjects.GameCard;
@@ -186,7 +188,8 @@ namespace Ryujinx.HLE.FileSystem
             {
                 DeviceOperator = fsServerObjects.DeviceOperator,
                 ExternalKeySet = KeySet.ExternalKeySet,
-                FsCreators = fsServerObjects.FsCreators
+                FsCreators = fsServerObjects.FsCreators,
+                RandomGenerator = randomGenerator
             };
 
             FileSystemServerInitializer.InitializeWithConfig(fsServerClient, fsServer, fsServerConfig);

--- a/Ryujinx.HLE/HOS/ApplicationLoader.cs
+++ b/Ryujinx.HLE/HOS/ApplicationLoader.cs
@@ -850,7 +850,7 @@ namespace Ryujinx.HLE.HOS
             for (int i = 0; i < programCount; i++)
             {
                 mapInfo[i].ProgramId = new ProgramId(applicationId + (uint)i);
-                mapInfo[i].MainProgramId = new ProgramId(applicationId);
+                mapInfo[i].MainProgramId = new ApplicationId(applicationId);
                 mapInfo[i].ProgramIndex = (byte)i;
             }
 

--- a/Ryujinx.HLE/HOS/Services/Fs/IDeviceOperator.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/IDeviceOperator.cs
@@ -1,6 +1,7 @@
 ﻿using LibHac;
 using LibHac.Common;
-using LibHac.Fs;
+
+using GameCardHandle = System.UInt32;
 
 namespace Ryujinx.HLE.HOS.Services.Fs
 {
@@ -41,7 +42,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
         {
             Result result = _baseOperator.Get.GetGameCardHandle(out GameCardHandle handle);
 
-            context.ResponseData.Write(handle.Value);
+            context.ResponseData.Write(handle);
 
             return (ResultCode)result.Value;
         }

--- a/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
@@ -19,6 +19,7 @@ using static Ryujinx.HLE.Utilities.StringUtils;
 using IFileSystem = LibHac.FsSrv.Sf.IFileSystem;
 using IStorage = LibHac.FsSrv.Sf.IStorage;
 using RightsId = LibHac.Fs.RightsId;
+using GameCardHandle = System.UInt32;
 
 namespace Ryujinx.HLE.HOS.Services.Fs
 {
@@ -239,7 +240,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
         // OpenGameCardStorage(u32 handle, u32 partitionId) -> object<nn::fssrv::sf::IStorage>
         public ResultCode OpenGameCardStorage(ServiceCtx context)
         {
-            GameCardHandle handle = new GameCardHandle(context.RequestData.ReadInt32());
+            GameCardHandle handle = context.RequestData.ReadUInt32();
             GameCardPartitionRaw partitionId = (GameCardPartitionRaw)context.RequestData.ReadInt32();
             using var storage = new SharedRef<IStorage>();
 
@@ -255,7 +256,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
         // OpenGameCardFileSystem(u32 handle, u32 partitionId) -> object<nn::fssrv::sf::IFileSystem>
         public ResultCode OpenGameCardFileSystem(ServiceCtx context)
         {
-            GameCardHandle handle = new GameCardHandle(context.RequestData.ReadInt32());
+            GameCardHandle handle = context.RequestData.ReadUInt32();
             GameCardPartition partitionId = (GameCardPartition)context.RequestData.ReadInt32();
             using var fileSystem = new SharedRef<IFileSystem>();
 
@@ -313,6 +314,17 @@ namespace Ryujinx.HLE.HOS.Services.Fs
             HashSalt hashSalt = context.RequestData.ReadStruct<HashSalt>();
 
             return (ResultCode)_baseFileSystemProxy.Get.CreateSaveDataFileSystemWithHashSalt(in attribute, in creationInfo, in metaCreateInfo, in hashSalt).Value;
+        }
+
+        [CommandHipc(37)] // 14.0.0+
+        // CreateSaveDataFileSystemWithCreationInfo2(buffer<nn::fs::SaveDataCreationInfo2, 25> creationInfo) -> ()
+        public ResultCode CreateSaveDataFileSystemWithCreationInfo2(ServiceCtx context)
+        {
+            byte[] creationInfoBuffer = new byte[context.Request.SendBuff[0].Size];
+            context.Memory.Read(context.Request.SendBuff[0].Position, creationInfoBuffer);
+            ref readonly SaveDataCreationInfo2 creationInfo = ref SpanHelpers.AsReadOnlyStruct<SaveDataCreationInfo2>(creationInfoBuffer);
+
+            return (ResultCode)_baseFileSystemProxy.Get.CreateSaveDataFileSystemWithCreationInfo2(in creationInfo).Value;
         }
 
         [CommandHipc(51)]

--- a/Ryujinx.HLE/Ryujinx.HLE.csproj
+++ b/Ryujinx.HLE/Ryujinx.HLE.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Concentus" Version="1.1.7" />
-    <PackageReference Include="LibHac" Version="0.16.1" />
+    <PackageReference Include="LibHac" Version="0.17.0" />
     <PackageReference Include="MsgPack.Cli" Version="1.0.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta11" />


### PR DESCRIPTION
- Remove some leftover debug code for `CompressedStorage`
- Add key sources for system version 15.0.0
- Update save data service functionality for changes in 14.0.0
- Implement the `CreateSaveDataFileSystemWithCreationInfo2` method in `IFileSystemProxy` introduced in 14.0.0
- Remove workaround that cleared the saves on the SD card when starting the emulator. Fixes #3800
- General system stability improvements to enhance the user's experience