### PR TITLE
amadeus: Fix wrong channel mapping check and an old typo

### DIFF
--- a/src/Ryujinx.Audio/Renderer/Dsp/Command/DelayCommand.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/Command/DelayCommand.cs
@@ -49,8 +49,8 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
                 OutputBufferIndices[i] = (ushort)(bufferOffset + Parameter.Output[i]);
             }
 
-            DataSourceHelper.RemapLegacyChannelEffectMappingToChannelResourceMapping(newEffectChannelMappingSupported, InputBufferIndices);
-            DataSourceHelper.RemapLegacyChannelEffectMappingToChannelResourceMapping(newEffectChannelMappingSupported, OutputBufferIndices);
+            DataSourceHelper.RemapLegacyChannelEffectMappingToChannelResourceMapping(newEffectChannelMappingSupported, InputBufferIndices, Parameter.ChannelCount);
+            DataSourceHelper.RemapLegacyChannelEffectMappingToChannelResourceMapping(newEffectChannelMappingSupported, OutputBufferIndices, Parameter.ChannelCount);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]

--- a/src/Ryujinx.Audio/Renderer/Dsp/Command/Reverb3dCommand.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/Command/Reverb3dCommand.cs
@@ -116,7 +116,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
                 for (int i = 0; i < targetEarlyDelayLineIndicesTable.Length; i++)
                 {
                     int earlyDelayIndex = targetEarlyDelayLineIndicesTable[i];
-                    int outputIndex = outputEarlyIndicesTable[i];
+                    int outputIndex = outputEarlyIndicesTable[earlyDelayIndex];
 
                     float tempTapOut = state.PreDelayLine.TapUnsafe(state.EarlyDelayTime[earlyDelayIndex], delayLineSampleIndexOffset);
 

--- a/src/Ryujinx.Audio/Renderer/Dsp/Command/Reverb3dCommand.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/Command/Reverb3dCommand.cs
@@ -66,8 +66,8 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
             // NOTE: We do the opposite as Nintendo here for now to restore previous behaviour
             // TODO: Update reverb 3d processing and remove this to use RemapLegacyChannelEffectMappingToChannelResourceMapping.
-            DataSourceHelper.RemapChannelResourceMappingToLegacy(newEffectChannelMappingSupported, InputBufferIndices);
-            DataSourceHelper.RemapChannelResourceMappingToLegacy(newEffectChannelMappingSupported, OutputBufferIndices);
+            DataSourceHelper.RemapChannelResourceMappingToLegacy(newEffectChannelMappingSupported, InputBufferIndices, Parameter.ChannelCount);
+            DataSourceHelper.RemapChannelResourceMappingToLegacy(newEffectChannelMappingSupported, OutputBufferIndices, Parameter.ChannelCount);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Ryujinx.Audio/Renderer/Dsp/Command/ReverbCommand.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/Command/ReverbCommand.cs
@@ -71,8 +71,8 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
             // NOTE: We do the opposite as Nintendo here for now to restore previous behaviour
             // TODO: Update reverb processing and remove this to use RemapLegacyChannelEffectMappingToChannelResourceMapping.
-            DataSourceHelper.RemapChannelResourceMappingToLegacy(newEffectChannelMappingSupported, InputBufferIndices);
-            DataSourceHelper.RemapChannelResourceMappingToLegacy(newEffectChannelMappingSupported, OutputBufferIndices);
+            DataSourceHelper.RemapChannelResourceMappingToLegacy(newEffectChannelMappingSupported, InputBufferIndices, Parameter.ChannelCount);
+            DataSourceHelper.RemapChannelResourceMappingToLegacy(newEffectChannelMappingSupported, OutputBufferIndices, Parameter.ChannelCount);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Ryujinx.Audio/Renderer/Dsp/DataSourceHelper.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/DataSourceHelper.cs
@@ -430,9 +430,9 @@ namespace Ryujinx.Audio.Renderer.Dsp
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void RemapLegacyChannelEffectMappingToChannelResourceMapping(bool isSupported, Span<ushort> bufferIndices)
+        public static void RemapLegacyChannelEffectMappingToChannelResourceMapping(bool isSupported, Span<ushort> bufferIndices, uint channelCount)
         {
-            if (!isSupported && bufferIndices.Length == 6)
+            if (!isSupported && channelCount == 6)
             {
                 ushort backLeft = bufferIndices[2];
                 ushort backRight = bufferIndices[3];
@@ -447,9 +447,9 @@ namespace Ryujinx.Audio.Renderer.Dsp
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void RemapChannelResourceMappingToLegacy(bool isSupported, Span<ushort> bufferIndices)
+        public static void RemapChannelResourceMappingToLegacy(bool isSupported, Span<ushort> bufferIndices, uint channelCount)
         {
-            if (isSupported && bufferIndices.Length == 6)
+            if (isSupported && channelCount == 6)
             {
                 ushort frontCenter = bufferIndices[2];
                 ushort lowFrequency = bufferIndices[3];


### PR DESCRIPTION
This was always going to happens, as a result quadratic would break and move index after the channel count point, effectively breaking input/output indices.

Fixes TOTK audio but also possible newer game using quadratic.

I also fixed an index issue on reverb 3d early delay.

PS: As a reminder, if this change is reused anywhere else, work should be credited as Ryujinx and not my person.