### PR TITLE
Inheritance should not be redundant

### DIFF
--- a/src/ARMeilleure/Decoders/OpCode32SimdSel.cs
+++ b/src/ARMeilleure/Decoders/OpCode32SimdSel.cs
@@ -13,7 +13,7 @@
         }
     }
 
-    enum OpCode32SimdSelMode : int
+    enum OpCode32SimdSelMode
     {
         Eq = 0,
         Vs,

--- a/src/ARMeilleure/State/ExecutionMode.cs
+++ b/src/ARMeilleure/State/ExecutionMode.cs
@@ -1,6 +1,6 @@
 namespace ARMeilleure.State
 {
-    enum ExecutionMode : int
+    enum ExecutionMode
     {
         Aarch32Arm = 0,
         Aarch32Thumb = 1,

--- a/src/Ryujinx.Audio.Backends.SoundIo/Native/SoundIoBackend.cs
+++ b/src/Ryujinx.Audio.Backends.SoundIo/Native/SoundIoBackend.cs
@@ -1,6 +1,6 @@
 ﻿namespace Ryujinx.Audio.Backends.SoundIo.Native
 {
-    public enum SoundIoBackend : int
+    public enum SoundIoBackend
     {
         None = 0,
         Jack = 1,

--- a/src/Ryujinx.Common/Configuration/Hid/ControllerType.cs
+++ b/src/Ryujinx.Common/Configuration/Hid/ControllerType.cs
@@ -7,7 +7,7 @@ namespace Ryujinx.Common.Configuration.Hid
     // This enum was duplicated from Ryujinx.HLE.HOS.Services.Hid.PlayerIndex and should be kept identical
     [Flags]
     [JsonConverter(typeof(TypedStringEnumConverter<ControllerType>))]
-    public enum ControllerType : int
+    public enum ControllerType
     {
         None,
         ProController  = 1 << 0,

--- a/src/Ryujinx.Common/Configuration/Hid/PlayerIndex.cs
+++ b/src/Ryujinx.Common/Configuration/Hid/PlayerIndex.cs
@@ -5,7 +5,7 @@ namespace Ryujinx.Common.Configuration.Hid
 {
     // This enum was duplicated from Ryujinx.HLE.HOS.Services.Hid.PlayerIndex and should be kept identical
     [JsonConverter(typeof(TypedStringEnumConverter<PlayerIndex>))]
-    public enum PlayerIndex : int
+    public enum PlayerIndex
     {
         Player1  = 0,
         Player2  = 1,

--- a/src/Ryujinx.Graphics.Vulkan/MoltenVK/MVKConfiguration.cs
+++ b/src/Ryujinx.Graphics.Vulkan/MoltenVK/MVKConfiguration.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace Ryujinx.Graphics.Vulkan.MoltenVK
 {
-    enum MVKConfigLogLevel : int
+    enum MVKConfigLogLevel
     {
         None = 0,
         Error = 1,
@@ -12,7 +12,7 @@ namespace Ryujinx.Graphics.Vulkan.MoltenVK
         Debug = 4
     }
 
-    enum MVKConfigTraceVulkanCalls : int
+    enum MVKConfigTraceVulkanCalls
     {
         None = 0,
         Enter = 1,
@@ -20,7 +20,7 @@ namespace Ryujinx.Graphics.Vulkan.MoltenVK
         Duration = 3
     }
 
-    enum MVKConfigAutoGPUCaptureScope : int
+    enum MVKConfigAutoGPUCaptureScope
     {
         None = 0,
         Device = 1,
@@ -28,7 +28,7 @@ namespace Ryujinx.Graphics.Vulkan.MoltenVK
     }
 
     [Flags]
-    enum MVKConfigAdvertiseExtensions : int
+    enum MVKConfigAdvertiseExtensions
     {
         All = 0x00000001,
         MoltenVK = 0x00000002,
@@ -36,7 +36,7 @@ namespace Ryujinx.Graphics.Vulkan.MoltenVK
         Portability = 0x00000008
     }
 
-    enum MVKVkSemaphoreSupportStyle : int
+    enum MVKVkSemaphoreSupportStyle
     {
         MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_SINGLE_QUEUE = 0,
         MVK_CONFIG_VK_SEMAPHORE_SUPPORT_STYLE_METAL_EVENTS_WHERE_SAFE = 1,

--- a/src/Ryujinx.HLE/HOS/Services/Hid/Types/Npad/ControllerType.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Hid/Types/Npad/ControllerType.cs
@@ -3,7 +3,7 @@ using System;
 namespace Ryujinx.HLE.HOS.Services.Hid
 {
     [Flags]
-    public enum ControllerType : int
+    public enum ControllerType
     {
         None,
         ProController  = 1 << 0,

--- a/src/Ryujinx.HLE/HOS/Services/Hid/Types/Npad/NpadIdType.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Hid/Types/Npad/NpadIdType.cs
@@ -1,6 +1,6 @@
 ﻿namespace Ryujinx.HLE.HOS.Services.Hid
 {
-    public enum NpadIdType : int
+    public enum NpadIdType
     {
         Player1  = 0,
         Player2  = 1,

--- a/src/Ryujinx.HLE/HOS/Services/Hid/Types/Npad/PlayerIndex.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Hid/Types/Npad/PlayerIndex.cs
@@ -1,6 +1,6 @@
 namespace Ryujinx.HLE.HOS.Services.Hid
 {
-    public enum PlayerIndex : int
+    public enum PlayerIndex
     {
         Player1  = 0,
         Player2  = 1,

--- a/src/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Npad/DeviceType.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Npad/DeviceType.cs
@@ -3,7 +3,7 @@
 namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Npad
 {
     [Flags]
-    enum DeviceType : int
+    enum DeviceType
     {
         None = 0,
 

--- a/src/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Npad/NpadBatteryLevel.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Hid/Types/SharedMemory/Npad/NpadBatteryLevel.cs
@@ -1,6 +1,6 @@
 ﻿namespace Ryujinx.HLE.HOS.Services.Hid.Types.SharedMemory.Npad
 {
-    enum NpadBatteryLevel : int
+    enum NpadBatteryLevel
     {
         Percent0,
         Percent25,

--- a/src/Ryujinx.HLE/HOS/Services/Mii/Types/CoreData.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Mii/Types/CoreData.cs
@@ -775,7 +775,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.Types
 
         private static ReadOnlySpan<ElementInfo> ElementInfos => MemoryMarshal.Cast<byte, ElementInfo>(ElementInfoArray);
 
-        private enum ElementInfoIndex : int
+        private enum ElementInfoIndex
         {
             HairType,
             Height,

--- a/src/Ryujinx.HLE/HOS/Services/Mii/Types/RandomMiiConstants.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Mii/Types/RandomMiiConstants.cs
@@ -21,7 +21,7 @@ namespace Ryujinx.HLE.HOS.Services.Mii.Types
         };
 
         [Flags]
-        public enum BeardAndMustacheFlag : int
+        public enum BeardAndMustacheFlag
         {
             Beard = 1,
             Mustache

--- a/src/Ryujinx.HLE/HOS/Services/Mii/Types/Source.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Mii/Types/Source.cs
@@ -1,6 +1,6 @@
 ﻿namespace Ryujinx.HLE.HOS.Services.Mii.Types
 {
-    enum Source : int
+    enum Source
     {
         Database,
         Default

--- a/src/Ryujinx.HLE/HOS/Services/Mii/Types/SourceFlag.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Mii/Types/SourceFlag.cs
@@ -3,7 +3,7 @@
 namespace Ryujinx.HLE.HOS.Services.Mii.Types
 {
     [Flags]
-    enum SourceFlag : int
+    enum SourceFlag
     {
         Database = 1 << Source.Database,
         Default  = 1 << Source.Default,

--- a/src/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvInternalResult.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvInternalResult.cs
@@ -1,6 +1,6 @@
 ﻿namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices
 {
-    enum NvInternalResult : int
+    enum NvInternalResult
     {
         Success               = 0,
         OperationNotPermitted = -1,

--- a/src/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvMap/Types/NvMapHandleParam.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Nv/NvDrvServices/NvMap/Types/NvMapHandleParam.cs
@@ -1,6 +1,6 @@
 namespace Ryujinx.HLE.HOS.Services.Nv.NvDrvServices.NvMap
 {
-    enum NvMapHandleParam : int
+    enum NvMapHandleParam
     {
         Size  = 1,
         Align = 2,

--- a/src/Ryujinx.HLE/HOS/Services/Sockets/Bsd/ISocket.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Sockets/Bsd/ISocket.cs
@@ -5,7 +5,7 @@ using System.Net.Sockets;
 
 namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
 {
-    interface ISocket : IDisposable, IFileDescriptor
+    interface ISocket : IFileDescriptor
     {
         IPEndPoint RemoteEndPoint { get; }
         IPEndPoint LocalEndPoint { get; }

--- a/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/NativeWindowApi.cs
+++ b/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/NativeWindowApi.cs
@@ -1,6 +1,6 @@
 ﻿namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 {
-    enum NativeWindowApi : int
+    enum NativeWindowApi
     {
         NoApi  = 0,
         NVN    = 1,

--- a/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/Status.cs
+++ b/src/Ryujinx.HLE/HOS/Services/SurfaceFlinger/Status.cs
@@ -1,6 +1,6 @@
 ﻿namespace Ryujinx.HLE.HOS.Services.SurfaceFlinger
 {
-    enum Status : int
+    enum Status
     {
         Success          = 0,
         WouldBlock       = -11,


### PR DESCRIPTION
An inheritance list entry is redundant if:

- It is `Object` - all classes extend `Object` implicitly.
- It is `int` for an `enum`
- It is a base class of another listed inheritance.

Such redundant declarations should be removed because they needlessly clutter the code and can be confusing.