### PR TITLE
Add concurrency restriction on release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
       - '*.yml'
       - 'README.md'
 
+concurrency: release
 
 jobs:
   release:


### PR DESCRIPTION
Smallest PR possible, so we don't need to wait for the first release job to finish before merging another PR.

Details about concurrency here: [Github docs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency)