### PR TITLE
GPU: Remove swizzle undefined matching and rework depth aliasing

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/src/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -98,6 +98,8 @@ namespace Ryujinx.Graphics.Gpu
         private Thread _gpuThread;
         private bool _pendingSync;
 
+        private long _modifiedSequence;
+
         /// <summary>
         /// Creates a new instance of the GPU emulation context.
         /// </summary>
@@ -198,6 +200,15 @@ namespace Ryujinx.Graphics.Gpu
             ulong errorBias = (nanoseconds - rounded) * NsToTicksFractionNumerator / NsToTicksFractionDenominator;
 
             return divided * NsToTicksFractionNumerator + errorBias;
+        }
+
+        /// <summary>
+        /// Gets a sequence number for resource modification ordering. This increments on each call.
+        /// </summary>
+        /// <returns>A sequence number for resource modification ordering</returns>
+        public long GetModifiedSequence()
+        {
+            return _modifiedSequence++;
         }
 
         /// <summary>

--- a/src/Ryujinx.Graphics.Gpu/Image/Texture.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/Texture.cs
@@ -1170,6 +1170,7 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="caps">Host GPU capabilities</param>
         /// <param name="firstLayer">Texture view initial layer on this texture</param>
         /// <param name="firstLevel">Texture view first mipmap level on this texture</param>
+        /// <param name="flags">Texture search flags</param>
         /// <returns>The level of compatiblilty a view with the given parameters created from this texture has</returns>
         public TextureViewCompatibility IsViewCompatible(
             TextureInfo info,
@@ -1178,11 +1179,12 @@ namespace Ryujinx.Graphics.Gpu.Image
             int layerSize,
             Capabilities caps,
             out int firstLayer,
-            out int firstLevel)
+            out int firstLevel,
+            TextureSearchFlags flags = TextureSearchFlags.None)
         {
             TextureViewCompatibility result = TextureViewCompatibility.Full;
 
-            result = TextureCompatibility.PropagateViewCompatibility(result, TextureCompatibility.ViewFormatCompatible(Info, info, caps));
+            result = TextureCompatibility.PropagateViewCompatibility(result, TextureCompatibility.ViewFormatCompatible(Info, info, caps, flags));
             if (result != TextureViewCompatibility.Incompatible)
             {
                 result = TextureCompatibility.PropagateViewCompatibility(result, TextureCompatibility.ViewTargetCompatible(Info, info, ref caps));

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -716,7 +716,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 else if (aliased)
                 {
                     // The format must be changed to match the parent.
-                    info = info.InheritFormat(overlap);
+                    info = info.CreateInfoWithFormat(overlap.Info.FormatInfo);
                 }
 
                 texture = overlap.CreateView(info, sizeInfo, range.Value, oInfo.FirstLayer, oInfo.FirstLevel);

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -678,7 +678,9 @@ namespace Ryujinx.Graphics.Gpu.Image
                 {
                     if (overlap.IsView)
                     {
-                        overlapCompatibility = TextureViewCompatibility.CopyOnly;
+                        overlapCompatibility = overlapCompatibility == TextureViewCompatibility.FormatAlias ?
+                            TextureViewCompatibility.Incompatible :
+                            TextureViewCompatibility.CopyOnly;
                     }
                     else
                     {
@@ -756,7 +758,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                     Texture overlap = _textureOverlaps[index];
                     OverlapInfo oInfo = _overlapInfo[index];
 
-                    if (oInfo.Compatibility <= TextureViewCompatibility.LayoutIncompatible)
+                    if (oInfo.Compatibility <= TextureViewCompatibility.LayoutIncompatible || oInfo.Compatibility == TextureViewCompatibility.FormatAlias)
                     {
                         if (!overlap.IsView && texture.DataOverlaps(overlap, oInfo.Compatibility))
                         {

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureCache.cs
@@ -569,7 +569,7 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             Texture texture = null;
 
-            TextureMatchQuality bestQuality = TextureMatchQuality.NoMatch;
+            long bestSequence = 0;
 
             for (int index = 0; index < sameAddressOverlapsCount; index++)
             {
@@ -601,17 +601,12 @@ namespace Ryujinx.Graphics.Gpu.Image
                             continue;
                         }
                     }
-                }
 
-                if (matchQuality == TextureMatchQuality.Perfect)
-                {
-                    texture = overlap;
-                    break;
-                }
-                else if (matchQuality > bestQuality)
-                {
-                    texture = overlap;
-                    bestQuality = matchQuality;
+                    if (texture == null || overlap.Group.ModifiedSequence - bestSequence > 0)
+                    {
+                        texture = overlap;
+                        bestSequence = overlap.Group.ModifiedSequence;
+                    }
                 }
             }
 
@@ -664,6 +659,7 @@ namespace Ryujinx.Graphics.Gpu.Image
             int fullyCompatible = 0;
 
             // Evaluate compatibility of overlaps, add temporary references
+            int preferredOverlap = -1;
 
             for (int index = 0; index < overlapsCount; index++)
             {
@@ -675,9 +671,10 @@ namespace Ryujinx.Graphics.Gpu.Image
                     sizeInfo.LayerSize,
                     _context.Capabilities,
                     out int firstLayer,
-                    out int firstLevel);
+                    out int firstLevel,
+                    flags);
 
-                if (overlapCompatibility == TextureViewCompatibility.Full)
+                if (overlapCompatibility >= TextureViewCompatibility.FormatAlias)
                 {
                     if (overlap.IsView)
                     {
@@ -686,6 +683,12 @@ namespace Ryujinx.Graphics.Gpu.Image
                     else
                     {
                         fullyCompatible++;
+
+                        if (preferredOverlap == -1 || overlap.Group.ModifiedSequence - bestSequence > 0)
+                        {
+                            preferredOverlap = index;
+                            bestSequence = overlap.Group.ModifiedSequence;
+                        }
                     }
                 }
 
@@ -695,37 +698,50 @@ namespace Ryujinx.Graphics.Gpu.Image
 
             // Search through the overlaps to find a compatible view and establish any copy dependencies.
 
-            for (int index = 0; index < overlapsCount; index++)
+            if (preferredOverlap != -1)
             {
-                Texture overlap = _textureOverlaps[index];
-                OverlapInfo oInfo = _overlapInfo[index];
+                Texture overlap = _textureOverlaps[preferredOverlap];
+                OverlapInfo oInfo = _overlapInfo[preferredOverlap];
 
-                if (oInfo.Compatibility == TextureViewCompatibility.Full)
+                bool aliased = oInfo.Compatibility == TextureViewCompatibility.FormatAlias;
+
+                if (!isSamplerTexture)
                 {
-                    if (!isSamplerTexture)
-                    {
-                        // If this is not a sampler texture, the size might be different from the requested size,
-                        // so we need to make sure the texture information has the correct size for this base texture,
-                        // before creating the view.
-                        info = info.CreateInfoForLevelView(overlap, oInfo.FirstLevel);
-                    }
+                    // If this is not a sampler texture, the size might be different from the requested size,
+                    // so we need to make sure the texture information has the correct size for this base texture,
+                    // before creating the view.
 
-                    texture = overlap.CreateView(info, sizeInfo, range.Value, oInfo.FirstLayer, oInfo.FirstLevel);
-                    texture.SynchronizeMemory();
-                    break;
+                    info = info.CreateInfoForLevelView(overlap, oInfo.FirstLevel, aliased);
                 }
-                else if (oInfo.Compatibility == TextureViewCompatibility.CopyOnly && fullyCompatible == 0)
+                else if (aliased)
                 {
-                    // Only copy compatible. If there's another choice for a FULLY compatible texture, choose that instead.
+                    // The format must be changed to match the parent.
+                    info = info.InheritFormat(overlap);
+                }
 
-                    texture = new Texture(_context, _physicalMemory, info, sizeInfo, range.Value, scaleMode);
+                texture = overlap.CreateView(info, sizeInfo, range.Value, oInfo.FirstLayer, oInfo.FirstLevel);
+                texture.SynchronizeMemory();
+            }
+            else
+            {
+                for (int index = 0; index < overlapsCount; index++)
+                {
+                    Texture overlap = _textureOverlaps[index];
+                    OverlapInfo oInfo = _overlapInfo[index];
 
-                    texture.InitializeGroup(true, true, new List<TextureIncompatibleOverlap>());
-                    texture.InitializeData(false, false);
+                    if (oInfo.Compatibility == TextureViewCompatibility.CopyOnly && fullyCompatible == 0)
+                    {
+                        // Only copy compatible. If there's another choice for a FULLY compatible texture, choose that instead.
 
-                    overlap.SynchronizeMemory();
-                    overlap.CreateCopyDependency(texture, oInfo.FirstLayer, oInfo.FirstLevel, true);
-                    break;
+                        texture = new Texture(_context, _physicalMemory, info, sizeInfo, range.Value, scaleMode);
+
+                        texture.InitializeGroup(true, true, new List<TextureIncompatibleOverlap>());
+                        texture.InitializeData(false, false);
+
+                        overlap.SynchronizeMemory();
+                        overlap.CreateCopyDependency(texture, oInfo.FirstLayer, oInfo.FirstLevel, true);
+                        break;
+                    }
                 }
             }
 

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -68,6 +68,11 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         public bool HasIncompatibleOverlaps => _incompatibleOverlaps.Count > 0;
 
+        /// <summary>
+        /// Number indicating the order this texture group was modified relative to others.
+        /// </summary>
+        public long ModifiedSequence { get; private set; }
+
         private readonly GpuContext _context;
         private readonly PhysicalMemory _physicalMemory;
 
@@ -664,6 +669,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="texture">The texture that has been modified</param>
         public void SignalModified(Texture texture)
         {
+            ModifiedSequence = _context.GetModifiedSequence();
+
             ClearIncompatibleOverlaps(texture);
 
             EvaluateRelevantHandles(texture, (baseHandle, regionCount, split) =>
@@ -684,6 +691,8 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// <param name="bound">True if this texture is being bound, false if unbound</param>
         public void SignalModifying(Texture texture, bool bound)
         {
+            ModifiedSequence = _context.GetModifiedSequence();
+
             ClearIncompatibleOverlaps(texture);
 
             EvaluateRelevantHandles(texture, (baseHandle, regionCount, split) =>

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureInfo.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureInfo.cs
@@ -300,8 +300,9 @@ namespace Ryujinx.Graphics.Gpu.Image
         /// </summary>
         /// <param name="parent">The parent texture</param>
         /// <param name="firstLevel">The first level of the texture view</param>
+        /// <param name="parentFormat">True if the parent format should be inherited</param>
         /// <returns>The adjusted texture information with the new size</returns>
-        public TextureInfo CreateInfoForLevelView(Texture parent, int firstLevel)
+        public TextureInfo CreateInfoForLevelView(Texture parent, int firstLevel, bool parentFormat)
         {
             // When the texture is used as view of another texture, we must
             // ensure that the sizes are valid, otherwise data uploads would fail
@@ -371,6 +372,35 @@ namespace Ryujinx.Graphics.Gpu.Image
                 GobBlocksInTileX,
                 target,
                 FormatInfo,
+                DepthStencilMode,
+                SwizzleR,
+                SwizzleG,
+                SwizzleB,
+                SwizzleA);
+        }
+
+        /// <summary>
+        /// Inherit the format from a parent texture.
+        /// </summary>
+        /// <param name="parent">Texture to inherit format from</param>
+        /// <returns>New info with the inherited format</returns>
+        public TextureInfo InheritFormat(Texture parent)
+        {
+            return new TextureInfo(
+                GpuAddress,
+                Width,
+                Height,
+                DepthOrLayers,
+                Levels,
+                SamplesInX,
+                SamplesInY,
+                Stride,
+                IsLinear,
+                GobBlocksInY,
+                GobBlocksInZ,
+                GobBlocksInTileX,
+                Target,
+                parent.Info.FormatInfo,
                 DepthStencilMode,
                 SwizzleR,
                 SwizzleG,

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureInfo.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureInfo.cs
@@ -371,7 +371,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 GobBlocksInZ,
                 GobBlocksInTileX,
                 target,
-                FormatInfo,
+                parentFormat ? parent.Info.FormatInfo : FormatInfo,
                 DepthStencilMode,
                 SwizzleR,
                 SwizzleG,
@@ -380,11 +380,11 @@ namespace Ryujinx.Graphics.Gpu.Image
         }
 
         /// <summary>
-        /// Inherit the format from a parent texture.
+        /// Creates texture information for a given format and this information.
         /// </summary>
-        /// <param name="parent">Texture to inherit format from</param>
-        /// <returns>New info with the inherited format</returns>
-        public TextureInfo InheritFormat(Texture parent)
+        /// <param name="formatInfo">Format for the new texture info</param>
+        /// <returns>New info with the specified format</returns>
+        public TextureInfo CreateInfoWithFormat(FormatInfo formatInfo)
         {
             return new TextureInfo(
                 GpuAddress,
@@ -400,7 +400,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                 GobBlocksInZ,
                 GobBlocksInTileX,
                 Target,
-                parent.Info.FormatInfo,
+                formatInfo,
                 DepthStencilMode,
                 SwizzleR,
                 SwizzleG,

--- a/src/Ryujinx.Graphics.Gpu/Image/TextureViewCompatibility.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureViewCompatibility.cs
@@ -9,6 +9,7 @@
         Incompatible = 0,
         LayoutIncompatible,
         CopyOnly,
+        FormatAlias,
         Full
     }
 }


### PR DESCRIPTION
@gdkchan pointed out that UI textures in TOTK seemed to be setting their texture swizzle incorrectly (texture was RGB but was sampling A, swizzle for A was wrong), so I determined that SwizzleComponentMatches was the problem and set on eliminating it. This PR combines existing work to select the most recently modified texture (now used when selecting which aliased texture to use) with some additional changes to remove the swizzle check and support aliased view creation.

The original observation (#1538) was that we wanted to match depth textures for the purposes of aliasing with color textures, but they often had different swizzle from what was sampled (as it's generally the identity swizzle once rendered). At the time, I decided to allow swizzles to match if only the defined components matched, which fixed the issue in all known cases but could easily be broken by a game _expecting_ a given swizzle, such as a 1/0 value on a component.

This error case could also occur in textures that don't even depth alias, such as R11G11B10, as the rule was created to generally apply to all cases.

The solution is now to fail this exact match test, and allow the search for an R32 texture to create a swizzled view of a D32 texture (and other such cases). This allows the creation of a view that mismatches the requested format, which wasn't present before and was the reason for the swizzle matching approach.

The exact match and view creation rules now follow the same rules over what textures to select when there are multiple options (such as a "perfect" match and an "aliased" match at the same time). It now selects the most recently modified texture, which is done with a new sequence number in the GpuContext, because we don't have enough of those.

Reportedly fixes UI having weird coloured backgrounds in TOTK. This also fixes an issue in MK8D where returning from a race resulted in the character selection cubemaps being broken. May work around issues introduced by the "short texture cache" PR due to modification ordering, though they won't be truly fixed.

Should allow (#4365) to avoid copies in more cases, but need to test that. May reduce copies in other games too.

I tested a bunch of games #1538 originally affected and they seem to be fine. This change affects all games so it would be good to get some wide testing on it.