### PR TITLE
Use method overloads that support trimming. Mark some types to be trimming friendly

### DIFF
--- a/Ryujinx.Ava/Input/AvaloniaKeyboardMappingHelper.cs
+++ b/Ryujinx.Ava/Input/AvaloniaKeyboardMappingHelper.cs
@@ -7,8 +7,7 @@ namespace Ryujinx.Ava.Input
 {
     internal static class AvaloniaKeyboardMappingHelper
     {
-        private static readonly AvaKey[] _keyMapping = new AvaKey[(int)Key.Count]
-        {
+        private static readonly AvaKey[] _keyMapping = {
             // NOTE: Invalid
             AvaKey.None,
 
@@ -151,16 +150,16 @@ namespace Ryujinx.Ava.Input
 
         static AvaloniaKeyboardMappingHelper()
         {
-            var inputKeys = Enum.GetValues(typeof(Key));
+            var inputKeys = Enum.GetValues<Key>();
 
             // NOTE: Avalonia.Input.Key is not contiguous and quite large, so use a dictionary instead of an array.
             _avaKeyMapping = new Dictionary<AvaKey, Key>();
 
             foreach (var key in inputKeys)
             {
-                if (TryGetAvaKey((Key)key, out var index))
+                if (TryGetAvaKey(key, out var index))
                 {
-                    _avaKeyMapping[index] = (Key)key;
+                    _avaKeyMapping[index] = key;
                 }
             }
         }

--- a/Ryujinx.Common/GraphicsDriver/NVThreadedOptimization.cs
+++ b/Ryujinx.Common/GraphicsDriver/NVThreadedOptimization.cs
@@ -152,7 +152,7 @@ namespace Ryujinx.Common.GraphicsDriver
 
             if (ptr != IntPtr.Zero)
             {
-                return Marshal.GetDelegateForFunctionPointer(ptr, typeof(T)) as T;
+                return Marshal.GetDelegateForFunctionPointer<T>(ptr);
             }
             else
             {

--- a/Ryujinx.Common/SystemInfo/WindowsSystemInfo.cs
+++ b/Ryujinx.Common/SystemInfo/WindowsSystemInfo.cs
@@ -60,7 +60,7 @@ namespace Ryujinx.Common.SystemInfo
 
             public MemoryStatusEx()
             {
-                Length = (uint)Marshal.SizeOf(typeof(MemoryStatusEx));
+                Length = (uint)Marshal.SizeOf<MemoryStatusEx>();
             }
         }
 

--- a/Ryujinx.Graphics.Device/DeviceState.cs
+++ b/Ryujinx.Graphics.Device/DeviceState.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Ryujinx.Graphics.Device
 {
-    public class DeviceState<TState> : IDeviceState where TState : unmanaged
+    public class DeviceState<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TState> : IDeviceState where TState : unmanaged
     {
         private const int RegisterSize = sizeof(int);
 

--- a/Ryujinx.Graphics.Gpu/Engine/DeviceStateWithShadow.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/DeviceStateWithShadow.cs
@@ -2,6 +2,7 @@ using Ryujinx.Graphics.Device;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace Ryujinx.Graphics.Gpu.Engine
@@ -21,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Engine
     /// Represents a device's state, with a additional shadow state.
     /// </summary>
     /// <typeparam name="TState">Type of the state</typeparam>
-    class DeviceStateWithShadow<TState> : IDeviceState where TState : unmanaged, IShadowState
+    class DeviceStateWithShadow<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TState> : IDeviceState where TState : unmanaged, IShadowState
     {
         private readonly DeviceState<TState> _state;
         private readonly DeviceState<TState> _shadowState;

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdateTracker.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdateTracker.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -39,7 +40,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
     /// GPU state update tracker.
     /// </summary>
     /// <typeparam name="TState">State type</typeparam>
-    class StateUpdateTracker<TState>
+    class StateUpdateTracker<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] TState>
     {
         private const int BlockSize = 0xe00;
         private const int RegisterSize = sizeof(uint);

--- a/Ryujinx.HLE/HOS/Applets/Error/ErrorApplet.cs
+++ b/Ryujinx.HLE/HOS/Applets/Error/ErrorApplet.cs
@@ -47,7 +47,7 @@ namespace Ryujinx.HLE.HOS.Applets.Error
 
             _errorStorage      = _normalSession.Pop();
             _errorCommonHeader = IApplet.ReadStruct<ErrorCommonHeader>(_errorStorage);
-            _errorStorage      = _errorStorage.Skip(Marshal.SizeOf(typeof(ErrorCommonHeader))).ToArray();
+            _errorStorage      = _errorStorage.Skip(Marshal.SizeOf<ErrorCommonHeader>()).ToArray();
 
             switch (_errorCommonHeader.Type)
             {

--- a/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardApplet.cs
+++ b/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardApplet.cs
@@ -9,6 +9,7 @@ using Ryujinx.HLE.Ui.Input;
 using Ryujinx.Memory;
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -797,7 +798,7 @@ namespace Ryujinx.HLE.HOS.Applets
             return sb.ToString();
         }
 
-        private static T ReadStruct<T>(byte[] data)
+        private static T ReadStruct<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] T>(byte[] data)
             where T : struct
         {
             GCHandle handle = GCHandle.Alloc(data, GCHandleType.Pinned);

--- a/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/INfp.cs
+++ b/Ryujinx.HLE/HOS/Services/Nfc/Nfp/NfpManager/INfp.cs
@@ -589,9 +589,9 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
 
             ulong outputPosition = context.Request.RecvListBuff[0].Position;
 
-            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize((uint)Marshal.SizeOf(typeof(TagInfo)));
+            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize((uint)Marshal.SizeOf<TagInfo>());
 
-            MemoryHelper.FillWithZeros(context.Memory, outputPosition, Marshal.SizeOf(typeof(TagInfo)));
+            MemoryHelper.FillWithZeros(context.Memory, outputPosition, Marshal.SizeOf<TagInfo>());
 
             uint deviceHandle = (uint)context.RequestData.ReadUInt64();
 
@@ -665,9 +665,9 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
 
             ulong outputPosition = context.Request.RecvListBuff[0].Position;
 
-            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize((uint)Marshal.SizeOf(typeof(RegisterInfo)));
+            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize((uint)Marshal.SizeOf<RegisterInfo>());
 
-            MemoryHelper.FillWithZeros(context.Memory, outputPosition, Marshal.SizeOf(typeof(RegisterInfo)));
+            MemoryHelper.FillWithZeros(context.Memory, outputPosition, Marshal.SizeOf<RegisterInfo>());
 
             uint deviceHandle = (uint)context.RequestData.ReadUInt64();
 
@@ -728,9 +728,9 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
 
             ulong outputPosition = context.Request.RecvListBuff[0].Position;
 
-            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize((uint)Marshal.SizeOf(typeof(CommonInfo)));
+            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize((uint)Marshal.SizeOf<CommonInfo>());
 
-            MemoryHelper.FillWithZeros(context.Memory, outputPosition, Marshal.SizeOf(typeof(CommonInfo)));
+            MemoryHelper.FillWithZeros(context.Memory, outputPosition, Marshal.SizeOf<CommonInfo>());
 
             uint deviceHandle = (uint)context.RequestData.ReadUInt64();
 
@@ -788,9 +788,9 @@ namespace Ryujinx.HLE.HOS.Services.Nfc.Nfp
 
             ulong outputPosition = context.Request.RecvListBuff[0].Position;
 
-            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize((uint)Marshal.SizeOf(typeof(ModelInfo)));
+            context.Response.PtrBuff[0] = context.Response.PtrBuff[0].WithSize((uint)Marshal.SizeOf<ModelInfo>());
 
-            MemoryHelper.FillWithZeros(context.Memory, outputPosition, Marshal.SizeOf(typeof(ModelInfo)));
+            MemoryHelper.FillWithZeros(context.Memory, outputPosition, Marshal.SizeOf<ModelInfo>());
 
             uint deviceHandle = (uint)context.RequestData.ReadUInt64();
 

--- a/Ryujinx.Tests.Unicorn/Native/Interface.cs
+++ b/Ryujinx.Tests.Unicorn/Native/Interface.cs
@@ -1,5 +1,6 @@
 using Ryujinx.Tests.Unicorn.Native.Const;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -43,9 +44,9 @@ namespace Ryujinx.Tests.Unicorn.Native
             }
         }
 
-        public static void MarshalArrayOf<T>(IntPtr input, int length, out T[] output)
+        public static void MarshalArrayOf<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] T>(IntPtr input, int length, out T[] output)
         {
-            int size = Marshal.SizeOf(typeof(T));
+            int size = Marshal.SizeOf<T>();
 
             output = new T[length];
 


### PR DESCRIPTION
This PR fixes some easy trimming warnings by using trimming friendly overloads. Some types were attributed too (it looks ugly though, but this is the only way to fix).

Other trimming warnings such as using dynamic code during JSON serialization/deserialization and reflection usages will be fixed in subsequent PRs.