### PR TITLE
Fix partial updates for textures.

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -336,24 +336,23 @@ namespace Ryujinx.Graphics.Gpu.Image
                 if (_loadNeeded[baseHandle + i])
                 {
                     var info = GetHandleInformation(baseHandle + i);
-                    int offsetIndex = info.Index;
 
                     // Only one of these will be greater than 1, as partial sync is only called when there are sub-image views.
                     for (int layer = 0; layer < info.Layers; layer++)
                     {
                         for (int level = 0; level < info.Levels; level++)
                         {
+                            int offsetIndex = GetOffsetIndex(info.BaseLayer + layer, info.BaseLevel + level);
+
                             int offset = _allOffsets[offsetIndex];
                             int endOffset = Math.Min(offset + _sliceSizes[info.BaseLevel + level], (int)Storage.Size);
                             int size = endOffset - offset;
 
                             ReadOnlySpan<byte> data = _physicalMemory.GetSpan(Storage.Range.GetSlice((ulong)offset, (ulong)size));
 
-                            SpanOrArray<byte> result = Storage.ConvertToHostCompatibleFormat(data, info.BaseLevel, true);
+                            SpanOrArray<byte> result = Storage.ConvertToHostCompatibleFormat(data, info.BaseLevel + level, true);
 
-                            Storage.SetData(result, info.BaseLayer, info.BaseLevel);
-
-                            offsetIndex++;
+                            Storage.SetData(result, info.BaseLayer + layer, info.BaseLevel + level);
                         }
                     }
                 }

--- a/Ryujinx.Graphics.Vulkan/TextureView.cs
+++ b/Ryujinx.Graphics.Vulkan/TextureView.cs
@@ -712,7 +712,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             for (int level = 0; level < levels; level++)
             {
-                int mipSize = GetBufferDataLength(Info.GetMipSize(dstLevel + level));
+                int mipSize = GetBufferDataLength(Info.GetMipSize2D(dstLevel + level) * dstLayers);
 
                 int endOffset = offset + mipSize;
 


### PR DESCRIPTION
I was forcing some types of texture to partially update when investigating performance with games that stream in data, and noticed that partially loading texture data was really broken on both backends.

Fixes Vulkan partial texture upload by getting the correct expected size for the texture. Fixes partial texture upload on both backends for both Texture 2D Array and Cubemap using the wrong offset and always uploading to the first layer/level for a handle. 3D might also be affected.

This might fix textures randomly having incorrect data in games that render to it - jumbled in the case of OpenGL, and outdated/black in the case of Vulkan. This case typically happens in UE4 games.