### PR TITLE
ava: Fix Open Applet menu enabled

### DIFF
--- a/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
@@ -257,6 +257,7 @@ namespace Ryujinx.Ava.UI.ViewModels
 
                 OnPropertyChanged();
                 OnPropertyChanged(nameof(EnableNonGameRunningControls));
+                OnPropertyChanged(nameof(IsAppletMenuActive));
                 OnPropertyChanged(nameof(StatusBarVisible));
                 OnPropertyChanged(nameof(ShowFirmwareStatus));
             }


### PR DESCRIPTION
Currently, the `Open Applet` menu is still enabled when a guest is running, which is wrong. This is now fixed by refreshing the property binding on `IsEnabled`.