### PR TITLE
Check if existing oldConfigPath is a Symlink

### DIFF
--- a/src/Ryujinx.Common/Configuration/AppDataManager.cs
+++ b/src/Ryujinx.Common/Configuration/AppDataManager.cs
@@ -96,7 +96,7 @@ namespace Ryujinx.Common.Configuration
             if (OperatingSystem.IsMacOS() && Mode == LaunchMode.UserProfile)
             {
                 string oldConfigPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), DefaultBaseDir);
-                if (Path.Exists(oldConfigPath) && !Path.Exists(BaseDirPath))
+                if (Path.Exists(oldConfigPath) && !IsPathSymlink(oldConfigPath) && !Path.Exists(BaseDirPath))
                 {
                     CopyDirectory(oldConfigPath, BaseDirPath);
                     Directory.Delete(oldConfigPath, true);
@@ -113,6 +113,14 @@ namespace Ryujinx.Common.Configuration
             Directory.CreateDirectory(GamesDirPath = Path.Combine(BaseDirPath, GamesDir));
             Directory.CreateDirectory(ProfilesDirPath = Path.Combine(BaseDirPath, ProfilesDir));
             Directory.CreateDirectory(KeysDirPath = Path.Combine(BaseDirPath, KeysDir));
+        }
+
+        // Check if existing old baseDirPath is a symlink, to prevent possible errors.
+        // Should be removed, when the existance of the old directory isn't checked anymore.
+        private static bool IsPathSymlink(string path)
+        {
+            FileAttributes attributes = File.GetAttributes(path);
+            return (attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint;
         }
 
         private static void CopyDirectory(string sourceDir, string destinationDir)


### PR DESCRIPTION
In #4296 there was an unhandled exception introduced, which I want to address with this PR.
I recognized this issue thanks to a user in macos-support on discord.

If you used the orinal macos ryujinx release and installed later versions, you have a symlink in the old directory (~/.config/Ryujinx) and the ryujinx config folder in the new one (~/Library/Application Support).
If you somehow (classical skill issue) manage to delete the new config folder, ryujinx won't start anymore, because it tries to copy the old directory (which is a symlink now).

I included a check, if the existing old path is just a symlink.
If it is true, a new ryujinx config folder will be created, and the app starts.

Of course we could just remove the symlink actions, but it is to early at this point because the official macos-2 release of ryujinx isn't even released yet.