### PR TITLE
Texture: Fix 3D texture size when totalBlocksOfGobsInZ > 1

### DIFF
--- a/src/Ryujinx.Graphics.Texture/SizeCalculator.cs
+++ b/src/Ryujinx.Graphics.Texture/SizeCalculator.cs
@@ -90,6 +90,7 @@ namespace Ryujinx.Graphics.Texture
 
                 mipOffsets[level] = layerSize;
                 sliceSizes[level] = totalBlocksOfGobsInY * robSize;
+                levelSizes[level] = totalBlocksOfGobsInZ * sliceSizes[level];
 
                 if (is3D)
                 {
@@ -116,11 +117,14 @@ namespace Ryujinx.Graphics.Texture
                         // The slice only covers up to the end of this slice's depth, rather than the full aligned size.
                         // Avoids size being too large on partial views of 3d textures.
 
-                        sliceSizes[level] -= gobSize * (mipGobBlocksInZ - gobRemainderZ);
+                        levelSizes[level] -= gobSize * (mipGobBlocksInZ - gobRemainderZ);
+
+                        if (sliceSizes[level] > levelSizes[level])
+                        {
+                            levelSizes[level] = sliceSizes[level];
+                        }
                     }
                 }
-
-                levelSizes[level] = totalBlocksOfGobsInZ * sliceSizes[level];
 
                 layerSize += levelSizes[level];
 

--- a/src/Ryujinx.Graphics.Texture/SizeCalculator.cs
+++ b/src/Ryujinx.Graphics.Texture/SizeCalculator.cs
@@ -121,7 +121,7 @@ namespace Ryujinx.Graphics.Texture
 
                         if (sliceSizes[level] > levelSizes[level])
                         {
-                            levelSizes[level] = sliceSizes[level];
+                            sliceSizes[level] = levelSizes[level];
                         }
                     }
                 }


### PR DESCRIPTION
When there is a remainder when dividing depth by gobs in z, it is used to remove the unused part of the 3D texture's size. This was done to calculate correct sizes for single slice views of 3D textures.

However, this case can also apply to 3D textures with many slices, and more than one total block of gobs in z. In this case it's meant to trim off the end of the level size. Most textures won't encounter this as their size will be aligned, but UE4 games tend to use 3D textures with funny unaligned sizes.

The size offset should have been applied to the level size instead of the slice size, and it should only affect the slice size if it ends up larger.

Hopefully should fix issues with UE4 games without breaking other stuff, I don't have much time to test.