### PR TITLE
Vulkan: Flush command buffers for queries less aggressively

### DIFF
--- a/Ryujinx.Graphics.Vulkan/PipelineFull.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineFull.cs
@@ -281,7 +281,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         protected override void SignalAttachmentChange()
         {
-            if (AutoFlush.ShouldFlush(DrawCount))
+            if (AutoFlush.ShouldFlushAttachmentChange(DrawCount))
             {
                 FlushCommandsImpl();
             }


### PR DESCRIPTION
The AutoFlushCounter would flush command buffers on any attachment change (write mask or bindings change) if there was a pending query. This is to get query results as soon as possible for draw skips, but it's assuming that a full occlusion query _pass_ happened, that we want to flush it's data before getting onto draws, rather than the queries being randomly interspersed throughout a pass that also draws.

Xenoblade 2 repeatedly switches between performing a samples passed query and outputting to a render target on each draw, and flips the write mask to do so. Flushing the command buffer every 2 draws isn't ideal, so it's best that we only do this if the pattern matches the large block style of occlusion query. Since #4329 this got a lot more expensive.

This change makes this flush only happen after a few consecutive query reports. "Consecutive" is interrupted by attachment changes or command buffer flush.

This doesn't really solve the issue where it resets more queries than it uses, it just stops the game doing it as often. I'm not sure of the best way to do that. The cost of resetting could probably be reduced by using query pools with more than one element and resetting in bulk.

I renamed `ShouldFlush` to better indicate that there is attachment change specific logic in there now.