### PR TITLE
 Vulkan: enable VK_EXT_custom_border_color features

### DIFF
--- a/Ryujinx.Graphics.Vulkan/VulkanInitialization.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanInitialization.cs
@@ -374,7 +374,24 @@ namespace Ryujinx.Graphics.Vulkan
             api.GetPhysicalDeviceProperties(physicalDevice, out var properties);
             bool useRobustBufferAccess = VendorUtils.FromId(properties.VendorID) == Vendor.Nvidia;
 
-            var supportedFeatures = api.GetPhysicalDeviceFeature(physicalDevice);
+            PhysicalDeviceFeatures2 features2 = new PhysicalDeviceFeatures2()
+            {
+                SType = StructureType.PhysicalDeviceFeatures2
+            };
+
+            PhysicalDeviceCustomBorderColorFeaturesEXT featuresCustomBorderColorSupported = new PhysicalDeviceCustomBorderColorFeaturesEXT()
+            {
+                SType = StructureType.PhysicalDeviceCustomBorderColorFeaturesExt
+            };
+
+            if (supportedExtensions.Contains("VK_EXT_custom_border_color"))
+            {
+                features2.PNext = &featuresCustomBorderColorSupported;
+            }
+
+            api.GetPhysicalDeviceFeatures2(physicalDevice, &features2);
+
+            var supportedFeatures = features2.Features;
 
             var features = new PhysicalDeviceFeatures()
             {
@@ -490,10 +507,12 @@ namespace Ryujinx.Graphics.Vulkan
 
                 pExtendedFeatures = &featuresSubgroupSizeControl;
             }
-            
+
             PhysicalDeviceCustomBorderColorFeaturesEXT featuresCustomBorderColor;
 
-            if (supportedExtensions.Contains("VK_EXT_custom_border_color"))
+            if (supportedExtensions.Contains("VK_EXT_custom_border_color") &&
+                featuresCustomBorderColorSupported.CustomBorderColors &&
+                featuresCustomBorderColorSupported.CustomBorderColorWithoutFormat)
             {
                 featuresCustomBorderColor = new PhysicalDeviceCustomBorderColorFeaturesEXT()
                 {

--- a/Ryujinx.Graphics.Vulkan/VulkanInitialization.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanInitialization.cs
@@ -490,6 +490,21 @@ namespace Ryujinx.Graphics.Vulkan
 
                 pExtendedFeatures = &featuresSubgroupSizeControl;
             }
+            
+            PhysicalDeviceCustomBorderColorFeaturesEXT featuresCustomBorderColor;
+
+            if (supportedExtensions.Contains("VK_EXT_custom_border_color"))
+            {
+                featuresCustomBorderColor = new PhysicalDeviceCustomBorderColorFeaturesEXT()
+                {
+                    SType = StructureType.PhysicalDeviceCustomBorderColorFeaturesExt,
+                    PNext = pExtendedFeatures,
+                    CustomBorderColors = true,
+                    CustomBorderColorWithoutFormat = true,
+                };
+
+                pExtendedFeatures = &featuresCustomBorderColor;
+            }
 
             var enabledExtensions = RequiredExtensions.Union(DesirableExtensions.Intersect(supportedExtensions)).ToArray();
 

--- a/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -177,6 +177,11 @@ namespace Ryujinx.Graphics.Vulkan
                 SType = StructureType.PhysicalDeviceShaderFloat16Int8Features
             };
 
+            PhysicalDeviceCustomBorderColorFeaturesEXT featuresCustomBorderColor = new PhysicalDeviceCustomBorderColorFeaturesEXT()
+            {
+                SType = StructureType.PhysicalDeviceCustomBorderColorFeaturesExt
+            };
+
             if (supportedExtensions.Contains("VK_EXT_robustness2"))
             {
                 features2.PNext = &featuresRobustness2;
@@ -188,7 +193,17 @@ namespace Ryujinx.Graphics.Vulkan
                 features2.PNext = &featuresShaderInt8;
             }
 
+            if (supportedExtensions.Contains("VK_EXT_custom_border_color"))
+            {
+                featuresCustomBorderColor.PNext = features2.PNext;
+                features2.PNext = &featuresCustomBorderColor;
+            }
+
             Api.GetPhysicalDeviceFeatures2(_physicalDevice, &features2);
+
+            bool customBorderColorSupported = supportedExtensions.Contains("VK_EXT_custom_border_color") &&
+                                              featuresCustomBorderColor.CustomBorderColors &&
+                                              featuresCustomBorderColor.CustomBorderColorWithoutFormat;
 
             ref var properties = ref properties2.Properties;
 
@@ -199,7 +214,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             Capabilities = new HardwareCapabilities(
                 supportedExtensions.Contains("VK_EXT_index_type_uint8"),
-                supportedExtensions.Contains("VK_EXT_custom_border_color"),
+                customBorderColorSupported,
                 supportedExtensions.Contains(KhrDrawIndirectCount.ExtensionName),
                 supportedExtensions.Contains("VK_EXT_fragment_shader_interlock"),
                 supportedExtensions.Contains("VK_NV_geometry_shader_passthrough"),


### PR DESCRIPTION
radv only create the border color bo if this feature is enabled, so it crashed when creating samplers with custom border colors 
Fixes #4072
Fixes #3993