### PR TITLE
Ava: Fix Linux Vulkan renderer regression

### DIFF
--- a/Ryujinx.Ava/UI/Renderer/EmbeddedWindow.cs
+++ b/Ryujinx.Ava/UI/Renderer/EmbeddedWindow.cs
@@ -82,7 +82,7 @@ namespace Ryujinx.Ava.UI.Renderer
             }
             else if (OperatingSystem.IsMacOS())
             {
-                return CreateMacOs();
+                return CreateMacOS();
             }
 
             return base.CreateNativeControlCore(control);
@@ -113,7 +113,7 @@ namespace Ryujinx.Ava.UI.Renderer
         }
 
         [SupportedOSPlatform("linux")]
-        protected virtual IPlatformHandle CreateLinux(IPlatformHandle control)
+        private IPlatformHandle CreateLinux(IPlatformHandle control)
         {
             if (ConfigurationState.Instance.Graphics.GraphicsBackend.Value == GraphicsBackend.Vulkan)
             {
@@ -125,7 +125,7 @@ namespace Ryujinx.Ava.UI.Renderer
                 X11Window = PlatformHelper.CreateOpenGLWindow(FramebufferFormat.Default, 0, 0, 100, 100) as GLXWindow;
             }
 
-            WindowHandle = X11Window.WindowHandle.RawHandle;
+            WindowHandle = X11Window!.WindowHandle.RawHandle;
             X11Display   = X11Window.DisplayHandle.RawHandle;
 
             return new PlatformHandle(WindowHandle, "X11");
@@ -228,7 +228,7 @@ namespace Ryujinx.Ava.UI.Renderer
         }
 
         [SupportedOSPlatform("macos")]
-        IPlatformHandle CreateMacOs()
+        IPlatformHandle CreateMacOS()
         {
             MetalLayer = MetalHelper.GetMetalLayer(out IntPtr nsView, out _updateBoundsCallback);
 

--- a/Ryujinx.Ava/UI/Renderer/EmbeddedWindow.cs
+++ b/Ryujinx.Ava/UI/Renderer/EmbeddedWindow.cs
@@ -118,6 +118,7 @@ namespace Ryujinx.Ava.UI.Renderer
             if (ConfigurationState.Instance.Graphics.GraphicsBackend.Value == GraphicsBackend.Vulkan)
             {
                 X11Window = new GLXWindow(new NativeHandle(X11.DefaultDisplay), new NativeHandle(control.Handle));
+                X11Window.Hide();
             }
             else
             {

--- a/Ryujinx.Ava/UI/Renderer/EmbeddedWindow.cs
+++ b/Ryujinx.Ava/UI/Renderer/EmbeddedWindow.cs
@@ -125,7 +125,7 @@ namespace Ryujinx.Ava.UI.Renderer
                 X11Window = PlatformHelper.CreateOpenGLWindow(FramebufferFormat.Default, 0, 0, 100, 100) as GLXWindow;
             }
 
-            WindowHandle = X11Window!.WindowHandle.RawHandle;
+            WindowHandle = X11Window.WindowHandle.RawHandle;
             X11Display   = X11Window.DisplayHandle.RawHandle;
 
             return new PlatformHandle(WindowHandle, "X11");

--- a/Ryujinx.Ava/UI/Renderer/RendererHost.axaml.cs
+++ b/Ryujinx.Ava/UI/Renderer/RendererHost.axaml.cs
@@ -2,14 +2,13 @@ using Avalonia;
 using Avalonia.Controls;
 using Ryujinx.Common.Configuration;
 using Ryujinx.Ui.Common.Configuration;
-using Silk.NET.Vulkan;
 using System;
 
 namespace Ryujinx.Ava.UI.Renderer
 {
     public partial class RendererHost : UserControl, IDisposable
     {
-        public EmbeddedWindow EmbeddedWindow;
+        public readonly EmbeddedWindow EmbeddedWindow;
 
         public event EventHandler<EventArgs> WindowCreated;
         public event Action<object, Size>    SizeChanged;
@@ -17,8 +16,6 @@ namespace Ryujinx.Ava.UI.Renderer
         public RendererHost()
         {
             InitializeComponent();
-
-            Dispose();
 
             if (ConfigurationState.Instance.Graphics.GraphicsBackend.Value == GraphicsBackend.OpenGl)
             {
@@ -47,6 +44,8 @@ namespace Ryujinx.Ava.UI.Renderer
                 EmbeddedWindow.WindowCreated -= CurrentWindow_WindowCreated;
                 EmbeddedWindow.SizeChanged   -= CurrentWindow_SizeChanged;
             }
+
+            GC.SuppressFinalize(this);
         }
 
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)


### PR DESCRIPTION
Regression from #4297, which removes the `X11Window.Hide()` call when creating an embedded Vulkan window.

This PR adds this call again and also performs some cleanup in related `Renderer` classes.