### PR TITLE
Fix paths and typos for macOS scripts

### DIFF
--- a/distribution/macos/create_app_bundle.sh
+++ b/distribution/macos/create_app_bundle.sh
@@ -41,7 +41,7 @@ then
         exit 1
     fi
 
-    # NOTE: Currently require https://github.com/indygreg/apple-platform-rs/pull/44 to work on other OSes.
+    # NOTE: Currently requires https://github.com/indygreg/apple-platform-rs/pull/44 to work on other OSes.
     # cargo install --git "https://github.com/marysaka/apple-platform-rs" --branch "fix/adhoc-app-bundle" apple-codesign --bin "rcodesign"
     echo "Usign rcodesign for ad-hoc signing"
     rcodesign sign --entitlements-xml-path "$ENTITLEMENTS_FILE_PATH" "$APP_BUNDLE_DIRECTORY"
@@ -49,4 +49,3 @@ else
     echo "Usign codesign for ad-hoc signing"
     codesign --entitlements "$ENTITLEMENTS_FILE_PATH" -f --deep -s - "$APP_BUNDLE_DIRECTORY"
 fi
-

--- a/distribution/macos/create_app_bundle.sh
+++ b/distribution/macos/create_app_bundle.sh
@@ -41,8 +41,7 @@ then
         exit 1
     fi
 
-    # NOTE: Currently requires https://github.com/indygreg/apple-platform-rs/pull/44 to work on other OSes.
-    # cargo install --git "https://github.com/marysaka/apple-platform-rs" --branch "fix/adhoc-app-bundle" apple-codesign --bin "rcodesign"
+    # cargo install apple-codesign
     echo "Usign rcodesign for ad-hoc signing"
     rcodesign sign --entitlements-xml-path "$ENTITLEMENTS_FILE_PATH" "$APP_BUNDLE_DIRECTORY"
 else

--- a/distribution/macos/create_macos_release.sh
+++ b/distribution/macos/create_macos_release.sh
@@ -30,14 +30,14 @@ mkdir -p "$TEMP_DIRECTORY"
 DOTNET_COMMON_ARGS="-p:DebugType=embedded -p:Version=$VERSION -p:SourceRevisionId=$SOURCE_REVISION_ID --self-contained true"
 
 dotnet restore
-dotnet build -c Release Ryujinx.Ava
-dotnet publish -c Release -r osx-arm64 -o "$TEMP_DIRECTORY/publish_arm64" $DOTNET_COMMON_ARGS Ryujinx.Ava
-dotnet publish -c Release -r osx-x64 -o "$TEMP_DIRECTORY/publish_x64" $DOTNET_COMMON_ARGS Ryujinx.Ava
+dotnet build -c Release src/Ryujinx.Ava
+dotnet publish -c Release -r osx-arm64 -o "$TEMP_DIRECTORY/publish_arm64" $DOTNET_COMMON_ARGS src/Ryujinx.Ava
+dotnet publish -c Release -r osx-x64 -o "$TEMP_DIRECTORY/publish_x64" $DOTNET_COMMON_ARGS src/Ryujinx.Ava
 
-# Get ride of the support library for ARMeilleur for x64 (that's only for arm64)
+# Get rid of the support library for ARMeilleure for x64 (that's only for arm64)
 rm -rf "$TEMP_DIRECTORY/publish_x64/libarmeilleure-jitsupport.dylib"
 
-# Get ride of libsoundio from arm64 builds as we don't have a arm64 variant
+# Get rid of libsoundio from arm64 builds as we don't have a arm64 variant
 # TODO: remove this once done
 rm -rf "$TEMP_DIRECTORY/publish_arm64/libsoundio.dylib"
 


### PR DESCRIPTION
This was missed in #4725.

---

Fixes #4737