### PR TITLE
ava: Fix exit dialog while guest is running.

### DIFF
--- a/src/Ryujinx.Ava/UI/Helpers/ContentDialogHelper.cs
+++ b/src/Ryujinx.Ava/UI/Helpers/ContentDialogHelper.cs
@@ -318,7 +318,7 @@ namespace Ryujinx.Ava.UI.Helpers
 
             Window parent = GetMainWindow();
 
-            if (parent.IsActive == true && (parent as MainWindow).ViewModel.IsGameRunning)
+            if (parent != null && parent.IsActive && (parent as MainWindow).ViewModel.IsGameRunning)
             {
                 contentDialogOverlayWindow = new()
                 {

--- a/src/Ryujinx.Ava/UI/Helpers/ContentDialogHelper.cs
+++ b/src/Ryujinx.Ava/UI/Helpers/ContentDialogHelper.cs
@@ -318,7 +318,7 @@ namespace Ryujinx.Ava.UI.Helpers
 
             Window parent = GetMainWindow();
 
-            if (parent is { IsActive: true } and MainWindow window && window.ViewModel.IsGameRunning)
+            if (parent.IsActive == true && (parent as MainWindow).ViewModel.IsGameRunning)
             {
                 contentDialogOverlayWindow = new()
                 {

--- a/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
@@ -520,12 +520,12 @@ namespace Ryujinx.Ava.UI.Windows
         {
             Dispatcher.UIThread.InvokeAsync(async () =>
             {
-               ViewModel.IsClosing = await ContentDialogHelper.CreateExitDialog();
+                ViewModel.IsClosing = await ContentDialogHelper.CreateExitDialog();
 
-               if (ViewModel.IsClosing)
-               {
-                   Close();
-               }
+                if (ViewModel.IsClosing)
+                {
+                    Close();
+                }
             });
         }
 

--- a/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
@@ -519,14 +519,14 @@ namespace Ryujinx.Ava.UI.Windows
         private void ConfirmExit()
         {
             Dispatcher.UIThread.InvokeAsync(async () =>
-           {
+            {
                ViewModel.IsClosing = await ContentDialogHelper.CreateExitDialog();
 
                if (ViewModel.IsClosing)
                {
                    Close();
                }
-           });
+            });
         }
 
         public async void LoadApplications()


### PR DESCRIPTION
There is currently an issue while a game runs, the content dialog creation method check if `IsGameRunning` is true to show the popup. But the condition here is wrong (`window` is null) so it throw a NullException silently in `Dispatcher.UIThread`. This is now fixed by using the right casting.