### PR TITLE
Ava: Make Avalonia use our logging system

### DIFF
--- a/Ryujinx.Ava/Helper/LoggerAdapter.cs
+++ b/Ryujinx.Ava/Helper/LoggerAdapter.cs
@@ -1,0 +1,163 @@
+using Avalonia.Utilities;
+using System;
+using System.Text;
+
+namespace Ryujinx.Ava.UI.Helper
+{
+    using AvaLogger = Avalonia.Logging.Logger;
+    using AvaLogLevel = Avalonia.Logging.LogEventLevel;
+    using RyuLogger = Ryujinx.Common.Logging.Logger;
+    using RyuLogClass = Ryujinx.Common.Logging.LogClass;
+
+    public class LoggerAdapter : Avalonia.Logging.ILogSink
+    {
+        public static void Register()
+        {
+            AvaLogger.Sink = new LoggerAdapter();
+        }
+
+        private static RyuLogger.Log? GetLog(AvaLogLevel level) => level switch {
+            AvaLogLevel.Verbose => RyuLogger.Trace,
+            AvaLogLevel.Debug => RyuLogger.Debug,
+            AvaLogLevel.Information => RyuLogger.Info,
+            AvaLogLevel.Warning => RyuLogger.Warning,
+            AvaLogLevel.Error => RyuLogger.Error,
+            AvaLogLevel.Fatal => RyuLogger.Notice,
+            _ => throw new ArgumentOutOfRangeException(nameof(level), level, null)
+        };
+
+        public bool IsEnabled(AvaLogLevel level, string area)
+        {
+            return GetLog(level) != null;
+        }
+
+        public void Log(AvaLogLevel level, string area, object source, string messageTemplate)
+        {
+            GetLog(level)?.PrintMsg(RyuLogClass.Avalonia, Format<object, object, object>(area, messageTemplate, source, null));
+        }
+
+        public void Log<T0>(AvaLogLevel level, string area, object source, string messageTemplate, T0 propertyValue0)
+        {
+            GetLog(level)?.PrintMsg(RyuLogClass.Avalonia, Format<object, object, object>(area, messageTemplate, source, new object[] {propertyValue0}));
+        }
+
+        public void Log<T0, T1>(AvaLogLevel level, string area, object source, string messageTemplate, T0 propertyValue0,  T1 propertyValue1)
+        {
+            GetLog(level)?.PrintMsg(RyuLogClass.Avalonia, Format<object, object, object>(area, messageTemplate, source, new object[] {propertyValue0, propertyValue1}));
+        }
+
+        public void Log<T0, T1, T2>(AvaLogLevel level, string area, object source, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
+        {
+            GetLog(level)?.PrintMsg(RyuLogClass.Avalonia, Format<object, object, object>(area, messageTemplate, source, new object[] {propertyValue0, propertyValue1, propertyValue2}));
+        }
+
+        public void Log(AvaLogLevel level, string area, object source, string messageTemplate, params object[] propertyValues)
+        {
+            GetLog(level)?.PrintMsg(RyuLogClass.Avalonia, Format<object, object, object>(area, messageTemplate, source, propertyValues));
+        }
+
+        private static string Format<T0, T1, T2>(
+            string area,
+            string template,
+            object source,
+            object[] values)
+        {
+            var result = new StringBuilder();
+            var r = new CharacterReader(template.AsSpan());
+            var i = 0;
+
+            result.Append('[');
+            result.Append(area);
+            result.Append("] ");
+
+            while (!r.End)
+            {
+                var c = r.Take();
+
+                if (c != '{')
+                {
+                    result.Append(c);
+                }
+                else
+                {
+                    if (r.Peek != '{')
+                    {
+                        result.Append('\'');
+                        result.Append(values?[i++]);
+                        result.Append('\'');
+                        r.TakeUntil('}');
+                        r.Take();
+                    }
+                    else
+                    {
+                        result.Append('{');
+                        r.Take();
+                    }
+                }
+            }
+
+            if (source is object)
+            {
+                result.Append(" (");
+                result.Append(source.GetType().Name);
+                result.Append(" #");
+                result.Append(source.GetHashCode());
+                result.Append(')');
+            }
+
+            return result.ToString();
+        }
+
+        private static string Format(
+            string area,
+            string template,
+            object source,
+            object[] v)
+        {
+            var result = new StringBuilder();
+            var r = new CharacterReader(template.AsSpan());
+            var i = 0;
+
+            result.Append('[');
+            result.Append(area);
+            result.Append(']');
+
+            while (!r.End)
+            {
+                var c = r.Take();
+
+                if (c != '{')
+                {
+                    result.Append(c);
+                }
+                else
+                {
+                    if (r.Peek != '{')
+                    {
+                        result.Append('\'');
+                        result.Append(i < v.Length ? v[i++] : null);
+                        result.Append('\'');
+                        r.TakeUntil('}');
+                        r.Take();
+                    }
+                    else
+                    {
+                        result.Append('{');
+                        r.Take();
+                    }
+                }
+            }
+
+            if (source is object)
+            {
+                result.Append('(');
+                result.Append(source.GetType().Name);
+                result.Append(" #");
+                result.Append(source.GetHashCode());
+                result.Append(')');
+            }
+
+            return result.ToString();
+        }
+    }
+}

--- a/Ryujinx.Ava/Helper/LoggerAdapter.cs
+++ b/Ryujinx.Ava/Helper/LoggerAdapter.cs
@@ -9,22 +9,26 @@ namespace Ryujinx.Ava.UI.Helper
     using RyuLogger = Ryujinx.Common.Logging.Logger;
     using RyuLogClass = Ryujinx.Common.Logging.LogClass;
 
-    public class LoggerAdapter : Avalonia.Logging.ILogSink
+    internal class LoggerAdapter : Avalonia.Logging.ILogSink
     {
         public static void Register()
         {
             AvaLogger.Sink = new LoggerAdapter();
         }
 
-        private static RyuLogger.Log? GetLog(AvaLogLevel level) => level switch {
-            AvaLogLevel.Verbose => RyuLogger.Trace,
-            AvaLogLevel.Debug => RyuLogger.Debug,
-            AvaLogLevel.Information => RyuLogger.Info,
-            AvaLogLevel.Warning => RyuLogger.Warning,
-            AvaLogLevel.Error => RyuLogger.Error,
-            AvaLogLevel.Fatal => RyuLogger.Notice,
-            _ => throw new ArgumentOutOfRangeException(nameof(level), level, null)
-        };
+        private static RyuLogger.Log? GetLog(AvaLogLevel level)
+        {
+            return level switch
+            {
+                AvaLogLevel.Verbose => RyuLogger.Trace,
+                AvaLogLevel.Debug => RyuLogger.Debug,
+                AvaLogLevel.Information => RyuLogger.Info,
+                AvaLogLevel.Warning => RyuLogger.Warning,
+                AvaLogLevel.Error => RyuLogger.Error,
+                AvaLogLevel.Fatal => RyuLogger.Notice,
+                _ => throw new ArgumentOutOfRangeException(nameof(level), level, null)
+            };
+        }
 
         public bool IsEnabled(AvaLogLevel level, string area)
         {
@@ -33,34 +37,30 @@ namespace Ryujinx.Ava.UI.Helper
 
         public void Log(AvaLogLevel level, string area, object source, string messageTemplate)
         {
-            GetLog(level)?.PrintMsg(RyuLogClass.Avalonia, Format<object, object, object>(area, messageTemplate, source, null));
+            GetLog(level)?.PrintMsg(RyuLogClass.Ui, Format(area, messageTemplate, source, null));
         }
 
         public void Log<T0>(AvaLogLevel level, string area, object source, string messageTemplate, T0 propertyValue0)
         {
-            GetLog(level)?.PrintMsg(RyuLogClass.Avalonia, Format<object, object, object>(area, messageTemplate, source, new object[] {propertyValue0}));
+            GetLog(level)?.PrintMsg(RyuLogClass.Ui, Format(area, messageTemplate, source, new object[] { propertyValue0 }));
         }
 
         public void Log<T0, T1>(AvaLogLevel level, string area, object source, string messageTemplate, T0 propertyValue0,  T1 propertyValue1)
         {
-            GetLog(level)?.PrintMsg(RyuLogClass.Avalonia, Format<object, object, object>(area, messageTemplate, source, new object[] {propertyValue0, propertyValue1}));
+            GetLog(level)?.PrintMsg(RyuLogClass.Ui, Format(area, messageTemplate, source, new object[] { propertyValue0, propertyValue1 }));
         }
 
         public void Log<T0, T1, T2>(AvaLogLevel level, string area, object source, string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2)
         {
-            GetLog(level)?.PrintMsg(RyuLogClass.Avalonia, Format<object, object, object>(area, messageTemplate, source, new object[] {propertyValue0, propertyValue1, propertyValue2}));
+            GetLog(level)?.PrintMsg(RyuLogClass.Ui, Format(area, messageTemplate, source, new object[] { propertyValue0, propertyValue1, propertyValue2 }));
         }
 
         public void Log(AvaLogLevel level, string area, object source, string messageTemplate, params object[] propertyValues)
         {
-            GetLog(level)?.PrintMsg(RyuLogClass.Avalonia, Format<object, object, object>(area, messageTemplate, source, propertyValues));
+            GetLog(level)?.PrintMsg(RyuLogClass.Ui, Format(area, messageTemplate, source, propertyValues));
         }
 
-        private static string Format<T0, T1, T2>(
-            string area,
-            string template,
-            object source,
-            object[] values)
+        private static string Format(string area, string template, object source, object[] v)
         {
             var result = new StringBuilder();
             var r = new CharacterReader(template.AsSpan());
@@ -69,58 +69,6 @@ namespace Ryujinx.Ava.UI.Helper
             result.Append('[');
             result.Append(area);
             result.Append("] ");
-
-            while (!r.End)
-            {
-                var c = r.Take();
-
-                if (c != '{')
-                {
-                    result.Append(c);
-                }
-                else
-                {
-                    if (r.Peek != '{')
-                    {
-                        result.Append('\'');
-                        result.Append(values?[i++]);
-                        result.Append('\'');
-                        r.TakeUntil('}');
-                        r.Take();
-                    }
-                    else
-                    {
-                        result.Append('{');
-                        r.Take();
-                    }
-                }
-            }
-
-            if (source is object)
-            {
-                result.Append(" (");
-                result.Append(source.GetType().Name);
-                result.Append(" #");
-                result.Append(source.GetHashCode());
-                result.Append(')');
-            }
-
-            return result.ToString();
-        }
-
-        private static string Format(
-            string area,
-            string template,
-            object source,
-            object[] v)
-        {
-            var result = new StringBuilder();
-            var r = new CharacterReader(template.AsSpan());
-            var i = 0;
-
-            result.Append('[');
-            result.Append(area);
-            result.Append(']');
 
             while (!r.End)
             {
@@ -148,9 +96,9 @@ namespace Ryujinx.Ava.UI.Helper
                 }
             }
 
-            if (source is object)
+            if (source != null)
             {
-                result.Append('(');
+                result.Append(" (");
                 result.Append(source.GetType().Name);
                 result.Append(" #");
                 result.Append(source.GetHashCode());

--- a/Ryujinx.Ava/Program.cs
+++ b/Ryujinx.Ava/Program.cs
@@ -1,5 +1,6 @@
 using Avalonia;
 using Avalonia.Threading;
+using Ryujinx.Ava.UI.Helper;
 using Ryujinx.Ava.UI.Windows;
 using Ryujinx.Common;
 using Ryujinx.Common.Configuration;
@@ -89,6 +90,8 @@ namespace Ryujinx.Ava
 
             Initialize(args);
 
+            LoggerAdapter.Register();
+
             BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
         }
 
@@ -110,8 +113,7 @@ namespace Ryujinx.Ava
                     AllowEglInitialization          = false,
                     CompositionBackdropCornerRadius = 8.0f,
                 })
-                .UseSkia()
-                .LogToTrace();
+                .UseSkia();
         }
 
         private static void Initialize(string[] args)

--- a/Ryujinx.Common/Logging/LogClass.cs
+++ b/Ryujinx.Common/Logging/LogClass.cs
@@ -67,6 +67,6 @@ namespace Ryujinx.Common.Logging
         SurfaceFlinger,
         TamperMachine,
         Ui,
-        Vic,
+        Vic
     }
 }

--- a/Ryujinx.Common/Logging/LogClass.cs
+++ b/Ryujinx.Common/Logging/LogClass.cs
@@ -5,11 +5,12 @@ namespace Ryujinx.Common.Logging
         Application,
         Audio,
         AudioRenderer,
+        Avalonia,
         Configuration,
         Cpu,
-        Font,
         Emulation,
         FFmpeg,
+        Font,
         Gpu,
         Hid,
         Host1x,
@@ -66,6 +67,6 @@ namespace Ryujinx.Common.Logging
         ServiceVi,
         SurfaceFlinger,
         TamperMachine,
-        Vic
+        Vic,
     }
 }

--- a/Ryujinx.Common/Logging/LogClass.cs
+++ b/Ryujinx.Common/Logging/LogClass.cs
@@ -5,7 +5,6 @@ namespace Ryujinx.Common.Logging
         Application,
         Audio,
         AudioRenderer,
-        Avalonia,
         Configuration,
         Cpu,
         Emulation,
@@ -67,6 +66,7 @@ namespace Ryujinx.Common.Logging
         ServiceVi,
         SurfaceFlinger,
         TamperMachine,
+        Ui,
         Vic,
     }
 }


### PR DESCRIPTION
Instead of outputting to `System.Diagnostics.Trace`, capture Avalonia logging events and adapt to our logging system.