### PR TITLE
GPU: Dispose Renderer after running deferred actions

### DIFF
--- a/src/Ryujinx.Graphics.GAL/IRenderer.cs
+++ b/src/Ryujinx.Graphics.GAL/IRenderer.cs
@@ -1,5 +1,6 @@
 using Ryujinx.Common.Configuration;
 using System;
+using System.Threading;
 
 namespace Ryujinx.Graphics.GAL
 {
@@ -52,7 +53,7 @@ namespace Ryujinx.Graphics.GAL
 
         void ResetCounter(CounterType type);
 
-        void RunLoop(Action gpuLoop)
+        void RunLoop(ThreadStart gpuLoop)
         {
             gpuLoop();
         }

--- a/src/Ryujinx.Graphics.GAL/IRenderer.cs
+++ b/src/Ryujinx.Graphics.GAL/IRenderer.cs
@@ -64,10 +64,5 @@ namespace Ryujinx.Graphics.GAL
         void SetInterruptAction(Action<Action> interruptAction);
 
         void Screenshot();
-
-        void Flush()
-        {
-            // On renderers without threading, doesn't need to wait.
-        }
     }
 }

--- a/src/Ryujinx.Graphics.GAL/IRenderer.cs
+++ b/src/Ryujinx.Graphics.GAL/IRenderer.cs
@@ -64,5 +64,10 @@ namespace Ryujinx.Graphics.GAL
         void SetInterruptAction(Action<Action> interruptAction);
 
         void Screenshot();
+
+        void Flush()
+        {
+            // On renderers without threading, doesn't need to wait.
+        }
     }
 }

--- a/src/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
+++ b/src/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
@@ -97,13 +97,13 @@ namespace Ryujinx.Graphics.GAL.Multithreading
             _refQueue = new object[MaxRefsPerCommand * QueueCount];
         }
 
-        public void RunLoop(Action gpuLoop)
+        public void RunLoop(ThreadStart gpuLoop)
         {
             _running = true;
 
             _backendThread = Thread.CurrentThread;
 
-            _gpuThread = new Thread(() => gpuLoop());
+            _gpuThread = new Thread(gpuLoop);
 
             _gpuThread.Name = "GPU.MainThread";
             _gpuThread.Start();

--- a/src/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
+++ b/src/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
@@ -30,7 +30,6 @@ namespace Ryujinx.Graphics.GAL.Multithreading
         private IRenderer _baseRenderer;
         private Thread _gpuThread;
         private Thread _backendThread;
-        private bool _disposed;
         private bool _running;
 
         private AutoResetEvent _frameComplete = new AutoResetEvent(true);
@@ -106,8 +105,6 @@ namespace Ryujinx.Graphics.GAL.Multithreading
 
             _gpuThread = new Thread(() => {
                 gpuLoop();
-                _running = false;
-                _galWorkAvailable.Set();
             });
 
             _gpuThread.Name = "GPU.MainThread";
@@ -120,7 +117,7 @@ namespace Ryujinx.Graphics.GAL.Multithreading
         {
             // Power through the render queue until the Gpu thread work is done.
 
-            while (_running && !_disposed)
+            while (_running)
             {
                 _galWorkAvailable.Wait();
                 _galWorkAvailable.Reset();
@@ -488,12 +485,23 @@ namespace Ryujinx.Graphics.GAL.Multithreading
             return _baseRenderer.PrepareHostMapping(address, size);
         }
 
+        public void Flush()
+        {
+            SpinWait wait = new();
+
+            while (Volatile.Read(ref _commandCount) > 0)
+            {
+                wait.SpinOnce();
+            }
+        }
+
         public void Dispose()
         {
             // Dispose must happen from the render thread, after all commands have completed.
 
             // Stop the GPU thread.
-            _disposed = true;
+            _running = false;
+            _galWorkAvailable.Set();
 
             if (_gpuThread != null && _gpuThread.IsAlive)
             {

--- a/src/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
+++ b/src/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
@@ -103,9 +103,11 @@ namespace Ryujinx.Graphics.GAL.Multithreading
 
             _backendThread = Thread.CurrentThread;
 
-            _gpuThread = new Thread(gpuLoop);
+            _gpuThread = new Thread(gpuLoop)
+            {
+                Name = "GPU.MainThread"
+            };
 
-            _gpuThread.Name = "GPU.MainThread";
             _gpuThread.Start();
 
             RenderLoop();

--- a/src/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
+++ b/src/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
@@ -103,9 +103,7 @@ namespace Ryujinx.Graphics.GAL.Multithreading
 
             _backendThread = Thread.CurrentThread;
 
-            _gpuThread = new Thread(() => {
-                gpuLoop();
-            });
+            _gpuThread = new Thread(() => gpuLoop());
 
             _gpuThread.Name = "GPU.MainThread";
             _gpuThread.Start();
@@ -485,7 +483,7 @@ namespace Ryujinx.Graphics.GAL.Multithreading
             return _baseRenderer.PrepareHostMapping(address, size);
         }
 
-        public void Flush()
+        public void FlushThreadedCommands()
         {
             SpinWait wait = new();
 

--- a/src/Ryujinx.Graphics.Gpu/GpuContext.cs
+++ b/src/Ryujinx.Graphics.Gpu/GpuContext.cs
@@ -390,7 +390,6 @@ namespace Ryujinx.Graphics.Gpu
         /// </summary>
         public void Dispose()
         {
-            Renderer.Dispose();
             GPFifo.Dispose();
             HostInitalized.Dispose();
 
@@ -403,6 +402,8 @@ namespace Ryujinx.Graphics.Gpu
             PhysicalMemoryRegistry.Clear();
 
             RunDeferredActions();
+
+            Renderer.Dispose();
         }
     }
 }

--- a/src/Ryujinx/Ui/RendererWidgetBase.cs
+++ b/src/Ryujinx/Ui/RendererWidgetBase.cs
@@ -65,6 +65,7 @@ namespace Ryujinx.Ui
         private KeyboardHotkeyState _prevHotkeyState;
 
         private readonly ManualResetEvent _exitEvent;
+        private readonly ManualResetEvent _gpuDoneEvent;
 
         private readonly CancellationTokenSource _gpuCancellationTokenSource;
 
@@ -110,6 +111,7 @@ namespace Ryujinx.Ui
                           | EventMask.KeyReleaseMask));
 
             _exitEvent = new ManualResetEvent(false);
+            _gpuDoneEvent = new ManualResetEvent(false);
 
             _gpuCancellationTokenSource = new CancellationTokenSource();
 
@@ -499,6 +501,10 @@ namespace Ryujinx.Ui
                         _ticks = Math.Min(_ticks - _ticksPerFrame, _ticksPerFrame);
                     }
                 }
+
+                // Make sure all commands in the run loop are fully executed before leaving the loop.
+                Device.Gpu.Renderer.Flush();
+                _gpuDoneEvent.Set();
             });
         }
 
@@ -542,7 +548,9 @@ namespace Ryujinx.Ui
 
             MainLoop();
 
-            renderLoopThread.Join();
+            // NOTE: The render loop is allowed to stay alive until the renderer itself is disposed, as it may handle resource dispose.
+            // We only need to wait for all commands submitted during the main gpu loop to be processed.
+            _gpuDoneEvent.WaitOne();
             nvStutterWorkaround?.Join();
 
             Exit();

--- a/src/Ryujinx/Ui/RendererWidgetBase.cs
+++ b/src/Ryujinx/Ui/RendererWidgetBase.cs
@@ -555,6 +555,7 @@ namespace Ryujinx.Ui
             // NOTE: The render loop is allowed to stay alive until the renderer itself is disposed, as it may handle resource dispose.
             // We only need to wait for all commands submitted during the main gpu loop to be processed.
             _gpuDoneEvent.WaitOne();
+            _gpuDoneEvent.Dispose();
             nvStutterWorkaround?.Join();
 
             Exit();

--- a/src/Ryujinx/Ui/RendererWidgetBase.cs
+++ b/src/Ryujinx/Ui/RendererWidgetBase.cs
@@ -503,7 +503,11 @@ namespace Ryujinx.Ui
                 }
 
                 // Make sure all commands in the run loop are fully executed before leaving the loop.
-                Device.Gpu.Renderer.Flush();
+                if (Device.Gpu.Renderer is ThreadedRenderer threaded)
+                {
+                    threaded.FlushThreadedCommands();
+                }
+
                 _gpuDoneEvent.Set();
             });
         }


### PR DESCRIPTION
Deferred actions from disposing physical memory instances always dispose the resources in their caches. The renderer can't be disposed before these resources get disposed, otherwise the dispose actions will not actually run (leaking memory), and the ThreadedRenderer may get stuck trying to enqueue too many commands when there is nothing consuming them (user must close console manually).

This should fix most instances of the emulator freezing on close.

Should fix #2863, should obsolete #5121. Needs a bunch of testing obviously.