### PR TITLE
ARMeilleure: Add initial support for AVX512 (EVEX encoding) (cont)

### DIFF
--- a/ARMeilleure/ARMeilleure.csproj
+++ b/ARMeilleure/ARMeilleure.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Ryujinx.Common\Ryujinx.Common.csproj" />
+    <ProjectReference Include="..\Ryujinx.Memory\Ryujinx.Memory.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ARMeilleure/CodeGen/X86/Assembler.cs
+++ b/ARMeilleure/CodeGen/X86/Assembler.cs
@@ -1033,7 +1033,13 @@ namespace ARMeilleure.CodeGen.X86
 
             Debug.Assert(opCode != BadOp, "Invalid opcode value.");
 
-            if ((flags & InstructionFlags.Vex) != 0 && HardwareCapabilities.SupportsVexEncoding)
+            if ((flags & InstructionFlags.Evex) != 0 && HardwareCapabilities.SupportsEvexEncoding)
+            {
+                WriteEvexInst(dest, src1, src2, type, flags, opCode);
+
+                opCode &= 0xff;
+            }
+            else if ((flags & InstructionFlags.Vex) != 0 && HardwareCapabilities.SupportsVexEncoding)
             {
                 // In a vex encoding, only one prefix can be active at a time. The active prefix is encoded in the second byte using two bits.
 
@@ -1150,6 +1156,103 @@ namespace ARMeilleure.CodeGen.X86
                     }
                 }
             }
+        }
+
+        private void WriteEvexInst(
+            Operand dest,
+            Operand src1,
+            Operand src2,
+            OperandType type,
+            InstructionFlags flags,
+            int opCode,
+            bool broadcast = false,
+            int registerWidth = 128,
+            int maskRegisterIdx = 0,
+            bool zeroElements = false)
+        {
+            int destIdx = dest.GetRegister().Index;
+            int src1Idx = src1.GetRegister().Index;
+            int src2Idx = src2.GetRegister().Index;
+
+            WriteByte(0x62);
+
+            // P0
+            // Extend dest register
+            bool r = (destIdx & 8) == 0;
+            // Extend src register
+            bool x = (src1Idx & 16) == 0;
+            // Extend src register
+            bool b = (src1Idx & 8) == 0;
+            // Extend dest register
+            bool rp = (destIdx & 16) == 0;
+            // Escape code index
+            byte mm = 0b00;
+
+            switch ((ushort)(opCode >> 8))
+            {
+                case 0xf00: mm = 0b01; break;
+                case 0xf38: mm = 0b10; break;
+                case 0xf3a: mm = 0b11; break;
+
+                default: Debug.Assert(false, $"Failed to EVEX encode opcode 0x{opCode:X}."); break;
+            }
+
+            WriteByte(
+                (byte)(
+                    (r ? 0x80 : 0) |
+                    (x ? 0x40 : 0) |
+                    (b ? 0x20 : 0) |
+                    (rp ? 0x10 : 0) |
+                    mm));
+
+            // P1
+            // Specify 64-bit lane mode
+            bool w = Is64Bits(type);
+            // Src2 register index
+            byte vvvv = (byte)(src2Idx & 0b1111);
+            // Opcode prefix
+            byte pp = (flags & InstructionFlags.PrefixMask) switch
+            {
+                InstructionFlags.Prefix66 => 0b01,
+                InstructionFlags.PrefixF3 => 0b10,
+                InstructionFlags.PrefixF2 => 0b11,
+                _ => 0
+            };
+            WriteByte(
+                (byte)(
+                    (w ? 0x80 : 0) |
+                    (vvvv << 3) |
+                    0b100 |
+                    pp));
+
+            // P2
+            // Mask register determines what elements to zero, rather than what elements to merge
+            bool z = zeroElements;
+            // Specifies register-width
+            byte ll = 0b00;
+            switch (registerWidth)
+            {
+                case 128: ll = 0b00; break;
+                case 256: ll = 0b01; break;
+                case 512: ll = 0b10; break;
+
+                default: Debug.Assert(false, $"Invalid EVEX vector register width {registerWidth}."); break;
+            }
+            // Embedded broadcast in the case of a memory operand
+            bool bcast = broadcast;
+            // Extend src2 register
+            bool vp = (src2Idx & 16) == 0;
+            // Mask register index
+            Debug.Assert(maskRegisterIdx < 8, $"Invalid mask register index {maskRegisterIdx}.");
+            byte aaa = (byte)(maskRegisterIdx & 0b111);
+
+            WriteByte(
+                (byte)(
+                    (z ? 0x80 : 0) |
+                    (ll << 5) |
+                    (bcast ? 0x10 : 0) |
+                    (vp ? 8 : 0) |
+                    aaa));
         }
 
         private void WriteCompactInst(Operand operand, int opCode)

--- a/ARMeilleure/CodeGen/X86/Assembler.cs
+++ b/ARMeilleure/CodeGen/X86/Assembler.cs
@@ -1170,21 +1170,21 @@ namespace ARMeilleure.CodeGen.X86
             int maskRegisterIdx = 0,
             bool zeroElements = false)
         {
-            int destIdx = dest.GetRegister().Index;
-            int src1Idx = src1.GetRegister().Index;
-            int src2Idx = src2.GetRegister().Index;
+            int op1Idx = dest.GetRegister().Index;
+            int op2Idx = src1.GetRegister().Index;
+            int op3Idx = src2.GetRegister().Index;
 
             WriteByte(0x62);
 
             // P0
-            // Extend dest register
-            bool r = (destIdx & 8) == 0;
-            // Extend src register
-            bool x = (src1Idx & 16) == 0;
-            // Extend src register
-            bool b = (src1Idx & 8) == 0;
-            // Extend dest register
-            bool rp = (destIdx & 16) == 0;
+            // Extend operand 1 register
+            bool r = (op1Idx & 8) == 0;
+            // Extend operand 3 register
+            bool x = (op3Idx & 16) == 0;
+            // Extend operand 3 register
+            bool b = (op3Idx & 8) == 0;
+            // Extend operand 1 register
+            bool rp = (op1Idx & 16) == 0;
             // Escape code index
             byte mm = 0b00;
 
@@ -1208,8 +1208,8 @@ namespace ARMeilleure.CodeGen.X86
             // P1
             // Specify 64-bit lane mode
             bool w = Is64Bits(type);
-            // Src2 register index
-            byte vvvv = (byte)(~src2Idx & 0b1111);
+            // operand 2 register index
+            byte vvvv = (byte)(~op2Idx & 0b1111);
             // Opcode prefix
             byte pp = (flags & InstructionFlags.PrefixMask) switch
             {
@@ -1240,8 +1240,8 @@ namespace ARMeilleure.CodeGen.X86
             }
             // Embedded broadcast in the case of a memory operand
             bool bcast = broadcast;
-            // Extend src2 register
-            bool vp = (src2Idx & 16) == 0;
+            // Extend operand 2 register
+            bool vp = (op2Idx & 16) == 0;
             // Mask register index
             Debug.Assert(maskRegisterIdx < 8, $"Invalid mask register index {maskRegisterIdx}.");
             byte aaa = (byte)(maskRegisterIdx & 0b111);

--- a/ARMeilleure/CodeGen/X86/Assembler.cs
+++ b/ARMeilleure/CodeGen/X86/Assembler.cs
@@ -1194,7 +1194,7 @@ namespace ARMeilleure.CodeGen.X86
                 case 0xf38: mm = 0b10; break;
                 case 0xf3a: mm = 0b11; break;
 
-                default: Debug.Assert(false, $"Failed to EVEX encode opcode 0x{opCode:X}."); break;
+                default: Debug.Fail($"Failed to EVEX encode opcode 0x{opCode:X}."); break;
             }
 
             WriteByte(
@@ -1236,7 +1236,7 @@ namespace ARMeilleure.CodeGen.X86
                 case 256: ll = 0b01; break;
                 case 512: ll = 0b10; break;
 
-                default: Debug.Assert(false, $"Invalid EVEX vector register width {registerWidth}."); break;
+                default: Debug.Fail($"Invalid EVEX vector register width {registerWidth}."); break;
             }
             // Embedded broadcast in the case of a memory operand
             bool bcast = broadcast;

--- a/ARMeilleure/CodeGen/X86/Assembler.cs
+++ b/ARMeilleure/CodeGen/X86/Assembler.cs
@@ -1209,7 +1209,7 @@ namespace ARMeilleure.CodeGen.X86
             // Specify 64-bit lane mode
             bool w = Is64Bits(type);
             // Src2 register index
-            byte vvvv = (byte)(src2Idx & 0b1111);
+            byte vvvv = (byte)(~src2Idx & 0b1111);
             // Opcode prefix
             byte pp = (flags & InstructionFlags.PrefixMask) switch
             {

--- a/ARMeilleure/CodeGen/X86/Assembler.cs
+++ b/ARMeilleure/CodeGen/X86/Assembler.cs
@@ -1208,7 +1208,7 @@ namespace ARMeilleure.CodeGen.X86
             // P1
             // Specify 64-bit lane mode
             bool w = Is64Bits(type);
-            // operand 2 register index
+            // Operand 2 register index
             byte vvvv = (byte)(~op2Idx & 0b1111);
             // Opcode prefix
             byte pp = (flags & InstructionFlags.PrefixMask) switch

--- a/ARMeilleure/CodeGen/X86/AssemblerTable.cs
+++ b/ARMeilleure/CodeGen/X86/AssemblerTable.cs
@@ -20,6 +20,7 @@ namespace ARMeilleure.CodeGen.X86
             Reg8Dest = 1 << 2,
             RexW     = 1 << 3,
             Vex      = 1 << 4,
+            Evex     = 1 << 5,
 
             PrefixBit  = 16,
             PrefixMask = 7 << PrefixBit,

--- a/ARMeilleure/CodeGen/X86/AssemblerTable.cs
+++ b/ARMeilleure/CodeGen/X86/AssemblerTable.cs
@@ -279,6 +279,7 @@ namespace ARMeilleure.CodeGen.X86
             Add(X86Instruction.Vfnmsub231sd,  new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x000f38bf, InstructionFlags.Vex | InstructionFlags.Prefix66 | InstructionFlags.RexW));
             Add(X86Instruction.Vfnmsub231ss,  new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x000f38bf, InstructionFlags.Vex | InstructionFlags.Prefix66));
             Add(X86Instruction.Vpblendvb,     new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x000f3a4c, InstructionFlags.Vex | InstructionFlags.Prefix66));
+            Add(X86Instruction.Vpternlogd,    new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x000f3a25, InstructionFlags.Evex | InstructionFlags.Prefix66));
             Add(X86Instruction.Xor,           new InstructionInfo(0x00000031, 0x06000083, 0x06000081, BadOp,      0x00000033, InstructionFlags.None));
             Add(X86Instruction.Xorpd,         new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x00000f57, InstructionFlags.Vex | InstructionFlags.Prefix66));
             Add(X86Instruction.Xorps,         new InstructionInfo(BadOp,      BadOp,      BadOp,      BadOp,      0x00000f57, InstructionFlags.Vex));

--- a/ARMeilleure/CodeGen/X86/HardwareCapabilities.cs
+++ b/ARMeilleure/CodeGen/X86/HardwareCapabilities.cs
@@ -29,6 +29,11 @@ namespace ARMeilleure.CodeGen.X86
                 FeatureInfo7Ecx = (FeatureFlags7Ecx)ecx7;
             }
 
+            Xcr0InfoEax = (Xcr0FlagsEax)GetXcr0Eax();
+        }
+
+        private static uint GetXcr0Eax()
+        {
             byte[] asmGetXcr0 = {
                 0x31, 0xc9, // xor ecx, ecx
                 0xf, 0x01, 0xd0, // xgetbv
@@ -43,7 +48,7 @@ namespace ARMeilleure.CodeGen.X86
 
             var fGetXcr0 = Marshal.GetDelegateForFunctionPointer<GetXcr0>(memGetXcr0.Pointer);
 
-            Xcr0InfoEax = (Xcr0FlagsEax)fGetXcr0();
+            return fGetXcr0();
         }
 
         [Flags]

--- a/ARMeilleure/CodeGen/X86/HardwareCapabilities.cs
+++ b/ARMeilleure/CodeGen/X86/HardwareCapabilities.cs
@@ -44,6 +44,7 @@ namespace ARMeilleure.CodeGen.X86
             Sse42 = 1 << 20,
             Popcnt = 1 << 23,
             Aes = 1 << 25,
+            Osxsave = 1 << 27,
             Avx = 1 << 28,
             F16c = 1 << 29
         }
@@ -80,12 +81,12 @@ namespace ARMeilleure.CodeGen.X86
         public static bool SupportsSse42 => FeatureInfo1Ecx.HasFlag(FeatureFlags1Ecx.Sse42);
         public static bool SupportsPopcnt => FeatureInfo1Ecx.HasFlag(FeatureFlags1Ecx.Popcnt);
         public static bool SupportsAesni => FeatureInfo1Ecx.HasFlag(FeatureFlags1Ecx.Aes);
-        public static bool SupportsAvx => FeatureInfo1Ecx.HasFlag(FeatureFlags1Ecx.Avx);
+        public static bool SupportsAvx => FeatureInfo1Ecx.HasFlag(FeatureFlags1Ecx.Avx | FeatureFlags1Ecx.Osxsave);
         public static bool SupportsAvx2 => FeatureInfo7Ebx.HasFlag(FeatureFlags7Ebx.Avx2) && SupportsAvx;
-        public static bool SupportsAvx512F => FeatureInfo7Ebx.HasFlag(FeatureFlags7Ebx.Avx512f);
-        public static bool SupportsAvx512Vl => FeatureInfo7Ebx.HasFlag(FeatureFlags7Ebx.Avx512vl);
-        public static bool SupportsAvx512Bw => FeatureInfo7Ebx.HasFlag(FeatureFlags7Ebx.Avx512bw);
-        public static bool SupportsAvx512Dq => FeatureInfo7Ebx.HasFlag(FeatureFlags7Ebx.Avx512dq);
+        public static bool SupportsAvx512F => FeatureInfo7Ebx.HasFlag(FeatureFlags7Ebx.Avx512f) && FeatureInfo1Ecx.HasFlag(FeatureFlags1Ecx.Osxsave);
+        public static bool SupportsAvx512Vl => FeatureInfo7Ebx.HasFlag(FeatureFlags7Ebx.Avx512vl) && SupportsAvx512F;
+        public static bool SupportsAvx512Bw => FeatureInfo7Ebx.HasFlag(FeatureFlags7Ebx.Avx512bw) && SupportsAvx512F;
+        public static bool SupportsAvx512Dq => FeatureInfo7Ebx.HasFlag(FeatureFlags7Ebx.Avx512dq) && SupportsAvx512F;
         public static bool SupportsF16c => FeatureInfo1Ecx.HasFlag(FeatureFlags1Ecx.F16c);
         public static bool SupportsSha => FeatureInfo7Ebx.HasFlag(FeatureFlags7Ebx.Sha);
         public static bool SupportsGfni => FeatureInfo7Ecx.HasFlag(FeatureFlags7Ecx.Gfni);

--- a/ARMeilleure/CodeGen/X86/HardwareCapabilities.cs
+++ b/ARMeilleure/CodeGen/X86/HardwareCapabilities.cs
@@ -34,7 +34,8 @@ namespace ARMeilleure.CodeGen.X86
 
         private static uint GetXcr0Eax()
         {
-            ReadOnlySpan<byte> asmGetXcr0 = new byte[]{
+            ReadOnlySpan<byte> asmGetXcr0 = new byte[]
+            {
                 0x31, 0xc9, // xor ecx, ecx
                 0xf, 0x01, 0xd0, // xgetbv
                 0xc3, // ret
@@ -98,7 +99,7 @@ namespace ARMeilleure.CodeGen.X86
             YmmHi128 = 1 << 2,
             Opmask = 1 << 5,
             ZmmHi256 = 1 << 6,
-            Hi16Zmm = 1 << 7,
+            Hi16Zmm = 1 << 7
         }
 
         public static FeatureFlags1Edx FeatureInfo1Edx { get; }

--- a/ARMeilleure/CodeGen/X86/HardwareCapabilities.cs
+++ b/ARMeilleure/CodeGen/X86/HardwareCapabilities.cs
@@ -52,7 +52,11 @@ namespace ARMeilleure.CodeGen.X86
         public enum FeatureFlags7Ebx
         {
             Avx2 = 1 << 5,
-            Sha = 1 << 29
+            Avx512f = 1 << 16,
+            Avx512dq = 1 << 17,
+            Sha = 1 << 29,
+            Avx512bw = 1 << 30,
+            Avx512vl = 1 << 31
         }
 
         [Flags]
@@ -78,6 +82,10 @@ namespace ARMeilleure.CodeGen.X86
         public static bool SupportsAesni => FeatureInfo1Ecx.HasFlag(FeatureFlags1Ecx.Aes);
         public static bool SupportsAvx => FeatureInfo1Ecx.HasFlag(FeatureFlags1Ecx.Avx);
         public static bool SupportsAvx2 => FeatureInfo7Ebx.HasFlag(FeatureFlags7Ebx.Avx2) && SupportsAvx;
+        public static bool SupportsAvx512F => FeatureInfo7Ebx.HasFlag(FeatureFlags7Ebx.Avx512f);
+        public static bool SupportsAvx512Vl => FeatureInfo7Ebx.HasFlag(FeatureFlags7Ebx.Avx512vl);
+        public static bool SupportsAvx512Bw => FeatureInfo7Ebx.HasFlag(FeatureFlags7Ebx.Avx512bw);
+        public static bool SupportsAvx512Dq => FeatureInfo7Ebx.HasFlag(FeatureFlags7Ebx.Avx512dq);
         public static bool SupportsF16c => FeatureInfo1Ecx.HasFlag(FeatureFlags1Ecx.F16c);
         public static bool SupportsSha => FeatureInfo7Ebx.HasFlag(FeatureFlags7Ebx.Sha);
         public static bool SupportsGfni => FeatureInfo7Ecx.HasFlag(FeatureFlags7Ecx.Gfni);
@@ -85,5 +93,6 @@ namespace ARMeilleure.CodeGen.X86
         public static bool ForceLegacySse { get; set; }
 
         public static bool SupportsVexEncoding => SupportsAvx && !ForceLegacySse;
+        public static bool SupportsEvexEncoding => SupportsAvx512F && !ForceLegacySse;
     }
 }

--- a/ARMeilleure/CodeGen/X86/HardwareCapabilities.cs
+++ b/ARMeilleure/CodeGen/X86/HardwareCapabilities.cs
@@ -8,6 +8,7 @@ namespace ARMeilleure.CodeGen.X86
     static class HardwareCapabilities
     {
         private delegate uint GetXcr0();
+
         static HardwareCapabilities()
         {
             if (!X86Base.IsSupported)
@@ -34,9 +35,7 @@ namespace ARMeilleure.CodeGen.X86
                 0xc3, // ret
             };
 
-            MemoryBlock memGetXcr0 = new MemoryBlock((ulong)asmGetXcr0.Length);
-
-            memGetXcr0.Reprotect(0, (ulong)asmGetXcr0.Length, MemoryPermission.ReadWriteExecute);
+            using MemoryBlock memGetXcr0 = new MemoryBlock((ulong)asmGetXcr0.Length);
 
             memGetXcr0.Write(0, asmGetXcr0);
 
@@ -45,8 +44,6 @@ namespace ARMeilleure.CodeGen.X86
             var fGetXcr0 = Marshal.GetDelegateForFunctionPointer<GetXcr0>(memGetXcr0.Pointer);
 
             Xcr0InfoEax = (Xcr0FlagsEax)fGetXcr0();
-
-            memGetXcr0.Dispose();
         }
 
         [Flags]

--- a/ARMeilleure/CodeGen/X86/HardwareCapabilities.cs
+++ b/ARMeilleure/CodeGen/X86/HardwareCapabilities.cs
@@ -34,7 +34,7 @@ namespace ARMeilleure.CodeGen.X86
 
         private static uint GetXcr0Eax()
         {
-            byte[] asmGetXcr0 = {
+            ReadOnlySpan<byte> asmGetXcr0 = new byte[]{
                 0x31, 0xc9, // xor ecx, ecx
                 0xf, 0x01, 0xd0, // xgetbv
                 0xc3, // ret

--- a/ARMeilleure/CodeGen/X86/IntrinsicTable.cs
+++ b/ARMeilleure/CodeGen/X86/IntrinsicTable.cs
@@ -180,6 +180,7 @@ namespace ARMeilleure.CodeGen.X86
             Add(Intrinsic.X86Vfnmadd231ss,  new IntrinsicInfo(X86Instruction.Vfnmadd231ss,  IntrinsicType.Fma));
             Add(Intrinsic.X86Vfnmsub231sd,  new IntrinsicInfo(X86Instruction.Vfnmsub231sd,  IntrinsicType.Fma));
             Add(Intrinsic.X86Vfnmsub231ss,  new IntrinsicInfo(X86Instruction.Vfnmsub231ss,  IntrinsicType.Fma));
+            Add(Intrinsic.X86Vpternlogd,    new IntrinsicInfo(X86Instruction.Vpternlogd,    IntrinsicType.TernaryImm));
             Add(Intrinsic.X86Xorpd,         new IntrinsicInfo(X86Instruction.Xorpd,         IntrinsicType.Binary));
             Add(Intrinsic.X86Xorps,         new IntrinsicInfo(X86Instruction.Xorps,         IntrinsicType.Binary));
         }

--- a/ARMeilleure/CodeGen/X86/X86Instruction.cs
+++ b/ARMeilleure/CodeGen/X86/X86Instruction.cs
@@ -219,6 +219,7 @@ namespace ARMeilleure.CodeGen.X86
         Vfnmsub231sd,
         Vfnmsub231ss,
         Vpblendvb,
+        Vpternlogd,
         Xor,
         Xorpd,
         Xorps,

--- a/ARMeilleure/Instructions/InstEmitSimdLogical.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdLogical.cs
@@ -260,7 +260,7 @@ namespace ARMeilleure.Instructions
 
                 Operand n = GetVec(op.Rn);
 
-                Operand res = context.AddIntrinsic(Intrinsic.X86Vpternlogd, n, n, Const(0b01010101));
+                Operand res = context.AddIntrinsic(Intrinsic.X86Vpternlogd, n, n, Const(~0b10101010));
 
                 if (op.RegisterSize == RegisterSize.Simd64)
                 {
@@ -297,6 +297,22 @@ namespace ARMeilleure.Instructions
             if (Optimizations.UseAdvSimd)
             {
                 InstEmitSimdHelperArm64.EmitVectorBinaryOp(context, Intrinsic.Arm64OrnV);
+            }
+            else if (Optimizations.UseAvx512Ortho)
+            {
+                OpCodeSimdReg op = (OpCodeSimdReg)context.CurrOp;
+
+                Operand n = GetVec(op.Rn);
+                Operand m = GetVec(op.Rm);
+
+                Operand res = context.AddIntrinsic(Intrinsic.X86Vpternlogd, n, m, Const(0b11001100 | ~0b10101010));
+
+                if (op.RegisterSize == RegisterSize.Simd64)
+                {
+                    res = context.VectorZeroUpper64(res);
+                }
+
+                context.Copy(GetVec(op.Rd), res);
             }
             else if (Optimizations.UseSse2)
             {

--- a/ARMeilleure/Instructions/InstEmitSimdLogical.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdLogical.cs
@@ -254,7 +254,22 @@ namespace ARMeilleure.Instructions
 
         public static void Not_V(ArmEmitterContext context)
         {
-            if (Optimizations.UseSse2)
+            if (Optimizations.UseAvx512Ortho)
+            {
+                OpCodeSimd op = (OpCodeSimd)context.CurrOp;
+
+                Operand n = GetVec(op.Rn);
+
+                Operand res = context.AddIntrinsic(Intrinsic.X86Vpternlogd, n, n, Const(0b01010101));
+
+                if (op.RegisterSize == RegisterSize.Simd64)
+                {
+                    res = context.VectorZeroUpper64(res);
+                }
+
+                context.Copy(GetVec(op.Rd), res);
+            }
+            else if (Optimizations.UseSse2)
             {
                 OpCodeSimd op = (OpCodeSimd)context.CurrOp;
 

--- a/ARMeilleure/Instructions/InstEmitSimdLogical32.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdLogical32.cs
@@ -151,6 +151,13 @@ namespace ARMeilleure.Instructions
             {
                 InstEmitSimdHelper32Arm64.EmitVectorBinaryOpSimd32(context, (n, m) => context.AddIntrinsic(Intrinsic.Arm64OrnV | Intrinsic.Arm64V128, n, m));
             }
+            else if (Optimizations.UseAvx512Ortho)
+            {
+                EmitVectorBinaryOpSimd32(context, (n, m) =>
+                {
+                    return context.AddIntrinsic(Intrinsic.X86Vpternlogd, n, m, Const(0b11001100 | ~0b10101010));
+                });
+            }
             else if (Optimizations.UseSse2)
             {
                 Operand mask = context.VectorOne();

--- a/ARMeilleure/Instructions/InstEmitSimdMove32.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdMove32.cs
@@ -34,7 +34,14 @@ namespace ARMeilleure.Instructions
 
         public static void Vmvn_I(ArmEmitterContext context)
         {
-            if (Optimizations.UseSse2)
+            if (Optimizations.UseAvx512Ortho)
+            {
+                EmitVectorUnaryOpSimd32(context, (op1) =>
+                {
+                    return context.AddIntrinsic(Intrinsic.X86Vpternlogd, op1, op1, Const(0b01010101));
+                });
+            }
+            else if (Optimizations.UseSse2)
             {
                 EmitVectorUnaryOpSimd32(context, (op1) =>
                 {

--- a/ARMeilleure/IntermediateRepresentation/Intrinsic.cs
+++ b/ARMeilleure/IntermediateRepresentation/Intrinsic.cs
@@ -173,6 +173,7 @@ namespace ARMeilleure.IntermediateRepresentation
         X86Vfnmadd231ss,
         X86Vfnmsub231sd,
         X86Vfnmsub231ss,
+        X86Vpternlogd,
         X86Xorpd,
         X86Xorps,
 

--- a/ARMeilleure/Optimizations.cs
+++ b/ARMeilleure/Optimizations.cs
@@ -23,6 +23,10 @@ namespace ARMeilleure
         public static bool UseSse42IfAvailable     { get; set; } = true;
         public static bool UsePopCntIfAvailable    { get; set; } = true;
         public static bool UseAvxIfAvailable       { get; set; } = true;
+        public static bool UseAvx512FIfAvailable   { get; set; } = true;
+        public static bool UseAvx512VlIfAvailable  { get; set; } = true;
+        public static bool UseAvx512BwIfAvailable  { get; set; } = true;
+        public static bool UseAvx512DqIfAvailable  { get; set; } = true;
         public static bool UseF16cIfAvailable      { get; set; } = true;
         public static bool UseFmaIfAvailable       { get; set; } = true;
         public static bool UseAesniIfAvailable     { get; set; } = true;
@@ -47,11 +51,18 @@ namespace ARMeilleure
         internal static bool UseSse42     => UseSse42IfAvailable     && X86HardwareCapabilities.SupportsSse42;
         internal static bool UsePopCnt    => UsePopCntIfAvailable    && X86HardwareCapabilities.SupportsPopcnt;
         internal static bool UseAvx       => UseAvxIfAvailable       && X86HardwareCapabilities.SupportsAvx && !ForceLegacySse;
+        internal static bool UseAvx512F   => UseAvx512FIfAvailable   && X86HardwareCapabilities.SupportsAvx512F && !ForceLegacySse;
+        internal static bool UseAvx512Vl  => UseAvx512VlIfAvailable  && X86HardwareCapabilities.SupportsAvx512Vl && !ForceLegacySse;
+        internal static bool UseAvx512Bw  => UseAvx512BwIfAvailable  && X86HardwareCapabilities.SupportsAvx512Bw && !ForceLegacySse;
+        internal static bool UseAvx512Dq  => UseAvx512DqIfAvailable  && X86HardwareCapabilities.SupportsAvx512Dq && !ForceLegacySse;
         internal static bool UseF16c      => UseF16cIfAvailable      && X86HardwareCapabilities.SupportsF16c;
         internal static bool UseFma       => UseFmaIfAvailable       && X86HardwareCapabilities.SupportsFma;
         internal static bool UseAesni     => UseAesniIfAvailable     && X86HardwareCapabilities.SupportsAesni;
         internal static bool UsePclmulqdq => UsePclmulqdqIfAvailable && X86HardwareCapabilities.SupportsPclmulqdq;
         internal static bool UseSha       => UseShaIfAvailable       && X86HardwareCapabilities.SupportsSha;
         internal static bool UseGfni      => UseGfniIfAvailable      && X86HardwareCapabilities.SupportsGfni;
+
+        internal static bool UseAvx512Ortho => UseAvx512F && UseAvx512Vl;
+        internal static bool UseAvx512OrthoFloat => UseAvx512Ortho && UseAvx512Dq;
     }
 }

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -29,7 +29,7 @@ namespace ARMeilleure.Translation.PTC
         private const string OuterHeaderMagicString = "PTCohd\0\0";
         private const string InnerHeaderMagicString = "PTCihd\0\0";
 
-        private const uint InternalVersion = 4484; //! To be incremented manually for each change to the ARMeilleure project.
+        private const uint InternalVersion = 4485; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -968,6 +968,7 @@ namespace ARMeilleure.Translation.PTC
                     (ulong)Arm64HardwareCapabilities.LinuxFeatureInfoHwCap,
                     (ulong)Arm64HardwareCapabilities.LinuxFeatureInfoHwCap2,
                     (ulong)Arm64HardwareCapabilities.MacOsFeatureInfo,
+                    0,
                     0);
             }
             else if (RuntimeInformation.ProcessArchitecture == Architecture.X64)
@@ -976,11 +977,12 @@ namespace ARMeilleure.Translation.PTC
                     (ulong)X86HardwareCapabilities.FeatureInfo1Ecx,
                     (ulong)X86HardwareCapabilities.FeatureInfo1Edx,
                     (ulong)X86HardwareCapabilities.FeatureInfo7Ebx,
-                    (ulong)X86HardwareCapabilities.FeatureInfo7Ecx);
+                    (ulong)X86HardwareCapabilities.FeatureInfo7Ecx,
+                    (ulong)X86HardwareCapabilities.Xcr0InfoEax);
             }
             else
             {
-                return new FeatureInfo(0, 0, 0, 0);
+                return new FeatureInfo(0, 0, 0, 0, 0);
             }
         }
 
@@ -1001,7 +1003,7 @@ namespace ARMeilleure.Translation.PTC
             return osPlatform;
         }
 
-        [StructLayout(LayoutKind.Sequential, Pack = 1/*, Size = 78*/)]
+        [StructLayout(LayoutKind.Sequential, Pack = 1/*, Size = 86*/)]
         private struct OuterHeader
         {
             public ulong Magic;
@@ -1033,8 +1035,8 @@ namespace ARMeilleure.Translation.PTC
             }
         }
 
-        [StructLayout(LayoutKind.Sequential, Pack = 1/*, Size = 32*/)]
-        private record struct FeatureInfo(ulong FeatureInfo0, ulong FeatureInfo1, ulong FeatureInfo2, ulong FeatureInfo3);
+        [StructLayout(LayoutKind.Sequential, Pack = 1/*, Size = 40*/)]
+        private record struct FeatureInfo(ulong FeatureInfo0, ulong FeatureInfo1, ulong FeatureInfo2, ulong FeatureInfo3, ulong FeatureInfo4);
 
         [StructLayout(LayoutKind.Sequential, Pack = 1/*, Size = 128*/)]
         private struct InnerHeader


### PR DESCRIPTION
Continuation of https://github.com/Ryujinx/Ryujinx/pull/3663

This PR addresses an issue in register-indexing, register-designations, and other issues the original PR was found to have.

`vpternlogd` is now utilized for `mvn`, `orn`, and `not`