### PR TITLE
Dont Error on Invalid Enum Values

### DIFF
--- a/src/Ryujinx.Common/Utilities/TypedStringEnumConverter.cs
+++ b/src/Ryujinx.Common/Utilities/TypedStringEnumConverter.cs
@@ -23,7 +23,14 @@ namespace Ryujinx.Common.Utilities
                 return default;
             }
 
-            return Enum.Parse<TEnum>(enumValue);
+            try
+            {
+                return Enum.Parse<TEnum>(enumValue);
+            }
+            catch
+            {
+                return default;
+            }
         }
 
         public override void Write(Utf8JsonWriter writer, TEnum value, JsonSerializerOptions options)

--- a/src/Ryujinx.Common/Utilities/TypedStringEnumConverter.cs
+++ b/src/Ryujinx.Common/Utilities/TypedStringEnumConverter.cs
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+using Ryujinx.Common.Logging;
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -24,6 +25,7 @@ namespace Ryujinx.Common.Utilities
                 return value;
             }
 
+            Logger.Warning?.Print(LogClass.Configuration, $"Failed to parse enum value \"{enumValue}\" for {typeof(TEnum)}, using default \"{default(TEnum)}\"");
             return default;
         }
 

--- a/src/Ryujinx.Common/Utilities/TypedStringEnumConverter.cs
+++ b/src/Ryujinx.Common/Utilities/TypedStringEnumConverter.cs
@@ -18,19 +18,13 @@ namespace Ryujinx.Common.Utilities
         public override TEnum Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             var enumValue = reader.GetString();
-            if (string.IsNullOrEmpty(enumValue))
+
+            if (Enum.TryParse(enumValue, out TEnum value))
             {
-                return default;
+                return value;
             }
 
-            try
-            {
-                return Enum.Parse<TEnum>(enumValue);
-            }
-            catch
-            {
-                return default;
-            }
+            return default;
         }
 
         public override void Write(Utf8JsonWriter writer, TEnum value, JsonSerializerOptions options)


### PR DESCRIPTION
Stops Ryujinx from throwing out the whole config file if one enum has an invalid value (very annoying if you're working on a PR to add a new backend lol)