### PR TITLE
misc: Some fixes to the updaters

### DIFF
--- a/Ryujinx.Ava/Modules/Updater/Updater.cs
+++ b/Ryujinx.Ava/Modules/Updater/Updater.cs
@@ -11,6 +11,7 @@ using Ryujinx.Ava.Ui.Controls;
 using Ryujinx.Ava.Ui.Windows;
 using Ryujinx.Common;
 using Ryujinx.Common.Logging;
+using Ryujinx.Ui.Common.Helper;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -278,14 +279,15 @@ namespace Ryujinx.Modules
                 {
                     string ryuName = Path.GetFileName(Environment.ProcessPath);
                     string ryuExe = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ryuName);
-                    var ryuArg = Environment.GetCommandLineArgs().Skip(1);
 
-                    if (!OperatingSystem.IsWindows())
+                    if (!Path.Exists(ryuExe))
                     {
-                        chmod(ryuExe, Convert.ToUInt32("0777", 8));
+                        ryuExe = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, OperatingSystem.IsWindows() ? "Ryujinx.exe" : "Ryujinx");
                     }
 
-                    Process.Start(ryuExe, ryuArg);
+                    SetFileExecutable(ryuExe);
+
+                    Process.Start(ryuExe, CommandLineState.Arguments);
 
                     Environment.Exit(0);
                 }
@@ -456,16 +458,19 @@ namespace Ryujinx.Modules
             worker.Start();
         }
 
-        [DllImport("libc", SetLastError = true)]
-        private static extern int chmod(string path, uint mode);
-
-        private static void SetUnixPermissions()
+        private static void SetFileExecutable(string path)
         {
-            string ryuBin = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Ryujinx");
+            const UnixFileMode ExecutableFileMode = UnixFileMode.UserExecute |
+                                                    UnixFileMode.UserWrite |
+                                                    UnixFileMode.UserRead |
+                                                    UnixFileMode.GroupRead |
+                                                    UnixFileMode.GroupWrite |
+                                                    UnixFileMode.OtherRead |
+                                                    UnixFileMode.OtherWrite;
 
-            if (!OperatingSystem.IsWindows())
+            if (!OperatingSystem.IsWindows() && File.Exists(path))
             {
-                chmod(ryuBin, 493);
+                File.SetUnixFileMode(path, ExecutableFileMode);
             }
         }
 
@@ -586,7 +591,7 @@ namespace Ryujinx.Modules
 
             Directory.Delete(UpdateDir, true);
 
-            SetUnixPermissions();
+            SetFileExecutable(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Ryujinx"));
 
             UpdateSuccessful = true;
 

--- a/Ryujinx/Modules/Updater/Updater.cs
+++ b/Ryujinx/Modules/Updater/Updater.cs
@@ -387,16 +387,19 @@ namespace Ryujinx.Modules
             worker.Start();
         }
 
-        [DllImport("libc", SetLastError = true)]
-        private static extern int chmod(string path, uint mode);
-
-        private static void SetUnixPermissions()
+        private static void SetFileExecutable(string path)
         {
-            string ryuBin = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Ryujinx");
+            const UnixFileMode ExecutableFileMode = UnixFileMode.UserExecute |
+                                                    UnixFileMode.UserWrite |
+                                                    UnixFileMode.UserRead |
+                                                    UnixFileMode.GroupRead |
+                                                    UnixFileMode.GroupWrite |
+                                                    UnixFileMode.OtherRead |
+                                                    UnixFileMode.OtherWrite;
 
-            if (!OperatingSystem.IsWindows())
+            if (!OperatingSystem.IsWindows() && File.Exists(path))
             {
-                chmod(ryuBin, 493);
+                File.SetUnixFileMode(path, ExecutableFileMode);
             }
         }
 
@@ -519,7 +522,7 @@ namespace Ryujinx.Modules
 
             Directory.Delete(UpdateDir, true);
 
-            SetUnixPermissions();
+            SetFileExecutable(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Ryujinx"));
 
             updateDialog.MainText.Text      = "Update Complete!";
             updateDialog.SecondaryText.Text = "Do you want to restart Ryujinx now?";


### PR DESCRIPTION
This was meant to be only an upgrade of how we set unix permission in the updater to use .NET 7 new APIs, but I end up finding bugs along the way.

Changelog:
- Remove direct usage of chmod to use File.SetUnixFileMode.
- Fix command line being broken when updating (#3744) but on Ryujinx.Ava.
- Makes Ryujinx.Ava updater fallback to Ryujinx executable if current name isn't found.
- Make permission setter function more generic.