### PR TITLE
Ava: Fix OpenGL on Linux again

### DIFF
--- a/src/Ryujinx.Ava/AppHost.cs
+++ b/src/Ryujinx.Ava/AppHost.cs
@@ -478,27 +478,13 @@ namespace Ryujinx.Ava
 
             if (_rendererHost.EmbeddedWindow is EmbeddedWindowOpenGL openGlWindow)
             {
-                // Try to bind the OpenGL context before calling the shutdown event
-                try
-                {
-                    openGlWindow.MakeCurrent();
-                }
-                catch (ContextException e)
-                {
-                    Logger.Warning?.Print(LogClass.Ui, $"Failed to bind OpenGL context: {e}");
-                }
+                // Try to bind the OpenGL context before calling the shutdown event.
+                openGlWindow.MakeCurrent(false, false);
 
                 Device.DisposeGpu();
 
-                // Unbind context and destroy everything
-                try
-                {
-                    openGlWindow.MakeCurrent(null);
-                }
-                catch (ContextException e)
-                {
-                    Logger.Warning?.Print(LogClass.Ui, $"Failed to unbind OpenGL context: {e}");
-                }
+                // Unbind context and destroy everything.
+                openGlWindow.MakeCurrent(true, false);
             }
             else
             {
@@ -954,7 +940,7 @@ namespace Ryujinx.Ava
                 _gpuDoneEvent.Set();
             });
 
-            (_rendererHost.EmbeddedWindow as EmbeddedWindowOpenGL)?.MakeCurrent(null);
+            (_rendererHost.EmbeddedWindow as EmbeddedWindowOpenGL)?.MakeCurrent(true);
         }
 
         public void UpdateStatus()

--- a/src/Ryujinx.Ava/UI/Renderer/EmbeddedWindow.cs
+++ b/src/Ryujinx.Ava/UI/Renderer/EmbeddedWindow.cs
@@ -123,7 +123,7 @@ namespace Ryujinx.Ava.UI.Renderer
             }
             else
             {
-                X11Window = PlatformHelper.CreateOpenGLWindow(new FramebufferFormat(), 0, 0, 100, 100) as GLXWindow;
+                X11Window = PlatformHelper.CreateOpenGLWindow(new FramebufferFormat(new ColorFormat(8, 8, 8, 0), 16, 0, ColorFormat.Zero, 0, 2, false), 0, 0, 100, 100) as GLXWindow;
             }
 
             WindowHandle = X11Window.WindowHandle.RawHandle;

--- a/src/Ryujinx.Ava/UI/Renderer/EmbeddedWindow.cs
+++ b/src/Ryujinx.Ava/UI/Renderer/EmbeddedWindow.cs
@@ -123,7 +123,7 @@ namespace Ryujinx.Ava.UI.Renderer
             }
             else
             {
-                X11Window = PlatformHelper.CreateOpenGLWindow(FramebufferFormat.Default, 0, 0, 100, 100) as GLXWindow;
+                X11Window = PlatformHelper.CreateOpenGLWindow(new FramebufferFormat(), 0, 0, 100, 100) as GLXWindow;
             }
 
             WindowHandle = X11Window.WindowHandle.RawHandle;

--- a/src/Ryujinx.Ava/UI/Renderer/EmbeddedWindowOpenGL.cs
+++ b/src/Ryujinx.Ava/UI/Renderer/EmbeddedWindowOpenGL.cs
@@ -18,8 +18,6 @@ namespace Ryujinx.Ava.UI.Renderer
 
         public OpenGLContextBase Context { get; set; }
 
-        public EmbeddedWindowOpenGL() { }
-
         protected override void OnWindowDestroying()
         {
             Context.Dispose();

--- a/src/Ryujinx.Ava/UI/Renderer/EmbeddedWindowOpenGL.cs
+++ b/src/Ryujinx.Ava/UI/Renderer/EmbeddedWindowOpenGL.cs
@@ -1,9 +1,11 @@
 using OpenTK.Graphics.OpenGL;
 using Ryujinx.Common.Configuration;
+using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.GAL;
 using Ryujinx.Graphics.OpenGL;
 using Ryujinx.Ui.Common.Configuration;
 using SPB.Graphics;
+using SPB.Graphics.Exceptions;
 using SPB.Graphics.OpenGL;
 using SPB.Platform;
 using SPB.Platform.WGL;
@@ -60,14 +62,21 @@ namespace Ryujinx.Ava.UI.Renderer
             Context.MakeCurrent(null);
         }
 
-        public void MakeCurrent()
+        public void MakeCurrent(bool unbind = false, bool shouldThrow = true)
         {
-            Context?.MakeCurrent(_window);
-        }
+            try
+            {
+                Context?.MakeCurrent(!unbind ? _window : null);
+            }
+            catch (ContextException e)
+            {
+                if (shouldThrow)
+                {
+                    throw;
+                }
 
-        public void MakeCurrent(NativeWindowBase window)
-        {
-            Context?.MakeCurrent(window);
+                Logger.Warning?.Print(LogClass.Ui, $"Failed to {(!unbind ? "bind" : "unbind")} OpenGL context: {e}");
+            }
         }
 
         public void SwapBuffers()

--- a/src/Ryujinx/Ui/GLRenderer.cs
+++ b/src/Ryujinx/Ui/GLRenderer.cs
@@ -1,8 +1,10 @@
 ﻿using OpenTK.Graphics.OpenGL;
 using Ryujinx.Common.Configuration;
+using Ryujinx.Common.Logging;
 using Ryujinx.Graphics.OpenGL;
 using Ryujinx.Input.HLE;
 using SPB.Graphics;
+using SPB.Graphics.Exceptions;
 using SPB.Graphics.OpenGL;
 using SPB.Platform;
 using SPB.Platform.GLX;
@@ -117,7 +119,10 @@ namespace Ryujinx.Ui
             {
                 _openGLContext?.MakeCurrent(_nativeWindow);
             }
-            catch (Exception) { }
+            catch (ContextException e)
+            {
+                Logger.Warning?.Print(LogClass.Ui, $"Failed to bind OpenGL context: {e}");
+            }
 
             Device?.DisposeGpu();
             NpadManager.Dispose();
@@ -127,7 +132,10 @@ namespace Ryujinx.Ui
             {
                 _openGLContext?.MakeCurrent(null);
             }
-            catch (Exception) { }
+            catch (ContextException e)
+            {
+                Logger.Warning?.Print(LogClass.Ui, $"Failed to unbind OpenGL context: {e}");
+            }
 
             _openGLContext?.Dispose();
         }

--- a/src/Ryujinx/Ui/GLRenderer.cs
+++ b/src/Ryujinx/Ui/GLRenderer.cs
@@ -114,7 +114,7 @@ namespace Ryujinx.Ui
 
         protected override void Dispose(bool disposing)
         {
-            // Try to bind the OpenGL context before calling the shutdown event
+            // Try to bind the OpenGL context before calling the shutdown event.
             try
             {
                 _openGLContext?.MakeCurrent(_nativeWindow);
@@ -127,7 +127,7 @@ namespace Ryujinx.Ui
             Device?.DisposeGpu();
             NpadManager.Dispose();
 
-            // Unbind context and destroy everything
+            // Unbind context and destroy everything.
             try
             {
                 _openGLContext?.MakeCurrent(null);


### PR DESCRIPTION
I have absolutely no clue why this works.

The error produced by X11 looks like that: `XError: X_Error result is BadMatch (invalid parameter attributes) (code: 8)`
(You can get the error by applying https://github.com/marysaka/SPB/pull/4 to SPB.)

As far as I understood, the issue was related to one of the `FramebufferFormat` parameters being incorrect.
I was about to test different values for `depthBits` (as this [answer](https://stackoverflow.com/a/17127200) suggested), but tried the empty constructor once just to see what would happen. To my surprise it just started to work, so here we are.

---

Fixes #4600