### PR TITLE
Ava: Fix wrong MouseButton

### DIFF
--- a/src/Ryujinx.Ava/Input/AvaloniaMouseDriver.cs
+++ b/src/Ryujinx.Ava/Input/AvaloniaMouseDriver.cs
@@ -70,11 +70,14 @@ namespace Ryujinx.Ava.Input
 
         private void Parent_PointerReleaseEvent(object o, PointerReleasedEventArgs args)
         {
-            int button = (int)args.InitialPressMouseButton - 1;
-
-            if (PressedButtons.Count() >= button)
+            if (args.InitialPressMouseButton != Avalonia.Input.MouseButton.None)
             {
-                PressedButtons[button] = false;
+                int button = (int)args.InitialPressMouseButton;
+
+                if (PressedButtons.Count() >= button)
+                {
+                    PressedButtons[button] = false;
+                }
             }
         }
 


### PR DESCRIPTION
https://github.com/Ryujinx/Ryujinx/issues/3662#issuecomment-1544744756 report an issue when you goes fullscreen, it's because we remap mouse button to a Ryujinx enum, but we used `-1` on the passed arg for a strange reason. I've removed it and added an extra check in case `MouseButton.None` is used to fix it. 