### PR TITLE
Change GetPageSize to use Environment.SystemPageSize

### DIFF
--- a/Ryujinx.Memory/MemoryBlock.cs
+++ b/Ryujinx.Memory/MemoryBlock.cs
@@ -435,7 +435,7 @@ namespace Ryujinx.Memory
 
         public static ulong GetPageSize()
         {
-            return (ulong) Environment.SystemPageSize;
+            return (ulong)Environment.SystemPageSize;
         }
 
         private static void ThrowInvalidMemoryRegionException() => throw new InvalidMemoryRegionException();

--- a/Ryujinx.Memory/MemoryBlock.cs
+++ b/Ryujinx.Memory/MemoryBlock.cs
@@ -435,12 +435,7 @@ namespace Ryujinx.Memory
 
         public static ulong GetPageSize()
         {
-            if (OperatingSystem.IsMacOS() && RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
-            {
-                return 1UL << 14;
-            }
-
-            return 1UL << 12;
+            return (ulong) Environment.SystemPageSize;
         }
 
         private static void ThrowInvalidMemoryRegionException() => throw new InvalidMemoryRegionException();


### PR DESCRIPTION
Change GetPageSize to use Environment.SystemPageSize #4258

Tested Environment.SystemPageSize on M1 mac and Windows 11 x64, the results are 16384 and 4096
Not sure how it will behave on SteamOS 
Closes #4258