### PR TITLE
ServerBase thread safety

### DIFF
--- a/src/Ryujinx.HLE/HOS/Services/ServerBase.cs
+++ b/src/Ryujinx.HLE/HOS/Services/ServerBase.cs
@@ -201,9 +201,9 @@ namespace Ryujinx.HLE.HOS.Services
                     handleLockTaken = _handleLock.TryEnterReadLock(Timeout.Infinite);
 
                     portHandleCount = _ports.Count;
-                    
+
                     handleCount = portHandleCount + _sessions.Count;
-                    
+
                     handles = ArrayPool<int>.Shared.Rent(handleCount);
 
                     _ports.Keys.CopyTo(handles, 0);
@@ -336,7 +336,7 @@ namespace Ryujinx.HLE.HOS.Services
                     _requestDataReader,
                     _responseDataWriter);
 
-                _sessions[serverSessionHandle].CallCmifMethod(context);
+                GetSessionObj(serverSessionHandle).CallCmifMethod(context);
 
                 response.RawData = _responseDataStream.ToArray();
             }

--- a/src/Ryujinx.HLE/HOS/Services/ServerBase.cs
+++ b/src/Ryujinx.HLE/HOS/Services/ServerBase.cs
@@ -488,7 +488,7 @@ namespace Ryujinx.HLE.HOS.Services
             {
                 if (!_threadStopped.Wait(ThreadStoppedWaitTimeout))
                 {
-                    Logger.Warning.Value.PrintRawMsg($"the ServerBase thread didn't signal as stopped within {ThreadStoppedWaitTimeout:g}, resources will be leaked!");
+                    Logger.Warning?.Print(LogClass.Service, $"the ServerBase thread didn't signal it has stopped within {ThreadStoppedWaitTimeout:g}, resources may be leaked!");
                 }
                 else if (Interlocked.Exchange(ref _isDisposed, 1) == 0)
                 {

--- a/src/Ryujinx.HLE/HOS/Services/ServerBase.cs
+++ b/src/Ryujinx.HLE/HOS/Services/ServerBase.cs
@@ -87,6 +87,7 @@ namespace Ryujinx.HLE.HOS.Services
             try
             {
                 lockTaken = _handleLock.TryEnterWriteLock(Timeout.Infinite);
+
                 _ports.Add(serverPortHandle, objectFactory);
             }
             finally
@@ -104,6 +105,7 @@ namespace Ryujinx.HLE.HOS.Services
             InitDone.WaitOne();
 
             _selfProcess.HandleTable.GenerateHandle(serverSession, out int serverSessionHandle);
+
             AddSessionObj(serverSessionHandle, obj);
         }
 
@@ -113,6 +115,7 @@ namespace Ryujinx.HLE.HOS.Services
             try
             {
                 lockTaken = _handleLock.TryEnterWriteLock(Timeout.Infinite);
+
                 _sessions.Add(serverSessionHandle, obj);
             }
             finally
@@ -130,6 +133,7 @@ namespace Ryujinx.HLE.HOS.Services
             try
             {
                 lockTaken = _handleLock.TryEnterReadLock(Timeout.Infinite);
+
                 return _sessions[serverSessionHandle];
             }
             finally
@@ -147,6 +151,7 @@ namespace Ryujinx.HLE.HOS.Services
             try
             {
                 lockTaken = _handleLock.TryEnterWriteLock(Timeout.Infinite);
+
                 return _sessions.Remove(serverSessionHandle, out obj);
             }
             finally
@@ -475,10 +480,10 @@ namespace Ryujinx.HLE.HOS.Services
         {
             if (disposing && _selfThread != null)
             {
-                if (_selfThread.HostThread.ManagedThreadId != Environment.CurrentManagedThreadId
-                    && _selfThread.HostThread.Join(ThreadJoinTimeout) == false)
+                if (_selfThread.HostThread.ManagedThreadId != Environment.CurrentManagedThreadId && _selfThread.HostThread.Join(ThreadJoinTimeout) == false)
                 {
                     Logger.Warning?.Print(LogClass.Service, $"The ServerBase thread didn't terminate within {ThreadJoinTimeout:g}, resources will not have Dispose() called to avoid a race condition.");
+
                     return;
                 }
 

--- a/src/Ryujinx.HLE/HOS/Services/ServerBase.cs
+++ b/src/Ryujinx.HLE/HOS/Services/ServerBase.cs
@@ -482,9 +482,9 @@ namespace Ryujinx.HLE.HOS.Services
             {
                 if (_selfThread.HostThread.ManagedThreadId != Environment.CurrentManagedThreadId && _selfThread.HostThread.Join(ThreadJoinTimeout) == false)
                 {
-                    Logger.Warning?.Print(LogClass.Service, $"The ServerBase thread didn't terminate within {ThreadJoinTimeout:g}, resources will not have Dispose() called to avoid a race condition.");
+                    Logger.Warning?.Print(LogClass.Service, $"The ServerBase thread didn't terminate within {ThreadJoinTimeout:g}, waiting longer.");
 
-                    return;
+                    _selfThread.HostThread.Join(Timeout.Infinite);
                 }
 
                 if (Interlocked.Exchange(ref _isDisposed, 1) == 0)

--- a/src/Ryujinx.HLE/HOS/Services/ServerBase.cs
+++ b/src/Ryujinx.HLE/HOS/Services/ServerBase.cs
@@ -1,4 +1,3 @@
-using LibHac.Diag;
 using Ryujinx.Common;
 using Ryujinx.Common.Logging;
 using Ryujinx.Common.Memory;
@@ -7,14 +6,12 @@ using Ryujinx.HLE.HOS.Kernel;
 using Ryujinx.HLE.HOS.Kernel.Ipc;
 using Ryujinx.HLE.HOS.Kernel.Process;
 using Ryujinx.HLE.HOS.Kernel.Threading;
-using Ryujinx.HLE.Loaders.Elf;
 using Ryujinx.Horizon.Common;
 using System;
 using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace Ryujinx.HLE.HOS.Services


### PR DESCRIPTION
@lostromb [commented](https://github.com/Ryujinx/Ryujinx/pull/4537#issuecomment-1477130450) on closed PR #4537 about an intermittent exception when stopping emulation. This PR fixes some issues I found while investigating, and though I was unable to reproduce @lostromb's reported exception, I believe this will fix it.

- ServerBase.Dispose() could be (and often was) called multiple times.
- ServerBase.Dispose() had no checks to ensure the ServerLoop() had stopped first.
- Reworked the port and session storage to use a Dictionary only, instead of a Dictionary and List
- Reworked the locking to use a ReaderWriterLockSlim, and made every access of the port and session stores thread-safe.
