### PR TITLE
Stop SDL from inhibiting sleep (#4828).

### DIFF
--- a/src/Ryujinx.SDL2.Common/SDL2Driver.cs
+++ b/src/Ryujinx.SDL2.Common/SDL2Driver.cs
@@ -63,6 +63,7 @@ namespace Ryujinx.SDL2.Common
                 SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1");
                 SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_SWITCH_HOME_LED, "0");
                 SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_JOY_CONS, "1");
+                SDL_SetHint(SDL_HINT_VIDEO_ALLOW_SCREENSAVER, "1");
 
 
                 // NOTE: As of SDL2 2.24.0, joycons are combined by default but the motion source only come from one of them.


### PR DESCRIPTION
This fixes #4828.

The problem was that SDL was inhibiting the display from sleeping even when a game was not running.  I added a hint to disable that SDL feature.  The normal behavior in `DisplaySleep.cs` will still apply and prevent sleep while a game is currently running.