### PR TITLE
Fix the restart after an update.

### DIFF
--- a/src/Ryujinx.Ava/Modules/Updater/Updater.cs
+++ b/src/Ryujinx.Ava/Modules/Updater/Updater.cs
@@ -295,14 +295,7 @@ namespace Ryujinx.Modules
                 if (shouldRestart)
                 {
                     List<string> arguments = CommandLineState.Arguments.ToList();
-                    string ryuName = Path.GetFileName(Environment.ProcessPath);
                     string executableDirectory = AppDomain.CurrentDomain.BaseDirectory;
-                    string executablePath = Path.Combine(executableDirectory, ryuName);
-
-                    if (!Path.Exists(executablePath))
-                    {
-                        executablePath = Path.Combine(executableDirectory, OperatingSystem.IsWindows() ? "Ryujinx.exe" : "Ryujinx");
-                    }
 
                     // On macOS we perform the update at relaunch.
                     if (OperatingSystem.IsMacOS())
@@ -310,14 +303,20 @@ namespace Ryujinx.Modules
                         string baseBundlePath = Path.GetFullPath(Path.Combine(executableDirectory, "..", ".."));
                         string newBundlePath = Path.Combine(UpdateDir, "Ryujinx.app");
                         string updaterScriptPath = Path.Combine(newBundlePath, "Contents", "Resources", "updater.sh");
-                        string currentPid = Process.GetCurrentProcess().Id.ToString();
+                        string currentPid = Environment.ProcessId.ToString();
 
-                        executablePath = "/bin/bash";
                         arguments.InsertRange(0, new List<string> { updaterScriptPath, baseBundlePath, newBundlePath, currentPid });
-                        Process.Start(executablePath, arguments);
+                        Process.Start("/bin/bash", arguments);
                     }
                     else
                     {
+                        // Find the process name.
+                        string ryuName = Path.GetFileName(Environment.ProcessPath);
+                        if (!Path.Exists(Path.Combine(executableDirectory, ryuName)))
+                        {
+                            ryuName = OperatingSystem.IsWindows() ? "Ryujinx.exe" : "Ryujinx";
+                        }
+
                         ProcessStartInfo processStart = new(ryuName, string.Join(' ', arguments))
                         {
                             UseShellExecute = true,
@@ -327,7 +326,6 @@ namespace Ryujinx.Modules
                         Process.Start(processStart);
                     }
 
-                    Process.Start(executablePath, arguments);
                     Environment.Exit(0);
                 }
             }

--- a/src/Ryujinx.Ava/Modules/Updater/Updater.cs
+++ b/src/Ryujinx.Ava/Modules/Updater/Updater.cs
@@ -314,6 +314,17 @@ namespace Ryujinx.Modules
 
                         executablePath = "/bin/bash";
                         arguments.InsertRange(0, new List<string> { updaterScriptPath, baseBundlePath, newBundlePath, currentPid });
+                        Process.Start(executablePath, arguments);
+                    }
+                    else
+                    {
+                        ProcessStartInfo processStart = new(ryuName, string.Join(' ', arguments))
+                        {
+                            UseShellExecute = true,
+                            WorkingDirectory = executableDirectory
+                        };
+
+                        Process.Start(processStart);
                     }
 
                     Process.Start(executablePath, arguments);

--- a/src/Ryujinx.Ava/Modules/Updater/Updater.cs
+++ b/src/Ryujinx.Ava/Modules/Updater/Updater.cs
@@ -312,9 +312,17 @@ namespace Ryujinx.Modules
                     {
                         // Find the process name.
                         string ryuName = Path.GetFileName(Environment.ProcessPath);
+
+                        // Some operating systems can see the renamed executable, so strip off the .ryuold if found.
+                        if (ryuName.EndsWith(".ryuold"))
+                        {
+                            ryuName = ryuName[..^7];
+                        }
+
+                        // Fallback if the executable could not be found.
                         if (!Path.Exists(Path.Combine(executableDirectory, ryuName)))
                         {
-                            ryuName = OperatingSystem.IsWindows() ? "Ryujinx.exe" : "Ryujinx";
+                            ryuName = OperatingSystem.IsWindows() ? "Ryujinx.Ava.exe" : "Ryujinx.Ava";
                         }
 
                         ProcessStartInfo processStart = new(ryuName, string.Join(' ', arguments))

--- a/src/Ryujinx.Ava/Modules/Updater/Updater.cs
+++ b/src/Ryujinx.Ava/Modules/Updater/Updater.cs
@@ -325,11 +325,16 @@ namespace Ryujinx.Modules
                             ryuName = OperatingSystem.IsWindows() ? "Ryujinx.Ava.exe" : "Ryujinx.Ava";
                         }
 
-                        ProcessStartInfo processStart = new(ryuName, string.Join(' ', arguments))
+                        ProcessStartInfo processStart = new(ryuName)
                         {
                             UseShellExecute = true,
                             WorkingDirectory = executableDirectory
                         };
+
+                        foreach (string argument in CommandLineState.Arguments)
+                        {
+                            processStart.ArgumentList.Add(argument);
+                        }
 
                         Process.Start(processStart);
                     }

--- a/src/Ryujinx/Modules/Updater/UpdateDialog.cs
+++ b/src/Ryujinx/Modules/Updater/UpdateDialog.cs
@@ -49,11 +49,16 @@ namespace Ryujinx.Modules
             {
                 string ryuName = OperatingSystem.IsWindows() ? "Ryujinx.exe" : "Ryujinx";
 
-                ProcessStartInfo processStart = new(ryuName, string.Join(' ', CommandLineState.Arguments))
+                ProcessStartInfo processStart = new(ryuName)
                 {
                     UseShellExecute = true,
                     WorkingDirectory = ReleaseInformation.GetBaseApplicationDirectory()
                 };
+
+                foreach (string argument in CommandLineState.Arguments)
+                {
+                    processStart.ArgumentList.Add(argument);
+                }
 
                 Process.Start(processStart);
 

--- a/src/Ryujinx/Modules/Updater/UpdateDialog.cs
+++ b/src/Ryujinx/Modules/Updater/UpdateDialog.cs
@@ -1,5 +1,6 @@
 using Gdk;
 using Gtk;
+using Ryujinx.Common;
 using Ryujinx.Ui;
 using Ryujinx.Ui.Common.Configuration;
 using Ryujinx.Ui.Common.Helper;
@@ -47,9 +48,14 @@ namespace Ryujinx.Modules
             if (_restartQuery)
             {
                 string ryuName = OperatingSystem.IsWindows() ? "Ryujinx.exe" : "Ryujinx";
-                string ryuExe  = System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ryuName);
 
-                Process.Start(ryuExe, CommandLineState.Arguments);
+                ProcessStartInfo processStart = new(ryuName, string.Join(' ', CommandLineState.Arguments))
+                {
+                    UseShellExecute = true,
+                    WorkingDirectory = ReleaseInformation.GetBaseApplicationDirectory()
+                };
+
+                Process.Start(processStart);
 
                 Environment.Exit(0);
             }


### PR DESCRIPTION
After running the updater for Ryujinx and clicking Yes to restart, I am greeted with an error message:

> The application was unable to start correctly (0xc0000142).
> Click OK to close the application.

I then have to manually start Ryujinx to finish the update.  This PR changes the way that Ryujinx is launched after an update to fix this error.