### PR TITLE
Fix incorrect vertex attribute format change

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/FormatCapabilities.cs
+++ b/src/Ryujinx.Graphics.Vulkan/FormatCapabilities.cs
@@ -65,6 +65,13 @@ namespace Ryujinx.Graphics.Vulkan
             return (formatFeatureFlags & flags) == flags;
         }
 
+        public bool BufferFormatSupports(FormatFeatureFlags flags, VkFormat format)
+        {
+            _api.GetPhysicalDeviceFormatProperties(_physicalDevice, format, out var fp);
+
+            return (fp.BufferFeatures & flags) == flags;
+        }
+
         public bool OptimalFormatSupports(FormatFeatureFlags flags, GAL.Format format)
         {
             var formatFeatureFlags = _optimalTable[(int)format];

--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -551,7 +551,6 @@ namespace Ryujinx.Graphics.Vulkan
                         (uint)maxDrawCount,
                         (uint)stride);
                 }
-
             }
             else
             {

--- a/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
@@ -407,7 +407,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             if (isMoltenVk)
             {
-                UpdateVertexAttributeDescriptions();
+                UpdateVertexAttributeDescriptions(gd);
             }
 
             fixed (VertexInputAttributeDescription* pVertexAttributeDescriptions = &Internal.VertexAttributeDescriptions[0])
@@ -623,7 +623,7 @@ namespace Ryujinx.Graphics.Vulkan
             }
         }
 
-        private void UpdateVertexAttributeDescriptions()
+        private void UpdateVertexAttributeDescriptions(VulkanRenderer gd)
         {
             // Vertex attributes exceeding the stride are invalid.
             // In metal, they cause glitches with the vertex shader fetching incorrect values.
@@ -656,7 +656,10 @@ namespace Ryujinx.Graphics.Vulkan
                         format = newFormat;
                     }
 
-                    attribute.Format = format;
+                    if (attribute.Format != format && gd.FormatCapabilities.BufferFormatSupports(FormatFeatureFlags.VertexBufferBit, format))
+                    {
+                        attribute.Format = format;
+                    }
                 }
 
                 _vertexAttributeDescriptions2[index] = attribute;

--- a/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
@@ -633,28 +633,47 @@ namespace Ryujinx.Graphics.Vulkan
             for (int index = 0; index < VertexAttributeDescriptionsCount; index++)
             {
                 var attribute = Internal.VertexAttributeDescriptions[index];
-                ref var vb = ref Internal.VertexBindingDescriptions[(int)attribute.Binding];
+                int vbIndex = GetVertexBufferIndex(attribute.Binding);
 
-                Format format = attribute.Format;
-
-                while (vb.Stride != 0 && attribute.Offset + FormatTable.GetAttributeFormatSize(format) > vb.Stride)
+                if (vbIndex >= 0)
                 {
-                    Format newFormat = FormatTable.DropLastComponent(format);
+                    ref var vb = ref Internal.VertexBindingDescriptions[vbIndex];
 
-                    if (newFormat == format)
+                    Format format = attribute.Format;
+
+                    while (vb.Stride != 0 && attribute.Offset + FormatTable.GetAttributeFormatSize(format) > vb.Stride)
                     {
-                        // That case means we failed to find a format that fits within the stride,
-                        // so just restore the original format and give up.
-                        format = attribute.Format;
-                        break;
+                        Format newFormat = FormatTable.DropLastComponent(format);
+
+                        if (newFormat == format)
+                        {
+                            // That case means we failed to find a format that fits within the stride,
+                            // so just restore the original format and give up.
+                            format = attribute.Format;
+                            break;
+                        }
+
+                        format = newFormat;
                     }
 
-                    format = newFormat;
+                    attribute.Format = format;
                 }
 
-                attribute.Format = format;
                 _vertexAttributeDescriptions2[index] = attribute;
             }
+        }
+
+        private int GetVertexBufferIndex(uint binding)
+        {
+            for (int index = 0; index < VertexBindingDescriptionsCount; index++)
+            {
+                if (Internal.VertexBindingDescriptions[index].Binding == binding)
+                {
+                    return index;
+                }
+            }
+
+            return -1;
         }
 
         public void Dispose()


### PR DESCRIPTION
This fixes an oversight from #5094. The `Binding` value on the vertex attribute struct is not an index into the vertex descriptors array, it must match the actual vertex buffer `Binding` value. So I have changed the code and added a function to look for the binding return the correct vertex buffer index.

This fixes a regression on macOS where a few games would not render correctly due to it changing the format of some attributes to the wrong format. It only affect games that have gaps on the vertex buffer bindings, which is something uncommon. So far the only game I tested that was affected is Gun Gun Pixies.