### PR TITLE
Ava UI: Implement built-in console window

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,6 +24,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageVersion Include="MsgPack.Cli" Version="1.0.1" />
+    <PackageVersion Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.1.0" />
     <PackageVersion Include="OpenTK.Core" Version="4.7.5" />

--- a/Ryujinx.Ava/App.axaml.cs
+++ b/Ryujinx.Ava/App.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using Avalonia.Styling;
@@ -20,6 +21,8 @@ namespace Ryujinx.Ava
 {
     public class App : Application
     {
+        private ConsoleWindow _consoleWindow;
+
         public override void Initialize()
         {
             Name = $"Ryujinx {Program.Version}";
@@ -32,6 +35,7 @@ namespace Ryujinx.Ava
             if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             {
                 desktop.MainWindow = new MainWindow();
+                desktop.ShutdownMode = ShutdownMode.OnMainWindowClose;
             }
 
             base.OnFrameworkInitializationCompleted();
@@ -43,12 +47,32 @@ namespace Ryujinx.Ava
                 ConfigurationState.Instance.Ui.BaseStyle.Event += ThemeChanged_Event;
                 ConfigurationState.Instance.Ui.CustomThemePath.Event += ThemeChanged_Event;
                 ConfigurationState.Instance.Ui.EnableCustomTheme.Event += CustomThemeChanged_Event;
+                ConfigurationState.Instance.Ui.ShowConsole.Event += ShowConsoleChanged_Event;
+
+                if (ConfigurationState.Instance.Ui.ShowConsole.Value)
+                {
+                    _consoleWindow ??= new ConsoleWindow();
+                    _consoleWindow.Show();
+                }
             }
         }
 
         private void CustomThemeChanged_Event(object sender, ReactiveEventArgs<bool> e)
         {
             ApplyConfiguredTheme();
+        }
+
+        private void ShowConsoleChanged_Event(object sender, ReactiveEventArgs<bool> e)
+        {
+            _consoleWindow ??= new ConsoleWindow();
+            if (e.NewValue)
+            {
+                _consoleWindow.Show();
+            }
+            else
+            {
+                _consoleWindow.Hide();
+            }
         }
 
         private void ShowRestartDialog()

--- a/Ryujinx.Ava/Assets/Locales/en_US.json
+++ b/Ryujinx.Ava/Assets/Locales/en_US.json
@@ -609,5 +609,6 @@
   "Search": "Search",
   "UserProfilesRecoverLostAccounts": "Recover Lost Accounts",
   "Recover": "Recover",
-  "UserProfilesRecoverHeading" : "Saves were found for the following accounts"
+  "UserProfilesRecoverHeading" : "Saves were found for the following accounts",
+  "ConsoleWindowAutoScroll" : "Auto-scroll",
 }

--- a/Ryujinx.Ava/Program.cs
+++ b/Ryujinx.Ava/Program.cs
@@ -123,8 +123,6 @@ namespace Ryujinx.Ava
             // Delete backup files after updating.
             Task.Run(Updater.CleanupUpdate);
 
-            Console.Title = $"Ryujinx Console {Version}";
-
             // Hook unhandled exception and process exit events.
             AppDomain.CurrentDomain.UnhandledException += (sender, e) => ProcessUnhandledException(e.ExceptionObject as Exception, e.IsTerminating);
             AppDomain.CurrentDomain.ProcessExit        += (sender, e) => Exit();

--- a/Ryujinx.Ava/Program.cs
+++ b/Ryujinx.Ava/Program.cs
@@ -1,5 +1,6 @@
 using Avalonia;
 using Avalonia.Threading;
+using Ryujinx.Ava.UI.Models;
 using Ryujinx.Ava.UI.Windows;
 using Ryujinx.Common;
 using Ryujinx.Common.Configuration;
@@ -136,6 +137,7 @@ namespace Ryujinx.Ava
 
             // Initialize the logger system.
             LoggerModule.Initialize();
+            InMemoryLogTarget.Register();
 
             // Register mime types on linux.
             if (OperatingSystem.IsLinux())

--- a/Ryujinx.Ava/Ryujinx.Ava.csproj
+++ b/Ryujinx.Ava/Ryujinx.Ava.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <RuntimeIdentifiers>win10-x64;osx-x64;linux-x64</RuntimeIdentifiers>
-    <OutputType>Exe</OutputType>
+    <OutputType>WinExe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Version>1.0.0-dirty</Version>
     <DefineConstants Condition=" '$(ExtraDefineConstants)' != '' ">$(DefineConstants);$(ExtraDefineConstants)</DefineConstants>

--- a/Ryujinx.Ava/UI/Models/InMemoryLogTarget.cs
+++ b/Ryujinx.Ava/UI/Models/InMemoryLogTarget.cs
@@ -4,20 +4,8 @@ using System.Collections.ObjectModel;
 
 namespace Ryujinx.Ava.UI.Models
 {
-    internal class InMemoryLogTarget : ILogTarget
+    class InMemoryLogTarget : ILogTarget
     {
-        internal struct Entry
-        {
-            public Entry(Color color, string text)
-            {
-                Color = color;
-                Text = text;
-            }
-
-            public Color Color { get; }
-            public string Text { get; }
-        }
-
         private static Color GetLogColor(LogLevel level)
         {
             return level switch
@@ -40,7 +28,7 @@ namespace Ryujinx.Ava.UI.Models
 
         private const int MaximumSize = 1000;
 
-        public readonly ObservableCollection<Entry> Entries;
+        public readonly ObservableCollection<InMemoryLogTargetEntry> Entries;
 
         string ILogTarget.Name => _name;
 
@@ -50,7 +38,7 @@ namespace Ryujinx.Ava.UI.Models
         {
             _formatter = new DefaultLogFormatter();
             _name      = name;
-            Entries    = new ObservableCollection<Entry>();
+            Entries    = new ObservableCollection<InMemoryLogTargetEntry>();
         }
 
         public static void Register()
@@ -65,11 +53,11 @@ namespace Ryujinx.Ava.UI.Models
 
         private void AddEntry(Color color, string text)
         {
-            Entries.Insert(0, new Entry(color, text));
+            Entries.Add(new InMemoryLogTargetEntry(color, text));
 
             if (Entries.Count > MaximumSize)
             {
-                Entries.RemoveAt(Entries.Count - 1);
+                Entries.RemoveAt(0);
             }
         }
 

--- a/Ryujinx.Ava/UI/Models/InMemoryLogTarget.cs
+++ b/Ryujinx.Ava/UI/Models/InMemoryLogTarget.cs
@@ -4,41 +4,47 @@ using System.Collections.ObjectModel;
 
 namespace Ryujinx.Ava.UI.Models
 {
-    public class InMemoryLogTarget : ILogTarget
+    internal class InMemoryLogTarget : ILogTarget
     {
-        public class Entry
+        internal struct Entry
         {
-            public Color Color { get; set; }
-            public string Text { get; set; }
+            public Entry(Color color, string text)
+            {
+                Color = color;
+                Text = text;
+            }
+
+            public Color Color { get; }
+            public string Text { get; }
         }
 
-        private static Color GetLogColor(LogLevel level) => level switch {
-            LogLevel.Info    => Colors.White,
-            LogLevel.Warning => Colors.Yellow,
-            LogLevel.Error   => Colors.Red,
-            LogLevel.Stub    => Colors.DarkGray,
-            LogLevel.Notice  => Colors.Cyan,
-            LogLevel.Trace   => Colors.DarkCyan,
-            LogLevel.StdErr  => Colors.Gray,
-            _                => Colors.Gray,
-        };
+        private static Color GetLogColor(LogLevel level)
+        {
+            return level switch
+            {
+                LogLevel.Info    => Colors.White,
+                LogLevel.Warning => Colors.Yellow,
+                LogLevel.Error   => Colors.Red,
+                LogLevel.Stub    => Colors.DarkGray,
+                LogLevel.Notice  => Colors.Cyan,
+                LogLevel.Trace   => Colors.DarkCyan,
+                LogLevel.StdErr  => Colors.Gray,
+                _                => Colors.Gray,
+            };
+        }
 
         private static readonly InMemoryLogTarget _instance = new InMemoryLogTarget("inMemory");
 
         private readonly ILogFormatter _formatter;
         private readonly string _name;
 
-        private const int _maximumSize = 20000;
+        private const int MaximumSize = 20000;
 
-        public ObservableCollection<Entry> Entries;
+        public readonly ObservableCollection<Entry> Entries;
 
-        string ILogTarget.Name { get => _name; }
+        string ILogTarget.Name => _name;
 
         public static InMemoryLogTarget Instance => _instance;
-
-        static InMemoryLogTarget()
-        {
-        }
 
         private InMemoryLogTarget(string name)
         {
@@ -59,13 +65,9 @@ namespace Ryujinx.Ava.UI.Models
 
         private void AddEntry(Color color, string text)
         {
-            Entries.Add(new Entry()
-            {
-                Color = color,
-                Text = text,
-            });
+            Entries.Add(new Entry(color, text));
 
-            if (Entries.Count > _maximumSize)
+            if (Entries.Count > MaximumSize)
             {
                 Entries.RemoveAt(0);
             }

--- a/Ryujinx.Ava/UI/Models/InMemoryLogTarget.cs
+++ b/Ryujinx.Ava/UI/Models/InMemoryLogTarget.cs
@@ -38,7 +38,7 @@ namespace Ryujinx.Ava.UI.Models
         private readonly ILogFormatter _formatter;
         private readonly string _name;
 
-        private const int MaximumSize = 50;
+        private const int MaximumSize = 1000;
 
         public readonly ObservableCollection<Entry> Entries;
 
@@ -65,11 +65,11 @@ namespace Ryujinx.Ava.UI.Models
 
         private void AddEntry(Color color, string text)
         {
-            Entries.Add(new Entry(color, text));
+            Entries.Insert(0, new Entry(color, text));
 
             if (Entries.Count > MaximumSize)
             {
-                Entries.RemoveAt(0);
+                Entries.RemoveAt(Entries.Count - 1);
             }
         }
 

--- a/Ryujinx.Ava/UI/Models/InMemoryLogTarget.cs
+++ b/Ryujinx.Ava/UI/Models/InMemoryLogTarget.cs
@@ -38,7 +38,7 @@ namespace Ryujinx.Ava.UI.Models
         private readonly ILogFormatter _formatter;
         private readonly string _name;
 
-        private const int MaximumSize = 20000;
+        private const int MaximumSize = 50;
 
         public readonly ObservableCollection<Entry> Entries;
 

--- a/Ryujinx.Ava/UI/Models/InMemoryLogTarget.cs
+++ b/Ryujinx.Ava/UI/Models/InMemoryLogTarget.cs
@@ -1,6 +1,5 @@
 using Avalonia.Media;
 using Ryujinx.Common.Logging;
-using System;
 using System.Collections.ObjectModel;
 
 namespace Ryujinx.Ava.UI.Models
@@ -20,14 +19,16 @@ namespace Ryujinx.Ava.UI.Models
             LogLevel.Stub    => Colors.DarkGray,
             LogLevel.Notice  => Colors.Cyan,
             LogLevel.Trace   => Colors.DarkCyan,
+            LogLevel.StdErr  => Colors.Gray,
             _                => Colors.Gray,
         };
 
         private static readonly InMemoryLogTarget _instance = new InMemoryLogTarget("inMemory");
 
-        private static int _maximumSize = 20000;
         private readonly ILogFormatter _formatter;
         private readonly string _name;
+
+        private const int _maximumSize = 20000;
 
         public ObservableCollection<Entry> Entries;
 
@@ -49,15 +50,19 @@ namespace Ryujinx.Ava.UI.Models
         public static void Register()
         {
             Logger.AddTarget(new AsyncLogTargetWrapper(Instance, 1000, AsyncLogTargetOverflowAction.Block));
-            Logger.RemoveTarget("console");
         }
 
         public void Log(object sender, LogEventArgs args)
         {
+            AddEntry(GetLogColor(args.Level), _formatter.Format(args));
+        }
+
+        private void AddEntry(Color color, string text)
+        {
             Entries.Add(new Entry()
             {
-                Color = GetLogColor(args.Level),
-                Text = _formatter.Format(args),
+                Color = color,
+                Text = text,
             });
 
             if (Entries.Count > _maximumSize)

--- a/Ryujinx.Ava/UI/Models/InMemoryLogTarget.cs
+++ b/Ryujinx.Ava/UI/Models/InMemoryLogTarget.cs
@@ -1,0 +1,73 @@
+using Avalonia.Media;
+using Ryujinx.Common.Logging;
+using System;
+using System.Collections.ObjectModel;
+
+namespace Ryujinx.Ava.UI.Models
+{
+    public class InMemoryLogTarget : ILogTarget
+    {
+        public class Entry
+        {
+            public Color Color { get; set; }
+            public string Text { get; set; }
+        }
+
+        private static Color GetLogColor(LogLevel level) => level switch {
+            LogLevel.Info    => Colors.White,
+            LogLevel.Warning => Colors.Yellow,
+            LogLevel.Error   => Colors.Red,
+            LogLevel.Stub    => Colors.DarkGray,
+            LogLevel.Notice  => Colors.Cyan,
+            LogLevel.Trace   => Colors.DarkCyan,
+            _                => Colors.Gray,
+        };
+
+        private static readonly InMemoryLogTarget _instance = new InMemoryLogTarget("inMemory");
+
+        private static int _maximumSize = 20000;
+        private readonly ILogFormatter _formatter;
+        private readonly string _name;
+
+        public ObservableCollection<Entry> Entries;
+
+        string ILogTarget.Name { get => _name; }
+
+        public static InMemoryLogTarget Instance => _instance;
+
+        static InMemoryLogTarget()
+        {
+        }
+
+        private InMemoryLogTarget(string name)
+        {
+            _formatter = new DefaultLogFormatter();
+            _name      = name;
+            Entries    = new ObservableCollection<Entry>();
+        }
+
+        public static void Register()
+        {
+            Logger.AddTarget(new AsyncLogTargetWrapper(Instance, 1000, AsyncLogTargetOverflowAction.Block));
+            Logger.RemoveTarget("console");
+        }
+
+        public void Log(object sender, LogEventArgs args)
+        {
+            Entries.Add(new Entry()
+            {
+                Color = GetLogColor(args.Level),
+                Text = _formatter.Format(args),
+            });
+
+            if (Entries.Count > _maximumSize)
+            {
+                Entries.RemoveAt(0);
+            }
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/Ryujinx.Ava/UI/Models/InMemoryLogTargetEntry.cs
+++ b/Ryujinx.Ava/UI/Models/InMemoryLogTargetEntry.cs
@@ -1,0 +1,16 @@
+using Avalonia.Media;
+
+namespace Ryujinx.Ava.UI.Models
+{
+    struct InMemoryLogTargetEntry
+    {
+        public InMemoryLogTargetEntry(Color color, string text)
+        {
+            Color = color;
+            Text = text;
+        }
+
+        public Color Color { get; }
+        public string Text { get; }
+    }
+}

--- a/Ryujinx.Ava/UI/ViewModels/ConsoleWindowViewModel.cs
+++ b/Ryujinx.Ava/UI/ViewModels/ConsoleWindowViewModel.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.Ava.UI.ViewModels
             _owner = window;
         }
 
-        public ObservableCollection<InMemoryLogTarget.Entry> LogEntries => InMemoryLogTarget.Instance.Entries;
+        public ObservableCollection<InMemoryLogTargetEntry> LogEntries => InMemoryLogTarget.Instance.Entries;
 
         public static void OpenLogsFolder()
         {

--- a/Ryujinx.Ava/UI/ViewModels/ConsoleWindowViewModel.cs
+++ b/Ryujinx.Ava/UI/ViewModels/ConsoleWindowViewModel.cs
@@ -1,0 +1,20 @@
+using Avalonia.Logging;
+using LibHac.Diag;
+using Ryujinx.Ava.UI.Models;
+using Ryujinx.Ava.UI.Windows;
+using System.Collections.ObjectModel;
+
+namespace Ryujinx.Ava.UI.ViewModels
+{
+    internal class ConsoleWindowViewModel : BaseModel
+    {
+        private readonly ConsoleWindow _owner;
+
+        public ConsoleWindowViewModel(ConsoleWindow window)
+        {
+            _owner = window;
+        }
+
+        public ObservableCollection<InMemoryLogTarget.Entry> LogEntries => InMemoryLogTarget.Instance.Entries;
+    }
+}

--- a/Ryujinx.Ava/UI/ViewModels/ConsoleWindowViewModel.cs
+++ b/Ryujinx.Ava/UI/ViewModels/ConsoleWindowViewModel.cs
@@ -1,5 +1,4 @@
-using Avalonia.Logging;
-using LibHac.Diag;
+using Avalonia.Controls.Primitives;
 using Ryujinx.Ava.UI.Models;
 using Ryujinx.Ava.UI.Windows;
 using System.Collections.ObjectModel;
@@ -9,6 +8,7 @@ namespace Ryujinx.Ava.UI.ViewModels
     internal class ConsoleWindowViewModel : BaseModel
     {
         private readonly ConsoleWindow _owner;
+        private bool _autoScroll = true;
 
         public ConsoleWindowViewModel(ConsoleWindow window)
         {
@@ -16,5 +16,26 @@ namespace Ryujinx.Ava.UI.ViewModels
         }
 
         public ObservableCollection<InMemoryLogTarget.Entry> LogEntries => InMemoryLogTarget.Instance.Entries;
+
+        public ScrollBarVisibility ScrollBarVisible
+        {
+            get { return _autoScroll ? ScrollBarVisibility.Hidden : ScrollBarVisibility.Visible; }
+        }
+
+        public bool AutoScroll
+        {
+            get { return _autoScroll; }
+            set
+            {
+                _autoScroll = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(ScrollBarVisible));
+            }
+        }
+
+        public static void OpenLogsFolder()
+        {
+            MainWindowViewModel.OpenLogsFolder();
+        }
     }
 }

--- a/Ryujinx.Ava/UI/ViewModels/ConsoleWindowViewModel.cs
+++ b/Ryujinx.Ava/UI/ViewModels/ConsoleWindowViewModel.cs
@@ -8,7 +8,6 @@ namespace Ryujinx.Ava.UI.ViewModels
     internal class ConsoleWindowViewModel : BaseModel
     {
         private readonly ConsoleWindow _owner;
-        private bool _autoScroll = true;
 
         public ConsoleWindowViewModel(ConsoleWindow window)
         {
@@ -16,22 +15,6 @@ namespace Ryujinx.Ava.UI.ViewModels
         }
 
         public ObservableCollection<InMemoryLogTarget.Entry> LogEntries => InMemoryLogTarget.Instance.Entries;
-
-        public ScrollBarVisibility ScrollBarVisible
-        {
-            get { return _autoScroll ? ScrollBarVisibility.Hidden : ScrollBarVisibility.Visible; }
-        }
-
-        public bool AutoScroll
-        {
-            get { return _autoScroll; }
-            set
-            {
-                _autoScroll = value;
-                OnPropertyChanged();
-                OnPropertyChanged(nameof(ScrollBarVisible));
-            }
-        }
 
         public static void OpenLogsFolder()
         {

--- a/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
+++ b/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
@@ -119,6 +119,8 @@ namespace Ryujinx.Ava.UI.ViewModels
 
                 Volume = ConfigurationState.Instance.System.AudioVolume;
             }
+
+            ConfigurationState.Instance.Ui.ShowConsole.Event += delegate { OnPropertyChanged(nameof(ShowConsole)); };
         }
 
         public void Initialize(
@@ -667,11 +669,6 @@ namespace Ryujinx.Ava.UI.ViewModels
 
                 OnPropertyChanged();
             }
-        }
-
-        public bool ShowConsoleVisible
-        {
-            get => ConsoleHelper.SetConsoleWindowStateSupported;
         }
 
         public ObservableCollection<ApplicationData> Applications

--- a/Ryujinx.Ava/UI/Views/Main/MainMenuBarView.axaml
+++ b/Ryujinx.Ava/UI/Views/Main/MainMenuBarView.axaml
@@ -68,7 +68,7 @@
                         </CheckBox>
                     </MenuItem.Icon>
                 </MenuItem>
-                <MenuItem IsVisible="{Binding ShowConsoleVisible}">
+                <MenuItem>
                     <MenuItem.Icon>
                         <CheckBox IsChecked="{Binding ShowConsole, Mode=TwoWay}"
                                   MinWidth="250">

--- a/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml
+++ b/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml
@@ -7,6 +7,7 @@
     xmlns:viewModels="clr-namespace:Ryujinx.Ava.UI.ViewModels"
     xmlns:window="clr-namespace:Ryujinx.Ava.UI.Windows"
     xmlns:locale="clr-namespace:Ryujinx.Ava.Common.Locale"
+    xmlns:models="clr-namespace:Ryujinx.Ava.UI.Models"
     Title="Ryujinx Console"
     Width="800"
     Height="480"
@@ -20,46 +21,44 @@
     mc:Ignorable="d"
     Focusable="True">
     <Grid>
-        <ListBox
+        <ScrollViewer 
             Grid.Row="0"
             Grid.Column="0"
-            Name="ConsoleListBox"
-            ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-            ScrollViewer.VerticalScrollBarVisibility="Visible"
-            Items="{Binding LogEntries}">
-            <ListBox.RenderTransform>
-                <ScaleTransform ScaleY="-1" />
-            </ListBox.RenderTransform>
-            <ListBox.Styles>
-                <Style Selector="TextBlock">
-                    <Setter Property="FontFamily" Value="Inconsolata, Consolas, Monospace, Courier" />
-                    <Setter Property="TextWrapping" Value="Wrap" />
-                </Style>
-                <Style Selector="ListBoxItem">
-                    <Setter Property="MinHeight" Value="0" />
-                    <Setter Property="RenderTransform">
-                        <Setter.Value>
-                            <ScaleTransform ScaleY="-1" />
-                        </Setter.Value>
-                    </Setter>
-                </Style>
-            </ListBox.Styles>
-            <ListBox.DataTemplates>
-                <DataTemplate>
-                    <TextBlock Text="{Binding Text}">
-                        <TextBlock.Foreground>
-                            <SolidColorBrush Color="{Binding Color}" />
-                        </TextBlock.Foreground>
-                    </TextBlock>
-                </DataTemplate>
-            </ListBox.DataTemplates>
-        </ListBox>
+            Name="ConsoleScrollViewer"
+            HorizontalScrollBarVisibility="Disabled"
+            VerticalScrollBarVisibility="Visible">
+            <ItemsRepeater 
+                Name="ConsoleRepeater"
+                Background="Transparent"
+                Items="{Binding LogEntries}">
+                <ItemsRepeater.Styles>
+                    <Style Selector="TextBlock">
+                        <Setter Property="FontFamily" Value="Inconsolata, Consolas, Monospace, Courier" />
+                        <Setter Property="TextWrapping" Value="Wrap" />
+                    </Style>
+                </ItemsRepeater.Styles>
+                <ItemsRepeater.ItemTemplate>
+                    <DataTemplate x:DataType="models:InMemoryLogTargetEntry">
+                        <TextBlock Text="{Binding Text}">
+                            <TextBlock.Foreground>
+                                <SolidColorBrush Color="{Binding Color}" />
+                            </TextBlock.Foreground>
+                        </TextBlock>
+                    </DataTemplate>
+                </ItemsRepeater.ItemTemplate>
+            </ItemsRepeater>
+        </ScrollViewer>
         <StackPanel
             Grid.Row="0"
             Grid.Column="0"
             VerticalAlignment="Top"
             HorizontalAlignment="Right"
             Background="{DynamicResource ThemeContentBackgroundColor}">
+            <CheckBox
+                HorizontalAlignment="Center"
+                Name="AutoScrollCheckBox"
+                IsChecked="True"
+                Content="{locale:Locale ConsoleWindowAutoScroll}" />
             <Button
                 HorizontalAlignment="Center"
                 Command="{ReflectionBinding OpenLogsFolder}"

--- a/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml
+++ b/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml
@@ -20,43 +20,46 @@
     mc:Ignorable="d"
     Focusable="True">
     <Grid>
-        <ScrollViewer
+        <ListBox
             Grid.Row="0"
             Grid.Column="0"
-            Name="ConsoleScrollViewer"
-            HorizontalScrollBarVisibility="Disabled"
-            VerticalScrollBarVisibility="Visible">
-            <ItemsControl
-                Name="ConsoleItemsControl"
-                Items="{Binding LogEntries}">
-                <ItemsControl.Styles>
-                    <Style Selector="TextBlock">
-                        <Setter Property="FontFamily" Value="Inconsolata, Consolas, Monospace, Courier" />
-                        <Setter Property="TextWrapping" Value="Wrap" />
-                    </Style>
-                </ItemsControl.Styles>
-                <ItemsControl.DataTemplates>
-                    <DataTemplate>
-                        <TextBlock Text="{Binding Text}">
-                            <TextBlock.Foreground>
-                                <SolidColorBrush Color="{Binding Color}" />
-                            </TextBlock.Foreground>
-                        </TextBlock>
-                    </DataTemplate>
-                </ItemsControl.DataTemplates>
-            </ItemsControl>
-        </ScrollViewer>
+            Name="ConsoleListBox"
+            ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+            ScrollViewer.VerticalScrollBarVisibility="Visible"
+            Items="{Binding LogEntries}">
+            <ListBox.RenderTransform>
+                <ScaleTransform ScaleY="-1" />
+            </ListBox.RenderTransform>
+            <ListBox.Styles>
+                <Style Selector="TextBlock">
+                    <Setter Property="FontFamily" Value="Inconsolata, Consolas, Monospace, Courier" />
+                    <Setter Property="TextWrapping" Value="Wrap" />
+                </Style>
+                <Style Selector="ListBoxItem">
+                    <Setter Property="MinHeight" Value="0" />
+                    <Setter Property="RenderTransform">
+                        <Setter.Value>
+                            <ScaleTransform ScaleY="-1" />
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+            </ListBox.Styles>
+            <ListBox.DataTemplates>
+                <DataTemplate>
+                    <TextBlock Text="{Binding Text}">
+                        <TextBlock.Foreground>
+                            <SolidColorBrush Color="{Binding Color}" />
+                        </TextBlock.Foreground>
+                    </TextBlock>
+                </DataTemplate>
+            </ListBox.DataTemplates>
+        </ListBox>
         <StackPanel
             Grid.Row="0"
             Grid.Column="0"
             VerticalAlignment="Top"
             HorizontalAlignment="Right"
             Background="{DynamicResource ThemeContentBackgroundColor}">
-            <CheckBox
-                HorizontalAlignment="Center"
-                Name="AutoScrollCheckBox"
-                IsChecked="True"
-                Content="{locale:Locale ConsoleWindowAutoScroll}" />
             <Button
                 HorizontalAlignment="Center"
                 Command="{ReflectionBinding OpenLogsFolder}"

--- a/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml
+++ b/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml
@@ -25,7 +25,7 @@
             Grid.Column="0"
             Name="ConsoleScrollViewer"
             HorizontalScrollBarVisibility="Disabled"
-            VerticalScrollBarVisibility="{Binding ScrollBarVisible}">
+            VerticalScrollBarVisibility="Visible">
             <ItemsControl
                 Name="ConsoleItemsControl"
                 Items="{Binding LogEntries}">
@@ -55,7 +55,7 @@
             <CheckBox
                 HorizontalAlignment="Center"
                 Name="AutoScrollCheckBox"
-                IsChecked="{Binding AutoScroll}"
+                IsChecked="True"
                 Content="{locale:Locale ConsoleWindowAutoScroll}" />
             <Button
                 HorizontalAlignment="Center"

--- a/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml
+++ b/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml
@@ -6,7 +6,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:viewModels="clr-namespace:Ryujinx.Ava.UI.ViewModels"
     xmlns:window="clr-namespace:Ryujinx.Ava.UI.Windows"
-    xmlns:system="clr-namespace:System;assembly=System.Runtime"
     Title="Ryujinx Console"
     Width="800"
     Height="480"
@@ -24,12 +23,11 @@
             x:Name="ConsoleListBox"
             Items="{Binding LogEntries}"
             ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-            SelectionMode="Multiple"
-            PointerPressed="ConsoleListBox_OnPointerPressed">
+            ScrollViewer.VerticalScrollBarVisibility="Visible"
+            SelectionChanged="ConsoleListBox_OnSelectionChanged">
             <ListBox.Styles>
                 <Style Selector="ListBoxItem">
                     <Setter Property="FontFamily" Value="Inconsolata, Consolas, Monospace, Courier" />
-                    <Setter Property="Margin" Value="0" />
                     <Setter Property="Padding" Value="0" />
                     <Setter Property="MinHeight" Value="0" />
                 </Style>
@@ -37,9 +35,6 @@
             <ListBox.DataTemplates>
                 <DataTemplate>
                     <TextBlock
-                        HorizontalAlignment="Stretch"
-                        PointerEnter="InputElement_OnPointerEnter"
-                        PointerPressed="InputElement_OnPointerPressed"
                         Text="{Binding Text}"
                         TextWrapping="Wrap">
                         <TextBlock.Foreground>

--- a/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml
+++ b/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml
@@ -18,31 +18,48 @@
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d"
     Focusable="True">
-    <DockPanel>
-        <ListBox
-            x:Name="ConsoleListBox"
-            Items="{Binding LogEntries}"
-            ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-            ScrollViewer.VerticalScrollBarVisibility="Visible"
-            SelectionChanged="ConsoleListBox_OnSelectionChanged">
-            <ListBox.Styles>
-                <Style Selector="ListBoxItem">
-                    <Setter Property="FontFamily" Value="Inconsolata, Consolas, Monospace, Courier" />
-                    <Setter Property="Padding" Value="0" />
-                    <Setter Property="MinHeight" Value="0" />
-                </Style>
-            </ListBox.Styles>
-            <ListBox.DataTemplates>
-                <DataTemplate>
-                    <TextBlock
-                        Text="{Binding Text}"
-                        TextWrapping="Wrap">
-                        <TextBlock.Foreground>
-                            <SolidColorBrush Color="{Binding Color}" />
-                        </TextBlock.Foreground>
-                    </TextBlock>
-                </DataTemplate>
-            </ListBox.DataTemplates>
-        </ListBox>
-    </DockPanel>
+    <Grid>
+        <ScrollViewer
+            Grid.Row="0"
+            Grid.Column="0"
+            Name="ConsoleScrollViewer"
+            HorizontalScrollBarVisibility="Disabled"
+            VerticalScrollBarVisibility="{Binding ScrollBarVisible}">
+            <ItemsControl
+                Name="ConsoleItemsControl"
+                Items="{Binding LogEntries}">
+                <ItemsControl.Styles>
+                    <Style Selector="TextBlock">
+                        <Setter Property="FontFamily" Value="Inconsolata, Consolas, Monospace, Courier" />
+                        <Setter Property="TextWrapping" Value="Wrap" />
+                    </Style>
+                </ItemsControl.Styles>
+                <ItemsControl.DataTemplates>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Text}">
+                            <TextBlock.Foreground>
+                                <SolidColorBrush Color="{Binding Color}" />
+                            </TextBlock.Foreground>
+                        </TextBlock>
+                    </DataTemplate>
+                </ItemsControl.DataTemplates>
+            </ItemsControl>
+        </ScrollViewer>
+        <StackPanel
+            Grid.Row="0"
+            Grid.Column="0"
+            VerticalAlignment="Top"
+            HorizontalAlignment="Right"
+            Background="{DynamicResource ThemeContentBackgroundColor}">
+            <CheckBox
+                HorizontalAlignment="Center"
+                Name="AutoScrollCheckBox"
+                IsChecked="{Binding AutoScroll}"
+                Content="Auto-scroll" />
+            <Button
+                HorizontalAlignment="Center"
+                Command="{ReflectionBinding OpenLogsFolder}"
+                Content="Open Logs" />
+        </StackPanel>
+    </Grid>
 </window:StyleableWindow>

--- a/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml
+++ b/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml
@@ -6,6 +6,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:viewModels="clr-namespace:Ryujinx.Ava.UI.ViewModels"
     xmlns:window="clr-namespace:Ryujinx.Ava.UI.Windows"
+    xmlns:locale="clr-namespace:Ryujinx.Ava.Common.Locale"
     Title="Ryujinx Console"
     Width="800"
     Height="480"
@@ -55,11 +56,11 @@
                 HorizontalAlignment="Center"
                 Name="AutoScrollCheckBox"
                 IsChecked="{Binding AutoScroll}"
-                Content="Auto-scroll" />
+                Content="{locale:Locale ConsoleWindowAutoScroll}" />
             <Button
                 HorizontalAlignment="Center"
                 Command="{ReflectionBinding OpenLogsFolder}"
-                Content="Open Logs" />
+                Content="{locale:Locale MenuBarFileOpenLogsFolder}" />
         </StackPanel>
     </Grid>
 </window:StyleableWindow>

--- a/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml
+++ b/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml
@@ -1,0 +1,53 @@
+<window:StyleableWindow
+    x:Class="Ryujinx.Ava.UI.Windows.ConsoleWindow"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:viewModels="clr-namespace:Ryujinx.Ava.UI.ViewModels"
+    xmlns:window="clr-namespace:Ryujinx.Ava.UI.Windows"
+    xmlns:system="clr-namespace:System;assembly=System.Runtime"
+    Title="Ryujinx Console"
+    Width="800"
+    Height="480"
+    MinWidth="400"
+    MinHeight="400"
+    d:DesignWidth="800"
+    d:DesignHeight="480"
+    x:CompileBindings="True"
+    x:DataType="viewModels:ConsoleWindowViewModel"
+    WindowStartupLocation="CenterScreen"
+    mc:Ignorable="d"
+    Focusable="True">
+    <DockPanel>
+        <ListBox
+            x:Name="ConsoleListBox"
+            Items="{Binding LogEntries}"
+            ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+            SelectionMode="Multiple"
+            PointerPressed="ConsoleListBox_OnPointerPressed">
+            <ListBox.Styles>
+                <Style Selector="ListBoxItem">
+                    <Setter Property="FontFamily" Value="Inconsolata, Consolas, Monospace, Courier" />
+                    <Setter Property="Margin" Value="0" />
+                    <Setter Property="Padding" Value="0" />
+                    <Setter Property="MinHeight" Value="0" />
+                </Style>
+            </ListBox.Styles>
+            <ListBox.DataTemplates>
+                <DataTemplate>
+                    <TextBlock
+                        HorizontalAlignment="Stretch"
+                        PointerEnter="InputElement_OnPointerEnter"
+                        PointerPressed="InputElement_OnPointerPressed"
+                        Text="{Binding Text}"
+                        TextWrapping="Wrap">
+                        <TextBlock.Foreground>
+                            <SolidColorBrush Color="{Binding Color}" />
+                        </TextBlock.Foreground>
+                    </TextBlock>
+                </DataTemplate>
+            </ListBox.DataTemplates>
+        </ListBox>
+    </DockPanel>
+</window:StyleableWindow>

--- a/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml.cs
+++ b/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml.cs
@@ -1,6 +1,12 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
 using Ryujinx.Ava.UI.ViewModels;
 using Ryujinx.Ui.Common.Configuration;
+using System;
 using System.ComponentModel;
+using System.Threading.Tasks;
 
 namespace Ryujinx.Ava.UI.Windows
 {
@@ -17,6 +23,28 @@ namespace Ryujinx.Ava.UI.Windows
             InitializeComponent();
 
             Title = $"Ryujinx Console {Program.Version}";
+
+            ConsoleScrollViewer.ScrollChanged += ConsoleScrollViewerOnScrollChanged;
+            AutoScrollCheckBox.Checked += delegate { MaybeScrollToBottom(); };
+        }
+
+        private void ConsoleScrollViewerOnScrollChanged(object sender, ScrollChangedEventArgs e)
+        {
+            if (e.ExtentDelta != Vector.Zero)
+            {
+                MaybeScrollToBottom();
+            }
+        }
+
+        private void MaybeScrollToBottom()
+        {
+            if (AutoScrollCheckBox.IsChecked == true)
+            {
+                Dispatcher.UIThread.Post(delegate
+                {
+                    ConsoleScrollViewer.ScrollToEnd();
+                });
+            }
         }
 
         protected override void OnClosing(CancelEventArgs e)

--- a/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml.cs
+++ b/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml.cs
@@ -1,11 +1,17 @@
+using Avalonia.Interactivity;
 using Ryujinx.Ava.UI.ViewModels;
 using Ryujinx.Ui.Common.Configuration;
+using System;
+using System.Collections.Specialized;
 using System.ComponentModel;
 
 namespace Ryujinx.Ava.UI.Windows
 {
     public partial class ConsoleWindow : StyleableWindow
     {
+        private int changeCount = 0;
+        private int autoScrollChangeCount = 0;
+
         private static ConsoleWindowViewModel ConsoleWindowViewModel { get; set; }
 
         public ConsoleWindow()
@@ -16,14 +22,29 @@ namespace Ryujinx.Ava.UI.Windows
 
             InitializeComponent();
 
-            ConsoleScrollViewer.ScrollChanged += OnScrollChanged;
-            AutoScrollCheckBox.Checked += OnScrollChanged;
+            ConsoleWindowViewModel.LogEntries.CollectionChanged += LogEntriesOnCollectionChanged;
+            AutoScrollCheckBox.Checked += AutoScrollCheckBoxOnChecked;
+            ConsoleItemsControl.LayoutUpdated += ConsoleItemsControlOnLayoutUpdated;
         }
 
-        private void OnScrollChanged(object sender, object e)
+        private void LogEntriesOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            changeCount++;
+        }
+
+        private void AutoScrollCheckBoxOnChecked(object sender, RoutedEventArgs e)
         {
             if (AutoScrollCheckBox.IsChecked == true)
             {
+                ConsoleScrollViewer.ScrollToEnd();
+            }
+        }
+
+        private void ConsoleItemsControlOnLayoutUpdated(object sender, EventArgs e)
+        {
+            if (AutoScrollCheckBox.IsChecked == true && autoScrollChangeCount != changeCount)
+            {
+                autoScrollChangeCount = changeCount;
                 ConsoleScrollViewer.ScrollToEnd();
             }
         }

--- a/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml.cs
+++ b/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml.cs
@@ -22,6 +22,8 @@ namespace Ryujinx.Ava.UI.Windows
 
             InitializeComponent();
 
+            Title = $"Ryujinx Console {Program.Version}";
+
             ConsoleWindowViewModel.LogEntries.CollectionChanged += LogEntriesOnCollectionChanged;
             AutoScrollCheckBox.Checked += AutoScrollCheckBoxOnChecked;
             ConsoleItemsControl.LayoutUpdated += ConsoleItemsControlOnLayoutUpdated;

--- a/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml.cs
+++ b/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml.cs
@@ -1,0 +1,66 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Logging;
+using Ryujinx.Ava.UI.Models;
+using Ryujinx.Ava.UI.ViewModels;
+using Ryujinx.Ui.Common.Configuration;
+using SixLabors.ImageSharp;
+using System;
+using System.ComponentModel;
+
+namespace Ryujinx.Ava.UI.Windows
+{
+    public partial class ConsoleWindow : StyleableWindow
+    {
+        internal static ConsoleWindowViewModel ConsoleWindowViewModel { get; private set; }
+
+        public ConsoleWindow()
+        {
+            ConsoleWindowViewModel = new ConsoleWindowViewModel(this);
+
+            DataContext = ConsoleWindowViewModel;
+
+            InitializeComponent();
+        }
+
+        private void InputElement_OnPointerEnter(object? sender, PointerEventArgs e)
+        {
+            if (e.GetCurrentPoint(null).Properties.IsLeftButtonPressed)
+            {
+                ListBoxItem lbi = (sender as TextBlock)?.Parent as ListBoxItem;
+                ListBox lb = lbi.Parent as ListBox;
+                lb.SelectedItems.Add((sender as TextBlock)?.DataContext);
+                e.Pointer.Capture(null);
+                e.Handled = true;
+            }
+        }
+
+        private void InputElement_OnPointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            if (e.GetCurrentPoint(null).Properties.IsLeftButtonPressed)
+            {
+                ListBoxItem lbi = (sender as TextBlock)?.Parent as ListBoxItem;
+                ListBox lb = lbi.Parent as ListBox;
+                lb.SelectedItems.Clear();
+                lb.SelectedItems.Add((sender as TextBlock)?.DataContext);
+                e.Pointer.Capture(null);
+                e.Handled = true;
+            }
+        }
+
+        private void ConsoleListBox_OnPointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            e.Handled = true;
+        }
+
+        protected override void OnClosing(CancelEventArgs e)
+        {
+            Hide();
+            e.Cancel = true;
+            ConfigurationState.Instance.Ui.ShowConsole.Value = false;
+
+            base.OnClosing(e);
+        }
+    }
+}

--- a/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml.cs
+++ b/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml.cs
@@ -1,17 +1,11 @@
-using Avalonia.Interactivity;
 using Ryujinx.Ava.UI.ViewModels;
 using Ryujinx.Ui.Common.Configuration;
-using System;
-using System.Collections.Specialized;
 using System.ComponentModel;
 
 namespace Ryujinx.Ava.UI.Windows
 {
     public partial class ConsoleWindow : StyleableWindow
     {
-        private int changeCount = 0;
-        private int autoScrollChangeCount = 0;
-
         private static ConsoleWindowViewModel ConsoleWindowViewModel { get; set; }
 
         public ConsoleWindow()
@@ -23,32 +17,6 @@ namespace Ryujinx.Ava.UI.Windows
             InitializeComponent();
 
             Title = $"Ryujinx Console {Program.Version}";
-
-            ConsoleWindowViewModel.LogEntries.CollectionChanged += LogEntriesOnCollectionChanged;
-            AutoScrollCheckBox.Checked += AutoScrollCheckBoxOnChecked;
-            ConsoleItemsControl.LayoutUpdated += ConsoleItemsControlOnLayoutUpdated;
-        }
-
-        private void LogEntriesOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-        {
-            changeCount++;
-        }
-
-        private void AutoScrollCheckBoxOnChecked(object sender, RoutedEventArgs e)
-        {
-            if (AutoScrollCheckBox.IsChecked == true)
-            {
-                ConsoleScrollViewer.ScrollToEnd();
-            }
-        }
-
-        private void ConsoleItemsControlOnLayoutUpdated(object sender, EventArgs e)
-        {
-            if (AutoScrollCheckBox.IsChecked == true && autoScrollChangeCount != changeCount)
-            {
-                autoScrollChangeCount = changeCount;
-                ConsoleScrollViewer.ScrollToEnd();
-            }
         }
 
         protected override void OnClosing(CancelEventArgs e)

--- a/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml.cs
+++ b/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml.cs
@@ -24,36 +24,6 @@ namespace Ryujinx.Ava.UI.Windows
             InitializeComponent();
         }
 
-        private void InputElement_OnPointerEnter(object? sender, PointerEventArgs e)
-        {
-            if (e.GetCurrentPoint(null).Properties.IsLeftButtonPressed)
-            {
-                ListBoxItem lbi = (sender as TextBlock)?.Parent as ListBoxItem;
-                ListBox lb = lbi.Parent as ListBox;
-                lb.SelectedItems.Add((sender as TextBlock)?.DataContext);
-                e.Pointer.Capture(null);
-                e.Handled = true;
-            }
-        }
-
-        private void InputElement_OnPointerPressed(object? sender, PointerPressedEventArgs e)
-        {
-            if (e.GetCurrentPoint(null).Properties.IsLeftButtonPressed)
-            {
-                ListBoxItem lbi = (sender as TextBlock)?.Parent as ListBoxItem;
-                ListBox lb = lbi.Parent as ListBox;
-                lb.SelectedItems.Clear();
-                lb.SelectedItems.Add((sender as TextBlock)?.DataContext);
-                e.Pointer.Capture(null);
-                e.Handled = true;
-            }
-        }
-
-        private void ConsoleListBox_OnPointerPressed(object? sender, PointerPressedEventArgs e)
-        {
-            e.Handled = true;
-        }
-
         protected override void OnClosing(CancelEventArgs e)
         {
             Hide();
@@ -61,6 +31,19 @@ namespace Ryujinx.Ava.UI.Windows
             ConfigurationState.Instance.Ui.ShowConsole.Value = false;
 
             base.OnClosing(e);
+        }
+
+        private void ConsoleListBox_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (sender is ListBox listBox)
+            {
+                if (listBox.Selection.Count > 0)
+                {
+                    string text = ((InMemoryLogTarget.Entry)listBox.SelectedItem).Text;
+                    Application.Current.Clipboard.SetTextAsync(text).Wait();
+                    listBox.Selection.Clear();
+                }
+            }
         }
     }
 }

--- a/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml.cs
+++ b/Ryujinx.Ava/UI/Windows/ConsoleWindow.axaml.cs
@@ -1,19 +1,12 @@
-using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Input;
-using Avalonia.Logging;
-using Ryujinx.Ava.UI.Models;
 using Ryujinx.Ava.UI.ViewModels;
 using Ryujinx.Ui.Common.Configuration;
-using SixLabors.ImageSharp;
-using System;
 using System.ComponentModel;
 
 namespace Ryujinx.Ava.UI.Windows
 {
     public partial class ConsoleWindow : StyleableWindow
     {
-        internal static ConsoleWindowViewModel ConsoleWindowViewModel { get; private set; }
+        private static ConsoleWindowViewModel ConsoleWindowViewModel { get; set; }
 
         public ConsoleWindow()
         {
@@ -22,6 +15,17 @@ namespace Ryujinx.Ava.UI.Windows
             DataContext = ConsoleWindowViewModel;
 
             InitializeComponent();
+
+            ConsoleScrollViewer.ScrollChanged += OnScrollChanged;
+            AutoScrollCheckBox.Checked += OnScrollChanged;
+        }
+
+        private void OnScrollChanged(object sender, object e)
+        {
+            if (AutoScrollCheckBox.IsChecked == true)
+            {
+                ConsoleScrollViewer.ScrollToEnd();
+            }
         }
 
         protected override void OnClosing(CancelEventArgs e)
@@ -31,19 +35,6 @@ namespace Ryujinx.Ava.UI.Windows
             ConfigurationState.Instance.Ui.ShowConsole.Value = false;
 
             base.OnClosing(e);
-        }
-
-        private void ConsoleListBox_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
-        {
-            if (sender is ListBox listBox)
-            {
-                if (listBox.Selection.Count > 0)
-                {
-                    string text = ((InMemoryLogTarget.Entry)listBox.SelectedItem).Text;
-                    Application.Current.Clipboard.SetTextAsync(text).Wait();
-                    listBox.Selection.Clear();
-                }
-            }
         }
     }
 }

--- a/Ryujinx.Ava/UI/Windows/MainWindow.axaml
+++ b/Ryujinx.Ava/UI/Windows/MainWindow.axaml
@@ -67,7 +67,7 @@
                 VerticalAlignment="Stretch"
                 IsVisible="{Binding ShowMenuAndStatusBar}"
                 Orientation="Vertical">
-                <main:MainMenuBarView 
+                <main:MainMenuBarView
                     Name="MenuBarView" />
             </StackPanel>
             <ContentControl
@@ -197,7 +197,7 @@
                     </Grid>
                 </Grid>
             </Grid>
-            <main:MainStatusBarView 
+            <main:MainStatusBarView
                 Name="StatusBarView"
                 Grid.Row="2" />
         </Grid>

--- a/Ryujinx.Common/Logging/Formatters/DefaultLogFormatter.cs
+++ b/Ryujinx.Common/Logging/Formatters/DefaultLogFormatter.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace Ryujinx.Common.Logging
 {
-    internal class DefaultLogFormatter : ILogFormatter
+    public class DefaultLogFormatter : ILogFormatter
     {
         private static readonly ObjectPool<StringBuilder> _stringBuilderPool = SharedPools.Default<StringBuilder>();
 

--- a/Ryujinx.Common/Logging/Formatters/ILogFormatter.cs
+++ b/Ryujinx.Common/Logging/Formatters/ILogFormatter.cs
@@ -1,6 +1,6 @@
 ﻿namespace Ryujinx.Common.Logging
 {
-    interface ILogFormatter
+    public interface ILogFormatter
     {
         string Format(LogEventArgs args);
     }

--- a/Ryujinx.Common/Logging/LogLevel.cs
+++ b/Ryujinx.Common/Logging/LogLevel.cs
@@ -10,6 +10,7 @@ namespace Ryujinx.Common.Logging
         Guest,
         AccessLog,
         Notice,
-        Trace
+        Trace,
+        StdErr,
     }
 }

--- a/Ryujinx.Common/Logging/Logger.cs
+++ b/Ryujinx.Common/Logging/Logger.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.Common.Logging
 
         private static readonly List<ILogTarget> m_LogTargets;
 
-        private static readonly StdErrAdapter m_stdErrAdapter;
+        private static readonly StdErrAdapter _mStdErrAdapter;
 
         public static event EventHandler<LogEventArgs> Updated;
 
@@ -131,7 +131,7 @@ namespace Ryujinx.Common.Logging
             Info = new Log(LogLevel.Info);
             Trace = new Log(LogLevel.Trace);
 
-            m_stdErrAdapter = new StdErrAdapter();
+            _mStdErrAdapter = new StdErrAdapter();
         }
 
         public static void RestartTime()
@@ -177,7 +177,7 @@ namespace Ryujinx.Common.Logging
         {
             Updated = null;
 
-            m_stdErrAdapter.Dispose();
+            _mStdErrAdapter.Dispose();
 
             foreach (var target in m_LogTargets)
             {

--- a/Ryujinx.Common/Logging/Targets/ConsoleLogTarget.cs
+++ b/Ryujinx.Common/Logging/Targets/ConsoleLogTarget.cs
@@ -17,6 +17,7 @@ namespace Ryujinx.Common.Logging
             LogLevel.Stub    => ConsoleColor.DarkGray,
             LogLevel.Notice  => ConsoleColor.Cyan,
             LogLevel.Trace   => ConsoleColor.DarkCyan,
+            LogLevel.StdErr  => ConsoleColor.Gray,
             _                => ConsoleColor.Gray,
         };
 

--- a/Ryujinx.Common/Ryujinx.Common.csproj
+++ b/Ryujinx.Common/Ryujinx.Common.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Mono.Unix" />
     <PackageReference Include="MsgPack.Cli" />
     <PackageReference Include="System.Management" />
   </ItemGroup>

--- a/Ryujinx.Common/SystemInterop/StdErrAdapter.cs
+++ b/Ryujinx.Common/SystemInterop/StdErrAdapter.cs
@@ -1,0 +1,67 @@
+using System;
+using System.IO;
+using System.Runtime.Versioning;
+using System.Threading;
+using Mono.Unix;
+using Ryujinx.Common.Logging;
+
+namespace Ryujinx.Common.SystemInterop
+{
+    public class StdErrAdapter : IDisposable
+    {
+        private bool _disposable = false;
+        private UnixPipes _stdErrPipe;
+        private Thread _worker;
+
+        public StdErrAdapter()
+        {
+            if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
+            {
+                RegisterPosix();
+            }
+        }
+
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macos")]
+        private void RegisterPosix()
+        {
+            const int stdErrFileno = 2;
+
+            _stdErrPipe = UnixPipes.CreatePipes();
+            Mono.Unix.Native.Syscall.dup2(_stdErrPipe.Writing.Handle, stdErrFileno);
+            _worker = new Thread(EventWorker);
+            _disposable = true;
+            _worker.Start();
+        }
+
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macos")]
+        private void EventWorker()
+        {
+            TextReader reader = new StreamReader(_stdErrPipe.Reading);
+            string line;
+            while ((line = reader.ReadLine()) != null)
+            {
+                Logger.StdErr.PrintRawMsg(line);
+            }
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposable)
+            {
+                _stdErrPipe.Reading.Close();
+                _stdErrPipe.Writing.Close();
+                _stdErrPipe.Reading.Dispose();
+                _stdErrPipe.Writing.Dispose();
+
+                _disposable = false;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+    }
+}

--- a/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
+++ b/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
@@ -6,7 +6,6 @@ using Ryujinx.Common.Configuration.Hid.Keyboard;
 using Ryujinx.Common.Logging;
 using Ryujinx.Ui.Common.Configuration.System;
 using Ryujinx.Ui.Common.Configuration.Ui;
-using Ryujinx.Ui.Common.Helper;
 using System;
 using System.Collections.Generic;
 
@@ -145,7 +144,6 @@ namespace Ryujinx.Ui.Common.Configuration
                 IsAscendingOrder  = new ReactiveObject<bool>();
                 LanguageCode      = new ReactiveObject<string>();
                 ShowConsole       = new ReactiveObject<bool>();
-                ShowConsole.Event += static (s, e) => { ConsoleHelper.SetConsoleWindowState(e.NewValue); };
             }
         }
 

--- a/Ryujinx/Ui/MainWindow.cs
+++ b/Ryujinx/Ui/MainWindow.cs
@@ -214,6 +214,7 @@ namespace Ryujinx.Ui
             }
 
             _showConsole.Active = ConfigurationState.Instance.Ui.ShowConsole.Value;
+            ConsoleHelper.SetConsoleWindowState(_showConsole.Active);
             _showConsole.Visible = ConsoleHelper.SetConsoleWindowStateSupported;
 
             _actionMenu.Sensitive = false;
@@ -1545,6 +1546,8 @@ namespace Ryujinx.Ui
         private void ShowConsole_Toggled(object sender, EventArgs args)
         {
             ConfigurationState.Instance.Ui.ShowConsole.Value = _showConsole.Active;
+
+            ConsoleHelper.SetConsoleWindowState(_showConsole.Active);
 
             SaveConfig();
         }


### PR DESCRIPTION
<img width="912" alt="image" src="https://user-images.githubusercontent.com/8682882/211173408-0d772d0e-17d4-4030-bd0f-4a1ef4adee19.png">

Auto-scroll keeps scroll locked to end.
Open Logs open the logs folder for easy copying of logs.

Linked to Show Console configuration option:
<img width="266" alt="image" src="https://user-images.githubusercontent.com/8682882/211173412-cb15d409-436b-4771-b1eb-144171efd47f.png">

Note: I attempted to also capture stdout for mvk, but unfortunately the simple implementation using Console.SetOut/Console.SetError didn't work.