### PR TITLE
ava: Fix crash when extracting sections from NCA with no data section

### DIFF
--- a/src/Ryujinx.Ava/Common/ApplicationHelper.cs
+++ b/src/Ryujinx.Ava/Common/ApplicationHelper.cs
@@ -193,7 +193,7 @@ namespace Ryujinx.Ava.Common
                             if (nca.Header.ContentType == NcaContentType.Program)
                             {
                                 int dataIndex = Nca.GetSectionIndexFromType(NcaSectionType.Data, NcaContentType.Program);
-                                if (nca.Header.GetFsHeader(dataIndex).IsPatchSection())
+                                if (nca.SectionExists(NcaSectionType.Data) && nca.Header.GetFsHeader(dataIndex).IsPatchSection())
                                 {
                                     patchNca = nca;
                                 }


### PR DESCRIPTION
Tested against Omega Strickers.