### PR TITLE
Avoid LM service crashes by not reading more than the buffer size

### DIFF
--- a/Ryujinx.Common/Memory/SpanReader.cs
+++ b/Ryujinx.Common/Memory/SpanReader.cs
@@ -33,6 +33,11 @@ namespace Ryujinx.Common.Memory
             return data;
         }
 
+        public ReadOnlySpan<byte> GetSpanSafe(int size)
+        {
+            return GetSpan((int)Math.Min((uint)_input.Length, (uint)size));
+        }
+
         public T ReadAt<T>(int offset) where T : unmanaged
         {
             return MemoryMarshal.Cast<byte, T>(_input.Slice(offset))[0];

--- a/Ryujinx.Horizon/LogManager/Ipc/LmLogger.cs
+++ b/Ryujinx.Horizon/LogManager/Ipc/LmLogger.cs
@@ -113,7 +113,7 @@ namespace Ryujinx.Horizon.LogManager.Ipc
                 }
                 else if (key == LogDataChunkKey.Message)
                 {
-                    string text = Encoding.UTF8.GetString(reader.GetSpan(size)).TrimEnd();
+                    string text = Encoding.UTF8.GetString(reader.GetSpanSafe(size)).TrimEnd();
 
                     if (isHeadPacket && isTailPacket)
                     {
@@ -131,23 +131,23 @@ namespace Ryujinx.Horizon.LogManager.Ipc
                 }
                 else if (key == LogDataChunkKey.Filename)
                 {
-                    _logPacket.Filename = Encoding.UTF8.GetString(reader.GetSpan(size)).TrimEnd();
+                    _logPacket.Filename = Encoding.UTF8.GetString(reader.GetSpanSafe(size)).TrimEnd();
                 }
                 else if (key == LogDataChunkKey.Function)
                 {
-                    _logPacket.Function = Encoding.UTF8.GetString(reader.GetSpan(size)).TrimEnd();
+                    _logPacket.Function = Encoding.UTF8.GetString(reader.GetSpanSafe(size)).TrimEnd();
                 }
                 else if (key == LogDataChunkKey.Module)
                 {
-                    _logPacket.Module = Encoding.UTF8.GetString(reader.GetSpan(size)).TrimEnd();
+                    _logPacket.Module = Encoding.UTF8.GetString(reader.GetSpanSafe(size)).TrimEnd();
                 }
                 else if (key == LogDataChunkKey.Thread)
                 {
-                    _logPacket.Thread = Encoding.UTF8.GetString(reader.GetSpan(size)).TrimEnd();
+                    _logPacket.Thread = Encoding.UTF8.GetString(reader.GetSpanSafe(size)).TrimEnd();
                 }
                 else if (key == LogDataChunkKey.ProgramName)
                 {
-                    _logPacket.ProgramName = Encoding.UTF8.GetString(reader.GetSpan(size)).TrimEnd();
+                    _logPacket.ProgramName = Encoding.UTF8.GetString(reader.GetSpanSafe(size)).TrimEnd();
                 }
             }
 


### PR DESCRIPTION
This PR introduces a new method on `SpanReader` that ensures the length of the span is valid, so it does not try to get a span that is larger than the buffer size. This fixes a crash on Rune Factory 4 Special on newlywed mode when talking with your spouse (at least, that's the only instance where it was reported). While I was testing this change, I made it log the invalid size. The size specified is 1024 bytes, but the remaining buffer size is just 956 bytes. The `LogDataChunkKey` is `Message`. The message appears correct, but the end is truncated, which *might* indicate that the size *was* supposed to be 1024 bytes?

In any case, LM is stubbed in production firmware, so that would not cause issues on a retail Switch, I think this safer behaviour to avoid crash with invalid lengths is fine.