### PR TITLE
Filter hidden game files from the Game List

### DIFF
--- a/Ryujinx.Ui.Common/App/ApplicationLibrary.cs
+++ b/Ryujinx.Ui.Common/App/ApplicationLibrary.cs
@@ -18,6 +18,7 @@ using Ryujinx.Ui.Common.Configuration.System;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Text.Json;
@@ -104,7 +105,18 @@ namespace Ryujinx.Ui.App.Common
                         continue;
                     }
 
-                    foreach (string app in Directory.EnumerateFiles(appDir, "*", SearchOption.AllDirectories))
+                    IEnumerable<string> content = Enumerable.Empty<string>();
+
+                    try
+                    {
+                        content = Directory.EnumerateFiles(appDir, "*", SearchOption.AllDirectories);
+                    }
+                    catch (UnauthorizedAccessException)
+                    {
+                        Logger.Warning?.Print(LogClass.Application, $"Failed to get access to directory: \"{appDir}\"");
+                    }
+
+                    foreach (string app in content)
                     {
                         if (_cancellationToken.Token.IsCancellationRequested)
                         {

--- a/Ryujinx.Ui.Common/App/ApplicationLibrary.cs
+++ b/Ryujinx.Ui.Common/App/ApplicationLibrary.cs
@@ -160,12 +160,13 @@ namespace Ryujinx.Ui.App.Common
 
                         string extension = Path.GetExtension(app).ToLower();
 
-                        if ((extension == ".nsp")  ||
+                        if (((extension == ".nsp") ||
                             (extension == ".pfs0") ||
                             (extension == ".xci")  ||
                             (extension == ".nca")  ||
                             (extension == ".nro")  ||
-                            (extension == ".nso"))
+                            (extension == ".nso")) &&
+                            (Path.GetFileName(app).Substring(0, 2) != "._"))
                         {
                             applications.Add(app);
                             numApplicationsFound++;

--- a/Ryujinx.Ui.Common/App/ApplicationLibrary.cs
+++ b/Ryujinx.Ui.Common/App/ApplicationLibrary.cs
@@ -77,43 +77,43 @@ namespace Ryujinx.Ui.App.Common
             while (stack.Count > 0)
             {
                 string   dir     = stack.Pop();
-                string[] content = Array.Empty<string>();
+                IEnumerable<string> content = Array.Empty<string>();
+                IEnumerator<string> contentEnum = content.GetEnumerator();
 
                 try
                 {
-                    content = Directory.GetFiles(dir, "*");
+                    content = Directory.EnumerateFiles(dir);
+                    contentEnum = content.GetEnumerator();
                 }
                 catch (UnauthorizedAccessException)
                 {
                     Logger.Warning?.Print(LogClass.Application, $"Failed to get access to directory: \"{dir}\"");
                 }
 
-                if (content.Length > 0)
+                while (contentEnum.MoveNext())
                 {
-                    foreach (string file in content)
+                    string file = contentEnum.Current;
+
+                    if (!File.GetAttributes(file).HasFlag(FileAttributes.Hidden))
                     {
-                        if (!File.GetAttributes(file).HasFlag(FileAttributes.Hidden))
-                        {
-                            yield return file;
-                        }
+                         yield return file;
                     }
                 }
 
                 try
                 {
-                    content = Directory.GetDirectories(dir);
+                    content = Directory.EnumerateDirectories(dir);
+                    contentEnum = content.GetEnumerator();
                 }
                 catch (UnauthorizedAccessException)
                 {
                     Logger.Warning?.Print(LogClass.Application, $"Failed to get access to directory: \"{dir}\"");
                 }
 
-                if (content.Length > 0)
+                while (contentEnum.MoveNext())
                 {
-                    foreach (string subdir in content)
-                    {
-                        stack.Push(subdir);
-                    }
+                    string subdir = contentEnum.Current;
+                    stack.Push(subdir);
                 }
             }
         }

--- a/Ryujinx.Ui.Common/App/ApplicationLibrary.cs
+++ b/Ryujinx.Ui.Common/App/ApplicationLibrary.cs
@@ -92,7 +92,8 @@ namespace Ryujinx.Ui.App.Common
                 {
                     foreach (string file in content)
                     {
-                        if (!File.GetAttributes(file).HasFlag(FileAttributes.Hidden)) {
+                        if (!File.GetAttributes(file).HasFlag(FileAttributes.Hidden))
+                        {
                             yield return file;
                         }
                     }

--- a/Ryujinx.Ui.Common/App/ApplicationLibrary.cs
+++ b/Ryujinx.Ui.Common/App/ApplicationLibrary.cs
@@ -163,12 +163,7 @@ namespace Ryujinx.Ui.App.Common
 
                         string extension = Path.GetExtension(app).ToLower();
 
-                        if ((extension == ".nsp")  ||
-                            (extension == ".pfs0") ||
-                            (extension == ".xci")  ||
-                            (extension == ".nca")  ||
-                            (extension == ".nro")  ||
-                            (extension == ".nso"))
+                        if (extension is ".nsp" or ".pfs0" or ".xci" or ".nca" or ".nro" or ".nso")
                         {
                             applications.Add(app);
                             numApplicationsFound++;

--- a/Ryujinx.Ui.Common/App/ApplicationLibrary.cs
+++ b/Ryujinx.Ui.Common/App/ApplicationLibrary.cs
@@ -113,8 +113,7 @@ namespace Ryujinx.Ui.App.Common
 
                         string extension = Path.GetExtension(app).ToLower();
 
-                        if (!File.GetAttributes(app).HasFlag(FileAttributes.Hidden) &&
-                            extension is ".nsp" or ".pfs0" or ".xci" or ".nca" or ".nro" or ".nso")
+                        if (!File.GetAttributes(app).HasFlag(FileAttributes.Hidden) && extension is ".nsp" or ".pfs0" or ".xci" or ".nca" or ".nro" or ".nso")
                         {
                             applications.Add(app);
                             numApplicationsFound++;

--- a/Ryujinx.Ui.Common/App/ApplicationLibrary.cs
+++ b/Ryujinx.Ui.Common/App/ApplicationLibrary.cs
@@ -92,7 +92,9 @@ namespace Ryujinx.Ui.App.Common
                 {
                     foreach (string file in content)
                     {
-                        yield return file;
+                        if (!File.GetAttributes(file).HasFlag(FileAttributes.Hidden)) {
+                            yield return file;
+                        }
                     }
                 }
 
@@ -160,13 +162,12 @@ namespace Ryujinx.Ui.App.Common
 
                         string extension = Path.GetExtension(app).ToLower();
 
-                        if (((extension == ".nsp") ||
+                        if ((extension == ".nsp")  ||
                             (extension == ".pfs0") ||
                             (extension == ".xci")  ||
                             (extension == ".nca")  ||
                             (extension == ".nro")  ||
-                            (extension == ".nso")) &&
-                            (Path.GetFileName(app).Substring(0, 2) != "._"))
+                            (extension == ".nso"))
                         {
                             applications.Add(app);
                             numApplicationsFound++;


### PR DESCRIPTION
`._` files are automatically generated by macOS to store certain metadata about files when you transfer them to an SD card. These files are hidden in finder (even if you enable “show hidden files”) and can only be deleted through terminal. Some users have reported that these files appeared in the game list, so this is a PR that filters them out of the game list. 