### PR TITLE
Vulkan: Include DepthMode in ProgramPipelineState

### DIFF
--- a/src/Ryujinx.Graphics.GAL/ProgramPipelineState.cs
+++ b/src/Ryujinx.Graphics.GAL/ProgramPipelineState.cs
@@ -63,6 +63,8 @@ namespace Ryujinx.Graphics.GAL
         public bool PrimitiveRestartEnable;
         public uint PatchControlPoints;
 
+        public DepthMode DepthMode;
+
         public void SetVertexAttribs(ReadOnlySpan<VertexAttribDescriptor> vertexAttribs)
         {
             VertexAttribCount = vertexAttribs.Length;

--- a/src/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Threed/StateUpdater.cs
@@ -771,7 +771,11 @@ namespace Ryujinx.Graphics.Gpu.Engine.Threed
         /// </summary>
         private void UpdateDepthMode()
         {
-            _context.Renderer.Pipeline.SetDepthMode(GetDepthMode());
+            DepthMode mode = GetDepthMode();
+
+            _pipeline.DepthMode = mode;
+
+            _context.Renderer.Pipeline.SetDepthMode(mode);
         }
 
         /// <summary>

--- a/src/Ryujinx.Graphics.Gpu/Shader/ShaderSpecializationState.cs
+++ b/src/Ryujinx.Graphics.Gpu/Shader/ShaderSpecializationState.cs
@@ -737,6 +737,19 @@ namespace Ryujinx.Graphics.Gpu.Shader
         }
 
         /// <summary>
+        /// Populates pipeline state that doesn't exist in older caches with default values
+        /// based on specialization state.
+        /// </summary>
+        /// <param name="pipelineState">Pipeline state to prepare</param>
+        private void PreparePipelineState(ref ProgramPipelineState pipelineState)
+        {
+            if (!_compute)
+            {
+                pipelineState.DepthMode = GraphicsState.DepthMode ? DepthMode.MinusOneToOne : DepthMode.ZeroToOne;
+            }
+        }
+
+        /// <summary>
         /// Reads shader specialization state that has been serialized.
         /// </summary>
         /// <param name="dataReader">Data reader</param>
@@ -776,6 +789,8 @@ namespace Ryujinx.Graphics.Gpu.Shader
             {
                 ProgramPipelineState pipelineState = default;
                 dataReader.ReadWithMagicAndSize(ref pipelineState, PgpsMagic);
+
+                specState.PreparePipelineState(ref pipelineState);
                 specState.PipelineState = pipelineState;
             }
 

--- a/src/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
+++ b/src/Ryujinx.Graphics.Vulkan/PipelineConverter.cs
@@ -165,6 +165,7 @@ namespace Ryujinx.Graphics.Vulkan
             pipeline.DepthTestEnable = state.DepthTest.TestEnable;
             pipeline.DepthWriteEnable = state.DepthTest.WriteEnable;
             pipeline.DepthCompareOp = state.DepthTest.Func.Convert();
+            pipeline.DepthMode = state.DepthMode == DepthMode.MinusOneToOne;
 
             pipeline.FrontFace = state.FrontFace.Convert();
 


### PR DESCRIPTION
Depth mode has been added to the pipeline state by #5027, but was not properly recorded for background compilation or shader caching, which would result in the pipeline compiled to mismatch on first draw, and have to compile another. This could cause additional stuttering.

This PR adds depth mode to the pipeline state and handles it in the converter. Since this already exists in the specialization state, it is always sourced from there when not available (but really, just always). In future it might be worth passing the read size of the struct to the method to decide to overwrite values based on that, for example if this state were to somehow become optional.