### PR TITLE
Remove MultiRange Min/MaxAddress and rename GetSlice to Slice

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -1475,8 +1475,8 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             MultiRange otherRange = texture.Range;
 
-            IEnumerable<MultiRange> regions = _sizeInfo.AllRegions().Select((region) => Range.GetSlice((ulong)region.Offset, (ulong)region.Size));
-            IEnumerable<MultiRange> otherRegions = texture._sizeInfo.AllRegions().Select((region) => otherRange.GetSlice((ulong)region.Offset, (ulong)region.Size));
+            IEnumerable<MultiRange> regions = _sizeInfo.AllRegions().Select((region) => Range.Slice((ulong)region.Offset, (ulong)region.Size));
+            IEnumerable<MultiRange> otherRegions = texture._sizeInfo.AllRegions().Select((region) => otherRange.Slice((ulong)region.Offset, (ulong)region.Size));
 
             foreach (MultiRange region in regions)
             {

--- a/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -397,7 +397,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                         int endOffset = Math.Min(spanLast + _sliceSizes[endInfo.BaseLevel + endInfo.Levels - 1], (int)Storage.Size);
                         int size = endOffset - spanBase;
 
-                        dataSpan = _physicalMemory.GetSpan(Storage.Range.GetSlice((ulong)spanBase, (ulong)size));
+                        dataSpan = _physicalMemory.GetSpan(Storage.Range.Slice((ulong)spanBase, (ulong)size));
                     }
 
                     // Only one of these will be greater than 1, as partial sync is only called when there are sub-image views.
@@ -473,7 +473,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             int endOffset = Math.Min(offset + _sliceSizes[level], (int)Storage.Size);
             int size = endOffset - offset;
 
-            using WritableRegion region = _physicalMemory.GetWritableRegion(Storage.Range.GetSlice((ulong)offset, (ulong)size), tracked);
+            using WritableRegion region = _physicalMemory.GetWritableRegion(Storage.Range.Slice((ulong)offset, (ulong)size), tracked);
 
             Storage.GetTextureDataSliceFromGpu(region.Memory.Span, layer, level, tracked, texture);
         }
@@ -1419,13 +1419,13 @@ namespace Ryujinx.Graphics.Gpu.Image
             for (int i = 0; i < _allOffsets.Length; i++)
             {
                 (int layer, int level) = GetLayerLevelForView(i);
-                MultiRange handleRange = Storage.Range.GetSlice((ulong)_allOffsets[i], 1);
+                MultiRange handleRange = Storage.Range.Slice((ulong)_allOffsets[i], 1);
                 ulong handleBase = handleRange.GetSubRange(0).Address;
 
                 for (int j = 0; j < other._handles.Length; j++)
                 {
                     (int otherLayer, int otherLevel) = other.GetLayerLevelForView(j);
-                    MultiRange otherHandleRange = other.Storage.Range.GetSlice((ulong)other._allOffsets[j], 1);
+                    MultiRange otherHandleRange = other.Storage.Range.Slice((ulong)other._allOffsets[j], 1);
                     ulong otherHandleBase = otherHandleRange.GetSubRange(0).Address;
 
                     if (handleBase == otherHandleBase)
@@ -1502,7 +1502,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 // Handles list is not modified by another thread, only replaced, so this is thread safe.
                 // Remove modified flags from all overlapping handles, so that the textures don't flush to unmapped/remapped GPU memory.
 
-                MultiRange subRange = Storage.Range.GetSlice((ulong)handle.Offset, (ulong)handle.Size);
+                MultiRange subRange = Storage.Range.Slice((ulong)handle.Offset, (ulong)handle.Size);
 
                 if (range.OverlapsWith(subRange))
                 {

--- a/Ryujinx.Memory/Range/MultiRange.cs
+++ b/Ryujinx.Memory/Range/MultiRange.cs
@@ -48,7 +48,7 @@ namespace Ryujinx.Memory.Range
         /// <param name="offset">Offset of the slice into the multi-range in bytes</param>
         /// <param name="size">Size of the slice in bytes</param>
         /// <returns>A new multi-range representing the given slice of this one</returns>
-        public MultiRange GetSlice(ulong offset, ulong size)
+        public MultiRange Slice(ulong offset, ulong size)
         {
             if (HasSingleRange)
             {

--- a/Ryujinx.Memory/Range/MultiRange.cs
+++ b/Ryujinx.Memory/Range/MultiRange.cs
@@ -21,16 +21,6 @@ namespace Ryujinx.Memory.Range
         public int Count => HasSingleRange ? 1 : _ranges.Length;
 
         /// <summary>
-        /// Minimum start address of all sub-ranges.
-        /// </summary>
-        public ulong MinAddress { get; }
-
-        /// <summary>
-        /// Maximum end address of all sub-ranges.
-        /// </summary>
-        public ulong MaxAddress { get; }
-
-        /// <summary>
         /// Creates a new multi-range with a single physical region.
         /// </summary>
         /// <param name="address">Start address of the region</param>
@@ -39,8 +29,6 @@ namespace Ryujinx.Memory.Range
         {
             _singleRange = new MemoryRange(address, size);
             _ranges = null;
-            MinAddress = address;
-            MaxAddress = address + size;
         }
 
         /// <summary>
@@ -52,30 +40,6 @@ namespace Ryujinx.Memory.Range
         {
             _singleRange = MemoryRange.Empty;
             _ranges = ranges ?? throw new ArgumentNullException(nameof(ranges));
-
-            if (ranges.Length != 0)
-            {
-                MinAddress = ulong.MaxValue;
-                MaxAddress = 0UL;
-
-                foreach (MemoryRange range in ranges)
-                {
-                    if (MinAddress > range.Address)
-                    {
-                        MinAddress = range.Address;
-                    }
-
-                    if (MaxAddress < range.EndAddress)
-                    {
-                        MaxAddress = range.EndAddress;
-                    }
-                }
-            }
-            else
-            {
-                MinAddress = 0UL;
-                MaxAddress = 0UL;
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
This removes the `MinAddress` and `MaxAddress` properties, that were unused, so it was just wasting memory and time calculating those, and renames `GetSlice` to `Slice` to be consistent with other APIs.