### PR TITLE
lm: Handle Tail flag in LogPacket

### DIFF
--- a/Ryujinx.Horizon/LogManager/Types/LogPacket.cs
+++ b/Ryujinx.Horizon/LogManager/Types/LogPacket.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 namespace Ryujinx.Horizon.LogManager.Types
 {
-    class LogPacket
+    struct LogPacket
     {
         public string      Message;
         public int         Line;

--- a/Ryujinx.Horizon/LogManager/Types/LogPacket.cs
+++ b/Ryujinx.Horizon/LogManager/Types/LogPacket.cs
@@ -1,0 +1,72 @@
+﻿using Ryujinx.Horizon.Sdk.Diag;
+using System.Text;
+
+namespace Ryujinx.Horizon.LogManager.Types
+{
+    class LogPacket
+    {
+        public string      Message;
+        public int         Line;
+        public string      Filename;
+        public string      Function;
+        public string      Module;
+        public string      Thread;
+        public long        DropCount;
+        public long        Time;
+        public string      ProgramName;
+        public LogSeverity Severity;
+
+        public override string ToString()
+        {
+            StringBuilder builder = new();
+            builder.AppendLine($"Guest Log:\n  Log level: {Severity}");
+
+            if (Time > 0)
+            {
+                builder.AppendLine($"    Time: {Time}s");
+            }
+
+            if (DropCount > 0)
+            {
+                builder.AppendLine($"    DropCount: {DropCount}");
+            }
+
+            if (!string.IsNullOrEmpty(ProgramName))
+            {
+                builder.AppendLine($"    ProgramName: {ProgramName}");
+            }
+            
+            if (!string.IsNullOrEmpty(Module))
+            {
+                builder.AppendLine($"    Module: {Module}");
+            }
+            
+            if (!string.IsNullOrEmpty(Thread))
+            {
+                builder.AppendLine($"    Thread: {Thread}");
+            }
+
+            if (!string.IsNullOrEmpty(Filename))
+            {
+                builder.AppendLine($"    Filename: {Filename}");
+            }
+
+            if (Line > 0)
+            {
+                builder.AppendLine($"    Line: {Line}");
+            }
+
+            if (!string.IsNullOrEmpty(Function))
+            {
+                builder.AppendLine($"    Function: {Function}");
+            }
+
+            if (!string.IsNullOrEmpty(Message))
+            {
+                builder.AppendLine($"    Message: {Message}");
+            }
+
+            return builder.ToString();
+        }
+    }
+}


### PR DESCRIPTION
When guest use `lm` service to print some logging, sent packets have a flag field. We currently doesn't take care of the flags, that could lead to strange logging like that:

![image](https://user-images.githubusercontent.com/4905390/211930773-4e78f3fe-ae62-4d24-b869-c2be0d4eb7f1.png)

This is now fixed:

![image](https://user-images.githubusercontent.com/4905390/211930827-971e163a-7802-4aaa-8c02-1d245894671d.png)

It's not useful at all, but... Why not 😄 !