### PR TITLE
Ava UI: Fixes PerformanceCheck condition

### DIFF
--- a/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
+++ b/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
@@ -1918,7 +1918,7 @@ namespace Ryujinx.Ava.UI.ViewModels
                     LocaleManager.Instance[LocaleKeys.InputDialogNo],
                     LocaleManager.Instance[LocaleKeys.RyujinxConfirm]);
 
-                if (result != UserResult.Yes)
+                if (result == UserResult.Yes)
                 {
                     ConfigurationState.Instance.Logger.EnableTrace.Value = false;
 
@@ -1938,7 +1938,7 @@ namespace Ryujinx.Ava.UI.ViewModels
                     LocaleManager.Instance[LocaleKeys.InputDialogNo],
                     LocaleManager.Instance[LocaleKeys.RyujinxConfirm]);
 
-                if (result != UserResult.Yes)
+                if (result == UserResult.Yes)
                 {
                     ConfigurationState.Instance.Graphics.ShadersDumpPath.Value = "";
 


### PR DESCRIPTION
> When you set a "Graphics shader dump path", Avalonia shows a prompt asking if you want to disable it when the game is started. However, clicking on "Yes" does nothing. The path is still set and it asks it every time you launch the game, even if you click on "Yes".

This is now fixed.

(Closes item of https://github.com/Ryujinx/Ryujinx/issues/3662)