### PR TITLE
Remove textures from cache on unmap if not mapped and modified

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -1676,6 +1676,13 @@ namespace Ryujinx.Graphics.Gpu.Image
             }
 
             RemoveFromPools(true);
+
+            // We only want to remove if there's no mapped region of the texture that was modified by the GPU,
+            // otherwise we could lose data.
+            if (!Group.AnyModified(this))
+            {
+                _physicalMemory.TextureCache.QueueAutoDeleteCacheRemoval(this);
+            }
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -1166,6 +1166,19 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Queues the removal of a texture from the auto delete cache.
+        /// </summary>
+        /// <remarks>
+        /// This function is thread safe and can be called from any thread.
+        /// The texture will be deleted on the next time the cache is used.
+        /// </remarks>
+        /// <param name="texture">The texture to be removed</param>
+        public void QueueAutoDeleteCacheRemoval(Texture texture)
+        {
+            _cache.RemoveDeferred(texture);
+        }
+
+        /// <summary>
         /// Disposes all textures and samplers in the cache.
         /// It's an error to use the texture cache after disposal.
         /// </summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -435,6 +435,32 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Checks if a texture was modified by the GPU.
+        /// </summary>
+        /// <param name="texture">The texture to be checked</param>
+        /// <returns>True if any region of the texture was modified by the GPU, false otherwise</returns>
+        public bool AnyModified(Texture texture)
+        {
+            bool anyModified = false;
+
+            EvaluateRelevantHandles(texture, (baseHandle, regionCount, split) =>
+            {
+                for (int i = 0; i < regionCount; i++)
+                {
+                    TextureGroupHandle group = _handles[baseHandle + i];
+
+                    if (group.Modified)
+                    {
+                        anyModified = true;
+                        break;
+                    }
+                }
+            });
+
+            return anyModified;
+        }
+
+        /// <summary>
         /// Flush modified ranges for a given texture.
         /// </summary>
         /// <param name="texture">The texture being used</param>


### PR DESCRIPTION
Currently we have a `AutoDeleteCache` that keeps the mostly frequently used textures on the cache, while deleting the least used ones. It has a hard limit of 2048 entries right now, so if the count gets past that limit, it will start deleting textures. In addition to that we remove data when the storage for different textures overlaps, and that works well for most games. However there is a rare scenario where this does not work well, which is the game frequently remapping textures at different memory regions. The fixed limit on the number of entries does not work well when each texture is very large. We can use a very high amount of VRAM with a low amount of textures. And the overlap removal doesn't help because the textures are located in different memory regions.

To fix this issue, this change forces the texture to be removed from the `AutoDeleteCache` if it has been unmapped, and there's no GPU modified region left that is still on a mapped sub-range. Since we already force remove the texture from the pools on unmap, this effectively causes the texture to be deleted since nothing will be holding a reference to it.

This fixes a VRAM "leak" on the game Witch`s Garden (which is technically not a "leak" because it would eventually stop growing, but the usage is so high that probably anyone would run out of memory after a while, so we might as well call it a leak).

VRAM usage on task manager:
master:
![image](https://user-images.githubusercontent.com/5624669/210911240-5ccdefc6-6496-43b2-af84-69bf443f7e29.png)
(Eventually would run out of memory and crash).
PR:
![image](https://user-images.githubusercontent.com/5624669/210911291-dc4c81f6-d6a3-448b-b85b-51a815126c02.png)
Scene:
![image](https://user-images.githubusercontent.com/5624669/210911300-ff6352ea-41d2-4369-acf1-10ce1670a8f6.png)

Testing is welcome.