### PR TITLE
HIPC: Fix reply possibly also receiving one request

### DIFF
--- a/Ryujinx.Horizon.Common/Result.cs
+++ b/Ryujinx.Horizon.Common/Result.cs
@@ -100,14 +100,6 @@ namespace Ryujinx.Horizon.Common
             }
         }
 
-        public void AbortOnFailureUnless(Result result, Result result2)
-        {
-            if (this != Success && this != result && this != result2)
-            {
-                ThrowInvalidResult();
-            }
-        }
-
         private void ThrowInvalidResult()
         {
             throw new InvalidResultException(this);

--- a/Ryujinx.Horizon/Sdk/Sf/Hipc/Api.cs
+++ b/Ryujinx.Horizon/Sdk/Sf/Hipc/Api.cs
@@ -51,22 +51,18 @@ namespace Ryujinx.Horizon.Sdk.Sf.Hipc
         {
             Result result = ReplyImpl(sessionHandle, messageBuffer);
 
-            result.AbortOnFailureUnless(KernelResult.TimedOut, KernelResult.PortRemoteClosed);
+            result.AbortUnless(KernelResult.TimedOut, KernelResult.PortRemoteClosed);
 
             return Result.Success;
         }
 
         private static Result ReplyImpl(int sessionHandle, ReadOnlySpan<byte> messageBuffer)
         {
-            Span<int> handles = stackalloc int[1];
-
-            handles[0] = sessionHandle;
-
             var tlsSpan = HorizonStatic.AddressSpace.GetSpan(HorizonStatic.ThreadContext.TlsAddress, TlsMessageBufferSize);
 
             if (messageBuffer == tlsSpan)
             {
-                return HorizonStatic.Syscall.ReplyAndReceive(out _, handles, sessionHandle, 0);
+                return HorizonStatic.Syscall.ReplyAndReceive(out _, ReadOnlySpan<int>.Empty, sessionHandle, 0);
             }
             else
             {


### PR DESCRIPTION
Because `Reply` was passing the session handle to `ReplyAndReceive`, it would in some cases also receive one request (if a request has been made by the client since the last call to `WaitSynchronization`. This would cause the request to never be actually processed. This fixes the issue by not passing any handle which is the correct behaviour. Result check was also changed, this function is not expected to ever return success. Since it does not pass any handle to wait on, it should always return time out (since nothing was signalled) or port remote closed if the client clossed the session before the service had time to reply.

This is an issue from #4188.