### PR TITLE
ConfigurationState: Default to Vulkan on macOS

### DIFF
--- a/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
+++ b/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
@@ -617,7 +617,7 @@ namespace Ryujinx.Ui.Common.Configuration
             Graphics.ResScaleCustom.Value             = 1.0f;
             Graphics.MaxAnisotropy.Value              = -1.0f;
             Graphics.AspectRatio.Value                = AspectRatio.Fixed16x9;
-            Graphics.GraphicsBackend.Value            = GraphicsBackend.OpenGl;
+            Graphics.GraphicsBackend.Value            = OperatingSystem.IsMacOS() ? GraphicsBackend.Vulkan : GraphicsBackend.OpenGl;
             Graphics.PreferredGpu.Value               = "";
             Graphics.ShadersDumpPath.Value            = "";
             Logger.EnableDebug.Value                  = false;


### PR DESCRIPTION
Starting on macOS and having it immediately crash when loading something in is not a great first-experience.

Set graphics backend to Vulkan on macOS in default settings.

(Let me know if you want something more substantial than this, or if this is something you're alreadly planning, and I'll close this.)