### PR TITLE
Vulkan: Simplify MultiFenceHolder and managing them

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/Auto.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Auto.cs
@@ -105,6 +105,23 @@ namespace Ryujinx.Graphics.Vulkan
             }
         }
 
+        public bool TryIncrementReferenceCount()
+        {
+            int lastValue;
+            do
+            {
+                lastValue = _referenceCount;
+
+                if (lastValue == 0)
+                {
+                    return false;
+                }
+            }
+            while (Interlocked.CompareExchange(ref _referenceCount, lastValue + 1, lastValue) != lastValue);
+
+            return true;
+        }
+
         public void IncrementReferenceCount()
         {
             if (Interlocked.Increment(ref _referenceCount) == 1)

--- a/src/Ryujinx.Graphics.Vulkan/BufferHolder.cs
+++ b/src/Ryujinx.Graphics.Vulkan/BufferHolder.cs
@@ -599,9 +599,10 @@ namespace Ryujinx.Graphics.Vulkan
             Auto<DisposableBuffer> dst,
             int srcOffset,
             int dstOffset,
-            int size)
+            int size,
+            bool registerSrcUsage = true)
         {
-            var srcBuffer = src.Get(cbs, srcOffset, size).Value;
+            var srcBuffer = registerSrcUsage ? src.Get(cbs, srcOffset, size).Value : src.GetUnsafe().Value;
             var dstBuffer = dst.Get(cbs, dstOffset, size).Value;
 
             InsertBufferBarrier(

--- a/src/Ryujinx.Graphics.Vulkan/FenceHolder.cs
+++ b/src/Ryujinx.Graphics.Vulkan/FenceHolder.cs
@@ -32,15 +32,28 @@ namespace Ryujinx.Graphics.Vulkan
             return _fence;
         }
 
+        public bool TryGet(out Fence fence)
+        {
+            int lastValue;
+            do
+            {
+                lastValue = _referenceCount;
+
+                if (lastValue == 0)
+                {
+                    fence = default;
+                    return false;
+                }
+            }
+            while (Interlocked.CompareExchange(ref _referenceCount, lastValue + 1, lastValue) != lastValue);
+
+            fence = _fence;
+            return true;
+        }
+
         public Fence Get()
         {
-            if (Interlocked.Increment(ref _referenceCount) == 1)
-            {
-                Interlocked.Decrement(ref _referenceCount);
-
-                return default;
-            }
-
+            Interlocked.Increment(ref _referenceCount);
             return _fence;
         }
 

--- a/src/Ryujinx.Graphics.Vulkan/FenceHolder.cs
+++ b/src/Ryujinx.Graphics.Vulkan/FenceHolder.cs
@@ -34,7 +34,13 @@ namespace Ryujinx.Graphics.Vulkan
 
         public Fence Get()
         {
-            Interlocked.Increment(ref _referenceCount);
+            if (Interlocked.Increment(ref _referenceCount) == 1)
+            {
+                Interlocked.Decrement(ref _referenceCount);
+
+                return default;
+            }
+
             return _fence;
         }
 

--- a/src/Ryujinx.Graphics.Vulkan/MultiFenceHolder.cs
+++ b/src/Ryujinx.Graphics.Vulkan/MultiFenceHolder.cs
@@ -82,7 +82,7 @@ namespace Ryujinx.Graphics.Vulkan
         /// </summary>
         /// <param name="cbIndex">Command buffer index of the command buffer that owns the fence</param>
         /// <param name="fence">Fence to be added</param>
-        /// <returns>True if the constant buffer's previous fence value was null</returns>
+        /// <returns>True if the command buffer's previous fence value was null</returns>
         public bool AddFence(int cbIndex, FenceHolder fence)
         {
             ref FenceHolder fenceRef = ref _fences[cbIndex];
@@ -106,7 +106,7 @@ namespace Ryujinx.Graphics.Vulkan
         }
 
         /// <summary>
-        /// Determines if a fence referenced on the given constant buffer.
+        /// Determines if a fence referenced on the given command buffer.
         /// </summary>
         /// <param name="cbIndex"></param>
         /// <returns></returns>

--- a/src/Ryujinx.Graphics.Vulkan/MultiFenceHolder.cs
+++ b/src/Ryujinx.Graphics.Vulkan/MultiFenceHolder.cs
@@ -170,15 +170,15 @@ namespace Ryujinx.Graphics.Vulkan
 
             for (int i = 0; i < count; i++)
             {
-                fences[fenceCount] = fenceHolders[i].Get();
-
-                if (fenceCount < i)
+                if (fenceHolders[i].TryGet(out Fence fence))
                 {
-                    fenceHolders[fenceCount] = fenceHolders[i];
-                }
+                    fences[fenceCount] = fence;
 
-                if (fences[i].Handle != 0)
-                {
+                    if (fenceCount < i)
+                    {
+                        fenceHolders[fenceCount] = fenceHolders[i];
+                    }
+
                     fenceCount++;
                 }
             }

--- a/src/Ryujinx.Graphics.Vulkan/MultiFenceHolder.cs
+++ b/src/Ryujinx.Graphics.Vulkan/MultiFenceHolder.cs
@@ -1,8 +1,5 @@
 ﻿using Silk.NET.Vulkan;
 using System;
-using System.Buffers;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Ryujinx.Graphics.Vulkan
 {
@@ -108,8 +105,8 @@ namespace Ryujinx.Graphics.Vulkan
         /// <summary>
         /// Determines if a fence referenced on the given command buffer.
         /// </summary>
-        /// <param name="cbIndex"></param>
-        /// <returns></returns>
+        /// <param name="cbIndex">Index of the command buffer to check if it's used</param>
+        /// <returns>True if referenced, false otherwise</returns>
         public bool HasFence(int cbIndex)
         {
             return _fences[cbIndex] != null;

--- a/src/Ryujinx.Graphics.Vulkan/PersistentFlushBuffer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PersistentFlushBuffer.cs
@@ -41,13 +41,11 @@ namespace Ryujinx.Graphics.Vulkan
                 srcBuffer = buffer.GetBuffer(cbs.CommandBuffer);
                 var dstBuffer = flushStorage.GetBuffer(cbs.CommandBuffer);
 
-                try
+                if (srcBuffer.TryIncrementReferenceCount())
                 {
-                    srcBuffer.IncrementReferenceCount();
-
                     BufferHolder.Copy(_gd, cbs, srcBuffer, dstBuffer, offset, 0, size, registerSrcUsage: false);
                 }
-                catch (InvalidOperationException)
+                else
                 {
                     // Source buffer is no longer alive, don't copy anything to flush storage.
                     srcBuffer = null;


### PR DESCRIPTION
MultiFenceHolder is currently absolutely reliant on all users submitting to the _same command buffer pool_, which means they must all come from the same thread. This is because waitiers register the command buffer index, which is only valid for entries of the same pool. The locking and dictionary structures greatly slow down the process of binding and ref counting for _all types of buffer_, while also being unnecessary when these rules are followed.

This PR simplifies MultiFenceHolder in a few ways:
- `ReservedCommandBuffer.Waitables` is now a List for less overhead. Enforcing uniqueness is done by `MultiFenceHolder.AddFence` returning true only when the command buffer index is not yet registered on the waitable. Similarly, the call to Contains has been replaced with asking the waitable if it has the current fence, rather than checking the set on the command buffer.
- `MultiFenceHolder` now maintains an array of fences rather than a dictionary. Each entry in the array represents a command buffer in the pool. If the value in the array at that command buffer index is null, there is no registered fence yet. This removes all cost for trying to add and trying to remove fences, which was pretty considerable.
  - The WaitForFences methods have been updated to extract active fences from this array, and properly handle a fence already being disposed by the time it's iterated.
  - Everything is completely lockless, which is good for a method this hot.
- Added "Try" methods to `Auto<>` and `FenceHolder` to properly handle cases where we get a resource but it might already be disposed. These are a bit slower as they use a compare exchange to increment the value only if it's not 0, but they are at least correct if a bunch of threads are contending with each other.

There was an existing case where the rules about keeping `Get(cbs)` uses to the same pool are broken, which is the copy source when flushing data from a device local buffer. The destination is fine, because it is only used by the command buffer pool owned by the background thread. This will probably cause issues right now, but to avoid creating new ones I decided it's worth fixing.

I've changed this case to manage keeping the source buffer alive outside the copy method. Since it waits for the copy to complete anyways, it can just increment and decrement the reference count around the use manually.

---

Improves performance in Vulkan bottlenecked games such as BOTW. (at least on my system)

Testing various games would be helpful to ensure nothing ends up broken.