### PR TITLE
Add support for installing firmware from an NSP file.

### DIFF
--- a/Ryujinx.Ava/Assets/Locales/en_US.json
+++ b/Ryujinx.Ava/Assets/Locales/en_US.json
@@ -23,7 +23,7 @@
   "MenuBarActionsScanAmiibo": "Scan An Amiibo",
   "MenuBarTools": "_Tools",
   "MenuBarToolsInstallFirmware": "Install Firmware",
-  "MenuBarFileToolsInstallFirmwareFromFile": "Install a firmware from XCI or ZIP",
+  "MenuBarFileToolsInstallFirmwareFromFile": "Install a firmware from NSP, XCI, or ZIP",
   "MenuBarFileToolsInstallFirmwareFromDirectory": "Install a firmware from a directory",
   "MenuBarHelp": "Help",
   "MenuBarHelpCheckForUpdates": "Check for Updates",

--- a/Ryujinx.Ava/Ui/ViewModels/MainWindowViewModel.cs
+++ b/Ryujinx.Ava/Ui/ViewModels/MainWindowViewModel.cs
@@ -1509,7 +1509,8 @@ namespace Ryujinx.Ava.Ui.ViewModels
         public async void InstallFirmwareFromFile()
         {
             OpenFileDialog dialog = new() { AllowMultiple = false };
-            dialog.Filters.Add(new FileDialogFilter { Name = LocaleManager.Instance["FileDialogAllTypes"], Extensions = { "xci", "zip" } });
+            dialog.Filters.Add(new FileDialogFilter { Name = LocaleManager.Instance["FileDialogAllTypes"], Extensions = { "nsp", "xci", "zip" } });
+            dialog.Filters.Add(new FileDialogFilter { Name = "NSP",                                        Extensions = { "nsp" } });
             dialog.Filters.Add(new FileDialogFilter { Name = "XCI",                                        Extensions = { "xci" } });
             dialog.Filters.Add(new FileDialogFilter { Name = "ZIP",                                        Extensions = { "zip" } });
 

--- a/Ryujinx.HLE/FileSystem/ContentManager.cs
+++ b/Ryujinx.HLE/FileSystem/ContentManager.cs
@@ -531,6 +531,10 @@ namespace Ryujinx.HLE.FileSystem
                         Xci xci = new Xci(_virtualFileSystem.KeySet, file.AsStorage());
                         InstallFromCart(xci, temporaryDirectory);
                         break;
+                    case ".nsp":
+                        PartitionFileSystem pfs = new PartitionFileSystem(file.AsStorage());
+                        InstallFromPartition(pfs, temporaryDirectory);
+                        break;
                     default:
                         throw new InvalidFirmwarePackageException("Input file is not a valid firmware package");
                 }
@@ -700,6 +704,9 @@ namespace Ryujinx.HLE.FileSystem
                         {
                             throw new InvalidFirmwarePackageException("Update not found in xci file.");
                         }
+                    case ".nsp":
+                        PartitionFileSystem pfs = new PartitionFileSystem(file.AsStorage());
+                        return VerifyAndGetVersion(pfs);
                     default:
                         break;
                 }

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -1373,6 +1373,7 @@ namespace Ryujinx.Ui
             };
             filter.AddPattern("*.zip");
             filter.AddPattern("*.xci");
+            filter.AddPattern("*.nsp");
 
             fileChooser.AddFilter(filter);
 

--- a/Ryujinx/Ui/MainWindow.glade
+++ b/Ryujinx/Ui/MainWindow.glade
@@ -412,7 +412,7 @@
                               <object class="GtkMenuItem" id="_firmwareInstallFile">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Install a firmware from XCI or ZIP</property>
+                                <property name="label" translatable="yes">Install a firmware from NSP, XCI, or ZIP</property>
                                 <property name="use_underline">True</property>
                                 <signal name="activate" handler="Installer_File_Pressed" swapped="no"/>
                               </object>


### PR DESCRIPTION
Adds support for installing firmware from an NSP file containing all of the firmware NCAs. Since code already exists for installing from an XCI update partition, most of it was just reused but with the NSP's PartitionFileSystem instead.

Tested on both Avalonia and GTK UIs with my own 15.0.1 NSP dump.