### PR TITLE
Better filtering of invalid NPadIds when games request unknown supported players

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Hid/HidServer/HidUtils.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/HidServer/HidUtils.cs
@@ -38,7 +38,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid.HidServer
 
         public static bool IsValidNpadIdType(NpadIdType npadIdType)
         {
-            return npadIdType <= NpadIdType.Player8 || npadIdType == NpadIdType.Handheld || npadIdType == NpadIdType.Unknown;
+            return (npadIdType >= NpadIdType.Player1 && npadIdType <= NpadIdType.Player8) ||
+                npadIdType == NpadIdType.Handheld ||
+                npadIdType == NpadIdType.Unknown;
         }
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/IHidServer.cs
@@ -722,7 +722,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             for (int i = 0; i < supportedPlayerIds.Length; ++i)
             {
-                if (supportedPlayerIds[i] >= 0)
+                if (HidUtils.IsValidNpadIdType(supportedPlayerIds[i]))
                 {
                     context.Device.Hid.Npads.SetSupportedPlayer(HidUtils.GetIndexFromNpadIdType(supportedPlayerIds[i]));
                 }
@@ -1101,7 +1101,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid
 
             if (deviceType < NpadStyleIndex.System || deviceType >= NpadStyleIndex.FullKey)
             {
-                if (npadIdType >= (NpadIdType.Player8 + 1) && npadIdType != NpadIdType.Handheld && npadIdType != NpadIdType.Unknown)
+                if (!HidUtils.IsValidNpadIdType(npadIdType))
                 {
                     return ResultCode.InvalidNpadIdType;
                 }


### PR DESCRIPTION
While testing the game Kingdom Rush [0100A280121F6000], I noticed Ryujinx would crash in HidUtils.GetIndexFromNpadIdType() because the game was requesting an unknown NPad ID. The data the game actually sends is:
[0] 0x1d635b53
[1] 0x00000000 (Player1)

This PR adds extra `IsValidNpadIdType()` checks to ignore these unknown values. It also improves the logic of `IsValidNpadIdType()` a bit and makes it more centralized to other functions within IHidServer (for example, where the check used to be just `nPadId >= 0`

With this change the game now boots fine

![image](https://user-images.githubusercontent.com/918053/217347271-98dd4bb8-6802-4310-a70c-c31381209442.png)

I assume the game is not expecting HID service to return `ResultCode.InvalidNpadIdType` because if I do then it breaks execution

![image](https://user-images.githubusercontent.com/918053/217347391-b593af36-4842-421d-b368-14b138eda10e.png)
