### PR TITLE
Use variables to configure job timeouts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
   build:
     name: ${{ matrix.OS_NAME }} (${{ matrix.configuration }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 35
+    timeout-minutes: ${{ vars.JOB_TIMEOUT }}
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
@@ -110,7 +110,7 @@ jobs:
   build_macos:
     name: macOS Universal (${{ matrix.configuration }})
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: ${{ vars.JOB_TIMEOUT }}
     strategy:
       matrix:
         configuration: [ Debug, Release ]

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -12,7 +12,7 @@ concurrency: flatpak-release
 
 jobs:
   release:
-    timeout-minutes: 35
+    timeout-minutes: ${{ vars.JOB_TIMEOUT }}
     runs-on: ubuntu-latest
 
     env:

--- a/.github/workflows/nightly_pr_comment.yml
+++ b/.github/workflows/nightly_pr_comment.yml
@@ -7,7 +7,7 @@ jobs:
   pr_comment:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: ${{ vars.JOB_TIMEOUT }}
     steps:
       - uses: actions/github-script@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
   release:
     name: Release ${{ matrix.OS_NAME }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 35
+    timeout-minutes: ${{ vars.JOB_TIMEOUT }}
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
@@ -144,7 +144,7 @@ jobs:
   macos_release:
     name: Release MacOS universal
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: ${{ vars.JOB_TIMEOUT }}
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Since the workflows are currently timing out too early, we need to adjust the timeouts again.

But to make this easier to change in the future we will be using a config variable that can be set for the repo or for the whole org.

Before this PR gets merged we need to [create a variable](https://docs.github.com/en/actions/learn-github-actions/variables#creating-configuration-variables-for-a-repository) `JOB_TIMEOUT` for this repo. I think a good start for the value would be `45` minutes.
