### PR TITLE
Fix regression in macOS updater

### DIFF
--- a/src/Ryujinx.Ava/Modules/Updater/Updater.cs
+++ b/src/Ryujinx.Ava/Modules/Updater/Updater.cs
@@ -741,7 +741,7 @@ namespace Ryujinx.Modules
             var files = Directory.EnumerateFiles(HomeDir); // All files directly in base dir.
 
             // Determine and exclude user files only when the updater is running, not when cleaning old files
-            if (_running)
+            if (_running && !OperatingSystem.IsMacOS())
             {
                 // Compare the loose files in base directory against the loose files from the incoming update, and store foreign ones in a user list.
                 var oldFiles = Directory.EnumerateFiles(HomeDir, "*", SearchOption.TopDirectoryOnly).Select(Path.GetFileName);


### PR DESCRIPTION
This should fix a regression introduced by 1.1.869 where the macOS updater won't work anymore.

Because we use a `*.app` package, it isn't necessary to check if the user changed any files in this directory.
The updater for macos is designed, that it always replaces the whole package.