### PR TITLE
Add Ryujinx license to builds

### DIFF
--- a/Ryujinx.Ava/Ryujinx.Ava.csproj
+++ b/Ryujinx.Ava/Ryujinx.Ava.csproj
@@ -59,14 +59,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ContentWithTargetPath Include="..\distribution\windows\alsoft.ini" Condition="'$(RuntimeIdentifier)' != 'linux-x64' AND '$(RuntimeIdentifier)' != 'osx-x64'">
+    <Content Include="..\distribution\windows\alsoft.ini" Condition="'$(RuntimeIdentifier)' != 'linux-x64' AND '$(RuntimeIdentifier)' != 'osx-x64'">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <TargetPath>alsoft.ini</TargetPath>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Include="..\distribution\legal\THIRDPARTY.md">
+    </Content>
+    <Content Include="..\distribution\legal\THIRDPARTY.md">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <TargetPath>THIRDPARTY.md</TargetPath>
-    </ContentWithTargetPath>
+    </Content>
+    <Content Include="..\LICENSE.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <TargetPath>LICENSE.txt</TargetPath>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/Ryujinx.Headless.SDL2/Ryujinx.Headless.SDL2.csproj
+++ b/Ryujinx.Headless.SDL2/Ryujinx.Headless.SDL2.csproj
@@ -33,10 +33,14 @@
   </ItemGroup>
 
 	<ItemGroup>
-		<ContentWithTargetPath Include="..\distribution\legal\THIRDPARTY.md">
-			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
-			<TargetPath>THIRDPARTY.md</TargetPath>
-		</ContentWithTargetPath>
+      <Content Include="..\distribution\legal\THIRDPARTY.md">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        <TargetPath>THIRDPARTY.md</TargetPath>
+      </Content>
+      <Content Include="..\LICENSE.txt">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        <TargetPath>LICENSE.txt</TargetPath>
+      </Content>
 	</ItemGroup>
 
   <!-- Due to .net core 3.1 embedded resource loading -->

--- a/Ryujinx/Ryujinx.csproj
+++ b/Ryujinx/Ryujinx.csproj
@@ -49,14 +49,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ContentWithTargetPath Include="..\distribution\windows\alsoft.ini" Condition="'$(RuntimeIdentifier)' != 'linux-x64' AND '$(RuntimeIdentifier)' != 'osx-x64'">
+    <Content Include="..\distribution\windows\alsoft.ini" Condition="'$(RuntimeIdentifier)' != 'linux-x64' AND '$(RuntimeIdentifier)' != 'osx-x64'">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <TargetPath>alsoft.ini</TargetPath>
-    </ContentWithTargetPath>
-    <ContentWithTargetPath Include="..\distribution\legal\THIRDPARTY.md">
+    </Content>
+    <Content Include="..\distribution\legal\THIRDPARTY.md">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <TargetPath>THIRDPARTY.md</TargetPath>
-    </ContentWithTargetPath>
+    </Content>
+    <Content Include="..\LICENSE.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <TargetPath>LICENSE.txt</TargetPath>
+    </Content>
   </ItemGroup>
 
   <!-- Due to .net core 3.1 embedded resource loading -->


### PR DESCRIPTION
This PR closes #2400.

I think I prefer keeping `THIRDPARTY.md` as is and not split it into multiple files. But I'll let @AcK77 decide if that's sufficient to close the referenced issue.