### PR TITLE
make UI display correct content in Chinese

### DIFF
--- a/Ryujinx.HLE/HOS/SystemState/SystemStateMgr.cs
+++ b/Ryujinx.HLE/HOS/SystemState/SystemStateMgr.cs
@@ -57,9 +57,9 @@ namespace Ryujinx.HLE.HOS.SystemState
             DesiredTitleLanguage = language switch
             {
                 SystemLanguage.Taiwanese or
-                SystemLanguage.TraditionalChinese => TitleLanguage.Taiwanese,
+                SystemLanguage.TraditionalChinese => TitleLanguage.TraditionalChinese,
                 SystemLanguage.Chinese or
-                SystemLanguage.SimplifiedChinese  => TitleLanguage.Chinese,
+                SystemLanguage.SimplifiedChinese  => TitleLanguage.SimplifiedChinese,
                 _                                 => Enum.Parse<TitleLanguage>(Enum.GetName<SystemLanguage>(language)),
             };
         }

--- a/Ryujinx.HLE/HOS/SystemState/TitleLanguage.cs
+++ b/Ryujinx.HLE/HOS/SystemState/TitleLanguage.cs
@@ -15,8 +15,8 @@
         Portuguese,
         Russian,
         Korean,
-        Taiwanese,
-        Chinese,
+        TraditionalChinese,
+        SimplifiedChinese,
         BrazilianPortuguese
     }
 }


### PR DESCRIPTION
Due to enum.Parse can't transform SystemLanguage to TitleLanguage correctly, it makes 
```
private void GetGameInformation(ref ApplicationControlProperty controlData, out string titleName, out string titleId, out string publisher, out string version)
{
     _ = Enum.TryParse(_desiredTitleLanguage.ToString(), out TitleLanguage desiredTitleLanguage);
    ...
}
```
below transform always get AmericanEnglish in desiredTitleLanguage which is not right, and UI will always show English Title in game table even if you chose SimplifiedChinese as Title Language .

Here are some compartions.

Before (SimplifiedChinese, TraditionalChinese)
![image](https://user-images.githubusercontent.com/11457297/208717589-dc4aaa91-1e0c-481f-b292-f92491b2d2ac.png)
![image](https://user-images.githubusercontent.com/11457297/208717798-0c4e42d9-29d6-4384-8e18-3fe42f4b2a17.png)


After (SimplifiedChinese, TraditionalChinese)
![image](https://user-images.githubusercontent.com/11457297/208719418-b2aa63d1-2de4-4c96-9ffe-31e7164ad63a.png)
![image](https://user-images.githubusercontent.com/11457297/208719730-ed2fa276-d259-4a2e-9f61-3d142f670b2f.png)

Fixes #2510.