### PR TITLE
Shader: Implement PrimitiveID

### DIFF
--- a/Ryujinx.Graphics.Shader/Translation/AttributeConsts.cs
+++ b/Ryujinx.Graphics.Shader/Translation/AttributeConsts.cs
@@ -8,6 +8,7 @@ namespace Ryujinx.Graphics.Shader.Translation
         public const int TessLevelOuter3     = 0x00c;
         public const int TessLevelInner0     = 0x010;
         public const int TessLevelInner1     = 0x014;
+        public const int PrimitiveId         = 0x060;
         public const int Layer               = 0x064;
         public const int ViewportIndex       = 0x068;
         public const int PointSize           = 0x06c;
@@ -85,8 +86,7 @@ namespace Ryujinx.Graphics.Shader.Translation
         public const int LaneId = 0x2000020;
 
         public const int InvocationId = 0x2000024;
-        public const int PrimitiveId = 0x2000028;
-        public const int PatchVerticesIn = 0x200002c;
+        public const int PatchVerticesIn = 0x2000028;
 
         public const int EqMask = 0x2000030;
         public const int GeMask = 0x2000034;


### PR DESCRIPTION
Implement the Primitive ID output (on the geometry shader), which can be accessed on tessellation and fragment shaders.

Fixes scene being too dark on DARK SOULS: REMASTERED.

Before:
![image](https://user-images.githubusercontent.com/5624669/206365026-ddcd1d6e-689d-4dca-a842-e64f32be3ed4.png)
After:
![image](https://user-images.githubusercontent.com/5624669/206365041-b8b0a474-2e5f-46f7-98e9-fcb1205a0168.png)

(it writes a 2D array texture where layer is indicated by PrimitiveID, without the fix, only the first layer was being written).