### PR TITLE
sfdnsres: Fix deserializer of AddrInfoSerialized when addresses are empty

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/IResolver.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/IResolver.cs
@@ -566,7 +566,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
 
         private static List<AddrInfoSerialized> DeserializeAddrInfos(IVirtualMemoryManager memory, ulong address, ulong size)
         {
-            List<AddrInfoSerialized> result = new List<AddrInfoSerialized>();
+            List<AddrInfoSerialized> result = new();
 
             ReadOnlySpan<byte> data = memory.GetSpan(address, (int)size);
 
@@ -606,9 +606,9 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
                     }
 
                     // NOTE: 0 = Any
-                    AddrInfoSerializedHeader header = new AddrInfoSerializedHeader(ip, 0);
-                    AddrInfo4 addr = new AddrInfo4(ip, (short)port);
-                    AddrInfoSerialized info = new AddrInfoSerialized(header, addr, null, hostEntry.HostName);
+                    AddrInfoSerializedHeader header = new(ip, 0);
+                    AddrInfo4                addr   = new(ip, (short)port);
+                    AddrInfoSerialized       info   = new(header, addr, null, hostEntry.HostName);
 
                     data = info.Write(data);
                 }

--- a/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Types/AddrInfo4.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Types/AddrInfo4.cs
@@ -14,6 +14,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Types
         public byte         Family;
         public short        Port;
         public Array4<byte> Address;
+        public Array8<byte> Padding;
 
         public AddrInfo4(IPAddress address, short port)
         {

--- a/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Types/AddrInfoSerialized.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Types/AddrInfoSerialized.cs
@@ -35,7 +35,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Types
 
             AddrInfo4? socketAddress = null;
             Array4<byte>? rawIPv4Address = null;
-            string canonicalName = null;
+            string canonicalName;
 
             buffer = buffer[Unsafe.SizeOf<AddrInfoSerializedHeader>()..];
 
@@ -49,6 +49,13 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Types
             }
 
             Debug.Assert(header.Magic == SfdnsresContants.AddrInfoMagic);
+
+            if (header.AddressLength == 0)
+            {
+                rest = buffer;
+
+                return null;
+            }
 
             if (header.Family == (int)AddressFamily.InterNetwork)
             {


### PR DESCRIPTION
We currently doesn't check the `AddressLength` of the `AddrInfoSerializedHeader` and this could lead to an oob since we still trying to parse addresses for the (unused) passed `hints` in `GetAddrInfoRequestImpl`.

I've cleaned up a bit the code too, and added a missing padding which could help to understand the size of `AddrInfo4`.

Fixes https://github.com/Ryujinx/Ryujinx/issues/3918

HB App Store seems to works (at least run, I haven't tried it more):
![image](https://user-images.githubusercontent.com/4905390/204164693-39dd446c-1948-441a-a34a-6d8dfb80b6a6.png)
