### PR TITLE
Duplicate casts should not be made

### DIFF
--- a/src/ARMeilleure/Instructions/InstEmitSimdMemory32.cs
+++ b/src/ARMeilleure/Instructions/InstEmitSimdMemory32.cs
@@ -53,10 +53,8 @@ namespace ARMeilleure.Instructions
 
         public static void EmitVStoreOrLoadN(ArmEmitterContext context, int count, bool load)
         {
-            if (context.CurrOp is OpCode32SimdMemSingle)
+            if (context.CurrOp is OpCode32SimdMemSingle op)
             {
-                OpCode32SimdMemSingle op = (OpCode32SimdMemSingle)context.CurrOp;
-
                 int eBytes = 1 << op.Size;
 
                 Operand n = context.Copy(GetIntA32(context, op.Rn));

--- a/src/ARMeilleure/Instructions/InstEmitSimdMemory32.cs
+++ b/src/ARMeilleure/Instructions/InstEmitSimdMemory32.cs
@@ -127,8 +127,6 @@ namespace ARMeilleure.Instructions
             }
             else
             {
-                OpCode32SimdMemPair op = (OpCode32SimdMemPair)context.CurrOp;
-
                 int increment = count > 1 ? op.Increment : 1;
                 int eBytes = 1 << op.Size;
 

--- a/src/Ryujinx.HLE/HOS/Diagnostics/Demangler/Ast/PackedTemplateParameterExpansion.cs
+++ b/src/Ryujinx.HLE/HOS/Diagnostics/Demangler/Ast/PackedTemplateParameterExpansion.cs
@@ -8,9 +8,9 @@ namespace Ryujinx.HLE.HOS.Diagnostics.Demangler.Ast
 
         public override void PrintLeft(TextWriter writer)
         {
-            if (Child is PackedTemplateParameter)
+            if (Child is PackedTemplateParameter param)
             {
-                if (((PackedTemplateParameter)Child).Nodes.Count !=  0)
+                if (param.Nodes.Count !=  0)
                 {
                     Child.Print(writer);
                 }

--- a/src/Ryujinx.HLE/HOS/Services/Audio/AudioIn/AudioIn.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Audio/AudioIn/AudioIn.cs
@@ -80,9 +80,9 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioIn
         {
             IWritableEvent outEvent = _system.RegisterBufferEvent();
 
-            if (outEvent is AudioKernelEvent)
+            if (outEvent is AudioKernelEvent evt)
             {
-                return ((AudioKernelEvent)outEvent).Event;
+                return evt.Event;
             }
             else
             {

--- a/src/Ryujinx.HLE/HOS/Services/Audio/AudioOut/AudioOut.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Audio/AudioOut/AudioOut.cs
@@ -80,9 +80,9 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioOut
         {
             IWritableEvent outEvent = _system.RegisterBufferEvent();
 
-            if (outEvent is AudioKernelEvent)
+            if (outEvent is AudioKernelEvent evt)
             {
-                return ((AudioKernelEvent)outEvent).Event;
+                return evt.Event;
             }
             else
             {

--- a/src/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/AudioRenderer.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Audio/AudioRenderer/AudioRenderer.cs
@@ -55,9 +55,9 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRenderer
 
             if (resultCode == ResultCode.Success)
             {
-                if (outEvent is AudioKernelEvent)
+                if (outEvent is AudioKernelEvent evt)
                 {
-                    systemEvent = ((AudioKernelEvent)outEvent).Event;
+                    systemEvent = evt.Event;
                 }
                 else
                 {


### PR DESCRIPTION
Because the `is` operator performs a cast if the object is not null, using `is` to check type and then casting the same argument to that type, necessarily performs two casts.