### PR TITLE
GPU: Swap bindings array instead of copying

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Compute/ComputeClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Compute/ComputeClass.cs
@@ -202,57 +202,9 @@ namespace Ryujinx.Graphics.Gpu.Engine.Compute
                 _channel.BufferManager.SetComputeUniformBuffer(cb.Slot, cbDescriptor.PackAddress(), (uint)cbDescriptor.Size);
             }
 
-            _channel.BufferManager.SetComputeStorageBufferBindings(info.SBuffers);
-            _channel.BufferManager.SetComputeUniformBufferBindings(info.CBuffers);
+            _channel.BufferManager.SetComputeBufferBindings(cs.Bindings);
 
-            int maxTextureBinding = -1;
-            int maxImageBinding = -1;
-
-            TextureBindingInfo[] textureBindings = _channel.TextureManager.RentComputeTextureBindings(info.Textures.Count);
-
-            for (int index = 0; index < info.Textures.Count; index++)
-            {
-                var descriptor = info.Textures[index];
-
-                Target target = ShaderTexture.GetTarget(descriptor.Type);
-
-                textureBindings[index] = new TextureBindingInfo(
-                    target,
-                    descriptor.Binding,
-                    descriptor.CbufSlot,
-                    descriptor.HandleIndex,
-                    descriptor.Flags);
-
-                if (descriptor.Binding > maxTextureBinding)
-                {
-                    maxTextureBinding = descriptor.Binding;
-                }
-            }
-
-            TextureBindingInfo[] imageBindings = _channel.TextureManager.RentComputeImageBindings(info.Images.Count);
-
-            for (int index = 0; index < info.Images.Count; index++)
-            {
-                var descriptor = info.Images[index];
-
-                Target target = ShaderTexture.GetTarget(descriptor.Type);
-                Format format = ShaderTexture.GetFormat(descriptor.Format);
-
-                imageBindings[index] = new TextureBindingInfo(
-                    target,
-                    format,
-                    descriptor.Binding,
-                    descriptor.CbufSlot,
-                    descriptor.HandleIndex,
-                    descriptor.Flags);
-
-                if (descriptor.Binding > maxImageBinding)
-                {
-                    maxImageBinding = descriptor.Binding;
-                }
-            }
-
-            _channel.TextureManager.SetComputeMaxBindings(maxTextureBinding, maxImageBinding);
+            _channel.TextureManager.SetComputeBindings(cs.Bindings);
 
             // Should never return false for mismatching spec state, since the shader was fetched above.
             _channel.TextureManager.CommitComputeBindings(cs.SpecializationState);

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -57,45 +57,22 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Rents the texture bindings array of the compute pipeline.
+        /// Sets the texture and image bindings for the compute pipeline.
         /// </summary>
-        /// <param name="count">The number of bindings needed</param>
-        /// <returns>The texture bindings array</returns>
-        public TextureBindingInfo[] RentComputeTextureBindings(int count)
+        /// <param name="bindings">Bindings for the active shader</param>
+        public void SetComputeBindings(CachedShaderBindings bindings)
         {
-            return _cpBindingsManager.RentTextureBindings(0, count);
+            _cpBindingsManager.SetBindings(bindings);
         }
 
-        /// <summary>
-        /// Rents the texture bindings array for a given stage on the graphics pipeline.
-        /// </summary>
-        /// <param name="stage">The index of the shader stage to bind the textures</param>
-        /// <param name="count">The number of bindings needed</param>
-        /// <returns>The texture bindings array</returns>
-        public TextureBindingInfo[] RentGraphicsTextureBindings(int stage, int count)
-        {
-            return _gpBindingsManager.RentTextureBindings(stage, count);
-        }
 
         /// <summary>
-        /// Rents the image bindings array of the compute pipeline.
+        /// Sets the texture and image bindings for the graphics pipeline.
         /// </summary>
-        /// <param name="count">The number of bindings needed</param>
-        /// <returns>The image bindings array</returns>
-        public TextureBindingInfo[] RentComputeImageBindings(int count)
+        /// <param name="bindings">Bindings for the active shader</param>
+        public void SetGraphicsBindings(CachedShaderBindings bindings)
         {
-            return _cpBindingsManager.RentImageBindings(0, count);
-        }
-
-        /// <summary>
-        /// Rents the image bindings array for a given stage on the graphics pipeline.
-        /// </summary>
-        /// <param name="stage">The index of the shader stage to bind the images</param>
-        /// <param name="count">The number of bindings needed</param>
-        /// <returns>The image bindings array</returns>
-        public TextureBindingInfo[] RentGraphicsImageBindings(int stage, int count)
-        {
-            return _gpBindingsManager.RentImageBindings(stage, count);
+            _gpBindingsManager.SetBindings(bindings);
         }
 
         /// <summary>
@@ -108,32 +85,12 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Sets the max binding indexes on the compute pipeline.
-        /// </summary>
-        /// <param name="maxTextureBinding">The maximum texture binding</param>
-        /// <param name="maxImageBinding">The maximum image binding</param>
-        public void SetComputeMaxBindings(int maxTextureBinding, int maxImageBinding)
-        {
-            _cpBindingsManager.SetMaxBindings(maxTextureBinding, maxImageBinding);
-        }
-
-        /// <summary>
         /// Sets the texture constant buffer index on the graphics pipeline.
         /// </summary>
         /// <param name="index">The texture constant buffer index</param>
         public void SetGraphicsTextureBufferIndex(int index)
         {
             _gpBindingsManager.SetTextureBufferIndex(index);
-        }
-
-        /// <summary>
-        /// Sets the max binding indexes on the graphics pipeline.
-        /// </summary>
-        /// <param name="maxTextureBinding">The maximum texture binding</param>
-        /// <param name="maxImageBinding">The maximum image binding</param>
-        public void SetGraphicsMaxBindings(int maxTextureBinding, int maxImageBinding)
-        {
-            _gpBindingsManager.SetMaxBindings(maxTextureBinding, maxImageBinding);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -65,7 +65,6 @@ namespace Ryujinx.Graphics.Gpu.Image
             _cpBindingsManager.SetBindings(bindings);
         }
 
-
         /// <summary>
         /// Sets the texture and image bindings for the graphics pipeline.
         /// </summary>

--- a/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -1,10 +1,10 @@
 ﻿using Ryujinx.Common;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Image;
+using Ryujinx.Graphics.Gpu.Shader;
 using Ryujinx.Graphics.Shader;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Runtime.CompilerServices;
 
 namespace Ryujinx.Graphics.Gpu.Memory
@@ -34,7 +34,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
             /// <summary>
             /// Shader buffer binding information.
             /// </summary>
-            public BufferDescriptor[] Bindings { get; }
+            public BufferDescriptor[] Bindings { get; private set; }
 
             /// <summary>
             /// Buffer regions.
@@ -78,16 +78,17 @@ namespace Ryujinx.Graphics.Gpu.Memory
             /// Sets shader buffer binding information.
             /// </summary>
             /// <param name="descriptors">Buffer binding information</param>
-            public void SetBindings(ReadOnlyCollection<BufferDescriptor> descriptors)
+            public void SetBindings(BufferDescriptor[] descriptors)
             {
+                Bindings = descriptors;
+
                 if (descriptors == null)
                 {
                     Count = 0;
                     return;
                 }
 
-                descriptors.CopyTo(Bindings, 0);
-                Count = descriptors.Count;
+                Count = descriptors.Length;
             }
         }
 
@@ -320,41 +321,26 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <summary>
         /// Sets the binding points for the storage buffers bound on the compute pipeline.
         /// </summary>
-        /// <param name="descriptors">Buffer descriptors with the binding point values</param>
-        public void SetComputeStorageBufferBindings(ReadOnlyCollection<BufferDescriptor> descriptors)
+        /// <param name="bindings">Bindings for the active shader</param>
+        public void SetComputeBufferBindings(CachedShaderBindings bindings)
         {
-            _cpStorageBuffers.SetBindings(descriptors);
+            _cpStorageBuffers.SetBindings(bindings.StorageBufferBindings[0]);
+            _cpUniformBuffers.SetBindings(bindings.ConstantBufferBindings[0]);
         }
 
         /// <summary>
         /// Sets the binding points for the storage buffers bound on the graphics pipeline.
         /// </summary>
-        /// <param name="stage">Index of the shader stage</param>
-        /// <param name="descriptors">Buffer descriptors with the binding point values</param>
-        public void SetGraphicsStorageBufferBindings(int stage, ReadOnlyCollection<BufferDescriptor> descriptors)
+        /// <param name="bindings">Bindings for the active shader</param>
+        public void SetGraphicsBufferBindings(CachedShaderBindings bindings)
         {
-            _gpStorageBuffers[stage].SetBindings(descriptors);
+            for (int i = 0; i < Constants.ShaderStages; i++)
+            {
+                _gpStorageBuffers[i].SetBindings(bindings.StorageBufferBindings[i]);
+                _gpUniformBuffers[i].SetBindings(bindings.ConstantBufferBindings[i]);
+            }
+
             _gpStorageBuffersDirty = true;
-        }
-
-        /// <summary>
-        /// Sets the binding points for the uniform buffers bound on the compute pipeline.
-        /// </summary>
-        /// <param name="descriptors">Buffer descriptors with the binding point values</param>
-        public void SetComputeUniformBufferBindings(ReadOnlyCollection<BufferDescriptor> descriptors)
-        {
-            _cpUniformBuffers.SetBindings(descriptors);
-        }
-
-        /// <summary>
-        /// Sets the enabled uniform buffers mask on the graphics pipeline.
-        /// Each bit set on the mask indicates that the respective buffer index is enabled.
-        /// </summary>
-        /// <param name="stage">Index of the shader stage</param>
-        /// <param name="descriptors">Buffer descriptors with the binding point values</param>
-        public void SetGraphicsUniformBufferBindings(int stage, ReadOnlyCollection<BufferDescriptor> descriptors)
-        {
-            _gpUniformBuffers[stage].SetBindings(descriptors);
             _gpUniformBuffersDirty = true;
         }
 

--- a/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -80,15 +80,16 @@ namespace Ryujinx.Graphics.Gpu.Memory
             /// <param name="descriptors">Buffer binding information</param>
             public void SetBindings(BufferDescriptor[] descriptors)
             {
-                Bindings = descriptors;
-
                 if (descriptors == null)
                 {
                     Count = 0;
                     return;
                 }
 
-                Count = descriptors.Length;
+                if ((Count = descriptors.Length) != 0)
+                {
+                    Bindings = descriptors;
+                }
             }
         }
 

--- a/Ryujinx.Graphics.Gpu/Shader/CachedShaderBindings.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/CachedShaderBindings.cs
@@ -23,8 +23,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Create a new cached shader bindings collection.
         /// </summary>
-        /// <param name="isCompute"></param>
-        /// <param name="stages"></param>
+        /// <param name="isCompute">Whether the shader is for compute</param>
+        /// <param name="stages">The stages used by the shader</param>
         public CachedShaderBindings(bool isCompute, CachedShaderStage[] stages)
         {
             int stageCount = isCompute ? 1 : Constants.ShaderStages;

--- a/Ryujinx.Graphics.Gpu/Shader/CachedShaderBindings.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/CachedShaderBindings.cs
@@ -1,0 +1,103 @@
+﻿using Ryujinx.Graphics.GAL;
+using Ryujinx.Graphics.Gpu.Engine;
+using Ryujinx.Graphics.Gpu.Image;
+using Ryujinx.Graphics.Shader;
+using System;
+using System.Linq;
+
+namespace Ryujinx.Graphics.Gpu.Shader
+{
+    /// <summary>
+    /// A collection of shader bindings ready for insertion into the buffer and texture managers.
+    /// </summary>
+    internal class CachedShaderBindings
+    {
+        public TextureBindingInfo[][] TextureBindings { get; }
+        public TextureBindingInfo[][] ImageBindings { get; }
+        public BufferDescriptor[][] ConstantBufferBindings { get; }
+        public BufferDescriptor[][] StorageBufferBindings { get; }
+
+        public int MaxTextureBinding { get; }
+        public int MaxImageBinding { get; }
+
+        /// <summary>
+        /// Create a new cached shader bindings collection.
+        /// </summary>
+        /// <param name="isCompute"></param>
+        /// <param name="stages"></param>
+        public CachedShaderBindings(bool isCompute, CachedShaderStage[] stages)
+        {
+            int stageCount = isCompute ? 1 : Constants.ShaderStages;
+
+            TextureBindings = new TextureBindingInfo[stageCount][];
+            ImageBindings = new TextureBindingInfo[stageCount][];
+            ConstantBufferBindings = new BufferDescriptor[stageCount][];
+            StorageBufferBindings = new BufferDescriptor[stageCount][];
+
+            int maxTextureBinding = -1;
+            int maxImageBinding = -1;
+            int offset = isCompute ? 0 : 1;
+
+            for (int i = 0; i < stageCount; i++)
+            {
+                CachedShaderStage stage = stages[i + offset];
+
+                if (stage == null)
+                {
+                    TextureBindings[i] = Array.Empty<TextureBindingInfo>();
+                    ImageBindings[i] = Array.Empty<TextureBindingInfo>();
+                    ConstantBufferBindings[i] = Array.Empty<BufferDescriptor>();
+                    StorageBufferBindings[i] = Array.Empty<BufferDescriptor>();
+
+                    continue;
+                }
+
+                TextureBindings[i] = stage.Info.Textures.Select(descriptor =>
+                {
+                    Target target = ShaderTexture.GetTarget(descriptor.Type);
+
+                    var result = new TextureBindingInfo(
+                        target,
+                        descriptor.Binding,
+                        descriptor.CbufSlot,
+                        descriptor.HandleIndex,
+                        descriptor.Flags);
+
+                    if (descriptor.Binding > maxTextureBinding)
+                    {
+                        maxTextureBinding = descriptor.Binding;
+                    }
+
+                    return result;
+                }).ToArray();
+
+                ImageBindings[i] = stage.Info.Images.Select(descriptor =>
+                {
+                    Target target = ShaderTexture.GetTarget(descriptor.Type);
+                    Format format = ShaderTexture.GetFormat(descriptor.Format);
+
+                    var result = new TextureBindingInfo(
+                        target,
+                        format,
+                        descriptor.Binding,
+                        descriptor.CbufSlot,
+                        descriptor.HandleIndex,
+                        descriptor.Flags);
+
+                    if (descriptor.Binding > maxImageBinding)
+                    {
+                        maxImageBinding = descriptor.Binding;
+                    }
+
+                    return result;
+                }).ToArray();
+
+                ConstantBufferBindings[i] = stage.Info.CBuffers.ToArray();
+                StorageBufferBindings[i] = stage.Info.SBuffers.ToArray();
+            }
+
+            MaxTextureBinding = maxTextureBinding;
+            MaxImageBinding = maxImageBinding;
+        }
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Shader/CachedShaderProgram.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/CachedShaderProgram.cs
@@ -25,6 +25,11 @@ namespace Ryujinx.Graphics.Gpu.Shader
         public CachedShaderStage[] Shaders { get; }
 
         /// <summary>
+        /// Cached shader bindings, ready for placing into the bindings manager.
+        /// </summary>
+        public CachedShaderBindings Bindings { get; }
+
+        /// <summary>
         /// Creates a new instance of the shader bundle.
         /// </summary>
         /// <param name="hostProgram">Host program with all the shader stages</param>
@@ -37,6 +42,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
             Shaders = shaders;
 
             SpecializationState.Prepare(shaders);
+            Bindings = new CachedShaderBindings(shaders.Length == 1, shaders);
         }
 
         /// <summary>


### PR DESCRIPTION
Reduces work on UpdateShaderState. Now the cost is a few reference moves for arrays (for stages with bindings), rather than copying data. Cached bindings arrays are created when shaders are loaded.

1-2 fps here on the usual spot in SMO.

Upside: Removes a bunch of redundant code from ComputeClass, cheaper UpdateShaderState.
Downside: bindings arrays are no longer readonly (though it was only the top level array that was readonly, not the contained ones).