### PR TITLE
[hipc] Fix 'Unexpected result code Success returned' in Reply()

### DIFF
--- a/Ryujinx.Horizon.Common/Result.cs
+++ b/Ryujinx.Horizon.Common/Result.cs
@@ -100,6 +100,14 @@ namespace Ryujinx.Horizon.Common
             }
         }
 
+        public void AbortOnFailureUnless(Result result, Result result2)
+        {
+            if (this != Success && this != result && this != result2)
+            {
+                ThrowInvalidResult();
+            }
+        }
+
         private void ThrowInvalidResult()
         {
             throw new InvalidResultException(this);

--- a/Ryujinx.Horizon/Sdk/Sf/Hipc/Api.cs
+++ b/Ryujinx.Horizon/Sdk/Sf/Hipc/Api.cs
@@ -51,7 +51,7 @@ namespace Ryujinx.Horizon.Sdk.Sf.Hipc
         {
             Result result = ReplyImpl(sessionHandle, messageBuffer);
 
-            result.AbortUnless(KernelResult.TimedOut, KernelResult.PortRemoteClosed);
+            result.AbortOnFailureUnless(KernelResult.TimedOut, KernelResult.PortRemoteClosed);
 
             return Result.Success;
         }


### PR DESCRIPTION
I recently noticed a crash I was getting when minimizing Ryujinx.Headless.SDL2 while it was loading a game.

This PR fixes this crash by adding a new method `AbortOnFailureUnless` and replacing the call to `AbortUnless` with it inside the `Api.Reply` method.

This results in `AbortUnless` being unused currently, should it be removed?