### PR TITLE
Eliminate redundant multiplications by gl_FragCoord.w on the shader

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 4892;
+        private const uint CodeGenVersion = 4578;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/src/Ryujinx.Graphics.Shader/Translation/Optimizations/Utils.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/Optimizations/Utils.cs
@@ -4,6 +4,35 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
 {
     static class Utils
     {
+        public static bool IsInputLoad(INode node)
+        {
+            return (node is Operation operation) &&
+                   operation.Inst == Instruction.Load &&
+                   operation.StorageKind == StorageKind.Input;
+        }
+
+        public static bool IsInputLoad(INode node, IoVariable ioVariable, int elemIndex)
+        {
+            if (!(node is Operation operation) ||
+                operation.Inst != Instruction.Load ||
+                operation.StorageKind != StorageKind.Input ||
+                operation.SourcesCount != 2)
+            {
+                return false;
+            }
+
+            Operand ioVariableSrc = operation.GetSource(0);
+
+            if (ioVariableSrc.Type != OperandType.Constant || (IoVariable)ioVariableSrc.Value != ioVariable)
+            {
+                return false;
+            }
+
+            Operand elemIndexSrc = operation.GetSource(1);
+
+            return elemIndexSrc.Type == OperandType.Constant && elemIndexSrc.Value == elemIndex;
+        }
+
         private static Operation FindBranchSource(BasicBlock block)
         {
             foreach (BasicBlock sourceBlock in block.Predecessors)


### PR DESCRIPTION
This change removes a somewhat redundant pattern on the shader, cause by some code produced by the compiler for perspective correction on fragment shaders. Basically the compiler uses the "Multiply" mode on the IPA instruction for those inputs. The multiplier is `1.0 / gl_FragCoord.w`. To counter-act this, the emulator insert a multiplication by `gl_FragCoord.w` for perspective inputs, and the end result is a `(x * gl_FragCoord.w) * (1.0 / gl_FragCoord.w)`. This is adding an additional step that can recognize an eliminate this pattern.

Sample diff:
Before:
```glsl
    // 0x000010: 0xE003FF87CFF7FF09 Ipa
    // 0x000018: 0x508000000047090D Mufu
    temp_0 = 1.0 / gl_FragCoord.w;
    // 0x000028: 0xE043FF8A00D7FF04 Ipa
    temp_1 = in_attr2.x * gl_FragCoord.w;
    temp_2 = temp_1 * temp_0;
```
After:
```glsl
    // 0x000010: 0xE003FF87CFF7FF09 Ipa
    // 0x000018: 0x508000000047090D Mufu
    // 0x000028: 0xE043FF8A00D7FF04 Ipa
    temp_0 = in_attr2.x;
```
This was actually causing glitches in a few games, like Demon Slayer, likely due to floating point error making the value slightly different after those operations. So this change fixes this game as well.
Before:
![image](https://user-images.githubusercontent.com/5624669/226790478-1df1e461-9fbe-452c-84ac-225a69e6f914.png)
![image](https://user-images.githubusercontent.com/5624669/226790491-8a741ac0-cc0c-4a44-9166-1893a4a9bd3a.png)
After:
![image](https://user-images.githubusercontent.com/5624669/226790503-16c69948-78cc-4ec0-982b-5dfd142a7e56.png)
![image](https://user-images.githubusercontent.com/5624669/226790512-737d93c8-e1b3-4f45-a9cf-dc99d3bf296b.png)
The only thing I was worried about is the optimisation being applied to cases that are not compiler generated, so I limited it as much as possible. It will only affect multiplication by any fragment shader *inputs* by `gl_FragCoord.w` followed by a multiplication by `1.0 / gl_FragCoord.w`, everything else is untouched.

Testing is welcome.