### PR TITLE
Set LSApplicationCategoryType to games

### DIFF
--- a/distribution/macos/Info.plist
+++ b/distribution/macos/Info.plist
@@ -40,6 +40,8 @@
     <true/>
     <key>NSHumanReadableCopyright</key>
     <string>Copyright © 2018 - 2022 Ryujinx Team and Contributors.</string>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.games</string>
     <key>LSMinimumSystemVersion</key>
     <string>11.0</string>
 </dict>


### PR DESCRIPTION
https://developer.apple.com/documentation/bundleresources/information_property_list/lsapplicationcategorytype Makes it auto-add to the macOS Launchpad games folder