### PR TITLE
Vulkan: Record modifications for barriers after changing the framebuffer

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -1015,8 +1015,8 @@ namespace Ryujinx.Graphics.Vulkan
 
         private void SetRenderTargetsInternal(ITexture[] colors, ITexture depthStencil, bool filterWriteMasked)
         {
-            FramebufferParams?.UpdateModifications();
             CreateFramebuffer(colors, depthStencil, filterWriteMasked);
+            FramebufferParams?.UpdateModifications();
             CreateRenderPass();
             SignalStateChange();
             SignalAttachmentChange();


### PR DESCRIPTION
Our Vulkan backend inserts image barriers when a texture is sampled after it is rendered. This is done via a "modification flag" which is set when a render target is unbound (presuming that a texture has finished drawing to it).

Imagine the following scenario:
- Game sets render target to texture A
- Game renders to texture A
- (render pass ends)
- Game binds texture A to a sampler
- Game sets render target to texture B
- Renders to texture B using texture A (barrier required)

Because of the previous behaviour, the check to add a barrier for sampling a texture actually happens _before_ it is registered as modified, meaning no barrier was added at all. This isn't always the case, but it was definitely causing issues in Xenoblade 2.

This change adds the modification flag as soon as the texture is bound. A barrier will be inserted the next time the texture is used from that point.

This doesn't fix any more complicated issues where a texture is repeatedly sampled while it is currently being rendered.

Fixes visual glitches at lower resolutions in Xenoblade 2 on NVIDIA RTX 3000 and 4000 series GPUs. May fix other cases. Needs some testing to make sure I didn't make any new bugs crop up elsewhere.