### PR TITLE
Move Ryujinx Folder from ~/.config to ~/Library/Application Support on macOS

### DIFF
--- a/Ryujinx.Common/Configuration/AppDataManager.cs
+++ b/Ryujinx.Common/Configuration/AppDataManager.cs
@@ -100,7 +100,6 @@ namespace Ryujinx.Common.Configuration
                 {
                     CopyDirectory(oldConfigPath, BaseDirPath);
                     Directory.Delete(oldConfigPath, true);
-                    Directory.CreateSymbolicLink(oldConfigPath, BaseDirPath);
                 }
             }
 

--- a/Ryujinx.Common/Configuration/AppDataManager.cs
+++ b/Ryujinx.Common/Configuration/AppDataManager.cs
@@ -100,6 +100,7 @@ namespace Ryujinx.Common.Configuration
                 {
                     CopyDirectory(oldConfigPath, BaseDirPath);
                     Directory.Delete(oldConfigPath, true);
+                    Directory.CreateSymbolicLink(oldConfigPath, BaseDirPath);
                 }
             }
 

--- a/Ryujinx.Common/Configuration/AppDataManager.cs
+++ b/Ryujinx.Common/Configuration/AppDataManager.cs
@@ -89,7 +89,7 @@ namespace Ryujinx.Common.Configuration
 
             BaseDirPath = Path.GetFullPath(BaseDirPath); // convert relative paths
 
-            // NOTE: Copies the Ryujinx folder in `~/.config` to `~/Library/Application Support` if one is found
+            // NOTE: Moves the Ryujinx folder in `~/.config` to `~/Library/Application Support` if one is found
             // and a Ryujinx folder does not already exist in Application Support.
             // Also creates a symlink from `~/.config/Ryujinx` to `~/Library/Application Support/Ryujinx` to preserve backwards compatibility.
             // This should be removed in the future.
@@ -102,7 +102,6 @@ namespace Ryujinx.Common.Configuration
                     Directory.Delete(oldConfigPath, true);
                     Directory.CreateSymbolicLink(oldConfigPath, BaseDirPath);
                 }
-
             }
 
             SetupBasePaths();

--- a/Ryujinx.Common/Configuration/AppDataManager.cs
+++ b/Ryujinx.Common/Configuration/AppDataManager.cs
@@ -132,6 +132,7 @@ namespace Ryujinx.Common.Configuration
                 {
                     continue;
                 }
+
                 file.CopyTo(Path.Combine(destinationDir, file.Name));
             }
 


### PR DESCRIPTION
This change makes Ryujinx more consistent with other apps on macOS. This PR also implements automatic migration of Ryujinx data from the old path to the new one, whenever Ryujinx detects the old data directory exists, but the new one does not.