### PR TITLE
Ryujinx.Ava: Add missing redefinition of app name

### DIFF
--- a/Ryujinx.Ava/App.axaml.cs
+++ b/Ryujinx.Ava/App.axaml.cs
@@ -21,6 +21,8 @@ namespace Ryujinx.Ava
     {
         public override void Initialize()
         {
+            Name = $"Ryujinx {Program.Version}";
+
             AvaloniaXamlLoader.Load(this);
         }
 


### PR DESCRIPTION
Before this, Ryujinx would possibly report as "Avalonia Application".