### PR TITLE
Fix missing domain service object dispose

### DIFF
--- a/src/Ryujinx.Horizon/Sdk/Sf/Cmif/ServerDomainManager.cs
+++ b/src/Ryujinx.Horizon/Sdk/Sf/Cmif/ServerDomainManager.cs
@@ -165,6 +165,12 @@ namespace Ryujinx.Horizon.Sdk.Sf.Cmif
 
                     entry.Owner = null;
                     obj = entry.Obj;
+
+                    if (obj.ServiceObject is IDisposable disposableObj)
+                    {
+                        disposableObj.Dispose();
+                    }
+
                     entry.Obj = null;
                     _entries.Remove(entry.Node);
                     entry.Node = null;


### PR DESCRIPTION
Fixes a regression caused by #4803 that caused Animal Crossing New Horizons to hang when loading a save, because one of the BCAT service objects was not being disposed, and so future access would return `TargetLocked` errors forever.

Fixes #4877.