### PR TITLE
Logging: Redirect StdErr into logging system

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,6 +24,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageVersion Include="MsgPack.Cli" Version="1.0.1" />
+    <PackageVersion Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.1.0" />
     <PackageVersion Include="OpenTK.Core" Version="4.7.5" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,7 +24,6 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageVersion Include="MsgPack.Cli" Version="1.0.1" />
-    <PackageVersion Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.1.0" />
     <PackageVersion Include="OpenTK.Core" Version="4.7.5" />

--- a/Ryujinx.Common/Ryujinx.Common.csproj
+++ b/Ryujinx.Common/Ryujinx.Common.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Unix" />
     <PackageReference Include="MsgPack.Cli" />
     <PackageReference Include="System.Management" />
   </ItemGroup>

--- a/Ryujinx.Common/Ryujinx.Common.csproj
+++ b/Ryujinx.Common/Ryujinx.Common.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Mono.Unix" />
     <PackageReference Include="MsgPack.Cli" />
     <PackageReference Include="System.Management" />
   </ItemGroup>

--- a/Ryujinx.Common/SystemInterop/StdErrAdapter.cs
+++ b/Ryujinx.Common/SystemInterop/StdErrAdapter.cs
@@ -68,7 +68,7 @@ namespace Ryujinx.Common.SystemInterop
         }
 
         [LibraryImport("libc", SetLastError = true)]
-        private static partial int dup2 (int fd, int fd2);
+        private static partial int dup2(int fd, int fd2);
 
         [LibraryImport("libc", SetLastError = true)]
         private static unsafe partial int pipe(int* pipefd);
@@ -84,7 +84,7 @@ namespace Ryujinx.Common.SystemInterop
                 }
                 else
                 {
-                    throw new ();
+                    throw new();
                 }
             }
         }

--- a/Ryujinx.Common/SystemInterop/StdErrAdapter.cs
+++ b/Ryujinx.Common/SystemInterop/StdErrAdapter.cs
@@ -55,8 +55,11 @@ namespace Ryujinx.Common.SystemInterop
         {
             if (_disposable)
             {
-                _pipeReader?.Close();
-                _pipeWriter?.Close();
+                if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
+                {
+                    _pipeReader?.Close();
+                    _pipeWriter?.Close();
+                }
 
                 _disposable = false;
             }
@@ -75,17 +78,15 @@ namespace Ryujinx.Common.SystemInterop
 
         private static unsafe (int, int) MakePipe()
         {
-            Span<int> pipefd = stackalloc int[2];
-            fixed (int* ptr = pipefd)
+            int *pipefd = stackalloc int[2];
+
+            if (pipe(pipefd) == 0)
             {
-                if (pipe(ptr) == 0)
-                {
-                    return (pipefd[0], pipefd[1]);
-                }
-                else
-                {
-                    throw new();
-                }
+                return (pipefd[0], pipefd[1]);
+            }
+            else
+            {
+                throw new();
             }
         }
     }

--- a/Ryujinx.Common/SystemInterop/StdErrAdapter.cs
+++ b/Ryujinx.Common/SystemInterop/StdErrAdapter.cs
@@ -1,0 +1,67 @@
+using System;
+using System.IO;
+using System.Runtime.Versioning;
+using System.Threading;
+using Mono.Unix;
+using Ryujinx.Common.Logging;
+
+namespace Ryujinx.Common.SystemInterop
+{
+    public class StdErrAdapter : IDisposable
+    {
+        private bool _disposable = false;
+        private UnixPipes _stdErrPipe;
+        private Thread _worker;
+
+        public StdErrAdapter()
+        {
+            if (OperatingSystem.IsLinux() || OperatingSystem.IsMacOS())
+            {
+                RegisterPosix();
+            }
+        }
+
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macos")]
+        private void RegisterPosix()
+        {
+            const int stdErrFileno = 2;
+
+            _stdErrPipe = UnixPipes.CreatePipes();
+            Mono.Unix.Native.Syscall.dup2(_stdErrPipe.Writing.Handle, stdErrFileno);
+            _worker = new Thread(EventWorker);
+            _disposable = true;
+            _worker.Start();
+        }
+
+        [SupportedOSPlatform("linux")]
+        [SupportedOSPlatform("macos")]
+        private void EventWorker()
+        {
+            TextReader reader = new StreamReader(_stdErrPipe.Reading);
+            string line;
+            while ((line = reader.ReadLine()) != null)
+            {
+                Logger.Error?.PrintRawMsg(line);
+            }
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposable)
+            {
+                _stdErrPipe.Reading.Close();
+                _stdErrPipe.Writing.Close();
+                _stdErrPipe.Reading.Dispose();
+                _stdErrPipe.Writing.Dispose();
+
+                _disposable = false;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+        }
+    }
+}

--- a/Ryujinx.Common/SystemInterop/UnixStream.cs
+++ b/Ryujinx.Common/SystemInterop/UnixStream.cs
@@ -1,9 +1,12 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace Ryujinx.Common.SystemInterop
 {
+    [SupportedOSPlatform("linux")]
+    [SupportedOSPlatform("macos")]
     public partial class UnixStream : Stream, IDisposable
     {
         private const int InvalidFd = -1;
@@ -23,7 +26,7 @@ namespace Ryujinx.Common.SystemInterop
         {
             if (InvalidFd == fd)
             {
-                throw new ArgumentException("invalid fd");
+                throw new ArgumentException("Invalid file descriptor");
             }
 
             _fd = fd;
@@ -32,7 +35,7 @@ namespace Ryujinx.Common.SystemInterop
             CanWrite = write(fd, IntPtr.Zero, 0) != -1;  
         }
 
-        ~UnixStream ()
+        ~UnixStream()
         {
             Close();
         }
@@ -143,7 +146,7 @@ namespace Ryujinx.Common.SystemInterop
                     return true;
                 }
 
-                throw new SystemException($"errno {errno}");
+                throw new SystemException($"Operation failed with error 0x{errno:X}");
             }
 
             return false;

--- a/Ryujinx.Common/SystemInterop/UnixStream.cs
+++ b/Ryujinx.Common/SystemInterop/UnixStream.cs
@@ -1,0 +1,152 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Ryujinx.Common.SystemInterop
+{
+    public partial class UnixStream : Stream, IDisposable
+    {
+        private const int InvalidFd = -1;
+
+        private int _fd;
+
+        [LibraryImport("libc", SetLastError = true)]
+        private static partial long read(int fd, IntPtr buf, ulong count);
+
+        [LibraryImport("libc", SetLastError = true)]
+        private static partial long write(int fd, IntPtr buf, ulong count);
+
+        [LibraryImport("libc", SetLastError = true)]
+        private static partial int close(int fd);
+
+        public UnixStream(int fd)
+        {
+            if (InvalidFd == fd)
+            {
+                throw new ArgumentException("invalid fd");
+            }
+
+            _fd = fd;
+            
+            CanRead = read(fd, IntPtr.Zero, 0) != -1;
+            CanWrite = write(fd, IntPtr.Zero, 0) != -1;  
+        }
+
+        ~UnixStream ()
+        {
+            Close();
+        }
+
+        public override bool CanRead { get; }
+        public override bool CanWrite { get; }
+        public override bool CanSeek => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override unsafe int Read([In, Out] byte[] buffer, int offset, int count)
+        {
+            if (offset < 0 || offset > (buffer.Length - count) || count < 0)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            if (buffer.Length == 0)
+            {
+                return 0;
+            }
+
+            long r = 0;
+            fixed (byte* buf = &buffer[offset])
+            {
+                do
+                {
+                    r = read(_fd, (IntPtr)buf, (ulong)count);
+                } while (ShouldRetry(r));
+            }
+
+            return (int)r;
+        }
+        
+        public override unsafe void Write(byte[] buffer, int offset, int count)
+        {
+            if (offset < 0 || offset > (buffer.Length - count) || count < 0)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            if (buffer.Length == 0)
+            {
+                return;
+            }
+
+            fixed (byte* buf = &buffer[offset])
+            {
+                long r = 0;
+                do {
+                    r = write(_fd, (IntPtr)buf, (ulong)count);
+                } while (ShouldRetry(r));
+            }
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Close()
+        {
+            if (_fd == InvalidFd)
+            {
+                return;
+            }
+
+            Flush();
+
+            int r;
+            do {
+                r = close(_fd);
+            } while (ShouldRetry(r));
+
+            _fd = InvalidFd;
+        }
+
+        void IDisposable.Dispose()
+        {
+            Close();
+        }
+
+        private bool ShouldRetry(long r)
+        {
+            if (r == -1)
+            {
+                const int eintr = 4;
+
+                int errno = Marshal.GetLastPInvokeError();
+
+                if (errno == eintr)
+                {
+                    return true;
+                }
+
+                throw new SystemException($"errno {errno}");
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Redirect stderr output into logging system.

This allows for easier mvk/mesa debugging since stderr will now show up in log files.

Extracted from #4227.