### PR TITLE
Changed LastPlayed field from string to nullable DateTime

### DIFF
--- a/src/Ryujinx.Ava/AppHost.cs
+++ b/src/Ryujinx.Ava/AppHost.cs
@@ -671,7 +671,7 @@ namespace Ryujinx.Ava
 
             _viewModel.ApplicationLibrary.LoadAndSaveMetaData(Device.Processes.ActiveApplication.ProgramIdText, appMetadata =>
             {
-                appMetadata.LastPlayed = DateTime.UtcNow.ToString();
+                appMetadata.LastPlayed = DateTime.UtcNow;
             });
 
             return true;

--- a/src/Ryujinx.Ava/UI/Controls/ApplicationListView.axaml
+++ b/src/Ryujinx.Ava/UI/Controls/ApplicationListView.axaml
@@ -13,7 +13,6 @@
     mc:Ignorable="d">
     <UserControl.Resources>
         <helpers:BitmapArrayValueConverter x:Key="ByteImage" />
-        <helpers:NullableDateTimeConverter x:Key="NullableDateTime" />
         <controls:ApplicationContextMenu x:Key="ApplicationContextMenu" />
     </UserControl.Resources>
     <Grid>
@@ -130,7 +129,7 @@
                                         TextWrapping="Wrap" />
                                     <TextBlock
                                         HorizontalAlignment="Stretch"
-                                        Text="{Binding LastPlayed, Converter={StaticResource NullableDateTime}}"
+                                        Text="{Binding LastPlayed, Converter={helpers:NullableDateTimeConverter}}"
                                         TextAlignment="Right"
                                         TextWrapping="Wrap" />
                                     <TextBlock

--- a/src/Ryujinx.Ava/UI/Controls/ApplicationListView.axaml
+++ b/src/Ryujinx.Ava/UI/Controls/ApplicationListView.axaml
@@ -13,6 +13,7 @@
     mc:Ignorable="d">
     <UserControl.Resources>
         <helpers:BitmapArrayValueConverter x:Key="ByteImage" />
+        <helpers:NullableDateTimeConverter x:Key="NullableDateTime" />
         <controls:ApplicationContextMenu x:Key="ApplicationContextMenu" />
     </UserControl.Resources>
     <Grid>
@@ -129,7 +130,7 @@
                                         TextWrapping="Wrap" />
                                     <TextBlock
                                         HorizontalAlignment="Stretch"
-                                        Text="{Binding LastPlayed}"
+                                        Text="{Binding LastPlayed, Converter={StaticResource NullableDateTime}}"
                                         TextAlignment="Right"
                                         TextWrapping="Wrap" />
                                     <TextBlock

--- a/src/Ryujinx.Ava/UI/Helpers/NullableDateTimeConverter.cs
+++ b/src/Ryujinx.Ava/UI/Helpers/NullableDateTimeConverter.cs
@@ -1,0 +1,35 @@
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+using Avalonia.Media.Imaging;
+using Ryujinx.Ava.Common.Locale;
+using System;
+using System.Globalization;
+using System.IO;
+
+namespace Ryujinx.Ava.UI.Helpers
+{
+    internal class NullableDateTimeConverter : IValueConverter
+    {
+        public static NullableDateTimeConverter Instance = new();
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null)
+            {
+                return LocaleManager.Instance[LocaleKeys.Never];
+            }
+
+            if (value is DateTime dateTime)
+            {
+                return dateTime.ToLocalTime().ToString(culture);
+            }
+
+            throw new NotSupportedException();
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/src/Ryujinx.Ava/UI/Helpers/NullableDateTimeConverter.cs
+++ b/src/Ryujinx.Ava/UI/Helpers/NullableDateTimeConverter.cs
@@ -1,16 +1,14 @@
 using Avalonia.Data.Converters;
-using Avalonia.Media;
-using Avalonia.Media.Imaging;
+using Avalonia.Markup.Xaml;
 using Ryujinx.Ava.Common.Locale;
 using System;
 using System.Globalization;
-using System.IO;
 
 namespace Ryujinx.Ava.UI.Helpers
 {
-    internal class NullableDateTimeConverter : IValueConverter
+    internal class NullableDateTimeConverter : MarkupExtension, IValueConverter
     {
-        public static NullableDateTimeConverter Instance = new();
+        private static readonly NullableDateTimeConverter _instance = new();
 
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
@@ -30,6 +28,11 @@ namespace Ryujinx.Ava.UI.Helpers
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
             throw new NotSupportedException();
+        }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return _instance;
         }
     }
 }

--- a/src/Ryujinx.Ava/UI/Models/Generic/LastPlayedSortComparer.cs
+++ b/src/Ryujinx.Ava/UI/Models/Generic/LastPlayedSortComparer.cs
@@ -1,4 +1,3 @@
-using Ryujinx.Ava.Common.Locale;
 using Ryujinx.Ui.App.Common;
 using System;
 using System.Collections.Generic;
@@ -14,20 +13,20 @@ namespace Ryujinx.Ava.UI.Models.Generic
 
         public int Compare(ApplicationData x, ApplicationData y)
         {
-            string aValue = x.LastPlayed;
-            string bValue = y.LastPlayed;
+            var aValue = x.LastPlayed;
+            var bValue = y.LastPlayed;
 
-            if (aValue == LocaleManager.Instance[LocaleKeys.Never])
+            if (!aValue.HasValue)
             {
-                aValue = DateTime.UnixEpoch.ToString();
+                aValue = DateTime.UnixEpoch;
             }
 
-            if (bValue == LocaleManager.Instance[LocaleKeys.Never])
+            if (!bValue.HasValue)
             {
-                bValue = DateTime.UnixEpoch.ToString();
+                bValue = DateTime.UnixEpoch;
             }
 
-            return (IsAscending ? 1 : -1) * DateTime.Compare(DateTime.Parse(bValue), DateTime.Parse(aValue));
+            return (IsAscending ? 1 : -1) * DateTime.Compare(bValue.Value, aValue.Value);
         }
     }
 }

--- a/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
@@ -1524,10 +1524,9 @@ namespace Ryujinx.Ava.UI.ViewModels
         {
             ApplicationLibrary.LoadAndSaveMetaData(titleId, appMetadata =>
             {
-                if (DateTime.TryParse(appMetadata.LastPlayed, out DateTime lastPlayedDateTime))
+                if (appMetadata.LastPlayed.HasValue)
                 {
-                    double sessionTimePlayed = DateTime.UtcNow.Subtract(lastPlayedDateTime).TotalSeconds;
-
+                    double sessionTimePlayed = DateTime.UtcNow.Subtract(appMetadata.LastPlayed.Value).TotalSeconds;
                     appMetadata.TimePlayed += Math.Round(sessionTimePlayed, MidpointRounding.AwayFromZero);
                 }
             });

--- a/src/Ryujinx.Ui.Common/App/ApplicationData.cs
+++ b/src/Ryujinx.Ui.Common/App/ApplicationData.cs
@@ -10,27 +10,44 @@ using LibHac.Tools.FsSystem.NcaUtils;
 using Ryujinx.Common.Logging;
 using Ryujinx.HLE.FileSystem;
 using System;
+using System.Globalization;
 using System.IO;
+using System.Text.Json.Serialization;
 
 namespace Ryujinx.Ui.App.Common
 {
     public class ApplicationData
     {
-        public bool   Favorite      { get; set; }
-        public byte[] Icon          { get; set; }
-        public string TitleName     { get; set; }
-        public string TitleId       { get; set; }
-        public string Developer     { get; set; }
-        public string Version       { get; set; }
-        public string TimePlayed    { get; set; }
-        public double TimePlayedNum { get; set; }
-        public string LastPlayed    { get; set; }
-        public string FileExtension { get; set; }
-        public string FileSize      { get; set; }
-        public double FileSizeBytes { get; set; }
-        public string Path          { get; set; }
+        public bool      Favorite      { get; set; }
+        public byte[]    Icon          { get; set; }
+        public string    TitleName     { get; set; }
+        public string    TitleId       { get; set; }
+        public string    Developer     { get; set; }
+        public string    Version       { get; set; }
+        public string    TimePlayed    { get; set; }
+        public double    TimePlayedNum { get; set; }
+        public DateTime? LastPlayed    { get; set; }
+        public string    FileExtension { get; set; }
+        public string    FileSize      { get; set; }
+        public double    FileSizeBytes { get; set; }
+        public string    Path          { get; set; }
         public BlitStruct<ApplicationControlProperty> ControlHolder { get; set; }
-        
+
+        [JsonIgnore]
+        public string LastPlayedString
+        {
+            get
+            {
+                if (!LastPlayed.HasValue)
+                {
+                    // TODO: maybe put localized string here instead of just "Never"
+                    return "Never";
+                }
+
+                return LastPlayed.Value.ToLocalTime().ToString(CultureInfo.CurrentCulture);
+            }
+        }
+
         public static string GetApplicationBuildId(VirtualFileSystem virtualFileSystem, string titleFilePath)
         {
             using FileStream file = new(titleFilePath, FileMode.Open, FileAccess.Read);

--- a/src/Ryujinx.Ui.Common/App/ApplicationLibrary.cs
+++ b/src/Ryujinx.Ui.Common/App/ApplicationLibrary.cs
@@ -417,22 +417,22 @@ namespace Ryujinx.Ui.App.Common
 
                         if (appMetadata.LastPlayedOld == default || appMetadata.LastPlayed.HasValue)
                         {
-                            // don't do the migration if last_played doesn't exist or last_played_utc already has a value
+                            // Don't do the migration if last_played doesn't exist or last_played_utc already has a value.
                             return;
                         }
 
-                        // migrate from string-based last_played to DateTime-based last_played_utc
+                        // Migrate from string-based last_played to DateTime-based last_played_utc.
                         if (DateTime.TryParse(appMetadata.LastPlayedOld, out DateTime lastPlayedOldParsed))
                         {
                             Logger.Info?.Print(LogClass.Application, $"last_played found: \"{appMetadata.LastPlayedOld}\", migrating to last_played_utc");
                             appMetadata.LastPlayed = lastPlayedOldParsed;
 
-                            // migration successful: deleting last_played from the metadata file
+                            // Migration successful: deleting last_played from the metadata file
                             appMetadata.LastPlayedOld = default;
                         }
                         else
                         {
-                            // migration failed: emitting warning but leaving the unparsable value in the metadata file so the user can fix it
+                            // Migration failed: emitting warning but leaving the unparsable value in the metadata file so the user can fix it.
                             Logger.Warning?.Print(LogClass.Application, $"Last played string \"{appMetadata.LastPlayedOld}\" is invalid for current system culture, skipping (did current culture change?)");
                         }
                     });

--- a/src/Ryujinx.Ui.Common/App/ApplicationLibrary.cs
+++ b/src/Ryujinx.Ui.Common/App/ApplicationLibrary.cs
@@ -416,20 +416,6 @@ namespace Ryujinx.Ui.App.Common
                         appMetadata.Title = titleName;
                     });
 
-                    if (appMetadata.LastPlayed != "Never")
-                    {
-                        if (!DateTime.TryParse(appMetadata.LastPlayed, out _))
-                        {
-                            Logger.Warning?.Print(LogClass.Application, $"Last played datetime \"{appMetadata.LastPlayed}\" is invalid for current system culture, skipping (did current culture change?)");
-
-                            appMetadata.LastPlayed = "Never";
-                        }
-                        else
-                        {
-                            appMetadata.LastPlayed = appMetadata.LastPlayed[..^3];
-                        }
-                    }
-
                     ApplicationData data = new()
                     {
                         Favorite = appMetadata.Favorite,

--- a/src/Ryujinx.Ui.Common/App/ApplicationLibrary.cs
+++ b/src/Ryujinx.Ui.Common/App/ApplicationLibrary.cs
@@ -414,6 +414,27 @@ namespace Ryujinx.Ui.App.Common
                     ApplicationMetadata appMetadata = LoadAndSaveMetaData(titleId, appMetadata =>
                     {
                         appMetadata.Title = titleName;
+
+                        if (appMetadata.LastPlayedOld == default || appMetadata.LastPlayed.HasValue)
+                        {
+                            // don't do the migration if last_played doesn't exist or last_played_utc already has a value
+                            return;
+                        }
+
+                        // migrate from string-based last_played to DateTime-based last_played_utc
+                        if (DateTime.TryParse(appMetadata.LastPlayedOld, out DateTime lastPlayedOldParsed))
+                        {
+                            Logger.Info?.Print(LogClass.Application, $"last_played found: \"{appMetadata.LastPlayedOld}\", migrating to last_played_utc");
+                            appMetadata.LastPlayed = lastPlayedOldParsed;
+
+                            // migration successful: deleting last_played from the metadata file
+                            appMetadata.LastPlayedOld = default;
+                        }
+                        else
+                        {
+                            // migration failed: emitting warning but leaving the unparsable value in the metadata file so the user can fix it
+                            Logger.Warning?.Print(LogClass.Application, $"Last played string \"{appMetadata.LastPlayedOld}\" is invalid for current system culture, skipping (did current culture change?)");
+                        }
                     });
 
                     ApplicationData data = new()

--- a/src/Ryujinx.Ui.Common/App/ApplicationLibrary.cs
+++ b/src/Ryujinx.Ui.Common/App/ApplicationLibrary.cs
@@ -427,7 +427,7 @@ namespace Ryujinx.Ui.App.Common
                             Logger.Info?.Print(LogClass.Application, $"last_played found: \"{appMetadata.LastPlayedOld}\", migrating to last_played_utc");
                             appMetadata.LastPlayed = lastPlayedOldParsed;
 
-                            // Migration successful: deleting last_played from the metadata file
+                            // Migration successful: deleting last_played from the metadata file.
                             appMetadata.LastPlayedOld = default;
                         }
                         else

--- a/src/Ryujinx.Ui.Common/App/ApplicationMetadata.cs
+++ b/src/Ryujinx.Ui.Common/App/ApplicationMetadata.cs
@@ -1,10 +1,14 @@
-﻿namespace Ryujinx.Ui.App.Common
+﻿using System;
+using System.Globalization;
+using System.Text.Json.Serialization;
+
+namespace Ryujinx.Ui.App.Common
 {
     public class ApplicationMetadata
     {
         public string Title { get; set; }
         public bool   Favorite   { get; set; }
         public double TimePlayed { get; set; }
-        public string LastPlayed { get; set; } = "Never";
+        public DateTime? LastPlayed { get; set; } = null;
     }
 }

--- a/src/Ryujinx.Ui.Common/App/ApplicationMetadata.cs
+++ b/src/Ryujinx.Ui.Common/App/ApplicationMetadata.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Globalization;
 using System.Text.Json.Serialization;
 
 namespace Ryujinx.Ui.App.Common
@@ -9,6 +8,12 @@ namespace Ryujinx.Ui.App.Common
         public string Title { get; set; }
         public bool   Favorite   { get; set; }
         public double TimePlayed { get; set; }
+
+        [JsonPropertyName("last_played_utc")]
         public DateTime? LastPlayed { get; set; } = null;
+
+        [JsonPropertyName("last_played")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+        public string LastPlayedOld { get; set; }
     }
 }

--- a/src/Ryujinx/Ui/MainWindow.cs
+++ b/src/Ryujinx/Ui/MainWindow.cs
@@ -876,7 +876,7 @@ namespace Ryujinx.Ui
 
                 _applicationLibrary.LoadAndSaveMetaData(_emulationContext.Processes.ActiveApplication.ProgramIdText, appMetadata =>
                 {
-                    appMetadata.LastPlayed = DateTime.UtcNow.ToString();
+                    appMetadata.LastPlayed = DateTime.UtcNow;
                 });
             }
         }
@@ -1019,10 +1019,11 @@ namespace Ryujinx.Ui
             {
                 _applicationLibrary.LoadAndSaveMetaData(titleId, appMetadata =>
                 {
-                    DateTime lastPlayedDateTime = DateTime.Parse(appMetadata.LastPlayed);
-                    double   sessionTimePlayed  = DateTime.UtcNow.Subtract(lastPlayedDateTime).TotalSeconds;
-
-                    appMetadata.TimePlayed += Math.Round(sessionTimePlayed, MidpointRounding.AwayFromZero);
+                    if (appMetadata.LastPlayed.HasValue)
+                    {
+                        double sessionTimePlayed = DateTime.UtcNow.Subtract(appMetadata.LastPlayed.Value).TotalSeconds;
+                        appMetadata.TimePlayed += Math.Round(sessionTimePlayed, MidpointRounding.AwayFromZero);
+                    }
                 });
             }
         }
@@ -1089,7 +1090,7 @@ namespace Ryujinx.Ui
                     args.AppData.Developer,
                     args.AppData.Version,
                     args.AppData.TimePlayed,
-                    args.AppData.LastPlayed,
+                    args.AppData.LastPlayedString,
                     args.AppData.FileExtension,
                     args.AppData.FileSize,
                     args.AppData.Path,


### PR DESCRIPTION
This should fix #2660 and make #2661 obsolete by changing the type of `ApplicationData`/`ApplicationMetadata`'s `LastPlayed` fields from string to nullable DateTime.

I fixed most the problems that cropped up after the change and added a value converter for Avalonia as well as a new readonly property `ApplicationData.LastPlayedString` for the GTK UI.

The one big problem that remains is that after the change, Ryujinx will consider old metadata.json files invalid and reset everything but the title back to default. I'm working on a solution that allows for a graceful migration but I wanted to submit the PR now to get feedback regarding the rest.