### PR TITLE
Fix HasUnalignedStorageBuffers value when buffers are always unaligned

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Threed/SpecializationStateUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/SpecializationStateUpdater.cs
@@ -253,14 +253,19 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         /// Indicates that any storage buffer use is unaligned.
         /// </summary>
         /// <param name="value">The new value</param>
-        public void SetHasUnalignedStorageBuffer(bool value)
+        /// <returns>True if the unaligned state changed, false otherwise</returns>
+        public bool SetHasUnalignedStorageBuffer(bool value)
         {
             if (value != _graphics.HasUnalignedStorageBuffer)
             {
                 _graphics.HasUnalignedStorageBuffer = value;
 
                 Signal();
+
+                return true;
             }
+
+            return false;
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -304,14 +304,12 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         /// </summary>
         private void CommitBindings()
         {
-            var buffers = _channel.BufferManager;
-            var hasUnaligned = buffers.HasUnalignedStorageBuffers;
-
             UpdateStorageBuffers();
 
-            if (!_channel.TextureManager.CommitGraphicsBindings(_shaderSpecState) || (buffers.HasUnalignedStorageBuffers != hasUnaligned))
+            bool unalignedChanged = _currentSpecState.SetHasUnalignedStorageBuffer(_channel.BufferManager.HasUnalignedStorageBuffers);
+
+            if (!_channel.TextureManager.CommitGraphicsBindings(_shaderSpecState) || unalignedChanged)
             {
-                _currentSpecState.SetHasUnalignedStorageBuffer(buffers.HasUnalignedStorageBuffers);
                 // Shader must be reloaded. _vtgWritesRtLayer should not change.
                 UpdateShaderState();
             }


### PR DESCRIPTION
Fixes a regression from #4004. The value on `SpecializationStateUpdater` was only updated if the value was actually changed. If the value is always true, then it would be never be updated and `SpecializationStateUpdater` would have a value of `false`, which is incorrect. This change fixes the issue by always updating the `SpecializationStateUpdater` value, and forcing a shader update only if that value changed.

Fixes #4076.