### PR TITLE
Texture: Fix layout conversion when gobs in z is used with depth = 1

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TextureCompatibility.cs
@@ -541,7 +541,8 @@ namespace Ryujinx.Graphics.Gpu.Image
                     depth,
                     lhs.FormatInfo.BlockHeight,
                     lhs.GobBlocksInY,
-                    lhs.GobBlocksInZ);
+                    lhs.GobBlocksInZ,
+                    level);
 
                 return gobBlocksInY == rhs.GobBlocksInY &&
                        gobBlocksInZ == rhs.GobBlocksInZ;
@@ -587,7 +588,8 @@ namespace Ryujinx.Graphics.Gpu.Image
                     lhsDepth,
                     lhs.FormatInfo.BlockHeight,
                     lhs.GobBlocksInY,
-                    lhs.GobBlocksInZ);
+                    lhs.GobBlocksInZ,
+                    lhsLevel);
 
                 int rhsHeight = Math.Max(1, rhs.Height >> rhsLevel);
                 int rhsDepth = Math.Max(1, rhs.GetDepth() >> rhsLevel);
@@ -597,7 +599,8 @@ namespace Ryujinx.Graphics.Gpu.Image
                     rhsDepth,
                     rhs.FormatInfo.BlockHeight,
                     rhs.GobBlocksInY,
-                    rhs.GobBlocksInZ);
+                    rhs.GobBlocksInZ,
+                    rhsLevel);
 
                 return lhsGobBlocksInY == rhsGobBlocksInY &&
                        lhsGobBlocksInZ == rhsGobBlocksInZ;

--- a/src/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
+++ b/src/Ryujinx.Graphics.Gpu/Image/TexturePool.cs
@@ -484,7 +484,7 @@ namespace Ryujinx.Graphics.Gpu.Image
                         depthOrLayers = Math.Max(1, depthOrLayers >> minLod);
                     }
 
-                    (gobBlocksInY, gobBlocksInZ) = SizeCalculator.GetMipGobBlockSizes(height, depth, formatInfo.BlockHeight, gobBlocksInY, gobBlocksInZ);
+                    (gobBlocksInY, gobBlocksInZ) = SizeCalculator.GetMipGobBlockSizes(height, depth, formatInfo.BlockHeight, gobBlocksInY, gobBlocksInZ, minLod);
                 }
 
                 levels = (maxLod - minLod) + 1;

--- a/src/Ryujinx.Graphics.Texture/LayoutConverter.cs
+++ b/src/Ryujinx.Graphics.Texture/LayoutConverter.cs
@@ -143,7 +143,7 @@ namespace Ryujinx.Graphics.Texture
                     mipGobBlocksInY >>= 1;
                 }
 
-                while (d <= (mipGobBlocksInZ >> 1) && mipGobBlocksInZ != 1)
+                if (level > 0 && d <= (mipGobBlocksInZ >> 1) && mipGobBlocksInZ != 1)
                 {
                     mipGobBlocksInZ >>= 1;
                 }
@@ -407,7 +407,7 @@ namespace Ryujinx.Graphics.Texture
                     mipGobBlocksInY >>= 1;
                 }
 
-                while (d <= (mipGobBlocksInZ >> 1) && mipGobBlocksInZ != 1)
+                if (level > 0 && d <= (mipGobBlocksInZ >> 1) && mipGobBlocksInZ != 1)
                 {
                     mipGobBlocksInZ >>= 1;
                 }

--- a/src/Ryujinx.Graphics.Texture/SizeCalculator.cs
+++ b/src/Ryujinx.Graphics.Texture/SizeCalculator.cs
@@ -113,7 +113,7 @@ namespace Ryujinx.Graphics.Texture
 
                     if (gobRemainderZ != 0 && level == levels - 1)
                     {
-                        // The slice only covers up to the end of this slice's depth, rather than the full area.
+                        // The slice only covers up to the end of this slice's depth, rather than the full aligned size.
                         // Avoids size being too large on partial views of 3d textures.
 
                         sliceSizes[level] -= gobSize * (mipGobBlocksInZ - gobRemainderZ);

--- a/src/Ryujinx.Graphics.Texture/SizeCalculator.cs
+++ b/src/Ryujinx.Graphics.Texture/SizeCalculator.cs
@@ -36,7 +36,7 @@ namespace Ryujinx.Graphics.Texture
             int gobBlocksInTileX,
             int gpuLayerSize = 0)
         {
-            bool is3D = depth > 1;
+            bool is3D = depth > 1 || gobBlocksInZ > 1;
 
             int layerSize = 0;
 
@@ -67,7 +67,7 @@ namespace Ryujinx.Graphics.Texture
                     mipGobBlocksInY >>= 1;
                 }
 
-                while (d <= (mipGobBlocksInZ >> 1) && mipGobBlocksInZ != 1)
+                if (level > 0 && d <= (mipGobBlocksInZ >> 1) && mipGobBlocksInZ != 1)
                 {
                     mipGobBlocksInZ >>= 1;
                 }
@@ -88,6 +88,9 @@ namespace Ryujinx.Graphics.Texture
 
                 int robSize = widthInGobs * mipGobBlocksInY * mipGobBlocksInZ * GobSize;
 
+                mipOffsets[level] = layerSize;
+                sliceSizes[level] = totalBlocksOfGobsInY * robSize;
+
                 if (is3D)
                 {
                     int gobSize = mipGobBlocksInY * GobSize;
@@ -105,10 +108,18 @@ namespace Ryujinx.Graphics.Texture
 
                         allOffsets[z + depthLevelOffset] = baseOffset + zLow * gobSize + zHigh * sliceSize;
                     }
+
+                    int gobRemainderZ = d % mipGobBlocksInZ;
+
+                    if (gobRemainderZ != 0 && level == levels - 1)
+                    {
+                        // The rob only covers up to the end of this slice's depth.
+                        // Avoids size being too large on partial views of 3d textures.
+
+                        sliceSizes[level] -= gobSize * (mipGobBlocksInZ - gobRemainderZ);
+                    }
                 }
 
-                mipOffsets[level] = layerSize;
-                sliceSizes[level] = totalBlocksOfGobsInY * robSize;
                 levelSizes[level] = totalBlocksOfGobsInZ * sliceSizes[level];
 
                 layerSize += levelSizes[level];
@@ -267,7 +278,8 @@ namespace Ryujinx.Graphics.Texture
             int depth,
             int blockHeight,
             int gobBlocksInY,
-            int gobBlocksInZ)
+            int gobBlocksInZ,
+            int level = int.MaxValue)
         {
             height = BitUtils.DivRoundUp(height, blockHeight);
 
@@ -276,7 +288,7 @@ namespace Ryujinx.Graphics.Texture
                 gobBlocksInY >>= 1;
             }
 
-            while (depth <= (gobBlocksInZ >> 1) && gobBlocksInZ != 1)
+            while (level-- > 0 && depth <= (gobBlocksInZ >> 1) && gobBlocksInZ != 1)
             {
                 gobBlocksInZ >>= 1;
             }

--- a/src/Ryujinx.Graphics.Texture/SizeCalculator.cs
+++ b/src/Ryujinx.Graphics.Texture/SizeCalculator.cs
@@ -113,7 +113,7 @@ namespace Ryujinx.Graphics.Texture
 
                     if (gobRemainderZ != 0 && level == levels - 1)
                     {
-                        // The rob only covers up to the end of this slice's depth.
+                        // The slice only covers up to the end of this slice's depth, rather than the full area.
                         // Avoids size being too large on partial views of 3d textures.
 
                         sliceSizes[level] -= gobSize * (mipGobBlocksInZ - gobRemainderZ);


### PR DESCRIPTION
The size calculator methods deliberately reduce the gob size of textures if they are deemed too small for it. This is required to get correct sizes when iterating mip levels of a texture.

Rendering to a slice of a 3D texture can produce a 3D texture with depth 1, but a gob size matching a much larger texture. We _can't_ "correct" this gob size, as it is intended as a slice of a larger 3D texture. Ignoring it causes layout conversion to break on read and flush.

This caused an issue in Tears of the Kingdom where the compressed 3D texture used for the gloom would always break on OpenGL, and seemingly randomly break on Vulkan. In the first case, the data is forcibly flushed to decompress the BC4 texture on the CPU to upload it as 3D, which was broken due to the incorrect layout. In the second, the data may be randomly flushed if it falls out of the cache, but it will appear correct if it's able to form copy dependencies.

This change only allows gob sizes to be reduced once per mip level. For the purpose of aligned size, it can still be reduced infinitely as our texture cache isn't properly able to handle a view being _misaligned_.

The SizeCalculator has also been changed to reduce the size of rendered depth slices to only include the exact range a single depth slice will cover. (before, the size was way too small with gobs in z reduced to 1, and too large when using the correct value)

Gobs in Y logic remains untouched, we don't support Y slices of textures so it's fine as is.

This is probably worth testing in a few games as it also affects texture size and view logic. I've tested a few myself and they seem OK.