### PR TITLE
ARMeilleure: Hash _data pointer instead of value for Operand

### DIFF
--- a/ARMeilleure/IntermediateRepresentation/Operand.cs
+++ b/ARMeilleure/IntermediateRepresentation/Operand.cs
@@ -378,14 +378,7 @@ namespace ARMeilleure.IntermediateRepresentation
 
         public override int GetHashCode()
         {
-            if (Kind == OperandKind.LocalVariable)
-            {
-                return base.GetHashCode();
-            }
-            else
-            {
-                return (int)Value ^ ((int)Kind << 16) ^ ((int)Type << 20);
-            }
+            return ((ulong)_data).GetHashCode();
         }
 
         public bool Equals(Operand operand)


### PR DESCRIPTION
I noticed a weirdly high cost for dictionary accesses from MarkLabel etc. Turns out that the hash code was always the same for labels, so the whole point of having a dictionary was missed and it was putting everything in the same bucket. I made it always hash the _data pointer as that's a good source of identifiable and "random" data.

![image](https://user-images.githubusercontent.com/6294155/208788829-20050244-0c25-48a9-8e1e-a8f951251961.png)

Will likely affect lowCq (first boot time) more than highCq (pptc, generally).