### PR TITLE
About window: Add changelog link under ver. number

### DIFF
--- a/src/Ryujinx.Ava/Assets/Locales/en_US.json
+++ b/src/Ryujinx.Ava/Assets/Locales/en_US.json
@@ -637,5 +637,7 @@
   "SettingsTabNetworkInterface": "Network Interface:",
   "NetworkInterfaceTooltip": "The network interface used for LAN features",
   "NetworkInterfaceDefault": "Default",
-  "PackagingShaders": "Packaging Shaders"
+  "PackagingShaders": "Packaging Shaders",
+  "AboutChangelogButton": "View Changelog on GitHub",
+  "AboutChangelogButtonTooltipMessage": "Click to open the changelog for this version in your default browser."
 }

--- a/src/Ryujinx.Ava/UI/Windows/AboutWindow.axaml
+++ b/src/Ryujinx.Ava/UI/Windows/AboutWindow.axaml
@@ -72,6 +72,18 @@
                     LineHeight="12"
                     Text="{Binding Version}"
                     TextAlignment="Center" />
+                <Button
+                    Padding="5"
+                    HorizontalAlignment="Center"
+                    Background="Transparent"
+                    Click="Button_OnClick"
+                    Tag="https://github.com/Ryujinx/Ryujinx/wiki/Changelog#ryujinx-changelog">
+                    <TextBlock
+                        FontSize="10"
+                        Text="{locale:Locale AboutChangelogButton}"
+                        TextAlignment="Center"
+                        ToolTip.Tip="{locale:Locale AboutChangelogButtonTooltipMessage}" />
+                </Button>
             </StackPanel>
             <StackPanel
                 Grid.Row="2"

--- a/src/Ryujinx/Ui/Windows/AboutWindow.Designer.cs
+++ b/src/Ryujinx/Ui/Windows/AboutWindow.Designer.cs
@@ -48,6 +48,8 @@ namespace Ryujinx.Ui.Windows
         private Label          _patreonNamesLabel;
         private ScrolledWindow _patreonNamesScrolled;
         private TextView       _patreonNamesText;
+        private EventBox       _changelogEventBox;
+        private Label          _changelogLinkLabel;
 
         private void InitializeComponent()
         {
@@ -147,6 +149,23 @@ namespace Ryujinx.Ui.Windows
                 Justify = Justification.Center,
                 Margin  = 5
             };
+
+            //
+            // _changelogEventBox
+            //
+            _changelogEventBox = new EventBox();
+            _changelogEventBox.ButtonPressEvent += ChangelogButton_Pressed;
+
+            //
+            // _changelogLinkLabel
+            //
+            _changelogLinkLabel = new Label("View Changelog on GitHub")
+            {
+                TooltipText = "Click to open the changelog for this version in your default browser.",
+                Justify = Justification.Center,
+                Attributes  = new AttrList()
+            };
+            _changelogLinkLabel.Attributes.Insert(new Pango.AttrUnderline(Underline.Single));
 
             //
             // _disclaimerLabel
@@ -464,8 +483,11 @@ namespace Ryujinx.Ui.Windows
             _socialBox.Add(_discordEventBox);
             _socialBox.Add(_twitterEventBox);
 
+            _changelogEventBox.Add(_changelogLinkLabel);
+
             _leftBox.Add(_logoBox);
             _leftBox.Add(_versionLabel);
+            _leftBox.Add(_changelogEventBox);
             _leftBox.Add(_disclaimerLabel);
             _leftBox.Add(_amiiboApiLink);
             _leftBox.Add(_socialBox);

--- a/src/Ryujinx/Ui/Windows/AboutWindow.cs
+++ b/src/Ryujinx/Ui/Windows/AboutWindow.cs
@@ -76,5 +76,10 @@ namespace Ryujinx.Ui.Windows
         {
             OpenHelper.OpenUrl("https://github.com/Ryujinx/Ryujinx/graphs/contributors?type=a");
         }
+
+        private void ChangelogButton_Pressed(object sender, ButtonPressEventArgs args)
+        {
+            OpenHelper.OpenUrl("https://github.com/Ryujinx/Ryujinx/wiki/Changelog#ryujinx-changelog");
+        }
     }
 }


### PR DESCRIPTION
Add a really simple changelog link under the version number in the About dialog.

While waiting for the actual solution to show the changelog directly in the app (https://github.com/Ryujinx/Ryujinx/issues/3262), adding a link to open in the browser is the convenient way to check the changelog as of now.

![Screenshot 2023-05-25 132800](https://github.com/Ryujinx/Ryujinx/assets/5692900/ad6fabf7-bdbb-46d3-b625-d86b6df1b77a)
![Screenshot 2023-05-25 134259](https://github.com/Ryujinx/Ryujinx/assets/5692900/a9381fc0-b6bf-4542-8182-d4b0f663f42e)
