### PR TITLE
UI: Warn if user attempts to open more than 1 Ryujinx instances

### DIFF
--- a/src/Ryujinx.Ava/Assets/Locales/en_US.json
+++ b/src/Ryujinx.Ava/Assets/Locales/en_US.json
@@ -639,5 +639,6 @@
   "NetworkInterfaceDefault": "Default",
   "PackagingShaders": "Packaging Shaders",
   "AboutChangelogButton": "View Changelog on GitHub",
-  "AboutChangelogButtonTooltipMessage": "Click to open the changelog for this version in your default browser."
+  "AboutChangelogButtonTooltipMessage": "Click to open the changelog for this version in your default browser.",
+  "DialogMessageOnlyOneInstance": "Only 1 instance of Ryujinx is allowed. Please close other Ryujinx instances if necessary."
 }

--- a/src/Ryujinx.Ava/Program.cs
+++ b/src/Ryujinx.Ava/Program.cs
@@ -17,6 +17,7 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using System.Diagnostics;
 
 namespace Ryujinx.Ava
 {
@@ -125,6 +126,17 @@ namespace Ryujinx.Ava
             if (CommandLineState.LaunchPathArg != null)
             {
                 MainWindow.DeferLoadApplication(CommandLineState.LaunchPathArg, CommandLineState.StartFullscreenArg);
+            }
+
+            // Check for multiple instances of Ryujinx
+            Process currentProcess = Process.GetCurrentProcess();
+            foreach (Process process in Process.GetProcessesByName(currentProcess.ProcessName))
+            {
+                if (process.Id != currentProcess.Id)
+                {
+                   MainWindow.ShowMultipleInstancesDialog = true;
+                   Logger.Warning?.PrintMsg(LogClass.Application, "Only 1 instance of Ryujinx is allowed, please close other Ryujinx instances if necessary"); // Add warning in the console just in case the GUI sometimes doesn't show up.
+                }
             }
         }
 

--- a/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
@@ -25,6 +25,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Threading.Tasks;
 using InputManager = Ryujinx.Input.HLE.InputManager;
+using System.Diagnostics;
 
 namespace Ryujinx.Ava.UI.Windows
 {
@@ -53,6 +54,8 @@ namespace Ryujinx.Ava.UI.Windows
 
         public static bool ShowKeyErrorOnLoad { get; set; }
         public ApplicationLibrary ApplicationLibrary { get; set; }
+
+        public static bool ShowMultipleInstancesDialog { get; set; }
 
         public MainWindow()
         {
@@ -281,6 +284,18 @@ namespace Ryujinx.Ava.UI.Windows
                 {
                     Logger.Error?.Print(LogClass.Application, $"Updater Error: {task.Exception}");
                 }, TaskContinuationOptions.OnlyOnFaulted);
+            }
+
+            // Check for multiple instances of Ryujinx
+            if (ShowMultipleInstancesDialog)
+            {
+                ShowMultipleInstancesDialog = false;
+
+                Dispatcher.UIThread.InvokeAsync(async () =>
+                {
+                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance[LocaleKeys.DialogMessageOnlyOneInstance]);
+                    Process.GetCurrentProcess().Kill();
+                });
             }
         }
 

--- a/src/Ryujinx/Program.cs
+++ b/src/Ryujinx/Program.cs
@@ -260,6 +260,18 @@ namespace Ryujinx
                 UserErrorDialog.CreateUserErrorDialog(UserError.NoKeys);
             }
 
+            // Check for multiple instances of Ryujinx
+            Process currentProcess = Process.GetCurrentProcess();
+            foreach (Process process in Process.GetProcessesByName(currentProcess.ProcessName))
+            {
+                if (process.Id != currentProcess.Id)
+                {
+                    Logger.Warning?.PrintMsg(LogClass.Application, "Only 1 instance of Ryujinx is allowed, please close other Ryujinx instances if necessary"); // Add warning in the console just in case the GUI sometimes doesn't show up.
+                    GtkDialog.CreateErrorDialog("Only 1 instance of Ryujinx is allowed. Please close other Ryujinx instances if necessary.");
+                    Process.GetCurrentProcess().Kill();
+                }
+            }
+
             // Show the main window UI.
             MainWindow mainWindow = new MainWindow();
             mainWindow.Show();


### PR DESCRIPTION
Users are not supposed to open more than 1 instance of Ryujinx at once. In addition, it also serves as a useful information in case there's *that* one Ryujinx instance stuck in the background which takes up GBs of precious RAM memory \*shrug\*. RPCS3 emulator has it, so why not?

I also added in the console window in case the GUI sometimes doesn't show up for some reasons.

Screenshots:

Ava UI:

![image](https://github.com/Ryujinx/Ryujinx/assets/5692900/5f1f228c-a78a-49f0-8a6f-f86d2defa0fa)

GTK UI:

![image](https://github.com/Ryujinx/Ryujinx/assets/5692900/d96e5707-99c9-4e07-8e37-ec61f2018695)
