### PR TITLE
Removed MotionInput Calibration

### DIFF
--- a/Ryujinx.Input/Motion/MotionInput.cs
+++ b/Ryujinx.Input/Motion/MotionInput.cs
@@ -12,7 +12,6 @@ namespace Ryujinx.Input
         public Vector3 Rotation      { get; set; }
 
         private readonly MotionSensorFilter _filter;
-        private int _calibrationFrame = 0;
 
         public MotionInput()
         {
@@ -29,26 +28,6 @@ namespace Ryujinx.Input
         {
             if (TimeStamp != 0)
             {
-                if (gyro.Length() <= 1f && accel.Length() >= 0.8f && accel.Z >= 0.8f)
-                {
-                    _calibrationFrame++;
-
-                    if (_calibrationFrame >= 90)
-                    {
-                        gyro = Vector3.Zero;
-
-                        Rotation = Vector3.Zero;
-
-                        _filter.Reset();
-
-                        _calibrationFrame = 0;
-                    }
-                }
-                else
-                {
-                    _calibrationFrame = 0;
-                }
-
                 Accelerometer = -accel;
 
                 if (gyro.Length() < deadzone)


### PR DESCRIPTION
Don't know why this is here.
It just seems to set the filter to an identity. Which then quickly returns to where it's supposed to be anyways.
Fixes #4366