### PR TITLE
Update syscall capabilites to include SVCs from FW 15.0.0

### DIFF
--- a/Ryujinx.HLE/HOS/Horizon.cs
+++ b/Ryujinx.HLE/HOS/Horizon.cs
@@ -338,7 +338,7 @@ namespace Ryujinx.HLE.HOS
 
                 ProcessCreationInfo creationInfo = new ProcessCreationInfo("Service", 1, 0, 0x8000000, 1, flags, 0, 0);
 
-                int[] defaultCapabilities = new int[]
+                uint[] defaultCapabilities = new uint[]
                 {
                     0x030363F7,
                     0x1FFFFFCF,

--- a/Ryujinx.HLE/HOS/Kernel/KernelConstants.cs
+++ b/Ryujinx.HLE/HOS/Kernel/KernelConstants.cs
@@ -7,6 +7,8 @@ namespace Ryujinx.HLE.HOS.Kernel
         public const int InitialKipId = 1;
         public const int InitialProcessId = 0x51;
 
+        public const int SupervisorCallCount = 0xC0;
+
         public const int MemoryBlockAllocatorSize = 0x2710;
 
         public const ulong UserSlabHeapBase = DramMemoryMap.SlabHeapBase;

--- a/Ryujinx.HLE/HOS/Kernel/KernelStatic.cs
+++ b/Ryujinx.HLE/HOS/Kernel/KernelStatic.cs
@@ -18,7 +18,7 @@ namespace Ryujinx.HLE.HOS.Kernel
         public static Result StartInitialProcess(
             KernelContext context,
             ProcessCreationInfo creationInfo,
-            ReadOnlySpan<int> capabilities,
+            ReadOnlySpan<uint> capabilities,
             int mainThreadPriority,
             ThreadStart customThreadStart)
         {

--- a/Ryujinx.HLE/HOS/Kernel/Process/CapabilityExtensions.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/CapabilityExtensions.cs
@@ -1,0 +1,22 @@
+using System.Numerics;
+
+namespace Ryujinx.HLE.HOS.Kernel.Process
+{
+    static class CapabilityExtensions
+    {
+        public static CapabilityType GetCapabilityType(this uint cap)
+        {
+            return (CapabilityType)(((cap + 1) & ~cap) - 1);
+        }
+
+        public static uint GetFlag(this CapabilityType type)
+        {
+            return (uint)type + 1;
+        }
+
+        public static uint GetId(this CapabilityType type)
+        {
+            return (uint)BitOperations.TrailingZeroCount(type.GetFlag());
+        }
+    }
+}

--- a/Ryujinx.HLE/HOS/Kernel/Process/CapabilityType.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/CapabilityType.cs
@@ -1,0 +1,19 @@
+namespace Ryujinx.HLE.HOS.Kernel.Process
+{
+    enum CapabilityType : uint
+    {
+        CorePriority  = (1u <<  3),
+        SyscallMask   = (1u <<  4),
+        MapRange      = (1u <<  6),
+        MapIoPage     = (1u <<  7),
+        MapRegion     = (1u << 10),
+        InterruptPair = (1u << 11),
+        ProgramType   = (1u << 13),
+        KernelVersion = (1u << 14),
+        HandleTable   = (1u << 15),
+        DebugFlags    = (1u << 16),
+
+        Invalid       = 0u,
+        Padding       = ~0u
+    }
+}

--- a/Ryujinx.HLE/HOS/Kernel/Process/CapabilityType.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/CapabilityType.cs
@@ -2,16 +2,16 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 {
     enum CapabilityType : uint
     {
-        CorePriority  = (1u <<  3),
-        SyscallMask   = (1u <<  4),
-        MapRange      = (1u <<  6),
-        MapIoPage     = (1u <<  7),
-        MapRegion     = (1u << 10),
-        InterruptPair = (1u << 11),
-        ProgramType   = (1u << 13),
-        KernelVersion = (1u << 14),
-        HandleTable   = (1u << 15),
-        DebugFlags    = (1u << 16),
+        CorePriority  = (1u <<  3) - 1,
+        SyscallMask   = (1u <<  4) - 1,
+        MapRange      = (1u <<  6) - 1,
+        MapIoPage     = (1u <<  7) - 1,
+        MapRegion     = (1u << 10) - 1,
+        InterruptPair = (1u << 11) - 1,
+        ProgramType   = (1u << 13) - 1,
+        KernelVersion = (1u << 14) - 1,
+        HandleTable   = (1u << 15) - 1,
+        DebugFlags    = (1u << 16) - 1,
 
         Invalid       = 0u,
         Padding       = ~0u

--- a/Ryujinx.HLE/HOS/Kernel/Process/KHandleTable.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/KHandleTable.cs
@@ -19,7 +19,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
         private int _activeSlotsCount;
 
-        private int _size;
+        private uint _size;
 
         private ushort _idCounter;
 
@@ -28,9 +28,9 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
             _context = context;
         }
 
-        public Result Initialize(int size)
+        public Result Initialize(uint size)
         {
-            if ((uint)size > 1024)
+            if (size > 1024)
             {
                 return KernelResult.OutOfMemory;
             }

--- a/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
@@ -16,11 +16,11 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 {
     class KProcess : KSynchronizationObject
     {
-        public const int KernelVersionMajor = 10;
-        public const int KernelVersionMinor = 4;
-        public const int KernelVersionRevision = 0;
+        public const uint KernelVersionMajor = 10;
+        public const uint KernelVersionMinor = 4;
+        public const uint KernelVersionRevision = 0;
 
-        public const int KernelVersionPacked =
+        public const uint KernelVersionPacked =
             (KernelVersionMajor << 19) |
             (KernelVersionMinor << 15) |
             (KernelVersionRevision << 0);
@@ -119,7 +119,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
         public Result InitializeKip(
             ProcessCreationInfo creationInfo,
-            ReadOnlySpan<int> capabilities,
+            ReadOnlySpan<uint> capabilities,
             KPageList pageList,
             KResourceLimit resourceLimit,
             MemoryRegion memRegion,
@@ -190,7 +190,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
         public Result Initialize(
             ProcessCreationInfo creationInfo,
-            ReadOnlySpan<int> capabilities,
+            ReadOnlySpan<uint> capabilities,
             KResourceLimit resourceLimit,
             MemoryRegion memRegion,
             IProcessContextFactory contextFactory,

--- a/Ryujinx.HLE/HOS/Kernel/Process/KProcessCapabilities.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/KProcessCapabilities.cs
@@ -8,8 +8,8 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 {
     class KProcessCapabilities
     {
-        public byte[] SvcAccessMask { get; private set; }
-        public byte[] IrqAccessMask { get; private set; }
+        public byte[] SvcAccessMask { get; }
+        public byte[] IrqAccessMask { get; }
 
         public ulong AllowedCpuCoresMask    { get; private set; }
         public ulong AllowedThreadPriosMask { get; private set; }
@@ -226,6 +226,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
                 case CapabilityType.MapRegion:
                 {
                     // TODO: Implement capabilities for MapRegion
+
                     break;
                 }
 

--- a/Ryujinx.HLE/HOS/Kernel/Process/KProcessCapabilities.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/KProcessCapabilities.cs
@@ -120,13 +120,13 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
         private Result ParseCapability(int cap, ref int mask0, ref int mask1, KPageTableBase memoryManager)
         {
-            int code = (cap + 1) & ~cap;
+            CapabilityType code = (CapabilityType)((cap + 1) & ~cap);
 
-            if (code == 1)
+            if (code == CapabilityType.Invalid)
             {
                 return KernelResult.InvalidCapability;
             }
-            else if (code == 0)
+            else if (code == CapabilityType.Padding)
             {
                 return Result.Success;
             }
@@ -143,7 +143,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
             switch (code)
             {
-                case 8:
+                case CapabilityType.CorePriority:
                 {
                     if (AllowedCpuCoresMask != 0 || AllowedThreadPriosMask != 0)
                     {
@@ -177,7 +177,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
                     break;
                 }
 
-                case 0x10:
+                case CapabilityType.SyscallMask:
                 {
                     int slot = (cap >> 29) & 7;
 
@@ -214,7 +214,13 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
                     break;
                 }
 
-                case 0x80:
+                case CapabilityType.MapRange:
+                {
+                    // TODO: Implement capabilities for MapRange
+                    break;
+                }
+
+                case CapabilityType.MapIoPage:
                 {
                     long address = ((long)(uint)cap << 4) & 0xffffff000;
 
@@ -223,7 +229,13 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
                     break;
                 }
 
-                case 0x800:
+                case CapabilityType.MapRegion:
+                {
+                    // TODO: Implement capabilities for MapRegion
+                    break;
+                }
+
+                case CapabilityType.InterruptPair:
                 {
                     // TODO: GIC distributor check.
                     int irq0 = (cap >> 12) & 0x3ff;
@@ -242,7 +254,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
                     break;
                 }
 
-                case 0x2000:
+                case CapabilityType.ProgramType:
                 {
                     int applicationType = cap >> 14;
 
@@ -256,7 +268,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
                     break;
                 }
 
-                case 0x4000:
+                case CapabilityType.KernelVersion:
                 {
                     // Note: This check is bugged on kernel too, we are just replicating the bug here.
                     if ((KernelReleaseVersion >> 17) != 0 || cap < 0x80000)
@@ -269,7 +281,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
                     break;
                 }
 
-                case 0x8000:
+                case CapabilityType.HandleTable:
                 {
                     int handleTableSize = cap >> 26;
 
@@ -283,7 +295,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
                     break;
                 }
 
-                case 0x10000:
+                case CapabilityType.DebugFlags:
                 {
                     int debuggingFlags = cap >> 19;
 

--- a/Ryujinx.HLE/HOS/Kernel/Process/KProcessCapabilities.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/KProcessCapabilities.cs
@@ -22,7 +22,8 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
         public KProcessCapabilities()
         {
-            SvcAccessMask = new byte[0x10];
+            // length / number of bits of the underlying type
+            SvcAccessMask = new byte[KernelConstants.SupervisorCallCount / 8];
             IrqAccessMask = new byte[0x80];
         }
 
@@ -203,7 +204,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
                         int svcId = baseSvc + index;
 
-                        if (svcId > 0x7f)
+                        if (svcId >= KernelConstants.SupervisorCallCount)
                         {
                             return KernelResult.MaximumExceeded;
                         }

--- a/Ryujinx.HLE/HOS/Kernel/Process/ProcessCreationFlags.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Process/ProcessCreationFlags.cs
@@ -1,5 +1,8 @@
-﻿namespace Ryujinx.HLE.HOS.Kernel.Process
+﻿using System;
+
+namespace Ryujinx.HLE.HOS.Kernel.Process
 {
+    [Flags]
     enum ProcessCreationFlags
     {
         Is64Bit = 1 << 0,

--- a/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
+++ b/Ryujinx.HLE/HOS/Kernel/SupervisorCall/Syscall.cs
@@ -54,7 +54,7 @@ namespace Ryujinx.HLE.HOS.Kernel.SupervisorCall
         public Result CreateProcess(
             out int handle,
             ProcessCreationInfo info,
-            ReadOnlySpan<int> capabilities,
+            ReadOnlySpan<uint> capabilities,
             IProcessContextFactory contextFactory,
             ThreadStart customThreadStart = null)
         {

--- a/Ryujinx.HLE/HOS/ProgramLoader.cs
+++ b/Ryujinx.HLE/HOS/ProgramLoader.cs
@@ -318,7 +318,7 @@ namespace Ryujinx.HLE.HOS
 
             result = process.Initialize(
                 creationInfo,
-                MemoryMarshal.Cast<byte, int>(npdm.KernelCapabilityData).ToArray(),
+                MemoryMarshal.Cast<byte, uint>(npdm.KernelCapabilityData).ToArray(),
                 resourceLimit,
                 memoryRegion,
                 processContextFactory);

--- a/Ryujinx.HLE/HOS/ProgramLoader.cs
+++ b/Ryujinx.HLE/HOS/ProgramLoader.cs
@@ -80,7 +80,7 @@ namespace Ryujinx.HLE.HOS
 
             ulong codeBaseAddress = kip.Is64BitAddressSpace ? 0x8000000UL : 0x200000UL;
 
-            ulong codeAddress = codeBaseAddress + (ulong)kip.TextOffset;
+            ulong codeAddress = codeBaseAddress + kip.TextOffset;
 
             ProcessCreationFlags flags = 0;
 
@@ -231,13 +231,13 @@ namespace Ryujinx.HLE.HOS
 
                 nsoSize = BitUtils.AlignUp<uint>(nsoSize, KPageTableBase.PageSize);
 
-                nsoBase[index] = codeStart + (ulong)codeSize;
+                nsoBase[index] = codeStart + codeSize;
 
                 codeSize += nsoSize;
 
                 if (arguments != null && argsSize == 0)
                 {
-                    argsStart = (ulong)codeSize;
+                    argsStart = codeSize;
 
                     argsSize = (uint)BitUtils.AlignDown(arguments.Length * 2 + ArgsTotalSize - 1, KPageTableBase.PageSize);
 
@@ -318,7 +318,7 @@ namespace Ryujinx.HLE.HOS
 
             result = process.Initialize(
                 creationInfo,
-                MemoryMarshal.Cast<byte, uint>(npdm.KernelCapabilityData).ToArray(),
+                MemoryMarshal.Cast<byte, uint>(npdm.KernelCapabilityData),
                 resourceLimit,
                 memoryRegion,
                 processContextFactory);

--- a/Ryujinx.HLE/HOS/Services/ServerBase.cs
+++ b/Ryujinx.HLE/HOS/Services/ServerBase.cs
@@ -19,7 +19,7 @@ namespace Ryujinx.HLE.HOS.Services
         // not large enough.
         private const int PointerBufferSize = 0x8000;
 
-        private readonly static int[] DefaultCapabilities = new int[]
+        private readonly static uint[] DefaultCapabilities = new uint[]
         {
             0x030363F7,
             0x1FFFFFCF,

--- a/Ryujinx.HLE/Loaders/Executables/KipExecutable.cs
+++ b/Ryujinx.HLE/Loaders/Executables/KipExecutable.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.HLE.Loaders.Executables
         public uint DataSize { get; }
         public uint BssSize  { get; }
 
-        public int[] Capabilities       { get; }
+        public uint[] Capabilities      { get; }
         public bool UsesSecureMemory    { get; }
         public bool Is64BitAddressSpace { get; }
         public bool Is64Bit             { get; }
@@ -57,11 +57,11 @@ namespace Ryujinx.HLE.Loaders.Executables
             Version     = reader.Version;
             Name        = reader.Name.ToString();
 
-            Capabilities = new int[32];
+            Capabilities = new uint[32];
 
             for (int index = 0; index < Capabilities.Length; index++)
             {
-                Capabilities[index] = (int)reader.Capabilities[index];
+                Capabilities[index] = reader.Capabilities[index];
             }
 
             reader.GetSegmentSize(KipReader.SegmentType.Data, out int uncompressedSize).ThrowIfFailure();


### PR DESCRIPTION
This PR introduces a new KernelConstant `SupervisorCallCount` which gets used to make sure we are not setting SVCs that are out of range.

Since the amount of SVCs increased with firmware version 15.0.0, I also increased the size of `SvcAccessMask` to make room for them.

Additionally an enum (`CapabilityType`) was introduced along with some common operations in `CapabilityExtensions` to make the code a little bit more readable.

As a result of this PR the homebrew menu (using `hbl.nsp`) can now be launched again!

---

~~I'm planning on adding the logic for `MapRegion` capabilities, which is why this PR is currently marked as a draft.~~
Nvm, it seems `MapRegion` is mostly unused and is probably not worth the effort required to support it for now.
If you still want me to add it before accepting this PR feel free to tell me.