### PR TITLE
Avalonia - Move swkbd message null check into constructor

### DIFF
--- a/Ryujinx.Ava/UI/Applet/SwkbdAppletDialog.axaml.cs
+++ b/Ryujinx.Ava/UI/Applet/SwkbdAppletDialog.axaml.cs
@@ -23,10 +23,11 @@ namespace Ryujinx.Ava.UI.Controls
 
         private ContentDialog _host;
 
-        public SwkbdAppletDialog(string mainText, string secondaryText, string placeholder)
+        public SwkbdAppletDialog(string mainText, string secondaryText, string placeholder, string message)
         {
             MainText = mainText;
             SecondaryText = secondaryText;
+            Message = message ?? "";
             DataContext = this;
             _placeholder = placeholder;
             InitializeComponent();
@@ -54,10 +55,7 @@ namespace Ryujinx.Ava.UI.Controls
 
             UserResult result = UserResult.Cancel;
 
-            SwkbdAppletDialog content = new SwkbdAppletDialog(args.HeaderText, args.SubtitleText, args.GuideText)
-            {
-                Message = args.InitialText ?? ""
-            };
+            SwkbdAppletDialog content = new SwkbdAppletDialog(args.HeaderText, args.SubtitleText, args.GuideText, args.InitialText);
 
             string input = string.Empty;
 


### PR DESCRIPTION
Fixes an issue in https://github.com/Ryujinx/Ryujinx/issues/3662 where the software keyboard in Avalonia does not populate any example text the game provides such as default character names etc.

Before:
![image](https://user-images.githubusercontent.com/44103205/231309882-020ffd57-b2e8-4954-9c67-8c3e94c68986.png)

After: 
![image](https://user-images.githubusercontent.com/44103205/231309910-7be536a3-ac24-4c3d-93c4-86ad92be8212.png)
