### PR TITLE
Account for multisample when calculating render target size hint

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -439,7 +439,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             int samplesInY = msaaMode.SamplesInY();
 
             var scissor = _state.State.ScreenScissorState;
-            Size sizeHint = new Size(scissor.X + scissor.Width, scissor.Y + scissor.Height, 1);
+            Size sizeHint = new Size((scissor.X + scissor.Width) * samplesInX, (scissor.Y + scissor.Height) * samplesInY, 1);
 
             int clipRegionWidth = int.MaxValue;
             int clipRegionHeight = int.MaxValue;


### PR DESCRIPTION
This is fixing a regression caused by #4364 that caused some data loss because it would render to a texture with a slightly incorrect size, causing some pixels on the right side to be missing. The problem is caused because the render target texture size is in samples, not "pixels", while the scissor size is in pixels. This is fixed by multiplying the scissor size used as hint by the amount of samples in each direction. Technically this issue already existed before, but apparently with the previous way of handling size mismatches, it was not a problem (or at least, not in this specific case).

Before:
![image](https://user-images.githubusercontent.com/5624669/220785739-fff49190-d3f0-4f33-b841-1d50d9c3cc53.png)
After:
![image](https://user-images.githubusercontent.com/5624669/220785745-a8e04ba9-7a2f-4a10-885e-c453fde6b0a6.png)

Fixes #4396.