### PR TITLE
Fix incorrect ASTC endpoint color when using LuminanceDelta mode

### DIFF
--- a/src/Ryujinx.Graphics.Texture/Astc/AstcDecoder.cs
+++ b/src/Ryujinx.Graphics.Texture/Astc/AstcDecoder.cs
@@ -956,7 +956,7 @@ namespace Ryujinx.Graphics.Texture.Astc
                 {
                     Span<uint> val = ReadUintColorValues(2, colorValues, ref colorValuesPosition);
                     int l0 = (int)((val[0] >> 2) | (val[1] & 0xC0));
-                    int l1 = (int)Math.Max(l0 + (val[1] & 0x3F), 0xFFU);
+                    int l1 = (int)Math.Min(l0 + (val[1] & 0x3F), 0xFFU);
 
                     endPoints[0] = new AstcPixel(0xFF, (short)l0, (short)l0, (short)l0);
                     endPoints[1] = new AstcPixel(0xFF, (short)l1, (short)l1, (short)l1);


### PR DESCRIPTION
This fixes a bug on the ASTC decoder that caused some ASTC texture to be corrupt and have white pixels where they shouldn't. Only affects GPUs that don't support ASTC natively (which is pretty much everything other than Apple Silicon and old Intel integrated GPUs).

Reference form the official decoder: https://github.com/ARM-software/astc-encoder/blob/0a3269f9de2b457dbeb7c5c6265e96c45b64647c/Source/astcenc_color_unquantize.cpp#L229

This fixes some texture corruption in The Legend of Zelda: Tears of the Kingdom.
Before:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/01fad175-7223-4c32-84e1-2cdd02444e5e)
After:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/7b0684e9-4868-490f-95d3-9c9315605d3e)
