### PR TITLE
Fix macOS Update Script

### DIFF
--- a/distribution/macos/updater.sh
+++ b/distribution/macos/updater.sh
@@ -25,13 +25,13 @@ error_handler() {
     exit 1
 }
 
-trap 'error_handler ${LINENO}' ERR
-
 # Wait for Ryujinx to exit
 # NOTE: in case no fds are open, lsof could be returning with a process still living.
 # We wait 1s and assume the process stopped after that
 lsof -p $APP_PID +r 1 &>/dev/null
 sleep 1
+
+trap 'error_handler ${LINENO}' ERR
 
 # Now replace and reopen.
 rm -rf "$INSTALL_DIRECTORY"


### PR DESCRIPTION
`lsof` will return an error if the process with the given PID does not exist (i.e., already closed), causing the script to fail. We should wait till we're moving stuff around to do error checking.