### PR TITLE
Updater: Keep reshade files and opengl hook intact

### DIFF
--- a/src/Ryujinx/Modules/Updater/Updater.cs
+++ b/src/Ryujinx/Modules/Updater/Updater.cs
@@ -473,6 +473,8 @@ namespace Ryujinx.Modules
             {
                 foreach (string file in allFiles)
                 {
+                    if (file.Contains("ReShade", StringComparison.OrdinalIgnoreCase) || file.Contains("opengl32", StringComparison.OrdinalIgnoreCase))
+                        break;
                     try
                     {
                         File.Move(file, file + ".ryuold");


### PR DESCRIPTION
It's done in a very simple manner, I wasn't getting far with testing on my end, but at the very least it stopped appending the intended files with `.ryuold`. I made the check case insensitive because reshade itself doesn't seem to care, and it's feasable to imagine that config files shared by users wouldn't have the standard `ReShade.ini` naming.