### PR TITLE
misc: changes base application directory behaviour

### DIFF
--- a/Ryujinx.Common/ReleaseInformation.cs
+++ b/Ryujinx.Common/ReleaseInformation.cs
@@ -40,14 +40,21 @@ namespace Ryujinx.Common
             }
         }
 
+#if FORCE_EXTERNAL_BASE_DIR
         public static string GetBaseApplicationDirectory()
         {
-            if (IsFlatHubBuild())
+            return AppDataManager.BaseDirPath;
+        }
+#else
+        public static string GetBaseApplicationDirectory()
+        {
+            if (IsFlatHubBuild() || OperatingSystem.IsMacOS())
             {
                 return AppDataManager.BaseDirPath;
             }
 
             return AppDomain.CurrentDomain.BaseDirectory;
         }
+#endif
     }
 }


### PR DESCRIPTION
This allows changing base application directory behavior at build time via FORCE_EXTERNAL_BASE_DIR.

This is intended to be used by nixpkgs and flathub builds.

I also added the missing patch for macOS that we have on macos1 to avoid invalidating code signature.