### PR TITLE
Allow partially mapped textures with unmapped start

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -474,6 +474,13 @@ namespace Ryujinx.Graphics.Gpu.Image
             {
                 address = memoryManager.Translate(info.GpuAddress);
 
+                // If the start address is unmapped, let's try to find a page of memory that is mapped.
+                if (address == MemoryManager.PteUnmapped)
+                {
+                    address = memoryManager.TranslateFirstMapped(info.GpuAddress, (ulong)info.CalculateSizeInfo(layerSize).TotalSize);
+                }
+
+                // If address is still invalid, the texture is fully unmapped, so it has no data, just return null.
                 if (address == MemoryManager.PteUnmapped)
                 {
                     return null;


### PR DESCRIPTION
Currently, we allow textures to be partially mapped (that is, not all pages of the texture are mapped). This is required to support sparse textures. However, it did not support having the start of the texture unmapped. For this case, it just assumed the texture didn't exist. This PR updates the code to allow partially mapped textures with a unmapped start region. For the lookup, it uses the address of the first page that is mapped.

Fixes broken lighting on Metroid Prime Remastered.

Before:
![image](https://user-images.githubusercontent.com/5624669/217915291-47b1e8dd-cb37-4f5c-8bcc-a4fe6e34dd9b.png)
After:
![image](https://user-images.githubusercontent.com/5624669/217915324-a9f1681e-05cb-41d9-b25f-ddcb39dc0aaa.png)

Testing is welcome. Would be nice to know if there's any performance regression (or increase of stuttering/memory usage) since it is creating a large texture now, which was not being created before. 