### PR TITLE
Add missing check for thread termination on ArbitrateLock

### DIFF
--- a/Ryujinx.HLE/HOS/Kernel/Ipc/KServerSession.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Ipc/KServerSession.cs
@@ -188,8 +188,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Ipc
 
             if (request.AsyncEvent == null)
             {
-                if (request.ClientThread.ShallBeTerminated ||
-                    request.ClientThread.SchedFlags == ThreadSchedState.TerminationPending)
+                if (request.ClientThread.TerminationRequested)
                 {
                     return KernelResult.ThreadTerminating;
                 }
@@ -1104,8 +1103,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Ipc
         {
             foreach (KSessionRequest request in IterateWithRemovalOfAllRequests())
             {
-                if (request.ClientThread.ShallBeTerminated ||
-                    request.ClientThread.SchedFlags == ThreadSchedState.TerminationPending)
+                if (request.ClientThread.TerminationRequested)
                 {
                     continue;
                 }

--- a/Ryujinx.HLE/HOS/Kernel/Threading/KAddressArbiter.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Threading/KAddressArbiter.cs
@@ -31,6 +31,14 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
 
             _context.CriticalSection.Enter();
 
+            if (currentThread.ShallBeTerminated ||
+                currentThread.SchedFlags == ThreadSchedState.TerminationPending)
+            {
+                _context.CriticalSection.Leave();
+
+                return KernelResult.ThreadTerminating;
+            }
+
             currentThread.SignaledObj   = null;
             currentThread.ObjSyncResult = Result.Success;
 

--- a/Ryujinx.HLE/HOS/Kernel/Threading/KAddressArbiter.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Threading/KAddressArbiter.cs
@@ -31,8 +31,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
 
             _context.CriticalSection.Enter();
 
-            if (currentThread.ShallBeTerminated ||
-                currentThread.SchedFlags == ThreadSchedState.TerminationPending)
+            if (currentThread.TerminationRequested)
             {
                 _context.CriticalSection.Leave();
 
@@ -122,8 +121,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
             currentThread.SignaledObj   = null;
             currentThread.ObjSyncResult = KernelResult.TimedOut;
 
-            if (currentThread.ShallBeTerminated ||
-                currentThread.SchedFlags == ThreadSchedState.TerminationPending)
+            if (currentThread.TerminationRequested)
             {
                 _context.CriticalSection.Leave();
 
@@ -288,8 +286,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
 
             _context.CriticalSection.Enter();
 
-            if (currentThread.ShallBeTerminated ||
-                currentThread.SchedFlags == ThreadSchedState.TerminationPending)
+            if (currentThread.TerminationRequested)
             {
                 _context.CriticalSection.Leave();
 
@@ -359,8 +356,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
 
             _context.CriticalSection.Enter();
 
-            if (currentThread.ShallBeTerminated ||
-                currentThread.SchedFlags == ThreadSchedState.TerminationPending)
+            if (currentThread.TerminationRequested)
             {
                 _context.CriticalSection.Leave();
 

--- a/Ryujinx.HLE/HOS/Kernel/Threading/KConditionVariable.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Threading/KConditionVariable.cs
@@ -19,8 +19,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
 
             currentThread.WithholderNode = threadList.AddLast(currentThread);
 
-            if (currentThread.ShallBeTerminated ||
-                currentThread.SchedFlags == ThreadSchedState.TerminationPending)
+            if (currentThread.TerminationRequested)
             {
                 threadList.Remove(currentThread.WithholderNode);
 

--- a/Ryujinx.HLE/HOS/Kernel/Threading/KSynchronization.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Threading/KSynchronization.cs
@@ -47,8 +47,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
 
             KThread currentThread = KernelStatic.GetCurrentThread();
 
-            if (currentThread.ShallBeTerminated ||
-                currentThread.SchedFlags == ThreadSchedState.TerminationPending)
+            if (currentThread.TerminationRequested)
             {
                 result = KernelResult.ThreadTerminating;
             }
@@ -61,7 +60,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
             else
             {
                 LinkedListNode<KThread>[] syncNodesArray = ArrayPool<LinkedListNode<KThread>>.Shared.Rent(syncObjs.Length);
-                
+
                 Span<LinkedListNode<KThread>> syncNodes = syncNodesArray.AsSpan(0, syncObjs.Length);
 
                 for (int index = 0; index < syncObjs.Length; index++)

--- a/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
@@ -99,7 +99,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
 
         private int _shallBeTerminated;
 
-        public bool ShallBeTerminated => _shallBeTerminated != 0;
+        private bool ShallBeTerminated => _shallBeTerminated != 0;
 
         public bool TerminationRequested => ShallBeTerminated || SchedFlags == ThreadSchedState.TerminationPending;
 
@@ -466,7 +466,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
         {
             KernelContext.CriticalSection.Enter();
 
-            if (ShallBeTerminated || SchedFlags == ThreadSchedState.TerminationPending)
+            if (TerminationRequested)
             {
                 KernelContext.CriticalSection.Leave();
 
@@ -548,7 +548,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
                     return KernelResult.InvalidState;
                 }
 
-                if (!ShallBeTerminated && SchedFlags != ThreadSchedState.TerminationPending)
+                if (!TerminationRequested)
                 {
                     if (pause)
                     {

--- a/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
+++ b/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
@@ -99,11 +99,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
 
         private int _shallBeTerminated;
 
-        public bool ShallBeTerminated
-        {
-            get => _shallBeTerminated != 0;
-            set => _shallBeTerminated = value ? 1 : 0;
-        }
+        public bool ShallBeTerminated => _shallBeTerminated != 0;
 
         public bool TerminationRequested => ShallBeTerminated || SchedFlags == ThreadSchedState.TerminationPending;
 
@@ -322,7 +318,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
 
             ThreadSchedState result;
 
-            if (Interlocked.CompareExchange(ref _shallBeTerminated, 1, 0) == 0)
+            if (Interlocked.Exchange(ref _shallBeTerminated, 1) == 0)
             {
                 if ((SchedFlags & ThreadSchedState.LowMask) == ThreadSchedState.None)
                 {


### PR DESCRIPTION
Because `ArbitrateLock` was not checking `TerminationRequested` for the current thread, it would wait for the lock even if the thread was already terminated, which would cause the thread to never exit (since the thread that owns the lock is most likely already terminated as well and has exited).

This should fix one of the instances of the emulator freezing when you stop emulation or close, it will not fix *all* of them since they are caused by different issues. Also it's hard to test this since this specific only happens if you close exactly when a guest thread call `ArbitrateLock`, but before the function gets a chance to run.

I also replaced all usages of the pattern `ShallBeTerminated || SchedFlags == ThreadSchedState.TerminationPending` with the `TerminationRequested ` property, and did other minor improvements that should not affect functionality.