### PR TITLE
CPU: Fix NRE when disposing AddressSpace with 4KB pages support

### DIFF
--- a/Ryujinx.Cpu/AddressSpace.cs
+++ b/Ryujinx.Cpu/AddressSpace.cs
@@ -462,7 +462,7 @@ namespace Ryujinx.Cpu
 
         public void Dispose()
         {
-            _privateMemoryAllocator.Dispose();
+            _privateMemoryAllocator?.Dispose();
             Base.Dispose();
             Mirror.Dispose();
         }


### PR DESCRIPTION
This PR fixes a small issue from #4252 that results in a NRE when disposing an AddressSpace with 4KB pages support.

Now `_privateMemoryAllocator` only executes `Dispose()` if it was in use