### PR TITLE
chore: Update Ryujinx.SDL2-CS to 2.26.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,7 +34,7 @@
     <PackageVersion Include="Ryujinx.Graphics.Nvdec.Dependencies" Version="5.0.1-build13" />
     <PackageVersion Include="Ryujinx.Graphics.Vulkan.Dependencies.MoltenVK" Version="1.2.0" />
     <PackageVersion Include="Ryujinx.GtkSharp" Version="3.24.24.59-ryujinx" />
-    <PackageVersion Include="Ryujinx.SDL2-CS" Version="2.24.2-build21" />
+    <PackageVersion Include="Ryujinx.SDL2-CS" Version="2.26.1-build23" />
     <PackageVersion Include="shaderc.net" Version="0.1.0" />
     <PackageVersion Include="SharpZipLib" Version="1.4.1" />
     <PackageVersion Include="Silk.NET.Vulkan" Version="2.16.0" />


### PR DESCRIPTION
As title say.

This doesn't include the motion changes of #3894.