### PR TITLE
Avalonia - Force activate parent window before dialog is shown

### DIFF
--- a/Ryujinx.Ava/UI/Applet/AvaHostUiHandler.cs
+++ b/Ryujinx.Ava/UI/Applet/AvaHostUiHandler.cs
@@ -53,6 +53,8 @@ namespace Ryujinx.Ava.UI.Applet
 
                     bool opened = false;
 
+                    _parent.Activate();
+
                     UserResult response = await ContentDialogHelper.ShowDeferredContentDialog(_parent,
                        title,
                        message,


### PR DESCRIPTION
Fixes an issue in https://github.com/Ryujinx/Ryujinx/issues/3662 where content dialogs would not be spawned if the window was minimized or otherwise lost focus by the user.