### PR TITLE
SPIR-V: Only allow implicit LOD sampling on fragment

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 4578;
+        private const uint CodeGenVersion = 5026;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 5026;
+        private const uint CodeGenVersion = 5027;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/Instructions.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/Instructions.cs
@@ -1580,13 +1580,6 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
             {
                 lod = Src(coordType);
             }
-            else if (!hasDerivatives && context.Config.Stage != ShaderStage.Fragment)
-            {
-                // Implicit LOD is only valid on fragment.
-
-                hasLodLevel = true;
-                lod = context.Constant(context.TypeFP32(), 0f);
-            }
 
             SpvInstruction AssembleOffsetVector(int count)
             {
@@ -1630,7 +1623,19 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
 
             if (hasLodBias)
             {
-               lodBias = Src(AggregateType.FP32);
+                lodBias = Src(AggregateType.FP32);
+            }
+
+            if (!isGather && !intCoords && !isMultisample && !hasLodLevel && !hasDerivatives && context.Config.Stage != ShaderStage.Fragment)
+            {
+                // Implicit LOD is only valid on fragment.
+                // Use the LOD bias as explicit LOD if available.
+
+                lod = lodBias ?? context.Constant(context.TypeFP32(), 0f);
+
+                lodBias = null;
+                hasLodBias = false;
+                hasLodLevel = true;
             }
 
             SpvInstruction compIdx = null;

--- a/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/Instructions.cs
+++ b/src/Ryujinx.Graphics.Shader/CodeGen/Spirv/Instructions.cs
@@ -1580,6 +1580,13 @@ namespace Ryujinx.Graphics.Shader.CodeGen.Spirv
             {
                 lod = Src(coordType);
             }
+            else if (!hasDerivatives && context.Config.Stage != ShaderStage.Fragment)
+            {
+                // Implicit LOD is only valid on fragment.
+
+                hasLodLevel = true;
+                lod = context.Constant(context.TypeFP32(), 0f);
+            }
 
             SpvInstruction AssembleOffsetVector(int count)
             {


### PR DESCRIPTION
Sometimes games were emitting implicit LOD texture sampling instructions, which are invalid on anything except fragment, as only fragment can calculate implicit derivatives. Compute does have an implicit derivatives mode with an NV extension, though I think more would need to be done if the switch does actually support this, as it needs to select the mode used for that (linear/quads).

On AMD windows, this caused texture sampling from compute to fail. This caused gloom to malfunction in TOTK. Other drivers likely ignored the "implicit" part and just sampled LOD 0.

Testing is welcome to make sure nothing broke, and that it works on all AMD gpus.