### PR TITLE
Skip draws with zero vertex count

### DIFF
--- a/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineBase.cs
@@ -358,7 +358,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         public void Draw(int vertexCount, int instanceCount, int firstVertex, int firstInstance)
         {
-            if (!_program.IsLinked)
+            if (!_program.IsLinked || vertexCount == 0)
             {
                 return;
             }
@@ -422,7 +422,7 @@ namespace Ryujinx.Graphics.Vulkan
 
         public void DrawIndexed(int indexCount, int instanceCount, int firstIndex, int firstVertex, int firstInstance)
         {
-            if (!_program.IsLinked)
+            if (!_program.IsLinked || indexCount == 0)
             {
                 return;
             }


### PR DESCRIPTION
Draws with a vertex count of 0 doesn't actually draw anything, so it should be fine to just skip them. There's a case where trying to do the 0 vertices draw triggers a bug: When doing topology coversion, it will try to create a buffer large enough to hold all vertices, and in this case it would try to create a buffer with size 0 which is invalid, and later causes a NRE crash. This change prevents that crash.

This was reported by a user on Discord using macOS with the game Marvel Ultimate Alliance 3. That game does not render correctly though for the same reason as Nier Automata: The game does subgroup operations and writes index buffer (?) and at least in MUA3 case, also indirect data from a geometry shader, which is likely also the root case of this issue.