### PR TITLE
GPU: Force rebind when pool changes

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -320,10 +320,15 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             // Check if the texture pool has been modified since bindings were last committed.
             // If it wasn't, then it's possible to avoid looking up textures again when the handle remains the same.
-            bool poolModified = _cachedTexturePool != texturePool || _cachedSamplerPool != samplerPool;
+            if (_cachedTexturePool != texturePool || _cachedSamplerPool != samplerPool)
+            {
+                Rebind();
 
-            _cachedTexturePool = texturePool;
-            _cachedSamplerPool = samplerPool;
+                _cachedTexturePool = texturePool;
+                _cachedSamplerPool = samplerPool;
+            }
+
+            bool poolModified = false;
 
             if (texturePool != null)
             {


### PR DESCRIPTION
There was an issue after the optimization that tries to avoid updating textures and samplers when the state didn't change. The issue was that the checks weren't enough if the texture or sampler pool changed, but the handles remained the same. I fixed that by forcing it to update if the current texture pool or sampler pool changed, but that only fixed the issue partially. The scenario below is still possible for example:
- Draw is done with sampler pool A, uses samplers 1 and 2 from pool A.
- Current sampler pool is changed to sampler pool B.
- Draw is done with sampler pool B, uses sampler 1 from pool B (correct).
- Draw is done with sampler pool B, uses sampler 1 from pool B (correct), and sampler 2 from pool A (wrong).

To fix this issue, I changed it to just clear all cached state when those pools change, also forcing bindings to be updated on future draws with the new pool.

This fixes graphical issues on "The New Prince of Tennis: LET'S GO!! ~Daily Life~ from RisingBeat".
Before:
![image](https://user-images.githubusercontent.com/5624669/207987455-fbee9613-4210-4709-abee-1658c0a3c07a.png)
After:
![image](https://user-images.githubusercontent.com/5624669/207987468-49502fe2-c2f2-45aa-a750-bedeacd9e5b7.png)
(Pay attention to the right side character arms, bottom of the screen, behind the dialog box).