### PR TITLE
Validate dimensions before creating texture

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -477,7 +477,23 @@ namespace Ryujinx.Graphics.Gpu.Image
                 // If the start address is unmapped, let's try to find a page of memory that is mapped.
                 if (address == MemoryManager.PteUnmapped)
                 {
-                    address = memoryManager.TranslateFirstMapped(info.GpuAddress, (ulong)info.CalculateSizeInfo(layerSize).TotalSize);
+                    // Make sure that the dimensions are valid before calculating the texture size.
+                    if (info.Width < 1 || info.Height < 1 || info.Levels < 1)
+                    {
+                        return null;
+                    }
+
+                    if ((info.Target == Target.Texture3D ||
+                         info.Target == Target.Texture2DArray ||
+                         info.Target == Target.Texture2DMultisampleArray ||
+                         info.Target == Target.CubemapArray) && info.DepthOrLayers < 1)
+                    {
+                        return null;
+                    }
+
+                    ulong dataSize = (ulong)info.CalculateSizeInfo(layerSize).TotalSize;
+
+                    address = memoryManager.TranslateFirstMapped(info.GpuAddress, dataSize);
                 }
 
                 // If address is still invalid, the texture is fully unmapped, so it has no data, just return null.


### PR DESCRIPTION
There are some cases where texture pool entries are completely invalid and would contain garbage. Those cases would usually have a invalid GPU virtual address too which would prevent the texture from being created. But since #4394, an attempt is made to create the texture even if the start address is unmapped ("invalid"), to allow sparse textures to work. This change is adds additional validation to prevent an attempt of calculating the texture size with invalid dimensions, which causes exception.

This fixes a regression caused by the linked PR on SSBU while using ARCropolis mods.