### PR TITLE
Fix CPU FCVTN instruction implementation (slow path)

### DIFF
--- a/ARMeilleure/Instructions/InstEmitSimdCvt.cs
+++ b/ARMeilleure/Instructions/InstEmitSimdCvt.cs
@@ -381,15 +381,13 @@ namespace ARMeilleure.Instructions
 
                 for (int index = 0; index < elems; index++)
                 {
-                    Operand ne = context.VectorExtract(type, GetVec(op.Rn), 0);
+                    Operand ne = context.VectorExtract(type, GetVec(op.Rn), index);
 
                     if (sizeF == 0)
                     {
                         context.StoreToContext();
                         Operand e = context.Call(typeof(SoftFloat32_16).GetMethod(nameof(SoftFloat32_16.FPConvert)), ne);
                         context.LoadFromContext();
-
-                        e = context.ZeroExtend16(OperandType.I64, e);
 
                         res = EmitVectorInsert(context, res, e, part + index, 1);
                     }

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -27,7 +27,7 @@ namespace ARMeilleure.Translation.PTC
         private const string OuterHeaderMagicString = "PTCohd\0\0";
         private const string InnerHeaderMagicString = "PTCihd\0\0";
 
-        private const uint InternalVersion = 4140; //! To be incremented manually for each change to the ARMeilleure project.
+        private const uint InternalVersion = 4159; //! To be incremented manually for each change to the ARMeilleure project.
 
         private const string ActualDir = "0";
         private const string BackupDir = "1";

--- a/Ryujinx.Tests/Cpu/CpuTestSimd.cs
+++ b/Ryujinx.Tests/Cpu/CpuTestSimd.cs
@@ -2176,8 +2176,8 @@ namespace Ryujinx.Tests.Cpu
             opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
             opcodes |= ((q & 1) << 30);
 
-            V128 v0 = MakeVectorE0E1(z, z);
-            V128 v1 = MakeVectorE0E1(a, a);
+            V128 v0 = MakeVectorE0E1(z, a);
+            V128 v1 = MakeVectorE0E1(a, z);
 
             int rnd = (int)TestContext.CurrentContext.Random.NextUInt();
 
@@ -2202,8 +2202,8 @@ namespace Ryujinx.Tests.Cpu
             opcodes |= ((rn & 31) << 5) | ((rd & 31) << 0);
             opcodes |= ((q & 1) << 30);
 
-            V128 v0 = MakeVectorE0E1(z, z);
-            V128 v1 = MakeVectorE0E1(a, a);
+            V128 v0 = MakeVectorE0E1(z, a);
+            V128 v1 = MakeVectorE0E1(a, z);
 
             SingleOpcode(opcodes, v0: v0, v1: v1);
 


### PR DESCRIPTION
The implementation of the slow path for this instruction was incorrect because it would always extract the first element (0) of the input vector, and it was not getting caught by the tests because the input vectors used had the same value in all elements. This change fixes the issue and updates the test to be able to catch this kind of error by using different element values.

Note that by default we use a fast path here that use equivalent x86 instructions directly to emulate this, and the fast path does not suffer from this bug, so the only users affected are those using CPUs that does not support the F16C extension, on games that uses half-float. Intel supports this extension since Ivy Bridge, so only 2nd gen Intel Core CPUs and older should be affected. AMD supports it from even longer.

Thanks to kakasita for reporting that issue.