### PR TITLE
Vulkan: add situational "Fast Flush" mode

### DIFF
--- a/Ryujinx.Graphics.Vulkan/AutoFlushCounter.cs
+++ b/Ryujinx.Graphics.Vulkan/AutoFlushCounter.cs
@@ -8,10 +8,10 @@ namespace Ryujinx.Graphics.Vulkan
     internal class AutoFlushCounter
     {
         // How often to flush on framebuffer change.
-        private readonly static long FramebufferFlushTimer = Stopwatch.Frequency / 1000;
+        private readonly static long FramebufferFlushTimer = Stopwatch.Frequency / 1000; // (1ms)
 
         // How often to flush on draw when fast flush mode is enabled.
-        private readonly static long DrawFlushTimer = Stopwatch.Frequency / 666;
+        private readonly static long DrawFlushTimer = Stopwatch.Frequency / 666; // (1.5ms)
 
         // Average wait time that triggers fast flush mode to be entered.
         private readonly static long FastFlushEnterThreshold = Stopwatch.Frequency / 666; // (1.5ms)

--- a/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -1562,6 +1562,11 @@ namespace Ryujinx.Graphics.Vulkan
 
         private void RecreatePipelineIfNeeded(PipelineBindPoint pbp)
         {
+            if (AutoFlush.ShouldFlushDraw(DrawCount))
+            {
+                Gd.FlushAllCommands();
+            }
+
             DynamicState.ReplayIfDirty(Gd.Api, CommandBuffer);
 
             // Commit changes to the support buffer before drawing.

--- a/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -86,7 +86,7 @@ namespace Ryujinx.Graphics.Vulkan
             Gd = gd;
             Device = device;
 
-            AutoFlush = new AutoFlushCounter();
+            AutoFlush = new AutoFlushCounter(gd);
 
             var pipelineCacheCreateInfo = new PipelineCacheCreateInfo()
             {

--- a/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -49,6 +49,7 @@ namespace Ryujinx.Graphics.Vulkan
         internal PipelineLayoutCache PipelineLayoutCache { get; private set; }
         internal BackgroundResources BackgroundResources { get; private set; }
         internal Action<Action> InterruptAction { get; private set; }
+        internal SyncManager SyncManager { get; private set; }
 
         internal BufferManager BufferManager { get; private set; }
 
@@ -58,7 +59,6 @@ namespace Ryujinx.Graphics.Vulkan
 
         private VulkanDebugMessenger _debugMessenger;
         private Counters _counters;
-        private SyncManager _syncManager;
 
         private PipelineFull _pipeline;
 
@@ -327,7 +327,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             BufferManager = new BufferManager(this, _device);
 
-            _syncManager = new SyncManager(this, _device);
+            SyncManager = new SyncManager(this, _device);
             _pipeline = new PipelineFull(this, _device);
             _pipeline.Initialize();
 
@@ -436,7 +436,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         internal void RegisterFlush()
         {
-            _syncManager.RegisterFlush();
+            SyncManager.RegisterFlush();
         }
 
         public PinnedSpan<byte> GetBufferData(BufferHandle buffer, int offset, int size)
@@ -696,7 +696,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         public void PreFrame()
         {
-            _syncManager.Cleanup();
+            SyncManager.Cleanup();
         }
 
         public ICounterEvent ReportCounter(CounterType type, EventHandler<ulong> resultHandler, bool hostReserved)
@@ -736,7 +736,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         public void CreateSync(ulong id, bool strict)
         {
-            _syncManager.Create(id, strict);
+            SyncManager.Create(id, strict);
         }
 
         public IProgram LoadProgramBinary(byte[] programBinary, bool isFragment, ShaderInfo info)
@@ -746,12 +746,12 @@ namespace Ryujinx.Graphics.Vulkan
 
         public void WaitSync(ulong id)
         {
-            _syncManager.Wait(id);
+            SyncManager.Wait(id);
         }
 
         public ulong GetCurrentSync()
         {
-            return _syncManager.GetCurrent();
+            return SyncManager.GetCurrent();
         }
 
         public void SetInterruptAction(Action<Action> interruptAction)


### PR DESCRIPTION
The AutoFlushCounter class was added to periodically flush Vulkan command buffers throughout a frame, which reduces latency to the GPU as commands are submitted and processed much sooner. This was done by allowing command buffers to flush when framebuffer attachments changed.

However, some games have incredibly long render passes with a large number of draws, and really aggressive data access that forces GPU sync.

The Vulkan backend could potentially end up building a single command buffer for 4-5ms if a pass has enough draws, such as in BOTW. In the scenario where sync is waited on immediately after submission, this would have to wait for the completion of a much longer command buffer than usual.

The solution is to force command buffer submission periodically in a "fast flush" mode. This will end up splitting render passes, but it will only enable if sync is aggressive enough.

This should improve performance in GPU limited scenarios, or in games that aggressively wait on synchronization. In some games, it may only kick in when res scaling. It won't trigger in games like SMO where sync is not an issue, or games like Scarlet/Violet at 1x when GPU performance is not the bottleneck.

Improves performance in Pokemon Scarlet/Violet (res scaled) and BOTW (in general).