### PR TITLE
Handle parsing of corrupt Profiles.json and prevent crash on launch

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Account/Acc/AccountSaveDataManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/AccountSaveDataManager.cs
@@ -1,5 +1,7 @@
 ﻿using Ryujinx.Common.Configuration;
+using Ryujinx.Common.Logging;
 using Ryujinx.Common.Utilities;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -43,16 +45,24 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
 
             if (File.Exists(_profilesJsonPath))
             {
-                ProfilesJson profilesJson = JsonHelper.DeserializeFromFile<ProfilesJson>(_profilesJsonPath);
-
-                foreach (var profile in profilesJson.Profiles)
+                try
                 {
-                    UserProfile addedProfile = new UserProfile(new UserId(profile.UserId), profile.Name, profile.Image, profile.LastModifiedTimestamp);
+                    ProfilesJson profilesJson = JsonHelper.DeserializeFromFile<ProfilesJson>(_profilesJsonPath);
 
-                    profiles.AddOrUpdate(profile.UserId, addedProfile, (key, old) => addedProfile);
+                    foreach (var profile in profilesJson.Profiles)
+                    {
+                        UserProfile addedProfile = new UserProfile(new UserId(profile.UserId), profile.Name, profile.Image, profile.LastModifiedTimestamp);
+
+                        profiles.AddOrUpdate(profile.UserId, addedProfile, (key, old) => addedProfile);
+                    }
+
+                    LastOpened = new UserId(profilesJson.LastOpened);
                 }
-
-                LastOpened = new UserId(profilesJson.LastOpened);
+                catch
+                {
+                    Logger.Error?.PrintMsg(LogClass.Application, $"Failed to load profiles! Loading the default profile instead.\nFailed profiles location {_profilesJsonPath}");
+                    LastOpened = AccountManager.DefaultUserId;
+                }
             }
             else
             {


### PR DESCRIPTION
In case of corrupted json JsonHelper.DeserializeFromFile<ProfilesJson>(_profilesJsonPath) throws an exception.
Solution is to catch the parsing error and use default profile.
It will prevent crash on launch of Ryujinx and improve the user experience