### PR TITLE
Update short cache textures if modified

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -130,6 +130,10 @@ namespace Ryujinx.Graphics.Gpu.Image
                         return ref descriptor;
                     }
                 }
+                else
+                {
+                    texture.SynchronizeMemory();
+                }
 
                 Items[id] = texture;
 
@@ -233,7 +237,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Queues a request to update a texture's mapping. 
+        /// Queues a request to update a texture's mapping.
         /// Mapping is updated later to avoid deleting the texture if it is still sparsely mapped.
         /// </summary>
         /// <param name="texture">Texture with potential mapping change</param>


### PR DESCRIPTION
This is fixing a regression from #3754 where textures would not be updated if they are from the short cache. I don't know if not calling `SynchronizeMemory` was intentional or not (I'm assuming that it wasn't).

Fixes #4339.