### PR TITLE
Revert "chore: Update Silk.NET to 2.17.1"

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,9 +37,9 @@
     <PackageVersion Include="Ryujinx.SDL2-CS" Version="2.26.3-build25" />
     <PackageVersion Include="shaderc.net" Version="0.1.0" />
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
-    <PackageVersion Include="Silk.NET.Vulkan" Version="2.17.1" />
-    <PackageVersion Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.17.1" />
-    <PackageVersion Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.17.1" />
+    <PackageVersion Include="Silk.NET.Vulkan" Version="2.16.0" />
+    <PackageVersion Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.16.0" />
+    <PackageVersion Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.16.0" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="1.0.4" />
     <PackageVersion Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta11" />
     <PackageVersion Include="SPB" Version="0.0.4-build28" />


### PR DESCRIPTION
Reverts Ryujinx/Ryujinx#4686

The newer version of Silk.NET is not working on macOS, it can't find MoltenVK, so reverting until the problem is investigated and fixed (either own our or Silk.NET side).

Fixes #4689.