### PR TITLE
Vulkan: Batch vertex buffer updates

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -1233,23 +1233,28 @@ namespace Ryujinx.Graphics.Vulkan
                         ref var buffer = ref _vertexBuffers[binding];
                         int oldScalarAlign = buffer.AttributeScalarAlignment;
 
-                        buffer.Dispose();
-
                         if (Gd.Capabilities.VertexBufferAlignment < 2 &&
                             (vertexBuffer.Stride % FormatExtensions.MaxBufferFormatScalarSize) == 0)
                         {
-                            buffer = new VertexBufferState(
-                                vb,
-                                descriptorIndex,
-                                vertexBuffer.Buffer.Offset,
-                                vbSize,
-                                vertexBuffer.Stride);
+                            if (!buffer.Matches(vb, descriptorIndex, vertexBuffer.Buffer.Offset, vbSize, vertexBuffer.Stride))
+                            {
+                                buffer.Dispose();
 
-                            buffer.BindVertexBuffer(Gd, Cbs, (uint)binding, ref _newState, _vertexBufferUpdater);
+                                buffer = new VertexBufferState(
+                                    vb,
+                                    descriptorIndex,
+                                    vertexBuffer.Buffer.Offset,
+                                    vbSize,
+                                    vertexBuffer.Stride);
+
+                                buffer.BindVertexBuffer(Gd, Cbs, (uint)binding, ref _newState, _vertexBufferUpdater);
+                            }
                         }
                         else
                         {
                             // May need to be rewritten. Bind this buffer before draw.
+
+                            buffer.Dispose();
 
                             buffer = new VertexBufferState(
                                 vertexBuffer.Buffer.Handle,

--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -1732,6 +1732,7 @@ namespace Ryujinx.Graphics.Vulkan
                 _framebuffer?.Dispose();
                 _newState.Dispose();
                 _descriptorSetUpdater.Dispose();
+                _vertexBufferUpdater.Dispose();
 
                 for (int i = 0; i < _vertexBuffers.Length; i++)
                 {

--- a/src/Ryujinx.Graphics.Vulkan/VertexBufferState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VertexBufferState.cs
@@ -101,6 +101,11 @@ namespace Ryujinx.Graphics.Vulkan
             return _buffer == buffer;
         }
 
+        public bool Matches(Auto<DisposableBuffer> buffer, int descriptorIndex, int offset, int size, int stride = 0)
+        {
+            return _buffer == buffer && DescriptorIndex == descriptorIndex && _offset == offset && _size == size && _stride == stride;
+        }
+
         public void Swap(Auto<DisposableBuffer> from, Auto<DisposableBuffer> to)
         {
             if (_buffer == from)

--- a/src/Ryujinx.Graphics.Vulkan/VertexBufferState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VertexBufferState.cs
@@ -46,7 +46,7 @@ namespace Ryujinx.Graphics.Vulkan
             AttributeScalarAlignment = 1;
         }
 
-        public void BindVertexBuffer(VulkanRenderer gd, CommandBufferScoped cbs, uint binding, ref PipelineState state)
+        public void BindVertexBuffer(VulkanRenderer gd, CommandBufferScoped cbs, uint binding, ref PipelineState state, VertexBufferUpdater updater)
         {
             var autoBuffer = _buffer;
 
@@ -65,21 +65,7 @@ namespace Ryujinx.Graphics.Vulkan
 
                         var buffer = autoBuffer.Get(cbs, 0, newSize).Value;
 
-                        if (gd.Capabilities.SupportsExtendedDynamicState)
-                        {
-                            gd.ExtendedDynamicStateApi.CmdBindVertexBuffers2(
-                                cbs.CommandBuffer,
-                                binding,
-                                1,
-                                buffer,
-                                0,
-                                (ulong)newSize,
-                                (ulong)stride);
-                        }
-                        else
-                        {
-                            gd.Api.CmdBindVertexBuffers(cbs.CommandBuffer, binding, 1, buffer, 0);
-                        }
+                        updater.BindVertexBuffer(cbs, binding, buffer, 0, (ulong)newSize, (ulong)stride);
 
                         _buffer = autoBuffer;
 
@@ -106,21 +92,7 @@ namespace Ryujinx.Graphics.Vulkan
             {
                 var buffer = autoBuffer.Get(cbs, _offset, _size).Value;
 
-                if (gd.Capabilities.SupportsExtendedDynamicState)
-                {
-                    gd.ExtendedDynamicStateApi.CmdBindVertexBuffers2(
-                        cbs.CommandBuffer,
-                        binding,
-                        1,
-                        buffer,
-                        (ulong)_offset,
-                        (ulong)_size,
-                        (ulong)_stride);
-                }
-                else
-                {
-                    gd.Api.CmdBindVertexBuffers(cbs.CommandBuffer, binding, 1, buffer, (ulong)_offset);
-                }
+                updater.BindVertexBuffer(cbs, binding, buffer, (ulong)_offset, (ulong)_size, (ulong)_stride);
             }
         }
 

--- a/src/Ryujinx.Graphics.Vulkan/VertexBufferUpdater.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VertexBufferUpdater.cs
@@ -1,16 +1,18 @@
 ﻿using Silk.NET.Vulkan;
+using System;
+
+using VkBuffer = Silk.NET.Vulkan.Buffer;
 
 namespace Ryujinx.Graphics.Vulkan
 {
-    internal class VertexBufferUpdater
+    internal class VertexBufferUpdater : IDisposable
     {
-        private int MaxVertexBuffers = 16;
         private VulkanRenderer _gd;
 
         private uint _baseBinding;
         private uint _count;
 
-        private NativeArray<Buffer> _buffers;
+        private NativeArray<VkBuffer> _buffers;
         private NativeArray<ulong> _offsets;
         private NativeArray<ulong> _sizes;
         private NativeArray<ulong> _strides;
@@ -19,13 +21,13 @@ namespace Ryujinx.Graphics.Vulkan
         {
             _gd = gd;
 
-            _buffers = new NativeArray<Buffer>(MaxVertexBuffers);
-            _offsets = new NativeArray<ulong>(MaxVertexBuffers);
-            _sizes = new NativeArray<ulong>(MaxVertexBuffers);
-            _strides = new NativeArray<ulong>(MaxVertexBuffers);
+            _buffers = new NativeArray<VkBuffer>(Constants.MaxVertexBuffers);
+            _offsets = new NativeArray<ulong>(Constants.MaxVertexBuffers);
+            _sizes = new NativeArray<ulong>(Constants.MaxVertexBuffers);
+            _strides = new NativeArray<ulong>(Constants.MaxVertexBuffers);
         }
 
-        public void BindVertexBuffer(CommandBufferScoped cbs, uint binding, Buffer buffer, ulong offset, ulong size, ulong stride)
+        public void BindVertexBuffer(CommandBufferScoped cbs, uint binding, VkBuffer buffer, ulong offset, ulong size, ulong stride)
         {
             if (_count == 0)
             {
@@ -69,6 +71,14 @@ namespace Ryujinx.Graphics.Vulkan
 
                 _count = 0;
             }
+        }
+
+        public void Dispose()
+        {
+            _buffers.Dispose();
+            _offsets.Dispose();
+            _sizes.Dispose();
+            _strides.Dispose();
         }
     }
 }

--- a/src/Ryujinx.Graphics.Vulkan/VertexBufferUpdater.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VertexBufferUpdater.cs
@@ -1,0 +1,74 @@
+﻿using Silk.NET.Vulkan;
+
+namespace Ryujinx.Graphics.Vulkan
+{
+    internal class VertexBufferUpdater
+    {
+        private int MaxVertexBuffers = 16;
+        private VulkanRenderer _gd;
+
+        private uint _baseBinding;
+        private uint _count;
+
+        private NativeArray<Buffer> _buffers;
+        private NativeArray<ulong> _offsets;
+        private NativeArray<ulong> _sizes;
+        private NativeArray<ulong> _strides;
+
+        public VertexBufferUpdater(VulkanRenderer gd)
+        {
+            _gd = gd;
+
+            _buffers = new NativeArray<Buffer>(MaxVertexBuffers);
+            _offsets = new NativeArray<ulong>(MaxVertexBuffers);
+            _sizes = new NativeArray<ulong>(MaxVertexBuffers);
+            _strides = new NativeArray<ulong>(MaxVertexBuffers);
+        }
+
+        public void BindVertexBuffer(CommandBufferScoped cbs, uint binding, Buffer buffer, ulong offset, ulong size, ulong stride)
+        {
+            if (_count == 0)
+            {
+                _baseBinding = binding;
+            }
+            else if (_baseBinding + _count != binding)
+            {
+                Commit(cbs);
+                _baseBinding = binding;
+            }
+
+            int index = (int)_count;
+
+            _buffers[index] = buffer;
+            _offsets[index] = offset;
+            _sizes[index] = size;
+            _strides[index] = stride;
+
+            _count++;
+        }
+
+        public unsafe void Commit(CommandBufferScoped cbs)
+        {
+            if (_count != 0)
+            {
+                if (_gd.Capabilities.SupportsExtendedDynamicState)
+                {
+                    _gd.ExtendedDynamicStateApi.CmdBindVertexBuffers2(
+                        cbs.CommandBuffer,
+                        _baseBinding,
+                        _count,
+                        _buffers.Pointer,
+                        _offsets.Pointer,
+                        _sizes.Pointer,
+                        _strides.Pointer);
+                }
+                else
+                {
+                    _gd.Api.CmdBindVertexBuffers(cbs.CommandBuffer, _baseBinding, _count, _buffers.Pointer, _offsets.Pointer);
+                }
+
+                _count = 0;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR batches together vertex buffer updates to reduce the number of individual calls to update vertex buffers. It also avoids rebinding vertex buffers that have not changed, which is common when games are doing instanced rendering.

![image](https://user-images.githubusercontent.com/6294155/236690711-116257d7-29c8-4704-b36c-f2c56cbca1ea.png)

Improves performance slightly on BOTW on my system. Some areas bind more vertex buffers per draw than others.

Note that any improvement greatly depends on the game and the driver.