### PR TITLE
Fix shaders with global memory access from unknown locations

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 4011;
+        private const uint CodeGenVersion = 4029;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";


### PR DESCRIPTION
Fixes a regression from #4011 where shaders with global memory access from unknown location would do the global -> storage replacement, but since there are no storage buffers declared, it would fail to generate the SPIR-V, resulting in crashes. Affected game is Mario Golf Super Rush, and maybe a few more (but generally those games are not working properly anyway, with the exception of Mario Golf, since the global memory access will be wrong in those cases).