### PR TITLE
Bsd: Add support for dns_mitm

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/IResolver.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/IResolver.cs
@@ -18,11 +18,9 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
     [Service("sfdnsres")]
     class IResolver : IpcService
     {
-        private static DnsMitmResolver _dnsMitmResolver;
-
         public IResolver(ServiceCtx context)
         {
-            _dnsMitmResolver = DnsMitmResolver.Initialize(context);
+            DnsMitmResolver.Instance.ReloadEntries(context);
         }
 
         [CommandHipc(0)]
@@ -269,7 +267,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
         // AtmosphereReloadHostsFile()
         public ResultCode AtmosphereReloadHostsFile(ServiceCtx context)
         {
-            _dnsMitmResolver.ReloadEntries(context);
+            DnsMitmResolver.Instance.ReloadEntries(context);
 
             return ResultCode.Success;
         }
@@ -336,7 +334,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
 
                     try
                     {
-                        hostEntry = _dnsMitmResolver.ResolveAddress(targetHost);
+                        hostEntry = DnsMitmResolver.Instance.ResolveAddress(targetHost);
                     }
                     catch (SocketException exception)
                     {
@@ -552,7 +550,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres
 
                     try
                     {
-                        hostEntry = _dnsMitmResolver.ResolveAddress(targetHost);
+                        hostEntry = DnsMitmResolver.Instance.ResolveAddress(targetHost);
                     }
                     catch (SocketException exception)
                     {

--- a/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsMitmResolver.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsMitmResolver.cs
@@ -38,8 +38,8 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Proxy
                         break;
                     }
 
-                    // Ignore comments
-                    if (line.StartsWith("#"))
+                    // Ignore comments and empty lines
+                    if (line.StartsWith("#") || line.Trim().Length == 0)
                     {
                         continue;
                     }

--- a/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsMitmResolver.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsMitmResolver.cs
@@ -53,8 +53,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Proxy
                         continue;
                     }
 
-                    string[] entry = line.Split(new[] { ' ', '\t' },
-                        StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+                    string[] entry = line.Split(new[] { ' ', '\t' }, StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
 
                     // Hosts file example entry:
                     // 127.0.0.1  localhost loopback
@@ -63,6 +62,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Proxy
                     if (entry.Length < 2)
                     {
                         Logger.Warning?.PrintMsg(LogClass.ServiceBsd, $"Invalid entry in hosts file: {line}");
+                        
                         continue;
                     }
 
@@ -70,6 +70,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Proxy
                     if (!IPAddress.TryParse(entry[0], out IPAddress address))
                     {
                         Logger.Warning?.PrintMsg(LogClass.ServiceBsd, $"Failed to parse IP address in hosts file: {entry[0]}");
+                        
                         continue;
                     }
 

--- a/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsMitmResolver.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsMitmResolver.cs
@@ -24,16 +24,12 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Proxy
         private DnsMitmResolver(ServiceCtx context)
         {
             ReloadEntries(context);
-
-            Logger.Info?.PrintMsg(LogClass.ServiceBsd, $"Successfully loaded {_mitmHostEntries.Count} hosts file entries!");
         }
 
         public void ReloadEntries(ServiceCtx context)
         {
             string sdPath = context.Device.Configuration.VirtualFileSystem.GetSdCardPath();
             string filePath = context.Device.Configuration.VirtualFileSystem.GetFullPath(sdPath, HostsFilePath);
-
-            Logger.Info?.PrintMsg(LogClass.ServiceBsd, $"Checking hosts file path: {filePath}");
 
             _mitmHostEntries.Clear();
 
@@ -100,7 +96,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Proxy
                 // NOTE: MatchesSimpleExpression also allows "?" as a wildcard
                 if (FileSystemName.MatchesSimpleExpression(hostEntry.Key, host))
                 {
-                    Logger.Info?.PrintMsg(LogClass.ServiceBsd, $"Match found for '{host}': {hostEntry.Value}");
+                    Logger.Info?.PrintMsg(LogClass.ServiceBsd, $"Redirecting '{host}' to: {hostEntry.Value}");
 
                     return new IPHostEntry
                     {

--- a/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsMitmResolver.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsMitmResolver.cs
@@ -1,0 +1,117 @@
+using Ryujinx.Common.Logging;
+using Ryujinx.HLE.HOS.Services.Sockets.Nsd;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Enumeration;
+using System.Net;
+
+namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Proxy
+{
+    class DnsMitmResolver
+    {
+        private const string HostsFilePath = "/atmosphere/hosts/default.txt";
+
+        private static DnsMitmResolver Instance;
+
+        private Dictionary<string, IPAddress> _mitmHostEntries = new();
+
+        public static DnsMitmResolver Initialize(ServiceCtx context)
+        {
+            return Instance ??= new DnsMitmResolver(context);
+        }
+
+        private DnsMitmResolver(ServiceCtx context)
+        {
+            ReloadEntries(context);
+
+            Logger.Info?.PrintMsg(LogClass.ServiceBsd, $"Successfully loaded {_mitmHostEntries.Count} hosts file entries!");
+        }
+
+        public void ReloadEntries(ServiceCtx context)
+        {
+            string sdPath = context.Device.Configuration.VirtualFileSystem.GetSdCardPath();
+            string filePath = context.Device.Configuration.VirtualFileSystem.GetFullPath(sdPath, HostsFilePath);
+
+            Logger.Info?.PrintMsg(LogClass.ServiceBsd, $"Checking hosts file path: {filePath}");
+
+            _mitmHostEntries.Clear();
+
+            if (File.Exists(filePath))
+            {
+                using FileStream fileStream = File.Open(filePath, FileMode.Open, FileAccess.Read);
+                using StreamReader reader = new(fileStream);
+
+                while (!reader.EndOfStream)
+                {
+                    string line = reader.ReadLine();
+
+                    if (line == null)
+                    {
+                        break;
+                    }
+
+                    // Ignore comments
+                    if (line.StartsWith("#"))
+                    {
+                        continue;
+                    }
+
+                    string[] entry = line.Split(new[] { ' ', '\t' },
+                        StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+
+                    // Hosts file example entry:
+                    // 127.0.0.1  localhost loopback
+
+                    // 0. Check the size of the array
+                    if (entry.Length < 2)
+                    {
+                        Logger.Warning?.PrintMsg(LogClass.ServiceBsd, $"Invalid entry in hosts file: {line}");
+                        continue;
+                    }
+
+                    // 1. Parse the address
+                    if (!IPAddress.TryParse(entry[0], out IPAddress address))
+                    {
+                        Logger.Warning?.PrintMsg(LogClass.ServiceBsd, $"Failed to parse IP address in hosts file: {entry[0]}");
+                        continue;
+                    }
+
+                    // 2. Check for AMS hosts file extension: "%"
+                    for (int i = 1; i < entry.Length; i++)
+                    {
+                        entry[i] = entry[i].Replace("%", IManager.NsdSettings.Environment);
+                    }
+
+                    // 3. Add hostname to entry dictionary (updating duplicate entries)
+                    foreach (string hostname in entry[1..])
+                    {
+                        _mitmHostEntries[hostname] = address;
+                    }
+                }
+            }
+        }
+
+        public IPHostEntry ResolveAddress(string host)
+        {
+            foreach (var hostEntry in _mitmHostEntries)
+            {
+                // Check for AMS hosts file extension: "*"
+                // NOTE: MatchesSimpleExpression also allows "?" as a wildcard
+                if (FileSystemName.MatchesSimpleExpression(hostEntry.Key, host))
+                {
+                    Logger.Info?.PrintMsg(LogClass.ServiceBsd, $"Match found for '{host}': {hostEntry.Value}");
+
+                    return new IPHostEntry
+                    {
+                        AddressList = new[] { hostEntry.Value },
+                        HostName = hostEntry.Key
+                    };
+                }
+            }
+
+            // No match has been found, resolve the host using regular dns
+            return Dns.GetHostEntry(host);
+        }
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsMitmResolver.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsMitmResolver.cs
@@ -12,19 +12,10 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Proxy
     {
         private const string HostsFilePath = "/atmosphere/hosts/default.txt";
 
-        private static DnsMitmResolver Instance;
+        private static DnsMitmResolver _instance;
+        public static DnsMitmResolver Instance => _instance ??= new DnsMitmResolver();
 
         private Dictionary<string, IPAddress> _mitmHostEntries = new();
-
-        public static DnsMitmResolver Initialize(ServiceCtx context)
-        {
-            return Instance ??= new DnsMitmResolver(context);
-        }
-
-        private DnsMitmResolver(ServiceCtx context)
-        {
-            ReloadEntries(context);
-        }
 
         public void ReloadEntries(ServiceCtx context)
         {
@@ -62,7 +53,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Proxy
                     if (entry.Length < 2)
                     {
                         Logger.Warning?.PrintMsg(LogClass.ServiceBsd, $"Invalid entry in hosts file: {line}");
-                        
+
                         continue;
                     }
 
@@ -70,7 +61,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Proxy
                     if (!IPAddress.TryParse(entry[0], out IPAddress address))
                     {
                         Logger.Warning?.PrintMsg(LogClass.ServiceBsd, $"Failed to parse IP address in hosts file: {entry[0]}");
-                        
+
                         continue;
                     }
 

--- a/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsMitmResolver.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsMitmResolver.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Proxy
         private static DnsMitmResolver _instance;
         public static DnsMitmResolver Instance => _instance ??= new DnsMitmResolver();
 
-        private Dictionary<string, IPAddress> _mitmHostEntries = new();
+        private readonly Dictionary<string, IPAddress> _mitmHostEntries = new();
 
         public void ReloadEntries(ServiceCtx context)
         {

--- a/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsMitmResolver.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Sfdnsres/Proxy/DnsMitmResolver.cs
@@ -93,7 +93,8 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Sfdnsres.Proxy
                     return new IPHostEntry
                     {
                         AddressList = new[] { hostEntry.Value },
-                        HostName = hostEntry.Key
+                        HostName = hostEntry.Key,
+                        Aliases = Array.Empty<string>()
                     };
                 }
             }


### PR DESCRIPTION
This PR adds support for Atmosphère's [dns_mitm](https://github.com/Atmosphere-NX/Atmosphere/blob/master/docs/features/dns_mitm.md).
This also includes support for the IPC extension command 6500 ("AtmosphereReloadHostsFile").

Since we don't need to differentiate between sysmmc and emummc, we will only be reading `/atmosphere/hosts/default.txt`.

This allows for simple DNS redirection which is used by some mods.

---

Relevant AMS source files:

- [dnsmitm_resolver_impl.cpp](https://github.com/Atmosphere-NX/Atmosphere/blob/master/stratosphere/ams_mitm/source/dns_mitm/dnsmitm_resolver_impl.cpp)
- [dnsmitm_host_redirection.cpp](https://github.com/Atmosphere-NX/Atmosphere/blob/master/stratosphere/ams_mitm/source/dns_mitm/dnsmitm_host_redirection.cpp)