### PR TITLE
fix: linux launcher breaks when there are spaces in the directory path

### DIFF
--- a/distribution/linux/Ryujinx.sh
+++ b/distribution/linux/Ryujinx.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-SCRIPT_DIR=$(dirname "$(realpath $0)")
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
 RYUJINX_BIN="Ryujinx"
 
 if [ -f "$SCRIPT_DIR/Ryujinx.Ava" ]; then

--- a/distribution/linux/Ryujinx.sh
+++ b/distribution/linux/Ryujinx.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-SCRIPT_DIR=$(dirname $(realpath $0))
+SCRIPT_DIR=$(dirname "$(realpath $0)")
 RYUJINX_BIN="Ryujinx"
 
 if [ -f "$SCRIPT_DIR/Ryujinx.Ava" ]; then


### PR DESCRIPTION
Fixes #4791