### PR TITLE
Fix resolution scaling of image operation coordinates

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/DiskCache/DiskCacheHostStorage.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Gpu.Shader.DiskCache
         private const ushort FileFormatVersionMajor = 1;
         private const ushort FileFormatVersionMinor = 2;
         private const uint FileFormatVersionPacked = ((uint)FileFormatVersionMajor << 16) | FileFormatVersionMinor;
-        private const uint CodeGenVersion = 4714;
+        private const uint CodeGenVersion = 5102;
 
         private const string SharedTocFileName = "shared.toc";
         private const string SharedDataFileName = "shared.data";

--- a/src/Ryujinx.Graphics.Shader/Translation/Rewriter.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/Rewriter.cs
@@ -366,7 +366,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             bool isImage = IsImageInstructionWithScale(texOp.Inst);
 
             if ((texOp.Inst == Instruction.TextureSample || isImage) &&
-                intCoords &&
+                (intCoords || isImage) &&
                 !isBindless &&
                 !isIndexed &&
                 config.Stage.SupportsRenderScale() &&


### PR DESCRIPTION
Fixes a regression from #4714 that caused image operations to not have their coordinates scaled on the shader.
It was causing block flickering on Xenoblade Chronicles 3 title screen when using scale, and probably affected other games too.