### PR TITLE
Fix NRE on Avalonia for error applets with unknown error message

### DIFF
--- a/Ryujinx.Ava/Ui/Applet/AvaHostUiHandler.cs
+++ b/Ryujinx.Ava/Ui/Applet/AvaHostUiHandler.cs
@@ -57,14 +57,14 @@ namespace Ryujinx.Ava.Ui.Applet
 
                     bool opened = false;
 
-                    UserResult response = await ContentDialogHelper.ShowDeferredContentDialog(_parent, 
-                       title, 
-                       message, 
-                       "", 
-                       LocaleManager.Instance["DialogOpenSettingsWindowLabel"], 
-                       "", 
-                       LocaleManager.Instance["SettingsButtonClose"], 
-                       (int)Symbol.Important, 
+                    UserResult response = await ContentDialogHelper.ShowDeferredContentDialog(_parent,
+                       title,
+                       message,
+                       "",
+                       LocaleManager.Instance["DialogOpenSettingsWindowLabel"],
+                       "",
+                       LocaleManager.Instance["SettingsButtonClose"],
+                       (int)Symbol.Important,
                        deferEvent,
                        async (window) =>
                        {
@@ -168,7 +168,7 @@ namespace Ryujinx.Ava.Ui.Applet
 
                     object response = await msgDialog.Run();
 
-                    if (response != null && buttons.Length > 1 && (int)response != buttons.Length - 1)
+                    if (response != null && buttons != null && buttons.Length > 1 && (int)response != buttons.Length - 1)
                     {
                         showDetails = true;
                     }


### PR DESCRIPTION
When the error message is unknown (not found on the firmware), the emulator currently passes a generic message and null as the buttons array. Some code on the Avalonia UI doesn't expect that to be null so it throws a `NullReferenceException`. This PR adds a explicit null check to handle that case.

Before this change, it would show this dialog after the generic error dialog:
![image](https://user-images.githubusercontent.com/5624669/203700054-3f40940d-9759-4b1c-93db-6d168923994b.png)
With this change, it only shows the generic error dialog as expected.