### PR TITLE
Enable explicit LOD for array textures with depth compare on SPIR-V

### DIFF
--- a/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/Instructions.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/Instructions.cs
@@ -1442,14 +1442,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
                 return GetZeroOperationResult(context, texOp, AggregateType.FP32, colorIsVector);
             }
 
-            // This combination is valid, but not available on GLSL.
-            // For now, ignore the LOD level and do a normal sample.
-            // TODO: How to implement it properly?
-            if (hasLodLevel && isArray && isShadow)
-            {
-                hasLodLevel = false;
-            }
-
             int srcIndex = isBindless ? 1 : 0;
 
             SpvInstruction Src(AggregateType type)


### PR DESCRIPTION
This removes what I believe to be a leftover from the GLSL backend (before it started using the shadow LOD extension). It was forcing explicit LOD to be removed when using depth-comparison with array textures, since that is not supported on unextended GLSL. AFAIK that limitation does not exist on SPIR-V.

This fixes some glitches on The Legend of Zelda: Tears of the Kingdom when using the Vulkan backend (as it's the only backend that uses SPIR-V shaders right now).
Before:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/a1901206-1472-4bd9-85d1-e24cf51b1410)
After:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/b62c8c23-55f3-415e-9e9f-dd18505d5ed3)
I recommend testing on AMD and making sure it doesn't break.