### PR TITLE
Use source generated regular expressions

### DIFF
--- a/Ryujinx.Graphics.Vulkan/Vendor.cs
+++ b/Ryujinx.Graphics.Vulkan/Vendor.cs
@@ -11,9 +11,10 @@ namespace Ryujinx.Graphics.Vulkan
         Unknown
     }
 
-    static class VendorUtils
+    static partial class VendorUtils
     {
-        public static Regex AmdGcnRegex = new Regex(@"Radeon (((HD|R(5|7|9|X)) )?((M?[2-6]\d{2}(\D|$))|([7-8]\d{3}(\D|$))|Fury|Nano))|(Pro Duo)");
+        [GeneratedRegex("Radeon (((HD|R(5|7|9|X)) )?((M?[2-6]\\d{2}(\\D|$))|([7-8]\\d{3}(\\D|$))|Fury|Nano))|(Pro Duo)")]
+        public static partial Regex AmdGcnRegex();
 
         public static Vendor FromId(uint id)
         {

--- a/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -471,7 +471,7 @@ namespace Ryujinx.Graphics.Vulkan
             GpuRenderer = Marshal.PtrToStringAnsi((IntPtr)properties.DeviceName);
             GpuVersion = $"Vulkan v{ParseStandardVulkanVersion(properties.ApiVersion)}, Driver v{ParseDriverVersion(ref properties)}";
 
-            IsAmdGcn = Vendor == Vendor.Amd && VendorUtils.AmdGcnRegex.IsMatch(GpuRenderer);
+            IsAmdGcn = Vendor == Vendor.Amd && VendorUtils.AmdGcnRegex().IsMatch(GpuRenderer);
 
             Logger.Notice.Print(LogClass.Gpu, $"{GpuVendor} {GpuRenderer} ({GpuVersion})");
         }

--- a/Ryujinx.HLE/HOS/Applets/Error/ErrorApplet.cs
+++ b/Ryujinx.HLE/HOS/Applets/Error/ErrorApplet.cs
@@ -18,7 +18,7 @@ using System.Text.RegularExpressions;
 
 namespace Ryujinx.HLE.HOS.Applets.Error
 {
-    internal class ErrorApplet : IApplet
+    internal partial class ErrorApplet : IApplet
     {
         private const long ErrorMessageBinaryTitleId = 0x0100000000000801;
 
@@ -29,6 +29,9 @@ namespace Ryujinx.HLE.HOS.Applets.Error
         private byte[]            _errorStorage;
 
         public event EventHandler AppletStateChanged;
+
+        [GeneratedRegex(@"[^\u0000\u0009\u000A\u000D\u0020-\uFFFF]..")]
+        private static partial Regex CleanTextRegex();
 
         public ErrorApplet(Horizon horizon)
         {
@@ -101,7 +104,7 @@ namespace Ryujinx.HLE.HOS.Applets.Error
 
         private static string CleanText(string value)
         {
-            return Regex.Replace(value, @"[^\u0000\u0009\u000A\u000D\u0020-\uFFFF]..", "").Replace("\0", "");
+            return CleanTextRegex().Replace(value, "").Replace("\0", "");
         }
 
         private string GetMessageText(uint module, uint description, string key)

--- a/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsBlacklist.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsBlacklist.cs
@@ -2,18 +2,30 @@
 
 namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Proxy
 {
-    static class DnsBlacklist
+    static partial class DnsBlacklist
     {
-        const RegexOptions RegexOpts = RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture | RegexOptions.Compiled;
+        const RegexOptions RegexOpts = RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture;
 
-        private static readonly Regex[] BlockedHosts = new Regex[]
-        {
-            new Regex(@"^(.*)\-lp1\.(n|s)\.n\.srv\.nintendo\.net$", RegexOpts),
-            new Regex(@"^(.*)\-lp1\.lp1\.t\.npln\.srv\.nintendo\.net$", RegexOpts),
-            new Regex(@"^(.*)\-lp1\.(znc|p)\.srv\.nintendo\.net$", RegexOpts),
-            new Regex(@"^(.*)\-sb\-api\.accounts\.nintendo\.com$", RegexOpts),
-            new Regex(@"^(.*)\-sb\.accounts\.nintendo\.com$", RegexOpts),
-            new Regex(@"^accounts\.nintendo\.com$", RegexOpts)
+        [GeneratedRegex(@"^(.*)\-lp1\.(n|s)\.n\.srv\.nintendo\.net$", RegexOpts)]
+        private static partial Regex BlockedHost1();
+        [GeneratedRegex(@"^(.*)\-lp1\.lp1\.t\.npln\.srv\.nintendo\.net$", RegexOpts)]
+        private static partial Regex BlockedHost2();
+        [GeneratedRegex(@"^(.*)\-lp1\.(znc|p)\.srv\.nintendo\.net$", RegexOpts)]
+        private static partial Regex BlockedHost3();
+        [GeneratedRegex(@"^(.*)\-sb\-api\.accounts\.nintendo\.com$", RegexOpts)]
+        private static partial Regex BlockedHost4();
+        [GeneratedRegex(@"^(.*)\-sb\.accounts\.nintendo\.com$", RegexOpts)]
+        private static partial Regex BlockedHost5();
+        [GeneratedRegex(@"^accounts\.nintendo\.com$", RegexOpts)]
+        private static partial Regex BlockedHost6();
+
+        private static readonly Regex[] BlockedHosts = {
+            BlockedHost1(),
+            BlockedHost2(),
+            BlockedHost3(),
+            BlockedHost4(),
+            BlockedHost5(),
+            BlockedHost6()
         };
 
         public static bool IsHostBlocked(string host)


### PR DESCRIPTION
This PR replaces all regular expressions with [source generated ones](https://learn.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-source-generators). Small change, but it (at least in theory) should enable better application trimming and NativeAOT friendliness. The only downside is that classes need to be made partial.