### PR TITLE
GPU: Access non-prefetch command buffers directly

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoDevice.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoDevice.cs
@@ -223,7 +223,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
                 }
 
                 _currentCommandBuffer = entry;
-                ReadOnlySpan<int> words = _currentCommandBuffer.Fetch(entry.Processor.MemoryManager, flushCommandBuffer);
+                ReadOnlySpan<int> words = entry.Fetch(entry.Processor.MemoryManager, flushCommandBuffer);
 
                 // If we are changing the current channel,
                 // we need to force all the host state to be updated.

--- a/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoDevice.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoDevice.cs
@@ -79,12 +79,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
             /// <returns>The command buffer words</returns>
             public ReadOnlySpan<int> Fetch(MemoryManager memoryManager, bool flush)
             {
-                if (Words == null)
-                {
-                    return GetWords(memoryManager, flush);
-                }
-
-                return Words;
+                return Words ?? GetWords(memoryManager, flush);
             }
         }
 

--- a/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoDevice.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoDevice.cs
@@ -52,15 +52,39 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
             public uint EntryCount;
 
             /// <summary>
+            /// Get the entries for the command buffer from memory.
+            /// </summary>
+            /// <param name="memoryManager">The memory manager used to fetch the data</param>
+            /// <param name="flush">If true, flushes potential GPU written data before reading the command buffer</param>
+            /// <returns>The fetched data</returns>
+            private ReadOnlySpan<int> GetWords(MemoryManager memoryManager, bool flush)
+            {
+                return MemoryMarshal.Cast<byte, int>(memoryManager.GetSpan(EntryAddress, (int)EntryCount * 4, flush));
+            }
+
+            /// <summary>
+            /// Prefetch the command buffer.
+            /// </summary>
+            /// <param name="memoryManager">The memory manager used to fetch the data</param>
+            public void Prefetch(MemoryManager memoryManager)
+            {
+                Words = GetWords(memoryManager, true).ToArray();
+            }
+
+            /// <summary>
             /// Fetch the command buffer.
             /// </summary>
+            /// <param name="memoryManager">The memory manager used to fetch the data</param>
             /// <param name="flush">If true, flushes potential GPU written data before reading the command buffer</param>
-            public void Fetch(MemoryManager memoryManager, bool flush = true)
+            /// <returns>The command buffer words</returns>
+            public ReadOnlySpan<int> Fetch(MemoryManager memoryManager, bool flush)
             {
                 if (Words == null)
                 {
-                    Words = MemoryMarshal.Cast<byte, int>(memoryManager.GetSpan(EntryAddress, (int)EntryCount * 4, flush)).ToArray();
+                    return GetWords(memoryManager, flush);
                 }
+
+                return Words;
             }
         }
 
@@ -158,7 +182,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
 
                 if (beforeBarrier && commandBuffer.Type == CommandBufferType.Prefetch)
                 {
-                    commandBuffer.Fetch(processor.MemoryManager);
+                    commandBuffer.Prefetch(processor.MemoryManager);
                 }
 
                 if (commandBuffer.Type == CommandBufferType.NoPrefetch)
@@ -199,7 +223,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
                 }
 
                 _currentCommandBuffer = entry;
-                _currentCommandBuffer.Fetch(entry.Processor.MemoryManager, flushCommandBuffer);
+                ReadOnlySpan<int> words = _currentCommandBuffer.Fetch(entry.Processor.MemoryManager, flushCommandBuffer);
 
                 // If we are changing the current channel,
                 // we need to force all the host state to be updated.
@@ -209,7 +233,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
                     entry.Processor.ForceAllDirty();
                 }
 
-                entry.Processor.Process(entry.EntryAddress, _currentCommandBuffer.Words);
+                entry.Processor.Process(entry.EntryAddress, words);
             }
 
             _interrupt = false;


### PR DESCRIPTION
Saves allocating/copying new arrays for them constantly - they can be quite small so it can be very wasteful. About 0.4% of GPU thread in SMO, but was 2.24% in Pokemon S/V when I checked. I guess this will typically happen more when indirect draw macros are used. I didn't see it at all on SMO's title screen, for example.

Avoiding allocations on prefetch and the special pushes will be a bit harder due to pooling+copying having a cost of its own, and it might not be as effective since it's not done on that critical GPU thread, but an OS one. I left it out of this PR, though not without trying some things and being disappointed.

Assumes that non-prefetch command buffers won't be randomly clobbered before they finish executing, though that's probably a safe bet.