### PR TITLE
Allow window to remember its size, position and state (GTK + Avalonia)

### DIFF
--- a/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
@@ -96,10 +96,9 @@ namespace Ryujinx.Ava.UI.ViewModels
         private string _currentEmulatedGamePath;
         private AutoResetEvent _rendererWaitEvent;
         private WindowState _windowState;
-        private double _windowWidth = ConfigurationState.Instance.Ui.WindowSizeWidth / Program.WindowScaleFactor;
-        private double _windowHeight = ConfigurationState.Instance.Ui.WindowSizeHeight / Program.WindowScaleFactor;
-        private PixelPoint _windowXY = new PixelPoint(ConfigurationState.Instance.Ui.WindowPositionX, 
-                                                      ConfigurationState.Instance.Ui.WindowPositionY);
+        private double _windowWidth;
+        private double _windowHeight;
+        private PixelPoint _windowXY;
 
         private bool _isActive;
 

--- a/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
@@ -1,4 +1,3 @@
-using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Input;

--- a/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
@@ -98,7 +98,6 @@ namespace Ryujinx.Ava.UI.ViewModels
         private WindowState _windowState;
         private double _windowWidth;
         private double _windowHeight;
-        private PixelPoint _windowXY;
 
         private bool _isActive;
 
@@ -646,17 +645,6 @@ namespace Ryujinx.Ava.UI.ViewModels
             {
                 _windowHeight = value;
 
-                OnPropertyChanged();
-            }
-        }
-
-        public PixelPoint WindowXY
-        {
-            get => _windowXY;
-            set
-            {
-                _windowXY = value;
-                
                 OnPropertyChanged();
             }
         }

--- a/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
@@ -96,9 +96,10 @@ namespace Ryujinx.Ava.UI.ViewModels
         private string _currentEmulatedGamePath;
         private AutoResetEvent _rendererWaitEvent;
         private WindowState _windowState;
-        private int _windowWidth = 1920;
-        private int _windowHeight = 1080;
-        private PixelPoint _windowXY = new PixelPoint(10000,10000);
+        private double _windowWidth = ConfigurationState.Instance.Ui.WindowSizeWidth / Program.WindowScaleFactor;
+        private double _windowHeight = ConfigurationState.Instance.Ui.WindowSizeHeight / Program.WindowScaleFactor;
+        private PixelPoint _windowXY = new PixelPoint(ConfigurationState.Instance.Ui.WindowPositionX, 
+                                                      ConfigurationState.Instance.Ui.WindowPositionY);
 
         private bool _isActive;
 
@@ -627,25 +628,23 @@ namespace Ryujinx.Ava.UI.ViewModels
                 OnPropertyChanged();
             }
         }
-
-        public int WindowWidth
+        
+        public double WindowWidth
         {
             get => _windowWidth;
-            internal set
+            set
             {
-                // TODO: Check if value is equal or less than monitor dimensions
                 _windowWidth = value;
 
                 OnPropertyChanged();
             }
         }
 
-        public int WindowHeight
+        public double WindowHeight
         {
             get => _windowHeight;
-            internal set
+            set
             {
-                // TODO: Check if value is equal or less than monitor dimensions
                 _windowHeight = value;
 
                 OnPropertyChanged();
@@ -655,10 +654,10 @@ namespace Ryujinx.Ava.UI.ViewModels
         public PixelPoint WindowXY
         {
             get => _windowXY;
-            internal set
+            set
             {
                 _windowXY = value;
-
+                
                 OnPropertyChanged();
             }
         }

--- a/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
@@ -1,3 +1,4 @@
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Input;
@@ -95,6 +96,10 @@ namespace Ryujinx.Ava.UI.ViewModels
         private string _currentEmulatedGamePath;
         private AutoResetEvent _rendererWaitEvent;
         private WindowState _windowState;
+        private int _windowWidth = 1920;
+        private int _windowHeight = 1080;
+        private PixelPoint _windowXY = new PixelPoint(10000,10000);
+
         private bool _isActive;
 
         public ApplicationData ListSelectedApplication;
@@ -618,6 +623,41 @@ namespace Ryujinx.Ava.UI.ViewModels
             internal set
             {
                 _windowState = value;
+
+                OnPropertyChanged();
+            }
+        }
+
+        public int WindowWidth
+        {
+            get => _windowWidth;
+            internal set
+            {
+                // TODO: Check if value is equal or less than monitor dimensions
+                _windowWidth = value;
+
+                OnPropertyChanged();
+            }
+        }
+
+        public int WindowHeight
+        {
+            get => _windowHeight;
+            internal set
+            {
+                // TODO: Check if value is equal or less than monitor dimensions
+                _windowHeight = value;
+
+                OnPropertyChanged();
+            }
+        }
+
+        public PixelPoint WindowXY
+        {
+            get => _windowXY;
+            internal set
+            {
+                _windowXY = value;
 
                 OnPropertyChanged();
             }

--- a/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml
+++ b/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml
@@ -12,15 +12,15 @@
     Cursor="{Binding Cursor}"
     Title="{Binding Title}"
     WindowState="{Binding WindowState}"
-    Width="1280"
-    Height="777"
+    Width="{Binding WindowWidth}"
+    Height="{Binding WindowHeight}"
     MinWidth="1092"
     MinHeight="672"
     d:DesignHeight="720"
     d:DesignWidth="1280"
     x:CompileBindings="True"
     x:DataType="viewModels:MainWindowViewModel"
-    WindowStartupLocation="CenterScreen"
+    WindowStartupLocation="{Binding WindowXY}"
     mc:Ignorable="d"
     Focusable="True">
     <Window.Styles>

--- a/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml
+++ b/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml
@@ -20,7 +20,6 @@
     d:DesignWidth="1280"
     x:CompileBindings="True"
     x:DataType="viewModels:MainWindowViewModel"
-    WindowStartupLocation="{Binding WindowXY}"
     mc:Ignorable="d"
     Focusable="True">
     <Window.Styles>

--- a/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
@@ -301,13 +301,13 @@ namespace Ryujinx.Ava.UI.Windows
 
         private void SetWindowSizePosition()
         {
-            PixelPoint SavedPoint = new PixelPoint(ConfigurationState.Instance.Ui.WindowPositionX, 
-                                                   ConfigurationState.Instance.Ui.WindowPositionY);
+            PixelPoint SavedPoint = new PixelPoint(ConfigurationState.Instance.Ui.WindowStartup.WindowPositionX, 
+                                                   ConfigurationState.Instance.Ui.WindowStartup.WindowPositionY);
 
-            ViewModel.WindowHeight = ConfigurationState.Instance.Ui.WindowSizeHeight * Program.WindowScaleFactor;
-            ViewModel.WindowWidth = ConfigurationState.Instance.Ui.WindowSizeWidth * Program.WindowScaleFactor;
+            ViewModel.WindowHeight = ConfigurationState.Instance.Ui.WindowStartup.WindowSizeHeight * Program.WindowScaleFactor;
+            ViewModel.WindowWidth = ConfigurationState.Instance.Ui.WindowStartup.WindowSizeWidth * Program.WindowScaleFactor;
 
-            ViewModel.WindowState = ConfigurationState.Instance.Ui.WindowMaximized.Value is true ? WindowState.Maximized : WindowState.Normal;
+            ViewModel.WindowState = ConfigurationState.Instance.Ui.WindowStartup.WindowMaximized.Value is true ? WindowState.Maximized : WindowState.Normal;
         
             Position = CheckScreenBounds(SavedPoint) ? SavedPoint : new PixelPoint(0,0);
         }
@@ -328,13 +328,13 @@ namespace Ryujinx.Ava.UI.Windows
 
         private void SaveWindowSizePosition()
         {
-            ConfigurationState.Instance.Ui.WindowSizeHeight.Value = (int)Height;
-            ConfigurationState.Instance.Ui.WindowSizeWidth.Value = (int)Width;
+            ConfigurationState.Instance.Ui.WindowStartup.WindowSizeHeight.Value = (int)Height;
+            ConfigurationState.Instance.Ui.WindowStartup.WindowSizeWidth.Value = (int)Width;
 
-            ConfigurationState.Instance.Ui.WindowPositionX.Value = Position.X;
-            ConfigurationState.Instance.Ui.WindowPositionY.Value = Position.Y;
+            ConfigurationState.Instance.Ui.WindowStartup.WindowPositionX.Value = Position.X;
+            ConfigurationState.Instance.Ui.WindowStartup.WindowPositionY.Value = Position.Y;
 
-            ConfigurationState.Instance.Ui.WindowMaximized.Value = WindowState == WindowState.Maximized;
+            ConfigurationState.Instance.Ui.WindowStartup.WindowMaximized.Value = WindowState == WindowState.Maximized;
 
             MainWindowViewModel.SaveConfig();
         }

--- a/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
@@ -319,7 +319,7 @@ namespace Ryujinx.Ava.UI.Windows
             ConfigurationState.Instance.Ui.WindowPositionX.Value = window.Position.X;
             ConfigurationState.Instance.Ui.WindowPositionY.Value = window.Position.Y;
 
-            ConfigurationState.Instance.Ui.WindowMaximized.Value = window.WindowState is WindowState.Maximized ? true : false;
+            ConfigurationState.Instance.Ui.WindowMaximized.Value = window.WindowState == WindowState.Maximized;
 
             MainWindowViewModel.SaveConfig();
         }

--- a/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
@@ -301,13 +301,29 @@ namespace Ryujinx.Ava.UI.Windows
 
         private void SetWindowSizePosition()
         {
+            PixelPoint SavedPoint = new PixelPoint(ConfigurationState.Instance.Ui.WindowPositionX, 
+                                                   ConfigurationState.Instance.Ui.WindowPositionY);
+
             ViewModel.WindowHeight = ConfigurationState.Instance.Ui.WindowSizeHeight * Program.WindowScaleFactor;
             ViewModel.WindowWidth = ConfigurationState.Instance.Ui.WindowSizeWidth * Program.WindowScaleFactor;
 
             ViewModel.WindowState = ConfigurationState.Instance.Ui.WindowMaximized.Value is true ? WindowState.Maximized : WindowState.Normal;
+        
+            Position = CheckScreenBounds(SavedPoint) ? SavedPoint : new PixelPoint(0,0);
+        }
 
-            Position = new PixelPoint(ConfigurationState.Instance.Ui.WindowPositionX, 
-                                             ConfigurationState.Instance.Ui.WindowPositionY);
+        private bool CheckScreenBounds(PixelPoint configPoint)
+        {   
+            for (int i = 0; i < Screens.ScreenCount; i++)
+            {
+                if (Screens.All[i].Bounds.Contains(configPoint))
+                {
+                    return true;
+                }
+            }
+
+            Logger.Warning?.Print(LogClass.Application, $"Failed to find valid start-up coordinates. Defaulting to 0,0.");
+            return false;
         }
 
         private void SaveWindowSizePosition()

--- a/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
@@ -69,6 +69,8 @@ namespace Ryujinx.Ava.UI.Windows
 
             ViewModel.Title = $"Ryujinx {Program.Version}";
 
+            this.Position = ViewModel.WindowXY;
+
             // NOTE: Height of MenuBar and StatusBar is not usable here, since it would still be 0 at this point.
             double barHeight = MenuBar.MinHeight + StatusBarView.StatusBar.MinHeight;
             Height = ((Height - barHeight) / Program.WindowScaleFactor) + barHeight;

--- a/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
@@ -62,14 +62,14 @@ namespace Ryujinx.Ava.UI.Windows
 
             DataContext = ViewModel;
 
+            SetWindowSizePosition(this);
+
             InitializeComponent();
             Load();
 
             UiHandler = new AvaHostUiHandler(this);
 
             ViewModel.Title = $"Ryujinx {Program.Version}";
-
-            this.Position = ViewModel.WindowXY;
 
             // NOTE: Height of MenuBar and StatusBar is not usable here, since it would still be 0 at this point.
             double barHeight = MenuBar.MinHeight + StatusBarView.StatusBar.MinHeight;
@@ -101,6 +101,8 @@ namespace Ryujinx.Ava.UI.Windows
                 LoadGameList();
 
                 this.GetObservable(IsActiveProperty).Subscribe(IsActiveChanged);
+                this.GetObservable(WidthProperty).Subscribe(GetWidthChange);
+                this.GetObservable(HeightProperty).Subscribe(GetHeightChange);
             }
 
             ApplicationLibrary.ApplicationCountUpdated += ApplicationLibrary_ApplicationCountUpdated;
@@ -113,6 +115,18 @@ namespace Ryujinx.Ava.UI.Windows
         private void IsActiveChanged(bool obj)
         {
             ViewModel.IsActive = obj;
+        }
+
+        private void GetWidthChange(double obj)
+        {
+            ConfigurationState.Instance.Ui.WindowSizeWidth.Value = (int)obj;
+            MainWindowViewModel.SaveConfig();
+        }
+
+        private void GetHeightChange(double obj)
+        {
+            ConfigurationState.Instance.Ui.WindowSizeHeight.Value = (int)obj;
+            MainWindowViewModel.SaveConfig();
         }
 
         public void LoadGameList()
@@ -297,6 +311,24 @@ namespace Ryujinx.Ava.UI.Windows
             GameList.DataContext = ViewModel;
 
             LoadHotKeys();
+        }
+
+        private void SetWindowSizePosition(MainWindow parent)
+        {
+            ViewModel.WindowHeight = ConfigurationState.Instance.Ui.WindowSizeHeight * Program.WindowScaleFactor;
+            ViewModel.WindowWidth = ConfigurationState.Instance.Ui.WindowSizeWidth * Program.WindowScaleFactor;
+            ViewModel.WindowXY = new PixelPoint(ConfigurationState.Instance.Ui.WindowPositionX, 
+                                                ConfigurationState.Instance.Ui.WindowPositionY);
+
+            parent.Position = ViewModel.WindowXY;
+        }
+
+        private void SaveWindowSizePosition(MainWindow parent)
+        {
+            ConfigurationState.Instance.Ui.WindowSizeHeight.Value = (int)parent.Height;
+            ConfigurationState.Instance.Ui.WindowSizeWidth.Value = (int)parent.Width;
+
+            MainWindowViewModel.SaveConfig();
         }
 
         protected override void OnOpened(EventArgs e)

--- a/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
@@ -62,7 +62,7 @@ namespace Ryujinx.Ava.UI.Windows
 
             DataContext = ViewModel;
 
-            SetWindowSizePosition(this);
+            SetWindowSizePosition();
 
             InitializeComponent();
             Load();
@@ -299,27 +299,26 @@ namespace Ryujinx.Ava.UI.Windows
             LoadHotKeys();
         }
 
-        private void SetWindowSizePosition(MainWindow window)
+        private void SetWindowSizePosition()
         {
             ViewModel.WindowHeight = ConfigurationState.Instance.Ui.WindowSizeHeight * Program.WindowScaleFactor;
             ViewModel.WindowWidth = ConfigurationState.Instance.Ui.WindowSizeWidth * Program.WindowScaleFactor;
 
             ViewModel.WindowState = ConfigurationState.Instance.Ui.WindowMaximized.Value is true ? WindowState.Maximized : WindowState.Normal;
 
-            window.Position = new PixelPoint(ConfigurationState.Instance.Ui.WindowPositionX, 
+            Position = new PixelPoint(ConfigurationState.Instance.Ui.WindowPositionX, 
                                              ConfigurationState.Instance.Ui.WindowPositionY);
         }
 
-        private void SaveWindowSizePosition(MainWindow window)
+        private void SaveWindowSizePosition()
         {
-            // Avalonia/GTK use different structures. Conversion is required for inter-operation.
-            ConfigurationState.Instance.Ui.WindowSizeHeight.Value = (int)window.Height;
-            ConfigurationState.Instance.Ui.WindowSizeWidth.Value = (int)window.Width;
+            ConfigurationState.Instance.Ui.WindowSizeHeight.Value = (int)Height;
+            ConfigurationState.Instance.Ui.WindowSizeWidth.Value = (int)Width;
 
-            ConfigurationState.Instance.Ui.WindowPositionX.Value = window.Position.X;
-            ConfigurationState.Instance.Ui.WindowPositionY.Value = window.Position.Y;
+            ConfigurationState.Instance.Ui.WindowPositionX.Value = Position.X;
+            ConfigurationState.Instance.Ui.WindowPositionY.Value = Position.Y;
 
-            ConfigurationState.Instance.Ui.WindowMaximized.Value = window.WindowState == WindowState.Maximized;
+            ConfigurationState.Instance.Ui.WindowMaximized.Value = WindowState == WindowState.Maximized;
 
             MainWindowViewModel.SaveConfig();
         }
@@ -415,7 +414,7 @@ namespace Ryujinx.Ava.UI.Windows
                 return;
             }
 
-            SaveWindowSizePosition(this);
+            SaveWindowSizePosition();
 
             ApplicationLibrary.CancelLoading();
             InputManager.Dispose();

--- a/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
@@ -309,7 +309,12 @@ namespace Ryujinx.Ava.UI.Windows
 
             ViewModel.WindowState = ConfigurationState.Instance.Ui.WindowStartup.WindowMaximized.Value is true ? WindowState.Maximized : WindowState.Normal;
         
-            Position = CheckScreenBounds(SavedPoint) ? SavedPoint : new PixelPoint(0,0);
+            if (CheckScreenBounds(SavedPoint))
+            {
+                Position = SavedPoint;
+            }
+
+            else WindowStartupLocation = WindowStartupLocation.CenterScreen;
         }
 
         private bool CheckScreenBounds(PixelPoint configPoint)
@@ -322,7 +327,7 @@ namespace Ryujinx.Ava.UI.Windows
                 }
             }
 
-            Logger.Warning?.Print(LogClass.Application, $"Failed to find valid start-up coordinates. Defaulting to 0,0.");
+            Logger.Warning?.Print(LogClass.Application, $"Failed to find valid start-up coordinates. Defaulting to primary monitor center.");
             return false;
         }
 

--- a/src/Ryujinx.Ui.Common/Configuration/ConfigurationFileFormat.cs
+++ b/src/Ryujinx.Ui.Common/Configuration/ConfigurationFileFormat.cs
@@ -252,6 +252,11 @@ namespace Ryujinx.Ui.Common.Configuration
         public ShownFileTypes ShownFileTypes { get; set; }
 
         /// <summary>
+        /// A list of file types to be hidden in the games List
+        /// </summary>
+        public WindowStartup WindowStartup { get; set; }
+
+        /// <summary>
         /// Language Code for the UI
         /// </summary>
         public string LanguageCode { get; set; }
@@ -305,31 +310,6 @@ namespace Ryujinx.Ui.Common.Configuration
         /// Show console window
         /// </summary>
         public bool ShowConsole { get; set; }
-        
-        /// <summary>
-        /// Width of the main window in pixels. 
-        /// </summary>
-        public int WindowSizeWidth { get; set;}
-
-        /// <summary>
-        /// Height of the main window in pixels. 
-        /// </summary>
-        public int WindowSizeHeight { get; set;}
-
-        /// <summary>
-        /// Horizontal position of the main window in pixels. 
-        /// </summary>
-        public int WindowPositionX { get; set;}
-
-        /// <summary>
-        /// Vertical position of the main window in pixels. 
-        /// </summary>
-        public int WindowPositionY { get; set;}
-        
-        /// <summary>
-        /// Whether the main window is maximized or not.
-        /// </summary>
-        public bool WindowMaximized { get; set;}
 
         /// <summary>
         /// Enable or disable keyboard support (Independent from controllers binding)

--- a/src/Ryujinx.Ui.Common/Configuration/ConfigurationFileFormat.cs
+++ b/src/Ryujinx.Ui.Common/Configuration/ConfigurationFileFormat.cs
@@ -305,6 +305,26 @@ namespace Ryujinx.Ui.Common.Configuration
         /// Show console window
         /// </summary>
         public bool ShowConsole { get; set; }
+        
+        /// <summary>
+        /// Width of the main window in pixels. 
+        /// </summary>
+        public int WindowSizeWidth { get; set;}
+
+        /// <summary>
+        /// Height of the main window in pixels. 
+        /// </summary>
+        public int WindowSizeHeight { get; set;}
+
+        /// <summary>
+        /// Horizontal position of the main window in pixels. 
+        /// </summary>
+        public int WindowPositionX { get; set;}
+
+        /// <summary>
+        /// Vertical position of the main window in pixels. 
+        /// </summary>
+        public int WindowPositionY { get; set;}
 
         /// <summary>
         /// Enable or disable keyboard support (Independent from controllers binding)

--- a/src/Ryujinx.Ui.Common/Configuration/ConfigurationFileFormat.cs
+++ b/src/Ryujinx.Ui.Common/Configuration/ConfigurationFileFormat.cs
@@ -252,7 +252,7 @@ namespace Ryujinx.Ui.Common.Configuration
         public ShownFileTypes ShownFileTypes { get; set; }
 
         /// <summary>
-        /// A list of file types to be hidden in the games List
+        /// Main window start-up position, size and state
         /// </summary>
         public WindowStartup WindowStartup { get; set; }
 

--- a/src/Ryujinx.Ui.Common/Configuration/ConfigurationFileFormat.cs
+++ b/src/Ryujinx.Ui.Common/Configuration/ConfigurationFileFormat.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.Ui.Common.Configuration
         /// <summary>
         /// The current version of the file format
         /// </summary>
-        public const int CurrentVersion = 46;
+        public const int CurrentVersion = 47;
 
         /// <summary>
         /// Version of the configuration file format

--- a/src/Ryujinx.Ui.Common/Configuration/ConfigurationFileFormat.cs
+++ b/src/Ryujinx.Ui.Common/Configuration/ConfigurationFileFormat.cs
@@ -325,6 +325,11 @@ namespace Ryujinx.Ui.Common.Configuration
         /// Vertical position of the main window in pixels. 
         /// </summary>
         public int WindowPositionY { get; set;}
+        
+        /// <summary>
+        /// Whether the main window is maximized or not.
+        /// </summary>
+        public bool WindowMaximized { get; set;}
 
         /// <summary>
         /// Enable or disable keyboard support (Independent from controllers binding)

--- a/src/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
@@ -132,6 +132,26 @@ namespace Ryujinx.Ui.Common.Configuration
             /// Hide / Show Console Window
             /// </summary>
             public ReactiveObject<bool> ShowConsole { get; private set; }
+            
+            /// <summary>
+            /// Width of the main window in pixels. 
+            /// </summary>
+            public ReactiveObject<int> WindowSizeWidth { get; private set; }
+
+            /// <summary>
+            /// Height of the main window in pixels. 
+            /// </summary>
+            public ReactiveObject<int> WindowSizeHeight { get; private set; }
+
+            /// <summary>
+            /// Horizontal position of the main window in pixels. 
+            /// </summary>
+            public ReactiveObject<int> WindowPositionX { get; private set; }
+
+            /// <summary>
+            /// Vertical position of the main window in pixels. 
+            /// </summary>
+            public ReactiveObject<int> WindowPositionY { get; private set; }
 
             /// <summary>
             /// View Mode of the Game list
@@ -176,6 +196,10 @@ namespace Ryujinx.Ui.Common.Configuration
                 LanguageCode      = new ReactiveObject<string>();
                 ShowConsole       = new ReactiveObject<bool>();
                 ShowConsole.Event += static (s, e) => { ConsoleHelper.SetConsoleWindowState(e.NewValue); };
+                WindowSizeWidth   = new ReactiveObject<int>();
+                WindowSizeHeight   = new ReactiveObject<int>();
+                WindowPositionX   = new ReactiveObject<int>();
+                WindowPositionY   = new ReactiveObject<int>();
             }
         }
 
@@ -689,6 +713,10 @@ namespace Ryujinx.Ui.Common.Configuration
                 IsAscendingOrder           = Ui.IsAscendingOrder,
                 StartFullscreen            = Ui.StartFullscreen,
                 ShowConsole                = Ui.ShowConsole,
+                WindowSizeWidth            = Ui.WindowSizeWidth,
+                WindowSizeHeight           = Ui.WindowSizeHeight,
+                WindowPositionX            = Ui.WindowPositionX,
+                WindowPositionY            = Ui.WindowPositionY,
                 EnableKeyboard             = Hid.EnableKeyboard,
                 EnableMouse                = Hid.EnableMouse,
                 Hotkeys                    = Hid.Hotkeys,
@@ -781,6 +809,8 @@ namespace Ryujinx.Ui.Common.Configuration
             Ui.IsAscendingOrder.Value                 = true;
             Ui.StartFullscreen.Value                  = false;
             Ui.ShowConsole.Value                      = true;
+            Ui.WindowSizeWidth.Value                  = 1280;
+            Ui.WindowSizeHeight.Value                 = 760;
             Hid.EnableKeyboard.Value                  = false;
             Hid.EnableMouse.Value                     = false;
             Hid.Hotkeys.Value = new KeyboardHotkeys
@@ -1416,6 +1446,10 @@ namespace Ryujinx.Ui.Common.Configuration
             Ui.ApplicationSort.Value                  = configurationFileFormat.ApplicationSort;
             Ui.StartFullscreen.Value                  = configurationFileFormat.StartFullscreen;
             Ui.ShowConsole.Value                      = configurationFileFormat.ShowConsole;
+            Ui.WindowSizeWidth.Value                  = configurationFileFormat.WindowSizeWidth;
+            Ui.WindowSizeHeight.Value                 = configurationFileFormat.WindowSizeHeight;
+            Ui.WindowPositionX.Value                  = configurationFileFormat.WindowPositionX;
+            Ui.WindowPositionY.Value                  = configurationFileFormat.WindowPositionY;
             Hid.EnableKeyboard.Value                  = configurationFileFormat.EnableKeyboard;
             Hid.EnableMouse.Value                     = configurationFileFormat.EnableMouse;
             Hid.Hotkeys.Value                         = configurationFileFormat.Hotkeys;

--- a/src/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
@@ -202,7 +202,7 @@ namespace Ryujinx.Ui.Common.Configuration
                 ShowConsole       = new ReactiveObject<bool>();
                 ShowConsole.Event += static (s, e) => { ConsoleHelper.SetConsoleWindowState(e.NewValue); };
                 WindowSizeWidth   = new ReactiveObject<int>();
-                WindowSizeHeight   = new ReactiveObject<int>();
+                WindowSizeHeight  = new ReactiveObject<int>();
                 WindowPositionX   = new ReactiveObject<int>();
                 WindowPositionY   = new ReactiveObject<int>();
                 WindowMaximized   = new ReactiveObject<bool>();

--- a/src/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
@@ -1366,9 +1366,21 @@ namespace Ryujinx.Ui.Common.Configuration
                     NRO  = true,
                     NSO  = true
                 };
+            }
+
+            if (configurationFileFormat.Version < 46)
+            {
+                Ryujinx.Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 46.");
+
+                configurationFileFormat.WindowPositionX = 0;
+                configurationFileFormat.WindowPositionY = 0;
+                configurationFileFormat.WindowSizeHeight = 760;
+                configurationFileFormat.WindowSizeWidth = 1280;
+                configurationFileFormat.WindowMaximized = false;
+            }
+                
 
                 configurationFileUpdated = true;
-            }
 
             if (configurationFileFormat.Version < 46)
             {

--- a/src/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
@@ -152,6 +152,11 @@ namespace Ryujinx.Ui.Common.Configuration
             /// Vertical position of the main window in pixels. 
             /// </summary>
             public ReactiveObject<int> WindowPositionY { get; private set; }
+            
+            /// <summary>
+            /// Whether the main window is maximized or not. 
+            /// </summary>
+            public ReactiveObject<bool> WindowMaximized { get; private set; }
 
             /// <summary>
             /// View Mode of the Game list
@@ -200,6 +205,7 @@ namespace Ryujinx.Ui.Common.Configuration
                 WindowSizeHeight   = new ReactiveObject<int>();
                 WindowPositionX   = new ReactiveObject<int>();
                 WindowPositionY   = new ReactiveObject<int>();
+                WindowMaximized   = new ReactiveObject<bool>();
             }
         }
 
@@ -717,6 +723,7 @@ namespace Ryujinx.Ui.Common.Configuration
                 WindowSizeHeight           = Ui.WindowSizeHeight,
                 WindowPositionX            = Ui.WindowPositionX,
                 WindowPositionY            = Ui.WindowPositionY,
+                WindowMaximized            = Ui.WindowMaximized,
                 EnableKeyboard             = Hid.EnableKeyboard,
                 EnableMouse                = Hid.EnableMouse,
                 Hotkeys                    = Hid.Hotkeys,
@@ -811,6 +818,7 @@ namespace Ryujinx.Ui.Common.Configuration
             Ui.ShowConsole.Value                      = true;
             Ui.WindowSizeWidth.Value                  = 1280;
             Ui.WindowSizeHeight.Value                 = 760;
+            Ui.WindowMaximized.Value                  = false;
             Hid.EnableKeyboard.Value                  = false;
             Hid.EnableMouse.Value                     = false;
             Hid.Hotkeys.Value = new KeyboardHotkeys
@@ -1450,6 +1458,7 @@ namespace Ryujinx.Ui.Common.Configuration
             Ui.WindowSizeHeight.Value                 = configurationFileFormat.WindowSizeHeight;
             Ui.WindowPositionX.Value                  = configurationFileFormat.WindowPositionX;
             Ui.WindowPositionY.Value                  = configurationFileFormat.WindowPositionY;
+            Ui.WindowMaximized.Value                  = configurationFileFormat.WindowMaximized;
             Hid.EnableKeyboard.Value                  = configurationFileFormat.EnableKeyboard;
             Hid.EnableMouse.Value                     = configurationFileFormat.EnableMouse;
             Hid.Hotkeys.Value                         = configurationFileFormat.Hotkeys;

--- a/src/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
@@ -1374,21 +1374,20 @@ namespace Ryujinx.Ui.Common.Configuration
             {
                 Ryujinx.Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 46.");
 
+                configurationFileFormat.MultiplayerLanInterfaceId = "0";
+
+                configurationFileUpdated = true;
+            }
+
+            if (configurationFileFormat.Version < 47)
+            {
+                Ryujinx.Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 47.");
+
                 configurationFileFormat.WindowPositionX = 0;
                 configurationFileFormat.WindowPositionY = 0;
                 configurationFileFormat.WindowSizeHeight = 760;
                 configurationFileFormat.WindowSizeWidth = 1280;
                 configurationFileFormat.WindowMaximized = false;
-            }
-                
-
-                configurationFileUpdated = true;
-
-            if (configurationFileFormat.Version < 46)
-            {
-                Ryujinx.Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 45.");
-
-                configurationFileFormat.MultiplayerLanInterfaceId = "0";
 
                 configurationFileUpdated = true;
             }

--- a/src/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
@@ -1368,6 +1368,8 @@ namespace Ryujinx.Ui.Common.Configuration
                     NRO  = true,
                     NSO  = true
                 };
+
+                configurationFileUpdated = true;
             }
 
             if (configurationFileFormat.Version < 46)

--- a/src/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
@@ -818,6 +818,8 @@ namespace Ryujinx.Ui.Common.Configuration
             Ui.ShowConsole.Value                      = true;
             Ui.WindowSizeWidth.Value                  = 1280;
             Ui.WindowSizeHeight.Value                 = 760;
+            Ui.WindowPositionX.Value                  = 0;
+            Ui.WindowPositionY.Value                  = 0;
             Ui.WindowMaximized.Value                  = false;
             Hid.EnableKeyboard.Value                  = false;
             Hid.EnableMouse.Value                     = false;

--- a/src/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.Ui.Common/Configuration/ConfigurationState.cs
@@ -83,6 +83,27 @@ namespace Ryujinx.Ui.Common.Configuration
                 }
             }
 
+            // <summary>
+            /// Determines main window start-up position, size and state
+            ///<summary>
+            public class WindowStartupSettings
+            {
+                public ReactiveObject<int> WindowSizeWidth { get; private set; }
+                public ReactiveObject<int> WindowSizeHeight { get; private set; }
+                public ReactiveObject<int> WindowPositionX { get; private set; }
+                public ReactiveObject<int> WindowPositionY { get; private set; }
+                public ReactiveObject<bool> WindowMaximized { get; private set; }
+
+                public WindowStartupSettings()
+                {
+                    WindowSizeWidth = new ReactiveObject<int>();
+                    WindowSizeHeight = new ReactiveObject<int>();
+                    WindowPositionX = new ReactiveObject<int>();
+                    WindowPositionY = new ReactiveObject<int>();
+                    WindowMaximized = new ReactiveObject<bool>();
+                }
+            }
+
             /// <summary>
             /// Used to toggle columns in the GUI
             /// </summary>
@@ -102,6 +123,11 @@ namespace Ryujinx.Ui.Common.Configuration
             /// A list of file types to be hidden in the games List
             /// </summary>
             public ShownFileTypeSettings ShownFileTypes { get; private set; }
+
+            /// <summary>
+            /// Determines main window start-up position, size and state
+            /// </summary>
+            public WindowStartupSettings WindowStartup { get; private set; }
 
             /// <summary>
             /// Language Code for the UI
@@ -132,31 +158,6 @@ namespace Ryujinx.Ui.Common.Configuration
             /// Hide / Show Console Window
             /// </summary>
             public ReactiveObject<bool> ShowConsole { get; private set; }
-            
-            /// <summary>
-            /// Width of the main window in pixels. 
-            /// </summary>
-            public ReactiveObject<int> WindowSizeWidth { get; private set; }
-
-            /// <summary>
-            /// Height of the main window in pixels. 
-            /// </summary>
-            public ReactiveObject<int> WindowSizeHeight { get; private set; }
-
-            /// <summary>
-            /// Horizontal position of the main window in pixels. 
-            /// </summary>
-            public ReactiveObject<int> WindowPositionX { get; private set; }
-
-            /// <summary>
-            /// Vertical position of the main window in pixels. 
-            /// </summary>
-            public ReactiveObject<int> WindowPositionY { get; private set; }
-            
-            /// <summary>
-            /// Whether the main window is maximized or not. 
-            /// </summary>
-            public ReactiveObject<bool> WindowMaximized { get; private set; }
 
             /// <summary>
             /// View Mode of the Game list
@@ -188,7 +189,8 @@ namespace Ryujinx.Ui.Common.Configuration
                 GuiColumns        = new Columns();
                 ColumnSort        = new ColumnSortSettings();
                 GameDirs          = new ReactiveObject<List<string>>();
-                ShownFileTypes   = new ShownFileTypeSettings();
+                ShownFileTypes    = new ShownFileTypeSettings();
+                WindowStartup     = new WindowStartupSettings();
                 EnableCustomTheme = new ReactiveObject<bool>();
                 CustomThemePath   = new ReactiveObject<string>();
                 BaseStyle         = new ReactiveObject<string>();
@@ -201,11 +203,6 @@ namespace Ryujinx.Ui.Common.Configuration
                 LanguageCode      = new ReactiveObject<string>();
                 ShowConsole       = new ReactiveObject<bool>();
                 ShowConsole.Event += static (s, e) => { ConsoleHelper.SetConsoleWindowState(e.NewValue); };
-                WindowSizeWidth   = new ReactiveObject<int>();
-                WindowSizeHeight  = new ReactiveObject<int>();
-                WindowPositionX   = new ReactiveObject<int>();
-                WindowPositionY   = new ReactiveObject<int>();
-                WindowMaximized   = new ReactiveObject<bool>();
             }
         }
 
@@ -693,12 +690,12 @@ namespace Ryujinx.Ui.Common.Configuration
                     FileSizeColumn   = Ui.GuiColumns.FileSizeColumn,
                     PathColumn       = Ui.GuiColumns.PathColumn
                 },
-                ColumnSort                 = new ColumnSort
+                ColumnSort                = new ColumnSort
                 {
                     SortColumnId  = Ui.ColumnSort.SortColumnId,
                     SortAscending = Ui.ColumnSort.SortAscending
                 },
-                GameDirs                   = Ui.GameDirs,
+                GameDirs                  = Ui.GameDirs,
                 ShownFileTypes            = new ShownFileTypes
                 {
                     NSP = Ui.ShownFileTypes.NSP,
@@ -707,6 +704,14 @@ namespace Ryujinx.Ui.Common.Configuration
                     NCA = Ui.ShownFileTypes.NCA,
                     NRO = Ui.ShownFileTypes.NRO,
                     NSO = Ui.ShownFileTypes.NSO,
+                },
+                WindowStartup              = new WindowStartup
+                {
+                    WindowSizeWidth = Ui.WindowStartup.WindowSizeWidth,
+                    WindowSizeHeight = Ui.WindowStartup.WindowSizeHeight,
+                    WindowPositionX = Ui.WindowStartup.WindowPositionX,
+                    WindowPositionY = Ui.WindowStartup.WindowPositionY,
+                    WindowMaximized = Ui.WindowStartup.WindowMaximized,
                 },
                 LanguageCode               = Ui.LanguageCode,
                 EnableCustomTheme          = Ui.EnableCustomTheme,
@@ -719,11 +724,6 @@ namespace Ryujinx.Ui.Common.Configuration
                 IsAscendingOrder           = Ui.IsAscendingOrder,
                 StartFullscreen            = Ui.StartFullscreen,
                 ShowConsole                = Ui.ShowConsole,
-                WindowSizeWidth            = Ui.WindowSizeWidth,
-                WindowSizeHeight           = Ui.WindowSizeHeight,
-                WindowPositionX            = Ui.WindowPositionX,
-                WindowPositionY            = Ui.WindowPositionY,
-                WindowMaximized            = Ui.WindowMaximized,
                 EnableKeyboard             = Hid.EnableKeyboard,
                 EnableMouse                = Hid.EnableMouse,
                 Hotkeys                    = Hid.Hotkeys,
@@ -816,11 +816,11 @@ namespace Ryujinx.Ui.Common.Configuration
             Ui.IsAscendingOrder.Value                 = true;
             Ui.StartFullscreen.Value                  = false;
             Ui.ShowConsole.Value                      = true;
-            Ui.WindowSizeWidth.Value                  = 1280;
-            Ui.WindowSizeHeight.Value                 = 760;
-            Ui.WindowPositionX.Value                  = 0;
-            Ui.WindowPositionY.Value                  = 0;
-            Ui.WindowMaximized.Value                  = false;
+            Ui.WindowStartup.WindowSizeWidth.Value    = 1280;
+            Ui.WindowStartup.WindowSizeHeight.Value   = 760;
+            Ui.WindowStartup.WindowPositionX.Value    = 0;
+            Ui.WindowStartup.WindowPositionY.Value    = 0;
+            Ui.WindowStartup.WindowMaximized.Value    = false;
             Hid.EnableKeyboard.Value                  = false;
             Hid.EnableMouse.Value                     = false;
             Hid.Hotkeys.Value = new KeyboardHotkeys
@@ -1383,12 +1383,15 @@ namespace Ryujinx.Ui.Common.Configuration
             {
                 Ryujinx.Common.Logging.Logger.Warning?.Print(LogClass.Application, $"Outdated configuration version {configurationFileFormat.Version}, migrating to version 47.");
 
-                configurationFileFormat.WindowPositionX = 0;
-                configurationFileFormat.WindowPositionY = 0;
-                configurationFileFormat.WindowSizeHeight = 760;
-                configurationFileFormat.WindowSizeWidth = 1280;
-                configurationFileFormat.WindowMaximized = false;
-
+                configurationFileFormat.WindowStartup = new WindowStartup
+                {
+                    WindowPositionX = 0,
+                    WindowPositionY = 0,
+                    WindowSizeHeight = 760,
+                    WindowSizeWidth = 1280,
+                    WindowMaximized = false,
+                };
+                
                 configurationFileUpdated = true;
             }
 
@@ -1467,11 +1470,11 @@ namespace Ryujinx.Ui.Common.Configuration
             Ui.ApplicationSort.Value                  = configurationFileFormat.ApplicationSort;
             Ui.StartFullscreen.Value                  = configurationFileFormat.StartFullscreen;
             Ui.ShowConsole.Value                      = configurationFileFormat.ShowConsole;
-            Ui.WindowSizeWidth.Value                  = configurationFileFormat.WindowSizeWidth;
-            Ui.WindowSizeHeight.Value                 = configurationFileFormat.WindowSizeHeight;
-            Ui.WindowPositionX.Value                  = configurationFileFormat.WindowPositionX;
-            Ui.WindowPositionY.Value                  = configurationFileFormat.WindowPositionY;
-            Ui.WindowMaximized.Value                  = configurationFileFormat.WindowMaximized;
+            Ui.WindowStartup.WindowSizeWidth.Value    = configurationFileFormat.WindowStartup.WindowSizeWidth;
+            Ui.WindowStartup.WindowSizeHeight.Value   = configurationFileFormat.WindowStartup.WindowSizeHeight;
+            Ui.WindowStartup.WindowPositionX.Value    = configurationFileFormat.WindowStartup.WindowPositionX;
+            Ui.WindowStartup.WindowPositionY.Value    = configurationFileFormat.WindowStartup.WindowPositionY;
+            Ui.WindowStartup.WindowMaximized.Value    = configurationFileFormat.WindowStartup.WindowMaximized;
             Hid.EnableKeyboard.Value                  = configurationFileFormat.EnableKeyboard;
             Hid.EnableMouse.Value                     = configurationFileFormat.EnableMouse;
             Hid.Hotkeys.Value                         = configurationFileFormat.Hotkeys;

--- a/src/Ryujinx.Ui.Common/Configuration/Ui/WindowStartup.cs
+++ b/src/Ryujinx.Ui.Common/Configuration/Ui/WindowStartup.cs
@@ -1,0 +1,11 @@
+namespace Ryujinx.Ui.Common.Configuration.Ui
+{
+    public struct WindowStartup
+    {
+        public int WindowSizeWidth { get; set; }
+        public int WindowSizeHeight { get; set; }
+        public int WindowPositionX { get; set; }
+        public int WindowPositionY { get; set; }
+        public bool WindowMaximized { get; set; }
+    }
+}

--- a/src/Ryujinx/Ui/MainWindow.cs
+++ b/src/Ryujinx/Ui/MainWindow.cs
@@ -161,6 +161,7 @@ namespace Ryujinx.Ui
             DefaultWidth  = monitorWidth  < 1280 ? monitorWidth  : ConfigurationState.Instance.Ui.WindowSizeWidth;
             DefaultHeight = monitorHeight < 760  ? monitorHeight : ConfigurationState.Instance.Ui.WindowSizeHeight;
             Move(ConfigurationState.Instance.Ui.WindowPositionX,ConfigurationState.Instance.Ui.WindowPositionY);
+            if (ConfigurationState.Instance.Ui.WindowMaximized == true) { Maximize(); };
 
             Icon  = new Gdk.Pixbuf(Assembly.GetAssembly(typeof(ConfigurationState)), "Ryujinx.Ui.Common.Resources.Logo_Ryujinx.png");
             Title = $"Ryujinx {Program.Version}";
@@ -1323,6 +1324,7 @@ namespace Ryujinx.Ui
                 GetSize(out windowWidth, out windowHeight);
                 GetPosition(out windowXPos, out windowYPos);
 
+                ConfigurationState.Instance.Ui.WindowMaximized.Value = IsMaximized;
                 ConfigurationState.Instance.Ui.WindowSizeWidth.Value = windowWidth;
                 ConfigurationState.Instance.Ui.WindowSizeHeight.Value = windowHeight;
                 ConfigurationState.Instance.Ui.WindowPositionX.Value = windowXPos;
@@ -1345,6 +1347,7 @@ namespace Ryujinx.Ui
                 GetSize(out windowWidth, out windowHeight);
                 GetPosition(out windowXPos, out windowYPos);
 
+                ConfigurationState.Instance.Ui.WindowMaximized.Value = IsMaximized;
                 ConfigurationState.Instance.Ui.WindowSizeWidth.Value = windowWidth;
                 ConfigurationState.Instance.Ui.WindowSizeHeight.Value = windowHeight;
                 ConfigurationState.Instance.Ui.WindowPositionX.Value = windowXPos;

--- a/src/Ryujinx/Ui/MainWindow.cs
+++ b/src/Ryujinx/Ui/MainWindow.cs
@@ -1319,21 +1319,7 @@ namespace Ryujinx.Ui
         {
             if (!_gameLoaded || !ConfigurationState.Instance.ShowConfirmExit || GtkDialog.CreateExitDialog())
             {
-                int windowWidth;
-                int windowHeight;
-                int windowXPos;
-                int windowYPos;
-
-                GetSize(out windowWidth, out windowHeight);
-                GetPosition(out windowXPos, out windowYPos);
-
-                ConfigurationState.Instance.Ui.WindowMaximized.Value = IsMaximized;
-                ConfigurationState.Instance.Ui.WindowSizeWidth.Value = windowWidth;
-                ConfigurationState.Instance.Ui.WindowSizeHeight.Value = windowHeight;
-                ConfigurationState.Instance.Ui.WindowPositionX.Value = windowXPos;
-                ConfigurationState.Instance.Ui.WindowPositionY.Value = windowYPos;
-
-                SaveConfig();        
+                SaveWindowSizePosition();
                 End();
             }
         }
@@ -1342,27 +1328,32 @@ namespace Ryujinx.Ui
         {
             if (!_gameLoaded || !ConfigurationState.Instance.ShowConfirmExit || GtkDialog.CreateExitDialog())
             {
-                int windowWidth;
-                int windowHeight;
-                int windowXPos;
-                int windowYPos;
-
-                GetSize(out windowWidth, out windowHeight);
-                GetPosition(out windowXPos, out windowYPos);
-
-                ConfigurationState.Instance.Ui.WindowMaximized.Value = IsMaximized;
-                ConfigurationState.Instance.Ui.WindowSizeWidth.Value = windowWidth;
-                ConfigurationState.Instance.Ui.WindowSizeHeight.Value = windowHeight;
-                ConfigurationState.Instance.Ui.WindowPositionX.Value = windowXPos;
-                ConfigurationState.Instance.Ui.WindowPositionY.Value = windowYPos;
-
-                SaveConfig();        
+                SaveWindowSizePosition();        
                 End();
             }
             else
             {
                 args.RetVal = true;
             }
+        }
+
+        private void SaveWindowSizePosition()
+        {
+            int windowWidth;
+            int windowHeight;
+            int windowXPos;
+            int windowYPos;
+
+            GetSize(out windowWidth, out windowHeight);
+            GetPosition(out windowXPos, out windowYPos);
+
+            ConfigurationState.Instance.Ui.WindowMaximized.Value = IsMaximized;
+            ConfigurationState.Instance.Ui.WindowSizeWidth.Value = windowWidth;
+            ConfigurationState.Instance.Ui.WindowSizeHeight.Value = windowHeight;
+            ConfigurationState.Instance.Ui.WindowPositionX.Value = windowXPos;
+            ConfigurationState.Instance.Ui.WindowPositionY.Value = windowYPos;
+
+            SaveConfig();        
         }
 
         private void StopEmulation_Pressed(object sender, EventArgs args)

--- a/src/Ryujinx/Ui/MainWindow.cs
+++ b/src/Ryujinx/Ui/MainWindow.cs
@@ -161,7 +161,10 @@ namespace Ryujinx.Ui
             DefaultWidth  = monitorWidth  < 1280 ? monitorWidth  : ConfigurationState.Instance.Ui.WindowSizeWidth;
             DefaultHeight = monitorHeight < 760  ? monitorHeight : ConfigurationState.Instance.Ui.WindowSizeHeight;
             Move(ConfigurationState.Instance.Ui.WindowPositionX,ConfigurationState.Instance.Ui.WindowPositionY);
-            if (ConfigurationState.Instance.Ui.WindowMaximized) { Maximize(); };
+            if (ConfigurationState.Instance.Ui.WindowMaximized) 
+            { 
+                Maximize(); 
+            };
 
             Icon  = new Gdk.Pixbuf(Assembly.GetAssembly(typeof(ConfigurationState)), "Ryujinx.Ui.Common.Resources.Logo_Ryujinx.png");
             Title = $"Ryujinx {Program.Version}";

--- a/src/Ryujinx/Ui/MainWindow.cs
+++ b/src/Ryujinx/Ui/MainWindow.cs
@@ -154,6 +154,8 @@ namespace Ryujinx.Ui
             // Apply custom theme if needed.
             ThemeHelper.ApplyTheme();
 
+            SetWindowSizePosition();
+
             Icon  = new Gdk.Pixbuf(Assembly.GetAssembly(typeof(ConfigurationState)), "Ryujinx.Ui.Common.Resources.Logo_Ryujinx.png");
             Title = $"Ryujinx {Program.Version}";
 

--- a/src/Ryujinx/Ui/MainWindow.cs
+++ b/src/Ryujinx/Ui/MainWindow.cs
@@ -160,11 +160,13 @@ namespace Ryujinx.Ui
 
             DefaultWidth  = monitorWidth  < 1280 ? monitorWidth  : ConfigurationState.Instance.Ui.WindowSizeWidth;
             DefaultHeight = monitorHeight < 760  ? monitorHeight : ConfigurationState.Instance.Ui.WindowSizeHeight;
+
             Move(ConfigurationState.Instance.Ui.WindowPositionX, ConfigurationState.Instance.Ui.WindowPositionY);
+
             if (ConfigurationState.Instance.Ui.WindowMaximized) 
             { 
                 Maximize(); 
-            };
+            }
 
             Icon  = new Gdk.Pixbuf(Assembly.GetAssembly(typeof(ConfigurationState)), "Ryujinx.Ui.Common.Resources.Logo_Ryujinx.png");
             Title = $"Ryujinx {Program.Version}";

--- a/src/Ryujinx/Ui/MainWindow.cs
+++ b/src/Ryujinx/Ui/MainWindow.cs
@@ -158,8 +158,9 @@ namespace Ryujinx.Ui
             int monitorWidth  = monitor.Geometry.Width  * monitor.ScaleFactor;
             int monitorHeight = monitor.Geometry.Height * monitor.ScaleFactor;
 
-            DefaultWidth  = monitorWidth  < 1280 ? monitorWidth  : 1280;
-            DefaultHeight = monitorHeight < 760  ? monitorHeight : 760;
+            DefaultWidth  = monitorWidth  < 1280 ? monitorWidth  : ConfigurationState.Instance.Ui.WindowSizeWidth;
+            DefaultHeight = monitorHeight < 760  ? monitorHeight : ConfigurationState.Instance.Ui.WindowSizeHeight;
+            Move(ConfigurationState.Instance.Ui.WindowPositionX,ConfigurationState.Instance.Ui.WindowPositionY);
 
             Icon  = new Gdk.Pixbuf(Assembly.GetAssembly(typeof(ConfigurationState)), "Ryujinx.Ui.Common.Resources.Logo_Ryujinx.png");
             Title = $"Ryujinx {Program.Version}";
@@ -1314,6 +1315,20 @@ namespace Ryujinx.Ui
         {
             if (!_gameLoaded || !ConfigurationState.Instance.ShowConfirmExit || GtkDialog.CreateExitDialog())
             {
+                int windowWidth;
+                int windowHeight;
+                int windowXPos;
+                int windowYPos;
+
+                GetSize(out windowWidth, out windowHeight);
+                GetPosition(out windowXPos, out windowYPos);
+
+                ConfigurationState.Instance.Ui.WindowSizeWidth.Value = windowWidth;
+                ConfigurationState.Instance.Ui.WindowSizeHeight.Value = windowHeight;
+                ConfigurationState.Instance.Ui.WindowPositionX.Value = windowXPos;
+                ConfigurationState.Instance.Ui.WindowPositionY.Value = windowYPos;
+
+                SaveConfig();        
                 End();
             }
         }
@@ -1322,6 +1337,20 @@ namespace Ryujinx.Ui
         {
             if (!_gameLoaded || !ConfigurationState.Instance.ShowConfirmExit || GtkDialog.CreateExitDialog())
             {
+                int windowWidth;
+                int windowHeight;
+                int windowXPos;
+                int windowYPos;
+
+                GetSize(out windowWidth, out windowHeight);
+                GetPosition(out windowXPos, out windowYPos);
+
+                ConfigurationState.Instance.Ui.WindowSizeWidth.Value = windowWidth;
+                ConfigurationState.Instance.Ui.WindowSizeHeight.Value = windowHeight;
+                ConfigurationState.Instance.Ui.WindowPositionX.Value = windowXPos;
+                ConfigurationState.Instance.Ui.WindowPositionY.Value = windowYPos;
+
+                SaveConfig();        
                 End();
             }
             else

--- a/src/Ryujinx/Ui/MainWindow.cs
+++ b/src/Ryujinx/Ui/MainWindow.cs
@@ -161,7 +161,7 @@ namespace Ryujinx.Ui
             DefaultWidth  = monitorWidth  < 1280 ? monitorWidth  : ConfigurationState.Instance.Ui.WindowSizeWidth;
             DefaultHeight = monitorHeight < 760  ? monitorHeight : ConfigurationState.Instance.Ui.WindowSizeHeight;
             Move(ConfigurationState.Instance.Ui.WindowPositionX,ConfigurationState.Instance.Ui.WindowPositionY);
-            if (ConfigurationState.Instance.Ui.WindowMaximized == true) { Maximize(); };
+            if (ConfigurationState.Instance.Ui.WindowMaximized) { Maximize(); };
 
             Icon  = new Gdk.Pixbuf(Assembly.GetAssembly(typeof(ConfigurationState)), "Ryujinx.Ui.Common.Resources.Logo_Ryujinx.png");
             Title = $"Ryujinx {Program.Version}";

--- a/src/Ryujinx/Ui/MainWindow.cs
+++ b/src/Ryujinx/Ui/MainWindow.cs
@@ -160,7 +160,7 @@ namespace Ryujinx.Ui
 
             DefaultWidth  = monitorWidth  < 1280 ? monitorWidth  : ConfigurationState.Instance.Ui.WindowSizeWidth;
             DefaultHeight = monitorHeight < 760  ? monitorHeight : ConfigurationState.Instance.Ui.WindowSizeHeight;
-            Move(ConfigurationState.Instance.Ui.WindowPositionX,ConfigurationState.Instance.Ui.WindowPositionY);
+            Move(ConfigurationState.Instance.Ui.WindowPositionX, ConfigurationState.Instance.Ui.WindowPositionY);
             if (ConfigurationState.Instance.Ui.WindowMaximized) 
             { 
                 Maximize(); 

--- a/src/Ryujinx/Ui/MainWindow.cs
+++ b/src/Ryujinx/Ui/MainWindow.cs
@@ -158,12 +158,12 @@ namespace Ryujinx.Ui
             int monitorWidth  = monitor.Geometry.Width  * monitor.ScaleFactor;
             int monitorHeight = monitor.Geometry.Height * monitor.ScaleFactor;
 
-            DefaultWidth  = monitorWidth  < 1280 ? monitorWidth  : ConfigurationState.Instance.Ui.WindowSizeWidth;
-            DefaultHeight = monitorHeight < 760  ? monitorHeight : ConfigurationState.Instance.Ui.WindowSizeHeight;
+            DefaultWidth  = monitorWidth  < 1280 ? monitorWidth  : ConfigurationState.Instance.Ui.WindowStartup.WindowSizeWidth;
+            DefaultHeight = monitorHeight < 760  ? monitorHeight : ConfigurationState.Instance.Ui.WindowStartup.WindowSizeHeight;
 
-            Move(ConfigurationState.Instance.Ui.WindowPositionX, ConfigurationState.Instance.Ui.WindowPositionY);
+            Move(ConfigurationState.Instance.Ui.WindowStartup.WindowPositionX, ConfigurationState.Instance.Ui.WindowStartup.WindowPositionY);
 
-            if (ConfigurationState.Instance.Ui.WindowMaximized) 
+            if (ConfigurationState.Instance.Ui.WindowStartup.WindowMaximized) 
             { 
                 Maximize(); 
             }
@@ -1341,19 +1341,14 @@ namespace Ryujinx.Ui
 
         private void SaveWindowSizePosition()
         {
-            int windowWidth;
-            int windowHeight;
-            int windowXPos;
-            int windowYPos;
+            GetSize(out int windowWidth, out int windowHeight);
+            GetPosition(out int windowXPos, out int windowYPos);
 
-            GetSize(out windowWidth, out windowHeight);
-            GetPosition(out windowXPos, out windowYPos);
-
-            ConfigurationState.Instance.Ui.WindowMaximized.Value = IsMaximized;
-            ConfigurationState.Instance.Ui.WindowSizeWidth.Value = windowWidth;
-            ConfigurationState.Instance.Ui.WindowSizeHeight.Value = windowHeight;
-            ConfigurationState.Instance.Ui.WindowPositionX.Value = windowXPos;
-            ConfigurationState.Instance.Ui.WindowPositionY.Value = windowYPos;
+            ConfigurationState.Instance.Ui.WindowStartup.WindowMaximized.Value = IsMaximized;
+            ConfigurationState.Instance.Ui.WindowStartup.WindowSizeWidth.Value = windowWidth;
+            ConfigurationState.Instance.Ui.WindowStartup.WindowSizeHeight.Value = windowHeight;
+            ConfigurationState.Instance.Ui.WindowStartup.WindowPositionX.Value = windowXPos;
+            ConfigurationState.Instance.Ui.WindowStartup.WindowPositionY.Value = windowYPos;
 
             SaveConfig();        
         }

--- a/src/Ryujinx/Ui/MainWindow.cs
+++ b/src/Ryujinx/Ui/MainWindow.cs
@@ -153,20 +153,6 @@ namespace Ryujinx.Ui
 
             // Apply custom theme if needed.
             ThemeHelper.ApplyTheme();
-            Gdk.Monitor monitor = Display.GetMonitor(0);
-            // Sets overridden fields.
-            int monitorWidth  = monitor.Geometry.Width  * monitor.ScaleFactor;
-            int monitorHeight = monitor.Geometry.Height * monitor.ScaleFactor;
-
-            DefaultWidth  = monitorWidth  < 1280 ? monitorWidth  : ConfigurationState.Instance.Ui.WindowStartup.WindowSizeWidth;
-            DefaultHeight = monitorHeight < 760  ? monitorHeight : ConfigurationState.Instance.Ui.WindowStartup.WindowSizeHeight;
-
-            Move(ConfigurationState.Instance.Ui.WindowStartup.WindowPositionX, ConfigurationState.Instance.Ui.WindowStartup.WindowPositionY);
-
-            if (ConfigurationState.Instance.Ui.WindowStartup.WindowMaximized) 
-            { 
-                Maximize(); 
-            }
 
             Icon  = new Gdk.Pixbuf(Assembly.GetAssembly(typeof(ConfigurationState)), "Ryujinx.Ui.Common.Resources.Logo_Ryujinx.png");
             Title = $"Ryujinx {Program.Version}";
@@ -1336,6 +1322,19 @@ namespace Ryujinx.Ui
             else
             {
                 args.RetVal = true;
+            }
+        }
+
+        private void SetWindowSizePosition()
+        {
+            DefaultWidth  = ConfigurationState.Instance.Ui.WindowStartup.WindowSizeWidth;
+            DefaultHeight = ConfigurationState.Instance.Ui.WindowStartup.WindowSizeHeight;
+
+            Move(ConfigurationState.Instance.Ui.WindowStartup.WindowPositionX, ConfigurationState.Instance.Ui.WindowStartup.WindowPositionY);
+
+            if (ConfigurationState.Instance.Ui.WindowStartup.WindowMaximized) 
+            { 
+                Maximize(); 
             }
         }
 


### PR DESCRIPTION
Based on #4439 with support for Avalonia. 

As the two frameworks fight over data types and the like, GTK is given priority for now. It will be a quick job to edit and expand upon once deprecated e.g. WindowState could start in fullscreen instead of just maximised etc.

CC @HaizenTrist 