### PR TITLE
Avalonia: Adjust Grid Library alignment

### DIFF
--- a/src/Ryujinx.Ava/UI/Controls/ApplicationGridView.axaml
+++ b/src/Ryujinx.Ava/UI/Controls/ApplicationGridView.axaml
@@ -32,10 +32,10 @@
             <ListBox.ItemsPanel>
                 <ItemsPanelTemplate>
                     <flex:FlexPanel
-                        HorizontalAlignment="Stretch"
+                        HorizontalAlignment="Center"
                         VerticalAlignment="Stretch"
                         AlignContent="FlexStart"
-                        JustifyContent="Center" />
+                        JustifyContent="FlexStart" />
                 </ItemsPanelTemplate>
             </ListBox.ItemsPanel>
             <ListBox.Styles>


### PR DESCRIPTION
Personally I found the center alignment for rows that are not full to look off. I updated the flexbox constraints so empty rows would left-align and the items would always line up with the rows above. 

**This is a subjective change, so I'm happy to make it an option in the settings somewhere if people would prefer.** 

Some examples of the difference: 

| Before                                                                                           | After                                                                                            |
|--------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
| ![image](https://github.com/Ryujinx/Ryujinx/assets/5017270/32f4547a-33b7-49b2-b7c9-a3d5b96833fc) | ![image](https://github.com/Ryujinx/Ryujinx/assets/5017270/bc5454b3-001d-4958-8351-26bd943760c7) |
| ![image](https://github.com/Ryujinx/Ryujinx/assets/5017270/8c36c8c3-3530-4010-a02a-a472cebe980e) | ![image](https://github.com/Ryujinx/Ryujinx/assets/5017270/57f184be-0717-410b-bd5f-5641e89a3ef2) |

