### PR TITLE
Use vector transform feedback outputs with fragment shaders

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 4703;
+        private const uint CodeGenVersion = 4708;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 4708;
+        private const uint CodeGenVersion = 4707;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -449,7 +449,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
                         if (translatorContexts[i] != null)
                         {
                             translatorContexts[i].SetGeometryShaderLayerInputAttribute(info.GpLayerInputAttribute);
-                            translatorContexts[i].SetLastInVertexPipeline(translatorContexts[5] != null);
+                            translatorContexts[i].SetLastInVertexPipeline();
                             break;
                         }
                     }

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
@@ -569,7 +569,23 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
             if (context.Config.TransformFeedbackEnabled && context.Config.Stage == ShaderStage.Fragment)
             {
-                for (int c = 0; c < 4; c++)
+                int attrOffset = AttributeConsts.UserAttributeBase + attr * 16;
+                int components = context.Info.GetTransformFeedbackOutputComponents(attrOffset);
+
+                if (components > 1)
+                {
+                    string type = components switch
+                    {
+                        2 => "vec2",
+                        3 => "vec3",
+                        4 => "vec4",
+                        _ => "float"
+                    };
+
+                    context.AppendLine($"layout (location = {attr}) in {type} {name};");
+                }
+
+                for (int c = components > 1 ? components : 0; c < 4; c++)
                 {
                     char swzMask = "xyzw"[c];
 
@@ -664,22 +680,20 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
 
                     context.AppendLine($"layout (location = {attr}{xfb}) out {type} {name};");
                 }
-                else
+
+                for (int c = components > 1 ? components : 0; c < 4; c++)
                 {
-                    for (int c = 0; c < 4; c++)
+                    char swzMask = "xyzw"[c];
+
+                    string xfb = string.Empty;
+
+                    var tfOutput = context.Info.GetTransformFeedbackOutput(attrOffset + c * 4);
+                    if (tfOutput.Valid)
                     {
-                        char swzMask = "xyzw"[c];
-
-                        string xfb = string.Empty;
-
-                        var tfOutput = context.Info.GetTransformFeedbackOutput(attrOffset + c * 4);
-                        if (tfOutput.Valid)
-                        {
-                            xfb = $", xfb_buffer = {tfOutput.Buffer}, xfb_offset = {tfOutput.Offset}, xfb_stride = {tfOutput.Stride}";
-                        }
-
-                        context.AppendLine($"layout (location = {attr}, component = {c}{xfb}) out float {name}_{swzMask};");
+                        xfb = $", xfb_buffer = {tfOutput.Buffer}, xfb_offset = {tfOutput.Offset}, xfb_stride = {tfOutput.Stride}";
                     }
+
+                    context.AppendLine($"layout (location = {attr}, component = {c}{xfb}) out float {name}_{swzMask};");
                 }
             }
             else

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/Declarations.cs
@@ -642,7 +642,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
             if (context.Config.TransformFeedbackEnabled && context.Config.LastInVertexPipeline)
             {
                 int attrOffset = AttributeConsts.UserAttributeBase + attr * 16;
-                int components = context.Config.LastInPipeline ? context.Info.GetTransformFeedbackOutputComponents(attrOffset) : 1;
+                int components = context.Info.GetTransformFeedbackOutputComponents(attrOffset);
 
                 if (components > 1)
                 {

--- a/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Glsl/OperandManager.cs
@@ -220,7 +220,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Glsl
                     ((config.LastInVertexPipeline && isOutAttr) ||
                     (config.Stage == ShaderStage.Fragment && !isOutAttr)))
                 {
-                    int components = config.LastInPipeline ? context.Info.GetTransformFeedbackOutputComponents(attrOffset) : 1;
+                    int components = context.Info.GetTransformFeedbackOutputComponents(attrOffset);
                     string name = components > 1 ? $"{prefix}{(value >> 4)}" : $"{prefix}{(value >> 4)}_{swzMask}";
 
                     if (AttributeInfo.IsArrayAttributeGlsl(config.Stage, isOutAttr))

--- a/Ryujinx.Graphics.Shader/CodeGen/Spirv/CodeGenContext.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Spirv/CodeGenContext.cs
@@ -341,7 +341,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
                 attrOffset = attr;
                 type = elemType;
 
-                if (Config.LastInPipeline && isOutAttr)
+                if (isOutAttr)
                 {
                     int components = Info.GetTransformFeedbackOutputComponents(attr);
 

--- a/Ryujinx.Graphics.Shader/CodeGen/Spirv/Declarations.cs
+++ b/Ryujinx.Graphics.Shader/CodeGen/Spirv/Declarations.cs
@@ -673,7 +673,7 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
             int components = 1;
             var type = attrInfo.Type & AggregateType.ElementTypeMask;
 
-            if (context.Config.LastInPipeline && isOutAttr)
+            if (isOutAttr)
             {
                 components = context.Info.GetTransformFeedbackOutputComponents(attr);
 

--- a/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgram.cs
+++ b/Ryujinx.Graphics.Shader/StructuredIr/StructuredProgram.cs
@@ -65,7 +65,7 @@ namespace Ryujinx.Graphics.Shader.StructuredIr
                 context.LeaveFunction();
             }
 
-            if (config.TransformFeedbackEnabled && config.LastInVertexPipeline)
+            if (config.TransformFeedbackEnabled && (config.LastInVertexPipeline || config.Stage == ShaderStage.Fragment))
             {
                 for (int tfbIndex = 0; tfbIndex < 4; tfbIndex++)
                 {

--- a/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -17,7 +17,6 @@ namespace Ryujinx.Graphics.Shader.Translation
         public ShaderStage Stage { get; }
 
         public bool GpPassthrough { get; }
-        public bool LastInPipeline { get; private set; }
         public bool LastInVertexPipeline { get; private set; }
 
         public bool HasLayerInputAttribute { get; private set; }
@@ -145,7 +144,6 @@ namespace Ryujinx.Graphics.Shader.Translation
             OmapSampleMask           = header.OmapSampleMask;
             OmapDepth                = header.OmapDepth;
             TransformFeedbackEnabled = gpuAccessor.QueryTransformFeedbackEnabled();
-            LastInPipeline           = true;
             LastInVertexPipeline     = header.Stage < ShaderStage.Fragment;
         }
 
@@ -253,13 +251,8 @@ namespace Ryujinx.Graphics.Shader.Translation
             GpLayerInputAttribute = attr;
         }
 
-        public void SetLastInVertexPipeline(bool hasFragment)
+        public void SetLastInVertexPipeline()
         {
-            if (!hasFragment)
-            {
-                LastInPipeline = true;
-            }
-
             LastInVertexPipeline = true;
         }
 
@@ -330,8 +323,6 @@ namespace Ryujinx.Graphics.Shader.Translation
                 _perPatchAttributeLocations = locationsMap;
                 config._perPatchAttributeLocations = locationsMap;
             }
-
-            LastInPipeline = false;
 
             // We don't consider geometry shaders using the geometry shader passthrough feature
             // as being the last because when this feature is used, it can't actually modify any of the outputs,

--- a/Ryujinx.Graphics.Shader/Translation/TranslatorContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/TranslatorContext.cs
@@ -143,9 +143,9 @@ namespace Ryujinx.Graphics.Shader.Translation
             _config.SetGeometryShaderLayerInputAttribute(attr);
         }
 
-        public void SetLastInVertexPipeline(bool hasFragment)
+        public void SetLastInVertexPipeline()
         {
-            _config.SetLastInVertexPipeline(hasFragment);
+            _config.SetLastInVertexPipeline();
         }
 
         public ShaderProgram Translate(TranslatorContext other = null)


### PR DESCRIPTION
Transform feedback is a feature that writes the VTG stages output into a buffer. It is possible to write different output components to different offsets into that buffer. To make that work, instead of declaring a `vec4` as output, the emulator breaks that down into 4 individual `float` outputs. The problem is that drivers (other than NVIDIA) usually have problems with this for some reason, resulting in weird bugs, so I made #3832 to address this.

When there are consecutive outputs that are supposed to be written into consecutive buffer offsets, it just "joins" them and makes a vector. The problem is that right now, this is only done when the draw has no fragment shader, because for the cases where it does have a fragment shader, the VTG outputs would not match the fragment shader inputs. It turns out that this is not a problem. I tested games that uses transform feedback and have a fragment shader, and had no errors with OpenGL or Vulkan, with both NVIDIA and Intel on Windows, and @riperiperi tested it on AMD.

This fixes characters not rendering on Pokémon Legends Arceus with newer AMD driver.
Fixes #4546.