### PR TITLE
Fix NRE when MemoryUnmappedHandler is called for a destroyed channel

### DIFF
--- a/Ryujinx.Graphics.Gpu/GpuChannel.cs
+++ b/Ryujinx.Graphics.Gpu/GpuChannel.cs
@@ -73,7 +73,7 @@ namespace Ryujinx.Graphics.Gpu
 
             // Since the memory manager changed, make sure we will get pools from addresses of the new memory manager.
             TextureManager.ReloadPools();
-            MemoryManager.Physical.BufferCache.QueuePrune();
+            memoryManager.Physical.BufferCache.QueuePrune();
         }
 
         /// <summary>
@@ -84,7 +84,9 @@ namespace Ryujinx.Graphics.Gpu
         private void MemoryUnmappedHandler(object sender, UnmapEventArgs e)
         {
             TextureManager.ReloadPools();
-            MemoryManager.Physical.BufferCache.QueuePrune();
+
+            var memoryManager = Volatile.Read(ref _memoryManager);
+            memoryManager?.Physical.BufferCache.QueuePrune();
         }
 
         /// <summary>


### PR DESCRIPTION
While testing EVE ghost enemies I got some random NRE crashes here. It is hard to debug since they are random and don't happen at the same place (but generally happen after playing a video, which is when channels are destroyed). My theory is that MemoryUnmappedHandler is being called after the memory manager is set to null, but before the event is unregistered. So this adds a explicit null check to avoid that.

This is likely a regression from #3862.