### PR TITLE
Shader: Bias textureGather instructions on AMD/Intel

### DIFF
--- a/Ryujinx.Graphics.GAL/Capabilities.cs
+++ b/Ryujinx.Graphics.GAL/Capabilities.cs
@@ -48,6 +48,8 @@ namespace Ryujinx.Graphics.GAL
         public readonly float MaximumSupportedAnisotropy;
         public readonly int StorageBufferOffsetAlignment;
 
+        public readonly int GatherBiasPrecision;
+
         public Capabilities(
             TargetApi api,
             string vendorName,
@@ -87,7 +89,8 @@ namespace Ryujinx.Graphics.GAL
             uint maximumImagesPerStage,
             int maximumComputeSharedMemorySize,
             float maximumSupportedAnisotropy,
-            int storageBufferOffsetAlignment)
+            int storageBufferOffsetAlignment,
+            int gatherBiasPrecision)
         {
             Api = api;
             VendorName = vendorName;
@@ -128,6 +131,7 @@ namespace Ryujinx.Graphics.GAL
             MaximumComputeSharedMemorySize = maximumComputeSharedMemorySize;
             MaximumSupportedAnisotropy = maximumSupportedAnisotropy;
             StorageBufferOffsetAlignment = storageBufferOffsetAlignment;
+            GatherBiasPrecision = gatherBiasPrecision;
         }
     }
 }

--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 4404;
+        private const uint CodeGenVersion = 4703;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/Ryujinx.Graphics.Gpu/Shader/GpuAccessorBase.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/GpuAccessorBase.cs
@@ -112,6 +112,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
             };
         }
 
+        public int QueryHostGatherBiasPrecision() => _context.Capabilities.GatherBiasPrecision;
+
         public bool QueryHostReducedPrecision() => _context.Capabilities.ReduceShaderPrecision;
 
         public bool QueryHostHasFrontFacingBug() => _context.Capabilities.HasFrontFacingBug;

--- a/Ryujinx.Graphics.OpenGL/OpenGLRenderer.cs
+++ b/Ryujinx.Graphics.OpenGL/OpenGLRenderer.cs
@@ -103,11 +103,14 @@ namespace Ryujinx.Graphics.OpenGL
 
         public Capabilities GetCapabilities()
         {
+            bool intelWindows = HwCapabilities.Vendor == HwCapabilities.GpuVendor.IntelWindows;
+            bool amdWindows = HwCapabilities.Vendor == HwCapabilities.GpuVendor.AmdWindows;
+
             return new Capabilities(
                 api: TargetApi.OpenGL,
                 vendorName: GpuVendor,
-                hasFrontFacingBug: HwCapabilities.Vendor == HwCapabilities.GpuVendor.IntelWindows,
-                hasVectorIndexingBug: HwCapabilities.Vendor == HwCapabilities.GpuVendor.AmdWindows,
+                hasFrontFacingBug: intelWindows,
+                hasVectorIndexingBug: amdWindows,
                 needsFragmentOutputSpecialization: false,
                 reduceShaderPrecision: false,
                 supportsAstcCompression: HwCapabilities.SupportsAstcCompression,
@@ -142,7 +145,8 @@ namespace Ryujinx.Graphics.OpenGL
                 maximumImagesPerStage: 8,
                 maximumComputeSharedMemorySize: HwCapabilities.MaximumComputeSharedMemorySize,
                 maximumSupportedAnisotropy: HwCapabilities.MaximumSupportedAnisotropy,
-                storageBufferOffsetAlignment: HwCapabilities.StorageBufferOffsetAlignment);
+                storageBufferOffsetAlignment: HwCapabilities.StorageBufferOffsetAlignment,
+                gatherBiasPrecision: intelWindows || amdWindows ? 8 : 0); // Precision is 8 for these vendors on Vulkan.
         }
 
         public void SetBufferData(BufferHandle buffer, int offset, ReadOnlySpan<byte> data)

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
@@ -679,7 +679,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
 
             string ApplyBias(string vector)
             {
-                int gatherBiasPrecision = 8;
+                int gatherBiasPrecision = context.Config.GpuAccessor.QueryHostGatherBiasPrecision();
                 if (isGather && gatherBiasPrecision != 0)
                 {
                     // GPU requires texture gather to be slightly offset to match NVIDIA behaviour when point is exactly between two texels.

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
@@ -684,7 +684,15 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
                 {
                     // GPU requires texture gather to be slightly offset to match NVIDIA behaviour when point is exactly between two texels.
                     // Offset by the gather precision divided by 2 to correct for rounding.
-                    vector = $"{vector} + (1.0 / (vec{pCount}(textureSize({samplerName}, 0).{"xyz".Substring(0, pCount)}) * float({1 << (gatherBiasPrecision + 1)})))";
+
+                    if (pCount == 1)
+                    {
+                        vector = $"{vector} + (1.0 / (float(textureSize({samplerName}, 0)) * float({1 << (gatherBiasPrecision + 1)})))";
+                    }
+                    else
+                    {
+                        vector = $"{vector} + (1.0 / (vec{pCount}(textureSize({samplerName}, 0).{"xyz".Substring(0, pCount)}) * float({1 << (gatherBiasPrecision + 1)})))";
+                    }
                 }
 
                 return vector;

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
@@ -677,7 +677,19 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
                 return vector;
             }
 
-            Append(ApplyScaling(AssemblePVector(pCount)));
+            string ApplyBias(string vector)
+            {
+                int gatherBiasPrecision = 8;
+                if (isGather && gatherBiasPrecision != 0)
+                {
+                    // GPU requires texture gather to be slightly offset.
+                    vector = $"{vector} + (1.0 / (vec{pCount}(textureSize({samplerName}, 0).{"xyz".Substring(0, pCount)}) * float({1 << gatherBiasPrecision})))";
+                }
+
+                return vector;
+            }
+
+            Append(ApplyBias(ApplyScaling(AssemblePVector(pCount))));
 
             string AssembleDerivativesVector(int count)
             {

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Instructions/InstGenMemory.cs
@@ -682,8 +682,9 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl.Instructions
                 int gatherBiasPrecision = 8;
                 if (isGather && gatherBiasPrecision != 0)
                 {
-                    // GPU requires texture gather to be slightly offset.
-                    vector = $"{vector} + (1.0 / (vec{pCount}(textureSize({samplerName}, 0).{"xyz".Substring(0, pCount)}) * float({1 << gatherBiasPrecision})))";
+                    // GPU requires texture gather to be slightly offset to match NVIDIA behaviour when point is exactly between two texels.
+                    // Offset by the gather precision divided by 2 to correct for rounding.
+                    vector = $"{vector} + (1.0 / (vec{pCount}(textureSize({samplerName}, 0).{"xyz".Substring(0, pCount)}) * float({1 << (gatherBiasPrecision + 1)})))";
                 }
 
                 return vector;

--- a/Ryujinx.Graphics.Shader/CodeGen/Spirv/Instructions.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Spirv/Instructions.cs
@@ -4,6 +4,7 @@ using Ryujinx.Graphics.Shader.Translation;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Numerics;
 using static Spv.Specification;
 
@@ -1556,6 +1557,33 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
                 }
             }
 
+            SpvInstruction ApplyBias(SpvInstruction vector, SpvInstruction image)
+            {
+                int gatherBiasPrecision = 8;
+                if (isGather && gatherBiasPrecision != 0)
+                {
+                    // GPU requires texture gather to be slightly offset to match NVIDIA behaviour when point is exactly between two texels.
+                    // Offset by the gather precision divided by 2 to correct for rounding.
+                    var sizeType = pCount == 1 ? context.TypeS32() : context.TypeVector(context.TypeS32(), pCount);
+                    var pVectorType = pCount == 1 ? context.TypeFP32() : context.TypeVector(context.TypeFP32(), pCount);
+
+                    var bias = context.Constant(context.TypeFP32(), (float)(1 << (gatherBiasPrecision + 1)));
+                    var biasVector = context.CompositeConstruct(pVectorType, Enumerable.Repeat(bias, pCount).ToArray());
+
+                    var one = context.Constant(context.TypeFP32(), 1f);
+                    var oneVector = context.CompositeConstruct(pVectorType, Enumerable.Repeat(one, pCount).ToArray());
+
+                    var divisor = context.FMul(
+                        pVectorType,
+                        context.ConvertSToF(pVectorType, context.ImageQuerySize(sizeType, image)),
+                        biasVector);
+
+                    vector = context.FAdd(pVectorType, vector, context.FDiv(pVectorType, oneVector, divisor));
+                }
+
+                return vector;
+            }
+
             SpvInstruction pCoords = AssemblePVector(pCount);
             pCoords = ScalingHelpers.ApplyScaling(context, texOp, pCoords, intCoords, isBindless, isIndexed, isArray, pCount);
 
@@ -1715,6 +1743,8 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
             {
                 image = context.Image(imageType, image);
             }
+
+            pCoords = ApplyBias(pCoords, image);
 
             var operands = operandsList.ToArray();
 

--- a/Ryujinx.Graphics.Shader/CodeGen/Spirv/Instructions.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Spirv/Instructions.cs
@@ -1559,7 +1559,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
 
             SpvInstruction ApplyBias(SpvInstruction vector, SpvInstruction image)
             {
-                int gatherBiasPrecision = 8;
+                int gatherBiasPrecision = context.Config.GpuAccessor.QueryHostGatherBiasPrecision();
                 if (isGather && gatherBiasPrecision != 0)
                 {
                     // GPU requires texture gather to be slightly offset to match NVIDIA behaviour when point is exactly between two texels.

--- a/Ryujinx.Graphics.Shader/IGpuAccessor.cs
+++ b/Ryujinx.Graphics.Shader/IGpuAccessor.cs
@@ -197,6 +197,15 @@ namespace Ryujinx.Graphics.Shader
         }
 
         /// <summary>
+        /// Queries host's gather operation precision bits for biasing their coordinates. Zero means no bias.
+        /// </summary>
+        /// <returns>Bits of gater operation precision to use for coordinate bias</returns>
+        int QueryHostGatherBiasPrecision()
+        {
+            return 0;
+        }
+
+        /// <summary>
         /// Queries host about whether to reduce precision to improve performance.
         /// </summary>
         /// <returns>True if precision is limited to vertex position, false otherwise</returns>

--- a/Ryujinx.Graphics.Shader/IGpuAccessor.cs
+++ b/Ryujinx.Graphics.Shader/IGpuAccessor.cs
@@ -199,7 +199,7 @@ namespace Ryujinx.Graphics.Shader
         /// <summary>
         /// Queries host's gather operation precision bits for biasing their coordinates. Zero means no bias.
         /// </summary>
-        /// <returns>Bits of gater operation precision to use for coordinate bias</returns>
+        /// <returns>Bits of gather operation precision to use for coordinate bias</returns>
         int QueryHostGatherBiasPrecision()
         {
             return 0;

--- a/Ryujinx.Graphics.Vulkan/HardwareCapabilities.cs
+++ b/Ryujinx.Graphics.Vulkan/HardwareCapabilities.cs
@@ -46,6 +46,7 @@ namespace Ryujinx.Graphics.Vulkan
         public readonly SampleCountFlags SupportedSampleCounts;
         public readonly PortabilitySubsetFlags PortabilitySubset;
         public readonly uint VertexBufferAlignment;
+        public readonly uint SubTexelPrecisionBits;
 
         public HardwareCapabilities(
             bool supportsIndexTypeUint8,
@@ -77,7 +78,8 @@ namespace Ryujinx.Graphics.Vulkan
             ShaderStageFlags requiredSubgroupSizeStages,
             SampleCountFlags supportedSampleCounts,
             PortabilitySubsetFlags portabilitySubset,
-            uint vertexBufferAlignment)
+            uint vertexBufferAlignment,
+            uint subTexelPrecisionBits)
         {
             SupportsIndexTypeUint8 = supportsIndexTypeUint8;
             SupportsCustomBorderColor = supportsCustomBorderColor;
@@ -109,6 +111,7 @@ namespace Ryujinx.Graphics.Vulkan
             SupportedSampleCounts = supportedSampleCounts;
             PortabilitySubset = portabilitySubset;
             VertexBufferAlignment = vertexBufferAlignment;
+            SubTexelPrecisionBits = subTexelPrecisionBits;
         }
     }
 }

--- a/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -311,7 +311,8 @@ namespace Ryujinx.Graphics.Vulkan
                 propertiesSubgroupSizeControl.RequiredSubgroupSizeStages,
                 supportedSampleCounts,
                 portabilityFlags,
-                vertexBufferAlignment);
+                vertexBufferAlignment,
+                properties.Limits.SubTexelPrecisionBits);
 
             IsSharedMemory = MemoryAllocator.IsDeviceMemoryShared(_physicalDevice);
 
@@ -576,7 +577,8 @@ namespace Ryujinx.Graphics.Vulkan
                 maximumImagesPerStage: Constants.MaxImagesPerStage,
                 maximumComputeSharedMemorySize: (int)limits.MaxComputeSharedMemorySize,
                 maximumSupportedAnisotropy: (int)limits.MaxSamplerAnisotropy,
-                storageBufferOffsetAlignment: (int)limits.MinStorageBufferOffsetAlignment);
+                storageBufferOffsetAlignment: (int)limits.MinStorageBufferOffsetAlignment,
+                gatherBiasPrecision: IsIntelWindows || IsAmdWindows ? (int)Capabilities.SubTexelPrecisionBits : 0);
         }
 
         public HardwareInfo GetHardwareInfo()


### PR DESCRIPTION
There seems to be a bit of a disagreement on how textureGather should select texels when it is exactly half way between them. On BOTW, this tie breaks incorrectly for AMD and Intel on windows on both Vulkan and OpenGL, but correctly on NVIDIA, Apple and mesa drivers.

This is most noticeable in BOTW, where the difference in texel choice breaks the shadows in the game with a weird looking misalignment. A small positive bias causes the instruction to return the correct texels, so I decided to make it determine and add the smallest bias it possibly could.

This PR adds a capability that reveals both the sub texel precision and whether it should be used to bias textureGather. In OpenGL this is assumed, because I don't think it's reported.

This needs to apply after scaling (and with unscaled texture sizes) so this is currently performed in the shader backend. The offset is `1 / (textureSize() * float(1 << (texelPrecisionBits + 1)))`

Some testing with both AMD and Intel GPUs to ensure I didn't blow up any other games would be nice, and also that it fixes other AMD GPUs (I only tested steam deck).