### PR TITLE
Allow BGRA storage images on Vulkan

### DIFF
--- a/src/Ryujinx.Graphics.GAL/Format.cs
+++ b/src/Ryujinx.Graphics.GAL/Format.cs
@@ -383,6 +383,7 @@ namespace Ryujinx.Graphics.GAL
                 case Format.R10G10B10A2Unorm:
                 case Format.R10G10B10A2Uint:
                 case Format.R11G11B10Float:
+                case Format.B8G8R8A8Unorm:
                     return true;
             }
 

--- a/src/Ryujinx.Graphics.Vulkan/Effects/FsrScalingFilter.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Effects/FsrScalingFilter.cs
@@ -96,8 +96,6 @@ namespace Ryujinx.Graphics.Vulkan.Effects
             {
                 var originalInfo = view.Info;
 
-                var swapRB = originalInfo.Format.IsBgr() && originalInfo.SwizzleR == SwizzleComponent.Red;
-
                 var info = new TextureCreateInfo(
                     width,
                     height,
@@ -110,9 +108,9 @@ namespace Ryujinx.Graphics.Vulkan.Effects
                     originalInfo.Format,
                     originalInfo.DepthStencilMode,
                     originalInfo.Target,
-                    swapRB ? originalInfo.SwizzleB : originalInfo.SwizzleR,
+                    originalInfo.SwizzleR,
                     originalInfo.SwizzleG,
-                    swapRB ? originalInfo.SwizzleR : originalInfo.SwizzleB,
+                    originalInfo.SwizzleB,
                     originalInfo.SwizzleA);
                 _intermediaryTexture?.Dispose();
                 _intermediaryTexture = _renderer.CreateTexture(info, view.ScaleFactor) as TextureView;
@@ -155,7 +153,7 @@ namespace Ryujinx.Graphics.Vulkan.Effects
 
             var bufferRanges = new BufferRange(bufferHandle, 0, rangeSize);
             _pipeline.SetUniformBuffers(stackalloc[] { new BufferAssignment(2, bufferRanges) });
-            _pipeline.SetImage(0, _intermediaryTexture, GAL.Format.R8G8B8A8Unorm);
+            _pipeline.SetImage(0, _intermediaryTexture, FormatTable.ConvertRgba8SrgbToUnorm(view.Info.Format));
             _pipeline.DispatchCompute(dispatchX, dispatchY, 1);
             _pipeline.ComputeBarrier();
 

--- a/src/Ryujinx.Graphics.Vulkan/Effects/FxaaPostProcessingEffect.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Effects/FxaaPostProcessingEffect.cs
@@ -56,28 +56,7 @@ namespace Ryujinx.Graphics.Vulkan.Effects
             if (_texture == null || _texture.Width != view.Width || _texture.Height != view.Height)
             {
                 _texture?.Dispose();
-
-                var info = view.Info;
-
-                if (view.Info.Format.IsBgr())
-                {
-                    info = new TextureCreateInfo(info.Width,
-                        info.Height,
-                        info.Depth,
-                        info.Levels,
-                        info.Samples,
-                        info.BlockWidth,
-                        info.BlockHeight,
-                        info.BytesPerPixel,
-                        info.Format,
-                        info.DepthStencilMode,
-                        info.Target,
-                        info.SwizzleB,
-                        info.SwizzleG,
-                        info.SwizzleR,
-                        info.SwizzleA);
-                }
-                _texture = _renderer.CreateTexture(info, view.ScaleFactor) as TextureView;
+                _texture = _renderer.CreateTexture(view.Info, view.ScaleFactor) as TextureView;
             }
 
             _pipeline.SetCommandBuffer(cbs);
@@ -96,7 +75,7 @@ namespace Ryujinx.Graphics.Vulkan.Effects
             var dispatchX = BitUtils.DivRoundUp(view.Width, IPostProcessingEffect.LocalGroupSize);
             var dispatchY = BitUtils.DivRoundUp(view.Height, IPostProcessingEffect.LocalGroupSize);
 
-            _pipeline.SetImage(0, _texture, GAL.Format.R8G8B8A8Unorm);
+            _pipeline.SetImage(0, _texture, FormatTable.ConvertRgba8SrgbToUnorm(view.Info.Format));
             _pipeline.DispatchCompute(dispatchX, dispatchY, 1);
 
             _renderer.BufferManager.Delete(bufferHandle);

--- a/src/Ryujinx.Graphics.Vulkan/FormatTable.cs
+++ b/src/Ryujinx.Graphics.Vulkan/FormatTable.cs
@@ -169,6 +169,16 @@ namespace Ryujinx.Graphics.Vulkan
             return _table[(int)format];
         }
 
+        public static Format ConvertRgba8SrgbToUnorm(Format format)
+        {
+            return format switch
+            {
+                Format.R8G8B8A8Srgb => Format.R8G8B8A8Unorm,
+                Format.B8G8R8A8Srgb => Format.B8G8R8A8Unorm,
+                _ => format
+            };
+        }
+
         public static int GetAttributeFormatSize(VkFormat format)
         {
             switch (format)


### PR DESCRIPTION
There's a bug on the FXAA and SMAA filters, where if the presentation texture has a BGRA format, it will create a intermediary BGRA texture, but bind it as a RGBA format. This causes the R and B components to be inverted once the filter is applied. It seems there was an attempt to correct that by inverting the R and B components on the swizzle, but that does nothing on *storage image operations*, at least on Vulkan.

This change fixes the issue by simply allowing the BGRA format to be bound directly as a storage image. Most vendors supports this. It also makes the code simpler and more efficient as we don't need to create a new view with different format.

Fixes the issue on Persona 4 Golden and any other game presenting BGRA textures, with FXAA and SMAA filters.
Before:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/7c72c679-4dad-42dd-8f1b-7e450f552d3a)
After:
![image](https://github.com/Ryujinx/Ryujinx/assets/5624669/58e4af2c-f3b0-4b88-89cf-ce9048cbec7b)
Fixes #5193.