### PR TITLE
Ava UI: Fix `string.Format` issues in Locale

### DIFF
--- a/Ryujinx.Ava/AppHost.cs
+++ b/Ryujinx.Ava/AppHost.cs
@@ -460,10 +460,11 @@ namespace Ryujinx.Ava
                         {
                             if (userError == UserError.NoFirmware)
                             {
+                                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogFirmwareInstallEmbeddedMessage, firmwareVersion.VersionString);
+
                                 UserResult result = await ContentDialogHelper.CreateConfirmationDialog(
                                     LocaleManager.Instance[LocaleKeys.DialogFirmwareNoFirmwareInstalledMessage],
-                                    string.Format(LocaleManager.Instance[LocaleKeys.DialogFirmwareInstallEmbeddedMessage],
-                                    firmwareVersion.VersionString),
+                                    LocaleManager.Instance[LocaleKeys.DialogFirmwareInstallEmbeddedMessage],
                                     LocaleManager.Instance[LocaleKeys.InputDialogYes],
                                     LocaleManager.Instance[LocaleKeys.InputDialogNo],
                                     "");
@@ -492,11 +493,12 @@ namespace Ryujinx.Ava
 
                                 _viewModel.RefreshFirmwareStatus();
 
+                                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogFirmwareInstalledMessage, firmwareVersion.VersionString);
+                                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogFirmwareInstallEmbeddedSuccessMessage, firmwareVersion.VersionString);
+
                                 await ContentDialogHelper.CreateInfoDialog(
-                                    string.Format(LocaleManager.Instance[LocaleKeys.DialogFirmwareInstalledMessage],
-                                    firmwareVersion.VersionString),
-                                    string.Format(LocaleManager.Instance[LocaleKeys.DialogFirmwareInstallEmbeddedSuccessMessage],
-                                    firmwareVersion.VersionString),
+                                    LocaleManager.Instance[LocaleKeys.DialogFirmwareInstalledMessage],
+                                    LocaleManager.Instance[LocaleKeys.DialogFirmwareInstallEmbeddedSuccessMessage],
                                     LocaleManager.Instance[LocaleKeys.InputDialogOk],
                                     "",
                                     LocaleManager.Instance[LocaleKeys.RyujinxInfo]);

--- a/Ryujinx.Ava/AppHost.cs
+++ b/Ryujinx.Ava/AppHost.cs
@@ -460,11 +460,9 @@ namespace Ryujinx.Ava
                         {
                             if (userError == UserError.NoFirmware)
                             {
-                                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogFirmwareInstallEmbeddedMessage, firmwareVersion.VersionString);
-
                                 UserResult result = await ContentDialogHelper.CreateConfirmationDialog(
                                     LocaleManager.Instance[LocaleKeys.DialogFirmwareNoFirmwareInstalledMessage],
-                                    LocaleManager.Instance[LocaleKeys.DialogFirmwareInstallEmbeddedMessage],
+                                    LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogFirmwareInstallEmbeddedMessage, firmwareVersion.VersionString),
                                     LocaleManager.Instance[LocaleKeys.InputDialogYes],
                                     LocaleManager.Instance[LocaleKeys.InputDialogNo],
                                     "");
@@ -493,12 +491,9 @@ namespace Ryujinx.Ava
 
                                 _viewModel.RefreshFirmwareStatus();
 
-                                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogFirmwareInstalledMessage, firmwareVersion.VersionString);
-                                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogFirmwareInstallEmbeddedSuccessMessage, firmwareVersion.VersionString);
-
                                 await ContentDialogHelper.CreateInfoDialog(
-                                    LocaleManager.Instance[LocaleKeys.DialogFirmwareInstalledMessage],
-                                    LocaleManager.Instance[LocaleKeys.DialogFirmwareInstallEmbeddedSuccessMessage],
+                                    LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogFirmwareInstalledMessage, firmwareVersion.VersionString),
+                                    LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogFirmwareInstallEmbeddedSuccessMessage, firmwareVersion.VersionString),
                                     LocaleManager.Instance[LocaleKeys.InputDialogOk],
                                     "",
                                     LocaleManager.Instance[LocaleKeys.RyujinxInfo]);

--- a/Ryujinx.Ava/Assets/Locales/de_DE.json
+++ b/Ryujinx.Ava/Assets/Locales/de_DE.json
@@ -370,7 +370,7 @@
   "DialogUserProfileDeletionConfirmMessage": "Möchtest du das ausgewählte Profil löschen?",
   "DialogControllerSettingsModifiedConfirmMessage": "Die aktuellen Controller-Einstellungen wurden aktualisiert.",
   "DialogControllerSettingsModifiedConfirmSubMessage": "Controller-Einstellungen speichern?",
-  "DialogDlcLoadNcaErrorMessage": "{0}. Fehlerhafte Datei: {1}",
+  "DialogLoadNcaErrorMessage": "{0}. Fehlerhafte Datei: {1}",
   "DialogDlcNoDlcErrorMessage": "Die angegebene Datei enthält keinen DLC für den ausgewählten Titel!",
   "DialogPerformanceCheckLoggingEnabledMessage": "Es wurde die Debug Protokollierung aktiviert",
   "DialogPerformanceCheckLoggingEnabledConfirmMessage": "Um eine optimale Leistung zu erzielen, wird empfohlen, die Debug Protokollierung zu deaktivieren. Debug Protokollierung jetzt deaktivieren?",

--- a/Ryujinx.Ava/Assets/Locales/el_GR.json
+++ b/Ryujinx.Ava/Assets/Locales/el_GR.json
@@ -370,7 +370,7 @@
   "DialogUserProfileDeletionConfirmMessage": "Θέλετε να διαγράψετε το επιλεγμένο προφίλ",
   "DialogControllerSettingsModifiedConfirmMessage": "Οι τρέχουσες ρυθμίσεις χειρισμού έχουν ενημερωθεί.",
   "DialogControllerSettingsModifiedConfirmSubMessage": "Θέλετε να αποθηκεύσετε;",
-  "DialogDlcLoadNcaErrorMessage": "{0}. Σφάλμα Αρχείου: {1}",
+  "DialogLoadNcaErrorMessage": "{0}. Σφάλμα Αρχείου: {1}",
   "DialogDlcNoDlcErrorMessage": "Το αρχείο δεν περιέχει DLC για τον επιλεγμένο τίτλο!",
   "DialogPerformanceCheckLoggingEnabledMessage": "Έχετε ενεργοποιημένη την καταγραφή εντοπισμού σφαλμάτων, η οποία έχει σχεδιαστεί για χρήση μόνο από προγραμματιστές.",
   "DialogPerformanceCheckLoggingEnabledConfirmMessage": "Για βέλτιστη απόδοση, συνιστάται η απενεργοποίηση καταγραφής εντοπισμού σφαλμάτων. Θέλετε να απενεργοποιήσετε την καταγραφή τώρα;",

--- a/Ryujinx.Ava/Assets/Locales/en_US.json
+++ b/Ryujinx.Ava/Assets/Locales/en_US.json
@@ -375,7 +375,7 @@
   "DialogUserProfileUnsavedChangesSubMessage": "Do you want to discard your changes?",
   "DialogControllerSettingsModifiedConfirmMessage": "The current controller settings has been updated.",
   "DialogControllerSettingsModifiedConfirmSubMessage": "Do you want to save?",
-  "DialogDlcLoadNcaErrorMessage": "{0}. Errored File: {1}",
+  "DialogLoadNcaErrorMessage": "{0}. Errored File: {1}",
   "DialogDlcNoDlcErrorMessage": "The specified file does not contain a DLC for the selected title!",
   "DialogPerformanceCheckLoggingEnabledMessage": "You have trace logging enabled, which is designed to be used by developers only.",
   "DialogPerformanceCheckLoggingEnabledConfirmMessage": "For optimal performance, it's recommended to disable trace logging. Would you like to disable trace logging now?",

--- a/Ryujinx.Ava/Assets/Locales/es_ES.json
+++ b/Ryujinx.Ava/Assets/Locales/es_ES.json
@@ -370,7 +370,7 @@
   "DialogUserProfileDeletionConfirmMessage": "¿Quieres eliminar el perfil seleccionado?",
   "DialogControllerSettingsModifiedConfirmMessage": "Se ha actualizado la configuración del mando actual.",
   "DialogControllerSettingsModifiedConfirmSubMessage": "¿Guardar cambios?",
-  "DialogDlcLoadNcaErrorMessage": "{0}. Archivo con error: {1}",
+  "DialogLoadNcaErrorMessage": "{0}. Archivo con error: {1}",
   "DialogDlcNoDlcErrorMessage": "¡Ese archivo no contiene contenido descargable para el título seleccionado!",
   "DialogPerformanceCheckLoggingEnabledMessage": "Has habilitado los registros debug, diseñados solo para uso de los desarrolladores.",
   "DialogPerformanceCheckLoggingEnabledConfirmMessage": "Para un rendimiento óptimo, se recomienda deshabilitar los registros debug. ¿Quieres deshabilitarlos ahora?",

--- a/Ryujinx.Ava/Assets/Locales/fr_FR.json
+++ b/Ryujinx.Ava/Assets/Locales/fr_FR.json
@@ -370,7 +370,7 @@
   "DialogUserProfileDeletionConfirmMessage": "Voulez-vous supprimer le profil sélectionné ?",
   "DialogControllerSettingsModifiedConfirmMessage": "Les paramètres actuels du contrôleur ont été mis à jour.",
   "DialogControllerSettingsModifiedConfirmSubMessage": "Voulez-vous sauvegarder?",
-  "DialogDlcLoadNcaErrorMessage": "{0}. Fichier erroné : {1}",
+  "DialogLoadNcaErrorMessage": "{0}. Fichier erroné : {1}",
   "DialogDlcNoDlcErrorMessage": "Le fichier spécifié ne contient pas de DLC pour le titre sélectionné !",
   "DialogPerformanceCheckLoggingEnabledMessage": "Vous avez activé la journalisation des traces, conçue pour être utilisée uniquement par les développeurs.",
   "DialogPerformanceCheckLoggingEnabledConfirmMessage": "Pour des performances optimales, il est recommandé de désactiver la journalisation des traces. Souhaitez-vous désactiver la journalisation des traces maintenant ?",

--- a/Ryujinx.Ava/Assets/Locales/it_IT.json
+++ b/Ryujinx.Ava/Assets/Locales/it_IT.json
@@ -370,7 +370,7 @@
   "DialogUserProfileDeletionConfirmMessage": "Vuoi eliminare il profilo selezionato?",
   "DialogControllerSettingsModifiedConfirmMessage": "Le attuali impostazioni del controller sono state aggiornate.",
   "DialogControllerSettingsModifiedConfirmSubMessage": "Vuoi salvare?",
-  "DialogDlcLoadNcaErrorMessage": "{0}. File errato: {1}",
+  "DialogLoadNcaErrorMessage": "{0}. File errato: {1}",
   "DialogDlcNoDlcErrorMessage": "Il file specificato non contiene un DLC per il titolo selezionato!",
   "DialogPerformanceCheckLoggingEnabledMessage": "Hai abilitato il trace logging, che è progettato per essere usato solo dagli sviluppatori.",
   "DialogPerformanceCheckLoggingEnabledConfirmMessage": "Per prestazioni ottimali, si raccomanda di disabilitare il trace logging. Vuoi disabilitare il debug logging adesso?",

--- a/Ryujinx.Ava/Assets/Locales/ja_JP.json
+++ b/Ryujinx.Ava/Assets/Locales/ja_JP.json
@@ -370,7 +370,7 @@
   "DialogUserProfileDeletionConfirmMessage": "選択されたプロファイルを削除しますか",
   "DialogControllerSettingsModifiedConfirmMessage": "現在のコントローラ設定が更新されました.",
   "DialogControllerSettingsModifiedConfirmSubMessage": "セーブしますか?",
-  "DialogDlcLoadNcaErrorMessage": "{0}. エラー発生ファイル: {1}",
+  "DialogLoadNcaErrorMessage": "{0}. エラー発生ファイル: {1}",
   "DialogDlcNoDlcErrorMessage": "選択されたファイルはこのタイトル用の DLC ではありません!",
   "DialogPerformanceCheckLoggingEnabledMessage": "トレースロギングを有効にします. これは開発者のみに有用な機能です.",
   "DialogPerformanceCheckLoggingEnabledConfirmMessage": "パフォーマンス最適化のためには,トレースロギングを無効にすることを推奨します. トレースロギングを無効にしてよろしいですか?",

--- a/Ryujinx.Ava/Assets/Locales/ko_KR.json
+++ b/Ryujinx.Ava/Assets/Locales/ko_KR.json
@@ -370,7 +370,7 @@
   "DialogUserProfileDeletionConfirmMessage": "선택한 프로파일을 삭제하겠습니까?",
   "DialogControllerSettingsModifiedConfirmMessage": "현재 컨트롤러 설정이 업데이트되었습니다.",
   "DialogControllerSettingsModifiedConfirmSubMessage": "저장하겠습니까?",
-  "DialogDlcLoadNcaErrorMessage": "{0}입니다. 오류 발생 파일: {1}",
+  "DialogLoadNcaErrorMessage": "{0}입니다. 오류 발생 파일: {1}",
   "DialogDlcNoDlcErrorMessage": "지정된 파일에 선택한 타이틀에 대한 DLC가 포함되어 있지 않습니다!",
   "DialogPerformanceCheckLoggingEnabledMessage": "개발자만 사용하도록 설계된 추적 로깅이 활성화되어 있습니다.",
   "DialogPerformanceCheckLoggingEnabledConfirmMessage": "최적의 성능을 위해 추적 로깅을 비활성화하는 것이 좋습니다. 지금 추적 로깅을 비활성화하겠습니까?",

--- a/Ryujinx.Ava/Assets/Locales/pl_PL.json
+++ b/Ryujinx.Ava/Assets/Locales/pl_PL.json
@@ -370,7 +370,7 @@
   "DialogUserProfileDeletionConfirmMessage": "Czy chcesz usunąć wybrany profil",
   "DialogControllerSettingsModifiedConfirmMessage": "Aktualne ustawienia kontrolera zostały zaktualizowane.",
   "DialogControllerSettingsModifiedConfirmSubMessage": "Czy chcesz zapisać?",
-  "DialogDlcLoadNcaErrorMessage": "{0}. Błędny Plik: {1}",
+  "DialogLoadNcaErrorMessage": "{0}. Błędny Plik: {1}",
   "DialogDlcNoDlcErrorMessage": "Określony plik nie zawiera DLC dla wybranego tytułu!",
   "DialogPerformanceCheckLoggingEnabledMessage": "Masz włączone rejestrowanie śledzenia, które jest przeznaczone tylko dla programistów.",
   "DialogPerformanceCheckLoggingEnabledConfirmMessage": "Aby uzyskać optymalną wydajność, zaleca się wyłączenie rejestrowania śledzenia. Czy chcesz teraz wyłączyć rejestrowanie śledzenia?",

--- a/Ryujinx.Ava/Assets/Locales/pt_BR.json
+++ b/Ryujinx.Ava/Assets/Locales/pt_BR.json
@@ -370,7 +370,7 @@
   "DialogUserProfileDeletionConfirmMessage": "Deseja deletar o perfil selecionado",
   "DialogControllerSettingsModifiedConfirmMessage": "As configurações de controle atuais foram atualizadas.",
   "DialogControllerSettingsModifiedConfirmSubMessage": "Deseja salvar?",
-  "DialogDlcLoadNcaErrorMessage": "{0}. Arquivo com erro: {1}",
+  "DialogLoadNcaErrorMessage": "{0}. Arquivo com erro: {1}",
   "DialogDlcNoDlcErrorMessage": "O arquivo especificado não contém DLCs para o título selecionado!",
   "DialogPerformanceCheckLoggingEnabledMessage": "Os logs de depuração estão ativos, esse recurso é feito para ser usado apenas por desenvolvedores.",
   "DialogPerformanceCheckLoggingEnabledConfirmMessage": "Para melhor performance, é recomendável desabilitar os logs de depuração. Gostaria de desabilitar os logs de depuração agora?",

--- a/Ryujinx.Ava/Assets/Locales/ru_RU.json
+++ b/Ryujinx.Ava/Assets/Locales/ru_RU.json
@@ -370,7 +370,7 @@
   "DialogUserProfileDeletionConfirmMessage": "Вы хотите удалить выбранный профиль",
   "DialogControllerSettingsModifiedConfirmMessage": "Текущие настройки контроллера обновлены.",
   "DialogControllerSettingsModifiedConfirmSubMessage": "Вы хотите сохранить?",
-  "DialogDlcLoadNcaErrorMessage": "{0}. Файл с ошибкой: {1}",
+  "DialogLoadNcaErrorMessage": "{0}. Файл с ошибкой: {1}",
   "DialogDlcNoDlcErrorMessage": "Указанный файл не содержит DLC для выбранной игры!",
   "DialogPerformanceCheckLoggingEnabledMessage": "У вас включено ведение журнала отладки, предназначенное только для разработчиков.",
   "DialogPerformanceCheckLoggingEnabledConfirmMessage": "Для оптимальной производительности рекомендуется отключить ведение журнала отладки. Вы хотите отключить ведение журнала отладки сейчас?",

--- a/Ryujinx.Ava/Assets/Locales/tr_TR.json
+++ b/Ryujinx.Ava/Assets/Locales/tr_TR.json
@@ -370,7 +370,7 @@
   "DialogUserProfileDeletionConfirmMessage": "Seçilen profili silmek istiyor musunuz",
   "DialogControllerSettingsModifiedConfirmMessage": "Güncel kontrolcü seçenekleri güncellendi.",
   "DialogControllerSettingsModifiedConfirmSubMessage": "Kaydetmek istiyor musunuz?",
-  "DialogDlcLoadNcaErrorMessage": "{0}. Hatalı Dosya: {1}",
+  "DialogLoadNcaErrorMessage": "{0}. Hatalı Dosya: {1}",
   "DialogDlcNoDlcErrorMessage": "Belirtilen dosya seçilen oyun için DLC içermiyor!",
   "DialogPerformanceCheckLoggingEnabledMessage": "Sadece geliştiriler için dizayn edilen Trace Loglama seçeneği etkin.",
   "DialogPerformanceCheckLoggingEnabledConfirmMessage": "En iyi performans için trace loglama'nın devre dışı bırakılması tavsiye edilir. Trace loglama seçeneğini şimdi devre dışı bırakmak ister misiniz?",

--- a/Ryujinx.Ava/Assets/Locales/uk_UA.json
+++ b/Ryujinx.Ava/Assets/Locales/uk_UA.json
@@ -370,7 +370,7 @@
   "DialogUserProfileDeletionConfirmMessage": "Ви хочете видалити вибраний профіль",
   "DialogControllerSettingsModifiedConfirmMessage": "Поточні налаштування контролера оновлено.",
   "DialogControllerSettingsModifiedConfirmSubMessage": "Ви хочете зберегти?",
-  "DialogDlcLoadNcaErrorMessage": "{0}. Файл з помилкою: {1}",
+  "DialogLoadNcaErrorMessage": "{0}. Файл з помилкою: {1}",
   "DialogDlcNoDlcErrorMessage": "Зазначений файл не містить DLC для вибраного заголовку!",
   "DialogPerformanceCheckLoggingEnabledMessage": "Ви увімкнули журнал налагодження, призначений лише для розробників.",
   "DialogPerformanceCheckLoggingEnabledConfirmMessage": "Для оптимальної продуктивності рекомендується вимкнути ведення журналу налагодження. Ви хочете вимкнути ведення журналу налагодження зараз?",

--- a/Ryujinx.Ava/Assets/Locales/zh_CN.json
+++ b/Ryujinx.Ava/Assets/Locales/zh_CN.json
@@ -370,7 +370,7 @@
   "DialogUserProfileDeletionConfirmMessage": "是否删除选择的账户",
   "DialogControllerSettingsModifiedConfirmMessage": "目前的输入预设已更新",
   "DialogControllerSettingsModifiedConfirmSubMessage": "要保存吗？",
-  "DialogDlcLoadNcaErrorMessage": "{0}. 错误的文件: {1}",
+  "DialogLoadNcaErrorMessage": "{0}. 错误的文件: {1}",
   "DialogDlcNoDlcErrorMessage": "选择的文件不包含所选游戏的 DLC！",
   "DialogPerformanceCheckLoggingEnabledMessage": "您启用了跟踪日志，仅供开发人员使用。",
   "DialogPerformanceCheckLoggingEnabledConfirmMessage": "为了获得最佳性能，建议禁用跟踪日志记录。您是否要立即禁用？",

--- a/Ryujinx.Ava/Assets/Locales/zh_TW.json
+++ b/Ryujinx.Ava/Assets/Locales/zh_TW.json
@@ -370,7 +370,7 @@
   "DialogUserProfileDeletionConfirmMessage": "是否刪除選擇的帳號",
   "DialogControllerSettingsModifiedConfirmMessage": "目前的輸入預設已更新",
   "DialogControllerSettingsModifiedConfirmSubMessage": "要儲存嗎？",
-  "DialogDlcLoadNcaErrorMessage": "{0}. 錯誤的檔案: {1}",
+  "DialogLoadNcaErrorMessage": "{0}. 錯誤的檔案: {1}",
   "DialogDlcNoDlcErrorMessage": "選擇的檔案不包含所選遊戲的 DLC！",
   "DialogPerformanceCheckLoggingEnabledMessage": "您啟用了跟蹤日誌，僅供開發人員使用。",
   "DialogPerformanceCheckLoggingEnabledConfirmMessage": "為了獲得最佳效能，建議停用跟蹤日誌記錄。您是否要立即停用？",

--- a/Ryujinx.Ava/Common/ApplicationHelper.cs
+++ b/Ryujinx.Ava/Common/ApplicationHelper.cs
@@ -80,8 +80,9 @@ namespace Ryujinx.Ava.Common
                 {
                     Dispatcher.UIThread.Post(async () =>
                     {
-                        await ContentDialogHelper.CreateErrorDialog(
-                            string.Format(LocaleManager.Instance[LocaleKeys.DialogMessageCreateSaveErrorMessage], result.ToStringWithName()));
+                        LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogMessageCreateSaveErrorMessage, result.ToStringWithName());
+
+                        await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance[LocaleKeys.DialogMessageCreateSaveErrorMessage]);
                     });
 
                     return false;
@@ -100,7 +101,9 @@ namespace Ryujinx.Ava.Common
 
             Dispatcher.UIThread.Post(async () =>
             {
-                await ContentDialogHelper.CreateErrorDialog(string.Format(LocaleManager.Instance[LocaleKeys.DialogMessageFindSaveErrorMessage], result.ToStringWithName()));
+                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogMessageFindSaveErrorMessage, result.ToStringWithName());
+
+                await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance[LocaleKeys.DialogMessageFindSaveErrorMessage]);
             });
 
             return false;
@@ -163,8 +166,10 @@ namespace Ryujinx.Ava.Common
                 {
                     Dispatcher.UIThread.Post(async () =>
                     {
+                        LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogNcaExtractionMessage, ncaSectionType, Path.GetFileName(titleFilePath));
+
                         UserResult result = await ContentDialogHelper.CreateConfirmationDialog(
-                            string.Format(LocaleManager.Instance[LocaleKeys.DialogNcaExtractionMessage], ncaSectionType, Path.GetFileName(titleFilePath)),
+                            LocaleManager.Instance[LocaleKeys.DialogNcaExtractionMessage],
                             "",
                             "",
                             LocaleManager.Instance[LocaleKeys.InputDialogCancel],

--- a/Ryujinx.Ava/Common/ApplicationHelper.cs
+++ b/Ryujinx.Ava/Common/ApplicationHelper.cs
@@ -80,9 +80,7 @@ namespace Ryujinx.Ava.Common
                 {
                     Dispatcher.UIThread.Post(async () =>
                     {
-                        LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogMessageCreateSaveErrorMessage, result.ToStringWithName());
-
-                        await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance[LocaleKeys.DialogMessageCreateSaveErrorMessage]);
+                        await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogMessageCreateSaveErrorMessage, result.ToStringWithName()));
                     });
 
                     return false;
@@ -101,9 +99,7 @@ namespace Ryujinx.Ava.Common
 
             Dispatcher.UIThread.Post(async () =>
             {
-                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogMessageFindSaveErrorMessage, result.ToStringWithName());
-
-                await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance[LocaleKeys.DialogMessageFindSaveErrorMessage]);
+                await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogMessageFindSaveErrorMessage, result.ToStringWithName()));
             });
 
             return false;
@@ -166,10 +162,8 @@ namespace Ryujinx.Ava.Common
                 {
                     Dispatcher.UIThread.Post(async () =>
                     {
-                        LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogNcaExtractionMessage, ncaSectionType, Path.GetFileName(titleFilePath));
-
                         UserResult result = await ContentDialogHelper.CreateConfirmationDialog(
-                            LocaleManager.Instance[LocaleKeys.DialogNcaExtractionMessage],
+                            LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogNcaExtractionMessage, ncaSectionType, Path.GetFileName(titleFilePath)),
                             "",
                             "",
                             LocaleManager.Instance[LocaleKeys.InputDialogCancel],

--- a/Ryujinx.Ava/Common/Locale/LocaleExtension.cs
+++ b/Ryujinx.Ava/Common/Locale/LocaleExtension.cs
@@ -20,7 +20,7 @@ namespace Ryujinx.Ava.Common.Locale
 
             ReflectionBindingExtension binding = new($"[{keyToUse}]")
             {
-                Mode = BindingMode.OneWay,
+                Mode   = BindingMode.OneWay,
                 Source = LocaleManager.Instance
             };
 

--- a/Ryujinx.Ava/Common/Locale/LocaleManager.cs
+++ b/Ryujinx.Ava/Common/Locale/LocaleManager.cs
@@ -59,7 +59,7 @@ namespace Ryujinx.Ava.Common.Locale
                 // Check if the locale contains the key.
                 if (_localeStrings.TryGetValue(key, out string value))
                 {
-                    // Check if the locale needs to be formatted.
+                    // Check if the localized string needs to be formatted.
                     if (_dynamicValues.TryGetValue(key, out var dynamicValue))
                     {
                         try
@@ -68,7 +68,7 @@ namespace Ryujinx.Ava.Common.Locale
                         }
                         catch (Exception)
                         {
-                            // If formatting failed, then use the default locale text.
+                            // If formatting failed use the default text instead.
                             if (_localeDefaultStrings.TryGetValue(key, out value))
                             {
                                 try
@@ -77,7 +77,7 @@ namespace Ryujinx.Ava.Common.Locale
                                 }
                                 catch (Exception)
                                 {
-                                    // If formatting locale default text failed, then returns the key.
+                                    // If formatting the default text failed return the key.
                                     return key.ToString();
                                 }
                             }
@@ -87,13 +87,13 @@ namespace Ryujinx.Ava.Common.Locale
                     return value;
                 }
 
-                // If the locale doesn't contain the key, then returns the default one.
+                // If the locale doesn't contain the key return the default one.
                 if (_localeDefaultStrings.TryGetValue(key, out string defaultValue))
                 {
                     return defaultValue;
                 }
 
-                // If the locale text doesn't exist, then returns the key.
+                // If the locale text doesn't exist return the key.
                 return key.ToString();
             }
             set

--- a/Ryujinx.Ava/Common/Locale/LocaleManager.cs
+++ b/Ryujinx.Ava/Common/Locale/LocaleManager.cs
@@ -104,11 +104,13 @@ namespace Ryujinx.Ava.Common.Locale
             }
         }
 
-        public void UpdateDynamicValue(LocaleKeys key, params object[] values)
+        public string UpdateAndGetDynamicValue(LocaleKeys key, params object[] values)
         {
             _dynamicValues[key] = values;
 
             OnPropertyChanged("Item");
+
+            return this[key];
         }
 
         private void LoadDefaultLanguage()

--- a/Ryujinx.Ava/Common/Locale/LocaleManager.cs
+++ b/Ryujinx.Ava/Common/Locale/LocaleManager.cs
@@ -49,10 +49,7 @@ namespace Ryujinx.Ava.Common.Locale
             // Load en_US as default, if the target language translation is incomplete.
             LoadDefaultLanguage();
 
-            if (localeLanguageCode != DefaultLanguageCode)
-            {
-                LoadLanguage(localeLanguageCode);
-            }
+            LoadLanguage(localeLanguageCode);
         }
 
         public string this[LocaleKeys key]

--- a/Ryujinx.Ava/Modules/Updater/Updater.cs
+++ b/Ryujinx.Ava/Modules/Updater/Updater.cs
@@ -577,9 +577,7 @@ namespace Ryujinx.Modules
                     }
                     catch
                     {
-                        LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.UpdaterRenameFailed, file);
-
-                        Logger.Warning?.Print(LogClass.Application, LocaleManager.Instance[LocaleKeys.UpdaterRenameFailed]);
+                        Logger.Warning?.Print(LogClass.Application, LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.UpdaterRenameFailed, file));
                     }
                 }
 

--- a/Ryujinx.Ava/Modules/Updater/Updater.cs
+++ b/Ryujinx.Ava/Modules/Updater/Updater.cs
@@ -577,7 +577,9 @@ namespace Ryujinx.Modules
                     }
                     catch
                     {
-                        Logger.Warning?.Print(LogClass.Application, string.Format(LocaleManager.Instance[LocaleKeys.UpdaterRenameFailed], file));
+                        LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.UpdaterRenameFailed, file);
+
+                        Logger.Warning?.Print(LogClass.Application, LocaleManager.Instance[LocaleKeys.UpdaterRenameFailed]);
                     }
                 }
 

--- a/Ryujinx.Ava/UI/Applet/AvaHostUiHandler.cs
+++ b/Ryujinx.Ava/UI/Applet/AvaHostUiHandler.cs
@@ -35,11 +35,13 @@ namespace Ryujinx.Ava.UI.Applet
 
             LocaleKeys key = args.PlayerCountMin == args.PlayerCountMax ? LocaleKeys.DialogControllerAppletMessage : LocaleKeys.DialogControllerAppletMessagePlayerRange;
 
-            string message = string.Format(LocaleManager.Instance[key],
-                                           playerCount,
-                                           args.SupportedStyles,
-                                           string.Join(", ", args.SupportedPlayers),
-                                           args.IsDocked ? LocaleManager.Instance[LocaleKeys.DialogControllerAppletDockModeSet] : "");
+            LocaleManager.Instance.UpdateDynamicValue(key,
+                playerCount,
+                args.SupportedStyles,
+                string.Join(", ", args.SupportedPlayers),
+                args.IsDocked ? LocaleManager.Instance[LocaleKeys.DialogControllerAppletDockModeSet] : "");
+
+            string message = LocaleManager.Instance[key];
 
             return DisplayMessageDialog(LocaleManager.Instance[LocaleKeys.DialogControllerAppletTitle], message);
         }
@@ -92,7 +94,9 @@ namespace Ryujinx.Ava.UI.Applet
                 }
                 catch (Exception ex)
                 {
-                    await ContentDialogHelper.CreateErrorDialog(string.Format(LocaleManager.Instance[LocaleKeys.DialogMessageDialogErrorExceptionMessage], ex));
+                    LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogMessageDialogErrorExceptionMessage, ex);
+            
+                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance[LocaleKeys.DialogMessageDialogErrorExceptionMessage]);
 
                     dialogCloseEvent.Set();
                 }
@@ -126,7 +130,10 @@ namespace Ryujinx.Ava.UI.Applet
                 catch (Exception ex)
                 {
                     error = true;
-                    await ContentDialogHelper.CreateErrorDialog(string.Format(LocaleManager.Instance[LocaleKeys.DialogSoftwareKeyboardErrorExceptionMessage], ex));
+
+                    LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogSoftwareKeyboardErrorExceptionMessage, ex);
+
+                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance[LocaleKeys.DialogSoftwareKeyboardErrorExceptionMessage]);
                 }
                 finally
                 {
@@ -181,7 +188,10 @@ namespace Ryujinx.Ava.UI.Applet
                 catch (Exception ex)
                 {
                     dialogCloseEvent.Set();
-                    await ContentDialogHelper.CreateErrorDialog(string.Format(LocaleManager.Instance[LocaleKeys.DialogErrorAppletErrorExceptionMessage], ex));
+
+                    LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogErrorAppletErrorExceptionMessage, ex);
+
+                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance[LocaleKeys.DialogErrorAppletErrorExceptionMessage]);
                 }
             });
 

--- a/Ryujinx.Ava/UI/Applet/AvaHostUiHandler.cs
+++ b/Ryujinx.Ava/UI/Applet/AvaHostUiHandler.cs
@@ -29,19 +29,12 @@ namespace Ryujinx.Ava.UI.Applet
 
         public bool DisplayMessageDialog(ControllerAppletUiArgs args)
         {
-            string playerCount = args.PlayerCountMin == args.PlayerCountMax
-                ? args.PlayerCountMin.ToString()
-                : $"{args.PlayerCountMin}-{args.PlayerCountMax}";
-
-            LocaleKeys key = args.PlayerCountMin == args.PlayerCountMax ? LocaleKeys.DialogControllerAppletMessage : LocaleKeys.DialogControllerAppletMessagePlayerRange;
-
-            LocaleManager.Instance.UpdateDynamicValue(key,
-                playerCount,
+            string message = LocaleManager.Instance.UpdateAndGetDynamicValue(
+                args.PlayerCountMin == args.PlayerCountMax ? LocaleKeys.DialogControllerAppletMessage : LocaleKeys.DialogControllerAppletMessagePlayerRange,
+                args.PlayerCountMin == args.PlayerCountMax ? args.PlayerCountMin.ToString() : $"{args.PlayerCountMin}-{args.PlayerCountMax}",
                 args.SupportedStyles,
                 string.Join(", ", args.SupportedPlayers),
                 args.IsDocked ? LocaleManager.Instance[LocaleKeys.DialogControllerAppletDockModeSet] : "");
-
-            string message = LocaleManager.Instance[key];
 
             return DisplayMessageDialog(LocaleManager.Instance[LocaleKeys.DialogControllerAppletTitle], message);
         }
@@ -94,9 +87,7 @@ namespace Ryujinx.Ava.UI.Applet
                 }
                 catch (Exception ex)
                 {
-                    LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogMessageDialogErrorExceptionMessage, ex);
-            
-                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance[LocaleKeys.DialogMessageDialogErrorExceptionMessage]);
+                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogMessageDialogErrorExceptionMessage, ex));
 
                     dialogCloseEvent.Set();
                 }
@@ -131,9 +122,7 @@ namespace Ryujinx.Ava.UI.Applet
                 {
                     error = true;
 
-                    LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogSoftwareKeyboardErrorExceptionMessage, ex);
-
-                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance[LocaleKeys.DialogSoftwareKeyboardErrorExceptionMessage]);
+                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogSoftwareKeyboardErrorExceptionMessage, ex));
                 }
                 finally
                 {
@@ -189,9 +178,7 @@ namespace Ryujinx.Ava.UI.Applet
                 {
                     dialogCloseEvent.Set();
 
-                    LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogErrorAppletErrorExceptionMessage, ex);
-
-                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance[LocaleKeys.DialogErrorAppletErrorExceptionMessage]);
+                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogErrorAppletErrorExceptionMessage, ex));
                 }
             });
 

--- a/Ryujinx.Ava/UI/Applet/SwkbdAppletDialog.axaml.cs
+++ b/Ryujinx.Ava/UI/Applet/SwkbdAppletDialog.axaml.cs
@@ -140,9 +140,7 @@ namespace Ryujinx.Ava.UI.Controls
             {
                 Error.IsVisible = true;
 
-                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.SwkbdMinCharacters, _inputMin);
-
-                Error.Text = LocaleManager.Instance[LocaleKeys.SwkbdMinCharacters];
+                Error.Text = LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.SwkbdMinCharacters, _inputMin);
 
                 _checkLength = length => _inputMin <= length;
             }
@@ -150,9 +148,7 @@ namespace Ryujinx.Ava.UI.Controls
             {
                 Error.IsVisible = true;
 
-                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.SwkbdMinRangeCharacters, _inputMin, _inputMax);
-
-                Error.Text = LocaleManager.Instance[LocaleKeys.SwkbdMinRangeCharacters];
+                Error.Text = LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.SwkbdMinRangeCharacters, _inputMin, _inputMax);
 
                 _checkLength = length => _inputMin <= length && length <= _inputMax;
             }

--- a/Ryujinx.Ava/UI/Applet/SwkbdAppletDialog.axaml.cs
+++ b/Ryujinx.Ava/UI/Applet/SwkbdAppletDialog.axaml.cs
@@ -139,14 +139,20 @@ namespace Ryujinx.Ava.UI.Controls
             else if (_inputMin > 0 && _inputMax == int.MaxValue)
             {
                 Error.IsVisible = true;
-                Error.Text = string.Format(LocaleManager.Instance[LocaleKeys.SwkbdMinCharacters], _inputMin);
+
+                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.SwkbdMinCharacters, _inputMin);
+
+                Error.Text = LocaleManager.Instance[LocaleKeys.SwkbdMinCharacters];
 
                 _checkLength = length => _inputMin <= length;
             }
             else
             {
                 Error.IsVisible = true;
-                Error.Text = string.Format(LocaleManager.Instance[LocaleKeys.SwkbdMinRangeCharacters], _inputMin, _inputMax);
+
+                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.SwkbdMinRangeCharacters, _inputMin, _inputMax);
+
+                Error.Text = LocaleManager.Instance[LocaleKeys.SwkbdMinRangeCharacters];
 
                 _checkLength = length => _inputMin <= length && length <= _inputMax;
             }

--- a/Ryujinx.Ava/UI/Helpers/UserErrorDialog.cs
+++ b/Ryujinx.Ava/UI/Helpers/UserErrorDialog.cs
@@ -75,15 +75,12 @@ namespace Ryujinx.Ava.UI.Helpers
 
             string setupButtonLabel = isInSetupGuide ? LocaleManager.Instance[LocaleKeys.OpenSetupGuideMessage] : "";
 
-            LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogUserErrorDialogMessage, errorCode, GetErrorTitle(error));
-            LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogUserErrorDialogTitle, errorCode);
-
             var result = await ContentDialogHelper.CreateInfoDialog(
-                LocaleManager.Instance[LocaleKeys.DialogUserErrorDialogMessage],
+                LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogUserErrorDialogMessage, errorCode, GetErrorTitle(error)),
                 GetErrorDescription(error) + (isInSetupGuide
                     ? LocaleManager.Instance[LocaleKeys.DialogUserErrorDialogInfoMessage]
                     : ""), setupButtonLabel, LocaleManager.Instance[LocaleKeys.InputDialogOk],
-                LocaleManager.Instance[LocaleKeys.DialogUserErrorDialogTitle]);
+                LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogUserErrorDialogTitle, errorCode));
 
             if (result == UserResult.Ok)
             {

--- a/Ryujinx.Ava/UI/Helpers/UserErrorDialog.cs
+++ b/Ryujinx.Ava/UI/Helpers/UserErrorDialog.cs
@@ -75,12 +75,15 @@ namespace Ryujinx.Ava.UI.Helpers
 
             string setupButtonLabel = isInSetupGuide ? LocaleManager.Instance[LocaleKeys.OpenSetupGuideMessage] : "";
 
+            LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogUserErrorDialogMessage, errorCode, GetErrorTitle(error));
+            LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogUserErrorDialogTitle, errorCode);
+
             var result = await ContentDialogHelper.CreateInfoDialog(
-                string.Format(LocaleManager.Instance[LocaleKeys.DialogUserErrorDialogMessage], errorCode, GetErrorTitle(error)),
+                LocaleManager.Instance[LocaleKeys.DialogUserErrorDialogMessage],
                 GetErrorDescription(error) + (isInSetupGuide
                     ? LocaleManager.Instance[LocaleKeys.DialogUserErrorDialogInfoMessage]
                     : ""), setupButtonLabel, LocaleManager.Instance[LocaleKeys.InputDialogOk],
-                string.Format(LocaleManager.Instance[LocaleKeys.DialogUserErrorDialogTitle], errorCode));
+                LocaleManager.Instance[LocaleKeys.DialogUserErrorDialogTitle]);
 
             if (result == UserResult.Ok)
             {

--- a/Ryujinx.Ava/UI/Models/TitleUpdateModel.cs
+++ b/Ryujinx.Ava/UI/Models/TitleUpdateModel.cs
@@ -8,15 +8,7 @@ namespace Ryujinx.Ava.UI.Models
         public ApplicationControlProperty Control { get; }
         public string Path { get; }
 
-        public string Label
-        {
-            get
-            {
-                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.TitleUpdateVersionLabel, Control.DisplayVersionString.ToString());
-
-                return LocaleManager.Instance[LocaleKeys.TitleUpdateVersionLabel];
-            }
-        }
+        public string Label => LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.TitleUpdateVersionLabel, Control.DisplayVersionString.ToString());
 
         public TitleUpdateModel(ApplicationControlProperty control, string path)
         {

--- a/Ryujinx.Ava/UI/Models/TitleUpdateModel.cs
+++ b/Ryujinx.Ava/UI/Models/TitleUpdateModel.cs
@@ -8,7 +8,15 @@ namespace Ryujinx.Ava.UI.Models
         public ApplicationControlProperty Control { get; }
         public string Path { get; }
 
-        public string Label => string.Format(LocaleManager.Instance[LocaleKeys.TitleUpdateVersionLabel], Control.DisplayVersionString.ToString());
+        public string Label
+        {
+            get
+            {
+                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.TitleUpdateVersionLabel, Control.DisplayVersionString.ToString());
+
+                return LocaleManager.Instance[LocaleKeys.TitleUpdateVersionLabel];
+            }
+        }
 
         public TitleUpdateModel(ApplicationControlProperty control, string path)
         {

--- a/Ryujinx.Ava/UI/ViewModels/AboutWindowViewModel.cs
+++ b/Ryujinx.Ava/UI/ViewModels/AboutWindowViewModel.cs
@@ -83,7 +83,12 @@ namespace Ryujinx.Ava.UI.ViewModels
 
         public string Developers
         {
-            get => string.Format(LocaleManager.Instance[LocaleKeys.AboutPageDeveloperListMore], "gdkchan, Ac_K, marysaka, rip in peri peri, LDj3SNuD, emmaus, Thealexbarney, GoffyDude, TSRBerry, IsaacMarovitz");
+            get
+            {
+                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.AboutPageDeveloperListMore, "gdkchan, Ac_K, marysaka, rip in peri peri, LDj3SNuD, emmaus, Thealexbarney, GoffyDude, TSRBerry, IsaacMarovitz");
+
+                return LocaleManager.Instance[LocaleKeys.AboutPageDeveloperListMore];
+            }
         }
 
         public AboutWindowViewModel()

--- a/Ryujinx.Ava/UI/ViewModels/AboutWindowViewModel.cs
+++ b/Ryujinx.Ava/UI/ViewModels/AboutWindowViewModel.cs
@@ -81,15 +81,7 @@ namespace Ryujinx.Ava.UI.ViewModels
             }
         }
 
-        public string Developers
-        {
-            get
-            {
-                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.AboutPageDeveloperListMore, "gdkchan, Ac_K, marysaka, rip in peri peri, LDj3SNuD, emmaus, Thealexbarney, GoffyDude, TSRBerry, IsaacMarovitz");
-
-                return LocaleManager.Instance[LocaleKeys.AboutPageDeveloperListMore];
-            }
-        }
+        public string Developers => LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.AboutPageDeveloperListMore, "gdkchan, Ac_K, marysaka, rip in peri peri, LDj3SNuD, emmaus, Thealexbarney, GoffyDude, TSRBerry, IsaacMarovitz");
 
         public AboutWindowViewModel()
         {

--- a/Ryujinx.Ava/UI/ViewModels/ControllerSettingsViewModel.cs
+++ b/Ryujinx.Ava/UI/ViewModels/ControllerSettingsViewModel.cs
@@ -3,6 +3,8 @@ using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Svg.Skia;
 using Avalonia.Threading;
+using LibHac.Bcat;
+using LibHac.Tools.Fs;
 using Ryujinx.Ava.Common.Locale;
 using Ryujinx.Ava.Input;
 using Ryujinx.Ava.UI.Controls;
@@ -717,7 +719,9 @@ namespace Ryujinx.Ava.UI.ViewModels
                 {
                     Logger.Error?.Print(LogClass.Configuration, $"Profile {ProfileName} is incompatible with the current input configuration system.");
 
-                    await ContentDialogHelper.CreateErrorDialog(string.Format(LocaleManager.Instance[LocaleKeys.DialogProfileInvalidProfileErrorMessage], ProfileName));
+                    LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogProfileInvalidProfileErrorMessage, ProfileName);
+
+                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance[LocaleKeys.DialogProfileInvalidProfileErrorMessage]);
 
                     return;
                 }

--- a/Ryujinx.Ava/UI/ViewModels/ControllerSettingsViewModel.cs
+++ b/Ryujinx.Ava/UI/ViewModels/ControllerSettingsViewModel.cs
@@ -719,9 +719,7 @@ namespace Ryujinx.Ava.UI.ViewModels
                 {
                     Logger.Error?.Print(LogClass.Configuration, $"Profile {ProfileName} is incompatible with the current input configuration system.");
 
-                    LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogProfileInvalidProfileErrorMessage, ProfileName);
-
-                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance[LocaleKeys.DialogProfileInvalidProfileErrorMessage]);
+                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogProfileInvalidProfileErrorMessage, ProfileName));
 
                     return;
                 }

--- a/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
+++ b/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
@@ -950,25 +950,18 @@ namespace Ryujinx.Ava.UI.ViewModels
 
                 if (firmwareVersion == null)
                 {
-                    LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogFirmwareInstallerFirmwareNotFoundErrorMessage, filename);
-
-                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance[LocaleKeys.DialogFirmwareInstallerFirmwareNotFoundErrorMessage]);
+                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogFirmwareInstallerFirmwareNotFoundErrorMessage, filename));
 
                     return;
                 }
 
-                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogFirmwareInstallerFirmwareInstallTitle, firmwareVersion.VersionString);
-                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogFirmwareInstallerFirmwareInstallMessage, firmwareVersion.VersionString);
-
-                string dialogTitle = LocaleManager.Instance[LocaleKeys.DialogFirmwareInstallerFirmwareInstallTitle];
-                string dialogMessage = LocaleManager.Instance[LocaleKeys.DialogFirmwareInstallerFirmwareInstallMessage];
+                string dialogTitle = LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogFirmwareInstallerFirmwareInstallTitle, firmwareVersion.VersionString);
+                string dialogMessage = LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogFirmwareInstallerFirmwareInstallMessage, firmwareVersion.VersionString);
 
                 SystemVersion currentVersion = ContentManager.GetCurrentFirmwareVersion();
                 if (currentVersion != null)
                 {
-                    LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogFirmwareInstallerFirmwareInstallSubMessage, currentVersion.VersionString);
-
-                    dialogMessage += LocaleManager.Instance[LocaleKeys.DialogFirmwareInstallerFirmwareInstallSubMessage];
+                    dialogMessage += LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogFirmwareInstallerFirmwareInstallSubMessage, currentVersion.VersionString);
                 }
 
                 dialogMessage += LocaleManager.Instance[LocaleKeys.DialogFirmwareInstallerFirmwareInstallConfirmMessage];
@@ -1001,9 +994,7 @@ namespace Ryujinx.Ava.UI.ViewModels
                             {
                                 waitingDialog.Close();
 
-                                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogFirmwareInstallerFirmwareInstallSuccessMessage, firmwareVersion.VersionString);
-
-                                string message = LocaleManager.Instance[LocaleKeys.DialogFirmwareInstallerFirmwareInstallSuccessMessage];
+                                string message = LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogFirmwareInstallerFirmwareInstallSuccessMessage, firmwareVersion.VersionString);
 
                                 await ContentDialogHelper.CreateInfoDialog(dialogTitle, message, LocaleManager.Instance[LocaleKeys.InputDialogOk], "", LocaleManager.Instance[LocaleKeys.RyujinxInfo]);
 
@@ -1073,9 +1064,7 @@ namespace Ryujinx.Ava.UI.ViewModels
                                 IsLoadingIndeterminate = false;
                                 break;
                             case LoadState.Loaded:
-                                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.LoadingHeading, TitleName);
-
-                                LoadHeading = LocaleManager.Instance[LocaleKeys.LoadingHeading];
+                                LoadHeading = LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.LoadingHeading, TitleName);
                                 IsLoadingIndeterminate = true;
                                 CacheLoadStatus = "";
                                 break;
@@ -1091,9 +1080,7 @@ namespace Ryujinx.Ava.UI.ViewModels
                                 IsLoadingIndeterminate = false;
                                 break;
                             case ShaderCacheLoadingState.Loaded:
-                                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.LoadingHeading, TitleName);
-
-                                LoadHeading = LocaleManager.Instance[LocaleKeys.LoadingHeading];
+                                LoadHeading = LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.LoadingHeading, TitleName);
                                 IsLoadingIndeterminate = true;
                                 CacheLoadStatus = "";
                                 break;
@@ -1391,11 +1378,9 @@ namespace Ryujinx.Ava.UI.ViewModels
                 DirectoryInfo mainDir = new(Path.Combine(AppDataManager.GamesDirPath, selection.TitleId, "cache", "cpu", "0"));
                 DirectoryInfo backupDir = new(Path.Combine(AppDataManager.GamesDirPath, selection.TitleId, "cache", "cpu", "1"));
 
-                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogPPTCDeletionMessage, selection.TitleName);
-
                 // FIXME: Found a way to reproduce the bold effect on the title name (fork?).
                 UserResult result = await ContentDialogHelper.CreateConfirmationDialog(LocaleManager.Instance[LocaleKeys.DialogWarning],
-                                                                                       LocaleManager.Instance[LocaleKeys.DialogPPTCDeletionMessage],
+                                                                                       LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogPPTCDeletionMessage, selection.TitleName),
                                                                                        LocaleManager.Instance[LocaleKeys.InputDialogYes],
                                                                                        LocaleManager.Instance[LocaleKeys.InputDialogNo],
                                                                                        LocaleManager.Instance[LocaleKeys.RyujinxConfirm]);
@@ -1422,9 +1407,7 @@ namespace Ryujinx.Ava.UI.ViewModels
                         }
                         catch (Exception e)
                         {
-                            LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogPPTCDeletionErrorMessage, file.Name, e);
-
-                            await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance[LocaleKeys.DialogPPTCDeletionErrorMessage]);
+                            await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogPPTCDeletionErrorMessage, file.Name, e));
                         }
                     }
                 }
@@ -1459,11 +1442,9 @@ namespace Ryujinx.Ava.UI.ViewModels
             {
                 DirectoryInfo shaderCacheDir = new(Path.Combine(AppDataManager.GamesDirPath, selection.TitleId, "cache", "shader"));
 
-                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogShaderDeletionMessage, selection.TitleName);
-
                 // FIXME: Found a way to reproduce the bold effect on the title name (fork?).
                 UserResult result = await ContentDialogHelper.CreateConfirmationDialog(LocaleManager.Instance[LocaleKeys.DialogWarning],
-                                                                                       LocaleManager.Instance[LocaleKeys.DialogShaderDeletionMessage],
+                                                                                       LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogShaderDeletionMessage, selection.TitleName),
                                                                                        LocaleManager.Instance[LocaleKeys.InputDialogYes],
                                                                                        LocaleManager.Instance[LocaleKeys.InputDialogNo],
                                                                                        LocaleManager.Instance[LocaleKeys.RyujinxConfirm]);
@@ -1488,9 +1469,7 @@ namespace Ryujinx.Ava.UI.ViewModels
                         }
                         catch (Exception e)
                         {
-                            LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogPPTCDeletionErrorMessage, directory.Name, e);
-
-                            await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance[LocaleKeys.DialogPPTCDeletionErrorMessage]);
+                            await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogPPTCDeletionErrorMessage, directory.Name, e));
                         }
                     }
                 }
@@ -1503,9 +1482,7 @@ namespace Ryujinx.Ava.UI.ViewModels
                     }
                     catch (Exception e)
                     {
-                        LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.ShaderCachePurgeError, file.Name, e);
-
-                        await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance[LocaleKeys.ShaderCachePurgeError]);
+                        await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.ShaderCachePurgeError, file.Name, e));
                     }
                 }
             }
@@ -1670,7 +1647,7 @@ namespace Ryujinx.Ava.UI.ViewModels
                 StatusBarProgressMaximum = 0;
                 StatusBarProgressValue   = 0;
 
-                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.StatusBarGamesLoaded, 0, 0);
+                LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.StatusBarGamesLoaded, 0, 0);
             });
 
             ReloadGameList?.Invoke();
@@ -1789,9 +1766,7 @@ namespace Ryujinx.Ava.UI.ViewModels
 
                 if (string.IsNullOrWhiteSpace(titleName))
                 {
-                    LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.LoadingHeading, AppHost.Device.Application.TitleName);
-
-                    LoadHeading = LocaleManager.Instance[LocaleKeys.LoadingHeading];
+                    LoadHeading = LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.LoadingHeading, AppHost.Device.Application.TitleName);
                     TitleName   = AppHost.Device.Application.TitleName;
                 }
 
@@ -1844,14 +1819,13 @@ namespace Ryujinx.Ava.UI.ViewModels
 
             if (version != null)
             {
-                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.StatusBarSystemVersion,
-                    version.VersionString);
+                LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.StatusBarSystemVersion, version.VersionString);
 
                 hasApplet = version.Major > 3;
             }
             else
             {
-                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.StatusBarSystemVersion, "0.0");
+                LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.StatusBarSystemVersion, "0.0");
             }
 
             IsAppletMenuActive = hasApplet;

--- a/Ryujinx.Ava/UI/ViewModels/TitleUpdateViewModel.cs
+++ b/Ryujinx.Ava/UI/ViewModels/TitleUpdateViewModel.cs
@@ -181,7 +181,9 @@ public class TitleUpdateViewModel : BaseModel
             {
                 Dispatcher.UIThread.Post(async () =>
                 {
-                    await ContentDialogHelper.CreateErrorDialog(string.Format(LocaleManager.Instance[LocaleKeys.DialogDlcLoadNcaErrorMessage], ex.Message, path));
+                    LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogLoadNcaErrorMessage, ex.Message, path);
+
+                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance[LocaleKeys.DialogLoadNcaErrorMessage]);
                 });
             }
         }

--- a/Ryujinx.Ava/UI/ViewModels/TitleUpdateViewModel.cs
+++ b/Ryujinx.Ava/UI/ViewModels/TitleUpdateViewModel.cs
@@ -181,9 +181,7 @@ public class TitleUpdateViewModel : BaseModel
             {
                 Dispatcher.UIThread.Post(async () =>
                 {
-                    LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogLoadNcaErrorMessage, ex.Message, path);
-
-                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance[LocaleKeys.DialogLoadNcaErrorMessage]);
+                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogLoadNcaErrorMessage, ex.Message, path));
                 });
             }
         }

--- a/Ryujinx.Ava/UI/ViewModels/UserSaveManagerViewModel.cs
+++ b/Ryujinx.Ava/UI/ViewModels/UserSaveManagerViewModel.cs
@@ -17,8 +17,16 @@ namespace Ryujinx.Ava.UI.ViewModels
         private ObservableCollection<SaveModel> _views = new();
         private AccountManager _accountManager;
 
-        public string SaveManagerHeading =>
-            string.Format(LocaleManager.Instance[LocaleKeys.SaveManagerHeading], _accountManager.LastOpenedUser.Name, _accountManager.LastOpenedUser.UserId);
+        public string SaveManagerHeading
+        {
+            get
+            {
+                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.SaveManagerHeading, _accountManager.LastOpenedUser.Name, _accountManager.LastOpenedUser.UserId);
+
+                return LocaleManager.Instance[LocaleKeys.SaveManagerHeading];
+            }
+        }
+            
 
         public int SortIndex
         {

--- a/Ryujinx.Ava/UI/ViewModels/UserSaveManagerViewModel.cs
+++ b/Ryujinx.Ava/UI/ViewModels/UserSaveManagerViewModel.cs
@@ -17,16 +17,7 @@ namespace Ryujinx.Ava.UI.ViewModels
         private ObservableCollection<SaveModel> _views = new();
         private AccountManager _accountManager;
 
-        public string SaveManagerHeading
-        {
-            get
-            {
-                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.SaveManagerHeading, _accountManager.LastOpenedUser.Name, _accountManager.LastOpenedUser.UserId);
-
-                return LocaleManager.Instance[LocaleKeys.SaveManagerHeading];
-            }
-        }
-            
+        public string SaveManagerHeading => LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.SaveManagerHeading, _accountManager.LastOpenedUser.Name, _accountManager.LastOpenedUser.UserId);
 
         public int SortIndex
         {

--- a/Ryujinx.Ava/UI/Windows/CheatWindow.axaml.cs
+++ b/Ryujinx.Ava/UI/Windows/CheatWindow.axaml.cs
@@ -31,7 +31,9 @@ namespace Ryujinx.Ava.UI.Windows
         {
             LoadedCheats = new AvaloniaList<CheatsList>();
 
-            Heading = string.Format(LocaleManager.Instance[LocaleKeys.CheatWindowHeading], titleName, titleId.ToUpper());
+            LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.CheatWindowHeading, titleName, titleId.ToUpper());
+
+            Heading = LocaleManager.Instance[LocaleKeys.CheatWindowHeading];
 
             InitializeComponent();
 

--- a/Ryujinx.Ava/UI/Windows/CheatWindow.axaml.cs
+++ b/Ryujinx.Ava/UI/Windows/CheatWindow.axaml.cs
@@ -31,9 +31,7 @@ namespace Ryujinx.Ava.UI.Windows
         {
             LoadedCheats = new AvaloniaList<CheatsList>();
 
-            LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.CheatWindowHeading, titleName, titleId.ToUpper());
-
-            Heading = LocaleManager.Instance[LocaleKeys.CheatWindowHeading];
+            Heading = LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.CheatWindowHeading, titleName, titleId.ToUpper());
 
             InitializeComponent();
 

--- a/Ryujinx.Ava/UI/Windows/DownloadableContentManagerWindow.axaml.cs
+++ b/Ryujinx.Ava/UI/Windows/DownloadableContentManagerWindow.axaml.cs
@@ -86,9 +86,7 @@ namespace Ryujinx.Ava.UI.Windows
 
         private void PrintHeading()
         {
-            LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DlcWindowHeading, _downloadableContents.Count, _titleName, _titleId.ToString("X16"));
-
-            Heading.Text = LocaleManager.Instance[LocaleKeys.DlcWindowHeading];
+            Heading.Text = LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DlcWindowHeading, _downloadableContents.Count, _titleName, _titleId.ToString("X16"));
         }
 
         private void LoadDownloadableContents()
@@ -135,9 +133,7 @@ namespace Ryujinx.Ava.UI.Windows
             {
                 Dispatcher.UIThread.InvokeAsync(async () =>
                 {
-                    LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogLoadNcaErrorMessage, ex.Message, containerPath);
-
-                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance[LocaleKeys.DialogLoadNcaErrorMessage]);
+                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogLoadNcaErrorMessage, ex.Message, containerPath));
                 });
             }
 

--- a/Ryujinx.Ava/UI/Windows/DownloadableContentManagerWindow.axaml.cs
+++ b/Ryujinx.Ava/UI/Windows/DownloadableContentManagerWindow.axaml.cs
@@ -86,7 +86,9 @@ namespace Ryujinx.Ava.UI.Windows
 
         private void PrintHeading()
         {
-            Heading.Text = string.Format(LocaleManager.Instance[LocaleKeys.DlcWindowHeading], _downloadableContents.Count, _titleName, _titleId.ToString("X16"));
+            LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DlcWindowHeading, _downloadableContents.Count, _titleName, _titleId.ToString("X16"));
+
+            Heading.Text = LocaleManager.Instance[LocaleKeys.DlcWindowHeading];
         }
 
         private void LoadDownloadableContents()
@@ -133,7 +135,9 @@ namespace Ryujinx.Ava.UI.Windows
             {
                 Dispatcher.UIThread.InvokeAsync(async () =>
                 {
-                    await ContentDialogHelper.CreateErrorDialog(string.Format(LocaleManager.Instance[LocaleKeys.DialogDlcLoadNcaErrorMessage], ex.Message, containerPath));
+                    LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.DialogLoadNcaErrorMessage, ex.Message, containerPath);
+
+                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance[LocaleKeys.DialogLoadNcaErrorMessage]);
                 });
             }
 

--- a/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
+++ b/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
@@ -146,7 +146,7 @@ namespace Ryujinx.Ava.UI.Windows
 
         private void ApplicationLibrary_ApplicationCountUpdated(object sender, ApplicationCountUpdatedEventArgs e)
         {
-            LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.StatusBarGamesLoaded, e.NumAppsLoaded, e.NumAppsFound);
+            LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.StatusBarGamesLoaded, e.NumAppsLoaded, e.NumAppsFound);
 
             Dispatcher.UIThread.Post(() =>
             {
@@ -415,7 +415,7 @@ namespace Ryujinx.Ava.UI.Windows
                 ViewModel.StatusBarProgressMaximum      = 0;
                 ViewModel.StatusBarProgressValue        = 0;
 
-                LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.StatusBarGamesLoaded, 0, 0);
+                LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.StatusBarGamesLoaded, 0, 0);
             });
 
             ReloadGameList();

--- a/Ryujinx.Ava/UI/Windows/TitleUpdateWindow.axaml.cs
+++ b/Ryujinx.Ava/UI/Windows/TitleUpdateWindow.axaml.cs
@@ -36,15 +36,13 @@ namespace Ryujinx.Ava.UI.Windows
 
         public static async Task Show(VirtualFileSystem virtualFileSystem, ulong titleId, string titleName)
         {
-            LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.GameUpdateWindowHeading, titleName, titleId.ToString("X16"));
-
             ContentDialog contentDialog = new()
             {
                 PrimaryButtonText   = "",
                 SecondaryButtonText = "",
                 CloseButtonText     = "",
                 Content             = new TitleUpdateWindow(virtualFileSystem, titleId, titleName),
-                Title               = LocaleManager.Instance[LocaleKeys.GameUpdateWindowHeading]
+                Title               = LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.GameUpdateWindowHeading, titleName, titleId.ToString("X16"))
             };
 
             Style bottomBorder = new(x => x.OfType<Grid>().Name("DialogSpace").Child().OfType<Border>());

--- a/Ryujinx.Ava/UI/Windows/TitleUpdateWindow.axaml.cs
+++ b/Ryujinx.Ava/UI/Windows/TitleUpdateWindow.axaml.cs
@@ -36,13 +36,15 @@ namespace Ryujinx.Ava.UI.Windows
 
         public static async Task Show(VirtualFileSystem virtualFileSystem, ulong titleId, string titleName)
         {
+            LocaleManager.Instance.UpdateDynamicValue(LocaleKeys.GameUpdateWindowHeading, titleName, titleId.ToString("X16"));
+
             ContentDialog contentDialog = new()
             {
                 PrimaryButtonText   = "",
                 SecondaryButtonText = "",
                 CloseButtonText     = "",
                 Content             = new TitleUpdateWindow(virtualFileSystem, titleId, titleName),
-                Title               = string.Format(LocaleManager.Instance[LocaleKeys.GameUpdateWindowHeading], titleName, titleId.ToString("X16"))
+                Title               = LocaleManager.Instance[LocaleKeys.GameUpdateWindowHeading]
             };
 
             Style bottomBorder = new(x => x.OfType<Grid>().Name("DialogSpace").Child().OfType<Border>());


### PR DESCRIPTION
We currently use a bunch of `string.Format` when locale uses dynamic fields (`{0}`). We already have a method for that in the LocaleManager, so I changed all call to `string.Format` to this method.

This is needed because the `string.Format` could failed because of an updated locale in `en_US` which don't have the same args as the previous one.

But it could crash in the `LocaleManager` instead since our current implementation doesn't handle that too. I have rewrited it to support that and returns the default locale instead, or the locale key name.

If `string.Format` failed, then the UI does nothing, so we currently can't open the Title Update Manager in other languages than `en_US`. It's now fixed.

During my change I've found `TitleUpdate` using a locale named `DialogDlcLoadNcaErrorMessage`, I renamed it `DialogLoadNcaErrorMessage` to be more generic.