### PR TITLE
Relax Vulkan requirements

### DIFF
--- a/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
+++ b/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
@@ -23,7 +23,7 @@ namespace Ryujinx.Graphics.Vulkan
         public int[] AttachmentIndices { get; }
 
         public int AttachmentsCount { get; }
-        public int MaxColorAttachmentIndex { get; }
+        public int MaxColorAttachmentIndex => AttachmentIndices.Length > 0 ? AttachmentIndices[AttachmentIndices.Length - 1] : -1;
         public bool HasDepthStencil { get; }
         public int ColorAttachmentsCount => AttachmentsCount - (HasDepthStencil ? 1 : 0);
 
@@ -67,7 +67,6 @@ namespace Ryujinx.Graphics.Vulkan
             AttachmentSamples = new uint[count];
             AttachmentFormats = new VkFormat[count];
             AttachmentIndices = new int[count];
-            MaxColorAttachmentIndex = colors.Length - 1;
 
             uint width = uint.MaxValue;
             uint height = uint.MaxValue;

--- a/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -1344,8 +1344,7 @@ namespace Ryujinx.Graphics.Vulkan
             var dstAttachmentFormats = _newState.Internal.AttachmentFormats.AsSpan();
             FramebufferParams.AttachmentFormats.CopyTo(dstAttachmentFormats);
 
-            int maxAttachmentIndex = FramebufferParams.MaxColorAttachmentIndex + (FramebufferParams.HasDepthStencil ? 1 : 0);
-            for (int i = FramebufferParams.AttachmentFormats.Length; i <= maxAttachmentIndex; i++)
+            for (int i = FramebufferParams.AttachmentFormats.Length; i < dstAttachmentFormats.Length; i++)
             {
                 dstAttachmentFormats[i] = 0;
             }

--- a/Ryujinx.Graphics.Vulkan/Vendor.cs
+++ b/Ryujinx.Graphics.Vulkan/Vendor.cs
@@ -9,6 +9,7 @@ namespace Ryujinx.Graphics.Vulkan
         Intel,
         Nvidia,
         ARM,
+        Broadcom,
         Qualcomm,
         Apple,
         Unknown
@@ -28,6 +29,7 @@ namespace Ryujinx.Graphics.Vulkan
                 0x106B => Vendor.Apple,
                 0x10DE => Vendor.Nvidia,
                 0x13B5 => Vendor.ARM,
+                0x14E4 => Vendor.Broadcom,
                 0x8086 => Vendor.Intel,
                 0x5143 => Vendor.Qualcomm,
                 _ => Vendor.Unknown
@@ -43,6 +45,7 @@ namespace Ryujinx.Graphics.Vulkan
                 0x106B => "Apple",
                 0x10DE => "NVIDIA",
                 0x13B5 => "ARM",
+                0x14E4 => "Broadcom",
                 0x1AE0 => "Google",
                 0x5143 => "Qualcomm",
                 0x8086 => "Intel",

--- a/Ryujinx.Graphics.Vulkan/VulkanInitialization.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanInitialization.cs
@@ -162,7 +162,6 @@ namespace Ryujinx.Graphics.Vulkan
             if (messageSeverity.HasFlag(DebugUtilsMessageSeverityFlagsEXT.ErrorBitExt))
             {
                 Logger.Error?.Print(LogClass.Gpu, msg);
-                //throw new Exception(msg);
             }
             else if (messageSeverity.HasFlag(DebugUtilsMessageSeverityFlagsEXT.WarningBitExt))
             {
@@ -379,14 +378,34 @@ namespace Ryujinx.Graphics.Vulkan
                 SType = StructureType.PhysicalDeviceFeatures2
             };
 
-            PhysicalDeviceCustomBorderColorFeaturesEXT featuresCustomBorderColorSupported = new PhysicalDeviceCustomBorderColorFeaturesEXT()
+            PhysicalDeviceVulkan11Features supportedFeaturesVk11 = new PhysicalDeviceVulkan11Features()
             {
-                SType = StructureType.PhysicalDeviceCustomBorderColorFeaturesExt
+                SType = StructureType.PhysicalDeviceVulkan11Features,
+                PNext = features2.PNext
+            };
+
+            features2.PNext = &supportedFeaturesVk11;
+
+            PhysicalDeviceCustomBorderColorFeaturesEXT supportedFeaturesCustomBorderColor = new PhysicalDeviceCustomBorderColorFeaturesEXT()
+            {
+                SType = StructureType.PhysicalDeviceCustomBorderColorFeaturesExt,
+                PNext = features2.PNext
             };
 
             if (supportedExtensions.Contains("VK_EXT_custom_border_color"))
             {
-                features2.PNext = &featuresCustomBorderColorSupported;
+                features2.PNext = &supportedFeaturesCustomBorderColor;
+            }
+
+            PhysicalDeviceTransformFeedbackFeaturesEXT supportedFeaturesTransformFeedback = new PhysicalDeviceTransformFeedbackFeaturesEXT()
+            {
+                SType = StructureType.PhysicalDeviceTransformFeedbackFeaturesExt,
+                PNext = features2.PNext
+            };
+
+            if (supportedExtensions.Contains(ExtTransformFeedback.ExtensionName))
+            {
+                features2.PNext = &supportedFeaturesTransformFeedback;
             }
 
             PhysicalDeviceRobustness2FeaturesEXT supportedFeaturesRobustness2 = new PhysicalDeviceRobustness2FeaturesEXT()
@@ -408,41 +427,48 @@ namespace Ryujinx.Graphics.Vulkan
             var features = new PhysicalDeviceFeatures()
             {
                 DepthBiasClamp = true,
-                DepthClamp = true,
-                DualSrcBlend = true,
+                DepthClamp = supportedFeatures.DepthClamp,
+                DualSrcBlend = supportedFeatures.DualSrcBlend,
                 FragmentStoresAndAtomics = true,
                 GeometryShader = supportedFeatures.GeometryShader,
                 ImageCubeArray = true,
                 IndependentBlend = true,
                 LogicOp = supportedFeatures.LogicOp,
-                MultiViewport = true,
+                MultiViewport = supportedFeatures.MultiViewport,
                 PipelineStatisticsQuery = supportedFeatures.PipelineStatisticsQuery,
                 SamplerAnisotropy = true,
                 ShaderClipDistance = true,
                 ShaderFloat64 = supportedFeatures.ShaderFloat64,
-                ShaderImageGatherExtended = true,
+                ShaderImageGatherExtended = supportedFeatures.ShaderImageGatherExtended,
                 ShaderStorageImageMultisample = supportedFeatures.ShaderStorageImageMultisample,
                 // ShaderStorageImageReadWithoutFormat = true,
                 // ShaderStorageImageWriteWithoutFormat = true,
-                TessellationShader = true,
+                TessellationShader = supportedFeatures.TessellationShader,
                 VertexPipelineStoresAndAtomics = true,
                 RobustBufferAccess = useRobustBufferAccess
             };
 
             void* pExtendedFeatures = null;
 
-            var featuresTransformFeedback = new PhysicalDeviceTransformFeedbackFeaturesEXT()
-            {
-                SType = StructureType.PhysicalDeviceTransformFeedbackFeaturesExt,
-                PNext = pExtendedFeatures,
-                TransformFeedback = true
-            };
+            PhysicalDeviceTransformFeedbackFeaturesEXT featuresTransformFeedback;
 
-            pExtendedFeatures = &featuresTransformFeedback;
+            if (supportedExtensions.Contains(ExtTransformFeedback.ExtensionName))
+            {
+                featuresTransformFeedback = new PhysicalDeviceTransformFeedbackFeaturesEXT()
+                {
+                    SType = StructureType.PhysicalDeviceTransformFeedbackFeaturesExt,
+                    PNext = pExtendedFeatures,
+                    TransformFeedback = supportedFeaturesTransformFeedback.TransformFeedback
+                };
+
+                pExtendedFeatures = &featuresTransformFeedback;
+            }
+
+            PhysicalDeviceRobustness2FeaturesEXT featuresRobustness2;
 
             if (supportedExtensions.Contains("VK_EXT_robustness2"))
             {
-                var featuresRobustness2 = new PhysicalDeviceRobustness2FeaturesEXT()
+                featuresRobustness2 = new PhysicalDeviceRobustness2FeaturesEXT()
                 {
                     SType = StructureType.PhysicalDeviceRobustness2FeaturesExt,
                     PNext = pExtendedFeatures,
@@ -465,7 +491,7 @@ namespace Ryujinx.Graphics.Vulkan
             {
                 SType = StructureType.PhysicalDeviceVulkan11Features,
                 PNext = pExtendedFeatures,
-                ShaderDrawParameters = true
+                ShaderDrawParameters = supportedFeaturesVk11.ShaderDrawParameters
             };
 
             pExtendedFeatures = &featuresVk11;
@@ -526,8 +552,8 @@ namespace Ryujinx.Graphics.Vulkan
             PhysicalDeviceCustomBorderColorFeaturesEXT featuresCustomBorderColor;
 
             if (supportedExtensions.Contains("VK_EXT_custom_border_color") &&
-                featuresCustomBorderColorSupported.CustomBorderColors &&
-                featuresCustomBorderColorSupported.CustomBorderColorWithoutFormat)
+                supportedFeaturesCustomBorderColor.CustomBorderColors &&
+                supportedFeaturesCustomBorderColor.CustomBorderColorWithoutFormat)
             {
                 featuresCustomBorderColor = new PhysicalDeviceCustomBorderColorFeaturesEXT()
                 {

--- a/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -590,7 +590,11 @@ namespace Ryujinx.Graphics.Vulkan
 
             IsAmdWindows = Vendor == Vendor.Amd && RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             IsIntelWindows = Vendor == Vendor.Intel && RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-            IsTBDR = IsMoltenVk || Vendor == Vendor.Qualcomm || Vendor == Vendor.ARM || Vendor == Vendor.ImgTec;
+            IsTBDR = IsMoltenVk ||
+                Vendor == Vendor.Qualcomm ||
+                Vendor == Vendor.ARM ||
+                Vendor == Vendor.Broadcom ||
+                Vendor == Vendor.ImgTec;
 
             GpuVendor = vendorName;
             GpuRenderer = Marshal.PtrToStringAnsi((IntPtr)properties.DeviceName);

--- a/Ryujinx.Graphics.Vulkan/Window.cs
+++ b/Ryujinx.Graphics.Vulkan/Window.cs
@@ -113,7 +113,7 @@ namespace Ryujinx.Graphics.Vulkan
                 ImageSharingMode = SharingMode.Exclusive,
                 ImageArrayLayers = 1,
                 PreTransform = capabilities.CurrentTransform,
-                CompositeAlpha = CompositeAlphaFlagsKHR.OpaqueBitKhr,
+                CompositeAlpha = ChooseCompositeAlpha(capabilities.SupportedCompositeAlpha),
                 PresentMode = ChooseSwapPresentMode(presentModes, _vsyncEnabled),
                 Clipped = true,
                 OldSwapchain = oldSwapchain
@@ -182,6 +182,22 @@ namespace Ryujinx.Graphics.Vulkan
             return availableFormats[0];
         }
 
+        private static CompositeAlphaFlagsKHR ChooseCompositeAlpha(CompositeAlphaFlagsKHR supportedFlags)
+        {
+            if (supportedFlags.HasFlag(CompositeAlphaFlagsKHR.OpaqueBitKhr))
+            {
+                return CompositeAlphaFlagsKHR.OpaqueBitKhr;
+            }
+            else if (supportedFlags.HasFlag(CompositeAlphaFlagsKHR.PreMultipliedBitKhr))
+            {
+                return CompositeAlphaFlagsKHR.PreMultipliedBitKhr;
+            }
+            else
+            {
+                return CompositeAlphaFlagsKHR.InheritBitKhr;
+            }
+        }
+
         private static PresentModeKHR ChooseSwapPresentMode(PresentModeKHR[] availablePresentModes, bool vsyncEnabled)
         {
             if (!vsyncEnabled && availablePresentModes.Contains(PresentModeKHR.ImmediateKhr))
@@ -191,10 +207,6 @@ namespace Ryujinx.Graphics.Vulkan
             else if (availablePresentModes.Contains(PresentModeKHR.MailboxKhr))
             {
                 return PresentModeKHR.MailboxKhr;
-            }
-            else if (availablePresentModes.Contains(PresentModeKHR.FifoKhr))
-            {
-               return PresentModeKHR.FifoKhr;
             }
             else
             {


### PR DESCRIPTION
This is relaxing the Vulkan requirements, basically optionally requesting more features, to allow it to run on more GPUs.
This mainly targets the Raspberry Pi 4, but it can benefit other mobile GPUs too.

Changes:
- More features are now only requested if the drivers supports it, instead of being always requested.
- Transform feedback is only enabled if the extension is supported and the feature is supported.
- Choose composite alpha flags based on what the driver supports. Not all drivers supports the "Opaque" mode.
- The number of color attachment on a sub pass was always 8 due to the way how `MaxAttachmentIndex` was set. However the Raspberry Pi GPU only supports up to 4. `MaxAttachmentIndex` was changed to actually reflect the maximum index used. This allows games that uses 4 attachments or less to work on those GPUs.
- Buffers were only created on memory pools with the `HostCached` flag. However not all driver exposes a `HostCached` memory pool, and that would make the memory allocation fail on those drivers. It was now changed to take "alternative" flags. If no memory pool is found with the requested flags, it returns one with the alternative flags. The new functionality is used to request an allocation without the "HostCached" flag.

This along with #4114 allows some games to work on the Raspberry Pi 4. Host mapped mode does not work due to the issue mentioned on the Arm64 PR. There are other things to note:
- Performance is too low right now for any game to be considered playable.
  - I'm also using an outdated version of the Vulkan driver. It's possible that the latest version has better performance.
  - I'm also running with stock clocks and don't have any kind of cooling on the board. I don't know how much that would impact performance.
  - I'm also using VNC to stream the video to my computer since I don't have an actual display connected to it. I don't know if or how much the VNC server impacts performance.
- It was only tested on the 8 GB model. I don't think it would work with the 4 GB or lower models.

I'm not sure how we will maintain support for the Raspberry Pi going forward, but I don't think it's worth working around Pi limitations given it likely can't run most games with playable performance anyway. So the fixes it will receive will likely be to issues that also affects more capable GPUs.

Screenshot of some games running:
![image](https://user-images.githubusercontent.com/5624669/211174296-c7554a6d-e12d-4d6d-9ed8-f86c8519536f.png)
![image](https://user-images.githubusercontent.com/5624669/211174299-108387a0-9974-4e0e-86b3-14a6103d559c.png)
![image](https://user-images.githubusercontent.com/5624669/211174303-fd514420-6fec-416c-8103-e0fae8346966.png)
![image](https://user-images.githubusercontent.com/5624669/211174322-9268e9c4-1931-482b-a210-fb6e2362140f.png)
![image](https://user-images.githubusercontent.com/5624669/211174324-8492d4b2-b7a3-43b9-bb6e-ec49744e10e1.png)
