### PR TITLE
Fix DrawArrays vertex buffer size

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
@@ -142,6 +142,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
             _drawState.FirstIndex = firstIndex;
             _drawState.IndexCount = indexCount;
+            _drawState.DrawFirstVertex = drawFirstVertex;
+            _drawState.DrawVertexCount = drawVertexCount;
             _currentSpecState.SetHasConstantBufferDrawParameters(false);
 
             engine.UpdateState();
@@ -163,10 +165,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
                 _instancedIndexCount = ibCount != 0 ? ibCount : indexCount;
 
-                var drawState = _state.State.VertexBufferDrawState;
-
-                _instancedDrawStateFirst = drawState.First;
-                _instancedDrawStateCount = drawState.Count;
+                _instancedDrawStateFirst = drawFirstVertex;
+                _instancedDrawStateCount = drawVertexCount;
 
                 _drawState.DrawIndexed = false;
 
@@ -415,6 +415,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             bool oldDrawIndexed = _drawState.DrawIndexed;
 
             _drawState.DrawIndexed = false;
+            engine.ForceStateDirty(VertexBufferFirstMethodOffset * 4);
 
             DrawEnd(engine, 0, 0, firstVertex, vertexCount);
 
@@ -526,8 +527,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             }
             else
             {
-                _state.State.VertexBufferDrawState.First = firstVertex;
-                _state.State.VertexBufferDrawState.Count = count;
+                _drawState.DrawFirstVertex = firstVertex;
+                _drawState.DrawVertexCount = count;
                 engine.ForceStateDirty(VertexBufferFirstMethodOffset * 4);
             }
 

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/DrawState.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/DrawState.cs
@@ -18,6 +18,16 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         public int IndexCount;
 
         /// <summary>
+        /// First vertex used on non-indexed draws. This value is stored somewhere else on indexed draws.
+        /// </summary>
+        public int DrawFirstVertex;
+
+        /// <summary>
+        /// Vertex count used on non-indexed draws. Indexed draws have a index count instead.
+        /// </summary>
+        public int DrawVertexCount;
+
+        /// <summary>
         /// Indicates if the next draw will be a indexed draw.
         /// </summary>
         public bool DrawIndexed;

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -989,6 +989,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
             bool drawIndexed = _drawState.DrawIndexed;
             bool drawIndirect = _drawState.DrawIndirect;
+            int drawFirstVertex = _drawState.DrawFirstVertex;
+            int drawVertexCount = _drawState.DrawVertexCount;
             uint vbEnableMask = 0;
 
             for (int index = 0; index < Constants.TotalVertexBuffers; index++)
@@ -1050,9 +1052,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
                     int firstInstance = (int)_state.State.FirstInstance;
 
-                    var drawState = _state.State.VertexBufferDrawState;
-
-                    size = Math.Min(vbSize, (ulong)((firstInstance + drawState.First + drawState.Count) * stride));
+                    size = Math.Min(vbSize, (ulong)((firstInstance + drawFirstVertex + drawVertexCount) * stride));
                 }
 
                 _pipeline.VertexBuffers[index] = new BufferPipelineDescriptor(_channel.MemoryManager.IsMapped(address), stride, divisor);


### PR DESCRIPTION
This is just adding some things I missed on #4123. The vertex buffer size was incorrect in some cases because it was still using the first vertex and count value from the GPU state to calculate it, rather than the parameters that are passed on those methods. This updates the code to use the correct values and calculate the correct vertex buffer size.

Fixes vertex explosions in Sphinx and the Cursed Mummy on OpenGL.
Before:
![image](https://user-images.githubusercontent.com/5624669/208279088-6850b787-99ce-4b31-b9b1-8e0c19eea8b9.png)
After:
![image](https://user-images.githubusercontent.com/5624669/208279089-47162de0-863d-43b7-bf3f-3bd97c046c7d.png)

Technically also fixes it on Vulkan, but the game is not rendering on Vulkan + NVIDIA right now due to a different issue (it does render on Intel).