### PR TITLE
Some minor cleanups and optimizations

### DIFF
--- a/ARMeilleure/Translation/SsaConstruction.cs
+++ b/ARMeilleure/Translation/SsaConstruction.cs
@@ -140,7 +140,7 @@ namespace ARMeilleure.Translation
                     }
                 }
 
-                Array.Clear(localDefs, 0, localDefs.Length);
+                Array.Clear(localDefs);
             }
         }
 

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/Types/UserProfile.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/Types/UserProfile.cs
@@ -4,8 +4,6 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
 {
     public class UserProfile
     {
-        private static readonly DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-
         public UserId UserId { get; }
 
         public long LastModifiedTimestamp { get; set; }
@@ -83,7 +81,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
 
         private void UpdateLastModifiedTimestamp()
         {
-            LastModifiedTimestamp = (long)(DateTime.Now - Epoch).TotalSeconds;
+            LastModifiedTimestamp = (long)(DateTime.Now - DateTime.UnixEpoch).TotalSeconds;
         }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Caps/CaptureManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Caps/CaptureManager.cs
@@ -100,26 +100,23 @@ namespace Ryujinx.HLE.HOS.Services.Caps
                     Unknown0x1f       = 1
                 };
 
-                using (SHA256 sha256Hash = SHA256.Create())
+                // NOTE: The hex hash is a HMAC-SHA256 (first 32 bytes) using a hardcoded secret key over the titleId, we can simulate it by hashing the titleId instead.
+                string hash       = BitConverter.ToString(SHA256.HashData(BitConverter.GetBytes(titleId))).Replace("-", "").Remove(0x20);
+                string folderPath = Path.Combine(_sdCardPath, "Nintendo", "Album", currentDateTime.Year.ToString("00"), currentDateTime.Month.ToString("00"), currentDateTime.Day.ToString("00"));
+                string filePath   = GenerateFilePath(folderPath, applicationAlbumEntry, currentDateTime, hash);
+
+                // TODO: Handle that using the FS service implementation and return the right error code instead of throwing exceptions.
+                Directory.CreateDirectory(folderPath);
+
+                while (File.Exists(filePath))
                 {
-                    // NOTE: The hex hash is a HMAC-SHA256 (first 32 bytes) using a hardcoded secret key over the titleId, we can simulate it by hashing the titleId instead.
-                    string hash       = BitConverter.ToString(sha256Hash.ComputeHash(BitConverter.GetBytes(titleId))).Replace("-", "").Remove(0x20);
-                    string folderPath = Path.Combine(_sdCardPath, "Nintendo", "Album", currentDateTime.Year.ToString("00"), currentDateTime.Month.ToString("00"), currentDateTime.Day.ToString("00"));
-                    string filePath   = GenerateFilePath(folderPath, applicationAlbumEntry, currentDateTime, hash);
+                    applicationAlbumEntry.AlbumFileDateTime.UniqueId++;
 
-                    // TODO: Handle that using the FS service implementation and return the right error code instead of throwing exceptions.
-                    Directory.CreateDirectory(folderPath);
-
-                    while (File.Exists(filePath))
-                    {
-                        applicationAlbumEntry.AlbumFileDateTime.UniqueId++;
-
-                        filePath = GenerateFilePath(folderPath, applicationAlbumEntry, currentDateTime, hash);
-                    }
-                
-                    // NOTE: The saved JPEG file doesn't have the limitation in the extra EXIF data.
-                    Image.LoadPixelData<Rgba32>(screenshotData, 1280, 720).SaveAsJpegAsync(filePath);
+                    filePath = GenerateFilePath(folderPath, applicationAlbumEntry, currentDateTime, hash);
                 }
+
+                // NOTE: The saved JPEG file doesn't have the limitation in the extra EXIF data.
+                Image.LoadPixelData<Rgba32>(screenshotData, 1280, 720).SaveAsJpegAsync(filePath);
 
                 return ResultCode.Success;
             }

--- a/Ryujinx.HLE/HOS/Services/Pcv/Bpc/IRtcManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Pcv/Bpc/IRtcManager.cs
@@ -24,9 +24,7 @@ namespace Ryujinx.HLE.HOS.Services.Pcv.Bpc
         public static ResultCode GetExternalRtcValue(out ulong rtcValue)
         {
             // TODO: emulate MAX77620/MAX77812 RTC
-            DateTime unixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-
-            rtcValue = (ulong)(DateTime.Now.ToUniversalTime() - unixEpoch).TotalSeconds;
+            rtcValue = (ulong)(DateTime.Now.ToUniversalTime() - DateTime.UnixEpoch).TotalSeconds;
 
             return ResultCode.Success;
         }

--- a/Ryujinx.HLE/HOS/Services/Ro/IRoInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Ro/IRoInterface.cs
@@ -142,14 +142,9 @@ namespace Ryujinx.HLE.HOS.Services.Ro
 
             _owner.CpuMemory.Read(nroAddress, nroData);
 
-            byte[] nroHash = null;
-
             MemoryStream stream = new MemoryStream(nroData);
 
-            using (SHA256 hasher = SHA256.Create())
-            {
-                nroHash = hasher.ComputeHash(stream);
-            }
+            byte[] nroHash = SHA256.HashData(stream);
 
             if (!IsNroHashPresent(nroHash))
             {

--- a/Ryujinx.HLE/HOS/Services/Time/Clock/Types/TimeSpanType.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/Clock/Types/TimeSpanType.cs
@@ -10,8 +10,6 @@ namespace Ryujinx.HLE.HOS.Services.Time.Clock
 
         public static readonly TimeSpanType Zero = new TimeSpanType(0);
 
-        private static readonly DateTime UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-
         public long NanoSeconds;
 
         public TimeSpanType(long nanoSeconds)
@@ -31,7 +29,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.Clock
 
         public bool IsDaylightSavingTime()
         {
-            return UnixEpoch.AddSeconds(ToSeconds()).ToLocalTime().IsDaylightSavingTime();
+            return DateTime.UnixEpoch.AddSeconds(ToSeconds()).ToLocalTime().IsDaylightSavingTime();
         }
 
         public static TimeSpanType FromSeconds(long seconds)


### PR DESCRIPTION
1st commit: Replace a Array.Clear(x, 0, x.Length) call with Array.Clear(x) (more performant)

2nd commit: Use DateTime.UnixEpoch field instead of manually initializing a static field in some places.

3rd commit: Replace SHA256.ComputeHash calls with new static SHA256.HashData method (More performant and avoids the need to initialize a SHA256 instance)