### PR TITLE
Fix NRE when loading Vulkan shader cache with Vertex A shaders

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/ShaderBinarySerializer.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/ShaderBinarySerializer.cs
@@ -53,7 +53,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
             {
                 CachedShaderStage currentStage = stages[i];
 
-                if (currentStage != null && currentStage.Info.Stage == stage && currentStage.Info != null)
+                if (currentStage?.Info != null && currentStage.Info.Stage == stage)
                 {
                     return ShaderCache.GetBindings(currentStage.Info);
                 }


### PR DESCRIPTION
Fixes a silly mistake that was causing NRE when loading shader caches for games that uses Vertex A. `Info` is expected to be null in this case, because Vertex A shaders are merged with Vertex B, and Vertex B is the one that has the actual `Info`. The Vertex A entry is only there to hold the guest code which is used for modification checks.

One of the affected games is Catherine. The issue only manifests if the user has a shader cache, so it won't happen on the first time playing or after purging the shader cache.

This is likely a regression from #3868.