### PR TITLE
Per-User Profile Metadata

### DIFF
--- a/src/Ryujinx.Ava/AppHost.cs
+++ b/src/Ryujinx.Ava/AppHost.cs
@@ -682,7 +682,7 @@ namespace Ryujinx.Ava
 
             DiscordIntegrationModule.SwitchToPlayingState(Device.Processes.ActiveApplication.ProgramIdText, Device.Processes.ActiveApplication.Name);
 
-            _viewModel.ApplicationLibrary.LoadAndSaveMetaData(Device.Processes.ActiveApplication.ProgramIdText, appMetadata =>
+            _viewModel.ApplicationLibrary.LoadAndSaveMetaData(_accountManager.LastOpenedUser.UserId.ToLibHacFsUid(), Device.Processes.ActiveApplication.ProgramIdText, appMetadata =>
             {
                 appMetadata.LastPlayed = DateTime.UtcNow;
             });

--- a/src/Ryujinx.Ava/UI/Controls/ApplicationContextMenu.axaml.cs
+++ b/src/Ryujinx.Ava/UI/Controls/ApplicationContextMenu.axaml.cs
@@ -42,7 +42,7 @@ namespace Ryujinx.Ava.UI.Controls
             {
                 viewModel.SelectedApplication.Favorite = !viewModel.SelectedApplication.Favorite;
 
-                viewModel.ApplicationLibrary.LoadAndSaveMetaData(viewModel.SelectedApplication.TitleId, appMetadata =>
+                viewModel.ApplicationLibrary.LoadAndSaveMetaData(viewModel.AccountManager.LastOpenedUser.UserId.ToLibHacFsUid(), viewModel.SelectedApplication.TitleId, appMetadata =>
                 {
                     appMetadata.Favorite = viewModel.SelectedApplication.Favorite;
                 });

--- a/src/Ryujinx.Ava/UI/Models/SaveModel.cs
+++ b/src/Ryujinx.Ava/UI/Models/SaveModel.cs
@@ -74,7 +74,7 @@ namespace Ryujinx.Ava.UI.Models
             }
             else
             {
-                var appMetadata = MainWindow.MainWindowViewModel.ApplicationLibrary.LoadAndSaveMetaData(TitleIdString);
+                var appMetadata = MainWindow.MainWindowViewModel.ApplicationLibrary.LoadAndSaveMetaData(UserId, TitleIdString);
                 Title = appMetadata.Title ?? TitleIdString;
             }
 

--- a/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
@@ -1357,7 +1357,14 @@ namespace Ryujinx.Ava.UI.ViewModels
 
         public async void ManageProfiles()
         {
+            var prevUserId = AccountManager.LastOpenedUser.UserId;
             await NavigationDialogHost.Show(AccountManager, ContentManager, VirtualFileSystem, LibHacHorizonManager.RyujinxClient);
+            
+            if (prevUserId != AccountManager.LastOpenedUser.UserId)
+            {
+                // current user changed, so refresh application metadata
+                LoadApplications();
+            }
         }
 
         public void SimulateWakeUpMessage()

--- a/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Ryujinx.Ava/UI/ViewModels/MainWindowViewModel.cs
@@ -1523,7 +1523,7 @@ namespace Ryujinx.Ava.UI.ViewModels
 
         public void UpdateGameMetadata(string titleId)
         {
-            ApplicationLibrary.LoadAndSaveMetaData(titleId, appMetadata =>
+            ApplicationLibrary.LoadAndSaveMetaData(AccountManager.LastOpenedUser.UserId.ToLibHacFsUid(), titleId, appMetadata =>
             {
                 if (appMetadata.LastPlayed.HasValue)
                 {

--- a/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx.Ava/UI/Windows/MainWindow.axaml.cs
@@ -554,7 +554,7 @@ namespace Ryujinx.Ava.UI.Windows
 
             _isLoading = true;
 
-            ApplicationLibrary.LoadApplications(ConfigurationState.Instance.Ui.GameDirs.Value, ConfigurationState.Instance.System.Language);
+            ApplicationLibrary.LoadApplications(ViewModel.AccountManager.LastOpenedUser.UserId.ToLibHacFsUid(), ConfigurationState.Instance.Ui.GameDirs.Value, ConfigurationState.Instance.System.Language);
 
             _isLoading = false;
         }

--- a/src/Ryujinx.HLE/HOS/Services/Account/Acc/Types/UserId.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Account/Acc/Types/UserId.cs
@@ -56,6 +56,11 @@ namespace Ryujinx.HLE.HOS.Services.Account.Acc
             return new Uid((ulong)High, (ulong)Low);
         }
 
+        public LibHac.Fs.UserId ToLibHacFsUid()
+        {
+            return new LibHac.Fs.UserId((ulong)High, (ulong)Low);
+        }
+
         public UInt128 ToUInt128()
         {
             return new UInt128((ulong)High, (ulong)Low);

--- a/src/Ryujinx.Ui.Common/App/ApplicationLibrary.cs
+++ b/src/Ryujinx.Ui.Common/App/ApplicationLibrary.cs
@@ -521,12 +521,20 @@ namespace Ryujinx.Ui.App.Common
 
             // Handle migration from old default to current user
             string legacyFile = Path.Combine(guiFolder, "metadata.json");
-            if (File.Exists(legacyFile) && !File.Exists(metadataFile))
+            if (File.Exists(legacyFile))
             {
-                File.Move(legacyFile, metadataFile);
-                File.Delete(legacyFile);
+                if (!File.Exists(metadataFile))
+                {
+                    File.Move(legacyFile, metadataFile);
+                }
+                
+                if (File.Exists(metadataFile))
+                {
+                    File.Delete(legacyFile);
+                }
             }
 
+            // Create metadata file if it doesn't exist yet
             ApplicationMetadata appMetadata;
 
             if (!File.Exists(metadataFile))
@@ -536,6 +544,7 @@ namespace Ryujinx.Ui.App.Common
                 JsonHelper.SerializeToFile(metadataFile, appMetadata, SerializerContext.ApplicationMetadata);
             }
 
+            // Read from the metadata file
             try
             {
                 appMetadata = JsonHelper.DeserializeFromFile(metadataFile, SerializerContext.ApplicationMetadata);
@@ -547,6 +556,7 @@ namespace Ryujinx.Ui.App.Common
                 appMetadata = new ApplicationMetadata();
             }
 
+            // Modify the metadata and save it back to the file
             if (modifyFunction != null)
             {
                 modifyFunction(appMetadata);

--- a/src/Ryujinx/Ui/MainWindow.cs
+++ b/src/Ryujinx/Ui/MainWindow.cs
@@ -657,7 +657,7 @@ namespace Ryujinx.Ui
 
             Thread applicationLibraryThread = new Thread(() =>
             {
-                _applicationLibrary.LoadApplications(ConfigurationState.Instance.Ui.GameDirs, ConfigurationState.Instance.System.Language);
+                _applicationLibrary.LoadApplications(_accountManager.LastOpenedUser.UserId.ToLibHacFsUid(), ConfigurationState.Instance.Ui.GameDirs, ConfigurationState.Instance.System.Language);
 
                 _updatingGameTable = false;
             });
@@ -874,7 +874,7 @@ namespace Ryujinx.Ui
                 DiscordIntegrationModule.SwitchToPlayingState(_emulationContext.Processes.ActiveApplication.ProgramIdText,
                                                               _emulationContext.Processes.ActiveApplication.ApplicationControlProperties.Title[(int)_emulationContext.System.State.DesiredTitleLanguage].NameString.ToString());
 
-                _applicationLibrary.LoadAndSaveMetaData(_emulationContext.Processes.ActiveApplication.ProgramIdText, appMetadata =>
+                _applicationLibrary.LoadAndSaveMetaData(_accountManager.LastOpenedUser.UserId.ToLibHacFsUid(), _emulationContext.Processes.ActiveApplication.ProgramIdText, appMetadata =>
                 {
                     appMetadata.LastPlayed = DateTime.UtcNow;
                 });
@@ -1017,7 +1017,7 @@ namespace Ryujinx.Ui
         {
             if (_gameLoaded)
             {
-                _applicationLibrary.LoadAndSaveMetaData(titleId, appMetadata =>
+                _applicationLibrary.LoadAndSaveMetaData(_accountManager.LastOpenedUser.UserId.ToLibHacFsUid(), titleId, appMetadata =>
                 {
                     if (appMetadata.LastPlayed.HasValue)
                     {
@@ -1156,7 +1156,7 @@ namespace Ryujinx.Ui
 
             _tableStore.SetValue(treeIter, 0, newToggleValue);
 
-            _applicationLibrary.LoadAndSaveMetaData(titleId, appMetadata =>
+            _applicationLibrary.LoadAndSaveMetaData(_accountManager.LastOpenedUser.UserId.ToLibHacFsUid(), titleId, appMetadata =>
             {
                 appMetadata.Favorite = newToggleValue;
             });

--- a/src/Ryujinx/Ui/MainWindow.cs
+++ b/src/Ryujinx/Ui/MainWindow.cs
@@ -1648,7 +1648,7 @@ namespace Ryujinx.Ui
 
         private void ManageUserProfiles_Pressed(object sender, EventArgs args)
         {
-            UserProfilesManagerWindow userProfilesManagerWindow = new UserProfilesManagerWindow(_accountManager, _contentManager, _virtualFileSystem);
+            UserProfilesManagerWindow userProfilesManagerWindow = new UserProfilesManagerWindow(_accountManager, _contentManager, _virtualFileSystem, UpdateGameTable);
 
             userProfilesManagerWindow.SetSizeRequest((int)(userProfilesManagerWindow.DefaultWidth * Program.WindowScaleFactor), (int)(userProfilesManagerWindow.DefaultHeight * Program.WindowScaleFactor));
             userProfilesManagerWindow.Show();

--- a/src/Ryujinx/Ui/Windows/UserProfilesManagerWindow.cs
+++ b/src/Ryujinx/Ui/Windows/UserProfilesManagerWindow.cs
@@ -13,7 +13,6 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Image = SixLabors.ImageSharp.Image;
-using UserId = Ryujinx.HLE.HOS.Services.Account.Acc.UserId;
 
 namespace Ryujinx.Ui.Windows
 {
@@ -24,6 +23,9 @@ namespace Ryujinx.Ui.Windows
         private readonly AccountManager _accountManager;
         private readonly ContentManager _contentManager;
 
+        public delegate void ChangedUserDelegate();
+        private readonly ChangedUserDelegate _changedUserDelegate;
+
         private byte[] _bufferImageProfile;
         private string _tempNewProfileName;
 
@@ -31,7 +33,7 @@ namespace Ryujinx.Ui.Windows
 
         private ManualResetEvent _avatarsPreloadingEvent = new ManualResetEvent(false);
 
-        public UserProfilesManagerWindow(AccountManager accountManager, ContentManager contentManager, VirtualFileSystem virtualFileSystem) : base($"Ryujinx {Program.Version} - Manage User Profiles")
+        public UserProfilesManagerWindow(AccountManager accountManager, ContentManager contentManager, VirtualFileSystem virtualFileSystem, ChangedUserDelegate changedUserDelegate) : base($"Ryujinx {Program.Version} - Manage User Profiles")
         {
             Icon = new Gdk.Pixbuf(Assembly.GetAssembly(typeof(ConfigurationState)), "Ryujinx.Ui.Common.Resources.Logo_Ryujinx.png");
 
@@ -44,6 +46,7 @@ namespace Ryujinx.Ui.Windows
 
             _accountManager = accountManager;
             _contentManager = contentManager;
+            _changedUserDelegate = changedUserDelegate;
 
             CellRendererToggle userSelectedToggle = new CellRendererToggle();
             userSelectedToggle.Toggled += UserSelectedToggle_Toggled;
@@ -128,6 +131,7 @@ namespace Ryujinx.Ui.Windows
 
             // Open the selected one.
             _accountManager.OpenUser(new UserId(userId));
+            _changedUserDelegate();
 
             _deleteButton.Sensitive = userId != AccountManager.DefaultUserId.ToString();
 


### PR DESCRIPTION
Logically, data such as whether an app is a Favorite or not, when it was last played, and how long it was played should all belong to each user profile, not Ryujinx as a whole. 

For time played, this better reflects the behavior of the Switch console itself.
As far as I know, the Switch doesn't have Favorites so there is no precedent for that, but IMO it makes more sense as a per-user setting. 


This PR:
- Adjusts this information to be tracked per user profile. 
- Handles the migration from the old system
  - On first boot, it will migrate the previous global data to the last opened user profile. (Thoughts welcome on a better migration strategy)
- Handles refreshing the application library when the user profile changes to reflect that user's metadata
  - Implemented for GTK and Avalonia