### PR TITLE
SPIR-V: Change BitfieldExtract and BitfieldInsert for SPIRV-Cross

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 4318;
+        private const uint CodeGenVersion = 4336;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/Ryujinx.Graphics.Shader/CodeGen/Spirv/Instructions.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Spirv/Instructions.cs
@@ -261,17 +261,17 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
 
         private static OperationResult GenerateBitfieldExtractS32(CodeGenContext context, AstOperation operation)
         {
-            return GenerateTernaryS32(context, operation, context.Delegates.BitFieldSExtract);
+            return GenerateBitfieldExtractS32(context, operation, context.Delegates.BitFieldSExtract);
         }
 
         private static OperationResult GenerateBitfieldExtractU32(CodeGenContext context, AstOperation operation)
         {
-            return GenerateTernaryS32(context, operation, context.Delegates.BitFieldUExtract);
+            return GenerateTernaryU32(context, operation, context.Delegates.BitFieldUExtract);
         }
 
         private static OperationResult GenerateBitfieldInsert(CodeGenContext context, AstOperation operation)
         {
-            return GenerateQuaternaryS32(context, operation, context.Delegates.BitFieldInsert);
+            return GenerateBitfieldInsert(context, operation, context.Delegates.BitFieldInsert);
         }
 
         private static OperationResult GenerateBitfieldReverse(CodeGenContext context, AstOperation operation)
@@ -2290,22 +2290,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
             }
         }
 
-        private static OperationResult GenerateTernaryS32(
-            CodeGenContext context,
-            AstOperation operation,
-            Func<SpvInstruction, SpvInstruction, SpvInstruction, SpvInstruction, SpvInstruction> emitS)
-        {
-            var src1 = operation.GetSource(0);
-            var src2 = operation.GetSource(1);
-            var src3 = operation.GetSource(2);
-
-            return new OperationResult(AggregateType.S32, emitS(
-                context.TypeS32(),
-                context.GetS32(src1),
-                context.GetS32(src2),
-                context.GetS32(src3)));
-        }
-
         private static OperationResult GenerateTernaryU32(
             CodeGenContext context,
             AstOperation operation,
@@ -2322,7 +2306,23 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
                 context.GetU32(src3)));
         }
 
-        private static OperationResult GenerateQuaternaryS32(
+        private static OperationResult GenerateBitfieldExtractS32(
+            CodeGenContext context,
+            AstOperation operation,
+            Func<SpvInstruction, SpvInstruction, SpvInstruction, SpvInstruction, SpvInstruction> emitS)
+        {
+            var src1 = operation.GetSource(0);
+            var src2 = operation.GetSource(1);
+            var src3 = operation.GetSource(2);
+
+            return new OperationResult(AggregateType.S32, emitS(
+                context.TypeS32(),
+                context.GetS32(src1),
+                context.GetU32(src2),
+                context.GetU32(src3)));
+        }
+
+        private static OperationResult GenerateBitfieldInsert(
             CodeGenContext context,
             AstOperation operation,
             Func<SpvInstruction, SpvInstruction, SpvInstruction, SpvInstruction, SpvInstruction, SpvInstruction> emitS)
@@ -2332,12 +2332,12 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
             var src3 = operation.GetSource(2);
             var src4 = operation.GetSource(3);
 
-            return new OperationResult(AggregateType.S32, emitS(
-                context.TypeS32(),
-                context.GetS32(src1),
-                context.GetS32(src2),
-                context.GetS32(src3),
-                context.GetS32(src4)));
+            return new OperationResult(AggregateType.U32, emitS(
+                context.TypeU32(),
+                context.GetU32(src1),
+                context.GetU32(src2),
+                context.GetU32(src3),
+                context.GetU32(src4)));
         }
     }
 }


### PR DESCRIPTION
According to the spec, the operands of bitfield operations can have any integer types, but because MoltenVK uses SPIRV-Cross to translate the shader to MSL, and it does not take into account the integer type, if the types does not matter the MSL built-in function types, the Metal shader will be invalid and won't compile. This change the integer types to what the Metal compiler expects.

Contributes to #4062 even though this one is not listed there.