### PR TITLE
Specify image view usage flags on Vulkan

### DIFF
--- a/Ryujinx.Graphics.Vulkan/TextureStorage.cs
+++ b/Ryujinx.Graphics.Vulkan/TextureStorage.cs
@@ -79,21 +79,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             var sampleCountFlags = ConvertToSampleCountFlags(gd.Capabilities.SupportedSampleCounts, (uint)info.Samples);
 
-            var usage = DefaultUsageFlags;
-
-            if (info.Format.IsDepthOrStencil())
-            {
-                usage |= ImageUsageFlags.DepthStencilAttachmentBit;
-            }
-            else if (info.Format.IsRtColorCompatible())
-            {
-                usage |= ImageUsageFlags.ColorAttachmentBit;
-            }
-
-            if (info.Format.IsImageCompatible())
-            {
-                usage |= ImageUsageFlags.StorageBit;
-            }
+            var usage = GetImageUsageFromFormat(info.Format);
 
             var flags = ImageCreateFlags.CreateMutableFormatBit;
 
@@ -304,6 +290,27 @@ namespace Ryujinx.Graphics.Vulkan
             {
                 cbs.Dispose();
             }
+        }
+
+        public static ImageUsageFlags GetImageUsageFromFormat(GAL.Format format)
+        {
+            var usage = DefaultUsageFlags;
+
+            if (format.IsDepthOrStencil())
+            {
+                usage |= ImageUsageFlags.DepthStencilAttachmentBit;
+            }
+            else if (format.IsRtColorCompatible())
+            {
+                usage |= ImageUsageFlags.ColorAttachmentBit;
+            }
+
+            if (format.IsImageCompatible())
+            {
+                usage |= ImageUsageFlags.StorageBit;
+            }
+
+            return usage;
         }
 
         public static SampleCountFlags ConvertToSampleCountFlags(SampleCountFlags supportedSampleCounts, uint samples)

--- a/Ryujinx.Graphics.Vulkan/TextureView.cs
+++ b/Ryujinx.Graphics.Vulkan/TextureView.cs
@@ -54,6 +54,7 @@ namespace Ryujinx.Graphics.Vulkan
             gd.Textures.Add(this);
 
             var format = _gd.FormatCapabilities.ConvertToVkFormat(info.Format);
+            var usage = TextureStorage.GetImageUsageFromFormat(info.Format);
             var levels = (uint)info.Levels;
             var layers = (uint)info.GetLayers();
 
@@ -117,7 +118,7 @@ namespace Ryujinx.Graphics.Vulkan
                 return new Auto<DisposableImageView>(new DisposableImageView(gd.Api, device, imageView), null, storage.GetImage());
             }
 
-            _imageView = CreateImageView(componentMapping, subresourceRange, type);
+            _imageView = CreateImageView(componentMapping, subresourceRange, type, ImageUsageFlags.SampledBit);
 
             // Framebuffer attachments and storage images requires a identity component mapping.
             var identityComponentMapping = new ComponentMapping(
@@ -126,7 +127,7 @@ namespace Ryujinx.Graphics.Vulkan
                 ComponentSwizzle.B,
                 ComponentSwizzle.A);
 
-            _imageViewIdentity = CreateImageView(identityComponentMapping, subresourceRangeDepth, type);
+            _imageViewIdentity = CreateImageView(identityComponentMapping, subresourceRangeDepth, type, usage);
 
             // Framebuffer attachments also require 3D textures to be bound as 2D array.
             if (info.Target == Target.Texture3D)
@@ -144,7 +145,7 @@ namespace Ryujinx.Graphics.Vulkan
                 {
                     subresourceRange = new ImageSubresourceRange(aspectFlags, (uint)firstLevel, levels, (uint)firstLayer, (uint)info.Depth);
 
-                    _imageView2dArray = CreateImageView(identityComponentMapping, subresourceRange, ImageViewType.Type2DArray);
+                    _imageView2dArray = CreateImageView(identityComponentMapping, subresourceRange, ImageViewType.Type2DArray, usage);
                 }
             }
 

--- a/Ryujinx.Graphics.Vulkan/TextureView.cs
+++ b/Ryujinx.Graphics.Vulkan/TextureView.cs
@@ -95,7 +95,7 @@ namespace Ryujinx.Graphics.Vulkan
             var subresourceRange = new ImageSubresourceRange(aspectFlags, (uint)firstLevel, levels, (uint)firstLayer, layers);
             var subresourceRangeDepth = new ImageSubresourceRange(aspectFlagsDepth, (uint)firstLevel, levels, (uint)firstLayer, layers);
 
-            unsafe Auto<DisposableImageView> CreateImageView(ComponentMapping cm, ImageSubresourceRange sr, ImageViewType viewType, ImageUsageFlags usageFlags = 0)
+            unsafe Auto<DisposableImageView> CreateImageView(ComponentMapping cm, ImageSubresourceRange sr, ImageViewType viewType, ImageUsageFlags usageFlags)
             {
                 var usage = new ImageViewUsageCreateInfo()
                 {
@@ -111,7 +111,7 @@ namespace Ryujinx.Graphics.Vulkan
                     Format = format,
                     Components = cm,
                     SubresourceRange = sr,
-                    PNext = usageFlags == 0 ? null : &usage
+                    PNext = &usage
                 };
 
                 gd.Api.CreateImageView(device, imageCreateInfo, null, out var imageView).ThrowOnError();


### PR DESCRIPTION
Image stores doesn't work on NVIDIA if you don't specify the `StorageBit` in the usage flags. Because this was only being specified for the base `VkImage`, if the image had a format which is not storage compatible, and the view did, the store would not actually work because the storage bit was never specified. This change fixes the issue by also specifying the image usage flags for the image view.

Fixes black screen on games using multisample sRGB textures, such as Pinball FX3 and Sphinx and the Cursed Mummy.
Before:
![image](https://user-images.githubusercontent.com/5624669/212367719-4ee5812c-d64a-4e4c-840b-c5a95cb2e73f.png)
![image](https://user-images.githubusercontent.com/5624669/212367733-5eb2432e-bb86-4350-9e56-ca728b3e13b6.png)
After:
![image](https://user-images.githubusercontent.com/5624669/212367759-ccb85850-4d25-4856-80c1-f760e12257c4.png)
![image](https://user-images.githubusercontent.com/5624669/212367777-c5bd9508-988e-4734-812e-0ee8599c35bc.png)

May also fix issues on games doing image store on sRGB textures on Vulkan (Kirby?). Intel is not affected, it never had this issue. Dunno about AMD.

Fixes #4280.