### PR TITLE
Vulkan: Reset queries on same command buffer

### DIFF
--- a/Ryujinx.Graphics.Vulkan/AutoFlushCounter.cs
+++ b/Ryujinx.Graphics.Vulkan/AutoFlushCounter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Linq;
 
 namespace Ryujinx.Graphics.Vulkan
 {
@@ -16,6 +17,10 @@ namespace Ryujinx.Graphics.Vulkan
         private bool _hasPendingQuery;
         private int _queryCount;
 
+        private int[] _queryCountHistory = new int[3];
+        private int _queryCountHistoryPtr;
+        private int _remainingQueries;
+
         public void RegisterFlush(ulong drawCount)
         {
             _lastFlush = Stopwatch.GetTimestamp();
@@ -27,6 +32,9 @@ namespace Ryujinx.Graphics.Vulkan
         public bool RegisterPendingQuery()
         {
             _hasPendingQuery = true;
+            _remainingQueries--;
+
+            _queryCountHistory[_queryCountHistoryPtr]++;
 
             // Interrupt render passes to flush queries, so that early results arrive sooner.
             if (++_queryCount == InitialQueryCountForFlush)
@@ -35,6 +43,21 @@ namespace Ryujinx.Graphics.Vulkan
             }
 
             return false;
+        }
+
+        public int GetRemainingQueries()
+        {
+            if (_remainingQueries <= 0)
+            {
+                _remainingQueries = 16;
+            }
+
+            if (_queryCount < InitialQueryCountForFlush)
+            {
+                return Math.Min(InitialQueryCountForFlush - _queryCount, _remainingQueries);
+            }
+
+            return _remainingQueries;
         }
 
         public bool ShouldFlushQuery()
@@ -68,6 +91,15 @@ namespace Ryujinx.Graphics.Vulkan
             long now = Stopwatch.GetTimestamp();
 
             return now > _lastFlush + flushTimeout;
+        }
+
+        public void Present()
+        {
+            _queryCountHistoryPtr = (_queryCountHistoryPtr + 1) % 3;
+
+            _remainingQueries = _queryCountHistory.Max() + 10;
+
+            _queryCountHistory[_queryCountHistoryPtr] = 0;
         }
     }
 }

--- a/Ryujinx.Graphics.Vulkan/AutoFlushCounter.cs
+++ b/Ryujinx.Graphics.Vulkan/AutoFlushCounter.cs
@@ -18,7 +18,7 @@ namespace Ryujinx.Graphics.Vulkan
         private int _queryCount;
 
         private int[] _queryCountHistory = new int[3];
-        private int _queryCountHistoryPtr;
+        private int _queryCountHistoryIndex;
         private int _remainingQueries;
 
         public void RegisterFlush(ulong drawCount)
@@ -34,7 +34,7 @@ namespace Ryujinx.Graphics.Vulkan
             _hasPendingQuery = true;
             _remainingQueries--;
 
-            _queryCountHistory[_queryCountHistoryPtr]++;
+            _queryCountHistory[_queryCountHistoryIndex]++;
 
             // Interrupt render passes to flush queries, so that early results arrive sooner.
             if (++_queryCount == InitialQueryCountForFlush)
@@ -95,11 +95,11 @@ namespace Ryujinx.Graphics.Vulkan
 
         public void Present()
         {
-            _queryCountHistoryPtr = (_queryCountHistoryPtr + 1) % 3;
+            _queryCountHistoryIndex = (_queryCountHistoryIndex + 1) % 3;
 
             _remainingQueries = _queryCountHistory.Max() + 10;
 
-            _queryCountHistory[_queryCountHistoryPtr] = 0;
+            _queryCountHistory[_queryCountHistoryIndex] = 0;
         }
     }
 }

--- a/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Vulkan
         protected readonly Device Device;
         public readonly PipelineCache PipelineCache;
 
-        protected readonly AutoFlushCounter AutoFlush;
+        public readonly AutoFlushCounter AutoFlush;
 
         protected PipelineDynamicState DynamicState;
         private PipelineState _newState;

--- a/Ryujinx.Graphics.Vulkan/Queries/CounterQueueEvent.cs
+++ b/Ryujinx.Graphics.Vulkan/Queries/CounterQueueEvent.cs
@@ -34,7 +34,7 @@ namespace Ryujinx.Graphics.Vulkan.Queries
 
             DrawIndex = drawIndex;
 
-            _counter.Begin();
+            _counter.Begin(_queue.ResetSequence);
         }
 
         public Auto<DisposableBuffer> GetBuffer()

--- a/Ryujinx.Graphics.Vulkan/Queries/Counters.cs
+++ b/Ryujinx.Graphics.Vulkan/Queries/Counters.cs
@@ -24,6 +24,19 @@ namespace Ryujinx.Graphics.Vulkan.Queries
             }
         }
 
+        public void ResetCounterPool()
+        {
+            foreach (var queue in _counterQueues)
+            {
+                queue.ResetCounterPool();
+            }
+        }
+
+        public void ResetFutureCounters(CommandBuffer cmd, int count)
+        {
+            _counterQueues[(int)CounterType.SamplesPassed].ResetFutureCounters(cmd, count);
+        }
+
         public CounterQueueEvent QueueReport(CounterType type, EventHandler<ulong> resultHandler, bool hostReserved)
         {
             return _counterQueues[(int)type].QueueReport(resultHandler, _pipeline.DrawCount, hostReserved);

--- a/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -679,6 +679,16 @@ namespace Ryujinx.Graphics.Vulkan
             _counters.Update();
         }
 
+        public void ResetCounterPool()
+        {
+            _counters.ResetCounterPool();
+        }
+
+        public void ResetFutureCounters(CommandBuffer cmd, int count)
+        {
+            _counters?.ResetFutureCounters(cmd, count);
+        }
+
         public void BackgroundContextAction(Action action, bool alwaysBackground = false)
         {
             action();

--- a/Ryujinx.Graphics.Vulkan/Window.cs
+++ b/Ryujinx.Graphics.Vulkan/Window.cs
@@ -225,8 +225,9 @@ namespace Ryujinx.Graphics.Vulkan
 
         public unsafe override void Present(ITexture texture, ImageCrop crop, Action swapBuffersCallback)
         {
-            uint nextImage = 0;
             _gd.PipelineInternal.AutoFlush.Present();
+
+            uint nextImage = 0;
 
             while (true)
             {

--- a/Ryujinx.Graphics.Vulkan/Window.cs
+++ b/Ryujinx.Graphics.Vulkan/Window.cs
@@ -226,6 +226,7 @@ namespace Ryujinx.Graphics.Vulkan
         public unsafe override void Present(ITexture texture, ImageCrop crop, Action swapBuffersCallback)
         {
             uint nextImage = 0;
+            _gd.PipelineInternal.AutoFlush.Present();
 
             while (true)
             {


### PR DESCRIPTION
Vulkan seems to complain when the queries are reset on another command buffer. No idea why, the spec really could be written better in this regard. This fixes complaints logged by the validation layers, and hopefully any implementations that care extensively about them.

This change _guesses_ how many queries need to be reset and resets as many as possible at the same time to avoid splitting render passes. If it resets too many queries, we didn't waste too much time - if it runs out of resets it will batch reset 10 more.

The number of queries reset is the maximum number of queries in the last 3 frames. This has been worked into the AutoFlushCounter so that it only resets up to 32 if it is yet to force a command buffer submission in this attachment.

This is only done for samples passed queries right now, as they have by far the most resets. Maybe in future, shared query pools with multiple entries can be used so that they can be reset in bulk rather than by a ton of sequential calls.

This fixes occlusion queries having bogus results on macOS, mostly visible in Super Mario Odyssey and A Hat in Time. This is also already in `macos1`.