### PR TITLE
Improve macOS updater

### DIFF
--- a/distribution/macos/updater.sh
+++ b/distribution/macos/updater.sh
@@ -34,7 +34,7 @@ trap 'error_handler ${LINENO}' ERR
 
 attempt=0
 while true; do
-    if lsof -p $APP_PID +r 1 &>/dev/null; then
+    if lsof -p $APP_PID +r 1 &>/dev/null || kill -0 "$APP_PID" 2>/dev/null; then
         if [ $attempt -eq 2 ]; then
             exit 1
         fi

--- a/distribution/macos/updater.sh
+++ b/distribution/macos/updater.sh
@@ -36,7 +36,6 @@ attempt=0
 while true; do
     process_status=$(ps -p "$APP_PID" -o state=)
     child_processes=$(pgrep -P "$APP_PID")
-
     if [ -n "$process_status" ] || [ -n "$child_processes" ]; then
         if [ "$attempt" -eq 2 ]; then
             exit 1
@@ -45,7 +44,6 @@ while true; do
     else
         break
     fi
-
     (( attempt++ ))
 done
 

--- a/distribution/macos/updater.sh
+++ b/distribution/macos/updater.sh
@@ -28,8 +28,8 @@ error_handler() {
 trap 'error_handler ${LINENO}' ERR
 
 # Wait for Ryujinx to exit
-# If the main process as well as child processes are still acitve, we wait for 1 second and check it again.
-# After the third time checking, this script exits with status 1
+# If the main process is still acitve, we wait for 1 second and check it again.
+# After the fifth time checking, this script exits with status 1
 
 attempt=0
 

--- a/distribution/macos/updater.sh
+++ b/distribution/macos/updater.sh
@@ -34,8 +34,7 @@ trap 'error_handler ${LINENO}' ERR
 attempt=0
 
 while true; do
-    process_status=$(ps -p "$APP_PID" -o state=)
-    if [ -n "$process_status" ]; then
+    if kill -0 $APP_PID 2>/dev/null; then
         if [ "$attempt" -eq 4 ]; then
             exit 1
         fi

--- a/distribution/macos/updater.sh
+++ b/distribution/macos/updater.sh
@@ -32,9 +32,8 @@ trap 'error_handler ${LINENO}' ERR
 # After the fifth time checking, this script exits with status 1.
 
 attempt=0
-
 while true; do
-    if kill -0 $APP_PID 2>/dev/null; then
+    if lsof -p $APP_PID +r 1 &>/dev/null || ps -p "$APP_PID" &>/dev/null; then
         if [ "$attempt" -eq 4 ]; then
             exit 1
         fi

--- a/distribution/macos/updater.sh
+++ b/distribution/macos/updater.sh
@@ -47,6 +47,8 @@ while true; do
     (( attempt++ ))
 done
 
+sleep 1
+
 # Now replace and reopen.
 rm -rf "$INSTALL_DIRECTORY"
 mv "$NEW_APP_DIRECTORY" "$INSTALL_DIRECTORY"

--- a/distribution/macos/updater.sh
+++ b/distribution/macos/updater.sh
@@ -33,9 +33,9 @@ trap 'error_handler ${LINENO}' ERR
 # After the third time checking, this script exits with status 1
 
 attempt=0
-while [ attempt -lt 3 ]; do
+do
     if lsof -p $APP_PID +r 1 &>/dev/null; then
-        if [ attempt -eq 2 ]; then
+        if [ $attempt -eq 2 ]; then
             exit 1
         fi
         sleep 1

--- a/distribution/macos/updater.sh
+++ b/distribution/macos/updater.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 INSTALL_DIRECTORY=$1
 NEW_APP_DIRECTORY=$2
 APP_PID=$3
@@ -42,8 +44,6 @@ while true; do
     fi
   (( attempt++ ))
 done
-
-set -e
 
 # Now replace and reopen.
 rm -rf "$INSTALL_DIRECTORY"

--- a/distribution/macos/updater.sh
+++ b/distribution/macos/updater.sh
@@ -27,9 +27,9 @@ error_handler() {
 
 trap 'error_handler ${LINENO}' ERR
 
-# Wait for Ryujinx to exit
+# Wait for Ryujinx to exit.
 # If the main process is still acitve, we wait for 1 second and check it again.
-# After the fifth time checking, this script exits with status 1
+# After the fifth time checking, this script exits with status 1.
 
 attempt=0
 

--- a/distribution/macos/updater.sh
+++ b/distribution/macos/updater.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 INSTALL_DIRECTORY=$1
 NEW_APP_DIRECTORY=$2
 APP_PID=$3
@@ -44,6 +42,8 @@ do
     fi
   (( attempt++ ))
 done
+
+set -e
 
 # Now replace and reopen.
 rm -rf "$INSTALL_DIRECTORY"

--- a/distribution/macos/updater.sh
+++ b/distribution/macos/updater.sh
@@ -25,13 +25,25 @@ error_handler() {
     exit 1
 }
 
+trap 'error_handler ${LINENO}' ERR
+
 # Wait for Ryujinx to exit
 # NOTE: in case no fds are open, lsof could be returning with a process still living.
-# We wait 1s and assume the process stopped after that
-lsof -p $APP_PID +r 1 &>/dev/null
-sleep 1
+# If the process is still acitve, we wait for 1 second and check it again.
+# After the third time checking, this script exits with status 1
 
-trap 'error_handler ${LINENO}' ERR
+attempt=0
+while [ attempt -lt 3 ]; do
+    if lsof -p $APP_PID +r 1 &>/dev/null; then
+        if [ attempt -eq 2 ]; then
+            exit 1
+        fi
+        sleep 1
+    else
+        break
+    fi
+  (( attempt++ ))
+done
 
 # Now replace and reopen.
 rm -rf "$INSTALL_DIRECTORY"

--- a/distribution/macos/updater.sh
+++ b/distribution/macos/updater.sh
@@ -31,7 +31,7 @@ trap 'error_handler ${LINENO}' ERR
 # After the third time checking, this script exits with status 1
 
 attempt=0
-do
+while true; do
     if lsof -p $APP_PID +r 1 &>/dev/null; then
         if [ $attempt -eq 2 ]; then
             exit 1

--- a/distribution/macos/updater.sh
+++ b/distribution/macos/updater.sh
@@ -37,7 +37,7 @@ while true; do
     process_status=$(ps -p "$APP_PID" -o state=)
     child_processes=$(pgrep -P "$APP_PID")
     if [ -n "$process_status" ] || [ -n "$child_processes" ]; then
-        if [ "$attempt" -eq 2 ]; then
+        if [ "$attempt" -eq 4 ]; then
             exit 1
         fi
         sleep 1

--- a/distribution/macos/updater.sh
+++ b/distribution/macos/updater.sh
@@ -35,8 +35,7 @@ attempt=0
 
 while true; do
     process_status=$(ps -p "$APP_PID" -o state=)
-    child_processes=$(pgrep -P "$APP_PID")
-    if [ -n "$process_status" ] || [ -n "$child_processes" ]; then
+    if [ -n "$process_status" ]; then
         if [ "$attempt" -eq 4 ]; then
             exit 1
         fi


### PR DESCRIPTION
In the current version of the `updater.sh` I had an issue, where the update was downloaded, but the Ryujinx.app never got replaced at first try.

I had a look at the script and found the following issue:
Because `set -e` is defined, every command with an exit status other than 0 will cause the script to stop.
In my case, the `lsof`command exited with a status > 0, because there seemed to be still fds open.
The `sleep 1` after that had no effect, because the script exited already.

My approach is to check if the PID still exists in the process table additionally to check for open fds.
If the process is closed correctly and has no open fds, the script continues like it has before.
There will be a 1 second delay until there is a new try (up to 5 times).
If it fails, the script will exit with code 1.

Also the error handling was moved up again, because it makes no sense to display anything when there is no UI anymore.

I am happy for any suggestions to further improve this script.