### PR TITLE
Vulkan: Partially workaround MoltenVK InvalidResource error

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/PipelineLayoutFactory.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineLayoutFactory.cs
@@ -12,6 +12,28 @@ namespace Ryujinx.Graphics.Vulkan
             ShaderStageFlags.FragmentBit |
             ShaderStageFlags.ComputeBit;
 
+        private static ShaderStageFlags ActiveStages(uint stages, bool supportsGeometryShader)
+        {
+            ShaderStageFlags stageFlags = 0;
+
+            while (stages != 0)
+            {
+                int stage = BitOperations.TrailingZeroCount(stages);
+                stages &= ~(1u << stage);
+
+                stageFlags |= stage switch
+                {
+                    1 => ShaderStageFlags.FragmentBit,
+                    2 => supportsGeometryShader ? ShaderStageFlags.GeometryBit : ShaderStageFlags.VertexBit,
+                    3 => ShaderStageFlags.TessellationControlBit,
+                    4 => ShaderStageFlags.TessellationEvaluationBit,
+                    _ => ShaderStageFlags.VertexBit | ShaderStageFlags.ComputeBit
+                };
+            }
+
+            return stageFlags;
+        }
+
         public static unsafe DescriptorSetLayout[] Create(VulkanRenderer gd, Device device, uint stages, bool usePd, out PipelineLayout layout)
         {
             int stagesCount = BitOperations.PopCount(stages);
@@ -34,6 +56,7 @@ namespace Ryujinx.Graphics.Vulkan
             };
 
             int iter = 0;
+            var activeStages = ActiveStages(stages, gd.Capabilities.SupportsGeometryShader);
 
             while (stages != 0)
             {
@@ -67,6 +90,10 @@ namespace Ryujinx.Graphics.Vulkan
 
                 void SetStorage(DescriptorSetLayoutBinding* bindings, int maxPerStage, int start = 0)
                 {
+                    // There's a bug on MoltenVK where using the same buffer across different stages
+                    // causes invalid resource errors, allow the binding on all active stages as workaround.
+                    var flags = gd.IsMoltenVk ? activeStages : stageFlags;
+
                     bindings[start + iter] = new DescriptorSetLayoutBinding
                     {
                         Binding = (uint)(start + stage * maxPerStage),

--- a/src/Ryujinx.Graphics.Vulkan/PipelineLayoutFactory.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineLayoutFactory.cs
@@ -99,7 +99,7 @@ namespace Ryujinx.Graphics.Vulkan
                         Binding = (uint)(start + stage * maxPerStage),
                         DescriptorType = DescriptorType.StorageBuffer,
                         DescriptorCount = (uint)maxPerStage,
-                        StageFlags = stageFlags
+                        StageFlags = flags
                     };
                 }
 

--- a/src/Ryujinx.Graphics.Vulkan/PipelineLayoutFactory.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineLayoutFactory.cs
@@ -12,7 +12,7 @@ namespace Ryujinx.Graphics.Vulkan
             ShaderStageFlags.FragmentBit |
             ShaderStageFlags.ComputeBit;
 
-        private static ShaderStageFlags ActiveStages(uint stages, bool supportsGeometryShader)
+        private static ShaderStageFlags ActiveStages(uint stages)
         {
             ShaderStageFlags stageFlags = 0;
 
@@ -56,7 +56,7 @@ namespace Ryujinx.Graphics.Vulkan
             };
 
             int iter = 0;
-            var activeStages = ActiveStages(stages, gd.Capabilities.SupportsGeometryShader);
+            var activeStages = ActiveStages(stages);
 
             while (stages != 0)
             {

--- a/src/Ryujinx.Graphics.Vulkan/PipelineLayoutFactory.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineLayoutFactory.cs
@@ -24,7 +24,7 @@ namespace Ryujinx.Graphics.Vulkan
                 stageFlags |= stage switch
                 {
                     1 => ShaderStageFlags.FragmentBit,
-                    2 => supportsGeometryShader ? ShaderStageFlags.GeometryBit : ShaderStageFlags.VertexBit,
+                    2 => ShaderStageFlags.GeometryBit,
                     3 => ShaderStageFlags.TessellationControlBit,
                     4 => ShaderStageFlags.TessellationEvaluationBit,
                     _ => ShaderStageFlags.VertexBit | ShaderStageFlags.ComputeBit


### PR DESCRIPTION
There's a bug with MoltenVK where binding a storage buffer more than once with different stage flags causes resource usage to register incorrectly, which causes the command buffer to fail. There's more information here: https://github.com/KhronosGroup/MoltenVK/issues/1870

This PR partially works around this issue by setting the storage buffer usage flags to all active stages when running under MVK. This means that it will always register the buffer with all possible stages it can be used on.

This can still break if there are non-rasterizing draws, which generally happens with TFB games. Working around that is a lot more involved, and it's probably not worth it when we don't have TFB emulation anyways.

This should be removed when the issue is fixed in MoltenVK.