### PR TITLE
Fix texture modified on CPU from GPU thread after being modified on GPU not being updated

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -1431,10 +1431,10 @@ namespace Ryujinx.Graphics.Gpu.Image
                 return;
             }
 
+            handle.Sync(_context);
+
             _context.Renderer.BackgroundContextAction(() =>
             {
-                handle.Sync(_context);
-
                 Storage.SignalModifiedDirty();
 
                 lock (handle.Overlaps)


### PR DESCRIPTION
Because the `Modified` flag was not being cleared for those textures, the data written from CPU (on GPU thread) was never uploaded to GPU on the modified texture. The texture would keep stale, incorrect data. The fix here is clearing the modified flag if the data is modified from the CPU on the GPU thread.

This fixes missing textures on EVE ghost enemies, and possibly other games.

Before:
![image](https://user-images.githubusercontent.com/5624669/212430570-0eb8fa48-1957-4278-b16a-1b48703c1c77.png)
After:
![image](https://user-images.githubusercontent.com/5624669/212430903-e503c56e-c4a7-4321-8943-dea076a60e0a.png)

Note that on Vulkan, the issue only happens with backend multithreading set to On or Auto. On OpenGL it should happen regardless of this setting. That's because the flag was already being cleared if the `Sync` call happens from the GPU thread (which was always the case on Vulkan with backend threading disabled).
