### PR TITLE
Shader: Use correct offset for storage constant buffer elimination

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 2237;
+        private const uint CodeGenVersion = 4821;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";


### PR DESCRIPTION
This fixes a regression from #2237 where constant buffer access elimination would not work if the newly mapped storage slot didn't match up with the storage slot on hardware.

I've also changed it to work no matter what constant buffer the address is on.