### PR TITLE
macos: Fix relaunch with updater when no arguments were provided to the emulator

### DIFF
--- a/distribution/macos/updater.sh
+++ b/distribution/macos/updater.sh
@@ -36,4 +36,9 @@ sleep 1
 # Now replace and reopen.
 rm -rf "$INSTALL_DIRECTORY"
 mv "$NEW_APP_DIRECTORY" "$INSTALL_DIRECTORY"
-open -a "$INSTALL_DIRECTORY" --args "$APP_ARGUMENTS"
+
+if [ "$#" -le 3 ]; then
+    open -a "$INSTALL_DIRECTORY"
+else
+    open -a "$INSTALL_DIRECTORY" --args "$APP_ARGUMENTS"
+fi


### PR DESCRIPTION
The updater still seems to be erroring when replacing installed folder under normal operations.

Will attempt to address that separately as it's not easy to debug locally.