### PR TITLE
Allow GPU resources to be backed by different PhysicalMemory

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Dma/DmaClass.cs
@@ -215,7 +215,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
 
                 if (completeSource && completeDest)
                 {
-                    var target = memoryManager.Physical.TextureCache.FindTexture(
+                    var target = memoryManager.GetBackingMemory(dstGpuVa).TextureCache.FindTexture(
                         memoryManager,
                         dstGpuVa,
                         dstBpp,
@@ -336,6 +336,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
             }
             else
             {
+                var bufferCache = memoryManager.GetBackingMemory(dstGpuVa).BufferCache;
+
                 if (remap &&
                     _state.State.SetRemapComponentsDstX == SetRemapComponentsDst.ConstA &&
                     _state.State.SetRemapComponentsDstY == SetRemapComponentsDst.ConstA &&
@@ -346,7 +348,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                     _state.State.SetRemapComponentsComponentSize == SetRemapComponentsComponentSize.Four)
                 {
                     // Fast path for clears when remap is enabled.
-                    memoryManager.Physical.BufferCache.ClearBuffer(memoryManager, dstGpuVa, size * 4, _state.State.SetRemapConstA);
+                    BufferCache.ClearBuffer(_context, memoryManager, dstGpuVa, size * 4, _state.State.SetRemapConstA);
                 }
                 else
                 {
@@ -366,7 +368,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Dma
                     }
                     else
                     {
-                        memoryManager.Physical.BufferCache.CopyBuffer(memoryManager, srcGpuVa, dstGpuVa, size);
+                        BufferCache.CopyBuffer(_context, memoryManager, srcGpuVa, dstGpuVa, size);
                     }
                 }
             }

--- a/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/InlineToMemory/InlineToMemoryClass.cs
@@ -183,7 +183,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.InlineToMemory
                 // Right now the copy code at the bottom assumes that it is used on both which might be incorrect.
                 if (!_isLinear)
                 {
-                    var target = memoryManager.Physical.TextureCache.FindTexture(
+                    var target = memoryManager.GetBackingMemory(_dstGpuVa).TextureCache.FindTexture(
                         memoryManager,
                         _dstGpuVa,
                         1,

--- a/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLE.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/MME/MacroHLE.cs
@@ -177,7 +177,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
 
             ulong indirectBufferGpuVa = count.GpuVa;
 
-            var bufferCache = _processor.MemoryManager.Physical.BufferCache;
+            var bufferCache = _processor.MemoryManager.GetBackingMemory(indirectBufferGpuVa).BufferCache;
 
             bool useBuffer = bufferCache.CheckModified(_processor.MemoryManager, indirectBufferGpuVa, IndirectIndexedDataEntrySize, out ulong indirectBufferAddress);
 
@@ -187,6 +187,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
 
                 _processor.ThreedClass.DrawIndirect(
                     topology,
+                    bufferCache,
+                    null,
                     indirectBufferAddress,
                     0,
                     1,
@@ -283,15 +285,18 @@ namespace Ryujinx.Graphics.Gpu.Engine.MME
                 }
             }
 
-            var bufferCache = _processor.MemoryManager.Physical.BufferCache;
+            var indirectBufferCache = _processor.MemoryManager.GetBackingMemory(indirectBufferGpuVa).BufferCache;
+            var parameterBufferCache = _processor.MemoryManager.GetBackingMemory(parameterBufferGpuVa).BufferCache;
 
             ulong indirectBufferSize = (ulong)maxDrawCount * (ulong)stride;
 
-            ulong indirectBufferAddress = bufferCache.TranslateAndCreateBuffer(_processor.MemoryManager, indirectBufferGpuVa, indirectBufferSize);
-            ulong parameterBufferAddress = bufferCache.TranslateAndCreateBuffer(_processor.MemoryManager, parameterBufferGpuVa, 4);
+            ulong indirectBufferAddress = indirectBufferCache.TranslateAndCreateBuffer(_processor.MemoryManager, indirectBufferGpuVa, indirectBufferSize);
+            ulong parameterBufferAddress = parameterBufferCache.TranslateAndCreateBuffer(_processor.MemoryManager, parameterBufferGpuVa, 4);
 
             _processor.ThreedClass.DrawIndirect(
                 topology,
+                indirectBufferCache,
+                parameterBufferCache,
                 indirectBufferAddress,
                 parameterBufferAddress,
                 maxDrawCount,

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
@@ -564,6 +564,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         /// </summary>
         /// <param name="engine">3D engine where this method is being called</param>
         /// <param name="topology">Primitive topology</param>
+        /// <param name="indirectBufferCache">Buffer cache owning the buffer with the draw parameters</param>
+        /// <param name="parameterBufferCache">Buffer cache owning the buffer with the draw count</param>
         /// <param name="indirectBufferAddress">Address of the buffer with the draw parameters, such as count, first index, etc</param>
         /// <param name="parameterBufferAddress">Address of the buffer with the draw count</param>
         /// <param name="maxDrawCount">Maximum number of draws that can be made</param>
@@ -573,6 +575,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         public void DrawIndirect(
             ThreedClass engine,
             PrimitiveTopology topology,
+            BufferCache indirectBufferCache,
+            BufferCache parameterBufferCache,
             ulong indirectBufferAddress,
             ulong parameterBufferAddress,
             int maxDrawCount,
@@ -594,8 +598,6 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 return;
             }
 
-            PhysicalMemory memory = _channel.MemoryManager.Physical;
-
             bool hasCount = (drawType & IndirectDrawType.Count) != 0;
             bool indexed = (drawType & IndirectDrawType.Indexed) != 0;
 
@@ -615,8 +617,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
             if (hasCount)
             {
-                var indirectBuffer = memory.BufferCache.GetBufferRange(indirectBufferAddress, (ulong)maxDrawCount * (ulong)stride);
-                var parameterBuffer = memory.BufferCache.GetBufferRange(parameterBufferAddress, 4);
+                var indirectBuffer = indirectBufferCache.GetBufferRange(indirectBufferAddress, (ulong)maxDrawCount * (ulong)stride);
+                var parameterBuffer = parameterBufferCache.GetBufferRange(parameterBufferAddress, 4);
 
                 if (indexed)
                 {
@@ -629,7 +631,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             }
             else
             {
-                var indirectBuffer = memory.BufferCache.GetBufferRange(indirectBufferAddress, (ulong)stride);
+                var indirectBuffer = indirectBufferCache.GetBufferRange(indirectBufferAddress, (ulong)stride);
 
                 if (indexed)
                 {

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -351,13 +351,13 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 {
                     BufferDescriptor sb = info.SBuffers[index];
 
-                    ulong sbDescAddress = _channel.BufferManager.GetGraphicsUniformBufferAddress(stage, 0);
+                    (var physical, ulong sbDescAddress) = _channel.BufferManager.GetGraphicsUniformBufferAddress(stage, 0);
 
                     int sbDescOffset = 0x110 + stage * 0x100 + sb.Slot * 0x10;
 
                     sbDescAddress += (ulong)sbDescOffset;
 
-                    SbDescriptor sbDescriptor = _channel.MemoryManager.Physical.Read<SbDescriptor>(sbDescAddress);
+                    SbDescriptor sbDescriptor = physical.Read<SbDescriptor>(sbDescAddress);
 
                     _channel.BufferManager.SetGraphicsStorageBuffer(stage, sb.Slot, sbDescriptor.PackAddress(), (uint)sbDescriptor.Size, sb.Flags);
                 }
@@ -465,7 +465,9 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                     rtNoAlphaMask |= 1u << index;
                 }
 
-                Image.Texture color = memoryManager.Physical.TextureCache.FindOrCreateTexture(
+                var colorTextureCache = memoryManager.GetBackingMemory(colorState.Address.Pack()).TextureCache;
+
+                Image.Texture color = colorTextureCache.FindOrCreateTexture(
                     memoryManager,
                     colorState,
                     _vtgWritesRtLayer || layered,
@@ -498,7 +500,9 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 var dsState = _state.State.RtDepthStencilState;
                 var dsSize = _state.State.RtDepthStencilSize;
 
-                depthStencil = memoryManager.Physical.TextureCache.FindOrCreateTexture(
+                var dsTextureCache = memoryManager.GetBackingMemory(dsState.Address.Pack()).TextureCache;
+
+                depthStencil = dsTextureCache.FindOrCreateTexture(
                     memoryManager,
                     dsState,
                     dsSize,
@@ -1299,8 +1303,6 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         /// </summary>
         private void UpdateShaderState()
         {
-            var shaderCache = _channel.MemoryManager.Physical.ShaderCache;
-
             _vtgWritesRtLayer = false;
 
             ShaderAddresses addresses = new ShaderAddresses();
@@ -1318,6 +1320,10 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
                 addressesSpan[index] = baseAddress + shader.Offset;
             }
+
+            // Shader stages on different address spaces are not supported right now,
+            // but it should never happen in practice anyway.
+            var shaderCache = _channel.MemoryManager.GetBackingMemory(addresses.VertexB).ShaderCache;
 
             CachedShaderProgram gs = shaderCache.GetGraphicsShader(ref _state.State, ref _pipeline, _channel, ref _currentSpecState.GetPoolState(), ref _currentSpecState.GetGraphicsState(), addresses);
 

--- a/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/ThreedClass.cs
@@ -3,6 +3,7 @@ using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Engine.GPFifo;
 using Ryujinx.Graphics.Gpu.Engine.InlineToMemory;
 using Ryujinx.Graphics.Gpu.Engine.Threed.Blender;
+using Ryujinx.Graphics.Gpu.Memory;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
@@ -588,6 +589,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         /// Performs a indirect draw, with parameters from a GPU buffer.
         /// </summary>
         /// <param name="topology">Primitive topology</param>
+        /// <param name="indirectBufferCache">Buffer cache owning the buffer with the draw parameters</param>
+        /// <param name="parameterBufferCache">Buffer cache owning the buffer with the draw count</param>
         /// <param name="indirectBufferAddress">Address of the buffer with the draw parameters, such as count, first index, etc</param>
         /// <param name="parameterBufferAddress">Address of the buffer with the draw count</param>
         /// <param name="maxDrawCount">Maximum number of draws that can be made</param>
@@ -596,6 +599,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         /// <param name="drawType">Type of the indirect draw, which can be indexed or non-indexed, with or without a draw count</param>
         public void DrawIndirect(
             PrimitiveTopology topology,
+            BufferCache indirectBufferCache,
+            BufferCache parameterBufferCache,
             ulong indirectBufferAddress,
             ulong parameterBufferAddress,
             int maxDrawCount,
@@ -603,7 +608,17 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             int indexCount,
             IndirectDrawType drawType)
         {
-            _drawManager.DrawIndirect(this, topology, indirectBufferAddress, parameterBufferAddress, maxDrawCount, stride, indexCount, drawType);
+            _drawManager.DrawIndirect(
+                this,
+                topology,
+                indirectBufferCache,
+                parameterBufferCache,
+                indirectBufferAddress,
+                parameterBufferAddress,
+                maxDrawCount,
+                stride,
+                indexCount,
+                drawType);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Engine/Twod/TwodClass.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Twod/TwodClass.cs
@@ -233,6 +233,9 @@ namespace Ryujinx.Graphics.Gpu.Engine.Twod
             var dstCopyTexture = Unsafe.As<uint, TwodTexture>(ref _state.State.SetDstFormat);
             var srcCopyTexture = Unsafe.As<uint, TwodTexture>(ref _state.State.SetSrcFormat);
 
+            var srcTextureCache = memoryManager.GetBackingMemory(srcCopyTexture.Address.Pack()).TextureCache;
+            var dstTextureCache = memoryManager.GetBackingMemory(dstCopyTexture.Address.Pack()).TextureCache;
+
             long srcX = ((long)_state.State.SetPixelsFromMemorySrcX0Int << 32) | (long)(ulong)_state.State.SetPixelsFromMemorySrcX0Frac;
             long srcY = ((long)_state.State.PixelsFromMemorySrcY0Int << 32) | (long)(ulong)_state.State.SetPixelsFromMemorySrcY0Frac;
 
@@ -300,7 +303,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Twod
                 IsCopyRegionComplete(srcCopyTexture, srcCopyTextureFormat, srcX1, srcY1, srcX2, srcY2) &&
                 IsCopyRegionComplete(dstCopyTexture, dstCopyTextureFormat, dstX1, dstY1, dstX2, dstY2);
 
-            var srcTexture = memoryManager.Physical.TextureCache.FindOrCreateTexture(
+            var srcTexture = srcTextureCache.FindOrCreateTexture(
                 memoryManager,
                 srcCopyTexture,
                 offset,
@@ -320,7 +323,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Twod
                 return;
             }
 
-            memoryManager.Physical.TextureCache.Lift(srcTexture);
+            srcTextureCache.Lift(srcTexture);
 
             // When the source texture that was found has a depth format,
             // we must enforce the target texture also has a depth format,
@@ -335,7 +338,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Twod
                 dstCopyTextureFormat = dstCopyTexture.Format.Convert();
             }
 
-            var dstTexture = memoryManager.Physical.TextureCache.FindOrCreateTexture(
+            var dstTexture = dstTextureCache.FindOrCreateTexture(
                 memoryManager,
                 dstCopyTexture,
                 0,

--- a/Ryujinx.Graphics.Gpu/GpuChannel.cs
+++ b/Ryujinx.Graphics.Gpu/GpuChannel.cs
@@ -58,22 +58,24 @@ namespace Ryujinx.Graphics.Gpu
         public void BindMemory(MemoryManager memoryManager)
         {
             var oldMemoryManager = Interlocked.Exchange(ref _memoryManager, memoryManager ?? throw new ArgumentNullException(nameof(memoryManager)));
+            if (oldMemoryManager == memoryManager)
+            {
+                return;
+            }
 
-            memoryManager.Physical.IncrementReferenceCount();
+            memoryManager.AttachToChannel(BufferManager.Rebind);
 
             if (oldMemoryManager != null)
             {
-                oldMemoryManager.Physical.BufferCache.NotifyBuffersModified -= BufferManager.Rebind;
-                oldMemoryManager.Physical.DecrementReferenceCount();
+                oldMemoryManager.DetachFromChannel(BufferManager.Rebind);
                 oldMemoryManager.MemoryUnmapped -= MemoryUnmappedHandler;
             }
 
-            memoryManager.Physical.BufferCache.NotifyBuffersModified += BufferManager.Rebind;
             memoryManager.MemoryUnmapped += MemoryUnmappedHandler;
 
             // Since the memory manager changed, make sure we will get pools from addresses of the new memory manager.
             TextureManager.ReloadPools();
-            memoryManager.Physical.BufferCache.QueuePrune();
+            memoryManager.QueuePrune();
         }
 
         /// <summary>
@@ -86,7 +88,7 @@ namespace Ryujinx.Graphics.Gpu
             TextureManager.ReloadPools();
 
             var memoryManager = Volatile.Read(ref _memoryManager);
-            memoryManager?.Physical.BufferCache.QueuePrune();
+            memoryManager?.QueuePrune();
         }
 
         /// <summary>
@@ -139,8 +141,7 @@ namespace Ryujinx.Graphics.Gpu
             var oldMemoryManager = Interlocked.Exchange(ref _memoryManager, null);
             if (oldMemoryManager != null)
             {
-                oldMemoryManager.Physical.BufferCache.NotifyBuffersModified -= BufferManager.Rebind;
-                oldMemoryManager.Physical.DecrementReferenceCount();
+                oldMemoryManager.DetachFromChannel(BufferManager.Rebind);
                 oldMemoryManager.MemoryUnmapped -= MemoryUnmappedHandler;
             }
         }

--- a/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -145,7 +145,7 @@ namespace Ryujinx.Graphics.Gpu
                 throw new ArgumentException("The PID is invalid or the process was not registered", nameof(pid));
             }
 
-            return new MemoryManager(physicalMemory);
+            return new MemoryManager(this, physicalMemory);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/PoolCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/PoolCache.cs
@@ -1,3 +1,4 @@
+using Ryujinx.Graphics.Gpu.Memory;
 using System;
 using System.Collections.Generic;
 
@@ -60,10 +61,11 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Finds a cache texture pool, or creates a new one if not found.
         /// </summary>
         /// <param name="channel">GPU channel that the texture pool cache belongs to</param>
+        /// <param name="physicalMemory">Backing memory of the pool</param>
         /// <param name="address">Start address of the texture pool</param>
         /// <param name="maximumId">Maximum ID of the texture pool</param>
         /// <returns>The found or newly created texture pool</returns>
-        public T FindOrCreate(GpuChannel channel, ulong address, int maximumId)
+        public T FindOrCreate(GpuChannel channel, PhysicalMemory physicalMemory, ulong address, int maximumId)
         {
             // Remove old entries from the cache, if possible.
             while (_pools.Count > MaxCapacity && (_currentTimestamp - _pools.First.Value.CacheTimestamp) >= MinDeltaForRemoval)
@@ -98,7 +100,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             }
 
             // If not found, create a new one.
-            pool = CreatePool(_context, channel, address, maximumId);
+            pool = CreatePool(_context, channel, physicalMemory, address, maximumId);
 
             pool.CacheNode = _pools.AddLast(pool);
             pool.CacheTimestamp = _currentTimestamp;
@@ -111,9 +113,10 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         /// <param name="context">GPU context that the pool belongs to</param>
         /// <param name="channel">GPU channel that the pool belongs to</param>
+        /// <param name="physicalMemory">Backing memory of the pool</param>
         /// <param name="address">Address of the pool in guest memory</param>
         /// <param name="maximumId">Maximum ID of the pool (equal to maximum minus one)</param>
-        protected abstract T CreatePool(GpuContext context, GpuChannel channel, ulong address, int maximumId);
+        protected abstract T CreatePool(GpuContext context, GpuChannel channel, PhysicalMemory physicalMemory, ulong address, int maximumId);
 
         public void Dispose()
         {

--- a/Ryujinx.Graphics.Gpu/Image/SamplerPoolCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/SamplerPoolCache.cs
@@ -1,3 +1,5 @@
+using Ryujinx.Graphics.Gpu.Memory;
+
 namespace Ryujinx.Graphics.Gpu.Image
 {
     /// <summary>
@@ -20,11 +22,17 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         /// <param name="context">GPU context that the sampler pool belongs to</param>
         /// <param name="channel">GPU channel that the texture pool belongs to</param>
+        /// <param name="physicalMemory">Backing memory of the pool</param>
         /// <param name="address">Address of the sampler pool in guest memory</param>
         /// <param name="maximumId">Maximum sampler ID of the sampler pool (equal to maximum samplers minus one)</param>
-        protected override SamplerPool CreatePool(GpuContext context, GpuChannel channel, ulong address, int maximumId)
+        protected override SamplerPool CreatePool(
+            GpuContext context,
+            GpuChannel channel,
+            PhysicalMemory physicalMemory,
+            ulong address,
+            int maximumId)
         {
-            return new SamplerPool(context, channel.MemoryManager.Physical, address, maximumId);
+            return new SamplerPool(context, physicalMemory, address, maximumId);
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureManager.cs
@@ -363,9 +363,10 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <returns>The texture pool</returns>
         public TexturePool GetTexturePool(ulong poolGpuVa, int maximumId)
         {
+            var physical = _channel.MemoryManager.GetBackingMemory(poolGpuVa);
             ulong poolAddress = _channel.MemoryManager.Translate(poolGpuVa);
 
-            TexturePool texturePool = _texturePoolCache.FindOrCreate(_channel, poolAddress, maximumId);
+            TexturePool texturePool = _texturePoolCache.FindOrCreate(_channel, physical, poolAddress, maximumId);
 
             return texturePool;
         }

--- a/Ryujinx.Graphics.Gpu/Image/TexturePoolCache.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePoolCache.cs
@@ -1,3 +1,5 @@
+using Ryujinx.Graphics.Gpu.Memory;
+
 namespace Ryujinx.Graphics.Gpu.Image
 {
     /// <summary>
@@ -20,11 +22,17 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         /// <param name="context">GPU context that the texture pool belongs to</param>
         /// <param name="channel">GPU channel that the texture pool belongs to</param>
+        /// <param name="physicalMemory">Backing memory of the pool</param>
         /// <param name="address">Address of the texture pool in guest memory</param>
         /// <param name="maximumId">Maximum texture ID of the texture pool (equal to maximum textures minus one)</param>
-        protected override TexturePool CreatePool(GpuContext context, GpuChannel channel, ulong address, int maximumId)
+        protected override TexturePool CreatePool(
+            GpuContext context,
+            GpuChannel channel,
+            PhysicalMemory physicalMemory,
+            ulong address,
+            int maximumId)
         {
-            return new TexturePool(context, channel, address, maximumId);
+            return new TexturePool(context, channel, physicalMemory, address, maximumId);
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Memory/BufferBounds.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferBounds.cs
@@ -8,6 +8,16 @@ namespace Ryujinx.Graphics.Gpu.Memory
     readonly struct BufferBounds
     {
         /// <summary>
+        /// Physical memory backing the buffer.
+        /// </summary>
+        public PhysicalMemory Physical { get; }
+
+        /// <summary>
+        /// Buffer cache that owns the buffer.
+        /// </summary>
+        public BufferCache BufferCache => Physical.BufferCache;
+
+        /// <summary>
         /// Region virtual address.
         /// </summary>
         public ulong Address { get; }
@@ -25,11 +35,13 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <summary>
         /// Creates a new buffer region.
         /// </summary>
+        /// <param name="physical">Physical memory backing the buffer</param>
         /// <param name="address">Region address</param>
         /// <param name="size">Region size</param>
         /// <param name="flags">Buffer usage flags</param>
-        public BufferBounds(ulong address, ulong size, BufferUsageFlags flags = BufferUsageFlags.None)
+        public BufferBounds(PhysicalMemory physical, ulong address, ulong size, BufferUsageFlags flags = BufferUsageFlags.None)
         {
+            Physical = physical;
             Address = address;
             Size = size;
             Flags = flags;

--- a/Ryujinx.Graphics.Gpu/Memory/BufferCache.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferCache.cs
@@ -313,22 +313,26 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <remarks>
         /// This does a GPU side copy.
         /// </remarks>
+        /// <param name="context">GPU context</param>
         /// <param name="memoryManager">GPU memory manager where the buffer is mapped</param>
         /// <param name="srcVa">GPU virtual address of the copy source</param>
         /// <param name="dstVa">GPU virtual address of the copy destination</param>
         /// <param name="size">Size in bytes of the copy</param>
-        public void CopyBuffer(MemoryManager memoryManager, ulong srcVa, ulong dstVa, ulong size)
+        public static void CopyBuffer(GpuContext context, MemoryManager memoryManager, ulong srcVa, ulong dstVa, ulong size)
         {
-            ulong srcAddress = TranslateAndCreateBuffer(memoryManager, srcVa, size);
-            ulong dstAddress = TranslateAndCreateBuffer(memoryManager, dstVa, size);
+            PhysicalMemory srcPhysical = memoryManager.GetBackingMemory(srcVa);
+            PhysicalMemory dstPhysical = memoryManager.GetBackingMemory(dstVa);
 
-            Buffer srcBuffer = GetBuffer(srcAddress, size);
-            Buffer dstBuffer = GetBuffer(dstAddress, size);
+            ulong srcAddress = srcPhysical.BufferCache.TranslateAndCreateBuffer(memoryManager, srcVa, size);
+            ulong dstAddress = dstPhysical.BufferCache.TranslateAndCreateBuffer(memoryManager, dstVa, size);
+
+            Buffer srcBuffer = srcPhysical.BufferCache.GetBuffer(srcAddress, size);
+            Buffer dstBuffer = dstPhysical.BufferCache.GetBuffer(dstAddress, size);
 
             int srcOffset = (int)(srcAddress - srcBuffer.Address);
             int dstOffset = (int)(dstAddress - dstBuffer.Address);
 
-            _context.Renderer.Pipeline.CopyBuffer(
+            context.Renderer.Pipeline.CopyBuffer(
                 srcBuffer.Handle,
                 dstBuffer.Handle,
                 srcOffset,
@@ -344,7 +348,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 // Optimization: If the data being copied is already in memory, then copy it directly instead of flushing from GPU.
 
                 dstBuffer.ClearModified(dstAddress, size);
-                memoryManager.Physical.WriteUntracked(dstAddress, memoryManager.Physical.GetSpan(srcAddress, (int)size));
+                dstPhysical.WriteUntracked(dstAddress, srcPhysical.GetSpan(srcAddress, (int)size));
             }
         }
 
@@ -354,21 +358,24 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <remarks>
         /// Both the address and size must be aligned to 4 bytes.
         /// </remarks>
+        /// <param name="context">GPU context</param>
         /// <param name="memoryManager">GPU memory manager where the buffer is mapped</param>
         /// <param name="gpuVa">GPU virtual address of the region to clear</param>
         /// <param name="size">Number of bytes to clear</param>
         /// <param name="value">Value to be written into the buffer</param>
-        public void ClearBuffer(MemoryManager memoryManager, ulong gpuVa, ulong size, uint value)
+        public static void ClearBuffer(GpuContext context, MemoryManager memoryManager, ulong gpuVa, ulong size, uint value)
         {
-            ulong address = TranslateAndCreateBuffer(memoryManager, gpuVa, size);
+            PhysicalMemory physical = memoryManager.GetBackingMemory(gpuVa);
 
-            Buffer buffer = GetBuffer(address, size);
+            ulong address = physical.BufferCache.TranslateAndCreateBuffer(memoryManager, gpuVa, size);
+
+            Buffer buffer = physical.BufferCache.GetBuffer(address, size);
 
             int offset = (int)(address - buffer.Address);
 
-            _context.Renderer.Pipeline.ClearBuffer(buffer.Handle, offset, (int)size, value);
+            context.Renderer.Pipeline.ClearBuffer(buffer.Handle, offset, (int)size, value);
 
-            memoryManager.Physical.FillTrackedResource(address, size, value, ResourceKind.Buffer);
+            physical.FillTrackedResource(address, size, value, ResourceKind.Buffer);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Memory/BufferTextureBinding.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferTextureBinding.cs
@@ -20,6 +20,11 @@ namespace Ryujinx.Graphics.Gpu.Memory
         public ITexture Texture { get; }
 
         /// <summary>
+        /// Buffer cache that owns the buffer.
+        /// </summary>
+        public BufferCache BufferCache { get; }
+
+        /// <summary>
         /// The base address of the buffer binding.
         /// </summary>
         public ulong Address { get; }
@@ -49,6 +54,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// </summary>
         /// <param name="stage">Shader stage accessing the texture</param>
         /// <param name="texture">Buffer texture</param>
+        /// <param name="bufferCache">Buffer cache that owns the buffer</param>
         /// <param name="address">Base address</param>
         /// <param name="size">Size in bytes</param>
         /// <param name="bindingInfo">Binding info</param>
@@ -57,6 +63,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         public BufferTextureBinding(
             ShaderStage stage,
             ITexture texture,
+            BufferCache bufferCache,
             ulong address,
             ulong size,
             TextureBindingInfo bindingInfo,
@@ -65,6 +72,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         {
             Stage = stage;
             Texture = texture;
+            BufferCache = bufferCache;
             Address = address;
             Size = size;
             BindingInfo = bindingInfo;

--- a/Ryujinx.Graphics.Gpu/Memory/IndexBuffer.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/IndexBuffer.cs
@@ -7,6 +7,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
     /// </summary>
     struct IndexBuffer
     {
+        public BufferCache BufferCache;
         public ulong Address;
         public ulong Size;
 

--- a/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
@@ -34,10 +34,9 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
         public event EventHandler<UnmapEventArgs> MemoryUnmapped;
 
-        /// <summary>
-        /// Physical memory where the virtual memory is mapped into.
-        /// </summary>
-        private PhysicalMemory Physical { get; }
+        private readonly GpuContext _context;
+        private readonly List<PhysicalMemory> _physicalMemoryList;
+        private readonly Dictionary<PhysicalMemory, byte> _physicalMemoryMap;
 
         /// <summary>
         /// Cache of GPU counters.
@@ -47,14 +46,26 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <summary>
         /// Creates a new instance of the GPU memory manager.
         /// </summary>
+        /// <param name="context">GPU context</param>
         /// <param name="physicalMemory">Physical memory that this memory manager will map into</param>
-        internal MemoryManager(PhysicalMemory physicalMemory)
+        internal MemoryManager(GpuContext context, PhysicalMemory physicalMemory)
         {
-            Physical = physicalMemory;
+            _context = context;
+
+            _physicalMemoryList = new List<PhysicalMemory>()
+            {
+                physicalMemory
+            };
+
+            _physicalMemoryMap = new Dictionary<PhysicalMemory, byte>
+            {
+                { physicalMemory, 0 }
+            };
+
             CounterCache = new CounterCache();
             _pageTable = new ulong[PtLvl0Size][];
-            MemoryUnmapped += Physical.TextureCache.MemoryUnmappedHandler;
-            MemoryUnmapped += Physical.BufferCache.MemoryUnmappedHandler;
+            MemoryUnmapped += physicalMemory.TextureCache.MemoryUnmappedHandler;
+            MemoryUnmapped += physicalMemory.BufferCache.MemoryUnmappedHandler;
             MemoryUnmapped += CounterCache.MemoryUnmappedHandler;
         }
 
@@ -64,9 +75,11 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="rebind">Action to be performed when the buffer cache changes</param>
         internal void AttachToChannel(Action rebind)
         {
-            Physical.IncrementReferenceCount();
-            Physical.BufferCache.NotifyBuffersModified += rebind;
-            Physical.BufferCache.QueuePrune();
+            PhysicalMemory physicalMemory = GetOwnPhysicalMemory();
+
+            physicalMemory.IncrementReferenceCount();
+            physicalMemory.BufferCache.NotifyBuffersModified += rebind;
+            physicalMemory.BufferCache.QueuePrune();
         }
 
         /// <summary>
@@ -75,8 +88,10 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="rebind">Action that was performed when the buffer cache changed</param>
         internal void DetachFromChannel(Action rebind)
         {
-            Physical.BufferCache.NotifyBuffersModified -= rebind;
-            Physical.DecrementReferenceCount();
+            PhysicalMemory physicalMemory = GetOwnPhysicalMemory();
+
+            physicalMemory.BufferCache.NotifyBuffersModified -= rebind;
+            physicalMemory.DecrementReferenceCount();
         }
 
         /// <summary>
@@ -84,7 +99,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// </summary>
         internal void QueuePrune()
         {
-            Physical.BufferCache.QueuePrune();
+            GetOwnPhysicalMemory().BufferCache.QueuePrune();
         }
 
         /// <summary>
@@ -100,15 +115,15 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
             if (IsContiguous(va, size))
             {
-                ulong address = Translate(va);
+                (PhysicalMemory physicalMemory, ulong address) = TranslateWithPhysicalMemory(va);
 
                 if (tracked)
                 {
-                    return Physical.ReadTracked<T>(address);
+                    return physicalMemory.ReadTracked<T>(address);
                 }
                 else
                 {
-                    return Physical.Read<T>(address);
+                    return physicalMemory.Read<T>(address);
                 }
             }
             else
@@ -132,7 +147,9 @@ namespace Ryujinx.Graphics.Gpu.Memory
         {
             if (IsContiguous(va, size))
             {
-                return Physical.GetSpan(Translate(va), size, tracked);
+                (PhysicalMemory physicalMemory, ulong address) = TranslateWithPhysicalMemory(va);
+
+                return physicalMemory.GetSpan(address, size, tracked);
             }
             else
             {
@@ -157,7 +174,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
             bool isContiguous = true;
             int mappedSize;
 
-            if (ValidateAddress(va) && GetPte(va) != PteUnmapped && Physical.IsMapped(Translate(va)))
+            if (ValidateAddress(va) && IsMappedOnGpuAndPhysical(va))
             {
                 ulong endVa = va + (ulong)size;
                 ulong endVaAligned = (endVa + PageMask) & ~PageMask;
@@ -170,7 +187,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                     ulong nextVa = currentVa + PageSize;
                     ulong nextPa = Translate(nextVa);
 
-                    if (!ValidateAddress(nextVa) || GetPte(nextVa) == PteUnmapped || !Physical.IsMapped(nextPa))
+                    if (!ValidateAddress(nextVa) || !IsMappedOnGpuAndPhysical(nextVa))
                     {
                         break;
                     }
@@ -199,7 +216,9 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
             if (isContiguous)
             {
-                return Physical.GetSpan(Translate(va), mappedSize, tracked);
+                (PhysicalMemory physicalMemory, ulong address) = TranslateWithPhysicalMemory(va);
+
+                return physicalMemory.GetSpan(address, mappedSize, tracked);
             }
             else
             {
@@ -209,6 +228,23 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
                 return data;
             }
+        }
+
+        /// <summary>
+        /// Checks if a page of memory is mapped on the GPU and its backing memory.
+        /// </summary>
+        /// <param name="va">GPU virtual address of the page</param>
+        /// <returns>True if mapped, false otherwise</returns>
+        private bool IsMappedOnGpuAndPhysical(ulong va)
+        {
+            (PhysicalMemory physicalMemory, ulong address) = TranslateWithPhysicalMemory(va);
+
+            if (address == PteUnmapped)
+            {
+                return false;
+            }
+
+            return physicalMemory.IsMapped(address);
         }
 
         /// <summary>
@@ -228,22 +264,22 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
             if ((va & PageMask) != 0)
             {
-                ulong pa = Translate(va);
+                (PhysicalMemory physicalMemory, ulong pa) = TranslateWithPhysicalMemory(va);
 
                 size = Math.Min(data.Length, (int)PageSize - (int)(va & PageMask));
 
-                Physical.GetSpan(pa, size, tracked).CopyTo(data.Slice(0, size));
+                physicalMemory.GetSpan(pa, size, tracked).CopyTo(data.Slice(0, size));
 
                 offset += size;
             }
 
             for (; offset < data.Length; offset += size)
             {
-                ulong pa = Translate(va + (ulong)offset);
+                (PhysicalMemory physicalMemory, ulong pa) = TranslateWithPhysicalMemory(va + (ulong)offset);
 
                 size = Math.Min(data.Length - offset, (int)PageSize);
 
-                Physical.GetSpan(pa, size, tracked).CopyTo(data.Slice(offset, size));
+                physicalMemory.GetSpan(pa, size, tracked).CopyTo(data.Slice(offset, size));
             }
         }
 
@@ -258,7 +294,9 @@ namespace Ryujinx.Graphics.Gpu.Memory
         {
             if (IsContiguous(va, size))
             {
-                return Physical.GetWritableRegion(Translate(va), size, tracked);
+                (PhysicalMemory physicalMemory, ulong address) = TranslateWithPhysicalMemory(va);
+
+                return physicalMemory.GetWritableRegion(address, size, tracked);
             }
             else
             {
@@ -288,7 +326,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="data">The data to be written</param>
         public void Write(ulong va, ReadOnlySpan<byte> data)
         {
-            WriteImpl(va, data, Physical.Write);
+            WriteImpl(va, data, (physical, va, data) => physical.Write(va, data));
         }
 
         /// <summary>
@@ -298,7 +336,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="data">The data to be written</param>
         public void WriteTrackedResource(ulong va, ReadOnlySpan<byte> data)
         {
-            WriteImpl(va, data, Physical.WriteTrackedResource);
+            WriteImpl(va, data, (physical, va, data) => physical.WriteTrackedResource(va, data));
         }
 
         /// <summary>
@@ -308,10 +346,10 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="data">The data to be written</param>
         public void WriteUntracked(ulong va, ReadOnlySpan<byte> data)
         {
-            WriteImpl(va, data, Physical.WriteUntracked);
+            WriteImpl(va, data, (physical, va, data) => physical.WriteUntracked(va, data));
         }
 
-        private delegate void WriteCallback(ulong address, ReadOnlySpan<byte> data);
+        private delegate void WriteCallback(PhysicalMemory physicalMemory, ulong address, ReadOnlySpan<byte> data);
 
         /// <summary>
         /// Writes data to possibly non-contiguous GPU mapped memory.
@@ -323,7 +361,9 @@ namespace Ryujinx.Graphics.Gpu.Memory
         {
             if (IsContiguous(va, data.Length))
             {
-                writeCallback(Translate(va), data);
+                (PhysicalMemory physicalMemory, ulong address) = TranslateWithPhysicalMemory(va);
+
+                writeCallback(physicalMemory, address, data);
             }
             else
             {
@@ -331,22 +371,22 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
                 if ((va & PageMask) != 0)
                 {
-                    ulong pa = Translate(va);
+                    (PhysicalMemory physicalMemory, ulong pa) = TranslateWithPhysicalMemory(va);
 
                     size = Math.Min(data.Length, (int)PageSize - (int)(va & PageMask));
 
-                    writeCallback(pa, data.Slice(0, size));
+                    writeCallback(physicalMemory, pa, data.Slice(0, size));
 
                     offset += size;
                 }
 
                 for (; offset < data.Length; offset += size)
                 {
-                    ulong pa = Translate(va + (ulong)offset);
+                    (PhysicalMemory physicalMemory, ulong pa) = TranslateWithPhysicalMemory(va + (ulong)offset);
 
                     size = Math.Min(data.Length - offset, (int)PageSize);
 
-                    writeCallback(pa, data.Slice(offset, size));
+                    writeCallback(physicalMemory, pa, data.Slice(offset, size));
                 }
             }
         }
@@ -360,7 +400,9 @@ namespace Ryujinx.Graphics.Gpu.Memory
         {
             if (IsContiguous(va, data.Length))
             {
-                Physical.Write(Translate(va), data);
+                (PhysicalMemory physicalMemory, ulong address) = TranslateWithPhysicalMemory(va);
+
+                physicalMemory.Write(address, data);
             }
             else
             {
@@ -368,13 +410,13 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
                 if ((va & PageMask) != 0)
                 {
-                    ulong pa = Translate(va);
+                    (PhysicalMemory physicalMemory, ulong pa) = TranslateWithPhysicalMemory(va);
 
                     size = Math.Min(data.Length, (int)PageSize - (int)(va & PageMask));
 
-                    if (pa != PteUnmapped && Physical.IsMapped(pa))
+                    if (pa != PteUnmapped && physicalMemory.IsMapped(pa))
                     {
-                        Physical.Write(pa, data.Slice(0, size));
+                        physicalMemory.Write(pa, data.Slice(0, size));
                     }
 
                     offset += size;
@@ -382,13 +424,13 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
                 for (; offset < data.Length; offset += size)
                 {
-                    ulong pa = Translate(va + (ulong)offset);
+                    (PhysicalMemory physicalMemory, ulong pa) = TranslateWithPhysicalMemory(va + (ulong)offset);
 
                     size = Math.Min(data.Length - offset, (int)PageSize);
 
-                    if (pa != PteUnmapped && Physical.IsMapped(pa))
+                    if (pa != PteUnmapped && physicalMemory.IsMapped(pa))
                     {
-                        Physical.Write(pa, data.Slice(offset, size));
+                        physicalMemory.Write(pa, data.Slice(offset, size));
                     }
                 }
             }
@@ -406,13 +448,49 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <param name="kind">Kind of the resource located at the mapping</param>
         public void Map(ulong pa, ulong va, ulong size, PteKind kind)
         {
+            MapImpl(pa, va, size, kind);
+        }
+
+        /// <summary>
+        /// Maps a given range of pages to the specified CPU virtual address from a different process.
+        /// </summary>
+        /// <remarks>
+        /// All addresses and sizes must be page aligned.
+        /// </remarks>
+        /// <param name="pa">CPU virtual address to map into</param>
+        /// <param name="va">GPU virtual address to be mapped</param>
+        /// <param name="size">Size in bytes of the mapping</param>
+        /// <param name="kind">Kind of the resource located at the mapping</param>
+        /// <param name="ownedPid">PID of the process that owns the mapping</param>
+        public void MapForeign(ulong pa, ulong va, ulong size, PteKind kind, ulong ownedPid)
+        {
+            if (_context.PhysicalMemoryRegistry.TryGetValue(ownedPid, out PhysicalMemory physicalMemory))
+            {
+                MapImpl(pa, va, size, kind, physicalMemory);
+            }
+        }
+
+        /// <summary>
+        /// Maps a given range of pages to the specified CPU virtual address.
+        /// </summary>
+        /// <remarks>
+        /// All addresses and sizes must be page aligned.
+        /// </remarks>
+        /// <param name="pa">CPU virtual address to map into</param>
+        /// <param name="va">GPU virtual address to be mapped</param>
+        /// <param name="size">Size in bytes of the mapping</param>
+        /// <param name="kind">Kind of the resource located at the mapping</param>
+        /// <param name="physicalMemory">Optional physical memory to import for the mapping</param>
+        private void MapImpl(ulong pa, ulong va, ulong size, PteKind kind, PhysicalMemory physicalMemory = null)
+        {
             lock (_pageTable)
             {
                 MemoryUnmapped?.Invoke(this, new UnmapEventArgs(va, size));
+                byte pIndex = physicalMemory != null ? GetOrAddPhysicalMemory(physicalMemory) : (byte)0;
 
                 for (ulong offset = 0; offset < size; offset += PageSize)
                 {
-                    SetPte(va + offset, PackPte(pa + offset, kind));
+                    SetPte(va + offset, PackPte(pa + offset, pIndex, kind));
                 }
             }
         }
@@ -458,12 +536,14 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
             for (int page = 0; page < pages - 1; page++)
             {
-                if (!ValidateAddress(va + PageSize) || GetPte(va + PageSize) == PteUnmapped)
+                ulong nextPte = GetPte(va + PageSize);
+
+                if (!ValidateAddress(va + PageSize) || nextPte == PteUnmapped)
                 {
                     return false;
                 }
 
-                if (Translate(va) + PageSize != Translate(va + PageSize))
+                if (GetPte(va) + PageSize != nextPte)
                 {
                     return false;
                 }
@@ -570,9 +650,47 @@ namespace Ryujinx.Graphics.Gpu.Memory
             return true;
         }
 
+        /// <summary>
+        /// Gets the backing memory for a given GPU virtual address.
+        /// </summary>
+        /// <param name="va">GPU virtual address to get the backing memory from</param>
+        /// <returns>The backing memory for the specified GPU virtual address</returns>
         internal PhysicalMemory GetBackingMemory(ulong va)
         {
-            return Physical;
+            ulong pte = GetPte(va);
+
+            if (pte == PteUnmapped)
+            {
+                return GetOwnPhysicalMemory();
+            }
+
+            return _physicalMemoryList[UnpackPIndexFromPte(pte)];
+        }
+
+        /// <summary>
+        /// Gets the backing memory that is owned by this GPU memory manager.
+        /// </summary>
+        /// <returns>The backing memory owned by this memory manager</returns>
+        private PhysicalMemory GetOwnPhysicalMemory()
+        {
+            return _physicalMemoryList[0];
+        }
+
+        /// <summary>
+        /// Gets the index for a given physical memory on the list, adding it to the list if needed.
+        /// </summary>
+        /// <param name="physicalMemory">Physical memory to get the index from</param>
+        /// <returns>The index of the physical memory on the list</returns>
+        private byte GetOrAddPhysicalMemory(PhysicalMemory physicalMemory)
+        {
+            if (!_physicalMemoryMap.TryGetValue(physicalMemory, out byte pIndex))
+            {
+                pIndex = checked((byte)_physicalMemoryList.Count);
+                _physicalMemoryList.Add(physicalMemory);
+                _physicalMemoryMap.Add(physicalMemory, pIndex);
+            }
+
+            return pIndex;
         }
 
         /// <summary>
@@ -615,6 +733,28 @@ namespace Ryujinx.Graphics.Gpu.Memory
             }
 
             return UnpackPaFromPte(pte) + (va & PageMask);
+        }
+
+        /// <summary>
+        /// Translates a GPU virtual address to a CPU virtual address and the associated physical memory.
+        /// </summary>
+        /// <param name="va">GPU virtual address to be translated</param>
+        /// <returns>CPU virtual address with the physical memory, or <see cref="PteUnmapped"/> if unmapped</returns>
+        private (PhysicalMemory, ulong) TranslateWithPhysicalMemory(ulong va)
+        {
+            if (!ValidateAddress(va))
+            {
+                return (GetOwnPhysicalMemory(), PteUnmapped);
+            }
+
+            ulong pte = GetPte(va);
+
+            if (pte == PteUnmapped)
+            {
+                return (GetOwnPhysicalMemory(), PteUnmapped);
+            }
+
+            return (_physicalMemoryList[UnpackPIndexFromPte(pte)], UnpackPaFromPte(pte) + (va & PageMask));
         }
 
         /// <summary>
@@ -717,11 +857,12 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// Creates a page table entry from a physical address and kind.
         /// </summary>
         /// <param name="pa">Physical address</param>
+        /// <param name="pIndex">Index of the physical memory on the list</param>
         /// <param name="kind">Kind</param>
         /// <returns>Page table entry</returns>
-        private static ulong PackPte(ulong pa, PteKind kind)
+        private static ulong PackPte(ulong pa, byte pIndex, PteKind kind)
         {
-            return pa | ((ulong)kind << 56);
+            return pa | ((ulong)pIndex << 48) | ((ulong)kind << 56);
         }
 
         /// <summary>
@@ -732,6 +873,16 @@ namespace Ryujinx.Graphics.Gpu.Memory
         private static PteKind UnpackKindFromPte(ulong pte)
         {
             return (PteKind)(pte >> 56);
+        }
+
+        /// <summary>
+        /// Unpacks the physical memory index in the list from a page table entry.
+        /// </summary>
+        /// <param name="pte">Page table entry</param>
+        /// <returns>Physical memory index</returns>
+        private static byte UnpackPIndexFromPte(ulong pte)
+        {
+            return (byte)(pte >> 48);
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
@@ -37,7 +37,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <summary>
         /// Physical memory where the virtual memory is mapped into.
         /// </summary>
-        internal PhysicalMemory Physical { get; }
+        private PhysicalMemory Physical { get; }
 
         /// <summary>
         /// Cache of GPU counters.
@@ -56,6 +56,35 @@ namespace Ryujinx.Graphics.Gpu.Memory
             MemoryUnmapped += Physical.TextureCache.MemoryUnmappedHandler;
             MemoryUnmapped += Physical.BufferCache.MemoryUnmappedHandler;
             MemoryUnmapped += CounterCache.MemoryUnmappedHandler;
+        }
+
+        /// <summary>
+        /// Attaches the memory manager to a new GPU channel.
+        /// </summary>
+        /// <param name="rebind">Action to be performed when the buffer cache changes</param>
+        internal void AttachToChannel(Action rebind)
+        {
+            Physical.IncrementReferenceCount();
+            Physical.BufferCache.NotifyBuffersModified += rebind;
+            Physical.BufferCache.QueuePrune();
+        }
+
+        /// <summary>
+        /// Attaches the memory manager to a new GPU channel.
+        /// </summary>
+        /// <param name="rebind">Action that was performed when the buffer cache changed</param>
+        internal void DetachFromChannel(Action rebind)
+        {
+            Physical.BufferCache.NotifyBuffersModified -= rebind;
+            Physical.DecrementReferenceCount();
+        }
+
+        /// <summary>
+        /// Queues a prune of invalid entries on the buffer cache.
+        /// </summary>
+        internal void QueuePrune()
+        {
+            Physical.BufferCache.QueuePrune();
         }
 
         /// <summary>
@@ -541,6 +570,11 @@ namespace Ryujinx.Graphics.Gpu.Memory
             return true;
         }
 
+        internal PhysicalMemory GetBackingMemory(ulong va)
+        {
+            return Physical;
+        }
+
         /// <summary>
         /// Validates a GPU virtual address.
         /// </summary>
@@ -707,7 +741,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         /// <returns>Physical address</returns>
         private static ulong UnpackPaFromPte(ulong pte)
         {
-            return pte & 0xffffffffffffffUL;
+            return pte & 0xffffffffffffUL;
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Memory/VertexBuffer.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/VertexBuffer.cs
@@ -5,9 +5,10 @@ namespace Ryujinx.Graphics.Gpu.Memory
     /// </summary>
     struct VertexBuffer
     {
+        public BufferCache BufferCache;
         public ulong Address;
         public ulong Size;
-        public int   Stride;
-        public int   Divisor;
+        public int Stride;
+        public int Divisor;
     }
 }

--- a/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
@@ -54,11 +54,11 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <inheritdoc/>
         public uint ConstantBuffer1Read(int offset)
         {
-            ulong baseAddress = _compute
+            (var physical, ulong baseAddress) = _compute
                 ? _channel.BufferManager.GetComputeUniformBufferAddress(1)
                 : _channel.BufferManager.GetGraphicsUniformBufferAddress(_stageIndex, 1);
 
-            return _channel.MemoryManager.Physical.Read<uint>(baseAddress + (ulong)offset);
+            return physical.Read<uint>(baseAddress + (ulong)offset);
         }
 
         /// <inheritdoc/>

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -644,14 +644,14 @@ namespace Ryujinx.Graphics.Gpu.Shader
             byte[] codeA,
             byte[] codeB)
         {
-            ulong cb1DataAddress = channel.BufferManager.GetGraphicsUniformBufferAddress(0, 1);
+            (var physical, ulong cb1DataAddress) = channel.BufferManager.GetGraphicsUniformBufferAddress(0, 1);
 
             var memoryManager = channel.MemoryManager;
 
             codeA ??= memoryManager.GetSpan(vertexA.Address, vertexA.Size).ToArray();
             codeB ??= memoryManager.GetSpan(currentStage.Address, currentStage.Size).ToArray();
-            byte[] cb1DataA = memoryManager.Physical.GetSpan(cb1DataAddress, vertexA.Cb1DataSize).ToArray();
-            byte[] cb1DataB = memoryManager.Physical.GetSpan(cb1DataAddress, currentStage.Cb1DataSize).ToArray();
+            byte[] cb1DataA = physical.GetSpan(cb1DataAddress, vertexA.Cb1DataSize).ToArray();
+            byte[] cb1DataB = physical.GetSpan(cb1DataAddress, currentStage.Cb1DataSize).ToArray();
 
             ShaderDumpPaths pathsA = default;
             ShaderDumpPaths pathsB = default;
@@ -685,11 +685,11 @@ namespace Ryujinx.Graphics.Gpu.Shader
         {
             var memoryManager = channel.MemoryManager;
 
-            ulong cb1DataAddress = context.Stage == ShaderStage.Compute
+            (var physical, ulong cb1DataAddress) = context.Stage == ShaderStage.Compute
                 ? channel.BufferManager.GetComputeUniformBufferAddress(1)
                 : channel.BufferManager.GetGraphicsUniformBufferAddress(StageToStageIndex(context.Stage), 1);
 
-            byte[] cb1Data = memoryManager.Physical.GetSpan(cb1DataAddress, context.Cb1DataSize).ToArray();
+            byte[] cb1Data = physical.GetSpan(cb1DataAddress, context.Cb1DataSize).ToArray();
             code ??= memoryManager.GetSpan(context.Address, context.Size).ToArray();
 
             ShaderDumpPaths paths = dumper?.Dump(code, context.Stage == ShaderStage.Compute) ?? default;

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -650,8 +650,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
 
             codeA ??= memoryManager.GetSpan(vertexA.Address, vertexA.Size).ToArray();
             codeB ??= memoryManager.GetSpan(currentStage.Address, currentStage.Size).ToArray();
-            byte[] cb1DataA = physical.GetSpan(cb1DataAddress, vertexA.Cb1DataSize).ToArray();
-            byte[] cb1DataB = physical.GetSpan(cb1DataAddress, currentStage.Cb1DataSize).ToArray();
+            byte[] cb1DataA = Read(physical, cb1DataAddress, vertexA.Cb1DataSize);
+            byte[] cb1DataB = Read(physical, cb1DataAddress, currentStage.Cb1DataSize);
 
             ShaderDumpPaths pathsA = default;
             ShaderDumpPaths pathsB = default;
@@ -689,7 +689,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
                 ? channel.BufferManager.GetComputeUniformBufferAddress(1)
                 : channel.BufferManager.GetGraphicsUniformBufferAddress(StageToStageIndex(context.Stage), 1);
 
-            byte[] cb1Data = physical.GetSpan(cb1DataAddress, context.Cb1DataSize).ToArray();
+            byte[] cb1Data = Read(physical, cb1DataAddress, context.Cb1DataSize);
             code ??= memoryManager.GetSpan(context.Address, context.Size).ToArray();
 
             ShaderDumpPaths paths = dumper?.Dump(code, context.Stage == ShaderStage.Compute) ?? default;
@@ -698,6 +698,23 @@ namespace Ryujinx.Graphics.Gpu.Shader
             paths.Prepend(program);
 
             return new TranslatedShader(new CachedShaderStage(program.Info, code, cb1Data), program);
+        }
+
+        /// <summary>
+        /// Reads data from physical memory, if it exists.
+        /// </summary>
+        /// <param name="physicalMemory">Physical memory to read the data from, might be null</param>
+        /// <param name="address">Address to read the data from</param>
+        /// <param name="size">Size of the data to read</param>
+        /// <returns>An array with the data</returns>
+        private static byte[] Read(PhysicalMemory physicalMemory, ulong address, int size)
+        {
+            if (size == 0 || physicalMemory == null)
+            {
+                return Array.Empty<byte>();
+            }
+
+            return physicalMemory.GetSpan(address, size).ToArray();
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderSpecializationState.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderSpecializationState.cs
@@ -588,7 +588,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
             {
                 ref BufferBounds bounds = ref channel.BufferManager.GetUniformBufferBounds(isCompute, stageIndex, textureBufferIndex);
 
-                cachedTextureBuffer = MemoryMarshal.Cast<byte, int>(channel.MemoryManager.Physical.GetSpan(bounds.Address, (int)bounds.Size));
+                cachedTextureBuffer = MemoryMarshal.Cast<byte, int>(bounds.Physical.GetSpan(bounds.Address, (int)bounds.Size));
                 cachedTextureBufferIndex = textureBufferIndex;
 
                 if (samplerBufferIndex == textureBufferIndex)
@@ -602,7 +602,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
             {
                 ref BufferBounds bounds = ref channel.BufferManager.GetUniformBufferBounds(isCompute, stageIndex, samplerBufferIndex);
 
-                cachedSamplerBuffer = MemoryMarshal.Cast<byte, int>(channel.MemoryManager.Physical.GetSpan(bounds.Address, (int)bounds.Size));
+                cachedSamplerBuffer = MemoryMarshal.Cast<byte, int>(bounds.Physical.GetSpan(bounds.Address, (int)bounds.Size));
                 cachedSamplerBufferIndex = samplerBufferIndex;
             }
 


### PR DESCRIPTION
Those changes enable the GPU emulation to use GPU resources owned by a different address space. This allows sharing of GPU resources between multiple guest processes. A new `MapForeign` method was added that allows the PID of the process that owns the resource to be specified. It is currently unused, but I plan to use it in the future.

Testing is welcome to ensure there's no regressions.