### PR TITLE
Relax Vulkan requirements

### DIFF
--- a/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
+++ b/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
@@ -23,7 +23,7 @@ namespace Ryujinx.Graphics.Vulkan
         public int[] AttachmentIndices { get; }
 
         public int AttachmentsCount { get; }
-        public int MaxColorAttachmentIndex { get; }
+        public int MaxColorAttachmentIndex => AttachmentIndices.Length > 0 ? AttachmentIndices[AttachmentIndices.Length - 1] : -1;
         public bool HasDepthStencil { get; }
         public int ColorAttachmentsCount => AttachmentsCount - (HasDepthStencil ? 1 : 0);
 
@@ -67,7 +67,6 @@ namespace Ryujinx.Graphics.Vulkan
             AttachmentSamples = new uint[count];
             AttachmentFormats = new VkFormat[count];
             AttachmentIndices = new int[count];
-            MaxColorAttachmentIndex = colors.Length - 1;
 
             uint width = uint.MaxValue;
             uint height = uint.MaxValue;

--- a/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
+++ b/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
@@ -66,7 +66,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             AttachmentSamples = new uint[count];
             AttachmentFormats = new VkFormat[count];
-            AttachmentIndices = new int[count];
+            AttachmentIndices = new int[colorsCount];
 
             uint width = uint.MaxValue;
             uint height = uint.MaxValue;

--- a/Ryujinx.Graphics.Vulkan/HardwareCapabilities.cs
+++ b/Ryujinx.Graphics.Vulkan/HardwareCapabilities.cs
@@ -28,10 +28,11 @@ namespace Ryujinx.Graphics.Vulkan
         public readonly bool SupportsExtendedDynamicState;
         public readonly bool SupportsMultiView;
         public readonly bool SupportsNullDescriptors;
-        public readonly bool SupportsPreciseOcclusionQueries;
         public readonly bool SupportsPushDescriptors;
         public readonly bool SupportsTransformFeedback;
         public readonly bool SupportsTransformFeedbackQueries;
+        public readonly bool SupportsPreciseOcclusionQueries;
+        public readonly bool SupportsPipelineStatisticsQuery;
         public readonly bool SupportsGeometryShader;
         public readonly uint MinSubgroupSize;
         public readonly uint MaxSubgroupSize;
@@ -55,6 +56,7 @@ namespace Ryujinx.Graphics.Vulkan
             bool supportsTransformFeedback,
             bool supportsTransformFeedbackQueries,
             bool supportsPreciseOcclusionQueries,
+            bool supportsPipelineStatisticsQuery,
             bool supportsGeometryShader,
             uint minSubgroupSize,
             uint maxSubgroupSize,
@@ -77,6 +79,7 @@ namespace Ryujinx.Graphics.Vulkan
             SupportsTransformFeedback = supportsTransformFeedback;
             SupportsTransformFeedbackQueries = supportsTransformFeedbackQueries;
             SupportsPreciseOcclusionQueries = supportsPreciseOcclusionQueries;
+            SupportsPipelineStatisticsQuery = supportsPipelineStatisticsQuery;
             SupportsGeometryShader = supportsGeometryShader;
             MinSubgroupSize = minSubgroupSize;
             MaxSubgroupSize = maxSubgroupSize;

--- a/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -1344,8 +1344,7 @@ namespace Ryujinx.Graphics.Vulkan
             var dstAttachmentFormats = _newState.Internal.AttachmentFormats.AsSpan();
             FramebufferParams.AttachmentFormats.CopyTo(dstAttachmentFormats);
 
-            int maxAttachmentIndex = FramebufferParams.MaxColorAttachmentIndex + (FramebufferParams.HasDepthStencil ? 1 : 0);
-            for (int i = FramebufferParams.AttachmentFormats.Length; i <= maxAttachmentIndex; i++)
+            for (int i = FramebufferParams.AttachmentFormats.Length; i < dstAttachmentFormats.Length; i++)
             {
                 dstAttachmentFormats[i] = 0;
             }

--- a/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -1375,8 +1375,6 @@ namespace Ryujinx.Graphics.Vulkan
 
                 for (int i = 0; i < FramebufferParams.AttachmentsCount; i++)
                 {
-                    int bindIndex = FramebufferParams.AttachmentIndices[i];
-
                     attachmentDescs[i] = new AttachmentDescription(
                         0,
                         FramebufferParams.AttachmentFormats[i],

--- a/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
@@ -27,14 +27,11 @@ namespace Ryujinx.Graphics.Vulkan
 
             int attachmentCount = 0;
             int colorCount = 0;
-            int maxColorAttachmentIndex = 0;
 
             for (int i = 0; i < state.AttachmentEnable.Length; i++)
             {
                 if (state.AttachmentEnable[i])
                 {
-                    maxColorAttachmentIndex = i;
-
                     attachmentFormats[attachmentCount] = gd.FormatCapabilities.ConvertToVkFormat(state.AttachmentFormats[i]);
 
                     attachmentIndices[attachmentCount++] = i;
@@ -270,7 +267,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             // NOTE: Viewports, Scissors are dynamic.
 
-            for (int i = 0; i < 8; i++)
+            for (int i = 0; i < Constants.MaxRenderTargets; i++)
             {
                 var blend = state.BlendDescriptors[i];
 
@@ -293,21 +290,24 @@ namespace Ryujinx.Graphics.Vulkan
                 }
             }
 
-            int maxAttachmentIndex = 0;
-            for (int i = 0; i < 8; i++)
+            int attachmentCount = 0;
+            int maxColorAttachmentIndex = -1;
+
+            for (int i = 0; i < Constants.MaxRenderTargets; i++)
             {
                 if (state.AttachmentEnable[i])
                 {
-                    pipeline.Internal.AttachmentFormats[maxAttachmentIndex++] = gd.FormatCapabilities.ConvertToVkFormat(state.AttachmentFormats[i]);
+                    pipeline.Internal.AttachmentFormats[attachmentCount++] = gd.FormatCapabilities.ConvertToVkFormat(state.AttachmentFormats[i]);
+                    maxColorAttachmentIndex = i;
                 }
             }
 
             if (state.DepthStencilEnable)
             {
-                pipeline.Internal.AttachmentFormats[maxAttachmentIndex++] = gd.FormatCapabilities.ConvertToVkFormat(state.DepthStencilFormat);
+                pipeline.Internal.AttachmentFormats[attachmentCount++] = gd.FormatCapabilities.ConvertToVkFormat(state.DepthStencilFormat);
             }
 
-            pipeline.ColorBlendAttachmentStateCount = 8;
+            pipeline.ColorBlendAttachmentStateCount = (uint)(maxColorAttachmentIndex + 1);
             pipeline.VertexAttributeDescriptionsCount = (uint)Math.Min(Constants.MaxVertexAttributes, state.VertexAttribCount);
 
             return pipeline;

--- a/Ryujinx.Graphics.Vulkan/Queries/BufferedQuery.cs
+++ b/Ryujinx.Graphics.Vulkan/Queries/BufferedQuery.cs
@@ -67,8 +67,8 @@ namespace Ryujinx.Graphics.Vulkan.Queries
             return type switch
             {
                 CounterType.SamplesPassed => true,
+                CounterType.PrimitivesGenerated => gd.Capabilities.SupportsPipelineStatisticsQuery,
                 CounterType.TransformFeedbackPrimitivesWritten => gd.Capabilities.SupportsTransformFeedbackQueries,
-                CounterType.PrimitivesGenerated => gd.Capabilities.SupportsGeometryShader,
                 _ => false
             };
         }

--- a/Ryujinx.Graphics.Vulkan/Vendor.cs
+++ b/Ryujinx.Graphics.Vulkan/Vendor.cs
@@ -9,6 +9,7 @@ namespace Ryujinx.Graphics.Vulkan
         Intel,
         Nvidia,
         ARM,
+        Broadcom,
         Qualcomm,
         Apple,
         Unknown
@@ -28,6 +29,7 @@ namespace Ryujinx.Graphics.Vulkan
                 0x106B => Vendor.Apple,
                 0x10DE => Vendor.Nvidia,
                 0x13B5 => Vendor.ARM,
+                0x14E4 => Vendor.Broadcom,
                 0x8086 => Vendor.Intel,
                 0x5143 => Vendor.Qualcomm,
                 _ => Vendor.Unknown
@@ -43,6 +45,7 @@ namespace Ryujinx.Graphics.Vulkan
                 0x106B => "Apple",
                 0x10DE => "NVIDIA",
                 0x13B5 => "ARM",
+                0x14E4 => "Broadcom",
                 0x1AE0 => "Google",
                 0x5143 => "Qualcomm",
                 0x8086 => "Intel",

--- a/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -591,7 +591,11 @@ namespace Ryujinx.Graphics.Vulkan
 
             IsAmdWindows = Vendor == Vendor.Amd && RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             IsIntelWindows = Vendor == Vendor.Intel && RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-            IsTBDR = IsMoltenVk || Vendor == Vendor.Qualcomm || Vendor == Vendor.ARM || Vendor == Vendor.ImgTec;
+            IsTBDR = IsMoltenVk ||
+                Vendor == Vendor.Qualcomm ||
+                Vendor == Vendor.ARM ||
+                Vendor == Vendor.Broadcom ||
+                Vendor == Vendor.ImgTec;
 
             GpuVendor = vendorName;
             GpuRenderer = Marshal.PtrToStringAnsi((IntPtr)properties.DeviceName);

--- a/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -271,6 +271,7 @@ namespace Ryujinx.Graphics.Vulkan
                 supportsTransformFeedback,
                 propertiesTransformFeedback.TransformFeedbackQueries,
                 features2.Features.OcclusionQueryPrecise,
+                supportedFeatures.PipelineStatisticsQuery,
                 supportedFeatures.GeometryShader,
                 propertiesSubgroupSizeControl.MinSubgroupSize,
                 propertiesSubgroupSizeControl.MaxSubgroupSize,
@@ -589,8 +590,8 @@ namespace Ryujinx.Graphics.Vulkan
 
             Vendor = VendorUtils.FromId(properties.VendorID);
 
-            IsAmdWindows = Vendor == Vendor.Amd && RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-            IsIntelWindows = Vendor == Vendor.Intel && RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            IsAmdWindows = Vendor == Vendor.Amd && OperatingSystem.IsWindows();
+            IsIntelWindows = Vendor == Vendor.Intel && OperatingSystem.IsWindows();
             IsTBDR = IsMoltenVk ||
                 Vendor == Vendor.Qualcomm ||
                 Vendor == Vendor.ARM ||

--- a/Ryujinx.Graphics.Vulkan/Window.cs
+++ b/Ryujinx.Graphics.Vulkan/Window.cs
@@ -120,7 +120,7 @@ namespace Ryujinx.Graphics.Vulkan
                 ImageSharingMode = SharingMode.Exclusive,
                 ImageArrayLayers = 1,
                 PreTransform = capabilities.CurrentTransform,
-                CompositeAlpha = CompositeAlphaFlagsKHR.OpaqueBitKhr,
+                CompositeAlpha = ChooseCompositeAlpha(capabilities.SupportedCompositeAlpha),
                 PresentMode = ChooseSwapPresentMode(presentModes, _vsyncEnabled),
                 Clipped = true
             };
@@ -188,6 +188,22 @@ namespace Ryujinx.Graphics.Vulkan
             return availableFormats[0];
         }
 
+        private static CompositeAlphaFlagsKHR ChooseCompositeAlpha(CompositeAlphaFlagsKHR supportedFlags)
+        {
+            if (supportedFlags.HasFlag(CompositeAlphaFlagsKHR.OpaqueBitKhr))
+            {
+                return CompositeAlphaFlagsKHR.OpaqueBitKhr;
+            }
+            else if (supportedFlags.HasFlag(CompositeAlphaFlagsKHR.PreMultipliedBitKhr))
+            {
+                return CompositeAlphaFlagsKHR.PreMultipliedBitKhr;
+            }
+            else
+            {
+                return CompositeAlphaFlagsKHR.InheritBitKhr;
+            }
+        }
+
         private static PresentModeKHR ChooseSwapPresentMode(PresentModeKHR[] availablePresentModes, bool vsyncEnabled)
         {
             if (!vsyncEnabled && availablePresentModes.Contains(PresentModeKHR.ImmediateKhr))
@@ -197,10 +213,6 @@ namespace Ryujinx.Graphics.Vulkan
             else if (availablePresentModes.Contains(PresentModeKHR.MailboxKhr))
             {
                 return PresentModeKHR.MailboxKhr;
-            }
-            else if (availablePresentModes.Contains(PresentModeKHR.FifoKhr))
-            {
-               return PresentModeKHR.FifoKhr;
             }
             else
             {


### PR DESCRIPTION
Same as #4228, but now I also fixed `MaxColorAttachmentIndex` which was wrong and was breaking a lot of games. `AttachmentIndices` also had an additional index at the end for depth-stencil which was always 0. Due to that, if a depth-stencil texture was bound, `MaxColorAttachmentIndex` would be always 0. I have removed the useless 0 index at the end which should make the value of `MaxColorAttachmentIndex` correct, as it will be the index of the last color attachment as it should be.

I recommend actually testing it this time.