### PR TITLE
AvaloniaKeyboardDriver: Swallow TextInput events to avoid bell on macOS

### DIFF
--- a/Ryujinx.Ava/Input/AvaloniaKeyboardDriver.cs
+++ b/Ryujinx.Ava/Input/AvaloniaKeyboardDriver.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Ryujinx.Ava.Common.Locale;
 using Ryujinx.Input;
 using System;
@@ -30,11 +31,18 @@ namespace Ryujinx.Ava.Input
             _control.KeyDown   += OnKeyPress;
             _control.KeyUp     += OnKeyRelease;
             _control.TextInput += Control_TextInput;
+            _control.AddHandler(InputElement.TextInputEvent, Control_LastChanceTextInput, RoutingStrategies.Bubble);
         }
 
         private void Control_TextInput(object sender, TextInputEventArgs e)
         {
             TextInput?.Invoke(this, e.Text);
+        }
+
+        private void Control_LastChanceTextInput(object sender, TextInputEventArgs e)
+        {
+            // Swallow event
+            e.Handled = true;
         }
 
         public event Action<string> OnGamepadConnected


### PR DESCRIPTION
On macOS, one often has the bell noise when using a keyboard as a controller.

Here we propose a fix to this by swallowing the TextInputEvent when it bubbles back up to MainWindow if Handled wasn't set during tunnelling.

We don't do this on KeyDownEvent because we want TextInputEvent to occur.

Comments very welcome.