### PR TITLE
bsd::RecvFrom: verify output buffer size before writing socket address

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
@@ -530,7 +530,9 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
 
                     receiveRegion.Dispose();
 
-                    if (sockAddrOutSize != 0)
+                    var bsdSockAddr = BsdSockAddr.FromIPEndPoint(endPoint);
+
+                    if (sockAddrOutSize != 0 && sockAddrOutSize >= (ulong) bsdSockAddr.Size())
                     {
                         context.Memory.Write(sockAddrOutPosition, BsdSockAddr.FromIPEndPoint(endPoint));
                     }

--- a/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
@@ -536,6 +536,10 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                     {
                         context.Memory.Write(sockAddrOutPosition, bsdSockAddr);
                     }
+                    else
+                    {
+                        errno = LinuxError.ENOMEM;
+                    }
                 }
             }
 

--- a/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
@@ -532,7 +532,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
 
                     var bsdSockAddr = BsdSockAddr.FromIPEndPoint(endPoint);
 
-                    if (sockAddrOutSize != 0 && sockAddrOutSize >= (ulong) bsdSockAddr.Size())
+                    if (sockAddrOutSize != 0 && sockAddrOutSize >= (ulong) Unsafe.SizeOf<BsdSockAddr>())
                     {
                         context.Memory.Write(sockAddrOutPosition, bsdSockAddr);
                     }

--- a/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
@@ -530,7 +530,10 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
 
                     receiveRegion.Dispose();
 
-                    context.Memory.Write(sockAddrOutPosition, BsdSockAddr.FromIPEndPoint(endPoint));
+                    if (sockAddrOutSize != 0)
+                    {
+                        context.Memory.Write(sockAddrOutPosition, BsdSockAddr.FromIPEndPoint(endPoint));
+                    }
                 }
             }
 

--- a/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
@@ -530,8 +530,6 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
 
                     receiveRegion.Dispose();
 
-                    var bsdSockAddr = BsdSockAddr.FromIPEndPoint(endPoint);
-
                     if (sockAddrOutSize != 0 && sockAddrOutSize >= (ulong) Unsafe.SizeOf<BsdSockAddr>())
                     {
                         context.Memory.Write(sockAddrOutPosition, BsdSockAddr.FromIPEndPoint(endPoint));

--- a/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
@@ -534,7 +534,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
 
                     if (sockAddrOutSize != 0 && sockAddrOutSize >= (ulong) bsdSockAddr.Size())
                     {
-                        context.Memory.Write(sockAddrOutPosition, BsdSockAddr.FromIPEndPoint(endPoint));
+                        context.Memory.Write(sockAddrOutPosition, bsdSockAddr);
                     }
                 }
             }

--- a/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
@@ -534,7 +534,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
 
                     if (sockAddrOutSize != 0 && sockAddrOutSize >= (ulong) Unsafe.SizeOf<BsdSockAddr>())
                     {
-                        context.Memory.Write(sockAddrOutPosition, bsdSockAddr);
+                        context.Memory.Write(sockAddrOutPosition, BsdSockAddr.FromIPEndPoint(endPoint));
                     }
                     else
                     {

--- a/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Types/BsdSockAddr.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Types/BsdSockAddr.cs
@@ -35,5 +35,10 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd.Types
 
             return result;
         }
+        
+        public int Size()
+        {
+            return MemoryMarshal.Cast<BsdSockAddr, byte>(MemoryMarshal.CreateSpan(ref this, 1)).Length;
+        }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Types/BsdSockAddr.cs
+++ b/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Types/BsdSockAddr.cs
@@ -35,10 +35,5 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd.Types
 
             return result;
         }
-        
-        public int Size()
-        {
-            return MemoryMarshal.Cast<BsdSockAddr, byte>(MemoryMarshal.CreateSpan(ref this, 1)).Length;
-        }
     }
 }


### PR DESCRIPTION
bsd::RecvFrom: verify output buffer size (sockAddrOutSize) is non zero before writing socket address
fix for #3458 