### PR TITLE
Add command line arguments to override docked mode

### DIFF
--- a/Ryujinx.Ava/Program.cs
+++ b/Ryujinx.Ava/Program.cs
@@ -228,7 +228,7 @@ namespace Ryujinx.Ava
                 }
             }
 
-            // Check if docked mode was overriden
+            // Check if docked mode was overriden.
             if (CommandLineState.OverrideDockedMode.HasValue)
             {
                 ConfigurationState.Instance.System.EnableDockedMode.Value = CommandLineState.OverrideDockedMode.Value;

--- a/Ryujinx.Ava/Program.cs
+++ b/Ryujinx.Ava/Program.cs
@@ -6,8 +6,8 @@ using Ryujinx.Common;
 using Ryujinx.Common.Configuration;
 using Ryujinx.Common.GraphicsDriver;
 using Ryujinx.Common.Logging;
-using Ryujinx.Common.SystemInterop;
 using Ryujinx.Common.SystemInfo;
+using Ryujinx.Common.SystemInterop;
 using Ryujinx.Modules;
 using Ryujinx.SDL2.Common;
 using Ryujinx.Ui.Common;
@@ -226,6 +226,12 @@ namespace Ryujinx.Ava
                 {
                     ConfigurationState.Instance.Graphics.GraphicsBackend.Value = GraphicsBackend.Vulkan;
                 }
+            }
+
+            // Check if docked mode was overriden
+            if (CommandLineState.OverrideDockedMode.HasValue)
+            {
+                ConfigurationState.Instance.System.EnableDockedMode.Value = CommandLineState.OverrideDockedMode.Value;
             }
         }
 

--- a/Ryujinx.Ui.Common/Helper/CommandLineState.cs
+++ b/Ryujinx.Ui.Common/Helper/CommandLineState.cs
@@ -7,6 +7,7 @@ namespace Ryujinx.Ui.Common.Helper
     {
         public static string[] Arguments { get; private set; }
 
+        public static bool?  OverrideDockedMode      { get; private set; }
         public static string OverrideGraphicsBackend { get; private set; }
         public static string BaseDirPathArg          { get; private set; }
         public static string Profile                 { get; private set; }
@@ -68,6 +69,12 @@ namespace Ryujinx.Ui.Common.Helper
                         }
 
                         OverrideGraphicsBackend = args[++i];
+                        break;
+                    case "--docked-mode":
+                        OverrideDockedMode = true;
+                        break;
+                    case "--handheld-mode":
+                        OverrideDockedMode = false;
                         break;
                     default:
                         LaunchPathArg = arg;

--- a/Ryujinx/Program.cs
+++ b/Ryujinx/Program.cs
@@ -271,7 +271,7 @@ namespace Ryujinx
                 }
             }
 
-            // Check if docked mode was overriden
+            // Check if docked mode was overriden.
             if (CommandLineState.OverrideDockedMode.HasValue)
             {
                 ConfigurationState.Instance.System.EnableDockedMode.Value = CommandLineState.OverrideDockedMode.Value;

--- a/Ryujinx/Program.cs
+++ b/Ryujinx/Program.cs
@@ -3,8 +3,8 @@ using Ryujinx.Common;
 using Ryujinx.Common.Configuration;
 using Ryujinx.Common.GraphicsDriver;
 using Ryujinx.Common.Logging;
-using Ryujinx.Common.SystemInterop;
 using Ryujinx.Common.SystemInfo;
+using Ryujinx.Common.SystemInterop;
 using Ryujinx.Modules;
 using Ryujinx.SDL2.Common;
 using Ryujinx.Ui;
@@ -269,6 +269,12 @@ namespace Ryujinx
                     ConfigurationState.Instance.Graphics.GraphicsBackend.Value = GraphicsBackend.Vulkan;
                     showVulkanPrompt = false;
                 }
+            }
+
+            // Check if docked mode was overriden
+            if (CommandLineState.OverrideDockedMode.HasValue)
+            {
+                ConfigurationState.Instance.System.EnableDockedMode.Value = CommandLineState.OverrideDockedMode.Value;
             }
 
             // Logging system information.


### PR DESCRIPTION
This small PR adds two command line arguments for both GUIs to override the state of `EnableDockedMode`:

- `--docked-mode`
- `--handheld-mode`

A user on discord has a usecase where this makes sense and I like the idea, so I quickly added it.