### PR TITLE
Fix Vulkan blit-like operations swizzle

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/HelperShader.cs
+++ b/src/Ryujinx.Graphics.Vulkan/HelperShader.cs
@@ -415,7 +415,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             var sampler = linearFilter ? _samplerLinear : _samplerNearest;
 
-            _pipeline.SetTextureAndSampler(ShaderStage.Fragment, 0, src, sampler);
+            _pipeline.SetTextureAndSamplerIdentitySwizzle(ShaderStage.Fragment, 0, src, sampler);
 
             Span<float> region = stackalloc float[RegionBufferSize / sizeof(float)];
 
@@ -625,7 +625,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         private void BlitDepthStencilDraw(TextureView src, bool isDepth)
         {
-            _pipeline.SetTextureAndSampler(ShaderStage.Fragment, 0, src, _samplerNearest);
+            _pipeline.SetTextureAndSamplerIdentitySwizzle(ShaderStage.Fragment, 0, src, _samplerNearest);
 
             if (isDepth)
             {
@@ -1037,7 +1037,7 @@ namespace Ryujinx.Graphics.Vulkan
                     var srcView = Create2DLayerView(src, srcLayer + z, srcLevel + l, srcFormat);
                     var dstView = Create2DLayerView(dst, dstLayer + z, dstLevel + l);
 
-                    _pipeline.SetTextureAndSampler(ShaderStage.Compute, 0, srcView, null);
+                    _pipeline.SetTextureAndSamplerIdentitySwizzle(ShaderStage.Compute, 0, srcView, null);
                     _pipeline.SetImage(0, dstView, dstFormat);
 
                     int dispatchX = (Math.Min(srcView.Info.Width, dstView.Info.Width) + 31) / 32;
@@ -1177,7 +1177,7 @@ namespace Ryujinx.Graphics.Vulkan
                     var srcView = Create2DLayerView(src, srcLayer + z, 0, format);
                     var dstView = Create2DLayerView(dst, dstLayer + z, 0);
 
-                    _pipeline.SetTextureAndSampler(ShaderStage.Compute, 0, srcView, null);
+                    _pipeline.SetTextureAndSamplerIdentitySwizzle(ShaderStage.Compute, 0, srcView, null);
                     _pipeline.SetImage(0, dstView, format);
 
                     _pipeline.DispatchCompute(dispatchX, dispatchY, 1);
@@ -1313,7 +1313,7 @@ namespace Ryujinx.Graphics.Vulkan
                     var srcView = Create2DLayerView(src, srcLayer + z, 0, format);
                     var dstView = Create2DLayerView(dst, dstLayer + z, 0);
 
-                    _pipeline.SetTextureAndSampler(ShaderStage.Fragment, 0, srcView, null);
+                    _pipeline.SetTextureAndSamplerIdentitySwizzle(ShaderStage.Fragment, 0, srcView, null);
                     _pipeline.SetRenderTarget(
                         ((TextureView)dstView).GetView(format).GetImageViewForAttachment(),
                         (uint)dst.Width,
@@ -1384,7 +1384,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         private void CopyMSAspectDraw(TextureView src, bool fromMS, bool isDepth)
         {
-            _pipeline.SetTextureAndSampler(ShaderStage.Fragment, 0, src, _samplerNearest);
+            _pipeline.SetTextureAndSamplerIdentitySwizzle(ShaderStage.Fragment, 0, src, _samplerNearest);
 
             if (isDepth)
             {

--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -1098,6 +1098,11 @@ namespace Ryujinx.Graphics.Vulkan
             _descriptorSetUpdater.SetTextureAndSampler(Cbs, stage, binding, texture, sampler);
         }
 
+        public void SetTextureAndSamplerIdentitySwizzle(ShaderStage stage, int binding, ITexture texture, ISampler sampler)
+        {
+            _descriptorSetUpdater.SetTextureAndSamplerIdentitySwizzle(Cbs, stage, binding, texture, sampler);
+        }
+
         public void SetTransformFeedbackBuffers(ReadOnlySpan<BufferRange> buffers)
         {
             PauseTransformFeedbackInternal();


### PR DESCRIPTION
On Vulkan, there are a few cases where blit operations are "emulated" using regular draws. Those cases would take the texture component swizzle into account, which is incorrect as swizzle does not affect blits or rendering, they are only supposed to affect regular texture sampling from shaders. This fixes the issue by adding a new `SetTextureAndSamplerIdentitySwizzle` that is now used to bind a `ImageView` with identity (RGBA) swizzle.

Fixes colors flashing on Omega Strikers.
Before:

https://github.com/Ryujinx/Ryujinx/assets/5624669/5acd0beb-2288-4c61-a3d0-e593b63821a2

After:

https://github.com/Ryujinx/Ryujinx/assets/5624669/d10613e3-96b4-413b-89b1-d9d0d5cf54ac