### PR TITLE
Avalonia: Fix invisible swkbd applet on Linux

### DIFF
--- a/Ryujinx.Ava/Ui/Applet/SwkbdAppletDialog.axaml.cs
+++ b/Ryujinx.Ava/Ui/Applet/SwkbdAppletDialog.axaml.cs
@@ -111,7 +111,7 @@ namespace Ryujinx.Ava.Ui.Controls
 
                 overlay.Position = window.PointToScreen(new Point());
 
-                await contentDialog.ShowAsync();
+                await contentDialog.ShowAsync(overlay);
                 contentDialog.Closed -= handler;
                 overlay.Close();
             };


### PR DESCRIPTION
This should have been done in #3938, but was overlooked.

This PR makes the swkbd applet visible again on Linux.