### PR TITLE
Implement copy dependency for depth and color textures

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -735,9 +735,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 {
                     if (overlap.IsView)
                     {
-                        overlapCompatibility = overlapCompatibility == TextureViewCompatibility.FormatAlias ?
-                            TextureViewCompatibility.Incompatible :
-                            TextureViewCompatibility.CopyOnly;
+                        overlapCompatibility = TextureViewCompatibility.CopyOnly;
                     }
                     else
                     {
@@ -815,7 +813,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     Texture overlap = _textureOverlaps[index];
                     OverlapInfo oInfo = _overlapInfo[index];
 
-                    if (oInfo.Compatibility <= TextureViewCompatibility.LayoutIncompatible || oInfo.Compatibility == TextureViewCompatibility.FormatAlias)
+                    if (oInfo.Compatibility <= TextureViewCompatibility.LayoutIncompatible)
                     {
                         if (!overlap.IsView && texture.DataOverlaps(overlap, oInfo.Compatibility))
                         {

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -619,12 +619,20 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             if (lhsFormat.Format.IsDepthOrStencil() || rhsFormat.Format.IsDepthOrStencil())
             {
-                if (lhsFormat.Format == rhsFormat.Format)
+                bool forSampler = flags.HasFlag(TextureSearchFlags.ForSampler);
+                bool depthAlias = flags.HasFlag(TextureSearchFlags.DepthAlias);
+
+                TextureMatchQuality matchQuality = FormatMatches(lhs, rhs, forSampler, depthAlias);
+
+                if (matchQuality == TextureMatchQuality.Perfect)
                 {
                     return TextureViewCompatibility.Full;
                 }
-                else if (IsValidColorAsDepthAlias(lhsFormat.Format, rhsFormat.Format) ||
-                         IsValidDepthAsColorAlias(lhsFormat.Format, rhsFormat.Format))
+                else if (matchQuality == TextureMatchQuality.FormatAlias)
+                {
+                    return TextureViewCompatibility.FormatAlias;
+                }
+                else if (IsValidColorAsDepthAlias(lhsFormat.Format, rhsFormat.Format) || IsValidDepthAsColorAlias(lhsFormat.Format, rhsFormat.Format))
                 {
                     return TextureViewCompatibility.CopyOnly;
                 }

--- a/src/Ryujinx.Graphics.OpenGL/Image/TextureCopy.cs
+++ b/src/Ryujinx.Graphics.OpenGL/Image/TextureCopy.cs
@@ -367,7 +367,7 @@ namespace Ryujinx.Graphics.OpenGL.Image
             return to;
         }
 
-        private TextureView PboCopy(TextureView from, TextureView to, int srcLayer, int dstLayer, int srcLevel, int dstLevel, int width, int height)
+        public void PboCopy(TextureView from, TextureView to, int srcLayer, int dstLayer, int srcLevel, int dstLevel, int width, int height)
         {
             int dstWidth = width;
             int dstHeight = height;
@@ -445,8 +445,6 @@ namespace Ryujinx.Graphics.OpenGL.Image
             }
 
             GL.BindBuffer(BufferTarget.PixelUnpackBuffer, 0);
-
-            return to;
         }
 
         private void EnsurePbo(TextureView view)

--- a/src/Ryujinx.Graphics.Vulkan/TextureView.cs
+++ b/src/Ryujinx.Graphics.Vulkan/TextureView.cs
@@ -211,6 +211,13 @@ namespace Ryujinx.Graphics.Vulkan
                 int levels = Math.Min(Info.Levels, dst.Info.Levels - firstLevel);
                 _gd.HelperShader.CopyIncompatibleFormats(_gd, cbs, src, dst, 0, firstLayer, 0, firstLevel, layers, levels);
             }
+            else if (src.Info.Format.IsDepthOrStencil() != dst.Info.Format.IsDepthOrStencil())
+            {
+                int layers = Math.Min(Info.GetLayers(), dst.Info.GetLayers() - firstLayer);
+                int levels = Math.Min(Info.Levels, dst.Info.Levels - firstLevel);
+
+                _gd.HelperShader.CopyColor(_gd, cbs, src, dst, 0, firstLayer, 0, FirstLevel, layers, levels);
+            }
             else
             {
                 TextureCopy.Copy(
@@ -259,6 +266,10 @@ namespace Ryujinx.Graphics.Vulkan
             else if (dst.Info.BytesPerPixel != Info.BytesPerPixel)
             {
                 _gd.HelperShader.CopyIncompatibleFormats(_gd, cbs, src, dst, srcLayer, dstLayer, srcLevel, dstLevel, 1, 1);
+            }
+            else if (src.Info.Format.IsDepthOrStencil() != dst.Info.Format.IsDepthOrStencil())
+            {
+                _gd.HelperShader.CopyColor(_gd, cbs, src, dst, srcLayer, dstLayer, srcLevel, dstLevel, 1, 1);
             }
             else
             {


### PR DESCRIPTION
Luigi's Mansion 3 renders a texture using the R16Unorm format, and samples it using the D16Unorm format. We did not support that case before since those formats are not view compatible. This change adds support for this case using copies (copy dependency).

Fixes shadow issues on Luigi's Mansion 3.
Before:

https://user-images.githubusercontent.com/5624669/216788492-7c69012d-6641-467a-8c17-cb321faf0d2b.mp4

After:

https://user-images.githubusercontent.com/5624669/216788486-e85b3e8a-43e4-4713-ae9b-7205bd4dc92d.mp4

Thanks to @riperiperi for finding the issue.

Fixes #2791.