### PR TITLE
Misc performance tweaks

### DIFF
--- a/ARMeilleure/CodeGen/Arm64/CodeGenContext.cs
+++ b/ARMeilleure/CodeGen/Arm64/CodeGenContext.cs
@@ -265,7 +265,7 @@ namespace ARMeilleure.CodeGen.Arm64
             }
             else
             {
-                relocInfo = new RelocInfo(new RelocEntry[0]);
+                relocInfo = new RelocInfo(Array.Empty<RelocEntry>());
             }
 
             return (code, relocInfo);

--- a/ARMeilleure/CodeGen/RegisterAllocators/LinearScanAllocator.cs
+++ b/ARMeilleure/CodeGen/RegisterAllocators/LinearScanAllocator.cs
@@ -433,16 +433,11 @@ namespace ARMeilleure.CodeGen.RegisterAllocators
 
         private static int GetHighestValueIndex(Span<int> span)
         {
-            int highest = span[0];
-
-            if (highest == int.MaxValue)
-            {
-                return 0;
-            }
+            int highest = int.MinValue;
 
             int selected = 0;
 
-            for (int index = 1; index < span.Length; index++)
+            for (int index = 0; index < span.Length; index++)
             {
                 int current = span[index];
 

--- a/ARMeilleure/Decoders/DecoderHelper.cs
+++ b/ARMeilleure/Decoders/DecoderHelper.cs
@@ -17,7 +17,7 @@ namespace ARMeilleure.Decoders
         {
             uint[] tbl = new uint[256];
 
-            for (int idx = 0; idx < 256; idx++)
+            for (int idx = 0; idx < tbl.Length; idx++)
             {
                 tbl[idx] = ExpandImm8ToFP32((uint)idx);
             }
@@ -29,7 +29,7 @@ namespace ARMeilleure.Decoders
         {
             ulong[] tbl = new ulong[256];
 
-            for (int idx = 0; idx < 256; idx++)
+            for (int idx = 0; idx < tbl.Length; idx++)
             {
                 tbl[idx] = ExpandImm8ToFP64((ulong)idx);
             }

--- a/ARMeilleure/Decoders/OpCodeTable.cs
+++ b/ARMeilleure/Decoders/OpCodeTable.cs
@@ -1301,7 +1301,7 @@ namespace ARMeilleure.Decoders
         {
             List<InstInfo>[] temp = new List<InstInfo>[FastLookupSize];
 
-            for (int index = 0; index < FastLookupSize; index++)
+            for (int index = 0; index < temp.Length; index++)
             {
                 temp[index] = new List<InstInfo>();
             }
@@ -1311,7 +1311,7 @@ namespace ARMeilleure.Decoders
                 int mask  = ToFastLookupIndex(inst.Mask);
                 int value = ToFastLookupIndex(inst.Value);
 
-                for (int index = 0; index < FastLookupSize; index++)
+                for (int index = 0; index < temp.Length; index++)
                 {
                     if ((index & mask) == value)
                     {
@@ -1320,7 +1320,7 @@ namespace ARMeilleure.Decoders
                 }
             }
 
-            for (int index = 0; index < FastLookupSize; index++)
+            for (int index = 0; index < temp.Length; index++)
             {
                 table[index] = temp[index].ToArray();
             }

--- a/Ryujinx.Audio/Common/AudioDeviceSession.cs
+++ b/Ryujinx.Audio/Common/AudioDeviceSession.cs
@@ -400,7 +400,9 @@ namespace Ryujinx.Audio.Common
         {
             uint bufferIndex = (_releasedBufferIndex - _bufferReleasedCount) % Constants.AudioDeviceBufferCountMax;
 
-            for (int i = 0; i < GetTotalBufferCount(); i++)
+            uint totalBufferCount = GetTotalBufferCount();
+
+            for (int i = 0; i < totalBufferCount; i++)
             {
                 if (_buffers[bufferIndex].BufferTag == bufferTag)
                 {

--- a/Ryujinx.Ava/UI/Windows/IconColorPicker.cs
+++ b/Ryujinx.Ava/UI/Windows/IconColorPicker.cs
@@ -125,7 +125,7 @@ namespace Ryujinx.Ava.UI.Windows
 
         public static Bgra32[] GetBuffer(Image<Bgra32> image)
         {
-            return image.TryGetSinglePixelSpan(out var data) ? data.ToArray() : new Bgra32[0];
+            return image.TryGetSinglePixelSpan(out var data) ? data.ToArray() : Array.Empty<Bgra32>();
         }
 
         private static int GetColorScore(Dictionary<int, int> dominantColorBin, int maxHitCount, PaletteColor color)

--- a/Ryujinx.Graphics.Vulkan/Queries/Counters.cs
+++ b/Ryujinx.Graphics.Vulkan/Queries/Counters.cs
@@ -17,7 +17,7 @@ namespace Ryujinx.Graphics.Vulkan.Queries
 
             _counterQueues = new CounterQueue[count];
 
-            for (int index = 0; index < count; index++)
+            for (int index = 0; index < _counterQueues.Length; index++)
             {
                 CounterType type = (CounterType)index;
                 _counterQueues[index] = new CounterQueue(gd, device, pipeline, type);

--- a/Ryujinx.Graphics.Vulkan/SpecInfo.cs
+++ b/Ryujinx.Graphics.Vulkan/SpecInfo.cs
@@ -29,7 +29,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             uint structSize = 0;
 
-            for (int i = 0; i < count; ++i)
+            for (int i = 0; i < Map.Length; ++i)
             {
                 var typeSize = SizeOf(description[i].Type);
                 Map[i] = new SpecializationMapEntry(description[i].Id, structSize, typeSize);
@@ -46,11 +46,10 @@ namespace Ryujinx.Graphics.Vulkan
         // For advanced mapping with overlapping or staggered fields
         public SpecDescription(SpecializationMapEntry[] map)
         {
-            int count = map.Length;
             Map = map;
 
             uint structSize = 0;
-            for (int i = 0; i < count; ++i)
+            for (int i = 0; i < map.Length; ++i)
             {
                 structSize = Math.Max(structSize, map[i].Offset + (uint)map[i].Size);
             }

--- a/Ryujinx.Graphics.Vulkan/Window.cs
+++ b/Ryujinx.Graphics.Vulkan/Window.cs
@@ -60,10 +60,9 @@ namespace Ryujinx.Graphics.Vulkan
         private void RecreateSwapchain()
         {
             var oldSwapchain = _swapchain;
-            int imageCount = _swapchainImageViews.Length;
             _vsyncModeChanged = false;
 
-            for (int i = 0; i < imageCount; i++)
+            for (int i = 0; i < _swapchainImageViews.Length; i++)
             {
                 _swapchainImageViews[i].Dispose();
             }
@@ -147,7 +146,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             _swapchainImageViews = new Auto<DisposableImageView>[imageCount];
 
-            for (int i = 0; i < imageCount; i++)
+            for (int i = 0; i < _swapchainImageViews.Length; i++)
             {
                 _swapchainImageViews[i] = CreateSwapchainImageView(_swapchainImages[i], surfaceFormat.Format);
             }

--- a/Ryujinx.HLE/HOS/Ipc/IpcHandleDesc.cs
+++ b/Ryujinx.HLE/HOS/Ipc/IpcHandleDesc.cs
@@ -49,12 +49,12 @@ namespace Ryujinx.HLE.HOS.Ipc
 
         public static IpcHandleDesc MakeCopy(params int[] handles)
         {
-            return new IpcHandleDesc(handles, new int[0]);
+            return new IpcHandleDesc(handles, Array.Empty<int>());
         }
 
         public static IpcHandleDesc MakeMove(params int[] handles)
         {
-            return new IpcHandleDesc(new int[0], handles);
+            return new IpcHandleDesc(Array.Empty<int>(), handles);
         }
 
         public byte[] GetBytes()

--- a/Ryujinx.HLE/HOS/Ipc/IpcMessage.cs
+++ b/Ryujinx.HLE/HOS/Ipc/IpcMessage.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -132,7 +133,7 @@ namespace Ryujinx.HLE.HOS.Ipc
                 word0 |= (ReceiveBuff.Count  & 0xf) << 24;
                 word0 |= (ExchangeBuff.Count & 0xf) << 28;
 
-                byte[] handleData = new byte[0];
+                byte[] handleData = Array.Empty<byte>();
 
                 if (HandleDesc != null)
                 {
@@ -202,7 +203,7 @@ namespace Ryujinx.HLE.HOS.Ipc
                 word0 |= (ReceiveBuff.Count & 0xf) << 24;
                 word0 |= (ExchangeBuff.Count & 0xf) << 28;
 
-                byte[] handleData = new byte[0];
+                byte[] handleData = Array.Empty<byte>();
 
                 if (HandleDesc != null)
                 {

--- a/Ryujinx.HLE/HOS/Kernel/Common/KTimeManager.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Common/KTimeManager.cs
@@ -152,6 +152,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Common
                 if (current.TimePoint < lowestTimePoint)
                 {
                     selected = current;
+                    lowestTimePoint = current.TimePoint;
                 }
             }
 

--- a/Ryujinx.HLE/HOS/Kernel/Common/KTimeManager.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Common/KTimeManager.cs
@@ -149,7 +149,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Common
             {
                 WaitingObject current = _waitingObjects[index];
 
-                if (current.TimePoint < lowestTimePoint)
+                if (current.TimePoint <= lowestTimePoint)
                 {
                     selected = current;
                     lowestTimePoint = current.TimePoint;

--- a/Ryujinx.HLE/HOS/Kernel/Common/KTimeManager.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Common/KTimeManager.cs
@@ -145,7 +145,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Common
             
             long lowestTimePoint = long.MaxValue;
 
-            for (int index = 0; index < _waitingObjects.Count; index++)
+            for (int index = _waitingObjects.Count - 1; index >= 0; index--)
             {
                 WaitingObject current = _waitingObjects[index];
 

--- a/Ryujinx.HLE/HOS/Kernel/Common/KTimeManager.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Common/KTimeManager.cs
@@ -1,7 +1,6 @@
 using Ryujinx.Common;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 
 namespace Ryujinx.HLE.HOS.Kernel.Common
@@ -86,7 +85,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Common
                     {
                         Interlocked.Exchange(ref _enforceWakeupFromSpinWait, 0);
 
-                        next = _waitingObjects.OrderBy(x => x.TimePoint).FirstOrDefault();
+                        next = GetNextWaitingObject();
                     }
 
                     if (next != null)
@@ -138,6 +137,25 @@ namespace Ryujinx.HLE.HOS.Kernel.Common
                     }
                 }
             }
+        }
+
+        private WaitingObject GetNextWaitingObject()
+        {
+            WaitingObject selected = null;
+            
+            long lowestTimePoint = long.MaxValue;
+
+            for (int index = 0; index < _waitingObjects.Count; index++)
+            {
+                WaitingObject current = _waitingObjects[index];
+
+                if (current.TimePoint < lowestTimePoint)
+                {
+                    selected = current;
+                }
+            }
+
+            return selected;
         }
 
         public static long ConvertNanosecondsToMilliseconds(long time)

--- a/Ryujinx.HLE/HOS/Services/Time/TimeZone/TimeZoneContentManager.cs
+++ b/Ryujinx.HLE/HOS/Services/Time/TimeZone/TimeZoneContentManager.cs
@@ -233,7 +233,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.TimeZone
                 // If the location name is too long, error out.
                 if (locationName.Length > 0x24)
                 {
-                    outLocationNameArray = new string[0];
+                    outLocationNameArray = Array.Empty<string>();
 
                     return ResultCode.LocationNameTooLong;
                 }

--- a/Ryujinx.Input.SDL2/SDL2GamepadDriver.cs
+++ b/Ryujinx.Input.SDL2/SDL2GamepadDriver.cs
@@ -27,7 +27,8 @@ namespace Ryujinx.Input.SDL2
             SDL2Driver.Instance.OnJoystickDisconnected += HandleJoyStickDisconnected;
 
             // Add already connected gamepads
-            for (int joystickIndex = 0; joystickIndex < SDL_NumJoysticks(); joystickIndex++)
+            int numJoysticks = SDL_NumJoysticks();
+            for (int joystickIndex = 0; joystickIndex < numJoysticks; joystickIndex++)
             {
                 HandleJoyStickConnected(joystickIndex, SDL_JoystickGetDeviceInstanceID(joystickIndex));
             }

--- a/Ryujinx.Input.SDL2/SDL2GamepadDriver.cs
+++ b/Ryujinx.Input.SDL2/SDL2GamepadDriver.cs
@@ -28,6 +28,7 @@ namespace Ryujinx.Input.SDL2
 
             // Add already connected gamepads
             int numJoysticks = SDL_NumJoysticks();
+
             for (int joystickIndex = 0; joystickIndex < numJoysticks; joystickIndex++)
             {
                 HandleJoyStickConnected(joystickIndex, SDL_JoystickGetDeviceInstanceID(joystickIndex));

--- a/Ryujinx.Memory.Tests/MockVirtualMemoryManager.cs
+++ b/Ryujinx.Memory.Tests/MockVirtualMemoryManager.cs
@@ -78,7 +78,7 @@ namespace Ryujinx.Memory.Tests
 
         IEnumerable<MemoryRange> IVirtualMemoryManager.GetPhysicalRegions(ulong va, ulong size)
         {
-            return NoMappings ? new MemoryRange[0] : new MemoryRange[] { new MemoryRange(va, size) };
+            return NoMappings ? Array.Empty<MemoryRange>() : new MemoryRange[] { new MemoryRange(va, size) };
         }
 
         public bool IsMapped(ulong va)


### PR DESCRIPTION
Miscellaneous performance tweaks:
- remove the use of LINQ in a hot path
- use `Array.Empty<T>()` to avoid allocating 0-byte arrays
- adjust some for loops so that the JIT will elide bounds checking