### PR TITLE
Vulkan: Don't flush commands when creating most sync

### DIFF
--- a/Ryujinx.Graphics.GAL/IRenderer.cs
+++ b/Ryujinx.Graphics.GAL/IRenderer.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.GAL
         ISampler CreateSampler(SamplerCreateInfo info);
         ITexture CreateTexture(TextureCreateInfo info, float scale);
 
-        void CreateSync(ulong id);
+        void CreateSync(ulong id, bool strict);
 
         void DeleteBuffer(BufferHandle buffer);
 
@@ -52,6 +52,8 @@ namespace Ryujinx.Graphics.GAL
         void WaitSync(ulong id);
 
         void Initialize(GraphicsDebugLevel logLevel);
+
+        void SetInterruptAction(Action<Action> interruptAction);
 
         void Screenshot();
     }

--- a/Ryujinx.Graphics.GAL/Multithreading/Commands/Renderer/CreateSyncCommand.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/Commands/Renderer/CreateSyncCommand.cs
@@ -4,15 +4,17 @@
     {
         public CommandType CommandType => CommandType.CreateSync;
         private ulong _id;
+        private bool _strict;
 
-        public void Set(ulong id)
+        public void Set(ulong id, bool strict)
         {
             _id = id;
+            _strict = strict;
         }
 
         public static void Run(ref CreateSyncCommand command, ThreadedRenderer threaded, IRenderer renderer)
         {
-            renderer.CreateSync(command._id);
+            renderer.CreateSync(command._id, command._strict);
 
             threaded.Sync.AssignSync(command._id);
         }

--- a/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
@@ -1,5 +1,6 @@
 ﻿using Ryujinx.Common;
 using Ryujinx.Common.Configuration;
+using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.GAL.Multithreading.Commands;
 using Ryujinx.Graphics.GAL.Multithreading.Commands.Buffer;
 using Ryujinx.Graphics.GAL.Multithreading.Commands.Renderer;
@@ -39,7 +40,7 @@ namespace Ryujinx.Graphics.GAL.Multithreading
         private CircularSpanPool _spanPool;
 
         private ManualResetEventSlim _invokeRun;
-        private ManualResetEventSlim _interruptRun;
+        private AutoResetEvent _interruptRun;
 
         private bool _lastSampleCounterClear = true;
 
@@ -87,7 +88,7 @@ namespace Ryujinx.Graphics.GAL.Multithreading
 
             _galWorkAvailable = new ManualResetEventSlim(false);
             _invokeRun = new ManualResetEventSlim();
-            _interruptRun = new ManualResetEventSlim();
+            _interruptRun = new AutoResetEvent(false);
             _spanPool = new CircularSpanPool(this, SpanPoolBytes);
             SpanPool = _spanPool;
 
@@ -452,7 +453,7 @@ namespace Ryujinx.Graphics.GAL.Multithreading
 
                 _galWorkAvailable.Set();
 
-                _interruptRun.Wait();
+                _interruptRun.WaitOne();
             }
         }
 

--- a/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
@@ -1,6 +1,5 @@
 ﻿using Ryujinx.Common;
 using Ryujinx.Common.Configuration;
-using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.GAL.Multithreading.Commands;
 using Ryujinx.Graphics.GAL.Multithreading.Commands.Buffer;
 using Ryujinx.Graphics.GAL.Multithreading.Commands.Renderer;

--- a/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
@@ -480,6 +480,7 @@ namespace Ryujinx.Graphics.GAL.Multithreading
             _frameComplete.Dispose();
             _galWorkAvailable.Dispose();
             _invokeRun.Dispose();
+            _interruptRun.Dispose();
 
             Sync.Dispose();
         }

--- a/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoClass.cs
@@ -184,7 +184,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
         {
             _context.Renderer.Pipeline.CommandBufferBarrier();
 
-            _context.CreateHostSyncIfNeeded(false);
+            _context.CreateHostSyncIfNeeded(true);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/GPFifo/GPFifoClass.cs
@@ -59,7 +59,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
             if (_createSyncPending)
             {
                 _createSyncPending = false;
-                _context.CreateHostSyncIfNeeded(false);
+                _context.CreateHostSyncIfNeeded(false, false);
             }
         }
 
@@ -157,7 +157,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
             }
             else if (operation == SyncpointbOperation.Incr)
             {
-                _context.CreateHostSyncIfNeeded(true);
+                _context.CreateHostSyncIfNeeded(true, true);
                 _context.Synchronization.IncrementSyncpoint(syncpointId);
             }
 
@@ -184,7 +184,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.GPFifo
         {
             _context.Renderer.Pipeline.CommandBufferBarrier();
 
-            _context.CreateHostSyncIfNeeded(true);
+            _context.CreateHostSyncIfNeeded(false, true);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
@@ -250,7 +250,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             uint syncpointId = (uint)argument & 0xFFFF;
 
             _context.AdvanceSequence();
-            _context.CreateHostSyncIfNeeded(true);
+            _context.CreateHostSyncIfNeeded(true, true);
             _context.Renderer.UpdateCounters(); // Poll the query counters, the game may want an updated result.
             _context.Synchronization.IncrementSyncpoint(syncpointId);
         }

--- a/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -337,7 +337,7 @@ namespace Ryujinx.Graphics.Gpu
 
             if (_pendingSync || (syncpoint && SyncpointActions.Count > 0))
             {
-                Renderer.CreateSync(SyncNumber);
+                Renderer.CreateSync(SyncNumber, syncpoint);
 
                 SyncNumber++;
 

--- a/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -316,7 +316,8 @@ namespace Ryujinx.Graphics.Gpu
         /// If no actions are present, a host sync object is not created.
         /// </summary>
         /// <param name="syncpoint">True if host sync is being created by a syncpoint</param>
-        public void CreateHostSyncIfNeeded(bool syncpoint)
+        /// <param name="strict">True if the sync should signal as soon as possible</param>
+        public void CreateHostSyncIfNeeded(bool syncpoint, bool strict)
         {
             if (BufferMigrations.Count > 0)
             {
@@ -337,7 +338,7 @@ namespace Ryujinx.Graphics.Gpu
 
             if (_pendingSync || (syncpoint && SyncpointActions.Count > 0))
             {
-                Renderer.CreateSync(SyncNumber, syncpoint);
+                Renderer.CreateSync(SyncNumber, strict);
 
                 SyncNumber++;
 

--- a/Ryujinx.Graphics.OpenGL/OpenGLRenderer.cs
+++ b/Ryujinx.Graphics.OpenGL/OpenGLRenderer.cs
@@ -229,7 +229,7 @@ namespace Ryujinx.Graphics.OpenGL
             return new Program(programBinary, hasFragmentShader, info.FragmentOutputMap);
         }
 
-        public void CreateSync(ulong id)
+        public void CreateSync(ulong id, bool strict)
         {
             _sync.Create(id);
         }
@@ -242,6 +242,11 @@ namespace Ryujinx.Graphics.OpenGL
         public ulong GetCurrentSync()
         {
             return _sync.GetCurrent();
+        }
+
+        public void SetInterruptAction(Action<Action> interruptAction)
+        {
+            // Currently no need for an interrupt action.
         }
 
         public void Screenshot()

--- a/Ryujinx.Graphics.Vulkan/CommandBufferPool.cs
+++ b/Ryujinx.Graphics.Vulkan/CommandBufferPool.cs
@@ -116,6 +116,22 @@ namespace Ryujinx.Graphics.Vulkan
             }
         }
 
+        public void AddInUseWaitable(MultiFenceHolder waitable)
+        {
+            lock (_commandBuffers)
+            {
+                for (int i = 0; i < _totalCommandBuffers; i++)
+                {
+                    ref var entry = ref _commandBuffers[i];
+
+                    if (entry.InUse)
+                    {
+                        AddWaitable(i, waitable);
+                    }
+                }
+            }
+        }
+
         public void AddDependency(int cbIndex, CommandBufferScoped dependencyCbs)
         {
             Debug.Assert(_commandBuffers[cbIndex].InUse);

--- a/Ryujinx.Graphics.Vulkan/PipelineFull.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineFull.cs
@@ -227,6 +227,7 @@ namespace Ryujinx.Graphics.Vulkan
             }
 
             CommandBuffer = (Cbs = Gd.CommandBufferPool.ReturnAndRent(Cbs)).CommandBuffer;
+            Gd.RegisterFlush();
 
             // Restore per-command buffer state.
 

--- a/Ryujinx.Graphics.Vulkan/SyncManager.cs
+++ b/Ryujinx.Graphics.Vulkan/SyncManager.cs
@@ -1,6 +1,4 @@
 using Ryujinx.Common.Logging;
-using shaderc;
-using Silk.NET.Core.Native;
 using Silk.NET.Vulkan;
 using System.Collections.Generic;
 using System.Linq;

--- a/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -83,6 +83,7 @@ namespace Ryujinx.Graphics.Vulkan
         public bool PreferThreading => true;
 
         public event EventHandler<ScreenCaptureImageInfo> ScreenCaptured;
+        public Action<Action> InterruptAction;
 
         public VulkanRenderer(Func<Instance, Vk, SurfaceKHR> surfaceFunc, Func<string[]> requiredExtensionsFunc, string preferredGpuId)
         {
@@ -354,6 +355,11 @@ namespace Ryujinx.Graphics.Vulkan
             _pipeline?.FlushCommandsImpl();
         }
 
+        internal void RegisterFlush()
+        {
+            _syncManager.RegisterFlush();
+        }
+
         public ReadOnlySpan<byte> GetBufferData(BufferHandle buffer, int offset, int size)
         {
             return BufferManager.GetData(buffer, offset, size);
@@ -572,9 +578,9 @@ namespace Ryujinx.Graphics.Vulkan
             action();
         }
 
-        public void CreateSync(ulong id)
+        public void CreateSync(ulong id, bool strict)
         {
-            _syncManager.Create(id);
+            _syncManager.Create(id, strict);
         }
 
         public IProgram LoadProgramBinary(byte[] programBinary, bool isFragment, ShaderInfo info)
@@ -590,6 +596,11 @@ namespace Ryujinx.Graphics.Vulkan
         public ulong GetCurrentSync()
         {
             return _syncManager.GetCurrent();
+        }
+
+        public void SetInterruptAction(Action<Action> interruptAction)
+        {
+            InterruptAction = interruptAction;
         }
 
         public void Screenshot()

--- a/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -48,6 +48,7 @@ namespace Ryujinx.Graphics.Vulkan
         internal DescriptorSetManager DescriptorSetManager { get; private set; }
         internal PipelineLayoutCache PipelineLayoutCache { get; private set; }
         internal BackgroundResources BackgroundResources { get; private set; }
+        internal Action<Action> InterruptAction { get; private set; };
 
         internal BufferManager BufferManager { get; private set; }
 
@@ -83,7 +84,6 @@ namespace Ryujinx.Graphics.Vulkan
         public bool PreferThreading => true;
 
         public event EventHandler<ScreenCaptureImageInfo> ScreenCaptured;
-        public Action<Action> InterruptAction;
 
         public VulkanRenderer(Func<Instance, Vk, SurfaceKHR> surfaceFunc, Func<string[]> requiredExtensionsFunc, string preferredGpuId)
         {

--- a/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -48,7 +48,7 @@ namespace Ryujinx.Graphics.Vulkan
         internal DescriptorSetManager DescriptorSetManager { get; private set; }
         internal PipelineLayoutCache PipelineLayoutCache { get; private set; }
         internal BackgroundResources BackgroundResources { get; private set; }
-        internal Action<Action> InterruptAction { get; private set; };
+        internal Action<Action> InterruptAction { get; private set; }
 
         internal BufferManager BufferManager { get; private set; }
 


### PR DESCRIPTION
When the WaitForIdle method is called, we create sync as some internal GPU method may read back written buffer data. Some games randomly intersperse compute dispatch into their render passes, which result in this happening an unbounded number of times depending on how many times they run compute or insert memory barriers.

Creating sync in Vulkan is expensive, as we need to flush the current command buffer so that it can be waited on. We have a limited number of active command buffers due to how we track resource usage, so submitting too many command buffers will force us to wait for them to return to the pool.

This PR allows less "important" sync (things which are less likely to be waited on) to wait on a command buffer's result without submitting it, instead relying on AutoFlush or another more important sync to flush it later on.

Because of the possibility of us waiting for a command buffer that hasn't submitted yet, any thread needs to be able to force the active command buffer to submit. The ability to do this has been added to the backend multithreading via an "Interrupt", though it is not currently supported without multithreading.

OpenGL drivers should already be doing something similar so they don't blow up when creating lots of sync, which is why this hasn't been a problem for these games over there.

Improves Vulkan performance on Xenoblade DE/3, Pokemon Scarlet/Violet, and Zelda BOTW (still another large issue here). Needs some testing to make sure nothing broke.