### PR TITLE
Limit texture cache based on total texture size

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
@@ -33,15 +33,18 @@ namespace Ryujinx.Graphics.Gpu.Image
     /// </summary>
     class AutoDeleteCache : IEnumerable<Texture>
     {
+        private const int MinCountForDeletion = 32;
         private const int MaxCapacity = 2048;
+        private const ulong MaxTextureSizeCapacity = 512 * 1024 * 1024; // MB;
 
         private readonly LinkedList<Texture> _textures;
-        private readonly ConcurrentQueue<Texture> _deferredRemovals;
+        private ulong _totalSize;
 
         private HashSet<ShortTextureCacheEntry> _shortCacheBuilder;
         private HashSet<ShortTextureCacheEntry> _shortCache;
 
         private Dictionary<TextureDescriptor, ShortTextureCacheEntry> _shortCacheLookup;
+
 
         /// <summary>
         /// Creates a new instance of the automatic deletion cache.
@@ -49,7 +52,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         public AutoDeleteCache()
         {
             _textures = new LinkedList<Texture>();
-            _deferredRemovals = new ConcurrentQueue<Texture>();
 
             _shortCacheBuilder = new HashSet<ShortTextureCacheEntry>();
             _shortCache = new HashSet<ShortTextureCacheEntry>();
@@ -67,37 +69,15 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="texture">The texture to be added to the cache</param>
         public void Add(Texture texture)
         {
-            texture.IncrementReferenceCount();
+            _totalSize += texture.Size;
 
+            texture.IncrementReferenceCount();
             texture.CacheNode = _textures.AddLast(texture);
 
-            if (_textures.Count > MaxCapacity)
+            if (_textures.Count > MaxCapacity ||
+                (_totalSize > MaxTextureSizeCapacity && _textures.Count >= MinCountForDeletion))
             {
-                Texture oldestTexture = _textures.First.Value;
-
-                if (!oldestTexture.CheckModified(false))
-                {
-                    // The texture must be flushed if it falls out of the auto delete cache.
-                    // Flushes out of the auto delete cache do not trigger write tracking,
-                    // as it is expected that other overlapping textures exist that have more up-to-date contents.
-
-                    oldestTexture.Group.SynchronizeDependents(oldestTexture);
-                    oldestTexture.FlushModified(false);
-                }
-
-                _textures.RemoveFirst();
-
-                oldestTexture.DecrementReferenceCount();
-
-                oldestTexture.CacheNode = null;
-            }
-
-            if (_deferredRemovals.Count > 0)
-            {
-                while (_deferredRemovals.TryDequeue(out Texture textureToRemove))
-                {
-                    Remove(textureToRemove, false);
-                }
+                RemoveLeastUsedTexture();
             }
         }
 
@@ -120,11 +100,41 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                     texture.CacheNode = _textures.AddLast(texture);
                 }
+
+                if (_totalSize > MaxTextureSizeCapacity && _textures.Count >= MinCountForDeletion)
+                {
+                    RemoveLeastUsedTexture();
+                }
             }
             else
             {
                 Add(texture);
             }
+        }
+
+        /// <summary>
+        /// Removes the least used texture from the cache.
+        /// </summary>
+        private void RemoveLeastUsedTexture()
+        {
+            Texture oldestTexture = _textures.First.Value;
+
+            _totalSize -= oldestTexture.Size;
+
+            if (!oldestTexture.CheckModified(false))
+            {
+                // The texture must be flushed if it falls out of the auto delete cache.
+                // Flushes out of the auto delete cache do not trigger write tracking,
+                // as it is expected that other overlapping textures exist that have more up-to-date contents.
+
+                oldestTexture.Group.SynchronizeDependents(oldestTexture);
+                oldestTexture.FlushModified(false);
+            }
+
+            _textures.RemoveFirst();
+
+            oldestTexture.DecrementReferenceCount();
+            oldestTexture.CacheNode = null;
         }
 
         /// <summary>
@@ -148,18 +158,11 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             _textures.Remove(texture.CacheNode);
 
+            _totalSize -= texture.Size;
+
             texture.CacheNode = null;
 
             return texture.DecrementReferenceCount();
-        }
-
-        /// <summary>
-        /// Queues removal of a texture from the cache in a thread safe way.
-        /// </summary>
-        /// <param name="texture">The texture to be removed from the cache</param>
-        public void RemoveDeferred(Texture texture)
-        {
-            _deferredRemovals.Enqueue(texture);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/AutoDeleteCache.cs
@@ -45,7 +45,6 @@ namespace Ryujinx.Graphics.Gpu.Image
 
         private Dictionary<TextureDescriptor, ShortTextureCacheEntry> _shortCacheLookup;
 
-
         /// <summary>
         /// Creates a new instance of the automatic deletion cache.
         /// </summary>

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -1750,13 +1750,6 @@ namespace Ryujinx.Graphics.Gpu.Image
             }
 
             RemoveFromPools(true);
-
-            // We only want to remove if there's no mapped region of the texture that was modified by the GPU,
-            // otherwise we could lose data.
-            if (!Group.AnyModified(this))
-            {
-                _physicalMemory.TextureCache.QueueAutoDeleteCacheRemoval(this);
-            }
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -1176,19 +1176,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Queues the removal of a texture from the auto delete cache.
-        /// </summary>
-        /// <remarks>
-        /// This function is thread safe and can be called from any thread.
-        /// The texture will be deleted on the next time the cache is used.
-        /// </remarks>
-        /// <param name="texture">The texture to be removed</param>
-        public void QueueAutoDeleteCacheRemoval(Texture texture)
-        {
-            _cache.RemoveDeferred(texture);
-        }
-
-        /// <summary>
         /// Adds a texture to the short duration cache. This typically keeps it alive for two ticks.
         /// </summary>
         /// <param name="texture">Texture to add to the short cache</param>

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -435,32 +435,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Checks if a texture was modified by the GPU.
-        /// </summary>
-        /// <param name="texture">The texture to be checked</param>
-        /// <returns>True if any region of the texture was modified by the GPU, false otherwise</returns>
-        public bool AnyModified(Texture texture)
-        {
-            bool anyModified = false;
-
-            EvaluateRelevantHandles(texture, (baseHandle, regionCount, split) =>
-            {
-                for (int i = 0; i < regionCount; i++)
-                {
-                    TextureGroupHandle group = _handles[baseHandle + i];
-
-                    if (group.Modified)
-                    {
-                        anyModified = true;
-                        break;
-                    }
-                }
-            });
-
-            return anyModified;
-        }
-
-        /// <summary>
         /// Flush modified ranges for a given texture.
         /// </summary>
         /// <param name="texture">The texture being used</param>


### PR DESCRIPTION
#4211 fixed memory leaks on a few games that have a specific texture/render target usage pattern. However this approach caused regressions on a few OpenGL games, that's what River City Girls Zero looks like on master right now for example:
![image](https://user-images.githubusercontent.com/5624669/215324177-4739673d-ea4c-459c-bac5-75e6ec5a180d.png)
This changes reverts the changes on the linked PR and instead solves the problem using a different approach. It introduces a hard limit on the size (in bytes) of the `AutoDeleteCache`. Before it would start deleting textures if the amount of textures in the cache was above a given limit (currently 2048 textures). Now in addition to this limit, it also deletes if the total size is above 512 MB. To make sure it will keep at least the currently used textures in the cache, there's also a lower bound, it won't delete if there are less than 32 textures in the cache.

With this change, River City Girls Zero menu renders correctly again:
![image](https://user-images.githubusercontent.com/5624669/215324331-bf886838-53f4-457a-9a52-402b97acf23c.png)
And there's still no memory leaks on Witch's Garden.

I recommend testing this on a bunch of games since it can potentially change for how long textures are kept in the cache, which might have unexpected effects in some games. Maybe UE4 games are a good target for testing this since they like doing several textures copies.