### PR TITLE
ava: Fix JsonSerializer warnings

### DIFF
--- a/Ryujinx.Ava/Common/Locale/LocaleManager.cs
+++ b/Ryujinx.Ava/Common/Locale/LocaleManager.cs
@@ -1,5 +1,6 @@
 ﻿using Ryujinx.Ava.Ui.ViewModels;
 using Ryujinx.Common;
+using Ryujinx.Common.Utilities;
 using Ryujinx.Ui.Common.Configuration;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -93,7 +94,7 @@ namespace Ryujinx.Ava.Common.Locale
                 return;
             }
 
-            var strings = JsonSerializer.Deserialize<Dictionary<string, string>>(languageJson);
+            var strings = JsonHelper.Deserialize<Dictionary<string, string>>(languageJson);
 
             foreach (var item in strings)
             {

--- a/Ryujinx.Ava/Ui/ViewModels/AmiiboWindowViewModel.cs
+++ b/Ryujinx.Ava/Ui/ViewModels/AmiiboWindowViewModel.cs
@@ -8,6 +8,7 @@ using Ryujinx.Ava.Ui.Models;
 using Ryujinx.Ava.Ui.Windows;
 using Ryujinx.Common;
 using Ryujinx.Common.Configuration;
+using Ryujinx.Common.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -189,7 +190,7 @@ namespace Ryujinx.Ava.Ui.ViewModels
             {
                 amiiboJsonString = File.ReadAllText(_amiiboJsonPath);
 
-                if (await NeedsUpdate(JsonSerializer.Deserialize<Amiibo.AmiiboJson>(amiiboJsonString).LastUpdated))
+                if (await NeedsUpdate(JsonHelper.Deserialize<Amiibo.AmiiboJson>(amiiboJsonString).LastUpdated))
                 {
                     amiiboJsonString = await DownloadAmiiboJson();
                 }
@@ -206,7 +207,7 @@ namespace Ryujinx.Ava.Ui.ViewModels
                 }
             }
 
-            _amiiboList = JsonSerializer.Deserialize<Amiibo.AmiiboJson>(amiiboJsonString).Amiibo;
+            _amiiboList = JsonHelper.Deserialize<Amiibo.AmiiboJson>(amiiboJsonString).Amiibo;
             _amiiboList = _amiiboList.OrderBy(amiibo => amiibo.AmiiboSeries).ToList();
 
             ParseAmiiboData();


### PR DESCRIPTION
Since we move to .NET7, JsonSerializer now needs to have explicit options as arguments, which leads to some warnings in Avalonia project. This is fixed by using our `JsonHelper` class.