### PR TITLE
Insert bitcast for assignment of fragment integer outputs on GLSL

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 4336;
+        private const uint CodeGenVersion = 4369;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
@@ -487,6 +487,16 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
                     return type.ToAggregateType();
                 }
+                else if (context.Config.Stage == ShaderStage.Fragment && isAsgDest &&
+                    operand.Value >= AttributeConsts.FragmentOutputColorBase &&
+                    operand.Value < AttributeConsts.FragmentOutputColorEnd)
+                {
+                    int location = (operand.Value - AttributeConsts.FragmentOutputColorBase) / 16;
+
+                    AttributeType type = context.Config.GpuAccessor.QueryFragmentOutputType(location);
+
+                    return type.ToAggregateType();
+                }
             }
 
             return OperandInfo.GetVarType(operand);


### PR DESCRIPTION
Fixes a regression caused by #4202 which caused GLSL shaders to fail to compile because with this change, fragment outputs might now have integer types, however when assigning from a float variable, it would not insert the variable because internally the code generator assumed it had a float type. This change updates the code to use the correct fragment output type.

Fixes games rendering to integer textures on OpenGL.
Before:
![image](https://user-images.githubusercontent.com/5624669/216803704-b1f24521-2aec-4c84-942b-69fc7f54f51b.png)
After:
![image](https://user-images.githubusercontent.com/5624669/216803698-b638d4ef-4efd-450a-91a9-3da1c70bce9f.png)