### PR TITLE
Prefer a 'TryGetValue' call over a Dictionary indexer access guarded by a 'ContainsKey'

### DIFF
--- a/src/Ryujinx.HLE/FileSystem/ContentManager.cs
+++ b/src/Ryujinx.HLE/FileSystem/ContentManager.cs
@@ -181,7 +181,7 @@ namespace Ryujinx.HLE.FileSystem
                         }
                     }
 
-                    if (_locationEntries.ContainsKey(storageId) && _locationEntries[storageId]?.Count == 0)
+                    if (_locationEntries.TryGetValue(storageId, out var locationEntriesItem) && locationEntriesItem?.Count == 0)
                     {
                         _locationEntries.Remove(storageId);
                     }
@@ -347,9 +347,9 @@ namespace Ryujinx.HLE.FileSystem
         {
             lock (_lock)
             {
-                if (_contentDictionary.ContainsKey((titleId, contentType)))
+                if (_contentDictionary.TryGetValue((titleId, contentType), out var contentDictionaryItem))
                 {
-                    return UInt128Utils.FromHex(_contentDictionary[(titleId, contentType)]);
+                    return UInt128Utils.FromHex(contentDictionaryItem);
                 }
             }
 
@@ -719,9 +719,9 @@ namespace Ryujinx.HLE.FileSystem
 
                             Nca nca = new Nca(_virtualFileSystem.KeySet, storage);
 
-                            if (updateNcas.ContainsKey(nca.Header.TitleId))
+                            if (updateNcas.TryGetValue(nca.Header.TitleId, out var updateNcasItem))
                             {
-                                updateNcas[nca.Header.TitleId].Add((nca.Header.ContentType, entry.FullName));
+                                updateNcasItem.Add((nca.Header.ContentType, entry.FullName));
                             }
                             else
                             {
@@ -732,10 +732,8 @@ namespace Ryujinx.HLE.FileSystem
                     }
                 }
 
-                if (updateNcas.ContainsKey(SystemUpdateTitleId))
+                if (updateNcas.TryGetValue(SystemUpdateTitleId, out var ncaEntry))
                 {
-                    var ncaEntry = updateNcas[SystemUpdateTitleId];
-
                     string metaPath = ncaEntry.Find(x => x.type == NcaContentType.Meta).path;
 
                     CnmtContentMetaEntry[] metaEntries = null;
@@ -770,9 +768,9 @@ namespace Ryujinx.HLE.FileSystem
                         throw new FileNotFoundException("System update title was not found in the firmware package.");
                     }
 
-                    if (updateNcas.ContainsKey(SystemVersionTitleId))
+                    if (updateNcas.TryGetValue(SystemVersionTitleId, out var updateNcasItem))
                     {
-                        string versionEntry = updateNcas[SystemVersionTitleId].Find(x => x.type != NcaContentType.Meta).path;
+                        string versionEntry = updateNcasItem.Find(x => x.type != NcaContentType.Meta).path;
 
                         using (Stream ncaStream = GetZipStream(archive.GetEntry(versionEntry)))
                         {
@@ -916,9 +914,9 @@ namespace Ryujinx.HLE.FileSystem
                         }
                     }
 
-                    if (updateNcas.ContainsKey(nca.Header.TitleId))
+                    if (updateNcas.TryGetValue(nca.Header.TitleId, out var updateNcasItem))
                     {
-                        updateNcas[nca.Header.TitleId].Add((nca.Header.ContentType, entry.FullPath));
+                        updateNcasItem.Add((nca.Header.ContentType, entry.FullPath));
                     }
                     else
                     {

--- a/src/Ryujinx.Input/Motion/CemuHook/Client.cs
+++ b/src/Ryujinx.Input/Motion/CemuHook/Client.cs
@@ -338,11 +338,11 @@ namespace Ryujinx.Input.Motion.CemuHook
                         {
                             int slot = inputData.Shared.Slot;
 
-                            if (_motionData.ContainsKey(clientId))
+                            if (_motionData.TryGetValue(clientId, out var motionDataItem))
                             {
-                                if (_motionData[clientId].ContainsKey(slot))
+                                if (motionDataItem.ContainsKey(slot))
                                 {
-                                    MotionInput previousData = _motionData[clientId][slot];
+                                    MotionInput previousData = motionDataItem[slot];
 
                                     previousData.Update(accelerometer, gyroscrope, timestamp, cemuHookConfig.Sensitivity, (float)cemuHookConfig.GyroDeadzone);
                                 }
@@ -352,7 +352,7 @@ namespace Ryujinx.Input.Motion.CemuHook
 
                                     input.Update(accelerometer, gyroscrope, timestamp, cemuHookConfig.Sensitivity, (float)cemuHookConfig.GyroDeadzone);
 
-                                    _motionData[clientId].Add(slot, input);
+                                    motionDataItem.Add(slot, input);
                                 }
                             }
                             else

--- a/src/Ryujinx.Input/Motion/CemuHook/Client.cs
+++ b/src/Ryujinx.Input/Motion/CemuHook/Client.cs
@@ -340,10 +340,8 @@ namespace Ryujinx.Input.Motion.CemuHook
 
                             if (_motionData.TryGetValue(clientId, out var motionDataItem))
                             {
-                                if (motionDataItem.ContainsKey(slot))
+                                if (motionDataItem.TryGetValue(slot, out var previousData))
                                 {
-                                    MotionInput previousData = motionDataItem[slot];
-
                                     previousData.Update(accelerometer, gyroscrope, timestamp, cemuHookConfig.Sensitivity, (float)cemuHookConfig.GyroDeadzone);
                                 }
                                 else


### PR DESCRIPTION
Benchmark:
```cs
[SimpleJob]
[MemoryDiagnoser]
[Orderer(SummaryOrderPolicy.FastestToSlowest)]
[RankColumn]
public class Test
{
    private Dictionary<int, string> dict = new Dictionary<int, string>();
    private int size = 1000;
    private int keyToFind = 999;

    [GlobalSetup]
    public void Setup()
    {
        for (int i = 0; i < size; i++)
        {
            dict.Add(i, "aaa");
        }
    }

    [Benchmark]
    public void ContainsKeyPlusArrayLookup()
    {
        if (dict.ContainsKey(keyToFind))
        {
            var response = dict[keyToFind];
        }
    }

    [Benchmark]
    public void TryGetValue()
    {
        dict.TryGetValue(keyToFind, out var response);
    }
}
```

Results:
```sh
|                     Method |      Mean |     Error |    StdDev |    Median | Rank | Allocated |
|--------------------------- |----------:|----------:|----------:|----------:|-----:|----------:|
|                TryGetValue |  9.649 ns | 0.3920 ns | 1.0927 ns |  9.136 ns |    1 |         - |
| ContainsKeyPlusArrayLookup | 14.196 ns | 0.1173 ns | 0.1040 ns | 14.186 ns |    2 |         - |
```