### PR TITLE
Update range for remapped sparse textures instead of recreating them

### DIFF
--- a/Ryujinx.Cpu/Tracking/CpuRegionHandle.cs
+++ b/Ryujinx.Cpu/Tracking/CpuRegionHandle.cs
@@ -28,5 +28,10 @@ namespace Ryujinx.Cpu.Tracking
         public void Reprotect(bool asDirty = false) => _impl.Reprotect(asDirty);
 
         public bool OverlapsWith(ulong address, ulong size) => _impl.OverlapsWith(address, size);
+
+        public bool RangeEquals(CpuRegionHandle other)
+        {
+            return _impl.RealAddress == other._impl.RealAddress && _impl.RealSize == other._impl.RealSize;
+        }
     }
 }

--- a/Ryujinx.Graphics.GAL/Target.cs
+++ b/Ryujinx.Graphics.GAL/Target.cs
@@ -20,5 +20,15 @@ namespace Ryujinx.Graphics.GAL
         {
             return target == Target.Texture2DMultisample || target == Target.Texture2DMultisampleArray;
         }
+
+        public static bool HasDepthOrLayers(this Target target)
+        {
+            return target == Target.Texture3D ||
+                target == Target.Texture1DArray ||
+                target == Target.Texture2DArray ||
+                target == Target.Texture2DMultisampleArray ||
+                target == Target.Cubemap ||
+                target == Target.CubemapArray;
+        }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -731,6 +731,8 @@ namespace Ryujinx.Graphics.Gpu.Image
             height = Math.Max(height >> level, 1);
             depth = Math.Max(depth >> level, 1);
 
+            int sliceDepth = single ? 1 : depth;
+
             SpanOrArray<byte> result;
 
             if (Info.IsLinear)
@@ -751,7 +753,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     width,
                     height,
                     depth,
-                    single ? 1 : depth,
+                    sliceDepth,
                     levels,
                     layers,
                     Info.FormatInfo.BlockWidth,
@@ -775,7 +777,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     Info.FormatInfo.BlockHeight,
                     width,
                     height,
-                    depth,
+                    sliceDepth,
                     levels,
                     layers,
                     out byte[] decoded))
@@ -787,7 +789,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                 if (GraphicsConfig.EnableTextureRecompression)
                 {
-                    decoded = BCnEncoder.EncodeBC7(decoded, width, height, depth, levels, layers);
+                    decoded = BCnEncoder.EncodeBC7(decoded, width, height, sliceDepth, levels, layers);
                 }
 
                 result = decoded;
@@ -798,15 +800,15 @@ namespace Ryujinx.Graphics.Gpu.Image
                 {
                     case Format.Etc2RgbaSrgb:
                     case Format.Etc2RgbaUnorm:
-                        result = ETC2Decoder.DecodeRgba(result, width, height, depth, levels, layers);
+                        result = ETC2Decoder.DecodeRgba(result, width, height, sliceDepth, levels, layers);
                         break;
                     case Format.Etc2RgbPtaSrgb:
                     case Format.Etc2RgbPtaUnorm:
-                        result = ETC2Decoder.DecodePta(result, width, height, depth, levels, layers);
+                        result = ETC2Decoder.DecodePta(result, width, height, sliceDepth, levels, layers);
                         break;
                     case Format.Etc2RgbSrgb:
                     case Format.Etc2RgbUnorm:
-                        result = ETC2Decoder.DecodeRgb(result, width, height, depth, levels, layers);
+                        result = ETC2Decoder.DecodeRgb(result, width, height, sliceDepth, levels, layers);
                         break;
                 }
             }
@@ -816,31 +818,31 @@ namespace Ryujinx.Graphics.Gpu.Image
                 {
                     case Format.Bc1RgbaSrgb:
                     case Format.Bc1RgbaUnorm:
-                        result = BCnDecoder.DecodeBC1(result, width, height, depth, levels, layers);
+                        result = BCnDecoder.DecodeBC1(result, width, height, sliceDepth, levels, layers);
                         break;
                     case Format.Bc2Srgb:
                     case Format.Bc2Unorm:
-                        result = BCnDecoder.DecodeBC2(result, width, height, depth, levels, layers);
+                        result = BCnDecoder.DecodeBC2(result, width, height, sliceDepth, levels, layers);
                         break;
                     case Format.Bc3Srgb:
                     case Format.Bc3Unorm:
-                        result = BCnDecoder.DecodeBC3(result, width, height, depth, levels, layers);
+                        result = BCnDecoder.DecodeBC3(result, width, height, sliceDepth, levels, layers);
                         break;
                     case Format.Bc4Snorm:
                     case Format.Bc4Unorm:
-                        result = BCnDecoder.DecodeBC4(result, width, height, depth, levels, layers, Format == Format.Bc4Snorm);
+                        result = BCnDecoder.DecodeBC4(result, width, height, sliceDepth, levels, layers, Format == Format.Bc4Snorm);
                         break;
                     case Format.Bc5Snorm:
                     case Format.Bc5Unorm:
-                        result = BCnDecoder.DecodeBC5(result, width, height, depth, levels, layers, Format == Format.Bc5Snorm);
+                        result = BCnDecoder.DecodeBC5(result, width, height, sliceDepth, levels, layers, Format == Format.Bc5Snorm);
                         break;
                     case Format.Bc6HSfloat:
                     case Format.Bc6HUfloat:
-                        result = BCnDecoder.DecodeBC6(result, width, height, depth, levels, layers, Format == Format.Bc6HSfloat);
+                        result = BCnDecoder.DecodeBC6(result, width, height, sliceDepth, levels, layers, Format == Format.Bc6HSfloat);
                         break;
                     case Format.Bc7Srgb:
                     case Format.Bc7Unorm:
-                        result = BCnDecoder.DecodeBC7(result, width, height, depth, levels, layers);
+                        result = BCnDecoder.DecodeBC7(result, width, height, sliceDepth, levels, layers);
                         break;
                 }
             }

--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -1624,7 +1624,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     }
                     else
                     {
-                        // If there is a different GPU va mapping, prefer the first and delete the others.
+                        // If there is a different GPU VA mapping, prefer the first and delete the others.
                         owner.Pool.ForceRemove(this, owner.ID, true);
                     }
                 }

--- a/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -195,6 +195,20 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Update a texture's physical memory range.
+        /// </summary>
+        /// <param name="texture">Texture to update</param>
+        /// <param name="range">New physical memory range</param>
+        public void UpdateMapping(Texture texture, MultiRange range)
+        {
+            _textures.Remove(texture);
+
+            texture.ReplaceRange(range);
+
+            _textures.Add(texture);
+        }
+
+        /// <summary>
         /// Tries to find an existing texture, or create a new one if not found.
         /// </summary>
         /// <param name="memoryManager">GPU memory manager where the texture is mapped</param>

--- a/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -1,5 +1,4 @@
 using Ryujinx.Common;
-using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Engine.Threed;
 using Ryujinx.Graphics.Gpu.Engine.Twod;

--- a/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -212,8 +212,8 @@ namespace Ryujinx.Graphics.Gpu.Image
                 var other = _textureOverlaps[i];
                 
                 if (texture != other &&
-                    (texture.IsViewCompatible(other.Info, other.Range, true, other.LayerSize, _context.Capabilities, out int _, out int _) != TextureViewCompatibility.Incompatible ||
-                    other.IsViewCompatible(texture.Info, texture.Range, true, texture.LayerSize, _context.Capabilities, out int _, out int _) != TextureViewCompatibility.Incompatible))
+                    (texture.IsViewCompatible(other.Info, other.Range, true, other.LayerSize, _context.Capabilities, out _, out _) != TextureViewCompatibility.Incompatible ||
+                    other.IsViewCompatible(texture.Info, texture.Range, true, texture.LayerSize, _context.Capabilities, out _, out _) != TextureViewCompatibility.Incompatible))
                 {
                     return false;
                 }

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -40,7 +40,7 @@ namespace Ryujinx.Graphics.Gpu.Image
     class TextureGroup : IDisposable
     {
         /// <summary>
-        /// Threshold of layers to force granular handles (and thus partial loading) on array/3d textures.
+        /// Threshold of layers to force granular handles (and thus partial loading) on array/3D textures.
         /// </summary>
         private const int GranularLayerThreshold = 8;
 
@@ -375,7 +375,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                         if (_is3D)
                         {
-                            // Look ahead to see how many handles need loaded.
+                            // Look ahead to see how many handles need to be loaded.
                             for (int j = i + 1; j < regionCount; j++)
                             {
                                 if (_loadNeeded[baseHandle + j])
@@ -1139,18 +1139,21 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                             foreach (var oldGroup in _handles)
                             {
-                                foreach (var oldHandle in oldGroup.Handles)
+                                if (groupHandle.OverlapsWith(oldGroup.Offset, oldGroup.Size))
                                 {
-                                    if (oldHandle.RangeEquals(handle))
+                                    foreach (var oldHandle in oldGroup.Handles)
                                     {
-                                        hasMatch = true;
+                                        if (oldHandle.RangeEquals(handle))
+                                        {
+                                            hasMatch = true;
+                                            break;
+                                        }
+                                    }
+
+                                    if (hasMatch)
+                                    {
                                         break;
                                     }
-                                }
-
-                                if (hasMatch)
-                                {
-                                    break;
                                 }
                             }
 

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -883,8 +883,11 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>A TextureGroupHandle covering the given views</returns>
         private TextureGroupHandle GenerateHandles(int viewStart, int views)
         {
+            int viewEnd = viewStart + views - 1;
+            (_, int lastLevel) = GetLayerLevelForView(viewEnd);
+
             int offset = _allOffsets[viewStart];
-            int endOffset = (viewStart + views == _allOffsets.Length) ? (int)Storage.Size : _allOffsets[viewStart + views];
+            int endOffset = _allOffsets[viewEnd] + _sliceSizes[lastLevel];
             int size = endOffset - offset;
 
             var result = new List<CpuRegionHandle>();

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -129,19 +129,19 @@ namespace Ryujinx.Graphics.Gpu.Image
             else
             {
                 (_hasLayerViews, _hasMipViews) = PropagateGranularity(hasLayerViews, hasMipViews);
-            }
 
-            // If the texture is partially mapped, fully subdivide handles immediately.
+                // If the texture is partially mapped, fully subdivide handles immediately.
 
-            MultiRange range = Storage.Range;
-            for (int i = 0; i < range.Count; i++)
-            {
-                if (range.GetSubRange(i).Address == MemoryManager.PteUnmapped)
+                MultiRange range = Storage.Range;
+                for (int i = 0; i < range.Count; i++)
                 {
-                    _hasLayerViews = true;
-                    _hasMipViews = true;
+                    if (range.GetSubRange(i).Address == MemoryManager.PteUnmapped)
+                    {
+                        _hasLayerViews = true;
+                        _hasMipViews = true;
 
-                    break;
+                        break;
+                    }
                 }
             }
 

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -1236,6 +1236,8 @@ namespace Ryujinx.Graphics.Gpu.Image
             _hasMipViews = true;
 
             RecalculateHandleRegions(true);
+
+            SignalAllDirty();
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -362,7 +362,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             int spanEndIndex = -1;
             int spanBase = 0;
-            ReadOnlySpan<byte> span = ReadOnlySpan<byte>.Empty;
+            ReadOnlySpan<byte> dataSpan = ReadOnlySpan<byte>.Empty;
 
             for (int i = 0; i < regionCount; i++)
             {
@@ -370,6 +370,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 {
                     var info = GetHandleInformation(baseHandle + i);
 
+                    // Ensure the data for this handle is loaded in the span.
                     if (spanEndIndex <= i - 1)
                     {
                         spanEndIndex = i;
@@ -397,7 +398,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                         int endOffset = Math.Min(spanLast + _sliceSizes[endInfo.BaseLevel + endInfo.Levels - 1], (int)Storage.Size);
                         int size = endOffset - spanBase;
 
-                        span = _physicalMemory.GetSpan(Storage.Range.GetSlice((ulong)spanBase, (ulong)size));
+                        dataSpan = _physicalMemory.GetSpan(Storage.Range.GetSlice((ulong)spanBase, (ulong)size));
                     }
 
                     // Only one of these will be greater than 1, as partial sync is only called when there are sub-image views.
@@ -408,7 +409,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                             int offsetIndex = GetOffsetIndex(info.BaseLayer + layer, info.BaseLevel + level);
                             int offset = _allOffsets[offsetIndex];
 
-                            ReadOnlySpan<byte> data = span.Slice(offset - spanBase);
+                            ReadOnlySpan<byte> data = dataSpan.Slice(offset - spanBase);
 
                             SpanOrArray<byte> result = Storage.ConvertToHostCompatibleFormat(data, info.BaseLevel + level, true);
 

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -264,6 +264,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 bool dirty = false;
                 bool anyModified = false;
                 bool anyUnmapped = false;
+                bool anyNonDirty = false;
 
                 for (int i = 0; i < regionCount; i++)
                 {
@@ -316,12 +317,15 @@ namespace Ryujinx.Graphics.Gpu.Image
                         texture.SignalGroupDirty();
                     }
 
-                    _loadNeeded[baseHandle + i] = handleDirty && !handleUnmapped;
+                    bool loadNeeded = handleDirty && !handleUnmapped;
+
+                    anyNonDirty |= !loadNeeded;
+                    _loadNeeded[baseHandle + i] = loadNeeded;
                 }
 
                 if (dirty)
                 {
-                    if (anyUnmapped || (_handles.Length > 1 && (anyModified || split)))
+                    if (anyUnmapped || anyNonDirty || (_handles.Length > 1 && (anyModified || split)))
                     {
                         // Partial texture invalidation. Only update the layers/levels with dirty flags of the storage.
 

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -1141,7 +1141,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                             {
                                 foreach (var oldHandle in oldGroup.Handles)
                                 {
-                                    if (oldHandle.Equals(handle))
+                                    if (oldHandle.RangeEquals(handle))
                                     {
                                         hasMatch = true;
                                         break;

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -35,27 +35,35 @@ namespace Ryujinx.Graphics.Gpu.Image
             public readonly int ID;
 
             /// <summary>
-            /// Create a dereference request for a texture.
-            /// </summary>
-            /// <param name="texture">The texture being dereferenced</param>
-            public DereferenceRequest(Texture texture)
-            {
-                Texture = texture;
-                IsRemapped = false;
-                ID = 0;
-            }
-
-            /// <summary>
             /// Create a dereference request for a texture with a specific pool ID, and remapped flag.
             /// </summary>
             /// <param name="isRemapped">Whether the dereference is due to a mapping change or not</param>
             /// <param name="texture">The texture being dereferenced</param>
             /// <param name="id">The ID of the pool entry, used to restore remapped textures</param>
-            public DereferenceRequest(bool isRemapped, Texture texture, int id)
+            private DereferenceRequest(bool isRemapped, Texture texture, int id)
             {
                 IsRemapped = isRemapped;
                 Texture = texture;
                 ID = id;
+            }
+
+            /// <summary>
+            /// Create a dereference request for a texture removal.
+            /// </summary>
+            /// <param name="texture">The texture being removed</param>
+            public static DereferenceRequest Remove(Texture texture)
+            {
+                return new DereferenceRequest(false, texture, 0);
+            }
+
+            /// <summary>
+            /// Create a dereference request for a texture remapping with a specific pool ID.
+            /// </summary>
+            /// <param name="texture">The texture being remapped</param>
+            /// <param name="id">The ID of the pool entry, used to restore remapped textures</param>
+            public static DereferenceRequest Remap(Texture texture, int id)
+            {
+                return new DereferenceRequest(true, texture, id);
             }
         }
 
@@ -210,7 +218,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             if (deferred)
             {
-                _dereferenceQueue.Enqueue(new DereferenceRequest(texture));
+                _dereferenceQueue.Enqueue(DereferenceRequest.Remove(texture));
             }
             else
             {
@@ -228,7 +236,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             Items[id] = null;
 
-            _dereferenceQueue.Enqueue(new DereferenceRequest(true, texture, id));
+            _dereferenceQueue.Enqueue(DereferenceRequest.Remap(texture, id));
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -240,7 +240,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="id">ID in cache of texture with potential mapping change</param>
         public void QueueUpdateMapping(Texture texture, int id)
         {
-            if (Interlocked.Exchange(ref Items[id], null) != null)
+            if (Interlocked.Exchange(ref Items[id], null) == texture)
             {
                 _dereferenceQueue.Enqueue(DereferenceRequest.Remap(texture, id));
             }

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -228,7 +228,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 // TODO: Needs to behave differently if a texture's mapping has already changed - must remove from cache if
                 // the mapping is different again, as the mapping cannot be different on two entries of the pool.
 
-                if (request.IsUnmapped && texture.Group.Storage == texture && texture.HasViews)
+                if (request.IsUnmapped && texture.Group.Storage == texture && !texture.HasViews)
                 {
                     // Has the mapping for this texture changed?
                     ref readonly TextureDescriptor descriptor = ref GetDescriptorRef(request.ID);

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -52,6 +52,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             /// Create a dereference request for a texture removal.
             /// </summary>
             /// <param name="texture">The texture being removed</param>
+            /// <returns>A texture removal dereference request</returns>
             public static DereferenceRequest Remove(Texture texture)
             {
                 return new DereferenceRequest(false, texture, 0);
@@ -62,6 +63,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             /// </summary>
             /// <param name="texture">The texture being remapped</param>
             /// <param name="id">The ID of the pool entry, used to restore remapped textures</param>
+            /// <returns>A remap dereference request</returns>
             public static DereferenceRequest Remap(Texture texture, int id)
             {
                 return new DereferenceRequest(true, texture, id);

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -246,8 +246,14 @@ namespace Ryujinx.Graphics.Gpu.Image
                     Items[request.ID] = texture;
 
                     // Create a new pool reference, as the last one was removed on unmap.
+
                     texture.IncrementReferenceCount(this, request.ID);
                     texture.DecrementReferenceCount();
+
+                    // Refetch the range. Changes since the last check could have been lost
+                    // as the cache entry was not restored (required to queue mapping change)
+
+                    range = _channel.MemoryManager.GetPhysicalRegions(descriptor.UnpackAddress(), texture.Size);
 
                     if (!range.Equals(texture.Range))
                     {

--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -222,10 +222,10 @@ namespace Ryujinx.Graphics.Gpu.Image
             {
                 Texture texture = request.Texture;
 
-                // Unmapped storage textures can swap their ranges. The texture must be storage with no views.
+                // Unmapped storage textures can swap their ranges. The texture must be storage with no views or dependencies.
                 // TODO: Would need to update ranges on views, or guarantee that ones where the range changes can be instantly deleted.
 
-                if (request.IsUnmapped && texture.Group.Storage == texture && !texture.HasViews)
+                if (request.IsUnmapped && texture.Group.Storage == texture && !texture.HasViews && !texture.Group.HasCopyDependencies)
                 {
                     // Has the mapping for this texture changed?
                     ref readonly TextureDescriptor descriptor = ref GetDescriptorRef(request.ID);

--- a/Ryujinx.Graphics.Texture/LayoutConverter.cs
+++ b/Ryujinx.Graphics.Texture/LayoutConverter.cs
@@ -112,7 +112,7 @@ namespace Ryujinx.Graphics.Texture
             int outSize = GetTextureSize(
                 width,
                 height,
-                depth,
+                sliceDepth,
                 levels,
                 layers,
                 blockWidth,

--- a/Ryujinx.Memory/Range/MultiRange.cs
+++ b/Ryujinx.Memory/Range/MultiRange.cs
@@ -8,6 +8,8 @@ namespace Ryujinx.Memory.Range
     /// </summary>
     public readonly struct MultiRange : IEquatable<MultiRange>
     {
+        private const ulong InvalidAddress = ulong.MaxValue;
+
         private readonly MemoryRange _singleRange;
         private readonly MemoryRange[] _ranges;
 
@@ -107,7 +109,16 @@ namespace Ryujinx.Memory.Range
                     else if (offset < range.Size)
                     {
                         ulong sliceSize = Math.Min(size, range.Size - offset);
-                        ranges.Add(new MemoryRange(range.Address + offset, sliceSize));
+
+                        if (range.Address == InvalidAddress)
+                        {
+                            ranges.Add(new MemoryRange(range.Address, sliceSize));
+                        }
+                        else
+                        {
+                            ranges.Add(new MemoryRange(range.Address + offset, sliceSize));
+                        }
+
                         size -= sliceSize;
                     }
 


### PR DESCRIPTION
Sparsely mapped textures are useful when a game wants texture data to cover a large area (say, an entire level), but loading the whole thing would take up too much memory. You can load and unload parts of the texture by mapping physical pages into the texture's virtual memory allocation in GPU address space, and unmapping them when you're finished. This way, you only pay for the pages you use.

Ryujinx's way of handling sparsely mapped textures was to delete their pool references entirely when _any_ mapping change happened, as the texture cache would simply recreate it the next time it was used. This works, but is slow, especially if your game has mapped several 48MB textures in this way, and changes mappings mid-game.

This PR adds the ability to migrate a texture to a new set of physical ranges. The existing texture data will remain intact, and any regions where the mapping has changed will be marked as dirty and synchronized on use. Note that it will only happen for the earliest GPU VA pool reference on the texture, any other pool references will be deleted as before.

Greatly improves stuttering going through doors on Metroid Prime: Remastered. Does not eliminate it entirely, because the game uses ASTC textures, which must be decoded before uploading on desktop, and are loaded around the same time a door is opened.

## Other fixes

This PR also fixes a few issues with partial updates and subresource tracking:
- Fixed an issue where handles for 3d texture slices would have a very small size, as it would only count to the beginning of the next slice (which may have been interleaved with this one)
- Partial updates are now enabled when using a texture and _any_ subresource is not modified, rather than only when a handle is unmapped. May improve performance in games with texture streaming.
- Subresource tracking (layers/levels) are now enabled on sufficiently large 3D and array textures to avoid impacts from synchronizing the whole thing. They are also enabled if the texture is partially mapped. This reduces stuttering from texture updates.
  - Greatly reduces FIFO% in NieR: Automata when travelling between areas. Framerate still dips due to Vulkan buffer memory stuff and cb0 accesses that can't be eliminated.
  - May affect texture streaming performance in Xenoblade. Who knows in what way.
- Gets blocks of slices from the source texture rather than one slice at a time, so that 3D textures don't copy the same interleaved data range each slice (potentially up to 16x the data)
- Partial uploads of 3D textures no longer allocate arrays for the full depth of the texture instead of one slice.

## Areas for improvement

A few things could still be improved:
- Handles are fully recreated every time a sparse mapping is changed, not just the handles that overlapped the ranges that changed mapping. Improving this could be very difficult.
- InheritHandles and ReplaceHandles are `O(n*m)` _best case_. This was the case for InheritHandles before, but it is more of a problem with sparse textures as they could be remapped whenever and the game assumes it's free.
- Texture ranges can't be updated if they have any views, are a view themselves, or have any form of copy dependency. This is because the texture on the other side could have a pool reference with a different GPU VA. I'm not sure if there's a way to handle this, or if there's any need to. It's very unlikely that a sparsely mapped texture will be rendered to, and that's typically what creates views. There's always swizzle and format alias, though...
- The backend could be made aware of layers/levels that are fully unmapped and do sparse mapping for real, though this could get quite complicated.

NOTE: draft for some small self-review cleanup and hopefully game testing.

This changes quite a lot regarding unmapped textures and data uploads, so it would be a good idea to test this in a variety of games.