### PR TITLE
Logger: Add warning that WinTerminal doesn't support hiding console window

### DIFF
--- a/src/Ryujinx.Ui.Common/Helper/ConsoleHelper.cs
+++ b/src/Ryujinx.Ui.Common/Helper/ConsoleHelper.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+using System.Diagnostics;
 
 namespace Ryujinx.Ui.Common.Helper
 {
@@ -13,7 +14,12 @@ namespace Ryujinx.Ui.Common.Helper
         {
             if (OperatingSystem.IsWindows())
             {
-                SetConsoleWindowStateWindows(show);
+                if (Process.GetProcessesByName("WindowsTerminal").Length < 0) {
+                    SetConsoleWindowStateWindows(show);
+                }
+                else {
+                    Logger.Warning?.Print(LogClass.Application, "Windows Terminal doesn't support hiding console window");
+                }
             }
             else if (show == false)
             {


### PR DESCRIPTION
Windows Terminal doesn't support hiding console window, and unfortunately this is by design. This small PR will write a warning in the log to inform users about that.

I haven't tested this on Windows 10 or Win 11 before 22H2 update.