### PR TITLE
Make PPTC state non-static

### DIFF
--- a/ARMeilleure/Translation/ArmEmitterContext.cs
+++ b/ARMeilleure/Translation/ArmEmitterContext.cs
@@ -6,7 +6,6 @@ using ARMeilleure.Instructions;
 using ARMeilleure.IntermediateRepresentation;
 using ARMeilleure.Memory;
 using ARMeilleure.State;
-using ARMeilleure.Translation.PTC;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -44,14 +43,13 @@ namespace ARMeilleure.Translation
 
         public IMemoryManager Memory { get; }
 
-        public bool HasPtc { get; }
-
         public EntryTable<uint> CountTable { get; }
         public AddressTable<ulong> FunctionTable { get; }
         public TranslatorStubs Stubs { get; }
 
         public ulong EntryAddress { get; }
         public bool HighCq { get; }
+        public bool HasPtc { get; }
         public Aarch32Mode Mode { get; }
 
         private int _ifThenBlockStateIndex = 0;
@@ -66,15 +64,16 @@ namespace ARMeilleure.Translation
             TranslatorStubs stubs,
             ulong entryAddress,
             bool highCq,
+            bool hasPtc,
             Aarch32Mode mode)
         {
-            HasPtc = Ptc.State != PtcState.Disabled;
             Memory = memory;
             CountTable = countTable;
             FunctionTable = funcTable;
             Stubs = stubs;
             EntryAddress = entryAddress;
             HighCq = highCq;
+            HasPtc = hasPtc;
             Mode = mode;
 
             _labels = new Dictionary<ulong, Operand>();

--- a/ARMeilleure/Translation/PTC/IPtcLoadState.cs
+++ b/ARMeilleure/Translation/PTC/IPtcLoadState.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace ARMeilleure.Translation.PTC
+{
+    public interface IPtcLoadState
+    {
+        event Action<PtcLoadingState, int, int> PtcStateChanged;
+        void Continue();
+    }
+}

--- a/Ryujinx.Ava/AppHost.cs
+++ b/Ryujinx.Ava/AppHost.cs
@@ -946,7 +946,7 @@ namespace Ryujinx.Ava
 
                     if (_keyboardInterface.GetKeyboardStateSnapshot().IsPressed(Key.Delete) && _parent.WindowState != WindowState.FullScreen)
                     {
-                        Device.Application.DiskCacheLoadState.Cancel();
+                        Device.Application.DiskCacheLoadState?.Cancel();
                     }
                 });
             }

--- a/Ryujinx.Ava/AppHost.cs
+++ b/Ryujinx.Ava/AppHost.cs
@@ -1,5 +1,4 @@
 ﻿using ARMeilleure.Translation;
-using ARMeilleure.Translation.PTC;
 using Avalonia.Input;
 using Avalonia.Threading;
 using LibHac.Tools.FsSystem;
@@ -280,7 +279,7 @@ namespace Ryujinx.Ava
                 _parent.Title = $"Ryujinx {Program.Version}{titleNameSection}{titleVersionSection}{titleIdSection}{titleArchSection}";
             });
 
-            _parent.ViewModel.HandleShaderProgress(Device);
+            _parent.ViewModel.SetUiProgressHandlers(Device);
 
             Renderer.SizeChanged += Window_SizeChanged;
 
@@ -357,8 +356,6 @@ namespace Ryujinx.Ava
 
             DisplaySleep.Restore();
 
-            Ptc.Close();
-            PtcProfiler.Stop();
             NpadManager.Dispose();
             TouchScreenManager.Dispose();
             Device.Dispose();
@@ -949,7 +946,7 @@ namespace Ryujinx.Ava
 
                     if (_keyboardInterface.GetKeyboardStateSnapshot().IsPressed(Key.Delete) && _parent.WindowState != WindowState.FullScreen)
                     {
-                        Ptc.Continue();
+                        Device.Application.DiskCacheLoadState.Cancel();
                     }
                 });
             }

--- a/Ryujinx.Ava/Program.cs
+++ b/Ryujinx.Ava/Program.cs
@@ -1,4 +1,3 @@
-using ARMeilleure.Translation.PTC;
 using Avalonia;
 using Avalonia.Threading;
 using Ryujinx.Ava.UI.Windows;
@@ -197,9 +196,6 @@ namespace Ryujinx.Ava
 
         private static void ProcessUnhandledException(Exception ex, bool isTerminating)
         {
-            Ptc.Close();
-            PtcProfiler.Stop();
-
             string message = $"Unhandled exception caught: {ex}";
 
             Logger.Error?.PrintMsg(LogClass.Application, message);
@@ -218,9 +214,6 @@ namespace Ryujinx.Ava
         public static void Exit()
         {
             DiscordIntegrationModule.Exit();
-
-            Ptc.Dispose();
-            PtcProfiler.Dispose();
 
             Logger.Shutdown();
         }

--- a/Ryujinx.Cpu/ICpuContext.cs
+++ b/Ryujinx.Cpu/ICpuContext.cs
@@ -35,5 +35,27 @@ namespace Ryujinx.Cpu
         /// <param name="address">Address of the region to be invalidated</param>
         /// <param name="size">Size of the region to be invalidated</param>
         void InvalidateCacheRegion(ulong address, ulong size);
+
+        /// <summary>
+        /// Loads cached code from disk for a given application.
+        /// </summary>
+        /// <remarks>
+        /// If the execution engine is recompiling guest code, this can be used to load cached code from disk.
+        /// </remarks>
+        /// <param name="titleIdText">Title ID of the application in padded hex form</param>
+        /// <param name="displayVersion">Version of the application</param>
+        /// <param name="enabled">True if the cache should be loaded from disk if it exists, false otherwise</param>
+        /// <returns>Disk cache load progress reporter and manager</returns>
+        IDiskCacheLoadState LoadDiskCache(string titleIdText, string displayVersion, bool enabled);
+
+        /// <summary>
+        /// Indicates that code has been loaded into guest memory, and that it might be executed in the future.
+        /// </summary>
+        /// <remarks>
+        /// Some execution engines might use this information to cache recompiled code on disk or to ensure it can be executed.
+        /// </remarks>
+        /// <param name="address">CPU virtual address where the code starts</param>
+        /// <param name="size">Size of the code range in bytes</param>
+        void PrepareCodeRange(ulong address, ulong size);
     }
 }

--- a/Ryujinx.Cpu/IDiskCacheState.cs
+++ b/Ryujinx.Cpu/IDiskCacheState.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Ryujinx.Cpu
+{
+    /// <summary>
+    /// Disk cache load state report and management interface.
+    /// </summary>
+    public interface IDiskCacheLoadState
+    {
+        /// <summary>
+        /// Event used to report the cache load progress.
+        /// </summary>
+        event Action<LoadState, int, int> StateChanged;
+
+        /// <summary>
+        /// Cancels the disk cache load process.
+        /// </summary>
+        void Cancel();
+    }
+}

--- a/Ryujinx.Cpu/Jit/JitCpuContext.cs
+++ b/Ryujinx.Cpu/Jit/JitCpuContext.cs
@@ -37,5 +37,17 @@ namespace Ryujinx.Cpu.Jit
         {
             _translator.InvalidateJitCacheRegion(address, size);
         }
+
+        /// <inheritdoc/>
+        public IDiskCacheLoadState LoadDiskCache(string titleIdText, string displayVersion, bool enabled)
+        {
+            return new JitDiskCacheLoadState(_translator.LoadDiskCache(titleIdText, displayVersion, enabled));
+        }
+
+        /// <inheritdoc/>
+        public void PrepareCodeRange(ulong address, ulong size)
+        {
+            _translator.PrepareCodeRange(address, size);
+        }
     }
 }

--- a/Ryujinx.Cpu/Jit/JitDiskCacheLoadState.cs
+++ b/Ryujinx.Cpu/Jit/JitDiskCacheLoadState.cs
@@ -1,0 +1,38 @@
+using ARMeilleure.Translation.PTC;
+using System;
+
+namespace Ryujinx.Cpu.Jit
+{
+    public class JitDiskCacheLoadState : IDiskCacheLoadState
+    {
+        /// <inheritdoc/>
+        public event Action<LoadState, int, int> StateChanged;
+
+        private readonly IPtcLoadState _loadState;
+
+        public JitDiskCacheLoadState(IPtcLoadState loadState)
+        {
+            loadState.PtcStateChanged += LoadStateChanged;
+            _loadState = loadState;
+        }
+
+        private void LoadStateChanged(PtcLoadingState newState, int current, int total)
+        {
+            LoadState state = newState switch
+            {
+                PtcLoadingState.Start => LoadState.Unloaded,
+                PtcLoadingState.Loading => LoadState.Loading,
+                PtcLoadingState.Loaded => LoadState.Loaded,
+                _ => throw new ArgumentException($"Invalid load state \"{newState}\".")
+            };
+
+            StateChanged?.Invoke(state, current, total);
+        }
+
+        /// <inheritdoc/>
+        public void Cancel()
+        {
+            _loadState.Continue();
+        }
+    }
+}

--- a/Ryujinx.Cpu/LoadState.cs
+++ b/Ryujinx.Cpu/LoadState.cs
@@ -1,0 +1,12 @@
+namespace Ryujinx.Cpu
+{
+    /// <summary>
+    /// Load state.
+    /// </summary>
+    public enum LoadState
+    {
+        Unloaded,
+        Loading,
+        Loaded
+    }
+}

--- a/Ryujinx.HLE/HOS/ApplicationLoader.cs
+++ b/Ryujinx.HLE/HOS/ApplicationLoader.cs
@@ -1,4 +1,3 @@
-using ARMeilleure.Translation.PTC;
 using LibHac;
 using LibHac.Account;
 using LibHac.Common;
@@ -14,8 +13,8 @@ using LibHac.Tools.FsSystem;
 using LibHac.Tools.FsSystem.NcaUtils;
 using Ryujinx.Common.Configuration;
 using Ryujinx.Common.Logging;
+using Ryujinx.Cpu;
 using Ryujinx.HLE.FileSystem;
-using Ryujinx.HLE.HOS.Kernel.Process;
 using Ryujinx.HLE.Loaders.Executables;
 using Ryujinx.Memory;
 using System;
@@ -67,6 +66,8 @@ namespace Ryujinx.HLE.HOS
 
         public string TitleIdText => TitleId.ToString("x16");
 
+        public IDiskCacheLoadState DiskCacheLoadState { get; private set; }
+
         public ApplicationLoader(Switch device)
         {
             _device = device;
@@ -94,7 +95,7 @@ namespace Ryujinx.HLE.HOS
                 EnsureSaveData(new ApplicationId(TitleId));
             }
 
-            LoadExeFs(codeFs, metaData);
+            LoadExeFs(codeFs, string.Empty, metaData);
         }
 
         public static (Nca main, Nca patch, Nca control) GetGameData(VirtualFileSystem fileSystem, PartitionFileSystem pfs, int programIndex)
@@ -302,12 +303,6 @@ namespace Ryujinx.HLE.HOS
 
         public void LoadServiceNca(string ncaFile)
         {
-            // Disable PPTC here as it does not support multiple processes running.
-            // TODO: This should be eventually removed and it should stop using global state and
-            // instead manage the cache per process.
-            Ptc.Close();
-            PtcProfiler.Stop();
-
             FileStream file = new FileStream(ncaFile, FileMode.Open, FileAccess.Read);
             Nca mainNca = new Nca(_device.Configuration.VirtualFileSystem.KeySet, file.AsStorage(false));
 
@@ -369,16 +364,12 @@ namespace Ryujinx.HLE.HOS
             // Collect the nsos, ignoring ones that aren't used.
             NsoExecutable[] programs = nsos.Where(x => x != null).ToArray();
 
-            MemoryManagerMode memoryManagerMode = _device.Configuration.MemoryManagerMode;
-
-            if (!MemoryBlock.SupportsFlags(MemoryAllocationFlags.ViewCompatible))
-            {
-                memoryManagerMode = MemoryManagerMode.SoftwarePageTable;
-            }
+            string displayVersion = _device.System.ContentManager.GetCurrentFirmwareVersion().VersionString;
+            bool usePtc = _device.System.EnablePtc;
 
             metaData.GetNpdm(out Npdm npdm).ThrowIfFailure();
-            ProgramInfo programInfo = new ProgramInfo(in npdm, allowCodeMemoryForJit: false);
-            ProgramLoader.LoadNsos(_device.System.KernelContext, out _, metaData, programInfo, executables: programs);
+            ProgramInfo programInfo = new ProgramInfo(in npdm, displayVersion, usePtc, allowCodeMemoryForJit: false);
+            ProgramLoader.LoadNsos(_device.System.KernelContext, metaData, programInfo, executables: programs);
 
             string titleIdText = npdm.Aci.Value.ProgramId.Value.ToString("x16");
             bool titleIs64Bit = (npdm.Meta.Value.Flags & 1) != 0;
@@ -477,9 +468,11 @@ namespace Ryujinx.HLE.HOS
                 _device.Configuration.VirtualFileSystem.ModLoader.GetModsBasePath(),
                 _device.Configuration.VirtualFileSystem.ModLoader.GetSdModsBasePath());
 
+            string displayVersion = string.Empty;
+
             if (controlNca != null)
             {
-                ReadControlData(_device, controlNca, ref _controlData, ref _titleName, ref _displayVersion);
+                ReadControlData(_device, controlNca, ref _controlData, ref _titleName, ref displayVersion);
             }
             else
             {
@@ -493,8 +486,10 @@ namespace Ryujinx.HLE.HOS
                 string dummyTitleName = "";
                 BlitStruct<ApplicationControlProperty> dummyControl = new BlitStruct<ApplicationControlProperty>(1);
 
-                ReadControlData(_device, updateProgram0ControlNca, ref dummyControl, ref dummyTitleName, ref _displayVersion);
+                ReadControlData(_device, updateProgram0ControlNca, ref dummyControl, ref dummyTitleName, ref displayVersion);
             }
+
+            _displayVersion = displayVersion;
 
             if (dataStorage == null)
             {
@@ -515,7 +510,7 @@ namespace Ryujinx.HLE.HOS
                 EnsureSaveData(new ApplicationId(TitleId & ~0xFul));
             }
 
-            LoadExeFs(codeFs, metaData);
+            LoadExeFs(codeFs, displayVersion, metaData);
 
             Logger.Info?.Print(LogClass.Loader, $"Application Loaded: {TitleName} v{DisplayVersion} [{TitleIdText}] [{(TitleIs64Bit ? "64-bit" : "32-bit")}]");
         }
@@ -584,7 +579,7 @@ namespace Ryujinx.HLE.HOS
             }
         }
 
-        private void LoadExeFs(IFileSystem codeFs, MetaLoader metaData = null, bool isHomebrew = false)
+        private void LoadExeFs(IFileSystem codeFs, string displayVersion, MetaLoader metaData = null, bool isHomebrew = false)
         {
             if (_device.Configuration.VirtualFileSystem.ModLoader.ReplaceExefsPartition(TitleId, ref codeFs))
             {
@@ -649,23 +644,23 @@ namespace Ryujinx.HLE.HOS
                 memoryManagerMode = MemoryManagerMode.SoftwarePageTable;
             }
 
-            Ptc.Initialize(TitleIdText, DisplayVersion, usePtc, memoryManagerMode);
-
             // We allow it for nx-hbloader because it can be used to launch homebrew.
             bool allowCodeMemoryForJit = TitleId == 0x010000000000100DUL || isHomebrew;
 
             metaData.GetNpdm(out Npdm npdm).ThrowIfFailure();
-            ProgramInfo programInfo = new ProgramInfo(in npdm, allowCodeMemoryForJit);
-            ProgramLoader.LoadNsos(_device.System.KernelContext, out ProcessTamperInfo tamperInfo, metaData, programInfo, executables: programs);
+            ProgramInfo programInfo = new ProgramInfo(in npdm, displayVersion, usePtc, allowCodeMemoryForJit);
+            ProgramLoadResult result = ProgramLoader.LoadNsos(_device.System.KernelContext, metaData, programInfo, executables: programs);
 
-            _device.Configuration.VirtualFileSystem.ModLoader.LoadCheats(TitleId, tamperInfo, _device.TamperMachine);
+            DiskCacheLoadState = result.DiskCacheLoadState;
+
+            _device.Configuration.VirtualFileSystem.ModLoader.LoadCheats(TitleId, result.TamperInfo, _device.TamperMachine);
         }
 
         public void LoadProgram(string filePath)
         {
             MetaLoader metaData = GetDefaultNpdm();
             metaData.GetNpdm(out Npdm npdm).ThrowIfFailure();
-            ProgramInfo programInfo = new ProgramInfo(in npdm, allowCodeMemoryForJit: true);
+            ProgramInfo programInfo = new ProgramInfo(in npdm, string.Empty, diskCacheEnabled: false, allowCodeMemoryForJit: true);
 
             bool isNro = Path.GetExtension(filePath).ToLower() == ".nro";
 
@@ -761,9 +756,11 @@ namespace Ryujinx.HLE.HOS
             Graphics.Gpu.GraphicsConfig.TitleId = null;
             _device.Gpu.HostInitalized.Set();
 
-            ProgramLoader.LoadNsos(_device.System.KernelContext, out ProcessTamperInfo tamperInfo, metaData, programInfo, executables: executable);
+            ProgramLoadResult result = ProgramLoader.LoadNsos(_device.System.KernelContext, metaData, programInfo, executables: executable);
 
-            _device.Configuration.VirtualFileSystem.ModLoader.LoadCheats(TitleId, tamperInfo, _device.TamperMachine);
+            DiskCacheLoadState = result.DiskCacheLoadState;
+
+            _device.Configuration.VirtualFileSystem.ModLoader.LoadCheats(TitleId, result.TamperInfo, _device.TamperMachine);
         }
 
         private MetaLoader GetDefaultNpdm()

--- a/Ryujinx.HLE/HOS/ArmProcessContext.cs
+++ b/Ryujinx.HLE/HOS/ArmProcessContext.cs
@@ -6,7 +6,17 @@ using Ryujinx.Memory;
 
 namespace Ryujinx.HLE.HOS
 {
-    class ArmProcessContext<T> : IProcessContext where T : class, IVirtualMemoryManagerTracked, IMemoryManager
+    interface IArmProcessContext : IProcessContext
+    {
+        IDiskCacheLoadState Initialize(
+            string titleIdText,
+            string displayVersion,
+            bool diskCacheEnabled,
+            ulong codeAddress,
+            ulong codeSize);
+    }
+
+    class ArmProcessContext<T> : IArmProcessContext where T : class, IVirtualMemoryManagerTracked, IMemoryManager
     {
         private readonly ulong _pid;
         private readonly GpuContext _gpuContext;
@@ -38,6 +48,17 @@ namespace Ryujinx.HLE.HOS
         public void Execute(IExecutionContext context, ulong codeAddress)
         {
             _cpuContext.Execute(context, codeAddress);
+        }
+
+        public IDiskCacheLoadState Initialize(
+            string titleIdText,
+            string displayVersion,
+            bool diskCacheEnabled,
+            ulong codeAddress,
+            ulong codeSize)
+        {
+            _cpuContext.PrepareCodeRange(codeAddress, codeSize);
+            return _cpuContext.LoadDiskCache(titleIdText, displayVersion, diskCacheEnabled);
         }
 
         public void InvalidateCacheRegion(ulong address, ulong size)

--- a/Ryujinx.HLE/HOS/ArmProcessContextFactory.cs
+++ b/Ryujinx.HLE/HOS/ArmProcessContextFactory.cs
@@ -13,11 +13,30 @@ namespace Ryujinx.HLE.HOS
     {
         private readonly ICpuEngine _cpuEngine;
         private readonly GpuContext _gpu;
+        private readonly string _titleIdText;
+        private readonly string _displayVersion;
+        private readonly bool _diskCacheEnabled;
+        private readonly ulong _codeAddress;
+        private readonly ulong _codeSize;
 
-        public ArmProcessContextFactory(ICpuEngine cpuEngine, GpuContext gpu)
+        public IDiskCacheLoadState DiskCacheLoadState { get; private set; }
+
+        public ArmProcessContextFactory(
+            ICpuEngine cpuEngine,
+            GpuContext gpu,
+            string titleIdText,
+            string displayVersion,
+            bool diskCacheEnabled,
+            ulong codeAddress,
+            ulong codeSize)
         {
             _cpuEngine = cpuEngine;
             _gpu = gpu;
+            _titleIdText = titleIdText;
+            _displayVersion = displayVersion;
+            _diskCacheEnabled = diskCacheEnabled;
+            _codeAddress = codeAddress;
+            _codeSize = codeSize;
         }
 
         public IProcessContext Create(KernelContext context, ulong pid, ulong addressSpaceSize, InvalidAccessHandler invalidAccessHandler, bool for64Bit)
@@ -29,21 +48,29 @@ namespace Ryujinx.HLE.HOS
                 mode = MemoryManagerMode.SoftwarePageTable;
             }
 
+            IArmProcessContext processContext;
+
             switch (mode)
             {
                 case MemoryManagerMode.SoftwarePageTable:
                     var memoryManager = new MemoryManager(context.Memory, addressSpaceSize, invalidAccessHandler);
-                    return new ArmProcessContext<MemoryManager>(pid, _cpuEngine, _gpu, memoryManager, for64Bit);
+                    processContext = new ArmProcessContext<MemoryManager>(pid, _cpuEngine, _gpu, memoryManager, for64Bit);
+                    break;
 
                 case MemoryManagerMode.HostMapped:
                 case MemoryManagerMode.HostMappedUnsafe:
                     bool unsafeMode = mode == MemoryManagerMode.HostMappedUnsafe;
                     var memoryManagerHostMapped = new MemoryManagerHostMapped(context.Memory, addressSpaceSize, unsafeMode, invalidAccessHandler);
-                    return new ArmProcessContext<MemoryManagerHostMapped>(pid, _cpuEngine, _gpu, memoryManagerHostMapped, for64Bit);
+                    processContext = new ArmProcessContext<MemoryManagerHostMapped>(pid, _cpuEngine, _gpu, memoryManagerHostMapped, for64Bit);
+                    break;
 
                 default:
                     throw new ArgumentOutOfRangeException();
             }
+
+            DiskCacheLoadState = processContext.Initialize(_titleIdText, _displayVersion, _diskCacheEnabled, _codeAddress, _codeSize);
+
+            return processContext;
         }
     }
 }

--- a/Ryujinx.Headless.SDL2/Program.cs
+++ b/Ryujinx.Headless.SDL2/Program.cs
@@ -1,5 +1,4 @@
 ﻿using ARMeilleure.Translation;
-using ARMeilleure.Translation.PTC;
 using CommandLine;
 using LibHac.Tools.FsSystem;
 using Ryujinx.Audio.Backends.SDL2;
@@ -12,6 +11,7 @@ using Ryujinx.Common.Configuration.Hid.Keyboard;
 using Ryujinx.Common.Logging;
 using Ryujinx.Common.SystemInterop;
 using Ryujinx.Common.Utilities;
+using Ryujinx.Cpu;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.GAL.Multithreading;
 using Ryujinx.Graphics.Gpu;
@@ -447,8 +447,11 @@ namespace Ryujinx.Headless.SDL2
 
         private static void SetupProgressHandler()
         {
-            Ptc.PtcStateChanged -= ProgressHandler;
-            Ptc.PtcStateChanged += ProgressHandler;
+            if (_emulationContext.Application.DiskCacheLoadState != null)
+            {
+                _emulationContext.Application.DiskCacheLoadState.StateChanged -= ProgressHandler;
+                _emulationContext.Application.DiskCacheLoadState.StateChanged += ProgressHandler;
+            }
 
             _emulationContext.Gpu.ShaderCacheStateChanged -= ProgressHandler;
             _emulationContext.Gpu.ShaderCacheStateChanged += ProgressHandler;
@@ -460,7 +463,7 @@ namespace Ryujinx.Headless.SDL2
 
             switch (state)
             {
-                case PtcLoadingState ptcState:
+                case LoadState ptcState:
                     label = $"PTC : {current}/{total}";
                     break;
                 case ShaderCacheState shaderCacheState:
@@ -562,9 +565,6 @@ namespace Ryujinx.Headless.SDL2
             _window.Initialize(_emulationContext, _inputConfiguration, _enableKeyboard, _enableMouse);
 
             _window.Execute();
-
-            Ptc.Close();
-            PtcProfiler.Stop();
 
             _emulationContext.Dispose();
             _window.Dispose();

--- a/Ryujinx/Program.cs
+++ b/Ryujinx/Program.cs
@@ -1,4 +1,3 @@
-using ARMeilleure.Translation.PTC;
 using Gtk;
 using Ryujinx.Common;
 using Ryujinx.Common.Configuration;
@@ -308,9 +307,6 @@ namespace Ryujinx
 
         private static void ProcessUnhandledException(Exception ex, bool isTerminating)
         {
-            Ptc.Close();
-            PtcProfiler.Stop();
-
             string message = $"Unhandled exception caught: {ex}";
 
             Logger.Error?.PrintMsg(LogClass.Application, message);
@@ -329,9 +325,6 @@ namespace Ryujinx
         public static void Exit()
         {
             DiscordIntegrationModule.Exit();
-
-            Ptc.Dispose();
-            PtcProfiler.Dispose();
 
             Logger.Shutdown();
         }

--- a/Ryujinx/Ui/RendererWidgetBase.cs
+++ b/Ryujinx/Ui/RendererWidgetBase.cs
@@ -584,7 +584,7 @@ namespace Ryujinx.Ui
                     {
                         if (!ParentWindow.State.HasFlag(WindowState.Fullscreen))
                         {
-                            Device.Application.DiskCacheLoadState.Cancel();
+                            Device.Application.DiskCacheLoadState?.Cancel();
                         }
                     }
                 });

--- a/Ryujinx/Ui/RendererWidgetBase.cs
+++ b/Ryujinx/Ui/RendererWidgetBase.cs
@@ -1,5 +1,4 @@
 ﻿using ARMeilleure.Translation;
-using ARMeilleure.Translation.PTC;
 using Gdk;
 using Gtk;
 using Ryujinx.Common;
@@ -519,7 +518,7 @@ namespace Ryujinx.Ui
             _gpuCancellationTokenSource.Cancel();
 
             _isStopped = true;
-            
+
             if (_isActive)
             {
                 _isActive = false;
@@ -585,7 +584,7 @@ namespace Ryujinx.Ui
                     {
                         if (!ParentWindow.State.HasFlag(WindowState.Fullscreen))
                         {
-                            Ptc.Continue();
+                            Device.Application.DiskCacheLoadState.Cancel();
                         }
                     }
                 });


### PR DESCRIPTION
Right now PPTC has some global state, which means that when there are multiple guest processes running it can't work properly, so it won't be able to manage the caches for the separate processes. This changes it to have one PPTC cache instance per guest process (tied to the `Translator`). This is cleaner and allows the multi-process scenario to work. This allows the workaround where PPTC is disabled when the JIT service is loaded to be removed too (it will now also be cached).

Testing is welcome. Just to make sure PPTC is still working as it should.