### PR TITLE
Workaround for MoltenVK barrier issues

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -80,6 +80,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         private PipelineColorBlendAttachmentState[] _storedBlend;
 
+        private ulong _drawCountSinceBarrier;
         public ulong DrawCount { get; private set; }
         public bool RenderPassActive { get; private set; }
 
@@ -133,6 +134,18 @@ namespace Ryujinx.Graphics.Vulkan
 
         public unsafe void Barrier()
         {
+            if (_drawCountSinceBarrier != DrawCount)
+            {
+                _drawCountSinceBarrier = DrawCount;
+
+                // Barriers apparently have no effect inside a render pass on MoltenVK.
+                // As a workaround, end the render pass.
+                if (Gd.IsMoltenVk)
+                {
+                    EndRenderPass();
+                }
+            }
+
             MemoryBarrier memoryBarrier = new MemoryBarrier()
             {
                 SType = StructureType.MemoryBarrier,


### PR DESCRIPTION
On MoltenVK issuing a barrier in the middle of a render pass has no effect. So this ends the render pass as a work around. This fixes vertex explosions on Xenoblade on macOS (has to be tested with #5080 since the game uses transform feedback). This needs to be tested to ensure it does not regress performance on other games since render pass splits is every mobile GPU kryptonite.

Contributes to #4062.