### PR TITLE
Fix geometry shader layer passthrough regression

### DIFF
--- a/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 4565;
+        private const uint CodeGenVersion = 4735;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -322,10 +322,10 @@ namespace Ryujinx.Graphics.Shader.Translation
 
                 void WriteUserDefinedOutput(int index, int primIndex)
                 {
-                    Operand x = this.Load(StorageKind.Input, IoVariable.UserDefined, Const(primIndex), Const(index), Const(0));
-                    Operand y = this.Load(StorageKind.Input, IoVariable.UserDefined, Const(primIndex), Const(index), Const(1));
-                    Operand z = this.Load(StorageKind.Input, IoVariable.UserDefined, Const(primIndex), Const(index), Const(2));
-                    Operand w = this.Load(StorageKind.Input, IoVariable.UserDefined, Const(primIndex), Const(index), Const(3));
+                    Operand x = this.Load(StorageKind.Input, IoVariable.UserDefined, Const(index), Const(primIndex), Const(0));
+                    Operand y = this.Load(StorageKind.Input, IoVariable.UserDefined, Const(index), Const(primIndex), Const(1));
+                    Operand z = this.Load(StorageKind.Input, IoVariable.UserDefined, Const(index), Const(primIndex), Const(2));
+                    Operand w = this.Load(StorageKind.Input, IoVariable.UserDefined, Const(index), Const(primIndex), Const(3));
 
                     this.Store(StorageKind.Output, IoVariable.UserDefined, null, Const(index), Const(0), x);
                     this.Store(StorageKind.Output, IoVariable.UserDefined, null, Const(index), Const(1), y);

--- a/Ryujinx.Graphics.Shader/Translation/TranslatorContext.cs
+++ b/Ryujinx.Graphics.Shader/Translation/TranslatorContext.cs
@@ -208,7 +208,7 @@ namespace Ryujinx.Graphics.Shader.Translation
                     {
                         int attr = AttributeConsts.UserAttributeBase + attrIndex * 16 + c * 4;
 
-                        Operand value = context.Load(StorageKind.Input, IoVariable.UserDefined, Const(v), Const(attrIndex), Const(c));
+                        Operand value = context.Load(StorageKind.Input, IoVariable.UserDefined, Const(attrIndex), Const(v), Const(c));
 
                         if (attr == layerOutputAttr)
                         {


### PR DESCRIPTION
This fixes a regression from #4565 that caused the geometry shader generated to pass the `gl_Layer` value to pass the wrong values. The problem was caused by the rather confusing `Load` method that I added that takes a "primitive vertex", "vector index" and "element index". For user inputs/outputs, the first value should be the *location*, the second one should be the primitive vertex on geometry shaders, and the third one should be the element index. For arrays, the order changes, and first becomes the "primitive vertex", then the "array index" and lastly the "element index" (if the array entry type is a vector). The parameters where named after the array case, so it is rather confusing for the more common case where we have separate vectors with different location.

Fixes green-ish tint on Pokémon Scarlet/Violet on GPUs that don't support writing `gl_Layer` on the vertex shader (1st gen Maxwell and older for NVIDIA). Fixes #4733.