### PR TITLE
Unbreak bug_report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: Something doesn't work correctly in Ryujinx. Note that game-specific issues should be instead posted on the Game Compatibility List at https://github.com/Ryujinx/Ryujinx-Games-List, unless it is a provable regression.
+about: Something doesn't work correctly in Ryujinx. Game-specific issues should be posted on the Game Compatibility List at https://github.com/Ryujinx/Ryujinx-Games-List, unless it is a provable regression.
 #assignees:
 ---
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug Report
-about: Something doesn't work correctly in Ryujinx. Game-specific issues should be posted on the Game Compatibility List at https://github.com/Ryujinx/Ryujinx-Games-List, unless it is a provable regression.
+about: Something doesn't work correctly in Ryujinx. Game-specific issues should be posted at https://github.com/Ryujinx/Ryujinx-Games-List instead, unless it is a provable regression.
 #assignees:
 ---
 


### PR DESCRIPTION
It would appear that GitHub does not allow the "about" section of an issue template to exceed 200 characters.
![image](https://user-images.githubusercontent.com/462484/204141046-ff050a65-e50b-4ad0-9bf8-966c218a7f19.png)
Because of this, the template is missing from the issue type selector when opening a new issue, meaning that there is a bug that stops me from reporting bugs 😆
![image](https://user-images.githubusercontent.com/462484/204141015-853765c4-04c0-4f42-a2d5-d4aadb0d6111.png)
I have shortened the extra information (originally added in 51bb8707efbbb1af9ca959e68c8ab7d6bd26dc07) so that it fits under this limit, which should make the template usable again.