### PR TITLE
GPU: Allow granular buffer updates from the constant buffer updater

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
@@ -481,7 +481,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 else
                 {
                     _dirtyStart = Math.Min(_dirtyStart, mAddress);
-                    _dirtyEnd = Math.Max(_dirtyEnd, mAddress + mSize);
+                    _dirtyEnd = Math.Max(_dirtyEnd, end);
                 }
             }
         }

--- a/src/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
@@ -234,7 +234,14 @@ namespace Ryujinx.Graphics.Gpu.Memory
 
                 if (end > _dirtyStart && address < _dirtyEnd)
                 {
-                    LoadRegion(_dirtyStart, _dirtyEnd - _dirtyStart);
+                    if (_modifiedRanges != null)
+                    {
+                        _modifiedRanges.ExcludeModifiedRegions(_dirtyStart, _dirtyEnd - _dirtyStart, _loadDelegate);
+                    }
+                    else
+                    {
+                        LoadRegion(_dirtyStart, _dirtyEnd - _dirtyStart);
+                    }
 
                     _dirtyStart = ulong.MaxValue;
                 }
@@ -307,7 +314,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         }
 
         /// <summary>
-        /// Inherit modified ranges from another buffer.
+        /// Inherit modified and dirty ranges from another buffer.
         /// </summary>
         /// <param name="from">The buffer to inherit from</param>
         public void InheritModifiedRanges(Buffer from)
@@ -335,6 +342,11 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 EnsureRangeList();
 
                 _modifiedRanges.InheritRanges(from._modifiedRanges, registerRangeAction);
+            }
+
+            if (from._dirtyStart != ulong.MaxValue)
+            {
+                ForceDirty(from._dirtyStart, from._dirtyEnd - from._dirtyStart);
             }
         }
 

--- a/src/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/Buffer.cs
@@ -556,7 +556,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 return false;
             }
 
-            ForceDirty(maxAddress, minEndAddress - maxAddress);
+            ForceDirty(maxAddress, minEndAddress - maxAddress, true);
 
             return true;
         }

--- a/src/Ryujinx.Graphics.Gpu/Memory/BufferCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/BufferCache.cs
@@ -156,7 +156,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 _dirtyCache[gpuVa] = result;
             }
 
-            result.Buffer.ForceDirty(result.Address, size);
+            result.Buffer.ForceDirty(result.Address, size, true);
         }
 
         /// <summary>

--- a/src/Ryujinx.Graphics.Gpu/Memory/BufferCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/BufferCache.cs
@@ -156,7 +156,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 _dirtyCache[gpuVa] = result;
             }
 
-            result.Buffer.ForceDirty(result.Address, size, true);
+            result.Buffer.ForceDirty(result.Address, size);
         }
 
         /// <summary>


### PR DESCRIPTION
Sometimes, constant buffer updates can't be avoided, either due to a cb0 access that cannot be eliminated, or the game updating a buffer between draws to the detriment of everyone.

To avoid uploading the full 4096 bytes each time, this PR remembers the offset and size containing all constant buffer updates since the last sync. It will then upload that range after sync. If a newly dirty range is too far from the existing range, it will trigger the old mechanism for forcing a buffer dirty.

This greatly reduces buffer upload bytes per frame in various games:
 - BOTW korok forest: ~3.0MB -> ~1.6MB
 - Splatoon 2 1st level: ~1.1MB -> ~0.55MB
   - These two games update a 65536 byte constant buffer between draws (100s of them) for their own purposes. The actual updates are around 16 bytes in size, before it was submitting 4096.
 - NieR Automata: ~5.5MB -> ~3.0MB
   - This game cannot eliminate CB0 access due to storage buffer base addresses being misaligned.
   
This should remove some strain from all parts of the GPU pipeline in these games. (gpu thread, backend, inline update)
   
There is an additional cost of one read of `_dirtyStart` when doing SynchronizeMemory on buffers that don't do this, but I don't see any difference in games that are unaffected and limited by buffer sync.
