### PR TITLE
vulkan: Cleanup PhysicalDevice and Instance querying

### DIFF
--- a/Ryujinx.Graphics.Vulkan/VulkanInitialization.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanInitialization.cs
@@ -179,7 +179,6 @@ namespace Ryujinx.Graphics.Vulkan
                 EnabledLayerCount = 0
             };
 
-
             Result result = VulkanInstance.Create(api, ref instanceCreateInfo, out var rawInstance);
 
             Marshal.FreeHGlobal(appName);

--- a/Ryujinx.Graphics.Vulkan/VulkanInstance.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanInstance.cs
@@ -3,6 +3,7 @@ using Silk.NET.Core;
 using Silk.NET.Vulkan;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.InteropServices;
 
@@ -81,7 +82,7 @@ namespace Ryujinx.Graphics.Vulkan
             return Result.Success;
         }
 
-        public static HashSet<string> GetInstanceExtensions(Vk api)
+        public static IReadOnlySet<string> GetInstanceExtensions(Vk api)
         {
             uint propertiesCount = 0;
 
@@ -93,11 +94,11 @@ namespace Ryujinx.Graphics.Vulkan
 
             unsafe
             {
-                return extensionProperties.Select(x => Marshal.PtrToStringAnsi((IntPtr)x.ExtensionName)).ToHashSet();
+                return extensionProperties.Select(x => Marshal.PtrToStringAnsi((IntPtr)x.ExtensionName)).ToImmutableHashSet();
             }
         }
 
-        public static HashSet<string> GetInstanceLayers(Vk api)
+        public static IReadOnlySet<string> GetInstanceLayers(Vk api)
         {
             uint propertiesCount = 0;
 
@@ -109,7 +110,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             unsafe
             {
-                return layerProperties.Select(x => Marshal.PtrToStringAnsi((IntPtr)x.LayerName)).ToHashSet();
+                return layerProperties.Select(x => Marshal.PtrToStringAnsi((IntPtr)x.LayerName)).ToImmutableHashSet();
             }
         }
 
@@ -117,10 +118,7 @@ namespace Ryujinx.Graphics.Vulkan
         {
             if (!_disposed)
             {
-                unsafe
-                {
-                    _api.DestroyInstance(Instance, null);
-                }
+                _api.DestroyInstance(Instance, ReadOnlySpan<AllocationCallbacks>.Empty);
 
                 _disposed = true;
             }

--- a/Ryujinx.Graphics.Vulkan/VulkanInstance.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanInstance.cs
@@ -1,0 +1,129 @@
+using Ryujinx.Common.Utilities;
+using Silk.NET.Core;
+using Silk.NET.Vulkan;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace Ryujinx.Graphics.Vulkan
+{
+    class VulkanInstance : IDisposable
+    {
+        private readonly Vk _api;
+        public readonly Instance Instance;
+        public readonly Version32 InstanceVersion;
+
+        private bool _disposed;
+
+        private VulkanInstance(Vk api, Instance instance)
+        {
+            _api = api;
+            Instance = instance;
+
+            if (api.GetInstanceProcAddr(instance, "vkEnumerateInstanceVersion") == IntPtr.Zero)
+            {
+                InstanceVersion = Vk.Version10;
+            }
+            else
+            {
+                uint rawInstanceVersion = 0;
+
+                if (api.EnumerateInstanceVersion(ref rawInstanceVersion) != Result.Success)
+                {
+                    rawInstanceVersion = Vk.Version11.Value;
+                }
+
+                InstanceVersion = (Version32)rawInstanceVersion;
+            }
+        }
+
+        public static Result Create(Vk api, ref InstanceCreateInfo createInfo, out VulkanInstance instance)
+        {
+            instance = null;
+
+            Instance rawInstance = default;
+
+            Result result = api.CreateInstance(SpanHelpers.AsReadOnlySpan(ref createInfo), ReadOnlySpan<AllocationCallbacks>.Empty, SpanHelpers.AsSpan(ref rawInstance));
+
+            if (result == Result.Success)
+            {
+                instance = new VulkanInstance(api, rawInstance);
+            }
+
+            return result;
+        }
+
+        public Result EnumeratePhysicalDevices(out VulkanPhysicalDevice[] physicalDevices)
+        {
+            physicalDevices = null;
+
+            uint physicalDeviceCount = 0;
+
+            Result result = _api.EnumeratePhysicalDevices(Instance, SpanHelpers.AsSpan(ref physicalDeviceCount), Span<PhysicalDevice>.Empty);
+
+            if (result != Result.Success)
+            {
+                return result;
+            }
+
+            PhysicalDevice[] rawPhysicalDevices = new PhysicalDevice[physicalDeviceCount];
+
+            result = _api.EnumeratePhysicalDevices(Instance, SpanHelpers.AsSpan(ref physicalDeviceCount), rawPhysicalDevices);
+
+            if (result != Result.Success)
+            {
+                return result;
+            }
+
+            physicalDevices = rawPhysicalDevices.Select(x => new VulkanPhysicalDevice(_api, x)).ToArray();
+
+            return Result.Success;
+        }
+
+        public static HashSet<string> GetInstanceExtensions(Vk api)
+        {
+            uint propertiesCount = 0;
+
+            api.EnumerateInstanceExtensionProperties(ReadOnlySpan<byte>.Empty, SpanHelpers.AsSpan(ref propertiesCount), Span<ExtensionProperties>.Empty).ThrowOnError();
+
+            ExtensionProperties[] extensionProperties = new ExtensionProperties[propertiesCount];
+
+            api.EnumerateInstanceExtensionProperties(ReadOnlySpan<byte>.Empty, SpanHelpers.AsSpan(ref propertiesCount), extensionProperties).ThrowOnError();
+
+            unsafe
+            {
+                return extensionProperties.Select(x => Marshal.PtrToStringAnsi((IntPtr)x.ExtensionName)).ToHashSet();
+            }
+        }
+
+        public static HashSet<string> GetInstanceLayers(Vk api)
+        {
+            uint propertiesCount = 0;
+
+            api.EnumerateInstanceLayerProperties(SpanHelpers.AsSpan(ref propertiesCount), Span<LayerProperties>.Empty).ThrowOnError();
+
+            LayerProperties[] layerProperties = new LayerProperties[propertiesCount];
+
+            api.EnumerateInstanceLayerProperties(SpanHelpers.AsSpan(ref propertiesCount), layerProperties).ThrowOnError();
+
+            unsafe
+            {
+                return layerProperties.Select(x => Marshal.PtrToStringAnsi((IntPtr)x.LayerName)).ToHashSet();
+            }
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                unsafe
+                {
+                    _api.DestroyInstance(Instance, null);
+                }
+
+                _disposed = true;
+            }
+        }
+    }
+}

--- a/Ryujinx.Graphics.Vulkan/VulkanPhysicalDevice.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanPhysicalDevice.cs
@@ -3,6 +3,7 @@ using Ryujinx.Graphics.GAL;
 using Silk.NET.Vulkan;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.InteropServices;
 
@@ -16,7 +17,7 @@ namespace Ryujinx.Graphics.Vulkan
         public readonly PhysicalDeviceMemoryProperties PhysicalDeviceMemoryProperties;
         public readonly QueueFamilyProperties[] QueueFamilyProperties;
         public readonly string DeviceName;
-        public readonly HashSet<string> DeviceExtensions;
+        public readonly IReadOnlySet<string> DeviceExtensions;
 
         public VulkanPhysicalDevice(Vk api, PhysicalDevice physicalDevice)
         {
@@ -49,7 +50,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             unsafe
             {
-                DeviceExtensions = extensionProperties.Select(x => Marshal.PtrToStringAnsi((IntPtr)x.ExtensionName)).ToHashSet();
+                DeviceExtensions = extensionProperties.Select(x => Marshal.PtrToStringAnsi((IntPtr)x.ExtensionName)).ToImmutableHashSet();
             }
         }
 
@@ -60,10 +61,10 @@ namespace Ryujinx.Graphics.Vulkan
         public DeviceInfo ToDeviceInfo()
         {
             return new DeviceInfo(
-                    Id,
-                    VendorUtils.GetNameFromId(PhysicalDeviceProperties.VendorID),
-                    DeviceName,
-                    PhysicalDeviceProperties.DeviceType == PhysicalDeviceType.DiscreteGpu);
+                Id,
+                VendorUtils.GetNameFromId(PhysicalDeviceProperties.VendorID),
+                DeviceName,
+                PhysicalDeviceProperties.DeviceType == PhysicalDeviceType.DiscreteGpu);
         }
     }
 }

--- a/Ryujinx.Graphics.Vulkan/VulkanPhysicalDevice.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanPhysicalDevice.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 
 namespace Ryujinx.Graphics.Vulkan
 {
-    class VulkanPhysicalDevice
+    readonly struct VulkanPhysicalDevice
     {
         public readonly PhysicalDevice PhysicalDevice;
         public readonly PhysicalDeviceFeatures PhysicalDeviceFeatures;

--- a/Ryujinx.Graphics.Vulkan/VulkanPhysicalDevice.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanPhysicalDevice.cs
@@ -1,0 +1,69 @@
+using Ryujinx.Common.Utilities;
+using Ryujinx.Graphics.GAL;
+using Silk.NET.Vulkan;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+
+namespace Ryujinx.Graphics.Vulkan
+{
+    class VulkanPhysicalDevice
+    {
+        public readonly PhysicalDevice PhysicalDevice;
+        public readonly PhysicalDeviceFeatures PhysicalDeviceFeatures;
+        public readonly PhysicalDeviceProperties PhysicalDeviceProperties;
+        public readonly PhysicalDeviceMemoryProperties PhysicalDeviceMemoryProperties;
+        public readonly QueueFamilyProperties[] QueueFamilyProperties;
+        public readonly string DeviceName;
+        public readonly HashSet<string> DeviceExtensions;
+
+        public VulkanPhysicalDevice(Vk api, PhysicalDevice physicalDevice)
+        {
+            PhysicalDevice = physicalDevice;
+            PhysicalDeviceFeatures = api.GetPhysicalDeviceFeature(PhysicalDevice);
+
+            api.GetPhysicalDeviceProperties(PhysicalDevice, out var physicalDeviceProperties);
+            PhysicalDeviceProperties = physicalDeviceProperties;
+
+            api.GetPhysicalDeviceMemoryProperties(PhysicalDevice, out PhysicalDeviceMemoryProperties);
+
+            unsafe
+            {
+                DeviceName = Marshal.PtrToStringAnsi((IntPtr)physicalDeviceProperties.DeviceName);
+            }
+
+            uint propertiesCount = 0;
+
+            api.GetPhysicalDeviceQueueFamilyProperties(physicalDevice, SpanHelpers.AsSpan(ref propertiesCount), Span<QueueFamilyProperties>.Empty);
+
+            QueueFamilyProperties = new QueueFamilyProperties[propertiesCount];
+
+            api.GetPhysicalDeviceQueueFamilyProperties(physicalDevice, SpanHelpers.AsSpan(ref propertiesCount), QueueFamilyProperties);
+
+            api.EnumerateDeviceExtensionProperties(PhysicalDevice, Span<byte>.Empty, SpanHelpers.AsSpan(ref propertiesCount), Span<ExtensionProperties>.Empty).ThrowOnError();
+
+            ExtensionProperties[] extensionProperties = new ExtensionProperties[propertiesCount];
+
+            api.EnumerateDeviceExtensionProperties(PhysicalDevice, Span<byte>.Empty, SpanHelpers.AsSpan(ref propertiesCount), extensionProperties).ThrowOnError();
+
+            unsafe
+            {
+                DeviceExtensions = extensionProperties.Select(x => Marshal.PtrToStringAnsi((IntPtr)x.ExtensionName)).ToHashSet();
+            }
+        }
+
+        public string Id => $"0x{PhysicalDeviceProperties.VendorID:X}_0x{PhysicalDeviceProperties.DeviceID:X}";
+
+        public bool IsDeviceExtensionPresent(string extension) => DeviceExtensions.Contains(extension);
+
+        public DeviceInfo ToDeviceInfo()
+        {
+            return new DeviceInfo(
+                    Id,
+                    VendorUtils.GetNameFromId(PhysicalDeviceProperties.VendorID),
+                    DeviceName,
+                    PhysicalDeviceProperties.DeviceType == PhysicalDeviceType.DiscreteGpu);
+        }
+    }
+}

--- a/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -19,7 +19,7 @@ namespace Ryujinx.Graphics.Vulkan
     {
         private Instance _instance;
         private SurfaceKHR _surface;
-        private PhysicalDevice _physicalDevice;
+        private VulkanPhysicalDevice _physicalDevice;
         private Device _device;
         private WindowBase _window;
 
@@ -106,11 +106,9 @@ namespace Ryujinx.Graphics.Vulkan
             }
         }
 
-        private unsafe void LoadFeatures(string[] supportedExtensions, uint maxQueueCount, uint queueFamilyIndex)
+        private unsafe void LoadFeatures(uint maxQueueCount, uint queueFamilyIndex)
         {
-            FormatCapabilities = new FormatCapabilities(Api, _physicalDevice);
-
-            var supportedFeatures = Api.GetPhysicalDeviceFeature(_physicalDevice);
+            FormatCapabilities = new FormatCapabilities(Api, _physicalDevice.PhysicalDevice);
 
             if (Api.TryGetDeviceExtension(_instance, _device, out ExtConditionalRendering conditionalRenderingApi))
             {
@@ -154,7 +152,7 @@ namespace Ryujinx.Graphics.Vulkan
                 SType = StructureType.PhysicalDeviceBlendOperationAdvancedPropertiesExt
             };
 
-            bool supportsBlendOperationAdvanced = supportedExtensions.Contains("VK_EXT_blend_operation_advanced");
+            bool supportsBlendOperationAdvanced = _physicalDevice.IsDeviceExtensionPresent("VK_EXT_blend_operation_advanced");
 
             if (supportsBlendOperationAdvanced)
             {
@@ -167,14 +165,14 @@ namespace Ryujinx.Graphics.Vulkan
                 SType = StructureType.PhysicalDeviceSubgroupSizeControlPropertiesExt
             };
 
-            bool supportsSubgroupSizeControl = supportedExtensions.Contains("VK_EXT_subgroup_size_control");
+            bool supportsSubgroupSizeControl = _physicalDevice.IsDeviceExtensionPresent("VK_EXT_subgroup_size_control");
 
             if (supportsSubgroupSizeControl)
             {
                 properties2.PNext = &propertiesSubgroupSizeControl;
             }
 
-            bool supportsTransformFeedback = supportedExtensions.Contains(ExtTransformFeedback.ExtensionName);
+            bool supportsTransformFeedback = _physicalDevice.IsDeviceExtensionPresent(ExtTransformFeedback.ExtensionName);
 
             PhysicalDeviceTransformFeedbackPropertiesEXT propertiesTransformFeedback = new PhysicalDeviceTransformFeedbackPropertiesEXT()
             {
@@ -222,30 +220,30 @@ namespace Ryujinx.Graphics.Vulkan
                 SType = StructureType.PhysicalDevicePortabilitySubsetFeaturesKhr
             };
 
-            if (supportedExtensions.Contains("VK_EXT_primitive_topology_list_restart"))
+            if (_physicalDevice.IsDeviceExtensionPresent("VK_EXT_primitive_topology_list_restart"))
             {
                 features2.PNext = &featuresPrimitiveTopologyListRestart;
             }
 
-            if (supportedExtensions.Contains("VK_EXT_robustness2"))
+            if (_physicalDevice.IsDeviceExtensionPresent("VK_EXT_robustness2"))
             {
                 featuresRobustness2.PNext = features2.PNext;
                 features2.PNext = &featuresRobustness2;
             }
 
-            if (supportedExtensions.Contains("VK_KHR_shader_float16_int8"))
+            if (_physicalDevice.IsDeviceExtensionPresent("VK_KHR_shader_float16_int8"))
             {
                 featuresShaderInt8.PNext = features2.PNext;
                 features2.PNext = &featuresShaderInt8;
             }
 
-            if (supportedExtensions.Contains("VK_EXT_custom_border_color"))
+            if (_physicalDevice.IsDeviceExtensionPresent("VK_EXT_custom_border_color"))
             {
                 featuresCustomBorderColor.PNext = features2.PNext;
                 features2.PNext = &featuresCustomBorderColor;
             }
 
-            bool usePortability = supportedExtensions.Contains("VK_KHR_portability_subset");
+            bool usePortability = _physicalDevice.IsDeviceExtensionPresent("VK_KHR_portability_subset");
 
             if (usePortability)
             {
@@ -256,8 +254,8 @@ namespace Ryujinx.Graphics.Vulkan
                 features2.PNext = &featuresPortabilitySubset;
             }
 
-            Api.GetPhysicalDeviceProperties2(_physicalDevice, &properties2);
-            Api.GetPhysicalDeviceFeatures2(_physicalDevice, &features2);
+            Api.GetPhysicalDeviceProperties2(_physicalDevice.PhysicalDevice, &properties2);
+            Api.GetPhysicalDeviceFeatures2(_physicalDevice.PhysicalDevice, &features2);
 
             var portabilityFlags = PortabilitySubsetFlags.None;
             uint vertexBufferAlignment = 1;
@@ -272,7 +270,7 @@ namespace Ryujinx.Graphics.Vulkan
                 portabilityFlags |= featuresPortabilitySubset.SamplerMipLodBias ? 0 : PortabilitySubsetFlags.NoLodBias;
             }
 
-            bool supportsCustomBorderColor = supportedExtensions.Contains("VK_EXT_custom_border_color") &&
+            bool supportsCustomBorderColor = _physicalDevice.IsDeviceExtensionPresent("VK_EXT_custom_border_color") &&
                                              featuresCustomBorderColor.CustomBorderColors &&
                                              featuresCustomBorderColor.CustomBorderColorWithoutFormat;
 
@@ -284,30 +282,30 @@ namespace Ryujinx.Graphics.Vulkan
                 properties.Limits.FramebufferStencilSampleCounts;
 
             Capabilities = new HardwareCapabilities(
-                supportedExtensions.Contains("VK_EXT_index_type_uint8"),
+                _physicalDevice.IsDeviceExtensionPresent("VK_EXT_index_type_uint8"),
                 supportsCustomBorderColor,
                 supportsBlendOperationAdvanced,
                 propertiesBlendOperationAdvanced.AdvancedBlendCorrelatedOverlap,
                 propertiesBlendOperationAdvanced.AdvancedBlendNonPremultipliedSrcColor,
                 propertiesBlendOperationAdvanced.AdvancedBlendNonPremultipliedDstColor,
-                supportedExtensions.Contains(KhrDrawIndirectCount.ExtensionName),
-                supportedExtensions.Contains("VK_EXT_fragment_shader_interlock"),
-                supportedExtensions.Contains("VK_NV_geometry_shader_passthrough"),
+                _physicalDevice.IsDeviceExtensionPresent(KhrDrawIndirectCount.ExtensionName),
+                _physicalDevice.IsDeviceExtensionPresent("VK_EXT_fragment_shader_interlock"),
+                _physicalDevice.IsDeviceExtensionPresent("VK_NV_geometry_shader_passthrough"),
                 supportsSubgroupSizeControl,
                 featuresShaderInt8.ShaderInt8,
-                supportedExtensions.Contains("VK_EXT_shader_stencil_export"),
-                supportedExtensions.Contains(ExtConditionalRendering.ExtensionName),
-                supportedExtensions.Contains(ExtExtendedDynamicState.ExtensionName),
+                _physicalDevice.IsDeviceExtensionPresent("VK_EXT_shader_stencil_export"),
+                _physicalDevice.IsDeviceExtensionPresent(ExtConditionalRendering.ExtensionName),
+                _physicalDevice.IsDeviceExtensionPresent(ExtExtendedDynamicState.ExtensionName),
                 features2.Features.MultiViewport,
                 featuresRobustness2.NullDescriptor || IsMoltenVk,
-                supportedExtensions.Contains(KhrPushDescriptor.ExtensionName),
+                _physicalDevice.IsDeviceExtensionPresent(KhrPushDescriptor.ExtensionName),
                 featuresPrimitiveTopologyListRestart.PrimitiveTopologyListRestart,
                 featuresPrimitiveTopologyListRestart.PrimitiveTopologyPatchListRestart,
                 supportsTransformFeedback,
                 propertiesTransformFeedback.TransformFeedbackQueries,
                 features2.Features.OcclusionQueryPrecise,
-                supportedFeatures.PipelineStatisticsQuery,
-                supportedFeatures.GeometryShader,
+                _physicalDevice.PhysicalDeviceFeatures.PipelineStatisticsQuery,
+                _physicalDevice.PhysicalDeviceFeatures.GeometryShader,
                 propertiesSubgroupSizeControl.MinSubgroupSize,
                 propertiesSubgroupSizeControl.MaxSubgroupSize,
                 propertiesSubgroupSizeControl.RequiredSubgroupSizeStages,
@@ -315,9 +313,9 @@ namespace Ryujinx.Graphics.Vulkan
                 portabilityFlags,
                 vertexBufferAlignment);
 
-            IsSharedMemory = MemoryAllocator.IsDeviceMemoryShared(Api, _physicalDevice);
+            IsSharedMemory = MemoryAllocator.IsDeviceMemoryShared(_physicalDevice);
 
-            MemoryAllocator = new MemoryAllocator(Api, _physicalDevice, _device, properties.Limits.MaxMemoryAllocationCount);
+            MemoryAllocator = new MemoryAllocator(Api, _physicalDevice, _device);
 
             CommandBufferPool = new CommandBufferPool(Api, _device, Queue, QueueLock, queueFamilyIndex);
 
@@ -356,9 +354,8 @@ namespace Ryujinx.Graphics.Vulkan
             _physicalDevice = VulkanInitialization.FindSuitablePhysicalDevice(api, _instance, _surface, _preferredGpuId);
 
             var queueFamilyIndex = VulkanInitialization.FindSuitableQueueFamily(api, _physicalDevice, _surface, out uint maxQueueCount);
-            var supportedExtensions = VulkanInitialization.GetSupportedExtensions(api, _physicalDevice);
 
-            _device = VulkanInitialization.CreateDevice(api, _physicalDevice, queueFamilyIndex, supportedExtensions, maxQueueCount);
+            _device = VulkanInitialization.CreateDevice(api, _physicalDevice, queueFamilyIndex, maxQueueCount);
 
             if (api.TryGetDeviceExtension(_instance, _device, out KhrSwapchain swapchainApi))
             {
@@ -369,9 +366,9 @@ namespace Ryujinx.Graphics.Vulkan
             Queue = queue;
             QueueLock = new object();
 
-            LoadFeatures(supportedExtensions, maxQueueCount, queueFamilyIndex);
+            LoadFeatures(maxQueueCount, queueFamilyIndex);
 
-            _window = new Window(this, _surface, _physicalDevice, _device);
+            _window = new Window(this, _surface, _physicalDevice.PhysicalDevice, _device);
 
             _initialized = true;
         }
@@ -536,10 +533,9 @@ namespace Ryujinx.Graphics.Vulkan
                 PNext = &featuresVk12
             };
 
-            Api.GetPhysicalDeviceFeatures2(_physicalDevice, &features2);
-            Api.GetPhysicalDeviceProperties(_physicalDevice, out var properties);
+            Api.GetPhysicalDeviceFeatures2(_physicalDevice.PhysicalDevice, &features2);
 
-            var limits = properties.Limits;
+            var limits = _physicalDevice.PhysicalDeviceProperties.Limits;
 
             return new Capabilities(
                 api: TargetApi.Vulkan,
@@ -623,7 +619,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         private unsafe void PrintGpuInformation()
         {
-            Api.GetPhysicalDeviceProperties(_physicalDevice, out var properties);
+            var properties = _physicalDevice.PhysicalDeviceProperties;
 
             string vendorName = VendorUtils.GetNameFromId(properties.VendorID);
 

--- a/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -17,7 +17,7 @@ namespace Ryujinx.Graphics.Vulkan
 {
     public sealed class VulkanRenderer : IRenderer
     {
-        private Instance _instance;
+        private VulkanInstance _instance;
         private SurfaceKHR _surface;
         private VulkanPhysicalDevice _physicalDevice;
         private Device _device;
@@ -110,27 +110,27 @@ namespace Ryujinx.Graphics.Vulkan
         {
             FormatCapabilities = new FormatCapabilities(Api, _physicalDevice.PhysicalDevice);
 
-            if (Api.TryGetDeviceExtension(_instance, _device, out ExtConditionalRendering conditionalRenderingApi))
+            if (Api.TryGetDeviceExtension(_instance.Instance, _device, out ExtConditionalRendering conditionalRenderingApi))
             {
                 ConditionalRenderingApi = conditionalRenderingApi;
             }
 
-            if (Api.TryGetDeviceExtension(_instance, _device, out ExtExtendedDynamicState extendedDynamicStateApi))
+            if (Api.TryGetDeviceExtension(_instance.Instance, _device, out ExtExtendedDynamicState extendedDynamicStateApi))
             {
                 ExtendedDynamicStateApi = extendedDynamicStateApi;
             }
 
-            if (Api.TryGetDeviceExtension(_instance, _device, out KhrPushDescriptor pushDescriptorApi))
+            if (Api.TryGetDeviceExtension(_instance.Instance, _device, out KhrPushDescriptor pushDescriptorApi))
             {
                 PushDescriptorApi = pushDescriptorApi;
             }
 
-            if (Api.TryGetDeviceExtension(_instance, _device, out ExtTransformFeedback transformFeedbackApi))
+            if (Api.TryGetDeviceExtension(_instance.Instance, _device, out ExtTransformFeedback transformFeedbackApi))
             {
                 TransformFeedbackApi = transformFeedbackApi;
             }
 
-            if (Api.TryGetDeviceExtension(_instance, _device, out KhrDrawIndirectCount drawIndirectCountApi))
+            if (Api.TryGetDeviceExtension(_instance.Instance, _device, out KhrDrawIndirectCount drawIndirectCountApi))
             {
                 DrawIndirectCountApi = drawIndirectCountApi;
             }
@@ -343,21 +343,21 @@ namespace Ryujinx.Graphics.Vulkan
             Api = api;
 
             _instance = VulkanInitialization.CreateInstance(api, logLevel, _getRequiredExtensions());
-            _debugMessenger = new VulkanDebugMessenger(api, _instance, logLevel);
+            _debugMessenger = new VulkanDebugMessenger(api, _instance.Instance, logLevel);
 
-            if (api.TryGetInstanceExtension(_instance, out KhrSurface surfaceApi))
+            if (api.TryGetInstanceExtension(_instance.Instance, out KhrSurface surfaceApi))
             {
                 SurfaceApi = surfaceApi;
             }
 
-            _surface = _getSurface(_instance, api);
+            _surface = _getSurface(_instance.Instance, api);
             _physicalDevice = VulkanInitialization.FindSuitablePhysicalDevice(api, _instance, _surface, _preferredGpuId);
 
             var queueFamilyIndex = VulkanInitialization.FindSuitableQueueFamily(api, _physicalDevice, _surface, out uint maxQueueCount);
 
             _device = VulkanInitialization.CreateDevice(api, _physicalDevice, queueFamilyIndex, maxQueueCount);
 
-            if (api.TryGetDeviceExtension(_instance, _device, out KhrSwapchain swapchainApi))
+            if (api.TryGetDeviceExtension(_instance.Instance, _device, out KhrSwapchain swapchainApi))
             {
                 SwapchainApi = swapchainApi;
             }
@@ -803,14 +803,14 @@ namespace Ryujinx.Graphics.Vulkan
                 sampler.Dispose();
             }
 
-            SurfaceApi.DestroySurface(_instance, _surface, null);
+            SurfaceApi.DestroySurface(_instance.Instance, _surface, null);
 
             Api.DestroyDevice(_device, null);
 
             _debugMessenger.Dispose();
 
             // Last step destroy the instance
-            Api.DestroyInstance(_instance, null);
+            _instance.Dispose();
         }
     }
 }


### PR DESCRIPTION
That clean up a bit of duplicate logic and avoid querying for stuffs everywhere.

Also move to use an HashSet to store extensions string and use Span instead of unsafe pointers when possible.