### PR TITLE
Non-flags enums should not be used in bitwise operations

### DIFF
--- a/src/ARMeilleure/IntermediateRepresentation/Intrinsic.cs
+++ b/src/ARMeilleure/IntermediateRepresentation/Intrinsic.cs
@@ -1,5 +1,8 @@
+using System;
+
 namespace ARMeilleure.IntermediateRepresentation
 {
+    [Flags]
     enum Intrinsic : ushort
     {
         // X86 (SSE and AVX)

--- a/src/Ryujinx.Graphics.Shader/Decoders/InstDecoders.cs
+++ b/src/Ryujinx.Graphics.Shader/Decoders/InstDecoders.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Ryujinx.Graphics.Shader.Decoders
 {
     enum AlSize
@@ -711,6 +713,7 @@ namespace Ryujinx.Graphics.Shader.Decoders
         TexSamplerBorderColor = 22,
     }
 
+    [Flags]
     enum VectorSelect
     {
         U8B0 = 0,

--- a/src/Ryujinx.Graphics.Shader/Decoders/InstProps.cs
+++ b/src/Ryujinx.Graphics.Shader/Decoders/InstProps.cs
@@ -1,5 +1,8 @@
+using System;
+
 namespace Ryujinx.Graphics.Shader.Decoders
 {
+    [Flags]
     enum InstProps : ushort
     {
         None = 0,

--- a/src/Ryujinx.Graphics.Shader/Translation/AggregateType.cs
+++ b/src/Ryujinx.Graphics.Shader/Translation/AggregateType.cs
@@ -1,5 +1,8 @@
-﻿namespace Ryujinx.Graphics.Shader.Translation
+﻿using System;
+
+namespace Ryujinx.Graphics.Shader.Translation
 {
+    [Flags]
     enum AggregateType
     {
         Invalid,

--- a/src/Ryujinx.HLE/HOS/Kernel/Threading/ThreadSchedState.cs
+++ b/src/Ryujinx.HLE/HOS/Kernel/Threading/ThreadSchedState.cs
@@ -1,5 +1,8 @@
+using System;
+
 namespace Ryujinx.HLE.HOS.Kernel.Threading
 {
+    [Flags]
     enum ThreadSchedState : ushort
     {
         LowMask        = 0xf,


### PR DESCRIPTION
The `Flags` attribute in C# is used to indicate that an `enum` type is to be treated as a bit field; that is, a set of (binary) flags.

Without the `Flags` attribute, an `enum` is usually treated as a distinct set of values. For instance, you might define an `enum` to represent the days of the week, and each value in the `enum` (Sunday, Monday, etc.) is a distinct day.

However, in some cases, you want an `enum` where each value represents a different binary flag that can be combined with others. This is where the `Flags` attribute comes in.

For instance, consider an `enum` that represents a set of file permissions:

```cs
[Flags]
public enum FilePermissions
{
    None = 0,
    Read = 1 << 0, // Equivalent to 1
    Write = 1 << 1, // Equivalent to 2
    Execute = 1 << 2 // Equivalent to 4
}
```

The `Flags` attribute allows us to combine these values using bitwise operations, and also provides more meaningful output when the `enum` is converted to a string.

Without the `Flags` attribute, if you were to combine `Read` and `Write` permissions (`Read` | `Write`) and then call `ToString` on the result, you'd get "3" (the numeric result of 1 | 2).

With the `Flags` attribute, the same operation would produce "Read, Write" which is much more meaningful.

Note that the `Flags` attribute doesn't prevent you from assigning arbitrary values to an `enum` or from using it in ways not appropriate for a bit field. It's more of a hint to both programmers and the .NET runtime about the intended usage of the `enum`.