### PR TITLE
GPU: Scale counter results before addition

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Threed/SemaphoreUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/SemaphoreUpdater.cs
@@ -152,21 +152,10 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
             ulong ticks = _context.GetTimestamp();
 
-            float divisor = type switch
-            {
-                ReportCounterType.SamplesPassed => _channel.TextureManager.RenderTargetScale * _channel.TextureManager.RenderTargetScale,
-                _ => 1f
-            };
-
             ICounterEvent counter = null;
 
             void resultHandler(object evt, ulong result)
             {
-                if (divisor != 1f)
-                {
-                    result = (ulong)MathF.Ceiling(result / divisor);
-                }
-
                 CounterData counterData = new CounterData
                 {
                     Counter = result,

--- a/Ryujinx.Graphics.OpenGL/OpenGLRenderer.cs
+++ b/Ryujinx.Graphics.OpenGL/OpenGLRenderer.cs
@@ -177,7 +177,7 @@ namespace Ryujinx.Graphics.OpenGL
             }
 
             _pipeline.Initialize(this);
-            _counters.Initialize();
+            _counters.Initialize(_pipeline);
 
             // This is required to disable [0, 1] clamping for SNorm outputs on compatibility profiles.
             // This call is expected to fail if we're running with a core profile,

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -773,6 +773,16 @@ namespace Ryujinx.Graphics.OpenGL
             _tfEnabled = false;
         }
 
+        public double GetCounterDivisor(CounterType type)
+        {
+            if (type == CounterType.SamplesPassed)
+            {
+                return _renderScale[0].X * _renderScale[0].X;
+            }
+
+            return 1;
+        }
+
         public void SetAlphaTest(bool enable, float reference, CompareOp op)
         {
             if (!enable)

--- a/Ryujinx.Graphics.OpenGL/Queries/CounterQueue.cs
+++ b/Ryujinx.Graphics.OpenGL/Queries/CounterQueue.cs
@@ -13,6 +13,8 @@ namespace Ryujinx.Graphics.OpenGL.Queries
         public CounterType Type { get; }
         public bool Disposed { get; private set; }
 
+        private readonly Pipeline _pipeline;
+
         private Queue<CounterQueueEvent> _events = new Queue<CounterQueueEvent>();
         private CounterQueueEvent _current;
 
@@ -28,9 +30,11 @@ namespace Ryujinx.Graphics.OpenGL.Queries
 
         private Thread _consumerThread;
 
-        internal CounterQueue(CounterType type)
+        internal CounterQueue(Pipeline pipeline, CounterType type)
         {
             Type = type;
+
+            _pipeline = pipeline;
 
             QueryTarget glType = GetTarget(Type);
 
@@ -119,7 +123,7 @@ namespace Ryujinx.Graphics.OpenGL.Queries
                     _current.ReserveForHostAccess();
                 }
 
-                _current.Complete(draws > 0);
+                _current.Complete(draws > 0, _pipeline.GetCounterDivisor(Type));
                 _events.Enqueue(_current);
 
                 _current.OnResult += resultHandler;

--- a/Ryujinx.Graphics.OpenGL/Queries/CounterQueueEvent.cs
+++ b/Ryujinx.Graphics.OpenGL/Queries/CounterQueueEvent.cs
@@ -26,6 +26,7 @@ namespace Ryujinx.Graphics.OpenGL.Queries
 
         private object _lock = new object();
         private ulong _result = ulong.MaxValue;
+        private double _divisor = 1f;
 
         public CounterQueueEvent(CounterQueue queue, QueryTarget type, ulong drawIndex)
         {
@@ -45,9 +46,11 @@ namespace Ryujinx.Graphics.OpenGL.Queries
             ClearCounter = true;
         }
 
-        internal void Complete(bool withResult)
+        internal void Complete(bool withResult, double divisor)
         {
             _counter.End(withResult);
+
+            _divisor = divisor;
         }
 
         internal bool TryConsume(ref ulong result, bool block, AutoResetEvent wakeSignal = null)
@@ -78,7 +81,7 @@ namespace Ryujinx.Graphics.OpenGL.Queries
                     }
                 }
 
-                result += (ulong)queryResult;
+                result += _divisor == 1 ? (ulong)queryResult : (ulong)Math.Ceiling(queryResult / _divisor);
 
                 _result = result;
 

--- a/Ryujinx.Graphics.OpenGL/Queries/Counters.cs
+++ b/Ryujinx.Graphics.OpenGL/Queries/Counters.cs
@@ -14,12 +14,12 @@ namespace Ryujinx.Graphics.OpenGL.Queries
             _counterQueues = new CounterQueue[count];
         }
 
-        public void Initialize()
+        public void Initialize(Pipeline pipeline)
         {
             for (int index = 0; index < _counterQueues.Length; index++)
             {
                 CounterType type = (CounterType)index;
-                _counterQueues[index] = new CounterQueue(type);
+                _counterQueues[index] = new CounterQueue(pipeline, type);
             }
         }
 

--- a/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -662,6 +662,16 @@ namespace Ryujinx.Graphics.Vulkan
             _tfEnabled = false;
         }
 
+        public double GetCounterDivisor(CounterType type)
+        {
+            if (type == CounterType.SamplesPassed)
+            {
+                return _renderScale[0].X * _renderScale[0].X;
+            }
+
+            return 1;
+        }
+
         public bool IsCommandBufferActive(CommandBuffer cb)
         {
             return CommandBuffer.Handle == cb.Handle;

--- a/Ryujinx.Graphics.Vulkan/Queries/CounterQueue.cs
+++ b/Ryujinx.Graphics.Vulkan/Queries/CounterQueue.cs
@@ -148,7 +148,7 @@ namespace Ryujinx.Graphics.Vulkan.Queries
                     _current.ReserveForHostAccess();
                 }
 
-                _current.Complete(draws > 0 && Type != CounterType.TransformFeedbackPrimitivesWritten);
+                _current.Complete(draws > 0 && Type != CounterType.TransformFeedbackPrimitivesWritten, _pipeline.GetCounterDivisor(Type));
                 _events.Enqueue(_current);
 
                 _current.OnResult += resultHandler;

--- a/Ryujinx.Graphics.Vulkan/Queries/CounterQueueEvent.cs
+++ b/Ryujinx.Graphics.Vulkan/Queries/CounterQueueEvent.cs
@@ -24,6 +24,7 @@ namespace Ryujinx.Graphics.Vulkan.Queries
 
         private object _lock = new object();
         private ulong _result = ulong.MaxValue;
+        private double _divisor = 1f;
 
         public CounterQueueEvent(CounterQueue queue, CounterType type, ulong drawIndex)
         {
@@ -52,9 +53,11 @@ namespace Ryujinx.Graphics.Vulkan.Queries
             ClearCounter = true;
         }
 
-        internal void Complete(bool withResult)
+        internal void Complete(bool withResult, double divisor)
         {
             _counter.End(withResult);
+
+            _divisor = divisor;
         }
 
         internal bool TryConsume(ref ulong result, bool block, AutoResetEvent wakeSignal = null)
@@ -85,7 +88,7 @@ namespace Ryujinx.Graphics.Vulkan.Queries
                     }
                 }
 
-                result += (ulong)queryResult;
+                result += _divisor == 1 ? (ulong)queryResult : (ulong)Math.Ceiling(queryResult / _divisor);
 
                 _result = result;
 


### PR DESCRIPTION
Counter results were being scaled on ReportCounter, which meant that the _total_ value of the counter was being scaled. Not only could this result in very large numbers and weird overflows if the game doesn't clear the counter, but it also caused the result to change drastically.

This PR changes scaling to be done when the value is added to the counter on the backend. This should evaluate the scale at the same time as before, on report counter, but avoiding the issue with scaling the total.

I've also included a fix for the 64-bit result partially being written. Drivers tend to write the low half first, then the high half. Now, we retry if the high half is 0xFFFFFFFF. This fixes counter results reading as 0 randomly (game was interpreting 0xFFFFFFFF00000000 as 32-bit uint), which turned into a very large value when rescaled, as the low half was no longer 0. This might fix some random chance issues with counter results. It would be nice to write the availability as a separate value _after_ the result copy, but I don't think any of our current counter results will be negative, so this should be fine for now.

Fixes scaling in WarioWare: Get It Together, at least in the demo, where it seems to compare old/new counters and broke down when scaling was enabled. Verified to still work in Splatoon 3 with scaling on/off in opengl/vulkan.