### PR TITLE
Fix problem with console not closing when exiting app

### DIFF
--- a/src/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
+++ b/src/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
@@ -170,12 +170,15 @@ namespace Ryujinx.Graphics.GAL.Multithreading
 
         internal ref T New<T>() where T : struct
         {
-            while (_producerPtr == (Volatile.Read(ref _consumerPtr) + QueueCount - 1) % QueueCount)
+            if (_running && !_disposed)
             {
-                // If incrementing the producer pointer would overflow, we need to wait.
-                // _consumerPtr can only move forward, so there's no race to worry about here.
+                while (_producerPtr == (Volatile.Read(ref _consumerPtr) + QueueCount - 1) % QueueCount)
+                {
+                    // If incrementing the producer pointer would overflow, we need to wait.
+                    // _consumerPtr can only move forward, so there's no race to worry about here.
 
-                Thread.Sleep(1);
+                    Thread.Sleep(1);
+                }
             }
 
             int taken = _producerPtr;

--- a/src/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
+++ b/src/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
@@ -198,7 +198,7 @@ namespace Ryujinx.Graphics.GAL.Multithreading
         {
             // Execute commands left in _commandQueue when the app exits
 
-            while (!_running && _disposed && Volatile.Read(ref _commandCount) > 0)
+            while (!_running && !_disposed && Volatile.Read(ref _commandCount) > 0)
             {
                 int commandPtr = _consumerPtr;
 
@@ -247,9 +247,6 @@ namespace Ryujinx.Graphics.GAL.Multithreading
             {
                 _galWorkAvailable.Set();
             }
-
-            // Execute commands left in Queue when the app exits
-            DisposeCommandQueueRun();
         }
 
         internal void InvokeCommand()
@@ -517,6 +514,9 @@ namespace Ryujinx.Graphics.GAL.Multithreading
         public void Dispose()
         {
             // Dispose must happen from the render thread, after all commands have completed.
+
+            // Execute commands left in Queue when the app exits
+            DisposeCommandQueueRun();
 
             // Stop the GPU thread.
             _disposed = true;

--- a/src/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/src/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -390,7 +390,6 @@ namespace Ryujinx.Graphics.Gpu
         /// </summary>
         public void Dispose()
         {
-            Renderer.Dispose();
             GPFifo.Dispose();
             HostInitalized.Dispose();
 
@@ -403,6 +402,8 @@ namespace Ryujinx.Graphics.Gpu
             PhysicalMemoryRegistry.Clear();
 
             RunDeferredActions();
+
+            Renderer.Dispose();
         }
     }
 }


### PR DESCRIPTION
I ran into a problem with the console not exiting when exiting the app. #2863

I checked and found that I am stuck in an infinite loop in "Ryujinx.Graphics.GAL.Multithreading.ThreadedRenderer.New<>()".
This is due to the _consumerPtr not being changed in RenderLoop() when the app exits.
So I changed it to skip the code that falls into an infinite loop when the app exits.