### PR TITLE
Restrict shader storage buffer search when match fails

### DIFF
--- a/Ryujinx.Graphics.Shader/Translation/Optimizations/Optimizer.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Optimizations/Optimizer.cs
@@ -11,13 +11,17 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
         {
             RunOptimizationPasses(blocks);
 
+            int sbUseMask = 0;
+
             // Those passes are looking for specific patterns and only needs to run once.
             for (int blkIndex = 0; blkIndex < blocks.Length; blkIndex++)
             {
-                GlobalToStorage.RunPass(blocks[blkIndex], config);
+                GlobalToStorage.RunPass(blocks[blkIndex], config, ref sbUseMask);
                 BindlessToIndexed.RunPass(blocks[blkIndex], config);
                 BindlessElimination.RunPass(blocks[blkIndex], config);
             }
+
+            config.SetAccessibleStorageBuffersMask(sbUseMask);
 
             // Run optimizations one last time to remove any code that is now optimizable after above passes.
             RunOptimizationPasses(blocks);

--- a/Ryujinx.Graphics.Shader/Translation/Rewriter.cs
+++ b/Ryujinx.Graphics.Shader/Translation/Rewriter.cs
@@ -2,6 +2,7 @@ using Ryujinx.Graphics.Shader.IntermediateRepresentation;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Numerics;
 
 using static Ryujinx.Graphics.Shader.IntermediateRepresentation.OperandHelper;
 using static Ryujinx.Graphics.Shader.Translation.GlobalMemory;
@@ -87,8 +88,14 @@ namespace Ryujinx.Graphics.Shader.Translation
             Operand sbBaseAddrLow = Const(0);
             Operand sbSlot        = Const(0);
 
-            for (int slot = 0; slot < StorageMaxCount; slot++)
+            int sbUseMask = config.AccessibleStorageBuffersMask;
+
+            while (sbUseMask != 0)
             {
+                int slot = BitOperations.TrailingZeroCount(sbUseMask);
+
+                sbUseMask &= ~(1 << slot);
+
                 config.SetUsedStorageBuffer(slot, isWrite);
 
                 int cbOffset = GetStorageCbOffset(config.Stage, slot);

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -65,6 +65,8 @@ namespace Ryujinx.Graphics.Shader.Translation
         public UInt128 NextInputAttributesComponents { get; private set; }
         public UInt128 ThisInputAttributesComponents { get; private set; }
 
+        public int AccessibleStorageBuffersMask { get; private set; }
+
         private int _usedConstantBuffers;
         private int _usedStorageBuffers;
         private int _usedStorageBuffersWrite;
@@ -126,6 +128,8 @@ namespace Ryujinx.Graphics.Shader.Translation
             Stage       = ShaderStage.Compute;
             GpuAccessor = gpuAccessor;
             Options     = options;
+
+            AccessibleStorageBuffersMask = (1 << GlobalMemory.StorageMaxCount) - 1;
 
             UsedInputAttributesPerPatch  = new HashSet<int>();
             UsedOutputAttributesPerPatch = new HashSet<int>();
@@ -427,6 +431,11 @@ namespace Ryujinx.Graphics.Shader.Translation
         public void SetUsedFeature(FeatureFlags flags)
         {
             UsedFeatures |= flags;
+        }
+
+        public void SetAccessibleStorageBuffersMask(int mask)
+        {
+            AccessibleStorageBuffersMask = mask;
         }
 
         public void SetUsedConstantBuffer(int slot)


### PR DESCRIPTION
Right now, when the match for storage buffer fails, we generate code to check the current address against the address for all possible 16 storage buffers until we find a match. However it's very unlikely that a shader will use all 16, so this PR instead modifies the check so that only the storage buffers that might be accessed by the shader are checked. This is done based on the constant buffer (0) ranges that are accessed on the shader.

The advantages of doing this is that the shader code is smaller/a bit more efficient in the cases where the match fails. This should also help to avoid an error on macOS where it gets out of storage buffer bindings when taking unused storage buffers for other purposes.

Potential downside is that the cases where the base address comes from something other than the constant buffer 0 would not work, but I don't think this is actually possible since those accesses are compiler generated.

Testing is welcome.