### PR TITLE
amadeus: Fixes and initial 15.0.0 support

### DIFF
--- a/Ryujinx.Audio/Renderer/Dsp/AdpcmHelper.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/AdpcmHelper.cs
@@ -75,7 +75,7 @@ namespace Ryujinx.Audio.Renderer.Dsp
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static short GetCoefficientAtIndex(ReadOnlySpan<short> coefficients, int index)
         {
-            if ((uint)index > coefficients.Length)
+            if ((uint)index > (uint)coefficients.Length)
             {
                 Logger.Error?.Print(LogClass.AudioRenderer, $"Out of bound read for coefficient at index {index}");
 

--- a/Ryujinx.Audio/Renderer/Dsp/AdpcmHelper.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/AdpcmHelper.cs
@@ -75,7 +75,7 @@ namespace Ryujinx.Audio.Renderer.Dsp
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static short GetCoefficientAtIndex(ReadOnlySpan<short> coefficients, int index)
         {
-            if (index > coefficients.Length)
+            if ((uint)index > coefficients.Length)
             {
                 Logger.Error?.Print(LogClass.AudioRenderer, $"Out of bound read for coefficient at index {index}");
 

--- a/Ryujinx.Audio/Renderer/Dsp/AdpcmHelper.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/AdpcmHelper.cs
@@ -1,4 +1,5 @@
 using Ryujinx.Audio.Renderer.Dsp.State;
+using Ryujinx.Common.Logging;
 using System;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -72,6 +73,19 @@ namespace Ryujinx.Audio.Renderer.Dsp
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static short GetCoefficientAtIndex(ReadOnlySpan<short> coefficients, int index)
+        {
+            if (index > coefficients.Length)
+            {
+                Logger.Error?.Print(LogClass.AudioRenderer, $"Out of bound read for coefficient at index {index}");
+
+                return 0;
+            }
+
+            return coefficients[index];
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Decode(Span<short> output, ReadOnlySpan<byte> input, int startSampleOffset, int endSampleOffset, int offset, int count, ReadOnlySpan<short> coefficients, ref AdpcmLoopContext loopContext)
         {
             if (input.IsEmpty || endSampleOffset < startSampleOffset)
@@ -84,8 +98,8 @@ namespace Ryujinx.Audio.Renderer.Dsp
             byte coefficientIndex = (byte)((predScale >> 4) & 0xF);
             short history0 = loopContext.History0;
             short history1 = loopContext.History1;
-            short coefficient0 = coefficients[coefficientIndex * 2 + 0];
-            short coefficient1 = coefficients[coefficientIndex * 2 + 1];
+            short coefficient0 = GetCoefficientAtIndex(coefficients, coefficientIndex * 2 + 0);
+            short coefficient1 = GetCoefficientAtIndex(coefficients, coefficientIndex * 2 + 1);
 
             int decodedCount = Math.Min(count, endSampleOffset - startSampleOffset - offset);
             int nibbles = GetNibblesFromSampleCount(offset + startSampleOffset);
@@ -109,8 +123,8 @@ namespace Ryujinx.Audio.Renderer.Dsp
 
                     coefficientIndex = (byte)((predScale >> 4) & 0xF);
 
-                    coefficient0 = coefficients[coefficientIndex * 2 + 0];
-                    coefficient1 = coefficients[coefficientIndex * 2 + 1];
+                    coefficient0 = GetCoefficientAtIndex(coefficients, coefficientIndex * 2);
+                    coefficient1 = GetCoefficientAtIndex(coefficients, coefficientIndex * 2 + 1);
 
                     nibbles += 2;
 

--- a/Ryujinx.Audio/Renderer/Dsp/Command/AdpcmDataSourceCommandVersion1.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/AdpcmDataSourceCommandVersion1.cs
@@ -13,7 +13,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType => CommandType.AdpcmDataSourceVersion1;
 
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         public ushort OutputBufferIndex { get; }
         public uint SampleRate { get; }

--- a/Ryujinx.Audio/Renderer/Dsp/Command/AuxiliaryBufferCommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/AuxiliaryBufferCommand.cs
@@ -16,7 +16,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType => CommandType.AuxiliaryBuffer;
 
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         public uint InputBufferIndex { get; }
         public uint OutputBufferIndex { get; }

--- a/Ryujinx.Audio/Renderer/Dsp/Command/BiquadFilterCommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/BiquadFilterCommand.cs
@@ -12,7 +12,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType => CommandType.BiquadFilter;
 
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         public Memory<BiquadFilterState> BiquadFilterState { get; }
         public int InputBufferIndex { get; }

--- a/Ryujinx.Audio/Renderer/Dsp/Command/CaptureBufferCommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/CaptureBufferCommand.cs
@@ -16,7 +16,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType => CommandType.CaptureBuffer;
 
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         public uint InputBufferIndex { get; }
 

--- a/Ryujinx.Audio/Renderer/Dsp/Command/CircularBufferSinkCommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/CircularBufferSinkCommand.cs
@@ -12,7 +12,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType => CommandType.CircularBufferSink;
 
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         public ushort[] Input { get; }
         public uint InputCount { get; }

--- a/Ryujinx.Audio/Renderer/Dsp/Command/ClearMixBufferCommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/ClearMixBufferCommand.cs
@@ -8,7 +8,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType => CommandType.ClearMixBuffer;
 
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         public ClearMixBufferCommand(int nodeId)
         {

--- a/Ryujinx.Audio/Renderer/Dsp/Command/CopyMixBufferCommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/CopyMixBufferCommand.cs
@@ -8,7 +8,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType => CommandType.CopyMixBuffer;
 
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         public ushort InputBufferIndex { get; }
         public ushort OutputBufferIndex { get; }

--- a/Ryujinx.Audio/Renderer/Dsp/Command/DataSourceVersion2Command.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/DataSourceVersion2Command.cs
@@ -13,7 +13,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType { get; }
 
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         public ushort OutputBufferIndex { get; }
         public uint SampleRate { get; }

--- a/Ryujinx.Audio/Renderer/Dsp/Command/DelayCommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/DelayCommand.cs
@@ -58,6 +58,8 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
         private unsafe void ProcessDelayMono(ref DelayState state, float* outputBuffer, float* inputBuffer, uint sampleCount)
         {
+            const ushort channelCount = 1;
+
             float feedbackGain = FixedPointHelper.ToFloat(Parameter.FeedbackGain, FixedPointPrecision);
             float inGain = FixedPointHelper.ToFloat(Parameter.InGain, FixedPointPrecision);
             float dryGain = FixedPointHelper.ToFloat(Parameter.DryGain, FixedPointPrecision);
@@ -70,7 +72,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
                 float temp = input * inGain + delayLineValue * feedbackGain;
 
-                state.UpdateLowPassFilter(ref temp, 1);
+                state.UpdateLowPassFilter(ref temp, channelCount);
 
                 outputBuffer[i] = (input * dryGain + delayLineValue * outGain) / 64;
             }
@@ -104,7 +106,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
                     Y = state.DelayLines[1].Read(),
                 };
 
-                Vector2 temp = MatrixHelper.Transform(ref channelInput, ref delayFeedback) + channelInput * inGain;
+                Vector2 temp = MatrixHelper.Transform(ref delayLineValues, ref delayFeedback) + channelInput * inGain;
 
                 state.UpdateLowPassFilter(ref Unsafe.As<Vector2, float>(ref temp), channelCount);
 
@@ -148,7 +150,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
                     W = state.DelayLines[3].Read()
                 };
 
-                Vector4 temp = MatrixHelper.Transform(ref channelInput, ref delayFeedback) + channelInput * inGain;
+                Vector4 temp = MatrixHelper.Transform(ref delayLineValues, ref delayFeedback) + channelInput * inGain;
 
                 state.UpdateLowPassFilter(ref Unsafe.As<Vector4, float>(ref temp), channelCount);
 
@@ -200,7 +202,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
                     U = state.DelayLines[5].Read()
                 };
 
-                Vector6 temp = MatrixHelper.Transform(ref channelInput, ref delayFeedback) + channelInput * inGain;
+                Vector6 temp = MatrixHelper.Transform(ref delayLineValues, ref delayFeedback) + channelInput * inGain;
 
                 state.UpdateLowPassFilter(ref Unsafe.As<Vector6, float>(ref temp), channelCount);
 

--- a/Ryujinx.Audio/Renderer/Dsp/Command/DelayCommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/DelayCommand.cs
@@ -49,10 +49,8 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
                 OutputBufferIndices[i] = (ushort)(bufferOffset + Parameter.Output[i]);
             }
 
-            // NOTE: We do the opposite as Nintendo here for now to restore previous behaviour
-            // TODO: Update delay processing and remove this to use RemapLegacyChannelEffectMappingToChannelResourceMapping.
-            DataSourceHelper.RemapChannelResourceMappingToLegacy(newEffectChannelMappingSupported, InputBufferIndices);
-            DataSourceHelper.RemapChannelResourceMappingToLegacy(newEffectChannelMappingSupported, OutputBufferIndices);
+            DataSourceHelper.RemapLegacyChannelEffectMappingToChannelResourceMapping(newEffectChannelMappingSupported, InputBufferIndices);
+            DataSourceHelper.RemapLegacyChannelEffectMappingToChannelResourceMapping(newEffectChannelMappingSupported, OutputBufferIndices);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
@@ -173,12 +171,12 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
             float dryGain = FixedPointHelper.ToFloat(Parameter.DryGain, FixedPointPrecision);
             float outGain = FixedPointHelper.ToFloat(Parameter.OutGain, FixedPointPrecision);
 
-            Matrix6x6 delayFeedback = new Matrix6x6(delayFeedbackBaseGain, 0.0f, 0.0f, 0.0f, delayFeedbackCrossGain, delayFeedbackCrossGain,
-                                                    0.0f, delayFeedbackBaseGain, 0.0f, delayFeedbackCrossGain, delayFeedbackCrossGain, 0.0f,
-                                                    delayFeedbackCrossGain, 0.0f, delayFeedbackBaseGain, delayFeedbackCrossGain, 0.0f, 0.0f,
-                                                    0.0f, delayFeedbackCrossGain, delayFeedbackCrossGain, delayFeedbackBaseGain, 0.0f, 0.0f,
-                                                    delayFeedbackCrossGain, delayFeedbackCrossGain, 0.0f, 0.0f, delayFeedbackBaseGain, 0.0f,
-                                                    0.0f, 0.0f, 0.0f, 0.0f, 0.0f, feedbackGain);
+            Matrix6x6 delayFeedback = new Matrix6x6(delayFeedbackBaseGain, 0.0f, delayFeedbackCrossGain, 0.0f, delayFeedbackCrossGain, 0.0f,
+                                                    0.0f, delayFeedbackBaseGain, delayFeedbackCrossGain, 0.0f, 0.0f, delayFeedbackCrossGain,
+                                                    delayFeedbackCrossGain, delayFeedbackCrossGain, delayFeedbackBaseGain, 0.0f, 0.0f, 0.0f,
+                                                    0.0f, 0.0f, 0.0f, feedbackGain, 0.0f, 0.0f,
+                                                    delayFeedbackCrossGain, 0.0f, 0.0f, 0.0f, delayFeedbackBaseGain, delayFeedbackCrossGain,
+                                                    0.0f, delayFeedbackCrossGain, 0.0f, 0.0f, delayFeedbackCrossGain, delayFeedbackBaseGain);
 
             for (int i = 0; i < sampleCount; i++)
             {

--- a/Ryujinx.Audio/Renderer/Dsp/Command/DelayCommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/DelayCommand.cs
@@ -17,7 +17,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType => CommandType.Delay;
 
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         public DelayParameter Parameter => _parameter;
         public Memory<DelayState> State { get; }

--- a/Ryujinx.Audio/Renderer/Dsp/Command/DepopForMixBuffersCommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/DepopForMixBuffersCommand.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType => CommandType.DepopForMixBuffers;
 
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         public uint MixBufferOffset { get; }
 

--- a/Ryujinx.Audio/Renderer/Dsp/Command/DepopPrepareCommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/DepopPrepareCommand.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType => CommandType.DepopPrepare;
 
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         public uint MixBufferCount { get; }
 

--- a/Ryujinx.Audio/Renderer/Dsp/Command/DeviceSinkCommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/DeviceSinkCommand.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType => CommandType.DeviceSink;
 
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         public string DeviceName { get; }
 

--- a/Ryujinx.Audio/Renderer/Dsp/Command/DownMixSurroundToStereoCommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/DownMixSurroundToStereoCommand.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType => CommandType.DownMixSurroundToStereo;
 
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         public ushort[] InputBufferIndices { get; }
         public ushort[] OutputBufferIndices { get; }

--- a/Ryujinx.Audio/Renderer/Dsp/Command/GroupedBiquadFilterCommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/GroupedBiquadFilterCommand.cs
@@ -12,7 +12,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType => CommandType.GroupedBiquadFilter;
 
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         private BiquadFilterParameter[] _parameters;
         private Memory<BiquadFilterState> _biquadFilterStates;

--- a/Ryujinx.Audio/Renderer/Dsp/Command/GroupedBiquadFilterCommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/GroupedBiquadFilterCommand.cs
@@ -47,9 +47,8 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
                 }
             }
 
-            // NOTE: Nintendo also implements a hot path for double biquad filters, but no generic path when the command definition suggests it could be done.
-            // As such we currently only implement a generic path for simplicity.
-            // TODO: Implement double biquad filters fast path.
+            // NOTE: Nintendo only implement single and double biquad filters but no generic path when the command definition suggests it could be done.
+            // As such we currently only implement a generic path for simplicity for double biquad.
             if (_parameters.Length == 1)
             {
                 BiquadFilterHelper.ProcessBiquadFilter(ref _parameters[0], ref states[0], outputBuffer, inputBuffer, context.SampleCount);

--- a/Ryujinx.Audio/Renderer/Dsp/Command/ICommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/ICommand.cs
@@ -8,7 +8,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType { get; }
 
-        public ulong EstimatedProcessingTime { get; }
+        public uint EstimatedProcessingTime { get; }
 
         public void Process(CommandList context);
 

--- a/Ryujinx.Audio/Renderer/Dsp/Command/LimiterCommandVersion1.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/LimiterCommandVersion1.cs
@@ -13,7 +13,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType => CommandType.LimiterVersion1;
 
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         public LimiterParameter Parameter => _parameter;
         public Memory<LimiterState> State { get; }

--- a/Ryujinx.Audio/Renderer/Dsp/Command/LimiterCommandVersion2.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/LimiterCommandVersion2.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType => CommandType.LimiterVersion2;
 
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         public LimiterParameter Parameter => _parameter;
         public Memory<LimiterState> State { get; }

--- a/Ryujinx.Audio/Renderer/Dsp/Command/MixCommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/MixCommand.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType => CommandType.Mix;
 
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         public ushort InputBufferIndex { get; }
         public ushort OutputBufferIndex { get; }

--- a/Ryujinx.Audio/Renderer/Dsp/Command/MixRampCommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/MixRampCommand.cs
@@ -12,7 +12,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType => CommandType.MixRamp;
 
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         public ushort InputBufferIndex { get; }
         public ushort OutputBufferIndex { get; }

--- a/Ryujinx.Audio/Renderer/Dsp/Command/MixRampGroupedCommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/MixRampGroupedCommand.cs
@@ -12,7 +12,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType => CommandType.MixRampGrouped;
 
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         public uint MixBufferCount { get; }
 

--- a/Ryujinx.Audio/Renderer/Dsp/Command/PcmFloatDataSourceCommandVersion1.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/PcmFloatDataSourceCommandVersion1.cs
@@ -13,7 +13,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType => CommandType.PcmFloatDataSourceVersion1;
 
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         public ushort OutputBufferIndex { get; }
         public uint SampleRate { get; }

--- a/Ryujinx.Audio/Renderer/Dsp/Command/PcmInt16DataSourceCommandVersion1.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/PcmInt16DataSourceCommandVersion1.cs
@@ -13,7 +13,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType => CommandType.PcmInt16DataSourceVersion1;
 
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         public ushort OutputBufferIndex { get; }
         public uint SampleRate { get; }

--- a/Ryujinx.Audio/Renderer/Dsp/Command/PerformanceCommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/PerformanceCommand.cs
@@ -17,7 +17,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType => CommandType.Performance;
 
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         public PerformanceEntryAddresses PerformanceEntryAddresses { get; }
 

--- a/Ryujinx.Audio/Renderer/Dsp/Command/Reverb3dCommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/Reverb3dCommand.cs
@@ -31,7 +31,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType => CommandType.Reverb3d;
 
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         public ushort InputBufferIndex { get; }
         public ushort OutputBufferIndex { get; }

--- a/Ryujinx.Audio/Renderer/Dsp/Command/ReverbCommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/ReverbCommand.cs
@@ -34,7 +34,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType => CommandType.Reverb;
 
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         public ReverbParameter Parameter => _parameter;
         public Memory<ReverbState> State { get; }

--- a/Ryujinx.Audio/Renderer/Dsp/Command/UpsampleCommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/UpsampleCommand.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType => CommandType.Upsample;
 
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         public uint BufferCount { get; }
         public uint InputBufferIndex { get; }

--- a/Ryujinx.Audio/Renderer/Dsp/Command/VolumeCommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/VolumeCommand.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType => CommandType.Volume;
 
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         public ushort InputBufferIndex { get; }
         public ushort OutputBufferIndex { get; }

--- a/Ryujinx.Audio/Renderer/Dsp/Command/VolumeRampCommand.cs
+++ b/Ryujinx.Audio/Renderer/Dsp/Command/VolumeRampCommand.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
         public CommandType CommandType => CommandType.VolumeRamp;
 
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         public ushort InputBufferIndex { get; }
         public ushort OutputBufferIndex { get; }

--- a/Ryujinx.Audio/Renderer/Server/AudioRenderSystem.cs
+++ b/Ryujinx.Audio/Renderer/Server/AudioRenderSystem.cs
@@ -864,7 +864,7 @@ namespace Ryujinx.Audio.Renderer.Server
 
         public void SetVoiceDropParameter(float voiceDropParameter)
         {
-            _voiceDropParameter = Math.Min(Math.Max(voiceDropParameter, 0.0f), 2.0f);
+            _voiceDropParameter = Math.Clamp(voiceDropParameter, 0.0f, 2.0f);
         }
 
         public float GetVoiceDropParameter()
@@ -876,7 +876,7 @@ namespace Ryujinx.Audio.Renderer.Server
         {
             if (_executionMode == AudioRendererExecutionMode.Manual && _renderingDevice == AudioRendererRenderingDevice.Cpu)
             {
-                // NOTE: Here Nintendo abort with this error code, we don't want that.
+                // NOTE: Here Nintendo aborts with this error code, we don't want that.
                 return ResultCode.InvalidExecutionContextOperation;
             }
 

--- a/Ryujinx.Audio/Renderer/Server/AudioRenderSystem.cs
+++ b/Ryujinx.Audio/Renderer/Server/AudioRenderSystem.cs
@@ -28,6 +28,7 @@ namespace Ryujinx.Audio.Renderer.Server
     {
         private object _lock = new object();
 
+        private AudioRendererRenderingDevice _renderingDevice;
         private AudioRendererExecutionMode _executionMode;
         private IWritableEvent _systemEvent;
         private ManualResetEvent _terminationEvent;
@@ -63,6 +64,7 @@ namespace Ryujinx.Audio.Renderer.Server
         private uint _renderingTimeLimitPercent;
         private bool _voiceDropEnabled;
         private uint _voiceDropCount;
+        private float _voiceDropParameter;
         private bool _isDspRunningBehind;
 
         private ICommandProcessingTimeEstimator _commandProcessingTimeEstimator;
@@ -95,6 +97,7 @@ namespace Ryujinx.Audio.Renderer.Server
 
             _totalElapsedTicksUpdating = 0;
             _sessionId = 0;
+            _voiceDropParameter = 1.0f;
         }
 
         public ResultCode Initialize(
@@ -130,6 +133,7 @@ namespace Ryujinx.Audio.Renderer.Server
             _upsamplerCount = parameter.SinkCount + parameter.SubMixBufferCount;
             _appletResourceId = appletResourceId;
             _memoryPoolCount = parameter.EffectCount + parameter.VoiceCount * Constants.VoiceWaveBufferCount;
+            _renderingDevice = parameter.RenderingDevice;
             _executionMode = parameter.ExecutionMode;
             _sessionId = sessionId;
             MemoryManager = memoryManager;
@@ -337,6 +341,7 @@ namespace Ryujinx.Audio.Renderer.Server
 
             _processHandle = processHandle;
             _elapsedFrameCount = 0;
+            _voiceDropParameter = 1.0f;
 
             switch (_behaviourContext.GetCommandProcessingTimeEstimatorVersion())
             {
@@ -515,7 +520,7 @@ namespace Ryujinx.Audio.Renderer.Server
             return (ulong)(_manager.TickSource.ElapsedSeconds * Constants.TargetTimerFrequency);
         }
 
-        private uint ComputeVoiceDrop(CommandBuffer commandBuffer, long voicesEstimatedTime, long deltaTimeDsp)
+        private uint ComputeVoiceDrop(CommandBuffer commandBuffer, uint voicesEstimatedTime, long deltaTimeDsp)
         {
             int i;
 
@@ -584,7 +589,7 @@ namespace Ryujinx.Audio.Renderer.Server
                     {
                         command.Enabled = false;
 
-                        voicesEstimatedTime -= (long)command.EstimatedProcessingTime;
+                        voicesEstimatedTime -= (uint)(_voiceDropParameter * command.EstimatedProcessingTime);
                     }
                 }
             }
@@ -618,13 +623,13 @@ namespace Ryujinx.Audio.Renderer.Server
             _voiceContext.Sort();
             commandGenerator.GenerateVoices();
 
-            long voicesEstimatedTime = (long)commandBuffer.EstimatedProcessingTime;
+            uint voicesEstimatedTime = (uint)(_voiceDropParameter * commandBuffer.EstimatedProcessingTime);
 
             commandGenerator.GenerateSubMixes();
             commandGenerator.GenerateFinalMixes();
             commandGenerator.GenerateSinks();
 
-            long totalEstimatedTime = (long)commandBuffer.EstimatedProcessingTime;
+            uint totalEstimatedTime = (uint)(_voiceDropParameter * commandBuffer.EstimatedProcessingTime);
 
             if (_voiceDropEnabled)
             {
@@ -855,6 +860,27 @@ namespace Ryujinx.Audio.Renderer.Server
                     MemoryManager = null;
                 }
             }
+        }
+
+        public void SetVoiceDropParameter(float voiceDropParameter)
+        {
+            _voiceDropParameter = Math.Min(Math.Max(voiceDropParameter, 0.0f), 2.0f);
+        }
+
+        public float GetVoiceDropParameter()
+        {
+            return _voiceDropParameter;
+        }
+
+        public ResultCode ExecuteAudioRendererRendering()
+        {
+            if (_executionMode == AudioRendererExecutionMode.Manual && _renderingDevice == AudioRendererRenderingDevice.Cpu)
+            {
+                // NOTE: Here Nintendo abort with this error code, we don't want that.
+                return ResultCode.InvalidExecutionContextOperation;
+            }
+
+            return ResultCode.UnsupportedOperation;
         }
     }
 }

--- a/Ryujinx.Audio/Renderer/Server/BehaviourContext.cs
+++ b/Ryujinx.Audio/Renderer/Server/BehaviourContext.cs
@@ -94,8 +94,9 @@ namespace Ryujinx.Audio.Renderer.Server
         /// REV11:
         /// The "legacy" effects (Delay, Reverb and Reverb 3D) were updated to match the standard channel mapping used by the audio renderer.
         /// A new version of the command estimator was added to address timing changes caused by the legacy effects changes.
+        /// A voice drop parameter was added in 15.0.0: This allows an application to amplify or attenuate the estimated time of DSP commands.
         /// </summary>
-        /// <remarks>This was added in system update 14.0.0</remarks>
+        /// <remarks>This was added in system update 14.0.0 but some changes were made in 15.0.0</remarks>
         public const int Revision11 = 11 << 24;
 
         /// <summary>

--- a/Ryujinx.Audio/Renderer/Server/CommandBuffer.cs
+++ b/Ryujinx.Audio/Renderer/Server/CommandBuffer.cs
@@ -25,7 +25,7 @@ namespace Ryujinx.Audio.Renderer.Server
         /// <summary>
         /// The estimated total processing time.
         /// </summary>
-        public ulong EstimatedProcessingTime { get; set; }
+        public uint EstimatedProcessingTime { get; set; }
 
         /// <summary>
         /// The command list that is populated by the <see cref="CommandBuffer"/>.

--- a/Ryujinx.Audio/Renderer/Server/MemoryPool/PoolMapper.cs
+++ b/Ryujinx.Audio/Renderer/Server/MemoryPool/PoolMapper.cs
@@ -256,19 +256,19 @@ namespace Ryujinx.Audio.Renderer.Server.MemoryPool
 
             MemoryPoolUserState outputState;
 
-            const uint pageSize = 0x1000;
+            const uint PageSize = 0x1000;
 
             if (inputState != MemoryPoolUserState.RequestAttach && inputState != MemoryPoolUserState.RequestDetach)
             {
                 return UpdateResult.Success;
             }
 
-            if (inParameter.CpuAddress == 0 || (inParameter.CpuAddress & (pageSize - 1)) != 0)
+            if (inParameter.CpuAddress == 0 || (inParameter.CpuAddress % PageSize) != 0)
             {
                 return UpdateResult.InvalidParameter;
             }
 
-            if (inParameter.Size == 0 || (inParameter.Size & (pageSize - 1)) != 0)
+            if (inParameter.Size == 0 || (inParameter.Size % PageSize) != 0)
             {
                 return UpdateResult.InvalidParameter;
             }

--- a/Ryujinx.Audio/Renderer/Server/MemoryPool/PoolMapper.cs
+++ b/Ryujinx.Audio/Renderer/Server/MemoryPool/PoolMapper.cs
@@ -256,19 +256,19 @@ namespace Ryujinx.Audio.Renderer.Server.MemoryPool
 
             MemoryPoolUserState outputState;
 
-            const uint PageSize = 0x1000;
+            const uint pageSize = 0x1000;
 
             if (inputState != MemoryPoolUserState.RequestAttach && inputState != MemoryPoolUserState.RequestDetach)
             {
                 return UpdateResult.Success;
             }
 
-            if (inParameter.CpuAddress == 0 || (inParameter.CpuAddress % PageSize) != 0)
+            if (inParameter.CpuAddress == 0 || (inParameter.CpuAddress % pageSize) != 0)
             {
                 return UpdateResult.InvalidParameter;
             }
 
-            if (inParameter.Size == 0 || (inParameter.Size % PageSize) != 0)
+            if (inParameter.Size == 0 || (inParameter.Size % pageSize) != 0)
             {
                 return UpdateResult.InvalidParameter;
             }

--- a/Ryujinx.Audio/ResultCode.cs
+++ b/Ryujinx.Audio/ResultCode.cs
@@ -17,5 +17,6 @@ namespace Ryujinx.Audio
         InvalidAddressInfo = (42 << ErrorCodeShift) | ModuleId,
         InvalidMixSorting = (43 << ErrorCodeShift) | ModuleId,
         UnsupportedOperation = (513 << ErrorCodeShift) | ModuleId,
+        InvalidExecutionContextOperation = (514 << ErrorCodeShift) | ModuleId,
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/AudioRenderer.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/AudioRenderer.cs
@@ -16,7 +16,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
 
         public ResultCode ExecuteAudioRendererRendering()
         {
-            throw new NotImplementedException();
+            return (ResultCode)_impl.ExecuteAudioRendererRendering();
         }
 
         public uint GetMixBufferCount()
@@ -107,6 +107,16 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             {
                 _impl.Dispose();
             }
+        }
+
+        public void SetVoiceDropParameter(float voiceDropParameter)
+        {
+            _impl.SetVoiceDropParameter(voiceDropParameter);
+        }
+
+        public float GetVoiceDropParameter()
+        {
+            return _impl.GetVoiceDropParameter();
         }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/AudioRendererServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/AudioRendererServer.cs
@@ -172,6 +172,35 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
             return result;
         }
 
+        [CommandHipc(11)] // 3.0.0+
+        // ExecuteAudioRendererRendering()
+        public ResultCode ExecuteAudioRendererRendering(ServiceCtx context)
+        {
+            return _impl.ExecuteAudioRendererRendering();
+        }
+
+        [CommandHipc(12)] // 15.0.0+
+        // SetVoiceDropParameter(f32 voiceDropParameter)
+        public ResultCode SetVoiceDropParameter(ServiceCtx context)
+        {
+            float voiceDropParameter = context.RequestData.ReadSingle();
+
+            _impl.SetVoiceDropParameter(voiceDropParameter);
+
+            return ResultCode.Success;
+        }
+
+        [CommandHipc(13)] // 15.0.0+
+        // GetVoiceDropParameter() -> f32 voiceDropParameter
+        public ResultCode GetVoiceDropParameter(ServiceCtx context)
+        {
+            float voiceDropParameter = _impl.GetVoiceDropParameter();
+
+            context.ResponseData.Write(voiceDropParameter);
+
+            return ResultCode.Success;
+        }
+
         protected override void Dispose(bool isDisposing)
         {
             if (isDisposing)

--- a/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/IAudioRenderer.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/IAudioRenderer.cs
@@ -16,5 +16,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
         void SetRenderingTimeLimit(uint percent);
         uint GetRenderingTimeLimit();
         ResultCode ExecuteAudioRendererRendering();
+        void SetVoiceDropParameter(float voiceDropParameter);
+        float GetVoiceDropParameter();
     }
 }


### PR DESCRIPTION
Changelog:

- Allow out of bound read on ADPCM's coefficients by forcing a value of 0 to be returned.
  - Address crashes on [Ninja Gaiden Sigma 2](https://github.com/Ryujinx/Ryujinx-Games-List/issues/4200) and [NINJA GAIDEN 3: Razor's Edge](https://github.com/Ryujinx/Ryujinx-Games-List/issues/4141) intro crash.
  - Fix a crash in [Paper Mario: The Origami King](https://github.com/Ryujinx/Ryujinx-Games-List/issues/2138) (Close #2525)
- Fix Delay effect wrong variable usage for matrix transform on Stereo, Quadraphonic and Surround codepaths.
- Update Delay effect Surround matrix to support REV11 optimization. 
- Change voice drop logic to use 32 bits integer to be closer to real firmware. (Might fix voice drop issues on some games, need testing)
- Add voice drop parameter support that was introduced in 15.0.0.
- Accurately stub ExecuteAudioRendererRendering.
- Some documentation and misc cleanup.

Supersedes #3653