### PR TITLE
GPU: Fix errors handling texture remapping

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -1610,6 +1610,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         public void UpdatePoolMappings()
         {
+            ChangedMapping = true;
+
             lock (_poolOwners)
             {
                 ulong address = 0;
@@ -1685,8 +1687,6 @@ namespace Ryujinx.Graphics.Gpu.Image
             {
                 Group.ClearModified(unmapRange);
             }
-
-            UpdatePoolMappings();
         }
 
         /// <summary>

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -120,27 +120,6 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Handles removal of textures written to a memory region being remapped.
-        /// </summary>
-        /// <param name="sender">Sender object</param>
-        /// <param name="e">Event arguments</param>
-        public void MemoryRemappedHandler(object sender, UnmapEventArgs e)
-        {
-            // Any texture that has been unmapped at any point or is partially unmapped
-            // should update their pool references after the remap completes.
-
-            MultiRange unmapped = ((MemoryManager)sender).GetPhysicalRegions(e.Address, e.Size);
-
-            lock (_partiallyMappedTextures)
-            {
-                foreach (var texture in _partiallyMappedTextures)
-                {
-                    texture.UpdatePoolMappings();
-                }
-            }
-        }
-
-        /// <summary>
         /// Determines if a given texture is eligible for upscaling from its info.
         /// </summary>
         /// <param name="info">The texture info to check</param>

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -1171,6 +1171,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     if (range.GetSubRange(i).Address == MemoryManager.PteUnmapped)
                     {
                         partiallyMapped = true;
+                        break;
                     }
                 }
 

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -82,13 +82,39 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             if (overlapCount > 0)
             {
-                lock (_partiallyMappedTextures)
+                for (int i = 0; i < overlapCount; i++)
                 {
-                    for (int i = 0; i < overlapCount; i++)
+                    overlaps[i].Unmapped(unmapped);
+                }
+            }
+
+            lock (_partiallyMappedTextures)
+            {
+                if (overlapCount > 0 || _partiallyMappedTextures.Count > 0)
+                {
+                    e.AddRemapAction(() =>
                     {
-                        overlaps[i].Unmapped(unmapped);
-                        _partiallyMappedTextures.Add(overlaps[i]);
-                    }
+                        lock (_partiallyMappedTextures)
+                        {
+                            if (overlapCount > 0)
+                            {
+                                for (int i = 0; i < overlapCount; i++)
+                                {
+                                    _partiallyMappedTextures.Add(overlaps[i]);
+                                }
+                            }
+
+                            // Any texture that has been unmapped at any point or is partially unmapped
+                            // should update their pool references after the remap completes.
+
+                            MultiRange unmapped = ((MemoryManager)sender).GetPhysicalRegions(e.Address, e.Size);
+
+                            foreach (var texture in _partiallyMappedTextures)
+                            {
+                                texture.UpdatePoolMappings();
+                            }
+                        }
+                    });
                 }
             }
         }
@@ -1143,6 +1169,43 @@ namespace Ryujinx.Graphics.Gpu.Image
             {
                 _partiallyMappedTextures.Remove(texture);
             }
+        }
+
+        /// <summary>
+        /// Queries a texture's memory range and marks it as partially mapped or not.
+        /// Partially mapped textures re-evaluate their memory range after each time GPU memory is mapped.
+        /// </summary>
+        /// <param name="memoryManager">GPU memory manager where the texture is mapped</param>
+        /// <param name="address">The virtual address of the texture</param>
+        /// <param name="texture">The texture to be marked</param>
+        /// <returns>The physical regions for the texture, found when evaluating whether the texture was partially mapped</returns>
+        public MultiRange UpdatePartiallyMapped(MemoryManager memoryManager, ulong address, Texture texture)
+        {
+            MultiRange range;
+            lock (_partiallyMappedTextures)
+            {
+                range = memoryManager.GetPhysicalRegions(address, texture.Size);
+                bool partiallyMapped = false;
+
+                for (int i = 0; i < range.Count; i++)
+                {
+                    if (range.GetSubRange(i).Address == MemoryManager.PteUnmapped)
+                    {
+                        partiallyMapped = true;
+                    }
+                }
+
+                if (partiallyMapped)
+                {
+                    _partiallyMappedTextures.Add(texture);
+                }
+                else
+                {
+                    _partiallyMappedTextures.Remove(texture);
+                }
+            }
+
+            return range;
         }
 
         /// <summary>

--- a/src/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -272,6 +272,14 @@ namespace Ryujinx.Graphics.Gpu.Image
 
                     ulong address = descriptor.UnpackAddress();
 
+                    if (!descriptor.Equals(ref DescriptorCache[request.ID]))
+                    {
+                        // If the pool entry has already been replaced, just remove the texture.
+
+                        texture.DecrementReferenceCount();
+                        continue;
+                    }
+
                     MultiRange range = _channel.MemoryManager.GetPhysicalRegions(address, texture.Size);
 
                     // If the texture is not mapped at all, delete its reference.

--- a/src/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -280,7 +280,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                         continue;
                     }
 
-                    MultiRange range = _channel.MemoryManager.GetPhysicalRegions(address, texture.Size);
+                    MultiRange range = _channel.MemoryManager.Physical.TextureCache.UpdatePartiallyMapped(_channel.MemoryManager, address, texture);
 
                     // If the texture is not mapped at all, delete its reference.
 

--- a/src/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/MemoryManager.cs
@@ -33,6 +33,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         private readonly ulong[][] _pageTable;
 
         public event EventHandler<UnmapEventArgs> MemoryUnmapped;
+        public event EventHandler<UnmapEventArgs> MemoryRemapped;
 
         /// <summary>
         /// Physical memory where the virtual memory is mapped into.
@@ -56,6 +57,8 @@ namespace Ryujinx.Graphics.Gpu.Memory
             MemoryUnmapped += Physical.TextureCache.MemoryUnmappedHandler;
             MemoryUnmapped += Physical.BufferCache.MemoryUnmappedHandler;
             MemoryUnmapped += CounterCache.MemoryUnmappedHandler;
+
+            MemoryRemapped += Physical.TextureCache.MemoryRemappedHandler;
         }
 
         /// <summary>
@@ -385,6 +388,8 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 {
                     SetPte(va + offset, PackPte(pa + offset, kind));
                 }
+
+                MemoryRemapped?.Invoke(this, new UnmapEventArgs(va, size));
             }
         }
 
@@ -404,6 +409,8 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 {
                     SetPte(va + offset, PteUnmapped);
                 }
+
+                MemoryRemapped?.Invoke(this, new UnmapEventArgs(va, size));
             }
         }
 

--- a/src/Ryujinx.Graphics.Gpu/Memory/UnmapEventArgs.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/UnmapEventArgs.cs
@@ -1,14 +1,24 @@
-﻿namespace Ryujinx.Graphics.Gpu.Memory
+﻿using System;
+using System.Collections.Generic;
+
+namespace Ryujinx.Graphics.Gpu.Memory
 {
     public class UnmapEventArgs
     {
         public ulong Address { get; }
         public ulong Size { get; }
+        public List<Action> RemapActions { get; private set; }
 
         public UnmapEventArgs(ulong address, ulong size)
         {
             Address = address;
             Size = size;
+        }
+
+        public void AddRemapAction(Action action)
+        {
+            RemapActions ??= new List<Action>();
+            RemapActions.Add(action);
         }
     }
 }

--- a/src/Ryujinx.Memory/Range/MemoryRange.cs
+++ b/src/Ryujinx.Memory/Range/MemoryRange.cs
@@ -57,5 +57,19 @@
 
             return thisAddress < otherEndAddress && otherAddress < thisEndAddress;
         }
+
+        /// <summary>
+        /// Returns a string summary of the memory range.
+        /// </summary>
+        /// <returns>A string summary of the memory range</returns>
+        public override string ToString()
+        {
+            if (Address == ulong.MaxValue)
+            {
+                return $"[Unmapped 0x{Size:X}]";
+            }
+
+            return $"[0x{Address:X}, 0x{EndAddress:X})";
+        }
     }
 }

--- a/src/Ryujinx.Memory/Range/MultiRange.cs
+++ b/src/Ryujinx.Memory/Range/MultiRange.cs
@@ -321,6 +321,10 @@ namespace Ryujinx.Memory.Range
             return hash.ToHashCode();
         }
 
+        /// <summary>
+        /// Returns a string summary of the ranges contained in the MultiRange.
+        /// </summary>
+        /// <returns>A string summary of the ranges contained within</returns>
         public override string ToString()
         {
             if (HasSingleRange)

--- a/src/Ryujinx.Memory/Range/MultiRange.cs
+++ b/src/Ryujinx.Memory/Range/MultiRange.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Ryujinx.Memory.Range
 {

--- a/src/Ryujinx.Memory/Range/MultiRange.cs
+++ b/src/Ryujinx.Memory/Range/MultiRange.cs
@@ -327,14 +327,7 @@ namespace Ryujinx.Memory.Range
         /// <returns>A string summary of the ranges contained within</returns>
         public override string ToString()
         {
-            if (HasSingleRange)
-            {
-                return $"[{_singleRange.Address:x16}:{_singleRange.Size:x8}]";
-            }
-            else
-            {
-                return $"[{string.Join(", ", _ranges.Select(range => $"{range.Address:x16}:{range.Size:x8}"))}]";
-            }
+            return HasSingleRange ? _singleRange.ToString() : string.Join(", ", _ranges);
         }
     }
 }

--- a/src/Ryujinx.Memory/Range/MultiRange.cs
+++ b/src/Ryujinx.Memory/Range/MultiRange.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Ryujinx.Memory.Range
 {
@@ -318,6 +319,18 @@ namespace Ryujinx.Memory.Range
             }
 
             return hash.ToHashCode();
+        }
+
+        public override string ToString()
+        {
+            if (HasSingleRange)
+            {
+                return $"[{_singleRange.Address:x16}:{_singleRange.Size:x8}]";
+            }
+            else
+            {
+                return $"[{string.Join(", ", _ranges.Select(range => $"{range.Address:x16}:{range.Size:x8}"))}]";
+            }
         }
     }
 }


### PR DESCRIPTION
This PR fixes a few issues introduced by the sparse texture PR #4442, and also some others that might not have been caught previously.

- Fixes an error where a pool entry and memory mapping changing at the same time could cause a texture to rebind its data from the wrong GPU VA (data swaps).
  - This should fix most issues cause by that PR.
- Introduces "remap actions" which can be performed after a gpu mapping has completed. These can be added to when handling the event before the mapping occurs.
- Fixes an error where the texture pool could act on a mapping change before the mapping has actually been changed. ("Unmapped" event happens before change, we need to signal it changed _after_ it completes)
  - "Unmapped" event adds to the partial mapping list, "remap action" signals pool mapping change on all partially mapped textures.
  - When the pool mappings are processed, the textures remove themselves from the partial mapping list if they don't have any unmapped regions.
- Fixes an issue where a texture that became sparsely mapped after creation wouldn't be notified when new pages were mapped.

I also added a `ToString()` method for `MultiRange`, which makes debugging anything to do with memory ranges a bit easier.

Closes #4698.