### PR TITLE
Blocks should be synchronized on read-only fields

### DIFF
--- a/src/ARMeilleure/Signal/NativeSignalHandler.cs
+++ b/src/ARMeilleure/Signal/NativeSignalHandler.cs
@@ -78,7 +78,7 @@ namespace ARMeilleure.Signal
         private static IntPtr _signalHandlerPtr;
         private static IntPtr _signalHandlerHandle;
 
-        private static readonly object _lock = new object();
+        private static readonly object _lock = new();
         private static bool _initialized;
 
         static NativeSignalHandler()

--- a/src/ARMeilleure/Translation/Cache/JitCache.cs
+++ b/src/ARMeilleure/Translation/Cache/JitCache.cs
@@ -26,7 +26,7 @@ namespace ARMeilleure.Translation.Cache
 
         private static readonly List<CacheEntry> _cacheEntries = new List<CacheEntry>();
 
-        private static readonly object _lock = new object();
+        private static readonly object _lock = new();
         private static bool _initialized;
 
         [SupportedOSPlatform("windows")]

--- a/src/Ryujinx.Audio.Backends.OpenAL/OpenALHardwareDeviceSession.cs
+++ b/src/Ryujinx.Audio.Backends.OpenAL/OpenALHardwareDeviceSession.cs
@@ -17,7 +17,7 @@ namespace Ryujinx.Audio.Backends.OpenAL
         private Queue<OpenALAudioBuffer> _queuedBuffers;
         private ulong _playedSampleCount;
 
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
 
         public OpenALHardwareDeviceSession(OpenALHardwareDeviceDriver driver, IVirtualMemoryManager memoryManager, SampleFormat requestedSampleFormat, uint requestedSampleRate, uint requestedChannelCount, float requestedVolume) : base(memoryManager, requestedSampleFormat, requestedSampleRate, requestedChannelCount)
         {

--- a/src/Ryujinx.Audio.Backends.OpenAL/OpenALHardwareDeviceSession.cs
+++ b/src/Ryujinx.Audio.Backends.OpenAL/OpenALHardwareDeviceSession.cs
@@ -17,7 +17,7 @@ namespace Ryujinx.Audio.Backends.OpenAL
         private Queue<OpenALAudioBuffer> _queuedBuffers;
         private ulong _playedSampleCount;
 
-        private object _lock = new object();
+        private readonly object _lock = new object();
 
         public OpenALHardwareDeviceSession(OpenALHardwareDeviceDriver driver, IVirtualMemoryManager memoryManager, SampleFormat requestedSampleFormat, uint requestedSampleRate, uint requestedChannelCount, float requestedVolume) : base(memoryManager, requestedSampleFormat, requestedSampleRate, requestedChannelCount)
         {

--- a/src/Ryujinx.Audio/AudioManager.cs
+++ b/src/Ryujinx.Audio/AudioManager.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.Audio
         /// <summary>
         /// Lock used to control the waiters registration.
         /// </summary>
-        private object _lock = new object();
+        private readonly object _lock = new object();
 
         /// <summary>
         /// Events signaled when the driver played audio buffers.

--- a/src/Ryujinx.Audio/AudioManager.cs
+++ b/src/Ryujinx.Audio/AudioManager.cs
@@ -11,7 +11,7 @@ namespace Ryujinx.Audio
         /// <summary>
         /// Lock used to control the waiters registration.
         /// </summary>
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
 
         /// <summary>
         /// Events signaled when the driver played audio buffers.

--- a/src/Ryujinx.Audio/Backends/Common/DynamicRingBuffer.cs
+++ b/src/Ryujinx.Audio/Backends/Common/DynamicRingBuffer.cs
@@ -10,7 +10,7 @@ namespace Ryujinx.Audio.Backends.Common
     {
         private const int RingBufferAlignment = 2048;
 
-        private object _lock = new object();
+        private readonly object _lock = new object();
 
         private byte[] _buffer;
         private int _size;

--- a/src/Ryujinx.Audio/Backends/Common/DynamicRingBuffer.cs
+++ b/src/Ryujinx.Audio/Backends/Common/DynamicRingBuffer.cs
@@ -10,7 +10,7 @@ namespace Ryujinx.Audio.Backends.Common
     {
         private const int RingBufferAlignment = 2048;
 
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
 
         private byte[] _buffer;
         private int _size;

--- a/src/Ryujinx.Audio/Input/AudioInputManager.cs
+++ b/src/Ryujinx.Audio/Input/AudioInputManager.cs
@@ -19,7 +19,7 @@ namespace Ryujinx.Audio.Input
         /// <summary>
         /// Lock used for session allocation.
         /// </summary>
-        private readonly object _sessionLock = new object();
+        private readonly object _sessionLock = new();
 
         /// <summary>
         /// The session ids allocation table.

--- a/src/Ryujinx.Audio/Input/AudioInputManager.cs
+++ b/src/Ryujinx.Audio/Input/AudioInputManager.cs
@@ -19,7 +19,7 @@ namespace Ryujinx.Audio.Input
         /// <summary>
         /// Lock used for session allocation.
         /// </summary>
-        private object _sessionLock = new object();
+        private readonly object _sessionLock = new object();
 
         /// <summary>
         /// The session ids allocation table.

--- a/src/Ryujinx.Audio/Input/AudioInputManager.cs
+++ b/src/Ryujinx.Audio/Input/AudioInputManager.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.Audio.Input
     /// </summary>
     public class AudioInputManager : IDisposable
     {
-        private object _lock = new object();
+        private readonly object _lock = new object();
 
         /// <summary>
         /// Lock used for session allocation.

--- a/src/Ryujinx.Audio/Input/AudioInputManager.cs
+++ b/src/Ryujinx.Audio/Input/AudioInputManager.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.Audio.Input
     /// </summary>
     public class AudioInputManager : IDisposable
     {
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
 
         /// <summary>
         /// Lock used for session allocation.

--- a/src/Ryujinx.Audio/Input/AudioInputSystem.cs
+++ b/src/Ryujinx.Audio/Input/AudioInputSystem.cs
@@ -48,7 +48,7 @@ namespace Ryujinx.Audio.Input
         /// <summary>
         /// The lock of the parent.
         /// </summary>
-        private object _parentLock;
+        private readonly object _parentLock;
 
         /// <summary>
         /// The dispose state.

--- a/src/Ryujinx.Audio/Output/AudioOutputManager.cs
+++ b/src/Ryujinx.Audio/Output/AudioOutputManager.cs
@@ -19,7 +19,7 @@ namespace Ryujinx.Audio.Output
         /// <summary>
         /// Lock used for session allocation.
         /// </summary>
-        private readonly object _sessionLock = new object();
+        private readonly object _sessionLock = new();
 
         /// <summary>
         /// The session ids allocation table.

--- a/src/Ryujinx.Audio/Output/AudioOutputManager.cs
+++ b/src/Ryujinx.Audio/Output/AudioOutputManager.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.Audio.Output
     /// </summary>
     public class AudioOutputManager : IDisposable
     {
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
 
         /// <summary>
         /// Lock used for session allocation.

--- a/src/Ryujinx.Audio/Output/AudioOutputManager.cs
+++ b/src/Ryujinx.Audio/Output/AudioOutputManager.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.Audio.Output
     /// </summary>
     public class AudioOutputManager : IDisposable
     {
-        private object _lock = new object();
+        private readonly object _lock = new object();
 
         /// <summary>
         /// Lock used for session allocation.

--- a/src/Ryujinx.Audio/Output/AudioOutputManager.cs
+++ b/src/Ryujinx.Audio/Output/AudioOutputManager.cs
@@ -19,7 +19,7 @@ namespace Ryujinx.Audio.Output
         /// <summary>
         /// Lock used for session allocation.
         /// </summary>
-        private object _sessionLock = new object();
+        private readonly object _sessionLock = new object();
 
         /// <summary>
         /// The session ids allocation table.

--- a/src/Ryujinx.Audio/Output/AudioOutputSystem.cs
+++ b/src/Ryujinx.Audio/Output/AudioOutputSystem.cs
@@ -48,7 +48,7 @@ namespace Ryujinx.Audio.Output
         /// <summary>
         /// THe lock of the parent.
         /// </summary>
-        private object _parentLock;
+        private readonly object _parentLock;
 
         /// <summary>
         /// The dispose state.

--- a/src/Ryujinx.Audio/Renderer/Server/AudioRenderSystem.cs
+++ b/src/Ryujinx.Audio/Renderer/Server/AudioRenderSystem.cs
@@ -26,7 +26,7 @@ namespace Ryujinx.Audio.Renderer.Server
 {
     public class AudioRenderSystem : IDisposable
     {
-        private object _lock = new object();
+        private readonly object _lock = new object();
 
         private AudioRendererRenderingDevice _renderingDevice;
         private AudioRendererExecutionMode _executionMode;

--- a/src/Ryujinx.Audio/Renderer/Server/AudioRenderSystem.cs
+++ b/src/Ryujinx.Audio/Renderer/Server/AudioRenderSystem.cs
@@ -26,7 +26,7 @@ namespace Ryujinx.Audio.Renderer.Server
 {
     public class AudioRenderSystem : IDisposable
     {
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
 
         private AudioRendererRenderingDevice _renderingDevice;
         private AudioRendererExecutionMode _executionMode;

--- a/src/Ryujinx.Audio/Renderer/Server/AudioRendererManager.cs
+++ b/src/Ryujinx.Audio/Renderer/Server/AudioRendererManager.cs
@@ -19,12 +19,12 @@ namespace Ryujinx.Audio.Renderer.Server
         /// <summary>
         /// Lock used for session allocation.
         /// </summary>
-        private object _sessionLock = new object();
+        private readonly object _sessionLock = new object();
 
         /// <summary>
         /// Lock used to control the <see cref="AudioProcessor"/> running state.
         /// </summary>
-        private object _audioProcessorLock = new object();
+        private readonly object _audioProcessorLock = new object();
 
         /// <summary>
         /// The session ids allocation table.

--- a/src/Ryujinx.Audio/Renderer/Server/AudioRendererManager.cs
+++ b/src/Ryujinx.Audio/Renderer/Server/AudioRendererManager.cs
@@ -19,12 +19,12 @@ namespace Ryujinx.Audio.Renderer.Server
         /// <summary>
         /// Lock used for session allocation.
         /// </summary>
-        private readonly object _sessionLock = new object();
+        private readonly object _sessionLock = new();
 
         /// <summary>
         /// Lock used to control the <see cref="AudioProcessor"/> running state.
         /// </summary>
-        private readonly object _audioProcessorLock = new object();
+        private readonly object _audioProcessorLock = new();
 
         /// <summary>
         /// The session ids allocation table.

--- a/src/Ryujinx.Audio/Renderer/Server/Upsampler/UpsamplerManager.cs
+++ b/src/Ryujinx.Audio/Renderer/Server/Upsampler/UpsamplerManager.cs
@@ -16,7 +16,7 @@ namespace Ryujinx.Audio.Renderer.Server.Upsampler
         /// <summary>
         /// Global lock of the object.
         /// </summary>
-        private readonly object Lock = new object();
+        private readonly object Lock = new();
 
         /// <summary>
         /// The upsamplers instances.

--- a/src/Ryujinx.Audio/Renderer/Server/Upsampler/UpsamplerManager.cs
+++ b/src/Ryujinx.Audio/Renderer/Server/Upsampler/UpsamplerManager.cs
@@ -16,7 +16,7 @@ namespace Ryujinx.Audio.Renderer.Server.Upsampler
         /// <summary>
         /// Global lock of the object.
         /// </summary>
-        private object Lock = new object();
+        private readonly object Lock = new object();
 
         /// <summary>
         /// The upsamplers instances.

--- a/src/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
+++ b/src/Ryujinx.Graphics.GAL/Multithreading/ThreadedRenderer.cs
@@ -56,7 +56,7 @@ namespace Ryujinx.Graphics.GAL.Multithreading
         private int _refConsumerPtr;
 
         private Action _interruptAction;
-        private object _interruptLock = new();
+        private readonly object _interruptLock = new();
 
         public event EventHandler<ScreenCaptureImageInfo> ScreenCaptured;
 

--- a/src/Ryujinx.Graphics.Gpu/Memory/BufferModifiedRangeList.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/BufferModifiedRangeList.cs
@@ -78,7 +78,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         private List<BufferMigration> _sources;
         private BufferMigration _migrationTarget;
 
-        private object _lock = new object();
+        private readonly object _lock = new object();
 
         /// <summary>
         /// Whether the modified range list has any entries or not.
@@ -125,7 +125,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
                 for (int i = 0; i < count; i++)
                 {
                     BufferModifiedRange overlap = overlaps[i];
-                    
+
                     if (overlap.Address > address)
                     {
                         // The start of the remaining region is uncovered by this overlap. Call the action for it.

--- a/src/Ryujinx.Graphics.Gpu/Memory/BufferModifiedRangeList.cs
+++ b/src/Ryujinx.Graphics.Gpu/Memory/BufferModifiedRangeList.cs
@@ -78,7 +78,7 @@ namespace Ryujinx.Graphics.Gpu.Memory
         private List<BufferMigration> _sources;
         private BufferMigration _migrationTarget;
 
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
 
         /// <summary>
         /// Whether the modified range list has any entries or not.

--- a/src/Ryujinx.Graphics.OpenGL/Queries/CounterQueue.cs
+++ b/src/Ryujinx.Graphics.OpenGL/Queries/CounterQueue.cs
@@ -21,7 +21,7 @@ namespace Ryujinx.Graphics.OpenGL.Queries
         private ulong _accumulatedCounter;
         private int _waiterCount;
 
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
 
         private Queue<BufferedQuery> _queryPool;
         private AutoResetEvent _queuedEvent = new AutoResetEvent(false);

--- a/src/Ryujinx.Graphics.OpenGL/Queries/CounterQueue.cs
+++ b/src/Ryujinx.Graphics.OpenGL/Queries/CounterQueue.cs
@@ -21,7 +21,7 @@ namespace Ryujinx.Graphics.OpenGL.Queries
         private ulong _accumulatedCounter;
         private int _waiterCount;
 
-        private object _lock = new object();
+        private readonly object _lock = new object();
 
         private Queue<BufferedQuery> _queryPool;
         private AutoResetEvent _queuedEvent = new AutoResetEvent(false);

--- a/src/Ryujinx.Graphics.OpenGL/Queries/CounterQueueEvent.cs
+++ b/src/Ryujinx.Graphics.OpenGL/Queries/CounterQueueEvent.cs
@@ -24,7 +24,7 @@ namespace Ryujinx.Graphics.OpenGL.Queries
         private bool _hostAccessReserved = false;
         private int _refCount = 1; // Starts with a reference from the counter queue.
 
-        private object _lock = new object();
+        private readonly object _lock = new object();
         private ulong _result = ulong.MaxValue;
         private double _divisor = 1f;
 

--- a/src/Ryujinx.Graphics.OpenGL/Queries/CounterQueueEvent.cs
+++ b/src/Ryujinx.Graphics.OpenGL/Queries/CounterQueueEvent.cs
@@ -24,7 +24,7 @@ namespace Ryujinx.Graphics.OpenGL.Queries
         private bool _hostAccessReserved = false;
         private int _refCount = 1; // Starts with a reference from the counter queue.
 
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
         private ulong _result = ulong.MaxValue;
         private double _divisor = 1f;
 

--- a/src/Ryujinx.Graphics.OpenGL/ResourcePool.cs
+++ b/src/Ryujinx.Graphics.OpenGL/ResourcePool.cs
@@ -20,7 +20,7 @@ namespace Ryujinx.Graphics.OpenGL
     {
         private const int DisposedLiveFrames = 2;
 
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
         private readonly Dictionary<TextureCreateInfo, List<DisposedTexture>> _textures = new Dictionary<TextureCreateInfo, List<DisposedTexture>>();
 
         /// <summary>

--- a/src/Ryujinx.Graphics.Vulkan/Queries/CounterQueue.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Queries/CounterQueue.cs
@@ -24,7 +24,7 @@ namespace Ryujinx.Graphics.Vulkan.Queries
         private ulong _accumulatedCounter;
         private int _waiterCount;
 
-        private object _lock = new object();
+        private readonly object _lock = new object();
 
         private Queue<BufferedQuery> _queryPool;
         private AutoResetEvent _queuedEvent = new AutoResetEvent(false);

--- a/src/Ryujinx.Graphics.Vulkan/Queries/CounterQueue.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Queries/CounterQueue.cs
@@ -24,7 +24,7 @@ namespace Ryujinx.Graphics.Vulkan.Queries
         private ulong _accumulatedCounter;
         private int _waiterCount;
 
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
 
         private Queue<BufferedQuery> _queryPool;
         private AutoResetEvent _queuedEvent = new AutoResetEvent(false);

--- a/src/Ryujinx.Graphics.Vulkan/Queries/CounterQueueEvent.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Queries/CounterQueueEvent.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Vulkan.Queries
         private bool _hostAccessReserved = false;
         private int _refCount = 1; // Starts with a reference from the counter queue.
 
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
         private ulong _result = ulong.MaxValue;
         private double _divisor = 1f;
 

--- a/src/Ryujinx.Graphics.Vulkan/Queries/CounterQueueEvent.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Queries/CounterQueueEvent.cs
@@ -22,7 +22,7 @@ namespace Ryujinx.Graphics.Vulkan.Queries
         private bool _hostAccessReserved = false;
         private int _refCount = 1; // Starts with a reference from the counter queue.
 
-        private object _lock = new object();
+        private readonly object _lock = new object();
         private ulong _result = ulong.MaxValue;
         private double _divisor = 1f;
 

--- a/src/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardApplet.cs
+++ b/src/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardApplet.cs
@@ -60,7 +60,7 @@ namespace Ryujinx.HLE.HOS.Applets
         private bool                     _canAcceptController     = false;
         private KeyboardInputMode        _inputMode               = KeyboardInputMode.ControllerAndKeyboard;
 
-        private object _lock = new object();
+        private readonly object _lock = new object();
 
         public event EventHandler AppletStateChanged;
 

--- a/src/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardApplet.cs
+++ b/src/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardApplet.cs
@@ -60,7 +60,7 @@ namespace Ryujinx.HLE.HOS.Applets
         private bool                     _canAcceptController     = false;
         private KeyboardInputMode        _inputMode               = KeyboardInputMode.ControllerAndKeyboard;
 
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
 
         public event EventHandler AppletStateChanged;
 

--- a/src/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardRenderer.cs
+++ b/src/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardRenderer.cs
@@ -13,7 +13,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
         private const int TextBoxBlinkSleepMilliseconds   = 100;
         private const int RendererWaitTimeoutMilliseconds = 100;
 
-        private readonly object _stateLock  = new object();
+        private readonly object _stateLock  = new();
 
         private SoftwareKeyboardUiState      _state = new SoftwareKeyboardUiState();
         private SoftwareKeyboardRendererBase _renderer;

--- a/src/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardRendererBase.cs
+++ b/src/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/SoftwareKeyboardRendererBase.cs
@@ -26,7 +26,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
         const string CancelText           = "Cancel";
         const string ControllerToggleText = "Toggle input";
 
-        private readonly object _bufferLock = new object();
+        private readonly object _bufferLock = new();
 
         private RenderingSurfaceInfo _surfaceInfo = null;
         private Image<Argb32>        _surface     = null;
@@ -311,7 +311,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
         private static RectangleF MeasureString(ReadOnlySpan<char> text, Font font)
         {
             RendererOptions options = new RendererOptions(font);
-            
+
             if (text == "")
             {
                 FontRectangle emptyRectangle = TextMeasurer.Measure(" ", options);

--- a/src/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/TimedAction.cs
+++ b/src/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/TimedAction.cs
@@ -27,7 +27,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
 
         private TRef<bool> _cancelled = null;
         private Thread     _thread    = null;
-        private object     _lock      = new object();
+        private readonly object _lock = new object();
 
         public bool IsRunning
         {

--- a/src/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/TimedAction.cs
+++ b/src/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/TimedAction.cs
@@ -26,7 +26,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
         }
 
         private TRef<bool> _cancelled = null;
-        private Thread     _thread    = null;
+        private Thread _thread = null;
         private readonly object _lock = new object();
 
         public bool IsRunning

--- a/src/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/TimedAction.cs
+++ b/src/Ryujinx.HLE/HOS/Applets/SoftwareKeyboard/TimedAction.cs
@@ -27,7 +27,7 @@ namespace Ryujinx.HLE.HOS.Applets.SoftwareKeyboard
 
         private TRef<bool> _cancelled = null;
         private Thread _thread = null;
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
 
         public bool IsRunning
         {

--- a/src/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
+++ b/src/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
@@ -40,8 +40,8 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
         public ProcessState State { get; private set; }
 
-        private readonly object _processLock = new object();
-        private readonly object _threadingLock = new object();
+        private readonly object _processLock = new();
+        private readonly object _threadingLock = new();
 
         public KAddressArbiter AddressArbiter { get; private set; }
 

--- a/src/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
+++ b/src/Ryujinx.HLE/HOS/Kernel/Process/KProcess.cs
@@ -40,8 +40,8 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
         public ProcessState State { get; private set; }
 
-        private object _processLock;
-        private object _threadingLock;
+        private readonly object _processLock = new object();
+        private readonly object _threadingLock = new object();
 
         public KAddressArbiter AddressArbiter { get; private set; }
 
@@ -94,9 +94,6 @@ namespace Ryujinx.HLE.HOS.Kernel.Process
 
         public KProcess(KernelContext context, bool allowCodeMemoryForJit = false) : base(context)
         {
-            _processLock = new object();
-            _threadingLock = new object();
-
             AddressArbiter = new KAddressArbiter(context);
 
             _fullTlsPages = new SortedDictionary<ulong, KTlsPageInfo>();

--- a/src/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
+++ b/src/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
@@ -112,7 +112,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
 
         public bool WaitingInArbitration { get; set; }
 
-        private object _activityOperationLock;
+        private readonly object _activityOperationLock = new object();
 
         public KThread(KernelContext context) : base(context)
         {
@@ -123,8 +123,6 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
 
             _mutexWaiters = new LinkedList<KThread>();
             _pinnedWaiters = new LinkedList<KThread>();
-
-            _activityOperationLock = new object();
         }
 
         public Result Initialize(

--- a/src/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
+++ b/src/Ryujinx.HLE/HOS/Kernel/Threading/KThread.cs
@@ -112,7 +112,7 @@ namespace Ryujinx.HLE.HOS.Kernel.Threading
 
         public bool WaitingInArbitration { get; set; }
 
-        private readonly object _activityOperationLock = new object();
+        private readonly object _activityOperationLock = new();
 
         public KThread(KernelContext context) : base(context)
         {

--- a/src/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ISelfController.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ISelfController.cs
@@ -17,7 +17,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         private KEvent _accumulatedSuspendedTickChangedEvent;
         private int    _accumulatedSuspendedTickChangedEventHandle;
 
-        private object _fatalSectionLock = new object();
+        private readonly object _fatalSectionLock = new object();
         private int    _fatalSectionCount;
 
         // TODO: Set this when the game goes in suspension (go back to home menu ect), we currently don't support that so we can keep it set to 0.

--- a/src/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ISelfController.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ISelfController.cs
@@ -18,7 +18,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         private int    _accumulatedSuspendedTickChangedEventHandle;
 
         private readonly object _fatalSectionLock = new object();
-        private int    _fatalSectionCount;
+        private int _fatalSectionCount;
 
         // TODO: Set this when the game goes in suspension (go back to home menu ect), we currently don't support that so we can keep it set to 0.
         private ulong _accumulatedSuspendedTickValue = 0;

--- a/src/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ISelfController.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Am/AppletAE/AllSystemAppletProxiesService/SystemAppletProxy/ISelfController.cs
@@ -17,7 +17,7 @@ namespace Ryujinx.HLE.HOS.Services.Am.AppletAE.AllSystemAppletProxiesService.Sys
         private KEvent _accumulatedSuspendedTickChangedEvent;
         private int    _accumulatedSuspendedTickChangedEventHandle;
 
-        private readonly object _fatalSectionLock = new object();
+        private readonly object _fatalSectionLock = new();
         private int _fatalSectionCount;
 
         // TODO: Set this when the game goes in suspension (go back to home menu ect), we currently don't support that so we can keep it set to 0.

--- a/src/Ryujinx.HLE/HOS/Services/Friend/ServiceCreator/INotificationService.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Friend/ServiceCreator/INotificationService.cs
@@ -14,7 +14,7 @@ namespace Ryujinx.HLE.HOS.Services.Friend.ServiceCreator
         private readonly UserId                       _userId;
         private readonly FriendServicePermissionLevel _permissionLevel;
 
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
 
         private KEvent _notificationEvent;
         private int    _notificationEventHandle = 0;

--- a/src/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostCtrl/Types/NvHostEvent.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostCtrl/Types/NvHostEvent.cs
@@ -24,7 +24,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostCtrl
         private NvFence _previousFailingFence;
         private uint    _failingCount;
 
-        public readonly object Lock = new object();
+        public readonly object Lock = new();
 
         /// <summary>
         /// Max failing count until waiting on CPU.

--- a/src/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostCtrl/Types/NvHostSyncPt.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostCtrl/Types/NvHostSyncPt.cs
@@ -17,7 +17,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostCtrl
 
         private Switch _device;
 
-        private readonly object _syncpointAllocatorLock = new object();
+        private readonly object _syncpointAllocatorLock = new();
 
         public NvHostSyncpt(Switch device)
         {

--- a/src/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostCtrl/Types/NvHostSyncPt.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvHostCtrl/Types/NvHostSyncPt.cs
@@ -17,7 +17,7 @@ namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvHostCtrl
 
         private Switch _device;
 
-        private object _syncpointAllocatorLock = new object();
+        private readonly object _syncpointAllocatorLock = new object();
 
         public NvHostSyncpt(Switch device)
         {

--- a/src/Ryujinx.HLE/HOS/Services/Sockets/Bsd/BsdContext.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Sockets/Bsd/BsdContext.cs
@@ -10,7 +10,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
     {
         private static ConcurrentDictionary<ulong, BsdContext> _registry = new ConcurrentDictionary<ulong, BsdContext>();
 
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
 
         private List<IFileDescriptor> _fds;
 

--- a/src/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Impl/EventFileDescriptor.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Impl/EventFileDescriptor.cs
@@ -10,7 +10,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd.Impl
         private ulong _value;
         private readonly EventFdFlags _flags;
 
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
 
         public bool Blocking { get => !_flags.HasFlag(EventFdFlags.NonBlocking); set => throw new NotSupportedException(); }
 

--- a/src/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Impl/EventFileDescriptor.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Impl/EventFileDescriptor.cs
@@ -10,7 +10,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd.Impl
         private ulong _value;
         private readonly EventFdFlags _flags;
 
-        private object _lock = new object();
+        private readonly object _lock = new object();
 
         public bool Blocking { get => !_flags.HasFlag(EventFdFlags.NonBlocking); set => throw new NotSupportedException(); }
 

--- a/src/Ryujinx.HLE/HOS/Services/Spl/IRandomInterface.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Spl/IRandomInterface.cs
@@ -7,7 +7,7 @@ namespace Ryujinx.HLE.HOS.Services.Spl
     {
         private RandomNumberGenerator _rng;
 
-        private object _lock = new object();
+        private readonly object _lock = new object();
 
         public IRandomInterface(ServiceCtx context)
         {

--- a/src/Ryujinx.HLE/HOS/Services/Spl/IRandomInterface.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Spl/IRandomInterface.cs
@@ -7,7 +7,7 @@ namespace Ryujinx.HLE.HOS.Services.Spl
     {
         private RandomNumberGenerator _rng;
 
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
 
         public IRandomInterface(ServiceCtx context)
         {

--- a/src/Ryujinx.HLE/HOS/Services/Ssl/BuiltInCertificateManager.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ssl/BuiltInCertificateManager.cs
@@ -46,7 +46,7 @@ namespace Ryujinx.HLE.HOS.Services.Ssl
         private bool _initialized;
         private Dictionary<CaCertificateId, CertStoreEntry> _certificates;
 
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
 
         private struct CertStoreFileHeader
         {

--- a/src/Ryujinx.HLE/HOS/Services/Ssl/BuiltInCertificateManager.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ssl/BuiltInCertificateManager.cs
@@ -46,7 +46,7 @@ namespace Ryujinx.HLE.HOS.Services.Ssl
         private bool                _initialized;
         private Dictionary<CaCertificateId, CertStoreEntry> _certificates;
 
-        private object _lock = new object();
+        private readonly object _lock = new object();
 
         private struct CertStoreFileHeader
         {

--- a/src/Ryujinx.HLE/HOS/Services/Ssl/BuiltInCertificateManager.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ssl/BuiltInCertificateManager.cs
@@ -40,10 +40,10 @@ namespace Ryujinx.HLE.HOS.Services.Ssl
             }
         }
 
-        private VirtualFileSystem   _virtualFileSystem;
+        private VirtualFileSystem _virtualFileSystem;
         private IntegrityCheckLevel _fsIntegrityCheckLevel;
-        private ContentManager      _contentManager;
-        private bool                _initialized;
+        private ContentManager _contentManager;
+        private bool _initialized;
         private Dictionary<CaCertificateId, CertStoreEntry> _certificates;
 
         private readonly object _lock = new object();

--- a/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/BufferQueueCore.cs
+++ b/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/BufferQueueCore.cs
@@ -34,7 +34,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
         public bool                  EnableExternalEvent;
         public int                   MaxBufferCountCached;
 
-        public readonly object Lock = new object();
+        public readonly object Lock = new();
 
         private KEvent _waitBufferFreeEvent;
         private KEvent _frameAvailableEvent;

--- a/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/BufferQueueProducer.cs
+++ b/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/BufferQueueProducer.cs
@@ -21,7 +21,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
         private uint _currentCallbackTicket;
         private uint _callbackTicket;
 
-        private readonly object _callbackLock = new object();
+        private readonly object _callbackLock = new();
 
         public BufferQueueProducer(BufferQueueCore core, ITickSource tickSource)
         {

--- a/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/ConsumerBase.cs
+++ b/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/ConsumerBase.cs
@@ -23,7 +23,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
         protected BufferQueueConsumer Consumer;
 
-        protected readonly object Lock = new object();
+        protected readonly object Lock = new();
 
         private IConsumerListener _listener;
 
@@ -168,7 +168,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 
             Slot slot = Slots[slotIndex];
 
-            // TODO: Check this. On Android, this checks the "handle". I assume NvMapHandle is the handle, but it might not be. 
+            // TODO: Check this. On Android, this checks the "handle". I assume NvMapHandle is the handle, but it might not be.
             return !slot.GraphicBuffer.IsNull && slot.GraphicBuffer.Object.Buffer.Surfaces[0].NvMapHandle == graphicBuffer.Object.Buffer.Surfaces[0].NvMapHandle;
         }
     }

--- a/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
+++ b/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/SurfaceFlinger.cs
@@ -37,7 +37,7 @@ namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
         private int _swapInterval;
         private int _swapIntervalDelay;
 
-        private readonly object Lock = new object();
+        private readonly object Lock = new();
 
         public long RenderLayerId { get; private set; }
 

--- a/src/Ryujinx.HLE/HOS/Services/Time/TimeZone/TimeZoneManager.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Time/TimeZone/TimeZoneManager.cs
@@ -13,7 +13,7 @@ namespace Ryujinx.HLE.HOS.Services.Time.TimeZone
         private UInt128              _timeZoneRuleVersion;
         private uint                 _totalLocationNameCount;
         private SteadyClockTimePoint _timeZoneUpdateTimePoint;
-        private readonly object      _lock = new object();
+        private readonly object      _lock = new();
 
         public TimeZoneManager()
         {

--- a/src/Ryujinx.HLE/HOS/Services/Time/TimeZone/TimeZoneManager.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Time/TimeZone/TimeZoneManager.cs
@@ -13,14 +13,13 @@ namespace Ryujinx.HLE.HOS.Services.Time.TimeZone
         private UInt128              _timeZoneRuleVersion;
         private uint                 _totalLocationNameCount;
         private SteadyClockTimePoint _timeZoneUpdateTimePoint;
-        private object               _lock;
+        private readonly object      _lock = new object();
 
         public TimeZoneManager()
         {
             _isInitialized       = false;
             _deviceLocationName  = "UTC";
             _timeZoneRuleVersion = new UInt128();
-            _lock                = new object();
             _myRules             = new Box<TimeZoneRule>();
 
             _timeZoneUpdateTimePoint = SteadyClockTimePoint.GetRandom();

--- a/src/Ryujinx.Horizon/Sdk/OsTypes/Impl/MultiWaitImpl.cs
+++ b/src/Ryujinx.Horizon/Sdk/OsTypes/Impl/MultiWaitImpl.cs
@@ -13,7 +13,7 @@ namespace Ryujinx.Horizon.Sdk.OsTypes.Impl
 
         private readonly List<MultiWaitHolderBase> _multiWaits;
 
-        private object _lock;
+        private readonly object _lock = new object();
 
         private int _waitingThreadHandle;
 
@@ -24,8 +24,6 @@ namespace Ryujinx.Horizon.Sdk.OsTypes.Impl
         public MultiWaitImpl()
         {
             _multiWaits = new List<MultiWaitHolderBase>();
-
-            _lock = new object();
         }
 
         public void LinkMultiWaitHolder(MultiWaitHolderBase multiWaitHolder)

--- a/src/Ryujinx.Horizon/Sdk/OsTypes/Impl/MultiWaitImpl.cs
+++ b/src/Ryujinx.Horizon/Sdk/OsTypes/Impl/MultiWaitImpl.cs
@@ -13,7 +13,7 @@ namespace Ryujinx.Horizon.Sdk.OsTypes.Impl
 
         private readonly List<MultiWaitHolderBase> _multiWaits;
 
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
 
         private int _waitingThreadHandle;
 

--- a/src/Ryujinx.Input.SDL2/SDL2Gamepad.cs
+++ b/src/Ryujinx.Input.SDL2/SDL2Gamepad.cs
@@ -55,7 +55,7 @@ namespace Ryujinx.Input.SDL2
             SDL_GameControllerButton.SDL_CONTROLLER_BUTTON_INVALID,
         };
 
-        private readonly object _userMappingLock = new object();
+        private readonly object _userMappingLock = new();
 
         private List<ButtonMappingEntry> _buttonsUserMapping;
 

--- a/src/Ryujinx.Input.SDL2/SDL2Gamepad.cs
+++ b/src/Ryujinx.Input.SDL2/SDL2Gamepad.cs
@@ -46,7 +46,7 @@ namespace Ryujinx.Input.SDL2
             SDL_GameControllerButton.SDL_CONTROLLER_BUTTON_PADDLE2,
             SDL_GameControllerButton.SDL_CONTROLLER_BUTTON_PADDLE3,
             SDL_GameControllerButton.SDL_CONTROLLER_BUTTON_PADDLE4,
-            SDL_GameControllerButton.SDL_CONTROLLER_BUTTON_TOUCHPAD,            
+            SDL_GameControllerButton.SDL_CONTROLLER_BUTTON_TOUCHPAD,
 
             // Virtual buttons are invalid, ignored.
             SDL_GameControllerButton.SDL_CONTROLLER_BUTTON_INVALID,
@@ -55,7 +55,7 @@ namespace Ryujinx.Input.SDL2
             SDL_GameControllerButton.SDL_CONTROLLER_BUTTON_INVALID,
         };
 
-        private object _userMappingLock = new object();
+        private readonly object _userMappingLock = new object();
 
         private List<ButtonMappingEntry> _buttonsUserMapping;
 

--- a/src/Ryujinx.Input.SDL2/SDL2Keyboard.cs
+++ b/src/Ryujinx.Input.SDL2/SDL2Keyboard.cs
@@ -24,7 +24,7 @@ namespace Ryujinx.Input.SDL2
             }
         }
 
-        private readonly object _userMappingLock = new object();
+        private readonly object _userMappingLock = new();
 
         private readonly SDL2KeyboardDriver _driver;
         private StandardKeyboardInputConfig _configuration;

--- a/src/Ryujinx.Input.SDL2/SDL2Keyboard.cs
+++ b/src/Ryujinx.Input.SDL2/SDL2Keyboard.cs
@@ -24,7 +24,7 @@ namespace Ryujinx.Input.SDL2
             }
         }
 
-        private object _userMappingLock = new object();
+        private readonly object _userMappingLock = new object();
 
         private readonly SDL2KeyboardDriver _driver;
         private StandardKeyboardInputConfig _configuration;

--- a/src/Ryujinx.Input/HLE/NpadManager.cs
+++ b/src/Ryujinx.Input/HLE/NpadManager.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.Input.HLE
     {
         private CemuHookClient _cemuHookClient;
 
-        private object _lock = new object();
+        private readonly object _lock = new object();
 
         private bool _blockInputUpdates;
 
@@ -271,7 +271,7 @@ namespace Ryujinx.Input.HLE
 
                     _device.Hid.Mouse.Update((int)position.X, (int)position.Y, buttons, (int)mouseInput.Scroll.X, (int)mouseInput.Scroll.Y, true);
                 }
-                else 
+                else
                 {
                     _device.Hid.Mouse.Update(0, 0);
                 }

--- a/src/Ryujinx.Input/HLE/NpadManager.cs
+++ b/src/Ryujinx.Input/HLE/NpadManager.cs
@@ -15,7 +15,7 @@ namespace Ryujinx.Input.HLE
     {
         private CemuHookClient _cemuHookClient;
 
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
 
         private bool _blockInputUpdates;
 

--- a/src/Ryujinx.Memory/Tracking/RegionHandle.cs
+++ b/src/Ryujinx.Memory/Tracking/RegionHandle.cs
@@ -52,7 +52,7 @@ namespace Ryujinx.Memory.Tracking
 
         private event Action _onDirty;
 
-        private object _preActionLock = new object();
+        private readonly object _preActionLock = new object();
         private RegionSignal _preAction; // Action to perform before a read or write. This will block the memory access.
         private PreciseRegionSignal _preciseAction; // Action to perform on a precise read or write.
         private readonly List<VirtualRegion> _regions;

--- a/src/Ryujinx.Memory/Tracking/RegionHandle.cs
+++ b/src/Ryujinx.Memory/Tracking/RegionHandle.cs
@@ -52,7 +52,7 @@ namespace Ryujinx.Memory.Tracking
 
         private event Action _onDirty;
 
-        private readonly object _preActionLock = new object();
+        private readonly object _preActionLock = new();
         private RegionSignal _preAction; // Action to perform before a read or write. This will block the memory access.
         private PreciseRegionSignal _preciseAction; // Action to perform on a precise read or write.
         private readonly List<VirtualRegion> _regions;

--- a/src/Ryujinx.SDL2.Common/SDL2Driver.cs
+++ b/src/Ryujinx.SDL2.Common/SDL2Driver.cs
@@ -41,7 +41,7 @@ namespace Ryujinx.SDL2.Common
 
         private ConcurrentDictionary<uint, Action<SDL_Event>> _registeredWindowHandlers;
 
-        private readonly object _lock = new object();
+        private readonly object _lock = new();
 
         private SDL2Driver() {}
 

--- a/src/Ryujinx.SDL2.Common/SDL2Driver.cs
+++ b/src/Ryujinx.SDL2.Common/SDL2Driver.cs
@@ -41,7 +41,7 @@ namespace Ryujinx.SDL2.Common
 
         private ConcurrentDictionary<uint, Action<SDL_Event>> _registeredWindowHandlers;
 
-        private object _lock = new object();
+        private readonly object _lock = new object();
 
         private SDL2Driver() {}
 

--- a/src/Ryujinx/Input/GTK3/GTK3Keyboard.cs
+++ b/src/Ryujinx/Input/GTK3/GTK3Keyboard.cs
@@ -21,7 +21,7 @@ namespace Ryujinx.Input.GTK3
             }
         }
 
-        private readonly object _userMappingLock = new object();
+        private readonly object _userMappingLock = new();
 
         private readonly GTK3KeyboardDriver _driver;
         private StandardKeyboardInputConfig _configuration;

--- a/src/Ryujinx/Input/GTK3/GTK3Keyboard.cs
+++ b/src/Ryujinx/Input/GTK3/GTK3Keyboard.cs
@@ -21,7 +21,7 @@ namespace Ryujinx.Input.GTK3
             }
         }
 
-        private object _userMappingLock = new object();
+        private readonly object _userMappingLock = new object();
 
         private readonly GTK3KeyboardDriver _driver;
         private StandardKeyboardInputConfig _configuration;


### PR DESCRIPTION
Let's take a look at the example WITHOUT `readonly`:

```cs
public class ExampleClass
{
    private object _lock = new object();

    public void DoSomething()
    {
        lock(_lock)
        {
            // ...
        }
    }
}
```

The `_lock` object is not `readonly`, which means it can be modified elsewhere in the class. This is potentially dangerous because if `_lock` is accidentally reassigned somewhere else in the `ExampleClass`, it would mean that the `lock` statement would be using a different lock object. This could lead to race conditions because threads could potentially enter the `lock` statement concurrently, which would defeat the whole purpose of using `lock`.

On the other hand, in the example WITH `readonly`:

```cs
public class ExampleClass
{
    private readonly object _lock = new object();

    public void DoSomething()
    {
        lock(_lock)
        {
            // ...
        }
    }
}
```

The `_lock` object is declared as `readonly`. This means once it is assigned, it cannot be changed. This ensures that the same lock object is always used for the `lock` statement, which properly synchronizes access to the block of code and ensures thread safety.

Making the `_lock` object `readonly` is a good practice because it protects the lock object from being accidentally reassigned, which could lead to bugs that are hard to detect and diagnose.