### PR TITLE
UI: Fix amiibo issues & log errors and exceptions

### DIFF
--- a/Ryujinx.Ava/UI/ViewModels/AmiiboWindowViewModel.cs
+++ b/Ryujinx.Ava/UI/ViewModels/AmiiboWindowViewModel.cs
@@ -207,9 +207,9 @@ namespace Ryujinx.Ava.UI.ViewModels
                 {
                     amiiboJsonString = await DownloadAmiiboJson();
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    Logger.Error?.Print(LogClass.Application, $"Failed to download amiibo data: {e}");
+                    Logger.Error?.Print(LogClass.Application, $"Failed to download amiibo data: {ex}");
 
                     ShowInfoDialog();
                 }
@@ -375,9 +375,9 @@ namespace Ryujinx.Ava.UI.ViewModels
 
                 return false;
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Logger.Error?.Print(LogClass.Application, $"Failed to check for amiibo updates: {e}");
+                Logger.Error?.Print(LogClass.Application, $"Failed to check for amiibo updates: {ex}");
 
                 ShowInfoDialog();
 

--- a/Ryujinx.Ava/UI/ViewModels/AmiiboWindowViewModel.cs
+++ b/Ryujinx.Ava/UI/ViewModels/AmiiboWindowViewModel.cs
@@ -207,7 +207,7 @@ namespace Ryujinx.Ava.UI.ViewModels
                 {
                     amiiboJsonString = await DownloadAmiiboJson();
                 }
-                catch(Exception e)
+                catch (Exception e)
                 {
                     Logger.Error?.Print(LogClass.Application, $"Failed to download amiibo data: {e}");
 
@@ -375,7 +375,7 @@ namespace Ryujinx.Ava.UI.ViewModels
 
                 return false;
             }
-            catch(Exception e)
+            catch (Exception e)
             {
                 Logger.Error?.Print(LogClass.Application, $"Failed to check for amiibo updates: {e}");
 

--- a/Ryujinx.Ava/UI/ViewModels/AmiiboWindowViewModel.cs
+++ b/Ryujinx.Ava/UI/ViewModels/AmiiboWindowViewModel.cs
@@ -7,6 +7,7 @@ using Ryujinx.Ava.UI.Helpers;
 using Ryujinx.Ava.UI.Windows;
 using Ryujinx.Common;
 using Ryujinx.Common.Configuration;
+using Ryujinx.Common.Logging;
 using Ryujinx.Common.Utilities;
 using Ryujinx.Ui.Common.Models.Amiibo;
 using System;
@@ -42,13 +43,18 @@ namespace Ryujinx.Ava.UI.ViewModels
         private bool _showAllAmiibo;
         private bool _useRandomUuid;
         private string _usage;
-        
+
         private static readonly AmiiboJsonSerializerContext SerializerContext = new(JsonHelper.GetDefaultSerializerOptions());
 
         public AmiiboWindowViewModel(StyleableWindow owner, string lastScannedAmiiboId, string titleId)
         {
             _owner = owner;
-            _httpClient = new HttpClient { Timeout = TimeSpan.FromMilliseconds(5000) };
+
+            _httpClient = new HttpClient
+            {
+                Timeout = TimeSpan.FromSeconds(30)
+            };
+
             LastScannedAmiiboId = lastScannedAmiiboId;
             TitleId = titleId;
 
@@ -89,9 +95,7 @@ namespace Ryujinx.Ava.UI.ViewModels
             {
                 _showAllAmiibo = value;
 
-#pragma warning disable 4014
                 ParseAmiiboData();
-#pragma warning restore 4014
 
                 OnPropertyChanged();
             }
@@ -203,8 +207,10 @@ namespace Ryujinx.Ava.UI.ViewModels
                 {
                     amiiboJsonString = await DownloadAmiiboJson();
                 }
-                catch
+                catch(Exception e)
                 {
+                    Logger.Error?.Print(LogClass.Application, $"Failed to download amiibo data: {e}");
+
                     ShowInfoDialog();
                 }
             }
@@ -369,8 +375,10 @@ namespace Ryujinx.Ava.UI.ViewModels
 
                 return false;
             }
-            catch
+            catch(Exception e)
             {
+                Logger.Error?.Print(LogClass.Application, $"Failed to check for amiibo updates: {e}");
+
                 ShowInfoDialog();
 
                 return false;
@@ -392,6 +400,8 @@ namespace Ryujinx.Ava.UI.ViewModels
 
                 return amiiboJsonString;
             }
+
+            Logger.Error?.Print(LogClass.Application, $"Failed to download amiibo data. Response status code: {response.StatusCode}");
 
             await ContentDialogHelper.CreateInfoDialog(LocaleManager.Instance[LocaleKeys.DialogAmiiboApiTitle],
                 LocaleManager.Instance[LocaleKeys.DialogAmiiboApiFailFetchMessage],
@@ -428,6 +438,10 @@ namespace Ryujinx.Ava.UI.ViewModels
 
                     AmiiboImage = bitmap.CreateScaledBitmap(new PixelSize(resizeWidth, resizeHeight));
                 }
+            }
+            else
+            {
+                Logger.Error?.Print(LogClass.Application, $"Failed to get amiibo preview. Response status code: {response.StatusCode}");
             }
         }
 

--- a/Ryujinx/Ui/Windows/AmiiboWindow.cs
+++ b/Ryujinx/Ui/Windows/AmiiboWindow.cs
@@ -93,7 +93,7 @@ namespace Ryujinx.Ui.Windows
                 {
                     amiiboJsonString = await DownloadAmiiboJson();
                 }
-                catch(Exception e)
+                catch (Exception e)
                 {
                     Logger.Error?.Print(LogClass.Application, $"Failed to download amiibo data: {e}");
 
@@ -185,7 +185,7 @@ namespace Ryujinx.Ui.Windows
 
                 return false;
             }
-            catch(Exception e)
+            catch (Exception e)
             {
                 Logger.Error?.Print(LogClass.Application, $"Failed to check for amiibo updates: {e}");
 

--- a/Ryujinx/Ui/Windows/AmiiboWindow.cs
+++ b/Ryujinx/Ui/Windows/AmiiboWindow.cs
@@ -1,6 +1,7 @@
 ﻿using Gtk;
 using Ryujinx.Common;
 using Ryujinx.Common.Configuration;
+using Ryujinx.Common.Logging;
 using Ryujinx.Common.Utilities;
 using Ryujinx.Ui.Common.Configuration;
 using Ryujinx.Ui.Common.Models.Amiibo;
@@ -12,7 +13,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Reflection;
 using System.Text;
-using System.Text.Json;
 using System.Threading.Tasks;
 using AmiiboApi = Ryujinx.Ui.Common.Models.Amiibo.AmiiboApi;
 using AmiiboJsonSerializerContext = Ryujinx.Ui.Common.Models.Amiibo.AmiiboJsonSerializerContext;
@@ -57,7 +57,7 @@ namespace Ryujinx.Ui.Windows
 
             _httpClient = new HttpClient()
             {
-                Timeout = TimeSpan.FromMilliseconds(5000)
+                Timeout = TimeSpan.FromSeconds(30)
             };
 
             Directory.CreateDirectory(System.IO.Path.Join(AppDataManager.BaseDirPath, "system", "amiibo"));
@@ -93,8 +93,10 @@ namespace Ryujinx.Ui.Windows
                 {
                     amiiboJsonString = await DownloadAmiiboJson();
                 }
-                catch
+                catch(Exception e)
                 {
+                    Logger.Error?.Print(LogClass.Application, $"Failed to download amiibo data: {e}");
+
                     ShowInfoDialog();
 
                     Close();
@@ -183,8 +185,10 @@ namespace Ryujinx.Ui.Windows
 
                 return false;
             }
-            catch
+            catch(Exception e)
             {
+                Logger.Error?.Print(LogClass.Application, $"Failed to check for amiibo updates: {e}");
+
                 ShowInfoDialog();
 
                 return false;
@@ -208,6 +212,8 @@ namespace Ryujinx.Ui.Windows
             }
             else
             {
+                Logger.Error?.Print(LogClass.Application, $"Failed to download amiibo data. Response status code: {response.StatusCode}");
+
                 GtkDialog.CreateInfoDialog($"Amiibo API", "An error occured while fetching information from the API.");
 
                 Close();
@@ -232,6 +238,10 @@ namespace Ryujinx.Ui.Windows
                 int resizeWidth  = (int)(amiiboPreview.Width  * ratio);
 
                 _amiiboImage.Pixbuf = amiiboPreview.ScaleSimple(resizeWidth, resizeHeight, Gdk.InterpType.Bilinear);
+            }
+            else
+            {
+                Logger.Error?.Print(LogClass.Application, $"Failed to get amiibo preview. Response status code: {response.StatusCode}");
             }
         }
 

--- a/Ryujinx/Ui/Windows/AmiiboWindow.cs
+++ b/Ryujinx/Ui/Windows/AmiiboWindow.cs
@@ -93,9 +93,9 @@ namespace Ryujinx.Ui.Windows
                 {
                     amiiboJsonString = await DownloadAmiiboJson();
                 }
-                catch (Exception e)
+                catch (Exception ex)
                 {
-                    Logger.Error?.Print(LogClass.Application, $"Failed to download amiibo data: {e}");
+                    Logger.Error?.Print(LogClass.Application, $"Failed to download amiibo data: {ex}");
 
                     ShowInfoDialog();
 
@@ -185,9 +185,9 @@ namespace Ryujinx.Ui.Windows
 
                 return false;
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Logger.Error?.Print(LogClass.Application, $"Failed to check for amiibo updates: {e}");
+                Logger.Error?.Print(LogClass.Application, $"Failed to check for amiibo updates: {ex}");
 
                 ShowInfoDialog();
 


### PR DESCRIPTION
This PR addresses an issue where some people were unable to use the amiibo window, as it would fail to download the json in time before the timeout cancels the task.

In addition to that all the catch-blocks and other error paths are now logging the error, so when people upload their logs, we can at least figure out what's going wrong.

Thank you to `imDemon#8151` who greatly assisted me while I was trying to figure this out!

---

Fixes #4614