### PR TITLE
[Logger] Add print with stacktrace method

### DIFF
--- a/src/Ryujinx.Common/Logging/Formatters/DefaultLogFormatter.cs
+++ b/src/Ryujinx.Common/Logging/Formatters/DefaultLogFormatter.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Diagnostics;
+using System.Text;
 
 namespace Ryujinx.Common.Logging
 {
@@ -27,6 +28,14 @@ namespace Ryujinx.Common.Logging
 
                 if (args.Data is not null)
                 {
+                    if (args.Data is StackTrace trace)
+                    {
+                        sb.Append('\n');
+                        sb.Append(trace);
+
+                        return sb.ToString();
+                    }
+
                     sb.Append(' ');
                     DynamicObjectFormatter.Format(sb, args.Data);
                 }

--- a/src/Ryujinx.Common/Logging/Formatters/DefaultLogFormatter.cs
+++ b/src/Ryujinx.Common/Logging/Formatters/DefaultLogFormatter.cs
@@ -1,7 +1,7 @@
 ﻿using System.Diagnostics;
 using System.Text;
 
-namespace Ryujinx.Common.Logging
+namespace Ryujinx.Common.Logging.Formatters
 {
     internal class DefaultLogFormatter : ILogFormatter
     {

--- a/src/Ryujinx.Common/Logging/Formatters/DynamicObjectFormatter.cs
+++ b/src/Ryujinx.Common/Logging/Formatters/DynamicObjectFormatter.cs
@@ -3,7 +3,7 @@ using System;
 using System.Reflection;
 using System.Text;
 
-namespace Ryujinx.Common.Logging
+namespace Ryujinx.Common.Logging.Formatters
 {
     internal class DynamicObjectFormatter
     {
@@ -17,7 +17,7 @@ namespace Ryujinx.Common.Logging
             }
 
             StringBuilder sb = StringBuilderPool.Allocate();
-            
+
             try
             {
                 Format(sb, dynamicObject);

--- a/src/Ryujinx.Common/Logging/Formatters/DynamicObjectFormatter.cs
+++ b/src/Ryujinx.Common/Logging/Formatters/DynamicObjectFormatter.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace Ryujinx.Common.Logging.Formatters
 {
-    internal class DynamicObjectFormatter
+    internal static class DynamicObjectFormatter
     {
         private static readonly ObjectPool<StringBuilder> StringBuilderPool = SharedPools.Default<StringBuilder>();
 

--- a/src/Ryujinx.Common/Logging/Formatters/ILogFormatter.cs
+++ b/src/Ryujinx.Common/Logging/Formatters/ILogFormatter.cs
@@ -1,4 +1,4 @@
-﻿namespace Ryujinx.Common.Logging
+﻿namespace Ryujinx.Common.Logging.Formatters
 {
     interface ILogFormatter
     {

--- a/src/Ryujinx.Common/Logging/LogEventArgsJson.cs
+++ b/src/Ryujinx.Common/Logging/LogEventArgsJson.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Ryujinx.Common.Logging.Formatters;
+using System;
 using System.Text.Json.Serialization;
 
 namespace Ryujinx.Common.Logging

--- a/src/Ryujinx.Common/Logging/Logger.cs
+++ b/src/Ryujinx.Common/Logging/Logger.cs
@@ -1,3 +1,4 @@
+using Ryujinx.Common.Logging.Targets;
 using Ryujinx.Common.SystemInterop;
 using System;
 using System.Collections.Generic;

--- a/src/Ryujinx.Common/Logging/Logger.cs
+++ b/src/Ryujinx.Common/Logging/Logger.cs
@@ -55,6 +55,16 @@ namespace Ryujinx.Common.Logging
                 }
             }
 
+            [StackTraceHidden]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void PrintStack(LogClass logClass, string message, [CallerMemberName] string caller = "")
+            {
+                if (m_EnabledClasses[(int)logClass])
+                {
+                    Updated?.Invoke(null, new LogEventArgs(Level, m_Time.Elapsed, Thread.CurrentThread.Name, FormatMessage(logClass, caller, message), new StackTrace(true)));
+                }
+            }
+
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public void PrintStub(LogClass logClass, string message = "", [CallerMemberName] string caller = "")
             {
@@ -122,7 +132,7 @@ namespace Ryujinx.Common.Logging
                 AsyncLogTargetOverflowAction.Discard));
 
             Notice = new Log(LogLevel.Notice);
-            
+
             // Enable important log levels before configuration is loaded
             Error = new Log(LogLevel.Error);
             Warning = new Log(LogLevel.Warning);

--- a/src/Ryujinx.Common/Logging/Targets/AsyncLogTargetWrapper.cs
+++ b/src/Ryujinx.Common/Logging/Targets/AsyncLogTargetWrapper.cs
@@ -2,7 +2,7 @@
 using System.Collections.Concurrent;
 using System.Threading;
 
-namespace Ryujinx.Common.Logging
+namespace Ryujinx.Common.Logging.Targets
 {
     public enum AsyncLogTargetOverflowAction
     {

--- a/src/Ryujinx.Common/Logging/Targets/ConsoleLogTarget.cs
+++ b/src/Ryujinx.Common/Logging/Targets/ConsoleLogTarget.cs
@@ -1,6 +1,7 @@
-﻿using System;
+﻿using Ryujinx.Common.Logging.Formatters;
+using System;
 
-namespace Ryujinx.Common.Logging
+namespace Ryujinx.Common.Logging.Targets
 {
     public class ConsoleLogTarget : ILogTarget
     {

--- a/src/Ryujinx.Common/Logging/Targets/FileLogTarget.cs
+++ b/src/Ryujinx.Common/Logging/Targets/FileLogTarget.cs
@@ -1,8 +1,9 @@
-﻿using System;
+﻿using Ryujinx.Common.Logging.Formatters;
+using System;
 using System.IO;
 using System.Linq;
 
-namespace Ryujinx.Common.Logging
+namespace Ryujinx.Common.Logging.Targets
 {
     public class FileLogTarget : ILogTarget
     {

--- a/src/Ryujinx.Common/Logging/Targets/ILogTarget.cs
+++ b/src/Ryujinx.Common/Logging/Targets/ILogTarget.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Ryujinx.Common.Logging
+namespace Ryujinx.Common.Logging.Targets
 {
     public interface ILogTarget : IDisposable
     {

--- a/src/Ryujinx.Common/Logging/Targets/JsonLogTarget.cs
+++ b/src/Ryujinx.Common/Logging/Targets/JsonLogTarget.cs
@@ -1,7 +1,7 @@
 ﻿using Ryujinx.Common.Utilities;
 using System.IO;
 
-namespace Ryujinx.Common.Logging
+namespace Ryujinx.Common.Logging.Targets
 {
     public class JsonLogTarget : ILogTarget
     {

--- a/src/Ryujinx.Headless.SDL2/Program.cs
+++ b/src/Ryujinx.Headless.SDL2/Program.cs
@@ -9,6 +9,7 @@ using Ryujinx.Common.Configuration.Hid.Controller;
 using Ryujinx.Common.Configuration.Hid.Controller.Motion;
 using Ryujinx.Common.Configuration.Hid.Keyboard;
 using Ryujinx.Common.Logging;
+using Ryujinx.Common.Logging.Targets;
 using Ryujinx.Common.SystemInterop;
 using Ryujinx.Common.Utilities;
 using Ryujinx.Cpu;

--- a/src/Ryujinx.Ui.Common/Configuration/LoggerModule.cs
+++ b/src/Ryujinx.Ui.Common/Configuration/LoggerModule.cs
@@ -1,5 +1,6 @@
 ﻿using Ryujinx.Common;
 using Ryujinx.Common.Logging;
+using Ryujinx.Common.Logging.Targets;
 using System;
 
 namespace Ryujinx.Ui.Common.Configuration


### PR DESCRIPTION
This small PR adds a convenience method `PrintStack()` to log the current stacktrace in addition to the regular message.

I used this while I was debugging and think it'd be useful to upstream this as well.