### PR TITLE
hle: Handle GPU profiler and debugger device path correctly

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostDbgGpu/NvHostDbgGpuDeviceFile.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostDbgGpu/NvHostDbgGpuDeviceFile.cs
@@ -1,0 +1,11 @@
+﻿using Ryujinx.Memory;
+using System;
+namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostDbgGpu
+{
+    class NvHostDbgGpuDeviceFile : NvDeviceFile
+    {
+        public NvHostDbgGpuDeviceFile(ServiceCtx context, IVirtualMemoryManager memory, ulong owner) : base(context, owner) { }
+
+        public override void Close() { }
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostProfGpu/NvHostProfGpuDeviceFile.cs
+++ b/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostProfGpu/NvHostProfGpuDeviceFile.cs
@@ -1,0 +1,11 @@
+﻿using Ryujinx.Memory;
+
+namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostProfGpu
+{
+    class NvHostProfGpuDeviceFile : NvDeviceFile
+    {
+        public NvHostProfGpuDeviceFile(ServiceCtx context, IVirtualMemoryManager memory, ulong owner) : base(context, owner) { }
+
+        public override void Close() { }
+    }
+}

--- a/Ryujinx.HLE/Ryujinx.HLE.csproj
+++ b/Ryujinx.HLE/Ryujinx.HLE.csproj
@@ -11,9 +11,7 @@
     <ProjectReference Include="..\Ryujinx.Graphics.Host1x\Ryujinx.Graphics.Host1x.csproj" />
     <ProjectReference Include="..\Ryujinx.Graphics.Nvdec\Ryujinx.Graphics.Nvdec.csproj" />
     <ProjectReference Include="..\Ryujinx.Graphics.Vic\Ryujinx.Graphics.Vic.csproj" />
-    <ProjectReference Include="..\Ryujinx.Horizon.Generators\Ryujinx.Horizon.Generators.csproj"
-                      OutputItemType="Analyzer"
-                      ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\Ryujinx.Horizon.Generators\Ryujinx.Horizon.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\Ryujinx.Memory\Ryujinx.Memory.csproj" />
     <ProjectReference Include="..\ARMeilleure\ARMeilleure.csproj" />
     <ProjectReference Include="..\Ryujinx.Graphics.Gpu\Ryujinx.Graphics.Gpu.csproj" />


### PR DESCRIPTION
When debug mode isn't enabled, opening ``/dev/nvhost-dbg-gpu`` or ``/dev/nvhost-prof-gpu`` should fail with a not implemented error code.

This implement this behaviour and also define stubbed interfaces for completeness.

This fixes warning logs on [慟哭そして…](https://github.com/Ryujinx/Ryujinx-Games-List/issues/2901) related to that.