### PR TITLE
GPU: Keep rendered textures without any pool references alive

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -1,4 +1,5 @@
 using Ryujinx.Common;
+using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Engine.Threed;
 using Ryujinx.Graphics.Gpu.Engine.Twod;
@@ -833,7 +834,17 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                             if (overlapInCache)
                             {
-                                _cache.Remove(overlap, flush);
+                                if (flush || overlap.HadPoolOwner || overlap.IsView)
+                                {
+                                    _cache.Remove(overlap, flush);
+                                }
+                                else
+                                {
+                                    // This texture has only ever been referenced in the AutoDeleteCache.
+                                    // Keep this texture alive with the short duration cache, as it may be used often but not sampled.
+
+                                    _cache.AddShortCache(overlap);
+                                }
                             }
 
                             removeOverlap = modified;
@@ -1143,6 +1154,16 @@ namespace Ryujinx.Graphics.Gpu.Image
         public void AddShortCache(Texture texture, ref TextureDescriptor descriptor)
         {
             _cache.AddShortCache(texture, ref descriptor);
+        }
+
+        /// <summary>
+        /// Adds a texture to the short duration cache without a descriptor. This typically keeps it alive for two ticks.
+        /// On expiry, it will be removed from the AutoDeleteCache.
+        /// </summary>
+        /// <param name="texture">Texture to add to the short cache</param>
+        public void AddShortCache(Texture texture)
+        {
+            _cache.AddShortCache(texture);
         }
 
         /// <summary>

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -1,5 +1,4 @@
 using Ryujinx.Common;
-using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.Gpu.Engine.Threed;
 using Ryujinx.Graphics.Gpu.Engine.Twod;


### PR DESCRIPTION
Occasionally games are very wasteful and clear/write to a texture without ever sampling it. As rendered textures in NVN games seem to mostly have overlapping memory ranges (they are temporary), the texture will eventually get overwritten.

Normally, this would trigger a removal from the auto delete cache, but a pool entry would keep the texture alive. This is important so that games don't recreate all of their render targets every frame. However, with these textures that are never used, they will get deleted immediately and recreated on the next frame. This might also happen with textures that are rendered then copied somewhere else, as that also won't use a pool entry.

Because of the incompatible overlap, there won't be a data upload, but both OpenGL and Vulkan have costs when creating new texture storage. It really depends on your driver.

This change makes it so the ShortTextureCache can keep textures that have never had a pool reference alive for a few frames, so they're not constantly being created and deleted.

This improves performance in Zelda BOTW v1.6 a little bit, as it was recreating a number of textures every frame. v1.0 did not exhibit this behaviour. Example of a frame:

```
00:00:48.128 |E| GPU.MainThread Gpu : New texture: 320x180x1 1lv Texture2D R11G11B10Float
00:00:48.129 |E| GPU.MainThread Gpu : New texture: 96x96x1 1lv Texture2D R16G16B16A16Float
00:00:48.129 |E| GPU.MainThread Gpu : New texture: 48x48x1 1lv Texture2D R16G16B16A16Float
00:00:48.129 |E| GPU.MainThread Gpu : New texture: 24x24x1 1lv Texture2D R16G16B16A16Float
00:00:48.129 |E| GPU.MainThread Gpu : New texture: 12x12x1 1lv Texture2D R16G16B16A16Float
00:00:48.129 |E| GPU.MainThread Gpu : New texture: 6x6x1 1lv Texture2D R16G16B16A16Float
00:00:48.129 |E| GPU.MainThread Gpu : New texture: 696x42x1 1lv Texture2D R8G8B8A8Unorm
00:00:48.130 |E| GPU.MainThread Gpu : New texture: 2400x1140x1 1lv Texture2D R8Unorm
```
The last texture is pretty big. If your driver decides to clear/process the memory on creation, then it could be wasting a lot of time. Note that none of these are views, they all create storage.

It's possible that other games do this, it just depends how careless they are when it comes to rendering stuff that is never used. I'd recommend testing a bunch of games to ensure this doesn't break anything.
