### PR TITLE
GPU: Use lazy checks for specialization state

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Threed/SpecializationStateUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/SpecializationStateUpdater.cs
@@ -116,9 +116,10 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         }
 
         /// <summary>
-        /// Indicates whether alpha-to-coverage is enabled.
+        /// Updates alpha-to-coverage state, and sets it as changed.
         /// </summary>
-        /// <param name="value">The new value</param>
+        /// <param name="enable">Whether alpha-to-coverage is enabled</param>
+        /// <param name="ditherEnable">Whether alpha-to-coverage dithering is enabled</param>
         public void SetAlphaToCoverageEnable(bool enable, bool ditherEnable)
         {
             _graphics.AlphaToCoverageEnable = enable;

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/SpecializationStateUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/SpecializationStateUpdater.cs
@@ -1,0 +1,279 @@
+﻿using Ryujinx.Common.Memory;
+using Ryujinx.Graphics.GAL;
+using Ryujinx.Graphics.Gpu.Shader;
+using Ryujinx.Graphics.Shader;
+
+namespace Ryujinx.Graphics.Gpu.Engine.Threed
+{
+    /// <summary>
+    /// Maintains a "current" specialiation state, and provides a flag to check if it has changed meaningfully.
+    /// </summary>
+    internal class SpecializationStateUpdater
+    {
+        private GpuChannelGraphicsState _graphics;
+        private GpuChannelPoolState _pool;
+
+        private bool _usesDrawParameters;
+        private bool _usesTopology;
+
+        private bool _changed;
+
+        /// <summary>
+        /// Signal that the specialization state has changed.
+        /// </summary>
+        private void Signal()
+        {
+            _changed = true;
+        }
+
+        /// <summary>
+        /// Checks if the specialization state has changed since the last check.
+        /// </summary>
+        /// <returns>True if it has changed, false otherwise</returns>
+        public bool HasChanged()
+        {
+            if (_changed)
+            {
+                _changed = false;
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Sets the active shader, clearing the dirty state and recording if certain specializations are noteworthy.
+        /// </summary>
+        /// <param name="gs">The active shader</param>
+        public void SetShader(CachedShaderProgram gs)
+        {
+            _usesDrawParameters = gs.Shaders[1]?.Info.UsesDrawParameters ?? false;
+            _usesTopology = gs.SpecializationState.IsPrimitiveTopologyQueried();
+
+            _changed = false;
+        }
+
+        /// <summary>
+        /// Get the current graphics state.
+        /// </summary>
+        /// <returns>GPU graphics state</returns>
+        public ref GpuChannelGraphicsState GetGraphicsState()
+        {
+            return ref _graphics;
+        }
+
+        /// <summary>
+        /// Get the current pool state.
+        /// </summary>
+        /// <returns>GPU pool state</returns>
+        public ref GpuChannelPoolState GetPoolState()
+        {
+            return ref _pool;
+        }
+
+        /// <summary>
+        /// Early Z force enable.
+        /// </summary>
+        /// <param name="value">The new value</param>
+        public void SetEarlyZForce(bool value)
+        {
+            _graphics.EarlyZForce = value;
+
+            Signal();
+        }
+
+        /// <summary>
+        /// Primitive topology of current draw.
+        /// </summary>
+        /// <param name="value">The new value</param>
+        public void SetTopology(PrimitiveTopology value)
+        {
+            if (value != _graphics.Topology)
+            {
+                _graphics.Topology = value;
+
+                if (_usesTopology)
+                {
+                    Signal();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Tessellation mode.
+        /// </summary>
+        /// <param name="value">The new value</param>
+        public void SetTessellationMode(TessMode value)
+        {
+            if (value.Packed != _graphics.TessellationMode.Packed)
+            {
+                _graphics.TessellationMode = value;
+
+                Signal();
+            }
+        }
+
+        /// <summary>
+        /// Indicates whether alpha-to-coverage is enabled.
+        /// </summary>
+        /// <param name="value">The new value</param>
+        public void SetAlphaToCoverageEnable(bool enable, bool ditherEnable)
+        {
+            _graphics.AlphaToCoverageEnable = enable;
+            _graphics.AlphaToCoverageDitherEnable = ditherEnable;
+
+            Signal();
+        }
+
+        /// <summary>
+        /// Indicates whether the viewport transform is disabled.
+        /// </summary>
+        /// <param name="value">The new value</param>
+        public void SetViewportTransformDisable(bool value)
+        {
+            if (value != _graphics.ViewportTransformDisable)
+            {
+                _graphics.ViewportTransformDisable = value;
+
+                Signal();
+            }
+        }
+
+        /// <summary>
+        /// Depth mode zero to one or minus one to one.
+        /// </summary>
+        /// <param name="value">The new value</param>
+        public void SetDepthMode(bool value)
+        {
+            if (value != _graphics.DepthMode)
+            {
+                _graphics.DepthMode = value;
+
+                Signal();
+            }
+        }
+
+        /// <summary>
+        /// Indicates if the point size is set on the shader or is fixed.
+        /// </summary>
+        /// <param name="value">The new value</param>
+        public void SetProgramPointSizeEnable(bool value)
+        {
+            if (value != _graphics.ProgramPointSizeEnable)
+            {
+                _graphics.ProgramPointSizeEnable = value;
+
+                Signal();
+            }
+        }
+
+        /// <summary>
+        /// Point size used if <see cref="SetProgramPointSizeEnable" /> is provided false.
+        /// </summary>
+        /// <param name="value">The new value</param>
+        public void SetPointSize(float value)
+        {
+            if (value != _graphics.PointSize)
+            {
+                _graphics.PointSize = value;
+
+                Signal();
+            }
+        }
+
+        /// <summary>
+        /// Updates alpha test specialization state, and sets it as changed.
+        /// </summary>
+        /// <param name="enable">Whether alpha test is enabled</param>
+        /// <param name="reference">The value to compare with the fragment output alpha</param>
+        /// <param name="op">The comparison that decides if the fragment should be discarded</param>
+        public void SetAlphaTest(bool enable, float reference, CompareOp op)
+        {
+            _graphics.AlphaTestEnable = enable;
+            _graphics.AlphaTestReference = reference;
+            _graphics.AlphaTestCompare = op;
+
+            Signal();
+        }
+
+        /// <summary>
+        /// Updates the type of the vertex attributes consumed by the shader.
+        /// </summary>
+        /// <param name="state">The new state</param>
+        public void SetAttributeTypes(ref Array32<VertexAttribState> state)
+        {
+            bool changed = false;
+            ref Array32<AttributeType> attributeTypes = ref _graphics.AttributeTypes;
+
+            for (int location = 0; location < state.Length; location++)
+            {
+                VertexAttribType type = state[location].UnpackType();
+
+                AttributeType value = type switch
+                {
+                    VertexAttribType.Sint => AttributeType.Sint,
+                    VertexAttribType.Uint => AttributeType.Uint,
+                    _ => AttributeType.Float
+                };
+
+                if (attributeTypes[location] != value)
+                {
+                    attributeTypes[location] = value;
+                    changed = true;
+                }
+            }
+
+            if (changed)
+            {
+                Signal();
+            }
+        }
+
+        /// <summary>
+        /// Indicates that the draw is writing the base vertex, base instance and draw index to Constant Buffer 0.
+        /// </summary>
+        /// <param name="value">The new value</param>
+        public void SetHasConstantBufferDrawParameters(bool value)
+        {
+            if (value != _graphics.HasConstantBufferDrawParameters)
+            {
+                _graphics.HasConstantBufferDrawParameters = value;
+
+                if (_usesDrawParameters)
+                {
+                    Signal();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Indicates that any storage buffer use is unaligned.
+        /// </summary>
+        /// <param name="value">The new value</param>
+        public void SetHasUnalignedStorageBuffer(bool value)
+        {
+            if (value != _graphics.HasUnalignedStorageBuffer)
+            {
+                _graphics.HasUnalignedStorageBuffer = value;
+
+                Signal();
+            }
+        }
+
+        /// <summary>
+        /// Sets the GPU pool state.
+        /// </summary>
+        /// <param name="state">The new state</param>
+        public void SetPoolState(GpuChannelPoolState state)
+        {
+            if (!state.Equals(_pool))
+            {
+                _pool = state;
+
+                Signal();
+            }
+        }
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -268,8 +268,6 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
             _updateTracker.Update(ulong.MaxValue);
 
-            CommitBindings();
-
             // If any state that the shader depends on changed,
             // then we may need to compile/bind a different version
             // of the shader for the new state.
@@ -281,6 +279,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                     UpdateShaderState();
                 }
             }
+
+            CommitBindings();
 
             if (tfEnable && !_prevTfEnable)
             {

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
@@ -67,12 +67,13 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
             _i2mClass = new InlineToMemoryClass(context, channel, initializeState: false);
 
+            var spec = new SpecializationStateUpdater();
             var drawState = new DrawState();
 
-            _drawManager = new DrawManager(context, channel, _state, drawState);
+            _drawManager = new DrawManager(context, channel, _state, drawState, spec);
             _semaphoreUpdater = new SemaphoreUpdater(context, channel, _state);
             _cbUpdater = new ConstantBufferUpdater(channel, _state);
-            _stateUpdater = new StateUpdater(context, channel, _state, drawState);
+            _stateUpdater = new StateUpdater(context, channel, _state, drawState, spec);
 
             // This defaults to "always", even without any register write.
             // Reads just return 0, regardless of what was set there.

--- a/Ryujinx.Graphics.Gpu/Shader/GpuChannelGraphicsState.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/GpuChannelGraphicsState.cs
@@ -15,62 +15,62 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Early Z force enable.
         /// </summary>
-        public readonly bool EarlyZForce;
+        public bool EarlyZForce;
 
         /// <summary>
         /// Primitive topology of current draw.
         /// </summary>
-        public readonly PrimitiveTopology Topology;
+        public PrimitiveTopology Topology;
 
         /// <summary>
         /// Tessellation mode.
         /// </summary>
-        public readonly TessMode TessellationMode;
+        public TessMode TessellationMode;
 
         /// <summary>
         /// Indicates whether alpha-to-coverage is enabled.
         /// </summary>
-        public readonly bool AlphaToCoverageEnable;
+        public bool AlphaToCoverageEnable;
 
         /// <summary>
         /// Indicates whether alpha-to-coverage dithering is enabled.
         /// </summary>
-        public readonly bool AlphaToCoverageDitherEnable;
+        public bool AlphaToCoverageDitherEnable;
 
         /// <summary>
         /// Indicates whether the viewport transform is disabled.
         /// </summary>
-        public readonly bool ViewportTransformDisable;
+        public bool ViewportTransformDisable;
 
         /// <summary>
         /// Depth mode zero to one or minus one to one.
         /// </summary>
-        public readonly bool DepthMode;
+        public bool DepthMode;
 
         /// <summary>
         /// Indicates if the point size is set on the shader or is fixed.
         /// </summary>
-        public readonly bool ProgramPointSizeEnable;
+        public bool ProgramPointSizeEnable;
 
         /// <summary>
         /// Point size used if <see cref="ProgramPointSizeEnable" /> is false.
         /// </summary>
-        public readonly float PointSize;
+        public float PointSize;
 
         /// <summary>
         /// Indicates whether alpha test is enabled.
         /// </summary>
-        public readonly bool AlphaTestEnable;
+        public bool AlphaTestEnable;
 
         /// <summary>
         /// When alpha test is enabled, indicates the comparison that decides if the fragment should be discarded.
         /// </summary>
-        public readonly CompareOp AlphaTestCompare;
+        public CompareOp AlphaTestCompare;
 
         /// <summary>
         /// When alpha test is enabled, indicates the value to compare with the fragment output alpha.
         /// </summary>
-        public readonly float AlphaTestReference;
+        public float AlphaTestReference;
 
         /// <summary>
         /// Type of the vertex attributes consumed by the shader.
@@ -80,12 +80,12 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <summary>
         /// Indicates that the draw is writing the base vertex, base instance and draw index to Constant Buffer 0.
         /// </summary>
-        public readonly bool HasConstantBufferDrawParameters;
+        public bool HasConstantBufferDrawParameters;
 
         /// <summary>
         /// Indicates that any storage buffer use is unaligned.
         /// </summary>
-        public readonly bool HasUnalignedStorageBuffer;
+        public bool HasUnalignedStorageBuffer;
 
         /// <summary>
         /// Creates a new GPU graphics state.

--- a/Ryujinx.Graphics.Gpu/Shader/GpuChannelPoolState.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/GpuChannelPoolState.cs
@@ -1,9 +1,11 @@
+using System;
+
 namespace Ryujinx.Graphics.Gpu.Shader
 {
     /// <summary>
     /// State used by the <see cref="GpuAccessor"/>.
     /// </summary>
-    struct GpuChannelPoolState
+    struct GpuChannelPoolState : IEquatable<GpuChannelPoolState>
     {
         /// <summary>
         /// GPU virtual address of the texture pool.
@@ -31,6 +33,18 @@ namespace Ryujinx.Graphics.Gpu.Shader
             TexturePoolGpuVa = texturePoolGpuVa;
             TexturePoolMaximumId = texturePoolMaximumId;
             TextureBufferIndex = textureBufferIndex;
+        }
+
+        /// <summary>
+        /// Check if the pool states are equal.
+        /// </summary>
+        /// <param name="other">Pool state to compare with</param>
+        /// <returns>True if they are equal, false otherwise</returns>
+        public bool Equals(GpuChannelPoolState other)
+        {
+            return TexturePoolGpuVa == other.TexturePoolGpuVa &&
+                TexturePoolMaximumId == other.TexturePoolMaximumId &&
+                TextureBufferIndex == other.TextureBufferIndex;
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -300,16 +300,16 @@ namespace Ryujinx.Graphics.Gpu.Shader
             ref ThreedClassState state,
             ref ProgramPipelineState pipeline,
             GpuChannel channel,
-            GpuChannelPoolState poolState,
-            GpuChannelGraphicsState graphicsState,
+            ref GpuChannelPoolState poolState,
+            ref GpuChannelGraphicsState graphicsState,
             ShaderAddresses addresses)
         {
-            if (_gpPrograms.TryGetValue(addresses, out var gpShaders) && IsShaderEqual(channel, poolState, graphicsState, gpShaders, addresses))
+            if (_gpPrograms.TryGetValue(addresses, out var gpShaders) && IsShaderEqual(channel, ref poolState, ref graphicsState, gpShaders, addresses))
             {
                 return gpShaders;
             }
 
-            if (_graphicsShaderCache.TryFind(channel, poolState, graphicsState, addresses, out gpShaders, out var cachedGuestCode))
+            if (_graphicsShaderCache.TryFind(channel, ref poolState, ref graphicsState, addresses, out gpShaders, out var cachedGuestCode))
             {
                 _gpPrograms[addresses] = gpShaders;
                 return gpShaders;
@@ -498,7 +498,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         {
             if (IsShaderEqual(channel.MemoryManager, cpShader.Shaders[0], gpuVa))
             {
-                return cpShader.SpecializationState.MatchesCompute(channel, poolState, computeState, true);
+                return cpShader.SpecializationState.MatchesCompute(channel, ref poolState, computeState, true);
             }
 
             return false;
@@ -515,8 +515,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <returns>True if the code is different, false otherwise</returns>
         private static bool IsShaderEqual(
             GpuChannel channel,
-            GpuChannelPoolState poolState,
-            GpuChannelGraphicsState graphicsState,
+            ref GpuChannelPoolState poolState,
+            ref GpuChannelGraphicsState graphicsState,
             CachedShaderProgram gpShaders,
             ShaderAddresses addresses)
         {
@@ -536,7 +536,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
 
             bool usesDrawParameters = gpShaders.Shaders[1]?.Info.UsesDrawParameters ?? false;
 
-            return gpShaders.SpecializationState.MatchesGraphics(channel, poolState, graphicsState, usesDrawParameters, true);
+            return gpShaders.SpecializationState.MatchesGraphics(channel, ref poolState, ref graphicsState, usesDrawParameters, true);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCacheHashTable.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCacheHashTable.cs
@@ -215,8 +215,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <returns>True if a cached host program was found, false otherwise</returns>
         public bool TryFind(
             GpuChannel channel,
-            GpuChannelPoolState poolState,
-            GpuChannelGraphicsState graphicsState,
+            ref GpuChannelPoolState poolState,
+            ref GpuChannelGraphicsState graphicsState,
             ShaderAddresses addresses,
             out CachedShaderProgram program,
             out CachedGraphicsGuestCode guestCode)
@@ -236,7 +236,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
 
             if (found && _shaderPrograms.TryGetValue(idTable, out ShaderSpecializationList specList))
             {
-                return specList.TryFindForGraphics(channel, poolState, graphicsState, out program);
+                return specList.TryFindForGraphics(channel, ref poolState, ref graphicsState, out program);
             }
 
             return false;

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderSpecializationList.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderSpecializationList.cs
@@ -29,15 +29,15 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <returns>True if a compatible program is found, false otherwise</returns>
         public bool TryFindForGraphics(
             GpuChannel channel,
-            GpuChannelPoolState poolState,
-            GpuChannelGraphicsState graphicsState,
+            ref GpuChannelPoolState poolState,
+            ref GpuChannelGraphicsState graphicsState,
             out CachedShaderProgram program)
         {
             foreach (var entry in _entries)
             {
                 bool usesDrawParameters = entry.Shaders[1]?.Info.UsesDrawParameters ?? false;
 
-                if (entry.SpecializationState.MatchesGraphics(channel, poolState, graphicsState, usesDrawParameters, true))
+                if (entry.SpecializationState.MatchesGraphics(channel, ref poolState, ref graphicsState, usesDrawParameters, true))
                 {
                     program = entry;
                     return true;
@@ -60,7 +60,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         {
             foreach (var entry in _entries)
             {
-                if (entry.SpecializationState.MatchesCompute(channel, poolState, computeState, true))
+                if (entry.SpecializationState.MatchesCompute(channel, ref poolState, computeState, true))
                 {
                     program = entry;
                     return true;

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderSpecializationState.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderSpecializationState.cs
@@ -393,6 +393,15 @@ namespace Ryujinx.Graphics.Gpu.Shader
         }
 
         /// <summary>
+        /// Checks if primitive topology was queried by the shader.
+        /// </summary>
+        /// <returns>True if queried, false otherwise</returns>
+        public bool IsPrimitiveTopologyQueried()
+        {
+            return _queriedState.HasFlag(QueriedStateFlags.PrimitiveTopology);
+        }
+
+        /// <summary>
         /// Checks if a given texture was registerd on this specialization state.
         /// </summary>
         /// <param name="stageIndex">Shader stage where the texture is used</param>
@@ -486,8 +495,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <returns>True if the state matches, false otherwise</returns>
         public bool MatchesGraphics(
             GpuChannel channel,
-            GpuChannelPoolState poolState,
-            GpuChannelGraphicsState graphicsState,
+            ref GpuChannelPoolState poolState,
+            ref GpuChannelGraphicsState graphicsState,
             bool usesDrawParameters,
             bool checkTextures)
         {
@@ -536,7 +545,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 return false;
             }
 
-            return Matches(channel, poolState, checkTextures, isCompute: false);
+            return Matches(channel, ref poolState, checkTextures, isCompute: false);
         }
 
         /// <summary>
@@ -547,14 +556,14 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <param name="computeState">Compute state</param>
         /// <param name="checkTextures">Indicates whether texture descriptors should be checked</param>
         /// <returns>True if the state matches, false otherwise</returns>
-        public bool MatchesCompute(GpuChannel channel, GpuChannelPoolState poolState, GpuChannelComputeState computeState, bool checkTextures)
+        public bool MatchesCompute(GpuChannel channel, ref GpuChannelPoolState poolState, GpuChannelComputeState computeState, bool checkTextures)
         {
             if (computeState.HasUnalignedStorageBuffer != ComputeState.HasUnalignedStorageBuffer)
             {
                 return false;
             }
 
-            return Matches(channel, poolState, checkTextures, isCompute: true);
+            return Matches(channel, ref poolState, checkTextures, isCompute: true);
         }
 
         /// <summary>
@@ -618,7 +627,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <param name="checkTextures">Indicates whether texture descriptors should be checked</param>
         /// <param name="isCompute">Indicates whenever the check is requested by the 3D or compute engine</param>
         /// <returns>True if the state matches, false otherwise</returns>
-        private bool Matches(GpuChannel channel, GpuChannelPoolState poolState, bool checkTextures, bool isCompute)
+        private bool Matches(GpuChannel channel, ref GpuChannelPoolState poolState, bool checkTextures, bool isCompute)
         {
             int constantBufferUsePerStageMask = _constantBufferUsePerStage;
 


### PR DESCRIPTION
This PR adds a new class, the SpecializationStateUpdater, that allows elements of specialization state to be updated individually, and signal the state is checked when it changes between draws, instead of building and checking it on every draw. This also avoids building spec state switching shaders.

Most state updates have been moved behind the shader state update, so that their specialization state updates make it in before shaders are fetched.

Downside: Fields in GpuChannelGraphicsState are no longer readonly. To counteract copies that might be caused this I pass it as `ref` when possible, though maybe `in` would be better? Not really sure about the quirks of `in` and the difference probably won't show on a benchmark.

The result is around 2 extra FPS on SMO here in the usual spot. Not much right now, but it will remove costs when we're doing more expensive specialization checks, such as fragment output type specialization for macos. It may also help more on other games with more draws.