### PR TITLE
Avalonia: Update FluientAvalonia & Make dialogs work on Linux

### DIFF
--- a/Ryujinx.Ava/Ryujinx.Ava.csproj
+++ b/Ryujinx.Ava/Ryujinx.Ava.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Avalonia.Svg.Skia" Version="0.10.18" />
     <PackageReference Include="jp2masa.Avalonia.Flexbox" Version="0.2.0" />
     <PackageReference Include="DynamicData" Version="7.12.8" />
-    <PackageReference Include="FluentAvaloniaUI" Version="1.4.4" />
+    <PackageReference Include="FluentAvaloniaUI" Version="1.4.5" />
     <PackageReference Include="XamlNameReferenceGenerator" Version="1.4.2" />
 
     <PackageReference Include="OpenTK.Core" Version="4.7.2" />

--- a/Ryujinx.Ava/Ui/Controls/ContentDialogHelper.cs
+++ b/Ryujinx.Ava/Ui/Controls/ContentDialogHelper.cs
@@ -127,9 +127,16 @@ namespace Ryujinx.Ava.Ui.Controls
                     contentDialog.PrimaryButtonClick += deferCloseAction;
                 }
 
-                await contentDialog.ShowAsync(ContentDialogPlacement.Popup);
+                if (useOverlay)
+                {
+                    await contentDialog.ShowAsync(overlay, ContentDialogPlacement.Popup);
 
-                overlay?.Close();
+                    overlay!.Close();
+                }
+                else
+                {
+                    await contentDialog.ShowAsync(ContentDialogPlacement.Popup);
+                }
             }
 
             if (useOverlay)


### PR DESCRIPTION
Thanks to @amwx we are *finally* able to fix invisible dialogs on Linux! 

This PR updates FluentAvalonia to [1.4.5](https://github.com/amwx/FluentAvalonia/pull/248#issuecomment-1329844847) and adapts `ContentDialogHelper` to use the new function signature when using an overlay window.

As soon as this is merged, Avalonia will be completely usable on Linux again!