### PR TITLE
Implement missing service calls in `pm`

### DIFF
--- a/Ryujinx.HLE/HOS/Kernel/KernelStatic.cs
+++ b/Ryujinx.HLE/HOS/Kernel/KernelStatic.cs
@@ -69,18 +69,5 @@ namespace Ryujinx.HLE.HOS.Kernel
 
             return null;
         }
-
-        internal static KProcess GetApplicationProcess()
-        {
-            foreach (var process in Context.Processes.Values)
-            {
-                if (process.IsApplication)
-                {
-                    return process;
-                }
-            }
-
-            return null;
-        }
     }
 }

--- a/Ryujinx.HLE/HOS/Kernel/KernelStatic.cs
+++ b/Ryujinx.HLE/HOS/Kernel/KernelStatic.cs
@@ -1,5 +1,4 @@
-﻿using Ryujinx.HLE.HOS.Kernel.Common;
-using Ryujinx.HLE.HOS.Kernel.Memory;
+﻿using Ryujinx.HLE.HOS.Kernel.Memory;
 using Ryujinx.HLE.HOS.Kernel.Process;
 using Ryujinx.HLE.HOS.Kernel.Threading;
 using Ryujinx.Horizon.Common;
@@ -66,6 +65,19 @@ namespace Ryujinx.HLE.HOS.Kernel
             if (Context.Processes.TryGetValue(pid, out KProcess process))
             {
                 return process;
+            }
+
+            return null;
+        }
+
+        internal static KProcess GetApplicationProcess()
+        {
+            foreach (var process in Context.Processes.Values)
+            {
+                if (process.IsApplication)
+                {
+                    return process;
+                }
             }
 
             return null;

--- a/Ryujinx.HLE/HOS/Services/Pm/IDebugMonitorInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Pm/IDebugMonitorInterface.cs
@@ -15,13 +15,14 @@ namespace Ryujinx.HLE.HOS.Services.Pm
         public ResultCode GetApplicationProcessId(ServiceCtx context)
         {
             // TODO: Not correct as it shouldn't be directly using kernel objects here
-            KProcess process = KernelStatic.GetApplicationProcess();
-
-            if (process != null)
+            foreach (KProcess process in context.Device.System.KernelContext.Processes.Values)
             {
-                context.ResponseData.Write(process.Pid);
+                if (process.IsApplication)
+                {
+                    context.ResponseData.Write(process.Pid);
 
-                return ResultCode.Success;
+                    return ResultCode.Success;
+                }
             }
 
             return ResultCode.ProcessNotFound;

--- a/Ryujinx.HLE/HOS/Services/Pm/IDebugMonitorInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Pm/IDebugMonitorInterface.cs
@@ -14,6 +14,7 @@ namespace Ryujinx.HLE.HOS.Services.Pm
         // GetProgramId() -> sf::Out<ncm::ProgramId> out_process_id
         public ResultCode GetApplicationProcessId(ServiceCtx context)
         {
+            // TODO: Not correct as it shouldn't be directly using kernel objects here
             KProcess process = KernelStatic.GetApplicationProcess();
 
             if (process != null)

--- a/Ryujinx.HLE/HOS/Services/Pm/IDebugMonitorInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Pm/IDebugMonitorInterface.cs
@@ -10,6 +10,22 @@ namespace Ryujinx.HLE.HOS.Services.Pm
     {
         public IDebugMonitorInterface(ServiceCtx context) { }
 
+        [CommandHipc(4)]
+        // GetProgramId() -> sf::Out<ncm::ProgramId> out_process_id
+        public ResultCode GetApplicationProcessId(ServiceCtx context)
+        {
+            KProcess process = KernelStatic.GetApplicationProcess();
+
+            if (process != null)
+            {
+                context.ResponseData.Write(process.Pid);
+
+                return ResultCode.Success;
+            }
+
+            return ResultCode.ProcessNotFound;
+        }
+
         [CommandHipc(65000)]
         // AtmosphereGetProcessInfo(os::ProcessId process_id) -> sf::OutCopyHandle out_process_handle, sf::Out<ncm::ProgramLocation> out_loc, sf::Out<cfg::OverrideStatus> out_status
         public ResultCode GetProcessInfo(ServiceCtx context)

--- a/Ryujinx.HLE/HOS/Services/Pm/IInformationInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Pm/IInformationInterface.cs
@@ -15,9 +15,7 @@ namespace Ryujinx.HLE.HOS.Services.Pm
             ulong pid = context.RequestData.ReadUInt64();
 
             // TODO: Not correct as it shouldn't be directly using kernel objects here
-            KProcess process = KernelStatic.GetProcessByPid(pid);
-
-            if (process != null)
+            if (context.Device.System.KernelContext.Processes.TryGetValue(pid, out KProcess process))
             {
                 context.ResponseData.Write(process.TitleId);
 

--- a/Ryujinx.HLE/HOS/Services/Pm/IInformationInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Pm/IInformationInterface.cs
@@ -8,16 +8,21 @@ namespace Ryujinx.HLE.HOS.Services.Pm
         public IInformationInterface(ServiceCtx context) { }
 
         [CommandHipc(0)]
-        // GetTitleId(unknown<8>) -> unknown<8>
-        public ResultCode GetTitleId(ServiceCtx context)
+        // GetProgramId(unknown<8>) -> unknown<8>
+        public ResultCode GetProgramId(ServiceCtx context)
         {
             ulong pid = context.RequestData.ReadUInt64();
 
             var process = KernelStatic.GetProcessByPid(pid);
 
-            context.ResponseData.Write(process.TitleId);
+            if (process != null)
+            {
+                context.ResponseData.Write(process.TitleId);
 
-            return ResultCode.Success;
+                return ResultCode.Success;
+            }
+
+            return ResultCode.ProcessNotFound;
         }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Pm/IInformationInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Pm/IInformationInterface.cs
@@ -1,4 +1,5 @@
 ﻿using Ryujinx.HLE.HOS.Kernel;
+using Ryujinx.HLE.HOS.Kernel.Process;
 
 namespace Ryujinx.HLE.HOS.Services.Pm
 {
@@ -13,7 +14,7 @@ namespace Ryujinx.HLE.HOS.Services.Pm
         {
             ulong pid = context.RequestData.ReadUInt64();
 
-            var process = KernelStatic.GetProcessByPid(pid);
+            KProcess process = KernelStatic.GetProcessByPid(pid);
 
             if (process != null)
             {

--- a/Ryujinx.HLE/HOS/Services/Pm/IInformationInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Pm/IInformationInterface.cs
@@ -14,6 +14,7 @@ namespace Ryujinx.HLE.HOS.Services.Pm
         {
             ulong pid = context.RequestData.ReadUInt64();
 
+            // TODO: Not correct as it shouldn't be directly using kernel objects here
             KProcess process = KernelStatic.GetProcessByPid(pid);
 
             if (process != null)

--- a/Ryujinx.HLE/HOS/Services/Pm/IInformationInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Pm/IInformationInterface.cs
@@ -8,7 +8,7 @@ namespace Ryujinx.HLE.HOS.Services.Pm
         public IInformationInterface(ServiceCtx context) { }
 
         [CommandHipc(0)]
-        // GetProgramId(unknown<8>) -> unknown<8>
+        // GetProgramId(os::ProcessId process_id) -> sf::Out<ncm::ProgramId> out
         public ResultCode GetProgramId(ServiceCtx context)
         {
             ulong pid = context.RequestData.ReadUInt64();

--- a/Ryujinx.HLE/HOS/Services/Pm/IInformationInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Pm/IInformationInterface.cs
@@ -1,8 +1,23 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Pm
+﻿using Ryujinx.HLE.HOS.Kernel;
+
+namespace Ryujinx.HLE.HOS.Services.Pm
 {
     [Service("pm:info")]
     class IInformationInterface : IpcService
     {
         public IInformationInterface(ServiceCtx context) { }
+
+        [CommandHipc(0)]
+        // GetTitleId(unknown<8>) -> unknown<8>
+        public ResultCode GetTitleId(ServiceCtx context)
+        {
+            ulong pid = context.RequestData.ReadUInt64();
+
+            var process = KernelStatic.GetProcessByPid(pid);
+
+            context.ResponseData.Write(process.TitleId);
+
+            return ResultCode.Success;
+        }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Pm/ResultCode.cs
+++ b/Ryujinx.HLE/HOS/Services/Pm/ResultCode.cs
@@ -1,0 +1,17 @@
+namespace Ryujinx.HLE.HOS.Services.Pm
+{
+    enum ResultCode
+    {
+        ModuleId       = 15,
+        ErrorCodeShift = 9,
+
+        Success = 0,
+
+        ProcessNotFound    = (1 << ErrorCodeShift) | ModuleId,
+        AlreadyStarted     = (2 << ErrorCodeShift) | ModuleId,
+        NotTerminated      = (3 << ErrorCodeShift) | ModuleId,
+        DebugHookInUse     = (4 << ErrorCodeShift) | ModuleId,
+        ApplicationRunning = (5 << ErrorCodeShift) | ModuleId,
+        InvalidSize        = (6 << ErrorCodeShift) | ModuleId,
+    }
+}


### PR DESCRIPTION
Implement following missing service calls in `pm`

**`pm:info`:**
- `GetProgramId`

**`pm:dmnt`:**
- `GetApplicationProcessId`

Fixes #2516