### PR TITLE
macOS CI Adjustments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,15 +68,15 @@ jobs:
 
       - name: Publish Ryujinx
         run: dotnet publish -c "${{ matrix.configuration }}" -r "${{ matrix.DOTNET_RUNTIME_IDENTIFIER }}" -o ./publish -p:Version="${{ env.RYUJINX_BASE_VERSION }}" -p:DebugType=embedded -p:SourceRevisionId="${{ steps.git_short_hash.outputs.result }}" -p:ExtraDefineConstants=DISABLE_UPDATER src/Ryujinx --self-contained true
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && matrix.os != 'macOS-latest'
 
       - name: Publish Ryujinx.Headless.SDL2
         run: dotnet publish -c "${{ matrix.configuration }}" -r "${{ matrix.DOTNET_RUNTIME_IDENTIFIER }}" -o ./publish_sdl2_headless -p:Version="${{ env.RYUJINX_BASE_VERSION }}" -p:DebugType=embedded -p:SourceRevisionId="${{ steps.git_short_hash.outputs.result }}" -p:ExtraDefineConstants=DISABLE_UPDATER src/Ryujinx.Headless.SDL2 --self-contained true
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && matrix.os != 'macOS-latest'
 
       - name: Publish Ryujinx.Ava
         run: dotnet publish -c "${{ matrix.configuration }}" -r "${{ matrix.DOTNET_RUNTIME_IDENTIFIER }}" -o ./publish_ava -p:Version="${{ env.RYUJINX_BASE_VERSION }}" -p:DebugType=embedded -p:SourceRevisionId="${{ steps.git_short_hash.outputs.result }}" -p:ExtraDefineConstants=DISABLE_UPDATER src/Ryujinx.Ava --self-contained true
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && matrix.os != 'macOS-latest'
 
       - name: Set executable bit
         run: |
@@ -90,21 +90,21 @@ jobs:
         with:
           name: ryujinx-${{ matrix.configuration }}-${{ env.RYUJINX_BASE_VERSION }}+${{ steps.git_short_hash.outputs.result }}-${{ matrix.RELEASE_ZIP_OS_NAME }}
           path: publish
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && matrix.os != 'macOS-latest'
 
       - name: Upload Ryujinx.Headless.SDL2 artifact
         uses: actions/upload-artifact@v3
         with:
           name: sdl2-ryujinx-headless-${{ matrix.configuration }}-${{ env.RYUJINX_BASE_VERSION }}+${{ steps.git_short_hash.outputs.result }}-${{ matrix.RELEASE_ZIP_OS_NAME }}
           path: publish_sdl2_headless
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && matrix.os != 'macOS-latest'
 
       - name: Upload Ryujinx.Ava artifact
         uses: actions/upload-artifact@v3
         with:
           name: ava-ryujinx-${{ matrix.configuration }}-${{ env.RYUJINX_BASE_VERSION }}+${{ steps.git_short_hash.outputs.result }}-${{ matrix.RELEASE_ZIP_OS_NAME }}
           path: publish_ava
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && matrix.os != 'macOS-latest'
 
   build_macos:
     name: MacOS universal (${{ matrix.configuration }})

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
           RELEASE_ZIP_OS_NAME: linux_x64
 
         - os: macOS-latest
-          OS_NAME: MacOS x64
+          OS_NAME: macOS x64
           DOTNET_RUNTIME_IDENTIFIER: osx-x64
           RELEASE_ZIP_OS_NAME: osx_x64
 
@@ -107,7 +107,7 @@ jobs:
         if: github.event_name == 'pull_request' && matrix.os != 'macOS-latest'
 
   build_macos:
-    name: MacOS universal (${{ matrix.configuration }})
+    name: macOS Universal (${{ matrix.configuration }})
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/distribution/macos/create_macos_build.sh
+++ b/distribution/macos/create_macos_build.sh
@@ -22,7 +22,7 @@ EXTRA_ARGS=$8
 
 if [ "$VERSION" == "1.1.0" ];
 then
-  RELEASE_TAR_FILE_NAME=Ryujinx-$CONFIGURATION-$VERSION+$SOURCE_REVISION_ID-macos_universal.app.tar
+  RELEASE_TAR_FILE_NAME=test-ava-ryujinx-$CONFIGURATION-$VERSION+$SOURCE_REVISION_ID-macos_universal.app.tar
 else
   RELEASE_TAR_FILE_NAME=test-ava-ryujinx-$VERSION-macos_universal.app.tar
 fi

--- a/distribution/macos/create_macos_build.sh
+++ b/distribution/macos/create_macos_build.sh
@@ -20,13 +20,7 @@ SOURCE_REVISION_ID=$6
 CONFIGURATION=$7
 EXTRA_ARGS=$8
 
-if [ "$VERSION" == "1.1.0" ];
-then
-  RELEASE_TAR_FILE_NAME=Ryujinx-$CONFIGURATION-$VERSION+$SOURCE_REVISION_ID-macos_universal.app.tar
-else
-  RELEASE_TAR_FILE_NAME=Ryujinx-$VERSION-macos_universal.app.tar
-fi
-
+RELEASE_TAR_FILE_NAME=test-ava-ryujinx-$VERSION-macos_universal.app.tar
 ARM64_APP_BUNDLE="$TEMP_DIRECTORY/output_arm64/Ryujinx.app"
 X64_APP_BUNDLE="$TEMP_DIRECTORY/output_x64/Ryujinx.app"
 UNIVERSAL_APP_BUNDLE="$OUTPUT_DIRECTORY/Ryujinx.app"

--- a/distribution/macos/create_macos_build.sh
+++ b/distribution/macos/create_macos_build.sh
@@ -20,7 +20,13 @@ SOURCE_REVISION_ID=$6
 CONFIGURATION=$7
 EXTRA_ARGS=$8
 
-RELEASE_TAR_FILE_NAME=test-ava-ryujinx-$VERSION-macos_universal.app.tar
+if [ "$VERSION" == "1.1.0" ];
+then
+  RELEASE_TAR_FILE_NAME=Ryujinx-$CONFIGURATION-$VERSION+$SOURCE_REVISION_ID-macos_universal.app.tar
+else
+  RELEASE_TAR_FILE_NAME=test-ava-ryujinx-$VERSION-macos_universal.app.tar
+fi
+
 ARM64_APP_BUNDLE="$TEMP_DIRECTORY/output_arm64/Ryujinx.app"
 X64_APP_BUNDLE="$TEMP_DIRECTORY/output_x64/Ryujinx.app"
 UNIVERSAL_APP_BUNDLE="$OUTPUT_DIRECTORY/Ryujinx.app"


### PR DESCRIPTION
- macOS builds were not being named correctly; as a result, the updater couldn't find them. This PR brings them in line with the convention for Ava builds.
- Removes publishing for x86 Mac builds on PR runner.
- Adjust capitalisation `MacOS` -> `macOS`, `universal` -> `Universal`