### PR TITLE
Set OpenGL PixelPackBuffer to 0 when done

### DIFF
--- a/src/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
+++ b/src/Ryujinx.Graphics.OpenGL/Image/TextureView.cs
@@ -306,6 +306,8 @@ namespace Ryujinx.Graphics.OpenGL.Image
             int offset = WriteToPbo2D(range.Offset, layer, level);
 
             Debug.Assert(offset == 0);
+
+            GL.BindBuffer(BufferTarget.PixelPackBuffer, 0);
         }
 
         public void WriteToPbo(int offset, bool forceBgra)

--- a/src/Ryujinx.Graphics.OpenGL/Window.cs
+++ b/src/Ryujinx.Graphics.OpenGL/Window.cs
@@ -93,7 +93,7 @@ namespace Ryujinx.Graphics.OpenGL
                     oldView.Dispose();
                 }
             }
-            
+
             GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, drawFramebuffer);
             GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, readFramebuffer);
 


### PR DESCRIPTION
This fixes what appears to be a regression from #4711. It binds a buffer to `PixelPackBuffer` to perform a texture to buffer copy, but it never "clears" it back to 0, which means the buffer will remain bound there. When taking a screenshot on the emulator, `glReadPixels` would try to copy the data into that buffer since it's still bound and fail. That caused screenshots to be completely black on games where this texture flush is triggered.

Fixes #4918.
May fix #4919 but that also mentions a camera issue that I did not check.