### PR TITLE
UI: Correctly set 'shell/open/command; registry key for file associations

### DIFF
--- a/src/Ryujinx.Ui.Common/Helper/FileAssociationHelper.cs
+++ b/src/Ryujinx.Ui.Common/Helper/FileAssociationHelper.cs
@@ -1,11 +1,9 @@
-using Microsoft.IdentityModel.Tokens;
 using Microsoft.Win32;
 using Ryujinx.Common;
 using Ryujinx.Common.Logging;
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 
@@ -13,10 +11,10 @@ namespace Ryujinx.Ui.Common.Helper
 {
     public static partial class FileAssociationHelper
     {
-        private static string[] _fileExtensions = new string[] { ".nca", ".nro", ".nso", ".nsp", ".xci" };
+        private static readonly string[] _fileExtensions = { ".nca", ".nro", ".nso", ".nsp", ".xci" };
 
         [SupportedOSPlatform("linux")]
-        private static string _mimeDbPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "share", "mime");
+        private static readonly string _mimeDbPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local", "share", "mime");
 
         private const int SHCNE_ASSOCCHANGED = 0x8000000;
         private const int SHCNF_FLUSH        = 0x1000;
@@ -34,7 +32,7 @@ namespace Ryujinx.Ui.Common.Helper
         {
             string installKeyword = uninstall ? "uninstall" : "install";
 
-            if (!AreMimeTypesRegisteredLinux())
+            if ((uninstall && AreMimeTypesRegisteredLinux()) || (!uninstall && !AreMimeTypesRegisteredLinux()))
             {
                 string mimeTypesFile = Path.Combine(ReleaseInformation.GetBaseApplicationDirectory(), "mime", "Ryujinx.xml");
                 string additionalArgs = !uninstall ? "--novendor" : "";
@@ -109,7 +107,7 @@ namespace Ryujinx.Ui.Common.Helper
 
                 if (uninstall)
                 {
-                    // If the types don't already exist, there's nothing to do and we can call this operation successful. 
+                    // If the types don't already exist, there's nothing to do and we can call this operation successful.
                     if (!AreMimeTypesRegisteredWindows())
                     {
                         return true;

--- a/src/Ryujinx.Ui.Common/Helper/FileAssociationHelper.cs
+++ b/src/Ryujinx.Ui.Common/Helper/FileAssociationHelper.cs
@@ -116,16 +116,18 @@ namespace Ryujinx.Ui.Common.Helper
                 }
                 else
                 {
-                    RegistryKey key = Registry.CurrentUser.CreateSubKey(keyString);
-                    if (key is null)
+                    using (var key = Registry.CurrentUser.CreateSubKey(keyString))
                     {
-                        return false;
+                        if (key is null)
+                        {
+                            return false;
+                        }
+
+                        using (var openCmd = key.CreateSubKey(@"shell\open\command"))
+                        {
+                            openCmd.SetValue("", $"\"{Environment.ProcessPath}\" \"%1\"");
+                        }
                     }
-
-                    key.CreateSubKey(@"shell\open\command");
-
-                    key.SetValue("", $"\"{Environment.ProcessPath}\" \"%1\"");
-                    key.Close();
                 }
 
                 // Notify Explorer the file association has been changed.


### PR DESCRIPTION
Fixes #5243 by correctly setting the registry key for the open command.  

Also wraps IDisposable resources in `using` blocks. 