### PR TITLE
Revert "Bump MVK Version to 1.2.3"

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,7 @@
     <PackageVersion Include="OpenTK.Windowing.GraphicsLibraryFramework" Version="4.7.7" />
     <PackageVersion Include="Ryujinx.Audio.OpenAL.Dependencies" Version="1.21.0.1" />
     <PackageVersion Include="Ryujinx.Graphics.Nvdec.Dependencies" Version="5.0.1-build13" />
-    <PackageVersion Include="Ryujinx.Graphics.Vulkan.Dependencies.MoltenVK" Version="1.2.3" />
+    <PackageVersion Include="Ryujinx.Graphics.Vulkan.Dependencies.MoltenVK" Version="1.2.0" />
     <PackageVersion Include="Ryujinx.GtkSharp" Version="3.24.24.59-ryujinx" />
     <PackageVersion Include="Ryujinx.SDL2-CS" Version="2.26.3-build25" />
     <PackageVersion Include="shaderc.net" Version="0.1.0" />


### PR DESCRIPTION
Reverts Ryujinx/Ryujinx#5057

Reverting as it caused severe graphical regressions on some games while showing almost no noticeable benefit.