### PR TITLE
Correct tooltips for add,remove,removeall buttons

### DIFF
--- a/src/Ryujinx/Ui/Windows/DlcWindow.glade
+++ b/src/Ryujinx/Ui/Windows/DlcWindow.glade
@@ -89,7 +89,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="tooltip_text" translatable="yes">Adds an update to this list</property>
+                    <property name="tooltip_text" translatable="yes">Adds a DLC to this list</property>
                     <property name="margin_left">10</property>
                     <signal name="clicked" handler="AddButton_Clicked" swapped="no"/>
                   </object>
@@ -105,7 +105,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="tooltip_text" translatable="yes">Removes the selected update</property>
+                    <property name="tooltip_text" translatable="yes">Removes the selected DLC</property>
                     <property name="margin_left">10</property>
                     <signal name="clicked" handler="RemoveButton_Clicked" swapped="no"/>
                   </object>
@@ -121,7 +121,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="tooltip_text" translatable="yes">Removes the selected update</property>
+                    <property name="tooltip_text" translatable="yes">Removes all DLCs</property>
                     <property name="margin_left">10</property>
                     <signal name="clicked" handler="RemoveAllButton_Clicked" swapped="no"/>
                   </object>

--- a/src/Ryujinx/Ui/Windows/TitleUpdateWindow.glade
+++ b/src/Ryujinx/Ui/Windows/TitleUpdateWindow.glade
@@ -133,7 +133,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="tooltip_text" translatable="yes">Removes the selected update</property>
+                    <property name="tooltip_text" translatable="yes">Removes all the updates</property>
                     <property name="margin_left">10</property>
                     <signal name="clicked" handler="RemoveAllButton_Clicked" swapped="no"/>
                   </object>


### PR DESCRIPTION
When hovering over add , remove and removeall buttons in the dlc menu, it says the adds updates , removes updates. Changed to dlc.