### PR TITLE
Add timeout of 35 minutes to workflow jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
   build:
     name: ${{ matrix.OS_NAME }} (${{ matrix.configuration }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 35
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
@@ -109,6 +110,7 @@ jobs:
   build_macos:
     name: macOS Universal (${{ matrix.configuration }})
     runs-on: ubuntu-latest
+    timeout-minutes: 35
     strategy:
       matrix:
         configuration: [ Debug, Release ]

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -12,6 +12,7 @@ concurrency: flatpak-release
 
 jobs:
   release:
+    timeout-minutes: 35
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/nightly_pr_comment.yml
+++ b/.github/workflows/nightly_pr_comment.yml
@@ -7,6 +7,7 @@ jobs:
   pr_comment:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 35
     steps:
       - uses: actions/github-script@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
   release:
     name: Release ${{ matrix.OS_NAME }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 35
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
@@ -143,13 +144,14 @@ jobs:
   macos_release:
     name: Release MacOS universal
     runs-on: ubuntu-latest
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@v3
 
       - uses: actions/setup-dotnet@v3
         with:
           global-json-file: global.json
-          
+
       - name: Setup LLVM 14
         run: |
           wget https://apt.llvm.org/llvm.sh


### PR DESCRIPTION
Currently more workflows than usual run for an extremely long amount of time without actually doing anything.

This PR will cause these workflows to be cancelled a lot earlier by setting a timeout of 35 minutes per job.

We still need to restart them after that, but at least they won't run for 24 hours or until anyone notices it.