### PR TITLE
GPU: Always draw polygon topology as triangle fan

### DIFF
--- a/Ryujinx.Graphics.OpenGL/EnumConversion.cs
+++ b/Ryujinx.Graphics.OpenGL/EnumConversion.cs
@@ -331,7 +331,7 @@ namespace Ryujinx.Graphics.OpenGL
                 case PrimitiveTopology.QuadStrip:
                     return PrimitiveType.QuadStrip;
                 case PrimitiveTopology.Polygon:
-                    return PrimitiveType.Polygon;
+                    return PrimitiveType.TriangleFan;
                 case PrimitiveTopology.LinesAdjacency:
                     return PrimitiveType.LinesAdjacency;
                 case PrimitiveTopology.LineStripAdjacency:

--- a/Ryujinx.Graphics.Vulkan/EnumConversion.cs
+++ b/Ryujinx.Graphics.Vulkan/EnumConversion.cs
@@ -180,6 +180,7 @@ namespace Ryujinx.Graphics.Vulkan
                 GAL.PrimitiveTopology.TrianglesAdjacency => Silk.NET.Vulkan.PrimitiveTopology.TriangleListWithAdjacency,
                 GAL.PrimitiveTopology.TriangleStripAdjacency => Silk.NET.Vulkan.PrimitiveTopology.TriangleStripWithAdjacency,
                 GAL.PrimitiveTopology.Patches => Silk.NET.Vulkan.PrimitiveTopology.PatchList,
+                GAL.PrimitiveTopology.Polygon => Silk.NET.Vulkan.PrimitiveTopology.TriangleFan,
                 GAL.PrimitiveTopology.Quads => throw new NotSupportedException("Quad topology is not available in Vulkan."),
                 GAL.PrimitiveTopology.QuadStrip => throw new NotSupportedException("QuadStrip topology is not available in Vulkan."),
                 _ => LogInvalidAndReturn(topology, nameof(GAL.PrimitiveTopology), Silk.NET.Vulkan.PrimitiveTopology.TriangleList)

--- a/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -328,7 +328,8 @@ namespace Ryujinx.Graphics.Vulkan
                 IndexBufferPattern pattern = _topology switch
                 {
                     GAL.PrimitiveTopology.Quads => QuadsToTrisPattern,
-                    GAL.PrimitiveTopology.TriangleFan => TriFanToTrisPattern,
+                    GAL.PrimitiveTopology.TriangleFan or
+                    GAL.PrimitiveTopology.Polygon => TriFanToTrisPattern,
                     _ => throw new NotSupportedException($"Unsupported topology: {_topology}")
                 };
 
@@ -359,7 +360,8 @@ namespace Ryujinx.Graphics.Vulkan
                 pattern = _topology switch
                 {
                     GAL.PrimitiveTopology.Quads => QuadsToTrisPattern,
-                    GAL.PrimitiveTopology.TriangleFan => TriFanToTrisPattern,
+                    GAL.PrimitiveTopology.TriangleFan or
+                    GAL.PrimitiveTopology.Polygon => TriFanToTrisPattern,
                     _ => throw new NotSupportedException($"Unsupported topology: {_topology}")
                 };
             }


### PR DESCRIPTION
Polygon topology wasn't really supported and would only work on OpenGL on drivers that haven't removed it. As an alternative, this PR makes all cases of polygon topology use triangle fan. The topology type and transform feedback type have not been changed, as I don't think geo shader/tfb should be used with polygons.

The OpenGL spec states:
> Only convex polygons are guaranteed to be drawn correctly by the GL.

For convex polygons, triangle fan is equivalent to polygon. I imagine this is probably how it works on device, as this get-out-of-jail-free card is too enticing to pass up.

This fixes the stat display in Pokemon S/V in Vulkan, or on OpenGL on drivers that don't support GL_POLYGON in compatibility mode.