### PR TITLE
Avoid copying more handles than we have space for

### DIFF
--- a/Ryujinx.HLE/HOS/Services/ServerBase.cs
+++ b/Ryujinx.HLE/HOS/Services/ServerBase.cs
@@ -32,6 +32,8 @@ namespace Ryujinx.HLE.HOS.Services
             0x01007FFF
         };
 
+        private readonly object _handleLock = new();
+
         private readonly KernelContext _context;
         private KProcess _selfProcess;
 
@@ -77,7 +79,7 @@ namespace Ryujinx.HLE.HOS.Services
 
         private void AddPort(int serverPortHandle, Func<IpcService> objectFactory)
         {
-            lock (_portHandles)
+            lock (_handleLock)
             {
                 _portHandles.Add(serverPortHandle);
             }
@@ -95,7 +97,7 @@ namespace Ryujinx.HLE.HOS.Services
 
         public void AddSessionObj(int serverSessionHandle, IpcService obj)
         {
-            lock (_sessionHandles)
+            lock (_handleLock)
             {
                 _sessionHandles.Add(serverSessionHandle);
             }
@@ -132,8 +134,7 @@ namespace Ryujinx.HLE.HOS.Services
 
             while (true)
             {
-                lock (_portHandles)
-                lock (_sessionHandles)
+                lock (_handleLock)
                 {
                     int handleCount = _portHandles.Count + _sessionHandles.Count;
 
@@ -288,7 +289,7 @@ namespace Ryujinx.HLE.HOS.Services
             else if (request.Type == IpcMessageType.HipcCloseSession || request.Type == IpcMessageType.TipcCloseSession)
             {
                 _context.Syscall.CloseHandle(serverSessionHandle);
-                lock (_sessionHandles)
+                lock (_handleLock)
                 {
                     _sessionHandles.Remove(serverSessionHandle);
                 }

--- a/Ryujinx.HLE/HOS/Services/ServerBase.cs
+++ b/Ryujinx.HLE/HOS/Services/ServerBase.cs
@@ -77,7 +77,10 @@ namespace Ryujinx.HLE.HOS.Services
 
         private void AddPort(int serverPortHandle, Func<IpcService> objectFactory)
         {
-            _portHandles.Add(serverPortHandle);
+            lock (_portHandles)
+            {
+                _portHandles.Add(serverPortHandle);
+            }
             _ports.Add(serverPortHandle, objectFactory);
         }
 
@@ -92,7 +95,10 @@ namespace Ryujinx.HLE.HOS.Services
 
         public void AddSessionObj(int serverSessionHandle, IpcService obj)
         {
-            _sessionHandles.Add(serverSessionHandle);
+            lock (_sessionHandles)
+            {
+                _sessionHandles.Add(serverSessionHandle);
+            }
             _sessions.Add(serverSessionHandle, obj);
         }
 
@@ -282,7 +288,10 @@ namespace Ryujinx.HLE.HOS.Services
             else if (request.Type == IpcMessageType.HipcCloseSession || request.Type == IpcMessageType.TipcCloseSession)
             {
                 _context.Syscall.CloseHandle(serverSessionHandle);
-                _sessionHandles.Remove(serverSessionHandle);
+                lock (_sessionHandles)
+                {
+                    _sessionHandles.Remove(serverSessionHandle);
+                }
                 IpcService service = _sessions[serverSessionHandle];
                 (service as IDisposable)?.Dispose();
                 _sessions.Remove(serverSessionHandle);

--- a/Ryujinx.HLE/HOS/Services/ServerBase.cs
+++ b/Ryujinx.HLE/HOS/Services/ServerBase.cs
@@ -126,56 +126,60 @@ namespace Ryujinx.HLE.HOS.Services
 
             while (true)
             {
-                int portHandlesCount = _portHandles.Count;
-                int sessionHandlesCount = _sessionHandles.Count;
-                int handleCount = portHandlesCount + sessionHandlesCount;
-
-                int[] handles = ArrayPool<int>.Shared.Rent(handleCount);
-
-                _portHandles.CopyTo(0, handles, 0, portHandlesCount);
-                _sessionHandles.CopyTo(0, handles, portHandlesCount, sessionHandlesCount);
-
-                // We still need a timeout here to allow the service to pick up and listen new sessions...
-                var rc = _context.Syscall.ReplyAndReceive(out int signaledIndex, handles.AsSpan(0, handleCount), replyTargetHandle, 1000000L);
-
-                thread.HandlePostSyscall();
-
-                if (!thread.Context.Running)
+                lock (_portHandles)
                 {
-                    break;
-                }
-
-                replyTargetHandle = 0;
-
-                if (rc == Result.Success && signaledIndex >= portHandlesCount)
-                {
-                    // We got a IPC request, process it, pass to the appropriate service if needed.
-                    int signaledHandle = handles[signaledIndex];
-
-                    if (Process(signaledHandle, heapAddr))
+                    lock (_sessionHandles)
                     {
-                        replyTargetHandle = signaledHandle;
-                    }
-                }
-                else
-                {
-                    if (rc == Result.Success)
-                    {
-                        // We got a new connection, accept the session to allow servicing future requests.
-                        if (_context.Syscall.AcceptSession(out int serverSessionHandle, handles[signaledIndex]) == Result.Success)
+                        int handleCount = _portHandles.Count + _sessionHandles.Count;
+
+                        int[] handles = ArrayPool<int>.Shared.Rent(handleCount);
+
+                        _portHandles.CopyTo(handles, 0);
+                        _sessionHandles.CopyTo(handles, _portHandles.Count);
+
+                        // We still need a timeout here to allow the service to pick up and listen new sessions...
+                        var rc = _context.Syscall.ReplyAndReceive(out int signaledIndex, handles.AsSpan(0, handleCount), replyTargetHandle, 1000000L);
+
+                        thread.HandlePostSyscall();
+
+                        if (!thread.Context.Running)
                         {
-                            IpcService obj = _ports[handles[signaledIndex]].Invoke();
-
-                            AddSessionObj(serverSessionHandle, obj);
+                            break;
                         }
+
+                        replyTargetHandle = 0;
+
+                        if (rc == Result.Success && signaledIndex >= _portHandles.Count)
+                        {
+                            // We got a IPC request, process it, pass to the appropriate service if needed.
+                            int signaledHandle = handles[signaledIndex];
+
+                            if (Process(signaledHandle, heapAddr))
+                            {
+                                replyTargetHandle = signaledHandle;
+                            }
+                        }
+                        else
+                        {
+                            if (rc == Result.Success)
+                            {
+                                // We got a new connection, accept the session to allow servicing future requests.
+                                if (_context.Syscall.AcceptSession(out int serverSessionHandle, handles[signaledIndex]) == Result.Success)
+                                {
+                                    IpcService obj = _ports[handles[signaledIndex]].Invoke();
+
+                                    AddSessionObj(serverSessionHandle, obj);
+                                }
+                            }
+
+                            _selfProcess.CpuMemory.Write(messagePtr + 0x0, 0);
+                            _selfProcess.CpuMemory.Write(messagePtr + 0x4, 2 << 10);
+                            _selfProcess.CpuMemory.Write(messagePtr + 0x8, heapAddr | ((ulong)PointerBufferSize << 48));
+                        }
+
+                        ArrayPool<int>.Shared.Return(handles);
                     }
-
-                    _selfProcess.CpuMemory.Write(messagePtr + 0x0, 0);
-                    _selfProcess.CpuMemory.Write(messagePtr + 0x4, 2 << 10);
-                    _selfProcess.CpuMemory.Write(messagePtr + 0x8, heapAddr | ((ulong)PointerBufferSize << 48));
                 }
-
-                ArrayPool<int>.Shared.Return(handles);
             }
 
             Dispose();


### PR DESCRIPTION
This small PR is supposed to fix a regression introduced by #4537.

@riperiperi noticed this:
> _sessionHandles can be modified from other threads, before it would be converted to array then copied, but now it will create an array with the current size, then error out if it copies and it changed to be larger.

At first I used two locks for `_sessionHandles` and `_portHandles`, but thought it might be better to just ensure we are only copying the handles we reserved space for even if the size of the lists change.

I'm not quite sure which approach is better, so feel free to tell me to change it to locks (or something else I'm not thinking of).  