### PR TITLE
Ava: Fix Linux updater crashing when tarStream is null

### DIFF
--- a/Ryujinx.Ava/Modules/Updater/Updater.cs
+++ b/Ryujinx.Ava/Modules/Updater/Updater.cs
@@ -506,6 +506,11 @@ namespace Ryujinx.Modules
 
                             Dispatcher.UIThread.Post(() =>
                             {
+                                if (tarEntry is null)
+                                {
+                                    return;
+                                }
+
                                 taskDialog.SetProgressBarState(GetPercentage(tarEntry.Size, inStream.Length), TaskDialogProgressState.Normal);
                             });
                         }


### PR DESCRIPTION
This PR fixes an issue that shouldn't even happen.

For some reason the UIThread still tries to update the progress bar after the while loop is already done.
I'm not sure how this could be caused by #4315, but it has to be a regression.

This issue only happens using Ava and I was able to confirm the fix is working correctly.