### PR TITLE
Fix shader FSWZADD instruction

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 4067;
+        private const uint CodeGenVersion = 4069;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/SwizzleAdd.glsl
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/SwizzleAdd.glsl
@@ -2,6 +2,6 @@ float Helper_SwizzleAdd(float x, float y, int mask)
 {
     vec4 xLut = vec4(1.0, -1.0, 1.0, 0.0);
     vec4 yLut = vec4(1.0, 1.0, -1.0, 1.0);
-    int lutIdx = mask >> int($SUBGROUP_INVOCATION$ & 3u) * 2;
+    int lutIdx = (mask >> (int($SUBGROUP_INVOCATION$ & 3u) * 2)) & 3;
     return x * xLut[lutIdx] + y * yLut[lutIdx];
 }

--- a/Ryujinx.Graphics.Shader/CodeGen/Spirv/Instructions.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Spirv/Instructions.cs
@@ -1449,10 +1449,13 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
             var xLut = context.ConstantComposite(v4float, one, minusOne, one, zero);
             var yLut = context.ConstantComposite(v4float, one, one, minusOne, one);
 
+            var three = context.Constant(context.TypeU32(), 3);
+
             var threadId = context.GetAttribute(AggregateType.U32, AttributeConsts.LaneId, false);
-            var shift = context.BitwiseAnd(context.TypeU32(), threadId, context.Constant(context.TypeU32(), 3));
+            var shift = context.BitwiseAnd(context.TypeU32(), threadId, three);
             shift = context.ShiftLeftLogical(context.TypeU32(), shift, context.Constant(context.TypeU32(), 1));
             var lutIdx = context.ShiftRightLogical(context.TypeU32(), mask, shift);
+            lutIdx = context.BitwiseAnd(context.TypeU32(), lutIdx, three);
 
             var xLutValue = context.VectorExtractDynamic(context.TypeFP32(), xLut, lutIdx);
             var yLutValue = context.VectorExtractDynamic(context.TypeFP32(), yLut, lutIdx);


### PR DESCRIPTION
Fixes a mistake on the helper function for this shader instruciton that was causing the LUT index to be out of bounds.

Fixes text rendering on The Stanley Parable: Ultra Deluxe, and maybe other games.
Before:
![image](https://user-images.githubusercontent.com/5624669/206377751-9027fd85-ae21-4dfc-9faf-e1bc64cf5c3f.png)
After:
![image](https://user-images.githubusercontent.com/5624669/206377768-eec1ba64-650d-4bd8-bfe3-78fa4ed4eb08.png)