### PR TITLE
Fix missing string enum converters for the config

### DIFF
--- a/Ryujinx.Common/Configuration/Hid/Controller/GamepadInputId.cs
+++ b/Ryujinx.Common/Configuration/Hid/Controller/GamepadInputId.cs
@@ -1,5 +1,9 @@
-﻿namespace Ryujinx.Common.Configuration.Hid.Controller
+﻿using Ryujinx.Common.Utilities;
+using System.Text.Json.Serialization;
+
+namespace Ryujinx.Common.Configuration.Hid.Controller
 {
+    [JsonConverter(typeof(TypedStringEnumConverter<GamepadInputId>))]
     public enum GamepadInputId : byte
     {
         Unbound,

--- a/Ryujinx.Common/Configuration/Hid/Controller/StickInputId.cs
+++ b/Ryujinx.Common/Configuration/Hid/Controller/StickInputId.cs
@@ -1,5 +1,9 @@
-﻿namespace Ryujinx.Common.Configuration.Hid.Controller
+﻿using Ryujinx.Common.Utilities;
+using System.Text.Json.Serialization;
+
+namespace Ryujinx.Common.Configuration.Hid.Controller
 {
+    [JsonConverter(typeof(TypedStringEnumConverter<StickInputId>))]
     public enum StickInputId : byte
     {
         Unbound,

--- a/Ryujinx.Common/Configuration/Hid/KeyboardHotkeys.cs
+++ b/Ryujinx.Common/Configuration/Hid/KeyboardHotkeys.cs
@@ -1,6 +1,8 @@
 ﻿namespace Ryujinx.Common.Configuration.Hid
 {
-    public struct KeyboardHotkeys
+    // NOTE: Please don't change this to struct.
+    //       This breaks Avalonia's TwoWay binding, which makes us unable to save new KeyboardHotkeys.
+    public class KeyboardHotkeys
     {
         public Key ToggleVsync { get; set; }
         public Key Screenshot { get; set; }


### PR DESCRIPTION
This PR allows previous config versions to be parsed correctly again.