### PR TITLE
[GUI] Fix a NRE in Gtk when disposing GLRenderer

### DIFF
--- a/Ryujinx/Ui/GLRenderer.cs
+++ b/Ryujinx/Ui/GLRenderer.cs
@@ -119,7 +119,7 @@ namespace Ryujinx.Ui
             }
             catch (Exception) { }
 
-            Device.DisposeGpu();
+            Device?.DisposeGpu();
             NpadManager.Dispose();
 
             // Unbind context and destroy everything
@@ -129,7 +129,7 @@ namespace Ryujinx.Ui
             }
             catch (Exception) { }
 
-            _openGLContext.Dispose();
+            _openGLContext?.Dispose();
         }
     }
 }


### PR DESCRIPTION
This is the smallest PR I ever created, but I can't find another one where it would fit as well.

This fixes an issue where people would sometimes experience crashes if the switch instance wasn't set up yet or an invalid file was loaded which didn't initialize it at all.