### PR TITLE
Memory: Faster Split for NonOverlappingRangeList

### DIFF
--- a/Ryujinx.Memory/Range/NonOverlappingRangeList.cs
+++ b/Ryujinx.Memory/Range/NonOverlappingRangeList.cs
@@ -97,10 +97,8 @@ namespace Ryujinx.Memory.Range
         /// <returns>The new region (high part)</returns>
         private T Split(T region, ulong splitAddress)
         {
-            Remove(region);
-
             T newRegion = (T)region.Split(splitAddress);
-            Add(region);
+            Update(region);
             Add(newRegion);
             return newRegion;
         }

--- a/Ryujinx.Memory/Range/RangeList.cs
+++ b/Ryujinx.Memory/Range/RangeList.cs
@@ -67,6 +67,43 @@ namespace Ryujinx.Memory.Range
             Insert(index, new RangeItem<T>(item));
         }
 
+        /// <summary>
+        /// Updates an item's end address on the list. Address must be the same.
+        /// </summary>
+        /// <param name="item">The item to be updated</param>
+        /// <returns>True if the item was located and updated, false otherwise</returns>
+        public bool Update(T item)
+        {
+            int index = BinarySearch(item.Address);
+
+            if (index >= 0)
+            {
+                while (index > 0 && _items[index - 1].Address == item.Address)
+                {
+                    index--;
+                }
+
+                while (index < Count)
+                {
+                    if (_items[index].Value.Equals(item))
+                    {
+                        _items[index] = new RangeItem<T>(item);
+
+                        return true;
+                    }
+
+                    if (_items[index].Address > item.Address)
+                    {
+                        break;
+                    }
+
+                    index++;
+                }
+            }
+
+            return false;
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void Insert(int index, RangeItem<T> item)
         {


### PR DESCRIPTION
I noticed that in Xenoblade 2, the game can end up spending a lot of time adding and removing tracking handles. One of the main causes of this is actually splitting existing VirtualRegions, which does the following:

- Remove existing VirtualRegion from list
- Update existing VirtualRegion to end at split address, create new VirtualRegion starting at split address
- Add updated VirtualRegion (left) to list
- Add new VirtualRegion (right) to list

This costs 1 deletion and 2 insertions. When there are more VirtualRegions, this gets a lot more expensive, as insertions are done by copying all values to the right, and deletions by copying values to the left.

This PR simply allows it to look up the VirtualRegion being split, and replace its entry with the new end address without insertion or deletion. This makes a split only cost 1 insertion and a binary search lookup (very cheap). This isn't all of the cost on Xenoblade 2, but it does significantly reduce it.

There might be something else to this - we could find a way to reduce the handle count for the game (merging on deletion? buffer deletion?), we could use a different structure for virtual regions, as the current one is optimal for buffer lookups which nearly always read, memory tracking has more of a balance between read/write. That's for a later date though, this was an easy improvment.