### PR TITLE
Mark texture as modified and sync on I2M fast path

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
@@ -197,7 +197,9 @@ namespace Ryujinx.Graphics.Gpu.Engine.InlineToMemory
 
                     if (target != null)
                     {
+                        target.SynchronizeMemory();
                         target.SetData(data, 0, 0, new GAL.Rectangle<int>(_dstX, _dstY, _lineLengthIn / target.Info.FormatInfo.BytesPerPixel, _lineCount));
+                        target.SignalModified();
 
                         return;
                     }


### PR DESCRIPTION
This change makes sure that the texture data has the latest CPU modifications before setting the new data, and marks the texture as modified for Inline-To-Memory copies, similar to what it does on DMA copies. I'm not sure why I didn't do that originally, but it is required to ensure correctness in case the texture was modified from CPU prior to the operation, or is accessed from CPU after (and was not modified from GPU before).

This fixes some graphical issues on Tanuki Justice that were apparently introduced on #3610.
Before:
![image](https://user-images.githubusercontent.com/5624669/219963654-74ed98e9-cebd-4c34-8a61-913d8548f914.png)
After:
![image](https://user-images.githubusercontent.com/5624669/219963670-03cfc425-845f-46da-b463-5b9181a4eb0c.png)

This only affects games using OpenGL on the Switch. Testing on those games is welcome.
Fixes #4448.