### PR TITLE
Ava UI: Add Control+Cmd+F HotKey for Mac OS

### DIFF
--- a/Ryujinx.Ava/UI/Windows/MainWindow.axaml
+++ b/Ryujinx.Ava/UI/Windows/MainWindow.axaml
@@ -43,6 +43,7 @@
         <StackPanel Grid.Row="0" IsVisible="False">
             <helpers:HotKeyControl Name="FullscreenHotKey" Command="{ReflectionBinding ToggleFullscreen}" />
             <helpers:HotKeyControl Name="FullscreenHotKey2" Command="{ReflectionBinding ToggleFullscreen}" />
+            <helpers:HotKeyControl Name="FullscreenHotKeyMacOS" Command="{ReflectionBinding ToggleFullscreen}" />
             <helpers:HotKeyControl Name="DockToggleHotKey" Command="{ReflectionBinding ToggleDockMode}" />
             <helpers:HotKeyControl Name="ExitHotKey" Command="{ReflectionBinding ExitCurrentState}" />
         </StackPanel>

--- a/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
+++ b/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
@@ -329,6 +329,7 @@ namespace Ryujinx.Ava.UI.Windows
         {
             HotKeyManager.SetHotKey(FullscreenHotKey,  new KeyGesture(Key.Enter, KeyModifiers.Alt));
             HotKeyManager.SetHotKey(FullscreenHotKey2, new KeyGesture(Key.F11));
+            HotKeyManager.SetHotKey(FullscreenHotKeyMacOS, new KeyGesture(Key.F, KeyModifiers.Control | KeyModifiers.Meta)); //Mac OS Control+Cmd+F
             HotKeyManager.SetHotKey(DockToggleHotKey,  new KeyGesture(Key.F9));
             HotKeyManager.SetHotKey(ExitHotKey,        new KeyGesture(Key.Escape));
         }

--- a/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
+++ b/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
@@ -327,11 +327,11 @@ namespace Ryujinx.Ava.UI.Windows
 
         public void LoadHotKeys()
         {
-            HotKeyManager.SetHotKey(FullscreenHotKey,  new KeyGesture(Key.Enter, KeyModifiers.Alt));
-            HotKeyManager.SetHotKey(FullscreenHotKey2, new KeyGesture(Key.F11));
+            HotKeyManager.SetHotKey(FullscreenHotKey,      new KeyGesture(Key.Enter, KeyModifiers.Alt));
+            HotKeyManager.SetHotKey(FullscreenHotKey2,     new KeyGesture(Key.F11));
             HotKeyManager.SetHotKey(FullscreenHotKeyMacOS, new KeyGesture(Key.F, KeyModifiers.Control | KeyModifiers.Meta)); //Mac OS Control+Cmd+F
-            HotKeyManager.SetHotKey(DockToggleHotKey,  new KeyGesture(Key.F9));
-            HotKeyManager.SetHotKey(ExitHotKey,        new KeyGesture(Key.Escape));
+            HotKeyManager.SetHotKey(DockToggleHotKey,      new KeyGesture(Key.F9));
+            HotKeyManager.SetHotKey(ExitHotKey,            new KeyGesture(Key.Escape));
         }
 
         private void VolumeStatus_CheckedChanged(object sender, SplitButtonClickEventArgs e)

--- a/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
+++ b/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
@@ -329,7 +329,7 @@ namespace Ryujinx.Ava.UI.Windows
         {
             HotKeyManager.SetHotKey(FullscreenHotKey,      new KeyGesture(Key.Enter, KeyModifiers.Alt));
             HotKeyManager.SetHotKey(FullscreenHotKey2,     new KeyGesture(Key.F11));
-            HotKeyManager.SetHotKey(FullscreenHotKeyMacOS, new KeyGesture(Key.F, KeyModifiers.Control | KeyModifiers.Meta)); //Mac OS Control+Cmd+F
+            HotKeyManager.SetHotKey(FullscreenHotKeyMacOS, new KeyGesture(Key.F, KeyModifiers.Control | KeyModifiers.Meta));
             HotKeyManager.SetHotKey(DockToggleHotKey,      new KeyGesture(Key.F9));
             HotKeyManager.SetHotKey(ExitHotKey,            new KeyGesture(Key.Escape));
         }


### PR DESCRIPTION
Most Apps on Mac OS use ^+⌘+F (Control+Cmd+F) to toggle fullscreen mode
Added additional HotKey to toggle full screen by ^+⌘+F. 
Tested on Mac OS Ventura
Closes #3981