### PR TITLE
UI: Fix sections extraction

### DIFF
--- a/src/Ryujinx.Ava/Common/ApplicationHelper.cs
+++ b/src/Ryujinx.Ava/Common/ApplicationHelper.cs
@@ -233,9 +233,14 @@ namespace Ryujinx.Ava.Common
 
                     try
                     {
-                        IFileSystem ncaFileSystem = patchNca != null
-                            ? mainNca.OpenFileSystemWithPatch(patchNca, index, IntegrityCheckLevel.ErrorOnInvalid)
-                            : mainNca.OpenFileSystem(index, IntegrityCheckLevel.ErrorOnInvalid);
+                        bool isSectionExistInPatch = false;
+                        if (patchNca != null)
+                        {
+                            isSectionExistInPatch = patchNca.CanOpenSection(index);
+                        }
+
+                        IFileSystem ncaFileSystem = isSectionExistInPatch ? mainNca.OpenFileSystemWithPatch(patchNca, index, IntegrityCheckLevel.ErrorOnInvalid)
+                                                                          : mainNca.OpenFileSystem(index, IntegrityCheckLevel.ErrorOnInvalid);
 
                         FileSystemClient fsClient = _horizonClient.Fs;
 

--- a/src/Ryujinx.Ava/Common/ApplicationHelper.cs
+++ b/src/Ryujinx.Ava/Common/ApplicationHelper.cs
@@ -233,14 +233,14 @@ namespace Ryujinx.Ava.Common
 
                     try
                     {
-                        bool isSectionExistInPatch = false;
+                        bool sectionExistsInPatch = false;
                         if (patchNca != null)
                         {
-                            isSectionExistInPatch = patchNca.CanOpenSection(index);
+                            sectionExistsInPatch = patchNca.CanOpenSection(index);
                         }
 
-                        IFileSystem ncaFileSystem = isSectionExistInPatch ? mainNca.OpenFileSystemWithPatch(patchNca, index, IntegrityCheckLevel.ErrorOnInvalid)
-                                                                          : mainNca.OpenFileSystem(index, IntegrityCheckLevel.ErrorOnInvalid);
+                        IFileSystem ncaFileSystem = sectionExistsInPatch ? mainNca.OpenFileSystemWithPatch(patchNca, index, IntegrityCheckLevel.ErrorOnInvalid)
+                                                                         : mainNca.OpenFileSystem(index, IntegrityCheckLevel.ErrorOnInvalid);
 
                         FileSystemClient fsClient = _horizonClient.Fs;
 

--- a/src/Ryujinx.Ava/UI/Controls/ApplicationContextMenu.axaml
+++ b/src/Ryujinx.Ava/UI/Controls/ApplicationContextMenu.axaml
@@ -65,7 +65,7 @@
     </MenuItem>
     <MenuItem Header="{locale:Locale GameListContextMenuExtractData}">
         <MenuItem
-            Click="ExtractApplicationLogo_Click"
+            Click="ExtractApplicationExeFs_Click"
             Header="{locale:Locale GameListContextMenuExtractDataExeFS}"
             ToolTip.Tip="{locale:Locale GameListContextMenuExtractDataExeFSToolTip}" />
         <MenuItem
@@ -73,7 +73,7 @@
             Header="{locale:Locale GameListContextMenuExtractDataRomFS}"
             ToolTip.Tip="{locale:Locale GameListContextMenuExtractDataRomFSToolTip}" />
         <MenuItem
-            Click="ExtractApplicationExeFs_Click"
+            Click="ExtractApplicationLogo_Click"
             Header="{locale:Locale GameListContextMenuExtractDataLogo}"
             ToolTip.Tip="{locale:Locale GameListContextMenuExtractDataLogoToolTip}" />
     </MenuItem>

--- a/src/Ryujinx.Ava/UI/Controls/ApplicationContextMenu.axaml.cs
+++ b/src/Ryujinx.Ava/UI/Controls/ApplicationContextMenu.axaml.cs
@@ -289,13 +289,13 @@ namespace Ryujinx.Ava.UI.Controls
             }
         }
 
-        public async void ExtractApplicationLogo_Click(object sender, RoutedEventArgs args)
+        public async void ExtractApplicationExeFs_Click(object sender, RoutedEventArgs args)
         {
             var viewModel = (sender as MenuItem)?.DataContext as MainWindowViewModel;
 
             if (viewModel?.SelectedApplication != null)
             {
-                await ApplicationHelper.ExtractSection(NcaSectionType.Logo, viewModel.SelectedApplication.Path, viewModel.SelectedApplication.TitleName);
+                await ApplicationHelper.ExtractSection(NcaSectionType.Code, viewModel.SelectedApplication.Path, viewModel.SelectedApplication.TitleName);
             }
         }
 
@@ -309,13 +309,13 @@ namespace Ryujinx.Ava.UI.Controls
             }
         }
 
-        public async void ExtractApplicationExeFs_Click(object sender, RoutedEventArgs args)
+        public async void ExtractApplicationLogo_Click(object sender, RoutedEventArgs args)
         {
             var viewModel = (sender as MenuItem)?.DataContext as MainWindowViewModel;
 
             if (viewModel?.SelectedApplication != null)
             {
-                await ApplicationHelper.ExtractSection(NcaSectionType.Code, viewModel.SelectedApplication.Path, viewModel.SelectedApplication.TitleName);
+                await ApplicationHelper.ExtractSection(NcaSectionType.Logo, viewModel.SelectedApplication.Path, viewModel.SelectedApplication.TitleName);
             }
         }
     }

--- a/src/Ryujinx/Ui/Widgets/GameTableContextMenu.cs
+++ b/src/Ryujinx/Ui/Widgets/GameTableContextMenu.cs
@@ -270,14 +270,14 @@ namespace Ryujinx.Ui.Widgets
 
                         int index = Nca.GetSectionIndexFromType(ncaSectionType, mainNca.Header.ContentType);
 
-                        bool isSectionExistInPatch = false;
+                        bool sectionExistsInPatch = false;
                         if (patchNca != null)
                         {
-                            isSectionExistInPatch = patchNca.CanOpenSection(index);
+                            sectionExistsInPatch = patchNca.CanOpenSection(index);
                         }
 
-                        IFileSystem ncaFileSystem = isSectionExistInPatch ? mainNca.OpenFileSystemWithPatch(patchNca, index, IntegrityCheckLevel.ErrorOnInvalid)
-                                                                          : mainNca.OpenFileSystem(index, IntegrityCheckLevel.ErrorOnInvalid);
+                        IFileSystem ncaFileSystem = sectionExistsInPatch ? mainNca.OpenFileSystemWithPatch(patchNca, index, IntegrityCheckLevel.ErrorOnInvalid)
+                                                                         : mainNca.OpenFileSystem(index, IntegrityCheckLevel.ErrorOnInvalid);
 
                         FileSystemClient fsClient = _horizonClient.Fs;
 

--- a/src/Ryujinx/Ui/Widgets/GameTableContextMenu.cs
+++ b/src/Ryujinx/Ui/Widgets/GameTableContextMenu.cs
@@ -270,8 +270,14 @@ namespace Ryujinx.Ui.Widgets
 
                         int index = Nca.GetSectionIndexFromType(ncaSectionType, mainNca.Header.ContentType);
 
-                        IFileSystem ncaFileSystem = patchNca != null ? mainNca.OpenFileSystemWithPatch(patchNca, index, IntegrityCheckLevel.ErrorOnInvalid)
-                                                                     : mainNca.OpenFileSystem(index, IntegrityCheckLevel.ErrorOnInvalid);
+                        bool isSectionExistInPatch = false;
+                        if (patchNca != null)
+                        {
+                            isSectionExistInPatch = patchNca.CanOpenSection(index);
+                        }
+
+                        IFileSystem ncaFileSystem = isSectionExistInPatch ? mainNca.OpenFileSystemWithPatch(patchNca, index, IntegrityCheckLevel.ErrorOnInvalid)
+                                                                          : mainNca.OpenFileSystem(index, IntegrityCheckLevel.ErrorOnInvalid);
 
                         FileSystemClient fsClient = _horizonClient.Fs;
 


### PR DESCRIPTION
There is currently a crash if the updated NCA doesn't contain the section we want to extract, this is fixed by adding an extra check.
I have fixed the inverted handler of ExeFs/Logo introduced in #4755 too.

Fixes #4521