### PR TITLE
Ryujinx.Ava: fixes for random hangs on exit

### DIFF
--- a/src/Ryujinx.Audio/Renderer/Server/AudioRenderSystem.cs
+++ b/src/Ryujinx.Audio/Renderer/Server/AudioRenderSystem.cs
@@ -389,7 +389,12 @@ namespace Ryujinx.Audio.Renderer.Server
 
             if (_executionMode == AudioRendererExecutionMode.Auto)
             {
-                _terminationEvent.WaitOne();
+                TimeSpan terminationWaitTimeout = TimeSpan.FromSeconds(5);
+
+                if (_terminationEvent.WaitOne(terminationWaitTimeout) == false)
+                {
+                    Logger.Warning?.PrintMsg(LogClass.AudioRenderer, $"AudioRenderSystem.Stop() timed out after {terminationWaitTimeout} while waiting for the termination signal. Execution will continue to avoid interfering with emulation shutdown. Please file a detailed bug report.");
+                }
             }
 
             Logger.Info?.Print(LogClass.AudioRenderer, $"Stopped renderer id {_sessionId}");

--- a/src/Ryujinx.Audio/Renderer/Server/AudioRenderSystem.cs
+++ b/src/Ryujinx.Audio/Renderer/Server/AudioRenderSystem.cs
@@ -677,7 +677,6 @@ namespace Ryujinx.Audio.Renderer.Server
                         _isDspRunningBehind = true;
                     }
                 }
-
             }
         }
 

--- a/src/Ryujinx.Audio/Renderer/Server/AudioRenderSystem.cs
+++ b/src/Ryujinx.Audio/Renderer/Server/AudioRenderSystem.cs
@@ -31,7 +31,6 @@ namespace Ryujinx.Audio.Renderer.Server
         private AudioRendererRenderingDevice _renderingDevice;
         private AudioRendererExecutionMode _executionMode;
         private IWritableEvent _systemEvent;
-        private ManualResetEvent _terminationEvent;
         private MemoryPoolState _dspMemoryPoolState;
         private VoiceContext _voiceContext;
         private MixContext _mixContext;
@@ -83,7 +82,6 @@ namespace Ryujinx.Audio.Renderer.Server
         public AudioRenderSystem(AudioRendererManager manager, IWritableEvent systemEvent)
         {
             _manager = manager;
-            _terminationEvent = new ManualResetEvent(false);
             _dspMemoryPoolState = MemoryPoolState.Create(MemoryPoolState.LocationType.Dsp);
             _voiceContext = new VoiceContext();
             _mixContext = new MixContext();
@@ -387,16 +385,6 @@ namespace Ryujinx.Audio.Renderer.Server
                 _isActive = false;
             }
 
-            if (_executionMode == AudioRendererExecutionMode.Auto)
-            {
-                TimeSpan terminationWaitTimeout = TimeSpan.FromSeconds(5);
-
-                if (_terminationEvent.WaitOne(terminationWaitTimeout) == false)
-                {
-                    Logger.Warning?.PrintMsg(LogClass.AudioRenderer, $"AudioRenderSystem.Stop() timed out after {terminationWaitTimeout} while waiting for the termination signal. Execution will continue to avoid interfering with emulation shutdown. Please file a detailed bug report.");
-                }
-            }
-
             Logger.Info?.Print(LogClass.AudioRenderer, $"Stopped renderer id {_sessionId}");
         }
 
@@ -673,8 +661,6 @@ namespace Ryujinx.Audio.Renderer.Server
             {
                 if (_isActive)
                 {
-                    _terminationEvent.Reset();
-
                     if (!_manager.Processor.HasRemainingCommands(_sessionId))
                     {
                         GenerateCommandList(out CommandList commands);
@@ -691,10 +677,7 @@ namespace Ryujinx.Audio.Renderer.Server
                         _isDspRunningBehind = true;
                     }
                 }
-                else
-                {
-                    _terminationEvent.Set();
-                }
+
             }
         }
 
@@ -862,7 +845,6 @@ namespace Ryujinx.Audio.Renderer.Server
                 }
 
                 _manager.Unregister(this);
-                _terminationEvent.Dispose();
                 _workBufferMemoryPin.Dispose();
 
                 if (MemoryManager is IRefCounted rc)

--- a/src/Ryujinx.Ava/UI/Helpers/NotificationHelper.cs
+++ b/src/Ryujinx.Ava/UI/Helpers/NotificationHelper.cs
@@ -58,6 +58,8 @@ namespace Ryujinx.Ava.UI.Helpers
                     await Task.Delay(NotificationDelayInMs / MaxNotifications);
                 }
             });
+
+            _notificationManager.ApplyTemplate();
         }
 
         public static void Show(string title, string text, NotificationType type, bool waitingExit = false, Action onClick = null, Action onClose = null)

--- a/src/Ryujinx.Ava/UI/Helpers/NotificationHelper.cs
+++ b/src/Ryujinx.Ava/UI/Helpers/NotificationHelper.cs
@@ -38,7 +38,7 @@ namespace Ryujinx.Ava.UI.Helpers
             // The process will be ending soon (right?!) so we're not too concerned about proper disposal.
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
 
-            _notificationManager.DetachedFromLogicalTree += (sender, args) =>
+            host.Closing += (sender, args) =>
             {
                 cancellationTokenSource.Cancel();
                 _notifications.CompleteAdding();

--- a/src/Ryujinx.Ava/UI/Helpers/NotificationHelper.cs
+++ b/src/Ryujinx.Ava/UI/Helpers/NotificationHelper.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Notifications;
 using Avalonia.Threading;
 using Ryujinx.Ava.Common.Locale;
+using Ryujinx.Common;
 using System;
 using System.Collections.Concurrent;
 using System.Threading;
@@ -16,7 +17,6 @@ namespace Ryujinx.Ava.UI.Helpers
 
         private static WindowNotificationManager _notificationManager;
 
-        private static readonly ManualResetEventSlim             _templateAppliedEvent = new(false);
         private static readonly BlockingCollection<Notification> _notifications        = new();
 
         public static void SetNotificationManager(Window host)
@@ -28,50 +28,29 @@ namespace Ryujinx.Ava.UI.Helpers
                 Margin   = new Thickness(0, 0, 15, 40)
             };
 
+            Lazy<AsyncWorkQueue<Notification>> maybeAsyncWorkQueue = new Lazy<AsyncWorkQueue<Notification>>(
+                () => new AsyncWorkQueue<Notification>(notification =>
+                {
+                    Dispatcher.UIThread.Post(() =>
+                    {
+                        _notificationManager.Show(notification);
+                    });
+                }, "UI.NotificationThread", _notifications)
+                , LazyThreadSafetyMode.ExecutionAndPublication);
+
             _notificationManager.TemplateApplied += (sender, args) =>
             {
-                _templateAppliedEvent.Set();
+                // Force creation of the AsyncWorkQueue
+                _ = maybeAsyncWorkQueue.Value;
             };
-
-            // Ordinarily you'd want to Dispose() these, but we're using this one until the application start shutting down.
-            // The process will be ending soon (right?!) so we're not too concerned about proper disposal.
-            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
 
             host.Closing += (sender, args) =>
             {
-                cancellationTokenSource.Cancel();
-                _notifications.CompleteAdding();
-            };
-
-            var notificationThread = new Thread(() =>
-            {
-                _templateAppliedEvent.Wait(cancellationTokenSource.Token);
-
-                try
+                if (maybeAsyncWorkQueue.IsValueCreated)
                 {
-                    foreach (var notification in _notifications.GetConsumingEnumerable(cancellationTokenSource.Token))
-                    {
-                        Dispatcher.UIThread.Post(() =>
-                        {
-                            _notificationManager.Show(notification);
-                        });
-
-                        bool isCancelled = cancellationTokenSource.Token.WaitHandle.WaitOne(NotificationDelayInMs / MaxNotifications);
-                        if (isCancelled)
-                            break;
-                    }
+                    maybeAsyncWorkQueue.Value.Dispose();
                 }
-                catch (OperationCanceledException)
-                {
-                    // Do nothing.
-                }
-            })
-            {
-                Name = "UI.NotificationThread",
-                IsBackground = true,
             };
-
-            notificationThread.Start();
         }
 
         public static void Show(string title, string text, NotificationType type, bool waitingExit = false, Action onClick = null, Action onClose = null)

--- a/src/Ryujinx.Ava/UI/Helpers/NotificationHelper.cs
+++ b/src/Ryujinx.Ava/UI/Helpers/NotificationHelper.cs
@@ -3,7 +3,6 @@ using Avalonia.Controls;
 using Avalonia.Controls.Notifications;
 using Avalonia.Threading;
 using Ryujinx.Ava.Common.Locale;
-using Ryujinx.Common.Logging;
 using System;
 using System.Collections.Concurrent;
 using System.Threading;
@@ -41,8 +40,8 @@ namespace Ryujinx.Ava.UI.Helpers
 
             _notificationManager.DetachedFromLogicalTree += (sender, args) =>
             {
-                _notifications.CompleteAdding();
                 cancellationTokenSource.Cancel();
+                _notifications.CompleteAdding();
             };
 
             Task.Run(async () =>

--- a/src/Ryujinx.Ava/UI/Helpers/NotificationHelper.cs
+++ b/src/Ryujinx.Ava/UI/Helpers/NotificationHelper.cs
@@ -3,7 +3,6 @@ using Avalonia.Controls;
 using Avalonia.Controls.Notifications;
 using Avalonia.Threading;
 using Ryujinx.Ava.Common.Locale;
-using Ryujinx.Common;
 using System;
 using System.Collections.Concurrent;
 using System.Threading;
@@ -34,18 +33,45 @@ namespace Ryujinx.Ava.UI.Helpers
                 _templateAppliedEvent.Set();
             };
 
-            AsyncWorkQueue<Notification> asyncWorkQueue = new AsyncWorkQueue<Notification>(notification =>
-            {
-                Dispatcher.UIThread.Post(() =>
-                {
-                    _notificationManager.Show(notification);
-                });
-            }, "UI.NotificationThread", _notifications);
+            // Ordinarily you'd want to Dispose() these, but we're using this one until the application start shutting down.
+            // The process will be ending soon (right?!) so we're not too concerned about proper disposal.
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
 
             host.Closing += (sender, args) =>
             {
-                asyncWorkQueue.Dispose();
+                cancellationTokenSource.Cancel();
+                _notifications.CompleteAdding();
             };
+
+            var notificationThread = new Thread(() =>
+            {
+                _templateAppliedEvent.Wait(cancellationTokenSource.Token);
+
+                try
+                {
+                    foreach (var notification in _notifications.GetConsumingEnumerable(cancellationTokenSource.Token))
+                    {
+                        Dispatcher.UIThread.Post(() =>
+                        {
+                            _notificationManager.Show(notification);
+                        });
+
+                        bool isCancelled = cancellationTokenSource.Token.WaitHandle.WaitOne(NotificationDelayInMs / MaxNotifications);
+                        if (isCancelled)
+                            break;
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    // Do nothing.
+                }
+            })
+            {
+                Name = "UI.NotificationThread",
+                IsBackground = true,
+            };
+
+            notificationThread.Start();
         }
 
         public static void Show(string title, string text, NotificationType type, bool waitingExit = false, Action onClick = null, Action onClose = null)

--- a/src/Ryujinx.Ava/UI/Helpers/NotificationHelper.cs
+++ b/src/Ryujinx.Ava/UI/Helpers/NotificationHelper.cs
@@ -28,19 +28,21 @@ namespace Ryujinx.Ava.UI.Helpers
                 Margin   = new Thickness(0, 0, 15, 40)
             };
 
-            Lazy<AsyncWorkQueue<Notification>> maybeAsyncWorkQueue = new Lazy<AsyncWorkQueue<Notification>>(
+            var maybeAsyncWorkQueue = new Lazy<AsyncWorkQueue<Notification>>(
                 () => new AsyncWorkQueue<Notification>(notification =>
-                {
-                    Dispatcher.UIThread.Post(() =>
                     {
-                        _notificationManager.Show(notification);
-                    });
-                }, "UI.NotificationThread", _notifications)
-                , LazyThreadSafetyMode.ExecutionAndPublication);
+                        Dispatcher.UIThread.Post(() =>
+                        {
+                            _notificationManager.Show(notification);
+                        });
+                    },
+                    "UI.NotificationThread",
+                    _notifications),
+                LazyThreadSafetyMode.ExecutionAndPublication);
 
             _notificationManager.TemplateApplied += (sender, args) =>
             {
-                // Force creation of the AsyncWorkQueue
+                // NOTE: Force creation of the AsyncWorkQueue.
                 _ = maybeAsyncWorkQueue.Value;
             };
 

--- a/src/Ryujinx.Common/AsyncWorkQueue.cs
+++ b/src/Ryujinx.Common/AsyncWorkQueue.cs
@@ -22,9 +22,11 @@ namespace Ryujinx.Common
             _cts = new CancellationTokenSource();
             _queue = collection;
             _workerAction = callback;
-            _workerThread = new Thread(DoWork) { Name = name };
-
-            _workerThread.IsBackground = true;
+            _workerThread = new Thread(DoWork)
+            {
+                Name = name,
+                IsBackground = true
+            };
             _workerThread.Start();
         }
 


### PR DESCRIPTION
I've experienced a lot of instances recently where Ryujinx.Ava would hang on exit, sometimes for so long that I'd open up Task Manager and kill it. It was always with Release builds and attaching the debugger didn't show much. It happened so often, I didn't imagine I should have tried harder because today, try as I might, I've had a real hard time getting it to happen so that I could investigate.

**Hang #1**
I finally got it to happen though, and with a Debug build too. I found one thread stuck waiting, started by `NotificationHelper.SetNotificationManager()` with `Task.Run()`. The thread itself does a simple foreach over a `BlockingCollection<Notification>` but it doesn't have an exit condition. This PR adds one via a `CancellationTokenSource`.

This uses the ~~`WindowNotificationManager.DetachedFromLogicalTree`~~ `MainWindow.Closing` event to detect when it's time to shut down. I don't have much Avalonia experience, maybe someone who does can suggest a better way to detect when it's time to shut down.

**Hang #2**
After fixing the above, I found another location that appeared to hang up stopping was the `ManualResetEvent _terminationEvent` in `AudioRenderSystem`. It was determined this event was unnecessary, and so was removed completely.

With these changes, the # of hangs on exit are noticeably reduced. The ones that do occur all appear to be from known issues in the threaded renderer.
