### PR TITLE
Implement Account LoadOpenContext

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
@@ -168,7 +168,6 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             return ResultCode.Success;
         }
 
-
         [CommandHipc(60)] // 5.0.0-5.1.0
         [CommandHipc(131)] // 6.0.0+
         // ListOpenContextStoredUsers() -> array<nn::account::Uid, 0xa>

--- a/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
+++ b/Ryujinx.HLE/HOS/Services/Account/Acc/IAccountServiceForApplication.cs
@@ -137,7 +137,7 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
 
             return resultCode;
         }
-        
+
         [CommandHipc(110)]
         // StoreSaveDataThumbnail(nn::account::Uid, buffer<bytes, 5>)
         public ResultCode StoreSaveDataThumbnail(ServiceCtx context)
@@ -153,13 +153,21 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
         }
 
         [CommandHipc(130)] // 5.0.0+
-        // LoadOpenContext(nn::account::Uid)
+        // LoadOpenContext(nn::account::Uid) -> object<nn::account::baas::IManagerForApplication>
         public ResultCode LoadOpenContext(ServiceCtx context)
         {
-            Logger.Stub?.PrintStub(LogClass.ServiceAcc);
+            ResultCode resultCode = _applicationServiceServer.CheckUserId(context, out UserId userId);
+
+            if (resultCode != ResultCode.Success)
+            {
+                return resultCode;
+            }
+
+            MakeObject(context, new IManagerForApplication(userId));
 
             return ResultCode.Success;
         }
+
 
         [CommandHipc(60)] // 5.0.0-5.1.0
         [CommandHipc(131)] // 6.0.0+


### PR DESCRIPTION
This implements `LoadOpenContext` which is supposed to return a `IManagerForApplication`. Not sure why I assumed it doesn't return anything before.

This fixes a crash on multi-game collections that uses `LoadOpenContext`. It would crash after launching one of the games if it called a function that uses `IManagerForApplication` because it would be null.

Fixes Prinny Presents NIS Classics Volume 1: Phantom Brave: The Hermuda Triangle Remastered / Soul Nomad & the World Eaters and other games with a similar issue.
![image](https://user-images.githubusercontent.com/5624669/216046897-5aea6fbc-05a4-49bd-9d40-b09c6e733965.png)
![image](https://user-images.githubusercontent.com/5624669/216047057-1c8679e7-9707-438e-a004-bd714ee00c62.png)
This also fixes a crash on Prinny Presents NIS Classics Volume 3: La Pucelle: Ragnarok / Rhapsody: A Musical Adventure when trying to exit from the games back to the title selection.