### PR TITLE
Save manager backup/restore-backup 4006

### DIFF
--- a/Ryujinx.Ava/Common/AutoDownloadableContentLoader.cs
+++ b/Ryujinx.Ava/Common/AutoDownloadableContentLoader.cs
@@ -1,0 +1,188 @@
+﻿using Avalonia.Collections;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using LibHac.Common;
+using LibHac.Fs;
+using LibHac.Fs.Fsa;
+using LibHac.FsSystem;
+using LibHac.Tools.Fs;
+using LibHac.Tools.FsSystem;
+using LibHac.Tools.FsSystem.NcaUtils;
+using Ryujinx.Ava.Common.Locale;
+using Ryujinx.Ava.Ui.Controls;
+using Ryujinx.Ava.Ui.Models;
+using Ryujinx.Common.Configuration;
+using Ryujinx.Common.Utilities;
+using Ryujinx.HLE.FileSystem;
+using Ryujinx.Ui.App.Common;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Drawing.Printing;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Path = System.IO.Path;
+
+namespace Ryujinx.Ava.Ui.Controls
+{
+    internal class AutoDownloadableContentLoader
+    {
+        public readonly List<ApplicationData> Applications;
+        public AvaloniaList<DownloadableContentModel> DownloadableContents { get; private set; }
+        private readonly VirtualFileSystem FileSystem;
+
+        public AutoDownloadableContentLoader(Collection<ApplicationData> applications, VirtualFileSystem virtualFileSystem)
+        {
+            Applications = applications.ToList();
+            FileSystem = virtualFileSystem;
+        }
+
+        public async Task AutoLoadDlcsAsync(ApplicationData application, Dictionary<string, string> dlcPathAndGameNames)
+        {
+            DownloadableContents = new AvaloniaList<DownloadableContentModel>();
+
+            char[] bannedSymbols = { '.', ',', ':', ';', '>', '<', '\'', '\"', };
+            string gameTitle = string.Join("", application.TitleName.Split(bannedSymbols)).ToLower().Trim();
+
+
+            //Loops through the Dlcs to the given gameTitle and adds them to the downloadableContent List
+            dlcPathAndGameNames.Where(titleDlc => titleDlc.Value.ToLower() == gameTitle)
+                .ToList()
+                .ForEach(async dlc => await AddDownloadableContent(dlc.Key, application));
+
+
+            List<DownloadableContentContainer> downloadableContentContainers = new List<DownloadableContentContainer>();
+            string jsonPath = LoadJsonFromTitle(application, downloadableContentContainers);
+            Save(jsonPath, downloadableContentContainers);
+        }
+
+
+        private async Task AddDownloadableContent(string path, ApplicationData applicationData)
+        {
+            if (!File.Exists(path) || DownloadableContents.FirstOrDefault(x => x.ContainerPath == path) != null)
+            {
+                return;
+            }
+
+            using FileStream containerFile = File.OpenRead(path);
+
+            PartitionFileSystem partitionFileSystem = new(containerFile.AsStorage());
+            bool containsDownloadableContent = false;
+
+            FileSystem.ImportTickets(partitionFileSystem);
+
+            foreach (DirectoryEntryEx fileEntry in partitionFileSystem.EnumerateEntries("/", "*.nca"))
+            {
+                using var ncaFile = new UniqueRef<IFile>();
+
+                partitionFileSystem.OpenFile(ref ncaFile.Ref(), fileEntry.FullPath.ToU8Span(), OpenMode.Read).ThrowIfFailure();
+
+                Nca nca = TryOpenNca(ncaFile.Get.AsStorage(), path);
+                if (nca == null)
+                {
+                    continue;
+                }
+
+                if (nca.Header.ContentType == NcaContentType.PublicData)
+                {
+                    if ((nca.Header.TitleId & 0xFFFFFFFFFFFFE000) != ulong.Parse(applicationData.TitleId, NumberStyles.HexNumber))
+                    {
+                        break;
+                    }
+
+                    DownloadableContents.Add(new DownloadableContentModel(nca.Header.TitleId.ToString("X16"), path, fileEntry.FullPath, true));
+
+                    containsDownloadableContent = true;
+                }
+            }
+
+            if (!containsDownloadableContent)
+            {
+                await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance["DialogDlcNoDlcErrorMessage"]);
+            }
+        }
+
+
+        private Nca TryOpenNca(IStorage ncaStorage, string containerPath)
+        {
+            try
+            {
+                return new Nca(FileSystem.KeySet, ncaStorage);
+            }
+            catch (Exception ex)
+            {
+                Dispatcher.UIThread.InvokeAsync(async () =>
+                {
+                    await ContentDialogHelper.CreateErrorDialog(string.Format(LocaleManager.Instance["DialogDlcLoadNcaErrorMessage"], ex.Message, containerPath));
+                });
+            }
+
+            return null;
+        }
+
+
+        private string LoadJsonFromTitle(ApplicationData applicationdata, List<DownloadableContentContainer> _downloadableContentContainerList)
+        {
+            ulong titleId = ulong.Parse(applicationdata.TitleId, NumberStyles.HexNumber);
+
+            string _downloadableContentJsonPath = Path.Combine(AppDataManager.GamesDirPath, titleId.ToString("x16"), "dlc.json");
+
+            try
+            {
+                _downloadableContentContainerList = JsonHelper.DeserializeFromFile<List<DownloadableContentContainer>>(_downloadableContentJsonPath);
+            }
+            catch
+            {
+                _downloadableContentContainerList = new List<DownloadableContentContainer>();
+            }
+
+            return _downloadableContentJsonPath;
+        }
+
+
+        public void Save(string _downloadableContentJsonPath, List<DownloadableContentContainer> _downloadableContentContainerList)
+        {
+            _downloadableContentContainerList.Clear();
+
+            DownloadableContentContainer container = default;
+
+            foreach (DownloadableContentModel downloadableContent in DownloadableContents)
+            {
+                if (container.ContainerPath != downloadableContent.ContainerPath)
+                {
+                    if (!string.IsNullOrWhiteSpace(container.ContainerPath))
+                    {
+                        _downloadableContentContainerList.Add(container);
+                    }
+
+                    container = new DownloadableContentContainer
+                    {
+                        ContainerPath = downloadableContent.ContainerPath,
+                        DownloadableContentNcaList = new List<DownloadableContentNca>()
+                    };
+                }
+
+                container.DownloadableContentNcaList.Add(new DownloadableContentNca
+                {
+                    Enabled = downloadableContent.Enabled,
+                    TitleId = Convert.ToUInt64(downloadableContent.TitleId, 16),
+                    FullPath = downloadableContent.FullPath
+                });
+            }
+
+            if (!string.IsNullOrWhiteSpace(container.ContainerPath))
+            {
+                _downloadableContentContainerList.Add(container);
+            }
+
+            using (FileStream downloadableContentJsonStream = File.Create(_downloadableContentJsonPath, 4096, FileOptions.WriteThrough))
+            {
+                downloadableContentJsonStream.Write(Encoding.UTF8.GetBytes(JsonHelper.Serialize(_downloadableContentContainerList, true)));
+            }
+        }
+    }
+}

--- a/Ryujinx.Ava/Common/AutoTilteUpdateLoader.cs
+++ b/Ryujinx.Ava/Common/AutoTilteUpdateLoader.cs
@@ -1,0 +1,156 @@
+﻿using Avalonia.Collections;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using LibHac.Common;
+using LibHac.Fs;
+using LibHac.Fs.Fsa;
+using LibHac.FsSystem;
+using LibHac.Ns;
+using LibHac.Tools.Fs;
+using LibHac.Tools.FsSystem;
+using LibHac.Tools.FsSystem.NcaUtils;
+using Ryujinx.Ava.Common.Locale;
+using Ryujinx.Ava.Ui.Controls;
+using Ryujinx.Ava.Ui.Models;
+using Ryujinx.Common.Configuration;
+using Ryujinx.Common.Utilities;
+using Ryujinx.HLE.FileSystem;
+using Ryujinx.HLE.HOS;
+using Ryujinx.Ui.App.Common;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Path = System.IO.Path;
+using SpanHelpers = LibHac.Common.SpanHelpers;
+
+namespace Ryujinx.Ava.Ui.Controls
+{
+    internal class AutoTitleUpdateLoader
+    {
+        private TitleUpdateMetadata _titleUpdateWindowData;
+        public List<ApplicationData> Applications { get; private set; }
+        private readonly VirtualFileSystem FileSystem;
+        private AvaloniaList<TitleUpdateModel> titleUpdates { get; set; }
+
+        public AutoTitleUpdateLoader(Collection<ApplicationData> applications, VirtualFileSystem virtualFileSystem)
+        {
+            Applications = applications.ToList();
+            FileSystem = virtualFileSystem;
+        }
+
+
+        public async Task AutoLoadUpdatesAsync(ApplicationData application, Dictionary<string, string> updatePathandGameNames)
+        {
+            titleUpdates = new AvaloniaList<TitleUpdateModel>();
+
+            char[] bannedSymbols = { '.', ',', ':', ';', '>', '<', '\'', '\"', };
+            string gameTitle = string.Join("", application.TitleName.Split(bannedSymbols)).ToLower().Trim();
+
+
+            //Loops through the Updates to the given gameTitle and adds them to the downloadableContent List
+            updatePathandGameNames.Where(titleUpdate => titleUpdate.Value.ToLower() == gameTitle)
+                .ToList()
+                .ForEach(async update => await AddUpdate(update.Key, application));
+
+
+            List<DownloadableContentContainer> downloadableContentContainers = new List<DownloadableContentContainer>();
+            string jsonPath = LoadJsonFromTitle(application, downloadableContentContainers);
+            Save(jsonPath);
+        }
+
+        private string LoadJsonFromTitle(ApplicationData applicationdata, List<DownloadableContentContainer> _downloadableContentContainerList)
+        {
+            ulong titleId = ulong.Parse(applicationdata.TitleId, NumberStyles.HexNumber);
+
+            string _titleUpdateJsonPath = Path.Combine(AppDataManager.GamesDirPath, titleId.ToString("x16"), "updates.json");
+
+            try
+            {
+                _titleUpdateWindowData = JsonHelper.DeserializeFromFile<TitleUpdateMetadata>(_titleUpdateJsonPath);
+            }
+            catch
+            {
+                _titleUpdateWindowData = new TitleUpdateMetadata
+                {
+                    Selected = "",
+                    Paths = new List<string>()
+                };
+            }
+
+            return _titleUpdateJsonPath;
+        }
+
+        private async Task AddUpdate(string path, ApplicationData applicationData)
+        {
+            if (File.Exists(path) && !titleUpdates.Any(x => x.Path == path))
+            {
+                using FileStream file = new(path, FileMode.Open, FileAccess.Read);
+
+                try
+                {
+                    (Nca patchNca, Nca controlNca) = ApplicationLoader.GetGameUpdateDataFromPartition(FileSystem, new PartitionFileSystem(file.AsStorage()), ulong.Parse(applicationData.TitleId, NumberStyles.HexNumber).ToString("x16"), 0);
+
+                    if (controlNca != null && patchNca != null)
+                    {
+                        ApplicationControlProperty controlData = new();
+
+                        using UniqueRef<IFile> nacpFile = new();
+
+                        controlNca.OpenFileSystem(NcaSectionType.Data, IntegrityCheckLevel.None).OpenFile(ref nacpFile.Ref(), "/control.nacp".ToU8Span(), OpenMode.Read).ThrowIfFailure();
+                        nacpFile.Get.Read(out _, 0, SpanHelpers.AsByteSpan(ref controlData), ReadOption.None).ThrowIfFailure();
+
+                        titleUpdates.Add(new TitleUpdateModel(controlData, path));
+
+                        foreach (var update in titleUpdates)
+                        {
+                            update.IsEnabled = false;
+                        }
+
+                        titleUpdates.Last().IsEnabled = true;
+                    }
+                    else
+                    {
+                        Dispatcher.UIThread.Post(async () =>
+                        {
+                            await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance["DialogUpdateAddUpdateErrorMessage"]);
+                        });
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Dispatcher.UIThread.Post(async () =>
+                    {
+                        await ContentDialogHelper.CreateErrorDialog(string.Format(LocaleManager.Instance["DialogDlcLoadNcaErrorMessage"], ex.Message, path));
+                    });
+                }
+            }
+        }
+
+        public void Save(string titleUpdateJsonPath)
+        {
+            _titleUpdateWindowData.Paths.Clear();
+
+            _titleUpdateWindowData.Selected = "";
+
+            foreach (TitleUpdateModel update in titleUpdates)
+            {
+                _titleUpdateWindowData.Paths.Add(update.Path);
+
+                if (update.IsEnabled)
+                {
+                    _titleUpdateWindowData.Selected = update.Path;
+                }
+            }
+
+            using (FileStream titleUpdateJsonStream = File.Create(titleUpdateJsonPath, 4096, FileOptions.WriteThrough))
+            {
+                titleUpdateJsonStream.Write(Encoding.UTF8.GetBytes(JsonHelper.Serialize(_titleUpdateWindowData, true)));
+            }
+        }
+    }
+}

--- a/Ryujinx.Ava/Ui/Controls/BackupSavedataCommand.cs
+++ b/Ryujinx.Ava/Ui/Controls/BackupSavedataCommand.cs
@@ -1,0 +1,73 @@
+﻿using Avalonia.Controls;
+using Avalonia.Logging;
+using Ryujinx.Ava.Common.Locale;
+using Ryujinx.Ava.Ui.Windows;
+using Ryujinx.Common.Configuration;
+using Ryujinx.Common.Logging;
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Logger = Ryujinx.Common.Logging.Logger;
+using Path = System.IO.Path;
+
+namespace Ryujinx.Ava.Ui.Controls
+{
+    internal class BackupSavedataCommand : ICommand
+    {
+        public event EventHandler CanExecuteChanged;
+        private readonly IControl parentControl;
+
+        public BackupSavedataCommand(IControl parentControl)
+        {
+            this.parentControl = parentControl;
+        }
+
+        public bool CanExecute(object parameter)
+        {
+            return true;
+        }
+
+        public void Execute(object parameter)
+        {
+            SaveUserSaveDirectoryAsZip();
+        }
+
+        public async void SaveUserSaveDirectoryAsZip()
+        {
+            CreateBackupZip(await OpenFolderDialog());
+        }
+
+        private async Task<string> OpenFolderDialog()
+        {
+            OpenFolderDialog dialog = new()
+            {
+                Title = LocaleManager.Instance["OpenFolderDialogTitle"]
+            };
+
+            return await dialog.ShowAsync(parentControl.VisualRoot as MainWindow);
+        }
+
+        private void CreateBackupZip(string directoryPath)
+        {
+            if (!string.IsNullOrWhiteSpace(directoryPath) && Directory.Exists(directoryPath))
+            {
+                string saveDir = Path.Combine(AppDataManager.BaseDirPath, AppDataManager.DefaultNandDir, "user", "save");
+
+                string zipFolderPath = Path.Combine(directoryPath, "Ryujinx_backup.zip");
+
+                Logger.Info.Value.Print(LogClass.Application, $"Start creating backup...", nameof(BackupSavedataCommand));
+
+                if (File.Exists(zipFolderPath))
+                {
+                    File.Delete(zipFolderPath);
+                }
+                
+                ZipFile.CreateFromDirectory(saveDir, zipFolderPath);
+
+                Logger.Info.Value.Print(LogClass.Application, $"Backup done. Zip is locate under {directoryPath}", nameof(BackupSavedataCommand));
+            }
+        }
+    }
+}

--- a/Ryujinx.Ava/Ui/Controls/RestoreSavedataCommand.cs
+++ b/Ryujinx.Ava/Ui/Controls/RestoreSavedataCommand.cs
@@ -1,0 +1,119 @@
+﻿using Avalonia.Controls;
+using Ryujinx.Ava.Common.Locale;
+using Ryujinx.Ava.Ui.Windows;
+using Ryujinx.Common.Configuration;
+using Ryujinx.Common.Logging;
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Path = System.IO.Path;
+
+namespace Ryujinx.Ava.Ui.Controls
+{
+    internal class RestoreSavedataCommand : ICommand
+    {
+        public event EventHandler CanExecuteChanged;
+
+        private readonly IControl parentControl;
+
+        public RestoreSavedataCommand(IControl parentControl)
+        {
+            this.parentControl = parentControl;
+        }
+
+        private async Task<bool> ShowConditionMessage()
+        {
+            return await ContentDialogHelper.CreateChoiceDialog("Restore Backup",
+               "You have to start every game at least once to create a save directory for the game before you can Restore the backup save data!",
+               "Do you want to continue?");
+        }
+
+        public bool CanExecute(object parameter)
+        {
+            return true;
+        }
+
+        public void Execute(object parameter)
+        {
+            RestoreSavedataBackup();
+        }
+
+        public async void RestoreSavedataBackup()
+        {
+            if (!(await ShowConditionMessage())) return;
+
+            string[] backupZipFiles = await ShowFolderDialog();
+
+            ExtractBackupToSaveDirectory(backupZipFiles);
+
+            Logger.Info.Value.Print(LogClass.Application, $"Done extracting savedata backup!", nameof(RestoreSavedataCommand));
+        }
+
+        private async Task<string[]> ShowFolderDialog()
+        {
+            OpenFileDialog dialog = new()
+            {
+                Title = LocaleManager.Instance["OpenFileDialogTitle"],
+                AllowMultiple = false,
+            };
+
+            return await dialog.ShowAsync(parentControl.VisualRoot as MainWindow);
+        }
+
+        private void ExtractBackupToSaveDirectory(string[] backupZipFiles)
+        {
+            if (!string.IsNullOrWhiteSpace(backupZipFiles.First()) && File.Exists(backupZipFiles.First()))
+            {
+                string tempZipExtractionPath = Path.GetTempPath();
+                ZipFile.ExtractToDirectory(backupZipFiles.First(), tempZipExtractionPath, true);
+
+                Logger.Info.Value.Print(LogClass.Application, $"Extracted Backup zip to temp path: {tempZipExtractionPath}", nameof(RestoreSavedataCommand));
+
+                string saveDir = Path.Combine(AppDataManager.BaseDirPath, AppDataManager.DefaultNandDir, "user", "save");
+                ReplaceSavedataFilesWithBackupSaveFiles(Directory.GetDirectories(tempZipExtractionPath), saveDir);
+            }
+        }
+
+        private void ReplaceSavedataFilesWithBackupSaveFiles(string[] backupSavedataPath, string saveDirectory)
+        {
+            //All current save files for later replacement
+            string[] userSaveFiles = GetSaveFilesInAllSubDirectories(saveDirectory);
+
+            //Loops through every Title save folder and replaces all user save data files with the savedata files inside the extracted backup folder
+            //Logic to decide wich file is replaces is based on der filename and parent directory
+            foreach (string[] backupSaveFiles in backupSavedataPath.Select(GetSaveFilesInAllSubDirectories))
+            {
+                foreach (string backupSaveFile in backupSaveFiles)
+                {
+                    foreach (string userSaveFile in GetSaveFilesWithSameNameAndParentDir(userSaveFiles, backupSaveFile))
+                    {
+                        try
+                        {
+                            File.Copy(backupSaveFile, userSaveFile, true);
+                            Logger.Info.Value.Print(LogClass.Application, $"Copied Savedata {backupSaveFile} to {userSaveFile}", nameof(RestoreSavedataCommand));
+                        }
+                        catch (Exception)
+                        {
+                            Logger.Error.Value.Print(LogClass.Application, $"Could not copy Savedata {backupSaveFile} to {userSaveFile}", nameof(RestoreSavedataCommand));
+                        }
+                    }
+                }
+            }
+        }
+
+        private string[] GetSaveFilesWithSameNameAndParentDir(string[] userSaveFiles, string backupSaveFile)
+        {
+            return userSaveFiles.Where(sf => Path.GetFileName(sf) == Path.GetFileName(backupSaveFile) && Directory.GetParent(sf).Name == Directory.GetParent(backupSaveFile).Name).ToArray();
+        }
+
+        private string[] GetSaveFilesInAllSubDirectories(string rootDirectory)
+        {
+            string[] unnecessarySaveFiles = { ".lock", "ExtraData0", "ExtraData1" };
+
+            return Directory.GetFiles(rootDirectory, "*", SearchOption.AllDirectories).Where(file => !unnecessarySaveFiles.Any(usf => file.EndsWith(usf))).ToArray();
+        }
+    }
+}

--- a/Ryujinx.Ava/Ui/ViewModels/MainWindowViewModel.cs
+++ b/Ryujinx.Ava/Ui/ViewModels/MainWindowViewModel.cs
@@ -30,6 +30,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Path = System.IO.Path;
@@ -941,6 +942,58 @@ namespace Ryujinx.Ava.Ui.ViewModels
             new DirectoryInfo(logPath).Create();
 
             OpenHelper.OpenFolder(logPath);
+        }
+
+        public static void OpenGlobalDlcsFolder()
+        {
+            string globalDlcsPath = Path.Combine(ReleaseInformations.GetBaseApplicationDirectory(), "GlobalDlcs");
+
+            new DirectoryInfo(globalDlcsPath).Create();
+
+            OpenHelper.OpenFolder(globalDlcsPath);
+        }
+
+        public static void OpenGlobalUpdatesFolder()
+        {
+            string golbalUpdatesPath = Path.Combine(ReleaseInformations.GetBaseApplicationDirectory(), "GlobalUpdates");
+
+            new DirectoryInfo(golbalUpdatesPath).Create();
+
+            OpenHelper.OpenFolder(golbalUpdatesPath);
+        }
+
+        public async void LoadGlobalDlcs()
+        {
+            AutoDownloadableContentLoader downloadableContentManager = new AutoDownloadableContentLoader(Applications, _owner.VirtualFileSystem);
+
+            //Searches for the files in the Global Dlcs folder and puts their path and titlename (from folder) in a dictionary.
+            Dictionary<string, string> dlcsAndUpdatesPathWithGameName = Directory.GetFiles(Path.Combine(ReleaseInformations.GetBaseApplicationDirectory(), "GlobalDlcs"))
+                .ToDictionary(x => x, y => Path.GetFileName(y).Split(new[] { "[" }, StringSplitOptions.RemoveEmptyEntries)
+                .First()
+                .Trim());
+
+
+            foreach (ApplicationData application in Applications)
+            {
+                await downloadableContentManager.AutoLoadDlcsAsync(application, dlcsAndUpdatesPathWithGameName);
+            }
+        }
+
+        public async void LoadGlobalUpdates()
+        {
+            AutoTitleUpdateLoader titleUpdateManager = new AutoTitleUpdateLoader(Applications, _owner.VirtualFileSystem);
+
+            //Searches for the files in the Global Updates folder and puts their path and titlename (from folder) in a dictionary.
+            Dictionary<string, string> dlcsAndUpdatesPathWithGameName = Directory.GetFiles(Path.Combine(ReleaseInformations.GetBaseApplicationDirectory(), "GlobalUpdates"))
+                .ToDictionary(x => x, y => Path.GetFileName(y).Split(new[] { "[" }, StringSplitOptions.RemoveEmptyEntries)
+                .First()
+                .Trim());
+
+
+            foreach (ApplicationData application in Applications)
+            {
+                await titleUpdateManager.AutoLoadUpdatesAsync(application, dlcsAndUpdatesPathWithGameName);
+            }
         }
 
         public void ToggleFullscreen()

--- a/Ryujinx.Ava/Ui/ViewModels/UserProfileViewModel.cs
+++ b/Ryujinx.Ava/Ui/ViewModels/UserProfileViewModel.cs
@@ -99,7 +99,7 @@ namespace Ryujinx.Ava.Ui.ViewModels
                 default, saveDataId: default, index: default);
 
             using var saveDataIterator = new UniqueRef<SaveDataIterator>();
-
+           
             _owner.HorizonClient.Fs.OpenSaveDataIterator(ref saveDataIterator.Ref(), SaveDataSpaceId.User, in saveDataFilter).ThrowIfFailure();
 
             Span<SaveDataInfo> saveDataInfo = stackalloc SaveDataInfo[10];
@@ -148,8 +148,10 @@ namespace Ryujinx.Ava.Ui.ViewModels
             ContentDialog contentDialog = new ContentDialog
             {
                 Title = string.Format(LocaleManager.Instance["SaveManagerHeading"], userProfile.Name),
-                PrimaryButtonText = "",
-                SecondaryButtonText = "",
+                PrimaryButtonText = "Backup Savedata",
+                PrimaryButtonCommand = new BackupSavedataCommand(_owner),
+                SecondaryButtonText = "Restore Savedata",
+                SecondaryButtonCommand = new RestoreSavedataCommand(_owner),
                 CloseButtonText = LocaleManager.Instance["UserProfilesClose"],
                 Content = manager,
                 Padding = new Thickness(0)

--- a/Ryujinx.Ava/Ui/Windows/MainWindow.axaml
+++ b/Ryujinx.Ava/Ui/Windows/MainWindow.axaml
@@ -103,7 +103,25 @@
                                 Command="{ReflectionBinding OpenLogsFolder}"
                                 Header="{locale:Locale MenuBarFileOpenLogsFolder}"
                                 ToolTip.Tip="{locale:Locale OpenRyujinxLogsTooltip}" />
-                            <Separator />
+							<Separator />
+							<MenuItem
+							Command="{ReflectionBinding OpenGlobalUpdatesFolder}"
+							Header="Open Global Updates Folder"
+							ToolTip.Tip="{locale:Locale OpenRyujinxLogsTooltip}" />
+							<MenuItem
+                                Command="{ReflectionBinding LoadGlobalUpdates}"
+                                Header="Load Gobal Updates Folder"
+                                ToolTip.Tip="{locale:Locale OpenRyujinxLogsTooltip}" />
+							<Separator />
+							<MenuItem
+							Command="{ReflectionBinding OpenGlobalDlcsFolder}"
+							Header="Open Global Dlc Folder"
+							ToolTip.Tip="{locale:Locale OpenRyujinxLogsTooltip}" />
+							<MenuItem
+							Command="{ReflectionBinding LoadGlobalDlcs}"
+							Header="Load Gobal Dlcs"
+							ToolTip.Tip="{locale:Locale OpenRyujinxLogsTooltip}" />
+							<Separator />
                             <MenuItem
                                 Command="{ReflectionBinding CloseWindow}"
                                 Header="{locale:Locale MenuBarFileExit}"


### PR DESCRIPTION
Issue 4006 - Save savedata as backup and restore it
-----------------------------------------------------------
So i added 2 buttons in the save manager from the usesr profile menu.
One button compress the savedata folder into a zip located to a user specified path.
The other button extracts the backup and tries to replace the current savedata, with the same name and parent folder, with the backup save files.
All games i have had different savedata filenames so i assumed this could be a good approach because i got told theres no way to figure out which savedata folders and games are linked.


PS:
sadly i forgott to change branch so this feature comes when my recent pr is done.
The only files changed with this pr are ->
---------------------------------------------------------
Ryujinx.Ava/Ui/Controls/BackupSavedataCommand.cs
Ryujinx.Ava/Ui/Controls/RestoreSavedataCommand.cs
Ryujinx.Ava/Ui/ViewModels/UserProfileViewModel.cs

sry for the mess