### PR TITLE
Batch inline index buffer update

### DIFF
--- a/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
+++ b/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
@@ -180,7 +180,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
             int firstInstance = (int)_state.State.FirstInstance;
 
-            int inlineIndexCount = _drawState.IbStreamer.GetAndResetInlineIndexCount();
+            int inlineIndexCount = _drawState.IbStreamer.GetAndResetInlineIndexCount(_context.Renderer);
 
             if (inlineIndexCount != 0)
             {
@@ -670,7 +670,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 {
                     if (indexedInline)
                     {
-                        int inlineIndexCount = _drawState.IbStreamer.GetAndResetInlineIndexCount();
+                        int inlineIndexCount = _drawState.IbStreamer.GetAndResetInlineIndexCount(_context.Renderer);
                         BufferRange br = new BufferRange(_drawState.IbStreamer.GetInlineIndexBuffer(), 0, inlineIndexCount * 4);
 
                         _channel.BufferManager.SetIndexBuffer(br, IndexType.UInt);


### PR DESCRIPTION
Before, inline index buffer updates were done one index at a time. This means that, on the most common case, where 2 16-bit indices are uploaded, it would be doing many small 8 byte buffer uploads (since it expands the index size to 32-bits regardless of the original size). This is extremely inefficient, and although the OpenGL NVIDIA driver can cope with it, on Vulkan it was extremely slow.

With this change, the uploads are batched, and it can now submit up to 256 indices (1024 bytes, 1KB) at a time (before it was up to 4, 2 on the common case of 16-bit indices).

Before:

https://user-images.githubusercontent.com/5624669/227070650-cd33c309-c089-48ea-985c-66f2fe9357e8.mp4

https://user-images.githubusercontent.com/5624669/227070451-5d085082-4bc4-4278-bb56-2c0520b86d36.mp4

After:

https://user-images.githubusercontent.com/5624669/227070675-09b00055-b3fa-46c7-87f4-8ceb544c35fd.mp4

https://user-images.githubusercontent.com/5624669/227070461-31408ef5-ea88-4e84-9697-f300e2f670e9.mp4

This change only affects games that uses the OpenGL API on the Switch, and only those that does inline index buffer updates.
Both Vullkan and OpenGL are affected, but as I mentioned before, the NVIDIA driver is already pretty good at handling this on OpenGL, so most of the benefit for NVIDIA is on Vulkan. Other vendors might have a significant improvement on OpenGL too for those games.

An interesting note is that out of all games I tested, those are the last ones that had significant lower performance on Vulkan compared to OpenGL, so with this change Vulkan should be faster or at least as fast than OpenGL, even on NVIDIA, at least on the games I tested here.