### PR TITLE
Eliminate boxing allocations caused by ISampledData structs

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Common/AtomicStorage.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Common/AtomicStorage.cs
@@ -2,7 +2,7 @@
 
 namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Common
 {
-    struct AtomicStorage<T> where T: unmanaged
+    struct AtomicStorage<T> where T: unmanaged, ISampledDataStruct
     {
         public ulong SamplingNumber;
         public T Object;
@@ -14,9 +14,9 @@ namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Common
 
         public void SetObject(ref T obj)
         {
-            ISampledData samplingProvider = obj as ISampledData;
+            ulong samplingNumber = ISampledDataStruct.GetSamplingNumber(ref obj);
 
-            Interlocked.Exchange(ref SamplingNumber, samplingProvider.SamplingNumber);
+            Interlocked.Exchange(ref SamplingNumber, samplingNumber);
 
             Thread.MemoryBarrier();
 

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Common/ISampledData.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Common/ISampledData.cs
@@ -1,7 +1,0 @@
-﻿namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Common
-{
-    interface ISampledData
-    {
-        ulong SamplingNumber { get; }
-    }
-}

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Common/ISampledDataStruct.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Common/ISampledDataStruct.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Buffers.Binary;
+using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Common
+{
+    /// <summary>
+    /// This is a "marker interface" to add some compile-time safety to a convention-based optimization.
+    /// Any struct implementing this interface must use its first 8 bytes as a "Sampling Number".
+    /// This is most often accomplished by using <c>StructLayoutAttribute</c> and careful member ordering,
+    /// such that the first member is a <c>ulong</c> (.NET type: <c>System.UInt64</c>) field.
+    /// 
+    /// Example:
+    /// 
+    /// <c>
+    ///         [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    ///         struct DebugPadState : ISampledDataStruct
+    ///         {
+    ///             public ulong SamplingNumber;
+    ///             
+    ///             // other members...
+    ///         }
+    /// </c>
+    /// </summary>
+    internal interface ISampledDataStruct
+    {
+        // No Instance Members - marker interface only
+
+        public static ulong GetSamplingNumber<T>(ref T sampledDataStruct) where T : unmanaged, ISampledDataStruct
+        {
+            ReadOnlySpan<T> structSpan = MemoryMarshal.CreateReadOnlySpan(ref sampledDataStruct, 1);
+
+            ReadOnlySpan<byte> byteSpan = MemoryMarshal.Cast<T, byte>(structSpan);
+
+            ulong value = BitConverter.IsLittleEndian
+                ? BinaryPrimitives.ReadUInt64LittleEndian(byteSpan)
+                : BinaryPrimitives.ReadUInt64BigEndian(byteSpan);
+
+            return value;
+        }
+    }
+}

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Common/ISampledDataStruct.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Common/ISampledDataStruct.cs
@@ -32,9 +32,7 @@ namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Common
 
             ReadOnlySpan<byte> byteSpan = MemoryMarshal.Cast<T, byte>(structSpan);
 
-            ulong value = BitConverter.IsLittleEndian
-                ? BinaryPrimitives.ReadUInt64LittleEndian(byteSpan)
-                : BinaryPrimitives.ReadUInt64BigEndian(byteSpan);
+            ulong value = BinaryPrimitives.ReadUInt64LittleEndian(byteSpan);
 
             return value;
         }

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Common/RingLifo.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Common/RingLifo.cs
@@ -5,7 +5,7 @@ using System.Threading;
 
 namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Common
 {
-    struct RingLifo<T> where T: unmanaged
+    struct RingLifo<T> where T: unmanaged, ISampledDataStruct
     {
         private const ulong MaxEntries = 17;
 

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/DebugPad/DebugPadState.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/DebugPad/DebugPadState.cs
@@ -3,12 +3,10 @@ using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.DebugPad
 {
-    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    [StructLayout(LayoutKind.Sequential, Pack = 8)]
     struct DebugPadState : ISampledDataStruct
     {
-        // MUST BE THE 1st MEMBER
         public ulong SamplingNumber;
-
         public DebugPadAttribute Attributes;
         public DebugPadButton Buttons;
         public AnalogStickState AnalogStickR;

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/DebugPad/DebugPadState.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/DebugPad/DebugPadState.cs
@@ -1,15 +1,17 @@
 ﻿using Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Common;
+using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.DebugPad
 {
-    struct DebugPadState : ISampledData
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    struct DebugPadState : ISampledDataStruct
     {
+        // MUST BE THE 1st MEMBER
         public ulong SamplingNumber;
+
         public DebugPadAttribute Attributes;
         public DebugPadButton Buttons;
         public AnalogStickState AnalogStickR;
         public AnalogStickState AnalogStickL;
-
-        ulong ISampledData.SamplingNumber => SamplingNumber;
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/DebugPad/DebugPadState.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/DebugPad/DebugPadState.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.DebugPad
 {
-    [StructLayout(LayoutKind.Sequential, Pack = 8)]
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
     struct DebugPadState : ISampledDataStruct
     {
         public ulong SamplingNumber;

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Keyboard/KeyboardModifier.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Keyboard/KeyboardModifier.cs
@@ -2,9 +2,8 @@
 
 namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Keyboard
 {
-    // TODO: This seems entirely wrong
     [Flags]
-    enum KeyboardModifier : uint
+    enum KeyboardModifier : ulong
     {
         None = 0,
         Control = 1 << 0,

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Keyboard/KeyboardState.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Keyboard/KeyboardState.cs
@@ -8,7 +8,6 @@ namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Keyboard
     {
         public ulong SamplingNumber;
         public KeyboardModifier Modifiers;
-        public uint Unknown;
         public KeyboardKey Keys;
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Keyboard/KeyboardState.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Keyboard/KeyboardState.cs
@@ -3,12 +3,10 @@ using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Keyboard
 {
-    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    [StructLayout(LayoutKind.Sequential, Pack = 8)]
     struct KeyboardState : ISampledDataStruct
     {
-        // MUST BE THE 1st MEMBER
         public ulong SamplingNumber;
-
         public KeyboardModifier Modifiers;
         public KeyboardKey Keys;
     }

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Keyboard/KeyboardState.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Keyboard/KeyboardState.cs
@@ -3,11 +3,12 @@ using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Keyboard
 {
-    [StructLayout(LayoutKind.Sequential, Pack = 8)]
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
     struct KeyboardState : ISampledDataStruct
     {
         public ulong SamplingNumber;
         public KeyboardModifier Modifiers;
+        public uint Unknown;
         public KeyboardKey Keys;
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Keyboard/KeyboardState.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Keyboard/KeyboardState.cs
@@ -1,13 +1,15 @@
 ﻿using Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Common;
+using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Keyboard
 {
-    struct KeyboardState : ISampledData
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    struct KeyboardState : ISampledDataStruct
     {
+        // MUST BE THE 1st MEMBER
         public ulong SamplingNumber;
+
         public KeyboardModifier Modifiers;
         public KeyboardKey Keys;
-
-        ulong ISampledData.SamplingNumber => SamplingNumber;
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Mouse/MouseState.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Mouse/MouseState.cs
@@ -3,12 +3,10 @@ using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Mouse
 {
-    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    [StructLayout(LayoutKind.Sequential, Pack = 8)]
     struct MouseState : ISampledDataStruct
     {
-        // MUST BE THE 1st MEMBER
         public ulong SamplingNumber;
-
         public int X;
         public int Y;
         public int DeltaX;

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Mouse/MouseState.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Mouse/MouseState.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Mouse
 {
-    [StructLayout(LayoutKind.Sequential, Pack = 8)]
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
     struct MouseState : ISampledDataStruct
     {
         public ulong SamplingNumber;

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Mouse/MouseState.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Mouse/MouseState.cs
@@ -1,10 +1,14 @@
 ﻿using Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Common;
+using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Mouse
 {
-    struct MouseState : ISampledData
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    struct MouseState : ISampledDataStruct
     {
+        // MUST BE THE 1st MEMBER
         public ulong SamplingNumber;
+
         public int X;
         public int Y;
         public int DeltaX;
@@ -13,7 +17,5 @@ namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Mouse
         public int WheelDeltaY;
         public MouseButton Buttons;
         public MouseAttribute Attributes;
-
-        ulong ISampledData.SamplingNumber => SamplingNumber;
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Npad/NpadCommonState.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Npad/NpadCommonState.cs
@@ -1,16 +1,18 @@
 ﻿using Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Common;
+using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Npad
 {
-    struct NpadCommonState : ISampledData
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    struct NpadCommonState : ISampledDataStruct
     {
+        // MUST BE THE 1st MEMBER
         public ulong SamplingNumber;
+
         public NpadButton Buttons;
         public AnalogStickState AnalogStickL;
         public AnalogStickState AnalogStickR;
         public NpadAttribute Attributes;
         private uint _reserved;
-
-        ulong ISampledData.SamplingNumber => SamplingNumber;
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Npad/NpadCommonState.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Npad/NpadCommonState.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Npad
 {
-    [StructLayout(LayoutKind.Sequential, Pack = 8)]
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
     struct NpadCommonState : ISampledDataStruct
     {
         public ulong SamplingNumber;

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Npad/NpadCommonState.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Npad/NpadCommonState.cs
@@ -3,12 +3,10 @@ using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Npad
 {
-    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    [StructLayout(LayoutKind.Sequential, Pack = 8)]
     struct NpadCommonState : ISampledDataStruct
     {
-        // MUST BE THE 1st MEMBER
         public ulong SamplingNumber;
-
         public NpadButton Buttons;
         public AnalogStickState AnalogStickL;
         public AnalogStickState AnalogStickR;

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Npad/NpadGcTriggerState.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Npad/NpadGcTriggerState.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Npad
 {
-    [StructLayout(LayoutKind.Sequential, Pack = 8)]
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
     struct NpadGcTriggerState : ISampledDataStruct
     {
 #pragma warning disable CS0649

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Npad/NpadGcTriggerState.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Npad/NpadGcTriggerState.cs
@@ -1,15 +1,17 @@
 ﻿using Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Common;
+using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Npad
 {
-    struct NpadGcTriggerState : ISampledData
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    struct NpadGcTriggerState : ISampledDataStruct
     {
 #pragma warning disable CS0649
+        // MUST BE THE 1st MEMBER
         public ulong SamplingNumber;
+
         public uint TriggerL;
         public uint TriggerR;
 #pragma warning restore CS0649
-
-        ulong ISampledData.SamplingNumber => SamplingNumber;
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Npad/NpadGcTriggerState.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Npad/NpadGcTriggerState.cs
@@ -3,13 +3,11 @@ using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Npad
 {
-    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    [StructLayout(LayoutKind.Sequential, Pack = 8)]
     struct NpadGcTriggerState : ISampledDataStruct
     {
 #pragma warning disable CS0649
-        // MUST BE THE 1st MEMBER
         public ulong SamplingNumber;
-
         public uint TriggerL;
         public uint TriggerR;
 #pragma warning restore CS0649

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Npad/SixAxisSensorState.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Npad/SixAxisSensorState.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Npad
 {
-    [StructLayout(LayoutKind.Sequential, Pack = 8)]
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
     struct SixAxisSensorState : ISampledDataStruct
     {
         public ulong DeltaTime;

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Npad/SixAxisSensorState.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Npad/SixAxisSensorState.cs
@@ -1,19 +1,21 @@
 ﻿using Ryujinx.Common.Memory;
 using Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Common;
+using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Npad
 {
-    struct SixAxisSensorState : ISampledData
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    struct SixAxisSensorState : ISampledDataStruct
     {
-        public ulong DeltaTime;
+        // MUST BE THE 1st MEMBER
         public ulong SamplingNumber;
+
+        public ulong DeltaTime;
         public HidVector Acceleration;
         public HidVector AngularVelocity;
         public HidVector Angle;
         public Array9<float> Direction;
         public SixAxisSensorAttribute Attributes;
         private uint _reserved;
-
-        ulong ISampledData.SamplingNumber => SamplingNumber;
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Npad/SixAxisSensorState.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Npad/SixAxisSensorState.cs
@@ -4,13 +4,11 @@ using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Npad
 {
-    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    [StructLayout(LayoutKind.Sequential, Pack = 8)]
     struct SixAxisSensorState : ISampledDataStruct
     {
-        // MUST BE THE 1st MEMBER
-        public ulong SamplingNumber;
-
         public ulong DeltaTime;
+        public ulong SamplingNumber;
         public HidVector Acceleration;
         public HidVector AngularVelocity;
         public HidVector Angle;

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/TouchScreen/TouchScreenState.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/TouchScreen/TouchScreenState.cs
@@ -4,12 +4,10 @@ using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.TouchScreen
 {
-    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    [StructLayout(LayoutKind.Sequential, Pack = 8)]
     struct TouchScreenState : ISampledDataStruct
     {
-        // MUST BE THE 1st MEMBER
         public ulong SamplingNumber;
-
         public int TouchesCount;
         private int _reserved;
         public Array16<TouchState> Touches;

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/TouchScreen/TouchScreenState.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/TouchScreen/TouchScreenState.cs
@@ -1,15 +1,17 @@
 ﻿using Ryujinx.Common.Memory;
 using Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Common;
+using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.TouchScreen
 {
-    struct TouchScreenState : ISampledData
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    struct TouchScreenState : ISampledDataStruct
     {
+        // MUST BE THE 1st MEMBER
         public ulong SamplingNumber;
+
         public int TouchesCount;
         private int _reserved;
         public Array16<TouchState> Touches;
-
-        ulong ISampledData.SamplingNumber => SamplingNumber;
     }
 }

--- a/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/TouchScreen/TouchScreenState.cs
+++ b/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/TouchScreen/TouchScreenState.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.TouchScreen
 {
-    [StructLayout(LayoutKind.Sequential, Pack = 8)]
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
     struct TouchScreenState : ISampledDataStruct
     {
         public ulong SamplingNumber;


### PR DESCRIPTION
There are 7 structs used to hold input device data. These structs implemented interface `ISampledData` so that `AtomicStorage<T>` could access a `ulong SamplingNumber` field. C# implicitly boxes value types any time they are accessed through an interface, resulting in an allocation. These input device structs are so heavily used that on this developer's machine it results in between 30,000-40,000 boxing memory allocations _per second_ while a game is running.

This PR eliminates all of these allocations by:

- replacing the `ISampledData` interface with `ISampledDataStruct`
    - `ISampledDataStruct` contains no instance members - it is a "marker interface" only.
    - `ISampledDataStruct` is used to constrain static method `ISampledDataStruct.GetSamplingNumber(ref T sampledDataStruct)`, which casts a struct to a ReadOnlySpan<byte> and reads the first 8 bytes as the `SamplingNumber` field.
    - Thus this is a convention-based interface - implementers of `ISampledDataStruct` must follow the convention that the first 8 bytes of the struct point to a `ulong SamplingNumber`.
- AtomicStorage<T> and RingLifo<T> are now constrained to `unmanaged, ISampledDataStruct`
- Changed AtomicStorage<T> to use `ISampledDataStruct.GetSamplingNumber(ref T sampledDataStruct)` for getting a value's SamplingNumber where it was using the `ISampledData` interface before.

