### PR TITLE
Make sure blend is disabled if render target has integer format

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
+++ b/src/Ryujinx.Graphics.Vulkan/FramebufferParams.cs
@@ -21,6 +21,7 @@ namespace Ryujinx.Graphics.Vulkan
         public uint[] AttachmentSamples { get; }
         public VkFormat[] AttachmentFormats { get; }
         public int[] AttachmentIndices { get; }
+        public uint AttachmentIntegerFormatMask { get; }
 
         public int AttachmentsCount { get; }
         public int MaxColorAttachmentIndex => AttachmentIndices.Length > 0 ? AttachmentIndices[AttachmentIndices.Length - 1] : -1;
@@ -74,6 +75,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             int index = 0;
             int bindIndex = 0;
+            uint attachmentIntegerFormatMask = 0;
 
             foreach (ITexture color in colors)
             {
@@ -89,6 +91,11 @@ namespace Ryujinx.Graphics.Vulkan
                     AttachmentFormats[index] = texture.VkFormat;
                     AttachmentIndices[index] = bindIndex;
 
+                    if (texture.Info.Format.IsInteger())
+                    {
+                        attachmentIntegerFormatMask |= 1u << bindIndex;
+                    }
+
                     width = Math.Min(width, (uint)texture.Width);
                     height = Math.Min(height, (uint)texture.Height);
                     layers = Math.Min(layers, (uint)texture.Layers);
@@ -101,6 +108,8 @@ namespace Ryujinx.Graphics.Vulkan
 
                 bindIndex++;
             }
+
+            AttachmentIntegerFormatMask = attachmentIntegerFormatMask;
 
             if (depthStencil is TextureView dsTexture && dsTexture.Valid)
             {

--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -1471,6 +1471,7 @@ namespace Ryujinx.Graphics.Vulkan
         {
             var dstAttachmentFormats = _newState.Internal.AttachmentFormats.AsSpan();
             FramebufferParams.AttachmentFormats.CopyTo(dstAttachmentFormats);
+            _newState.Internal.AttachmentIntegerFormatMask = FramebufferParams.AttachmentIntegerFormatMask;
 
             for (int i = FramebufferParams.AttachmentFormats.Length; i < dstAttachmentFormats.Length; i++)
             {

--- a/src/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
@@ -272,11 +272,12 @@ namespace Ryujinx.Graphics.Vulkan
             for (int i = 0; i < Constants.MaxRenderTargets; i++)
             {
                 var blend = state.BlendDescriptors[i];
+                bool blendEnable = blend.Enable && !state.AttachmentFormats[i].IsInteger();
 
-                if (blend.Enable && state.ColorWriteMask[i] != 0)
+                if (blendEnable && state.ColorWriteMask[i] != 0)
                 {
                     pipeline.Internal.ColorBlendAttachmentState[i] = new PipelineColorBlendAttachmentState(
-                        blend.Enable,
+                        blendEnable,
                         blend.ColorSrcFactor.Convert(),
                         blend.ColorDstFactor.Convert(),
                         blend.ColorOp.Convert(),

--- a/src/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
@@ -272,12 +272,11 @@ namespace Ryujinx.Graphics.Vulkan
             for (int i = 0; i < Constants.MaxRenderTargets; i++)
             {
                 var blend = state.BlendDescriptors[i];
-                bool blendEnable = blend.Enable && !state.AttachmentFormats[i].IsInteger();
 
-                if (blendEnable && state.ColorWriteMask[i] != 0)
+                if (blend.Enable && state.ColorWriteMask[i] != 0)
                 {
                     pipeline.Internal.ColorBlendAttachmentState[i] = new PipelineColorBlendAttachmentState(
-                        blendEnable,
+                        blend.Enable,
                         blend.ColorSrcFactor.Convert(),
                         blend.ColorDstFactor.Convert(),
                         blend.ColorOp.Convert(),
@@ -295,6 +294,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             int attachmentCount = 0;
             int maxColorAttachmentIndex = -1;
+            uint attachmentIntegerFormatMask = 0;
 
             for (int i = 0; i < Constants.MaxRenderTargets; i++)
             {
@@ -302,6 +302,11 @@ namespace Ryujinx.Graphics.Vulkan
                 {
                     pipeline.Internal.AttachmentFormats[attachmentCount++] = gd.FormatCapabilities.ConvertToVkFormat(state.AttachmentFormats[i]);
                     maxColorAttachmentIndex = i;
+
+                    if (state.AttachmentFormats[i].IsInteger())
+                    {
+                        attachmentIntegerFormatMask |= 1u << i;
+                    }
                 }
             }
 
@@ -312,6 +317,7 @@ namespace Ryujinx.Graphics.Vulkan
 
             pipeline.ColorBlendAttachmentStateCount = (uint)(maxColorAttachmentIndex + 1);
             pipeline.VertexAttributeDescriptionsCount = (uint)Math.Min(Constants.MaxVertexAttributes, state.VertexAttribCount);
+            pipeline.Internal.AttachmentIntegerFormatMask = attachmentIntegerFormatMask;
 
             return pipeline;
         }

--- a/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineState.cs
@@ -1,6 +1,7 @@
 ﻿using Ryujinx.Common.Memory;
 using Silk.NET.Vulkan;
 using System;
+using System.Numerics;
 
 namespace Ryujinx.Graphics.Vulkan
 {
@@ -523,6 +524,19 @@ namespace Ryujinx.Graphics.Vulkan
                     MinDepthBounds = MinDepthBounds,
                     MaxDepthBounds = MaxDepthBounds
                 };
+
+                if (gd.IsMoltenVk && Internal.AttachmentIntegerFormatMask != 0)
+                {
+                    // Blend can't be enabled for integer formats, so let's make sure it is disabled.
+                    uint attachmentIntegerFormatMask = Internal.AttachmentIntegerFormatMask;
+
+                    while (attachmentIntegerFormatMask != 0)
+                    {
+                        int i = BitOperations.TrailingZeroCount(attachmentIntegerFormatMask);
+                        Internal.ColorBlendAttachmentState[i].BlendEnable = false;
+                        attachmentIntegerFormatMask &= ~(1u << i);
+                    }
+                }
 
                 var colorBlendState = new PipelineColorBlendStateCreateInfo()
                 {

--- a/src/Ryujinx.Graphics.Vulkan/PipelineUid.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineUid.cs
@@ -35,6 +35,7 @@ namespace Ryujinx.Graphics.Vulkan
         public Array16<Rect2D> Scissors;
         public Array8<PipelineColorBlendAttachmentState> ColorBlendAttachmentState;
         public Array9<Format> AttachmentFormats;
+        public uint AttachmentIntegerFormatMask;
 
         public override bool Equals(object obj)
         {


### PR DESCRIPTION
Having blend enabled for integer formats is invalid. The most common case where this happens is when logic operations are enabled, and in this case the blend is ignored. Since Metal/MoltenVK does not support logical operations, it is never enabled there, and having blend enabled in this case causes a Metal assert and crash. To avoid this, this change forces blend to be disabled if the respective framebuffer attachment is using a integer format.

This should be safe to enable for all vendors, but here I'm enabling it only on MoltenVK just to be on the safe side. But I can enable it for all vendors too.

Fixes crashes on Xenoblade games, and should fix also fix some crashes on Luigi's Mansion 3 (on macOS). The Luigi's Mansion 3 crash would usually happen when entering the bathroom on Luigi's room for example.

Contributes to #4062.