### PR TITLE
GPU: Track buffer migrations and flush source on incomplete copy

### DIFF
--- a/Ryujinx.Graphics.GAL/IRenderer.cs
+++ b/Ryujinx.Graphics.GAL/IRenderer.cs
@@ -29,6 +29,7 @@ namespace Ryujinx.Graphics.GAL
         ReadOnlySpan<byte> GetBufferData(BufferHandle buffer, int offset, int size);
 
         Capabilities GetCapabilities();
+        ulong GetCurrentSync();
         HardwareInfo GetHardwareInfo();
 
         IProgram LoadProgramBinary(byte[] programBinary, bool hasFragmentShader, ShaderInfo info);

--- a/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
@@ -338,6 +338,11 @@ namespace Ryujinx.Graphics.GAL.Multithreading
             return box.Result;
         }
 
+        public ulong GetCurrentSync()
+        {
+            return _baseRenderer.GetCurrentSync();
+        }
+
         public HardwareInfo GetHardwareInfo()
         {
             return _baseRenderer.GetHardwareInfo();

--- a/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -70,6 +70,12 @@ namespace Ryujinx.Graphics.Gpu
         internal List<Action> SyncpointActions { get; }
 
         /// <summary>
+        /// Buffer migrations that are currently in-flight. These are checked whenever sync is created to determine if buffer migration
+        /// copies have completed on the GPU, and their data can be freed.
+        /// </summary>
+        internal List<BufferMigration> BufferMigrations { get; }
+
+        /// <summary>
         /// Queue with deferred actions that must run on the render thread.
         /// </summary>
         internal Queue<Action> DeferredActions { get; }
@@ -90,6 +96,7 @@ namespace Ryujinx.Graphics.Gpu
         public event Action<ShaderCacheState, int, int> ShaderCacheStateChanged;
 
         private Thread _gpuThread;
+        private bool _pendingSync;
 
         /// <summary>
         /// Creates a new instance of the GPU emulation context.
@@ -109,6 +116,7 @@ namespace Ryujinx.Graphics.Gpu
 
             SyncActions = new List<Action>();
             SyncpointActions = new List<Action>();
+            BufferMigrations = new List<BufferMigration>();
 
             DeferredActions = new Queue<Action>();
 
@@ -274,6 +282,17 @@ namespace Ryujinx.Graphics.Gpu
         }
 
         /// <summary>
+        /// Registers a buffer migration. These are checked to see if they can be disposed when the sync number increases,
+        /// and the migration copy has completed.
+        /// </summary>
+        /// <param name="migration">The buffer migration</param>
+        internal void RegisterBufferMigration(BufferMigration migration)
+        {
+            BufferMigrations.Add(migration);
+            _pendingSync = true;
+        }
+
+        /// <summary>
         /// Registers an action to be performed the next time a syncpoint is incremented.
         /// This will also ensure a host sync object is created, and <see cref="SyncNumber"/> is incremented.
         /// </summary>
@@ -288,6 +307,7 @@ namespace Ryujinx.Graphics.Gpu
             else
             {
                 SyncActions.Add(action);
+                _pendingSync = true;
             }
         }
 
@@ -298,7 +318,24 @@ namespace Ryujinx.Graphics.Gpu
         /// <param name="syncpoint">True if host sync is being created by a syncpoint</param>
         public void CreateHostSyncIfNeeded(bool syncpoint)
         {
-            if (SyncActions.Count > 0 || (syncpoint && SyncpointActions.Count > 0))
+            if (BufferMigrations.Count > 0)
+            {
+                ulong currentSyncNumber = Renderer.GetCurrentSync();
+
+                for (int i = 0; i < BufferMigrations.Count; i++)
+                {
+                    BufferMigration migration = BufferMigrations[i];
+                    long diff = (long)(currentSyncNumber - migration.SyncNumber);
+
+                    if (diff >= 0)
+                    {
+                        migration.Dispose();
+                        BufferMigrations.RemoveAt(i--);
+                    }
+                }
+            }
+
+            if (_pendingSync || (syncpoint && SyncpointActions.Count > 0))
             {
                 Renderer.CreateSync(SyncNumber);
 
@@ -317,6 +354,8 @@ namespace Ryujinx.Graphics.Gpu
                 SyncActions.Clear();
                 SyncpointActions.Clear();
             }
+
+            _pendingSync = false;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
@@ -292,7 +292,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="from">The buffer to inherit from</param>
         public void InheritModifiedRanges(Buffer from)
         {
-            if (from._modifiedRanges != null)
+            if (from._modifiedRanges != null && from._modifiedRanges.HasRanges)
             {
                 if (from._syncActionRegistered && !_syncActionRegistered)
                 {

--- a/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
@@ -315,20 +315,6 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 EnsureRangeList();
 
                 _modifiedRanges.InheritRanges(from._modifiedRanges, registerRangeAction);
-
-                /* This may be incompatible with the new way of recording buffer migrations.
-                if (_modifiedRanges == null)
-                {
-                    _modifiedRanges = from._modifiedRanges;
-                    _modifiedRanges.ReregisterRanges(registerRangeAction);
-
-                    from._modifiedRanges = null;
-                }
-                else
-                {
-                    _modifiedRanges.InheritRanges(from._modifiedRanges, registerRangeAction);
-                }
-                */
             }
         }
 

--- a/Ryujinx.Graphics.Gpu/Memory/BufferCache.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferCache.cs
@@ -273,7 +273,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                         buffer.CopyTo(newBuffer, dstOffset);
                         newBuffer.InheritModifiedRanges(buffer);
 
-                        buffer.DisposeData();
+                        buffer.DecrementReferenceCount();
                     }
 
                     newBuffer.SynchronizeMemory(address, newSize);

--- a/Ryujinx.Graphics.Gpu/Memory/BufferMigration.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferMigration.cs
@@ -1,0 +1,120 @@
+﻿using System;
+
+namespace Ryujinx.Graphics.Gpu.Memory
+{
+    /// <summary>
+    /// A record of when buffer data was copied from one buffer to another, along with the SyncNumber when the migration will be complete.
+    /// Keeps the source buffer alive for data flushes until the migration is complete.
+    /// </summary>
+    internal class BufferMigration : IDisposable
+    {
+        /// <summary>
+        /// The offset for the migrated region.
+        /// </summary>
+        private readonly ulong _offset;
+
+        /// <summary>
+        /// The size for the migrated region.
+        /// </summary>
+        private readonly ulong _size;
+
+        /// <summary>
+        /// The buffer that was migrated from.
+        /// </summary>
+        private readonly Buffer _buffer;
+
+        /// <summary>
+        /// The source range action, to be called on overlap with an unreached sync number.
+        /// </summary>
+        private readonly Action<ulong, ulong> _sourceRangeAction;
+
+        /// <summary>
+        /// The source range list.
+        /// </summary>
+        private readonly BufferModifiedRangeList _source;
+
+        /// <summary>
+        /// The destination range list. This range list must be updated when flushing the source.
+        /// </summary>
+        public readonly BufferModifiedRangeList Destination;
+
+        /// <summary>
+        /// The sync number that needs to be reached for this migration to be removed. This is set to the pending sync number on creation.
+        /// </summary>
+        public readonly ulong SyncNumber;
+
+        /// <summary>
+        /// Creates a record for a buffer migration.
+        /// </summary>
+        /// <param name="buffer">The source buffer for this migration</param>
+        /// <param name="sourceRangeAction">The flush action for the source buffer</param>
+        /// <param name="source">The modified range list for the source buffer</param>
+        /// <param name="dest">The modified range list for the destination buffer</param>
+        /// <param name="syncNumber">The sync number for when the migration is complete</param>
+        public BufferMigration(Buffer buffer, Action<ulong, ulong> sourceRangeAction, BufferModifiedRangeList source, BufferModifiedRangeList dest, ulong syncNumber)
+        {
+            _offset = buffer.Address;
+            _size = buffer.Size;
+            _buffer = buffer;
+            _sourceRangeAction = sourceRangeAction;
+            _source = source;
+            Destination = dest;
+            SyncNumber = syncNumber;
+        }
+
+        /// <summary>
+        /// Determine if the given range overlaps this migration, and has not been completed yet.
+        /// </summary>
+        /// <param name="offset">Start offset</param>
+        /// <param name="size">Range size</param>
+        /// <param name="syncNumber">The sync number that was waited on</param>
+        /// <returns>True if overlapping and in progress, false otherwise</returns>
+        public bool Overlaps(ulong offset, ulong size, ulong syncNumber)
+        {
+            ulong end = offset + size;
+            ulong destEnd = _offset + _size;
+            long syncDiff = (long)(syncNumber - SyncNumber); // syncNumber is less if the copy has not completed.
+
+            return !(end <= _offset || offset >= destEnd) && syncDiff < 0;
+        }
+
+        /// <summary>
+        /// Determine if the given range matches this migration.
+        /// </summary>
+        /// <param name="offset">Start offset</param>
+        /// <param name="size">Range size</param>
+        /// <returns>True if the range exactly matches, false otherwise</returns>
+        public bool FullyMatches(ulong offset, ulong size)
+        {
+            return _offset == offset && _size == size;
+        }
+
+        /// <summary>
+        /// Perform the migration source's range action on the range provided, clamped to the bounds of the source buffer.
+        /// </summary>
+        /// <param name="offset">Start offset</param>
+        /// <param name="size">Range size</param>
+        /// <param name="syncNumber">Current sync number</param>
+        /// <param name="parent">The modified range list that originally owned this range</param>
+        public void RangeActionWithMigration(ulong offset, ulong size, ulong syncNumber, BufferModifiedRangeList parent)
+        {
+            ulong end = offset + size;
+            end = Math.Min(_offset + _size, end);
+            offset = Math.Max(_offset, offset);
+
+            size = end - offset;
+
+            _source.RangeActionWithMigration(offset, size, syncNumber, parent, _sourceRangeAction);
+        }
+
+        /// <summary>
+        /// Removes this reference to the range list, potentially allowing for the source buffer to be disposed.
+        /// </summary>
+        public void Dispose()
+        {
+            Destination.RemoveMigration(this);
+
+            _buffer.DecrementReferenceCount();
+        }
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Memory/BufferMigration.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferMigration.cs
@@ -51,7 +51,12 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="source">The modified range list for the source buffer</param>
         /// <param name="dest">The modified range list for the destination buffer</param>
         /// <param name="syncNumber">The sync number for when the migration is complete</param>
-        public BufferMigration(Buffer buffer, Action<ulong, ulong> sourceRangeAction, BufferModifiedRangeList source, BufferModifiedRangeList dest, ulong syncNumber)
+        public BufferMigration(
+            Buffer buffer,
+            Action<ulong, ulong> sourceRangeAction,
+            BufferModifiedRangeList source,
+            BufferModifiedRangeList dest,
+            ulong syncNumber)
         {
             _offset = buffer.Address;
             _size = buffer.Size;

--- a/Ryujinx.Graphics.Gpu/Memory/BufferModifiedRangeList.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferModifiedRangeList.cs
@@ -429,8 +429,6 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 {
                     (_sources ??= new List<BufferMigration>()).Add(migration);
 
-                    _sources.Add(migration);
-
                     foreach (BufferModifiedRange range in inheritRanges)
                     {
                         Add(range);

--- a/Ryujinx.Graphics.Gpu/Memory/BufferModifiedRangeList.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferModifiedRangeList.cs
@@ -81,6 +81,20 @@ namespace Ryujinx.Graphics.Gpu.Memory
         private object _lock = new object();
 
         /// <summary>
+        /// Whether the modified range list has any entries or not.
+        /// </summary>
+        public bool HasRanges
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return Count > 0;
+                }
+            }
+        }
+
+        /// <summary>
         /// Creates a new instance of a modified range list.
         /// </summary>
         /// <param name="context">GPU context that the buffer range list belongs to</param>

--- a/Ryujinx.Graphics.Gpu/Memory/BufferModifiedRangeList.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferModifiedRangeList.cs
@@ -1,6 +1,8 @@
-﻿using Ryujinx.Common.Pools;
+﻿using Ryujinx.Common.Logging;
+using Ryujinx.Common.Pools;
 using Ryujinx.Memory.Range;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Ryujinx.Graphics.Gpu.Memory
@@ -31,16 +33,23 @@ namespace Ryujinx.Graphics.Gpu.Memory
         public ulong SyncNumber { get; internal set; }
 
         /// <summary>
+        /// The range list that originally owned this range.
+        /// </summary>
+        public BufferModifiedRangeList Parent { get; internal set; }
+
+        /// <summary>
         /// Creates a new instance of a modified range.
         /// </summary>
         /// <param name="address">Start address of the range</param>
         /// <param name="size">Size of the range in bytes</param>
         /// <param name="syncNumber">The GPU sync number at the time of creation</param>
-        public BufferModifiedRange(ulong address, ulong size, ulong syncNumber)
+        /// <param name="parent">The range list that owns this range</param>
+        public BufferModifiedRange(ulong address, ulong size, ulong syncNumber, BufferModifiedRangeList parent)
         {
             Address = address;
             Size = size;
             SyncNumber = syncNumber;
+            Parent = parent;
         }
 
         /// <summary>
@@ -63,6 +72,11 @@ namespace Ryujinx.Graphics.Gpu.Memory
         private const int BackingInitialSize = 8;
 
         private GpuContext _context;
+        private Buffer _parent;
+        private Action<ulong, ulong> _flushAction;
+
+        private List<BufferMigration> _sources;
+        private BufferMigration _migrationTarget;
 
         private object _lock = new object();
 
@@ -70,9 +84,13 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// Creates a new instance of a modified range list.
         /// </summary>
         /// <param name="context">GPU context that the buffer range list belongs to</param>
-        public BufferModifiedRangeList(GpuContext context) : base(BackingInitialSize)
+        /// <param name="parent">The parent buffer that owns this range list</param>
+        /// <param name="flushAction">The flush action for the parent buffer</param>
+        public BufferModifiedRangeList(GpuContext context, Buffer parent, Action<ulong, ulong> flushAction) : base(BackingInitialSize)
         {
             _context = context;
+            _parent = parent;
+            _flushAction = flushAction;
         }
 
         /// <summary>
@@ -142,6 +160,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                     {
                         // Region already exists. Just update the existing sync number.
                         overlap.SyncNumber = syncNumber;
+                        overlap.Parent = this;
 
                         return;
                     }
@@ -152,18 +171,18 @@ namespace Ryujinx.Graphics.Gpu.Memory
                     {
                         // A split item must be created behind this overlap.
 
-                        Add(new BufferModifiedRange(overlap.Address, address - overlap.Address, overlap.SyncNumber));
+                        Add(new BufferModifiedRange(overlap.Address, address - overlap.Address, overlap.SyncNumber, overlap.Parent));
                     }
 
                     if (overlap.Address < endAddress && overlap.EndAddress > endAddress)
                     {
                         // A split item must be created after this overlap.
 
-                        Add(new BufferModifiedRange(endAddress, overlap.EndAddress - endAddress, overlap.SyncNumber));
+                        Add(new BufferModifiedRange(endAddress, overlap.EndAddress - endAddress, overlap.SyncNumber, overlap.Parent));
                     }
                 }
 
-                Add(new BufferModifiedRange(address, size, syncNumber));
+                Add(new BufferModifiedRange(address, size, syncNumber, this));
             }
         }
 
@@ -208,8 +227,88 @@ namespace Ryujinx.Graphics.Gpu.Memory
         }
 
         /// <summary>
+        /// Performs the given range action, or one from a migration that overlaps and has not synced yet.
+        /// </summary>
+        /// <param name="offset">The offset to pass to the action</param>
+        /// <param name="size">The size to pass to the action</param>
+        /// <param name="syncNumber">The sync number that has been reached</param>
+        /// <param name="parent">The modified range list that originally owned this range</param>
+        /// <param name="rangeAction">The action to perform</param>
+        public void RangeActionWithMigration(ulong offset, ulong size, ulong syncNumber, BufferModifiedRangeList parent, Action<ulong, ulong> rangeAction)
+        {
+            bool firstSource = true;
+
+            if (parent != this)
+            {
+                lock (_lock)
+                {
+                    if (_sources != null)
+                    {
+                        foreach (BufferMigration source in _sources)
+                        {
+                            if (source.Overlaps(offset, size, syncNumber))
+                            {
+                                if (firstSource && !source.FullyMatches(offset, size))
+                                {
+                                    // Perform this buffer's action first. The migrations will run after.
+                                    rangeAction(offset, size);
+                                }
+
+                                Logger.Error?.PrintMsg(LogClass.Gpu, $"Flushing from migration source");
+                                source.RangeActionWithMigration(offset, size, syncNumber, parent);
+
+                                firstSource = false;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (firstSource)
+            {
+                // No overlapping migrations, or they are not meant for this range, flush the data using the given action.
+                rangeAction(offset, size);
+            }
+        }
+
+        private void RemoveRangesAndFlush(BufferModifiedRange[] overlaps, int rangeCount, long highestDiff, ulong currentSync, ulong address, ulong endAddress)
+        {
+            lock (_lock)
+            {
+                if (_migrationTarget == null)
+                {
+                    ulong waitSync = currentSync + (ulong)highestDiff;
+
+                    for (int i = 0; i < rangeCount; i++)
+                    {
+                        BufferModifiedRange overlap = overlaps[i];
+
+                        long diff = (long)(overlap.SyncNumber - currentSync);
+
+                        if (diff <= highestDiff)
+                        {
+                            ulong clampAddress = Math.Max(address, overlap.Address);
+                            ulong clampEnd = Math.Min(endAddress, overlap.EndAddress);
+
+                            ClearPart(overlap, clampAddress, clampEnd);
+
+                            RangeActionWithMigration(clampAddress, clampEnd - clampAddress, waitSync, overlap.Parent, _flushAction);
+                        }
+                    }
+
+                    return;
+                }
+            }
+
+            // There is a migration target to call instead. This can't be changed after set so accessing it outside the lock is fine.
+
+            Logger.Error?.PrintMsg(LogClass.Gpu, $"Notifying migration target");
+            _migrationTarget.Destination.RemoveRangesAndFlush(overlaps, rangeCount, highestDiff, currentSync, address, endAddress);
+        }
+
+        /// <summary>
         /// Gets modified ranges within the specified region, waits on ones from a previous sync number,
-        /// and then fires the given action for each range individually.
+        /// and then fires the flush action for each range individually.
         /// </summary>
         /// <remarks>
         /// This function assumes it is called from the background thread.
@@ -218,8 +317,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// </remarks>
         /// <param name="address">Start address to query</param>
         /// <param name="size">Size to query</param>
-        /// <param name="rangeAction">The action to call for each modified range</param>
-        public void WaitForAndGetRanges(ulong address, ulong size, Action<ulong, ulong> rangeAction)
+        public void WaitForAndFlushRanges(ulong address, ulong size)
         {
             ulong endAddress = address + size;
             ulong currentSync = _context.SyncNumber;
@@ -231,10 +329,23 @@ namespace Ryujinx.Graphics.Gpu.Memory
             // Range list must be consistent for this operation
             lock (_lock)
             {
-                rangeCount = FindOverlapsNonOverlapping(address, size, ref overlaps);
+                if (_migrationTarget != null)
+                {
+                    rangeCount = -1;
+                }
+                else
+                {
+                    rangeCount = FindOverlapsNonOverlapping(address, size, ref overlaps);
+                }
             }
 
-            if (rangeCount == 0)
+            if (rangeCount == -1)
+            {
+                _migrationTarget.Destination.WaitForAndFlushRanges(address, size);
+
+                return;
+            }
+            else if (rangeCount == 0)
             {
                 return;
             }
@@ -264,47 +375,42 @@ namespace Ryujinx.Graphics.Gpu.Memory
             // Wait for the syncpoint.
             _context.Renderer.WaitSync(currentSync + (ulong)highestDiff);
 
-            // Flush and remove all regions with the older syncpoint.
-            lock (_lock)
-            {
-                for (int i = 0; i < rangeCount; i++)
-                {
-                    BufferModifiedRange overlap = overlaps[i];
-
-                    long diff = (long)(overlap.SyncNumber - currentSync);
-
-                    if (diff <= highestDiff)
-                    {
-                        ulong clampAddress = Math.Max(address, overlap.Address);
-                        ulong clampEnd = Math.Min(endAddress, overlap.EndAddress);
-
-                        ClearPart(overlap, clampAddress, clampEnd);
-
-                        rangeAction(clampAddress, clampEnd - clampAddress);
-                    }
-                }
-            }
+            RemoveRangesAndFlush(overlaps, rangeCount, highestDiff, currentSync, address, endAddress);
         }
 
         /// <summary>
         /// Inherit ranges from another modified range list.
         /// </summary>
         /// <param name="ranges">The range list to inherit from</param>
-        /// <param name="rangeAction">The action to call for each modified range</param>
-        public void InheritRanges(BufferModifiedRangeList ranges, Action<ulong, ulong> rangeAction)
+        /// <param name="registerRangeAction">The action to call for each modified range</param>
+        public void InheritRanges(BufferModifiedRangeList ranges, Action<ulong, ulong> registerRangeAction)
         {
             BufferModifiedRange[] inheritRanges;
 
             lock (ranges._lock)
             {
-                inheritRanges = ranges.ToArray();
-            }
+                BufferMigration migration = new (ranges._parent, ranges._flushAction, ranges, this, _context.SyncNumber);
 
-            lock (_lock)
-            {
-                foreach (BufferModifiedRange range in inheritRanges)
+                ranges._parent.IncrementReferenceCount();
+                ranges._migrationTarget = migration;
+
+                _context.RegisterBufferMigration(migration);
+
+                inheritRanges = ranges.ToArray();
+
+                lock (_lock)
                 {
-                    Add(range);
+                    if (_sources == null)
+                    {
+                        _sources = new List<BufferMigration>();
+                    }
+
+                    _sources.Add(migration);
+
+                    foreach (BufferModifiedRange range in inheritRanges)
+                    {
+                        Add(range);
+                    }
                 }
             }
 
@@ -313,13 +419,29 @@ namespace Ryujinx.Graphics.Gpu.Memory
             {
                 if (range.SyncNumber != currentSync)
                 {
-                    rangeAction(range.Address, range.Size);
+                    registerRangeAction(range.Address, range.Size);
                 }
             }
         }
 
         /// <summary>
+        /// Removes a source buffer migration, indicating its copy has completed.
+        /// </summary>
+        /// <param name="migration">The migration to remove</param>
+        public void RemoveMigration(BufferMigration migration)
+        {
+            lock (_lock)
+            {
+                bool removed = _sources.Remove(migration);
+
+                Logger.Warning?.PrintMsg(LogClass.Gpu, $"Removed buffer migration {removed}");
+            }
+        }
+
+        /// <summary>
         /// Calls the given action for modified ranges that aren't from the current sync number.
+        /// 
+        /// TODO: unused?
         /// </summary>
         /// <param name="rangeAction">The action to call for each modified range</param>
         public void ReregisterRanges(Action<ulong, ulong> rangeAction)
@@ -341,6 +463,8 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 {
                     ranges[i++] = range;
                 }
+
+                // TODO: either remove, or somehow do recursive migrations within the same range list
             }
 
             ulong currentSync = _context.SyncNumber;
@@ -362,12 +486,12 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
             if (overlap.Address < address)
             {
-                Add(new BufferModifiedRange(overlap.Address, address - overlap.Address, overlap.SyncNumber));
+                Add(new BufferModifiedRange(overlap.Address, address - overlap.Address, overlap.SyncNumber, overlap.Parent));
             }
 
             if (overlap.EndAddress > endAddress)
             {
-                Add(new BufferModifiedRange(endAddress, overlap.EndAddress - endAddress, overlap.SyncNumber));
+                Add(new BufferModifiedRange(endAddress, overlap.EndAddress - endAddress, overlap.SyncNumber, overlap.Parent));
             }
         }
 

--- a/Ryujinx.Graphics.Gpu/Memory/BufferModifiedRangeList.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferModifiedRangeList.cs
@@ -284,7 +284,22 @@ namespace Ryujinx.Graphics.Gpu.Memory
             }
         }
 
-        private void RemoveRangesAndFlush(BufferModifiedRange[] overlaps, int rangeCount, long highestDiff, ulong currentSync, ulong address, ulong endAddress)
+        /// <summary>
+        /// Removes modified ranges ready by the sync number from the list, and flushes their buffer data within a given address range.
+        /// </summary>
+        /// <param name="overlaps">Overlapping ranges to check</param>
+        /// <param name="rangeCount">Number of overlapping ranges</param>
+        /// <param name="highestDiff">The highest difference between an overlapping range's sync number and the current one</param>
+        /// <param name="currentSync">The current sync number</param>
+        /// <param name="address">The start address of the flush range</param>
+        /// <param name="endAddress">The end address of the flush range</param>
+        private void RemoveRangesAndFlush(
+            BufferModifiedRange[] overlaps,
+            int rangeCount,
+            long highestDiff,
+            ulong currentSync,
+            ulong address,
+            ulong endAddress)
         {
             lock (_lock)
             {
@@ -401,7 +416,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
             lock (ranges._lock)
             {
-                BufferMigration migration = new (ranges._parent, ranges._flushAction, ranges, this, _context.SyncNumber);
+                BufferMigration migration = new(ranges._parent, ranges._flushAction, ranges, this, _context.SyncNumber);
 
                 ranges._parent.IncrementReferenceCount();
                 ranges._migrationTarget = migration;
@@ -412,10 +427,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
                 lock (_lock)
                 {
-                    if (_sources == null)
-                    {
-                        _sources = new List<BufferMigration>();
-                    }
+                    (_sources ??= new List<BufferMigration>()).Add(migration);
 
                     _sources.Add(migration);
 
@@ -444,7 +456,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         {
             lock (_lock)
             {
-                bool removed = _sources.Remove(migration);
+                _sources.Remove(migration);
             }
         }
 

--- a/Ryujinx.Graphics.OpenGL/OpenGLRenderer.cs
+++ b/Ryujinx.Graphics.OpenGL/OpenGLRenderer.cs
@@ -238,6 +238,11 @@ namespace Ryujinx.Graphics.OpenGL
             _sync.Wait(id);
         }
 
+        public ulong GetCurrentSync()
+        {
+            return _sync.GetCurrent();
+        }
+
         public void Screenshot()
         {
             _window.ScreenCaptureRequested = true;

--- a/Ryujinx.Graphics.OpenGL/Sync.cs
+++ b/Ryujinx.Graphics.OpenGL/Sync.cs
@@ -57,9 +57,9 @@ namespace Ryujinx.Graphics.OpenGL
 
                         if (handle.ID > lastHandle)
                         {
-                            WaitSyncStatus syncResult = GL.ClientWaitSync(handle.Handle, _syncFlags, 1000000000);
+                            WaitSyncStatus syncResult = GL.ClientWaitSync(handle.Handle, _syncFlags, 0);
 
-                            if (syncResult != WaitSyncStatus.TimeoutExpired)
+                            if (syncResult == WaitSyncStatus.AlreadySignaled)
                             {
                                 lastHandle = handle.ID;
                             }

--- a/Ryujinx.Graphics.Vulkan/SyncManager.cs
+++ b/Ryujinx.Graphics.Vulkan/SyncManager.cs
@@ -11,6 +11,7 @@ namespace Ryujinx.Graphics.Vulkan
         {
             public ulong ID;
             public MultiFenceHolder Waitable;
+            public bool Signalled;
         }
 
         private ulong _firstHandle = 0;
@@ -62,10 +63,11 @@ namespace Ryujinx.Graphics.Vulkan
 
                         if (handle.ID > lastHandle)
                         {
-                            bool signaled = handle.Waitable.WaitForFences(_gd.Api, _device, 0);
+                            bool signaled = handle.Signalled || handle.Waitable.WaitForFences(_gd.Api, _device, 0);
                             if (signaled)
                             {
                                 lastHandle = handle.ID;
+                                handle.Signalled = true;
                             }
                         }
                     }
@@ -105,10 +107,14 @@ namespace Ryujinx.Graphics.Vulkan
                         return;
                     }
 
-                    bool signaled = result.Waitable.WaitForFences(_gd.Api, _device, 1000000000);
+                    bool signaled = result.Signalled || result.Waitable.WaitForFences(_gd.Api, _device, 1000000000);
                     if (!signaled)
                     {
                         Logger.Error?.PrintMsg(LogClass.Gpu, $"VK Sync Object {result.ID} failed to signal within 1000ms. Continuing...");
+                    }
+                    else
+                    {
+                        result.Signalled = true;
                     }
                 }
             }

--- a/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -565,6 +565,11 @@ namespace Ryujinx.Graphics.Vulkan
             _syncManager.Wait(id);
         }
 
+        public ulong GetCurrentSync()
+        {
+            return _syncManager.GetCurrent();
+        }
+
         public void Screenshot()
         {
             _window.ScreenCaptureRequested = true;


### PR DESCRIPTION
Makes sure that the modified range list is always from the latest iteration of the buffer, and flushes earlier iterations of a buffer if the data has not been migrated yet.

Before, flushes on migrated buffers could flush uninitialized data, as it would assume that a sync number for a previous write had been reached, but the copy to migrate the buffer data had not yet been reached. The flush's change to the modified range could also be lost when switching, as the change would be applied to the dead buffer.

Buffers now have a reference count to keep their data alive. When a migration is performed (with modified ranges), then it takes a reference to the source buffer and gets added to a list on `_context`. When any sync is created, we check the current reached sync number and pending migrations to see if any can be removed. If they can, 

Upsides:
- Avoids this cause of buffer data loss.
Downsides:
- Buffers with modifications are kept alive after migrations until the next sync number is reached. This could cause increased memory spikes when resizing often.
  - Buffers without modifications don't have any issues. Maybe this could be improved by force flushing buffer data where the sync number has been reached, but I'm not sure about the performance implications (on opengl this isn't as free, when vulkan is choosing buffer memory types we don't want our cleanup to influence that either).
- Can't reuse BufferModifiedRangeList when migrating, as we need to track old states for flush.

This fixes most cases of vertex explosions in Pokemon Scarlet/Violet. On master without vsync, going through Mesagoza to the school, then to the east loading zone caused the main character to explode and never recover very consistently. It took hours of running around with vsync off to get an explosion with these changes, and it was on NPCs, and they recovered when they were reloaded. There may be some other issue with buffer flush that might be causing these.