### PR TITLE
Eliminate zero-extension moves in more cases on 32-bit games

### DIFF
--- a/ARMeilleure/CodeGen/X86/CodeGenerator.cs
+++ b/ARMeilleure/CodeGen/X86/CodeGenerator.cs
@@ -1587,6 +1587,12 @@ namespace ARMeilleure.CodeGen.X86
 
             Debug.Assert(dest.Type.IsInteger() && source.Type.IsInteger());
 
+            // We can eliminate the move if source is already 32-bit and the registers are the same.
+            if (dest.Value == source.Value && source.Type == OperandType.I32)
+            {
+                return;
+            }
+
             context.Assembler.Mov(dest, source, OperandType.I32);
         }
 

--- a/ARMeilleure/CodeGen/X86/X86Optimizer.cs
+++ b/ARMeilleure/CodeGen/X86/X86Optimizer.cs
@@ -128,7 +128,7 @@ namespace ARMeilleure.CodeGen.X86
 
         private static int GetConstOp(ref Operand baseOp)
         {
-            Operation operation = GetAsgOpAddZx32(baseOp);
+            Operation operation = GetAsgOpWithInst(baseOp, Instruction.Add);
 
             if (operation == default)
             {
@@ -174,7 +174,7 @@ namespace ARMeilleure.CodeGen.X86
 
             Multiplier scale = Multiplier.x1;
 
-            Operation addOp = GetAsgOpAddZx32(baseOp);
+            Operation addOp = GetAsgOpWithInst(baseOp, Instruction.Add);
 
             if (addOp == default)
             {
@@ -224,41 +224,6 @@ namespace ARMeilleure.CodeGen.X86
             }
 
             return (indexOp, scale);
-        }
-
-        private static Operation GetAsgOpAddZx32(Operand op)
-        {
-            // If we have multiple assignments, folding is not safe
-            // as the value may be different depending on the
-            // control flow path.
-            if (op.AssignmentsCount != 1)
-            {
-                return default;
-            }
-
-            Operation asgOp = op.Assignments[0];
-
-            if (asgOp.Instruction == Instruction.ZeroExtend32)
-            {
-                // If we have a zero-extension, we might be able to ignore
-                // it if the input is I32, since in that case the upper bits should already be zero
-                // and re-interpreting it as I64 is safe.
-                op = asgOp.GetSource(0);
-
-                if (op.Type != OperandType.I32 || op.AssignmentsCount != 1)
-                {
-                    return default;
-                }
-
-                asgOp = op.Assignments[0];
-            }
-
-            if (asgOp.Instruction != Instruction.Add)
-            {
-                return default;
-            }
-
-            return asgOp;
         }
 
         private static Operation GetAsgOpWithInst(Operand op, Instruction inst)

--- a/ARMeilleure/CodeGen/X86/X86Optimizer.cs
+++ b/ARMeilleure/CodeGen/X86/X86Optimizer.cs
@@ -128,7 +128,7 @@ namespace ARMeilleure.CodeGen.X86
 
         private static int GetConstOp(ref Operand baseOp)
         {
-            Operation operation = GetAsgOpWithInst(baseOp, Instruction.Add);
+            Operation operation = GetAsgOpAddZx32(baseOp);
 
             if (operation == default)
             {
@@ -174,7 +174,7 @@ namespace ARMeilleure.CodeGen.X86
 
             Multiplier scale = Multiplier.x1;
 
-            Operation addOp = GetAsgOpWithInst(baseOp, Instruction.Add);
+            Operation addOp = GetAsgOpAddZx32(baseOp);
 
             if (addOp == default)
             {
@@ -224,6 +224,41 @@ namespace ARMeilleure.CodeGen.X86
             }
 
             return (indexOp, scale);
+        }
+
+        private static Operation GetAsgOpAddZx32(Operand op)
+        {
+            // If we have multiple assignments, folding is not safe
+            // as the value may be different depending on the
+            // control flow path.
+            if (op.AssignmentsCount != 1)
+            {
+                return default;
+            }
+
+            Operation asgOp = op.Assignments[0];
+
+            if (asgOp.Instruction == Instruction.ZeroExtend32)
+            {
+                // If we have a zero-extension, we might be able to ignore
+                // it if the input is I32, since in that case the upper bits should already be zero
+                // and re-interpreting it as I64 is safe.
+                op = asgOp.GetSource(0);
+
+                if (op.Type != OperandType.I32 || op.AssignmentsCount != 1)
+                {
+                    return default;
+                }
+
+                asgOp = op.Assignments[0];
+            }
+
+            if (asgOp.Instruction != Instruction.Add)
+            {
+                return default;
+            }
+
+            return asgOp;
         }
 
         private static Operation GetAsgOpWithInst(Operand op, Instruction inst)

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -27,7 +27,7 @@ namespace ARMeilleure.Translation.PTC
         private const string OuterHeaderMagicString = "PTCohd\0\0";
         private const string InnerHeaderMagicString = "PTCihd\0\0";
 
-        private const uint InternalVersion = 3713; //! To be incremented manually for each change to the ARMeilleure project.
+        private const uint InternalVersion = 4140; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";


### PR DESCRIPTION
This allows some zero-extension `mov`s to be removed, when the source and destination registers are the same, and the source is 32-bit. In this case, we know that the upper bits are already zero so the zero extension is redundant.

Sample diff.
Before:
```nasm
63: 41 89 34 10             mov    DWORD PTR [r8+rdx*1],esi
67: 41 8d 57 e8             lea    edx,[r15-0x18]
6b: 8d 71 04                lea    esi,[rcx+0x4]
6e: 89 f6                   mov    esi,esi
70: 41 89 3c 30             mov    DWORD PTR [r8+rsi*1],edi
74: 8d 71 08                lea    esi,[rcx+0x8]
77: 89 f6                   mov    esi,esi
79: 45 89 24 30             mov    DWORD PTR [r8+rsi*1],r12d
7d: 8d 71 0c                lea    esi,[rcx+0xc]
80: 89 f6                   mov    esi,esi
82: 45 89 2c 30             mov    DWORD PTR [r8+rsi*1],r13d
86: 8d 71 10                lea    esi,[rcx+0x10]
89: 89 f6                   mov    esi,esi
8b: 45 89 34 30             mov    DWORD PTR [r8+rsi*1],r14d
8f: 83 c1 14                add    ecx,0x14
```
After:
```nasm
63: 41 89 34 10             mov    DWORD PTR [r8+rdx*1],esi
67: 41 8d 57 e8             lea    edx,[r15-0x18]
6b: 8d 71 04                lea    esi,[rcx+0x4]
6e: 41 89 3c 30             mov    DWORD PTR [r8+rsi*1],edi
72: 8d 71 08                lea    esi,[rcx+0x8]
75: 45 89 24 30             mov    DWORD PTR [r8+rsi*1],r12d
79: 8d 71 0c                lea    esi,[rcx+0xc]
7c: 45 89 2c 30             mov    DWORD PTR [r8+rsi*1],r13d
80: 8d 71 10                lea    esi,[rcx+0x10]
83: 45 89 34 30             mov    DWORD PTR [r8+rsi*1],r14d
87: 83 c1 14                add    ecx,0x14
```
This is expected to affect mainly 32-bit games.
Testing is welcome to ensure there's no regressions.