### PR TITLE
CI: add a version tag to correlate release versions with commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,14 +114,14 @@ jobs:
 
       - name: Update Tag
         uses: actions/github-script@v5
-          with:
-            script: |
-              github.rest.git.createRef({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                ref: 'refs/tags/${{ steps.version_info.outputs.build_version }}',
-                sha: context.sha
-              })
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/${{ steps.version_info.outputs.build_version }}',
+              sha: context.sha
+            })
 
   flatpak_release:
     uses: ./.github/workflows/flatpak.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,17 @@ jobs:
           repo: ${{ env.RYUJINX_TARGET_RELEASE_CHANNEL_REPO }}
           token: ${{ secrets.RELEASE_TOKEN }}
 
+      - name: Update Tag
+        uses: actions/github-script@v5
+          with:
+            script: |
+              github.rest.git.createRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: 'refs/tags/${{ steps.version_info.outputs.build_version }}',
+                sha: context.sha
+              })
+
   flatpak_release:
     uses: ./.github/workflows/flatpak.yml
     needs: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
           repo: ${{ env.RYUJINX_TARGET_RELEASE_CHANNEL_REPO }}
           token: ${{ secrets.RELEASE_TOKEN }}
 
-      - name: Update Tag
+      - name: Create Tag
         uses: actions/github-script@v5
         with:
           script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
           repo: ${{ env.RYUJINX_TARGET_RELEASE_CHANNEL_REPO }}
           token: ${{ secrets.RELEASE_TOKEN }}
 
-      - name: Create Tag
+      - name: Create tag
         uses: actions/github-script@v5
         with:
           script: |


### PR DESCRIPTION
### Overview
Adds a step to the release GitHub action to tag the commit with the release's version number

### Why would this feature be useful?
This will make it easier for people to correlate their release versions with commits on GitHub.