### PR TITLE
Ava: Add missing null check to ContentDialogHelper.ShowAsync()

### DIFF
--- a/Ryujinx.Ava/UI/Helpers/ContentDialogHelper.cs
+++ b/Ryujinx.Ava/UI/Helpers/ContentDialogHelper.cs
@@ -349,7 +349,7 @@ namespace Ryujinx.Ava.UI.Helpers
 
             Window parent = GetMainWindow();
 
-            if (parent is not null && parent.IsActive && parent is MainWindow window && window.ViewModel.IsGameRunning)
+            if (parent != null && parent.IsActive && parent is MainWindow window && window.ViewModel.IsGameRunning)
             {
                 contentDialogOverlayWindow = new()
                 {

--- a/Ryujinx.Ava/UI/Helpers/ContentDialogHelper.cs
+++ b/Ryujinx.Ava/UI/Helpers/ContentDialogHelper.cs
@@ -349,7 +349,7 @@ namespace Ryujinx.Ava.UI.Helpers
 
             Window parent = GetMainWindow();
 
-            if (parent.IsActive && parent is MainWindow window && window.ViewModel.IsGameRunning)
+            if (parent is not null && parent.IsActive && parent is MainWindow window && window.ViewModel.IsGameRunning)
             {
                 contentDialogOverlayWindow = new()
                 {


### PR DESCRIPTION
Another small PR to fix a regression introduced with #4237.

This PR adds a missing null check to `ContentDialogHelper.ShowAsync()`. This is needed since `GetMainWindow()` can also return null, which is the case on first startup.

Example log from someone on Discord: 
[Ryujinx_1.1.526_2023-01-09_23-10-17.log](https://github.com/Ryujinx/Ryujinx/files/10377344/Ryujinx_1.1.526_2023-01-09_23-10-17.log)
