### PR TITLE
Handle parsing of corrupt Config.json and prevent crash on launch

### DIFF
--- a/Ryujinx.Ava/Program.cs
+++ b/Ryujinx.Ava/Program.cs
@@ -205,7 +205,17 @@ namespace Ryujinx.Ava
             {
                 if (ConfigurationFileFormat.TryLoad(ConfigurationPath, out ConfigurationFileFormat configurationFileFormat))
                 {
-                    ConfigurationState.Instance.Load(configurationFileFormat, ConfigurationPath);
+                    try
+                    {
+                        ConfigurationState.Instance.Load(configurationFileFormat, ConfigurationPath);
+                    }
+                    catch
+                    {
+                        ConfigurationState.Instance.LoadDefault();
+                        ConfigurationState.Instance.ToFileFormat().SaveConfig(ConfigurationPath);
+                        
+                        Logger.Warning?.PrintMsg(LogClass.Application, $"Failed to load config! Loading the default config instead.");
+                    }
                 }
                 else
                 {

--- a/Ryujinx.Ava/Program.cs
+++ b/Ryujinx.Ava/Program.cs
@@ -205,17 +205,7 @@ namespace Ryujinx.Ava
             {
                 if (ConfigurationFileFormat.TryLoad(ConfigurationPath, out ConfigurationFileFormat configurationFileFormat))
                 {
-                    try
-                    {
-                        ConfigurationState.Instance.Load(configurationFileFormat, ConfigurationPath);
-                    }
-                    catch
-                    {
-                        ConfigurationState.Instance.LoadDefault();
-                        ConfigurationState.Instance.ToFileFormat().SaveConfig(ConfigurationPath);
-                        
-                        Logger.Warning?.PrintMsg(LogClass.Application, $"Failed to load config! Loading the default config instead.");
-                    }
+                    ConfigurationState.Instance.Load(configurationFileFormat, ConfigurationPath);
                 }
                 else
                 {

--- a/Ryujinx.Ui.Common/Configuration/ConfigurationFileFormat.cs
+++ b/Ryujinx.Ui.Common/Configuration/ConfigurationFileFormat.cs
@@ -340,7 +340,7 @@ namespace Ryujinx.Ui.Common.Configuration
             {
                 configurationFileFormat = JsonHelper.DeserializeFromFile<ConfigurationFileFormat>(path);
 
-                return true;
+                return configurationFileFormat.Version != 0;
             }
             catch
             {


### PR DESCRIPTION
For some reason if Config.json is corrupted and contains only { }
JsonSerializer.Deserialize is not validating json against a schema.
ConfigurationFileFormat.TryLoad will return true but ConfigurationState.Instance.Load will throw an exception

It will prevent crash on launch of Ryujinx and improve the user experience