### PR TITLE
HLE: Deal with empty title names properly

### DIFF
--- a/Ryujinx.Ava/AppHost.cs
+++ b/Ryujinx.Ava/AppHost.cs
@@ -321,13 +321,11 @@ namespace Ryujinx.Ava
             _viewModel.IsGameRunning = true;
 
             var activeProcess   = Device.Processes.ActiveApplication;
-            var nacp            = activeProcess.ApplicationControlProperties;
-            int desiredLanguage = (int)Device.System.State.DesiredTitleLanguage;
 
-            string titleNameSection    = string.IsNullOrWhiteSpace(nacp.Title[desiredLanguage].NameString.ToString()) ? string.Empty : $" - {nacp.Title[desiredLanguage].NameString.ToString()}";
-            string titleVersionSection = string.IsNullOrWhiteSpace(nacp.DisplayVersionString.ToString())              ? string.Empty : $" v{nacp.DisplayVersionString.ToString()}";
-            string titleIdSection      = string.IsNullOrWhiteSpace(activeProcess.ProgramIdText)                       ? string.Empty : $" ({activeProcess.ProgramIdText.ToUpper()})";
-            string titleArchSection    = activeProcess.Is64Bit                                                        ? " (64-bit)"  : " (32-bit)";
+            string titleNameSection    = $" - {activeProcess.Name}";
+            string titleVersionSection = $" v{activeProcess.DisplayVersion}";
+            string titleIdSection      = $" ({activeProcess.ProgramIdText.ToUpper()})";
+            string titleArchSection    = activeProcess.Is64Bit ? " (64-bit)" : " (32-bit)";
 
             Dispatcher.UIThread.InvokeAsync(() =>
             {

--- a/Ryujinx.Ava/AppHost.cs
+++ b/Ryujinx.Ava/AppHost.cs
@@ -322,14 +322,14 @@ namespace Ryujinx.Ava
 
             var activeProcess   = Device.Processes.ActiveApplication;
 
-            string titleNameSection    = $" - {activeProcess.Name}";
-            string titleVersionSection = $" v{activeProcess.DisplayVersion}";
+            string titleNameSection    = string.IsNullOrWhiteSpace(activeProcess.Name) ? string.Empty : $" {activeProcess.Name}";
+            string titleVersionSection = string.IsNullOrWhiteSpace(activeProcess.DisplayVersion) ? string.Empty : $" v{activeProcess.DisplayVersion}";
             string titleIdSection      = $" ({activeProcess.ProgramIdText.ToUpper()})";
             string titleArchSection    = activeProcess.Is64Bit ? " (64-bit)" : " (32-bit)";
 
             Dispatcher.UIThread.InvokeAsync(() =>
             {
-                _viewModel.Title = $"Ryujinx {Program.Version}{titleNameSection}{titleVersionSection}{titleIdSection}{titleArchSection}";
+                _viewModel.Title = $"Ryujinx {Program.Version} -{titleNameSection}{titleVersionSection}{titleIdSection}{titleArchSection}";
             });
 
             _viewModel.SetUIProgressHandlers(Device);

--- a/Ryujinx.HLE/Loaders/Processes/ProcessResult.cs
+++ b/Ryujinx.HLE/Loaders/Processes/ProcessResult.cs
@@ -54,20 +54,11 @@ namespace Ryujinx.HLE.Loaders.Processes
             {
                 ulong programId = metaLoader.GetProgramId();
 
-                if (ApplicationControlProperties.Title.ItemsRo.Length > 0)
-                {
-                    var langIndex = ApplicationControlProperties.Title.ItemsRo.Length > (int)titleLanguage ? (int)titleLanguage : 0;
+                Name = ApplicationControlProperties.Title[(int)titleLanguage].NameString.ToString();
 
-                    Name = ApplicationControlProperties.Title[langIndex].NameString.ToString();
-
-                    if (string.IsNullOrWhiteSpace(Name))
-                    {
-                        Name = ApplicationControlProperties.Title.ItemsRo.ToArray().FirstOrDefault(x => x.Name[0] != 0).NameString.ToString();
-                    }
-                }
-                else
+                if (string.IsNullOrWhiteSpace(Name))
                 {
-                    Name = metaLoader.GetProgramName();
+                    Name = ApplicationControlProperties.Title.ItemsRo.ToArray().FirstOrDefault(x => x.Name[0] != 0).NameString.ToString();
                 }
 
                 DisplayVersion = ApplicationControlProperties.DisplayVersionString.ToString();

--- a/Ryujinx.HLE/Loaders/Processes/ProcessResult.cs
+++ b/Ryujinx.HLE/Loaders/Processes/ProcessResult.cs
@@ -22,8 +22,9 @@ namespace Ryujinx.HLE.Loaders.Processes
         public readonly ApplicationControlProperty ApplicationControlProperties;
 
         public readonly ulong  ProcessId;
-        public string          Name;
-        public ulong           ProgramId;
+        public readonly string Name;
+        public readonly string DisplayVersion;
+        public readonly ulong  ProgramId;
         public readonly string ProgramIdText;
         public readonly bool   Is64Bit;
         public readonly bool   DiskCacheEnabled;
@@ -69,9 +70,10 @@ namespace Ryujinx.HLE.Loaders.Processes
                     Name = metaLoader.GetProgramName();
                 }
 
-                ProgramId     = programId;
-                ProgramIdText = $"{programId:x16}";
-                Is64Bit       = metaLoader.IsProgram64Bit();
+                DisplayVersion = ApplicationControlProperties.DisplayVersionString.ToString();
+                ProgramId      = programId;
+                ProgramIdText  = $"{programId:x16}";
+                Is64Bit        = metaLoader.IsProgram64Bit();
             }
 
             DiskCacheEnabled      = diskCacheEnabled;
@@ -91,16 +93,7 @@ namespace Ryujinx.HLE.Loaders.Processes
             }
 
             // TODO: LibHac npdm currently doesn't support version field.
-            string version;
-
-            if (ProgramId > 0x0100000000007FFF)
-            {
-                version = ApplicationControlProperties.DisplayVersionString.ToString();
-            }
-            else
-            {
-                version = device.System.ContentManager.GetCurrentFirmwareVersion().VersionString;
-            }
+            string version = ProgramId > 0x0100000000007FFF ? DisplayVersion : device.System.ContentManager.GetCurrentFirmwareVersion().VersionString;
 
             Logger.Info?.Print(LogClass.Loader, $"Application Loaded: {Name} v{version} [{ProgramIdText}] [{(Is64Bit ? "64-bit" : "32-bit")}]");
 

--- a/Ryujinx.HLE/Loaders/Processes/ProcessResult.cs
+++ b/Ryujinx.HLE/Loaders/Processes/ProcessResult.cs
@@ -5,6 +5,7 @@ using Ryujinx.Cpu;
 using Ryujinx.HLE.HOS.SystemState;
 using Ryujinx.HLE.Loaders.Processes.Extensions;
 using Ryujinx.Horizon.Common;
+using System.Linq;
 
 namespace Ryujinx.HLE.Loaders.Processes
 {
@@ -57,6 +58,11 @@ namespace Ryujinx.HLE.Loaders.Processes
                     var langIndex = ApplicationControlProperties.Title.ItemsRo.Length > (int)titleLanguage ? (int)titleLanguage : 0;
 
                     Name = ApplicationControlProperties.Title[langIndex].NameString.ToString();
+
+                    if (string.IsNullOrWhiteSpace(Name))
+                    {
+                        Name = ApplicationControlProperties.Title.ItemsRo.ToArray().FirstOrDefault(x => x.Name[0] != 0).NameString.ToString();
+                    }
                 }
                 else
                 {

--- a/Ryujinx.HLE/Loaders/Processes/ProcessResult.cs
+++ b/Ryujinx.HLE/Loaders/Processes/ProcessResult.cs
@@ -84,7 +84,7 @@ namespace Ryujinx.HLE.Loaders.Processes
             }
 
             // TODO: LibHac npdm currently doesn't support version field.
-            string version = ProgramId > 0x0100000000007FFF ? DisplayVersion : device.System.ContentManager.GetCurrentFirmwareVersion().VersionString;
+            string version = ProgramId > 0x0100000000007FFF ? DisplayVersion : device.System.ContentManager.GetCurrentFirmwareVersion()?.VersionString ?? "?";
 
             Logger.Info?.Print(LogClass.Loader, $"Application Loaded: {Name} v{version} [{ProgramIdText}] [{(Is64Bit ? "64-bit" : "32-bit")}]");
 

--- a/Ryujinx/Ui/RendererWidgetBase.cs
+++ b/Ryujinx/Ui/RendererWidgetBase.cs
@@ -496,13 +496,11 @@ namespace Ryujinx.Ui
                 parent.Present();
 
                 var activeProcess   = Device.Processes.ActiveApplication;
-                var nacp            = activeProcess.ApplicationControlProperties;
-                int desiredLanguage = (int)Device.System.State.DesiredTitleLanguage;
 
-                string titleNameSection    = string.IsNullOrWhiteSpace(nacp.Title[desiredLanguage].NameString.ToString()) ? string.Empty : $" - {nacp.Title[desiredLanguage].NameString.ToString()}";
-                string titleVersionSection = string.IsNullOrWhiteSpace(nacp.DisplayVersionString.ToString())              ? string.Empty : $" v{nacp.DisplayVersionString.ToString()}";
-                string titleIdSection      = string.IsNullOrWhiteSpace(activeProcess.ProgramIdText)                       ? string.Empty : $" ({activeProcess.ProgramIdText.ToUpper()})";
-                string titleArchSection    = activeProcess.Is64Bit                                                        ? " (64-bit)"  : " (32-bit)";
+                string titleNameSection    = $" - {activeProcess.Name}";
+                string titleVersionSection = $" v{activeProcess.DisplayVersion}";
+                string titleIdSection      = $" ({activeProcess.ProgramIdText.ToUpper()})";
+                string titleArchSection    = activeProcess.Is64Bit ? " (64-bit)" : " (32-bit)";
 
                 parent.Title = $"Ryujinx {Program.Version}{titleNameSection}{titleVersionSection}{titleIdSection}{titleArchSection}";
             });

--- a/Ryujinx/Ui/RendererWidgetBase.cs
+++ b/Ryujinx/Ui/RendererWidgetBase.cs
@@ -497,12 +497,12 @@ namespace Ryujinx.Ui
 
                 var activeProcess   = Device.Processes.ActiveApplication;
 
-                string titleNameSection    = $" - {activeProcess.Name}";
-                string titleVersionSection = $" v{activeProcess.DisplayVersion}";
+                string titleNameSection    = string.IsNullOrWhiteSpace(activeProcess.Name) ? string.Empty : $" {activeProcess.Name}";
+                string titleVersionSection = string.IsNullOrWhiteSpace(activeProcess.DisplayVersion) ? string.Empty : $" v{activeProcess.DisplayVersion}";
                 string titleIdSection      = $" ({activeProcess.ProgramIdText.ToUpper()})";
                 string titleArchSection    = activeProcess.Is64Bit ? " (64-bit)" : " (32-bit)";
 
-                parent.Title = $"Ryujinx {Program.Version}{titleNameSection}{titleVersionSection}{titleIdSection}{titleArchSection}";
+                parent.Title = $"Ryujinx {Program.Version} -{titleNameSection}{titleVersionSection}{titleIdSection}{titleArchSection}";
             });
 
             Thread renderLoopThread = new Thread(Render)


### PR DESCRIPTION
This restores the behavior we had before #4480 to read title names in case the name of the desired language is empty.