### PR TITLE
Ensure that vertex attribute buffer index is valid on GPU

### DIFF
--- a/Ryujinx.Graphics.OpenGL/VertexArray.cs
+++ b/Ryujinx.Graphics.OpenGL/VertexArray.cs
@@ -10,13 +10,9 @@ namespace Ryujinx.Graphics.OpenGL
     {
         public int Handle { get; private set; }
 
-        private bool _needsAttribsUpdate;
-
         private readonly VertexAttribDescriptor[] _vertexAttribs;
         private readonly VertexBufferDescriptor[] _vertexBuffers;
 
-        private int _vertexAttribsCount;
-        private int _vertexBuffersCount;
         private int _minVertexCount;
 
         private uint _vertexAttribsInUse;
@@ -76,9 +72,7 @@ namespace Ryujinx.Graphics.OpenGL
                 _vertexBuffers[bindingIndex] = vb;
             }
 
-            _vertexBuffersCount = bindingIndex;
             _minVertexCount = minVertexCount;
-            _needsAttribsUpdate = true;
         }
 
         public void SetVertexAttributes(ReadOnlySpan<VertexAttribDescriptor> vertexAttribs)
@@ -130,8 +124,6 @@ namespace Ryujinx.Graphics.OpenGL
 
                 _vertexAttribs[index] = attrib;
             }
-
-            _vertexAttribsCount = index;
 
             for (; index < Constants.MaxVertexAttribs; index++)
             {

--- a/Ryujinx.Graphics.OpenGL/VertexArray.cs
+++ b/Ryujinx.Graphics.OpenGL/VertexArray.cs
@@ -160,13 +160,11 @@ namespace Ryujinx.Graphics.OpenGL
         public void PreDraw(int vertexCount)
         {
             LimitVertexBuffers(vertexCount);
-            Validate();
         }
 
         public void PreDrawVbUnbounded()
         {
             UnlimitVertexBuffers();
-            Validate();
         }
 
         public void LimitVertexBuffers(int vertexCount)
@@ -250,36 +248,6 @@ namespace Ryujinx.Graphics.OpenGL
             }
 
             _vertexBuffersLimited = 0;
-        }
-
-        public void Validate()
-        {
-            for (int attribIndex = 0; attribIndex < _vertexAttribsCount; attribIndex++)
-            {
-                VertexAttribDescriptor attrib = _vertexAttribs[attribIndex];
-
-                if (!attrib.IsZero)
-                {
-                    if ((uint)attrib.BufferIndex >= _vertexBuffersCount)
-                    {
-                        DisableVertexAttrib(attribIndex);
-                        continue;
-                    }
-
-                    if (_vertexBuffers[attrib.BufferIndex].Buffer.Handle == BufferHandle.Null)
-                    {
-                        DisableVertexAttrib(attribIndex);
-                        continue;
-                    }
-
-                    if (_needsAttribsUpdate)
-                    {
-                        EnableVertexAttrib(attribIndex);
-                    }
-                }
-            }
-
-            _needsAttribsUpdate = false;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Some games will have vertex attributes with a invalid buffer index (the vertex buffer doesn't exist). This is invalid and may cause crashes on both on OpenGL and Vulkan depending on the driver. The OpenGL backend was already validating this and disabling the attribute if the buffer index was invalid. However, Vulkan wasn't. This changes does the validation on the GPU project, and removes the validation from the OpenGL backend. So now both backends should be covered.

Fixes some crashes on specific games on Vulkan with some drivers. I don't think this issue affects NVIDIA.