### PR TITLE
Fix wrong unaligned SB state when fetching compute shaders

### DIFF
--- a/src/Ryujinx.Graphics.Gpu/Engine/Compute/ComputeClass.cs
+++ b/src/Ryujinx.Graphics.Gpu/Engine/Compute/ComputeClass.cs
@@ -151,8 +151,6 @@ namespace Ryujinx.Graphics.Gpu.Engine.Compute
 
             ShaderProgramInfo info = cs.Shaders[0].Info;
 
-            bool hasUnaligned = _channel.BufferManager.HasUnalignedStorageBuffers;
-
             for (int index = 0; index < info.SBuffers.Count; index++)
             {
                 BufferDescriptor sb = info.SBuffers[index];
@@ -177,9 +175,17 @@ namespace Ryujinx.Graphics.Gpu.Engine.Compute
                 _channel.BufferManager.SetComputeStorageBuffer(sb.Slot, sbDescriptor.PackAddress(), size, sb.Flags);
             }
 
-            if ((_channel.BufferManager.HasUnalignedStorageBuffers) != hasUnaligned)
+            if (_channel.BufferManager.HasUnalignedStorageBuffers != computeState.HasUnalignedStorageBuffer)
             {
                 // Refetch the shader, as assumptions about storage buffer alignment have changed.
+                computeState = new GpuChannelComputeState(
+                    qmd.CtaThreadDimension0,
+                    qmd.CtaThreadDimension1,
+                    qmd.CtaThreadDimension2,
+                    localMemorySize,
+                    sharedMemorySize,
+                    _channel.BufferManager.HasUnalignedStorageBuffers);
+
                 cs = memoryManager.Physical.ShaderCache.GetComputeShader(_channel, poolState, computeState, shaderGpuVa);
 
                 _context.Renderer.Pipeline.SetProgram(cs.HostProgram);


### PR DESCRIPTION
This fixes a "regression" caused by #4993 that introduced glitches on some games on Intel GPUs. Because we only know if there's a storage buffer with unaligned offset *after* we have the shader (since knowing which storage buffers are even used in the first places requires having the shader already translated), we need to re-fetch the shader once we know if any storage buffer is unaligned. While the existing code would correctly re-fetch the shader if the unaligned state changed, it would do so still using the old state, so it would return the same (incorrect) shader. This fixes the issue by updating `GpuChannelComputeState` with the new state.

This is a regression because the linked PR enables the optimization where we remove CB0 access to also work when host storage buffer offset alignment is greater than 16, and in Intel's case it is 64. On the other vendors, it is 16, so the changes of a storage buffer being unalgined are much lower, so it's much harder for the bug to manifest itself, but it is a existing issue.

Fixes #5217.