### PR TITLE
Fix handle leak on IShopServiceAccessServerInterface.CreateServerInterface

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Nim/IShopServiceAccessServerInterface.cs
+++ b/Ryujinx.HLE/HOS/Services/Nim/IShopServiceAccessServerInterface.cs
@@ -14,6 +14,9 @@ namespace Ryujinx.HLE.HOS.Services.Nim
         // CreateServerInterface(pid, handle<unknown>, u64) -> object<nn::ec::IShopServiceAccessServer>
         public ResultCode CreateServerInterface(ServiceCtx context)
         {
+            // Close transfer memory immediately as we don't use it.
+            context.Device.System.KernelContext.Syscall.CloseHandle(context.Request.HandleDesc.ToCopy[0]);
+
             MakeObject(context, new IShopServiceAccessServer());
 
             Logger.Stub?.PrintStub(LogClass.ServiceNim);


### PR DESCRIPTION
The game passes a transfer memory to the service, since the handle was never closed, it would cause the transfer memory to be mapped forever. If the game tried to call this more than once, the second transfer memory map would fail causing the game to crash.

Fixes crash on SD Shin Kamen Rider Ranbu.
![image](https://user-images.githubusercontent.com/5624669/227422645-9ecc8322-ce30-4584-8176-6a6f4c67b7e7.png)
![image](https://user-images.githubusercontent.com/5624669/227423131-f1bda544-a922-4788-be74-981d363244d6.png)