### PR TITLE
GPU: Fast path for adding one texture view to a group

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -354,7 +354,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             texture._viewStorage = this;
 
-            Group.UpdateViews(_views);
+            Group.UpdateViews(_views, texture);
 
             if (texture.Group != null && texture.Group != Group)
             {
@@ -377,6 +377,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         private void RemoveView(Texture texture)
         {
             _views.Remove(texture);
+
+            Group.RemoveView(texture);
 
             texture._viewStorage = texture;
 

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -926,7 +926,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// Update the views in this texture group, rebuilding the memory tracking if required.
         /// </summary>
         /// <param name="views">The views list of the storage texture</param>
-        public void UpdateViews(List<Texture> views)
+        /// <param name="texture">The texture that has been added, if that is the only change, otherwise null</param>
+        public void UpdateViews(List<Texture> views, Texture texture)
         {
             // This is saved to calculate overlapping views for each handle.
             _views = views;
@@ -964,15 +965,42 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             if (!regionsRebuilt)
             {
-                // Must update the overlapping views on all handles, but only if they were not just recreated.
-
-                foreach (TextureGroupHandle handle in _handles)
+                if (texture != null)
                 {
-                    handle.RecalculateOverlaps(this, views);
+                    int offset = FindOffset(texture);
+
+                    foreach (TextureGroupHandle handle in _handles)
+                    {
+                        handle.AddOverlap(offset, texture);
+                    }
+                }
+                else
+                {
+                    // Must update the overlapping views on all handles, but only if they were not just recreated.
+
+                    foreach (TextureGroupHandle handle in _handles)
+                    {
+                        handle.RecalculateOverlaps(this, views);
+                    }
                 }
             }
 
             SignalAllDirty();
+        }
+
+
+        /// <summary>
+        /// Removes a view from the group, removing it from all overlap lists.
+        /// </summary>
+        /// <param name="view">View to remove from the group</param>
+        public void RemoveView(Texture view)
+        {
+            int offset = FindOffset(view);
+
+            foreach (TextureGroupHandle handle in _handles)
+            {
+                handle.RemoveOverlap(offset, view);
+            }
         }
 
         /// <summary>

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
@@ -168,9 +168,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             // Overlaps can be accessed from the memory tracking signal handler, so access must be atomic.
 
-            int endOffset = Offset + Size;
-
-            if (offset < endOffset && Offset < offset + (int)view.Size)
+            if (OverlapsWith(offset, (int)view.Size))
             {
                 lock (Overlaps)
                 {
@@ -188,9 +186,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             // Overlaps can be accessed from the memory tracking signal handler, so access must be atomic.
 
-            int endOffset = Offset + Size;
-
-            if (offset < endOffset && Offset < offset + (int)view.Size)
+            if (OverlapsWith(offset, (int)view.Size))
             {
                 lock (Overlaps)
                 {

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroupHandle.cs
@@ -160,6 +160,46 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
+        /// Adds a single texture view as an overlap if its range overlaps.
+        /// </summary>
+        /// <param name="offset">The offset of the view in the group</param>
+        /// <param name="view">The texture to add as an overlap</param>
+        public void AddOverlap(int offset, Texture view)
+        {
+            // Overlaps can be accessed from the memory tracking signal handler, so access must be atomic.
+
+            int endOffset = Offset + Size;
+
+            if (offset < endOffset && Offset < offset + (int)view.Size)
+            {
+                lock (Overlaps)
+                {
+                    Overlaps.Add(view);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Removes a single texture view as an overlap if its range overlaps.
+        /// </summary>
+        /// <param name="offset">The offset of the view in the group</param>
+        /// <param name="view">The texture to add as an overlap</param>
+        public void RemoveOverlap(int offset, Texture view)
+        {
+            // Overlaps can be accessed from the memory tracking signal handler, so access must be atomic.
+
+            int endOffset = Offset + Size;
+
+            if (offset < endOffset && Offset < offset + (int)view.Size)
+            {
+                lock (Overlaps)
+                {
+                    Overlaps.Remove(view);
+                }
+            }
+        }
+
+        /// <summary>
         /// Registers a sync action to happen for this handle, and an interim flush action on the tracking handle.
         /// </summary>
         /// <param name="context">The GPU context to register a sync action on</param>


### PR DESCRIPTION
Texture group handles must store a list of their overlapping views, so they can be properly notified when a write is detected, and a few other things relating to texture readback. This is generally created when the group is established, with each handle looping over all views to find its overlaps. This whole process was also done when only a single view was added (and no handles were changed), however...

Sonic Frontiers had a huge cubemap array with 7350 faces (175 cubemaps * 6 faces * 7 levels), so iterating over both handles and existing views when adding a new one added up very fast (potentially 50 million iterations to add the final views). Since we are only adding a single view, we only need to _add_ that view to the existing overlaps, rather than recalculate them all.

This greatly improves performance during loading screens and a few seconds into gameplay on the "open zone" sections of Sonic Frontiers and its demo. May improve loading times or stutters on some other games.

Note that the current texture cache rules will cause these views to fall out of the cache, as there are more than the hard cap, so the cost will be repaid when reloading the open zone.

I also added some code to properly remove overlaps when texture views are removed, since it seems that was missing.

This can be improved further by only iterating handles that overlap the view (filter by range), but so can a few places in TextureGroup, so better to do all at once. The full generation of overlaps could probably be improved in a similar way.

I recommend testing a few games to make sure nothing breaks.