### PR TITLE
Fixed "ErrorOutOfDeviceMemory" crash.

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/MemoryAllocatorBlockList.cs
+++ b/src/Ryujinx.Graphics.Vulkan/MemoryAllocatorBlockList.cs
@@ -207,7 +207,14 @@ namespace Ryujinx.Graphics.Vulkan
                 MemoryTypeIndex = (uint)MemoryTypeIndex
             };
 
-            _api.AllocateMemory(_device, memoryAllocateInfo, null, out var deviceMemory).ThrowOnError();
+            // It seems that AllocateMemory sometimes fails and succeeds the second time.
+            DeviceMemory deviceMemory;
+            var allocateMemoryResult = _api.AllocateMemory(_device, memoryAllocateInfo, null, out deviceMemory);
+            if (allocateMemoryResult == Result.ErrorOutOfDeviceMemory)
+            {
+                _api.AllocateMemory(_device, memoryAllocateInfo, null, out deviceMemory).ThrowOnError();
+            }
+            allocateMemoryResult.ThrowOnError();
 
             IntPtr hostPointer = IntPtr.Zero;
 


### PR DESCRIPTION
"_api.AllocateMemory()" seems to fail sometimes and succeeds the second time.

Fixed crash in the following image.
![EroorOutOfDeviceMemory](https://github.com/Ryujinx/Ryujinx/assets/16017010/79e0ce6f-ac1e-4c4f-89e3-69508fd19d7a)
