### PR TITLE
ui/discord: Implement per-game image icons

### DIFF
--- a/Ryujinx.Ui.Common/DiscordIntegrationModule.cs
+++ b/Ryujinx.Ui.Common/DiscordIntegrationModule.cs
@@ -66,7 +66,7 @@ namespace Ryujinx.Ui.Common
             {
                 Assets = new Assets
                 {
-                    LargeImageKey  = "game",
+                    LargeImageKey  = $"https://img-eshop.worker.ryujinx.dev/titleid/${titleId}",
                     LargeImageText = titleName,
                     SmallImageKey  = "ryujinx",
                     SmallImageText = Description,


### PR DESCRIPTION
This makes use of an [undocumented Discord RPC](https://github.com/Mastermindzh/tidal-hifi/pull/84) feature that allows specifying a full URL to an image for the large image key, rather than a pre-defined key from a limited set of uploaded images.

In this instance, we use a custom image redirection service that redirects to a games icon served by the Nintendo eShop directly. This service acts as a dumb redirector, looking up a mapping between title IDs and Nintendo eShop icon images. This avoids the need to host any potentially copyrighted images directly on servers operated by the Ryujinx project. The title ID to eShop mapping data is sourced from a yet unreleased game compatibility DB I'm working on, and is currently updated ~weekly~ daily by a CI process, but this can be run more frequently if needed.

The title ID database is currently populated with all titles from the US, EU, and JPN regions. There may be the occasional title that isn't present if it was launched exclusively in another region.

The source code for the redirection service is available here: https://github.com/jduncanator/cf-eshop-image-redirector

An example URL can be found here: https://img-eshop.worker.ryujinx.dev/titleid/01006A800016E000, which redirects to https://img-eshop.cdn.nintendo.net/i/08af58551a19df2a73ccb36f720388434a1965776b34675c6f69af3f93280330.jpg.

<img src="https://user-images.githubusercontent.com/1518948/217781647-e5af3bc0-c1ad-4554-87ad-4dd0b038b391.png" width="384" /> <img src="https://user-images.githubusercontent.com/1518948/217782044-6b6118a7-7547-49c6-bcc7-f43514ad8157.png" width="384" />

The Discord CDN proxies all of these requests, so the Nintendo servers are never hit directly by an end user: https://media.discordapp.net/external/bFQjtVycdy95Irpy1wB9Y24JlHyxGIlqoHYwkKZv9B8/https/img-eshop.worker.ryujinx.dev/titleid/010012101468C000