### PR TITLE
Only run one workflow for a PR at a time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,10 @@ on:
       - '*.yml'
       - 'README.md'
 
+concurrency:
+  group: pr-checks-${{ github.event.number }}
+  cancel-in-progress: true
+
 env:
   POWERSHELL_TELEMETRY_OPTOUT: 1
   DOTNET_CLI_TELEMETRY_OPTOUT: 1


### PR DESCRIPTION
Small PR to only run one workflow per PR, since there may have been an [increase of running workflows](https://github.com/Ryujinx/Ryujinx/actions/workflows/build.yml?query=branch%3Ainput-refactor) in the last few minutes.