### PR TITLE
Vulkan: Add barriers for image uses

### DIFF
--- a/Ryujinx.Graphics.GAL/IPipeline.cs
+++ b/Ryujinx.Graphics.GAL/IPipeline.cs
@@ -58,7 +58,7 @@ namespace Ryujinx.Graphics.GAL
 
         void SetIndexBuffer(BufferRange buffer, IndexType type);
 
-        void SetImage(int binding, ITexture texture, Format imageFormat);
+        void SetImage(ShaderStage stage, int binding, ITexture texture, Format imageFormat);
 
         void SetLineParameters(float width, bool smooth);
 

--- a/Ryujinx.Graphics.GAL/Multithreading/Commands/SetImageCommand.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/Commands/SetImageCommand.cs
@@ -1,17 +1,20 @@
 ﻿using Ryujinx.Graphics.GAL.Multithreading.Model;
 using Ryujinx.Graphics.GAL.Multithreading.Resources;
+using Ryujinx.Graphics.Shader;
 
 namespace Ryujinx.Graphics.GAL.Multithreading.Commands
 {
     struct SetImageCommand : IGALCommand, IGALCommand<SetImageCommand>
     {
         public CommandType CommandType => CommandType.SetImage;
+        private ShaderStage _stage;
         private int _binding;
         private TableRef<ITexture> _texture;
         private Format _imageFormat;
 
-        public void Set(int binding, TableRef<ITexture> texture, Format imageFormat)
+        public void Set(ShaderStage stage, int binding, TableRef<ITexture> texture, Format imageFormat)
         {
+            _stage = stage;
             _binding = binding;
             _texture = texture;
             _imageFormat = imageFormat;
@@ -19,7 +22,7 @@ namespace Ryujinx.Graphics.GAL.Multithreading.Commands
 
         public static void Run(ref SetImageCommand command, ThreadedRenderer threaded, IRenderer renderer)
         {
-            renderer.Pipeline.SetImage(command._binding, command._texture.GetAs<ThreadedTexture>(threaded)?.Base, command._imageFormat);
+            renderer.Pipeline.SetImage(command._stage, command._binding, command._texture.GetAs<ThreadedTexture>(threaded)?.Base, command._imageFormat);
         }
     }
 }

--- a/Ryujinx.Graphics.GAL/Multithreading/ThreadedPipeline.cs
+++ b/Ryujinx.Graphics.GAL/Multithreading/ThreadedPipeline.cs
@@ -179,9 +179,9 @@ namespace Ryujinx.Graphics.GAL.Multithreading
             _renderer.QueueCommand();
         }
 
-        public void SetImage(int binding, ITexture texture, Format imageFormat)
+        public void SetImage(ShaderStage stage, int binding, ITexture texture, Format imageFormat)
         {
-            _renderer.New<SetImageCommand>().Set(binding, Ref(texture), imageFormat);
+            _renderer.New<SetImageCommand>().Set(stage, binding, Ref(texture), imageFormat);
             _renderer.QueueCommand();
         }
 

--- a/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureBindingsManager.cs
@@ -649,7 +649,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                         state.Texture = hostTextureRebind;
                         state.ImageFormat = format;
 
-                        _context.Renderer.Pipeline.SetImage(bindingInfo.Binding, hostTextureRebind, format);
+                        _context.Renderer.Pipeline.SetImage(stage, bindingInfo.Binding, hostTextureRebind, format);
                     }
 
                     continue;
@@ -707,7 +707,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                         state.ImageFormat = format;
 
-                        _context.Renderer.Pipeline.SetImage(bindingInfo.Binding, hostTexture, format);
+                        _context.Renderer.Pipeline.SetImage(stage, bindingInfo.Binding, hostTexture, format);
                     }
 
                     state.CachedTexture = texture;

--- a/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -458,7 +458,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
                     if (binding.IsImage)
                     {
-                        _context.Renderer.Pipeline.SetImage(binding.BindingInfo.Binding, binding.Texture, binding.Format);
+                        _context.Renderer.Pipeline.SetImage(binding.Stage, binding.BindingInfo.Binding, binding.Texture, binding.Format);
                     }
                     else
                     {

--- a/Ryujinx.Graphics.OpenGL/Pipeline.cs
+++ b/Ryujinx.Graphics.OpenGL/Pipeline.cs
@@ -977,7 +977,7 @@ namespace Ryujinx.Graphics.OpenGL
             SetFrontFace(_frontFace = frontFace.Convert());
         }
 
-        public void SetImage(int binding, ITexture texture, Format imageFormat)
+        public void SetImage(ShaderStage stage, int binding, ITexture texture, Format imageFormat)
         {
             if ((uint)binding < SavedImages)
             {

--- a/Ryujinx.Graphics.Vulkan/DescriptorSetUpdater.cs
+++ b/Ryujinx.Graphics.Vulkan/DescriptorSetUpdater.cs
@@ -236,7 +236,7 @@ namespace Ryujinx.Graphics.Vulkan
             }
             else if (texture is TextureView view)
             {
-                view.Storage.InsertBarrier(cbs, AccessFlags.ShaderReadBit, stage.ConvertToPipelineStageFlags());
+                view.Storage.InsertWriteToReadBarrier(cbs, AccessFlags.ShaderReadBit, stage.ConvertToPipelineStageFlags());
 
                 _textureRefs[binding] = view.GetImageView();
                 _samplerRefs[binding] = ((SamplerHolder)sampler)?.GetSampler();

--- a/Ryujinx.Graphics.Vulkan/DescriptorSetUpdater.cs
+++ b/Ryujinx.Graphics.Vulkan/DescriptorSetUpdater.cs
@@ -142,7 +142,7 @@ namespace Ryujinx.Graphics.Vulkan
             _dirty = DirtyFlags.All;
         }
 
-        public void SetImage(int binding, ITexture image, GAL.Format imageFormat)
+        public void SetImage(CommandBufferScoped cbs, ShaderStage stage, int binding, ITexture image, GAL.Format imageFormat)
         {
             if (image is TextureBuffer imageBuffer)
             {
@@ -151,6 +151,8 @@ namespace Ryujinx.Graphics.Vulkan
             }
             else if (image is TextureView view)
             {
+                view.Storage.InsertWriteToReadBarrier(cbs, AccessFlags.ShaderReadBit, stage.ConvertToPipelineStageFlags());
+
                 _imageRefs[binding] = view.GetView(imageFormat).GetIdentityImageView();
             }
             else

--- a/Ryujinx.Graphics.Vulkan/Effects/FsrScalingFilter.cs
+++ b/Ryujinx.Graphics.Vulkan/Effects/FsrScalingFilter.cs
@@ -171,7 +171,7 @@ namespace Ryujinx.Graphics.Vulkan.Effects
             _pipeline.SetUniformBuffers(stackalloc[] { new BufferAssignment(2, bufferRanges) });
             _pipeline.SetScissors(scissors);
             _pipeline.SetViewports(viewports, false);
-            _pipeline.SetImage(0, _intermediaryTexture, GAL.Format.R8G8B8A8Unorm);
+            _pipeline.SetImage(ShaderStage.Compute, 0, _intermediaryTexture, GAL.Format.R8G8B8A8Unorm);
             _pipeline.DispatchCompute(dispatchX, dispatchY, 1);
             _pipeline.ComputeBarrier();
 

--- a/Ryujinx.Graphics.Vulkan/Effects/FxaaPostProcessingEffect.cs
+++ b/Ryujinx.Graphics.Vulkan/Effects/FxaaPostProcessingEffect.cs
@@ -113,7 +113,7 @@ namespace Ryujinx.Graphics.Vulkan.Effects
             _pipeline.SetScissors(stackalloc[] { new Rectangle<int>(0, 0, view.Width, view.Height) });
             _pipeline.SetViewports(viewports, false);
 
-            _pipeline.SetImage(0, _texture, GAL.Format.R8G8B8A8Unorm);
+            _pipeline.SetImage(ShaderStage.Compute, 0, _texture, GAL.Format.R8G8B8A8Unorm);
             _pipeline.DispatchCompute(dispatchX, dispatchY, 1);
 
             _renderer.BufferManager.Delete(bufferHandle);

--- a/Ryujinx.Graphics.Vulkan/Effects/SmaaPostProcessingEffect.cs
+++ b/Ryujinx.Graphics.Vulkan/Effects/SmaaPostProcessingEffect.cs
@@ -273,7 +273,7 @@ namespace Ryujinx.Graphics.Vulkan.Effects
             _pipeline.SetUniformBuffers(stackalloc[] { new BufferAssignment(2, bufferRanges) });
             _pipeline.SetScissors(scissors);
             _pipeline.SetViewports(viewports, false);
-            _pipeline.SetImage(0, _edgeOutputTexture, GAL.Format.R8G8B8A8Unorm);
+            _pipeline.SetImage(ShaderStage.Compute, 0, _edgeOutputTexture, GAL.Format.R8G8B8A8Unorm);
             _pipeline.DispatchCompute(dispatchX, dispatchY, 1);
             _pipeline.ComputeBarrier();
 
@@ -287,7 +287,7 @@ namespace Ryujinx.Graphics.Vulkan.Effects
             _pipeline.SetUniformBuffers(stackalloc[] { new BufferAssignment(2, bufferRanges) });
             _pipeline.SetScissors(scissors);
             _pipeline.SetViewports(viewports, false);
-            _pipeline.SetImage(0, _blendOutputTexture, GAL.Format.R8G8B8A8Unorm);
+            _pipeline.SetImage(ShaderStage.Compute, 0, _blendOutputTexture, GAL.Format.R8G8B8A8Unorm);
             _pipeline.DispatchCompute(dispatchX, dispatchY, 1);
             _pipeline.ComputeBarrier();
 
@@ -300,7 +300,7 @@ namespace Ryujinx.Graphics.Vulkan.Effects
             _pipeline.SetUniformBuffers(stackalloc[] { new BufferAssignment(2, bufferRanges) });
             _pipeline.SetScissors(scissors);
             _pipeline.SetViewports(viewports, false);
-            _pipeline.SetImage(0, _outputTexture, GAL.Format.R8G8B8A8Unorm);
+            _pipeline.SetImage(ShaderStage.Compute, 0, _outputTexture, GAL.Format.R8G8B8A8Unorm);
             _pipeline.DispatchCompute(dispatchX, dispatchY, 1);
             _pipeline.ComputeBarrier();
 

--- a/Ryujinx.Graphics.Vulkan/EnumConversion.cs
+++ b/Ryujinx.Graphics.Vulkan/EnumConversion.cs
@@ -322,7 +322,7 @@ namespace Ryujinx.Graphics.Vulkan
                 GAL.Format.S8Uint => ImageAspectFlags.StencilBit,
                 GAL.Format.D24UnormS8Uint or
                 GAL.Format.D32FloatS8Uint or
-                GAL.Format.S8UintD24Unorm    => ImageAspectFlags.DepthBit | ImageAspectFlags.StencilBit,
+                GAL.Format.S8UintD24Unorm => ImageAspectFlags.DepthBit | ImageAspectFlags.StencilBit,
                 _ => ImageAspectFlags.ColorBit
             };
         }

--- a/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
+++ b/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
@@ -2,6 +2,7 @@
 using Silk.NET.Vulkan;
 using System;
 using System.Linq;
+using System.Reflection;
 using VkFormat = Silk.NET.Vulkan.Format;
 
 namespace Ryujinx.Graphics.Vulkan
@@ -217,6 +218,24 @@ namespace Ryujinx.Graphics.Vulkan
             _depthStencil?.Storage.SetModification(
                 AccessFlags.DepthStencilAttachmentWriteBit,
                 PipelineStageFlags.ColorAttachmentOutputBit);
+        }
+
+        public void InsertClearBarrier(CommandBufferScoped cbs, int index)
+        {
+            if (_colors != null)
+            {
+                int realIndex = Array.IndexOf(AttachmentIndices, index);
+
+                if (realIndex != -1)
+                {
+                    _colors[realIndex].Storage?.InsertReadToWriteBarrier(cbs, AccessFlags.ColorAttachmentWriteBit, PipelineStageFlags.ColorAttachmentOutputBit);
+                }
+            }
+        }
+
+        public void InsertClearBarrierDS(CommandBufferScoped cbs)
+        {
+            _depthStencil?.Storage?.InsertReadToWriteBarrier(cbs, AccessFlags.ColorAttachmentWriteBit, PipelineStageFlags.ColorAttachmentOutputBit);
         }
     }
 }

--- a/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
+++ b/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
@@ -234,7 +234,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         public void InsertClearBarrierDS(CommandBufferScoped cbs)
         {
-            _depthStencil?.Storage?.InsertReadToWriteBarrier(cbs, AccessFlags.ColorAttachmentWriteBit, PipelineStageFlags.ColorAttachmentOutputBit);
+            _depthStencil?.Storage?.InsertReadToWriteBarrier(cbs, AccessFlags.DepthStencilAttachmentWriteBit, PipelineStageFlags.EarlyFragmentTestsBit);
         }
     }
 }

--- a/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
+++ b/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
@@ -2,7 +2,6 @@
 using Silk.NET.Vulkan;
 using System;
 using System.Linq;
-using System.Reflection;
 using VkFormat = Silk.NET.Vulkan.Format;
 
 namespace Ryujinx.Graphics.Vulkan

--- a/Ryujinx.Graphics.Vulkan/HelperShader.cs
+++ b/Ryujinx.Graphics.Vulkan/HelperShader.cs
@@ -998,7 +998,7 @@ namespace Ryujinx.Graphics.Vulkan
                     var dstView = Create2DLayerView(dst, dstLayer + z, dstLevel + l);
 
                     _pipeline.SetTextureAndSampler(ShaderStage.Compute, 0, srcView, null);
-                    _pipeline.SetImage(0, dstView, dstFormat);
+                    _pipeline.SetImage(ShaderStage.Compute, 0, dstView, dstFormat);
 
                     int dispatchX = (Math.Min(srcView.Info.Width, dstView.Info.Width) + 31) / 32;
                     int dispatchY = (Math.Min(srcView.Info.Height, dstView.Info.Height) + 31) / 32;
@@ -1085,7 +1085,7 @@ namespace Ryujinx.Graphics.Vulkan
                 var dstView = Create2DLayerView(dst, dstLayer + z, 0);
 
                 _pipeline.SetTextureAndSampler(ShaderStage.Compute, 0, srcView, null);
-                _pipeline.SetImage(0, dstView, format);
+                _pipeline.SetImage(ShaderStage.Compute, 0, dstView, format);
 
                 _pipeline.DispatchCompute(dispatchX, dispatchY, 1);
 

--- a/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -226,6 +226,8 @@ namespace Ryujinx.Graphics.Vulkan
             var attachment = new ClearAttachment(ImageAspectFlags.ColorBit, (uint)index, clearValue);
             var clearRect = FramebufferParams.GetClearRect(ClearScissor, layer, layerCount);
 
+            FramebufferParams.InsertClearBarrier(Cbs, index);
+
             Gd.Api.CmdClearAttachments(CommandBuffer, 1, &attachment, 1, &clearRect);
         }
 
@@ -255,6 +257,8 @@ namespace Ryujinx.Graphics.Vulkan
 
             var attachment = new ClearAttachment(flags, 0, clearValue);
             var clearRect = FramebufferParams.GetClearRect(ClearScissor, layer, layerCount);
+
+            FramebufferParams.InsertClearBarrierDS(Cbs);
 
             Gd.Api.CmdClearAttachments(CommandBuffer, 1, &attachment, 1, &clearRect);
         }

--- a/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -834,9 +834,9 @@ namespace Ryujinx.Graphics.Vulkan
             SignalStateChange();
         }
 
-        public void SetImage(int binding, ITexture image, GAL.Format imageFormat)
+        public void SetImage(ShaderStage stage, int binding, ITexture image, GAL.Format imageFormat)
         {
-            _descriptorSetUpdater.SetImage(binding, image, imageFormat);
+            _descriptorSetUpdater.SetImage(Cbs, stage, binding, image, imageFormat);
         }
 
         public void SetImage(int binding, Auto<DisposableImageView> image)

--- a/Ryujinx.Graphics.Vulkan/TextureStorage.cs
+++ b/Ryujinx.Graphics.Vulkan/TextureStorage.cs
@@ -446,7 +446,7 @@ namespace Ryujinx.Graphics.Vulkan
         {
             if (_lastReadAccess != AccessFlags.NoneKhr)
             {
-                ImageAspectFlags aspectFlags = EnumConversion.ConvertAspectFlags(Info.Format);
+                ImageAspectFlags aspectFlags = Info.Format.ConvertAspectFlags();
 
                 TextureView.InsertImageBarrier(
                     _gd.Api,
@@ -474,7 +474,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             if (_lastModificationAccess != AccessFlags.NoneKhr)
             {
-                ImageAspectFlags aspectFlags = EnumConversion.ConvertAspectFlags(Info.Format);
+                ImageAspectFlags aspectFlags = Info.Format.ConvertAspectFlags();
 
                 TextureView.InsertImageBarrier(
                     _gd.Api,

--- a/Ryujinx.Graphics.Vulkan/TextureStorage.cs
+++ b/Ryujinx.Graphics.Vulkan/TextureStorage.cs
@@ -421,33 +421,6 @@ namespace Ryujinx.Graphics.Vulkan
             }
         }
 
-        private ImageAspectFlags GetAspectFlags()
-        {
-            ImageAspectFlags aspectFlags;
-
-            if (_info.Format.IsDepthOrStencil())
-            {
-                if (_info.Format == GAL.Format.S8Uint)
-                {
-                    aspectFlags = ImageAspectFlags.StencilBit;
-                }
-                else if (_info.Format == GAL.Format.D16Unorm || _info.Format == GAL.Format.D32Float)
-                {
-                    aspectFlags = ImageAspectFlags.DepthBit;
-                }
-                else
-                {
-                    aspectFlags = ImageAspectFlags.DepthBit | ImageAspectFlags.StencilBit;
-                }
-            }
-            else
-            {
-                aspectFlags = ImageAspectFlags.ColorBit;
-            }
-
-            return aspectFlags;
-        }
-
         private int GetBufferDataLength(int length)
         {
             if (NeedsD24S8Conversion())
@@ -473,7 +446,7 @@ namespace Ryujinx.Graphics.Vulkan
         {
             if (_lastReadAccess != AccessFlags.NoneKhr)
             {
-                ImageAspectFlags aspectFlags = GetAspectFlags();
+                ImageAspectFlags aspectFlags = EnumConversion.ConvertAspectFlags(Info.Format);
 
                 TextureView.InsertImageBarrier(
                     _gd.Api,
@@ -501,7 +474,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             if (_lastModificationAccess != AccessFlags.NoneKhr)
             {
-                ImageAspectFlags aspectFlags = GetAspectFlags();
+                ImageAspectFlags aspectFlags = EnumConversion.ConvertAspectFlags(Info.Format);
 
                 TextureView.InsertImageBarrier(
                     _gd.Api,

--- a/Ryujinx.Graphics.Vulkan/TextureStorage.cs
+++ b/Ryujinx.Graphics.Vulkan/TextureStorage.cs
@@ -46,6 +46,8 @@ namespace Ryujinx.Graphics.Vulkan
 
         private AccessFlags _lastModificationAccess;
         private PipelineStageFlags _lastModificationStage;
+        private AccessFlags _lastReadAccess;
+        private PipelineStageFlags _lastReadStage;
 
         private int _viewsCount;
         private ulong _size;
@@ -419,6 +421,33 @@ namespace Ryujinx.Graphics.Vulkan
             }
         }
 
+        private ImageAspectFlags GetAspectFlags()
+        {
+            ImageAspectFlags aspectFlags;
+
+            if (_info.Format.IsDepthOrStencil())
+            {
+                if (_info.Format == GAL.Format.S8Uint)
+                {
+                    aspectFlags = ImageAspectFlags.StencilBit;
+                }
+                else if (_info.Format == GAL.Format.D16Unorm || _info.Format == GAL.Format.D32Float)
+                {
+                    aspectFlags = ImageAspectFlags.DepthBit;
+                }
+                else
+                {
+                    aspectFlags = ImageAspectFlags.DepthBit | ImageAspectFlags.StencilBit;
+                }
+            }
+            else
+            {
+                aspectFlags = ImageAspectFlags.ColorBit;
+            }
+
+            return aspectFlags;
+        }
+
         private int GetBufferDataLength(int length)
         {
             if (NeedsD24S8Conversion())
@@ -440,31 +469,39 @@ namespace Ryujinx.Graphics.Vulkan
             _lastModificationStage = stage;
         }
 
-        public void InsertBarrier(CommandBufferScoped cbs, AccessFlags dstAccessFlags, PipelineStageFlags dstStageFlags)
+        public void InsertReadToWriteBarrier(CommandBufferScoped cbs, AccessFlags dstAccessFlags, PipelineStageFlags dstStageFlags)
         {
+            if (_lastReadAccess != AccessFlags.NoneKhr)
+            {
+                ImageAspectFlags aspectFlags = GetAspectFlags();
+
+                TextureView.InsertImageBarrier(
+                    _gd.Api,
+                    cbs.CommandBuffer,
+                    _imageAuto.Get(cbs).Value,
+                    _lastReadAccess,
+                    dstAccessFlags,
+                    _lastReadStage,
+                    dstStageFlags,
+                    aspectFlags,
+                    0,
+                    0,
+                    _info.GetLayers(),
+                    _info.Levels);
+
+                _lastReadAccess = AccessFlags.NoneKhr;
+                _lastReadStage = PipelineStageFlags.None;
+            }
+        }
+
+        public void InsertWriteToReadBarrier(CommandBufferScoped cbs, AccessFlags dstAccessFlags, PipelineStageFlags dstStageFlags)
+        {
+            _lastReadAccess |= dstAccessFlags;
+            _lastReadStage |= dstStageFlags;
+
             if (_lastModificationAccess != AccessFlags.NoneKhr)
             {
-                ImageAspectFlags aspectFlags;
-
-                if (_info.Format.IsDepthOrStencil())
-                {
-                    if (_info.Format == GAL.Format.S8Uint)
-                    {
-                        aspectFlags = ImageAspectFlags.StencilBit;
-                    }
-                    else if (_info.Format == GAL.Format.D16Unorm || _info.Format == GAL.Format.D32Float)
-                    {
-                        aspectFlags = ImageAspectFlags.DepthBit;
-                    }
-                    else
-                    {
-                        aspectFlags = ImageAspectFlags.DepthBit | ImageAspectFlags.StencilBit;
-                    }
-                }
-                else
-                {
-                    aspectFlags = ImageAspectFlags.ColorBit;
-                }
+                ImageAspectFlags aspectFlags = GetAspectFlags();
 
                 TextureView.InsertImageBarrier(
                     _gd.Api,


### PR DESCRIPTION
Texture+Sampler uses already have these, just adding them to images. This may fix some more issues with newer NVIDIA drivers, or possibly block artifacts on AMD (that aren't subgroup related, so appear on RDNA).

This is experimental to see if it actually affects anything. Based on #4596 .