### PR TITLE
Replace constant buffer access on shader with new Load instruction

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 5027;
+        private const uint CodeGenVersion = 4646;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Glsl/DefaultNames.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Glsl/DefaultNames.cs
@@ -15,17 +15,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
         public const string DataName = "data";
 
-        public const string SupportBlockName = "support_block";
-        public const string SupportBlockAlphaTestName = "s_alpha_test";
-        public const string SupportBlockIsBgraName = "s_is_bgra";
-        public const string SupportBlockViewportInverse = "s_viewport_inverse";
-        public const string SupportBlockFragmentScaleCount = "s_frag_scale_count";
-        public const string SupportBlockRenderScaleName = "s_render_scale";
-
         public const string BlockSuffix = "block";
-
-        public const string UniformNamePrefix = "c";
-        public const string UniformNameSuffix = "data";
 
         public const string LocalMemoryName  = "local_mem";
         public const string SharedMemoryName = "shared_mem";

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_cp.glsl
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_cp.glsl
@@ -1,6 +1,6 @@
 ﻿ivec2 Helper_TexelFetchScale(ivec2 inputVec, int samplerIndex)
 {
-    float scale = s_render_scale[samplerIndex];
+    float scale = support_buffer.s_render_scale[1 + samplerIndex];
     if (scale == 1.0)
     {
         return inputVec;
@@ -10,7 +10,7 @@
 
 int Helper_TextureSizeUnscale(int size, int samplerIndex)
 {
-    float scale = s_render_scale[samplerIndex];
+    float scale = support_buffer.s_render_scale[1 + samplerIndex];
     if (scale == 1.0)
     {
         return size;

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_fp.glsl
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_fp.glsl
@@ -1,6 +1,6 @@
 ﻿ivec2 Helper_TexelFetchScale(ivec2 inputVec, int samplerIndex)
 {
-    float scale = s_render_scale[1 + samplerIndex];
+    float scale = support_buffer.s_render_scale[1 + samplerIndex];
     if (scale == 1.0)
     {
         return inputVec;
@@ -17,7 +17,7 @@
 
 int Helper_TextureSizeUnscale(int size, int samplerIndex)
 {
-    float scale = abs(s_render_scale[1 + samplerIndex]);
+    float scale = abs(support_buffer.s_render_scale[1 + samplerIndex]);
     if (scale == 1.0)
     {
         return size;

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_vp.glsl
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Glsl/HelperFunctions/TexelFetchScale_vp.glsl
@@ -1,6 +1,6 @@
 ﻿ivec2 Helper_TexelFetchScale(ivec2 inputVec, int samplerIndex)
 {
-    float scale = abs(s_render_scale[1 + samplerIndex + s_frag_scale_count]);
+    float scale = abs(support_buffer.s_render_scale[1 + samplerIndex + support_buffer.s_frag_scale_count]);
     if (scale == 1.0)
     {
         return inputVec;
@@ -11,7 +11,7 @@
 
 int Helper_TextureSizeUnscale(int size, int samplerIndex)
 {
-    float scale = abs(s_render_scale[1 + samplerIndex + s_frag_scale_count]);
+    float scale = abs(support_buffer.s_render_scale[1 + samplerIndex + support_buffer.s_frag_scale_count]);
     if (scale == 1.0)
     {
         return size;

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGen.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGen.cs
@@ -167,9 +167,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
                     case Instruction.Load:
                         return Load(context, operation);
 
-                    case Instruction.LoadConstant:
-                        return LoadConstant(context, operation);
-
                     case Instruction.LoadLocal:
                         return LoadLocal(context, operation);
 

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenHelper.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenHelper.cs
@@ -83,7 +83,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
             Add(Instruction.ImageAtomic,              InstType.Special);
             Add(Instruction.IsNan,                    InstType.CallUnary,      "isnan");
             Add(Instruction.Load,                     InstType.Special);
-            Add(Instruction.LoadConstant,             InstType.Special);
             Add(Instruction.LoadLocal,                InstType.Special);
             Add(Instruction.LoadShared,               InstType.Special);
             Add(Instruction.LoadStorage,              InstType.Special);

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/IoMap.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/IoMap.cs
@@ -27,7 +27,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
                 IoVariable.FragmentCoord => ("gl_FragCoord", AggregateType.Vector4 | AggregateType.FP32),
                 IoVariable.FragmentOutputColor => GetFragmentOutputColorVariableName(config, location),
                 IoVariable.FragmentOutputDepth => ("gl_FragDepth", AggregateType.FP32),
-                IoVariable.FragmentOutputIsBgra => (DefaultNames.SupportBlockIsBgraName, AggregateType.Array | AggregateType.Bool),
                 IoVariable.FrontColorDiffuse => ("gl_FrontColor", AggregateType.Vector4 | AggregateType.FP32), // Deprecated.
                 IoVariable.FrontColorSpecular  => ("gl_FrontSecondaryColor", AggregateType.Vector4 | AggregateType.FP32), // Deprecated.
                 IoVariable.FrontFacing => ("gl_FrontFacing", AggregateType.Bool),
@@ -46,8 +45,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
                 IoVariable.SubgroupLaneId => GetSubgroupInvocationIdVariableName(config),
                 IoVariable.SubgroupLeMask => GetSubgroupMaskVariableName(config, "Le"),
                 IoVariable.SubgroupLtMask => GetSubgroupMaskVariableName(config, "Lt"),
-                IoVariable.SupportBlockRenderScale => (DefaultNames.SupportBlockRenderScaleName, AggregateType.Array | AggregateType.FP32),
-                IoVariable.SupportBlockViewInverse => (DefaultNames.SupportBlockViewportInverse, AggregateType.Vector2 | AggregateType.FP32),
                 IoVariable.TessellationCoord => ("gl_TessCoord", AggregateType.Vector3 | AggregateType.FP32),
                 IoVariable.TessellationLevelInner => ("gl_TessLevelInner", AggregateType.Array | AggregateType.FP32),
                 IoVariable.TessellationLevelOuter => ("gl_TessLevelOuter", AggregateType.Array | AggregateType.FP32),

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/ScalingHelpers.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/ScalingHelpers.cs
@@ -63,7 +63,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
             if (context.Config.Stage == ShaderStage.Vertex)
             {
                 var scaleCountPointerType = context.TypePointer(StorageClass.Uniform, context.TypeS32());
-                var scaleCountElemPointer = context.AccessChain(scaleCountPointerType, context.SupportBuffer, context.Constant(context.TypeU32(), 3));
+                var scaleCountElemPointer = context.AccessChain(scaleCountPointerType, context.ConstantBuffers[0], context.Constant(context.TypeU32(), 3));
                 var scaleCount = context.Load(context.TypeS32(), scaleCountElemPointer);
 
                 scaleIndex = context.IAdd(context.TypeU32(), scaleIndex, scaleCount);
@@ -71,7 +71,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
 
             scaleIndex = context.IAdd(context.TypeU32(), scaleIndex, context.Constant(context.TypeU32(), 1));
 
-            var scaleElemPointer = context.AccessChain(pointerType, context.SupportBuffer, fieldIndex, scaleIndex);
+            var scaleElemPointer = context.AccessChain(pointerType, context.ConstantBuffers[0], fieldIndex, scaleIndex);
             var scale = context.Load(context.TypeFP32(), scaleElemPointer);
 
             var ivector2Type = context.TypeVector(context.TypeS32(), 2);
@@ -201,7 +201,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
                 if (context.Config.Stage == ShaderStage.Vertex)
                 {
                     var scaleCountPointerType = context.TypePointer(StorageClass.Uniform, context.TypeS32());
-                    var scaleCountElemPointer = context.AccessChain(scaleCountPointerType, context.SupportBuffer, context.Constant(context.TypeU32(), 3));
+                    var scaleCountElemPointer = context.AccessChain(scaleCountPointerType, context.ConstantBuffers[0], context.Constant(context.TypeU32(), 3));
                     var scaleCount = context.Load(context.TypeS32(), scaleCountElemPointer);
 
                     scaleIndex = context.IAdd(context.TypeU32(), scaleIndex, scaleCount);
@@ -209,7 +209,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
 
                 scaleIndex = context.IAdd(context.TypeU32(), scaleIndex, context.Constant(context.TypeU32(), 1));
 
-                var scaleElemPointer = context.AccessChain(pointerType, context.SupportBuffer, fieldIndex, scaleIndex);
+                var scaleElemPointer = context.AccessChain(pointerType, context.ConstantBuffers[0], fieldIndex, scaleIndex);
                 var scale = context.GlslFAbs(context.TypeFP32(), context.Load(context.TypeFP32(), scaleElemPointer));
 
                 var passthrough = context.FOrdEqual(context.TypeBool(), scale, context.Constant(context.TypeFP32(), 1f));

--- a/src/Ryujinx.Graphics.Shader/Instructions/InstEmitAttribute.cs
+++ b/src/Ryujinx.Graphics.Shader/Instructions/InstEmitAttribute.cs
@@ -160,7 +160,7 @@ namespace Ryujinx.Graphics.Shader.Instructions
                 {
                     // FragCoord X/Y must be divided by the render target scale, if resolution scaling is active,
                     // because the shader code is not expecting scaled values.
-                    res = context.FPDivide(res, context.Load(StorageKind.Input, IoVariable.SupportBlockRenderScale, null, Const(0)));
+                    res = context.FPDivide(res, context.Load(StorageKind.ConstantBuffer, SupportBuffer.Binding, Const((int)SupportBufferField.RenderScale), Const(0)));
                 }
                 else if (op.Imm10 == AttributeConsts.FrontFacing && context.Config.GpuAccessor.QueryHostHasFrontFacingBug())
                 {

--- a/src/Ryujinx.Graphics.Shader/IntermediateRepresentation/Instruction.cs
+++ b/src/Ryujinx.Graphics.Shader/IntermediateRepresentation/Instruction.cs
@@ -79,7 +79,6 @@ namespace Ryujinx.Graphics.Shader.IntermediateRepresentation
         ImageAtomic,
         IsNan,
         Load,
-        LoadConstant,
         LoadGlobal,
         LoadLocal,
         LoadShared,

--- a/src/Ryujinx.Graphics.Shader/IntermediateRepresentation/IoVariable.cs
+++ b/src/Ryujinx.Graphics.Shader/IntermediateRepresentation/IoVariable.cs
@@ -15,7 +15,6 @@ namespace Ryujinx.Graphics.Shader.IntermediateRepresentation
         FragmentCoord,
         FragmentOutputColor,
         FragmentOutputDepth,
-        FragmentOutputIsBgra, // TODO: Remove and use constant buffer access.
         FrontColorDiffuse,
         FrontColorSpecular,
         FrontFacing,
@@ -34,8 +33,6 @@ namespace Ryujinx.Graphics.Shader.IntermediateRepresentation
         SubgroupLaneId,
         SubgroupLeMask,
         SubgroupLtMask,
-        SupportBlockViewInverse, // TODO: Remove and use constant buffer access.
-        SupportBlockRenderScale, // TODO: Remove and use constant buffer access.
         TessellationCoord,
         TessellationLevelInner,
         TessellationLevelOuter,

--- a/src/Ryujinx.Graphics.Shader/StructuredIr/AstOperand.cs
+++ b/src/Ryujinx.Graphics.Shader/StructuredIr/AstOperand.cs
@@ -15,9 +15,6 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
 
         public int Value { get; }
 
-        public int CbufSlot   { get; }
-        public int CbufOffset { get; }
-
         private AstOperand()
         {
             Defs = new HashSet<IAstNode>();
@@ -29,16 +26,7 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
         public AstOperand(Operand operand) : this()
         {
             Type = operand.Type;
-
-            if (Type == OperandType.ConstantBuffer)
-            {
-                CbufSlot   = operand.GetCbufSlot();
-                CbufOffset = operand.GetCbufOffset();
-            }
-            else
-            {
-                Value = operand.Value;
-            }
+            Value = operand.Value;
         }
 
         public AstOperand(OperandType type, int value = 0)  : this()

--- a/src/Ryujinx.Graphics.Shader/StructuredIr/BufferDefinition.cs
+++ b/src/Ryujinx.Graphics.Shader/StructuredIr/BufferDefinition.cs
@@ -1,0 +1,20 @@
+namespace Ryujinx.Graphics.Shader.StructuredIr
+{
+    readonly struct BufferDefinition
+    {
+        public BufferLayout Layout { get; }
+        public int Set { get; }
+        public int Binding { get; }
+        public string Name { get; }
+        public StructureType Type { get; }
+
+        public BufferDefinition(BufferLayout layout, int set, int binding, string name, StructureType type)
+        {
+            Layout = layout;
+            Set = set;
+            Binding = binding;
+            Name = name;
+            Type = type;
+        }
+    }
+}

--- a/src/Ryujinx.Graphics.Shader/StructuredIr/BufferLayout.cs
+++ b/src/Ryujinx.Graphics.Shader/StructuredIr/BufferLayout.cs
@@ -1,0 +1,8 @@
+namespace Ryujinx.Graphics.Shader.StructuredIr
+{
+    enum BufferLayout
+    {
+        Std140,
+        Std430
+    }
+}

--- a/src/Ryujinx.Graphics.Shader/StructuredIr/InstructionInfo.cs
+++ b/src/Ryujinx.Graphics.Shader/StructuredIr/InstructionInfo.cs
@@ -90,7 +90,6 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
             Add(Instruction.ImageAtomic,              AggregateType.S32);
             Add(Instruction.IsNan,                    AggregateType.Bool,   AggregateType.Scalar);
             Add(Instruction.Load,                     AggregateType.FP32);
-            Add(Instruction.LoadConstant,             AggregateType.FP32,   AggregateType.S32,     AggregateType.S32);
             Add(Instruction.LoadGlobal,               AggregateType.U32,    AggregateType.S32,     AggregateType.S32);
             Add(Instruction.LoadLocal,                AggregateType.U32,    AggregateType.S32);
             Add(Instruction.LoadShared,               AggregateType.U32,    AggregateType.S32);

--- a/src/Ryujinx.Graphics.Shader/StructuredIr/OperandInfo.cs
+++ b/src/Ryujinx.Graphics.Shader/StructuredIr/OperandInfo.cs
@@ -24,7 +24,6 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
             {
                 OperandType.Argument => AggregateType.S32,
                 OperandType.Constant => AggregateType.S32,
-                OperandType.ConstantBuffer => AggregateType.FP32,
                 OperandType.Undefined => AggregateType.S32,
                 _ => throw new ArgumentException($"Invalid operand type \"{type}\".")
             };

--- a/src/Ryujinx.Graphics.Shader/StructuredIr/ShaderProperties.cs
+++ b/src/Ryujinx.Graphics.Shader/StructuredIr/ShaderProperties.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace Ryujinx.Graphics.Shader.StructuredIr
+{
+    class ShaderProperties
+    {
+        private readonly Dictionary<int, BufferDefinition> _constantBuffers;
+
+        public IReadOnlyDictionary<int, BufferDefinition> ConstantBuffers => _constantBuffers;
+
+        public ShaderProperties()
+        {
+            _constantBuffers = new Dictionary<int, BufferDefinition>();
+        }
+
+        public void AddConstantBuffer(int binding, BufferDefinition definition)
+        {
+            _constantBuffers[binding] = definition;
+        }
+    }
+}

--- a/src/Ryujinx.Graphics.Shader/StructuredIr/StructureType.cs
+++ b/src/Ryujinx.Graphics.Shader/StructuredIr/StructureType.cs
@@ -1,0 +1,28 @@
+using Ryujinx.Graphics.Shader.Translation;
+
+namespace Ryujinx.Graphics.Shader.StructuredIr
+{
+    struct StructureField
+    {
+        public AggregateType Type { get; }
+        public string Name { get; }
+        public int ArrayLength { get; }
+
+        public StructureField(AggregateType type, string name, int arrayLength = 1)
+        {
+            Type = type;
+            Name = name;
+            ArrayLength = arrayLength;
+        }
+    }
+
+    class StructureType
+    {
+        public StructureField[] Fields { get; }
+
+        public StructureType(StructureField[] fields)
+        {
+            Fields = fields;
+        }
+    }
+}

--- a/src/Ryujinx.Graphics.Shader/SupportBuffer.cs
+++ b/src/Ryujinx.Graphics.Shader/SupportBuffer.cs
@@ -1,4 +1,6 @@
 using Ryujinx.Common.Memory;
+using Ryujinx.Graphics.Shader.StructuredIr;
+using Ryujinx.Graphics.Shader.Translation;
 using System.Runtime.CompilerServices;
 
 namespace Ryujinx.Graphics.Shader
@@ -11,8 +13,20 @@ namespace Ryujinx.Graphics.Shader
         public T W;
     }
 
+    enum SupportBufferField
+    {
+        // Must match the order of the fields on the struct.
+        FragmentAlphaTest,
+        FragmentIsBgra,
+        ViewportInverse,
+        FragmentRenderScaleCount,
+        RenderScale
+    }
+
     public struct SupportBuffer
     {
+        internal const int Binding = 0;
+
         public static int FieldSize;
         public static int RequiredSize;
 
@@ -45,6 +59,18 @@ namespace Ryujinx.Graphics.Shader
             FragmentRenderScaleCountOffset = OffsetOf(ref instance, ref instance.FragmentRenderScaleCount);
             GraphicsRenderScaleOffset = OffsetOf(ref instance, ref instance.RenderScale);
             ComputeRenderScaleOffset = GraphicsRenderScaleOffset + FieldSize;
+        }
+
+        internal static StructureType GetStructureType()
+        {
+            return new StructureType(new[]
+            {
+                new StructureField(AggregateType.U32, "s_alpha_test"),
+                new StructureField(AggregateType.Array | AggregateType.U32, "s_is_bgra", FragmentIsBgraCount),
+                new StructureField(AggregateType.Vector4 | AggregateType.FP32, "s_viewport_inverse"),
+                new StructureField(AggregateType.S32, "s_frag_scale_count"),
+                new StructureField(AggregateType.Array | AggregateType.FP32, "s_render_scale", RenderScaleMaxCount)
+            });
         }
 
         public Vector4<int> FragmentAlphaTest;

--- a/src/Ryujinx.Graphics.Shader/Translation/AggregateType.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/AggregateType.cs
@@ -22,4 +22,35 @@
 
         Array  = 1 << 10
     }
+
+    static class AggregateTypeExtensions
+    {
+        public static int GetSizeInBytes(this AggregateType type)
+        {
+            int elementSize = (type & AggregateType.ElementTypeMask) switch
+            {
+                AggregateType.Bool or
+                AggregateType.FP32 or
+                AggregateType.S32 or
+                AggregateType.U32 => 4,
+                AggregateType.FP64 => 8,
+                _ => 0
+            };
+
+            switch (type & AggregateType.ElementCountMask)
+            {
+                case AggregateType.Vector2:
+                    elementSize *= 2;
+                    break;
+                case AggregateType.Vector3:
+                    elementSize *= 3;
+                    break;
+                case AggregateType.Vector4:
+                    elementSize *= 4;
+                    break;
+            }
+
+            return elementSize;
+        }
+    }
 }

--- a/src/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -234,8 +234,8 @@ namespace Ryujinx.Graphics.Shader.Translation
             {
                 Operand x = this.Load(StorageKind.Output, IoVariable.Position, null, Const(0));
                 Operand y = this.Load(StorageKind.Output, IoVariable.Position, null, Const(1));
-                Operand xScale = this.Load(StorageKind.Input, IoVariable.SupportBlockViewInverse, null, Const(0));
-                Operand yScale = this.Load(StorageKind.Input, IoVariable.SupportBlockViewInverse, null, Const(1));
+                Operand xScale = this.Load(StorageKind.ConstantBuffer, SupportBuffer.Binding, Const((int)SupportBufferField.ViewportInverse), Const(0));
+                Operand yScale = this.Load(StorageKind.ConstantBuffer, SupportBuffer.Binding, Const((int)SupportBufferField.ViewportInverse), Const(1));
                 Operand negativeOne = ConstF(-1.0f);
 
                 this.Store(StorageKind.Output, IoVariable.Position, null, Const(0), this.FPFusedMultiplyAdd(x, xScale, negativeOne));
@@ -420,7 +420,7 @@ namespace Ryujinx.Graphics.Shader.Translation
                         // Perform B <-> R swap if needed, for BGRA formats (not supported on OpenGL).
                         if (!supportsBgra && (component == 0 || component == 2))
                         {
-                            Operand isBgra = this.Load(StorageKind.Input, IoVariable.FragmentOutputIsBgra, null, Const(rtIndex));
+                            Operand isBgra = this.Load(StorageKind.ConstantBuffer, SupportBuffer.Binding, Const((int)SupportBufferField.FragmentIsBgra), Const(rtIndex));
 
                             Operand lblIsBgra = Label();
                             Operand lblEnd = Label();

--- a/src/Ryujinx.Graphics.Shader/Translation/EmitterContextInsts.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/EmitterContextInsts.cs
@@ -549,11 +549,31 @@ namespace Ryujinx.Graphics.Shader.Translation
             return context.Add(fpType | Instruction.IsNan, Local(), a);
         }
 
+        public static Operand Load(this EmitterContext context, StorageKind storageKind, int binding)
+        {
+            return context.Add(Instruction.Load, storageKind, Local(), Const(binding));
+        }
+
+        public static Operand Load(this EmitterContext context, StorageKind storageKind, int binding, Operand e0)
+        {
+            return context.Add(Instruction.Load, storageKind, Local(), Const(binding), e0);
+        }
+
+        public static Operand Load(this EmitterContext context, StorageKind storageKind, int binding, Operand e0, Operand e1)
+        {
+            return context.Add(Instruction.Load, storageKind, Local(), Const(binding), e0, e1);
+        }
+
+        public static Operand Load(this EmitterContext context, StorageKind storageKind, int binding, Operand e0, Operand e1, Operand e2)
+        {
+            return context.Add(Instruction.Load, storageKind, Local(), Const(binding), e0, e1, e2);
+        }
+
         public static Operand Load(this EmitterContext context, StorageKind storageKind, IoVariable ioVariable, Operand primVertex = null)
         {
             return primVertex != null
-                ? context.Add(Instruction.Load, storageKind, Local(), Const((int)ioVariable), primVertex)
-                : context.Add(Instruction.Load, storageKind, Local(), Const((int)ioVariable));
+                ? context.Load(storageKind, (int)ioVariable, primVertex)
+                : context.Load(storageKind, (int)ioVariable);
         }
 
         public static Operand Load(
@@ -564,8 +584,8 @@ namespace Ryujinx.Graphics.Shader.Translation
             Operand elemIndex)
         {
             return primVertex != null
-                ? context.Add(Instruction.Load, storageKind, Local(), Const((int)ioVariable), primVertex, elemIndex)
-                : context.Add(Instruction.Load, storageKind, Local(), Const((int)ioVariable), elemIndex);
+                ? context.Load(storageKind, (int)ioVariable, primVertex, elemIndex)
+                : context.Load(storageKind, (int)ioVariable, elemIndex);
         }
 
         public static Operand Load(
@@ -577,22 +597,8 @@ namespace Ryujinx.Graphics.Shader.Translation
             Operand elemIndex)
         {
             return primVertex != null
-                ? context.Add(Instruction.Load, storageKind, Local(), Const((int)ioVariable), primVertex, arrayIndex, elemIndex)
-                : context.Add(Instruction.Load, storageKind, Local(), Const((int)ioVariable), arrayIndex, elemIndex);
-        }
-
-        public static Operand LoadConstant(this EmitterContext context, Operand a, Operand b)
-        {
-            if (a.Type == OperandType.Constant)
-            {
-                context.Config.SetUsedConstantBuffer(a.Value);
-            }
-            else
-            {
-                context.Config.SetUsedFeature(FeatureFlags.CbIndexing);
-            }
-
-            return context.Add(Instruction.LoadConstant, Local(), a, b);
+                ? context.Load(storageKind, (int)ioVariable, primVertex, arrayIndex, elemIndex)
+                : context.Load(storageKind, (int)ioVariable, arrayIndex, elemIndex);
         }
 
         public static Operand LoadGlobal(this EmitterContext context, Operand a, Operand b)

--- a/src/Ryujinx.Graphics.Shader/Translation/FeatureFlags.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/FeatureFlags.cs
@@ -19,7 +19,6 @@ namespace Ryujinx.Graphics.Shader.Translation
         InstanceId = 1 << 3,
         DrawParameters = 1 << 4,
         RtLayer = 1 << 5,
-        CbIndexing = 1 << 6,
         IaIndexing = 1 << 7,
         OaIndexing = 1 << 8,
         FixedFuncAttr = 1 << 9

--- a/src/Ryujinx.Graphics.Shader/Translation/Optimizations/ConstantFolding.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/Optimizations/ConstantFolding.cs
@@ -8,7 +8,7 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
 {
     static class ConstantFolding
     {
-        public static void RunPass(Operation operation)
+        public static void RunPass(ShaderConfig config, Operation operation)
         {
             if (!AreAllSourcesConstant(operation))
             {
@@ -153,8 +153,21 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
                     EvaluateFPUnary(operation, (x) => float.IsNaN(x));
                     break;
 
-                case Instruction.LoadConstant:
-                    operation.TurnIntoCopy(Cbuf(operation.GetSource(0).Value, operation.GetSource(1).Value));
+                case Instruction.Load:
+                    if (operation.StorageKind == StorageKind.ConstantBuffer && operation.SourcesCount == 4)
+                    {
+                        int binding = operation.GetSource(0).Value;
+                        int fieldIndex = operation.GetSource(1).Value;
+
+                        if (config.ResourceManager.TryGetConstantBufferSlot(binding, out int cbufSlot) && fieldIndex == 0)
+                        {
+                            int vecIndex = operation.GetSource(2).Value;
+                            int elemIndex = operation.GetSource(3).Value;
+                            int cbufOffset = vecIndex * 4 + elemIndex;
+
+                            operation.TurnIntoCopy(Cbuf(cbufSlot, cbufOffset));
+                        }
+                    }
                     break;
 
                 case Instruction.Maximum:

--- a/src/Ryujinx.Graphics.Shader/Translation/Optimizations/Optimizer.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/Optimizations/Optimizer.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
     {
         public static void RunPass(BasicBlock[] blocks, ShaderConfig config)
         {
-            RunOptimizationPasses(blocks);
+            RunOptimizationPasses(blocks, config);
 
             int sbUseMask = 0;
             int ubeUseMask = 0;
@@ -31,10 +31,10 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
             config.SetAccessibleBufferMasks(sbUseMask, ubeUseMask);
 
             // Run optimizations one last time to remove any code that is now optimizable after above passes.
-            RunOptimizationPasses(blocks);
+            RunOptimizationPasses(blocks, config);
         }
 
-        private static void RunOptimizationPasses(BasicBlock[] blocks)
+        private static void RunOptimizationPasses(BasicBlock[] blocks, ShaderConfig config)
         {
             bool modified;
 
@@ -73,7 +73,7 @@ namespace Ryujinx.Graphics.Shader.Translation.Optimizations
                             continue;
                         }
 
-                        ConstantFolding.RunPass(operation);
+                        ConstantFolding.RunPass(config, operation);
                         Simplification.RunPass(operation);
 
                         if (DestIsLocalVar(operation))

--- a/src/Ryujinx.Graphics.Shader/Translation/ResourceManager.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/ResourceManager.cs
@@ -1,0 +1,126 @@
+using Ryujinx.Graphics.Shader.StructuredIr;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Ryujinx.Graphics.Shader.Translation
+{
+    class ResourceManager
+    {
+        private static readonly string[] _stagePrefixes = new string[] { "cp", "vp", "tcp", "tep", "gp", "fp" };
+
+        private readonly IGpuAccessor _gpuAccessor;
+        private readonly ShaderProperties _properties;
+        private readonly string _stagePrefix;
+
+        private readonly int[] _cbSlotToBindingMap;
+
+        private readonly HashSet<int> _usedConstantBufferBindings;
+
+        public ResourceManager(ShaderStage stage, IGpuAccessor gpuAccessor, ShaderProperties properties)
+        {
+            _gpuAccessor = gpuAccessor;
+            _properties = properties;
+            _stagePrefix = GetShaderStagePrefix(stage);
+
+            _cbSlotToBindingMap = new int[18];
+            _cbSlotToBindingMap.AsSpan().Fill(-1);
+
+            _usedConstantBufferBindings = new HashSet<int>();
+
+            properties.AddConstantBuffer(0, new BufferDefinition(BufferLayout.Std140, 0, 0, "support_buffer", SupportBuffer.GetStructureType()));
+        }
+
+        public int GetConstantBufferBinding(int slot)
+        {
+            int binding = _cbSlotToBindingMap[slot];
+            if (binding < 0)
+            {
+                binding = _gpuAccessor.QueryBindingConstantBuffer(slot);
+                _cbSlotToBindingMap[slot] = binding;
+                string slotNumber = slot.ToString(CultureInfo.InvariantCulture);
+                AddNewConstantBuffer(binding, $"{_stagePrefix}_c{slotNumber}");
+            }
+
+            return binding;
+        }
+
+        public bool TryGetConstantBufferSlot(int binding, out int slot)
+        {
+            for (slot = 0; slot < _cbSlotToBindingMap.Length; slot++)
+            {
+                if (_cbSlotToBindingMap[slot] == binding)
+                {
+                    return true;
+                }
+            }
+
+            slot = 0;
+            return false;
+        }
+
+        public void SetUsedConstantBufferBinding(int binding)
+        {
+            _usedConstantBufferBindings.Add(binding);
+        }
+
+        public BufferDescriptor[] GetConstantBufferDescriptors()
+        {
+            var descriptors = new BufferDescriptor[_usedConstantBufferBindings.Count];
+
+            int descriptorIndex = 0;
+
+            for (int slot = 0; slot < _cbSlotToBindingMap.Length; slot++)
+            {
+                int binding = _cbSlotToBindingMap[slot];
+
+                if (binding >= 0 && _usedConstantBufferBindings.Contains(binding))
+                {
+                    descriptors[descriptorIndex++] = new BufferDescriptor(binding, slot);
+                }
+            }
+
+            if (descriptors.Length != descriptorIndex)
+            {
+                Array.Resize(ref descriptors, descriptorIndex);
+            }
+
+            return descriptors;
+        }
+
+        private void AddNewConstantBuffer(int binding, string name)
+        {
+            StructureType type = new StructureType(new[]
+            {
+                new StructureField(AggregateType.Array | AggregateType.Vector4 | AggregateType.FP32, "data", Constants.ConstantBufferSize / 16)
+            });
+
+            _properties.AddConstantBuffer(binding, new BufferDefinition(BufferLayout.Std140, 0, binding, name, type));
+        }
+
+        public void InheritFrom(ResourceManager other)
+        {
+            for (int i = 0; i < other._cbSlotToBindingMap.Length; i++)
+            {
+                int binding = other._cbSlotToBindingMap[i];
+
+                if (binding >= 0)
+                {
+                    _cbSlotToBindingMap[i] = binding;
+                }
+            }
+        }
+
+        public static string GetShaderStagePrefix(ShaderStage stage)
+        {
+            uint index = (uint)stage;
+
+            if (index >= _stagePrefixes.Length)
+            {
+                return "invalid";
+            }
+
+            return _stagePrefixes[index];
+        }
+    }
+}

--- a/src/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -39,6 +39,10 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public TranslationOptions Options { get; }
 
+        public ShaderProperties Properties { get; }
+
+        public ResourceManager ResourceManager { get; }
+
         public bool TransformFeedbackEnabled { get; }
 
         private TransformFeedbackOutput[] _transformFeedbackOutputs;
@@ -109,7 +113,6 @@ namespace Ryujinx.Graphics.Shader.Translation
         public int AccessibleStorageBuffersMask { get; private set; }
         public int AccessibleConstantBuffersMask { get; private set; }
 
-        private int _usedConstantBuffers;
         private int _usedStorageBuffers;
         private int _usedStorageBuffersWrite;
 
@@ -128,20 +131,17 @@ namespace Ryujinx.Graphics.Shader.Translation
         private readonly Dictionary<int, int> _sbSlots;
         private readonly Dictionary<int, int> _sbSlotsReverse;
 
-        private BufferDescriptor[] _cachedConstantBufferDescriptors;
         private BufferDescriptor[] _cachedStorageBufferDescriptors;
         private TextureDescriptor[] _cachedTextureDescriptors;
         private TextureDescriptor[] _cachedImageDescriptors;
 
-        private int _firstConstantBufferBinding;
         private int _firstStorageBufferBinding;
 
-        public int FirstConstantBufferBinding => _firstConstantBufferBinding;
         public int FirstStorageBufferBinding => _firstStorageBufferBinding;
 
-        public ShaderConfig(IGpuAccessor gpuAccessor, TranslationOptions options)
+        public ShaderConfig(ShaderStage stage, IGpuAccessor gpuAccessor, TranslationOptions options)
         {
-            Stage       = ShaderStage.Compute;
+            Stage       = stage;
             GpuAccessor = gpuAccessor;
             Options     = options;
 
@@ -158,6 +158,9 @@ namespace Ryujinx.Graphics.Shader.Translation
 
             _sbSlots        = new Dictionary<int, int>();
             _sbSlotsReverse = new Dictionary<int, int>();
+
+            Properties = new ShaderProperties();
+            ResourceManager = new ResourceManager(stage, gpuAccessor, Properties);
         }
 
         public ShaderConfig(
@@ -165,9 +168,8 @@ namespace Ryujinx.Graphics.Shader.Translation
             OutputTopology outputTopology,
             int maxOutputVertices,
             IGpuAccessor gpuAccessor,
-            TranslationOptions options) : this(gpuAccessor, options)
+            TranslationOptions options) : this(stage, gpuAccessor, options)
         {
-            Stage                    = stage;
             ThreadsPerInputPrimitive = 1;
             OutputTopology           = outputTopology;
             MaxOutputVertices        = maxOutputVertices;
@@ -179,9 +181,8 @@ namespace Ryujinx.Graphics.Shader.Translation
             }
         }
 
-        public ShaderConfig(ShaderHeader header, IGpuAccessor gpuAccessor, TranslationOptions options) : this(gpuAccessor, options)
+        public ShaderConfig(ShaderHeader header, IGpuAccessor gpuAccessor, TranslationOptions options) : this(header.Stage, gpuAccessor, options)
         {
-            Stage                    = header.Stage;
             GpPassthrough            = header.Stage == ShaderStage.Geometry && header.GpPassthrough;
             ThreadsPerInputPrimitive = header.ThreadsPerInputPrimitive;
             OutputTopology           = header.OutputTopology;
@@ -428,12 +429,13 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public void InheritFrom(ShaderConfig other)
         {
+            ResourceManager.InheritFrom(other.ResourceManager);
+
             ClipDistancesWritten |= other.ClipDistancesWritten;
             UsedFeatures |= other.UsedFeatures;
 
             UsedInputAttributes |= other.UsedInputAttributes;
             UsedOutputAttributes |= other.UsedOutputAttributes;
-            _usedConstantBuffers |= other._usedConstantBuffers;
             _usedStorageBuffers |= other._usedStorageBuffers;
             _usedStorageBuffersWrite |= other._usedStorageBuffersWrite;
 
@@ -641,11 +643,6 @@ namespace Ryujinx.Graphics.Shader.Translation
             AccessibleConstantBuffersMask = ubeMask;
         }
 
-        public void SetUsedConstantBuffer(int slot)
-        {
-            _usedConstantBuffers |= 1 << slot;
-        }
-
         public void SetUsedStorageBuffer(int slot, bool write)
         {
             int mask = 1 << slot;
@@ -762,27 +759,6 @@ namespace Ryujinx.Graphics.Shader.Translation
             return meta;
         }
 
-        public BufferDescriptor[] GetConstantBufferDescriptors()
-        {
-            if (_cachedConstantBufferDescriptors != null)
-            {
-                return _cachedConstantBufferDescriptors;
-            }
-
-            int usedMask = _usedConstantBuffers;
-
-            if (UsedFeatures.HasFlag(FeatureFlags.CbIndexing))
-            {
-                usedMask |= (int)GpuAccessor.QueryConstantBufferUse();
-            }
-
-            return _cachedConstantBufferDescriptors = GetUniformBufferDescriptors(
-                usedMask,
-                UsedFeatures.HasFlag(FeatureFlags.CbIndexing),
-                out _firstConstantBufferBinding,
-                GpuAccessor.QueryBindingConstantBuffer);
-        }
-
         public BufferDescriptor[] GetStorageBufferDescriptors()
         {
             if (_cachedStorageBufferDescriptors != null)
@@ -796,47 +772,6 @@ namespace Ryujinx.Graphics.Shader.Translation
                 true,
                 out _firstStorageBufferBinding,
                 GpuAccessor.QueryBindingStorageBuffer);
-        }
-
-        private static BufferDescriptor[] GetUniformBufferDescriptors(int usedMask, bool isArray, out int firstBinding, Func<int, int> getBindingCallback)
-        {
-            firstBinding = 0;
-            int lastSlot = -1;
-            bool hasFirstBinding = false;
-            var descriptors = new BufferDescriptor[BitOperations.PopCount((uint)usedMask)];
-
-            for (int i = 0; i < descriptors.Length; i++)
-            {
-                int slot = BitOperations.TrailingZeroCount(usedMask);
-
-                if (isArray)
-                {
-                    // The next array entries also consumes bindings, even if they are unused.
-                    for (int j = lastSlot + 1; j < slot; j++)
-                    {
-                        int binding = getBindingCallback(j);
-
-                        if (!hasFirstBinding)
-                        {
-                            firstBinding = binding;
-                            hasFirstBinding = true;
-                        }
-                    }
-                }
-
-                lastSlot = slot;
-                descriptors[i] = new BufferDescriptor(getBindingCallback(slot), slot);
-
-                if (!hasFirstBinding)
-                {
-                    firstBinding = descriptors[i].Binding;
-                    hasFirstBinding = true;
-                }
-
-                usedMask &= ~(1 << slot);
-            }
-
-            return descriptors;
         }
 
         private BufferDescriptor[] GetStorageBufferDescriptors(
@@ -1009,7 +944,7 @@ namespace Ryujinx.Graphics.Shader.Translation
         public ShaderProgramInfo CreateProgramInfo(ShaderIdentification identification = ShaderIdentification.None)
         {
             return new ShaderProgramInfo(
-                GetConstantBufferDescriptors(),
+                ResourceManager.GetConstantBufferDescriptors(),
                 GetStorageBufferDescriptors(),
                 GetTextureDescriptors(),
                 GetImageDescriptors(),

--- a/src/Ryujinx.Graphics.Shader/Translation/Translator.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/Translator.cs
@@ -99,7 +99,7 @@ namespace Ryujinx.Graphics.Shader.Translation
 
             if (options.Flags.HasFlag(TranslationFlags.Compute))
             {
-                config = new ShaderConfig(gpuAccessor, options);
+                config = new ShaderConfig(ShaderStage.Compute, gpuAccessor, options);
 
                 program = Decoder.Decode(config, address);
             }


### PR DESCRIPTION
Overview
---

This is a continuation of #4565 (and depends on it).

Like attributes, the shader IR currently has two way to represent constant buffer access, either by using the `ConstantBuffer` operand type, or using the `LoadConstant` instruction. The instruction is supposed to be used for non-constant offsets (or slot) access, since the operand can only have constant values.

Having two ways to represent the same operation is undesirable since it requires handling both cases which increases the complexity of the implementation. So this PR replaces both the constant buffer operand and the `LoadConstant` instruction with the new `Load` instruction introduced on the linked PR, with a `StorageKind` of `ConstantBuffer`.

There are other notable changes:
- The `Load` instruction has the host binding number rather than the guest constant buffer slot now. This allow using this method to also access the support buffer, which is always at binding 0. With the previous approach, accessing it would require some special slot number which again, requires special handling on various places and more complexity. The approach on this PR does not require any special handling on the backend, it is just a buffer like any other.
- The `Load` has a field index, vector index and element index as operands. Before it would just have a word offset of the data to access. Like the above, this is required to support loading from the support buffer with this instruction. If a offset was used, it would need to look up the struct field and element from that offset, which is more complicated, plus unaligned offsets would be "invalid" and I'm not sure how those would be handled.
- The `CbIndexable` feature, where it was possible to index the constant buffer slots was removed. Instead, it now compares the slot value with each bound constant buffer, and selects the correct one with a chain of `ConditionalSelect` operations. This makes the backend code simpler (since there's no need for a special case for `CbIndexable` now). This is also potentially a fix since the descriptor set was not really correct for this case (it would not set it was a uniform array, but as separate uniform buffer bindings, although I don't think this was causing problems in practice). It might help implementations where the indexing never worked (like AMD and MoltenVK), but it will require testing.

Downsides:

The main downside is that any pattern recognition that needs to find specific constant buffer usage becomes more complex. We no longer need to check just the constant buffer operand, but instead we need to check if the operand is the result of a `Load` instruction, and if all the load parameters matches what we expect (plus, we need to do a reverse look up of the slot from the binding number). This could also make the process a bit slower since there's more to check.

What to test
---

The only thing that I expect to be fixed here is the exploded models on Super Mario 3D All Stars games (Super Mario Sunshine and Super Mario Galaxy) with AMD GPUs. It worth testing.

Other than that it just needs general testing to ensure there's no regressions. It might be worth testing if the particles are still fine on BOTW since it depends on the constant buffer replacement which I did not test.