### PR TITLE
ui: Fixes disposing on GTK/Avalonia and Firmware Messages on Avalonia

### DIFF
--- a/Ryujinx.Ava/AppHost.cs
+++ b/Ryujinx.Ava/AppHost.cs
@@ -420,7 +420,6 @@ namespace Ryujinx.Ava
         public async Task<bool> LoadGuestApplication()
         {
             InitializeSwitchInstance();
-
             MainWindow.UpdateGraphicsConfig();
 
             SystemVersion firmwareVersion = ContentManager.GetCurrentFirmwareVersion();
@@ -431,35 +430,25 @@ namespace Ryujinx.Ava
                 {
                     if (userError == UserError.NoFirmware)
                     {
-                        UserResult result = UserResult.None;
-
-                        Dispatcher.UIThread.Post(async () =>
-                        {
-                            string message = string.Format(LocaleManager.Instance["DialogFirmwareInstallEmbeddedMessage"], firmwareVersion.VersionString);
-
-                            UserResult result = await ContentDialogHelper.CreateConfirmationDialog(
-                                LocaleManager.Instance["DialogFirmwareNoFirmwareInstalledMessage"],
-                                message,
-                                LocaleManager.Instance["InputDialogYes"],
-                                LocaleManager.Instance["InputDialogNo"],
-                                "");
-
-                            if (result != UserResult.Yes)
-                            {
-                                await UserErrorDialog.ShowUserErrorDialog(userError, _parent);
-                                Device.Dispose();
-                            }
-                        });
+                        UserResult result = await ContentDialogHelper.CreateConfirmationDialog(
+                            LocaleManager.Instance["DialogFirmwareNoFirmwareInstalledMessage"],
+                            string.Format(LocaleManager.Instance["DialogFirmwareInstallEmbeddedMessage"], firmwareVersion.VersionString),
+                            LocaleManager.Instance["InputDialogYes"],
+                            LocaleManager.Instance["InputDialogNo"],
+                            "");
 
                         if (result != UserResult.Yes)
                         {
+                            await UserErrorDialog.ShowUserErrorDialog(userError, _parent);
+                            Device.Dispose();
+
                             return false;
                         }
                     }
 
                     if (!SetupValidator.TryFixStartApplication(ContentManager, ApplicationPath, userError, out _))
                     {
-                        Dispatcher.UIThread.Post(async () => await UserErrorDialog.ShowUserErrorDialog(userError, _parent));
+                        await UserErrorDialog.ShowUserErrorDialog(userError, _parent);
                         Device.Dispose();
 
                         return false;
@@ -472,11 +461,9 @@ namespace Ryujinx.Ava
 
                         _parent.RefreshFirmwareStatus();
 
-                        string message = string.Format(LocaleManager.Instance["DialogFirmwareInstallEmbeddedSuccessMessage"], firmwareVersion.VersionString);
-
                         await ContentDialogHelper.CreateInfoDialog(
                             string.Format(LocaleManager.Instance["DialogFirmwareInstalledMessage"], firmwareVersion.VersionString),
-                            message,
+                            string.Format(LocaleManager.Instance["DialogFirmwareInstallEmbeddedSuccessMessage"], firmwareVersion.VersionString),
                             LocaleManager.Instance["InputDialogOk"],
                             "",
                             LocaleManager.Instance["RyujinxInfo"]);
@@ -484,9 +471,7 @@ namespace Ryujinx.Ava
                 }
                 else
                 {
-                    Dispatcher.UIThread.Post(async () => await
-                        UserErrorDialog.ShowUserErrorDialog(userError, _parent));
-
+                    await UserErrorDialog.ShowUserErrorDialog(userError, _parent);
                     Device.Dispose();
 
                     return false;
@@ -525,7 +510,7 @@ namespace Ryujinx.Ava
             }
             else if (File.Exists(ApplicationPath))
             {
-                switch (System.IO.Path.GetExtension(ApplicationPath).ToLowerInvariant())
+                switch (Path.GetExtension(ApplicationPath).ToLowerInvariant())
                 {
                     case ".xci":
                         {

--- a/Ryujinx.Ava/AppHost.cs
+++ b/Ryujinx.Ava/AppHost.cs
@@ -60,7 +60,7 @@ namespace Ryujinx.Ava
 
         private const float VolumeDelta = 0.05f;
 
-        private static readonly Cursor InvisibleCursor = new Cursor(StandardCursorType.None);        
+        private static readonly Cursor InvisibleCursor = new Cursor(StandardCursorType.None);
 
         private readonly long _ticksPerFrame;
         private readonly Stopwatch _chrono;
@@ -349,7 +349,10 @@ namespace Ryujinx.Ava
 
             _isActive = false;
 
-            _renderingThread.Join();
+            if (_renderingThread.IsAlive)
+            {
+                _renderingThread.Join();
+            }
 
             DisplaySleep.Restore();
 
@@ -378,7 +381,7 @@ namespace Ryujinx.Ava
 
             _gpuCancellationTokenSource.Cancel();
             _gpuCancellationTokenSource.Dispose();
-            
+
             _chrono.Stop();
         }
 
@@ -393,7 +396,7 @@ namespace Ryujinx.Ava
             Renderer?.MakeCurrent();
 
             Device.DisposeGpu();
-            
+
             Renderer?.MakeCurrent(null);
         }
 
@@ -602,7 +605,7 @@ namespace Ryujinx.Ava
             if (Renderer.IsVulkan)
             {
                 string preferredGpu = ConfigurationState.Instance.Graphics.PreferredGpu.Value;
-                
+
                 renderer = new VulkanRenderer(Renderer.CreateVulkanSurface, VulkanHelper.GetRequiredInstanceExtensions, preferredGpu);
             }
             else

--- a/Ryujinx.Ava/AppHost.cs
+++ b/Ryujinx.Ava/AppHost.cs
@@ -431,27 +431,35 @@ namespace Ryujinx.Ava
                 {
                     if (userError == UserError.NoFirmware)
                     {
-                        string message = string.Format(LocaleManager.Instance["DialogFirmwareInstallEmbeddedMessage"],
-                            firmwareVersion.VersionString);
+                        UserResult result = UserResult.None;
 
-                        UserResult result = await ContentDialogHelper.CreateConfirmationDialog(
-                            LocaleManager.Instance["DialogFirmwareNoFirmwareInstalledMessage"], message,
-                            LocaleManager.Instance["InputDialogYes"], LocaleManager.Instance["InputDialogNo"], "");
+                        Dispatcher.UIThread.Post(async () =>
+                        {
+                            string message = string.Format(LocaleManager.Instance["DialogFirmwareInstallEmbeddedMessage"], firmwareVersion.VersionString);
+
+                            UserResult result = await ContentDialogHelper.CreateConfirmationDialog(
+                                LocaleManager.Instance["DialogFirmwareNoFirmwareInstalledMessage"],
+                                message,
+                                LocaleManager.Instance["InputDialogYes"],
+                                LocaleManager.Instance["InputDialogNo"],
+                                "");
+
+                            if (result != UserResult.Yes)
+                            {
+                                await UserErrorDialog.ShowUserErrorDialog(userError, _parent);
+                                Device.Dispose();
+                            }
+                        });
 
                         if (result != UserResult.Yes)
                         {
-                            Dispatcher.UIThread.Post(async () => await
-                                UserErrorDialog.ShowUserErrorDialog(userError, _parent));
-                            Device.Dispose();
-
                             return false;
                         }
                     }
 
                     if (!SetupValidator.TryFixStartApplication(ContentManager, ApplicationPath, userError, out _))
                     {
-                        Dispatcher.UIThread.Post(async () => await
-                            UserErrorDialog.ShowUserErrorDialog(userError, _parent));
+                        Dispatcher.UIThread.Post(async () => await UserErrorDialog.ShowUserErrorDialog(userError, _parent));
                         Device.Dispose();
 
                         return false;

--- a/Ryujinx.Ava/Ui/Controls/OpenGLEmbeddedWindow.cs
+++ b/Ryujinx.Ava/Ui/Controls/OpenGLEmbeddedWindow.cs
@@ -49,7 +49,7 @@ namespace Ryujinx.Ava.Ui.Controls
             {
                 throw new PlatformNotSupportedException();
             }
-            
+
             var flags = OpenGLContextFlags.Compat;
             if (_graphicsDebugLevel != GraphicsDebugLevel.None)
             {
@@ -69,12 +69,12 @@ namespace Ryujinx.Ava.Ui.Controls
 
         public void MakeCurrent()
         {
-            Context.MakeCurrent(_window);
+            Context?.MakeCurrent(_window);
         }
 
         public void MakeCurrent(NativeWindowBase window)
         {
-            Context.MakeCurrent(window);
+            Context?.MakeCurrent(window);
         }
 
         public void SwapBuffers()

--- a/Ryujinx.Ava/Ui/Windows/MainWindow.axaml.cs
+++ b/Ryujinx.Ava/Ui/Windows/MainWindow.axaml.cs
@@ -254,6 +254,7 @@ namespace Ryujinx.Ava.Ui.Windows
             if (!AppHost.LoadGuestApplication().Result)
             {
                 AppHost.DisposeContext();
+                AppHost = null;
 
                 return;
             }
@@ -546,10 +547,12 @@ namespace Ryujinx.Ava.Ui.Windows
         {
             ApplicationLibrary.LoadAndSaveMetaData(titleId, appMetadata =>
             {
-                DateTime lastPlayedDateTime = DateTime.Parse(appMetadata.LastPlayed);
-                double sessionTimePlayed = DateTime.UtcNow.Subtract(lastPlayedDateTime).TotalSeconds;
+                if (DateTime.TryParse(appMetadata.LastPlayed, out DateTime lastPlayedDateTime))
+                {
+                    double sessionTimePlayed = DateTime.UtcNow.Subtract(lastPlayedDateTime).TotalSeconds;
 
-                appMetadata.TimePlayed += Math.Round(sessionTimePlayed, MidpointRounding.AwayFromZero);
+                    appMetadata.TimePlayed += Math.Round(sessionTimePlayed, MidpointRounding.AwayFromZero);
+                }
             });
         }
 

--- a/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
@@ -422,7 +422,11 @@ namespace Ryujinx.Graphics.GAL.Multithreading
 
             // Stop the GPU thread.
             _disposed = true;
-            _gpuThread.Join();
+
+            if (_gpuThread != null && _gpuThread.IsAlive)
+            {
+                _gpuThread.Join();
+            }
 
             // Dispose the renderer.
             _baseRenderer.Dispose();

--- a/Ryujinx.Graphics.OpenGL/Queries/Counters.cs
+++ b/Ryujinx.Graphics.OpenGL/Queries/Counters.cs
@@ -50,7 +50,7 @@ namespace Ryujinx.Graphics.OpenGL.Queries
         {
             foreach (var queue in _counterQueues)
             {
-                queue?.Dispose();
+                queue.Dispose();
             }
         }
     }

--- a/Ryujinx.Graphics.OpenGL/Queries/Counters.cs
+++ b/Ryujinx.Graphics.OpenGL/Queries/Counters.cs
@@ -50,7 +50,7 @@ namespace Ryujinx.Graphics.OpenGL.Queries
         {
             foreach (var queue in _counterQueues)
             {
-                queue.Dispose();
+                queue?.Dispose();
             }
         }
     }

--- a/Ryujinx.Graphics.OpenGL/Window.cs
+++ b/Ryujinx.Graphics.OpenGL/Window.cs
@@ -193,7 +193,7 @@ namespace Ryujinx.Graphics.OpenGL
 
         public void Dispose()
         {
-            BackgroundContext.Dispose();
+            BackgroundContext?.Dispose();
 
             if (_copyFramebufferHandle != 0)
             {

--- a/Ryujinx.Graphics.OpenGL/Window.cs
+++ b/Ryujinx.Graphics.OpenGL/Window.cs
@@ -10,6 +10,8 @@ namespace Ryujinx.Graphics.OpenGL
         private const int TextureCount = 3;
         private readonly OpenGLRenderer _renderer;
 
+        private bool _initialized;
+
         private int _width;
         private int _height;
         private int _copyFramebufferHandle;
@@ -179,6 +181,7 @@ namespace Ryujinx.Graphics.OpenGL
         public void InitializeBackgroundContext(IOpenGLContext baseContext)
         {
             BackgroundContext = new BackgroundContextWorker(baseContext);
+            _initialized = true;
         }
 
         public void CaptureFrame(int x, int y, int width, int height, bool isBgra, bool flipX, bool flipY)
@@ -193,7 +196,12 @@ namespace Ryujinx.Graphics.OpenGL
 
         public void Dispose()
         {
-            BackgroundContext?.Dispose();
+            if (!_initialized)
+            {
+                return;
+            }
+
+            BackgroundContext.Dispose();
 
             if (_copyFramebufferHandle != 0)
             {

--- a/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -22,6 +22,8 @@ namespace Ryujinx.Graphics.Vulkan
         private Device _device;
         private WindowBase _window;
 
+        private bool _initialized;
+
         internal FormatCapabilities FormatCapabilities { get; private set; }
         internal HardwareCapabilities Capabilities;
 
@@ -266,6 +268,8 @@ namespace Ryujinx.Graphics.Vulkan
             LoadFeatures(supportedExtensions, maxQueueCount, queueFamilyIndex);
 
             _window = new Window(this, _surface, _physicalDevice, _device);
+
+            _initialized = true;
         }
 
         public BufferHandle CreateBuffer(int size)
@@ -573,17 +577,22 @@ namespace Ryujinx.Graphics.Vulkan
 
         public unsafe void Dispose()
         {
-            CommandBufferPool?.Dispose();
-            BackgroundResources?.Dispose();
-            _counters?.Dispose();
-            _window?.Dispose();
-            HelperShader?.Dispose();
-            _pipeline?.Dispose();
-            BufferManager?.Dispose();
-            DescriptorSetManager?.Dispose();
-            PipelineLayoutCache?.Dispose();
+            if (!_initialized)
+            {
+                return;
+            }
 
-            MemoryAllocator?.Dispose();
+            CommandBufferPool.Dispose();
+            BackgroundResources.Dispose();
+            _counters.Dispose();
+            _window.Dispose();
+            HelperShader.Dispose();
+            _pipeline.Dispose();
+            BufferManager.Dispose();
+            DescriptorSetManager.Dispose();
+            PipelineLayoutCache.Dispose();
+
+            MemoryAllocator.Dispose();
 
             if (_debugUtilsMessenger.Handle != 0)
             {
@@ -605,12 +614,12 @@ namespace Ryujinx.Graphics.Vulkan
                 sampler.Dispose();
             }
 
-            SurfaceApi?.DestroySurface(_instance, _surface, null);
+            SurfaceApi.DestroySurface(_instance, _surface, null);
 
-            Api?.DestroyDevice(_device, null);
+            Api.DestroyDevice(_device, null);
 
             // Last step destroy the instance
-            Api?.DestroyInstance(_instance, null);
+            Api.DestroyInstance(_instance, null);
         }
     }
 }

--- a/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -573,17 +573,17 @@ namespace Ryujinx.Graphics.Vulkan
 
         public unsafe void Dispose()
         {
-            CommandBufferPool.Dispose();
-            BackgroundResources.Dispose();
-            _counters.Dispose();
-            _window.Dispose();
-            HelperShader.Dispose();
-            _pipeline.Dispose();
-            BufferManager.Dispose();
-            DescriptorSetManager.Dispose();
-            PipelineLayoutCache.Dispose();
+            CommandBufferPool?.Dispose();
+            BackgroundResources?.Dispose();
+            _counters?.Dispose();
+            _window?.Dispose();
+            HelperShader?.Dispose();
+            _pipeline?.Dispose();
+            BufferManager?.Dispose();
+            DescriptorSetManager?.Dispose();
+            PipelineLayoutCache?.Dispose();
 
-            MemoryAllocator.Dispose();
+            MemoryAllocator?.Dispose();
 
             if (_debugUtilsMessenger.Handle != 0)
             {
@@ -605,12 +605,12 @@ namespace Ryujinx.Graphics.Vulkan
                 sampler.Dispose();
             }
 
-            SurfaceApi.DestroySurface(_instance, _surface, null);
+            SurfaceApi?.DestroySurface(_instance, _surface, null);
 
-            Api.DestroyDevice(_device, null);
+            Api?.DestroyDevice(_device, null);
 
             // Last step destroy the instance
-            Api.DestroyInstance(_instance, null);
+            Api?.DestroyInstance(_instance, null);
         }
     }
 }

--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -479,7 +479,10 @@ namespace Ryujinx.HLE.HOS
 
                 AudioRendererManager.Dispose();
 
-                LibHacHorizonManager.PmClient.Fs.UnregisterProgram(LibHacHorizonManager.ApplicationClient.Os.GetCurrentProcessId().Value).ThrowIfFailure();
+                if (LibHacHorizonManager.ApplicationClient != null)
+                {
+                    LibHacHorizonManager.PmClient.Fs.UnregisterProgram(LibHacHorizonManager.ApplicationClient.Os.GetCurrentProcessId().Value).ThrowIfFailure();
+                }
 
                 KernelContext.Dispose();
             }

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -735,7 +735,6 @@ namespace Ryujinx.Ui
 
                                 _emulationContext.Dispose();
                                 SwitchToGameTable();
-                                RendererWidget.Dispose();
 
                                 return;
                             }
@@ -747,7 +746,6 @@ namespace Ryujinx.Ui
 
                             _emulationContext.Dispose();
                             SwitchToGameTable();
-                            RendererWidget.Dispose();
 
                             return;
                         }
@@ -770,7 +768,6 @@ namespace Ryujinx.Ui
 
                         _emulationContext.Dispose();
                         SwitchToGameTable();
-                        RendererWidget.Dispose();
 
                         return;
                     }

--- a/Ryujinx/Ui/RendererWidgetBase.cs
+++ b/Ryujinx/Ui/RendererWidgetBase.cs
@@ -519,10 +519,14 @@ namespace Ryujinx.Ui
             _gpuCancellationTokenSource.Cancel();
 
             _isStopped = true;
-            _isActive = false;
+            
+            if (_isActive)
+            {
+                _isActive = false;
 
-            _exitEvent.WaitOne();
-            _exitEvent.Dispose();
+                _exitEvent.WaitOne();
+                _exitEvent.Dispose();
+            }
         }
 
         private void NVStutterWorkaround()

--- a/Ryujinx/Ui/VKRenderer.cs
+++ b/Ryujinx/Ui/VKRenderer.cs
@@ -72,7 +72,11 @@ namespace Ryujinx.Ui
 
         protected override void Dispose(bool disposing)
         {
-            Device.DisposeGpu();
+            if (Device != null)
+            {
+                Device.DisposeGpu();
+            }
+
             NpadManager.Dispose();
         }
     }

--- a/Ryujinx/Ui/VKRenderer.cs
+++ b/Ryujinx/Ui/VKRenderer.cs
@@ -72,10 +72,7 @@ namespace Ryujinx.Ui
 
         protected override void Dispose(bool disposing)
         {
-            if (Device != null)
-            {
-                Device.DisposeGpu();
-            }
+            Device?.DisposeGpu();
 
             NpadManager.Dispose();
         }


### PR DESCRIPTION
This fixes a dispose issue under Horizon/GTK/Avalonia, we don't check if the ApplicationClient is null so it throw NRE. We don't check if the main loop is active and waiting an event which is set in the main loop... So that could lead to a freeze.
Avalonia code is running on a main thread and waiting for the popup result, popup are running on a UI thread for the main thread never get the result and freeze.

Everything works fine in GTK/Avalonia (Thanks to @TSRBerry and @emmauss for their help) now.

Fixes https://github.com/Ryujinx/Ryujinx/issues/3873