### PR TITLE
Fix some invalid blits involving depth textures

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -1118,7 +1118,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         {
             bool forSampler = (flags & TextureSearchFlags.ForSampler) != 0;
 
-            TextureMatchQuality matchQuality = TextureCompatibility.FormatMatches(Info, info, forSampler, (flags & TextureSearchFlags.ForCopy) != 0);
+            TextureMatchQuality matchQuality = TextureCompatibility.FormatMatches(Info, info, forSampler, (flags & TextureSearchFlags.DepthAlias) != 0);
 
             if (matchQuality == TextureMatchQuality.NoMatch)
             {

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -249,6 +249,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="copyTexture">Copy texture to find or create</param>
         /// <param name="offset">Offset to be added to the physical texture address</param>
         /// <param name="formatInfo">Format information of the copy texture</param>
+        /// <param name="depthAlias">Indicates if aliasing between color and depth format should be allowed</param>
+        /// <param name="shouldCreate">Indicates if a new texture should be created if none is found on the cache</param>
         /// <param name="preferScaling">Indicates if the texture should be scaled from the start</param>
         /// <param name="sizeHint">A hint indicating the minimum used size for the texture</param>
         /// <returns>The texture</returns>
@@ -257,6 +259,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             TwodTexture copyTexture,
             ulong offset,
             FormatInfo formatInfo,
+            bool depthAlias,
             bool shouldCreate,
             bool preferScaling,
             Size sizeHint)
@@ -292,6 +295,11 @@ namespace Ryujinx.Graphics.Gpu.Image
                 formatInfo);
 
             TextureSearchFlags flags = TextureSearchFlags.ForCopy;
+
+            if (depthAlias)
+            {
+                flags |= TextureSearchFlags.DepthAlias;
+            }
 
             if (preferScaling)
             {

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -220,18 +220,18 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="lhs">Texture information to compare</param>
         /// <param name="rhs">Texture information to compare with</param>
         /// <param name="forSampler">Indicates that the texture will be used for shader sampling</param>
-        /// <param name="forCopy">Indicates that the texture will be used as copy source or target</param>
+        /// <param name="depthAlias">Indicates if aliasing between color and depth format should be allowed</param>
         /// <returns>A value indicating how well the formats match</returns>
-        public static TextureMatchQuality FormatMatches(TextureInfo lhs, TextureInfo rhs, bool forSampler, bool forCopy)
+        public static TextureMatchQuality FormatMatches(TextureInfo lhs, TextureInfo rhs, bool forSampler, bool depthAlias)
         {
             // D32F and R32F texture have the same representation internally,
             // however the R32F format is used to sample from depth textures.
-            if (lhs.FormatInfo.Format == Format.D32Float && rhs.FormatInfo.Format == Format.R32Float && (forSampler || forCopy))
+            if (lhs.FormatInfo.Format == Format.D32Float && rhs.FormatInfo.Format == Format.R32Float && (forSampler || depthAlias))
             {
                 return TextureMatchQuality.FormatAlias;
             }
 
-            if (forCopy)
+            if (depthAlias)
             {
                 // The 2D engine does not support depth-stencil formats, so it will instead
                 // use equivalent color formats. We must also consider them as compatible.

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureSearchFlags.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureSearchFlags.cs
@@ -11,7 +11,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         None        = 0,
         ForSampler  = 1 << 1,
         ForCopy     = 1 << 2,
-        WithUpscale = 1 << 3,
-        NoCreate    = 1 << 4
+        DepthAlias  = 1 << 3,
+        WithUpscale = 1 << 4,
+        NoCreate    = 1 << 5
     }
 }


### PR DESCRIPTION
This is a change to prevent some cases of invalid blits involving depth-stencil textures. Both OpenGL and Vulkan only allows blits with depth textures with the *exact same* format. And of course, they don't allow blits between depth and color textures.

From the Vulkan spec:
>  If either of srcImage or dstImage was created with a depth/stencil format, the other must have exactly the same format

From the OpenGL spec:
> GL_INVALID_OPERATION is generated if mask contains GL_DEPTH_BUFFER_BIT or GL_STENCIL_BUFFER_BIT and the source and destination depth and stencil formats do not match. 

So first, this disables the additional depth aliasing rules when searching for the destination texture in the cache. If the source texture is a depth texture, destination *must* also be depth. If it's color, it *must* also be color. So we should not allow any aliasing of color and depth formats when looking for the destination texture. There's also an additional check where it will only allow the depth aliasing if the source and destination texture formats are the same, due to what I mentioned above: The host API does not support blits between different depth formats.

I originally made this change in an attempt to fix the reported error on Twelve Minutes on macOS, but I can't repro it anymore on `master`, so maybe the root cause of that problem was fixed already. Still, I think it's a good change since we should not allow invalid blits in any case.