### PR TITLE
Change default Vsync toggle hotkey to F1 instead of Tab

### DIFF
--- a/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
+++ b/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
@@ -680,7 +680,7 @@ namespace Ryujinx.Ui.Common.Configuration
             Hid.EnableMouse.Value                     = false;
             Hid.Hotkeys.Value = new KeyboardHotkeys
             {
-                ToggleVsync = Key.Tab,
+                ToggleVsync = Key.F1,
                 ToggleMute = Key.F2,
                 Screenshot = Key.F8,
                 ShowUi = Key.F4,
@@ -818,7 +818,7 @@ namespace Ryujinx.Ui.Common.Configuration
 
                 configurationFileFormat.Hotkeys = new KeyboardHotkeys
                 {
-                    ToggleVsync = Key.Tab
+                    ToggleVsync = Key.F1
                 };
 
                 configurationFileUpdated = true;
@@ -999,7 +999,7 @@ namespace Ryujinx.Ui.Common.Configuration
 
                 configurationFileFormat.Hotkeys = new KeyboardHotkeys
                 {
-                    ToggleVsync = Key.Tab,
+                    ToggleVsync = Key.F1,
                     Screenshot = Key.F8
                 };
 
@@ -1012,7 +1012,7 @@ namespace Ryujinx.Ui.Common.Configuration
 
                 configurationFileFormat.Hotkeys = new KeyboardHotkeys
                 {
-                    ToggleVsync = Key.Tab,
+                    ToggleVsync = Key.F1,
                     Screenshot = Key.F8,
                     ShowUi = Key.F4
                 };


### PR DESCRIPTION
People are constantly inadvertently uncapping their framerates with the hotkey being set to Tab due to Alt Tabbing. Furthermore, Avalonia uses Tab for UI navigation, so it doesn't even work there. As more people switch to Avalonia, it becomes more apparent that the default needs to change.

Chose F1 specifically because it's the closest to Tab. Was considering F9 instead as that has less chances of misclicking F2 (mute audio) or Esc (quit emulation), though I leave that up for debate. Regardless, it can be customized on Avalonia, so not too big of a deal.