### PR TITLE
Vulkan: Insert barriers before clears

### DIFF
--- a/Ryujinx.Graphics.Vulkan/DescriptorSetUpdater.cs
+++ b/Ryujinx.Graphics.Vulkan/DescriptorSetUpdater.cs
@@ -236,7 +236,7 @@ namespace Ryujinx.Graphics.Vulkan
             }
             else if (texture is TextureView view)
             {
-                view.Storage.InsertBarrier(cbs, AccessFlags.ShaderReadBit, stage.ConvertToPipelineStageFlags());
+                view.Storage.InsertWriteToReadBarrier(cbs, AccessFlags.ShaderReadBit, stage.ConvertToPipelineStageFlags());
 
                 _textureRefs[binding] = view.GetImageView();
                 _samplerRefs[binding] = ((SamplerHolder)sampler)?.GetSampler();

--- a/Ryujinx.Graphics.Vulkan/EnumConversion.cs
+++ b/Ryujinx.Graphics.Vulkan/EnumConversion.cs
@@ -322,7 +322,7 @@ namespace Ryujinx.Graphics.Vulkan
                 GAL.Format.S8Uint => ImageAspectFlags.StencilBit,
                 GAL.Format.D24UnormS8Uint or
                 GAL.Format.D32FloatS8Uint or
-                GAL.Format.S8UintD24Unorm    => ImageAspectFlags.DepthBit | ImageAspectFlags.StencilBit,
+                GAL.Format.S8UintD24Unorm => ImageAspectFlags.DepthBit | ImageAspectFlags.StencilBit,
                 _ => ImageAspectFlags.ColorBit
             };
         }

--- a/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
+++ b/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
@@ -2,6 +2,7 @@
 using Silk.NET.Vulkan;
 using System;
 using System.Linq;
+using System.Reflection;
 using VkFormat = Silk.NET.Vulkan.Format;
 
 namespace Ryujinx.Graphics.Vulkan
@@ -217,6 +218,24 @@ namespace Ryujinx.Graphics.Vulkan
             _depthStencil?.Storage.SetModification(
                 AccessFlags.DepthStencilAttachmentWriteBit,
                 PipelineStageFlags.ColorAttachmentOutputBit);
+        }
+
+        public void InsertClearBarrier(CommandBufferScoped cbs, int index)
+        {
+            if (_colors != null)
+            {
+                int realIndex = Array.IndexOf(AttachmentIndices, index);
+
+                if (realIndex != -1)
+                {
+                    _colors[realIndex].Storage?.InsertReadToWriteBarrier(cbs, AccessFlags.ColorAttachmentWriteBit, PipelineStageFlags.ColorAttachmentOutputBit);
+                }
+            }
+        }
+
+        public void InsertClearBarrierDS(CommandBufferScoped cbs)
+        {
+            _depthStencil?.Storage?.InsertReadToWriteBarrier(cbs, AccessFlags.ColorAttachmentWriteBit, PipelineStageFlags.ColorAttachmentOutputBit);
         }
     }
 }

--- a/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
+++ b/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
@@ -234,7 +234,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         public void InsertClearBarrierDS(CommandBufferScoped cbs)
         {
-            _depthStencil?.Storage?.InsertReadToWriteBarrier(cbs, AccessFlags.ColorAttachmentWriteBit, PipelineStageFlags.ColorAttachmentOutputBit);
+            _depthStencil?.Storage?.InsertReadToWriteBarrier(cbs, AccessFlags.DepthStencilAttachmentWriteBit, PipelineStageFlags.EarlyFragmentTestsBit);
         }
     }
 }

--- a/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
+++ b/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
@@ -2,7 +2,6 @@
 using Silk.NET.Vulkan;
 using System;
 using System.Linq;
-using System.Reflection;
 using VkFormat = Silk.NET.Vulkan.Format;
 
 namespace Ryujinx.Graphics.Vulkan

--- a/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -226,6 +226,8 @@ namespace Ryujinx.Graphics.Vulkan
             var attachment = new ClearAttachment(ImageAspectFlags.ColorBit, (uint)index, clearValue);
             var clearRect = FramebufferParams.GetClearRect(ClearScissor, layer, layerCount);
 
+            FramebufferParams.InsertClearBarrier(Cbs, index);
+
             Gd.Api.CmdClearAttachments(CommandBuffer, 1, &attachment, 1, &clearRect);
         }
 
@@ -255,6 +257,8 @@ namespace Ryujinx.Graphics.Vulkan
 
             var attachment = new ClearAttachment(flags, 0, clearValue);
             var clearRect = FramebufferParams.GetClearRect(ClearScissor, layer, layerCount);
+
+            FramebufferParams.InsertClearBarrierDS(Cbs);
 
             Gd.Api.CmdClearAttachments(CommandBuffer, 1, &attachment, 1, &clearRect);
         }

--- a/Ryujinx.Graphics.Vulkan/TextureStorage.cs
+++ b/Ryujinx.Graphics.Vulkan/TextureStorage.cs
@@ -446,7 +446,7 @@ namespace Ryujinx.Graphics.Vulkan
         {
             if (_lastReadAccess != AccessFlags.NoneKhr)
             {
-                ImageAspectFlags aspectFlags = EnumConversion.ConvertAspectFlags(Info.Format);
+                ImageAspectFlags aspectFlags = Info.Format.ConvertAspectFlags();
 
                 TextureView.InsertImageBarrier(
                     _gd.Api,
@@ -474,7 +474,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             if (_lastModificationAccess != AccessFlags.NoneKhr)
             {
-                ImageAspectFlags aspectFlags = EnumConversion.ConvertAspectFlags(Info.Format);
+                ImageAspectFlags aspectFlags = Info.Format.ConvertAspectFlags();
 
                 TextureView.InsertImageBarrier(
                     _gd.Api,

--- a/Ryujinx.Graphics.Vulkan/TextureStorage.cs
+++ b/Ryujinx.Graphics.Vulkan/TextureStorage.cs
@@ -421,33 +421,6 @@ namespace Ryujinx.Graphics.Vulkan
             }
         }
 
-        private ImageAspectFlags GetAspectFlags()
-        {
-            ImageAspectFlags aspectFlags;
-
-            if (_info.Format.IsDepthOrStencil())
-            {
-                if (_info.Format == GAL.Format.S8Uint)
-                {
-                    aspectFlags = ImageAspectFlags.StencilBit;
-                }
-                else if (_info.Format == GAL.Format.D16Unorm || _info.Format == GAL.Format.D32Float)
-                {
-                    aspectFlags = ImageAspectFlags.DepthBit;
-                }
-                else
-                {
-                    aspectFlags = ImageAspectFlags.DepthBit | ImageAspectFlags.StencilBit;
-                }
-            }
-            else
-            {
-                aspectFlags = ImageAspectFlags.ColorBit;
-            }
-
-            return aspectFlags;
-        }
-
         private int GetBufferDataLength(int length)
         {
             if (NeedsD24S8Conversion())
@@ -473,7 +446,7 @@ namespace Ryujinx.Graphics.Vulkan
         {
             if (_lastReadAccess != AccessFlags.NoneKhr)
             {
-                ImageAspectFlags aspectFlags = GetAspectFlags();
+                ImageAspectFlags aspectFlags = EnumConversion.ConvertAspectFlags(Info.Format);
 
                 TextureView.InsertImageBarrier(
                     _gd.Api,
@@ -501,7 +474,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             if (_lastModificationAccess != AccessFlags.NoneKhr)
             {
-                ImageAspectFlags aspectFlags = GetAspectFlags();
+                ImageAspectFlags aspectFlags = EnumConversion.ConvertAspectFlags(Info.Format);
 
                 TextureView.InsertImageBarrier(
                     _gd.Api,

--- a/Ryujinx.Graphics.Vulkan/TextureStorage.cs
+++ b/Ryujinx.Graphics.Vulkan/TextureStorage.cs
@@ -46,6 +46,8 @@ namespace Ryujinx.Graphics.Vulkan
 
         private AccessFlags _lastModificationAccess;
         private PipelineStageFlags _lastModificationStage;
+        private AccessFlags _lastReadAccess;
+        private PipelineStageFlags _lastReadStage;
 
         private int _viewsCount;
         private ulong _size;
@@ -419,6 +421,33 @@ namespace Ryujinx.Graphics.Vulkan
             }
         }
 
+        private ImageAspectFlags GetAspectFlags()
+        {
+            ImageAspectFlags aspectFlags;
+
+            if (_info.Format.IsDepthOrStencil())
+            {
+                if (_info.Format == GAL.Format.S8Uint)
+                {
+                    aspectFlags = ImageAspectFlags.StencilBit;
+                }
+                else if (_info.Format == GAL.Format.D16Unorm || _info.Format == GAL.Format.D32Float)
+                {
+                    aspectFlags = ImageAspectFlags.DepthBit;
+                }
+                else
+                {
+                    aspectFlags = ImageAspectFlags.DepthBit | ImageAspectFlags.StencilBit;
+                }
+            }
+            else
+            {
+                aspectFlags = ImageAspectFlags.ColorBit;
+            }
+
+            return aspectFlags;
+        }
+
         private int GetBufferDataLength(int length)
         {
             if (NeedsD24S8Conversion())
@@ -440,31 +469,39 @@ namespace Ryujinx.Graphics.Vulkan
             _lastModificationStage = stage;
         }
 
-        public void InsertBarrier(CommandBufferScoped cbs, AccessFlags dstAccessFlags, PipelineStageFlags dstStageFlags)
+        public void InsertReadToWriteBarrier(CommandBufferScoped cbs, AccessFlags dstAccessFlags, PipelineStageFlags dstStageFlags)
         {
+            if (_lastReadAccess != AccessFlags.NoneKhr)
+            {
+                ImageAspectFlags aspectFlags = GetAspectFlags();
+
+                TextureView.InsertImageBarrier(
+                    _gd.Api,
+                    cbs.CommandBuffer,
+                    _imageAuto.Get(cbs).Value,
+                    _lastReadAccess,
+                    dstAccessFlags,
+                    _lastReadStage,
+                    dstStageFlags,
+                    aspectFlags,
+                    0,
+                    0,
+                    _info.GetLayers(),
+                    _info.Levels);
+
+                _lastReadAccess = AccessFlags.NoneKhr;
+                _lastReadStage = PipelineStageFlags.None;
+            }
+        }
+
+        public void InsertWriteToReadBarrier(CommandBufferScoped cbs, AccessFlags dstAccessFlags, PipelineStageFlags dstStageFlags)
+        {
+            _lastReadAccess |= dstAccessFlags;
+            _lastReadStage |= dstStageFlags;
+
             if (_lastModificationAccess != AccessFlags.NoneKhr)
             {
-                ImageAspectFlags aspectFlags;
-
-                if (_info.Format.IsDepthOrStencil())
-                {
-                    if (_info.Format == GAL.Format.S8Uint)
-                    {
-                        aspectFlags = ImageAspectFlags.StencilBit;
-                    }
-                    else if (_info.Format == GAL.Format.D16Unorm || _info.Format == GAL.Format.D32Float)
-                    {
-                        aspectFlags = ImageAspectFlags.DepthBit;
-                    }
-                    else
-                    {
-                        aspectFlags = ImageAspectFlags.DepthBit | ImageAspectFlags.StencilBit;
-                    }
-                }
-                else
-                {
-                    aspectFlags = ImageAspectFlags.ColorBit;
-                }
+                ImageAspectFlags aspectFlags = GetAspectFlags();
 
                 TextureView.InsertImageBarrier(
                     _gd.Api,


### PR DESCRIPTION
Newer NVIDIA GPUs seem to be able to start clearing render targets before the last rasterization task is completed, which can cause it to clear a texture while it is being sampled.

This change adds a barrier from read to write when doing a clear, assuming it has been sampled in the past. It could be possible for this to be needed for sample into draw by some GPU, but it's not right now afaik.

This should fix visual artifacts on newer NVIDIA GPUs and driver combos. Contrary to popular belief, Tetris® Effect: Connected is not affected. Testing welcome, hopefully should fix most cases of this and not cost too much performance.