### PR TITLE
MainWindow: Vertically center SearchBox TextPresenter

### DIFF
--- a/Ryujinx.Ava/UI/Windows/MainWindow.axaml
+++ b/Ryujinx.Ava/UI/Windows/MainWindow.axaml
@@ -343,6 +343,7 @@
                             Margin="5,0,5,0"
                             HorizontalAlignment="Right"
                             VerticalAlignment="Center"
+                            VerticalContentAlignment="Center"
                             DockPanel.Dock="Right"
                             KeyUp="SearchBox_OnKeyUp"
                             Text="{Binding SearchText}"


### PR DESCRIPTION
Minor annoyance.

Before:
<img width="396" alt="image" src="https://user-images.githubusercontent.com/8682882/211158612-03aed360-4b0e-4329-bffc-744c6203fcba.png">

After:
<img width="396" alt="image" src="https://user-images.githubusercontent.com/8682882/211158582-1a88d4aa-cfad-492f-a6da-5c3664c3a016.png">
