### PR TITLE
Fix Avalonia Library header changes size when switching between List/Grid view

### DIFF
--- a/src/Ryujinx.Ava/UI/Views/Main/MainViewControls.axaml
+++ b/src/Ryujinx.Ava/UI/Views/Main/MainViewControls.axaml
@@ -16,6 +16,7 @@
     </Design.DataContext>
     <DockPanel
         Margin="0,0,0,5"
+        Height="35"
         HorizontalAlignment="Stretch">
         <Button
             Width="40"


### PR DESCRIPTION
Adds an explicit height to the panel so that it won't grow/shrink when the show names checkbox is added/removed. 
Only tested on Win11 on windowed & full screen modes. 