### PR TITLE
Remove use of GetFunctionPointerForDelegate to get JIT cache function pointer

### DIFF
--- a/ARMeilleure/CodeGen/CompiledFunction.cs
+++ b/ARMeilleure/CodeGen/CompiledFunction.cs
@@ -48,9 +48,21 @@ namespace ARMeilleure.CodeGen
         /// <returns>A delegate of type <typeparamref name="T"/> pointing to the mapped function</returns>
         public T Map<T>()
         {
-            IntPtr codePtr = JitCache.Map(this);
+            return MapWithPointer<T>(out _);
+        }
 
-            return Marshal.GetDelegateForFunctionPointer<T>(codePtr);
+        /// <summary>
+        /// Maps the <see cref="CompiledFunction"/> onto the <see cref="JitCache"/> and returns a delegate of type
+        /// <typeparamref name="T"/> pointing to the mapped function.
+        /// </summary>
+        /// <typeparam name="T">Type of delegate</typeparam>
+        /// <param name="codePointer">Pointer to the function code in memory</param>
+        /// <returns>A delegate of type <typeparamref name="T"/> pointing to the mapped function</returns>
+        public T MapWithPointer<T>(out IntPtr codePointer)
+        {
+            codePointer = JitCache.Map(this);
+
+            return Marshal.GetDelegateForFunctionPointer<T>(codePointer);
         }
     }
 }

--- a/ARMeilleure/Instructions/NativeInterface.cs
+++ b/ARMeilleure/Instructions/NativeInterface.cs
@@ -191,7 +191,7 @@ namespace ARMeilleure.Instructions
         {
             TranslatedFunction function = Context.Translator.GetOrTranslate(address, GetContext().ExecutionMode);
 
-            return (ulong)function.FuncPtr.ToInt64();
+            return (ulong)function.FuncPointer.ToInt64();
         }
 
         public static void InvalidateCacheLine(ulong address)

--- a/ARMeilleure/Translation/PTC/Ptc.cs
+++ b/ARMeilleure/Translation/PTC/Ptc.cs
@@ -745,9 +745,9 @@ namespace ARMeilleure.Translation.PTC
             bool highCq)
         {
             var cFunc = new CompiledFunction(code, unwindInfo, RelocInfo.Empty);
-            var gFunc = cFunc.Map<GuestFunction>();
+            var gFunc = cFunc.MapWithPointer<GuestFunction>(out IntPtr gFuncPointer);
 
-            return new TranslatedFunction(gFunc, callCounter, guestSize, highCq);
+            return new TranslatedFunction(gFunc, gFuncPointer, callCounter, guestSize, highCq);
         }
 
         private void UpdateInfo(InfoEntry infoEntry)

--- a/ARMeilleure/Translation/TranslatedFunction.cs
+++ b/ARMeilleure/Translation/TranslatedFunction.cs
@@ -7,7 +7,7 @@ namespace ARMeilleure.Translation
     {
         private readonly GuestFunction _func; // Ensure that this delegate will not be garbage collected.
 
-        public IntPtr FuncPtr { get; }
+        public IntPtr FuncPointer { get; }
         public Counter<uint> CallCounter { get; }
         public ulong GuestSize { get; }
         public bool HighCq { get; }
@@ -15,7 +15,7 @@ namespace ARMeilleure.Translation
         public TranslatedFunction(GuestFunction func, IntPtr funcPointer, Counter<uint> callCounter, ulong guestSize, bool highCq)
         {
             _func = func;
-            FuncPtr = funcPointer;
+            FuncPointer = funcPointer;
             CallCounter = callCounter;
             GuestSize = guestSize;
             HighCq = highCq;

--- a/ARMeilleure/Translation/TranslatedFunction.cs
+++ b/ARMeilleure/Translation/TranslatedFunction.cs
@@ -1,6 +1,5 @@
 using ARMeilleure.Common;
 using System;
-using System.Runtime.InteropServices;
 
 namespace ARMeilleure.Translation
 {
@@ -8,18 +7,18 @@ namespace ARMeilleure.Translation
     {
         private readonly GuestFunction _func; // Ensure that this delegate will not be garbage collected.
 
+        public IntPtr FuncPtr { get; }
         public Counter<uint> CallCounter { get; }
         public ulong GuestSize { get; }
         public bool HighCq { get; }
-        public IntPtr FuncPtr { get; }
 
-        public TranslatedFunction(GuestFunction func, Counter<uint> callCounter, ulong guestSize, bool highCq)
+        public TranslatedFunction(GuestFunction func, IntPtr funcPointer, Counter<uint> callCounter, ulong guestSize, bool highCq)
         {
             _func = func;
+            FuncPtr = funcPointer;
             CallCounter = callCounter;
             GuestSize = guestSize;
             HighCq = highCq;
-            FuncPtr = Marshal.GetFunctionPointerForDelegate(func);
         }
 
         public ulong Execute(State.ExecutionContext context)

--- a/ARMeilleure/Translation/Translator.cs
+++ b/ARMeilleure/Translation/Translator.cs
@@ -292,11 +292,11 @@ namespace ARMeilleure.Translation
                 _ptc.WriteCompiledFunction(address, funcSize, hash, highCq, compiledFunc);
             }
 
-            GuestFunction func = compiledFunc.Map<GuestFunction>();
+            GuestFunction func = compiledFunc.MapWithPointer<GuestFunction>(out IntPtr funcPointer);
 
             Allocators.ResetAll();
 
-            return new TranslatedFunction(func, counter, funcSize, highCq);
+            return new TranslatedFunction(func, funcPointer, counter, funcSize, highCq);
         }
 
         private void BackgroundTranslate()

--- a/ARMeilleure/Translation/Translator.cs
+++ b/ARMeilleure/Translation/Translator.cs
@@ -211,7 +211,7 @@ namespace ARMeilleure.Translation
 
                 if (oldFunc != func)
                 {
-                    JitCache.Unmap(func.FuncPtr);
+                    JitCache.Unmap(func.FuncPointer);
                     func = oldFunc;
                 }
 
@@ -230,7 +230,7 @@ namespace ARMeilleure.Translation
         {
             if (FunctionTable.IsValid(guestAddress) && (Optimizations.AllowLcqInFunctionTable || func.HighCq))
             {
-                Volatile.Write(ref FunctionTable.GetValue(guestAddress), (ulong)func.FuncPtr);
+                Volatile.Write(ref FunctionTable.GetValue(guestAddress), (ulong)func.FuncPointer);
             }
         }
 
@@ -537,7 +537,7 @@ namespace ARMeilleure.Translation
 
             foreach (var func in functions)
             {
-                JitCache.Unmap(func.FuncPtr);
+                JitCache.Unmap(func.FuncPointer);
 
                 func.CallCounter?.Dispose();
             }
@@ -546,7 +546,7 @@ namespace ARMeilleure.Translation
 
             while (_oldFuncs.TryDequeue(out var kv))
             {
-                JitCache.Unmap(kv.Value.FuncPtr);
+                JitCache.Unmap(kv.Value.FuncPointer);
 
                 kv.Value.CallCounter?.Dispose();
             }


### PR DESCRIPTION
This allows us to get rid of a call to `Marshal.GetFunctionPointerForDelegate`. Should make translating new functions a little bit faster on the JIT, but it's unlikely to give any noticeable improvements in practice.