### PR TITLE
Avoid removing Reshade config files on application upgrade (Vulkan)

### DIFF
--- a/src/Ryujinx.Ava/Modules/Updater/Updater.cs
+++ b/src/Ryujinx.Ava/Modules/Updater/Updater.cs
@@ -742,12 +742,15 @@ namespace Ryujinx.Modules
 
             if (OperatingSystem.IsWindows())
             {
+                var reshadeFiles = Directory.EnumerateFiles(HomeDir, "ReShade*.*").ToList();
+                IEnumerable<string> filesModified = files.Except(reshadeFiles);
+
                 foreach (string dir in WindowsDependencyDirs)
                 {
                     string dirPath = Path.Combine(HomeDir, dir);
                     if (Directory.Exists(dirPath))
                     {
-                        files = files.Concat(Directory.EnumerateFiles(dirPath, "*", SearchOption.AllDirectories));
+                        files = filesModified.Concat(Directory.EnumerateFiles(dirPath, "*", SearchOption.AllDirectories));
                     }
                 }
             }

--- a/src/Ryujinx/Modules/Updater/Updater.cs
+++ b/src/Ryujinx/Modules/Updater/Updater.cs
@@ -567,12 +567,15 @@ namespace Ryujinx.Modules
 
             if (OperatingSystem.IsWindows())
             {
+                var reshadeFiles = Directory.EnumerateFiles(HomeDir, "ReShade*.*").ToList();
+                IEnumerable<string> filesModified = files.Except(reshadeFiles);
+
                 foreach (string dir in WindowsDependencyDirs)
                 {
                     string dirPath = Path.Combine(HomeDir, dir);
                     if (Directory.Exists(dirPath))
                     {
-                        files = files.Concat(Directory.EnumerateFiles(dirPath, "*", SearchOption.AllDirectories));
+                        files = filesModified.Concat(Directory.EnumerateFiles(dirPath, "*", SearchOption.AllDirectories));
                     }
                 }
             }


### PR DESCRIPTION
Reshade (https://reshade.me/) uses two configuration files on Ryunjinx main folder for the dll injection.
When upgrading the app these two files, ReShade.ini and ReShadePreset.ini should be removed from the list of files to be excluded.
This works for Vulkan for now, for OpenGL it would necessary to add the opengl.dll file that ReShade creates too.