### PR TITLE
gtk: Fixes warnings about obsolete components

### DIFF
--- a/Ryujinx/Ui/Windows/AvatarWindow.cs
+++ b/Ryujinx/Ui/Windows/AvatarWindow.cs
@@ -46,7 +46,7 @@ namespace Ryujinx.Ui.Windows
             SetDefaultSize(740, 400);
             SetPosition(WindowPosition.Center);
 
-            VBox vbox = new VBox(false, 0);
+            Box vbox = new(Orientation.Vertical, 0);
             Add(vbox);
 
             ScrolledWindow scrolledWindow = new ScrolledWindow
@@ -55,7 +55,7 @@ namespace Ryujinx.Ui.Windows
             };
             scrolledWindow.SetPolicy(PolicyType.Automatic, PolicyType.Automatic);
 
-            HBox hbox = new HBox(false, 0);
+            Box hbox = new(Orientation.Horizontal, 0);
 
             Button chooseButton = new Button()
             {

--- a/Ryujinx/Ui/Windows/UserProfilesManagerWindow.Designer.cs
+++ b/Ryujinx/Ui/Windows/UserProfilesManagerWindow.Designer.cs
@@ -1,5 +1,6 @@
 ﻿using Gtk;
 using Pango;
+using Ryujinx.Audio.Renderer.Utils;
 
 namespace Ryujinx.Ui.Windows
 {
@@ -52,7 +53,8 @@ namespace Ryujinx.Ui.Windows
             _selectedLabel = new Label("Selected User Profile:")
             {
                 Margin     = 15,
-                Attributes = new AttrList()
+                Attributes = new AttrList(),
+                Halign     = Align.Start
             };
             _selectedLabel.Attributes.Insert(new Pango.AttrWeight(Weight.Bold));
 
@@ -136,7 +138,8 @@ namespace Ryujinx.Ui.Windows
             _availableUsersLabel = new Label("Available User Profiles:")
             {
                 Margin     = 15,
-                Attributes = new AttrList()
+                Attributes = new AttrList(),
+                Halign     = Align.Start
             };
             _availableUsersLabel.Attributes.Insert(new Pango.AttrWeight(Weight.Bold));
 
@@ -226,10 +229,9 @@ namespace Ryujinx.Ui.Windows
             _usersTreeViewWindow.Add(_usersTreeView);
 
             _usersTreeViewBox.Add(_usersTreeViewWindow);
-
-            _bottomBox.PackStart(new Gtk.Alignment(-1, 0, 0, 0) { _addButton }, false, false, 0);
-            _bottomBox.PackStart(new Gtk.Alignment(-1, 0, 0, 0) { _deleteButton }, false, false, 0);
-            _bottomBox.PackEnd(new Gtk.Alignment(1, 0, 0, 0) { _closeButton }, false, false, 0);
+            _bottomBox.PackStart(_addButton, false, false, 0);
+            _bottomBox.PackStart(_deleteButton, false, false, 0);
+            _bottomBox.PackEnd(_closeButton, false, false, 0);
 
             _selectedUserInfoBox.Add(_selectedUserNameEntry);
             _selectedUserInfoBox.Add(_selectedUserIdLabel);
@@ -238,12 +240,12 @@ namespace Ryujinx.Ui.Windows
             _selectedUserButtonsBox.Add(_changeProfileImageButton);
 
             _selectedUserBox.Add(_selectedUserImage);
-            _selectedUserBox.PackStart(new Gtk.Alignment(-1, 0, 0, 0) { _selectedUserInfoBox }, true, true, 0);
-            _selectedUserBox.Add(_selectedUserButtonsBox);
+            _selectedUserBox.PackStart(_selectedUserInfoBox, false, false, 0);
+            _selectedUserBox.PackEnd(_selectedUserButtonsBox, false, false, 0);
 
-            _mainBox.PackStart(new Gtk.Alignment(-1, 0, 0, 0) { _selectedLabel }, false, false, 0);
+            _mainBox.PackStart(_selectedLabel, false, false, 0);
             _mainBox.PackStart(_selectedUserBox, false, true, 0);
-            _mainBox.PackStart(new Gtk.Alignment(-1, 0, 0, 0) { _availableUsersLabel }, false, false, 0);
+            _mainBox.PackStart(_availableUsersLabel, false, false, 0);
             _mainBox.Add(_usersTreeViewBox);
             _mainBox.Add(_bottomBox);
 

--- a/Ryujinx/Ui/Windows/UserProfilesManagerWindow.Designer.cs
+++ b/Ryujinx/Ui/Windows/UserProfilesManagerWindow.Designer.cs
@@ -1,6 +1,5 @@
 ﻿using Gtk;
 using Pango;
-using Ryujinx.Audio.Renderer.Utils;
 
 namespace Ryujinx.Ui.Windows
 {


### PR DESCRIPTION
In #3980 the GtkSharp package were updated [here](https://github.com/Ryujinx/Ryujinx/commit/e211c3f00a847f50b286349918e5c51967862e93#diff-570835bf5164a409a35109d99b66fe54d190f34e8ecf3c93692eae26b5e7a04fR22), now `VBox`, `HBox` and `Alignment` are deprecated and adds some warnings. This PR fixes that.
