### PR TITLE
hle: Set ProcessResult name from NACP

### DIFF
--- a/Ryujinx.HLE/Loaders/Processes/ProcessLoaderHelper.cs
+++ b/Ryujinx.HLE/Loaders/Processes/ProcessLoaderHelper.cs
@@ -405,7 +405,16 @@ namespace Ryujinx.HLE.Loaders.Processes
             // Once everything is loaded, we can load cheats.
             device.Configuration.VirtualFileSystem.ModLoader.LoadCheats(programId, tamperInfo, device.TamperMachine);
 
-            return new ProcessResult(metaLoader, applicationControlProperties, diskCacheEnabled, allowCodeMemoryForJit, processContextFactory.DiskCacheLoadState, process.Pid, meta.MainThreadPriority, meta.MainThreadStackSize, device.System.State.DesiredTitleLanguage);
+            return new ProcessResult(
+                metaLoader,
+                applicationControlProperties,
+                diskCacheEnabled,
+                allowCodeMemoryForJit,
+                processContextFactory.DiskCacheLoadState,
+                process.Pid,
+                meta.MainThreadPriority,
+                meta.MainThreadStackSize,
+                device.System.State.DesiredTitleLanguage);
         }
 
         public static Result LoadIntoMemory(KProcess process, IExecutable image, ulong baseAddress)

--- a/Ryujinx.HLE/Loaders/Processes/ProcessLoaderHelper.cs
+++ b/Ryujinx.HLE/Loaders/Processes/ProcessLoaderHelper.cs
@@ -405,7 +405,7 @@ namespace Ryujinx.HLE.Loaders.Processes
             // Once everything is loaded, we can load cheats.
             device.Configuration.VirtualFileSystem.ModLoader.LoadCheats(programId, tamperInfo, device.TamperMachine);
 
-            return new ProcessResult(metaLoader, applicationControlProperties, diskCacheEnabled, allowCodeMemoryForJit, processContextFactory.DiskCacheLoadState, process.Pid, meta.MainThreadPriority, meta.MainThreadStackSize);
+            return new ProcessResult(metaLoader, applicationControlProperties, diskCacheEnabled, allowCodeMemoryForJit, processContextFactory.DiskCacheLoadState, process.Pid, meta.MainThreadPriority, meta.MainThreadStackSize, device.System.State.DesiredTitleLanguage);
         }
 
         public static Result LoadIntoMemory(KProcess process, IExecutable image, ulong baseAddress)

--- a/Ryujinx.HLE/Loaders/Processes/ProcessResult.cs
+++ b/Ryujinx.HLE/Loaders/Processes/ProcessResult.cs
@@ -52,7 +52,17 @@ namespace Ryujinx.HLE.Loaders.Processes
             {
                 ulong programId = metaLoader.GetProgramId();
 
-                Name          = ApplicationControlProperties.Title[(int)titleLanguage].NameString.ToString();
+                if (ApplicationControlProperties.Title.ItemsRo.Length > 0)
+                {
+                    var langIndex = ApplicationControlProperties.Title.ItemsRo.Length > (int)titleLanguage ? (int)titleLanguage : 0;
+
+                    Name = ApplicationControlProperties.Title[langIndex].NameString.ToString();
+                }
+                else
+                {
+                    Name = metaLoader.GetProgramName();
+                }
+
                 ProgramId     = programId;
                 ProgramIdText = $"{programId:x16}";
                 Is64Bit       = metaLoader.IsProgram64Bit();

--- a/Ryujinx.HLE/Loaders/Processes/ProcessResult.cs
+++ b/Ryujinx.HLE/Loaders/Processes/ProcessResult.cs
@@ -37,8 +37,7 @@ namespace Ryujinx.HLE.Loaders.Processes
             ulong                      pid,
             byte                       mainThreadPriority,
             uint                       mainThreadStackSize,
-            TitleLanguage              titleLanguage
-            )
+            TitleLanguage              titleLanguage)
         {
             _mainThreadPriority  = mainThreadPriority;
             _mainThreadStackSize = mainThreadStackSize;

--- a/Ryujinx.HLE/Loaders/Processes/ProcessResult.cs
+++ b/Ryujinx.HLE/Loaders/Processes/ProcessResult.cs
@@ -2,6 +2,7 @@
 using LibHac.Ns;
 using Ryujinx.Common.Logging;
 using Ryujinx.Cpu;
+using Ryujinx.HLE.HOS.SystemState;
 using Ryujinx.HLE.Loaders.Processes.Extensions;
 using Ryujinx.Horizon.Common;
 
@@ -9,7 +10,7 @@ namespace Ryujinx.HLE.Loaders.Processes
 {
     public struct ProcessResult
     {
-        public static ProcessResult Failed => new(null, new ApplicationControlProperty(), false, false, null, 0, 0, 0);
+        public static ProcessResult Failed => new(null, new ApplicationControlProperty(), false, false, null, 0, 0, 0, TitleLanguage.AmericanEnglish);
 
         private readonly byte _mainThreadPriority;
         private readonly uint _mainThreadStackSize;
@@ -35,7 +36,9 @@ namespace Ryujinx.HLE.Loaders.Processes
             IDiskCacheLoadState        diskCacheLoadState,
             ulong                      pid,
             byte                       mainThreadPriority,
-            uint                       mainThreadStackSize)
+            uint                       mainThreadStackSize,
+            TitleLanguage              titleLanguage
+            )
         {
             _mainThreadPriority  = mainThreadPriority;
             _mainThreadStackSize = mainThreadStackSize;
@@ -50,7 +53,7 @@ namespace Ryujinx.HLE.Loaders.Processes
             {
                 ulong programId = metaLoader.GetProgramId();
 
-                Name          = metaLoader.GetProgramName();
+                Name          = ApplicationControlProperties.Title[(int)titleLanguage].NameString.ToString();
                 ProgramId     = programId;
                 ProgramIdText = $"{programId:x16}";
                 Is64Bit       = metaLoader.IsProgram64Bit();


### PR DESCRIPTION
This PR reads the `Name` for ProcessResult from the NACP, so `Name` contains the title name which is more a lot more useful to know when we receive logs from users.

The title name will be logged in the language chosen by the user.