### PR TITLE
Misc: Support space in path on macOS distribution

### DIFF
--- a/Ryujinx.Ava/Ryujinx.Ava.csproj
+++ b/Ryujinx.Ava/Ryujinx.Ava.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="$([MSBuild]::IsOSPlatform('OSX'))">
-    <Exec Command="codesign --entitlements $(ProjectDir)..\distribution\macos\entitlements.xml -f --deep -s $(SigningCertificate) $(TargetDir)$(TargetName)" />
+    <Exec Command="codesign --entitlements '$(ProjectDir)..\distribution\macos\entitlements.xml' -f --deep -s $(SigningCertificate) '$(TargetDir)$(TargetName)'" />
   </Target>
 
   <PropertyGroup Condition="'$(RuntimeIdentifier)' != ''">

--- a/distribution/macos/create_app_bundle.sh
+++ b/distribution/macos/create_app_bundle.sh
@@ -19,7 +19,7 @@ cp "$PUBLISH_DIRECTORY/Ryujinx.Ava" "$APP_BUNDLE_DIRECTORY/Contents/MacOS/Ryujin
 chmod u+x "$APP_BUNDLE_DIRECTORY/Contents/MacOS/Ryujinx"
 
 # Then all libraries
-cp "$PUBLISH_DIRECTORY/*.dylib" "$APP_BUNDLE_DIRECTORY/Contents/Frameworks"
+cp "$PUBLISH_DIRECTORY"/*.dylib "$APP_BUNDLE_DIRECTORY/Contents/Frameworks"
 
 # Then resources
 cp Info.plist "$APP_BUNDLE_DIRECTORY/Contents"

--- a/distribution/macos/create_app_bundle.sh
+++ b/distribution/macos/create_app_bundle.sh
@@ -6,31 +6,31 @@ PUBLISH_DIRECTORY=$1
 OUTPUT_DIRECTORY=$2
 ENTITLEMENTS_FILE_PATH=$3
 
-APP_BUNDLE_DIRECTORY=$OUTPUT_DIRECTORY/Ryujinx.app
+APP_BUNDLE_DIRECTORY="$OUTPUT_DIRECTORY"/Ryujinx.app
 
-rm -rf $APP_BUNDLE_DIRECTORY
-mkdir -p $APP_BUNDLE_DIRECTORY/Contents
-mkdir $APP_BUNDLE_DIRECTORY/Contents/Frameworks
-mkdir $APP_BUNDLE_DIRECTORY/Contents/MacOS
-mkdir $APP_BUNDLE_DIRECTORY/Contents/Resources
+rm -rf "$APP_BUNDLE_DIRECTORY"
+mkdir -p "$APP_BUNDLE_DIRECTORY"/Contents
+mkdir "$APP_BUNDLE_DIRECTORY"/Contents/Frameworks
+mkdir "$APP_BUNDLE_DIRECTORY"/Contents/MacOS
+mkdir "$APP_BUNDLE_DIRECTORY"/Contents/Resources
 
 # Copy executables first
-cp $PUBLISH_DIRECTORY/Ryujinx.Ava $APP_BUNDLE_DIRECTORY/Contents/MacOS/Ryujinx
-chmod u+x $APP_BUNDLE_DIRECTORY/Contents/MacOS/Ryujinx
+cp "$PUBLISH_DIRECTORY"/Ryujinx.Ava "$APP_BUNDLE_DIRECTORY"/Contents/MacOS/Ryujinx
+chmod u+x "$APP_BUNDLE_DIRECTORY"/Contents/MacOS/Ryujinx
 
 # Then all libraries
-cp $PUBLISH_DIRECTORY/*.dylib $APP_BUNDLE_DIRECTORY/Contents/Frameworks
+cp "$PUBLISH_DIRECTORY"/*.dylib "$APP_BUNDLE_DIRECTORY"/Contents/Frameworks
 
 # Then resources
-cp Info.plist $APP_BUNDLE_DIRECTORY/Contents
-cp Ryujinx.icns $APP_BUNDLE_DIRECTORY/Contents/Resources/Ryujinx.icns
-cp updater.sh $APP_BUNDLE_DIRECTORY/Contents/Resources/updater.sh
-cp -r $PUBLISH_DIRECTORY/THIRDPARTY.md $APP_BUNDLE_DIRECTORY/Contents/Resources
+cp Info.plist "$APP_BUNDLE_DIRECTORY"/Contents
+cp Ryujinx.icns "$APP_BUNDLE_DIRECTORY"/Contents/Resources/Ryujinx.icns
+cp updater.sh "$APP_BUNDLE_DIRECTORY"/Contents/Resources/updater.sh
+cp -r "$PUBLISH_DIRECTORY"/THIRDPARTY.md "$APP_BUNDLE_DIRECTORY"/Contents/Resources
 
-echo -n "APPL????" > $APP_BUNDLE_DIRECTORY/Contents/PkgInfo
+echo -n "APPL????" > "$APP_BUNDLE_DIRECTORY"/Contents/PkgInfo
 
 # Fixup libraries and executable
-python3 bundle_fix_up.py $APP_BUNDLE_DIRECTORY MacOS/Ryujinx
+python3 bundle_fix_up.py "$APP_BUNDLE_DIRECTORY" MacOS/Ryujinx
 
 # Now sign it
 if ! [ -x "$(command -v codesign)" ];
@@ -44,9 +44,9 @@ then
     # NOTE: Currently require https://github.com/indygreg/apple-platform-rs/pull/44 to work on other OSes.
     # cargo install --git "https://github.com/marysaka/apple-platform-rs" --branch "fix/adhoc-app-bundle" apple-codesign --bin "rcodesign"
     echo "Usign rcodesign for ad-hoc signing"
-    rcodesign sign --entitlements-xml-path $ENTITLEMENTS_FILE_PATH $APP_BUNDLE_DIRECTORY
+    codesign sign --entitlements-xml-path "$ENTITLEMENTS_FILE_PATH" "$APP_BUNDLE_DIRECTORY"
 else
     echo "Usign codesign for ad-hoc signing"
-    codesign --entitlements $ENTITLEMENTS_FILE_PATH -f --deep -s - $APP_BUNDLE_DIRECTORY
+    codesign --entitlements "$ENTITLEMENTS_FILE_PATH" -f --deep -s - "$APP_BUNDLE_DIRECTORY"
 fi
 

--- a/distribution/macos/create_app_bundle.sh
+++ b/distribution/macos/create_app_bundle.sh
@@ -6,28 +6,28 @@ PUBLISH_DIRECTORY=$1
 OUTPUT_DIRECTORY=$2
 ENTITLEMENTS_FILE_PATH=$3
 
-APP_BUNDLE_DIRECTORY="$OUTPUT_DIRECTORY"/Ryujinx.app
+APP_BUNDLE_DIRECTORY="$OUTPUT_DIRECTORY/Ryujinx.app"
 
 rm -rf "$APP_BUNDLE_DIRECTORY"
-mkdir -p "$APP_BUNDLE_DIRECTORY"/Contents
-mkdir "$APP_BUNDLE_DIRECTORY"/Contents/Frameworks
-mkdir "$APP_BUNDLE_DIRECTORY"/Contents/MacOS
-mkdir "$APP_BUNDLE_DIRECTORY"/Contents/Resources
+mkdir -p "$APP_BUNDLE_DIRECTORY/Contents"
+mkdir "$APP_BUNDLE_DIRECTORY/Contents/Frameworks"
+mkdir "$APP_BUNDLE_DIRECTORY/Contents/MacOS"
+mkdir "$APP_BUNDLE_DIRECTORY/Contents/Resources"
 
 # Copy executables first
-cp "$PUBLISH_DIRECTORY"/Ryujinx.Ava "$APP_BUNDLE_DIRECTORY"/Contents/MacOS/Ryujinx
-chmod u+x "$APP_BUNDLE_DIRECTORY"/Contents/MacOS/Ryujinx
+cp "$PUBLISH_DIRECTORY/Ryujinx.Ava" "$APP_BUNDLE_DIRECTORY/Contents/MacOS/Ryujinx"
+chmod u+x "$APP_BUNDLE_DIRECTORY/Contents/MacOS/Ryujinx"
 
 # Then all libraries
-cp "$PUBLISH_DIRECTORY"/*.dylib "$APP_BUNDLE_DIRECTORY"/Contents/Frameworks
+cp "$PUBLISH_DIRECTORY/*.dylib" "$APP_BUNDLE_DIRECTORY/Contents/Frameworks"
 
 # Then resources
-cp Info.plist "$APP_BUNDLE_DIRECTORY"/Contents
-cp Ryujinx.icns "$APP_BUNDLE_DIRECTORY"/Contents/Resources/Ryujinx.icns
-cp updater.sh "$APP_BUNDLE_DIRECTORY"/Contents/Resources/updater.sh
-cp -r "$PUBLISH_DIRECTORY"/THIRDPARTY.md "$APP_BUNDLE_DIRECTORY"/Contents/Resources
+cp Info.plist "$APP_BUNDLE_DIRECTORY/Contents"
+cp Ryujinx.icns "$APP_BUNDLE_DIRECTORY/Contents/Resources/Ryujinx.icns"
+cp updater.sh "$APP_BUNDLE_DIRECTORY/Contents/Resources/updater.sh"
+cp -r "$PUBLISH_DIRECTORY/THIRDPARTY.md" "$APP_BUNDLE_DIRECTORY/Contents/Resources"
 
-echo -n "APPL????" > "$APP_BUNDLE_DIRECTORY"/Contents/PkgInfo
+echo -n "APPL????" > "$APP_BUNDLE_DIRECTORY/Contents/PkgInfo"
 
 # Fixup libraries and executable
 python3 bundle_fix_up.py "$APP_BUNDLE_DIRECTORY" MacOS/Ryujinx
@@ -44,7 +44,7 @@ then
     # NOTE: Currently require https://github.com/indygreg/apple-platform-rs/pull/44 to work on other OSes.
     # cargo install --git "https://github.com/marysaka/apple-platform-rs" --branch "fix/adhoc-app-bundle" apple-codesign --bin "rcodesign"
     echo "Usign rcodesign for ad-hoc signing"
-    codesign sign --entitlements-xml-path "$ENTITLEMENTS_FILE_PATH" "$APP_BUNDLE_DIRECTORY"
+    rcodesign sign --entitlements-xml-path "$ENTITLEMENTS_FILE_PATH" "$APP_BUNDLE_DIRECTORY"
 else
     echo "Usign codesign for ad-hoc signing"
     codesign --entitlements "$ENTITLEMENTS_FILE_PATH" -f --deep -s - "$APP_BUNDLE_DIRECTORY"

--- a/distribution/macos/create_macos_release.sh
+++ b/distribution/macos/create_macos_release.sh
@@ -7,54 +7,54 @@ if [ "$#" -ne 6 ]; then
     exit 1
 fi
 
-mkdir -p $1
-mkdir -p $2
-mkdir -p $3
+mkdir -p "$1"
+mkdir -p "$2"
+mkdir -p "$3"
 
-BASE_DIR=$(readlink -f $1)
-TEMP_DIRECTORY=$(readlink -f $2)
-OUTPUT_DIRECTORY=$(readlink -f $3)
-ENTITLEMENTS_FILE_PATH=$(readlink -f $4)
+BASE_DIR=$(readlink -f "$1")
+TEMP_DIRECTORY=$(readlink -f "$2")
+OUTPUT_DIRECTORY=$(readlink -f "$3")
+ENTITLEMENTS_FILE_PATH=$(readlink -f "$4")
 VERSION=$5
 SOURCE_REVISION_ID=$6
 
 RELEASE_TAR_FILE_NAME=Ryujinx-$VERSION-macos_universal.app.tar
-ARM64_APP_BUNDLE=$TEMP_DIRECTORY/output_arm64/Ryujinx.app
-X64_APP_BUNDLE=$TEMP_DIRECTORY/output_x64/Ryujinx.app
-UNIVERSAL_APP_BUNDLE=$OUTPUT_DIRECTORY/Ryujinx.app
+ARM64_APP_BUNDLE="$TEMP_DIRECTORY"/output_arm64/Ryujinx.app
+X64_APP_BUNDLE="$TEMP_DIRECTORY"/output_x64/Ryujinx.app
+UNIVERSAL_APP_BUNDLE="$OUTPUT_DIRECTORY"/Ryujinx.app
 EXECUTABLE_SUB_PATH=Contents/MacOS/Ryujinx
 
-rm -rf $TEMP_DIRECTORY
-mkdir -p $TEMP_DIRECTORY
+rm -rf "$TEMP_DIRECTORY"
+mkdir -p "$TEMP_DIRECTORY"
 
 DOTNET_COMMON_ARGS="-p:DebugType=embedded -p:Version=$VERSION -p:SourceRevisionId=$SOURCE_REVISION_ID --self-contained true"
 
 dotnet restore
 dotnet build -c Release Ryujinx.Ava
-dotnet publish -c Release -r osx-arm64 -o $TEMP_DIRECTORY/publish_arm64 $DOTNET_COMMON_ARGS Ryujinx.Ava
-dotnet publish -c Release -r osx-x64 -o $TEMP_DIRECTORY/publish_x64 $DOTNET_COMMON_ARGS Ryujinx.Ava
+dotnet publish -c Release -r osx-arm64 -o "$TEMP_DIRECTORY"/publish_arm64 $DOTNET_COMMON_ARGS Ryujinx.Ava
+dotnet publish -c Release -r osx-x64 -o "$TEMP_DIRECTORY"/publish_x64 $DOTNET_COMMON_ARGS Ryujinx.Ava
 
 # Get ride of the support library for ARMeilleur for x64 (that's only for arm64)
-rm -rf $TEMP_DIRECTORY/publish_x64/libarmeilleure-jitsupport.dylib
+rm -rf "$TEMP_DIRECTORY"/publish_x64/libarmeilleure-jitsupport.dylib
 
 # Get ride of libsoundio from arm64 builds as we don't have a arm64 variant
 # TODO: remove this once done
-rm -rf $TEMP_DIRECTORY/publish_arm64/libsoundio.dylib
+rm -rf "$TEMP_DIRECTORY"/publish_arm64/libsoundio.dylib
 
-pushd $BASE_DIR/distribution/macos
-./create_app_bundle.sh $TEMP_DIRECTORY/publish_x64 $TEMP_DIRECTORY/output_x64 $ENTITLEMENTS_FILE_PATH
-./create_app_bundle.sh $TEMP_DIRECTORY/publish_arm64 $TEMP_DIRECTORY/output_arm64 $ENTITLEMENTS_FILE_PATH
+pushd "$BASE_DIR"/distribution/macos
+./create_app_bundle.sh "$TEMP_DIRECTORY"/publish_x64 "$TEMP_DIRECTORY"/output_x64 "$ENTITLEMENTS_FILE_PATH"
+./create_app_bundle.sh "$TEMP_DIRECTORY"/publish_arm64 "$TEMP_DIRECTORY"/output_arm64 "$ENTITLEMENTS_FILE_PATH"
 popd
 
-rm -rf $UNIVERSAL_APP_BUNDLE
-mkdir -p $OUTPUT_DIRECTORY
+rm -rf "$UNIVERSAL_APP_BUNDLE"
+mkdir -p "$OUTPUT_DIRECTORY"
 
 # Let's copy one of the two different app bundle and remove the executable
-cp -R $ARM64_APP_BUNDLE $UNIVERSAL_APP_BUNDLE
-rm $UNIVERSAL_APP_BUNDLE/$EXECUTABLE_SUB_PATH
+cp -R "$ARM64_APP_BUNDLE" "$UNIVERSAL_APP_BUNDLE"
+rm "$UNIVERSAL_APP_BUNDLE"/$EXECUTABLE_SUB_PATH
 
 # Make it libraries universal
-python3 $BASE_DIR/distribution/macos/construct_universal_dylib.py $ARM64_APP_BUNDLE $X64_APP_BUNDLE $UNIVERSAL_APP_BUNDLE "**/*.dylib"
+python3 "$BASE_DIR"/distribution/macos/construct_universal_dylib.py "$ARM64_APP_BUNDLE" "$X64_APP_BUNDLE" "$UNIVERSAL_APP_BUNDLE" "**/*.dylib"
 
 if ! [ -x "$(command -v lipo)" ];
 then
@@ -69,12 +69,12 @@ else
 fi
 
 # Make it the executable universal
-$LIPO $ARM64_APP_BUNDLE/$EXECUTABLE_SUB_PATH $X64_APP_BUNDLE/$EXECUTABLE_SUB_PATH -output $UNIVERSAL_APP_BUNDLE/$EXECUTABLE_SUB_PATH -create
+$LIPO "$ARM64_APP_BUNDLE"/$EXECUTABLE_SUB_PATH "$X64_APP_BUNDLE"/$EXECUTABLE_SUB_PATH -output "$UNIVERSAL_APP_BUNDLE"/$EXECUTABLE_SUB_PATH -create
 
 # Patch up the Info.plist to have appropriate version
-sed -r -i.bck "s/\%\%RYUJINX_BUILD_VERSION\%\%/$VERSION/g;" $UNIVERSAL_APP_BUNDLE/Contents/Info.plist
-sed -r -i.bck "s/\%\%RYUJINX_BUILD_GIT_HASH\%\%/$SOURCE_REVISION_ID/g;" $UNIVERSAL_APP_BUNDLE/Contents/Info.plist
-rm $UNIVERSAL_APP_BUNDLE/Contents/Info.plist.bck
+sed -r -i.bck "s/\%\%RYUJINX_BUILD_VERSION\%\%/$VERSION/g;" "$UNIVERSAL_APP_BUNDLE"/Contents/Info.plist
+sed -r -i.bck "s/\%\%RYUJINX_BUILD_GIT_HASH\%\%/$SOURCE_REVISION_ID/g;" "$UNIVERSAL_APP_BUNDLE"/Contents/Info.plist
+rm "$UNIVERSAL_APP_BUNDLE"/Contents/Info.plist.bck
 
 # Now sign it
 if ! [ -x "$(command -v codesign)" ];
@@ -88,16 +88,16 @@ then
     # NOTE: Currently require https://github.com/indygreg/apple-platform-rs/pull/44 to work on other OSes.
     # cargo install --git "https://github.com/marysaka/apple-platform-rs" --branch "fix/adhoc-app-bundle" apple-codesign --bin "rcodesign"
     echo "Usign rcodesign for ad-hoc signing"
-    rcodesign sign --entitlements-xml-path $ENTITLEMENTS_FILE_PATH $UNIVERSAL_APP_BUNDLE
+    rcodesign sign --entitlements-xml-path "$ENTITLEMENTS_FILE_PATH" "$UNIVERSAL_APP_BUNDLE"
 else
     echo "Usign codesign for ad-hoc signing"
-    codesign --entitlements $ENTITLEMENTS_FILE_PATH -f --deep -s - $UNIVERSAL_APP_BUNDLE
+    codesign --entitlements "$ENTITLEMENTS_FILE_PATH" -f --deep -s - "$UNIVERSAL_APP_BUNDLE"
 fi
 
 echo "Creating archive"
-pushd $OUTPUT_DIRECTORY
+pushd "$OUTPUT_DIRECTORY"
 tar --exclude "Ryujinx.app/Contents/MacOS/Ryujinx" -cvf $RELEASE_TAR_FILE_NAME Ryujinx.app 1> /dev/null
-python3 $BASE_DIR/distribution/misc/add_tar_exec.py $RELEASE_TAR_FILE_NAME "Ryujinx.app/Contents/MacOS/Ryujinx" "Ryujinx.app/Contents/MacOS/Ryujinx"
+python3 "$BASE_DIR"/distribution/misc/add_tar_exec.py $RELEASE_TAR_FILE_NAME "Ryujinx.app/Contents/MacOS/Ryujinx" "Ryujinx.app/Contents/MacOS/Ryujinx"
 gzip -9 < $RELEASE_TAR_FILE_NAME > $RELEASE_TAR_FILE_NAME.gz
 rm $RELEASE_TAR_FILE_NAME
 popd

--- a/distribution/macos/create_macos_release.sh
+++ b/distribution/macos/create_macos_release.sh
@@ -19,9 +19,9 @@ VERSION=$5
 SOURCE_REVISION_ID=$6
 
 RELEASE_TAR_FILE_NAME=Ryujinx-$VERSION-macos_universal.app.tar
-ARM64_APP_BUNDLE="$TEMP_DIRECTORY"/output_arm64/Ryujinx.app
-X64_APP_BUNDLE="$TEMP_DIRECTORY"/output_x64/Ryujinx.app
-UNIVERSAL_APP_BUNDLE="$OUTPUT_DIRECTORY"/Ryujinx.app
+ARM64_APP_BUNDLE="$TEMP_DIRECTORY/output_arm64/Ryujinx.app"
+X64_APP_BUNDLE="$TEMP_DIRECTORY/output_x64/Ryujinx.app"
+UNIVERSAL_APP_BUNDLE="$OUTPUT_DIRECTORY/Ryujinx.app"
 EXECUTABLE_SUB_PATH=Contents/MacOS/Ryujinx
 
 rm -rf "$TEMP_DIRECTORY"
@@ -31,19 +31,19 @@ DOTNET_COMMON_ARGS="-p:DebugType=embedded -p:Version=$VERSION -p:SourceRevisionI
 
 dotnet restore
 dotnet build -c Release Ryujinx.Ava
-dotnet publish -c Release -r osx-arm64 -o "$TEMP_DIRECTORY"/publish_arm64 $DOTNET_COMMON_ARGS Ryujinx.Ava
-dotnet publish -c Release -r osx-x64 -o "$TEMP_DIRECTORY"/publish_x64 $DOTNET_COMMON_ARGS Ryujinx.Ava
+dotnet publish -c Release -r osx-arm64 -o "$TEMP_DIRECTORY/publish_arm64" $DOTNET_COMMON_ARGS Ryujinx.Ava
+dotnet publish -c Release -r osx-x64 -o "$TEMP_DIRECTORY/publish_x64" $DOTNET_COMMON_ARGS Ryujinx.Ava
 
 # Get ride of the support library for ARMeilleur for x64 (that's only for arm64)
-rm -rf "$TEMP_DIRECTORY"/publish_x64/libarmeilleure-jitsupport.dylib
+rm -rf "$TEMP_DIRECTORY/publish_x64/libarmeilleure-jitsupport.dylib"
 
 # Get ride of libsoundio from arm64 builds as we don't have a arm64 variant
 # TODO: remove this once done
-rm -rf "$TEMP_DIRECTORY"/publish_arm64/libsoundio.dylib
+rm -rf "$TEMP_DIRECTORY/publish_arm64/libsoundio.dylib"
 
-pushd "$BASE_DIR"/distribution/macos
-./create_app_bundle.sh "$TEMP_DIRECTORY"/publish_x64 "$TEMP_DIRECTORY"/output_x64 "$ENTITLEMENTS_FILE_PATH"
-./create_app_bundle.sh "$TEMP_DIRECTORY"/publish_arm64 "$TEMP_DIRECTORY"/output_arm64 "$ENTITLEMENTS_FILE_PATH"
+pushd "$BASE_DIR/distribution/macos"
+./create_app_bundle.sh "$TEMP_DIRECTORY/publish_x64" "$TEMP_DIRECTORY/output_x64" "$ENTITLEMENTS_FILE_PATH"
+./create_app_bundle.sh "$TEMP_DIRECTORY/publish_arm64" "$TEMP_DIRECTORY/output_arm64" "$ENTITLEMENTS_FILE_PATH"
 popd
 
 rm -rf "$UNIVERSAL_APP_BUNDLE"
@@ -51,10 +51,10 @@ mkdir -p "$OUTPUT_DIRECTORY"
 
 # Let's copy one of the two different app bundle and remove the executable
 cp -R "$ARM64_APP_BUNDLE" "$UNIVERSAL_APP_BUNDLE"
-rm "$UNIVERSAL_APP_BUNDLE"/$EXECUTABLE_SUB_PATH
+rm "$UNIVERSAL_APP_BUNDLE/$EXECUTABLE_SUB_PATH"
 
 # Make it libraries universal
-python3 "$BASE_DIR"/distribution/macos/construct_universal_dylib.py "$ARM64_APP_BUNDLE" "$X64_APP_BUNDLE" "$UNIVERSAL_APP_BUNDLE" "**/*.dylib"
+python3 "$BASE_DIR/distribution/macos/construct_universal_dylib.py" "$ARM64_APP_BUNDLE" "$X64_APP_BUNDLE" "$UNIVERSAL_APP_BUNDLE" "**/*.dylib"
 
 if ! [ -x "$(command -v lipo)" ];
 then
@@ -69,12 +69,12 @@ else
 fi
 
 # Make it the executable universal
-$LIPO "$ARM64_APP_BUNDLE"/$EXECUTABLE_SUB_PATH "$X64_APP_BUNDLE"/$EXECUTABLE_SUB_PATH -output "$UNIVERSAL_APP_BUNDLE"/$EXECUTABLE_SUB_PATH -create
+$LIPO "$ARM64_APP_BUNDLE/$EXECUTABLE_SUB_PATH" "$X64_APP_BUNDLE/$EXECUTABLE_SUB_PATH" -output "$UNIVERSAL_APP_BUNDLE/$EXECUTABLE_SUB_PATH" -create
 
 # Patch up the Info.plist to have appropriate version
-sed -r -i.bck "s/\%\%RYUJINX_BUILD_VERSION\%\%/$VERSION/g;" "$UNIVERSAL_APP_BUNDLE"/Contents/Info.plist
-sed -r -i.bck "s/\%\%RYUJINX_BUILD_GIT_HASH\%\%/$SOURCE_REVISION_ID/g;" "$UNIVERSAL_APP_BUNDLE"/Contents/Info.plist
-rm "$UNIVERSAL_APP_BUNDLE"/Contents/Info.plist.bck
+sed -r -i.bck "s/\%\%RYUJINX_BUILD_VERSION\%\%/$VERSION/g;" "$UNIVERSAL_APP_BUNDLE/Contents/Info.plist"
+sed -r -i.bck "s/\%\%RYUJINX_BUILD_GIT_HASH\%\%/$SOURCE_REVISION_ID/g;" "$UNIVERSAL_APP_BUNDLE/Contents/Info.plist"
+rm "$UNIVERSAL_APP_BUNDLE/Contents/Info.plist.bck"
 
 # Now sign it
 if ! [ -x "$(command -v codesign)" ];
@@ -97,7 +97,7 @@ fi
 echo "Creating archive"
 pushd "$OUTPUT_DIRECTORY"
 tar --exclude "Ryujinx.app/Contents/MacOS/Ryujinx" -cvf $RELEASE_TAR_FILE_NAME Ryujinx.app 1> /dev/null
-python3 "$BASE_DIR"/distribution/misc/add_tar_exec.py $RELEASE_TAR_FILE_NAME "Ryujinx.app/Contents/MacOS/Ryujinx" "Ryujinx.app/Contents/MacOS/Ryujinx"
+python3 "$BASE_DIR/distribution/misc/add_tar_exec.py" $RELEASE_TAR_FILE_NAME "Ryujinx.app/Contents/MacOS/Ryujinx" "Ryujinx.app/Contents/MacOS/Ryujinx"
 gzip -9 < $RELEASE_TAR_FILE_NAME > $RELEASE_TAR_FILE_NAME.gz
 rm $RELEASE_TAR_FILE_NAME
 popd


### PR DESCRIPTION
This should add support for space in any path causing build errors mentioned in #4434

```
git clean -fdx; sh -x ./distribution/macos/create_macos_release.sh /Users/timezlicer/test\ build/Ryujinx /Users/timezlicer/test\ build/Ryujinx/temp /Users/timezlicer/test\ build/Ryujinx/output /Users/timezlicer/test\ build/Ryujinx/distribution/macos/entitlements.xml 1.1.0-macos `git log | head -1 | cut -c8-14` 2>&1 | tee output.txt
```

Tested with the above

[output.txt](https://github.com/Ryujinx/Ryujinx/files/10798097/output.txt)

---

Fixed merge conflict from #4464