### PR TITLE
Enable `ContinuousIntegrationBuild` in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,8 @@ jobs:
       POWERSHELL_TELEMETRY_OPTOUT: 1
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       RYUJINX_BASE_VERSION: "1.1.0"
-      RYUJINX_BUILD_COMMON_ARGS: "-p:DebugType=embedded -p:ExtraDefineConstants=DISABLE_UPDATER -p:ContinuousIntegrationBuild=true"
-      RYUJINX_PUBLISH_COMMON_ARGS: "-p:DebugType=embedded -p:ExtraDefineConstants=DISABLE_UPDATER -p:ContinuousIntegrationBuild=true --self-contained true"
+      RYUJINX_BUILD_COMMON_ARGS: "-p:ExtraDefineConstants=DISABLE_UPDATER"
+      RYUJINX_PUBLISH_COMMON_ARGS: "-p:ExtraDefineConstants=DISABLE_UPDATER --self-contained true"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-dotnet@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,8 @@ jobs:
       POWERSHELL_TELEMETRY_OPTOUT: 1
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       RYUJINX_BASE_VERSION: "1.1.0"
+      RYUJINX_BUILD_COMMON_ARGS: "-p:DebugType=embedded -p:ExtraDefineConstants=DISABLE_UPDATER -p:ContinuousIntegrationBuild=true"
+      RYUJINX_PUBLISH_COMMON_ARGS: "-p:DebugType=embedded -p:ExtraDefineConstants=DISABLE_UPDATER -p:ContinuousIntegrationBuild=true --self-contained true"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-dotnet@v3
@@ -57,17 +59,17 @@ jobs:
         run: echo "result=$(git rev-parse --short "${{ github.sha }}")" >> $GITHUB_OUTPUT
         shell: bash
       - name: Build
-        run: dotnet build -c "${{ matrix.configuration }}" -p:Version="${{ env.RYUJINX_BASE_VERSION }}" -p:SourceRevisionId="${{ steps.git_short_hash.outputs.result }}" -p:ExtraDefineConstants=DISABLE_UPDATER
+        run: dotnet build -c "${{ matrix.configuration }}" ${{ env.RYUJINX_BUILD_COMMON_ARGS }} -p:Version="${{ env.RYUJINX_BASE_VERSION }}" -p:SourceRevisionId="${{ steps.git_short_hash.outputs.result }}"
       - name: Test
         run: dotnet test --no-build -c "${{ matrix.configuration }}"
       - name: Publish Ryujinx
-        run: dotnet publish -c "${{ matrix.configuration }}" -r "${{ matrix.DOTNET_RUNTIME_IDENTIFIER }}" -o ./publish -p:Version="${{ env.RYUJINX_BASE_VERSION }}" -p:DebugType=embedded -p:SourceRevisionId="${{ steps.git_short_hash.outputs.result }}" -p:ExtraDefineConstants=DISABLE_UPDATER Ryujinx --self-contained true
+        run: dotnet publish -c "${{ matrix.configuration }}" -r "${{ matrix.DOTNET_RUNTIME_IDENTIFIER }}" -o ./publish ${{ env.RYUJINX_PUBLISH_COMMON_ARGS }} -p:Version="${{ env.RYUJINX_BASE_VERSION }}" -p:SourceRevisionId="${{ steps.git_short_hash.outputs.result }}" Ryujinx
         if: github.event_name == 'pull_request'
       - name: Publish Ryujinx.Headless.SDL2
-        run: dotnet publish -c "${{ matrix.configuration }}" -r "${{ matrix.DOTNET_RUNTIME_IDENTIFIER }}" -o ./publish_sdl2_headless -p:Version="${{ env.RYUJINX_BASE_VERSION }}" -p:DebugType=embedded -p:SourceRevisionId="${{ steps.git_short_hash.outputs.result }}" -p:ExtraDefineConstants=DISABLE_UPDATER Ryujinx.Headless.SDL2 --self-contained true
+        run: dotnet publish -c "${{ matrix.configuration }}" -r "${{ matrix.DOTNET_RUNTIME_IDENTIFIER }}" -o ./publish_sdl2_headless ${{ env.RYUJINX_PUBLISH_COMMON_ARGS }} -p:Version="${{ env.RYUJINX_BASE_VERSION }}" -p:SourceRevisionId="${{ steps.git_short_hash.outputs.result }}" Ryujinx.Headless.SDL2
         if: github.event_name == 'pull_request'
       - name: Publish Ryujinx.Ava
-        run: dotnet publish -c "${{ matrix.configuration }}" -r "${{ matrix.DOTNET_RUNTIME_IDENTIFIER }}" -o ./publish_ava -p:Version="${{ env.RYUJINX_BASE_VERSION }}" -p:DebugType=embedded -p:SourceRevisionId="${{ steps.git_short_hash.outputs.result }}" -p:ExtraDefineConstants=DISABLE_UPDATER Ryujinx.Ava --self-contained true
+        run: dotnet publish -c "${{ matrix.configuration }}" -r "${{ matrix.DOTNET_RUNTIME_IDENTIFIER }}" -o ./publish_ava ${{ env.RYUJINX_PUBLISH_COMMON_ARGS }} -p:Version="${{ env.RYUJINX_BASE_VERSION }}" -p:SourceRevisionId="${{ steps.git_short_hash.outputs.result }}" Ryujinx.Ava
         if: github.event_name == 'pull_request'
       - name: Upload Ryujinx artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       RYUJINX_TARGET_RELEASE_CHANNEL_NAME: "master"
       RYUJINX_TARGET_RELEASE_CHANNEL_OWNER: "Ryujinx"
       RYUJINX_TARGET_RELEASE_CHANNEL_REPO: "release-channel-master"
-      RYUJINX_PUBLISH_COMMON_ARGS: "-p:DebugType=embedded -p:ContinuousIntegrationBuild=true --self-contained true"
+      RYUJINX_PUBLISH_COMMON_ARGS: "--self-contained true"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
       RYUJINX_TARGET_RELEASE_CHANNEL_NAME: "master"
       RYUJINX_TARGET_RELEASE_CHANNEL_OWNER: "Ryujinx"
       RYUJINX_TARGET_RELEASE_CHANNEL_REPO: "release-channel-master"
+      RYUJINX_PUBLISH_COMMON_ARGS: "-p:DebugType=embedded -p:ContinuousIntegrationBuild=true --self-contained true"
 
     steps:
       - uses: actions/checkout@v3
@@ -47,9 +48,9 @@ jobs:
         run: "mkdir release_output"
       - name: Publish Windows
         run: |
-          dotnet publish -c Release -r win10-x64 -o ./publish_windows/publish -p:Version="${{ steps.version_info.outputs.build_version }}" -p:SourceRevisionId="${{ steps.version_info.outputs.git_short_hash }}" -p:DebugType=embedded Ryujinx --self-contained true
-          dotnet publish -c Release -r win10-x64 -o ./publish_windows_sdl2_headless/publish -p:Version="${{ steps.version_info.outputs.build_version }}" -p:SourceRevisionId="${{ steps.version_info.outputs.git_short_hash }}" -p:DebugType=embedded Ryujinx.Headless.SDL2 --self-contained true
-          dotnet publish -c Release -r win10-x64 -o ./publish_windows_ava/publish -p:Version="${{ steps.version_info.outputs.build_version }}" -p:SourceRevisionId="${{ steps.version_info.outputs.git_short_hash }}" -p:DebugType=embedded Ryujinx.Ava --self-contained true
+          dotnet publish -c Release -r win10-x64 -o ./publish_windows/publish ${{ env.RYUJINX_PUBLISH_COMMON_ARGS }} -p:Version="${{ steps.version_info.outputs.build_version }}" -p:SourceRevisionId="${{ steps.version_info.outputs.git_short_hash }}" Ryujinx
+          dotnet publish -c Release -r win10-x64 -o ./publish_windows_sdl2_headless/publish ${{ env.RYUJINX_PUBLISH_COMMON_ARGS }} -p:Version="${{ steps.version_info.outputs.build_version }}" -p:SourceRevisionId="${{ steps.version_info.outputs.git_short_hash }}" Ryujinx.Headless.SDL2
+          dotnet publish -c Release -r win10-x64 -o ./publish_windows_ava/publish ${{ env.RYUJINX_PUBLISH_COMMON_ARGS }} -p:Version="${{ steps.version_info.outputs.build_version }}" -p:SourceRevisionId="${{ steps.version_info.outputs.git_short_hash }}" Ryujinx.Ava
       - name: Packing Windows builds
         run: |
           pushd publish_windows
@@ -67,9 +68,9 @@ jobs:
 
       - name: Publish Linux
         run: |
-          dotnet publish -c Release -r linux-x64 -o ./publish_linux/publish -p:Version="${{ steps.version_info.outputs.build_version }}" -p:SourceRevisionId="${{ steps.version_info.outputs.git_short_hash }}" -p:DebugType=embedded Ryujinx --self-contained true
-          dotnet publish -c Release -r linux-x64 -o ./publish_linux_sdl2_headless/publish -p:Version="${{ steps.version_info.outputs.build_version }}" -p:SourceRevisionId="${{ steps.version_info.outputs.git_short_hash }}" -p:DebugType=embedded Ryujinx.Headless.SDL2 --self-contained true
-          dotnet publish -c Release -r linux-x64 -o ./publish_linux_ava/publish -p:Version="${{ steps.version_info.outputs.build_version }}" -p:SourceRevisionId="${{ steps.version_info.outputs.git_short_hash }}" -p:DebugType=embedded Ryujinx.Ava --self-contained true
+          dotnet publish -c Release -r linux-x64 -o ./publish_linux/publish ${{ env.RYUJINX_PUBLISH_COMMON_ARGS }} -p:Version="${{ steps.version_info.outputs.build_version }}" -p:SourceRevisionId="${{ steps.version_info.outputs.git_short_hash }}" Ryujinx
+          dotnet publish -c Release -r linux-x64 -o ./publish_linux_sdl2_headless/publish ${{ env.RYUJINX_PUBLISH_COMMON_ARGS }} -p:Version="${{ steps.version_info.outputs.build_version }}" -p:SourceRevisionId="${{ steps.version_info.outputs.git_short_hash }}" Ryujinx.Headless.SDL2
+          dotnet publish -c Release -r linux-x64 -o ./publish_linux_ava/publish ${{ env.RYUJINX_PUBLISH_COMMON_ARGS }} -p:Version="${{ steps.version_info.outputs.build_version }}" -p:SourceRevisionId="${{ steps.version_info.outputs.git_short_hash }}" Ryujinx.Ava
 
       - name: Packing Linux builds
         run: |

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <PathMap>$(MSBuildProjectDirectory)=$(MSBuildProjectName)</PathMap>
+  </PropertyGroup>
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
-  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-    <PathMap>$(MSBuildProjectDirectory)=$(MSBuildProjectName)</PathMap>
-  </PropertyGroup>
+  <ItemGroup>
+    <SourceRoot Include="$(MSBuildThisFileDirectory)"/>
+  </ItemGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <PathMap>$(MSBuildProjectDirectory)=$(MSBuildProjectName)</PathMap>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <ItemGroup>
-    <SourceRoot Include="$(MSBuildThisFileDirectory)"/>
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1" PrivateAssets="All"/>
   </ItemGroup>
 </Project>

--- a/distribution/macos/create_macos_release.sh
+++ b/distribution/macos/create_macos_release.sh
@@ -27,7 +27,7 @@ EXECUTABLE_SUB_PATH=Contents/MacOS/Ryujinx
 rm -rf $TEMP_DIRECTORY
 mkdir -p $TEMP_DIRECTORY
 
-DOTNET_COMMON_ARGS="-p:DebugType=embedded -p:Version=$VERSION -p:SourceRevisionId=$SOURCE_REVISION_ID -p:ExtraDefineConstants=DISABLE_UPDATER --self-contained true"
+DOTNET_COMMON_ARGS="-p:Version=$VERSION -p:SourceRevisionId=$SOURCE_REVISION_ID -p:ExtraDefineConstants=DISABLE_UPDATER --self-contained true"
 
 dotnet restore
 dotnet build -c Release Ryujinx.Ava


### PR DESCRIPTION
Supersedes #3905 via `DeterministicSourcePaths` enabled by `ContinuousIntegrationBuild`.

Firstly, a bugfix: I noticed `build.yml` artifacts (PR builds) were missing debug metadata when not passing `-p:DebugType=embedded` to `dotnet build` so I fixed it.

Secondly, I pushed two approaches for enabling `ContinuousIntegrationBuild`-
ea71676f sets the flag in workflow scripts [as suggested in #3905]
b0fc6699 uses `DotNet.ReproducibleBuilds` pkg to automate this (https://github.com/dotnet/reproducible-builds) [thanks to marysaka for showing me this]

The package way carries extra baggage (most notably SourceLink) and I'm not sure about all the flags it sets so I'll let you decide.