### PR TITLE
hle: Fix wrong conversion in UserPresence.ToString

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Friend/ServiceCreator/FriendService/Types/UserPresence.cs
+++ b/Ryujinx.HLE/HOS/Services/Friend/ServiceCreator/FriendService/Types/UserPresence.cs
@@ -29,7 +29,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator.FriendService
 
         public override string ToString()
         {
-            return $"UserPresence {{ UserId: {UserId}, LastTimeOnlineTimestamp: {LastTimeOnlineTimestamp}, Status: {Status}, AppKeyValueStorage: {Encoding.ASCII.GetString(AppKeyValueStorage)} }}";
+            return $"UserPresence {{ UserId: {UserId}, LastTimeOnlineTimestamp: {LastTimeOnlineTimestamp}, Status: {Status} }}";
         }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Friend/ServiceCreator/FriendService/Types/UserPresence.cs
+++ b/Ryujinx.HLE/HOS/Services/Friend/ServiceCreator/FriendService/Types/UserPresence.cs
@@ -2,7 +2,6 @@
 using Ryujinx.HLE.HOS.Services.Account.Acc;
 using System;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator.FriendService
 {


### PR DESCRIPTION
This fixes an error from #3805 that caused a wrong conversion of ``AppKeyValueStorage`` to string.
As that information isn't really relevant without appropriate parsing, it was removed from ``ToString``.

This should get ride of "bell warning" in Mario Kart 8 when entering Time Trials.