### PR TITLE
hle: Do not add disabled AoC item to the list

### DIFF
--- a/Ryujinx.HLE/FileSystem/ContentManager.cs
+++ b/Ryujinx.HLE/FileSystem/ContentManager.cs
@@ -39,13 +39,11 @@ namespace Ryujinx.HLE.FileSystem
         {
             public readonly string ContainerPath;
             public readonly string NcaPath;
-            public bool Enabled;
 
-            public AocItem(string containerPath, string ncaPath, bool enabled)
+            public AocItem(string containerPath, string ncaPath)
             {
                 ContainerPath = containerPath;
                 NcaPath = ncaPath;
-                Enabled = enabled;
             }
         }
 
@@ -53,7 +51,7 @@ namespace Ryujinx.HLE.FileSystem
 
         private VirtualFileSystem _virtualFileSystem;
 
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
 
         public ContentManager(VirtualFileSystem virtualFileSystem)
         {
@@ -226,53 +224,52 @@ namespace Ryujinx.HLE.FileSystem
                 pfs0.OpenFile(ref cnmtFile.Ref(), pfs0.EnumerateEntries().Single().FullPath.ToU8Span(), OpenMode.Read);
 
                 var cnmt = new Cnmt(cnmtFile.Get.AsStream());
-
                 if (cnmt.Type != ContentMetaType.AddOnContent || (cnmt.TitleId & 0xFFFFFFFFFFFFE000) != aocBaseId)
                 {
                     continue;
                 }
 
                 string ncaId = BitConverter.ToString(cnmt.ContentEntries[0].NcaId).Replace("-", "").ToLower();
-                if (!_aocData.TryAdd(cnmt.TitleId, new AocItem(containerPath, $"{ncaId}.nca", true)))
-                {
-                    Logger.Warning?.Print(LogClass.Application, $"Duplicate AddOnContent detected. TitleId {cnmt.TitleId:X16}");
-                }
-                else
-                {
-                    Logger.Info?.Print(LogClass.Application, $"Found AddOnContent with TitleId {cnmt.TitleId:X16}");
-                }
+
+                AddAocItem(cnmt.TitleId, containerPath, $"{ncaId}.nca", true, true);
             }
         }
 
-        public void AddAocItem(ulong titleId, string containerPath, string ncaPath, bool enabled)
+        public void AddAocItem(ulong titleId, string containerPath, string ncaPath, bool enabled, bool mergedToContainer = false)
         {
-            if (!_aocData.TryAdd(titleId, new AocItem(containerPath, ncaPath, enabled)))
+            if (enabled)
             {
-                Logger.Warning?.Print(LogClass.Application, $"Duplicate AddOnContent detected. TitleId {titleId:X16}");
-            }
-            else
-            {
-                Logger.Info?.Print(LogClass.Application, $"Found AddOnContent with TitleId {titleId:X16}");
-
-                using (FileStream fileStream = File.OpenRead(containerPath))
-                using (PartitionFileSystem pfs = new PartitionFileSystem(fileStream.AsStorage()))
+                // TODO: Check Aoc version.
+                if (!_aocData.TryAdd(titleId, new AocItem(containerPath, ncaPath)))
                 {
-                    _virtualFileSystem.ImportTickets(pfs);
+                    Logger.Warning?.Print(LogClass.Application, $"Duplicate AddOnContent detected. TitleId {titleId:X16}");
+                }
+                else
+                {
+                    Logger.Info?.Print(LogClass.Application, $"Found AddOnContent with TitleId {titleId:X16}");
+
+                    if (!mergedToContainer)
+                    {
+                        using FileStream          fileStream          = File.OpenRead(containerPath);
+                        using PartitionFileSystem partitionFileSystem = new(fileStream.AsStorage());
+
+                        _virtualFileSystem.ImportTickets(partitionFileSystem);
+                    }
                 }
             }
         }
 
         public void ClearAocData() => _aocData.Clear();
 
-        public int GetAocCount() => _aocData.Where(e => e.Value.Enabled).Count();
+        public int GetAocCount() => _aocData.Count;
 
-        public IList<ulong> GetAocTitleIds() => _aocData.Where(e => e.Value.Enabled).Select(e => e.Key).ToList();
+        public IList<ulong> GetAocTitleIds() => _aocData.Select(e => e.Key).ToList();
 
         public bool GetAocDataStorage(ulong aocTitleId, out IStorage aocStorage, IntegrityCheckLevel integrityCheckLevel)
         {
             aocStorage = null;
 
-            if (_aocData.TryGetValue(aocTitleId, out AocItem aoc) && aoc.Enabled)
+            if (_aocData.TryGetValue(aocTitleId, out AocItem aoc))
             {
                 var file = new FileStream(aoc.ContainerPath, FileMode.Open, FileAccess.Read);
                 using var ncaFile = new UniqueRef<IFile>();

--- a/Ryujinx.HLE/FileSystem/ContentManager.cs
+++ b/Ryujinx.HLE/FileSystem/ContentManager.cs
@@ -231,30 +231,27 @@ namespace Ryujinx.HLE.FileSystem
 
                 string ncaId = BitConverter.ToString(cnmt.ContentEntries[0].NcaId).Replace("-", "").ToLower();
 
-                AddAocItem(cnmt.TitleId, containerPath, $"{ncaId}.nca", true, true);
+                AddAocItem(cnmt.TitleId, containerPath, $"{ncaId}.nca", true);
             }
         }
 
-        public void AddAocItem(ulong titleId, string containerPath, string ncaPath, bool enabled, bool mergedToContainer = false)
+        public void AddAocItem(ulong titleId, string containerPath, string ncaPath, bool mergedToContainer = false)
         {
-            if (enabled)
+            // TODO: Check Aoc version.
+            if (!_aocData.TryAdd(titleId, new AocItem(containerPath, ncaPath)))
             {
-                // TODO: Check Aoc version.
-                if (!_aocData.TryAdd(titleId, new AocItem(containerPath, ncaPath)))
-                {
-                    Logger.Warning?.Print(LogClass.Application, $"Duplicate AddOnContent detected. TitleId {titleId:X16}");
-                }
-                else
-                {
-                    Logger.Info?.Print(LogClass.Application, $"Found AddOnContent with TitleId {titleId:X16}");
+                Logger.Warning?.Print(LogClass.Application, $"Duplicate AddOnContent detected. TitleId {titleId:X16}");
+            }
+            else
+            {
+                Logger.Info?.Print(LogClass.Application, $"Found AddOnContent with TitleId {titleId:X16}");
 
-                    if (!mergedToContainer)
-                    {
-                        using FileStream          fileStream          = File.OpenRead(containerPath);
-                        using PartitionFileSystem partitionFileSystem = new(fileStream.AsStorage());
+                if (!mergedToContainer)
+                {
+                    using FileStream          fileStream          = File.OpenRead(containerPath);
+                    using PartitionFileSystem partitionFileSystem = new(fileStream.AsStorage());
 
-                        _virtualFileSystem.ImportTickets(partitionFileSystem);
-                    }
+                    _virtualFileSystem.ImportTickets(partitionFileSystem);
                 }
             }
         }

--- a/Ryujinx.HLE/HOS/ApplicationLoader.cs
+++ b/Ryujinx.HLE/HOS/ApplicationLoader.cs
@@ -426,9 +426,9 @@ namespace Ryujinx.HLE.HOS
                 {
                     foreach (DownloadableContentNca downloadableContentNca in downloadableContentContainer.DownloadableContentNcaList)
                     {
-                        if (File.Exists(downloadableContentContainer.ContainerPath))
+                        if (File.Exists(downloadableContentContainer.ContainerPath) && downloadableContentNca.Enabled)
                         {
-                            _device.Configuration.ContentManager.AddAocItem(downloadableContentNca.TitleId, downloadableContentContainer.ContainerPath, downloadableContentNca.FullPath, downloadableContentNca.Enabled);
+                            _device.Configuration.ContentManager.AddAocItem(downloadableContentNca.TitleId, downloadableContentContainer.ContainerPath, downloadableContentNca.FullPath);
                         }
                         else
                         {


### PR DESCRIPTION
We currently add all AoC items to a list in `ContentManager` and the enable check is only done when FS service ask for the data. Which is wrong. It causes an issue in MK8D which doesn't boot even if you have disabled a not updated DLC.

I've fixed it by not adding the disabled AoC item to the list, I've removed some duplicate code too. There is still an edge case because we currently don't check the AoC Item version, but that should be fixed later since now MK8D throw an error if the DLC isn't updated.

![image](https://user-images.githubusercontent.com/4905390/205973065-99019815-c1f8-414a-b6d3-ec3f5f319790.png)
