### PR TITLE
amadeus: Allow 5.1 sink output

### DIFF
--- a/src/Ryujinx.Audio/Renderer/Dsp/AudioProcessor.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/AudioProcessor.cs
@@ -65,7 +65,6 @@ namespace Ryujinx.Audio.Renderer.Dsp
         {
             OutputDevices = new IHardwareDevice[Constants.AudioRendererSessionCountMax];
 
-            // TODO: Before enabling this, we need up-mixing from stereo to 5.1.
             uint channelCount = GetHardwareChannelCount(deviceDriver);
 
             for (int i = 0; i < OutputDevices.Length; i++)

--- a/src/Ryujinx.Audio/Renderer/Dsp/AudioProcessor.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/AudioProcessor.cs
@@ -66,8 +66,7 @@ namespace Ryujinx.Audio.Renderer.Dsp
             OutputDevices = new IHardwareDevice[Constants.AudioRendererSessionCountMax];
 
             // TODO: Before enabling this, we need up-mixing from stereo to 5.1.
-            // uint channelCount = GetHardwareChannelCount(deviceDriver);
-            uint channelCount = 2;
+            uint channelCount = GetHardwareChannelCount(deviceDriver);
 
             for (int i = 0; i < OutputDevices.Length; i++)
             {

--- a/src/Ryujinx.Audio/Renderer/Dsp/Command/DeviceSinkCommand.cs
+++ b/src/Ryujinx.Audio/Renderer/Dsp/Command/DeviceSinkCommand.cs
@@ -67,7 +67,19 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
 
                 const int sampleCount = Constants.TargetSampleCount;
 
-                short[] outputBuffer = new short[bufferCount * sampleCount];
+                uint inputCount;
+
+                // In case of upmixing to 5.1, we allocate the right amount.
+                if (bufferCount != channelCount && channelCount == 6)
+                {
+                    inputCount = (uint)channelCount;
+                }
+                else
+                {
+                    inputCount = bufferCount;
+                }
+
+                short[] outputBuffer = new short[inputCount * sampleCount];
 
                 for (int i = 0; i < bufferCount; i++)
                 {
@@ -79,7 +91,7 @@ namespace Ryujinx.Audio.Renderer.Dsp.Command
                     }
                 }
 
-                device.AppendBuffer(outputBuffer, InputCount);
+                device.AppendBuffer(outputBuffer, inputCount);
             }
             else
             {


### PR DESCRIPTION
Also add a simple Stereo to 5.1 change for device sink.

Tested against NES - Nintendo Switch Online that output stereo on the audio renderer.

Close https://github.com/Ryujinx/Ryujinx/issues/4422.