### PR TITLE
Share ResourceManager between vertex A and B shaders

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Shader/GpuAccessorBase.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/GpuAccessorBase.cs
@@ -17,8 +17,6 @@ namespace Ryujinx.Graphics.Gpu.Shader
         private readonly ResourceCounts _resourceCounts;
         private readonly int _stageIndex;
 
-        private readonly int[] _constantBufferBindings;
-
         /// <summary>
         /// Creates a new GPU accessor.
         /// </summary>
@@ -28,12 +26,6 @@ namespace Ryujinx.Graphics.Gpu.Shader
             _context = context;
             _resourceCounts = resourceCounts;
             _stageIndex = stageIndex;
-
-            if (context.Capabilities.Api != TargetApi.Vulkan)
-            {
-                _constantBufferBindings = new int[Constants.TotalGpUniformBuffers];
-                _constantBufferBindings.AsSpan().Fill(-1);
-            }
         }
 
         public int QueryBindingConstantBuffer(int index)
@@ -45,15 +37,7 @@ namespace Ryujinx.Graphics.Gpu.Shader
             }
             else
             {
-                int binding = _constantBufferBindings[index];
-
-                if (binding < 0)
-                {
-                    binding = _resourceCounts.UniformBuffersCount++;
-                    _constantBufferBindings[index] = binding;
-                }
-
-                return binding;
+                return _resourceCounts.UniformBuffersCount++;
             }
         }
 

--- a/src/Ryujinx.Graphics.Shader/Translation/ResourceManager.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/ResourceManager.cs
@@ -17,6 +17,8 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         private readonly HashSet<int> _usedConstantBufferBindings;
 
+        public ShaderProperties Properties => _properties;
+
         public ResourceManager(ShaderStage stage, IGpuAccessor gpuAccessor, ShaderProperties properties)
         {
             _gpuAccessor = gpuAccessor;
@@ -96,19 +98,6 @@ namespace Ryujinx.Graphics.Shader.Translation
             });
 
             _properties.AddConstantBuffer(binding, new BufferDefinition(BufferLayout.Std140, 0, binding, name, type));
-        }
-
-        public void InheritFrom(ResourceManager other)
-        {
-            for (int i = 0; i < other._cbSlotToBindingMap.Length; i++)
-            {
-                int binding = other._cbSlotToBindingMap[i];
-
-                if (binding >= 0)
-                {
-                    _cbSlotToBindingMap[i] = binding;
-                }
-            }
         }
 
         public static string GetShaderStagePrefix(ShaderStage stage)

--- a/src/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/ShaderConfig.cs
@@ -39,9 +39,9 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public TranslationOptions Options { get; }
 
-        public ShaderProperties Properties { get; }
+        public ShaderProperties Properties => ResourceManager.Properties;
 
-        public ResourceManager ResourceManager { get; }
+        public ResourceManager ResourceManager { get; set; }
 
         public bool TransformFeedbackEnabled { get; }
 
@@ -159,8 +159,7 @@ namespace Ryujinx.Graphics.Shader.Translation
             _sbSlots        = new Dictionary<int, int>();
             _sbSlotsReverse = new Dictionary<int, int>();
 
-            Properties = new ShaderProperties();
-            ResourceManager = new ResourceManager(stage, gpuAccessor, Properties);
+            ResourceManager = new ResourceManager(stage, gpuAccessor, new ShaderProperties());
         }
 
         public ShaderConfig(
@@ -429,8 +428,6 @@ namespace Ryujinx.Graphics.Shader.Translation
 
         public void InheritFrom(ShaderConfig other)
         {
-            ResourceManager.InheritFrom(other.ResourceManager);
-
             ClipDistancesWritten |= other.ClipDistancesWritten;
             UsedFeatures |= other.UsedFeatures;
 

--- a/src/Ryujinx.Graphics.Shader/Translation/TranslatorContext.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/TranslatorContext.cs
@@ -155,6 +155,9 @@ namespace Ryujinx.Graphics.Shader.Translation
             {
                 other._config.MergeOutputUserAttributes(_config.UsedOutputAttributes, Enumerable.Empty<int>());
 
+                // We need to share the resource manager since both shaders accesses the same constant buffers.
+                other._config.ResourceManager = _config.ResourceManager;
+
                 FunctionCode[] otherCode = EmitShader(other._program, other._config, initializeOutputs: true, out int aStart);
 
                 code = Combine(otherCode, code, aStart);


### PR DESCRIPTION
This fixes a regression from #4646 that caused Borderlands 2 to crash before the title screen while generating a shader. It had an issue while trying to reconcile the bindings between the vertex A and B stages when they are combined. It would have missing bindings which would cause crashes later on as it would not be able to find the constant buffer from the binding when generating the SPIR-V or GLSL code. This change fixes the issue by using the same `ResourceManager` instance for both stages. This should be fine since they share the same constant buffers (and as consequence, also shares the same storage buffer and textures/images, since the base address for the storage buffer and handles for the textures also comes from constant buffers).