### PR TITLE
Handle mismatching texture size with copy dependencies

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
@@ -803,14 +803,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 _context.Renderer.Pipeline.SetScissors(scissors);
             }
 
-            if (clipMismatch)
-            {
-                _channel.TextureManager.UpdateRenderTarget(index);
-            }
-            else
-            {
-                _channel.TextureManager.UpdateRenderTargets();
-            }
+            _channel.TextureManager.UpdateRenderTargets();
 
             if (componentMask != 0)
             {

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
@@ -725,10 +725,25 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 return;
             }
 
+            bool clearDepth = (argument & 1) != 0;
+            bool clearStencil = (argument & 2) != 0;
+            uint componentMask = (uint)((argument >> 2) & 0xf);
             int index = (argument >> 6) & 0xf;
             int layer = (argument >> 10) & 0x3ff;
 
-            engine.UpdateRenderTargetState(useControl: false, layered: layer != 0 || layerCount > 1, singleUse: index);
+            RenderTargetUpdateFlags updateFlags = RenderTargetUpdateFlags.SingleColor;
+
+            if (layer != 0 || layerCount > 1)
+            {
+                updateFlags |= RenderTargetUpdateFlags.Layered;
+            }
+
+            if (clearDepth || clearStencil)
+            {
+                updateFlags |= RenderTargetUpdateFlags.UpdateDepthStencil;
+            }
+
+            engine.UpdateRenderTargetState(updateFlags, singleUse: componentMask != 0 ? index : -1);
 
             // If there is a mismatch on the host clip region and the one explicitly defined by the guest
             // on the screen scissor state, then we need to force only one texture to be bound to avoid
@@ -797,10 +812,6 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 _channel.TextureManager.UpdateRenderTargets();
             }
 
-            bool clearDepth = (argument & 1) != 0;
-            bool clearStencil = (argument & 2) != 0;
-            uint componentMask = (uint)((argument >> 2) & 0xf);
-
             if (componentMask != 0)
             {
                 var clearColor = _state.State.ClearColors;
@@ -841,7 +852,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 engine.UpdateScissorState();
             }
 
-            engine.UpdateRenderTargetState(useControl: true);
+            engine.UpdateRenderTargetState(RenderTargetUpdateFlags.UpdateAll);
 
             if (renderEnable == ConditionalRenderEnabled.Host)
             {

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/RenderTargetUpdateFlags.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/RenderTargetUpdateFlags.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace Ryujinx.Graphics.Gpu.Engine.Threed
+{
+    /// <summary>
+    /// Flags indicating how the render targets should be updated.
+    /// </summary>
+    [Flags]
+    enum RenderTargetUpdateFlags
+    {
+        /// <summary>
+        /// No flags.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Get render target index from the control register.
+        /// </summary>
+        UseControl = 1 << 0,
+
+        /// <summary>
+        /// Indicates that all render targets are 2D array textures.
+        /// </summary>
+        Layered = 1 << 1,
+
+        /// <summary>
+        /// Indicates that only a single color target will be used.
+        /// </summary>
+        SingleColor = 1 << 2,
+
+        /// <summary>
+        /// Indicates that the depth-stencil target will be used.
+        /// </summary>
+        UpdateDepthStencil = 1 << 3,
+
+        /// <summary>
+        /// Default update flags for draw.
+        /// </summary>
+        UpdateAll = UseControl | UpdateDepthStencil
+    }
+}

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
@@ -139,12 +139,11 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         /// <summary>
         /// Updates render targets (color and depth-stencil buffers) based on current render target state.
         /// </summary>
-        /// <param name="useControl">Use draw buffers information from render target control register</param>
-        /// <param name="layered">Indicates if the texture is layered</param>
+        /// <param name="updateFlags">Flags indicating which render targets should be updated and how</param>
         /// <param name="singleUse">If this is not -1, it indicates that only the given indexed target will be used.</param>
-        public void UpdateRenderTargetState(bool useControl, bool layered = false, int singleUse = -1)
+        public void UpdateRenderTargetState(RenderTargetUpdateFlags updateFlags, int singleUse = -1)
         {
-            _stateUpdater.UpdateRenderTargetState(useControl, layered, singleUse);
+            _stateUpdater.UpdateRenderTargetState(updateFlags, singleUse);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -1227,12 +1227,12 @@ namespace Ryujinx.Graphics.Gpu.Image
                 return TextureMatchQuality.NoMatch;
             }
 
-            if (!TextureCompatibility.SizeMatches(Info, info, (flags & TextureSearchFlags.Strict) == 0, FirstLevel))
+            if (!TextureCompatibility.SizeMatches(Info, info, FirstLevel))
             {
                 return TextureMatchQuality.NoMatch;
             }
 
-            if ((flags & TextureSearchFlags.ForSampler) != 0 || (flags & TextureSearchFlags.Strict) != 0)
+            if ((flags & TextureSearchFlags.ForSampler) != 0)
             {
                 if (!TextureCompatibility.SamplerParamsMatches(Info, info))
                 {

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -1227,7 +1227,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 return TextureMatchQuality.NoMatch;
             }
 
-            if (!TextureCompatibility.SizeMatches(Info, info, FirstLevel))
+            if (!TextureCompatibility.SizeMatches(Info, info))
             {
                 return TextureMatchQuality.NoMatch;
             }

--- a/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -427,7 +427,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>The minimum width of the texture with the same amount of GOBs per row</returns>
         private static int GetMinimumWidthInGob(int width, int minimumWidth, int bytesPerPixel, bool isLinear)
         {
-            if (isLinear)
+            if (isLinear || (uint)minimumWidth >= (uint)width)
             {
                 return width;
             }

--- a/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -596,6 +596,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 TextureViewCompatibility overlapCompatibility = overlap.IsViewCompatible(
                     info,
                     range.Value,
+                    isSamplerTexture,
                     sizeInfo.LayerSize,
                     _context.Capabilities,
                     out int firstLayer,
@@ -710,6 +711,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     TextureViewCompatibility compatibility = texture.IsViewCompatible(
                         overlap.Info,
                         overlap.Range,
+                        exactSize: true,
                         overlap.LayerSize,
                         _context.Capabilities,
                         out int firstLayer,
@@ -901,7 +903,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 // To fix that, we create a new texture with the correct
                 // size, and copy the data from the old one to the new one.
 
-                if (!TextureCompatibility.SizeMatches(texture.Info, info))
+                if (!TextureCompatibility.SizeMatches(texture.Info, info, true))
                 {
                     texture.ChangeSize(info.Width, info.Height, info.DepthOrLayers);
                 }

--- a/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -446,16 +446,15 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         /// <param name="lhs">Texture information to compare</param>
         /// <param name="rhs">Texture information to compare with</param>
-        /// <param name="lhsLevel">Mip level of the lhs texture. Aligned sizes are compared for the largest mip</param>
         /// <returns>True if the sizes matches, false otherwise</returns>
-        public static bool SizeMatches(TextureInfo lhs, TextureInfo rhs, int lhsLevel = 0)
+        public static bool SizeMatches(TextureInfo lhs, TextureInfo rhs)
         {
             if (lhs.GetLayers() != rhs.GetLayers())
             {
                 return false;
             }
 
-            Size lhsSize = GetSizeInBlocks(lhs, lhsLevel);
+            Size lhsSize = GetSizeInBlocks(lhs);
             Size rhsSize = GetSizeInBlocks(rhs);
 
             return lhsSize.Width == rhsSize.Width &&

--- a/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -515,22 +515,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Gets the aligned sizes of the specified texture information, shifted to the largest mip from a given level.
-        /// The alignment depends on the texture layout and format bytes per pixel.
-        /// </summary>
-        /// <param name="info">Texture information to calculate the aligned size from</param>
-        /// <param name="level">Mipmap level for texture views. Shifts the aligned size to represent the largest mip level</param>
-        /// <returns>The aligned texture size of the largest mip level</returns>
-        public static Size GetLargestAlignedSize(TextureInfo info, int level)
-        {
-            int width = info.Width << level;
-            int height = info.Height << level;
-            int depth = info.GetDepth() << level;
-
-            return GetAlignedSize(info, width, height, depth);
-        }
-
-        /// <summary>
         /// Gets the aligned sizes of the specified texture information.
         /// The alignment depends on the texture layout and format bytes per pixel.
         /// </summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -441,22 +441,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Update host framebuffer attachments based on currently bound render target buffers.
         /// </summary>
         /// <remarks>
-        /// All attachments other than <paramref name="index"/> will be unbound.
-        /// </remarks>
-        /// <param name="index">Index of the render target color to be updated</param>
-        public void UpdateRenderTarget(int index)
-        {
-            new Span<ITexture>(_rtHostColors).Fill(null);
-            _rtHostColors[index] = _rtColors[index]?.HostTexture;
-            _rtHostDs = null;
-
-            _context.Renderer.Pipeline.SetRenderTargets(_rtHostColors, null);
-        }
-
-        /// <summary>
-        /// Update host framebuffer attachments based on currently bound render target buffers.
-        /// </summary>
-        /// <remarks>
         /// All color attachments will be unbound.
         /// </remarks>
         public void UpdateRenderTargetDepthStencil()

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -77,22 +77,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             }
             else
             {
-                if (texture.ChangedSize)
-                {
-                    // Texture changed size at one point - it may be a different size than the sampler expects.
-                    // This can be triggered when the size is changed by a size hint on copy or draw, but the texture has been sampled before.
-
-                    int baseLevel = descriptor.UnpackBaseLevel();
-                    int width = Math.Max(1, descriptor.UnpackWidth() >> baseLevel);
-                    int height = Math.Max(1, descriptor.UnpackHeight() >> baseLevel);
-
-                    if (texture.Info.Width != width || texture.Info.Height != height)
-                    {
-                        texture.ChangeSize(width, height, texture.Info.DepthOrLayers);
-                    }
-                }
-
-                // Memory is automatically synchronized on texture creation.
+                // On the path above (texture not yet in the pool), memory is automatically synchronized on texture creation.
                 texture.SynchronizeMemory();
             }
 

--- a/Ryujinx.Graphics.Gpu/Image/TextureSearchFlags.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureSearchFlags.cs
@@ -9,7 +9,6 @@ namespace Ryujinx.Graphics.Gpu.Image
     enum TextureSearchFlags
     {
         None        = 0,
-        Strict      = 1 << 0,
         ForSampler  = 1 << 1,
         ForCopy     = 1 << 2,
         WithUpscale = 1 << 3,

--- a/Ryujinx.Graphics.Gpu/Window.cs
+++ b/Ryujinx.Graphics.Gpu/Window.cs
@@ -202,7 +202,7 @@ namespace Ryujinx.Graphics.Gpu
             {
                 pt.AcquireCallback(_context, pt.UserObj);
 
-                Texture texture = pt.Cache.FindOrCreateTexture(null, TextureSearchFlags.WithUpscale, pt.Info, 0, null, pt.Range);
+                Texture texture = pt.Cache.FindOrCreateTexture(null, TextureSearchFlags.WithUpscale, pt.Info, 0, pt.Range);
 
                 pt.Cache.Tick();
 


### PR DESCRIPTION
Because NVN aligns the width of the textures for copy and render, matching textures by size exactly on the texture cache does not always work. The texture entry on the texture pool always have the correct size, but render and copy textures do not, so cases where a texture was rendered or copied, and then later accessed on a shader would not work if we simply checked if the width of the texture matches with the one on the cache.

To make this case work we currently change the texture size when it is accessed on the shader. This is done with a `ChangeSize` method that under the hood creates a new texture, copies the old texture data to the new one, then handles re-creating all child views as needed. This not only adds unneeded complexity, but it's also a source of bugs. The main goal of this PR is getting rid of the `ChangeSize` method and instead handle that using existing methods (in this case copy dependency).

Using copy dependency is safer because there's no risk of data being lost. If for some reason the texture accessed on the shader is smaller than the one in the cache, but they overlap, copy dependency will ensure that the sub-region that is accessed is copied on use, but the original texture still exists, so the data is still there.

The first commit is making it use copy dependencies when the size does not match, but the aligned size does. Subsequent commits does other changes to ensure that we do copies on the minimal possible amount of cases, since copies are not exactly free. Those are some of the changes intended to reduce copies:
- We only assume that the width is aligned now. Height is always expected to match exactly. Since NVN does not align the height, that should be fine. It reduces the amount of "false" overlaps and useless copies that we do. The downside is higher VRAM usage, and that cases of height mismatch but aligned height being the same would no longer work properly.
- The width of the texture that is created for render or copy is now the minimum of the size hint and the lower bound of the aligned width. Since the size hint is *usually* equal to the real texture size, this allows the texture to be created with the correct size from the start, which avoids the need of a copy dependency for shader access later on.
- When finding textures for copy or render on the cache, the width if allowed to be greater than or equal to the requested width, as long the aligned width is equal. Because render and copy can only modify a sub-region of the texture, the texture being larger does not really matter as the additional space can't be accessed anyway.

This fixes a few games that were not rendering properly.
void tRrLM();
master:
![image](https://user-images.githubusercontent.com/5624669/216719350-d5a33186-b75a-4e31-acbf-6a41054ac3de.png)
PR:
![image](https://user-images.githubusercontent.com/5624669/216719376-e1580213-ed20-4a22-a1b1-50cf22d2c2d8.png)
The Longest Five Minutes:
master:
![image](https://user-images.githubusercontent.com/5624669/216719446-80bb9f28-e8a4-4475-8bde-b58a6e57f511.png)
PR:
![image](https://user-images.githubusercontent.com/5624669/216719466-87de63b0-10e4-4418-9f33-6931fda68a33.png)
Closes #1629, closes #4325.

It might also fix the "bike nuke" issue on Zelda BOTW, but this one is harder to test since the issue is somewhat random. But at least the cause of this issue that I was able to find should be fixed on this PR.

Might also fix random texture corruption in other games.

This should be tested extensively to ensure there are no graphical or performance regressions on games. Probably UE4 games are good candidates since they copy textures a lot.