### PR TITLE
HOS: Load RomFs by pid

### DIFF
--- a/Ryujinx.HLE/HOS/ProgramLoader.cs
+++ b/Ryujinx.HLE/HOS/ProgramLoader.cs
@@ -41,17 +41,19 @@ namespace Ryujinx.HLE.HOS
 
     struct ProgramLoadResult
     {
-        public static ProgramLoadResult Failed => new ProgramLoadResult(false, null, null);
+        public static ProgramLoadResult Failed => new ProgramLoadResult(false, null, null, 0);
 
         public readonly bool Success;
         public readonly ProcessTamperInfo TamperInfo;
         public readonly IDiskCacheLoadState DiskCacheLoadState;
+        public readonly ulong ProcessId;
 
-        public ProgramLoadResult(bool success, ProcessTamperInfo tamperInfo, IDiskCacheLoadState diskCacheLoadState)
+        public ProgramLoadResult(bool success, ProcessTamperInfo tamperInfo, IDiskCacheLoadState diskCacheLoadState, ulong pid)
         {
             Success = success;
             TamperInfo = tamperInfo;
             DiskCacheLoadState = diskCacheLoadState;
+            ProcessId = pid;
         }
     }
 
@@ -366,7 +368,7 @@ namespace Ryujinx.HLE.HOS
                 process.MemoryManager.AliasRegionStart,
                 process.MemoryManager.CodeRegionStart);
 
-            return new ProgramLoadResult(true, tamperInfo, processContextFactory.DiskCacheLoadState);
+            return new ProgramLoadResult(true, tamperInfo, processContextFactory.DiskCacheLoadState, process.Pid);
         }
 
         private static Result LoadIntoMemory(KProcess process, IExecutable image, ulong baseAddress)

--- a/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
+++ b/Ryujinx.HLE/HOS/Services/Fs/IFileSystemProxy.cs
@@ -27,6 +27,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
     class IFileSystemProxy : DisposableIpcService
     {
         private SharedRef<LibHac.FsSrv.Sf.IFileSystemProxy> _baseFileSystemProxy;
+        private ulong _pid;
 
         public IFileSystemProxy(ServiceCtx context) : base(context.Device.System.FsServer)
         {
@@ -38,6 +39,8 @@ namespace Ryujinx.HLE.HOS.Services.Fs
         // SetCurrentProcess(u64, pid)
         public ResultCode SetCurrentProcess(ServiceCtx context)
         {
+            _pid = context.Request.HandleDesc.PId;
+
             return ResultCode.Success;
         }
 
@@ -702,7 +705,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
         // OpenDataStorageByCurrentProcess() -> object<nn::fssrv::sf::IStorage> dataStorage
         public ResultCode OpenDataStorageByCurrentProcess(ServiceCtx context)
         {
-            var storage = context.Device.FileSystem.RomFs.AsStorage(true);
+            var storage = context.Device.FileSystem.GetRomFs(_pid).AsStorage(true);
             using var sharedStorage = new SharedRef<LibHac.Fs.IStorage>(storage);
             using var sfStorage = new SharedRef<IStorage>(new StorageInterfaceAdapter(ref sharedStorage.Ref()));
 
@@ -791,7 +794,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
         // OpenPatchDataStorageByCurrentProcess() -> object<nn::fssrv::sf::IStorage>
         public ResultCode OpenPatchDataStorageByCurrentProcess(ServiceCtx context)
         {
-            var storage = context.Device.FileSystem.RomFs.AsStorage(true);
+            var storage = context.Device.FileSystem.GetRomFs(_pid).AsStorage(true);
             using var sharedStorage = new SharedRef<LibHac.Fs.IStorage>(storage);
             using var sfStorage = new SharedRef<IStorage>(new StorageInterfaceAdapter(ref sharedStorage.Ref()));
 
@@ -811,7 +814,7 @@ namespace Ryujinx.HLE.HOS.Services.Fs
                 throw new NotImplementedException($"Accessing storage from other programs is not supported (program index = {programIndex}).");
             }
 
-            var storage = context.Device.FileSystem.RomFs.AsStorage(true);
+            var storage = context.Device.FileSystem.GetRomFs(_pid).AsStorage(true);
             using var sharedStorage = new SharedRef<LibHac.Fs.IStorage>(storage);
             using var sfStorage = new SharedRef<IStorage>(new StorageInterfaceAdapter(ref sharedStorage.Ref()));
 


### PR DESCRIPTION
We currently loading only one RomFs at a time, which could be wrong if one day we want to load more than one guest at time. This PR fixes that by loading romfs by pid.