### PR TITLE
Updater: Stop old exe from being left behind if renamed by user.

### DIFF
--- a/src/Ryujinx.Ava/Modules/Updater/Updater.cs
+++ b/src/Ryujinx.Ava/Modules/Updater/Updater.cs
@@ -748,6 +748,12 @@ namespace Ryujinx.Modules
                 var newFiles = Directory.EnumerateFiles(UpdatePublishDir, "*", SearchOption.TopDirectoryOnly).Select(Path.GetFileName);
                 var userFiles = oldFiles.Except(newFiles).Select(filename => Path.Combine(HomeDir, filename));
 
+                // Filter out renamed Ryujinx executables for proper disposal
+                if (Path.GetFileName(Environment.GetCommandLineArgs()[0]) != "Ryujinx.exe")
+                {
+                    oldFiles = oldFiles.Where(s => !s.Contains(Path.GetFileName(Environment.GetCommandLineArgs()[0])));
+                }
+
                 // Remove user files from the paths in files.
                 files = files.Except(userFiles);
             }

--- a/src/Ryujinx/Modules/Updater/Updater.cs
+++ b/src/Ryujinx/Modules/Updater/Updater.cs
@@ -571,6 +571,13 @@ namespace Ryujinx.Modules
                 // Compare the loose files in base directory against the loose files from the incoming update, and store foreign ones in a user list.
                 var oldFiles = Directory.EnumerateFiles(HomeDir, "*", SearchOption.TopDirectoryOnly).Select(Path.GetFileName);
                 var newFiles = Directory.EnumerateFiles(UpdatePublishDir, "*", SearchOption.TopDirectoryOnly).Select(Path.GetFileName);
+
+                // Filter out renamed Ryujinx executables for proper disposal
+                if (Path.GetFileName(Environment.GetCommandLineArgs()[0]) != "Ryujinx.exe")
+                {
+                    oldFiles = oldFiles.Where(s => !s.Contains(Path.GetFileName(Environment.GetCommandLineArgs()[0])));
+                }
+
                 var userFiles = oldFiles.Except(newFiles).Select(filename => Path.Combine(HomeDir, filename));
 
                 // Remove user files from the paths in files.


### PR DESCRIPTION
Fix edge-case scenario introduced by [#5092 ](https://github.com/Ryujinx/Ryujinx/pull/5092)
I'm unsure if this check needs to be performed against `Ryujinx` too, for compatibility with Linux / MacOS