### PR TITLE
[Headless] Fix for not receiving any SDL events on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,9 @@ ClientBin/
 packages/*
 *.config
 
+# Include nuget.config
+!nuget.config
+
 # RIA/Silverlight projects
 Generated_Code/
 

--- a/Ryujinx.Headless.SDL2/Program.cs
+++ b/Ryujinx.Headless.SDL2/Program.cs
@@ -77,7 +77,7 @@ namespace Ryujinx.Headless.SDL2
             _accountManager = new AccountManager(_libHacHorizonManager.RyujinxClient);
             _userChannelPersistence = new UserChannelPersistence();
 
-            if (OperatingSystem.IsMacOS())
+            if (OperatingSystem.IsMacOS() || OperatingSystem.IsLinux())
             {
                 AutoResetEvent invoked = new AutoResetEvent(false);
 

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
While trying to debug #3874 I noticed Ryujinx.Headless.SDL2 was not receiving any SDL events.

This PR fixes this issue and also adds a `nuget.config` I originally planned to add with #4128. 