### PR TITLE
Ava GUI: Add back locales removed in #3955

### DIFF
--- a/Ryujinx.Ava/Assets/Locales/de_DE.json
+++ b/Ryujinx.Ava/Assets/Locales/de_DE.json
@@ -166,6 +166,8 @@
   "SettingsTabInput": "Eingabe",
   "SettingsTabInputEnableDockedMode": "Docked Modus",
   "SettingsTabInputDirectKeyboardAccess": "Direkter Tastaturzugriff",
+  "SettingsButtonSave": "Speichern",
+  "SettingsButtonClose": "Schließen",
   "SettingsButtonOk": "OK",
   "SettingsButtonCancel": "Abbrechen",
   "SettingsButtonApply": "Übernehmen",

--- a/Ryujinx.Ava/Assets/Locales/el_GR.json
+++ b/Ryujinx.Ava/Assets/Locales/el_GR.json
@@ -166,6 +166,8 @@
   "SettingsTabInput": "Χειρισμός",
   "SettingsTabInputEnableDockedMode": "Ενεργοποίηση Docked Mode",
   "SettingsTabInputDirectKeyboardAccess": "Άμεση Πρόσβαση στο Πληκτρολόγιο",
+  "SettingsButtonSave": "Αποθήκευση",
+  "SettingsButtonClose": "Κλείσιμο",
   "SettingsButtonOk": "OK",
   "SettingsButtonCancel": "Ακύρωση",
   "SettingsButtonApply": "Εφαρμογή",

--- a/Ryujinx.Ava/Assets/Locales/en_US.json
+++ b/Ryujinx.Ava/Assets/Locales/en_US.json
@@ -166,6 +166,8 @@
   "SettingsTabInput": "Input",
   "SettingsTabInputEnableDockedMode": "Docked Mode",
   "SettingsTabInputDirectKeyboardAccess": "Direct Keyboard Access",
+  "SettingsButtonSave": "Save",
+  "SettingsButtonClose": "Close",
   "SettingsButtonOk": "OK",
   "SettingsButtonCancel": "Cancel",
   "SettingsButtonApply": "Apply",

--- a/Ryujinx.Ava/Assets/Locales/es_ES.json
+++ b/Ryujinx.Ava/Assets/Locales/es_ES.json
@@ -166,6 +166,8 @@
   "SettingsTabInput": "Entrada",
   "SettingsTabInputEnableDockedMode": "Modo dock/TV",
   "SettingsTabInputDirectKeyboardAccess": "Acceso directo al teclado",
+  "SettingsButtonSave": "Guardar",
+  "SettingsButtonClose": "Cerrar",
   "SettingsButtonOk": "OK",
   "SettingsButtonCancel": "Cancelar",
   "SettingsButtonApply": "Aplicar",

--- a/Ryujinx.Ava/Assets/Locales/fr_FR.json
+++ b/Ryujinx.Ava/Assets/Locales/fr_FR.json
@@ -159,6 +159,8 @@
   "SettingsTabInput": "Contrôles",
   "SettingsTabInputEnableDockedMode": "Active le mode station d'accueil",
   "SettingsTabInputDirectKeyboardAccess": "Accès direct au clavier",
+  "SettingsButtonSave": "Enregistrer",
+  "SettingsButtonClose": "Fermer",
   "SettingsButtonOk": "OK",
   "SettingsButtonCancel": "Annuler",
   "SettingsButtonApply": "Appliquer",

--- a/Ryujinx.Ava/Assets/Locales/it_IT.json
+++ b/Ryujinx.Ava/Assets/Locales/it_IT.json
@@ -166,6 +166,8 @@
     "SettingsTabInput": "Input",
     "SettingsTabInputEnableDockedMode": "Attiva modalità TV",
     "SettingsTabInputDirectKeyboardAccess": "Accesso diretto alla tastiera",
+    "SettingsButtonSave": "Salva",
+    "SettingsButtonClose": "Chiudi",
     "SettingsButtonOk": "OK",
     "SettingsButtonCancel": "Cancella",
     "SettingsButtonApply": "Applica",

--- a/Ryujinx.Ava/Assets/Locales/ja_JP.json
+++ b/Ryujinx.Ava/Assets/Locales/ja_JP.json
@@ -166,6 +166,8 @@
   "SettingsTabInput": "入力",
   "SettingsTabInputEnableDockedMode": "ドッキングモード",
   "SettingsTabInputDirectKeyboardAccess": "キーボード直接アクセス",
+  "SettingsButtonSave": "セーブ",
+  "SettingsButtonClose": "閉じる",
   "SettingsButtonOk": "オーケー",
   "SettingsButtonCancel": "キャンセル",
   "SettingsButtonApply": "適用",

--- a/Ryujinx.Ava/Assets/Locales/ko_KR.json
+++ b/Ryujinx.Ava/Assets/Locales/ko_KR.json
@@ -165,6 +165,8 @@
   "SettingsTabInput": "입력",
   "SettingsTabInputEnableDockedMode": "도킹 모드 활성화",
   "SettingsTabInputDirectKeyboardAccess": "직접 키보드 액세스",
+  "SettingsButtonSave": "구하다",
+  "SettingsButtonClose": "출구",
   "SettingsButtonOk": "좋아",
   "SettingsButtonCancel": "취소",
   "SettingsButtonApply": "적용하다",

--- a/Ryujinx.Ava/Assets/Locales/pl_PL.json
+++ b/Ryujinx.Ava/Assets/Locales/pl_PL.json
@@ -166,6 +166,8 @@
   "SettingsTabInput": "Sterowanie",
   "SettingsTabInputEnableDockedMode": "Tryb Zadokowany",
   "SettingsTabInputDirectKeyboardAccess": "Bezpośredni Dostęp do Klawiatury",
+  "SettingsButtonSave": "Zapisz",
+  "SettingsButtonClose": "Zamknij",
   "SettingsButtonOk": "OK",
   "SettingsButtonCancel": "Anuluj",
   "SettingsButtonApply": "Zastosuj",

--- a/Ryujinx.Ava/Assets/Locales/pt_BR.json
+++ b/Ryujinx.Ava/Assets/Locales/pt_BR.json
@@ -166,6 +166,8 @@
   "SettingsTabInput": "Controle",
   "SettingsTabInputEnableDockedMode": "Habilitar modo TV",
   "SettingsTabInputDirectKeyboardAccess": "Acesso direto ao teclado",
+  "SettingsButtonSave": "Salvar",
+  "SettingsButtonClose": "Fechar",
   "SettingsButtonOk": "OK",
   "SettingsButtonCancel": "Cancelar",
   "SettingsButtonApply": "Aplicar",

--- a/Ryujinx.Ava/Assets/Locales/ru_RU.json
+++ b/Ryujinx.Ava/Assets/Locales/ru_RU.json
@@ -165,6 +165,8 @@
   "SettingsTabInput": "Управление",
   "SettingsTabInputEnableDockedMode": "Включить режим закрепления",
   "SettingsTabInputDirectKeyboardAccess": "Прямой доступ с клавиатуры",
+  "SettingsButtonSave": "Сохранить",
+  "SettingsButtonClose": "Закрыть",
   "SettingsButtonOk": "OK",
   "SettingsButtonCancel": "Отмена",
   "SettingsButtonApply": "Применить",

--- a/Ryujinx.Ava/Assets/Locales/tr_TR.json
+++ b/Ryujinx.Ava/Assets/Locales/tr_TR.json
@@ -166,6 +166,8 @@
   "SettingsTabInput": "Giriş Yöntemi",
   "SettingsTabInputEnableDockedMode": "Docked Modunu Etkinleştir",
   "SettingsTabInputDirectKeyboardAccess": "Doğrudan Klavye Erişimi",
+  "SettingsButtonSave": "Kaydet",
+  "SettingsButtonClose": "Kapat",
   "SettingsButtonOk": "Tamam",
   "SettingsButtonCancel": "İptal",
   "SettingsButtonApply": "Uygula",

--- a/Ryujinx.Ava/Assets/Locales/zh_CN.json
+++ b/Ryujinx.Ava/Assets/Locales/zh_CN.json
@@ -166,6 +166,8 @@
   "SettingsTabInput": "输入",
   "SettingsTabInputEnableDockedMode": "主机模式",
   "SettingsTabInputDirectKeyboardAccess": "直通键盘控制",
+  "SettingsButtonSave": "保存",
+  "SettingsButtonClose": "关闭",
   "SettingsButtonOk": "批准",
   "SettingsButtonCancel": "取消",
   "SettingsButtonApply": "应用",

--- a/Ryujinx.Ava/Assets/Locales/zh_TW.json
+++ b/Ryujinx.Ava/Assets/Locales/zh_TW.json
@@ -166,6 +166,8 @@
   "SettingsTabInput": "輸入",
   "SettingsTabInputEnableDockedMode": "Docked 模式",
   "SettingsTabInputDirectKeyboardAccess": "直通鍵盤控制",
+  "SettingsButtonSave": "儲存",
+  "SettingsButtonClose": "關閉",
   "SettingsButtonOk": "嘛好",
   "SettingsButtonCancel": "取消",
   "SettingsButtonApply": "套用",


### PR DESCRIPTION
Add back `SettingsButtonSave` & `SettingsButtonClose` removed in #3955 

Fixes #3982 