### PR TITLE
macOS Headless Fixes

### DIFF
--- a/src/Ryujinx.Headless.SDL2/Options.cs
+++ b/src/Ryujinx.Headless.SDL2/Options.cs
@@ -129,8 +129,8 @@ namespace Ryujinx.Headless.SDL2
         [Option("audio-volume", Required = false, Default = 1.0f, HelpText ="The audio level (0 to 1).")]
         public float AudioVolume { get; set; }
 
-        [Option("use-hypervisor", Required = false, Default = false, HelpText = "Uses Hypervisor over JIT if available.")]
-        public bool UseHypervisor { get; set; }
+        [Option("use-hypervisor", Required = false, Default = true, HelpText = "Uses Hypervisor over JIT if available.")]
+        public bool? UseHypervisor { get; set; }
 
         [Option("lan-interface-id", Required = false, Default = "0", HelpText = "GUID for the network interface used by LAN.")]
         public string MultiplayerLanInterfaceId { get; set; }

--- a/src/Ryujinx.Headless.SDL2/Options.cs
+++ b/src/Ryujinx.Headless.SDL2/Options.cs
@@ -129,7 +129,7 @@ namespace Ryujinx.Headless.SDL2
         [Option("audio-volume", Required = false, Default = 1.0f, HelpText ="The audio level (0 to 1).")]
         public float AudioVolume { get; set; }
 
-        [Option("use-hypervisor", Required = false, Default = true, HelpText = "Uses Hypervisor over JIT if available.")]
+        [Option("use-hypervisor", Required = false, Default = false, HelpText = "Uses Hypervisor over JIT if available.")]
         public bool UseHypervisor { get; set; }
 
         [Option("lan-interface-id", Required = false, Default = "0", HelpText = "GUID for the network interface used by LAN.")]

--- a/src/Ryujinx.Headless.SDL2/Program.cs
+++ b/src/Ryujinx.Headless.SDL2/Program.cs
@@ -341,8 +341,11 @@ namespace Ryujinx.Headless.SDL2
 
             if (OperatingSystem.IsMacOS())
             {
-                option.GraphicsBackend = GraphicsBackend.Vulkan;
-                Logger.Warning?.Print(LogClass.Application, "OpenGL is not supported on macOS, switching to Vulkan!");
+                if (option.GraphicsBackend == GraphicsBackend.OpenGl)
+                {
+                    option.GraphicsBackend = GraphicsBackend.Vulkan;
+                    Logger.Warning?.Print(LogClass.Application, "OpenGL is not supported on macOS, switching to Vulkan!");
+                }
             }
 
             IGamepad gamepad;
@@ -556,7 +559,7 @@ namespace Ryujinx.Headless.SDL2
                                                                   options.IgnoreMissingServices,
                                                                   options.AspectRatio,
                                                                   options.AudioVolume,
-                                                                  options.UseHypervisor,
+                                                                  options.UseHypervisor ?? true,
                                                                   options.MultiplayerLanInterfaceId);
 
             return new Switch(configuration);

--- a/src/Ryujinx.Headless.SDL2/Program.cs
+++ b/src/Ryujinx.Headless.SDL2/Program.cs
@@ -339,6 +339,12 @@ namespace Ryujinx.Headless.SDL2
 
             GraphicsConfig.EnableShaderCache = true;
 
+            if (OperatingSystem.IsMacOS())
+            {
+                option.GraphicsBackend = GraphicsBackend.Vulkan;
+                Logger.Warning?.Print(LogClass.Application, "OpenGL is not supported on macOS, switching to Vulkan!");
+            }
+
             IGamepad gamepad;
 
             if (option.ListInputIds)

--- a/src/Ryujinx.Headless.SDL2/Ryujinx.Headless.SDL2.csproj
+++ b/src/Ryujinx.Headless.SDL2/Ryujinx.Headless.SDL2.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" />
+    <PackageReference Include="Ryujinx.Graphics.Vulkan.Dependencies.MoltenVK" Condition="'$(RuntimeIdentifier)' != 'linux-x64' AND '$(RuntimeIdentifier)' != 'win10-x64'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ryujinx.Headless.SDL2/Ryujinx.Headless.SDL2.csproj
+++ b/src/Ryujinx.Headless.SDL2/Ryujinx.Headless.SDL2.csproj
@@ -7,6 +7,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Version>1.0.0-dirty</Version>
     <DefineConstants Condition=" '$(ExtraDefineConstants)' != '' ">$(DefineConstants);$(ExtraDefineConstants)</DefineConstants>
+    <SigningCertificate Condition=" '$(SigningCertificate)' == '' ">-</SigningCertificate>
     <TieredPGO>true</TieredPGO>
   </PropertyGroup>
 
@@ -14,6 +15,10 @@
     <PackageReference Include="OpenTK.Core" />
     <PackageReference Include="Ryujinx.Graphics.Nvdec.Dependencies" />
   </ItemGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="$([MSBuild]::IsOSPlatform('OSX'))">
+    <Exec Command="codesign --entitlements '$(ProjectDir)..\..\distribution\macos\entitlements.xml' -f --deep -s $(SigningCertificate) '$(TargetDir)$(TargetName)'" />
+  </Target>
 
   <ItemGroup>
     <ProjectReference Include="..\Ryujinx.Graphics.Vulkan\Ryujinx.Graphics.Vulkan.csproj" />


### PR DESCRIPTION
- Make `use-hypervisor` nullable
   - There is a long-standing bug in CommandLineParser that makes it impossible to disable a bool argument if it is set to true by default and is not nullable
- Properly sign headless builds so they can use Hypervisor
- Bundle MoltenVK in headless builds when building for macOS
- Force Vulkan on macOS

Other Potential Fixes:
- CommandLineParser can't seem to read macOS path strings with escaped spaces in them correctly