### PR TITLE
Implement transform feedback emulation for hardware without native support

### DIFF
--- a/src/Ryujinx.Graphics.GAL/Capabilities.cs
+++ b/src/Ryujinx.Graphics.GAL/Capabilities.cs
@@ -28,6 +28,7 @@ namespace Ryujinx.Graphics.GAL
         public readonly bool SupportsFragmentShaderOrderingIntel;
         public readonly bool SupportsGeometryShader;
         public readonly bool SupportsGeometryShaderPassthrough;
+        public readonly bool SupportsTransformFeedback;
         public readonly bool SupportsImageLoadFormatted;
         public readonly bool SupportsLayerVertexTessellation;
         public readonly bool SupportsMismatchingViewFormat;
@@ -77,6 +78,7 @@ namespace Ryujinx.Graphics.GAL
             bool supportsFragmentShaderOrderingIntel,
             bool supportsGeometryShader,
             bool supportsGeometryShaderPassthrough,
+            bool supportsTransformFeedback,
             bool supportsImageLoadFormatted,
             bool supportsLayerVertexTessellation,
             bool supportsMismatchingViewFormat,
@@ -122,6 +124,7 @@ namespace Ryujinx.Graphics.GAL
             SupportsFragmentShaderOrderingIntel = supportsFragmentShaderOrderingIntel;
             SupportsGeometryShader = supportsGeometryShader;
             SupportsGeometryShaderPassthrough = supportsGeometryShaderPassthrough;
+            SupportsTransformFeedback = supportsTransformFeedback;
             SupportsImageLoadFormatted = supportsImageLoadFormatted;
             SupportsLayerVertexTessellation = supportsLayerVertexTessellation;
             SupportsMismatchingViewFormat = supportsMismatchingViewFormat;

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
@@ -536,6 +536,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
             _drawState.DrawIndexed = indexed;
             _currentSpecState.SetHasConstantBufferDrawParameters(true);
+            _channel.BufferManager.SetInstancedDrawVertexCount(count);
 
             engine.UpdateState();
 
@@ -676,6 +677,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                         _channel.BufferManager.SetIndexBuffer(br, IndexType.UInt);
                     }
 
+                    _channel.BufferManager.SetInstancedDrawVertexCount(_instancedIndexCount);
+
                     _context.Renderer.Pipeline.DrawIndexed(
                         _instancedIndexCount,
                         _instanceIndex + 1,
@@ -685,6 +688,8 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 }
                 else
                 {
+                    _channel.BufferManager.SetInstancedDrawVertexCount(_instancedDrawStateCount);
+
                     _context.Renderer.Pipeline.Draw(
                         _instancedDrawStateCount,
                         _instanceIndex + 1,

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
@@ -536,7 +536,11 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
             _drawState.DrawIndexed = indexed;
             _currentSpecState.SetHasConstantBufferDrawParameters(true);
-            _channel.BufferManager.SetInstancedDrawVertexCount(count);
+
+            if (instanceCount > 1)
+            {
+                _channel.BufferManager.SetInstancedDrawVertexCount(count);
+            }
 
             engine.UpdateState();
 

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
@@ -541,7 +541,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
 
             if (instanceCount > 1)
             {
-                // Must be called after UpdateState and it assumes the shader state
+                // Must be called after UpdateState as it assumes the shader state
                 // has already been set, and that bindings have been updated already.
 
                 _channel.BufferManager.SetInstancedDrawVertexCount(count);

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/DrawManager.cs
@@ -537,12 +537,15 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             _drawState.DrawIndexed = indexed;
             _currentSpecState.SetHasConstantBufferDrawParameters(true);
 
+            engine.UpdateState();
+
             if (instanceCount > 1)
             {
+                // Must be called after UpdateState and it assumes the shader state
+                // has already been set, and that bindings have been updated already.
+
                 _channel.BufferManager.SetInstancedDrawVertexCount(count);
             }
-
-            engine.UpdateState();
 
             if (indexed)
             {

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -269,7 +269,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                 _prevFirstVertex = _state.State.FirstVertex;
             }
 
-            bool tfEnable = _state.State.TfEnable;
+            bool tfEnable = _state.State.TfEnable && _context.Capabilities.SupportsTransformFeedback;
 
             if (!tfEnable && _prevTfEnable)
             {

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -47,6 +47,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         private IndexType _prevIndexType;
         private uint _prevFirstVertex;
         private bool _prevTfEnable;
+        private bool _prevShaderHasTf;
 
         private uint _prevRtNoAlphaMask;
 
@@ -1366,6 +1367,22 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             _drawState.VsUsesInstanceId = gs.Shaders[1]?.Info.UsesInstanceId ?? false;
             _vsUsesDrawParameters = gs.Shaders[1]?.Info.UsesDrawParameters ?? false;
             _vsClipDistancesWritten = gs.Shaders[1]?.Info.ClipDistancesWritten ?? 0;
+
+            bool hasTransformFeedback = gs.SpecializationState.TransformFeedbackDescriptors != null;
+            if (hasTransformFeedback != _prevShaderHasTf)
+            {
+                if (!_context.Capabilities.SupportsTransformFeedback)
+                {
+                    // If host does not support transform feedback, and the shader changed,
+                    // we might need to update bindings as transform feedback emulation
+                    // uses storage buffer bindings that might have been used for something
+                    // else in a previous draw.
+
+                    _channel.BufferManager.ForceTransformFeedbackAndStorageBuffersDirty();
+                }
+
+                _prevShaderHasTf = hasTransformFeedback;
+            }
 
             if (oldVsClipDistancesWritten != _vsClipDistancesWritten)
             {

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -47,7 +47,6 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         private IndexType _prevIndexType;
         private uint _prevFirstVertex;
         private bool _prevTfEnable;
-        private bool _prevShaderHasTf;
 
         private uint _prevRtNoAlphaMask;
 
@@ -1369,7 +1368,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
             _vsClipDistancesWritten = gs.Shaders[1]?.Info.ClipDistancesWritten ?? 0;
 
             bool hasTransformFeedback = gs.SpecializationState.TransformFeedbackDescriptors != null;
-            if (hasTransformFeedback != _prevShaderHasTf)
+            if (hasTransformFeedback != _channel.BufferManager.HasTransformFeedbackOutputs)
             {
                 if (!_context.Capabilities.SupportsTransformFeedback)
                 {
@@ -1381,7 +1380,7 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
                     _channel.BufferManager.ForceTransformFeedbackAndStorageBuffersDirty();
                 }
 
-                _prevShaderHasTf = hasTransformFeedback;
+                _channel.BufferManager.HasTransformFeedbackOutputs = hasTransformFeedback;
             }
 
             if (oldVsClipDistancesWritten != _vsClipDistancesWritten)

--- a/src/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/BufferManager.cs
@@ -360,6 +360,15 @@ namespace Ryujinx.Graphics.Gpu.Memory
         }
 
         /// <summary>
+        /// Forces transform feedback and storage buffers to be updated on the next draw.
+        /// </summary>
+        public void ForceTransformFeedbackAndStorageBuffersDirty()
+        {
+            _transformFeedbackBuffersDirty = true;
+            _gpStorageBuffersDirty = true;
+        }
+
+        /// <summary>
         /// Sets the binding points for the storage buffers bound on the compute pipeline.
         /// </summary>
         /// <param name="bindings">Bindings for the active shader</param>

--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheGpuAccessor.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheGpuAccessor.cs
@@ -37,7 +37,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
             ShaderSpecializationState oldSpecState,
             ShaderSpecializationState newSpecState,
             ResourceCounts counts,
-            int stageIndex) : base(context, counts, stageIndex)
+            int stageIndex) : base(context, counts, stageIndex, oldSpecState.TransformFeedbackDescriptors != null)
         {
             _data = data;
             _cb1Data = cb1Data;

--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -368,7 +368,11 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
 
                         if (hostCode != null)
                         {
-                            ShaderInfo shaderInfo = ShaderInfoBuilder.BuildForCache(context, shaders, specState.PipelineState);
+                            ShaderInfo shaderInfo = ShaderInfoBuilder.BuildForCache(
+                                context,
+                                shaders,
+                                specState.PipelineState,
+                                specState.TransformFeedbackDescriptors != null);
 
                             IProgram hostProgram;
 

--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 5044;
+        private const uint CodeGenVersion = 5080;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/ParallelDiskCacheLoader.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/ParallelDiskCacheLoader.cs
@@ -491,7 +491,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
             {
                 ShaderSource[] shaderSources = new ShaderSource[compilation.TranslatedStages.Length];
 
-                ShaderInfoBuilder shaderInfoBuilder = new ShaderInfoBuilder(_context);
+                ShaderInfoBuilder shaderInfoBuilder = new ShaderInfoBuilder(_context, compilation.SpecializationState.TransformFeedbackDescriptors != null);
 
                 for (int index = 0; index < compilation.TranslatedStages.Length; index++)
                 {

--- a/src/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/GpuAccessor.cs
@@ -30,7 +30,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
             GpuContext context,
             GpuChannel channel,
             GpuAccessorState state,
-            int stageIndex) : base(context, state.ResourceCounts, stageIndex)
+            int stageIndex) : base(context, state.ResourceCounts, stageIndex, state.TransformFeedbackDescriptors != null)
         {
             _isVulkan = context.Capabilities.Api == TargetApi.Vulkan;
             _channel = channel;
@@ -44,7 +44,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// <param name="context">GPU context</param>
         /// <param name="channel">GPU channel</param>
         /// <param name="state">Current GPU state</param>
-        public GpuAccessor(GpuContext context, GpuChannel channel, GpuAccessorState state) : base(context, state.ResourceCounts, 0)
+        public GpuAccessor(GpuContext context, GpuChannel channel, GpuAccessorState state) : base(context, state.ResourceCounts, 0, false)
         {
             _channel = channel;
             _state = state;

--- a/src/Ryujinx.Graphics.Gpu/Shader/GpuAccessorBase.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/GpuAccessorBase.cs
@@ -17,40 +17,56 @@ namespace Ryujinx.Graphics.Gpu.Shader
         private readonly ResourceCounts _resourceCounts;
         private readonly int _stageIndex;
 
+        private readonly int _reservedConstantBuffers;
+        private readonly int _reservedStorageBuffers;
+
         /// <summary>
         /// Creates a new GPU accessor.
         /// </summary>
         /// <param name="context">GPU context</param>
-        public GpuAccessorBase(GpuContext context, ResourceCounts resourceCounts, int stageIndex)
+        /// <param name="resourceCounts">Counter of GPU resources used by the shader</param>
+        /// <param name="stageIndex">Index of the shader stage, 0 for compute</param>
+        /// <param name="tfEnabled">Indicates if the current graphics shader is used with transform feedback enabled</param>
+        public GpuAccessorBase(GpuContext context, ResourceCounts resourceCounts, int stageIndex, bool tfEnabled)
         {
             _context = context;
             _resourceCounts = resourceCounts;
             _stageIndex = stageIndex;
+
+            _reservedConstantBuffers = 1; // For the support buffer.
+            _reservedStorageBuffers = !context.Capabilities.SupportsTransformFeedback && tfEnabled ? 5 : 0;
         }
 
         public int QueryBindingConstantBuffer(int index)
         {
+            int binding;
+
             if (_context.Capabilities.Api == TargetApi.Vulkan)
             {
-                // We need to start counting from 1 since binding 0 is reserved for the support uniform buffer.
-                return GetBindingFromIndex(index, _context.Capabilities.MaximumUniformBuffersPerStage, "Uniform buffer") + 1;
+                binding = GetBindingFromIndex(index, _context.Capabilities.MaximumUniformBuffersPerStage, "Uniform buffer");
             }
             else
             {
-                return _resourceCounts.UniformBuffersCount++;
+                binding = _resourceCounts.UniformBuffersCount++;
             }
+
+            return binding + _reservedConstantBuffers;
         }
 
         public int QueryBindingStorageBuffer(int index)
         {
+            int binding;
+
             if (_context.Capabilities.Api == TargetApi.Vulkan)
             {
-                return GetBindingFromIndex(index, _context.Capabilities.MaximumStorageBuffersPerStage, "Storage buffer");
+                binding = GetBindingFromIndex(index, _context.Capabilities.MaximumStorageBuffersPerStage, "Storage buffer");
             }
             else
             {
-                return _resourceCounts.StorageBuffersCount++;
+                binding = _resourceCounts.StorageBuffersCount++;
             }
+
+            return binding + _reservedStorageBuffers;
         }
 
         public int QueryBindingTexture(int index, bool isBuffer)
@@ -148,6 +164,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
         public bool QueryHostSupportsSnormBufferTextureFormat() => _context.Capabilities.SupportsSnormBufferTextureFormat;
 
         public bool QueryHostSupportsTextureShadowLod() => _context.Capabilities.SupportsTextureShadowLod;
+
+        public bool QueryHostSupportsTransformFeedback() => _context.Capabilities.SupportsTransformFeedback;
 
         public bool QueryHostSupportsViewportIndexVertexTessellation() => _context.Capabilities.SupportsViewportIndexVertexTessellation;
 

--- a/src/Ryujinx.Graphics.Gpu/Shader/ResourceCounts.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/ResourceCounts.cs
@@ -24,13 +24,5 @@ namespace Ryujinx.Graphics.Gpu.Shader
         /// Total of images used by the shaders.
         /// </summary>
         public int ImagesCount;
-
-        /// <summary>
-        /// Creates a new instance of the shader resource counts class.
-        /// </summary>
-        public ResourceCounts()
-        {
-            UniformBuffersCount = 1; // The first binding is reserved for the support buffer.
-        }
     }
 }

--- a/src/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/ShaderCache.cs
@@ -362,7 +362,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
 
             TranslatorContext previousStage = null;
 
-            ShaderInfoBuilder infoBuilder = new ShaderInfoBuilder(_context);
+            ShaderInfoBuilder infoBuilder = new ShaderInfoBuilder(_context, transformFeedbackDescriptors != null);
 
             for (int stageIndex = 0; stageIndex < Constants.ShaderStages; stageIndex++)
             {

--- a/src/Ryujinx.Graphics.OpenGL/OpenGLRenderer.cs
+++ b/src/Ryujinx.Graphics.OpenGL/OpenGLRenderer.cs
@@ -153,6 +153,7 @@ namespace Ryujinx.Graphics.OpenGL
                 supportsFragmentShaderOrderingIntel: HwCapabilities.SupportsFragmentShaderOrdering,
                 supportsGeometryShader: true,
                 supportsGeometryShaderPassthrough: HwCapabilities.SupportsGeometryShaderPassthrough,
+                supportsTransformFeedback: true,
                 supportsImageLoadFormatted: HwCapabilities.SupportsImageLoadFormatted,
                 supportsLayerVertexTessellation: HwCapabilities.SupportsShaderViewportLayerArray,
                 supportsMismatchingViewFormat: HwCapabilities.SupportsMismatchingViewFormat,

--- a/src/Ryujinx.Graphics.Shader/Constants.cs
+++ b/src/Ryujinx.Graphics.Shader/Constants.cs
@@ -10,5 +10,11 @@ namespace Ryujinx.Graphics.Shader
         public const int NvnBaseVertexByteOffset = 0x640;
         public const int NvnBaseInstanceByteOffset = 0x644;
         public const int NvnDrawIndexByteOffset = 0x648;
+
+        // Transform Feedback emulation.
+
+        public const int TfeInfoBinding = 0;
+        public const int TfeBufferBaseBinding = 1;
+        public const int TfeBuffersCount = 4;
     }
 }

--- a/src/Ryujinx.Graphics.Shader/IGpuAccessor.cs
+++ b/src/Ryujinx.Graphics.Shader/IGpuAccessor.cs
@@ -368,6 +368,15 @@ namespace Ryujinx.Graphics.Shader
         }
 
         /// <summary>
+        /// Queries host GPU transform feedback support.
+        /// </summary>
+        /// <returns>True if the GPU and driver supports transform feedback, false otherwise</returns>
+        bool QueryHostSupportsTransformFeedback()
+        {
+            return true;
+        }
+
+        /// <summary>
         /// Queries host support for writes to the viewport index from vertex or tessellation shader stages.
         /// </summary>
         /// <returns>True if writes to the viewport index from vertex or tessellation are supported, false otherwise</returns>

--- a/src/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/EmitterContext.cs
@@ -244,12 +244,16 @@ namespace Ryujinx.Graphics.Shader.Translation
                     var stride = Config.GpuAccessor.QueryTransformFeedbackStride(tfbIndex);
 
                     Operand baseOffset = this.Load(StorageKind.StorageBuffer, Constants.TfeInfoBinding, Const(0), Const(tfbIndex));
-                    Operand instanceIndex = this.Load(StorageKind.Input, IoVariable.InstanceIndex);
-                    Operand vertexIndex = this.Load(StorageKind.Input, IoVariable.VertexIndex);
                     Operand baseVertex = this.Load(StorageKind.Input, IoVariable.BaseVertex);
+                    Operand baseInstance = this.Load(StorageKind.Input, IoVariable.BaseInstance);
+                    Operand vertexIndex = this.Load(StorageKind.Input, IoVariable.VertexIndex);
+                    Operand instanceIndex = this.Load(StorageKind.Input, IoVariable.InstanceIndex);
 
-                    Operand outputBaseVertex = this.IMultiply(instanceIndex, vertexCount);
                     Operand outputVertexOffset = this.ISubtract(vertexIndex, baseVertex);
+                    Operand outputInstanceOffset = this.ISubtract(instanceIndex, baseInstance);
+
+                    Operand outputBaseVertex = this.IMultiply(outputInstanceOffset, vertexCount);
+
                     Operand vertexOffset = this.IMultiply(this.IAdd(outputBaseVertex, outputVertexOffset), Const(stride / 4));
                     baseOffset = this.IAdd(baseOffset, vertexOffset);
 

--- a/src/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -132,6 +132,11 @@ namespace Ryujinx.Graphics.Shader.Translation
 
             _transformFeedbackDefinitions = new Dictionary<TransformFeedbackVariable, TransformFeedbackOutput>();
 
+            TransformFeedbackEnabled =
+                stage != ShaderStage.Compute &&
+                gpuAccessor.QueryTransformFeedbackEnabled() &&
+                gpuAccessor.QueryHostSupportsTransformFeedback();
+
             UsedInputAttributesPerPatch  = new HashSet<int>();
             UsedOutputAttributesPerPatch = new HashSet<int>();
 
@@ -139,6 +144,31 @@ namespace Ryujinx.Graphics.Shader.Translation
             _usedImages   = new Dictionary<TextureInfo, TextureMeta>();
 
             ResourceManager = new ResourceManager(stage, gpuAccessor, new ShaderProperties());
+
+            if (!gpuAccessor.QueryHostSupportsTransformFeedback() && gpuAccessor.QueryTransformFeedbackEnabled())
+            {
+                StructureType tfeInfoStruct = new StructureType(new StructureField[]
+                {
+                    new StructureField(AggregateType.Array | AggregateType.U32, "base_offset", 4),
+                    new StructureField(AggregateType.U32, "vertex_count")
+                });
+
+                BufferDefinition tfeInfoBuffer = new BufferDefinition(BufferLayout.Std430, 1, Constants.TfeInfoBinding, "tfe_info", tfeInfoStruct);
+
+                Properties.AddStorageBuffer(Constants.TfeInfoBinding, tfeInfoBuffer);
+
+                StructureType tfeDataStruct = new StructureType(new StructureField[]
+                {
+                    new StructureField(AggregateType.Array | AggregateType.U32, "data", 0)
+                });
+
+                for (int i = 0; i < Constants.TfeBuffersCount; i++)
+                {
+                    int binding = Constants.TfeBufferBaseBinding + i;
+                    BufferDefinition tfeDataBuffer = new BufferDefinition(BufferLayout.Std430, 1, binding, $"tfe_data{i}", tfeDataStruct);
+                    Properties.AddStorageBuffer(binding, tfeDataBuffer);
+                }
+            }
         }
 
         public ShaderConfig(
@@ -151,7 +181,6 @@ namespace Ryujinx.Graphics.Shader.Translation
             ThreadsPerInputPrimitive = 1;
             OutputTopology           = outputTopology;
             MaxOutputVertices        = maxOutputVertices;
-            TransformFeedbackEnabled = gpuAccessor.QueryTransformFeedbackEnabled();
         }
 
         public ShaderConfig(ShaderHeader header, IGpuAccessor gpuAccessor, TranslationOptions options) : this(header.Stage, gpuAccessor, options)
@@ -165,7 +194,6 @@ namespace Ryujinx.Graphics.Shader.Translation
             OmapTargets              = header.OmapTargets;
             OmapSampleMask           = header.OmapSampleMask;
             OmapDepth                = header.OmapDepth;
-            TransformFeedbackEnabled = gpuAccessor.QueryTransformFeedbackEnabled();
             LastInVertexPipeline     = header.Stage < ShaderStage.Fragment;
         }
 

--- a/src/Ryujinx.Graphics.Vulkan/DescriptorSetCollection.cs
+++ b/src/Ryujinx.Graphics.Vulkan/DescriptorSetCollection.cs
@@ -16,9 +16,9 @@ namespace Ryujinx.Graphics.Vulkan
             _descriptorSets = descriptorSets;
         }
 
-        public void InitializeBuffers(int setIndex, int baseBinding, int countPerUnit, DescriptorType type, VkBuffer dummyBuffer)
+        public void InitializeBuffers(int setIndex, int baseBinding, int count, DescriptorType type, VkBuffer dummyBuffer)
         {
-            Span<DescriptorBufferInfo> infos = stackalloc DescriptorBufferInfo[countPerUnit];
+            Span<DescriptorBufferInfo> infos = stackalloc DescriptorBufferInfo[count];
 
             infos.Fill(new DescriptorBufferInfo()
             {

--- a/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
+++ b/src/Ryujinx.Graphics.Vulkan/VulkanRenderer.cs
@@ -589,6 +589,7 @@ namespace Ryujinx.Graphics.Vulkan
                 supportsFragmentShaderOrderingIntel: false,
                 supportsGeometryShader: Capabilities.SupportsGeometryShader,
                 supportsGeometryShaderPassthrough: Capabilities.SupportsGeometryShaderPassthrough,
+                supportsTransformFeedback: Capabilities.SupportsTransformFeedback,
                 supportsImageLoadFormatted: features2.Features.ShaderStorageImageReadWithoutFormat,
                 supportsLayerVertexTessellation: featuresVk12.ShaderOutputLayer,
                 supportsMismatchingViewFormat: true,


### PR DESCRIPTION
This implements partial support for transform feedback emulation, for platforms that do not have native support for this feature (like macOS).

Test results
-
I tested some games that uses transform feedback locally to validate that the implementation is working. Below I show the results and also some observations regarding issues that I found.

**Pokémon Scarlet/Violet:**
<img width="1392" alt="Captura de Tela 2023-05-23 às 20 25 06" src="https://github.com/Ryujinx/Ryujinx/assets/5624669/09af0b5f-6c47-4389-9f65-854f0d87cc80">
This test was done with buffer mirrors (#4899). ~~Without it, the performance is abysmal and for some reason, some objects are flickering (maybe related to the low performance)~~ (The performance issue was fixed on 5447548610a45c5305cc5affcc07aadbbaec5862). No `InvalidResource` error with and without mirrors.

**Pokémon Legends Arceus:**
<img width="1392" alt="Captura de Tela 2023-06-08 às 15 50 00" src="https://github.com/Ryujinx/Ryujinx/assets/5624669/834c164e-e4c4-42ea-9aac-90037799cf93">
~~This was tested without buffer mirrors.~~ (Can also reach 30 fps without mirrors now). With buffer mirros, it can reach 30 fps, but there are a lot of `InvalidResource` errors which prevents the game from rendering properly, so I don't recommend right now.

**SNK Heroines: Tag Team Frenzy:**
<img width="1392" alt="Captura de Tela 2023-05-23 às 20 33 47" src="https://github.com/Ryujinx/Ryujinx/assets/5624669/e8fdbf39-f086-4ae1-8ada-3b6dcfdfb532">
Tons of `InvalidResource` error with and without mirrors. But the characters does render when it is not erroring, which shows that transform feedback is working. Can reach 60 fps with and without mirrors.

**Xenoblade Chronicles Definitive Edition:**
<img width="1392" alt="Captura de Tela 2023-05-23 às 20 41 32" src="https://github.com/Ryujinx/Ryujinx/assets/5624669/aa873f42-d8de-4a0e-9fb1-94758409b72e">
Title screen render fine (the grass uses transform feedback). In-game it starts having a lot of `InvalidResource` errors and does not render properly unfortunately:
<img width="1392" alt="Captura de Tela 2023-05-23 às 20 43 22" src="https://github.com/Ryujinx/Ryujinx/assets/5624669/1b177064-e943-42d2-a006-6718ade393e1">
I did not test with mirrors.

**Pokkén Tournament:**
<img width="1392" alt="Captura de Tela 2023-05-23 às 20 47 11" src="https://github.com/Ryujinx/Ryujinx/assets/5624669/4bf75702-e73d-4365-af7e-91e8759c87d0">
<img width="1392" alt="Captura de Tela 2023-05-23 às 20 47 21" src="https://github.com/Ryujinx/Ryujinx/assets/5624669/6e629afe-1f67-4816-bea6-f4aee9eae2b1">
Works, no `InvalidResource` errors, can reach 60 fps. I did not test with mirrors.

**Metroid Prime Remastered:**
<img width="1392" alt="Captura de Tela 2023-05-23 às 21 16 43" src="https://github.com/Ryujinx/Ryujinx/assets/5624669/601e8470-65c9-4105-b4cc-7cf8567cc606">
What is uses transform feedback for (Samus shadows) is not really working since it does it from a geometry shader. But at least the game doesn't crash anymore.

**Donkey Kong Country: Tropical Freeze:**
<img width="1392" alt="Captura de Tela 2023-05-25 às 23 34 31" src="https://github.com/Ryujinx/Ryujinx/assets/5624669/fa4f6159-ef69-4044-8091-b2cccb9fdee3">
Tested without mirrors, looks fine and runs at 60 fps the entire time.

Note: All tests performed on 2020 MacBook Air.

What's still not supported:
-

So I mentioned before that this is *partial* support, because there are a few cases that are not yet supported:
- Indirect instanced draws. Should be easy to support, we just need to read the vertex count from the indirect data, but I'm not aware of any game that uses this to test.
- Indexed draws. This one is complicated to support (we have no way to tell from which "index" the invocation corresponds to  on the vertex shader). It might also have only one invocation per vertex. So this case needs a separate pass to re-order the feedback data.
- "Strip" topologies. Same problem as indexed draws, needs shuffling of the feedback output to match the correct primitive order.
- Continued feedback with more than one draw. But that is already not supported reliably even when the host does support transform feedback right now, because the backend can reset the transform feedback operation to match API requirements.
- Transform feedback from geometry or tessellation. For geometry is technically not a problem on macOS right now since it doesn't support geometry shaders at all. For tessellation, I don't know how it would work, but again no game does this.

What is implemented on this PR matches what is on the macos1 build, however the actual implementation here is different and makes use of the new methods I implement on the shader and backend to represent buffer access for emulator reserved buffers.
Contributes to #4062.
Closes #5068, closes #4889.