### PR TITLE
Increase access permissions for AvaloniaList<Timezone>

### DIFF
--- a/Ryujinx.Ava/UI/ViewModels/SettingsViewModel.cs
+++ b/Ryujinx.Ava/UI/ViewModels/SettingsViewModel.cs
@@ -236,7 +236,7 @@ namespace Ryujinx.Ava.UI.ViewModels
 
         public DateTimeOffset DateOffset { get; set; }
         public TimeSpan TimeOffset { get; set; }
-        private AvaloniaList<TimeZone> TimeZones { get; set; }
+        internal AvaloniaList<TimeZone> TimeZones { get; set; }
         public AvaloniaList<string> GameDirectories { get; set; }
         public ObservableCollection<ComboBoxItem> AvailableGpus { get; set; }
 


### PR DESCRIPTION
Fixes a regression from https://github.com/Ryujinx/Ryujinx/pull/4177 where the window couldn't access the timezone list in the ViewModel.

![image](https://user-images.githubusercontent.com/44103205/224543503-54c20b64-2c17-42a3-9ce7-0c2dadcf00e7.png)
