### PR TITLE
Fix some Vulkan validation errors

### DIFF
--- a/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
@@ -27,6 +27,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             int attachmentCount = 0;
             int colorCount = 0;
+            int maxColorAttachmentIndex = -1;
 
             for (int i = 0; i < state.AttachmentEnable.Length; i++)
             {
@@ -36,6 +37,7 @@ namespace Ryujinx.Graphics.Vulkan
 
                     attachmentIndices[attachmentCount++] = i;
                     colorCount++;
+                    maxColorAttachmentIndex = i;
                 }
             }
 
@@ -73,12 +75,11 @@ namespace Ryujinx.Graphics.Vulkan
 
                 if (colorAttachmentsCount != 0)
                 {
-                    int maxAttachmentIndex = Constants.MaxRenderTargets - 1;
-                    subpass.ColorAttachmentCount = (uint)maxAttachmentIndex + 1;
+                    subpass.ColorAttachmentCount = (uint)maxColorAttachmentIndex + 1;
                     subpass.PColorAttachments = &attachmentReferences[0];
 
                     // Fill with VK_ATTACHMENT_UNUSED to cover any gaps.
-                    for (int i = 0; i <= maxAttachmentIndex; i++)
+                    for (int i = 0; i <= maxColorAttachmentIndex; i++)
                     {
                         subpass.PColorAttachments[i] = new AttachmentReference(Vk.AttachmentUnused, ImageLayout.Undefined);
                     }

--- a/Ryujinx.Graphics.Vulkan/Queries/BufferedQuery.cs
+++ b/Ryujinx.Graphics.Vulkan/Queries/BufferedQuery.cs
@@ -100,7 +100,8 @@ namespace Ryujinx.Graphics.Vulkan.Queries
             if (_isSupported)
             {
                 bool needsReset = resetSequence == null || _resetSequence == null || resetSequence.Value != _resetSequence.Value;
-                _pipeline.BeginQuery(this, _queryPool, needsReset, _type == CounterType.SamplesPassed && resetSequence != null);
+                bool isOcclusion = _type == CounterType.SamplesPassed;
+                _pipeline.BeginQuery(this, _queryPool, needsReset, isOcclusion, isOcclusion && resetSequence != null);
             }
             _resetSequence = null;
         }

--- a/Ryujinx.Graphics.Vulkan/TextureView.cs
+++ b/Ryujinx.Graphics.Vulkan/TextureView.cs
@@ -90,7 +90,7 @@ namespace Ryujinx.Graphics.Vulkan
             var componentMapping = new ComponentMapping(swizzleR, swizzleG, swizzleB, swizzleA);
 
             var aspectFlags = info.Format.ConvertAspectFlags(info.DepthStencilMode);
-            var aspectFlagsDepth = info.Format.ConvertAspectFlags(DepthStencilMode.Depth);
+            var aspectFlagsDepth = info.Format.ConvertAspectFlags();
 
             var subresourceRange = new ImageSubresourceRange(aspectFlags, (uint)firstLevel, levels, (uint)firstLayer, layers);
             var subresourceRangeDepth = new ImageSubresourceRange(aspectFlagsDepth, (uint)firstLevel, levels, (uint)firstLayer, layers);


### PR DESCRIPTION
Fixes the following validation errors:

- Validation Error: [ VUID-VkGraphicsPipelineCreateInfo-renderPass-06042 ] Object 0: handle = 0x2eff7599310, type = VK_OBJECT_TYPE_DEVICE; | MessageID = 0x5c3a371 | vkCreateGraphicsPipelines() pCreateInfo[0]: VkRenderPass 0xbf26f100000002f5[] subpass 0 has colorAttachmentCount of 8 which doesn't match the pColorBlendState->attachmentCount of 1. The Vulkan spec states: If renderPass is not VK_NULL_HANDLE, and the pipeline is being created with fragment output interface state, and the subpass uses color attachments, the attachmentCount member of pColorBlendState must be equal to the colorAttachmentCount used to create subpass (https://vulkan.lunarg.com/doc/view/1.3.231.1/windows/1.3-extensions/vkspec.html#VUID-VkGraphicsPipelineCreateInfo-renderPass-06042) (Caused by #4282).
- Validation Error: [ VUID-vkCmdBeginQuery-queryType-00800 ] Object 0: handle = 0x1ee6659ae70, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0xdf111ec0 | vkCmdBeginQuery: VK_QUERY_CONTROL_PRECISE_BIT provided, but pool query type is not VK_QUERY_TYPE_OCCLUSION The Vulkan spec states: If the occlusionQueryPrecise feature is not enabled, or the queryType used to create queryPool was not VK_QUERY_TYPE_OCCLUSION, flags must not contain VK_QUERY_CONTROL_PRECISE_BIT (https://vulkan.lunarg.com/doc/view/1.3.231.1/windows/1.3-extensions/vkspec.html#VUID-vkCmdBeginQuery-queryType-00800) (Caused by #4292).
- Validation Error: [ VUID-vkCmdClearAttachments-pAttachments-07270 ] Object 0: handle = 0x1ee6659ae70, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x1b7ceb63 | vkCmdClearAttachments() pAttachments[0] is backed by an image view that does not have aspect VK_IMAGE_ASPECT_STENCIL_BIT for VkRenderPass 0xdb60a50000000306[] subpass 0. The Vulkan spec states: For each element of pAttachments, the corresponding attachment in the current render pass instance must either not be backed by an image view, or contain each of the aspects specified in aspectMask (https://vulkan.lunarg.com/doc/view/1.3.231.1/windows/1.3-extensions/vkspec.html#VUID-vkCmdClearAttachments-pAttachments-07270) (I don't know what caused this one, but I don't remember seeing it before).

I don't think they were causing issues with any driver, so no changes are expected. Testing is welcome.