### PR TITLE
ava: Restyle the Status Bar

### DIFF
--- a/Ryujinx.Ava/Assets/Styles/Styles.xaml
+++ b/Ryujinx.Ava/Assets/Styles/Styles.xaml
@@ -161,6 +161,7 @@
     <Style Selector="MenuItem">
         <Setter Property="Height" Value="{DynamicResource MenuItemHeight}" />
         <Setter Property="Padding" Value="{DynamicResource MenuItemPadding}" />
+        <Setter Property="FontSize" Value="12" />
     </Style>
     <Style Selector="MenuItem:selected /template/ Border#root">
         <Setter Property="Background" Value="{DynamicResource ThemeControlBorderColor}" />

--- a/Ryujinx.Ava/Ui/Controls/GameListView.axaml
+++ b/Ryujinx.Ava/Ui/Controls/GameListView.axaml
@@ -138,6 +138,9 @@
                 <Style Selector="ListBoxItem:selected /template/ ContentPresenter">
                     <Setter Property="Background" Value="{DynamicResource AppListBackgroundColor}" />
                 </Style>
+                <Style Selector="ListBoxItem:selected /template/ Border#SelectionIndicator">
+                    <Setter Property="MinHeight" Value="100" />
+                </Style>
                 <Style Selector="ListBoxItem:pointerover /template/ ContentPresenter">
                     <Setter Property="Background" Value="{DynamicResource AppListHoverBackgroundColor}" />
                 </Style>

--- a/Ryujinx.Ava/Ui/Windows/MainWindow.axaml
+++ b/Ryujinx.Ava/Ui/Windows/MainWindow.axaml
@@ -12,9 +12,9 @@
     xmlns:window="clr-namespace:Ryujinx.Ava.Ui.Windows"
     Title="Ryujinx"
     Width="1280"
-    Height="785"
+    Height="777"
     MinWidth="1092"
-    MinHeight="680"
+    MinHeight="672"
     d:DesignHeight="720"
     d:DesignWidth="1280"
     x:CompileBindings="True"
@@ -552,9 +552,8 @@
             <Grid
                 Name="StatusBar"
                 Grid.Row="2"
-                MinHeight="30"
-                Height="30"
-                Margin="0,0"
+                Margin="0"
+                MinHeight="22"
                 HorizontalAlignment="Stretch"
                 VerticalAlignment="Bottom"
                 Background="{DynamicResource ThemeContentBackgroundColor}"
@@ -568,7 +567,7 @@
                 </Grid.ColumnDefinitions>
                 <StackPanel
                     Grid.Column="0"
-                    Margin="10,0"
+                    Margin="5"
                     VerticalAlignment="Center"
                     IsVisible="{Binding EnableNonGameRunningControls}">
                     <Grid Margin="0">
@@ -610,14 +609,14 @@
                 </StackPanel>
                 <StackPanel
                     Grid.Column="1"
-                    Margin="10,0"
+                    Margin="0,2"
                     HorizontalAlignment="Left"
                     VerticalAlignment="Center"
                     IsVisible="{Binding IsGameRunning}"
                     Orientation="Horizontal">
                     <TextBlock
                         Name="VsyncStatus"
-                        Margin="0,0,5,0"
+                        Margin="5,0,5,0"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
                         Foreground="{Binding VsyncColor}"
@@ -628,7 +627,7 @@
                     <Border
                         Width="2"
                         Height="12"
-                        Margin="2,0"
+                        Margin="0"
                         BorderBrush="Gray"
                         BorderThickness="1"
                         IsVisible="{Binding !ShowLoadProgress}" />
@@ -644,7 +643,7 @@
                     <Border
                         Width="2"
                         Height="12"
-                        Margin="2,0"
+                        Margin="0"
                         BorderBrush="Gray"
                         BorderThickness="1"
                         IsVisible="{Binding !ShowLoadProgress}" />
@@ -660,13 +659,13 @@
                     <Border
                         Width="2"
                         Height="12"
-                        Margin="2,0"
+                        Margin="0"
                         BorderBrush="Gray"
                         BorderThickness="1"
                         IsVisible="{Binding !ShowLoadProgress}" />
                     <ui:ToggleSplitButton
                         Name="VolumeStatus"
-                        Padding="5"
+                        Padding="5,0,5,0"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
                         VerticalContentAlignment="Center"
@@ -679,6 +678,7 @@
                             <Flyout Placement="Bottom" ShowMode="TransientWithDismissOnPointerMoveAway">
                                 <Grid Margin="0">
                                     <Slider
+                                        MaxHeight="40"
                                         Width="150"
                                         Margin="0"
                                         Padding="0"
@@ -697,7 +697,7 @@
                     <Border
                         Width="2"
                         Height="12"
-                        Margin="2,0"
+                        Margin="0"
                         BorderBrush="Gray"
                         BorderThickness="1"
                         IsVisible="{Binding !ShowLoadProgress}" />
@@ -711,7 +711,7 @@
                     <Border
                         Width="2"
                         Height="12"
-                        Margin="2,0"
+                        Margin="0"
                         BorderBrush="Gray"
                         BorderThickness="1"
                         IsVisible="{Binding !ShowLoadProgress}" />
@@ -725,7 +725,7 @@
                     <Border
                         Width="2"
                         Height="12"
-                        Margin="2,0"
+                        Margin="0"
                         BorderBrush="Gray"
                         BorderThickness="1"
                         IsVisible="{Binding !ShowLoadProgress}" />
@@ -739,7 +739,7 @@
                     <Border
                         Width="2"
                         Height="12"
-                        Margin="2,0"
+                        Margin="0"
                         BorderBrush="Gray"
                         BorderThickness="1"
                         IsVisible="{Binding !ShowLoadProgress}" />
@@ -753,7 +753,7 @@
                 </StackPanel>
                 <StackPanel
                     Grid.Column="3"
-                    Margin="10,0"
+                    Margin="0,0,5,0"
                     VerticalAlignment="Center"
                     IsVisible="{Binding ShowFirmwareStatus}"
                     Orientation="Horizontal">


### PR DESCRIPTION
This PR change 3 things:

- The Menu font size is reduced to follow what any other application do (We could do it as a settings later).
- Status Bar margin/size is reduced to get something not too large for nothing and well aligned:

Before:
![image](https://user-images.githubusercontent.com/4905390/206041013-7a225dec-a166-4acd-aac1-e95039bc72b9.png)
After:
![image](https://user-images.githubusercontent.com/4905390/206041530-12d04569-25e4-4588-8cec-54b66fed026d.png)

- The selector height when you click on a game in the game list view is increased:
Before:
![image](https://user-images.githubusercontent.com/4905390/206041720-1abf5d04-e5da-4883-bf5d-beeefbdcb0a1.png)
After:
![image](https://user-images.githubusercontent.com/4905390/206041758-306cec77-c730-4f20-b89d-c2206f29c7f7.png)
