### PR TITLE
vulkan: Clean up MemoryAllocator

### DIFF
--- a/Ryujinx.Graphics.Vulkan/BufferManager.cs
+++ b/Ryujinx.Graphics.Vulkan/BufferManager.cs
@@ -39,7 +39,6 @@ namespace Ryujinx.Graphics.Vulkan
             BufferUsageFlags.VertexBufferBit |
             BufferUsageFlags.TransformFeedbackBufferBitExt;
 
-        private readonly PhysicalDevice _physicalDevice;
         private readonly Device _device;
 
         private readonly IdList<BufferHolder> _buffers;
@@ -48,9 +47,8 @@ namespace Ryujinx.Graphics.Vulkan
 
         public StagingBuffer StagingBuffer { get; }
 
-        public BufferManager(VulkanRenderer gd, PhysicalDevice physicalDevice, Device device)
+        public BufferManager(VulkanRenderer gd, Device device)
         {
-            _physicalDevice = physicalDevice;
             _device = device;
             _buffers = new IdList<BufferHolder>();
             StagingBuffer = new StagingBuffer(gd, this);
@@ -114,7 +112,7 @@ namespace Ryujinx.Graphics.Vulkan
                 allocateFlagsAlt = DefaultBufferMemoryAltFlags;
             }
 
-            var allocation = gd.MemoryAllocator.AllocateDeviceMemory(_physicalDevice, requirements, allocateFlags, allocateFlagsAlt);
+            var allocation = gd.MemoryAllocator.AllocateDeviceMemory(requirements, allocateFlags, allocateFlagsAlt);
 
             if (allocation.Memory.Handle == 0UL)
             {

--- a/Ryujinx.Graphics.Vulkan/TextureStorage.cs
+++ b/Ryujinx.Graphics.Vulkan/TextureStorage.cs
@@ -55,7 +55,6 @@ namespace Ryujinx.Graphics.Vulkan
 
         public unsafe TextureStorage(
             VulkanRenderer gd,
-            PhysicalDevice physicalDevice,
             Device device,
             TextureCreateInfo info,
             float scaleFactor,
@@ -118,7 +117,7 @@ namespace Ryujinx.Graphics.Vulkan
             if (foreignAllocation == null)
             {
                 gd.Api.GetImageMemoryRequirements(device, _image, out var requirements);
-                var allocation = gd.MemoryAllocator.AllocateDeviceMemory(physicalDevice, requirements, DefaultImageMemoryFlags);
+                var allocation = gd.MemoryAllocator.AllocateDeviceMemory(requirements, DefaultImageMemoryFlags);
 
                 if (allocation.Memory.Handle == 0UL)
                 {
@@ -173,7 +172,7 @@ namespace Ryujinx.Graphics.Vulkan
 
                 var info = NewCreateInfoWith(ref _info, format, _info.BytesPerPixel);
 
-                storage = new TextureStorage(_gd, default, _device, info, ScaleFactor, _allocationAuto);
+                storage = new TextureStorage(_gd, _device, info, ScaleFactor, _allocationAuto);
 
                 _aliasedStorages.Add(format, storage);
             }

--- a/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -280,7 +280,7 @@ namespace Ryujinx.Graphics.Vulkan
                 supportedSampleCounts,
                 portabilityFlags);
 
-            MemoryAllocator = new MemoryAllocator(Api, _device, properties.Limits.MaxMemoryAllocationCount);
+            MemoryAllocator = new MemoryAllocator(Api, _physicalDevice, _device, properties.Limits.MaxMemoryAllocationCount);
 
             CommandBufferPool = VulkanInitialization.CreateCommandBufferPool(Api, _device, Queue, QueueLock, queueFamilyIndex);
 
@@ -290,7 +290,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             BackgroundResources = new BackgroundResources(this, _device);
 
-            BufferManager = new BufferManager(this, _physicalDevice, _device);
+            BufferManager = new BufferManager(this, _device);
 
             _syncManager = new SyncManager(this, _device);
             _pipeline = new PipelineFull(this, _device);
@@ -388,7 +388,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         internal TextureStorage CreateTextureStorage(TextureCreateInfo info, float scale)
         {
-            return new TextureStorage(this, _physicalDevice, _device, info, scale);
+            return new TextureStorage(this, _device, info, scale);
         }
 
         public void DeleteBuffer(BufferHandle buffer)


### PR DESCRIPTION
This started as an attempt to remove `vkGetPhysicalDeviceMemoryProperties` in `FindSuitableMemoryTypeIndex` (As this could have some overhead and shouldn't change at runtime) and turned in a little bigger cleanup.