### PR TITLE
Ava UI: Various Fixes

### DIFF
--- a/Ryujinx.Ava/AppHost.cs
+++ b/Ryujinx.Ava/AppHost.cs
@@ -231,7 +231,7 @@ namespace Ryujinx.Ava
             }
         }
 
-        private unsafe void Renderer_ScreenCaptured(object sender, ScreenCaptureImageInfo e)
+        private void Renderer_ScreenCaptured(object sender, ScreenCaptureImageInfo e)
         {
             if (e.Data.Length > 0 && e.Height > 0 && e.Width > 0)
             {
@@ -240,7 +240,7 @@ namespace Ryujinx.Ava
                     lock (_lockObject)
                     {
                         DateTime currentTime = DateTime.Now;
-                        string   filename    = $"ryujinx_capture_{currentTime}-{currentTime:D2}-{currentTime:D2}_{currentTime:D2}-{currentTime:D2}-{currentTime:D2}.png";
+                        string   filename    = $"ryujinx_capture_{currentTime.Year}-{currentTime.Month:D2}-{currentTime.Day:D2}_{currentTime.Hour:D2}-{currentTime.Minute:D2}-{currentTime.Second:D2}.png";
                         
                         string directory = AppDataManager.Mode switch
                         {

--- a/Ryujinx.Ava/UI/Renderer/EmbeddedWindow.cs
+++ b/Ryujinx.Ava/UI/Renderer/EmbeddedWindow.cs
@@ -140,68 +140,75 @@ namespace Ryujinx.Ava.UI.Renderer
             {
                 if (VisualRoot != null)
                 {
-                    Point   rootVisualPosition = this.TranslatePoint(new Point((long)lParam & 0xFFFF, (long)lParam >> 16 & 0xFFFF), VisualRoot).Value;
-                    Pointer pointer            = new(0, PointerType.Mouse, true);
-
-                    switch (msg)
+                    if (msg == WindowsMessages.LBUTTONDOWN ||
+                        msg == WindowsMessages.RBUTTONDOWN ||
+                        msg == WindowsMessages.LBUTTONUP   ||
+                        msg == WindowsMessages.RBUTTONUP   ||
+                        msg == WindowsMessages.MOUSEMOVE)
                     {
-                        case WindowsMessages.LBUTTONDOWN:
-                        case WindowsMessages.RBUTTONDOWN:
-                            {
-                                bool                   isLeft               = msg == WindowsMessages.LBUTTONDOWN;
-                                RawInputModifiers      pointerPointModifier = isLeft ? RawInputModifiers.LeftMouseButton : RawInputModifiers.RightMouseButton;
-                                PointerPointProperties properties           = new(pointerPointModifier, isLeft ? PointerUpdateKind.LeftButtonPressed : PointerUpdateKind.RightButtonPressed);
+                        Point   rootVisualPosition = this.TranslatePoint(new Point((long)lParam & 0xFFFF, (long)lParam >> 16 & 0xFFFF), VisualRoot).Value;
+                        Pointer pointer            = new(0, PointerType.Mouse, true);
 
-                                var evnt = new PointerPressedEventArgs(
-                                    this,
-                                    pointer,
-                                    VisualRoot,
-                                    rootVisualPosition,
-                                    (ulong)Environment.TickCount64,
-                                    properties,
-                                    KeyModifiers.None);
+                        switch (msg)
+                        {
+                            case WindowsMessages.LBUTTONDOWN:
+                            case WindowsMessages.RBUTTONDOWN:
+                                {
+                                    bool                   isLeft               = msg == WindowsMessages.LBUTTONDOWN;
+                                    RawInputModifiers      pointerPointModifier = isLeft ? RawInputModifiers.LeftMouseButton : RawInputModifiers.RightMouseButton;
+                                    PointerPointProperties properties           = new(pointerPointModifier, isLeft ? PointerUpdateKind.LeftButtonPressed : PointerUpdateKind.RightButtonPressed);
 
-                                RaiseEvent(evnt);
+                                    var evnt = new PointerPressedEventArgs(
+                                        this,
+                                        pointer,
+                                        VisualRoot,
+                                        rootVisualPosition,
+                                        (ulong)Environment.TickCount64,
+                                        properties,
+                                        KeyModifiers.None);
 
-                                break;
-                            }
-                        case WindowsMessages.LBUTTONUP:
-                        case WindowsMessages.RBUTTONUP:
-                            {
-                                bool                   isLeft               = msg == WindowsMessages.LBUTTONUP;
-                                RawInputModifiers      pointerPointModifier = isLeft ? RawInputModifiers.LeftMouseButton : RawInputModifiers.RightMouseButton;
-                                PointerPointProperties properties           = new(pointerPointModifier, isLeft ? PointerUpdateKind.LeftButtonReleased : PointerUpdateKind.RightButtonReleased);
+                                    RaiseEvent(evnt);
 
-                                var evnt = new PointerReleasedEventArgs(
-                                    this,
-                                    pointer,
-                                    VisualRoot,
-                                    rootVisualPosition,
-                                    (ulong)Environment.TickCount64,
-                                    properties,
-                                    KeyModifiers.None,
-                                    isLeft ? MouseButton.Left : MouseButton.Right);
+                                    break;
+                                }
+                            case WindowsMessages.LBUTTONUP:
+                            case WindowsMessages.RBUTTONUP:
+                                {
+                                    bool                   isLeft               = msg == WindowsMessages.LBUTTONUP;
+                                    RawInputModifiers      pointerPointModifier = isLeft ? RawInputModifiers.LeftMouseButton : RawInputModifiers.RightMouseButton;
+                                    PointerPointProperties properties           = new(pointerPointModifier, isLeft ? PointerUpdateKind.LeftButtonReleased : PointerUpdateKind.RightButtonReleased);
 
-                                RaiseEvent(evnt);
+                                    var evnt = new PointerReleasedEventArgs(
+                                        this,
+                                        pointer,
+                                        VisualRoot,
+                                        rootVisualPosition,
+                                        (ulong)Environment.TickCount64,
+                                        properties,
+                                        KeyModifiers.None,
+                                        isLeft ? MouseButton.Left : MouseButton.Right);
 
-                                break;
-                            }
-                        case WindowsMessages.MOUSEMOVE:
-                            {
-                                var evnt = new PointerEventArgs(
-                                    PointerMovedEvent,
-                                    this,
-                                    pointer,
-                                    VisualRoot,
-                                    rootVisualPosition,
-                                    (ulong)Environment.TickCount64,
-                                    new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.Other),
-                                    KeyModifiers.None);
+                                    RaiseEvent(evnt);
 
-                                RaiseEvent(evnt);
+                                    break;
+                                }
+                            case WindowsMessages.MOUSEMOVE:
+                                {
+                                    var evnt = new PointerEventArgs(
+                                        PointerMovedEvent,
+                                        this,
+                                        pointer,
+                                        VisualRoot,
+                                        rootVisualPosition,
+                                        (ulong)Environment.TickCount64,
+                                        new PointerPointProperties(RawInputModifiers.None, PointerUpdateKind.Other),
+                                        KeyModifiers.None);
 
-                                break;
-                            }
+                                    RaiseEvent(evnt);
+
+                                    break;
+                                }
+                        }
                     }
                 }
 

--- a/Ryujinx.Ava/UI/ViewModels/TitleUpdateViewModel.cs
+++ b/Ryujinx.Ava/UI/ViewModels/TitleUpdateViewModel.cs
@@ -21,8 +21,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using SpanHelpers = LibHac.Common.SpanHelpers;
+using System.Text;
 using Path = System.IO.Path;
+using SpanHelpers = LibHac.Common.SpanHelpers;
 
 namespace Ryujinx.Ava.UI.ViewModels;
 
@@ -90,6 +91,8 @@ public class TitleUpdateViewModel : BaseModel
                 Selected = "",
                 Paths    = new List<string>()
             };
+
+            Save();
         }
 
         LoadUpdates();
@@ -101,6 +104,9 @@ public class TitleUpdateViewModel : BaseModel
         {
             AddUpdate(path);
         }
+
+        // NOTE: Save the list again to remove leftovers.
+        Save();
 
         TitleUpdateModel selected = TitleUpdates.FirstOrDefault(x => x.Path == _titleUpdateWindowData.Selected, null);
 
@@ -222,5 +228,25 @@ public class TitleUpdateViewModel : BaseModel
         }
 
         SortUpdates();
+    }
+
+    public void Save()
+    {
+        _titleUpdateWindowData.Paths.Clear();
+        _titleUpdateWindowData.Selected = "";
+
+        foreach (TitleUpdateModel update in TitleUpdates)
+        {
+            _titleUpdateWindowData.Paths.Add(update.Path);
+
+            if (update == SelectedUpdate)
+            {
+                _titleUpdateWindowData.Selected = update.Path;
+            }
+        }
+
+        using FileStream titleUpdateJsonStream = File.Create(_titleUpdateJsonPath, 4096, FileOptions.WriteThrough);
+
+        titleUpdateJsonStream.Write(Encoding.UTF8.GetBytes(JsonHelper.Serialize(_titleUpdateWindowData, true)));
     }
 }

--- a/Ryujinx.Ava/UI/ViewModels/TitleUpdateViewModel.cs
+++ b/Ryujinx.Ava/UI/ViewModels/TitleUpdateViewModel.cs
@@ -245,8 +245,6 @@ public class TitleUpdateViewModel : BaseModel
             }
         }
 
-        using FileStream titleUpdateJsonStream = File.Create(_titleUpdateJsonPath, 4096, FileOptions.WriteThrough);
-
-        titleUpdateJsonStream.Write(Encoding.UTF8.GetBytes(JsonHelper.Serialize(_titleUpdateWindowData, true)));
+        File.WriteAllBytes(_titleUpdateJsonPath, Encoding.UTF8.GetBytes(JsonHelper.Serialize(_titleUpdateWindowData, true)));
     }
 }

--- a/Ryujinx.Ava/UI/Windows/TitleUpdateWindow.axaml.cs
+++ b/Ryujinx.Ava/UI/Windows/TitleUpdateWindow.axaml.cs
@@ -60,24 +60,7 @@ namespace Ryujinx.Ava.UI.Windows
 
         public void Save(object sender, RoutedEventArgs e)
         {
-            ViewModel._titleUpdateWindowData.Paths.Clear();
-
-            ViewModel._titleUpdateWindowData.Selected = "";
-
-            foreach (TitleUpdateModel update in ViewModel.TitleUpdates)
-            {
-                ViewModel._titleUpdateWindowData.Paths.Add(update.Path);
-
-                if (update == ViewModel.SelectedUpdate)
-                {
-                    ViewModel._titleUpdateWindowData.Selected = update.Path;
-                }
-            }
-
-            using (FileStream titleUpdateJsonStream = File.Create(ViewModel._titleUpdateJsonPath, 4096, FileOptions.WriteThrough))
-            {
-                titleUpdateJsonStream.Write(Encoding.UTF8.GetBytes(JsonHelper.Serialize(ViewModel._titleUpdateWindowData, true)));
-            }
+            ViewModel.Save();
 
             if (VisualRoot is MainWindow window)
             {


### PR DESCRIPTION
This PR fixes :
- A screenshot path issue introduced in a recent PR (#4240), which currently doesn't allow users to take screenshots because of a malformed path.
- After the refactoring of `TitleUpdateManager` (#4276), if the JSON is malformed, it reset the internal field but not the file itself. If an update file doesn't exist anymore, it doesn't appear in the UI but still exist in the JSON file. This is now fixed.
- After the refactoring of `Renderer` (#4297), in `_wndProcDelegate` some fields are tested without taking care of the message send to the window, this is now fixed.